### PR TITLE
[services] set framework prefixed env var urls to relative path

### DIFF
--- a/.changeset/spicy-ties-serve.md
+++ b/.changeset/spicy-ties-serve.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[services] set framework prefixed env var urls to relative path

--- a/packages/build-utils/test/unit.get-service-url-env-vars.test.ts
+++ b/packages/build-utils/test/unit.get-service-url-env-vars.test.ts
@@ -34,8 +34,9 @@ describe('getServiceUrlEnvVars', () => {
     expect(result).toEqual({
       FRONTEND_URL: 'https://my-app.vercel.app',
       BACKEND_URL: 'https://my-app.vercel.app/_/backend',
-      VITE_FRONTEND_URL: 'https://my-app.vercel.app',
-      VITE_BACKEND_URL: 'https://my-app.vercel.app/_/backend',
+      // Framework-prefixed vars use relative paths to avoid CORS issues
+      VITE_FRONTEND_URL: '/',
+      VITE_BACKEND_URL: '/_/backend',
     });
   });
 
@@ -89,13 +90,13 @@ describe('getServiceUrlEnvVars', () => {
       WEB_URL: 'https://my-app.vercel.app',
       ADMIN_URL: 'https://my-app.vercel.app/admin',
       API_URL: 'https://my-app.vercel.app/_/api',
-      // Both prefixes applied to all services
-      NEXT_PUBLIC_WEB_URL: 'https://my-app.vercel.app',
-      NEXT_PUBLIC_ADMIN_URL: 'https://my-app.vercel.app/admin',
-      NEXT_PUBLIC_API_URL: 'https://my-app.vercel.app/_/api',
-      VITE_WEB_URL: 'https://my-app.vercel.app',
-      VITE_ADMIN_URL: 'https://my-app.vercel.app/admin',
-      VITE_API_URL: 'https://my-app.vercel.app/_/api',
+      // Framework-prefixed vars use relative paths to avoid CORS issues
+      NEXT_PUBLIC_WEB_URL: '/',
+      NEXT_PUBLIC_ADMIN_URL: '/admin',
+      NEXT_PUBLIC_API_URL: '/_/api',
+      VITE_WEB_URL: '/',
+      VITE_ADMIN_URL: '/admin',
+      VITE_API_URL: '/_/api',
     });
   });
 
@@ -117,8 +118,9 @@ describe('getServiceUrlEnvVars', () => {
     });
 
     // BACKEND_URL is not in result because it already exists
+    // Framework-prefixed var uses relative path
     expect(result).toEqual({
-      VITE_BACKEND_URL: 'https://my-app.vercel.app/_/backend',
+      VITE_BACKEND_URL: '/_/backend',
     });
   });
 


### PR DESCRIPTION
Treat the client-side auto-injected service url env vars and server-side env vars differently to solve CORS issues:
`NEXT_PUBLIC_BACKEND_URL` can just point to the service prefix, e.g. /_/backend
`BACKEND_URL` can point to the full deployment url, e.g. deployment-url.vercel.app/_/backend

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR changes framework-prefixed environment variables from absolute URLs to relative paths for client-side use, which is a behavioral change to build configuration but does not affect authentication, authorization, or security controls.
> 
> - Changes client-side env vars from absolute URLs to relative route prefixes
> - Server-side base env vars retain full absolute URLs
> - Test updates reflect new relative path values
>
> <sup>Risk assessment for [commit 1784ef7](https://github.com/vercel/vercel/commit/1784ef77342bae4b89028a3f7606a728ed7ffdce).</sup>
<!-- VADE_RISK_END -->