### PR TITLE
[cli] Add --plan flag to vercel integration add

### DIFF
--- a/.changeset/brave-plans-arrive.md
+++ b/.changeset/brave-plans-arrive.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `--plan` flag to `vercel integration add` for specifying a billing plan ID

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -26,6 +26,7 @@ import type { Metadata } from '../../util/integration/types';
 export interface AddAutoProvisionOptions extends PostProvisionOptions {
   metadata?: string[];
   productSlug?: string;
+  billingPlanId?: string;
 }
 
 export async function addAutoProvision(
@@ -43,6 +44,7 @@ export async function addAutoProvision(
   telemetry.trackCliOptionMetadata(options.metadata);
   telemetry.trackCliFlagNoConnect(options.noConnect);
   telemetry.trackCliFlagNoEnvPull(options.noEnvPull);
+  telemetry.trackCliOptionPlan(options.billingPlanId);
 
   // 1. Get team context
   const { contextName, team } = await getScope(client);
@@ -134,7 +136,8 @@ export async function addAutoProvision(
       product.slug,
       resourceName,
       metadata,
-      {} // Start with empty policies
+      {}, // Start with empty policies
+      options.billingPlanId
     );
   } catch (error) {
     output.stopSpinner();
@@ -185,7 +188,8 @@ export async function addAutoProvision(
         product.slug,
         resourceName,
         metadata,
-        acceptedPolicies
+        acceptedPolicies,
+        options.billingPlanId
       );
     } catch (error) {
       output.stopSpinner();
@@ -222,6 +226,9 @@ export async function addAutoProvision(
     }
     if (projectLink.value) {
       url.searchParams.set('projectSlug', projectLink.value);
+    }
+    if (options.billingPlanId) {
+      url.searchParams.set('planId', options.billingPlanId);
     }
     output.debug(`Opening URL: ${url.href}`);
     open(url.href);

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -31,6 +31,14 @@ export const addSubcommand = {
       argument: 'KEY=VALUE',
     },
     {
+      name: 'plan',
+      shorthand: 'p',
+      type: String,
+      deprecated: false,
+      argument: 'PLAN_ID',
+      description: 'Billing plan ID to use for the resource',
+    },
+    {
       name: 'no-connect',
       shorthand: null,
       type: Boolean,
@@ -75,6 +83,13 @@ export const addSubcommand = {
         `${packageName} integration add acme -m region=us-east-1 -m version=16`,
         `${packageName} integration add acme -m auth=true`,
         `${packageName} integration add acme -m "readRegions=sfo1,iad1"`,
+      ],
+    },
+    {
+      name: 'Install with a specific billing plan',
+      value: [
+        `${packageName} integration add acme --plan pro`,
+        `${packageName} integration add acme -p pro`,
       ],
     },
     {

--- a/packages/cli/src/util/integration/auto-provision-resource.ts
+++ b/packages/cli/src/util/integration/auto-provision-resource.ts
@@ -30,7 +30,8 @@ export async function autoProvisionResource(
   productSlug: string,
   name: string,
   metadata: Metadata,
-  acceptedPolicies: AcceptedPolicies
+  acceptedPolicies: AcceptedPolicies,
+  billingPlanId?: string
 ): Promise<AutoProvisionResult> {
   const endpoint = `/v1/integrations/integration/${encodeURIComponent(integrationSlug)}/marketplace/auto-provision/${encodeURIComponent(productSlug)}`;
   const body = {
@@ -38,6 +39,7 @@ export async function autoProvisionResource(
     metadata,
     acceptedPolicies,
     source: 'cli',
+    ...(billingPlanId ? { billingPlanId } : {}),
   };
   output.debug(`Auto-provision request: POST ${endpoint}`);
   output.debug(`Auto-provision body: ${JSON.stringify(body, null, 2)}`);

--- a/packages/cli/src/util/integration/format-billing-plans-help.ts
+++ b/packages/cli/src/util/integration/format-billing-plans-help.ts
@@ -1,0 +1,41 @@
+import chalk from 'chalk';
+import type { BillingPlan } from './types';
+
+/**
+ * Format available billing plans as help text for CLI display.
+ * Shows plan IDs (for use with --plan flag), names, and pricing info.
+ */
+export function formatBillingPlansHelp(
+  productName: string,
+  plans: BillingPlan[]
+): string {
+  const enabledPlans = plans.filter(p => !p.disabled);
+
+  if (enabledPlans.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(
+    `  ${chalk.dim('Available billing plans for')} "${chalk.bold(productName)}"${chalk.dim(':')}`
+  );
+  lines.push('');
+
+  // Find longest ID for alignment
+  const maxIdLen = Math.max(...enabledPlans.map(p => p.id.length));
+
+  for (const plan of enabledPlans) {
+    const paddedId = plan.id.padEnd(maxIdLen);
+    const cost = plan.cost ? chalk.dim(` (${plan.cost})`) : '';
+    lines.push(`    ${chalk.cyan(paddedId)}  ${plan.name}${cost}`);
+  }
+
+  lines.push('');
+  lines.push(`  ${chalk.dim('Usage:')}`);
+  lines.push('');
+  lines.push(`    ${chalk.cyan(`--plan ${enabledPlans[0].id}`)}`);
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/util/telemetry/commands/integration/add.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/add.ts
@@ -33,6 +33,15 @@ export class IntegrationAddTelemetryClient
     }
   }
 
+  trackCliOptionPlan(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'plan',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagNoConnect(v: boolean | undefined) {
     if (v) {
       this.trackCliFlag('no-connect');

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -1259,6 +1259,7 @@ export function useAutoProvision(opts?: {
 }) {
   let callCount = 0;
   const storeId = 'resource_123';
+  const requestBodies: unknown[] = [];
 
   // Integration fetch endpoint (needed for auto-provision flow)
   client.scenario.get(
@@ -1280,8 +1281,9 @@ export function useAutoProvision(opts?: {
   // Auto-provision endpoint
   client.scenario.post(
     '/v1/integrations/integration/:integrationSlug/marketplace/auto-provision/:productSlug',
-    (_req, res) => {
+    (req, res) => {
       callCount++;
+      requestBodies.push(req.body);
 
       // First call returns the first response, subsequent calls return second response
       const responseKey =
@@ -1321,4 +1323,6 @@ export function useAutoProvision(opts?: {
       res.end();
     }
   );
+
+  return { requestBodies };
 }

--- a/packages/cli/test/unit/util/integration/format-billing-plans-help.test.ts
+++ b/packages/cli/test/unit/util/integration/format-billing-plans-help.test.ts
@@ -1,0 +1,73 @@
+import stripAnsi from 'strip-ansi';
+import { describe, expect, it } from 'vitest';
+import { formatBillingPlansHelp } from '../../../../src/util/integration/format-billing-plans-help';
+import type { BillingPlan } from '../../../../src/util/integration/types';
+
+function makePlan(
+  overrides: Partial<BillingPlan> & { id: string; name: string }
+): BillingPlan {
+  return {
+    type: 'subscription',
+    scope: 'installation',
+    description: '',
+    paymentMethodRequired: false,
+    details: [],
+    ...overrides,
+  };
+}
+
+describe('formatBillingPlansHelp', () => {
+  it('should list enabled plans with aligned IDs', () => {
+    const plans = [
+      makePlan({ id: 'pro', name: 'Pro Plan', cost: '$25/m' }),
+      makePlan({ id: 'enterprise', name: 'Enterprise Plan', cost: '$599/m' }),
+    ];
+    const result = stripAnsi(formatBillingPlansHelp('Acme Product', plans));
+
+    expect(result).toContain('Available billing plans for "Acme Product"');
+    expect(result).toContain('pro         Pro Plan ($25/m)');
+    expect(result).toContain('enterprise  Enterprise Plan ($599/m)');
+  });
+
+  it('should show usage example with first plan ID', () => {
+    const plans = [
+      makePlan({ id: 'starter', name: 'Starter' }),
+      makePlan({ id: 'pro', name: 'Pro' }),
+    ];
+    const result = stripAnsi(formatBillingPlansHelp('Acme', plans));
+
+    expect(result).toContain('Usage:');
+    expect(result).toContain('--plan starter');
+  });
+
+  it('should return empty string when no plans', () => {
+    const result = formatBillingPlansHelp('Acme', []);
+    expect(result).toBe('');
+  });
+
+  it('should filter out disabled plans', () => {
+    const plans = [
+      makePlan({ id: 'pro', name: 'Pro Plan' }),
+      makePlan({ id: 'free', name: 'Free Plan', disabled: true }),
+    ];
+    const result = stripAnsi(formatBillingPlansHelp('Acme', plans));
+
+    expect(result).toContain('pro');
+    expect(result).not.toContain('free');
+  });
+
+  it('should return empty string when all plans are disabled', () => {
+    const plans = [makePlan({ id: 'free', name: 'Free Plan', disabled: true })];
+    const result = formatBillingPlansHelp('Acme', plans);
+    expect(result).toBe('');
+  });
+
+  it('should handle plans without cost', () => {
+    const plans = [makePlan({ id: 'free', name: 'Free Plan' })];
+    const result = stripAnsi(formatBillingPlansHelp('Acme', plans));
+
+    expect(result).toContain('free  Free Plan');
+    // No cost suffix
+    expect(result).not.toContain('($');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--plan` / `-p` option to `vercel integration add` command
- Thread `billingPlanId` through all code paths:
  - Auto-provision API request body (initial + policy retry)
  - Legacy CLI path: skip interactive plan prompt when `--plan` matches, error with available plans list if not found
  - Web UI fallback URLs (both missing-installation and non-subscription plan cases)
- **Dynamic help**: `vercel integration add <slug> --help` shows available billing plans with IDs and pricing
- Add telemetry tracking via `trackCliOptionPlan`
- Add `--plan` usage example to command help

## Dynamic help output

```
$ vercel integration add upstash/upstash-kv --help

  Available billing plans for "Upstash for Redis":

    paid         Pay As You Go ($0.2 per 100K commands)
    fixed_250mb  Fixed 250MB ($10 + ($5 ✕ per read region) per month)
    fixed_1gb    Fixed 1GB ($20 + ($10 ✕ per read region) per month)
    fixed_5gb    Fixed 5GB ($100 + ($50 ✕ per read region) per month)
    fixed_10gb   Fixed 10GB ($200 + ($100 ✕ per read region) per month)
    fixed_50gb   Fixed 50GB ($400 + ($200 ✕ per read region) per month)
    fixed_100gb  Fixed 100GB ($800 + ($400 ✕ per read region) per month)
    fixed_500gb  Fixed 500GB ($1500 + ($750 ✕ per read region) per month)

  Usage:

    --plan paid
```

## Dependent PRs

This is **part 2 of 3** — the full `--plan` feature spans three repos:

1. **API** [vercel/api#60302](https://github.com/vercel/api/pull/60302) — accepts `billingPlanId` in auto-provision endpoint body (must deploy first due to `additionalProperties: false` in body schema)
2. **CLI** [vercel/vercel#14965](https://github.com/vercel/vercel/pull/14965) — this PR
3. **Front** [vercel/front#61967](https://github.com/vercel/front/pull/61967) — preselects billing plan from `planId` URL query param

## Test plan
- [x] Auto-provision: `--plan` included in request body, `-p` shorthand, `planId` in fallback URL
- [x] Auto-provision: `billingPlanId` threaded through policy acceptance retry
- [x] Legacy CLI: plan lookup by ID skips prompt, invalid plan errors with available list, `-p` shorthand
- [x] Legacy CLI: `planId` in web UI URL (missing installation + non-subscription fallback)
- [x] `formatBillingPlansHelp` unit tests (alignment, disabled filtering, empty plans, no-cost plans)
- [ ] Run `pnpm --filter vercel test add-auto-provision`
- [ ] Manual: `FF_AUTO_PROVISION_INSTALL=1 vercel integration add upstash/upstash-kv --plan paid`
- [ ] Manual: `vercel integration add upstash/upstash-kv --help` shows billing plans
- [ ] Verify `vercel integration add --help` shows `--plan` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new --plan CLI flag to pass billing plan IDs through API requests and URLs, which is a feature addition that threads data through existing code paths without modifying authorization or validation logic.
> 
> - Adds --plan/-p flag to specify billing plan ID for integration provisioning
> - Threads billingPlanId through auto-provision API requests and web UI fallback URLs
> - Includes comprehensive unit tests for new flag behavior
>
> <sup>Risk assessment for [commit bb8731e](https://github.com/vercel/vercel/commit/bb8731e4f8e98b930e48c5824bc7235017049a1a).</sup>
<!-- VADE_RISK_END -->