### PR TITLE
static prebuilt - framework agnostic

### DIFF
--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -106,7 +106,21 @@ export const buildsSchema = {
         minLength: 3,
         maxLength: 256,
       },
-      config: { type: 'object' },
+      config: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          /**
+           * User-configured deployment ID for skew protection (e.g. prebuilt deployments).
+           * Max 32 chars; alphanumeric, hyphen, underscore only; must not start with "dpl_".
+           */
+          deploymentId: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 32,
+          },
+        },
+      },
     },
   },
 };

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -45,6 +45,11 @@ export interface Config {
   framework?: string | null;
   nodeVersion?: string;
   middleware?: boolean;
+  /**
+   * User-configured deployment ID for skew protection, provided via
+   * the `config` object in `vercel.json` for a given build.
+   */
+  deploymentId?: string;
   [key: string]: unknown;
 }
 

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -37,6 +37,7 @@ import {
   cloneEnv,
   getInstalledPackageVersion,
   defaultCachePathGlob,
+  type BuildResultV2,
 } from '@vercel/build-utils';
 import type { Route, RouteWithSrc } from '@vercel/routing-utils';
 import * as BuildOutputV1 from './utils/build-output-v1';
@@ -863,7 +864,13 @@ export const build: BuildV2 = async ({
       }
     }
 
-    return { routes, images, output };
+    const buildResult: BuildResultV2 = { routes, images, output };
+
+    if (typeof config.deploymentId === 'string' && config.deploymentId) {
+      buildResult.deploymentId = config.deploymentId;
+    }
+
+    return buildResult;
   }
 
   if (!config.zeroConfig && entrypoint.endsWith('.sh')) {


### PR DESCRIPTION
use vercel.json deploymentId if provided

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new optional deploymentId config property with schema validation and passes it through to build results, which is a straightforward feature addition with proper validation constraints.
> 
> - Adds deploymentId schema property with minLength: 1, maxLength: 32 validation
> - Passes config.deploymentId through to BuildResultV2 when present
> - Adds unit test verifying deploymentId flows from vercel.json to output config
>
> <sup>Risk assessment for [commit 69da30e](https://github.com/vercel/vercel/commit/69da30e30982d1cf02346fe2f8a21b8dccbeafdd).</sup>
<!-- VADE_RISK_END -->