### PR TITLE
[python] preserve uv error code

### DIFF
--- a/.changeset/many-laws-end.md
+++ b/.changeset/many-laws-end.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+[python] preserve error code on uv error

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -114,11 +114,20 @@ export class UvRunner {
         env: getProtectedUvEnv(process.env),
       });
     } catch (err) {
-      throw new Error(
+      const error: Error & { code?: unknown } = new Error(
         `Failed to run "${pretty}": ${
           err instanceof Error ? err.message : String(err)
         }`
       );
+      // retain code/signal to ensure it's treated as a build error
+      if (err && typeof err === 'object') {
+        if ('code' in err) {
+          error.code = (err as { code: number | string }).code;
+        } else if ('signal' in err) {
+          error.code = (err as { signal: string }).signal;
+        }
+      }
+      throw error;
     }
   }
 


### PR DESCRIPTION
Fixes integration test on API:
```
  ● that the error message is trimmed

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `that the error message is trimmed 1`

    Snapshot: "1"
    Received: ""

      39 |   }
      40 |
    > 41 |   expect(errorCode).toMatchInlineSnapshot(`"1"`);
         |                     ^
      42 |
      43 |   if (!errorMessage) {
      44 |     throw new Error('errorMessage is undefined');

      at Object.toMatchInlineSnapshot (patch-build-to-error-message-size.test.ts:41:21)
```


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR preserves error code/signal information when rethrowing errors in the uv runner, which is a minor error handling improvement to fix a test.
> 
> - Error handling: preserves code/signal property when rethrowing caught errors
> - Adds changeset for patch version bump
>
> <sup>Risk assessment for [commit b3562ff](https://github.com/vercel/vercel/commit/b3562ffc79ee0c29c0c38da1e3976902d0e6d45a).</sup>
<!-- VADE_RISK_END -->