### PR TITLE
fix(cli): accumulate all stdin data chunks for multiline env values

### DIFF
--- a/packages/cli/src/util/input/read-standard-input.ts
+++ b/packages/cli/src/util/input/read-standard-input.ts
@@ -4,14 +4,36 @@ export default async function readStandardInput(
   stdin: ReadableTTY
 ): Promise<string> {
   return new Promise<string>(resolve => {
-    setTimeout(() => resolve(''), 500);
-
     if (stdin.isTTY) {
       // found tty so we know there is nothing piped to stdin
       resolve('');
-    } else {
-      stdin.setEncoding('utf8');
-      stdin.once('data', resolve);
+      return;
     }
+
+    stdin.setEncoding('utf8');
+    let data = '';
+    let resolved = false;
+
+    const finish = () => {
+      if (!resolved) {
+        resolved = true;
+        resolve(data);
+      }
+    };
+
+    stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+
+    stdin.once('end', finish);
+    stdin.once('error', finish);
+
+    // Fallback timeout only triggers if no data was received
+    // This handles edge cases where stdin exists but has no content
+    setTimeout(() => {
+      if (data === '') {
+        finish();
+      }
+    }, 500);
   });
 }


### PR DESCRIPTION
## Summary

Fixes #14972

When piping multiline values (such as PEM private keys) to `vercel env add`, only the first line was being captured, silently dropping the rest of the content. This caused data corruption that was invisible at set-time but caused runtime failures (e.g., Firebase Admin SDK failing with cryptic errors).

## Root Cause

`readStandardInput()` was using `stdin.once('data', resolve)` which only captures the first data chunk from stdin. When Node.js streams deliver piped content, large data may arrive in multiple chunks rather than all at once.

## Fix

- Changed from `stdin.once('data', ...)` to `stdin.on('data', ...)` to accumulate all chunks
- Wait for the `end` event before resolving with the complete data
- Keep the timeout fallback (500ms) for edge cases where stdin exists but has no content

## Testing

Verified the fix works with:
1. Single-line values
2. Multiline values in a single chunk
3. Large multiline values (PEM keys ~1700 chars) delivered in multiple chunks
4. TTY mode (no stdin piped)

## Changes

- `packages/cli/src/util/input/read-standard-input.ts`: Accumulate all stdin data chunks instead of taking only the first

## Impact

This fix affects all commands that use `readStandardInput()`:
- `vercel env add` (reported in issue)
- `vercel env update`
- `vercel inspect`

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR fixes a bug in stdin reading by accumulating all data chunks instead of only capturing the first chunk, which is a straightforward stream handling improvement with no security implications.
> 
> - Changed from `stdin.once('data', ...)` to `stdin.on('data', ...)` to accumulate chunks
> - Added `end` and `error` event handlers for proper stream completion
> - Timeout fallback now only triggers when no data received
>
> <sup>Risk assessment for [commit f1c16d8](https://github.com/vercel/vercel/commit/f1c16d88700c8b4c996dd9e0c22b1298a7d042a7).</sup>
<!-- VADE_RISK_END -->