### PR TITLE
[service] sync service dependencies in dev mode

### DIFF
--- a/.changeset/cold-experts-beam.md
+++ b/.changeset/cold-experts-beam.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': minor
+'@vercel/python': minor
+'vercel': minor
+---
+
+[services] synchronize dependencies in dev mode for JS/TS and Python services

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -117,6 +117,29 @@ export interface SpawnOptionsExtended extends SpawnOptions {
    * the error code, stdout and stderr.
    */
   ignoreNon0Exit?: boolean;
+
+  /**
+   * Writable stream to pipe stdout to (e.g., for prefixing output in multi-service mode).
+   * When provided, stdio is automatically set to 'pipe'.
+   */
+  outputStream?: NodeJS.WritableStream;
+
+  /**
+   * Writable stream to pipe stderr to (e.g., for prefixing output in multi-service mode).
+   * When provided, stdio is automatically set to 'pipe'.
+   */
+  errorStream?: NodeJS.WritableStream;
+}
+
+export interface NpmInstallOutput {
+  /**
+   * Writable stream for stdout (e.g., for prefixing output in multi-service mode)
+   */
+  stdout?: NodeJS.WritableStream;
+  /**
+   * Writable stream for stderr (e.g., for prefixing output in multi-service mode)
+   */
+  stderr?: NodeJS.WritableStream;
 }
 
 export function spawnAsync(
@@ -126,10 +149,24 @@ export function spawnAsync(
 ) {
   return new Promise<void>((resolve, reject) => {
     const stderrLogs: Buffer[] = [];
-    opts = { stdio: 'inherit', ...opts };
+    const hasCustomStreams = opts.outputStream || opts.errorStream;
+
+    if (hasCustomStreams) {
+      opts = { ...opts, stdio: ['inherit', 'pipe', 'pipe'] };
+    } else {
+      opts = { stdio: 'inherit', ...opts };
+    }
+
     const child = spawn(command, args, opts);
 
-    if (opts.stdio === 'pipe' && child.stderr) {
+    if (hasCustomStreams) {
+      if (child.stdout && opts.outputStream) {
+        child.stdout.pipe(opts.outputStream);
+      }
+      if (child.stderr && opts.errorStream) {
+        child.stderr.pipe(opts.errorStream);
+      }
+    } else if (opts.stdio === 'pipe' && child.stderr) {
       child.stderr.on('data', data => stderrLogs.push(data));
     }
 
@@ -146,7 +183,7 @@ export function spawnAsync(
         new NowBuildError({
           code: `BUILD_UTILS_SPAWN_${code || signal}`,
           message:
-            opts.stdio === 'inherit'
+            opts.stdio === 'inherit' || hasCustomStreams
               ? `${cmd} exited with ${code || signal}`
               : stderrLogs.map(line => line.toString()).join(''),
         })
@@ -731,10 +768,12 @@ async function runInstallCommand({
   packageManager,
   args,
   opts,
+  output,
 }: {
   packageManager: CliType;
   args: string[];
   opts: SpawnOptionsExtended;
+  output?: NpmInstallOutput;
 }) {
   const { commandArguments, prettyCommand } =
     getInstallCommandForPackageManager(packageManager, args);
@@ -743,6 +782,9 @@ async function runInstallCommand({
   if (process.env.NPM_ONLY_PRODUCTION) {
     commandArguments.push('--production');
   }
+
+  opts.outputStream = output?.stdout;
+  opts.errorStream = output?.stderr;
 
   await spawnAsync(packageManager, commandArguments, opts);
 }
@@ -785,7 +827,8 @@ export async function runNpmInstall(
   args: string[] = [],
   spawnOpts?: SpawnOptions,
   meta?: Meta,
-  projectCreatedAt?: number
+  projectCreatedAt?: number,
+  output?: NpmInstallOutput
 ): Promise<boolean> {
   if (meta?.isDev) {
     debug('Skipping dependency installation because dev mode is enabled');
@@ -850,7 +893,11 @@ export async function runNpmInstall(
     }
 
     const installTime = Date.now();
-    console.log('Installing dependencies...');
+    if (output?.stdout) {
+      output.stdout.write('Installing dependencies...\n');
+    } else {
+      console.log('Installing dependencies...');
+    }
     debug(`Installing to ${destPath}`);
 
     const opts: SpawnOptionsExtended = { cwd: destPath, ...spawnOpts };
@@ -881,6 +928,7 @@ export async function runNpmInstall(
       packageManager: cliType,
       args,
       opts,
+      output,
     });
 
     debug(`Install complete [${Date.now() - installTime}ms]`);

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -38,6 +38,7 @@ import {
   findPackageJson,
   traverseUpDirectories,
   PipInstallResult,
+  NpmInstallOutput,
 } from './fs/run-user-scripts';
 import {
   getLatestNodeVersion,
@@ -85,6 +86,7 @@ export {
   getSupportedBunVersion,
   detectPackageManager,
   runNpmInstall,
+  NpmInstallOutput,
   runBundleInstall,
   runPipInstall,
   PipInstallResult,

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import ms from 'ms';
-import { Transform, type TransformCallback } from 'stream';
+import { Transform, Writable, type TransformCallback } from 'stream';
 import type { ChildProcess } from 'child_process';
 import getPort from 'get-port';
 import chalk from 'chalk';
@@ -11,7 +11,9 @@ import {
   getNodeBinPaths,
   spawnCommand,
   NowBuildError,
+  runNpmInstall,
   type BuilderV3,
+  type Config,
 } from '@vercel/build-utils';
 import { checkForPort } from './port-utils';
 import { importBuilders } from '../build/import-builders';
@@ -377,6 +379,7 @@ export class ServicesOrchestrator {
           env,
           serviceCount: this.services.length,
           pythonServiceCount: this.pythonServiceCount,
+          syncDependencies: true,
         },
         files: {},
         onStdout: (data: Buffer) => logger.stdout.write(data),
@@ -424,6 +427,8 @@ export class ServicesOrchestrator {
         `No dev server available for service "${service.name}" (framework: ${service.framework})`
       );
     }
+
+    await this.syncDependencies(service.builder?.config, workspacePath, logger);
 
     const port = await getPort();
     env.PORT = `${port}`;
@@ -506,6 +511,119 @@ export class ServicesOrchestrator {
     });
 
     return Promise.race([checkForPort(port, STARTUP_TIMEOUT), processError]);
+  }
+
+  // This is needed, because only BuilderV3 exposes a dev server,
+  // but we still want to keep dependencies in sync for BuilderV2 (e.g. Next/Vite/etc).
+  // We'll try with the provided installCommand (if any) and then fallback
+  // to just trying to install dependencnies for Node.
+  private async syncDependencies(
+    config: Config | undefined,
+    workspacePath: string,
+    logger: ServiceLogger
+  ): Promise<void> {
+    logger.stdout.write(`${chalk.gray('Synchronizing dependencies...')}\n`);
+    const installCommand =
+      typeof config?.installCommand === 'string'
+        ? config.installCommand.trim()
+        : '';
+    if (installCommand) {
+      await this.runInstallCommand(installCommand, workspacePath, logger);
+    } else {
+      await this.maybeInstallJSDependencies(workspacePath, logger);
+    }
+  }
+
+  private async runBuffered(
+    logger: ServiceLogger,
+    task: (stdout: Writable, stderr: Writable) => Promise<void>
+  ): Promise<void> {
+    const captured: Array<['stdout' | 'stderr', Buffer]> = [];
+    const bufStdout = new Writable({
+      write(chunk, _enc, cb) {
+        const b = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        captured.push(['stdout', b]);
+        if (output.debugEnabled) logger.stdout.write(b);
+        cb();
+      },
+    });
+    const bufStderr = new Writable({
+      write(chunk, _enc, cb) {
+        const b = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        captured.push(['stderr', b]);
+        if (output.debugEnabled) logger.stderr.write(b);
+        cb();
+      },
+    });
+
+    try {
+      await task(bufStdout, bufStderr);
+    } catch (err) {
+      for (const [channel, chunk] of captured) {
+        logger[channel].write(chunk);
+      }
+      throw err;
+    }
+  }
+
+  private async runInstallCommand(
+    command: string,
+    workspacePath: string,
+    logger: ServiceLogger
+  ): Promise<void> {
+    await this.runBuffered(logger, (stdout, stderr) => {
+      return new Promise<void>((resolve, reject) => {
+        output.debug(
+          `Running install command: "${command}" in ${workspacePath}`
+        );
+        const child = spawnCommand(command, {
+          cwd: workspacePath,
+          stdio: ['inherit', 'pipe', 'pipe'],
+        });
+
+        child.stdout?.on('data', (chunk: Buffer) => stdout.write(chunk));
+        child.stderr?.on('data', (chunk: Buffer) => stderr.write(chunk));
+
+        child.on('error', reject);
+        child.on('exit', (code, signal) => {
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(
+              new NowBuildError({
+                code: 'INSTALL_COMMAND_FAILED',
+                message: `Install command "${command}" failed with code ${code}, signal ${signal}`,
+              })
+            );
+          }
+        });
+      });
+    });
+  }
+
+  private async maybeInstallJSDependencies(
+    workspacePath: string,
+    logger: ServiceLogger
+  ): Promise<void> {
+    await this.runBuffered(logger, async (stdout, stderr) => {
+      try {
+        await runNpmInstall(
+          workspacePath,
+          [],
+          undefined,
+          undefined,
+          undefined,
+          { stdout, stderr }
+        );
+      } catch (err) {
+        throw new NowBuildError({
+          code: 'NODE_DEPENDENCY_SYNC_FAILED',
+          message: `Failed to install Node.JS dependencies: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        });
+      }
+    });
   }
 
   private generateServiceUrlEnvVars(

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -1,9 +1,9 @@
 import { spawn } from 'child_process';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join, delimiter } from 'path';
+import { join, delimiter, dirname } from 'path';
 import type { ChildProcess } from 'child_process';
 import type { StartDevServer } from '@vercel/build-utils';
-import { debug, NowBuildError } from '@vercel/build-utils';
+import { debug, glob, NowBuildError } from '@vercel/build-utils';
 import {
   PYTHON_CANDIDATE_ENTRYPOINTS,
   detectPythonEntrypoint,
@@ -16,7 +16,12 @@ import {
   getVenvPythonBin,
   getVenvBinDir,
 } from './utils';
-import { findUvBinary } from './uv';
+import { findUvBinary, getProtectedUvEnv } from './uv';
+import {
+  detectInstallSource,
+  exportRequirementsFromPipfile,
+  type ManifestType,
+} from './install';
 
 // Silence all Node.js warnings during the dev server lifecycle to avoid noise and only show the python logs.
 // Specifically, this is implemented to silence the [DEP0060] DeprecationWarning warning from the http-proxy library.
@@ -77,6 +82,190 @@ function createLogListener(
       }
     }
   };
+}
+
+interface SyncDependenciesOptions {
+  workPath: string;
+  uvPath: string | null;
+  pythonBin: string;
+  env: NodeJS.ProcessEnv;
+  onStdout?: (buf: Buffer) => void;
+  onStderr?: (buf: Buffer) => void;
+}
+
+async function syncDependencies({
+  workPath,
+  uvPath,
+  pythonBin,
+  env,
+  onStdout,
+  onStderr,
+}: SyncDependenciesOptions): Promise<void> {
+  let fsFiles = await glob('**', workPath);
+  const installInfo = await detectInstallSource({
+    workPath,
+    entryDirectory: '.',
+    fsFiles,
+  });
+
+  const { manifestType, manifestPath } = installInfo;
+
+  if (!manifestType || !manifestPath) {
+    debug('No Python project manifest found, skipping dependency sync');
+    return;
+  }
+
+  const writeOut = (msg: string) => {
+    if (onStdout) {
+      onStdout(Buffer.from(msg));
+    } else {
+      process.stdout.write(msg);
+    }
+  };
+
+  const writeErr = (msg: string) => {
+    if (onStderr) {
+      onStderr(Buffer.from(msg));
+    } else {
+      process.stderr.write(msg);
+    }
+  };
+
+  // Silence the output, but capture it for failures
+  const captured: Array<['stdout' | 'stderr', Buffer]> = [];
+
+  try {
+    await runSync({
+      manifestType,
+      manifestPath,
+      uvPath,
+      pythonBin,
+      env,
+      onStdout: data => captured.push(['stdout', data]),
+      onStderr: data => captured.push(['stderr', data]),
+    });
+  } catch (err) {
+    for (const [channel, chunk] of captured) {
+      (channel === 'stdout' ? writeOut : writeErr)(chunk.toString());
+    }
+
+    throw new NowBuildError({
+      code: 'PYTHON_DEPENDENCY_SYNC_FAILED',
+      message: `Failed to install Python dependencies from ${manifestType}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    });
+  }
+}
+
+interface RunSyncOptions {
+  manifestType: ManifestType;
+  manifestPath: string;
+  uvPath: string | null;
+  pythonBin: string;
+  env: NodeJS.ProcessEnv;
+  onStdout?: (buf: Buffer) => void;
+  onStderr?: (buf: Buffer) => void;
+}
+
+async function runSync({
+  manifestType,
+  manifestPath,
+  uvPath,
+  pythonBin,
+  env,
+  onStdout,
+  onStderr,
+}: RunSyncOptions): Promise<void> {
+  const projectDir = dirname(manifestPath);
+
+  const pip = uvPath
+    ? { cmd: uvPath, prefix: ['pip', 'install'] }
+    : { cmd: pythonBin, prefix: ['-m', 'pip', 'install'] };
+
+  let spawnCmd: string;
+  let spawnArgs: string[];
+
+  switch (manifestType) {
+    case 'uv.lock': {
+      if (!uvPath) {
+        throw new NowBuildError({
+          code: 'PYTHON_DEPENDENCY_SYNC_FAILED',
+          message: 'uv is required to install dependencies from uv.lock.',
+          link: 'https://docs.astral.sh/uv/getting-started/installation/',
+          action: 'Install uv',
+        });
+      }
+      spawnCmd = uvPath;
+      spawnArgs = ['sync'];
+      break;
+    }
+    case 'pyproject.toml': {
+      spawnCmd = pip.cmd;
+      spawnArgs = [...pip.prefix, '-e', '.'];
+      break;
+    }
+    case 'Pipfile.lock':
+    case 'Pipfile': {
+      const devPython = getDefaultPythonVersion({ isDev: true });
+      const requirementsPath = await exportRequirementsFromPipfile({
+        pythonPath: devPython.pythonPath,
+        pipPath: devPython.pipPath,
+        uvPath,
+        projectDir,
+        meta: { isDev: true },
+      });
+      spawnCmd = pip.cmd;
+      spawnArgs = [...pip.prefix, '-r', requirementsPath];
+      break;
+    }
+    case 'requirements.txt': {
+      spawnCmd = pip.cmd;
+      spawnArgs = [...pip.prefix, '-r', manifestPath];
+      break;
+    }
+    default:
+      debug(`Unknown manifest type: ${manifestType}`);
+      return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    debug(`Running "${spawnCmd} ${spawnArgs.join(' ')}" in ${projectDir}...`);
+    const child = spawn(spawnCmd, spawnArgs, {
+      cwd: projectDir,
+      env: getProtectedUvEnv(env),
+      stdio: ['inherit', 'pipe', 'pipe'],
+    });
+
+    child.stdout?.on('data', (data: Buffer) => {
+      if (onStdout) {
+        onStdout(data);
+      } else {
+        process.stdout.write(data.toString());
+      }
+    });
+
+    child.stderr?.on('data', (data: Buffer) => {
+      if (onStderr) {
+        onStderr(data);
+      } else {
+        process.stderr.write(data.toString());
+      }
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `Command "${spawnCmd} ${spawnArgs.join(' ')}" failed with code ${code}, signal ${signal}`
+          )
+        );
+      }
+    });
+  });
 }
 
 // Persistent dev servers keyed by workPath + modulePath so background tasks
@@ -203,7 +392,7 @@ async function getMultiServicePythonRunner(
 
   // Create a per-service .venv, so deps are managed separately.
   const venvPath = join(workPath, '.venv');
-  await ensureVenv({ pythonPath: systemPython, venvPath, uvPath });
+  await ensureVenv({ pythonPath: systemPython, venvPath, uvPath, quiet: true });
   debug(`Created virtualenv at ${venvPath} for multi-service dev`);
 
   const pythonBin = getVenvPythonBin(venvPath);
@@ -361,6 +550,26 @@ export const startDevServer: StartDevServer = async opts => {
           // ignore write errors
         }
       }
+    }
+
+    if (meta.syncDependencies) {
+      const gray = '\x1b[90m';
+      const reset = '\x1b[0m';
+      const syncMessage = `${gray}Synchronizing dependencies...${reset}\n`;
+      if (onStdout) {
+        onStdout(Buffer.from(syncMessage));
+      } else {
+        console.log(syncMessage);
+      }
+
+      await syncDependencies({
+        workPath,
+        uvPath,
+        pythonBin: spawnCommand,
+        env,
+        onStdout,
+        onStderr,
+      });
     }
 
     // Now spawn the actual server process

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -60,10 +60,12 @@ export async function ensureVenv({
   pythonPath,
   venvPath,
   uvPath,
+  quiet,
 }: {
   pythonPath: string;
   venvPath: string;
   uvPath?: string | null;
+  quiet?: boolean;
 }) {
   const marker = join(venvPath, 'pyvenv.cfg');
   try {
@@ -73,7 +75,9 @@ export async function ensureVenv({
     // fall through to creation
   }
   await fs.promises.mkdir(venvPath, { recursive: true });
-  console.log(`Creating virtual environment at "${venvPath}"...`);
+  if (!quiet) {
+    console.log(`Creating virtual environment at "${venvPath}"...`);
+  }
   if (uvPath) {
     await execa(uvPath, ['venv', venvPath]);
   } else {


### PR DESCRIPTION
Makes `vc dev` to synchronize service dependencies in multi-service mode, so a user only needs to call `vc dev` after `git clone` to start development. Currently, only JS and Python services are supported

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds dependency synchronization functionality for JS/Python services in dev mode, consisting of new helper functions, stream handling, and optional output parameters - all additive feature code with no security, auth, or data integrity changes.
> 
> - Adds `syncDependencies` flag and methods to orchestrate npm/pip installs in multi-service dev mode
> - Extends `spawnAsync` and `runNpmInstall` with optional output/error stream parameters
> - Adds Python manifest detection and sync logic for pyproject.toml, uv.lock, pylock.toml
>
> <sup>Risk assessment for [commit 7723e8e](https://github.com/vercel/vercel/commit/7723e8ea127102ce8b4067ff9957ac3a5efe5d84).</sup>
<!-- VADE_RISK_END -->