### PR TITLE
Fix vercel-cli skill discovery by adding description to SKILL.md

### DIFF
--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: vercel-cli
+description: Deploy, manage, and develop projects on Vercel from the command line
 ---
 
 # Vercel CLI Skill


### PR DESCRIPTION
The npx skills add command requires both name and description fields in the SKILL.md frontmatter. This fixes the "No valid skills found" error when installing the vercel-cli skill.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a description field to SKILL.md frontmatter metadata, which is a documentation-only change with no code logic impact.
> 
> - Adds description field to SKILL.md frontmatter for skill discovery
>
> <sup>Risk assessment for [commit 807f530](https://github.com/vercel/vercel/commit/807f53066904a4f84deca896b6ca614ab6959a6d).</sup>
<!-- VADE_RISK_END -->