### PR TITLE
Add `vercel metrics` CLI command for querying observability data

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -25,6 +25,7 @@ import { logoutCommand } from './logout/command';
 import { logsCommand } from './logs/command';
 import { logsv2Command } from './logsv2/command';
 import { mcpCommand } from './mcp/command';
+import { metricsCommand } from './metrics/command';
 import { microfrontendsCommand } from './microfrontends/command';
 import { openCommand } from './open/command';
 import { projectCommand } from './project/command';
@@ -72,6 +73,7 @@ const commandsStructs = [
   logsCommand,
   logsv2Command,
   mcpCommand,
+  metricsCommand,
   microfrontendsCommand,
   openCommand,
   projectCommand,

--- a/packages/cli/src/commands/metrics/command.ts
+++ b/packages/cli/src/commands/metrics/command.ts
@@ -1,0 +1,238 @@
+import { packageName } from '../../util/pkg-name';
+
+export const schemaSubcommand = {
+  name: 'schema',
+  aliases: [],
+  description: 'List available events, dimensions, and measures',
+  arguments: [],
+  options: [
+    {
+      name: 'event',
+      shorthand: 'e',
+      type: String,
+      deprecated: false,
+      description: 'Show details for specific event',
+    },
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output as JSON',
+    },
+  ],
+  examples: [
+    {
+      name: 'List all available events',
+      value: `${packageName} metrics schema`,
+    },
+    {
+      name: 'Show dimensions and measures for incomingRequest',
+      value: `${packageName} metrics schema -e incomingRequest`,
+    },
+    {
+      name: 'Output schema as JSON for agents',
+      value: `${packageName} metrics schema -e incomingRequest --json`,
+    },
+  ],
+} as const;
+
+export const querySubcommand = {
+  name: 'query',
+  aliases: [],
+  description: 'Run an observability query',
+  default: true,
+  arguments: [],
+  options: [
+    // Required
+    {
+      name: 'event',
+      shorthand: 'e',
+      type: String,
+      deprecated: false,
+      description: 'Event type to query (required)',
+    },
+    // Metric selection
+    {
+      name: 'measure',
+      shorthand: 'm',
+      type: String,
+      deprecated: false,
+      description: 'Measure to aggregate (default: count)',
+    },
+    {
+      name: 'aggregation',
+      shorthand: 'a',
+      type: String,
+      deprecated: false,
+      description: 'Aggregation function (default: sum)',
+    },
+    // Grouping
+    {
+      name: 'by',
+      shorthand: null,
+      type: [String],
+      deprecated: false,
+      description: 'Dimensions to group by',
+    },
+    {
+      name: 'limit',
+      shorthand: null,
+      type: Number,
+      deprecated: false,
+      description: 'Max groups to return (default: 100)',
+    },
+    // Filter shortcuts
+    {
+      name: 'status',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'HTTP status code (500, 4xx, 5xx)',
+    },
+    {
+      name: 'error',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Error code filter',
+    },
+    {
+      name: 'path',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Request path contains pattern',
+    },
+    {
+      name: 'method',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'HTTP method (GET, POST, etc.)',
+    },
+    {
+      name: 'region',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Edge or function region',
+    },
+    // Advanced filter
+    {
+      name: 'filter',
+      shorthand: 'f',
+      type: String,
+      deprecated: false,
+      description: 'Raw OData filter expression',
+    },
+    // Time range
+    {
+      name: 'since',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Start time (1h, 30m, 2d, ISO date)',
+    },
+    {
+      name: 'until',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'End time (default: now)',
+    },
+    {
+      name: 'granularity',
+      shorthand: 'g',
+      type: String,
+      deprecated: false,
+      description: 'Time bucket size (5m, 1h, 1d)',
+    },
+    // Scope
+    {
+      name: 'project',
+      shorthand: 'p',
+      type: String,
+      deprecated: false,
+      description: 'Project name or ID',
+    },
+    {
+      name: 'environment',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Environment filter (production, preview)',
+    },
+    {
+      name: 'deployment',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Deployment ID filter',
+    },
+    // Output
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output as JSON',
+    },
+    {
+      name: 'summary',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Summary only, no time series',
+    },
+  ],
+  examples: [
+    {
+      name: 'Get 5xx errors grouped by error code',
+      value: `${packageName} metrics -e incomingRequest --status 5xx --by errorCode --since 1h`,
+    },
+    {
+      name: 'P95 latency by route',
+      value: `${packageName} metrics -e incomingRequest -m requestDurationMs -a p95 --by route --since 24h`,
+    },
+    {
+      name: 'Function cold start analysis',
+      value: `${packageName} metrics -e functionExecution -m coldStartDurationMs -a avg --by route --since 1h`,
+    },
+    {
+      name: 'JSON output for scripting',
+      value: `${packageName} metrics -e incomingRequest --status 5xx --by errorCode --json`,
+    },
+  ],
+} as const;
+
+export const metricsCommand = {
+  name: 'metrics',
+  aliases: [],
+  description: 'Query observability metrics for debugging and analysis',
+  arguments: [],
+  subcommands: [querySubcommand, schemaSubcommand],
+  options: [],
+  examples: [
+    {
+      name: 'Error investigation: get 5xx errors grouped by error code',
+      value: `${packageName} metrics -e incomingRequest --status 5xx --by errorCode --since 1h`,
+    },
+    {
+      name: 'Performance analysis: P95 latency by route',
+      value: `${packageName} metrics -e incomingRequest -m requestDurationMs -a p95 --by route --since 24h`,
+    },
+    {
+      name: 'Traffic analysis: requests by status code',
+      value: `${packageName} metrics -e incomingRequest --by httpStatus --since 6h`,
+    },
+    {
+      name: 'List available events and dimensions',
+      value: `${packageName} metrics schema`,
+    },
+    {
+      name: 'Show schema for a specific event',
+      value: `${packageName} metrics schema -e incomingRequest`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/metrics/filter.ts
+++ b/packages/cli/src/commands/metrics/filter.ts
@@ -1,0 +1,103 @@
+import type { MetricsOptions } from './types';
+
+/**
+ * Build OData filter for HTTP status codes.
+ * Supports: exact codes (500), ranges (5xx, 4xx), and comma-separated (500,502,503).
+ */
+export function buildStatusFilter(status: string): string {
+  const parts = status.split(',').map(s => s.trim());
+
+  if (parts.length === 1) {
+    return buildSingleStatusFilter(parts[0]);
+  }
+
+  const conditions = parts.map(part => buildSingleStatusFilter(part));
+  return `(${conditions.join(' or ')})`;
+}
+
+function buildSingleStatusFilter(status: string): string {
+  if (status === '5xx') {
+    return 'httpStatus ge 500';
+  }
+  if (status === '4xx') {
+    return 'httpStatus ge 400 and httpStatus lt 500';
+  }
+  if (status === '3xx') {
+    return 'httpStatus ge 300 and httpStatus lt 400';
+  }
+  if (status === '2xx') {
+    return 'httpStatus ge 200 and httpStatus lt 300';
+  }
+  if (status === '1xx') {
+    return 'httpStatus ge 100 and httpStatus lt 200';
+  }
+
+  // Exact status code
+  const code = parseInt(status, 10);
+  if (!isNaN(code)) {
+    return `httpStatus eq ${code}`;
+  }
+
+  // Invalid format, return as-is and let the API reject it
+  return `httpStatus eq ${status}`;
+}
+
+/**
+ * Escape single quotes in OData string values.
+ */
+function escapeODataString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Build the complete OData filter from MetricsOptions shortcuts.
+ */
+export function buildFilter(options: MetricsOptions): string | undefined {
+  const conditions: string[] = [];
+
+  if (options.status) {
+    conditions.push(buildStatusFilter(options.status));
+  }
+
+  if (options.error) {
+    conditions.push(`errorCode eq '${escapeODataString(options.error)}'`);
+  }
+
+  if (options.path) {
+    conditions.push(
+      `contains(requestPath, '${escapeODataString(options.path)}')`
+    );
+  }
+
+  if (options.method) {
+    conditions.push(
+      `requestMethod eq '${escapeODataString(options.method.toUpperCase())}'`
+    );
+  }
+
+  if (options.region) {
+    const region = escapeODataString(options.region);
+    conditions.push(
+      `(edgeNetworkRegion eq '${region}' or functionRegion eq '${region}')`
+    );
+  }
+
+  if (options.environment) {
+    conditions.push(
+      `environment eq '${escapeODataString(options.environment)}'`
+    );
+  }
+
+  if (options.deployment) {
+    conditions.push(
+      `deploymentId eq '${escapeODataString(options.deployment)}'`
+    );
+  }
+
+  // Raw filter is appended at the end
+  if (options.filter) {
+    conditions.push(options.filter);
+  }
+
+  return conditions.length > 0 ? conditions.join(' and ') : undefined;
+}

--- a/packages/cli/src/commands/metrics/index.ts
+++ b/packages/cli/src/commands/metrics/index.ts
@@ -1,0 +1,219 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { type Command, help } from '../help';
+import { printError } from '../../util/error';
+import output from '../../output-manager';
+import { MetricsTelemetryClient } from '../../util/telemetry/commands/metrics';
+import { getLinkedProject } from '../../util/projects/link';
+import getProjectByIdOrName from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
+import getSubcommand from '../../util/get-subcommand';
+import { getCommandAliases } from '..';
+import getInvalidSubcommand from '../../util/get-invalid-subcommand';
+import { metricsCommand, querySubcommand, schemaSubcommand } from './command';
+import type { MetricsOptions } from './types';
+import schemaHandler from './schema';
+import queryHandler from './query';
+
+const COMMAND_CONFIG = {
+  query: getCommandAliases(querySubcommand),
+  schema: getCommandAliases(schemaSubcommand),
+};
+
+export default async function metrics(client: Client): Promise<number> {
+  const telemetry = new MetricsTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const {
+    subcommand,
+    args: subcommandArgs,
+    subcommandOriginal,
+  } = getSubcommand(client.argv.slice(3), COMMAND_CONFIG);
+
+  const needHelp = client.argv.includes('--help') || client.argv.includes('-h');
+
+  // If no subcommand and --help, show main help
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('metrics');
+    output.print(help(metricsCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  function printSubcommandHelp(command: Command) {
+    output.print(
+      help(command, {
+        parent: metricsCommand,
+        columns: client.stderr.columns,
+      })
+    );
+  }
+
+  try {
+    switch (subcommand) {
+      case 'schema': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('metrics', subcommandOriginal);
+          printSubcommandHelp(schemaSubcommand);
+          return 2;
+        }
+
+        const schemaFlags = parseArguments(
+          subcommandArgs,
+          getFlagsSpecification(schemaSubcommand.options)
+        );
+
+        telemetry.trackCliSubcommandSchema(subcommandOriginal!);
+        telemetry.trackCliOptionEvent(schemaFlags.flags['--event']);
+        telemetry.trackCliFlagJson(schemaFlags.flags['--json']);
+
+        return await schemaHandler(client, schemaFlags.flags);
+      }
+
+      case 'query':
+      default: {
+        // 'query' is the default subcommand
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('metrics', subcommandOriginal ?? 'query');
+          printSubcommandHelp(querySubcommand);
+          return 2;
+        }
+
+        // Parse query flags - if we came through default (no explicit subcommand),
+        // we need to use the full args minus 'metrics'
+        const queryArgs =
+          subcommand === 'query' ? subcommandArgs : client.argv.slice(3);
+        const queryFlags = parseArguments(
+          queryArgs,
+          getFlagsSpecification(querySubcommand.options)
+        );
+
+        // Track telemetry
+        if (subcommand === 'query') {
+          telemetry.trackCliSubcommandQuery(subcommandOriginal!);
+        }
+        telemetry.trackCliOptionEvent(queryFlags.flags['--event']);
+        telemetry.trackCliOptionMeasure(queryFlags.flags['--measure']);
+        telemetry.trackCliOptionAggregation(queryFlags.flags['--aggregation']);
+        telemetry.trackCliOptionBy(queryFlags.flags['--by']);
+        telemetry.trackCliOptionLimit(queryFlags.flags['--limit']);
+        telemetry.trackCliOptionStatus(queryFlags.flags['--status']);
+        telemetry.trackCliOptionError(queryFlags.flags['--error']);
+        telemetry.trackCliOptionPath(queryFlags.flags['--path']);
+        telemetry.trackCliOptionMethod(queryFlags.flags['--method']);
+        telemetry.trackCliOptionRegion(queryFlags.flags['--region']);
+        telemetry.trackCliOptionFilter(queryFlags.flags['--filter']);
+        telemetry.trackCliOptionSince(queryFlags.flags['--since']);
+        telemetry.trackCliOptionUntil(queryFlags.flags['--until']);
+        telemetry.trackCliOptionGranularity(queryFlags.flags['--granularity']);
+        telemetry.trackCliOptionProject(queryFlags.flags['--project']);
+        telemetry.trackCliOptionEnvironment(queryFlags.flags['--environment']);
+        telemetry.trackCliOptionDeployment(queryFlags.flags['--deployment']);
+        telemetry.trackCliFlagJson(queryFlags.flags['--json']);
+        telemetry.trackCliFlagSummary(queryFlags.flags['--summary']);
+
+        // Validate required --event flag
+        const eventOption = queryFlags.flags['--event'];
+        if (!eventOption) {
+          output.error(
+            `Missing required flag ${chalk.bold('--event')}. Specify the event type to query.`
+          );
+          output.print('\n');
+          output.print(
+            chalk.dim(
+              `Run ${chalk.cyan('vercel metrics schema')} to see available events.\n`
+            )
+          );
+          return 1;
+        }
+
+        // Resolve project scope
+        const projectOption = queryFlags.flags['--project'];
+        let teamSlug: string;
+        let projectName: string;
+
+        if (projectOption) {
+          // Use specified project
+          output.spinner(`Fetching project "${projectOption}"`, 1000);
+          const project = await getProjectByIdOrName(
+            client,
+            projectOption,
+            client.config.currentTeam
+          );
+          output.stopSpinner();
+
+          if (project instanceof ProjectNotFound) {
+            output.error(`Project not found: ${projectOption}`);
+            return 1;
+          }
+
+          projectName = project.name;
+          // Need to get team slug from context
+          const { contextName } = await import('../../util/get-scope').then(m =>
+            m.default(client)
+          );
+          teamSlug = contextName ?? '';
+        } else {
+          // Use linked project
+          const link = await getLinkedProject(client);
+          if (link.status === 'error') {
+            return link.exitCode;
+          }
+          if (link.status === 'not_linked') {
+            output.error(
+              `Your codebase isn't linked to a project on Vercel. Run ${chalk.cyan(
+                'vercel link'
+              )} to begin, or specify a project with ${chalk.bold('--project')}.`
+            );
+            return 1;
+          }
+
+          projectName = link.project.name;
+          teamSlug = link.org.slug;
+          client.config.currentTeam =
+            link.org.type === 'team' ? link.org.id : undefined;
+        }
+
+        // Build options
+        const options: MetricsOptions = {
+          event: eventOption,
+          measure: queryFlags.flags['--measure'] ?? 'count',
+          aggregation: queryFlags.flags['--aggregation'] ?? 'sum',
+          by: queryFlags.flags['--by'] ?? [],
+          limit: queryFlags.flags['--limit'] ?? 100,
+          status: queryFlags.flags['--status'],
+          error: queryFlags.flags['--error'],
+          path: queryFlags.flags['--path'],
+          method: queryFlags.flags['--method'],
+          region: queryFlags.flags['--region'],
+          filter: queryFlags.flags['--filter'],
+          since: queryFlags.flags['--since'],
+          until: queryFlags.flags['--until'],
+          granularity: queryFlags.flags['--granularity'],
+          project: projectOption,
+          environment: queryFlags.flags['--environment'],
+          deployment: queryFlags.flags['--deployment'],
+          json: queryFlags.flags['--json'] ?? false,
+          summary: queryFlags.flags['--summary'] ?? false,
+        };
+
+        return await queryHandler(client, teamSlug, projectName, options);
+      }
+    }
+  } catch (err: unknown) {
+    // Handle invalid subcommand
+    if (subcommand && !['query', 'schema'].includes(subcommand)) {
+      output.debug(`Invalid subcommand: ${subcommand}`);
+      output.error(getInvalidSubcommand(COMMAND_CONFIG));
+      output.print(help(metricsCommand, { columns: client.stderr.columns }));
+      return 2;
+    }
+
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/metrics/output.ts
+++ b/packages/cli/src/commands/metrics/output.ts
@@ -1,0 +1,165 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import table from '../../util/output/table';
+import type {
+  MetricsOptions,
+  MetricsResponse,
+  MetricsSummaryItem,
+  SonarQuery,
+} from './types';
+
+/**
+ * Format metric value with appropriate suffix.
+ */
+function formatValue(value: number, unit?: string): string {
+  if (unit === 'milliseconds') {
+    if (value >= 1000) {
+      return `${(value / 1000).toFixed(2)}s`;
+    }
+    return `${value.toFixed(0)}ms`;
+  }
+
+  if (unit === 'bytes') {
+    if (value >= 1024 * 1024 * 1024) {
+      return `${(value / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+    }
+    if (value >= 1024 * 1024) {
+      return `${(value / (1024 * 1024)).toFixed(2)} MB`;
+    }
+    if (value >= 1024) {
+      return `${(value / 1024).toFixed(2)} KB`;
+    }
+    return `${value.toFixed(0)} B`;
+  }
+
+  if (unit === 'megabytes') {
+    return `${value.toFixed(1)} MB`;
+  }
+
+  if (unit === 'percent') {
+    return `${value.toFixed(1)}%`;
+  }
+
+  if (unit === 'usd') {
+    return `$${value.toFixed(4)}`;
+  }
+
+  // Count or generic number
+  if (value >= 1000000) {
+    return `${(value / 1000000).toFixed(2)}M`;
+  }
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(1)}K`;
+  }
+
+  return value.toLocaleString();
+}
+
+/**
+ * Format table output for human consumption.
+ */
+export function formatTableOutput(
+  client: Client,
+  options: MetricsOptions,
+  response: MetricsResponse
+): void {
+  const { summary, statistics } = response;
+  const groupBy = options.by;
+
+  if (summary.length === 0) {
+    output.print(chalk.dim('No data found for the specified query.\n'));
+    return;
+  }
+
+  // Determine column headers
+  const headers: string[] = [...groupBy.map(d => d.toUpperCase()), 'VALUE'];
+  if (summary.length > 1) {
+    headers.push('% OF TOTAL');
+  }
+
+  // Build rows
+  const rows: string[][] = [];
+  const totalValue =
+    statistics.totalValue || summary.reduce((sum, item) => sum + item.value, 0);
+
+  for (const item of summary) {
+    const row: string[] = [];
+
+    // Dimension values
+    for (const dim of groupBy) {
+      const dimValue = item[dim];
+      row.push(
+        dimValue !== undefined && dimValue !== null
+          ? String(dimValue)
+          : '(empty)'
+      );
+    }
+
+    // Value
+    row.push(formatValue(item.value));
+
+    // Percentage
+    if (summary.length > 1 && totalValue > 0) {
+      const percent = (item.value / totalValue) * 100;
+      row.push(`${percent.toFixed(1)}%`);
+    }
+
+    rows.push(row);
+  }
+
+  // Print header row
+  const headerRow = [headers.map(h => chalk.dim(h))];
+  output.print(table(headerRow, { hsep: 4 }) + '\n');
+
+  // Print data rows
+  output.print(table(rows, { hsep: 4 }) + '\n\n');
+
+  // Print summary line
+  const timeRangeDesc = options.since ? `in last ${options.since}` : '';
+  output.print(
+    chalk.dim(
+      `Total: ${formatValue(totalValue)} ${timeRangeDesc} (${statistics.totalGroups} groups)\n`
+    )
+  );
+}
+
+/**
+ * Format JSON output for machine consumption.
+ */
+export function formatJsonOutput(
+  client: Client,
+  query: Partial<SonarQuery>,
+  options: MetricsOptions,
+  response: MetricsResponse
+): void {
+  output.stopSpinner();
+  client.stdout.write(
+    JSON.stringify(
+      {
+        query: {
+          event: options.event,
+          measure: options.measure,
+          aggregation: options.aggregation,
+          groupBy: options.by,
+          filter: query.filter,
+          startTime: query.startTime,
+          endTime: query.endTime,
+          granularity: query.granularity,
+        },
+        summary: response.summary,
+        data: response.data,
+        statistics: response.statistics,
+      },
+      null,
+      2
+    ) + '\n'
+  );
+}
+
+/**
+ * Get dimensions from summary item (all keys except 'value').
+ */
+export function getDimensionKeys(item: MetricsSummaryItem): string[] {
+  return Object.keys(item).filter(k => k !== 'value');
+}

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -1,0 +1,219 @@
+import ms from 'ms';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import type { MetricsOptions, MetricsResponse, SonarQuery } from './types';
+import { buildFilter } from './filter';
+import {
+  validateEvent,
+  validateDimension,
+  validateMeasure,
+  validateAggregation,
+  formatValidationError,
+} from './validation';
+import { formatTableOutput, formatJsonOutput } from './output';
+
+/**
+ * Parse relative or absolute time to ISO string.
+ */
+function parseTime(value: string | undefined, defaultDate: Date): string {
+  if (!value) {
+    return defaultDate.toISOString();
+  }
+
+  // Try parsing as relative duration (1h, 30m, 2d, 1w)
+  const relative = ms(value);
+  if (typeof relative === 'number' && relative > 0) {
+    return new Date(Date.now() - relative).toISOString();
+  }
+
+  // Try parsing as ISO date
+  const date = new Date(value);
+  if (!isNaN(date.getTime())) {
+    return date.toISOString();
+  }
+
+  // Fallback - let API handle invalid formats
+  return value;
+}
+
+/**
+ * Parse granularity to API format (ISO 8601 duration).
+ * Input: 5m, 1h, 1d
+ * Output: PT5M, PT1H, P1D
+ */
+function parseGranularity(value: string | undefined): string {
+  if (!value) {
+    return 'PT15M'; // Default: 15 minutes
+  }
+
+  // Parse the value and unit
+  const match = value.match(/^(\d+)([mhdw])$/i);
+  if (!match) {
+    return value; // Let API validate
+  }
+
+  const num = parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+
+  switch (unit) {
+    case 'm':
+      return `PT${num}M`;
+    case 'h':
+      return `PT${num}H`;
+    case 'd':
+      return `P${num}D`;
+    case 'w':
+      return `P${num * 7}D`;
+    default:
+      return value;
+  }
+}
+
+/**
+ * Validate all query options before making API call.
+ */
+function validateOptions(options: MetricsOptions): {
+  valid: boolean;
+  error?: string;
+} {
+  // Validate event
+  const eventResult = validateEvent(options.event);
+  if (!eventResult.valid) {
+    return { valid: false, error: formatValidationError(eventResult) };
+  }
+
+  // Validate dimensions
+  for (const dim of options.by) {
+    const dimResult = validateDimension(options.event, dim);
+    if (!dimResult.valid) {
+      return { valid: false, error: formatValidationError(dimResult) };
+    }
+  }
+
+  // Validate measure
+  const measureResult = validateMeasure(options.event, options.measure);
+  if (!measureResult.valid) {
+    return { valid: false, error: formatValidationError(measureResult) };
+  }
+
+  // Validate aggregation
+  const aggResult = validateAggregation(
+    options.event,
+    options.measure,
+    options.aggregation
+  );
+  if (!aggResult.valid) {
+    return { valid: false, error: formatValidationError(aggResult) };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Execute a metrics query.
+ */
+export default async function query(
+  client: Client,
+  teamSlug: string,
+  projectName: string,
+  options: MetricsOptions
+): Promise<number> {
+  // Validate inputs
+  const validation = validateOptions(options);
+  if (!validation.valid) {
+    output.error(validation.error!);
+    return 1;
+  }
+
+  // Build the query
+  const now = new Date();
+  const startTime = parseTime(
+    options.since,
+    new Date(now.getTime() - 60 * 60 * 1000)
+  ); // Default: 1h ago
+  const endTime = parseTime(options.until, now);
+  const filter = buildFilter(options);
+  const granularity = parseGranularity(options.granularity);
+
+  const queryBody: SonarQuery = {
+    scope: {
+      type: 'project-with-slug',
+      teamSlug,
+      projectName,
+    },
+    reason: 'cli',
+    event: options.event,
+    rollups: {
+      value: {
+        measure: options.measure,
+        aggregation: options.aggregation,
+      },
+    },
+    groupBy: options.by,
+    filter,
+    limit: options.limit,
+    tailRollup: 'truncate',
+    granularity,
+    startTime,
+    endTime,
+    summaryOnly: options.summary,
+  };
+
+  // Make the API call
+  // The observability API is on vercel.com, not api.vercel.com
+  const baseUrl =
+    client.apiUrl === 'https://api.vercel.com'
+      ? 'https://vercel.com'
+      : client.apiUrl;
+
+  output.spinner('Fetching metrics...');
+
+  try {
+    const response = await client.fetch<MetricsResponse>(
+      `${baseUrl}/api/observability/metrics`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(queryBody),
+      }
+    );
+
+    output.stopSpinner();
+
+    // Format output
+    if (options.json) {
+      formatJsonOutput(client, queryBody, options, response);
+    } else {
+      formatTableOutput(client, options, response);
+    }
+
+    return 0;
+  } catch (err: unknown) {
+    output.stopSpinner();
+
+    if (err instanceof Error) {
+      // Handle API errors gracefully
+      if ('status' in err && typeof (err as any).status === 'number') {
+        const status = (err as any).status;
+        if (status === 403) {
+          output.error(
+            'Permission denied. You may not have access to observability data for this project.'
+          );
+          return 1;
+        }
+        if (status === 404) {
+          output.error(
+            'Project not found or observability data is not available.'
+          );
+          return 1;
+        }
+      }
+      output.error(`Failed to fetch metrics: ${err.message}`);
+    } else {
+      output.error('Failed to fetch metrics.');
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/metrics/schema-data.ts
+++ b/packages/cli/src/commands/metrics/schema-data.ts
@@ -1,0 +1,424 @@
+import type { EventDef, DimensionDef, MeasureDef } from './types';
+
+export const EVENTS: EventDef[] = [
+  { name: 'incomingRequest', label: 'Edge Requests' },
+  { name: 'serverlessFunctionInvocation', label: 'Function Invocations' },
+  { name: 'functionExecution', label: 'Function Executions' },
+  { name: 'middlewareInvocation', label: 'Middleware Invocations' },
+  { name: 'edgeFunctionInvocation', label: 'Edge Function Invocations' },
+  { name: 'outgoingRequest', label: 'External APIs' },
+  { name: 'isrOperation', label: 'ISR Operations' },
+  { name: 'imageTransformation', label: 'Image Transformations' },
+  { name: 'vdcOperation', label: 'Cache Operations' },
+  { name: 'aiGatewayRequest', label: 'AI Gateway Requests' },
+  { name: 'firewallAction', label: 'Firewall Actions' },
+  { name: 'workflowOperation', label: 'Workflow Operations' },
+];
+
+// Common dimensions shared across multiple events
+const commonRequestDimensions: DimensionDef[] = [
+  {
+    name: 'requestPath',
+    label: 'Request Path',
+    type: 'string',
+    highCardinality: true,
+  },
+  { name: 'requestMethod', label: 'Request Method', type: 'string' },
+  { name: 'requestHostname', label: 'Request Hostname', type: 'string' },
+  { name: 'route', label: 'Route', type: 'string', highCardinality: true },
+  { name: 'httpStatus', label: 'HTTP Status', type: 'number' },
+  { name: 'errorCode', label: 'Error Code', type: 'string' },
+  {
+    name: 'errorMessage',
+    label: 'Error Message',
+    type: 'string',
+    highCardinality: true,
+  },
+  { name: 'environment', label: 'Environment', type: 'string' },
+  { name: 'deploymentId', label: 'Deployment ID', type: 'string' },
+];
+
+const infrastructureDimensions: DimensionDef[] = [
+  { name: 'edgeNetworkRegion', label: 'Edge Network Region', type: 'string' },
+  { name: 'functionRegion', label: 'Function Region', type: 'string' },
+  { name: 'runtime', label: 'Runtime', type: 'string' },
+  { name: 'pathType', label: 'Path Type', type: 'string' },
+  { name: 'functionStartType', label: 'Function Start Type', type: 'string' },
+];
+
+const clientDimensions: DimensionDef[] = [
+  {
+    name: 'clientIp',
+    label: 'Client IP',
+    type: 'string',
+    highCardinality: true,
+  },
+  { name: 'clientIpCountry', label: 'Client IP Country', type: 'string' },
+  {
+    name: 'clientUserAgent',
+    label: 'Client User Agent',
+    type: 'string',
+    highCardinality: true,
+  },
+  {
+    name: 'referrerUrl',
+    label: 'Referrer URL',
+    type: 'string',
+    highCardinality: true,
+  },
+  { name: 'referrerHostname', label: 'Referrer Hostname', type: 'string' },
+];
+
+const cacheDimensions: DimensionDef[] = [
+  { name: 'cacheResult', label: 'Cache Result', type: 'string' },
+  { name: 'cacheHitState', label: 'Cache Hit State', type: 'string' },
+  { name: 'cacheHitLevel', label: 'Cache Hit Level', type: 'string' },
+];
+
+export const DIMENSIONS: Record<string, DimensionDef[]> = {
+  incomingRequest: [
+    ...commonRequestDimensions,
+    ...infrastructureDimensions,
+    ...clientDimensions,
+    ...cacheDimensions,
+  ],
+  serverlessFunctionInvocation: [
+    ...commonRequestDimensions,
+    ...infrastructureDimensions.filter(d => d.name !== 'edgeNetworkRegion'),
+    { name: 'functionName', label: 'Function Name', type: 'string' },
+  ],
+  functionExecution: [
+    ...commonRequestDimensions,
+    ...infrastructureDimensions.filter(d => d.name !== 'edgeNetworkRegion'),
+    { name: 'functionName', label: 'Function Name', type: 'string' },
+  ],
+  middlewareInvocation: [
+    ...commonRequestDimensions,
+    ...infrastructureDimensions.filter(
+      d => !['functionRegion', 'functionStartType'].includes(d.name)
+    ),
+  ],
+  edgeFunctionInvocation: [
+    ...commonRequestDimensions,
+    ...infrastructureDimensions.filter(
+      d => !['functionRegion', 'functionStartType'].includes(d.name)
+    ),
+    { name: 'functionName', label: 'Function Name', type: 'string' },
+  ],
+  outgoingRequest: [
+    { name: 'requestHostname', label: 'Request Hostname', type: 'string' },
+    {
+      name: 'requestPath',
+      label: 'Request Path',
+      type: 'string',
+      highCardinality: true,
+    },
+    { name: 'requestMethod', label: 'Request Method', type: 'string' },
+    { name: 'httpStatus', label: 'HTTP Status', type: 'number' },
+    { name: 'errorCode', label: 'Error Code', type: 'string' },
+    { name: 'environment', label: 'Environment', type: 'string' },
+    { name: 'deploymentId', label: 'Deployment ID', type: 'string' },
+  ],
+  isrOperation: [
+    { name: 'route', label: 'Route', type: 'string', highCardinality: true },
+    { name: 'cacheResult', label: 'Cache Result', type: 'string' },
+    { name: 'environment', label: 'Environment', type: 'string' },
+    { name: 'deploymentId', label: 'Deployment ID', type: 'string' },
+    { name: 'functionRegion', label: 'Function Region', type: 'string' },
+  ],
+  imageTransformation: [
+    {
+      name: 'sourceImageHostname',
+      label: 'Source Image Hostname',
+      type: 'string',
+    },
+    {
+      name: 'sourceImagePath',
+      label: 'Source Image Path',
+      type: 'string',
+      highCardinality: true,
+    },
+    {
+      name: 'transformationType',
+      label: 'Transformation Type',
+      type: 'string',
+    },
+    { name: 'cacheResult', label: 'Cache Result', type: 'string' },
+    { name: 'environment', label: 'Environment', type: 'string' },
+    { name: 'deploymentId', label: 'Deployment ID', type: 'string' },
+  ],
+  vdcOperation: [
+    {
+      name: 'cacheKey',
+      label: 'Cache Key',
+      type: 'string',
+      highCardinality: true,
+    },
+    { name: 'cacheResult', label: 'Cache Result', type: 'string' },
+    { name: 'operationType', label: 'Operation Type', type: 'string' },
+    { name: 'environment', label: 'Environment', type: 'string' },
+    { name: 'deploymentId', label: 'Deployment ID', type: 'string' },
+  ],
+  aiGatewayRequest: [
+    { name: 'aiProvider', label: 'AI Provider', type: 'string' },
+    { name: 'aiModel', label: 'AI Model', type: 'string' },
+    { name: 'route', label: 'Route', type: 'string', highCardinality: true },
+    { name: 'httpStatus', label: 'HTTP Status', type: 'number' },
+    { name: 'errorCode', label: 'Error Code', type: 'string' },
+    { name: 'environment', label: 'Environment', type: 'string' },
+    { name: 'deploymentId', label: 'Deployment ID', type: 'string' },
+  ],
+  firewallAction: [
+    { name: 'wafAction', label: 'WAF Action', type: 'string' },
+    { name: 'wafRuleId', label: 'WAF Rule ID', type: 'string' },
+    {
+      name: 'requestPath',
+      label: 'Request Path',
+      type: 'string',
+      highCardinality: true,
+    },
+    { name: 'requestMethod', label: 'Request Method', type: 'string' },
+    {
+      name: 'clientIp',
+      label: 'Client IP',
+      type: 'string',
+      highCardinality: true,
+    },
+    { name: 'clientIpCountry', label: 'Client IP Country', type: 'string' },
+    { name: 'environment', label: 'Environment', type: 'string' },
+  ],
+  workflowOperation: [
+    { name: 'workflowId', label: 'Workflow ID', type: 'string' },
+    { name: 'workflowName', label: 'Workflow Name', type: 'string' },
+    { name: 'operationType', label: 'Operation Type', type: 'string' },
+    { name: 'status', label: 'Status', type: 'string' },
+    { name: 'errorCode', label: 'Error Code', type: 'string' },
+    { name: 'environment', label: 'Environment', type: 'string' },
+    { name: 'deploymentId', label: 'Deployment ID', type: 'string' },
+  ],
+};
+
+// Common measures
+const countMeasure: MeasureDef = {
+  name: 'count',
+  label: 'Count',
+  unit: 'count',
+  aggregations: ['sum', 'persecond', 'percent'],
+};
+
+const requestDurationMeasure: MeasureDef = {
+  name: 'requestDurationMs',
+  label: 'Request Duration',
+  unit: 'milliseconds',
+  aggregations: ['avg', 'p50', 'p75', 'p90', 'p95', 'p99', 'min', 'max'],
+};
+
+const functionDurationMeasure: MeasureDef = {
+  name: 'functionDurationMs',
+  label: 'Function Duration',
+  unit: 'milliseconds',
+  aggregations: ['avg', 'p50', 'p75', 'p90', 'p95', 'p99', 'min', 'max'],
+};
+
+export const MEASURES: Record<string, MeasureDef[]> = {
+  incomingRequest: [
+    countMeasure,
+    requestDurationMeasure,
+    {
+      name: 'ttfbMs',
+      label: 'Time to First Byte',
+      unit: 'milliseconds',
+      aggregations: ['avg', 'p50', 'p95', 'p99', 'min', 'max'],
+    },
+    {
+      name: 'fdtInBytes',
+      label: 'Fast Data Transfer In',
+      unit: 'bytes',
+      aggregations: ['sum', 'avg', 'p95'],
+    },
+    {
+      name: 'fdtOutBytes',
+      label: 'Fast Data Transfer Out',
+      unit: 'bytes',
+      aggregations: ['sum', 'avg', 'p95'],
+    },
+  ],
+  serverlessFunctionInvocation: [
+    countMeasure,
+    functionDurationMeasure,
+    {
+      name: 'coldStartDurationMs',
+      label: 'Cold Start Duration',
+      unit: 'milliseconds',
+      aggregations: ['avg', 'p50', 'p95', 'p99', 'min', 'max'],
+    },
+    {
+      name: 'functionDurationGbhr',
+      label: 'Function Duration (GB-hr)',
+      unit: 'gb-hr',
+      aggregations: ['sum', 'avg'],
+    },
+  ],
+  functionExecution: [
+    countMeasure,
+    functionDurationMeasure,
+    {
+      name: 'coldStartDurationMs',
+      label: 'Cold Start Duration',
+      unit: 'milliseconds',
+      aggregations: ['avg', 'p50', 'p95', 'p99', 'min', 'max'],
+    },
+    {
+      name: 'functionCpuTimeMs',
+      label: 'CPU Time',
+      unit: 'milliseconds',
+      aggregations: ['sum', 'avg', 'p95', 'p99', 'max'],
+    },
+    {
+      name: 'peakMemoryMb',
+      label: 'Peak Memory',
+      unit: 'megabytes',
+      aggregations: ['avg', 'p95', 'p99', 'max'],
+    },
+    {
+      name: 'provisionedMemoryMb',
+      label: 'Provisioned Memory',
+      unit: 'megabytes',
+      aggregations: ['avg', 'max'],
+    },
+    {
+      name: 'cpuThrottlePercent',
+      label: 'CPU Throttle',
+      unit: 'percent',
+      aggregations: ['avg', 'p95', 'p99', 'max'],
+    },
+  ],
+  middlewareInvocation: [
+    countMeasure,
+    {
+      name: 'executionDurationMs',
+      label: 'Execution Duration',
+      unit: 'milliseconds',
+      aggregations: ['avg', 'p50', 'p95', 'p99', 'min', 'max'],
+    },
+  ],
+  edgeFunctionInvocation: [
+    countMeasure,
+    {
+      name: 'executionDurationMs',
+      label: 'Execution Duration',
+      unit: 'milliseconds',
+      aggregations: ['avg', 'p50', 'p95', 'p99', 'min', 'max'],
+    },
+    {
+      name: 'cpuTimeMs',
+      label: 'CPU Time',
+      unit: 'milliseconds',
+      aggregations: ['sum', 'avg', 'p95', 'p99', 'max'],
+    },
+  ],
+  outgoingRequest: [countMeasure, requestDurationMeasure],
+  isrOperation: [
+    countMeasure,
+    {
+      name: 'revalidationDurationMs',
+      label: 'Revalidation Duration',
+      unit: 'milliseconds',
+      aggregations: ['avg', 'p50', 'p95', 'p99', 'min', 'max'],
+    },
+  ],
+  imageTransformation: [
+    countMeasure,
+    {
+      name: 'transformationDurationMs',
+      label: 'Transformation Duration',
+      unit: 'milliseconds',
+      aggregations: ['avg', 'p50', 'p95', 'p99', 'min', 'max'],
+    },
+    {
+      name: 'inputSizeBytes',
+      label: 'Input Size',
+      unit: 'bytes',
+      aggregations: ['sum', 'avg', 'max'],
+    },
+    {
+      name: 'outputSizeBytes',
+      label: 'Output Size',
+      unit: 'bytes',
+      aggregations: ['sum', 'avg', 'max'],
+    },
+  ],
+  vdcOperation: [
+    countMeasure,
+    {
+      name: 'operationDurationMs',
+      label: 'Operation Duration',
+      unit: 'milliseconds',
+      aggregations: ['avg', 'p50', 'p95', 'p99', 'min', 'max'],
+    },
+    {
+      name: 'valueSizeBytes',
+      label: 'Value Size',
+      unit: 'bytes',
+      aggregations: ['sum', 'avg', 'max'],
+    },
+  ],
+  aiGatewayRequest: [
+    countMeasure,
+    requestDurationMeasure,
+    {
+      name: 'inputTokens',
+      label: 'Input Tokens',
+      unit: 'tokens',
+      aggregations: ['sum', 'avg', 'max'],
+    },
+    {
+      name: 'outputTokens',
+      label: 'Output Tokens',
+      unit: 'tokens',
+      aggregations: ['sum', 'avg', 'max'],
+    },
+    {
+      name: 'cost',
+      label: 'Cost',
+      unit: 'usd',
+      aggregations: ['sum', 'avg', 'max'],
+    },
+  ],
+  firewallAction: [countMeasure],
+  workflowOperation: [
+    countMeasure,
+    {
+      name: 'operationDurationMs',
+      label: 'Operation Duration',
+      unit: 'milliseconds',
+      aggregations: ['avg', 'p50', 'p95', 'p99', 'min', 'max'],
+    },
+  ],
+};
+
+export function getEvent(name: string): EventDef | undefined {
+  return EVENTS.find(e => e.name === name);
+}
+
+export function getDimensions(eventName: string): DimensionDef[] {
+  return DIMENSIONS[eventName] ?? [];
+}
+
+export function getMeasures(eventName: string): MeasureDef[] {
+  return MEASURES[eventName] ?? [];
+}
+
+export function getDimension(
+  eventName: string,
+  dimensionName: string
+): DimensionDef | undefined {
+  return getDimensions(eventName).find(d => d.name === dimensionName);
+}
+
+export function getMeasure(
+  eventName: string,
+  measureName: string
+): MeasureDef | undefined {
+  return getMeasures(eventName).find(m => m.name === measureName);
+}

--- a/packages/cli/src/commands/metrics/schema.ts
+++ b/packages/cli/src/commands/metrics/schema.ts
@@ -1,0 +1,123 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import table from '../../util/output/table';
+import { EVENTS, getEvent, getDimensions, getMeasures } from './schema-data';
+import { validateEvent, formatValidationError } from './validation';
+
+interface SchemaFlags {
+  '--event'?: string;
+  '--json'?: boolean;
+}
+
+export default async function schema(
+  client: Client,
+  flags: SchemaFlags
+): Promise<number> {
+  const eventName = flags['--event'];
+  const asJson = flags['--json'];
+
+  if (eventName) {
+    return showEventSchema(client, eventName, asJson);
+  }
+
+  return showAllEvents(client, asJson);
+}
+
+function showAllEvents(client: Client, asJson?: boolean): number {
+  if (asJson) {
+    output.stopSpinner();
+    client.stdout.write(JSON.stringify({ events: EVENTS }, null, 2) + '\n');
+    return 0;
+  }
+
+  output.print(chalk.bold('Available Events:\n\n'));
+
+  const rows = EVENTS.map(event => [
+    chalk.cyan(event.name),
+    chalk.dim(event.label),
+  ]);
+
+  output.print(table(rows, { hsep: 4 }) + '\n\n');
+  output.print(
+    chalk.dim(
+      "Use 'vercel metrics schema -e <event>' to see dimensions and measures.\n"
+    )
+  );
+
+  return 0;
+}
+
+function showEventSchema(
+  client: Client,
+  eventName: string,
+  asJson?: boolean
+): number {
+  const validation = validateEvent(eventName);
+  if (!validation.valid) {
+    output.error(formatValidationError(validation));
+    output.print('\n');
+    showAllEvents(client, false);
+    return 1;
+  }
+
+  const event = getEvent(eventName)!;
+  const dimensions = getDimensions(eventName);
+  const measures = getMeasures(eventName);
+
+  if (asJson) {
+    output.stopSpinner();
+    client.stdout.write(
+      JSON.stringify(
+        {
+          event: event.name,
+          label: event.label,
+          dimensions,
+          measures,
+        },
+        null,
+        2
+      ) + '\n'
+    );
+    return 0;
+  }
+
+  output.print(
+    chalk.bold(`Event: ${chalk.cyan(event.name)} (${event.label})\n\n`)
+  );
+
+  // Dimensions
+  output.print(chalk.bold('Dimensions (--by):\n'));
+
+  const dimensionRows = dimensions.map(d => [
+    chalk.cyan(d.name),
+    d.label,
+    d.highCardinality ? chalk.dim('(high cardinality)') : '',
+  ]);
+
+  output.print(table(dimensionRows, { hsep: 2 }) + '\n\n');
+
+  // Measures
+  output.print(chalk.bold('Measures (--measure):\n'));
+
+  const measureRows = measures.map(m => [
+    chalk.cyan(m.name),
+    m.label,
+    chalk.dim(`[${m.aggregations.join(', ')}]`),
+  ]);
+
+  output.print(table(measureRows, { hsep: 2 }) + '\n\n');
+
+  // Example queries
+  output.print(chalk.bold('Example queries:\n\n'));
+  output.print(
+    chalk.dim(`  # Count by error code in last hour
+  vercel metrics -e ${eventName} --by errorCode --since 1h
+
+  # P95 latency by route
+  vercel metrics -e ${eventName} -m ${measures[1]?.name ?? 'count'} -a p95 --by route --since 24h
+\n`)
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/metrics/types.ts
+++ b/packages/cli/src/commands/metrics/types.ts
@@ -1,0 +1,100 @@
+export interface MetricsOptions {
+  // Event type (required)
+  event: string;
+
+  // Metric selection
+  measure: string;
+  aggregation: string;
+
+  // Grouping
+  by: string[];
+  limit: number;
+
+  // Filter shortcuts
+  status?: string;
+  error?: string;
+  path?: string;
+  method?: string;
+  region?: string;
+
+  // Advanced filter
+  filter?: string;
+
+  // Time range
+  since?: string;
+  until?: string;
+  granularity?: string;
+
+  // Scope
+  project?: string;
+  environment?: string;
+  deployment?: string;
+
+  // Output
+  json: boolean;
+  summary: boolean;
+}
+
+export interface QueryScope {
+  type: 'project-with-slug';
+  teamSlug: string;
+  projectName: string;
+}
+
+export interface RollupDefinition {
+  measure: string;
+  aggregation: string;
+}
+
+export interface SonarQuery {
+  scope: QueryScope;
+  reason: string;
+  event: string;
+  rollups: Record<string, RollupDefinition>;
+  groupBy: string[];
+  filter?: string;
+  limit: number;
+  tailRollup: 'truncate' | 'others';
+  granularity: string;
+  startTime: string;
+  endTime: string;
+  summaryOnly: boolean;
+}
+
+export interface MetricsDataPoint {
+  timestamp: string;
+  [key: string]: string | number;
+}
+
+export interface MetricsSummaryItem {
+  value: number;
+  [key: string]: string | number;
+}
+
+export interface MetricsResponse {
+  summary: MetricsSummaryItem[];
+  data: MetricsDataPoint[];
+  statistics: {
+    totalGroups: number;
+    totalValue: number;
+  };
+}
+
+export interface EventDef {
+  name: string;
+  label: string;
+}
+
+export interface DimensionDef {
+  name: string;
+  label: string;
+  type: 'string' | 'number' | 'boolean';
+  highCardinality?: boolean;
+}
+
+export interface MeasureDef {
+  name: string;
+  label: string;
+  unit: string;
+  aggregations: string[];
+}

--- a/packages/cli/src/commands/metrics/validation.ts
+++ b/packages/cli/src/commands/metrics/validation.ts
@@ -1,0 +1,163 @@
+import { EVENTS, getDimensions, getMeasures, getMeasure } from './schema-data';
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+  suggestions?: string[];
+}
+
+/**
+ * Calculate Levenshtein distance between two strings.
+ */
+function levenshteinDistance(a: string, b: string): number {
+  const matrix: number[][] = [];
+
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1, // substitution
+          matrix[i][j - 1] + 1, // insertion
+          matrix[i - 1][j] + 1 // deletion
+        );
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+}
+
+/**
+ * Find similar strings using Levenshtein distance.
+ */
+function findSimilar(
+  input: string,
+  candidates: string[],
+  maxDistance = 3
+): string[] {
+  const scored = candidates
+    .map(c => ({
+      name: c,
+      distance: levenshteinDistance(input.toLowerCase(), c.toLowerCase()),
+    }))
+    .filter(c => c.distance <= maxDistance)
+    .sort((a, b) => a.distance - b.distance);
+
+  return scored.slice(0, 3).map(c => c.name);
+}
+
+/**
+ * Validate that an event name exists.
+ */
+export function validateEvent(event: string): ValidationResult {
+  const eventNames = EVENTS.map(e => e.name);
+
+  if (eventNames.includes(event)) {
+    return { valid: true };
+  }
+
+  const suggestions = findSimilar(event, eventNames);
+
+  return {
+    valid: false,
+    error: `Unknown event "${event}".`,
+    suggestions,
+  };
+}
+
+/**
+ * Validate that a dimension is available for the given event.
+ */
+export function validateDimension(
+  event: string,
+  dimension: string
+): ValidationResult {
+  const dimensions = getDimensions(event);
+  const dimensionNames = dimensions.map(d => d.name);
+
+  if (dimensionNames.includes(dimension)) {
+    return { valid: true };
+  }
+
+  const suggestions = findSimilar(dimension, dimensionNames);
+
+  return {
+    valid: false,
+    error: `Dimension "${dimension}" is not available for event "${event}".`,
+    suggestions,
+  };
+}
+
+/**
+ * Validate that a measure is available for the given event.
+ */
+export function validateMeasure(
+  event: string,
+  measure: string
+): ValidationResult {
+  const measures = getMeasures(event);
+  const measureNames = measures.map(m => m.name);
+
+  if (measureNames.includes(measure)) {
+    return { valid: true };
+  }
+
+  const suggestions = findSimilar(measure, measureNames);
+
+  return {
+    valid: false,
+    error: `Measure "${measure}" is not available for event "${event}".`,
+    suggestions,
+  };
+}
+
+/**
+ * Validate that an aggregation is valid for the given measure.
+ */
+export function validateAggregation(
+  event: string,
+  measure: string,
+  aggregation: string
+): ValidationResult {
+  const measureDef = getMeasure(event, measure);
+
+  if (!measureDef) {
+    return {
+      valid: false,
+      error: `Measure "${measure}" is not available for event "${event}".`,
+    };
+  }
+
+  if (measureDef.aggregations.includes(aggregation)) {
+    return { valid: true };
+  }
+
+  return {
+    valid: false,
+    error: `Aggregation "${aggregation}" is not valid for measure "${measure}".`,
+    suggestions: measureDef.aggregations,
+  };
+}
+
+/**
+ * Format validation error with suggestions.
+ */
+export function formatValidationError(result: ValidationResult): string {
+  let message = result.error ?? 'Validation error.';
+
+  if (result.suggestions && result.suggestions.length > 0) {
+    message += `\n\nDid you mean: ${result.suggestions.join(', ')}?`;
+  }
+
+  return message;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -755,6 +755,10 @@ const main = async () => {
           telemetry.trackCliCommandLogout(userSuppliedSubCommand);
           func = require('./commands/logout').default;
           break;
+        case 'metrics':
+          telemetry.trackCliCommandMetrics(userSuppliedSubCommand);
+          func = require('./commands/metrics').default;
+          break;
         case 'microfrontends':
           telemetry.trackCliCommandMicrofrontends(userSuppliedSubCommand);
           func = require('./commands/microfrontends').default;

--- a/packages/cli/src/util/telemetry/commands/metrics/index.ts
+++ b/packages/cli/src/util/telemetry/commands/metrics/index.ts
@@ -1,0 +1,187 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { metricsCommand } from '../../../../commands/metrics/command';
+
+export class MetricsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof metricsCommand>
+{
+  trackCliSubcommandQuery(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'query',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandSchema(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'schema',
+      value: actual,
+    });
+  }
+
+  trackCliOptionEvent(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'event',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionMeasure(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'measure',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionAggregation(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'aggregation',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionBy(value: string[] | undefined) {
+    if (value && value.length > 0) {
+      this.trackCliOption({
+        option: 'by',
+        value: value.join(','),
+      });
+    }
+  }
+
+  trackCliOptionLimit(value: number | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'limit',
+        value: String(value),
+      });
+    }
+  }
+
+  trackCliOptionStatus(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'status',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionError(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'error',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionPath(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'path',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionMethod(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'method',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionRegion(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'region',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionFilter(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'filter',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSince(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'since',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionUntil(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'until',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionGranularity(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'granularity',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionProject(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEnvironment(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'environment',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionDeployment(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'deployment',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagJson(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('json');
+    }
+  }
+
+  trackCliFlagSummary(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('summary');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -208,6 +208,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandMetrics(actual: string) {
+    this.trackCliCommand({
+      command: 'metrics',
+      value: actual,
+    });
+  }
+
   trackCliCommandMicrofrontends(actual: string) {
     this.trackCliCommand({
       command: 'microfrontends',

--- a/packages/cli/test/unit/commands/metrics/filter.test.ts
+++ b/packages/cli/test/unit/commands/metrics/filter.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildStatusFilter,
+  buildFilter,
+} from '../../../../src/commands/metrics/filter';
+import type { MetricsOptions } from '../../../../src/commands/metrics/types';
+
+describe('buildStatusFilter', () => {
+  it('should handle 5xx range', () => {
+    expect(buildStatusFilter('5xx')).toBe('httpStatus ge 500');
+  });
+
+  it('should handle 4xx range', () => {
+    expect(buildStatusFilter('4xx')).toBe(
+      'httpStatus ge 400 and httpStatus lt 500'
+    );
+  });
+
+  it('should handle 3xx range', () => {
+    expect(buildStatusFilter('3xx')).toBe(
+      'httpStatus ge 300 and httpStatus lt 400'
+    );
+  });
+
+  it('should handle 2xx range', () => {
+    expect(buildStatusFilter('2xx')).toBe(
+      'httpStatus ge 200 and httpStatus lt 300'
+    );
+  });
+
+  it('should handle exact status code', () => {
+    expect(buildStatusFilter('500')).toBe('httpStatus eq 500');
+    expect(buildStatusFilter('404')).toBe('httpStatus eq 404');
+  });
+
+  it('should handle comma-separated status codes', () => {
+    expect(buildStatusFilter('500,502,503')).toBe(
+      '(httpStatus eq 500 or httpStatus eq 502 or httpStatus eq 503)'
+    );
+  });
+
+  it('should handle mixed ranges and codes', () => {
+    expect(buildStatusFilter('5xx,4xx')).toBe(
+      '(httpStatus ge 500 or httpStatus ge 400 and httpStatus lt 500)'
+    );
+  });
+});
+
+describe('buildFilter', () => {
+  const baseOptions: MetricsOptions = {
+    event: 'incomingRequest',
+    measure: 'count',
+    aggregation: 'sum',
+    by: [],
+    limit: 100,
+    json: false,
+    summary: false,
+  };
+
+  it('should return undefined when no filters are specified', () => {
+    expect(buildFilter(baseOptions)).toBeUndefined();
+  });
+
+  it('should build status filter', () => {
+    expect(buildFilter({ ...baseOptions, status: '5xx' })).toBe(
+      'httpStatus ge 500'
+    );
+  });
+
+  it('should build error filter', () => {
+    expect(
+      buildFilter({ ...baseOptions, error: 'FUNCTION_INVOCATION_TIMEOUT' })
+    ).toBe("errorCode eq 'FUNCTION_INVOCATION_TIMEOUT'");
+  });
+
+  it('should build path filter', () => {
+    expect(buildFilter({ ...baseOptions, path: '/api' })).toBe(
+      "contains(requestPath, '/api')"
+    );
+  });
+
+  it('should build method filter', () => {
+    expect(buildFilter({ ...baseOptions, method: 'post' })).toBe(
+      "requestMethod eq 'POST'"
+    );
+  });
+
+  it('should build region filter', () => {
+    expect(buildFilter({ ...baseOptions, region: 'iad1' })).toBe(
+      "(edgeNetworkRegion eq 'iad1' or functionRegion eq 'iad1')"
+    );
+  });
+
+  it('should build environment filter', () => {
+    expect(buildFilter({ ...baseOptions, environment: 'production' })).toBe(
+      "environment eq 'production'"
+    );
+  });
+
+  it('should combine multiple filters with AND', () => {
+    expect(
+      buildFilter({
+        ...baseOptions,
+        status: '5xx',
+        path: '/api',
+        method: 'POST',
+      })
+    ).toBe(
+      "httpStatus ge 500 and contains(requestPath, '/api') and requestMethod eq 'POST'"
+    );
+  });
+
+  it('should append raw filter at the end', () => {
+    expect(
+      buildFilter({
+        ...baseOptions,
+        status: '5xx',
+        filter: 'httpStatus in (500, 502, 503)',
+      })
+    ).toBe('httpStatus ge 500 and httpStatus in (500, 502, 503)');
+  });
+
+  it('should escape single quotes in string values', () => {
+    expect(buildFilter({ ...baseOptions, path: "/api/o'reilly" })).toBe(
+      "contains(requestPath, '/api/o''reilly')"
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/metrics/index.test.ts
+++ b/packages/cli/test/unit/commands/metrics/index.test.ts
@@ -1,0 +1,330 @@
+import { describe, beforeEach, expect, it, vi, afterEach } from 'vitest';
+import { client } from '../../../mocks/client';
+import metrics from '../../../../src/commands/metrics';
+import * as linkModule from '../../../../src/util/projects/link';
+
+vi.mock('../../../../src/util/projects/link');
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+
+describe('metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+
+    // Default mock for linked project
+    mockedGetLinkedProject.mockResolvedValue({
+      status: 'linked',
+      project: {
+        id: 'prj_123',
+        name: 'my-project',
+        accountId: 'org_123',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+      },
+      org: { id: 'org_123', slug: 'my-org', type: 'team' },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  describe('help', () => {
+    it('should show main help with --help flag', async () => {
+      client.setArgv('metrics', '--help');
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(2);
+      await expect(client.stderr).toOutput('Query observability metrics');
+    });
+
+    it('should show query help with query --help', async () => {
+      client.setArgv('metrics', 'query', '--help');
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(2);
+      await expect(client.stderr).toOutput('Run an observability query');
+    });
+  });
+
+  describe('query validation', () => {
+    it('should error when --event is missing', async () => {
+      client.setArgv('metrics', '--by', 'errorCode');
+
+      const exitCodePromise = metrics(client);
+
+      await expect(client.stderr).toOutput('Missing required flag --event');
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error on unknown event', async () => {
+      client.setArgv('metrics', '-e', 'unknownEvent');
+
+      const exitCodePromise = metrics(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Unknown event "unknownEvent"'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error on unknown dimension', async () => {
+      client.setArgv(
+        'metrics',
+        '-e',
+        'incomingRequest',
+        '--by',
+        'unknownDimension'
+      );
+
+      const exitCodePromise = metrics(client);
+
+      await expect(client.stderr).toOutput(
+        'Dimension "unknownDimension" is not available'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error on invalid aggregation for measure', async () => {
+      client.setArgv(
+        'metrics',
+        '-e',
+        'incomingRequest',
+        '-m',
+        'count',
+        '-a',
+        'p99'
+      );
+
+      const exitCodePromise = metrics(client);
+
+      await expect(client.stderr).toOutput(
+        'Aggregation "p99" is not valid for measure "count"'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+  });
+
+  describe('query execution', () => {
+    let requestBody: any;
+
+    beforeEach(() => {
+      requestBody = undefined;
+
+      client.scenario.post('/api/observability/metrics', (req, res) => {
+        requestBody = req.body;
+        res.json({
+          summary: [
+            { errorCode: 'FUNCTION_INVOCATION_TIMEOUT', value: 1234 },
+            { errorCode: 'FUNCTION_PAYLOAD_TOO_LARGE', value: 567 },
+          ],
+          data: [],
+          statistics: {
+            totalGroups: 2,
+            totalValue: 1801,
+          },
+        });
+      });
+    });
+
+    it('should make API call with correct query structure', async () => {
+      client.setArgv(
+        'metrics',
+        '-e',
+        'incomingRequest',
+        '--status',
+        '5xx',
+        '--by',
+        'errorCode',
+        '--since',
+        '1h'
+      );
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestBody).toBeDefined();
+      expect(requestBody.event).toBe('incomingRequest');
+      expect(requestBody.groupBy).toEqual(['errorCode']);
+      expect(requestBody.filter).toContain('httpStatus ge 500');
+      expect(requestBody.rollups.value.measure).toBe('count');
+      expect(requestBody.rollups.value.aggregation).toBe('sum');
+    });
+
+    it('should output table by default', async () => {
+      client.setArgv(
+        'metrics',
+        '-e',
+        'incomingRequest',
+        '--status',
+        '5xx',
+        '--by',
+        'errorCode',
+        '--since',
+        '1h'
+      );
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(0);
+      // Check the full output contains expected content
+      const output = client.stderr.getFullOutput();
+      expect(output).toContain('ERRORCODE');
+      expect(output).toContain('VALUE');
+      expect(output).toContain('FUNCTION_INVOCATION_TIMEOUT');
+    });
+
+    it('should output JSON with --json flag', async () => {
+      client.setArgv(
+        'metrics',
+        '-e',
+        'incomingRequest',
+        '--status',
+        '5xx',
+        '--by',
+        'errorCode',
+        '--json'
+      );
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(0);
+      const output = client.stdout.getFullOutput();
+      const parsed = JSON.parse(output);
+      expect(parsed.query.event).toBe('incomingRequest');
+      expect(parsed.summary).toHaveLength(2);
+      expect(parsed.statistics.totalValue).toBe(1801);
+    });
+
+    it('should support custom measure and aggregation', async () => {
+      client.setArgv(
+        'metrics',
+        '-e',
+        'incomingRequest',
+        '-m',
+        'requestDurationMs',
+        '-a',
+        'p95',
+        '--by',
+        'route'
+      );
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestBody.rollups.value.measure).toBe('requestDurationMs');
+      expect(requestBody.rollups.value.aggregation).toBe('p95');
+    });
+
+    it('should combine multiple filter shortcuts', async () => {
+      client.setArgv(
+        'metrics',
+        '-e',
+        'incomingRequest',
+        '--status',
+        '5xx',
+        '--path',
+        '/api',
+        '--method',
+        'POST',
+        '--region',
+        'iad1'
+      );
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestBody.filter).toContain('httpStatus ge 500');
+      expect(requestBody.filter).toContain("contains(requestPath, '/api')");
+      expect(requestBody.filter).toContain("requestMethod eq 'POST'");
+      expect(requestBody.filter).toContain("edgeNetworkRegion eq 'iad1'");
+    });
+  });
+
+  describe('project resolution', () => {
+    it('should error when project is not linked', async () => {
+      mockedGetLinkedProject.mockResolvedValue({
+        status: 'not_linked',
+        org: null,
+        project: null,
+      });
+
+      client.setArgv('metrics', '-e', 'incomingRequest');
+
+      const exitCodePromise = metrics(client);
+
+      await expect(client.stderr).toOutput("isn't linked to a project");
+      expect(await exitCodePromise).toBe(1);
+    });
+  });
+
+  describe('telemetry', () => {
+    beforeEach(() => {
+      client.scenario.post('/api/observability/metrics', (_req, res) => {
+        res.json({
+          summary: [],
+          data: [],
+          statistics: { totalGroups: 0, totalValue: 0 },
+        });
+      });
+    });
+
+    it('should track telemetry for query options', async () => {
+      client.setArgv(
+        'metrics',
+        '-e',
+        'incomingRequest',
+        '--status',
+        '5xx',
+        '--by',
+        'errorCode',
+        '--since',
+        '1h'
+      );
+
+      await metrics(client);
+
+      const events = client.telemetryEventStore.readonlyEvents;
+      expect(
+        events.some(
+          e => e.key === 'option:event' && e.value === 'incomingRequest'
+        )
+      ).toBe(true);
+      expect(
+        events.some(e => e.key === 'option:status' && e.value === '5xx')
+      ).toBe(true);
+      expect(
+        events.some(e => e.key === 'option:by' && e.value === 'errorCode')
+      ).toBe(true);
+      expect(
+        events.some(e => e.key === 'option:since' && e.value === '1h')
+      ).toBe(true);
+    });
+
+    it('should redact sensitive values', async () => {
+      client.setArgv(
+        'metrics',
+        '-e',
+        'incomingRequest',
+        '--path',
+        '/api/secret',
+        '--filter',
+        'secret eq true'
+      );
+
+      await metrics(client);
+
+      const events = client.telemetryEventStore.readonlyEvents;
+      expect(
+        events.some(e => e.key === 'option:path' && e.value === '[REDACTED]')
+      ).toBe(true);
+      expect(
+        events.some(e => e.key === 'option:filter' && e.value === '[REDACTED]')
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -1,0 +1,100 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import metrics from '../../../../src/commands/metrics';
+
+describe('metrics schema', () => {
+  beforeEach(() => {
+    client.reset();
+  });
+
+  describe('list all events', () => {
+    it('should list all available events', async () => {
+      client.setArgv('metrics', 'schema');
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(0);
+      // Check the full stderr output
+      const output = client.stderr.getFullOutput();
+      expect(output).toContain('Available Events');
+      expect(output).toContain('incomingRequest');
+      expect(output).toContain('functionExecution');
+    });
+
+    it('should output JSON when --json flag is used', async () => {
+      client.setArgv('metrics', 'schema', '--json');
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(0);
+      // stdout should contain JSON
+      const output = client.stdout.getFullOutput();
+      expect(output).toContain('"events"');
+      expect(output).toContain('"incomingRequest"');
+    });
+  });
+
+  describe('show event details', () => {
+    it('should show dimensions and measures for a specific event', async () => {
+      client.setArgv('metrics', 'schema', '-e', 'incomingRequest');
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(0);
+      const output = client.stderr.getFullOutput();
+      expect(output).toContain('Event: incomingRequest');
+      expect(output).toContain('Dimensions (--by)');
+      expect(output).toContain('httpStatus');
+      expect(output).toContain('Measures (--measure)');
+      expect(output).toContain('count');
+      expect(output).toContain('requestDurationMs');
+    });
+
+    it('should output JSON for a specific event', async () => {
+      client.setArgv('metrics', 'schema', '-e', 'incomingRequest', '--json');
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(0);
+      const output = client.stdout.getFullOutput();
+      const parsed = JSON.parse(output);
+      expect(parsed.event).toBe('incomingRequest');
+      expect(parsed.dimensions).toBeDefined();
+      expect(parsed.measures).toBeDefined();
+    });
+
+    it('should error on unknown event', async () => {
+      client.setArgv('metrics', 'schema', '-e', 'unknownEvent');
+
+      const exitCodePromise = metrics(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Unknown event "unknownEvent"'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should suggest similar events for typos', async () => {
+      client.setArgv('metrics', 'schema', '-e', 'incomingReques');
+
+      const exitCodePromise = metrics(client);
+
+      await expect(client.stderr).toOutput('Did you mean: incomingRequest');
+      expect(await exitCodePromise).toBe(1);
+    });
+  });
+
+  describe('help', () => {
+    it('should show help with --help flag', async () => {
+      client.setArgv('metrics', 'schema', '--help');
+
+      const exitCode = await metrics(client);
+
+      expect(exitCode).toBe(2);
+      const output = client.stderr.getFullOutput();
+      expect(output).toContain(
+        'List available events, dimensions, and measures'
+      );
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/metrics/validation.test.ts
+++ b/packages/cli/test/unit/commands/metrics/validation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  validateEvent,
+  validateDimension,
+  validateMeasure,
+  validateAggregation,
+  formatValidationError,
+} from '../../../../src/commands/metrics/validation';
+
+describe('validateEvent', () => {
+  it('should accept valid event names', () => {
+    expect(validateEvent('incomingRequest')).toEqual({ valid: true });
+    expect(validateEvent('functionExecution')).toEqual({ valid: true });
+    expect(validateEvent('aiGatewayRequest')).toEqual({ valid: true });
+  });
+
+  it('should reject invalid event names', () => {
+    const result = validateEvent('unknownEvent');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unknown event "unknownEvent"');
+  });
+
+  it('should provide suggestions for typos', () => {
+    const result = validateEvent('incomingReques');
+    expect(result.valid).toBe(false);
+    expect(result.suggestions).toContain('incomingRequest');
+  });
+});
+
+describe('validateDimension', () => {
+  it('should accept valid dimensions for an event', () => {
+    expect(validateDimension('incomingRequest', 'httpStatus')).toEqual({
+      valid: true,
+    });
+    expect(validateDimension('incomingRequest', 'requestPath')).toEqual({
+      valid: true,
+    });
+    expect(validateDimension('incomingRequest', 'errorCode')).toEqual({
+      valid: true,
+    });
+  });
+
+  it('should reject invalid dimensions', () => {
+    const result = validateDimension('incomingRequest', 'unknownDimension');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain(
+      'Dimension "unknownDimension" is not available'
+    );
+  });
+
+  it('should provide suggestions for typos', () => {
+    const result = validateDimension('incomingRequest', 'httpStatu');
+    expect(result.valid).toBe(false);
+    expect(result.suggestions).toContain('httpStatus');
+  });
+});
+
+describe('validateMeasure', () => {
+  it('should accept valid measures for an event', () => {
+    expect(validateMeasure('incomingRequest', 'count')).toEqual({
+      valid: true,
+    });
+    expect(validateMeasure('incomingRequest', 'requestDurationMs')).toEqual({
+      valid: true,
+    });
+  });
+
+  it('should reject invalid measures', () => {
+    const result = validateMeasure('incomingRequest', 'unknownMeasure');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Measure "unknownMeasure" is not available');
+  });
+
+  it('should provide suggestions for typos', () => {
+    const result = validateMeasure('incomingRequest', 'requestDuration');
+    expect(result.valid).toBe(false);
+    expect(result.suggestions).toContain('requestDurationMs');
+  });
+});
+
+describe('validateAggregation', () => {
+  it('should accept valid aggregations for a measure', () => {
+    expect(validateAggregation('incomingRequest', 'count', 'sum')).toEqual({
+      valid: true,
+    });
+    expect(
+      validateAggregation('incomingRequest', 'requestDurationMs', 'p95')
+    ).toEqual({ valid: true });
+  });
+
+  it('should reject invalid aggregations', () => {
+    const result = validateAggregation('incomingRequest', 'count', 'p95');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain(
+      'Aggregation "p95" is not valid for measure "count"'
+    );
+    expect(result.suggestions).toContain('sum');
+  });
+});
+
+describe('formatValidationError', () => {
+  it('should format error without suggestions', () => {
+    const result = formatValidationError({
+      valid: false,
+      error: 'Something went wrong.',
+    });
+    expect(result).toBe('Something went wrong.');
+  });
+
+  it('should format error with suggestions', () => {
+    const result = formatValidationError({
+      valid: false,
+      error: 'Unknown event "test".',
+      suggestions: ['testEvent', 'testOperation'],
+    });
+    expect(result).toContain('Unknown event "test".');
+    expect(result).toContain('Did you mean: testEvent, testOperation?');
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `vercel metrics` command to query Vercel's Observability API from the terminal
- Enables developers and agents to investigate errors, analyze performance, and debug production issues
- Adds `vercel metrics schema` subcommand to discover available events, dimensions, and measures
- Supports filter shortcuts (--status, --error, --path, --method, --region) for easy query construction
- Provides both human-readable table output and --json for scripting/agents
- Includes input validation with typo suggestions via Levenshtein distance

## Example Usage

```bash
# List available events
vercel metrics schema

# Show dimensions and measures for an event
vercel metrics schema -e incomingRequest

# Get 5xx errors grouped by error code
vercel metrics -e incomingRequest --status 5xx --by errorCode --since 1h

# P95 latency by route
vercel metrics -e incomingRequest -m requestDurationMs -a p95 --by route --since 24h

# JSON output for agents/scripts
vercel metrics -e incomingRequest --status 5xx --by errorCode --json
```

## Test Plan

- [x] Unit tests for filter building (17 tests)
- [x] Unit tests for validation with typo suggestions (13 tests)
- [x] Unit tests for schema subcommand (7 tests)
- [x] Integration tests for query execution (14 tests)
- [x] Manual testing of CLI commands

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> New CLI command implementation for querying observability metrics with comprehensive input validation, telemetry tracking, and extensive test coverage - no security-sensitive changes.
> 
> - Adds `vercel metrics` command with schema and query subcommands
> - Includes input validation with typo suggestions via Levenshtein distance
> - Comprehensive unit and integration tests (17 filter, 13 validation, 7 schema, 14 integration tests)
>
> <sup>Risk assessment for [commit f6161f4](https://github.com/vercel/vercel/commit/f6161f42d929546fb2f338221001cc0bfb354cf7).</sup>
<!-- VADE_RISK_END -->