### PR TITLE
[ci] fix workflow to release canaries

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -136,8 +136,10 @@ jobs:
       # Post-publish steps from release.yml (trigger update workflow, python
       # runtime release, update latest GitHub release) are intentionally omitted
       # since those are only relevant for production releases.
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN_ELEVATED }}" >> ~/.npmrc
+
       - name: Publish Canary to npm
         run: pnpm publish -r --tag canary --no-git-checks
         env:
           NPM_CONFIG_PROVENANCE: 'true'
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -140,6 +140,46 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN_ELEVATED }}" >> ~/.npmrc
 
       - name: Publish Canary to npm
-        run: pnpm publish -r --tag canary --no-git-checks
         env:
           NPM_CONFIG_PROVENANCE: 'true'
+        run: |
+          FAILED=""
+          PUBLISHED=""
+
+          PACKAGES=$(npx turbo ls --output json | node -e "
+            const chunks = [];
+            process.stdin.on('data', c => chunks.push(c));
+            process.stdin.on('end', () => {
+              const data = JSON.parse(chunks.join(''));
+              const paths = data.packages.items.map(p => p.path);
+              console.log(JSON.stringify(paths));
+            });
+          ")
+
+          for dir in $(node -e "JSON.parse(process.argv[1]).forEach(d => console.log(d))" "$PACKAGES"); do
+            PKG_JSON="$dir/package.json"
+            PRIVATE=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$PKG_JSON','utf8')).private || false)")
+            if [ "$PRIVATE" = "true" ]; then
+              continue
+            fi
+            NAME=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$PKG_JSON','utf8')).name)")
+            VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$PKG_JSON','utf8')).version)")
+
+            echo "Publishing $NAME@$VERSION..."
+            if pnpm publish --tag canary --no-git-checks -C "$dir" 2>&1; then
+              PUBLISHED="$PUBLISHED\n  $NAME@$VERSION"
+            else
+              echo "::warning::Failed to publish $NAME@$VERSION"
+              FAILED="$FAILED\n  $NAME@$VERSION"
+            fi
+          done
+
+          echo ""
+          echo "=== Publish Summary ==="
+          if [ -n "$PUBLISHED" ]; then
+            echo -e "Published:$PUBLISHED"
+          fi
+          if [ -n "$FAILED" ]; then
+            echo -e "Failed:$FAILED"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Configure registry auth token in `~/.npmrc` before `pnpm publish`, since the direct publish command doesn't pick up `NPM_TOKEN` from env vars (unlike the `changesets/action` used in `release.yml` which handles this internally).

Tested full publish works here: https://github.com/vercel/vercel/actions/runs/21915824170/job/63282746919

## Test plan

- [ ] Trigger canary release workflow and verify publish succeeds without `ENEEDAUTH`

Made with [Cursor](https://cursor.com)

<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR modifies CI/CD workflow to configure npm authentication via .npmrc file and adds a more robust package publishing loop with error handling for canary releases.
> 
> - Infrastructure: configures npm auth token in ~/.npmrc for registry authentication
> - Replaces single pnpm publish command with iterative per-package publish loop
> - Adds publish summary with success/failure tracking
>
> <sup>Risk assessment for [commit 9dc361f](https://github.com/vercel/vercel/commit/9dc361f0ed6e7e5ca16a5bf1d69ffab00914a416).</sup>
<!-- VADE_RISK_END -->