### PR TITLE
Add `vc link add` subcommand to append projects to existing repo.json

### DIFF
--- a/.changeset/olive-waves-worry.md
+++ b/.changeset/olive-waves-worry.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vc link add` subcommand to append projects to existing repo.json

--- a/packages/cli/src/commands/link/command.ts
+++ b/packages/cli/src/commands/link/command.ts
@@ -1,11 +1,33 @@
 import { packageName } from '../../util/pkg-name';
 import { confirmOption, yesOption } from '../../util/arg-common';
 
+export const addSubcommand = {
+  name: 'add',
+  aliases: [],
+  description:
+    'Add additional Vercel Projects to an existing repository link. Requires an existing repo.json (created by `link --repo`).',
+  arguments: [],
+  options: [
+    {
+      ...yesOption,
+      description:
+        'Skip questions when adding projects using default scope and settings',
+    },
+  ],
+  examples: [
+    {
+      name: 'Add projects to an existing repository link',
+      value: `${packageName} link add`,
+    },
+  ],
+} as const;
+
 export const linkCommand = {
   name: 'link',
   aliases: [],
   description: 'Link a local directory to a Vercel Project.',
   arguments: [],
+  subcommands: [addSubcommand],
   options: [
     {
       name: 'repo',
@@ -45,6 +67,10 @@ export const linkCommand = {
     {
       name: 'Link to the current Git repository, allowing for multiple Vercel Projects to be linked simultaneously (useful for monorepos)',
       value: `${packageName} link --repo`,
+    },
+    {
+      name: 'Add additional projects to an existing repository link',
+      value: `${packageName} link add`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -1,27 +1,40 @@
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
+import getSubcommand from '../../util/get-subcommand';
 import cmd from '../../util/output/cmd';
 import { ensureLink } from '../../util/link/ensure-link';
-import { ensureRepoLink } from '../../util/link/repo';
-import { help } from '../help';
-import { linkCommand } from './command';
+import { addRepoLink, ensureRepoLink } from '../../util/link/repo';
+import { type Command, help } from '../help';
+import { addSubcommand, linkCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { LinkTelemetryClient } from '../../util/telemetry/commands/link';
+import { getCommandAliases } from '..';
+
+const COMMAND_CONFIG = {
+  add: getCommandAliases(addSubcommand),
+};
 
 export default async function link(client: Client) {
   let parsedArgs = null;
 
   const flagsSpecification = getFlagsSpecification(linkCommand.options);
 
-  // Parse CLI args
+  // Parse CLI args (permissive to allow subcommand flags to pass through)
   try {
-    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
   } catch (error) {
     printError(error);
     return 1;
   }
+
+  const { subcommand, subcommandOriginal } = getSubcommand(
+    parsedArgs.args.slice(1),
+    COMMAND_CONFIG
+  );
 
   const telemetry = new LinkTelemetryClient({
     opts: {
@@ -29,10 +42,48 @@ export default async function link(client: Client) {
     },
   });
 
+  function printHelp(command: Command) {
+    output.print(
+      help(command, { parent: linkCommand, columns: client.stderr.columns })
+    );
+  }
+
+  if (subcommand === 'add') {
+    // `vc link add` subcommand
+    // `--yes` is shared with the parent and already parsed by the permissive parse
+    if (parsedArgs.flags['--help']) {
+      telemetry.trackCliFlagHelp('link', subcommandOriginal);
+      printHelp(addSubcommand);
+      return 2;
+    }
+
+    telemetry.trackCliSubcommandAdd(subcommandOriginal);
+
+    const yes = !!parsedArgs.flags['--yes'];
+
+    try {
+      await addRepoLink(client, client.cwd, { yes });
+    } catch (err) {
+      output.prettyError(err);
+      return 1;
+    }
+
+    return 0;
+  }
+
+  // Default behavior (no subcommand) - original `vc link` flow
+  // Re-parse strictly now that we know there's no subcommand
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('link');
     output.print(help(linkCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   telemetry.trackCliFlagRepo(parsedArgs.flags['--repo']);

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -84,6 +84,261 @@ export async function getRepoLink(
   return { rootPath, repoConfig, repoConfigPath };
 }
 
+/**
+ * Runs the project discovery flow: selects org, discovers/creates projects,
+ * and returns the selected projects as `RepoProjectConfig[]`.
+ *
+ * This is the shared core used by both `ensureRepoLink` and `addRepoLink`.
+ *
+ * @param existingProjectIds - Set of project IDs already in repo.json,
+ *   used to filter out already-linked projects from the API results.
+ * @param existingDirectories - Set of directories already linked in repo.json,
+ *   used to filter out locally-detected projects that are already covered.
+ */
+async function discoverRepoProjects(
+  client: Client,
+  rootPath: string,
+  {
+    yes,
+    existingProjectIds,
+    existingDirectories,
+  }: {
+    yes: boolean;
+    existingProjectIds?: Set<string>;
+    existingDirectories?: Set<string>;
+  }
+): Promise<
+  | { remoteName: string; projects: RepoProjectConfig[]; orgSlug: string }
+  | undefined
+> {
+  // Detect the projects on the filesystem out of band, so that
+  // they will be ready by the time the projects are listed
+  const detectedProjectsPromise = detectProjects(rootPath).catch(err => {
+    output.debug(`Failed to detect local projects: ${err}`);
+    return new Map<string, Framework[]>();
+  });
+
+  // Not yet linked, so prompt user to begin linking
+  const shouldLink =
+    yes ||
+    (await client.input.confirm(
+      `Link Git repository at ${chalk.cyan(
+        `"${toHumanPath(rootPath)}"`
+      )} to your Project(s)?`,
+      true
+    ));
+
+  if (!shouldLink) {
+    output.print(`Canceled. Repository not linked.\n`);
+    return;
+  }
+
+  const org = await selectOrg(
+    client,
+    'Which scope should contain your Project(s)?',
+    yes
+  );
+  client.config.currentTeam = org.type === 'team' ? org.id : undefined;
+
+  // Use getGitConfigPath to correctly resolve the config path for
+  // regular repos, worktrees, and submodules. Falls back to the
+  // traditional path if git commands fail.
+  const gitConfigPath =
+    getGitConfigPath({ cwd: rootPath }) ?? join(rootPath, '.git/config');
+  const remoteUrls = await getRemoteUrls(gitConfigPath);
+  if (!remoteUrls) {
+    throw new Error('Could not determine Git remote URLs');
+  }
+  const remoteNames = Object.keys(remoteUrls).sort();
+  let remoteName: string;
+  if (remoteNames.length === 1) {
+    remoteName = remoteNames[0];
+  } else {
+    // Prompt user to select which remote to use
+    const defaultRemote = remoteNames.includes('origin')
+      ? 'origin'
+      : remoteNames[0];
+    if (yes) {
+      remoteName = defaultRemote;
+    } else {
+      remoteName = await client.input.select({
+        message: 'Which Git remote should be used?',
+        choices: remoteNames.map(name => {
+          return { name: name, value: name };
+        }),
+        default: defaultRemote,
+      });
+    }
+  }
+  const repoUrl = remoteUrls[remoteName];
+  const parsedRepoUrl = parseRepoUrl(repoUrl);
+  if (!parsedRepoUrl) {
+    throw new Error(`Failed to parse Git URL: ${repoUrl}`);
+  }
+  const repoUrlLink = output.link(repoUrl, repoInfoToUrl(parsedRepoUrl), {
+    fallback: () => link(repoUrl),
+  });
+  output.spinner(
+    `Fetching Projects for ${repoUrlLink} under ${chalk.bold(org.slug)}…`
+  );
+  let projects: Project[] = [];
+  const query = new URLSearchParams({ repoUrl });
+  const projectsIterator = client.fetchPaginated<{
+    projects: Project[];
+  }>(`/v9/projects?${query}`);
+  const detectedProjects = await detectedProjectsPromise;
+  for await (const chunk of projectsIterator) {
+    projects = projects.concat(chunk.projects);
+    if (chunk.pagination.next) {
+      output.spinner(`Found ${chalk.bold(projects.length)} Projects…`, 0);
+    }
+  }
+
+  // Filter out projects that are already linked in repo.json
+  if (existingProjectIds) {
+    projects = projects.filter(p => !existingProjectIds.has(p.id));
+  }
+
+  if (projects.length === 0) {
+    output.log(
+      `No Projects are linked to ${repoUrlLink} under ${chalk.bold(org.slug)}.`
+    );
+  } else {
+    output.log(
+      `Found ${pluralize(
+        'Project',
+        projects.length,
+        true
+      )} linked to ${repoUrlLink} under ${chalk.bold(org.slug)}`
+    );
+  }
+
+  // For any projects that already exists on Vercel, remove them from the
+  // locally detected directories. Any remaining ones will be prompted to
+  // create new Projects for.
+  for (const project of projects) {
+    detectedProjects.delete(project.rootDirectory ?? '');
+  }
+  // Also remove detected projects whose directories are already linked
+  // in the existing repo.json (e.g. linked to a different org)
+  if (existingDirectories) {
+    for (const dir of existingDirectories) {
+      detectedProjects.delete(dir);
+    }
+  }
+
+  const detectedProjectsCount = Array.from(detectedProjects.values()).reduce(
+    (o, f) => o + f.length,
+    0
+  );
+  if (detectedProjectsCount > 0) {
+    output.log(
+      `Detected ${pluralize(
+        'new Project',
+        detectedProjectsCount,
+        true
+      )} that may be created.`
+    );
+  }
+
+  let selected: (Project | NewProject)[];
+  if (yes) {
+    selected = projects;
+  } else {
+    const addSeparators = projects.length > 0 && detectedProjectsCount > 0;
+    selected = await client.input.checkbox<Project | NewProject>({
+      message: `Which Projects should be ${
+        projects.length ? 'linked to' : 'created'
+      }?`,
+      choices: [
+        ...(addSeparators
+          ? [new Separator('----- Existing Projects -----')]
+          : []),
+        ...projects.map(project => {
+          return {
+            name: `${org.slug}/${project.name}`,
+            value: project,
+            checked: true,
+          };
+        }),
+        ...(addSeparators
+          ? [new Separator('----- New Projects to be created -----')]
+          : []),
+        ...Array.from(detectedProjects.entries()).flatMap(
+          ([rootDirectory, frameworks]) =>
+            frameworks.map((framework, i) => {
+              const name = slugify(
+                [
+                  basename(rootDirectory) || basename(rootPath),
+                  i > 0 ? framework.slug : '',
+                ]
+                  .filter(Boolean)
+                  .join('-')
+              );
+              return {
+                name: `${org.slug}/${name} (${framework.name})`,
+                value: {
+                  newProject: true,
+                  rootDirectory,
+                  name,
+                  framework,
+                },
+                // Checked by default when there are no other existing Projects
+                checked: projects.length === 0,
+              } as const;
+            })
+        ),
+      ],
+    });
+  }
+
+  if (selected.length === 0) {
+    output.print(`No Projects were selected. Repository not linked.\n`);
+    return;
+  }
+
+  for (let i = 0; i < selected.length; i++) {
+    const selection = selected[i];
+    if (!('newProject' in selection && selection.newProject)) continue;
+    const orgAndName = `${org.slug}/${selection.name}`;
+    output.spinner(`Creating new Project: ${orgAndName}`);
+    delete selection.newProject;
+    if (!selection.rootDirectory) delete selection.rootDirectory;
+    const project = (selected[i] = await createProject(client, {
+      ...selection,
+      framework: selection.framework.slug,
+    }));
+    await connectGitProvider(
+      client,
+      project.id,
+      parsedRepoUrl.provider,
+      `${parsedRepoUrl.org}/${parsedRepoUrl.repo}`
+    );
+    output.log(
+      `Created new Project: ${output.link(
+        orgAndName,
+        `https://vercel.com/${orgAndName}`,
+        { fallback: false }
+      )}`
+    );
+  }
+
+  const repoProjects = selected.map(project => {
+    if (!('id' in project)) {
+      // Shouldn't happen at this point, but just to make TS happy
+      throw new TypeError(`Not a Project: ${JSON.stringify(project)}`);
+    }
+    return {
+      id: project.id,
+      name: project.name,
+      directory: normalize(project.rootDirectory || ''),
+      orgId: org.id,
+    };
+  });
+
+  return { remoteName, projects: repoProjects, orgSlug: org.slug };
+}
+
 export async function ensureRepoLink(
   client: Client,
   cwd: string,
@@ -99,222 +354,14 @@ export async function ensureRepoLink(
   let { rootPath, repoConfig, repoConfigPath } = repoLink;
 
   if (overwrite || !repoConfig) {
-    // Detect the projects on the filesystem out of band, so that
-    // they will be ready by the time the projects are listed
-    const detectedProjectsPromise = detectProjects(rootPath).catch(err => {
-      output.debug(`Failed to detect local projects: ${err}`);
-      return new Map<string, Framework[]>();
-    });
-
-    // Not yet linked, so prompt user to begin linking
-    const shouldLink =
-      yes ||
-      (await client.input.confirm(
-        `Link Git repository at ${chalk.cyan(
-          `“${toHumanPath(rootPath)}”`
-        )} to your Project(s)?`,
-        true
-      ));
-
-    if (!shouldLink) {
-      output.print(`Canceled. Repository not linked.\n`);
+    const result = await discoverRepoProjects(client, rootPath, { yes });
+    if (!result) {
       return;
-    }
-
-    const org = await selectOrg(
-      client,
-      'Which scope should contain your Project(s)?',
-      yes
-    );
-    client.config.currentTeam = org.type === 'team' ? org.id : undefined;
-
-    // Use getGitConfigPath to correctly resolve the config path for
-    // regular repos, worktrees, and submodules. Falls back to the
-    // traditional path if git commands fail.
-    const gitConfigPath =
-      getGitConfigPath({ cwd: rootPath }) ?? join(rootPath, '.git/config');
-    const remoteUrls = await getRemoteUrls(gitConfigPath);
-    if (!remoteUrls) {
-      throw new Error('Could not determine Git remote URLs');
-    }
-    const remoteNames = Object.keys(remoteUrls).sort();
-    let remoteName: string;
-    if (remoteNames.length === 1) {
-      remoteName = remoteNames[0];
-    } else {
-      // Prompt user to select which remote to use
-      const defaultRemote = remoteNames.includes('origin')
-        ? 'origin'
-        : remoteNames[0];
-      if (yes) {
-        remoteName = defaultRemote;
-      } else {
-        remoteName = await client.input.select({
-          message: 'Which Git remote should be used?',
-          choices: remoteNames.map(name => {
-            return { name: name, value: name };
-          }),
-          default: defaultRemote,
-        });
-      }
-    }
-    const repoUrl = remoteUrls[remoteName];
-    const parsedRepoUrl = parseRepoUrl(repoUrl);
-    if (!parsedRepoUrl) {
-      throw new Error(`Failed to parse Git URL: ${repoUrl}`);
-    }
-    const repoUrlLink = output.link(repoUrl, repoInfoToUrl(parsedRepoUrl), {
-      fallback: () => link(repoUrl),
-    });
-    output.spinner(
-      `Fetching Projects for ${repoUrlLink} under ${chalk.bold(org.slug)}…`
-    );
-    let projects: Project[] = [];
-    const query = new URLSearchParams({ repoUrl });
-    const projectsIterator = client.fetchPaginated<{
-      projects: Project[];
-    }>(`/v9/projects?${query}`);
-    const detectedProjects = await detectedProjectsPromise;
-    for await (const chunk of projectsIterator) {
-      projects = projects.concat(chunk.projects);
-      if (chunk.pagination.next) {
-        output.spinner(`Found ${chalk.bold(projects.length)} Projects…`, 0);
-      }
-    }
-
-    if (projects.length === 0) {
-      output.log(
-        `No Projects are linked to ${repoUrlLink} under ${chalk.bold(
-          org.slug
-        )}.`
-      );
-    } else {
-      output.log(
-        `Found ${pluralize(
-          'Project',
-          projects.length,
-          true
-        )} linked to ${repoUrlLink} under ${chalk.bold(org.slug)}`
-      );
-    }
-
-    // For any projects that already exists on Vercel, remove them from the
-    // locally detected directories. Any remaining ones will be prompted to
-    // create new Projects for.
-    for (const project of projects) {
-      detectedProjects.delete(project.rootDirectory ?? '');
-    }
-
-    const detectedProjectsCount = Array.from(detectedProjects.values()).reduce(
-      (o, f) => o + f.length,
-      0
-    );
-    if (detectedProjectsCount > 0) {
-      output.log(
-        `Detected ${pluralize(
-          'new Project',
-          detectedProjectsCount,
-          true
-        )} that may be created.`
-      );
-    }
-
-    let selected: (Project | NewProject)[];
-    if (yes) {
-      selected = projects;
-    } else {
-      const addSeparators = projects.length > 0 && detectedProjectsCount > 0;
-      selected = await client.input.checkbox<Project | NewProject>({
-        message: `Which Projects should be ${
-          projects.length ? 'linked to' : 'created'
-        }?`,
-        choices: [
-          ...(addSeparators
-            ? [new Separator('----- Existing Projects -----')]
-            : []),
-          ...projects.map(project => {
-            return {
-              name: `${org.slug}/${project.name}`,
-              value: project,
-              checked: true,
-            };
-          }),
-          ...(addSeparators
-            ? [new Separator('----- New Projects to be created -----')]
-            : []),
-          ...Array.from(detectedProjects.entries()).flatMap(
-            ([rootDirectory, frameworks]) =>
-              frameworks.map((framework, i) => {
-                const name = slugify(
-                  [
-                    basename(rootDirectory) || basename(rootPath),
-                    i > 0 ? framework.slug : '',
-                  ]
-                    .filter(Boolean)
-                    .join('-')
-                );
-                return {
-                  name: `${org.slug}/${name} (${framework.name})`,
-                  value: {
-                    newProject: true,
-                    rootDirectory,
-                    name,
-                    framework,
-                  },
-                  // Checked by default when there are no other existing Projects
-                  checked: projects.length === 0,
-                } as const;
-              })
-          ),
-        ],
-      });
-    }
-
-    if (selected.length === 0) {
-      output.print(`No Projects were selected. Repository not linked.\n`);
-      return;
-    }
-
-    for (let i = 0; i < selected.length; i++) {
-      const selection = selected[i];
-      if (!('newProject' in selection && selection.newProject)) continue;
-      const orgAndName = `${org.slug}/${selection.name}`;
-      output.spinner(`Creating new Project: ${orgAndName}`);
-      delete selection.newProject;
-      if (!selection.rootDirectory) delete selection.rootDirectory;
-      const project = (selected[i] = await createProject(client, {
-        ...selection,
-        framework: selection.framework.slug,
-      }));
-      await connectGitProvider(
-        client,
-        project.id,
-        parsedRepoUrl.provider,
-        `${parsedRepoUrl.org}/${parsedRepoUrl.repo}`
-      );
-      output.log(
-        `Created new Project: ${output.link(
-          orgAndName,
-          `https://vercel.com/${orgAndName}`,
-          { fallback: false }
-        )}`
-      );
     }
 
     repoConfig = {
-      remoteName,
-      projects: selected.map(project => {
-        if (!('id' in project)) {
-          // Shouldn't happen at this point, but just to make TS happy
-          throw new TypeError(`Not a Project: ${JSON.stringify(project)}`);
-        }
-        return {
-          id: project.id,
-          name: project.name,
-          directory: normalize(project.rootDirectory || ''),
-          orgId: org.id,
-        };
-      }),
+      remoteName: result.remoteName,
+      projects: result.projects,
     };
     await outputJSON(repoConfigPath, repoConfig, { spaces: 2 });
 
@@ -327,9 +374,9 @@ export async function ensureRepoLink(
       prependEmoji(
         `Linked to ${pluralize(
           'Project',
-          selected.length,
+          result.projects.length,
           true
-        )} under ${chalk.bold(org.slug)} (created ${VERCEL_DIR}${
+        )} under ${chalk.bold(result.orgSlug)} (created ${VERCEL_DIR}${
           isGitIgnoreUpdated ? ' and added it to .gitignore' : ''
         })`,
         emoji('link')
@@ -339,6 +386,86 @@ export async function ensureRepoLink(
 
   return {
     repoConfig,
+    repoConfigPath,
+    rootPath,
+  };
+}
+
+/**
+ * Adds additional projects to an existing `repo.json` file.
+ * Requires that `repo.json` already exists (i.e., the repo has been linked
+ * with `vc link --repo`). Runs the same project discovery flow and merges
+ * the resulting projects into the existing config, deduplicating by project ID.
+ */
+export async function addRepoLink(
+  client: Client,
+  cwd: string,
+  { yes }: { yes: boolean }
+): Promise<RepoLink | undefined> {
+  const repoLink = await getRepoLink(client, cwd);
+  if (!repoLink) {
+    throw new Error('Could not determine Git repository root directory');
+  }
+
+  const { rootPath, repoConfig, repoConfigPath } = repoLink;
+
+  if (!repoConfig) {
+    output.error(
+      `No existing repository link found. Run \`vc link --repo\` first to link the repository.`
+    );
+    return;
+  }
+
+  output.debug(`Found Git repository root directory: ${rootPath}`);
+
+  // Collect existing project IDs and directories so we can filter them
+  const existingProjectIds = new Set(repoConfig.projects.map(p => p.id));
+  const existingDirectories = new Set(
+    repoConfig.projects.map(p => p.directory)
+  );
+
+  const result = await discoverRepoProjects(client, rootPath, {
+    yes,
+    existingProjectIds,
+    existingDirectories,
+  });
+  if (!result) {
+    return;
+  }
+
+  if (result.projects.length === 0) {
+    output.print(`No new Projects were added.\n`);
+    return { repoConfig, repoConfigPath, rootPath };
+  }
+
+  // Merge new projects into existing config, deduplicating by project ID
+  const mergedProjects = [...repoConfig.projects];
+  for (const project of result.projects) {
+    if (!existingProjectIds.has(project.id)) {
+      mergedProjects.push(project);
+    }
+  }
+
+  const updatedConfig: RepoProjectsConfig = {
+    ...repoConfig,
+    projects: mergedProjects,
+  };
+
+  await outputJSON(repoConfigPath, updatedConfig, { spaces: 2 });
+
+  output.print(
+    prependEmoji(
+      `Added ${pluralize(
+        'Project',
+        result.projects.length,
+        true
+      )} under ${chalk.bold(result.orgSlug)}`,
+      emoji('link')
+    ) + '\n'
+  );
+
+  return {
+    repoConfig: updatedConfig,
     repoConfigPath,
     rootPath,
   };

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -255,8 +255,9 @@ async function discoverRepoProjects(
           ? [new Separator('----- Existing Projects -----')]
           : []),
         ...projects.map(project => {
+          const dir = project.rootDirectory || '.';
           return {
-            name: `${org.slug}/${project.name}`,
+            name: `${org.slug}/${project.name} ${chalk.gray(`(${dir})`)}`,
             value: project,
             checked: true,
           };
@@ -276,7 +277,7 @@ async function discoverRepoProjects(
                   .join('-')
               );
               return {
-                name: `${org.slug}/${name} (${framework.name})`,
+                name: `${org.slug}/${name} ${chalk.gray(`(${rootDirectory || '.'} · ${framework.name})`)}`,
                 value: {
                   newProject: true,
                   rootDirectory,

--- a/packages/cli/src/util/telemetry/commands/link/index.ts
+++ b/packages/cli/src/util/telemetry/commands/link/index.ts
@@ -39,4 +39,11 @@ export class LinkTelemetryClient
       });
     }
   }
+
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3415,10 +3415,20 @@ exports[`help command > integration-resource help output snapshots > integration
 
 exports[`help command > link help output snapshots > link help column width 40 1`] = `
 "
-  ▲ vercel link [options]
+  ▲ vercel link command [options]
 
   Link a local directory to a Vercel    
   Project.                              
+
+  Commands:
+
+  add    Add additional Vercel  
+         Projects to an existing
+         repository link.       
+         Requires an existing   
+         repo.json (created by  
+         \`link --repo\`).        
+
 
   Options:
 
@@ -3503,14 +3513,24 @@ exports[`help command > link help output snapshots > link help column width 40 1
 
     $ vercel link --repo
 
+  - Add additional projects to an existing repository link
+
+    $ vercel link add
+
 "
 `;
 
 exports[`help command > link help output snapshots > link help column width 80 1`] = `
 "
-  ▲ vercel link [options]
+  ▲ vercel link command [options]
 
   Link a local directory to a Vercel Project.                                   
+
+  Commands:
+
+  add    Add additional Vercel Projects to an existing repository link. 
+         Requires an existing repo.json (created by \`link --repo\`).     
+
 
   Options:
 
@@ -3554,14 +3574,24 @@ exports[`help command > link help output snapshots > link help column width 80 1
 
     $ vercel link --repo
 
+  - Add additional projects to an existing repository link
+
+    $ vercel link add
+
 "
 `;
 
 exports[`help command > link help output snapshots > link help column width 120 1`] = `
 "
-  ▲ vercel link [options]
+  ▲ vercel link command [options]
 
   Link a local directory to a Vercel Project.                                                                           
+
+  Commands:
+
+  add    Add additional Vercel Projects to an existing repository link. Requires an existing repo.json (created 
+         by \`link --repo\`).                                                                                     
+
 
   Options:
 
@@ -3601,6 +3631,10 @@ exports[`help command > link help output snapshots > link help column width 120 
   - Link to the current Git repository, allowing for multiple Vercel Projects to be linked simultaneously (useful for monorepos)
 
     $ vercel link --repo
+
+  - Add additional projects to an existing repository link
+
+    $ vercel link add
 
 "
 `;

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -43,7 +43,7 @@ describe('link', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = link(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
@@ -403,6 +403,251 @@ describe('link', () => {
         {
           key: 'flag:yes',
           value: 'TRUE',
+        },
+      ]);
+    });
+  });
+
+  describe('add', () => {
+    it('should fail if repo.json does not exist', async () => {
+      useUser();
+      const cwd = setupTmpDir();
+
+      // Set up a `.git/config` file to simulate a repo (but no .vercel/repo.json)
+      await mkdirp(join(cwd, '.git'));
+      const repoUrl = 'https://github.com/test/test.git';
+      await writeFile(
+        join(cwd, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+
+      useTeams('team_dummy');
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('link', 'add', '--yes');
+      const exitCode = await link(client);
+
+      await expect(client.stderr).toOutput('No existing repository link found');
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should add projects to existing repo.json', async () => {
+      const user = useUser();
+      const cwd = setupTmpDir();
+
+      // Set up a `.git/config` file to simulate a repo
+      await mkdirp(join(cwd, '.git'));
+      const repoUrl = 'https://github.com/user/repo.git';
+      await writeFile(
+        join(cwd, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+
+      // Create an existing repo.json with one project
+      await mkdirp(join(cwd, '.vercel'));
+      await writeJSON(join(cwd, '.vercel/repo.json'), {
+        remoteName: 'origin',
+        projects: [
+          {
+            id: 'existing-project-id',
+            name: 'existing-project',
+            directory: 'packages/existing',
+            orgId: user.id,
+          },
+        ],
+      });
+
+      useTeams('team_dummy');
+      const { project: newProject } = useProject({
+        ...defaultProject,
+        id: 'new-project-id',
+        name: 'new-project',
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('link', 'add');
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Link Git repository at ');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your Project(s)?'
+      );
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(`Fetching Projects for ${repoUrl}`);
+      await expect(client.stderr).toOutput(
+        `Found 1 Project linked to ${repoUrl}`
+      );
+      await expect(client.stderr).toOutput(
+        `Which Projects should be linked to?`
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Added 1 Project under');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      const repoJson = await readJSON(join(cwd, '.vercel/repo.json'));
+      // Original project should still be there
+      expect(repoJson.projects).toHaveLength(2);
+      expect(repoJson.projects[0]).toMatchObject({
+        id: 'existing-project-id',
+        name: 'existing-project',
+        directory: 'packages/existing',
+        orgId: user.id,
+      });
+      // New project should be added
+      expect(repoJson.projects[1]).toMatchObject({
+        id: newProject.id,
+        name: newProject.name,
+        orgId: user.id,
+      });
+    });
+
+    it('should not duplicate already-linked projects', async () => {
+      const user = useUser();
+      const cwd = setupTmpDir();
+
+      // Set up a `.git/config` file to simulate a repo
+      await mkdirp(join(cwd, '.git'));
+      const repoUrl = 'https://github.com/user/repo.git';
+      await writeFile(
+        join(cwd, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+
+      // Create repo.json with a project that already matches what the API returns
+      const existingProjectId = basename(cwd);
+      await mkdirp(join(cwd, '.vercel'));
+      await writeJSON(join(cwd, '.vercel/repo.json'), {
+        remoteName: 'origin',
+        projects: [
+          {
+            id: existingProjectId,
+            name: basename(cwd),
+            directory: '.',
+            orgId: user.id,
+          },
+        ],
+      });
+
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: existingProjectId,
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('link', 'add', '--yes');
+      const exitCode = await link(client);
+
+      expect(exitCode).toEqual(0);
+
+      // Should still have only the original project (the API project was filtered)
+      const repoJson = await readJSON(join(cwd, '.vercel/repo.json'));
+      expect(repoJson.projects).toHaveLength(1);
+      expect(repoJson.projects[0].id).toEqual(existingProjectId);
+    });
+
+    it('should not show detected projects for directories already linked to another org', async () => {
+      useUser();
+      const cwd = setupTmpDir();
+
+      // Set up a `.git/config` file to simulate a repo
+      await mkdirp(join(cwd, '.git'));
+      const repoUrl = 'https://github.com/user/repo.git';
+      await writeFile(
+        join(cwd, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+
+      // Create a Next.js project at repo root that would normally be detected
+      await writeJSON(join(cwd, 'package.json'), {
+        dependencies: { next: 'latest' },
+      });
+
+      // Create repo.json where the root directory is already linked to a different org
+      await mkdirp(join(cwd, '.vercel'));
+      await writeJSON(join(cwd, '.vercel/repo.json'), {
+        remoteName: 'origin',
+        projects: [
+          {
+            id: 'other-org-project',
+            name: 'other-org-project',
+            directory: '.',
+            orgId: 'team_other',
+          },
+        ],
+      });
+
+      useTeams('team_dummy');
+      // API returns no projects for this org
+      client.scenario.get(`/v9/projects`, (_req, res) => {
+        res.json({
+          projects: [],
+          pagination: { count: 0, next: null, prev: null },
+        });
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('link', 'add', '--yes');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      // The root directory project should NOT have been re-created because
+      // it's already linked (to a different org). repo.json should be unchanged.
+      const repoJson = await readJSON(join(cwd, '.vercel/repo.json'));
+      expect(repoJson.projects).toHaveLength(1);
+      expect(repoJson.projects[0].id).toEqual('other-org-project');
+      expect(repoJson.projects[0].orgId).toEqual('team_other');
+    });
+
+    it('should track `add` subcommand telemetry', async () => {
+      useUser();
+      const cwd = setupTmpDir();
+
+      // Set up a `.git/config` file to simulate a repo
+      await mkdirp(join(cwd, '.git'));
+      const repoUrl = 'https://github.com/user/repo.git';
+      await writeFile(
+        join(cwd, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+
+      // Create an existing repo.json
+      await mkdirp(join(cwd, '.vercel'));
+      await writeJSON(join(cwd, '.vercel/repo.json'), {
+        remoteName: 'origin',
+        projects: [],
+      });
+
+      useTeams('team_dummy');
+      // Return no projects from API, so the flow will see 0 projects
+      client.scenario.get(`/v9/projects`, (_req, res) => {
+        res.json({
+          projects: [],
+          pagination: { count: 0, next: null, prev: null },
+        });
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('link', 'add', '--yes');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:add',
+          value: 'add',
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -429,7 +429,7 @@ describe('link', () => {
       const exitCode = await link(client);
 
       await expect(client.stderr).toOutput('No existing repository link found');
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
     });
 
     it('should add projects to existing repo.json', async () => {
@@ -470,7 +470,9 @@ describe('link', () => {
       client.setArgv('link', 'add');
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Link Git repository at ');
+      await expect(client.stderr).toOutput(
+        'Add Project(s) for Git repository at '
+      );
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(


### PR DESCRIPTION
Allows adding additional Vercel Projects to an already-linked repository without overwriting previously linked projects. Filters out both API projects and locally-detected projects whose directories are already covered by existing entries in `repo.json`.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new `vc link add` CLI subcommand to append projects to existing repo.json, consisting of command definition, argument parsing, refactored project discovery logic, and comprehensive tests.
> 
> - New `add` subcommand with command definition and argument parsing
> - Refactored `discoverRepoProjects` function extracted from `ensureRepoLink` for shared use
> - Extensive unit tests covering add flow, deduplication, and telemetry
>
> <sup>Risk assessment for [commit 229593d](https://github.com/vercel/vercel/commit/229593de807f9024b76ed4bc81eff08e53007e90).</sup>
<!-- VADE_RISK_END -->