### PR TITLE
cli: add more precise auth failure messages to error / debug logs

### DIFF
--- a/.changeset/eleven-foxes-worry.md
+++ b/.changeset/eleven-foxes-worry.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add more precise errors and debug messages for auth issues

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -39,6 +39,11 @@ interface AuthConfig {
    * Used to optimistically check if the token is still valid.
    */
   expiresAt?: number;
+  /**
+   * Indicates where the token was provided from when using external tokens.
+   * Only set when token is provided via `--token` flag or `VERCEL_TOKEN` env var.
+   */
+  tokenSource?: 'flag' | 'env';
 }
 
 export interface GlobalConfig {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -477,11 +477,13 @@ const main = async () => {
   }
 
   // Check for VERCEL_TOKEN environment variable if --token flag not provided
-  if (
-    typeof parsedArgs.flags['--token'] !== 'string' &&
-    process.env.VERCEL_TOKEN
-  ) {
+  // Track where the token came from for better error messages
+  let tokenSource: 'flag' | 'env' | undefined;
+  if (typeof parsedArgs.flags['--token'] === 'string') {
+    tokenSource = 'flag';
+  } else if (process.env.VERCEL_TOKEN) {
     parsedArgs.flags['--token'] = process.env.VERCEL_TOKEN;
+    tokenSource = 'env';
   }
 
   if (
@@ -525,7 +527,7 @@ const main = async () => {
       return 1;
     }
 
-    client.authConfig = { token, skipWrite: true };
+    client.authConfig = { token, skipWrite: true, tokenSource };
 
     // Don't use team from config if `--token` was set
     if (client.config && client.config.currentTeam) {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -117,6 +117,8 @@ export default class Client extends EventEmitter implements Stdio {
   nonInteractive: boolean;
   /** Dangerously skip all permission prompts (--dangerously-skip-permissions flag) */
   dangerouslySkipPermissions: boolean;
+  /** Track if we've already logged the token source debug message */
+  private _loggedTokenSource: boolean = false;
 
   constructor(opts: ClientOptions) {
     super();
@@ -193,7 +195,20 @@ export default class Client extends EventEmitter implements Stdio {
 
     // If we have a valid access token, do nothing
     if (isValidAccessToken(authConfig)) {
-      output.debug('Valid access token, skipping token refresh.');
+      if (!this._loggedTokenSource) {
+        if (authConfig.tokenSource === 'flag') {
+          output.debug(
+            'Using token from `--token` argument, skipping token refresh.'
+          );
+        } else if (authConfig.tokenSource === 'env') {
+          output.debug(
+            'Using token from VERCEL_TOKEN environment variable, skipping token refresh.'
+          );
+        } else {
+          output.debug('Valid access token, skipping token refresh.');
+        }
+        this._loggedTokenSource = true;
+      }
       return;
     }
 

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -92,12 +92,22 @@ export class TeamDeleted extends NowError<'TEAM_DELETED', {}> {
  * because the token is not valid anymore.
  */
 export class InvalidToken extends NowError<'NOT_AUTHORIZED', {}> {
-  constructor() {
+  constructor(tokenSource?: 'flag' | 'env') {
+    let message: string;
+    if (tokenSource === 'flag') {
+      message =
+        'The token provided via `--token` argument is not valid. Please provide a valid token.';
+    } else if (tokenSource === 'env') {
+      message =
+        'The token provided via VERCEL_TOKEN environment variable is not valid. Please provide a valid token.';
+    } else {
+      message = `The specified token is not valid. Use ${getCommandName(
+        'login'
+      )} to generate a new token.`;
+    }
     super({
-      code: `NOT_AUTHORIZED`,
-      message: `The specified token is not valid. Use ${getCommandName(
-        `login`
-      )} to generate a new token.`,
+      code: 'NOT_AUTHORIZED',
+      message,
       meta: {},
     });
   }

--- a/packages/cli/src/util/get-user.ts
+++ b/packages/cli/src/util/get-user.ts
@@ -15,7 +15,7 @@ export default async function getUser(client: Client) {
     return res.user;
   } catch (error) {
     if (error instanceof APIError && error.status === 403) {
-      throw new InvalidToken();
+      throw new InvalidToken(client.authConfig.tokenSource);
     }
 
     throw error;

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -274,7 +274,7 @@ export async function getLinkedProject(
       output.stopSpinner();
 
       if (err.missingToken || err.invalidToken) {
-        throw new InvalidToken();
+        throw new InvalidToken(client.authConfig.tokenSource);
       } else if (err.code === 'forbidden' || err.code === 'team_unauthorized') {
         throw new NowBuildError({
           message: `Could not retrieve Project Settings. To link your Project, remove the ${outputCode(

--- a/packages/cli/src/util/teams/get-teams.ts
+++ b/packages/cli/src/util/teams/get-teams.ts
@@ -62,7 +62,7 @@ export default async function getTeams(
     return body;
   } catch (error) {
     if (error instanceof APIError && error.status === 403) {
-      throw new InvalidToken();
+      throw new InvalidToken(client.authConfig.tokenSource);
     }
     throw error;
   }


### PR DESCRIPTION
This PR adds more precise auth error messages to errors / debug logs

## Before

Right now you can accidentally inject an env e.g. `VERCEL_TOKEN` which will lead to confusing error logs.

> I just logged in but it says the token is not valid

```
▲ vc
Vercel CLI 50.15.1
> NOTE: The Vercel CLI now collects telemetry regarding usage of the CLI.
> This information is used to shape the CLI roadmap and prioritize features.
> You can learn more, including how to opt-out if you'd not like to participate in this program, by visiting the following URL:
> https://vercel.com/docs/cli/about-telemetry
> No existing credentials found. Please log in:

  Visit https://vercel.com/oauth/device?user_code=VRND-TNVN

  Congratulations! You are now signed in.

  To deploy something, run `vercel`.

  💡 To deploy every commit automatically,
  connect a Git Repository (vercel.link/git (https://vercel.link/git)).
Error: The specified token is not valid. Use `vercel login` to generate a new token.
```

> It tells me my token is valid, but then the API returns `403`, why if it's valid?

```
▲ vc link --debug
> [debug] [2026-02-11T14:20:46.747Z] Found config in file "/Users/ecklf/Developer/vercel/rust-fluid/vercel.json"
Vercel CLI 50.15.1
> [debug] [2026-02-11T14:20:46.749Z] user supplied known subcommand: "link"
> [debug] [2026-02-11T14:20:46.751Z] Arrived at home directory
> [debug] [2026-02-11T14:20:46.762Z] Found git root via "git rev-parse --show-toplevel" - detected "/Users/ecklf/Developer/vercel/rust-fluid" as repo root
? Set up "~/Developer/vercel/rust-fluid"? yes
> [debug] [2026-02-11T14:20:48.365Z] Spinner invoked (Loading scopes…) with a 1000ms delay
> [debug] [2026-02-11T14:20:48.366Z] Valid access token, skipping token refresh.
> [debug] [2026-02-11T14:20:48.366Z] Valid access token, skipping token refresh.
> [debug] [2026-02-11T14:20:48.386Z] #1 → GET https://api.vercel.com/v2/user
> [debug] [2026-02-11T14:20:48.387Z] #2 → GET https://api.vercel.com/v1/teams
> [debug] [2026-02-11T14:20:48.917Z] #1 ← 403 Forbidden: sfo1::6q2tr-1770819648817-edd83698b280 [531ms]
Error: The specified token is not valid. Use `vercel login` to generate a new token.
> [debug] [2026-02-11T14:20:48.922Z] #2 ← 403 Forbidden: sfo1::bwtp8-1770819648820-0fc2916d7f11 [535ms]
```


## After

```diff
Vercel CLI 50.15.1
? Set up and deploy “~/Developer/vercel/rust-fluid”? yes
+ Error: The token provided via VERCEL_TOKEN environment variable is not valid. Please provide a valid token.
```

```diff
Vercel CLI 50.15.1
 [debug] [2026-02-11T14:48:09.628Z] user supplied no target, defaulting to deploy
 [debug] [2026-02-11T14:48:09.643Z] Arrived at home directory
 [debug] [2026-02-11T14:48:09.659Z] Found git root via "git rev-parse --show-toplevel" - detected "/Users/ecklf/Developer/vercel/rust-fluid" as repo root
? Set up and deploy “~/Developer/vercel/rust-fluid”? yes
 [debug] [2026-02-11T14:48:11.040Z] Spinner invoked (Loading scopes…) with a 1000ms delay
 [debug] [2026-02-11T14:48:11.041Z] Using token from VERCEL_TOKEN environment variable, skipping token refresh.
 [debug] [2026-02-11T14:48:11.059Z] #1 → GET https://api.vercel.com/v2/user
 [debug] [2026-02-11T14:48:11.060Z] #2 → GET https://api.vercel.com/v1/teams
(node:96529) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
 [debug] [2026-02-11T14:48:11.656Z] #1 ← 403 Forbidden: sfo1::m6m7m-1770821291563-86622a944cb1 [597ms]
+ Error: The token provided via VERCEL_TOKEN environment variable is not valid. Please provide a valid token.
 [debug] [2026-02-11T14:48:11.660Z] #2 ← 403 Forbidden: sfo1::mkct5-1770821291562-7589b64fc4b4 [600ms]
```

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR improves error messages by tracking token source (flag vs env var) and displaying more specific error messages when authentication fails, with no changes to authentication logic or security controls.
> 
> - Adds `tokenSource` field to track whether token came from `--token` flag or `VERCEL_TOKEN` env var
> - Updates `InvalidToken` error class to display source-specific error messages
> - Adds debug logging to indicate token source during refresh checks
>
> <sup>Risk assessment for [commit e05eb4a](https://github.com/vercel/vercel/commit/e05eb4ae190561504908ae8bf0d243f7db96a1c0).</sup>
<!-- VADE_RISK_END -->