### PR TITLE
[cli] Fix build failures

### DIFF
--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -41,5 +41,6 @@ export { default as target } from './commands/target';
 export { default as teams } from './commands/teams';
 export { default as telemetry } from './commands/telemetry';
 export { default as upgrade } from './commands/upgrade';
+export { default as usage } from './commands/usage';
 export { default as webhooks } from './commands/webhooks';
 export { default as whoami } from './commands/whoami';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -862,7 +862,7 @@ const main = async () => {
           break;
         case 'usage':
           telemetry.trackCliCommandUsage(userSuppliedSubCommand);
-          func = require('./commands/usage').default;
+          func = (await import('./commands-bulk.js')).usage;
           break;
         case 'whoami':
           telemetry.trackCliCommandWhoami(userSuppliedSubCommand);


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR is a trivial refactor that changes how the 'usage' command is imported, moving from a direct require to importing via a bulk exports file.
> 
> - Adds 'usage' export to commands-bulk.ts
> - Changes import mechanism for 'usage' command from require to dynamic import via bulk file
>
> <sup>Risk assessment for [commit 82a4709](https://github.com/vercel/vercel/commit/82a47090a85d3a2c7b5f4686d290aac79086f783).</sup>
<!-- VADE_RISK_END -->