### PR TITLE
[cli] Track deployment ID in telemetry

### DIFF
--- a/.changeset/track-deployment-id.md
+++ b/.changeset/track-deployment-id.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Track deployment ID in telemetry after successful deployment creation.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -570,6 +570,10 @@ export default async (client: Client): Promise<number> => {
       parsedArchive ? 'tgz' : undefined
     );
 
+    if (deployment && !(deployment instanceof Error)) {
+      telemetryClient.trackDeploymentId(deployment.id);
+    }
+
     if (deployment instanceof NotDomainOwner) {
       output.error(deployment.message);
       return 1;

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -144,4 +144,13 @@ export class DeployTelemetryClient
       this.trackCliFlag('yes');
     }
   }
+
+  trackDeploymentId(id: string | undefined) {
+    if (id) {
+      this.trackCommandOutput({
+        key: 'deployment-id',
+        value: id,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -103,6 +103,13 @@ export class TelemetryClient {
     });
   }
 
+  protected trackCommandOutput(eventData: { key: string; value: string }) {
+    this.track({
+      key: `output:${eventData.key}`,
+      value: eventData.value,
+    });
+  }
+
   protected trackCliFlag(flag: string) {
     this.track({
       key: `flag:${flag}`,

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1209,6 +1209,19 @@ describe('deploy', () => {
         },
       ]);
     });
+    it('tracks deployment id from response', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'output:deployment-id',
+          value: 'dpl_archive_test',
+        },
+      ]);
+    });
   });
 
   describe('first deploy', () => {

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -263,6 +263,7 @@ describe('deploy', () => {
         key: 'option:archive',
         value: 'tgz',
       },
+      { key: 'output:deployment-id', value: 'dpl_archive_test' },
     ]);
   });
 
@@ -315,6 +316,7 @@ describe('deploy', () => {
         key: 'flag:skip-domain',
         value: 'TRUE',
       },
+      { key: 'output:deployment-id', value: 'dpl_archive_test' },
     ]);
   });
 
@@ -751,6 +753,7 @@ describe('deploy', () => {
           key: 'flag:logs',
           value: 'TRUE',
         },
+        { key: 'output:deployment-id', value: expect.any(String) },
       ]);
     });
 
@@ -837,6 +840,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:force', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--with-cache', async () => {
@@ -853,6 +857,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:with-cache', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--public', async () => {
@@ -869,6 +874,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:public', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--env', async () => {
@@ -887,6 +893,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'option:env', value: '[REDACTED]' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--build-env', async () => {
@@ -911,6 +918,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'option:build-env', value: '[REDACTED]' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--meta', async () => {
@@ -929,6 +937,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'option:meta', value: '[REDACTED]' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--regions', async () => {
@@ -947,6 +956,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'option:regions', value: '[REDACTED]' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--prebuilt', async () => {
@@ -966,6 +976,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:prebuilt', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--archive=tgz', async () => {
@@ -982,6 +993,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'option:archive', value: 'tgz' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--archive=split-tgz', async () => {
@@ -998,6 +1010,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'option:archive', value: 'split-tgz' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--no-wait', async () => {
@@ -1016,6 +1029,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:no-wait', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--skip-domain', async () => {
@@ -1034,6 +1048,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:skip-domain', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--yes', async () => {
@@ -1052,6 +1067,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:yes', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--logs', async () => {
@@ -1070,6 +1086,7 @@ describe('deploy', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:logs', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--guidance', async () => {
@@ -1080,6 +1097,7 @@ describe('deploy', () => {
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:guidance', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--name', async () => {
@@ -1090,6 +1108,7 @@ describe('deploy', () => {
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'option:name', value: '[REDACTED]' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--no-clipboard', async () => {
@@ -1100,6 +1119,7 @@ describe('deploy', () => {
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'flag:no-clipboard', value: 'TRUE' },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--target=preview', async () => {
@@ -1122,6 +1142,7 @@ describe('deploy', () => {
           key: 'option:target',
           value: 'preview',
         },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--target=production', async () => {
@@ -1144,6 +1165,7 @@ describe('deploy', () => {
           key: 'option:target',
           value: 'production',
         },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--target=my-custom-env-slug', async () => {
@@ -1166,6 +1188,7 @@ describe('deploy', () => {
           key: 'option:target',
           value: '[REDACTED]',
         },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--prod', async () => {
@@ -1188,6 +1211,7 @@ describe('deploy', () => {
           key: 'flag:prod',
           value: 'TRUE',
         },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
     it('--confirm', async () => {
@@ -1201,6 +1225,7 @@ describe('deploy', () => {
           key: 'flag:confirm',
           value: 'TRUE',
         },
+        { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
       expect(client.telemetryEventStore).not.toHaveTelemetryEvents([
         {


### PR DESCRIPTION
## Summary
- Adds a new `trackCommandOutput` protected method to the base `TelemetryClient` for tracking API response data (using `output:` key prefix)
- Adds `trackDeploymentId` to `DeployTelemetryClient` to record the deployment ID after creation
- Calls the tracker in the deploy command after a successful `createDeploy` response

## Test plan
- [ ] New unit test verifies `output:deployment-id` telemetry event is emitted with the deployment ID
- [ ] Existing deploy telemetry tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds telemetry tracking for deployment IDs with new methods and corresponding unit tests, containing no security-sensitive changes.
> 
> - Adds `trackCommandOutput` protected method to base `TelemetryClient` class
> - Adds `trackDeploymentId` method to `DeployTelemetryClient` for recording deployment ID
> - Updates unit tests to verify new telemetry event emission
>
> <sup>Risk assessment for [commit f43e1f9](https://github.com/vercel/vercel/commit/f43e1f9381bc40aaa807eb28ba647ede78bcd143).</sup>
<!-- VADE_RISK_END -->