### PR TITLE
[ci] add canary release workflow

### DIFF
--- a/.changeset/canary-release-workflow.md
+++ b/.changeset/canary-release-workflow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add canary release workflow for publishing pre-release versions from branches.

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -104,13 +104,24 @@ jobs:
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
           CANARY_SUFFIX="canary.${TIMESTAMP}.${SHORT_SHA}"
 
-          # For each public package, bump to the next minor prerelease version.
+          # Use turbo ls to get the real list of packages, then bump each
+          # public package to the next minor prerelease version.
           # e.g. 1.2.3 -> 1.3.0-canary.20260211120000.abc1234
+          PACKAGES=$(npx turbo ls --output json | node -e "
+            const chunks = [];
+            process.stdin.on('data', c => chunks.push(c));
+            process.stdin.on('end', () => {
+              const data = JSON.parse(chunks.join(''));
+              const paths = data.packages.items.map(p => p.path);
+              console.log(JSON.stringify(paths));
+            });
+          ")
+
           node -e "
             const fs = require('fs');
-            const glob = require('glob');
-            const pkgPaths = glob.sync('packages/*/package.json');
-            for (const pkgPath of pkgPaths) {
+            const pkgDirs = JSON.parse(process.argv[1]);
+            for (const dir of pkgDirs) {
+              const pkgPath = dir + '/package.json';
               const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
               if (pkg.private) continue;
               const [major, minor] = pkg.version.split('.').map(Number);
@@ -118,7 +129,7 @@ jobs:
               fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
               console.log(pkg.name + '@' + pkg.version);
             }
-          "
+          " "$PACKAGES"
 
       # Post-publish steps from release.yml (trigger update workflow, python
       # runtime release, update latest GitHub release) are intentionally omitted

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -26,10 +26,15 @@ jobs:
     name: Release Canary
     needs: approve
     runs-on: ubuntu-latest
+    # Only contents: read is needed (release.yml uses contents: write because
+    # changesets pushes commits/tags back to the repo).
     permissions:
       contents: read
       id-token: write
     steps:
+      # Unlike release.yml, we use the default GITHUB_TOKEN and skip fetching
+      # git tags. The custom token and tags are only needed for changesets to
+      # push commits/tags back to the repo, which canary releases don't do.
       - name: Checkout Repo
         uses: actions/checkout@v4
 
@@ -79,6 +84,9 @@ jobs:
             }
           "
 
+      # Post-publish steps from release.yml (trigger update workflow, python
+      # runtime release, update latest GitHub release) are intentionally omitted
+      # since those are only relevant for production releases.
       - name: Publish Canary to npm
         run: pnpm publish -r --tag canary --no-git-checks
         env:

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -2,6 +2,11 @@ name: Release Canary
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to release from'
+        required: true
+        type: string
 
 env:
   TURBO_REMOTE_ONLY: 'true'
@@ -11,20 +16,48 @@ env:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  # Resolve the branch and SHA before the approval gate so the approver
+  # can see exactly what will be published in the workflow summary.
+  resolve:
+    name: Resolve Branch
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Verify branch and resolve SHA
+        id: resolve
+        run: |
+          SHA=$(git ls-remote --heads origin "${{ inputs.branch }}" | awk '{print $1}')
+          if [ -z "$SHA" ]; then
+            echo "::error::Branch '${{ inputs.branch }}' does not exist"
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Print release info
+        run: |
+          echo "## Canary Release" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Branch** | \`${{ inputs.branch }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **SHA** | \`${{ steps.resolve.outputs.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+
   # The "canary-release" environment must be configured in repo settings
   # with "vercel-cli-approvers" as a required reviewer. This is the only
   # way to gate a workflow_dispatch behind team approval in GitHub Actions.
   approve:
     name: Require Approval
+    needs: resolve
     runs-on: ubuntu-latest
     environment: canary-release
     steps:
       - name: Approved
-        run: echo "Release approved"
+        run: echo "Releasing ${{ inputs.branch }} @ ${{ needs.resolve.outputs.sha }}"
 
   release-canary:
     name: Release Canary
-    needs: approve
+    needs: [approve, resolve]
     runs-on: ubuntu-latest
     # Only contents: read is needed (release.yml uses contents: write because
     # changesets pushes commits/tags back to the repo).
@@ -37,6 +70,8 @@ jobs:
       # push commits/tags back to the repo, which canary releases don't do.
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -65,7 +100,7 @@ jobs:
 
       - name: Set Canary Versions
         run: |
-          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          SHORT_SHA=$(echo "${{ needs.resolve.outputs.sha }}" | cut -c1-7)
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
           CANARY_SUFFIX="canary.${TIMESTAMP}.${SHORT_SHA}"
 

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,0 +1,86 @@
+name: Release Canary
+
+on:
+  workflow_dispatch:
+
+env:
+  TURBO_REMOTE_ONLY: 'true'
+  TURBO_TEAM: 'vercel'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  # The "canary-release" environment must be configured in repo settings
+  # with "vercel-cli-approvers" as a required reviewer. This is the only
+  # way to gate a workflow_dispatch behind team approval in GitHub Actions.
+  approve:
+    name: Require Approval
+    runs-on: ubuntu-latest
+    environment: canary-release
+    steps:
+      - name: Approved
+        run: echo "Release approved"
+
+  release-canary:
+    name: Release Canary
+    needs: approve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16
+        with:
+          toolchain: stable
+          targets: wasm32-wasip2
+
+      - name: install npm@9
+        run: npm i -g npm@9
+
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Packages
+        run: pnpm build
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Set Canary Versions
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          CANARY_SUFFIX="canary.${TIMESTAMP}.${SHORT_SHA}"
+
+          # For each public package, append canary suffix to current version
+          node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const glob = require('glob');
+            const pkgPaths = glob.sync('packages/*/package.json');
+            for (const pkgPath of pkgPaths) {
+              const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+              if (pkg.private) continue;
+              pkg.version = pkg.version + '-${CANARY_SUFFIX}';
+              fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+              console.log(pkg.name + '@' + pkg.version);
+            }
+          "
+
+      - name: Publish Canary to npm
+        run: pnpm publish -r --tag canary --no-git-checks
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -104,16 +104,17 @@ jobs:
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
           CANARY_SUFFIX="canary.${TIMESTAMP}.${SHORT_SHA}"
 
-          # For each public package, append canary suffix to current version
+          # For each public package, bump to the next minor prerelease version.
+          # e.g. 1.2.3 -> 1.3.0-canary.20260211120000.abc1234
           node -e "
             const fs = require('fs');
-            const path = require('path');
             const glob = require('glob');
             const pkgPaths = glob.sync('packages/*/package.json');
             for (const pkgPath of pkgPaths) {
               const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
               if (pkg.private) continue;
-              pkg.version = pkg.version + '-${CANARY_SUFFIX}';
+              const [major, minor] = pkg.version.split('.').map(Number);
+              pkg.version = major + '.' + (minor + 1) + '.0-${CANARY_SUFFIX}';
               fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
               console.log(pkg.name + '@' + pkg.version);
             }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -62,6 +62,34 @@ pnpm vercel switch --debug
 
 When you are satisfied with your changes, make a commit and create a pull request!
 
+## Publishing
+
+### Production Releases
+
+Production releases are automated via the [`release.yml`](../../.github/workflows/release.yml) workflow, which runs on every push to `main`. It uses [changesets](https://github.com/changesets/changesets) to determine which packages need new versions. If there are pending changesets, the workflow either creates a "Version Packages" PR or publishes to npm with the `latest` dist-tag.
+
+To include your changes in a release, add a changeset before merging your PR:
+
+```bash
+pnpm changeset
+```
+
+### Canary Releases
+
+Canary releases let you publish pre-release versions from any branch. You can use this sparingly
+to test changes before they land on `main`.
+
+1. Go to the [Release Canary](../../.github/workflows/release-canary.yml) workflow in the Actions tab.
+2. Click **Run workflow** and enter the branch name.
+3. A member of the `vercel-cli-approvers` team must approve the release.
+4. Once approved, all public packages are published to npm with a canary version (e.g. `1.2.3-canary.20260211120000.abc1234`) under the `canary` dist-tag.
+
+To install a canary release:
+
+```bash
+npm i -g vercel@canary
+```
+
 ### Full Testing
 
 `pnpm vercel` executes a locally built dist. Because this dist lives locally in this monorepo,


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` workflow (`release-canary.yml`) that publishes canary-tagged versions of packages from any branch
- Requires approval via a `canary-release` GitHub environment (must be configured in repo settings with `vercel-cli-approvers` as required reviewers)
- Publishes with `--tag canary` so `latest` dist-tags are unaffected

## Setup required

Create a `canary-release` environment in **Settings > Environments** and add `vercel-cli-approvers` as a required reviewer.

## Test plan

- [ ] Verify workflow appears in Actions tab
- [ ] Trigger workflow from a non-main branch
- [ ] Confirm approval gate blocks until reviewer approves
- [ ] Confirm packages are published with canary tag

Made with [Cursor](https://cursor.com)

<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> New CI workflow enables publishing npm packages from any branch using elevated NPM token, gated by GitHub environment approval; requires careful review of release pipeline security.
> 
> - Adds workflow_dispatch workflow that publishes packages to npm with `--no-git-checks`
> - Uses `NPM_TOKEN_ELEVATED` secret for publishing canary releases
> - Approval gate via `canary-release` environment required before publish
>
> <sup>Risk assessment for [commit b4d2ddd](https://github.com/vercel/vercel/commit/b4d2dddf8d66722d409cd13d581308a159ff0609).</sup>
<!-- VADE_RISK_END -->