### PR TITLE
cli: make `integration add` non-interactive for post-provisioning

### DIFF
--- a/.changeset/no-connect-no-env-pull.md
+++ b/.changeset/no-connect-no-env-pull.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] `integration add`: auto-connect resources to all environments and auto-run `env pull` after provisioning. Add `--no-connect` and `--no-env-pull` opt-out flags. Print resource dashboard URL on success.

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -21,6 +21,21 @@ export const addSubcommand = {
       deprecated: false,
       argument: 'NAME',
     },
+    {
+      name: 'no-connect',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Skip connecting the resource to the current project (also skips env pull)',
+    },
+    {
+      name: 'no-env-pull',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Skip running env pull after provisioning',
+    },
   ],
   examples: [
     {

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -107,8 +107,17 @@ export default async function main(client: Client) {
         return 1;
       }
       const resourceName = addParsedArgs.flags['--name'] as string | undefined;
+      const noConnect = addParsedArgs.flags['--no-connect'] as
+        | boolean
+        | undefined;
+      const noEnvPull = addParsedArgs.flags['--no-env-pull'] as
+        | boolean
+        | undefined;
 
-      return add(client, addParsedArgs.args, resourceName);
+      return add(client, addParsedArgs.args, resourceName, {
+        noConnect,
+        noEnvPull,
+      });
     }
     case 'list': {
       if (needHelp) {

--- a/packages/cli/src/util/env/get-env-records.ts
+++ b/packages/cli/src/util/env/get-env-records.ts
@@ -13,7 +13,8 @@ export type EnvRecordsSource =
   | 'vercel-cli:env:run'
   | 'vercel-cli:dev'
   | 'vercel-cli:pull'
-  | 'vercel-cli:link';
+  | 'vercel-cli:link'
+  | 'vercel-cli:integration:add';
 
 export default async function getEnvRecords(
   client: Client,

--- a/packages/cli/src/util/integration/post-provision-setup.ts
+++ b/packages/cli/src/util/integration/post-provision-setup.ts
@@ -1,0 +1,107 @@
+import chalk from 'chalk';
+import type Client from '../client';
+import indent from '../output/indent';
+import output from '../../output-manager';
+import { getLinkedProject } from '../projects/link';
+import { connectResourceToProject } from '../integration-resource/connect-resource-to-project';
+import pull from '../../commands/env/pull';
+
+export interface PostProvisionOptions {
+  noConnect?: boolean;
+  noEnvPull?: boolean;
+}
+
+/**
+ * Handles post-provisioning setup: prints dashboard URL, auto-connects
+ * resource to the linked project (all environments), and runs env pull.
+ *
+ * Respects `--no-connect` (skip linking) and `--no-env-pull` (skip env pull).
+ */
+export async function postProvisionSetup(
+  client: Client,
+  resourceName: string,
+  resourceId: string,
+  contextName: string,
+  options: PostProvisionOptions = {}
+): Promise<number> {
+  const dashboardUrl = `https://vercel.com/${contextName}/~/stores/integration/${resourceId}`;
+  output.log(
+    indent(`Dashboard: ${output.link(dashboardUrl, dashboardUrl)}`, 4)
+  );
+
+  if (options.noConnect) {
+    return 0;
+  }
+
+  const linkedProject = await getLinkedProject(client);
+  if (linkedProject.status === 'error') {
+    return linkedProject.exitCode;
+  }
+  if (linkedProject.status === 'not_linked') {
+    return 0;
+  }
+
+  const { project } = linkedProject;
+  const environments = ['production', 'preview', 'development'];
+  output.debug(`Selected environments: ${JSON.stringify(environments)}`);
+
+  output.spinner(
+    `Connecting ${chalk.bold(resourceName)} to ${chalk.bold(project.name)}...`
+  );
+  output.debug(`Connecting resource ${resourceId} to project ${project.id}`);
+  try {
+    await connectResourceToProject(
+      client,
+      project.id,
+      resourceId,
+      environments
+    );
+  } catch (error) {
+    output.stopSpinner();
+    output.error(`Failed to connect: ${(error as Error).message}`);
+    return 1;
+  }
+  output.stopSpinner();
+
+  output.log(
+    `${chalk.bold(resourceName)} successfully connected to ${chalk.bold(project.name)}`
+  );
+
+  if (!options.noEnvPull) {
+    const pullExitCode = await pull(
+      client,
+      ['--yes'],
+      'vercel-cli:integration:add'
+    );
+    if (pullExitCode !== 0) {
+      output.warn(
+        'Failed to pull environment variables. You can run `vercel env pull` manually.'
+      );
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Auto-detect the linked project name without prompting.
+ * Returns the project name/id or undefined if not linked or --no-connect.
+ */
+export async function getLinkedProjectField(
+  client: Client,
+  noConnect: boolean | undefined,
+  field: 'name' | 'id' = 'name'
+): Promise<{ value: string | undefined; exitCode?: number }> {
+  if (noConnect) {
+    return { value: undefined };
+  }
+
+  const linkedProject = await getLinkedProject(client);
+  if (linkedProject.status === 'error') {
+    return { value: undefined, exitCode: linkedProject.exitCode };
+  }
+  if (linkedProject.status === 'linked') {
+    return { value: linkedProject.project[field] };
+  }
+  return { value: undefined };
+}

--- a/packages/cli/src/util/telemetry/commands/integration/add.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/add.ts
@@ -23,4 +23,16 @@ export class IntegrationAddTelemetryClient
       });
     }
   }
+
+  trackCliFlagNoConnect(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('no-connect');
+    }
+  }
+
+  trackCliFlagNoEnvPull(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('no-env-pull');
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Auto-connect provisioned resources to the current project (all 3 environments) without prompting
- Auto-run `vercel env pull` after connecting instead of printing a message
- Print resource dashboard URL on successful provisioning
- Add `--no-connect` flag to skip connecting the resource to the project
- Add `--no-env-pull` flag to skip running env pull after provisioning
- Remove interactive `getOptionalLinkedProject` helper (replaced with direct `getLinkedProject` call)
- Add telemetry tracking for both new flags

### Sample input/output

**`--help` — new flags visible:**

```
$ vc integration add --help

  ▲ vercel integration add integration [options]

  Installs a marketplace integration

  Options:

  -n,  --name <NAME>  Custom name for the resource (auto-generated if not provided)
       --no-connect   Skip connecting the resource to the current project
       --no-env-pull  Skip running env pull after provisioning
```

**FF path — default (auto-provision + auto-connect + auto env pull):**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add prisma

Vercel CLI 50.13.2
> Installing Prisma Postgres by Prisma under acme-marketplace-team-vtest314
? Region iad1
⠼ Provisioning resource...
> Success! Prisma Postgres successfully provisioned: prisma-postgres-lightblue-ocean
>     Dashboard: https://vercel.com/acme-marketplace-team-vtest314/~/stores/integration/store_tPTm1WyeAOTXRsDX
⠴ Connecting prisma-postgres-lightblue-ocean to cli-test-env-pull-tmp...
> prisma-postgres-lightblue-ocean successfully connected to cli-test-env-pull-tmp
> Downloading `development` Environment Variables for acme-marketplace-team-vtest314/cli-test-env-pull-tmp
✅  Created .env.local file and added it to .gitignore [297ms]
```

_(Tested on a fresh project with no conflicting env vars. Full happy path: provision → connect → env pull → `.env.local` created.)_

**FF path — `--no-connect` (provision only, clean exit):**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add prisma --no-connect

Vercel CLI 50.13.2
> Installing Prisma Postgres by Prisma under acme-marketplace-team-vtest314
? Region iad1
⠼ Provisioning resource...
> Success! Prisma Postgres successfully provisioned: prisma-postgres-fuchsia-chair
>     Dashboard: https://vercel.com/acme-marketplace-team-vtest314/~/stores/integration/store_DOXdFNRzxIMB1r8D
```

_(No connect attempt, no env pull — clean exit after provisioning.)_

**FF path — `--no-env-pull` (provision + connect, skip env pull):**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add prisma --no-env-pull

Vercel CLI 50.13.2
> Installing Prisma Postgres by Prisma under acme-marketplace-team-vtest314
? Region iad1
⠼ Provisioning resource...
> Success! Prisma Postgres successfully provisioned: prisma-postgres-gray-notebook
>     Dashboard: https://vercel.com/acme-marketplace-team-vtest314/~/stores/integration/store_Au6GwcFJBMFKnpzi
⠴ Connecting prisma-postgres-gray-notebook to cli-test-env-pull-tmp2...
> prisma-postgres-gray-notebook successfully connected to cli-test-env-pull-tmp2
```

_(Connect succeeded but NO "Downloading" / "Created .env.local" output. Verified `.env.local` does NOT exist after command exits.)_

**FF 422 fallback — default (URL includes `projectSlug`):**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add neon

Vercel CLI 50.13.2
> Installing Neon by Neon under acme-marketplace-team-vtest314
⠋ Provisioning resource...
> Additional setup required. Opening browser...
→ URL: https://vercel.com/.../checkout/neon?productSlug=neon&defaultResourceName=neon-lime-queen&source=cli&projectSlug=cli-test
```

**FF 422 fallback — `--no-connect` (URL omits `projectSlug`):**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add neon --no-connect

Vercel CLI 50.13.2
> Installing Neon by Neon under acme-marketplace-team-vtest314
> Additional setup required. Opening browser...
→ URL: https://vercel.com/.../checkout/neon?productSlug=neon&defaultResourceName=neon-lime-door&source=cli
```

_(No `projectSlug` — browser won't auto-connect to project.)_

**Legacy path — default (URL includes `projectId`):**

```
$ vc integration add neon

Vercel CLI 50.13.2
> Installing Neon by Neon under acme-marketplace-team-vtest314
? This resource must be provisioned through the Web UI. Open Vercel Dashboard? yes
Opening the Vercel Dashboard to continue the installation...
→ URL: https://vercel.com/api/marketplace/cli?teamId=...&integrationId=...&productId=...&source=cli&projectId=prj_ZZysOqOQrAlGD0TLHwcS9WEqEqrZ&defaultResourceName=neon-blue-elephant&cmd=add
```

**Legacy path — `--no-connect` (URL omits `projectId`):**

```
$ vc integration add neon --no-connect

Vercel CLI 50.13.2
> Installing Neon by Neon under acme-marketplace-team-vtest314
? This resource must be provisioned through the Web UI. Open Vercel Dashboard? yes
Opening the Vercel Dashboard to continue the installation...
→ URL: https://vercel.com/api/marketplace/cli?teamId=...&integrationId=...&productId=...&source=cli&defaultResourceName=neon-pink-village&cmd=add
```

_(No `projectId` — browser won't auto-connect to project.)_

## Test plan

### Unit Tests

```
$ cd packages/cli && pnpm exec vitest run test/unit/commands/integration/add.test.ts test/unit/commands/integration/add-auto-provision.test.ts

 ✓ test/unit/commands/integration/add-auto-provision.test.ts  (35 tests) 335ms
 ✓ test/unit/commands/integration/add.test.ts  (42 tests) 1007ms

 Test Files  2 passed (2)
      Tests  77 passed (77)
```

### Manual Testing

**FF path (auto-provision) — `prisma` on test team:**

| Test | Provision | Dashboard URL | Connect | Env Pull | Result |
|------|-----------|--------------|---------|----------|--------|
| Default | Yes | Yes | 201 Connected | `.env.local` created | Full happy path (fresh project) |
| `--no-connect` | Yes | Yes | Skipped | Skipped | Clean exit |
| `--no-env-pull` | Yes | Yes | 201 Connected | Skipped (no `.env.local`) | Verified on fresh project |

**FF path (422 → browser fallback) — `neon` on test team:**

| Test | URL has `projectSlug`? | Result |
|------|----------------------|--------|
| Default | Yes (`cli-test`) | Auto-detected, no prompt |
| `--no-connect` | No | Skipped project detection |

**Non-FF path (web UI fallback) — `neon` on test team:**

| Test | URL has `projectId`? | Result |
|------|---------------------|--------|
| Default | Yes (`prj_ZZysOqOQrAlGD0TLHwcS9WEqEqrZ`) | Auto-detected, no prompt |
| `--no-connect` | No | Skipped project detection |

**Non-FF path (CLI provision) — `prisma` on test team:**
Provisioning flow reached (region → billing → confirm → provision) but 409s due to test team resource limit (59 resources, limit 5). Post-provisioning code is structurally identical to FF path (unit only).

### Code paths covered

| Path | Expected | Tested by |
|------|----------|-----------|
| FF, provisioned, default | Auto-connect + auto env pull | Unit + manual |
| FF, provisioned, `--no-connect` | Skip connect and env pull | Unit + manual |
| FF, provisioned, `--no-env-pull` | Connect but skip env pull | Unit + manual |
| FF, 422 fallback, default | `projectSlug` in URL | Unit + manual |
| FF, 422 fallback, `--no-connect` | No `projectSlug` in URL | Unit + manual |
| Non-FF, no install → browser | `projectId` in URL | Unit + manual |
| Non-FF, no install, `--no-connect` | No `projectId` in URL | Unit + manual |
| Non-FF, CLI provision, default | Auto-connect + auto env pull | Unit only (409 resource limit) |
| Non-FF, CLI provision, `--no-connect` | Skip connect and env pull | Unit only (409 resource limit) |
| Non-FF, prepayment → browser | `projectId` in URL | Unit only |

Fixes: [MKT-2443](https://linear.app/vercel/issue/MKT-2443/accept-cli-params-for-all-interactive-flows-except-accept-terms)


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI feature addition that makes `integration add` non-interactive by auto-connecting resources and adding opt-out flags, with no security-sensitive changes - purely UX/workflow improvements with comprehensive test coverage.
> 
> - Adds `--no-connect` and `--no-env-pull` CLI flags with telemetry tracking
> - Replaces interactive prompts with auto-connect to all environments by default
> - New `postProvisionSetup` helper consolidates post-provision logic across code paths
>
> <sup>Risk assessment for [commit 6ebeb03](https://github.com/vercel/vercel/commit/6ebeb032a385c097f7179375ebcd61fb7f679932).</sup>
<!-- VADE_RISK_END -->