### PR TITLE
[cli] Properly wire the usage command

### DIFF
--- a/.changeset/twelve-pianos-drop.md
+++ b/.changeset/twelve-pianos-drop.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix usage command wiring

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -41,5 +41,6 @@ export { default as target } from './commands/target';
 export { default as teams } from './commands/teams';
 export { default as telemetry } from './commands/telemetry';
 export { default as upgrade } from './commands/upgrade';
+export { default as usage } from './commands/usage';
 export { default as webhooks } from './commands/webhooks';
 export { default as whoami } from './commands/whoami';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -862,7 +862,7 @@ const main = async () => {
           break;
         case 'usage':
           telemetry.trackCliCommandUsage(userSuppliedSubCommand);
-          func = require('./commands/usage').default;
+          func = (await import('./commands-bulk.js')).usage;
           break;
         case 'whoami':
           telemetry.trackCliCommandWhoami(userSuppliedSubCommand);


### PR DESCRIPTION
The just-merged #14733 broke the CLI build:

	vercel:build: > vercel@50.15.1 build
	vercel:build: > node scripts/build.mjs
	vercel:build:
	vercel:build:
	vercel:build: Error: src/index.ts uses require() to load commands (1 occurrence(s)).
	vercel:build: Commands must be loaded via: (await import('./commands-bulk.js')).<name>
	vercel:build: We use this pattern for more efficient code splitting and minimizing the startup time of the CLI.
	vercel:build:
	vercel:build:  ELIFECYCLE  Command failed with exit code 1.
	vercel:build: ERROR: command finished with error: command

Use correct import mechanism.


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR fixes a CLI build error by changing the import mechanism for the usage command from require() to dynamic import(), which is a trivial refactor with no security or logic changes.
> 
> - Adds usage export to commands-bulk.ts
> - Changes require() to dynamic import() for usage command in index.ts
> - Adds changeset for patch version
>
> <sup>Risk assessment for [commit 9162db9](https://github.com/vercel/vercel/commit/9162db9f1f7d73c6d11d20ae5c7293d31bf0bc46).</sup>
<!-- VADE_RISK_END -->