### PR TITLE
Fix PR title escaping in E2E trigger check

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -22,17 +22,21 @@ jobs:
       should-run: ${{ steps.check.outputs.should-run }}
     steps:
       - id: check
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HAS_E2E_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests') }}
         run: |
           # Run if run-e2e-tests label is present
-          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests') }}" = "true" ]; then
+          if [ "$HAS_E2E_LABEL" = "true" ]; then
             echo "E2E tests triggered by run-e2e-tests label"
             echo "should-run=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # Run if Version Packages PR from vercel-release-bot
-          if [ "${{ github.event.pull_request.title }}" = "Version Packages" ]; then
-            if [ "${{ github.event.pull_request.user.login }}" = "vercel-release-bot" ]; then
+          if [ "$PR_TITLE" = "Version Packages" ]; then
+            if [ "$PR_AUTHOR" = "vercel-release-bot" ]; then
               echo "E2E tests triggered by Version Packages PR from vercel-release-bot"
               echo "should-run=true" >> $GITHUB_OUTPUT
             else


### PR DESCRIPTION
Move GitHub Actions expressions into env block to prevent backticks and special characters in PR titles from being interpreted as command substitution in bash.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR refactors GitHub Actions workflow to move expressions into env block for safer shell variable handling, with no changes to security logic or access controls.
> 
> - Moves GitHub Actions expressions from inline bash to env block for proper escaping
> - CI workflow change only affects E2E test trigger conditions
> - No changes to authentication, authorization, or business logic
>
> <sup>Risk assessment for [commit c650831](https://github.com/vercel/vercel/commit/c65083134404e05c3a5c135678101150c4f78674).</sup>
<!-- VADE_RISK_END -->