### PR TITLE
[cli] Remove tags from the discover command (non-json) output

### DIFF
--- a/.changeset/product-centric-discover.md
+++ b/.changeset/product-centric-discover.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove tags column from `integration discover` table and compact terminal views to reduce width on small screens. Tags remain available in JSON output.

--- a/packages/cli/src/commands/integration/discover.ts
+++ b/packages/cli/src/commands/integration/discover.ts
@@ -190,7 +190,7 @@ export async function discover(client: Client, args: string[]) {
 function formatTable(products: ProductEntry[]) {
   return table(
     [
-      ['Product Name', 'Slug', 'Provider', 'Description', 'Tags'].map(header =>
+      ['Product Name', 'Slug', 'Provider', 'Description'].map(header =>
         chalk.bold(chalk.cyan(header))
       ),
       ...products.map(product => [
@@ -198,7 +198,6 @@ function formatTable(products: ProductEntry[]) {
         product.slug,
         product.provider,
         product.description || chalk.gray('-'),
-        product.tags.length > 0 ? product.tags.join(', ') : chalk.gray('-'),
       ]),
     ],
     { hsep: 4 }
@@ -212,7 +211,6 @@ function formatCompactList(products: ProductEntry[]) {
         `${chalk.bold(product.name)} (${product.slug})`,
         `  Provider: ${product.provider}`,
         `  Description: ${product.description || '-'}`,
-        `  Tags: ${product.tags.length > 0 ? product.tags.join(', ') : '-'}`,
       ].join('\n');
     })
     .join('\n\n');

--- a/packages/cli/test/unit/commands/integration/discover.test.ts
+++ b/packages/cli/test/unit/commands/integration/discover.test.ts
@@ -68,7 +68,6 @@ describe('integration', () => {
       expect(stderr).toContain('Neon Postgres (neon)');
       expect(stderr).toContain('Provider: Neon');
       expect(stderr).toContain('Description: Serverless Postgres database');
-      expect(stderr).toContain('Tags: Storage, DevTools, Postgres');
       expect(stderr).toContain('Acme KV (acme-multi/acme-kv)');
       expect(stderr).toContain('Acme DB (acme-multi/acme-db)');
     });


### PR DESCRIPTION
## Summary
- Remove the Tags column from `integration discover` table and compact views to reduce width on small screens
- Tags remain available in `--json` output for programmatic consumers

## Test plan
- [x] `npx vitest run packages/cli/test/unit/commands/integration/discover.test.ts` — 7/7 pass
- [x] `npx vitest run packages/cli/test/unit/commands/help.test.ts` — 124/124 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR removes the Tags column from CLI table and compact output views, a purely cosmetic change to reduce display width with no security or logic implications.
> 
> - Removes Tags column from `integration discover` table view
> - Removes Tags line from compact list view
> - Updates corresponding test expectations
>
> <sup>Risk assessment for [commit e7d8508](https://github.com/vercel/vercel/commit/e7d85087bc34089335940e9affed393bc4a7ea5f).</sup>
<!-- VADE_RISK_END -->