### PR TITLE
[next] Filter prerender-manifest.json for determinism

### DIFF
--- a/.changeset/witty-paws-develop.md
+++ b/.changeset/witty-paws-develop.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Strip prerender-manifest.json for more determinism

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1246,6 +1246,7 @@ export async function serverBuild({
       if (isCorrectManifests) {
         for (const manifest of [
           'routes-manifest.json',
+          'prerender-manifest.json',
           'server/pages-manifest.json',
           ...(mayFilterManifests && appPathRoutesManifest
             ? ['server/app-paths-manifest.json']
@@ -1265,6 +1266,18 @@ export async function serverBuild({
             manifestData.headers = [];
             manifestData.onMatchHeaders = [];
             delete manifestData.deploymentId;
+          } else if (manifest === 'prerender-manifest.json') {
+            // These can contain deployment id query strings, and are also very large.
+            // In Next.js minimal mode, they aren't used (the builder reads them and generates the
+            // config.json for Vercel)
+            for (const route of Object.values(manifestData.routes) as any) {
+              if (route.initialHeaders) {
+                route.initialHeaders = {};
+              }
+              if (route.experimentalBypassFor) {
+                route.experimentalBypassFor = [];
+              }
+            }
           } else if (
             manifest === 'server/pages-manifest.json' &&
             !shouldUse404Prerender

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1278,6 +1278,16 @@ export async function serverBuild({
                 route.experimentalBypassFor = [];
               }
             }
+            for (const route of Object.values(
+              manifestData.dynamicRoutes
+            ) as any) {
+              if (route.fallbackHeaders) {
+                route.fallbackHeaders = {};
+              }
+              if (route.experimentalBypassFor) {
+                route.experimentalBypassFor = [];
+              }
+            }
           } else if (
             manifest === 'server/pages-manifest.json' &&
             !shouldUse404Prerender

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1320,6 +1320,8 @@ export async function serverBuild({
             );
 
             switch (manifest) {
+              case 'prerender-manifest.json':
+                break;
               case 'routes-manifest.json': {
                 const filterItem = (item: { page: string }) =>
                   normalizedPages.has(item.page);


### PR DESCRIPTION
Example:
```json
{
  "version": 4,
  "routes": {
    "/abc": {
      "initialHeaders": {
        "link": "</_next/static/media/caa3a2e1cccd8315-s.p.853070df.woff2>; rel=preload; as=\"font\"; crossorigin=\"\"; type=\"font/woff2\", </_next/static/chunks/6c6fbc5083984022.css?dpl=1234>; rel=preload; as=\"style\"",
        "x-nextjs-stale-time": "300",
        "x-nextjs-prerender": "1",
        "x-next-cache-tags": "_N_T_/layout,_N_T_/[variants]/layout,_N_T_/[variants]/page,_N_T_/abc"
      },
      "renderingMode": "PARTIALLY_STATIC",
      "experimentalPPR": true,
      "experimentalBypassFor": [
        {
          "type": "header",
          "key": "next-action"
        },
        {
          "type": "header",
          "key": "content-type",
          "value": "multipart/form-data;.*"
        },
        {
          "type": "header",
          "key": "user-agent",
          "value": "[\\w-]+-Google|Google-[\\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight"
        }
      ],
      "initialRevalidateSeconds": false,
      "srcRoute": "/[variants]",
      "dataRoute": "/abc.rsc",
      "allowHeader": [
        "host",
        "x-matched-path",
        "x-prerender-revalidate",
        "x-prerender-revalidate-if-generated",
        "x-next-revalidated-tags",
        "x-next-revalidate-tag-token"
      ]
    }
  },
```

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds filtering of prerender-manifest.json during build to strip headers and bypass rules for determinism, which modifies build output but the comment indicates these fields aren't used in minimal mode as the builder reads them separately.
> 
> - Adds prerender-manifest.json to list of manifests filtered during server build
> - Clears initialHeaders, fallbackHeaders, and experimentalBypassFor fields from route data
> - Build-time manifest stripping for determinism, not runtime behavior change
>
> <sup>Risk assessment for [commit e92b4af](https://github.com/vercel/vercel/commit/e92b4af1fd1cbb0fdf81db024ffd8f5aadb64a6e).</sup>
<!-- VADE_RISK_END -->