### PR TITLE
docs: add missing-build-script error doc and fix Speed Insights link typo

### DIFF
--- a/.changeset/add-missing-build-script-doc.md
+++ b/.changeset/add-missing-build-script-doc.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add missing-build-script error documentation (Fixes #14406).

--- a/.changeset/fix-speed-insights-link-typo.md
+++ b/.changeset/fix-speed-insights-link-typo.md
@@ -1,0 +1,5 @@
+---
+'@vercel/static-build': patch
+---
+
+Fix typo in Speed Insights deprecation link: upgrate → upgrade.

--- a/errors/missing-build-script.md
+++ b/errors/missing-build-script.md
@@ -1,0 +1,54 @@
+# Missing Build Script
+
+#### Why This Error Occurred
+
+Your project's `package.json` is missing a `build` property inside the `scripts` property. Vercel runs the build script during deployment to produce the output that gets served.
+
+#### Possible Ways to Fix It
+
+Add a `build` script to the `scripts` section of your `package.json` that matches your framework's build command.
+
+**Next.js:**
+
+```json
+{
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev"
+  }
+}
+```
+
+**React (Create React App):**
+
+```json
+{
+  "scripts": {
+    "build": "react-scripts build",
+    "dev": "react-scripts start"
+  }
+}
+```
+
+**Vite:**
+
+```json
+{
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite"
+  }
+}
+```
+
+**Static site or no build step:** If your project does not require a build (e.g. static HTML), you can set `build` to a no-op:
+
+```json
+{
+  "scripts": {
+    "build": "echo 'No build step'"
+  }
+}
+```
+
+For more details, see [Build Step configuration](https://vercel.com/docs/build-step) in the Vercel documentation.

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -51,7 +51,7 @@ export async function injectPlugins(
     process.env.GATSBY_VERCEL_ANALYTICS_ID = process.env.VERCEL_ANALYTICS_ID;
     plugins.add('@vercel/gatsby-plugin-vercel-analytics');
     console.warn(
-      'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrate-to-speed-insights-package'
+      'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrade-to-speed-insights-package'
     );
   }
 

--- a/packages/static-build/src/utils/nuxt.ts
+++ b/packages/static-build/src/utils/nuxt.ts
@@ -8,7 +8,7 @@ const ANALYTICS_PLUGIN_PACKAGE = '@nuxtjs/web-vitals';
 
 export async function injectVercelAnalyticsPlugin(dir: string) {
   console.warn(
-    'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrate-to-speed-insights-package'
+    'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrade-to-speed-insights-package'
   );
   // First update the `.nuxtrc` file to inject the Speed Insights (formerly Analytics) plugin.
   // See: https://gist.github.com/pi0/23b5253ac19b4ed5a70add3b971545c9

--- a/packages/static-build/test/builds.test.js
+++ b/packages/static-build/test/builds.test.js
@@ -40,7 +40,7 @@ it(
       }
     `);
     expect(warnSpy).toHaveBeenCalledWith(
-      'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrate-to-speed-insights-package'
+      'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrade-to-speed-insights-package'
     );
   },
   FOUR_MINUTES
@@ -351,7 +351,7 @@ describe('when @vercel/speed-insights is present', () => {
     `);
 
       expect(warnSpy).not.toHaveBeenCalledWith(
-        'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrate-to-speed-insights-package'
+        'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrade-to-speed-insights-package'
       );
     },
     FOUR_MINUTES
@@ -375,7 +375,7 @@ describe('when @vercel/speed-insights is present', () => {
       expect(pkg.dependencies['@nuxtjs/web-vitals']).toBe(undefined);
 
       expect(warnSpy).not.toHaveBeenCalledWith(
-        'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrate-to-speed-insights-package'
+        'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrade-to-speed-insights-package'
       );
     },
     FOUR_MINUTES
@@ -397,7 +397,7 @@ it(
     expect(pkg.dependencies['@nuxtjs/web-vitals']).toBe('latest');
 
     expect(warnSpy).toHaveBeenCalledWith(
-      'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrate-to-speed-insights-package'
+      'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrade-to-speed-insights-package'
     );
   },
   FOUR_MINUTES


### PR DESCRIPTION
## Summary
- Adds error documentation for the missing build script case (Fixes #14406).
- Fixes typo in Speed Insights deprecation link: `upgrate` → `upgrade` in 6 places.

## Changes
- **errors/missing-build-script.md** – New doc for https://vercel.link/missing-build-script (Next.js, CRA, Vite, static examples).
- **packages/static-build** – Updated deprecation link in nuxt.ts, gatsby.ts, and builds.test.js.

## Checklist
- [x] Changesets added (docs + @vercel/static-build patch)
- [x] Matches existing error doc format and lint

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds new error documentation and fixes a typo in deprecation warning URLs, containing only documentation and test string changes with no logic modifications.
> 
> - New error doc for missing-build-script case
> - Typo fix: `upgrate` → `upgrade` in deprecation links across 3 files
> - Test assertions updated to match corrected URL strings
>
> <sup>Risk assessment for [commit fd37c04](https://github.com/vercel/vercel/commit/fd37c04b7822fca212bae575b79b6ba213b6f478).</sup>
<!-- VADE_RISK_END -->