### PR TITLE
Fix branch resolution in canary release workflow

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -26,8 +26,10 @@ jobs:
     steps:
       - name: Verify branch and resolve SHA
         id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          SHA=$(git ls-remote --heads origin "${{ inputs.branch }}" | awk '{print $1}')
+          SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/${{ inputs.branch }}" --jq '.object.sha' 2>/dev/null || true)
           if [ -z "$SHA" ]; then
             echo "::error::Branch '${{ inputs.branch }}' does not exist"
             exit 1


### PR DESCRIPTION
## Summary

- Use GitHub API (`gh api`) instead of `git ls-remote` in the `resolve` job, since it doesn't have a checkout step and `origin` doesn't exist.

Tested here (by using the workflow from this branch): https://github.com/vercel/vercel/actions/runs/21915304173

Made with [Cursor](https://cursor.com)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR changes the method of resolving a branch SHA in a CI workflow from git ls-remote to GitHub API, which is a minor infrastructure change but maintains the same validation logic.
> 
> - CI: switches from `git ls-remote` to `gh api` for branch resolution
> - Adds GH_TOKEN env var for API authentication
> - Existing validation logic (empty SHA check) remains unchanged
>
> <sup>Risk assessment for [commit 58ffde9](https://github.com/vercel/vercel/commit/58ffde9e4110ae94cfaceeaac507fee6b183d0cb).</sup>
<!-- VADE_RISK_END -->