### PR TITLE
[cli] Pass detected agent name as actor in deployments

### DIFF
--- a/.changeset/deploy-actor-param.md
+++ b/.changeset/deploy-actor-param.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+'@vercel/client': patch
+---
+
+Pass detected agent name as `actor` in deployment request body

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -524,6 +524,7 @@ export default async (client: Client): Promise<number> => {
       noWait,
       withFullLogs,
       autoAssignCustomDomains,
+      agentName: client.agentName,
     };
 
     if (!localConfig.builds || localConfig.builds.length === 0) {

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -53,6 +53,7 @@ export interface CreateOptions {
   noWait?: boolean;
   withFullLogs?: boolean;
   autoAssignCustomDomains?: boolean;
+  agentName?: string;
 }
 
 export interface RemoveOptions {
@@ -128,6 +129,7 @@ export default class Now {
       noWait,
       withFullLogs,
       autoAssignCustomDomains,
+      agentName,
     }: CreateOptions,
     org: Org,
     isSettingUpProject: boolean,
@@ -149,6 +151,7 @@ export default class Now {
       target: target || undefined,
       projectSettings,
       source: 'cli',
+      actor: agentName,
       autoAssignCustomDomains,
     };
 

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1190,6 +1190,22 @@ describe('deploy', () => {
         },
       ]);
     });
+    it('passes agentName from client', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.agentName = 'test-agent';
+      client.setArgv('deploy');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      expect(mock).toHaveBeenCalledWith(
+        ...Object.values({
+          ...baseCreateDeployArgs,
+          createArgs: expect.objectContaining({
+            agentName: 'test-agent',
+          }),
+        })
+      );
+    });
     it('--confirm', async () => {
       client.cwd = setupUnitFixture('commands/deploy/static');
       client.setArgv('deploy', '--confirm');

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -226,6 +226,7 @@ export interface DeploymentOptions {
   meta?: Dictionary<string>;
   projectSettings?: ProjectSettings;
   gitMetadata?: GitMetadata;
+  actor?: string;
   autoAssignCustomDomains?: boolean;
   customEnvironmentSlugOrId?: string;
   customErrorPage?:


### PR DESCRIPTION
## Summary
- Passes the detected AI agent name (from `client.agentName`) through to the deployment API request body as `actor`
- Adds `actor?: string` to the `DeploymentOptions` type in `@vercel/client`
- Adds test coverage verifying the `agentName` flows from the client through to `createDeploy`

## Test plan
- [x] Existing deploy unit tests pass (49/49)
- [x] New `passes agentName from client` test verifies the wiring
- [ ] Manual: `AI_AGENT=test-agent vercel deploy` and verify `actor` is in the request body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new optional `actor` parameter to deployment requests by passing through the detected AI agent name, which is a simple data passthrough with no security or authorization implications.
> 
> - Adds optional `agentName` field to CreateOptions and passes it through deploy flow
> - Maps `agentName` to `actor` field in deployment request body
> - Adds test coverage for agentName passthrough
>
> <sup>Risk assessment for [commit 94937a6](https://github.com/vercel/vercel/commit/94937a699700744b40030bd682a7a0c022b69954).</sup>
<!-- VADE_RISK_END -->