### PR TITLE
Vercel logs function type

### DIFF
--- a/.changeset/remove-function-type-icon-from-logs.md
+++ b/.changeset/remove-function-type-icon-from-logs.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Removed the request function type icon (lambda/epsilon) from `vercel logs` output.

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -567,7 +567,7 @@ export default async function logs(client: Client) {
           time: format(log.timestamp, timeFormat),
           host: log.domain || '',
           level: log.level,
-          path: `${getSourceIcon(log.source)} ${log.requestMethod} ${log.requestPath}`,
+          path: `${log.requestMethod} ${log.requestPath}`,
           status: !statusCode || statusCode <= 0 ? '---' : String(statusCode),
           statusCode,
           message: log.message?.replace(/\n/g, ' ').trim() || '',
@@ -684,24 +684,6 @@ function colorizeStatus(formatted: string, statusCode: number): string {
     return chalk.green(formatted);
   }
   return chalk.gray(formatted);
-}
-
-function getSourceIcon(source: string): string {
-  switch (source) {
-    case 'serverless':
-    case 'lambda':
-      return 'λ';
-    case 'edge-function':
-    case 'edge-middleware':
-    case 'middleware':
-      return 'ε';
-    case 'static':
-    case 'external':
-    case 'redirect':
-      return '◇';
-    default:
-      return ' ';
-  }
 }
 
 function colorizeMessage(message: string, level: string): string {

--- a/packages/cli/src/util/logs.ts
+++ b/packages/cli/src/util/logs.ts
@@ -250,18 +250,16 @@ function prettyPrintLogline(
     message,
     messageTruncated,
     timestampInMs,
-    source,
   }: RuntimeLog,
   print: Printer
 ) {
   const date = format(timestampInMs, dateTimeFormat);
   const levelIcon = getLevelIcon(level);
-  const sourceIcon = getSourceIcon(source);
   const detailsLine = `${chalk.dim(date)}  ${levelIcon}  ${chalk.bold(
     method
   )}  ${chalk.grey(status <= 0 ? '---' : status)}  ${chalk.dim(
     domain
-  )}  ${sourceIcon}  ${path}`;
+  )}  ${path}`;
   print(
     `${detailsLine}\n${'-'.repeat(
       [
@@ -270,7 +268,6 @@ function prettyPrintLogline(
         method.length,
         statusWidth,
         domain.length,
-        sourceIcon.length,
         path.length,
       ].reduce((sum, length) => sum + 2 + length)
     )}\n`
@@ -282,13 +279,6 @@ function prettyPrintLogline(
 
 function getLevelIcon(level: string) {
   return level === 'error' ? '🚫' : level === 'warning' ? '⚠️' : 'ℹ️';
-}
-
-function getSourceIcon(source: string) {
-  if (source === 'edge-function') return 'ന';
-  if (source === 'edge-middleware') return 'ɛ';
-  if (source === 'serverless') return 'ƒ';
-  return ' ';
 }
 
 function sanitize(log: BuildLog): string {


### PR DESCRIPTION
Remove request function type icons from `vercel logs` output.

---
Linear Issue: [O11Y-3844](https://linear.app/vercel/issue/O11Y-3844/remove-the-request-function-type-from-the-vercel-cli-logs)

<p><a href="https://cursor.com/background-agent?bcId=bc-0d462e09-c14c-4bc9-a4fe-f0ee7d581181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0d462e09-c14c-4bc9-a4fe-f0ee7d581181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR removes cosmetic function type icons (lambda/epsilon symbols) from CLI log output formatting, with no security, auth, or business logic changes.
> 
> - Removes `getSourceIcon` helper functions from two files
> - Removes source icon display from log line formatting
> - Adds changeset documenting the cosmetic change
>
> <sup>Risk assessment for [commit 45397bf](https://github.com/vercel/vercel/commit/45397bf726270e8f84318b9f7e754ef0e32b12e6).</sup>
<!-- VADE_RISK_END -->