### PR TITLE
Help flag exit status

### DIFF
--- a/.changeset/help-flag-exit-status.md
+++ b/.changeset/help-flag-exit-status.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fixed help flag (`-h`, `--help`) to exit with status code 0 instead of 2. Displaying help is a successful operation and should return a success exit code. This follows standard Unix conventions and improves compatibility with scripts and CI pipelines that check exit codes.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -70,7 +70,7 @@ export const mySubcommand = {
 
 The entry point resolves subcommands with `getSubcommand`, displays help for `--help`/`-h`, parses flags with `parseArguments(args, getFlagsSpecification(subcommand.options))`, tracks telemetry, and delegates to subcommand functions. Use `getCommandAliases` to build the `COMMAND_CONFIG` map. Wrap the body in `try/catch` with `printError(err)`. See `src/commands/rolling-release/index.ts` or `src/commands/alias/index.ts` for complete examples.
 
-**Exit codes**: `0` = success, `1` = error, `2` = help displayed.
+**Exit codes**: `0` = success (including when help is displayed via `--help`), `1` = error, `2` = usage error (invalid subcommand, missing required args).
 **Permissive parsing**: Parent commands with subcommands should use `permissive: true` so unknown flags pass through to subcommand handlers, which do strict parsing (default).
 
 ## Interactive Prompts vs Flags

--- a/packages/cli/src/commands/alias/index.ts
+++ b/packages/cli/src/commands/alias/index.ts
@@ -53,7 +53,7 @@ export default async function alias(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('alias');
     output.print(help(aliasCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -67,7 +67,7 @@ export default async function alias(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('alias', subcommandOriginal);
         printHelp(listSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);
@@ -75,7 +75,7 @@ export default async function alias(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('alias', subcommandOriginal);
         printHelp(removeSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
@@ -83,7 +83,7 @@ export default async function alias(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('alias', subcommandOriginal);
         printHelp(setSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandSet(subcommandOriginal);
       return set(client, args);
@@ -91,7 +91,7 @@ export default async function alias(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('alias', subcommandOriginal);
         printHelp(setSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandSet(subcommandOriginal);
       return set(client, args);

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -75,7 +75,7 @@ export default async function api(client: Client): Promise<number> {
           columns: client.stderr.columns,
         })
       );
-      return 2;
+      return 0;
     }
 
     telemetryClient.trackCliSubcommandList();
@@ -93,7 +93,7 @@ export default async function api(client: Client): Promise<number> {
   if (needHelp) {
     telemetryClient.trackCliFlagHelp('api');
     output.print(help(apiCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   // Set dangerously-skip-permissions flag for DELETE confirmation handling

--- a/packages/cli/src/commands/bisect/index.ts
+++ b/packages/cli/src/commands/bisect/index.ts
@@ -45,7 +45,7 @@ export default async function bisect(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('bisect');
     output.print(help(bisectCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   telemetry.trackCliOptionGood(parsedArgs.flags['--good']);

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -60,7 +60,7 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('blob', subcommand);
     output.print(help(blobCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -77,7 +77,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob', subcommandOriginal);
         printHelp(listSubcommand);
-        return 2;
+        return 0;
       }
 
       telemetry.trackCliSubcommandList(subcommandOriginal);
@@ -92,7 +92,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob', subcommandOriginal);
         printHelp(putSubcommand);
-        return 2;
+        return 0;
       }
 
       telemetry.trackCliSubcommandPut(subcommandOriginal);
@@ -107,7 +107,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob', subcommandOriginal);
         printHelp(delSubcommand);
-        return 2;
+        return 0;
       }
 
       telemetry.trackCliSubcommandDel(subcommandOriginal);
@@ -122,7 +122,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob', subcommandOriginal);
         printHelp(copySubcommand);
-        return 2;
+        return 0;
       }
 
       telemetry.trackCliSubcommandCopy(subcommandOriginal);

--- a/packages/cli/src/commands/blob/store.ts
+++ b/packages/cli/src/commands/blob/store.ts
@@ -54,7 +54,7 @@ export async function store(client: Client, rwToken: BlobRWToken) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('blob store', subcommand);
     output.print(help(storeSubcommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -68,7 +68,7 @@ export async function store(client: Client, rwToken: BlobRWToken) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob store', subcommandOriginal);
         printHelp(addStoreSubcommand);
-        return 2;
+        return 0;
       }
 
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
@@ -77,7 +77,7 @@ export async function store(client: Client, rwToken: BlobRWToken) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob store', subcommandOriginal);
         printHelp(removeStoreSubcommand);
-        return 2;
+        return 0;
       }
 
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
@@ -86,7 +86,7 @@ export async function store(client: Client, rwToken: BlobRWToken) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob store', subcommandOriginal);
         printHelp(getStoreSubcommand);
-        return 2;
+        return 0;
       }
 
       telemetry.trackCliSubcommandGet(subcommandOriginal);

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -196,7 +196,7 @@ export default async function main(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetryClient.trackCliFlagHelp('build');
     output.print(help(buildCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   // Build `target` influences which environment variables will be used

--- a/packages/cli/src/commands/cache/index.ts
+++ b/packages/cli/src/commands/cache/index.ts
@@ -67,21 +67,21 @@ export default async function main(client: Client) {
     case 'purge':
       if (needHelp) {
         printHelp(purgeSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandPurge(subcommandOriginal);
       return purge(client, args);
     case 'invalidate':
       if (needHelp) {
         printHelp(invalidateSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandInvalidate(subcommandOriginal);
       return invalidate(client, args);
     case 'dangerously-delete':
       if (needHelp) {
         printHelp(dangerouslyDeleteSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandDangerouslyDelete(subcommandOriginal);
       return dangerouslyDelete(client, args);

--- a/packages/cli/src/commands/certs/index.ts
+++ b/packages/cli/src/commands/certs/index.ts
@@ -58,7 +58,7 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('certs', subcommand);
     output.print(help(certsCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -72,7 +72,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('certs', subcommandOriginal);
         printHelp(issueSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandIssue(subcommandOriginal);
       return issue(client, args);
@@ -80,7 +80,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('certs', subcommandOriginal);
         printHelp(listSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);
@@ -88,7 +88,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('certs', subcommandOriginal);
         printHelp(removeSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
@@ -96,7 +96,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('certs', subcommandOriginal);
         printHelp(addSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);

--- a/packages/cli/src/commands/curl/shared.ts
+++ b/packages/cli/src/commands/curl/shared.ts
@@ -66,7 +66,7 @@ export function setupCurlLikeCommand(
 
   if (parsedArgs.flags['--help']) {
     print(help(command, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   // Remove command name from the args list

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -130,7 +130,7 @@ export default async (client: Client): Promise<number> => {
   if (parsedArguments.flags['--help']) {
     telemetryClient.trackCliFlagHelp('deploy');
     output.print(help(deployCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   if (parsedArguments.args[0] === deployCommand.name) {

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -69,7 +69,7 @@ export default async function main(client: Client) {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('dev');
     output.print(help(devCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const args = getSubcommand(parsedArgs.args.slice(1), COMMAND_CONFIG).args;

--- a/packages/cli/src/commands/dns/index.ts
+++ b/packages/cli/src/commands/dns/index.ts
@@ -56,7 +56,7 @@ export default async function dns(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('dns', subcommand);
     output.print(help(dnsCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -70,7 +70,7 @@ export default async function dns(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('dns', subcommandOriginal);
         printHelp(addSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
@@ -78,7 +78,7 @@ export default async function dns(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('dns', subcommandOriginal);
         printHelp(importSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandImport(subcommandOriginal);
       return importZone(client, args);
@@ -86,7 +86,7 @@ export default async function dns(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('dns', subcommandOriginal);
         printHelp(removeSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
@@ -94,7 +94,7 @@ export default async function dns(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('dns', subcommandOriginal);
         printHelp(listSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -61,14 +61,14 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('domains');
     output.print(help(domainsCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
     output.print(
       help(command, { parent: domainsCommand, columns: client.stderr.columns })
     );
-    return 2;
+    return 0;
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -62,7 +62,7 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('env', subcommand);
     output.print(help(envCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -76,7 +76,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(listSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);
@@ -84,7 +84,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(addSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
@@ -92,7 +92,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(removeSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
@@ -100,7 +100,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(pullSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandPull(subcommandOriginal);
       return pull(client, args);
@@ -115,7 +115,7 @@ export default async function main(client: Client) {
       if (needsHelpForRun(client)) {
         telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(runSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandRun(subcommandOriginal);
       return run(client);
@@ -123,7 +123,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(updateSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandUpdate(subcommandOriginal);
       return update(client, args);

--- a/packages/cli/src/commands/git/index.ts
+++ b/packages/cli/src/commands/git/index.ts
@@ -41,7 +41,7 @@ export default async function main(client: Client) {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('git', subcommand);
     output.print(help(gitCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/guidance/index.ts
+++ b/packages/cli/src/commands/guidance/index.ts
@@ -66,7 +66,7 @@ export default async function guidance(client: Client) {
   if (!subcommand && needHelp) {
     telemetryClient.trackCliFlagHelp('guidance', subcommand);
     output.print(help(guidanceCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   switch (subcommand) {
@@ -74,7 +74,7 @@ export default async function guidance(client: Client) {
       if (needHelp) {
         telemetryClient.trackCliFlagHelp('guidance', subcommandOriginal);
         printHelp(statusSubcommand);
-        return 2;
+        return 0;
       }
       telemetryClient.trackCliSubcommandStatus(subcommandOriginal);
       return status(client);
@@ -82,7 +82,7 @@ export default async function guidance(client: Client) {
       if (needHelp) {
         telemetryClient.trackCliFlagHelp('guidance', subcommandOriginal);
         printHelp(enableSubcommand);
-        return 2;
+        return 0;
       }
       telemetryClient.trackCliSubcommandEnable(subcommandOriginal);
       return enable(client);
@@ -90,7 +90,7 @@ export default async function guidance(client: Client) {
       if (needHelp) {
         telemetryClient.trackCliFlagHelp('guidance', subcommandOriginal);
         printHelp(disableSubcommand);
-        return 2;
+        return 0;
       }
       return disable(client);
     default: {

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -36,7 +36,7 @@ export default async function main(client: Client) {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('init');
     output.print(help(initCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const args = getSubcommand(parsedArgs.args.slice(1), COMMAND_CONFIG).args;

--- a/packages/cli/src/commands/inspect/index.ts
+++ b/packages/cli/src/commands/inspect/index.ts
@@ -48,7 +48,7 @@ export default async function inspect(client: Client) {
   if (parsedArguments.flags['--help']) {
     telemetry.trackCliFlagHelp('inspect');
     print(help(inspectCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   if (parsedArguments.args[0] === inspectCommand.name) {

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -219,7 +219,7 @@ export default async function logs(client: Client) {
   if (parsedArguments.flags['--help']) {
     telemetry.trackCliFlagHelp('logs');
     output.print(help(logsCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const subArgs = parsedArguments.args.slice(1);

--- a/packages/cli/src/commands/mcp/index.ts
+++ b/packages/cli/src/commands/mcp/index.ts
@@ -20,7 +20,7 @@ export default async function main(client: Client) {
 
   if (parsedArgs.flags['--help']) {
     output.print(help(mcpCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   // Add the parsed flags to client.argv so the mcp function can access them

--- a/packages/cli/src/commands/microfrontends/index.ts
+++ b/packages/cli/src/commands/microfrontends/index.ts
@@ -48,7 +48,7 @@ export default async function main(client: Client) {
     output.print(
       help(microfrontendsCommand, { columns: client.stderr.columns })
     );
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -58,7 +58,7 @@ export default async function main(client: Client) {
         columns: client.stderr.columns,
       })
     );
-    return 2;
+    return 0;
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/promote/index.ts
+++ b/packages/cli/src/commands/promote/index.ts
@@ -38,7 +38,7 @@ export default async (client: Client): Promise<number> => {
   if (!parsedArgs.args[1] && needHelp) {
     telemetry.trackCliFlagHelp('promote');
     output.print(help(promoteCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const yes = parsedArgs.flags['--yes'] ?? false;
@@ -65,7 +65,7 @@ export default async (client: Client): Promise<number> => {
             parent: promoteCommand,
           })
         );
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandStatus();
       const project = await getProjectByCwdOrLink({

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -79,7 +79,7 @@ export default async function main(client: Client) {
   if (parsedArgs.flags['--help']) {
     telemetryClient.trackCliFlagHelp('pull');
     output.print(help(pullCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const cwd = parsedArgs.args[1] || client.cwd;

--- a/packages/cli/src/commands/redeploy/index.ts
+++ b/packages/cli/src/commands/redeploy/index.ts
@@ -57,7 +57,7 @@ export default async function redeploy(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('redeploy');
     output.print(help(redeployCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const deployIdOrUrl = parsedArgs.args[1];

--- a/packages/cli/src/commands/redirects/index.ts
+++ b/packages/cli/src/commands/redirects/index.ts
@@ -65,7 +65,7 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('redirects');
     output.print(help(redirectsCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -82,7 +82,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('redirects', subcommandOriginal);
         printHelp(listSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return list(client, args);
@@ -90,7 +90,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('redirects', subcommandOriginal);
         printHelp(listVersionsSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandListVersions(subcommandOriginal);
       return listVersions(client, args);
@@ -98,7 +98,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('redirects', subcommandOriginal);
         printHelp(addSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
@@ -106,7 +106,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('redirects', subcommandOriginal);
         printHelp(uploadSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandUpload(subcommandOriginal);
       return upload(client, args);
@@ -114,7 +114,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('redirects', subcommandOriginal);
         printHelp(removeSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return remove(client, args);
@@ -122,7 +122,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('redirects', subcommandOriginal);
         printHelp(promoteSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandPromote(subcommandOriginal);
       return promote(client, args);
@@ -130,7 +130,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('redirects', subcommandOriginal);
         printHelp(restoreSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandRestore(subcommandOriginal);
       return restore(client, args);

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -50,7 +50,7 @@ export default async function remove(client: Client) {
   if (parsedArgs.flags['--help']) {
     telemetryClient.trackCliFlagHelp('remove');
     output.print(help(removeCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const ids = parsedArgs.args.slice(1);

--- a/packages/cli/src/commands/rollback/index.ts
+++ b/packages/cli/src/commands/rollback/index.ts
@@ -41,7 +41,7 @@ export default async (client: Client): Promise<number> => {
   if (!parsedArgs.args[1] && needHelp) {
     telemetry.trackCliFlagHelp('rollback');
     output.print(help(rollbackCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   // validate the timeout
@@ -63,7 +63,7 @@ export default async (client: Client): Promise<number> => {
             parent: rollbackCommand,
           })
         );
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandStatus();
       const project = await getProjectByCwdOrLink({

--- a/packages/cli/src/commands/rolling-release/index.ts
+++ b/packages/cli/src/commands/rolling-release/index.ts
@@ -56,7 +56,7 @@ export default async function rollingRelease(client: Client): Promise<number> {
     output.print(
       help(rollingReleaseCommand, { columns: client.stderr.columns })
     );
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -89,7 +89,7 @@ export default async function rollingRelease(client: Client): Promise<number> {
         if (needHelp) {
           telemetry.trackCliFlagHelp('rolling-release', subcommandOriginal);
           printHelp(configureSubcommand);
-          return 2;
+          return 0;
         }
         subcommandFlags = parseArguments(
           subcommandArgs,
@@ -132,7 +132,7 @@ export default async function rollingRelease(client: Client): Promise<number> {
         if (needHelp) {
           telemetry.trackCliFlagHelp('rolling-release', subcommandOriginal);
           printHelp(startSubcommand);
-          return 2;
+          return 0;
         }
         subcommandFlags = parseArguments(
           subcommandArgs,
@@ -156,7 +156,7 @@ export default async function rollingRelease(client: Client): Promise<number> {
         if (needHelp) {
           telemetry.trackCliFlagHelp('rolling-release', subcommandOriginal);
           printHelp(approveSubcommand);
-          return 2;
+          return 0;
         }
         subcommandFlags = parseArguments(
           subcommandArgs,
@@ -190,7 +190,7 @@ export default async function rollingRelease(client: Client): Promise<number> {
         if (needHelp) {
           telemetry.trackCliFlagHelp('rolling-release', subcommandOriginal);
           printHelp(abortSubcommand);
-          return 2;
+          return 0;
         }
         subcommandFlags = parseArguments(
           subcommandArgs,
@@ -213,7 +213,7 @@ export default async function rollingRelease(client: Client): Promise<number> {
         if (needHelp) {
           telemetry.trackCliFlagHelp('rolling-release', subcommandOriginal);
           printHelp(completeSubcommand);
-          return 2;
+          return 0;
         }
         subcommandFlags = parseArguments(
           subcommandArgs,
@@ -236,7 +236,7 @@ export default async function rollingRelease(client: Client): Promise<number> {
         if (needHelp) {
           telemetry.trackCliFlagHelp('rolling-release', subcommandOriginal);
           printHelp(fetchSubcommand);
-          return 2;
+          return 0;
         }
         const result = await requestRollingRelease({
           client,

--- a/packages/cli/src/commands/teams/index.ts
+++ b/packages/cli/src/commands/teams/index.ts
@@ -57,7 +57,7 @@ export default async function teams(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('teams', subcommand);
     output.print(help(teamsCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
@@ -71,7 +71,7 @@ export default async function teams(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('teams', subcommandOriginal);
         printHelp(listSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return list(client, args);
@@ -80,7 +80,7 @@ export default async function teams(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('teams', subcommandOriginal);
         printHelp(switchSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandSwitch(subcommandOriginal);
       return change(client, args);
@@ -89,7 +89,7 @@ export default async function teams(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('teams', subcommandOriginal);
         printHelp(addSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client);
@@ -98,7 +98,7 @@ export default async function teams(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('teams', subcommandOriginal);
         printHelp(inviteSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandInvite(subcommandOriginal);
       return invite(client, args);

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -63,7 +63,7 @@ export default async function telemetry(client: Client) {
   if (!subcommand && needHelp) {
     telemetryClient.trackCliFlagHelp('telemetry', subcommand);
     output.print(help(telemetryCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   switch (subcommand) {
@@ -71,7 +71,7 @@ export default async function telemetry(client: Client) {
       if (needHelp) {
         telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
         printHelp(statusSubcommand);
-        return 2;
+        return 0;
       }
       telemetryClient.trackCliSubcommandStatus(subcommandOriginal);
       return status(client);
@@ -81,7 +81,7 @@ export default async function telemetry(client: Client) {
       if (needHelp) {
         telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
         printHelp(enableSubcommand);
-        return 2;
+        return 0;
       }
       telemetryClient.trackCliSubcommandEnable(subcommandOriginal);
       return enable(client);
@@ -89,7 +89,7 @@ export default async function telemetry(client: Client) {
       if (needHelp) {
         telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
         printHelp(disableSubcommand);
-        return 2;
+        return 0;
       }
       return disable(client);
     default: {

--- a/packages/cli/src/commands/webhooks/index.ts
+++ b/packages/cli/src/commands/webhooks/index.ts
@@ -53,14 +53,14 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('webhooks');
     output.print(help(webhooksCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
     output.print(
       help(command, { parent: webhooksCommand, columns: client.stderr.columns })
     );
-    return 2;
+    return 0;
   }
 
   switch (subcommand) {

--- a/packages/cli/test/unit/commands/alias/index.test.ts
+++ b/packages/cli/test/unit/commands/alias/index.test.ts
@@ -16,7 +16,7 @@ describe('alias', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = alias(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/alias/ls.test.ts
+++ b/packages/cli/test/unit/commands/alias/ls.test.ts
@@ -26,7 +26,7 @@ describe('alias ls', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = alias(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/alias/rm.test.ts
+++ b/packages/cli/test/unit/commands/alias/rm.test.ts
@@ -11,7 +11,7 @@ describe('alias rm', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = alias(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/alias/set.test.ts
+++ b/packages/cli/test/unit/commands/alias/set.test.ts
@@ -14,7 +14,7 @@ describe('alias set', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = alias(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/api/index.test.ts
+++ b/packages/cli/test/unit/commands/api/index.test.ts
@@ -11,7 +11,7 @@ describe('api', () => {
     it('prints help message', async () => {
       client.setArgv('api', '--help');
       const exitCode = await api(client);
-      expect(exitCode).toEqual(2);
+      expect(exitCode).toEqual(0);
       expect(client.getFullOutput()).toContain(
         'Make authenticated HTTP requests to the Vercel API'
       );

--- a/packages/cli/test/unit/commands/bisect/index.test.ts
+++ b/packages/cli/test/unit/commands/bisect/index.test.ts
@@ -44,7 +44,7 @@ describe('bisect', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = bisect(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -31,7 +31,7 @@ describe.skipIf(flakey)('build', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = build(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/certs/add.test.ts
+++ b/packages/cli/test/unit/commands/certs/add.test.ts
@@ -10,7 +10,7 @@ describe('certs add', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = certs(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/certs/index.test.ts
+++ b/packages/cli/test/unit/commands/certs/index.test.ts
@@ -9,7 +9,7 @@ describe('certs', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = certs(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/certs/issue.test.ts
+++ b/packages/cli/test/unit/commands/certs/issue.test.ts
@@ -11,7 +11,7 @@ describe('certs issue', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCode = await certs(client);
-      expect(exitCode).toEqual(2);
+      expect(exitCode).toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/certs/ls.test.ts
+++ b/packages/cli/test/unit/commands/certs/ls.test.ts
@@ -23,7 +23,7 @@ describe('certs ls', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = certs(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/certs/rm.test.ts
+++ b/packages/cli/test/unit/commands/certs/rm.test.ts
@@ -12,7 +12,7 @@ describe('certs rm', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = certs(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/curl/index.test.ts
+++ b/packages/cli/test/unit/commands/curl/index.test.ts
@@ -62,7 +62,7 @@ describe('curl', () => {
     it('prints help message', async () => {
       client.setArgv('curl', '--help');
       const exitCode = await curl(client);
-      expect(exitCode).toEqual(2);
+      expect(exitCode).toEqual(0);
       expect(client.getFullOutput()).toContain(
         'Execute curl with automatic deployment URL and protection bypass'
       );

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -23,7 +23,7 @@ describe('deploy', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = deploy(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/dev/index.test.ts
+++ b/packages/cli/test/unit/commands/dev/index.test.ts
@@ -65,7 +65,7 @@ describe('dev', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = dev(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/dns/add.test.ts
+++ b/packages/cli/test/unit/commands/dns/add.test.ts
@@ -17,7 +17,7 @@ describe('dns add', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = dns(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/dns/import.test.ts
+++ b/packages/cli/test/unit/commands/dns/import.test.ts
@@ -32,7 +32,7 @@ describe('dns import', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = dns(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/dns/index.test.ts
+++ b/packages/cli/test/unit/commands/dns/index.test.ts
@@ -16,7 +16,7 @@ describe('dns', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = dns(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/dns/ls.test.ts
+++ b/packages/cli/test/unit/commands/dns/ls.test.ts
@@ -17,7 +17,7 @@ describe('dns ls', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = dns(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/dns/rm.test.ts
+++ b/packages/cli/test/unit/commands/dns/rm.test.ts
@@ -17,7 +17,7 @@ describe('dns rm', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = dns(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/domains/add.test.ts
+++ b/packages/cli/test/unit/commands/domains/add.test.ts
@@ -13,7 +13,7 @@ describe('domains add', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = domains(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/domains/buy.test.ts
+++ b/packages/cli/test/unit/commands/domains/buy.test.ts
@@ -37,7 +37,7 @@ describe('domains buy', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = domains(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/domains/index.test.ts
+++ b/packages/cli/test/unit/commands/domains/index.test.ts
@@ -16,7 +16,7 @@ describe('domains', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = domains(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/domains/inspect.test.ts
+++ b/packages/cli/test/unit/commands/domains/inspect.test.ts
@@ -13,7 +13,7 @@ describe('domains inspect', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = domains(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/domains/ls.test.ts
+++ b/packages/cli/test/unit/commands/domains/ls.test.ts
@@ -12,7 +12,7 @@ describe('domains ls', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = domains(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/domains/move.test.ts
+++ b/packages/cli/test/unit/commands/domains/move.test.ts
@@ -14,7 +14,7 @@ describe('domains mv', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = domains(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/domains/rm.test.ts
+++ b/packages/cli/test/unit/commands/domains/rm.test.ts
@@ -13,7 +13,7 @@ describe('domains rm', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = domains(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/domains/transfer-in.test.ts
+++ b/packages/cli/test/unit/commands/domains/transfer-in.test.ts
@@ -23,7 +23,7 @@ describe('domains transfer-in', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = domains(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -42,7 +42,7 @@ describe('env add', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = env(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/env/index.test.ts
+++ b/packages/cli/test/unit/commands/env/index.test.ts
@@ -13,7 +13,7 @@ describe('env', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = env(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/env/ls.test.ts
+++ b/packages/cli/test/unit/commands/env/ls.test.ts
@@ -51,7 +51,7 @@ describe('env ls', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = env(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -17,7 +17,7 @@ describe('env pull', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = env(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/env/rm.test.ts
+++ b/packages/cli/test/unit/commands/env/rm.test.ts
@@ -41,7 +41,7 @@ describe('env rm', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = env(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/env/run.test.ts
+++ b/packages/cli/test/unit/commands/env/run.test.ts
@@ -29,7 +29,7 @@ describe('env run', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = env(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -19,7 +19,7 @@ describe('git connect', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = git(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/git/disconnect.test.ts
+++ b/packages/cli/test/unit/commands/git/disconnect.test.ts
@@ -19,7 +19,7 @@ describe('git disconnect', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = git(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/git/index.test.ts
+++ b/packages/cli/test/unit/commands/git/index.test.ts
@@ -9,7 +9,7 @@ describe('git', () => {
 
       client.setArgv(command, '--help');
       const exitCode = await git(client);
-      expect(exitCode, 'exit code for git').toEqual(2);
+      expect(exitCode, 'exit code for git').toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/guidance/index.test.ts
+++ b/packages/cli/test/unit/commands/guidance/index.test.ts
@@ -32,7 +32,7 @@ describe('guidance', () => {
 
         client.setArgv(command, '--help');
         const exitCodePromise = guidance(client);
-        await expect(exitCodePromise).resolves.toEqual(2);
+        await expect(exitCodePromise).resolves.toEqual(0);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
           {

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -73,7 +73,7 @@ describe('help command', () => {
       it('outputs help', async () => {
         client.setArgv('dev', '--help');
         const exitCode = await dev(client);
-        expect(exitCode).toEqual(2);
+        expect(exitCode).toEqual(0);
         expect(client.stderr.read()).toMatchSnapshot();
       });
     });

--- a/packages/cli/test/unit/commands/httpstat/index.test.ts
+++ b/packages/cli/test/unit/commands/httpstat/index.test.ts
@@ -58,7 +58,7 @@ describe('httpstat', () => {
     it('prints help message', async () => {
       client.setArgv('httpstat', '--help');
       const exitCode = await httpstat(client);
-      expect(exitCode).toEqual(2);
+      expect(exitCode).toEqual(0);
       expect(client.getFullOutput()).toContain(
         'Execute httpstat with automatic deployment URL and protection bypass'
       );

--- a/packages/cli/test/unit/commands/init/index.test.ts
+++ b/packages/cli/test/unit/commands/init/index.test.ts
@@ -46,7 +46,7 @@ describe('init', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = init(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/inspect/index.test.ts
+++ b/packages/cli/test/unit/commands/inspect/index.test.ts
@@ -12,7 +12,7 @@ describe('inspect', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = inspect(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/logout/index.test.ts
+++ b/packages/cli/test/unit/commands/logout/index.test.ts
@@ -9,7 +9,7 @@ describe.todo('logout', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = logout(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -73,7 +73,7 @@ describe('logs', () => {
       client.setArgv('logs', '--help');
       const exitCode = await logs(client);
 
-      expect(exitCode).toEqual(2);
+      expect(exitCode).toEqual(0);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',

--- a/packages/cli/test/unit/commands/microfrontends/index.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/index.test.ts
@@ -17,7 +17,7 @@ describe('microfrontends', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = microfrontends(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/microfrontends/pull.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/pull.test.ts
@@ -20,7 +20,7 @@ describe('microfrontends pull', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = microfrontends(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -16,7 +16,7 @@ describe('pull', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = pull(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/redeploy/index.test.ts
+++ b/packages/cli/test/unit/commands/redeploy/index.test.ts
@@ -15,7 +15,7 @@ describe('redeploy', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = redeploy(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/redirects/add.test.ts
+++ b/packages/cli/test/unit/commands/redirects/add.test.ts
@@ -29,7 +29,7 @@ describe('redirects add', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = redirects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/redirects/list-versions.test.ts
+++ b/packages/cli/test/unit/commands/redirects/list-versions.test.ts
@@ -27,7 +27,7 @@ describe('redirects list-versions', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = redirects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/redirects/list.test.ts
+++ b/packages/cli/test/unit/commands/redirects/list.test.ts
@@ -27,7 +27,7 @@ describe('redirects list', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = redirects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/redirects/promote.test.ts
+++ b/packages/cli/test/unit/commands/redirects/promote.test.ts
@@ -29,7 +29,7 @@ describe('redirects promote', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = redirects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/redirects/remove.test.ts
+++ b/packages/cli/test/unit/commands/redirects/remove.test.ts
@@ -29,7 +29,7 @@ describe('redirects remove', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = redirects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/redirects/restore.test.ts
+++ b/packages/cli/test/unit/commands/redirects/restore.test.ts
@@ -29,7 +29,7 @@ describe('redirects restore', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = redirects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/redirects/upload.test.ts
+++ b/packages/cli/test/unit/commands/redirects/upload.test.ts
@@ -40,7 +40,7 @@ describe('redirects upload', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = redirects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/remove/index.test.ts
+++ b/packages/cli/test/unit/commands/remove/index.test.ts
@@ -16,7 +16,7 @@ describe('remove', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = remove(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/teams/add.test.ts
+++ b/packages/cli/test/unit/commands/teams/add.test.ts
@@ -24,7 +24,7 @@ describe('teams add', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = teams(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/teams/index.test.ts
+++ b/packages/cli/test/unit/commands/teams/index.test.ts
@@ -9,7 +9,7 @@ describe('teams', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = teams(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/teams/invite.test.ts
+++ b/packages/cli/test/unit/commands/teams/invite.test.ts
@@ -19,7 +19,7 @@ describe('teams invite', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = teams(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/teams/ls.test.ts
+++ b/packages/cli/test/unit/commands/teams/ls.test.ts
@@ -12,7 +12,7 @@ describe('teams ls', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = teams(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/telemetry/index.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/index.test.ts
@@ -16,7 +16,7 @@ describe('telemetry', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = telemetry(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/webhooks/create.test.ts
+++ b/packages/cli/test/unit/commands/webhooks/create.test.ts
@@ -12,7 +12,7 @@ describe('webhooks create', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = webhooks(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/webhooks/get.test.ts
+++ b/packages/cli/test/unit/commands/webhooks/get.test.ts
@@ -12,7 +12,7 @@ describe('webhooks get', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = webhooks(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/webhooks/index.test.ts
+++ b/packages/cli/test/unit/commands/webhooks/index.test.ts
@@ -16,7 +16,7 @@ describe('webhooks', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = webhooks(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/webhooks/ls.test.ts
+++ b/packages/cli/test/unit/commands/webhooks/ls.test.ts
@@ -12,7 +12,7 @@ describe('webhooks ls', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = webhooks(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/webhooks/rm.test.ts
+++ b/packages/cli/test/unit/commands/webhooks/rm.test.ts
@@ -16,7 +16,7 @@ describe('webhooks rm', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = webhooks(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {


### PR DESCRIPTION
Change CLI help flag (`-h`, `--help`) exit status to 0 to align with Unix conventions for successful operations.

---
[Slack Thread](https://vercel.slack.com/archives/C09MK639NMN/p1770656747931409?thread_ts=1770656747.931409&cid=C09MK639NMN)

<p><a href="https://cursor.com/background-agent?bcId=bc-ef8ffe24-efbe-569a-8edb-8624a97112f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef8ffe24-efbe-569a-8edb-8624a97112f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR changes CLI help flag exit status from 2 to 0 across all commands, which is a cosmetic/behavioral change following Unix conventions with no security implications.
> 
> - Changes `return 2` to `return 0` for help flag handling across ~30 CLI command files
> - Updates corresponding test assertions from `toEqual(2)` to `toEqual(0)`
> - Documentation update in AGENTS.md clarifying exit code semantics
>
> <sup>Risk assessment for [commit c254424](https://github.com/vercel/vercel/commit/c2544245cecf14541e13eb7a94891bc17d75c329).</sup>
<!-- VADE_RISK_END -->