### PR TITLE
[cli] Add interactive terms acceptance for Marketplace integrations

### DIFF
--- a/.changeset/last-tall-cats.md
+++ b/.changeset/last-tall-cats.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Prompt for Marketplace terms inline and install before provisioning in `integration add`

--- a/packages/cli/src/util/integration/auto-provision-resource.ts
+++ b/packages/cli/src/util/integration/auto-provision-resource.ts
@@ -15,7 +15,7 @@ function isAutoProvisionFallback(
     typeof error === 'object' &&
     error !== null &&
     'kind' in error &&
-    ['install', 'metadata', 'unknown'].includes(
+    ['metadata', 'unknown'].includes(
       (error as { kind: unknown }).kind as string
     ) &&
     'url' in error &&

--- a/packages/cli/src/util/integration/prompt-for-terms.ts
+++ b/packages/cli/src/util/integration/prompt-for-terms.ts
@@ -1,0 +1,66 @@
+import output from '../../output-manager';
+import type Client from '../client';
+import type { AcceptedPolicies, Integration } from './types';
+
+const MARKETPLACE_ADDENDUM_URL =
+  'https://vercel.com/legal/integration-marketplace-end-users-addendum';
+
+export async function promptForTermAcceptance(
+  client: Client,
+  integration: Integration
+): Promise<AcceptedPolicies | null> {
+  if (client.isAgent) {
+    output.error(
+      'Term acceptance cannot be performed by an AI agent. Run this command directly in your terminal.'
+    );
+    return null;
+  }
+
+  if (!client.stdin.isTTY) {
+    output.error(
+      'Term acceptance requires an interactive terminal. Run this command in a TTY.'
+    );
+    return null;
+  }
+
+  const addendumAccepted = await client.input.confirm(
+    `Accept Vercel Marketplace End User Addendum? (${MARKETPLACE_ADDENDUM_URL})`,
+    false
+  );
+  if (!addendumAccepted) {
+    output.error(
+      'Vercel Marketplace End User Addendum must be accepted to continue.'
+    );
+    return null;
+  }
+
+  const acceptedPolicies: AcceptedPolicies = {
+    toc: new Date().toISOString(),
+  };
+
+  if (integration.privacyDocUri) {
+    const accepted = await client.input.confirm(
+      `Accept privacy policy? (${integration.privacyDocUri})`,
+      false
+    );
+    if (!accepted) {
+      output.error('Privacy policy must be accepted to continue.');
+      return null;
+    }
+    acceptedPolicies.privacy = new Date().toISOString();
+  }
+
+  if (integration.eulaDocUri) {
+    const accepted = await client.input.confirm(
+      `Accept terms of service? (${integration.eulaDocUri})`,
+      false
+    );
+    if (!accepted) {
+      output.error('Terms of service must be accepted to continue.');
+      return null;
+    }
+    acceptedPolicies.eula = new Date().toISOString();
+  }
+
+  return acceptedPolicies;
+}

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -83,6 +83,8 @@ export interface Integration {
   slug: string;
   name: string;
   products?: IntegrationProduct[];
+  eulaDocUri?: string;
+  privacyDocUri?: string;
 }
 
 export interface IntegrationInstallation {
@@ -156,8 +158,9 @@ export interface MarketplaceBillingAuthorizationState {
 
 // Auto-provision types
 
-// AcceptedPolicies: key = policy name ('privacy' | 'eula'), value = ISO timestamp
-export type AcceptedPolicies = Record<string, string>;
+export type AcceptedPolicies = Partial<
+  Record<'toc' | 'privacy' | 'eula', string>
+>;
 
 export interface AutoProvisionIntegration {
   id: string;
@@ -198,7 +201,7 @@ export interface AutoProvisionedResponse {
 }
 
 export interface AutoProvisionFallback {
-  kind: 'install' | 'metadata' | 'unknown';
+  kind: 'metadata' | 'unknown';
   url: string;
   integration: AutoProvisionIntegration;
   product: AutoProvisionProduct;

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -273,18 +273,23 @@ describe('integration add (auto-provision)', () => {
 
   describe('policy acceptance flow', () => {
     beforeEach(() => {
-      // First call returns 'install' (policies required), second call returns 'provisioned'
+      // No installation — triggers upfront term prompts
       useAutoProvision({
-        responseKey: 'install',
-        secondResponseKey: 'provisioned',
+        responseKey: 'provisioned',
+        withInstallation: false,
       });
     });
 
-    it('should prompt for policy acceptance and retry', async () => {
+    it('should prompt for terms upfront and provision', async () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // Auto-generated name, server fills metadata defaults — no prompts
+      // 3-term prompt sequence (upfront, before provisioning)
+      await expect(client.stderr).toOutput(
+        'Accept Vercel Marketplace End User Addendum?'
+      );
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('y\n');
 
@@ -299,11 +304,32 @@ describe('integration add (auto-provision)', () => {
       expect(exitCode).toEqual(0);
     });
 
+    it('should exit with code 1 when addendum declined', async () => {
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Accept Vercel Marketplace End User Addendum?'
+      );
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput(
+        'Vercel Marketplace End User Addendum must be accepted to continue.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+    });
+
     it('should exit with code 1 when privacy policy declined', async () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // Auto-generated name, server fills metadata defaults — no prompts
+      await expect(client.stderr).toOutput(
+        'Accept Vercel Marketplace End User Addendum?'
+      );
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('n\n');
 
@@ -319,7 +345,11 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // Auto-generated name, server fills metadata defaults — no prompts
+      await expect(client.stderr).toOutput(
+        'Accept Vercel Marketplace End User Addendum?'
+      );
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('y\n');
 
@@ -332,6 +362,70 @@ describe('integration add (auto-provision)', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(1);
+    });
+
+    it('should exit with code 1 in non-TTY mode when no installation exists', async () => {
+      client.stdin.isTTY = false;
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Term acceptance requires an interactive terminal.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+    });
+
+    it('should exit with code 1 when AI agent is detected (legal requirement)', async () => {
+      // Term acceptance must be performed by a human, not an AI agent.
+      // Agents running in a PTY can bypass the isTTY check, so we
+      // explicitly block detected agents from accepting terms.
+      client.isAgent = true;
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Term acceptance cannot be performed by an AI agent.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+    });
+
+    it('should reject --yes flag to prevent automated term bypass (legal requirement)', async () => {
+      // Term acceptance MUST be explicit — --yes must not be a recognized flag
+      // on this command. This is a legal requirement: users must consciously
+      // accept each term. If this test fails, someone added --yes support
+      // without considering the legal implications.
+      client.setArgv('integration', 'add', 'acme', '--yes');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'unknown or unexpected option: --yes'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+    });
+
+    it('should only prompt for addendum when integration has no privacy or EULA', async () => {
+      client.setArgv('integration', 'add', 'aws-apg');
+      const exitCodePromise = integrationCommand(client);
+
+      // Only the addendum prompt should appear (aws-apg has no eulaDocUri/privacyDocUri)
+      await expect(client.stderr).toOutput(
+        'Accept Vercel Marketplace End User Addendum?'
+      );
+      client.stdin.write('y\n');
+
+      // Should go straight to provisioning without privacy/EULA prompts
+      await expect(client.stderr).toOutput(
+        'Aurora Postgres successfully provisioned'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
     });
   });
 
@@ -467,11 +561,11 @@ describe('integration add (auto-provision)', () => {
       );
     });
 
-    it('should forward --metadata to browser URL after policy retry falls back', async () => {
-      // First call returns 'install' (policies required), second returns 'metadata' (still needs web)
+    it('should forward --metadata to browser URL after term acceptance falls back', async () => {
+      // No installation, auto-provision returns metadata fallback
       useAutoProvision({
-        responseKey: 'install',
-        secondResponseKey: 'metadata',
+        responseKey: 'metadata',
+        withInstallation: false,
       });
 
       client.setArgv(
@@ -483,14 +577,17 @@ describe('integration add (auto-provision)', () => {
       );
       const exitCodePromise = integrationCommand(client);
 
-      // Accept policies
+      // Upfront term prompts
+      await expect(client.stderr).toOutput(
+        'Accept Vercel Marketplace End User Addendum?'
+      );
+      client.stdin.write('y\n');
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Accept terms of service?');
       client.stdin.write('y\n');
 
-      // After retry, still falls back to browser
+      // After provisioning attempt, falls back to browser
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -505,18 +602,22 @@ describe('integration add (auto-provision)', () => {
       expect(parsed.searchParams.get('source')).toEqual('cli');
     });
 
-    it('should not include metadata in URL after policy retry falls back without --metadata', async () => {
+    it('should not include metadata in URL after term acceptance falls back without --metadata', async () => {
       useAutoProvision({
-        responseKey: 'install',
-        secondResponseKey: 'metadata',
+        responseKey: 'metadata',
+        withInstallation: false,
       });
 
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
+      // Upfront term prompts
+      await expect(client.stderr).toOutput(
+        'Accept Vercel Marketplace End User Addendum?'
+      );
+      client.stdin.write('y\n');
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Accept terms of service?');
       client.stdin.write('y\n');
 
@@ -872,18 +973,22 @@ describe('integration add (auto-provision)', () => {
       });
     });
 
-    it('should include billingPlanId in retry request after policy acceptance', async () => {
+    it('should include billingPlanId and acceptedPolicies after term acceptance', async () => {
       const { requestBodies } = useAutoProvision({
-        responseKey: 'install',
-        secondResponseKey: 'provisioned',
+        responseKey: 'provisioned',
+        withInstallation: false,
       });
 
       client.setArgv('integration', 'add', 'acme', '--plan', 'pro');
       const exitCodePromise = integrationCommand(client);
 
+      // Upfront term prompts
+      await expect(client.stderr).toOutput(
+        'Accept Vercel Marketplace End User Addendum?'
+      );
+      client.stdin.write('y\n');
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Accept terms of service?');
       client.stdin.write('y\n');
 
@@ -893,9 +998,16 @@ describe('integration add (auto-provision)', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
-      // Both initial and retry requests should include billingPlanId
-      expect(requestBodies[0]).toMatchObject({ billingPlanId: 'pro' });
-      expect(requestBodies[1]).toMatchObject({ billingPlanId: 'pro' });
+      // Single request with billingPlanId and accepted policies
+      expect(requestBodies).toHaveLength(1);
+      expect(requestBodies[0]).toMatchObject({
+        billingPlanId: 'pro',
+        acceptedPolicies: {
+          toc: expect.any(String),
+          privacy: expect.any(String),
+          eula: expect.any(String),
+        },
+      });
     });
   });
 
@@ -928,6 +1040,67 @@ describe('integration add (auto-provision)', () => {
       await expect(client.stderr).toOutput(
         'Error: Integration "acme-no-products" is not a Marketplace integration'
       );
+    });
+
+    it('should error when fetchInstallations fails', async () => {
+      // Reset and set up fresh mocks — the beforeEach's useAutoProvision
+      // already registered a configurations handler, and the mock server
+      // uses the first registered handler. Re-create the context with a
+      // failing installations endpoint.
+      client.reset();
+      useUser();
+      const teams = useTeams('team_dummy');
+      const t = Array.isArray(teams) ? teams[0] : teams.teams[0];
+      client.config.currentTeam = t.id;
+      process.env.FF_AUTO_PROVISION_INSTALL = '1';
+
+      // Integration endpoint (needed to fetch integration)
+      client.scenario.get(
+        '/:version/integrations/integration/:slug',
+        (_req, res) => {
+          res.json({
+            id: 'acme',
+            slug: 'acme',
+            name: 'Acme Integration',
+            products: [
+              {
+                id: 'acme-product',
+                slug: 'acme',
+                name: 'Acme Product',
+                type: 'storage',
+                shortDescription: 'The Acme product',
+                metadataSchema: {
+                  type: 'object',
+                  properties: {
+                    region: {
+                      type: 'string',
+                      'ui:control': 'vercel-region',
+                      'ui:label': 'Region',
+                    },
+                  },
+                },
+              },
+            ],
+          });
+        }
+      );
+
+      // Failing installations endpoint
+      client.scenario.get(
+        '/:version/integrations/configurations',
+        (_req, res) => {
+          res.status(500);
+          res.json({ error: { message: 'Internal Server Error' } });
+        }
+      );
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+      await expect(client.stderr).toOutput(
+        'Failed to get integration installations'
+      );
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
     });
 
     it('should error when integration is external', async () => {

--- a/packages/cli/test/unit/util/build/import-builders.test.ts
+++ b/packages/cli/test/unit/util/build/import-builders.test.ts
@@ -13,9 +13,9 @@ vi.mock('../../../../src/util/build/install-builders', async importOriginal => {
   )();
   return {
     ...actual,
-    untracedInstallBuilders: vi.fn(
-      (...args: Parameters<typeof actual.untracedInstallBuilders>) =>
-        actual.untracedInstallBuilders(...args)
+    installBuilders: vi.fn(
+      (...args: Parameters<typeof actual.installBuilders>) =>
+        actual.installBuilders(...args)
     ),
   };
 });
@@ -210,9 +210,9 @@ describe('importBuilders()', () => {
     const cwd = await getWriteableDirectory();
     const buildersDir = join(cwd, '.vercel', 'builders');
 
-    vi.mocked(
-      installBuildersModule.untracedInstallBuilders
-    ).mockResolvedValueOnce(new Map());
+    vi.mocked(installBuildersModule.installBuilders).mockResolvedValueOnce(
+      new Map()
+    );
     let err: Error | undefined;
     try {
       await importBuilders(specs, cwd);
@@ -222,9 +222,10 @@ describe('importBuilders()', () => {
       await remove(cwd);
     }
 
-    expect(installBuildersModule.untracedInstallBuilders).toHaveBeenCalledWith(
+    expect(installBuildersModule.installBuilders).toHaveBeenCalledWith(
       buildersDir,
-      new Set([spec])
+      new Set([spec]),
+      undefined
     );
     if (!err) {
       throw new Error('Expected `err` to be defined');
@@ -242,21 +243,21 @@ describe('importBuilders()', () => {
     const pkgName = 'fake-builder';
     const builderModuleDir = join(buildersDir, 'node_modules', pkgName);
 
-    vi.mocked(
-      installBuildersModule.untracedInstallBuilders
-    ).mockImplementationOnce(async (dir, buildersToAdd) => {
-      await ensureDir(join(dir, 'node_modules', pkgName));
-      await outputJSON(join(dir, 'node_modules', pkgName, 'package.json'), {
-        name: pkgName,
-        version: '1.0.0',
-        main: 'index.js',
-      });
-      await writeFile(
-        join(dir, 'node_modules', pkgName, 'index.js'),
-        `exports.version = 3; exports.build = async function() { return { output: {} }; };`
-      );
-      return new Map([[Array.from(buildersToAdd)[0], pkgName]]);
-    });
+    vi.mocked(installBuildersModule.installBuilders).mockImplementationOnce(
+      async (dir, buildersToAdd) => {
+        await ensureDir(join(dir, 'node_modules', pkgName));
+        await outputJSON(join(dir, 'node_modules', pkgName, 'package.json'), {
+          name: pkgName,
+          version: '1.0.0',
+          main: 'index.js',
+        });
+        await writeFile(
+          join(dir, 'node_modules', pkgName, 'index.js'),
+          `exports.version = 3; exports.build = async function() { return { output: {} }; };`
+        );
+        return new Map([[Array.from(buildersToAdd)[0], pkgName]]);
+      }
+    );
 
     try {
       const builders = await importBuilders(specs, cwd);


### PR DESCRIPTION
## Manual Testing

All tests run against real Vercel API using local CLI build.

### Legacy path (no FF), no installation — accept all 3 terms
`vc integration add braintrust` on `acme-marketplace-team-vtest314` (braintrust not previously installed):
```
> Installing Braintrust by Braintrust under acme-marketplace-team-vtest314
? Accept Vercel Marketplace End User Addendum? (https://vercel.com/docs/marketplace/addendum) yes
? Accept privacy policy? (https://www.braintrust.dev/legal/privacy-policy) yes
? Accept terms of service? (https://www.braintrust.dev/legal/terms-of-service) yes
> Success! Braintrust successfully provisioned: braintrust-violet-dog
>     Dashboard: https://vercel.com/acme-marketplace-team-vtest314/~/stores/integration/ir_JMiHaG0g5NVp7MzO
```

### Legacy path, already installed — terms skipped
`vc integration add braintrust` on `acme-marketplace-team-vtest314` (after install above):
```
> Installing Braintrust by Braintrust under acme-marketplace-team-vtest314
? Choose a billing plan (Use arrow keys)
```
No term prompts — installation already exists, straight to billing.

### FF=1 path, already installed — terms skipped, auto-provisioned
`FF_AUTO_PROVISION_INSTALL=1 vc integration add braintrust` on `acme-marketplace-team-vtest314`:
```
> Installing Braintrust by Braintrust under acme-marketplace-team-vtest314
⠋ Provisioning resource...
> Success! Braintrust successfully provisioned: braintrust-lightblue-house
>     Dashboard: https://vercel.com/acme-marketplace-team-vtest314/~/stores/integration/ir_kUzhAcy4Ag0Fkoto
```
No term prompts — installation exists, single auto-provision call with `acceptedPolicies: {}`.

### FF=1 path, no installation — term prompts, decline exits
`FF_AUTO_PROVISION_INSTALL=1 vc integration add braintrust` on `templates-test-vtest314` (bare team, no installations):
```
> Installing Braintrust by Braintrust under templates-test-vtest314
? Accept Vercel Marketplace End User Addendum? (https://vercel.com/docs/marketplace/addendum) no
Error: Vercel Marketplace End User Addendum must be accepted to continue.
```
Term prompts appeared, decline exits with code 1.


### FF=1 path, no installation — accept all 3 terms, provisioned
`FF_AUTO_PROVISION_INSTALL=1 vc integration add braintrust` on `templates-test-vtest314` (bare team):
```
> Installing Braintrust by Braintrust under templates-test-vtest314
? Accept Vercel Marketplace End User Addendum? (https://vercel.com/docs/marketplace/addendum) yes
? Accept privacy policy? (https://www.braintrust.dev/legal/privacy-policy) yes
? Accept terms of service? (https://www.braintrust.dev/legal/terms-of-service) yes
⠋ Provisioning resource...
> Success! Braintrust successfully provisioned: braintrust-lightblue-ocean
>     Dashboard: https://vercel.com/templates-test-vtest314/~/stores/integration/ir_e2REB4jqztNLtMml
```
3 term prompts → single auto-provision API call with acceptedPolicies → provisioned on first try.

### AI agent detection — blocked
`vc integration add inngest` with `CLAUDECODE=1` (detected as AI agent):
```
> Installing Inngest by Inngest under templates-test-vtest314
Error: Term acceptance cannot be performed by an AI agent. Run this command directly in your terminal.
```
Agent detection blocked term acceptance on both legacy and FF=1 paths.

### AI agent detection — normal flow when no agent
Same command with agent env vars unset:
```
> Installing Inngest by Inngest under templates-test-vtest314
? Accept Vercel Marketplace End User Addendum? (https://vercel.com/docs/marketplace/addendum) no
Error: Vercel Marketplace End User Addendum must be accepted to continue.
```
Term prompt shown normally when no agent is detected. Declined to avoid creating installation.

---

## Summary

Both `integration add` code paths (legacy and auto-provision) now detect upfront that an integration isn't installed, prompt for all 3 terms inline, install, and proceed — instead of kicking the user to the browser or doing a wasted API call.

**Fixes:** [MKT-2500](https://linear.app/vercel/issue/MKT-2500/term-acceptance-via-cli)
**Depends on:** [api#60638](https://github.com/vercel/api/pull/60638) (adds `acceptedPolicies` storage to IntegrationConfiguration)

### Interactive-only by design

Term acceptance is **interactive-only** (requires TTY) and **human-only** (blocks detected AI agents). There is no `--yes` flag or other mechanism to auto-accept terms — this is a legal requirement. The `add` subcommand intentionally does not define `--yes` in its options spec, so passing it errors with "unknown or unexpected option". Tests enforce this invariant in both code paths.

Three layers of protection prevent automated term bypass:

| Layer | What it catches |
|-------|-----------------|
| AI agent detection (`client.isAgent`) | Agents running in a PTY (Claude Code, Cursor, Devin, etc.) |
| TTY check (`client.stdin.isTTY`) | Piped input, CI environments, non-interactive shells |
| `--yes` flag rejection | Explicit flag-based bypass attempts |

Non-TTY environments (CI/scripts) that hit the term acceptance flow will get a clear error: `"Term acceptance requires an interactive terminal. Run this command in a TTY."` AI agents get: `"Term acceptance cannot be performed by an AI agent. Run this command directly in your terminal."` Teams must install integrations interactively first; subsequent provisioning works in CI/agents since the installation already exists.

### What changed

**Shared term acceptance utility** (`prompt-for-terms.ts`):
- Blocks detected AI agents (`client.isAgent`) and non-TTY environments before prompting
- Prompts for 3 terms in order: Vercel Marketplace Addendum (hardcoded URL), privacy policy, EULA
- Privacy/EULA only prompted if `integration.eulaDocUri`/`privacyDocUri` exist on the integration
- Records `toc` timestamp for addendum acceptance, `privacy` and `eula` timestamps for respective policies
- Returns `AcceptedPolicies` on accept, `null` on decline

**Legacy path** (`add.ts`):
- When no installation: prompts for terms → calls `POST /v2/integrations/integration/{id}/marketplace/install` → falls through to existing CLI provisioning
- Web UI fallback now only triggers for unsupported metadata schemas (no longer for missing installation)
- Added try/catch for `installMarketplaceIntegration` API call

**Auto-provision path** (`add-auto-provision.ts`):
- `fetchInstallations()` runs in parallel with `selectProduct()`
- If no team installation: prompts for terms upfront, passes `acceptedPolicies` on the first (and only) auto-provision call
- Removed the try-empty-policies → 422 → prompt → retry pattern entirely

**Types** (`types.ts`):
- Added `eulaDocUri?` and `privacyDocUri?` to `Integration` interface

### `acceptedPolicies` payload

The CLI now sends up to 3 keys in `acceptedPolicies`, aligning with api#60638:

| Key | When sent | Source |
|-----|-----------|--------|
| `toc` | Always (required for install) | Vercel Marketplace End User Addendum acceptance |
| `privacy` | When integration has `privacyDocUri` | Privacy policy acceptance |
| `eula` | When integration has `eulaDocUri` | Terms of service / EULA acceptance |

### Before → After

| Scenario | Before | After |
|----------|--------|-------|
| Legacy, no installation | "Terms not accepted. Open browser?" | 3 inline term prompts → install → CLI provisioning |
| Auto-provision, no installation | Empty-policies API call → 422 → prompt 2 terms → retry | Upfront install check → 3 term prompts → single API call |
| Either path, already installed | No change | No change (terms skipped) |
| `--yes` flag | N/A | Rejected as unknown option (legal requirement) |
| Non-TTY, no installation | Opened browser | Error: "Term acceptance requires an interactive terminal" |
| AI agent detected, no installation | Could accept terms via PTY | Error: "Term acceptance cannot be performed by an AI agent" |

## Test plan

### Unit Tests (134 pass)

```
$ vitest run test/unit/commands/integration/add.test.ts \
    test/unit/commands/integration/add-auto-provision.test.ts

 ✓ add-auto-provision.test.ts  (65 tests)
 ✓ add.test.ts  (69 tests)

 Test Files  2 passed (2)
      Tests  134 passed (134)
```

### Code Paths Covered

| Path | Expected | Tested by |
|------|----------|-----------|
| Legacy, no install → 3 terms → install → provision | Terms shown, install 201, then billing | Unit + manual (braintrust, acme-marketplace) |
| Legacy, no install → decline addendum | Error exit 1 | Unit |
| Legacy, no install → decline privacy | Error exit 1 | Unit |
| Legacy, no install → decline EULA | Error exit 1 | Unit |
| Legacy, with install → CLI provision (unchanged) | No term prompts, straight to billing | Unit + manual (braintrust, 2nd run) |
| Legacy, with install → unsupported wizard → web UI | No term prompts, web UI fallback | Unit |
| Legacy, non-subscription billing → web UI | Web UI fallback after terms + install | Unit |
| FF=1, no install → 3 terms → auto-provision | Terms upfront, single API call | Unit + manual (braintrust, bare team) |
| FF=1, no install → decline any term | Error exit 1 | Unit + manual (braintrust, bare team) |
| FF=1, with install → auto-provision (unchanged) | No term prompts, provisioned 201 | Unit + manual (braintrust, acme-marketplace) |
| FF=1, with install → metadata fallback → browser | No term prompts, browser fallback | Unit |
| FF=1, no install + metadata fallback | Terms then browser | Unit |
| FF=1, no install, no EULA/privacy | Only addendum prompted | Unit |
| --name, --metadata, --plan with term acceptance | Flags threaded through after terms | Unit |
| --yes flag rejected (legal requirement) | Error: "unknown or unexpected option" | Unit (both paths) |
| Non-TTY, no installation | Error: "Term acceptance requires an interactive terminal" | Unit (both paths) |
| AI agent detected, no installation | Error: "Term acceptance cannot be performed by an AI agent" | Unit + manual (both paths) |
| Existing "with installation" tests | Unchanged behavior | Unit (64+ tests) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds interactive terms acceptance for Marketplace integrations with defensive checks that BLOCK AI agents and non-TTY environments from accepting terms, which is a security-tightening change rather than a loosening one.
> 
> - New `promptForTermAcceptance` utility blocks AI agents and non-TTY environments
> - Refactors auto-provision flow to prompt for terms upfront before API call
> - Extensive test coverage for term acceptance, decline paths, and bypass prevention
>
> <sup>Risk assessment for [commit 434ebb1](https://github.com/vercel/vercel/commit/434ebb1f85c558fce59b7bdf6d0441b1f45bea89).</sup>
<!-- VADE_RISK_END -->