### PR TITLE
Support per-function regions overrides in vercel.json

### DIFF
--- a/.changeset/fresh-carpets-double.md
+++ b/.changeset/fresh-carpets-double.md
@@ -1,0 +1,9 @@
+---
+'@vercel/build-utils': patch
+'@vercel/config': patch
+'vercel': patch
+---
+
+Add support for `regions` in `vercel.json` function-level configuration.
+
+Matching function `regions` are now parsed from `functions` config, written into lambda output config, and documented in config types so they override top-level deployment regions for that function.

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -478,6 +478,7 @@ export async function getLambdaOptionsFromFunction({
     | 'architecture'
     | 'memory'
     | 'maxDuration'
+    | 'regions'
     | 'experimentalTriggers'
     | 'supportsCancellation'
   >
@@ -489,6 +490,7 @@ export async function getLambdaOptionsFromFunction({
           architecture: fn.architecture,
           memory: fn.memory,
           maxDuration: fn.maxDuration,
+          regions: fn.regions,
           experimentalTriggers: fn.experimentalTriggers,
           supportsCancellation: fn.supportsCancellation,
         };

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -61,6 +61,12 @@ export const functionsSchema = {
           minimum: 1,
           maximum: 900,
         },
+        regions: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
         includeFiles: {
           type: 'string',
           maxLength: 256,

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -404,6 +404,7 @@ export interface BuilderFunctions {
     architecture?: LambdaArchitecture;
     memory?: number;
     maxDuration?: number;
+    regions?: string[];
     runtime?: string;
     includeFiles?: string;
     excludeFiles?: string;

--- a/packages/build-utils/test/unit.get-lambda-options-from-function.test.ts
+++ b/packages/build-utils/test/unit.get-lambda-options-from-function.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { getLambdaOptionsFromFunction } from '../src/lambda';
+import type { Config } from '../src/types';
+
+describe('getLambdaOptionsFromFunction', () => {
+  it('returns matching function options including regions', async () => {
+    const config: Pick<Config, 'functions'> = {
+      functions: {
+        'api/*.js': {
+          architecture: 'arm64',
+          memory: 1024,
+          maxDuration: 60,
+          regions: ['sfo1', 'iad1'],
+        },
+      },
+    };
+
+    const options = await getLambdaOptionsFromFunction({
+      sourceFile: 'api/user.js',
+      config,
+    });
+
+    expect(options).toMatchObject({
+      architecture: 'arm64',
+      memory: 1024,
+      maxDuration: 60,
+      regions: ['sfo1', 'iad1'],
+    });
+  });
+
+  it('returns empty object when no function config matches', async () => {
+    const config: Pick<Config, 'functions'> = {
+      functions: {
+        'api/*.ts': {
+          regions: ['sfo1'],
+        },
+      },
+    };
+
+    const options = await getLambdaOptionsFromFunction({
+      sourceFile: 'api/user.js',
+      config,
+    });
+
+    expect(options).toEqual({});
+  });
+});

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -52,6 +52,7 @@ interface FunctionConfiguration {
   architecture?: string;
   memory?: number;
   maxDuration?: number;
+  regions?: Lambda['regions'];
   experimentalTriggers?: TriggerEvent[];
   supportsCancellation?: boolean;
 }
@@ -608,6 +609,7 @@ async function writeLambda(
     functionConfiguration?.architecture ?? lambda.architecture;
   const memory = functionConfiguration?.memory ?? lambda.memory;
   const maxDuration = functionConfiguration?.maxDuration ?? lambda.maxDuration;
+  const regions = functionConfiguration?.regions ?? lambda.regions;
   const experimentalTriggers =
     functionConfiguration?.experimentalTriggers ?? lambda.experimentalTriggers;
   const supportsCancellation =
@@ -619,6 +621,7 @@ async function writeLambda(
     architecture,
     memory,
     maxDuration,
+    regions,
     experimentalTriggers,
     supportsCancellation,
     filePathMap,

--- a/packages/cli/test/fixtures/unit/commands/build/lambda-with-128-memory/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/lambda-with-128-memory/vercel.json
@@ -1,7 +1,9 @@
 {
+  "regions": ["iad1"],
   "functions": {
     "api/**/*.js": {
-      "memory": 128
+      "memory": 128,
+      "regions": ["sfo1"]
     }
   }
 }

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -992,6 +992,7 @@ describe.skipIf(flakey)('build', () => {
     expect(vcConfig).toMatchObject({
       handler: 'api/memory.js',
       memory: 128,
+      regions: ['sfo1'],
       environment: {},
       launcherType: 'Nodejs',
       shouldAddHelpers: true,

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -266,6 +266,34 @@ describe('validateConfig', () => {
     );
   });
 
+  it('should not error with valid function regions', async () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          regions: ['sfo1', 'iad1'],
+        },
+      },
+    });
+    expect(error).toBeNull();
+  });
+
+  it('should error with invalid function regions type', async () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          // @ts-ignore
+          regions: 'iad1',
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].regions` should be array."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
   it('should error with "functions" and "builds"', async () => {
     const error = validateConfig({
       builds: [

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -81,6 +81,11 @@ export interface FunctionConfig {
    */
   memory?: number;
   /**
+   * An array of regions where this Serverless Function will be deployed.
+   * This setting overrides the top-level `regions` setting for matching functions.
+   */
+  regions?: string[];
+  /**
    * The npm package name of a Runtime, including its version
    */
   runtime?: string;


### PR DESCRIPTION
## Summary
- add `regions` support to `vercel.json` function config schema/types in `@vercel/build-utils` and `@vercel/config`
- propagate function-level `regions` through `getLambdaOptionsFromFunction()` and CLI lambda output serialization so matched function config overrides top-level `regions`
- add tests for option resolution, CLI config validation, and build output serialization, plus a changeset

## Test plan
- [x] `pnpm vitest-run test/unit.get-lambda-options-from-function.test.ts` (in `packages/build-utils`)
- [x] `pnpm vitest-run test/unit/util/dev/validate.test.ts` (in `packages/cli`)
- [x] `pnpm vitest-run test/unit/commands/build/index.test.ts -t "should apply function configuration from \"vercel.json\" to Serverless Functions"` (in `packages/cli`)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new optional `regions` configuration property to function-level config in vercel.json, propagating it through existing code paths with proper schema validation and comprehensive tests.
> 
> - Adds `regions` field to function config schema, types, and lambda options propagation
> - Includes validation tests ensuring regions must be array type
> - Test fixtures and unit tests cover option resolution and build output serialization
>
> <sup>Risk assessment for [commit c3550e1](https://github.com/vercel/vercel/commit/c3550e1669cce5ed6bd74eb40c7e33a46e00d435).</sup>
<!-- VADE_RISK_END -->