### PR TITLE
Expand CLI CODEOWNERS for broader team contributions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,14 +22,20 @@
 /packages/oidc                           @vercel/ci-cd @vercel/identity-and-access-management @vercel/ai-sdk
 /packages/oidc-aws-credentials-provider  @vercel/ci-cd @vercel/identity-and-access-management
 /packages/config                         @vercel/ci-cd @vercel/edge-ingress @pranavkarthik10 @MatthewStanciu
-/packages/cli/src/commands/integration/  @vercel/ci-cd @vercel/marketplace
-/packages/cli/src/commands/integration-resource/ @vercel/ci-cd @vercel/marketplace
-/packages/cli/src/util/integration/      @vercel/ci-cd @vercel/marketplace
-/packages/cli/src/util/telemetry/commands/integration/ @vercel/ci-cd @vercel/marketplace
-/packages/cli/test/mocks/integration.ts  @vercel/ci-cd @vercel/marketplace
-/packages/cli/test/unit/commands/integration/ @vercel/ci-cd @vercel/marketplace
-/packages/cli/test/unit/commands/integration-resource/ @vercel/ci-cd @vercel/marketplace
-/packages/cli/test/unit/util/integration/ @vercel/ci-cd @vercel/marketplace
+/packages/cli/                           @vercel/ci-cd @vercel/vercel-cli-approvers
+/packages/cli/src/commands/integration/  @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
+/packages/cli/src/commands/integration-resource/ @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
+/packages/cli/src/util/integration/      @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
+/packages/cli/src/util/telemetry/commands/integration/ @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
+/packages/cli/test/mocks/integration.ts  @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
+/packages/cli/test/unit/commands/integration/ @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
+/packages/cli/test/unit/commands/integration-resource/ @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
+/packages/cli/test/unit/util/integration/ @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
+/packages/cli-auth/                      @vercel/ci-cd @vercel/vercel-cli-approvers
+/packages/client/                        @vercel/ci-cd @vercel/vercel-cli-approvers
+/packages/frameworks/                    @vercel/ci-cd @vercel/vercel-cli-approvers
+/packages/error-utils/                   @vercel/ci-cd @vercel/vercel-cli-approvers
+/packages/detect-agent/                  @vercel/ci-cd @vercel/vercel-cli-approvers
 /packages/python*                        @vercel/ci-cd @vercel/team-python
 /python                                  @vercel/ci-cd @vercel/team-python
 /.github/workflows/*python*.yml          @vercel/ci-cd @vercel/team-python
@@ -40,3 +46,4 @@
 .changeset/
 /packages/*/CHANGELOG.md
 /packages/*/package.json
+/pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- Add `@vercel/vercel-cli-approvers` as an approved reviewer for `/packages/cli/` and related packages (`cli-auth`, `client`, `frameworks`, `error-utils`, `detect-agent`)
- Add `@vercel/vercel-cli-approvers` to existing marketplace integration paths within the CLI
- Make `/pnpm-lock.yaml` unrestricted (no owner required), matching the existing treatment of `.changeset/` and changelogs

## Test plan
- [ ] Verify `@vercel/vercel-cli-approvers` team exists on GitHub
- [ ] Confirm team slug matches `vercel-cli-approvers` (adjust if different)
- [ ] Validate CODEOWNERS syntax is correct via GitHub's PR file-ownership display

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR expands CODEOWNERS to add a new approver team for CLI packages and makes pnpm-lock.yaml unrestricted, which widens who can approve changes to security-sensitive paths like cli-auth.
> 
> - Adds @vercel/vercel-cli-approvers as owner for /packages/cli/ and /packages/cli-auth/
> - Makes /pnpm-lock.yaml unrestricted (no owner required)
> - Expands approval permissions for multiple CLI-related packages
>
> <sup>Risk assessment for [commit 7a22d97](https://github.com/vercel/vercel/commit/7a22d973c9a2d989502df3b29ec8e9a45b8e453f).</sup>
<!-- VADE_RISK_END -->