### PR TITLE
chore(@vercel/mcp-adapter): fix metadata for publishing

### DIFF
--- a/.changeset/itchy-hounds-double.md
+++ b/.changeset/itchy-hounds-double.md
@@ -1,0 +1,5 @@
+---
+'@vercel/mcp-adapter': patch
+---
+
+Fix .repository field in package.json to make it possible to publish

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@vercel/mcp-adapter",
   "version": "0.3.1",
-  "description": "Vercel MCP Adapter for Next.js and other frameworks"
+  "description": "Vercel MCP Adapter for Next.js and other frameworks",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/vercel.git",
+    "directory": "packages/mcp-adapter"
+  }
 }


### PR DESCRIPTION
I don't need a real release of this package. But I'm setting up the ability to do canary releases, this package is getting caught in there, and then failing to publish. We'll have to deal with this later if we ever want another release, so might as well fix it. 

Example failure: https://github.com/vercel/vercel/actions/runs/21915824170/job/63282746919#step:11:182