### PR TITLE
[python] Re-land python-analysis for manifest detection and conversion

### DIFF
--- a/.changeset/loud-impalas-sing.md
+++ b/.changeset/loud-impalas-sing.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python-analysis': minor
+'@vercel/python': minor
+---
+
+Use python-analysis for manifest detection and conversion

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -20,6 +20,7 @@ export { containsAppOrHandler } from './semantic/entrypoints';
 export type {
   PythonConfig,
   PythonConfigs,
+  PythonLockFile,
   PythonManifest,
   PythonManifestOrigin,
   PythonPackage,
@@ -29,9 +30,20 @@ export type {
 export {
   discoverPythonPackage,
   PythonConfigKind,
+  PythonLockFileKind,
   PythonManifestConvertedKind,
   PythonManifestKind,
 } from './manifest/package';
+
+// =============================================================================
+// Manifest serialization utilities
+// =============================================================================
+
+export {
+  createMinimalManifest,
+  stringifyManifest,
+  type CreateMinimalManifestOptions,
+} from './manifest/serialize';
 
 // =============================================================================
 // Python selection (runtime + types)

--- a/packages/python-analysis/src/manifest/pipfile-parser.ts
+++ b/packages/python-analysis/src/manifest/pipfile-parser.ts
@@ -271,6 +271,8 @@ export function convertPipfileToPyprojectToml(
   }
   if (deps.length > 0) {
     pyproject.project = {
+      name: 'app',
+      version: '0.1.0',
       dependencies: deps,
     };
   }
@@ -360,6 +362,8 @@ export function convertPipfileLockToPyprojectToml(
   }
   if (deps.length > 0) {
     pyproject.project = {
+      name: 'app',
+      version: '0.1.0',
       dependencies: deps,
     };
   }

--- a/packages/python-analysis/src/manifest/requirements-txt-parser.ts
+++ b/packages/python-analysis/src/manifest/requirements-txt-parser.ts
@@ -334,6 +334,8 @@ export function convertRequirementsToPyprojectToml(
 
   if (deps.length > 0) {
     pyproject.project = {
+      name: 'app',
+      version: '0.1.0',
       dependencies: deps,
     };
   }

--- a/packages/python-analysis/src/manifest/serialize.ts
+++ b/packages/python-analysis/src/manifest/serialize.ts
@@ -1,0 +1,47 @@
+import toml from 'smol-toml';
+import type { PyProjectToml } from './pyproject/types';
+
+/**
+ * Serialize a PyProjectToml to TOML string format.
+ */
+export function stringifyManifest(data: PyProjectToml): string {
+  return toml.stringify(data);
+}
+
+/**
+ * Options for creating a minimal pyproject.toml structure.
+ */
+export interface CreateMinimalManifestOptions {
+  /** Project name (defaults to 'app'). */
+  name?: string;
+  /** Project version (defaults to '0.1.0'). */
+  version?: string;
+  /** Python version constraint (e.g., '>=3.12' or '~=3.12.0'). */
+  requiresPython?: string;
+  /** Initial dependencies. */
+  dependencies?: string[];
+}
+
+/**
+ * Create a minimal PyProjectToml structure for projects without a manifest.
+ */
+export function createMinimalManifest(
+  options: CreateMinimalManifestOptions = {}
+): PyProjectToml {
+  const {
+    name = 'app',
+    version = '0.1.0',
+    requiresPython,
+    dependencies = [],
+  } = options;
+
+  return {
+    project: {
+      name,
+      version,
+      ...(requiresPython && { 'requires-python': requiresPython }),
+      dependencies,
+      classifiers: ['Private :: Do Not Upload'],
+    },
+  };
+}

--- a/packages/python-analysis/src/manifest/uv-config/schema.zod.ts
+++ b/packages/python-analysis/src/manifest/uv-config/schema.zod.ts
@@ -13,6 +13,7 @@ export const uvIndexEntrySchema = z.object({
   url: z.string(),
   default: z.boolean().optional(),
   explicit: z.boolean().optional(),
+  format: z.string().optional(),
 });
 
 export const uvConfigSchema = z.object({

--- a/packages/python-analysis/src/manifest/uv-config/types.ts
+++ b/packages/python-analysis/src/manifest/uv-config/types.ts
@@ -29,6 +29,8 @@ export interface UvIndexEntry {
   default?: boolean;
   /** Mark this index as explicit (must be explicitly referenced per-package) */
   explicit?: boolean;
+  /** Index format: omit for standard (PEP 503), or "flat" for flat indexes (--find-links) */
+  format?: string;
 }
 
 /**

--- a/packages/python-analysis/test/fixtures/with-both-locks/pylock.toml
+++ b/packages/python-analysis/test/fixtures/with-both-locks/pylock.toml
@@ -1,0 +1,3 @@
+# PEP 751 lock file
+lock-version = "1.0"
+requires-python = ">=3.10"

--- a/packages/python-analysis/test/fixtures/with-both-locks/pyproject.toml
+++ b/packages/python-analysis/test/fixtures/with-both-locks/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "both-locks-test"
+version = "0.1.0"
+requires-python = ">=3.10"

--- a/packages/python-analysis/test/fixtures/with-both-locks/uv.lock
+++ b/packages/python-analysis/test/fixtures/with-both-locks/uv.lock
@@ -1,0 +1,2 @@
+version = 1
+requires-python = ">=3.10"

--- a/packages/python-analysis/test/fixtures/with-pylock/pylock.toml
+++ b/packages/python-analysis/test/fixtures/with-pylock/pylock.toml
@@ -1,0 +1,3 @@
+# PEP 751 lock file
+lock-version = "1.0"
+requires-python = ">=3.11"

--- a/packages/python-analysis/test/fixtures/with-pylock/pyproject.toml
+++ b/packages/python-analysis/test/fixtures/with-pylock/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pylock-test"
+version = "0.1.0"
+requires-python = ">=3.11"

--- a/packages/python-analysis/test/fixtures/with-uv-lock/pyproject.toml
+++ b/packages/python-analysis/test/fixtures/with-uv-lock/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "lock-test"
+version = "0.1.0"
+requires-python = ">=3.10"

--- a/packages/python-analysis/test/fixtures/with-uv-lock/uv.lock
+++ b/packages/python-analysis/test/fixtures/with-uv-lock/uv.lock
@@ -1,0 +1,2 @@
+version = 1
+requires-python = ">=3.10"

--- a/packages/python-analysis/test/package.test.ts
+++ b/packages/python-analysis/test/package.test.ts
@@ -4,6 +4,7 @@ import {
   discoverPythonPackage,
   PythonAnalysisError,
   PythonConfigKind,
+  PythonLockFileKind,
   PythonManifestConvertedKind,
 } from '../src';
 
@@ -493,6 +494,63 @@ describe('discoverPythonPackage', () => {
       expect(result.manifest).toBeDefined();
       // Path should be relative
       expect(result.manifest?.path).toBe('pyproject.toml');
+    });
+  });
+
+  describe('lock file detection', () => {
+    it('discovers uv.lock when present with pyproject.toml', async () => {
+      const root = fixtureRoot('with-uv-lock');
+      const result = await discoverPythonPackage({
+        entrypointDir: root,
+        rootDir: root,
+      });
+
+      expect(result.manifest).toBeDefined();
+      expect(result.manifest?.path).toBe('pyproject.toml');
+      expect(result.manifest?.lockFile).toBeDefined();
+      expect(result.manifest?.lockFile?.kind).toBe(PythonLockFileKind.UvLock);
+      expect(result.manifest?.lockFile?.path).toBe('uv.lock');
+    });
+
+    it('discovers pylock.toml when present with pyproject.toml', async () => {
+      const root = fixtureRoot('with-pylock');
+      const result = await discoverPythonPackage({
+        entrypointDir: root,
+        rootDir: root,
+      });
+
+      expect(result.manifest).toBeDefined();
+      expect(result.manifest?.path).toBe('pyproject.toml');
+      expect(result.manifest?.lockFile).toBeDefined();
+      expect(result.manifest?.lockFile?.kind).toBe(
+        PythonLockFileKind.PylockToml
+      );
+      expect(result.manifest?.lockFile?.path).toBe('pylock.toml');
+    });
+
+    it('prefers uv.lock over pylock.toml when both exist', async () => {
+      const root = fixtureRoot('with-both-locks');
+      const result = await discoverPythonPackage({
+        entrypointDir: root,
+        rootDir: root,
+      });
+
+      expect(result.manifest).toBeDefined();
+      expect(result.manifest?.lockFile).toBeDefined();
+      // uv.lock should take precedence over pylock.toml
+      expect(result.manifest?.lockFile?.kind).toBe(PythonLockFileKind.UvLock);
+      expect(result.manifest?.lockFile?.path).toBe('uv.lock');
+    });
+
+    it('returns no lock file when none exists', async () => {
+      const root = fixtureRoot('simple-pyproject');
+      const result = await discoverPythonPackage({
+        entrypointDir: root,
+        rootDir: root,
+      });
+
+      expect(result.manifest).toBeDefined();
+      expect(result.manifest?.lockFile).toBeUndefined();
     });
   });
 });

--- a/packages/python-analysis/test/requirements-txt-parser.test.ts
+++ b/packages/python-analysis/test/requirements-txt-parser.test.ts
@@ -569,6 +569,8 @@ requests==2.28.0
     const result = convertRequirementsToPyprojectToml(content);
     expect(result).toEqual({
       project: {
+        name: 'app',
+        version: '0.1.0',
         dependencies: ['flask>=2.0.0', 'requests==2.28.0'],
       },
     });
@@ -581,6 +583,8 @@ uvicorn[standard]>=0.20.0
     const result = convertRequirementsToPyprojectToml(content);
     expect(result).toEqual({
       project: {
+        name: 'app',
+        version: '0.1.0',
         dependencies: ['uvicorn[standard]>=0.20.0'],
       },
     });
@@ -593,6 +597,8 @@ mypackage @ https://example.com/package.zip
     const result = convertRequirementsToPyprojectToml(content);
     expect(result).toEqual({
       project: {
+        name: 'app',
+        version: '0.1.0',
         dependencies: ['mypackage @ https://example.com/package.zip'],
       },
     });
@@ -613,6 +619,8 @@ requests==2.28.0
     const result = convertRequirementsToPyprojectToml(content);
     expect(result).toEqual({
       project: {
+        name: 'app',
+        version: '0.1.0',
         dependencies: ['flask>=2.0.0', 'requests==2.28.0'],
       },
       tool: {
@@ -648,6 +656,8 @@ requests==2.28.0 --hash=sha256:def456 --hash=sha256:ghi789
     const result = convertRequirementsToPyprojectToml(content);
     expect(result).toEqual({
       project: {
+        name: 'app',
+        version: '0.1.0',
         dependencies: ['flask==2.0.0', 'requests==2.28.0'],
       },
     });
@@ -671,6 +681,8 @@ django>=4.0
 
     expect(result).toEqual({
       project: {
+        name: 'app',
+        version: '0.1.0',
         dependencies: ['flask>=2.0.0', 'requests==2.28.0', 'django>=4.0'],
       },
     });
@@ -698,6 +710,8 @@ numpy>=1.24.0
 
     expect(result).toEqual({
       project: {
+        name: 'app',
+        version: '0.1.0',
         dependencies: ['flask>=2.0.0', 'requests==2.28.0', 'numpy>=1.24.0'],
       },
     });

--- a/packages/python-analysis/test/requirements-txt-parser.test.ts
+++ b/packages/python-analysis/test/requirements-txt-parser.test.ts
@@ -924,3 +924,730 @@ requests>=2.28.0
     expect(result.tool).toBeUndefined();
   });
 });
+
+describe('parseRequirementsFile with bare paths and URLs', () => {
+  it('parses relative wheel file paths', () => {
+    const content = `
+./wheels/example_pkg_one-1.0.0-py3-none-any.whl
+./wheels/example_pkg_two-2.0.0-py3-none-any.whl
+fastapi
+uvicorn
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'fastapi' },
+      { name: 'uvicorn' },
+      {
+        name: 'example-pkg-one',
+        version: '==1.0.0',
+        source: { path: './wheels/example_pkg_one-1.0.0-py3-none-any.whl' },
+      },
+      {
+        name: 'example-pkg-two',
+        version: '==2.0.0',
+        source: { path: './wheels/example_pkg_two-2.0.0-py3-none-any.whl' },
+      },
+    ]);
+  });
+
+  it('parses absolute wheel file paths', () => {
+    const content = `
+/opt/wheels/my_package-3.2.1-cp311-cp311-linux_x86_64.whl
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'my-package',
+        version: '==3.2.1',
+        source: {
+          path: '/opt/wheels/my_package-3.2.1-cp311-cp311-linux_x86_64.whl',
+        },
+      },
+    ]);
+  });
+
+  it('parses parent-relative paths', () => {
+    const content = `
+../shared/wheels/pkg-1.0.0-py3-none-any.whl
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'pkg',
+        version: '==1.0.0',
+        source: { path: '../shared/wheels/pkg-1.0.0-py3-none-any.whl' },
+      },
+    ]);
+  });
+
+  it('parses sdist archive paths', () => {
+    const content = `
+./vendor/my-cool-package-2.1.0.tar.gz
+./vendor/another-pkg-0.5.zip
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'my-cool-package',
+        version: '==2.1.0',
+        source: { path: './vendor/my-cool-package-2.1.0.tar.gz' },
+      },
+      {
+        name: 'another-pkg',
+        version: '==0.5',
+        source: { path: './vendor/another-pkg-0.5.zip' },
+      },
+    ]);
+  });
+
+  it('parses bare HTTP/HTTPS URLs', () => {
+    const content = `
+https://example.com/packages/my_pkg-1.0.0-py3-none-any.whl
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'my-pkg',
+        version: '==1.0.0',
+        url: 'https://example.com/packages/my_pkg-1.0.0-py3-none-any.whl',
+      },
+    ]);
+  });
+
+  it('parses file:// URLs', () => {
+    const content = `
+file:///opt/wheels/pkg-2.0.0-py3-none-any.whl
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'pkg',
+        version: '==2.0.0',
+        url: 'file:///opt/wheels/pkg-2.0.0-py3-none-any.whl',
+      },
+    ]);
+  });
+
+  it('parses directory paths using last component as name', () => {
+    const content = `
+./test/packages/black_editable
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'black-editable',
+        source: { path: './test/packages/black_editable' },
+      },
+    ]);
+  });
+
+  it('parses directory paths with extras', () => {
+    const content = `
+./test/packages/black_editable[dev]
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'black-editable',
+        extras: ['dev'],
+        source: { path: './test/packages/black_editable' },
+      },
+    ]);
+  });
+
+  it('parses path requirements with environment markers', () => {
+    const content = `
+./test/packages/my_pkg ; python_version >= "3.9"
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'my-pkg',
+        markers: 'python_version >= "3.9"',
+        source: { path: './test/packages/my_pkg' },
+      },
+    ]);
+  });
+
+  it('parses path requirements with inline comments', () => {
+    const content = `
+./test/packages/my_pkg # this is a comment
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'my-pkg',
+        source: { path: './test/packages/my_pkg' },
+      },
+    ]);
+  });
+
+  it('handles wheel paths with build tags', () => {
+    const content = `
+./wheels/pkg-1.0.0-1-py3-none-any.whl
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'pkg',
+        version: '==1.0.0',
+        source: { path: './wheels/pkg-1.0.0-1-py3-none-any.whl' },
+      },
+    ]);
+  });
+
+  it('converts wheel path requirements to pyproject.toml with sources', () => {
+    const content = `
+./wheels/example_pkg_one-1.0.0-py3-none-any.whl
+./wheels/example_pkg_two-2.0.0-py3-none-any.whl
+fastapi
+uvicorn
+`;
+    const result = convertRequirementsToPyprojectToml(content);
+    expect(result.project?.dependencies).toEqual([
+      'fastapi',
+      'uvicorn',
+      'example-pkg-one==1.0.0',
+      'example-pkg-two==2.0.0',
+    ]);
+    expect(result.tool?.uv?.sources).toEqual({
+      'example-pkg-one': [
+        { path: './wheels/example_pkg_one-1.0.0-py3-none-any.whl' },
+      ],
+      'example-pkg-two': [
+        { path: './wheels/example_pkg_two-2.0.0-py3-none-any.whl' },
+      ],
+    });
+  });
+
+  it('converts directory path requirements to pyproject.toml with sources', () => {
+    const content = `
+./packages/my_local_pkg
+flask>=2.0.0
+`;
+    const result = convertRequirementsToPyprojectToml(content);
+    expect(result.project?.dependencies).toEqual([
+      'flask>=2.0.0',
+      'my-local-pkg',
+    ]);
+    expect(result.tool?.uv?.sources).toEqual({
+      'my-local-pkg': [{ path: './packages/my_local_pkg' }],
+    });
+  });
+
+  it('converts bare URL requirements to pyproject.toml', () => {
+    const content = `
+https://example.com/my_pkg-1.0.0-py3-none-any.whl
+flask>=2.0.0
+`;
+    const result = convertRequirementsToPyprojectToml(content);
+    // PEP 508 URL requirements use name @ url (version is implicit in the URL)
+    expect(result.project?.dependencies).toEqual([
+      'flask>=2.0.0',
+      'my-pkg @ https://example.com/my_pkg-1.0.0-py3-none-any.whl',
+    ]);
+  });
+
+  it('handles home-relative paths', () => {
+    const content = `
+~/packages/my_pkg-1.0.0-py3-none-any.whl
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'my-pkg',
+        version: '==1.0.0',
+        source: { path: '~/packages/my_pkg-1.0.0-py3-none-any.whl' },
+      },
+    ]);
+  });
+});
+
+describe('parseRequirementsFile with editable requirements', () => {
+  it('parses -e with directory path', () => {
+    const content = `
+-e ./my-package
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '>=2.0.0' },
+      {
+        name: 'my-package',
+        source: { path: './my-package', editable: true },
+      },
+    ]);
+  });
+
+  it('parses -e with extras', () => {
+    const content = `
+-e ./editable[d,dev]
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'editable',
+        extras: ['d', 'dev'],
+        source: { path: './editable', editable: true },
+      },
+    ]);
+  });
+
+  it('parses -e with extras and whitespace (uv-compatible)', () => {
+    const content = `
+-e ./editable[d, dev]
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'editable',
+        extras: ['d', 'dev'],
+        source: { path: './editable', editable: true },
+      },
+    ]);
+  });
+
+  it('parses -e with environment markers', () => {
+    const content = `
+-e ./editable[d,dev] ; python_version >= "3.9" and os_name == "posix"
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'editable',
+        extras: ['d', 'dev'],
+        markers: 'python_version >= "3.9" and os_name == "posix"',
+        source: { path: './editable', editable: true },
+      },
+    ]);
+  });
+
+  it('parses -e with inline comment', () => {
+    const content = `
+-e ./editable # comment
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'editable',
+        source: { path: './editable', editable: true },
+      },
+    ]);
+  });
+
+  it('parses --editable long form', () => {
+    const content = `
+--editable ./my-package
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'my-package',
+        source: { path: './my-package', editable: true },
+      },
+    ]);
+  });
+
+  it('parses --editable=path form', () => {
+    const content = `
+--editable=./my-package
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'my-package',
+        source: { path: './my-package', editable: true },
+      },
+    ]);
+  });
+
+  it('parses -e with wheel file', () => {
+    const content = `
+-e ./wheels/pkg-1.0.0-py3-none-any.whl
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'pkg',
+        version: '==1.0.0',
+        source: {
+          path: './wheels/pkg-1.0.0-py3-none-any.whl',
+          editable: true,
+        },
+      },
+    ]);
+  });
+
+  it('converts editable to pyproject.toml with editable source', () => {
+    const content = `
+-e ./my-package
+flask>=2.0.0
+`;
+    const result = convertRequirementsToPyprojectToml(content);
+    expect(result.project?.dependencies).toEqual([
+      'flask>=2.0.0',
+      'my-package',
+    ]);
+    expect(result.tool?.uv?.sources).toEqual({
+      'my-package': [{ path: './my-package', editable: true }],
+    });
+  });
+});
+
+describe('parseRequirementsFile with bare archive filenames', () => {
+  it('parses bare wheel filename (no path prefix)', () => {
+    const content = `
+importlib_metadata-8.3.0-py3-none-any.whl
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '>=2.0.0' },
+      {
+        name: 'importlib-metadata',
+        version: '==8.3.0',
+        source: { path: 'importlib_metadata-8.3.0-py3-none-any.whl' },
+      },
+    ]);
+  });
+
+  it('parses bare wheel with extras', () => {
+    const content = `
+importlib_metadata-8.2.0-py3-none-any.whl[extra]
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'importlib-metadata',
+        version: '==8.2.0',
+        extras: ['extra'],
+        source: { path: 'importlib_metadata-8.2.0-py3-none-any.whl' },
+      },
+    ]);
+  });
+
+  it('parses bare wheel with markers', () => {
+    const content = `
+importlib_metadata-8.2.0-py3-none-any.whl ; sys_platform == 'win32'
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'importlib-metadata',
+        version: '==8.2.0',
+        markers: "sys_platform == 'win32'",
+        source: { path: 'importlib_metadata-8.2.0-py3-none-any.whl' },
+      },
+    ]);
+  });
+
+  it('parses bare sdist filename', () => {
+    const content = `
+my-package-1.0.0.tar.gz
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'my-package',
+        version: '==1.0.0',
+        source: { path: 'my-package-1.0.0.tar.gz' },
+      },
+    ]);
+  });
+
+  it('does not catch PEP 508 name @ url.zip as bare archive', () => {
+    const content = `
+mypackage @ https://github.com/user/repo/archive/v1.0.0.zip
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'mypackage',
+        url: 'https://github.com/user/repo/archive/v1.0.0.zip',
+      },
+    ]);
+  });
+});
+
+describe('parseRequirementsFile with find-links and no-index', () => {
+  it('extracts --find-links', () => {
+    const content = `
+--find-links ./wheels/
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '>=2.0.0' },
+    ]);
+    expect(result.pipOptions.findLinks).toEqual(['./wheels/']);
+  });
+
+  it('extracts --find-links=<url> form', () => {
+    const content = `
+--find-links=https://example.com/packages/
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.pipOptions.findLinks).toEqual([
+      'https://example.com/packages/',
+    ]);
+  });
+
+  it('extracts -f short form', () => {
+    const content = `
+-f https://example.com/packages/
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.pipOptions.findLinks).toEqual([
+      'https://example.com/packages/',
+    ]);
+  });
+
+  it('collects multiple --find-links', () => {
+    const content = `
+--find-links ./wheels/
+--find-links=https://example.com/packages/
+-f /opt/packages/
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.pipOptions.findLinks).toEqual([
+      './wheels/',
+      'https://example.com/packages/',
+      '/opt/packages/',
+    ]);
+  });
+
+  it('extracts --no-index', () => {
+    const content = `
+--no-index
+--find-links ./wheels/
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.pipOptions.noIndex).toBe(true);
+    expect(result.pipOptions.findLinks).toEqual(['./wheels/']);
+  });
+
+  it('converts --find-links to flat index entries in pyproject.toml', () => {
+    const content = `
+--find-links ./wheels/
+--find-links https://example.com/packages/
+flask>=2.0.0
+`;
+    const result = convertRequirementsToPyprojectToml(content);
+    expect(result.project?.dependencies).toEqual(['flask>=2.0.0']);
+    expect(result.tool?.uv?.index).toEqual([
+      {
+        name: 'find-links-1',
+        url: './wheels/',
+        format: 'flat',
+      },
+      {
+        name: 'find-links-2',
+        url: 'https://example.com/packages/',
+        format: 'flat',
+      },
+    ]);
+  });
+
+  it('converts --find-links alongside --index-url to pyproject.toml', () => {
+    const content = `
+--index-url https://private.pypi.org/simple/
+--find-links ./wheels/
+flask>=2.0.0
+`;
+    const result = convertRequirementsToPyprojectToml(content);
+    expect(result.project?.dependencies).toEqual(['flask>=2.0.0']);
+    expect(result.tool?.uv?.index).toEqual([
+      {
+        name: 'primary',
+        url: 'https://private.pypi.org/simple/',
+        default: true,
+      },
+      {
+        name: 'find-links-1',
+        url: './wheels/',
+        format: 'flat',
+      },
+    ]);
+  });
+
+  it('merges find-links from referenced files', () => {
+    const mainContent = `
+--find-links ./main-wheels/
+flask>=2.0.0
+-r deps.txt
+`;
+    const depsContent = `
+--find-links ./dep-wheels/
+requests==2.28.0
+`;
+    const readFile = (path: string) => {
+      if (path === 'deps.txt') return depsContent;
+      return null;
+    };
+
+    const result = parseRequirementsFile(mainContent, readFile);
+    expect(result.pipOptions.findLinks).toEqual([
+      './main-wheels/',
+      './dep-wheels/',
+    ]);
+  });
+});
+
+describe('parseRequirementsFile with unknown options', () => {
+  it('strips --no-binary without crashing', () => {
+    const content = `
+--no-binary :all:
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '>=2.0.0' },
+    ]);
+  });
+
+  it('strips --only-binary without crashing', () => {
+    const content = `
+--only-binary flask
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '>=2.0.0' },
+    ]);
+  });
+
+  it('strips --pre without crashing', () => {
+    const content = `
+--pre
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '>=2.0.0' },
+    ]);
+  });
+
+  it('strips --trusted-host without crashing', () => {
+    const content = `
+--trusted-host pypi.example.com
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '>=2.0.0' },
+    ]);
+  });
+
+  it('strips --prefer-binary without crashing', () => {
+    const content = `
+--prefer-binary
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '>=2.0.0' },
+    ]);
+  });
+
+  it('strips --require-hashes without crashing', () => {
+    const content = `
+--require-hashes
+flask==2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '==2.0.0' },
+    ]);
+  });
+
+  it('handles complex file with many options', () => {
+    const content = `
+# Production requirements
+--index-url https://pypi.org/simple/
+--extra-index-url https://private.pypi.com/simple/
+--no-binary :all:
+--trusted-host private.pypi.com
+--prefer-binary
+--find-links ./wheels/
+--no-index
+
+flask>=2.0.0
+requests[socks]==2.28.0
+-e ./my-local-package[dev]
+./wheels/custom_pkg-1.0.0-py3-none-any.whl
+custom_bare-2.0.0-py3-none-any.whl
+
+# Include other files
+-r dev.txt
+-c version-locks.txt
+
+django>=4.0
+`;
+    const result = parseRequirementsFile(content);
+
+    expect(result.requirements).toEqual([
+      { name: 'flask', version: '>=2.0.0' },
+      { name: 'requests', version: '==2.28.0', extras: ['socks'] },
+      { name: 'django', version: '>=4.0' },
+      {
+        name: 'custom-pkg',
+        version: '==1.0.0',
+        source: { path: './wheels/custom_pkg-1.0.0-py3-none-any.whl' },
+      },
+      {
+        name: 'custom-bare',
+        version: '==2.0.0',
+        source: { path: 'custom_bare-2.0.0-py3-none-any.whl' },
+      },
+      {
+        name: 'my-local-package',
+        extras: ['dev'],
+        source: { path: './my-local-package', editable: true },
+      },
+    ]);
+
+    expect(result.pipOptions.indexUrl).toBe('https://pypi.org/simple/');
+    expect(result.pipOptions.extraIndexUrls).toEqual([
+      'https://private.pypi.com/simple/',
+    ]);
+    expect(result.pipOptions.findLinks).toEqual(['./wheels/']);
+    expect(result.pipOptions.noIndex).toBe(true);
+    expect(result.pipOptions.requirementFiles).toEqual(['dev.txt']);
+    expect(result.pipOptions.constraintFiles).toEqual(['version-locks.txt']);
+  });
+});
+
+describe('inline comment stripping on option values', () => {
+  it('strips comments from --index-url value', () => {
+    const content = `
+--index-url https://pypi.org/simple/ # main index
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.pipOptions.indexUrl).toBe('https://pypi.org/simple/');
+  });
+
+  it('strips comments from --extra-index-url value', () => {
+    const content = `
+--extra-index-url https://private.pypi.com/simple/ # private
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.pipOptions.extraIndexUrls).toEqual([
+      'https://private.pypi.com/simple/',
+    ]);
+  });
+
+  it('strips comments from --find-links value', () => {
+    const content = `
+--find-links ./wheels/ # local wheels
+flask>=2.0.0
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.pipOptions.findLinks).toEqual(['./wheels/']);
+  });
+});

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -24,6 +24,9 @@
     "vitest-unit": "glob --absolute 'test/unit.test.ts'",
     "type-check": "tsc --noEmit"
   },
+  "dependencies": {
+    "@vercel/python-analysis": "workspace:*"
+  },
   "devDependencies": {
     "@renovatebot/pep440": "4.2.1",
     "@types/execa": "^0.9.0",

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -357,14 +357,9 @@ export const build: BuildV3 = async ({
     const { projectDir } = await ensureUvProject({
       workPath,
       entryDirectory,
-      fsFiles,
       repoRootPath,
-      pythonPath: pythonVersion.pythonPath,
-      pipPath: pythonVersion.pipPath,
       pythonVersion: pythonVersion.version,
       uv,
-      venvPath,
-      meta,
     });
 
     // `ensureUvProject` would have produced a `pyproject.toml` or `uv.lock`

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -1,20 +1,26 @@
 import execa from 'execa';
 import fs from 'fs';
-import os from 'os';
-import { join, dirname, resolve } from 'path';
+import { join, dirname } from 'path';
 import {
   FileFsRef,
   Files,
   Meta,
+  NowBuildError,
   debug,
   glob,
-  traverseUpDirectories,
 } from '@vercel/build-utils';
-import { getVenvPythonBin, findDir } from './utils';
+import {
+  discoverPythonPackage,
+  stringifyManifest,
+  createMinimalManifest,
+  PythonAnalysisError,
+  PythonLockFileKind,
+  PythonManifestConvertedKind,
+  type PythonPackage,
+} from '@vercel/python-analysis';
+import { getVenvPythonBin } from './utils';
 import { UvRunner, filterUnsafeUvPipArgs, getProtectedUvEnv } from './uv';
 import { DEFAULT_PYTHON_VERSION } from './version';
-
-const isWin = process.platform === 'win32';
 
 const makeDependencyCheckCode = (dependency: string) => `
 from importlib import util
@@ -111,93 +117,73 @@ export function resolveVendorDir() {
   return vendorDir;
 }
 
-export type ManifestType =
-  | 'uv.lock'
-  | 'pyproject.toml'
-  | 'Pipfile.lock'
-  | 'Pipfile'
-  | 'requirements.txt'
-  | null;
+function toBuildError(error: PythonAnalysisError): NowBuildError {
+  return new NowBuildError({
+    code: error.code,
+    message: error.message,
+    link: error.link,
+    action: error.action,
+  });
+}
+
+export type ManifestType = 'uv.lock' | 'pylock.toml' | 'pyproject.toml' | null;
+
 export interface InstallSourceInfo {
   manifestPath: string | null;
   manifestType: ManifestType;
-  manifestContent: string | undefined;
+  /** The discovered package info from python-analysis. */
+  pythonPackage?: PythonPackage;
 }
 
 interface DetectInstallSourceParams {
   workPath: string;
   entryDirectory: string;
-  fsFiles: Record<string, any>;
+  repoRootPath?: string;
 }
 
 export async function detectInstallSource({
   workPath,
   entryDirectory,
-  fsFiles,
+  repoRootPath,
 }: DetectInstallSourceParams): Promise<InstallSourceInfo> {
-  const uvLockDir = findDir({
-    file: 'uv.lock',
-    entryDirectory,
-    workPath,
-    fsFiles,
-  });
-  const pyprojectDir = findDir({
-    file: 'pyproject.toml',
-    entryDirectory,
-    workPath,
-    fsFiles,
-  });
-  const pipfileLockDir = findDir({
-    file: 'Pipfile.lock',
-    entryDirectory,
-    workPath,
-    fsFiles,
-  });
-  const pipfileDir = findDir({
-    file: 'Pipfile',
-    entryDirectory,
-    workPath,
-    fsFiles,
-  });
-  const requirementsDir = findDir({
-    file: 'requirements.txt',
-    entryDirectory,
-    workPath,
-    fsFiles,
-  });
+  const entrypointDir = join(workPath, entryDirectory);
+  const rootDir = repoRootPath ?? workPath;
 
-  let manifestPath: string | null = null;
-  let manifestType: ManifestType = null;
-
-  // Prefer uv.lock, then pyproject.toml, then Pipfile.lock, then Pipfile,
-  // then requirements.txt (local, then global).
-  if (uvLockDir && pyprojectDir) {
-    manifestType = 'uv.lock';
-    manifestPath = join(uvLockDir, 'uv.lock');
-  } else if (pyprojectDir) {
-    manifestType = 'pyproject.toml';
-    manifestPath = join(pyprojectDir, 'pyproject.toml');
-  } else if (pipfileLockDir) {
-    manifestType = 'Pipfile.lock';
-    manifestPath = join(pipfileLockDir, 'Pipfile.lock');
-  } else if (pipfileDir) {
-    manifestType = 'Pipfile';
-    manifestPath = join(pipfileDir, 'Pipfile');
-  } else if (requirementsDir) {
-    manifestType = 'requirements.txt';
-    manifestPath = join(requirementsDir, 'requirements.txt');
-  }
-
-  let manifestContent: string | undefined;
-  if (manifestPath) {
-    try {
-      manifestContent = await fs.promises.readFile(manifestPath, 'utf8');
-    } catch (err) {
-      debug('Failed to read install manifest contents', err);
+  let pythonPackage: PythonPackage;
+  try {
+    pythonPackage = await discoverPythonPackage({
+      entrypointDir,
+      rootDir,
+    });
+  } catch (error: unknown) {
+    if (error instanceof PythonAnalysisError) {
+      throw toBuildError(error);
     }
+    throw error;
   }
 
-  return { manifestPath, manifestType, manifestContent };
+  // Determine effective manifest type based on lock file and manifest presence
+  let manifestType: ManifestType = null;
+  let manifestPath: string | null = null;
+
+  // Check for lock file first (highest priority)
+  const lockFile =
+    pythonPackage.manifest?.lockFile ?? pythonPackage.workspaceLockFile;
+  if (lockFile) {
+    if (lockFile.kind === PythonLockFileKind.UvLock) {
+      manifestType = 'uv.lock';
+      manifestPath = join(rootDir, lockFile.path);
+    } else if (lockFile.kind === PythonLockFileKind.PylockToml) {
+      manifestType = 'pylock.toml';
+      manifestPath = join(rootDir, lockFile.path);
+    }
+  } else if (pythonPackage.manifest) {
+    // No lock file, but have a manifest (native or converted)
+    manifestType = 'pyproject.toml';
+    manifestPath = join(rootDir, pythonPackage.manifest.path);
+  }
+
+  return { manifestPath, manifestType, pythonPackage };
 }
 
 export async function createPyprojectToml({
@@ -214,27 +200,13 @@ export async function createPyprojectToml({
   const version = pythonVersion ?? DEFAULT_PYTHON_VERSION;
   const requiresPython = `~=${version}.0`;
 
-  const depsToml =
-    dependencies.length > 0
-      ? [
-          'dependencies = [',
-          ...dependencies.map(dep => `  "${dep}",`),
-          ']',
-        ].join('\n')
-      : 'dependencies = []';
+  const manifest = createMinimalManifest({
+    name: projectName,
+    requiresPython,
+    dependencies,
+  });
 
-  const content = [
-    '[project]',
-    `name = "${projectName}"`,
-    'version = "0.1.0"',
-    `requires-python = "${requiresPython}"`,
-    'classifiers = [',
-    '  "Private :: Do Not Upload",',
-    ']',
-    depsToml,
-    '',
-  ].join('\n');
-
+  const content = stringifyManifest(manifest);
   await fs.promises.writeFile(pyprojectPath, content);
 }
 
@@ -247,146 +219,95 @@ export interface UvProjectInfo {
 interface EnsureUvProjectParams {
   workPath: string;
   entryDirectory: string;
-  fsFiles: Record<string, any>;
   repoRootPath?: string;
-  pythonPath: string;
-  pipPath: string;
   pythonVersion: string;
   uv: UvRunner;
-  venvPath: string;
-  meta: Meta;
-}
-
-function findUvLockUpwards(
-  startDir: string,
-  repoRootPath?: string
-): string | null {
-  // In uv workspaces, `uv.lock` is typically written at the workspace root, not
-  // necessarily next to the member project being synced. When Vercel builds from
-  // a subdirectory (rootDirectory), we still want to honor that workspace lock.
-  const start = resolve(startDir);
-  const base = repoRootPath ? resolve(repoRootPath) : undefined;
-
-  for (const dir of traverseUpDirectories({ start, base })) {
-    const lockPath = join(dir, 'uv.lock');
-    const pyprojectPath = join(dir, 'pyproject.toml');
-    if (fs.existsSync(lockPath) && fs.existsSync(pyprojectPath)) {
-      return lockPath;
-    }
-  }
-  return null;
 }
 
 export async function ensureUvProject({
   workPath,
   entryDirectory,
-  fsFiles,
   repoRootPath,
-  pythonPath,
-  pipPath,
   pythonVersion,
   uv,
-  venvPath,
-  meta,
 }: EnsureUvProjectParams): Promise<UvProjectInfo> {
-  const uvPath = uv.getPath();
+  const rootDir = repoRootPath ?? workPath;
 
   const installInfo = await detectInstallSource({
     workPath,
     entryDirectory,
-    fsFiles,
+    repoRootPath,
   });
-  const { manifestType, manifestPath } = installInfo;
+  const { manifestType, pythonPackage } = installInfo;
+  const manifest = pythonPackage?.manifest;
 
   let projectDir: string;
   let pyprojectPath: string;
   let lockPath: string | null = null;
 
-  if (manifestType === 'uv.lock') {
-    if (!manifestPath) {
-      throw new Error('Expected uv.lock path to be resolved, but it was null');
+  if (manifestType === 'uv.lock' || manifestType === 'pylock.toml') {
+    // Lock file exists - use it directly
+    const lockFile =
+      pythonPackage?.manifest?.lockFile ?? pythonPackage?.workspaceLockFile;
+    if (!lockFile) {
+      throw new Error(
+        `Expected lock file path to be resolved, but it was null`
+      );
     }
-    projectDir = dirname(manifestPath);
+    lockPath = join(rootDir, lockFile.path);
+    // Project dir is where the lock file is located
+    projectDir = dirname(lockPath);
     pyprojectPath = join(projectDir, 'pyproject.toml');
+
     if (!fs.existsSync(pyprojectPath)) {
       throw new Error(
-        `Expected "pyproject.toml" next to "uv.lock" in "${projectDir}"`
+        `Expected "pyproject.toml" next to "${lockFile.kind}" in "${projectDir}"`
       );
     }
-    lockPath = manifestPath;
-    console.log('Installing required dependencies from uv.lock...');
-  } else if (manifestType === 'pyproject.toml') {
-    if (!manifestPath) {
-      throw new Error(
-        'Expected pyproject.toml path to be resolved, but it was null'
-      );
-    }
-    projectDir = dirname(manifestPath);
-    pyprojectPath = manifestPath;
-    console.log('Installing required dependencies from pyproject.toml...');
+    console.log(`Installing required dependencies from ${lockFile.kind}...`);
+  } else if (manifest) {
+    // Manifest exists (native pyproject.toml or converted from Pipfile/requirements.txt)
+    projectDir = join(rootDir, dirname(manifest.path));
+    pyprojectPath = join(rootDir, manifest.path);
 
-    // If a workspace-root uv.lock exists (common in monorepos), use it as-is.
-    const workspaceLock = findUvLockUpwards(projectDir, repoRootPath);
-    if (workspaceLock) {
-      lockPath = workspaceLock;
+    // Log the original source for user clarity
+    const originKind = manifest.origin?.kind;
+    if (originKind === PythonManifestConvertedKind.Pipfile) {
+      console.log('Installing required dependencies from Pipfile...');
+    } else if (originKind === PythonManifestConvertedKind.PipfileLock) {
+      console.log('Installing required dependencies from Pipfile.lock...');
+    } else if (
+      originKind === PythonManifestConvertedKind.RequirementsTxt ||
+      originKind === PythonManifestConvertedKind.RequirementsIn
+    ) {
+      console.log(
+        `Installing required dependencies from ${manifest.origin?.path ?? 'requirements.txt'}...`
+      );
     } else {
-      // Otherwise, generate a lock. In uv workspaces, this may still write
-      // the lockfile at the workspace root, not necessarily in projectDir.
+      console.log('Installing required dependencies from pyproject.toml...');
+    }
+
+    // If this is a converted manifest, write the pyproject.toml to disk
+    if (manifest.origin) {
+      // Inject requires-python for the target version if not already set,
+      // so that `uv lock` and `uv sync` agree on the Python constraint.
+      if (manifest.data.project && !manifest.data.project['requires-python']) {
+        manifest.data.project['requires-python'] = `~=${pythonVersion}.0`;
+      }
+      const content = stringifyManifest(manifest.data);
+      // Write to the same directory as the original manifest
+      pyprojectPath = join(projectDir, 'pyproject.toml');
+      await fs.promises.writeFile(pyprojectPath, content);
+    }
+
+    // Check for workspace lock file
+    const workspaceLockFile = pythonPackage?.workspaceLockFile;
+    if (workspaceLockFile) {
+      lockPath = join(rootDir, workspaceLockFile.path);
+    } else {
+      // Generate a lock file
       await uv.lock(projectDir);
     }
-  } else if (manifestType === 'Pipfile.lock' || manifestType === 'Pipfile') {
-    if (!manifestPath) {
-      throw new Error(
-        'Expected Pipfile/Pipfile.lock path to be resolved, but it was null'
-      );
-    }
-    projectDir = dirname(manifestPath);
-    console.log(`Installing required dependencies from ${manifestType}...`);
-    const exportedReq = await exportRequirementsFromPipfile({
-      pythonPath,
-      pipPath,
-      uvPath,
-      projectDir,
-      meta,
-    });
-    pyprojectPath = join(projectDir, 'pyproject.toml');
-    if (!fs.existsSync(pyprojectPath)) {
-      await createPyprojectToml({
-        projectName: 'app',
-        pyprojectPath,
-        dependencies: [],
-        pythonVersion,
-      });
-    }
-    await uv.addFromFile({
-      venvPath,
-      projectDir,
-      requirementsPath: exportedReq,
-    });
-  } else if (manifestType === 'requirements.txt') {
-    if (!manifestPath) {
-      throw new Error(
-        'Expected requirements.txt path to be resolved, but it was null'
-      );
-    }
-    projectDir = dirname(manifestPath);
-    pyprojectPath = join(projectDir, 'pyproject.toml');
-    console.log(
-      'Installing required dependencies from requirements.txt with uv...'
-    );
-    if (!fs.existsSync(pyprojectPath)) {
-      await createPyprojectToml({
-        projectName: 'app',
-        pyprojectPath,
-        dependencies: [],
-        pythonVersion,
-      });
-    }
-    await uv.addFromFile({
-      venvPath,
-      projectDir,
-      requirementsPath: manifestPath,
-    });
   } else {
     // No manifest detected – create a minimal uv project at the workPath so
     // that runtime dependencies are still managed and locked via uv.
@@ -395,12 +316,15 @@ export async function ensureUvProject({
     console.log(
       'No Python manifest found; creating an empty pyproject.toml and uv.lock...'
     );
-    await createPyprojectToml({
-      projectName: 'app',
-      pyprojectPath,
+
+    const requiresPython = `~=${pythonVersion}.0`;
+    const minimalManifest = createMinimalManifest({
+      name: 'app',
+      requiresPython,
       dependencies: [],
-      pythonVersion,
     });
+    const content = stringifyManifest(minimalManifest);
+    await fs.promises.writeFile(pyprojectPath, content);
     await uv.lock(projectDir);
   }
 
@@ -409,8 +333,7 @@ export async function ensureUvProject({
   const resolvedLockPath =
     lockPath && fs.existsSync(lockPath)
       ? lockPath
-      : findUvLockUpwards(projectDir, repoRootPath) ||
-        join(projectDir, 'uv.lock');
+      : join(projectDir, 'uv.lock');
 
   return { projectDir, pyprojectPath, lockPath: resolvedLockPath };
 }
@@ -562,61 +485,6 @@ export async function installRequirementsFile({
     ['--upgrade', '-r', filePath, ...args],
     targetDir
   );
-}
-
-export async function exportRequirementsFromPipfile({
-  pythonPath,
-  pipPath,
-  uvPath,
-  projectDir,
-  meta,
-}: {
-  pythonPath: string;
-  pipPath: string;
-  uvPath: string | null;
-  projectDir: string;
-  meta: Meta;
-}): Promise<string> {
-  // Install pipfile-requirements into a temp vendor dir, then run pipfile2req
-  const tempDir = await fs.promises.mkdtemp(
-    join(os.tmpdir(), 'vercel-pipenv-')
-  );
-  await installRequirement({
-    pythonPath,
-    pipPath,
-    dependency: 'pipfile-requirements',
-    version: '0.3.0',
-    workPath: tempDir,
-    meta,
-    args: ['--no-warn-script-location'],
-    uvPath,
-  });
-
-  const tempVendorDir = join(tempDir, resolveVendorDir());
-  const convertCmd = isWin
-    ? join(tempVendorDir, 'Scripts', 'pipfile2req.exe')
-    : join(tempVendorDir, 'bin', 'pipfile2req');
-
-  debug(`Running "${convertCmd}" in ${projectDir}...`);
-  let stdout: string;
-  try {
-    const { stdout: out } = await execa(convertCmd, [], {
-      cwd: projectDir,
-      env: { ...process.env, PYTHONPATH: tempVendorDir },
-    });
-    stdout = out;
-  } catch (err) {
-    throw new Error(
-      `Failed to run "${convertCmd}": ${
-        err instanceof Error ? err.message : String(err)
-      }`
-    );
-  }
-
-  const outPath = join(tempDir, 'requirements.pipenv.txt');
-  await fs.promises.writeFile(outPath, stdout);
-  debug(`Exported pipfile requirements to ${outPath}`);
-  return outPath;
 }
 
 export async function mirrorSitePackagesIntoVendor({

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1460,7 +1460,7 @@ describe('.python-version file priority', () => {
     );
   });
 
-  it('warns and falls back to default when .python-version has invalid content', async () => {
+  it('throws error when .python-version has invalid content', async () => {
     const files = {
       'handler.py': new FileBlob({ data: 'def handler(): pass' }),
       '.python-version': new FileBlob({ data: 'invalid-version\n' }),
@@ -1469,24 +1469,16 @@ describe('.python-version file priority', () => {
       }),
     } as Record<string, FileBlob>;
 
-    await build({
-      workPath: mockWorkPath,
-      files,
-      entrypoint: 'handler.py',
-      meta: { isDev: false },
-      config: {},
-      repoRootPath: mockWorkPath,
-    });
-
-    // Should warn about invalid .python-version and fall back to default
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Warning: Python version "invalid-version" detected in .python-version is invalid'
-      )
-    );
-    expect(consoleLogSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Using python version: 3.12')
-    );
+    await expect(
+      build({
+        workPath: mockWorkPath,
+        files,
+        entrypoint: 'handler.py',
+        meta: { isDev: false },
+        config: {},
+        repoRootPath: mockWorkPath,
+      })
+    ).rejects.toThrow(/could not parse \.python-version file/i);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2004,6 +2004,10 @@ importers:
         version: 2.0.1(@types/node@20.11.0)
 
   packages/python:
+    dependencies:
+      '@vercel/python-analysis':
+        specifier: workspace:*
+        version: link:../python-analysis
     devDependencies:
       '@renovatebot/pep440':
         specifier: 4.2.1


### PR DESCRIPTION
This re-lands commit 30aa4d33c14d7c5839ae6818bddb24d6be800763 (#14891) with fixes.

- Replace `detectInstallSource` with a `discoverPythonPackage` wrapper
- Refactor `ensureUvProject` to use returned manifest data
- Remove a bunch of now-dead code

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR refactors Python manifest detection and conversion logic, replacing file-based detection with python-analysis library; changes are internal tooling improvements with no auth/security/billing impact.
> 
> - Replaces manual manifest file detection with `discoverPythonPackage` from python-analysis
> - Adds lock file detection support for uv.lock and pylock.toml formats
> - Removes `exportRequirementsFromPipfile` in favor of python-analysis conversion
>
> <sup>Risk assessment for [commit 69a6575](https://github.com/vercel/vercel/commit/69a6575200ef7e1b57d806521e78a267dad68d68).</sup>
<!-- VADE_RISK_END -->