### PR TITLE
Update release workflows so release PR syncing is manual

### DIFF
--- a/.changeset/green-eggs-jump.md
+++ b/.changeset/green-eggs-jump.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update release workflows so release PR syncing is manual and production publishing runs only for merged Version Packages commits.

--- a/.github/workflows/release-version-pr-sync.yml
+++ b/.github/workflows/release-version-pr-sync.yml
@@ -2,11 +2,6 @@ name: Release Version PR Sync
 
 on:
   workflow_dispatch:
-    inputs:
-      reason:
-        description: 'Why sync the release PR now?'
-        required: false
-        type: string
 
 env:
   TURBO_REMOTE_ONLY: 'true'
@@ -64,12 +59,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-  summary:
-    name: Summary (release version PR sync)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs:
-      - sync-release-pr
-    steps:
-      - name: Check All
-        run: echo OK

--- a/.github/workflows/release-version-pr-sync.yml
+++ b/.github/workflows/release-version-pr-sync.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
 
 env:
-  TURBO_REMOTE_ONLY: "true"
-  TURBO_TEAM: "vercel"
+  TURBO_REMOTE_ONLY: 'true'
+  TURBO_TEAM: 'vercel'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-version-pr-sync.yml
+++ b/.github/workflows/release-version-pr-sync.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
 
 env:
-  TURBO_REMOTE_ONLY: 'true'
-  TURBO_TEAM: 'vercel'
+  TURBO_REMOTE_ONLY: "true"
+  TURBO_TEAM: "vercel"
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -58,4 +58,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-

--- a/.github/workflows/release-version-pr-sync.yml
+++ b/.github/workflows/release-version-pr-sync.yml
@@ -1,0 +1,75 @@
+name: Release Version PR Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why sync the release PR now?'
+        required: false
+        type: string
+
+env:
+  TURBO_REMOTE_ONLY: 'true'
+  TURBO_TEAM: 'vercel'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  sync-release-pr:
+    name: Sync Release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16
+        with:
+          toolchain: stable
+          targets: wasm32-wasip2
+
+      - name: install npm@9
+        run: npm i -g npm@9
+
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Packages
+        run: pnpm build
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Sync Release Pull Request
+        uses: changesets/action@v1
+        with:
+          version: pnpm ci:version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+  summary:
+    name: Summary (release version PR sync)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - sync-release-pr
+    steps:
+      - name: Check All
+        run: echo OK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: startsWith(github.event.head_commit.message, 'Version Packages')
     permissions:
       contents: write
       id-token: write
@@ -107,8 +108,16 @@ jobs:
     name: Summary (release)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Keep this status check deterministic even when `release` is intentionally skipped.
+    if: always()
     needs:
       - release
     steps:
       - name: Check All
-        run: echo OK
+        run: |
+          # Fail summary only when the gated `release` job actually fails/cancels.
+          if [ "${{ needs.release.result }}" = "failure" ] || [ "${{ needs.release.result }}" = "cancelled" ]; then
+            echo "Release job failed with result: ${{ needs.release.result }}"
+            exit 1
+          fi
+          echo "Release job result: ${{ needs.release.result }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - main
 
 env:
-  TURBO_REMOTE_ONLY: 'true'
-  TURBO_TEAM: 'vercel'
+  TURBO_REMOTE_ONLY: "true"
+  TURBO_TEAM: "vercel"
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -62,7 +62,7 @@ jobs:
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
-          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - main
 
 env:
-  TURBO_REMOTE_ONLY: "true"
-  TURBO_TEAM: "vercel"
+  TURBO_REMOTE_ONLY: 'true'
+  TURBO_TEAM: 'vercel'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -62,7 +62,7 @@ jobs:
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
-          NPM_CONFIG_PROVENANCE: "true"
+          NPM_CONFIG_PROVENANCE: 'true'
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 


### PR DESCRIPTION
- Stops automatic release PR churn by gating release.yml so changesets/action only runs on merged Version Packages commits.
- Adds a new manual workflow, release-version-pr-sync.yml, to explicitly sync/refresh the Version Packages PR when needed.
- Keeps status checks predictable with a summary job that passes on skipped releases and fails only on real release failures/cancellations.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR modifies GitHub Actions release workflows to gate automatic releases behind a commit message check and adds a manual workflow dispatch option, which are CI/CD configuration changes but don't affect security controls or application logic.
> 
> - New manual workflow_dispatch trigger for release PR syncing
> - Gates release job with commit message condition check
> - Summary job updated to handle skipped release states
>
> <sup>Risk assessment for [commit 0531157](https://github.com/vercel/vercel/commit/0531157e5184dda49157ab483131dce0a519fa11).</sup>
<!-- VADE_RISK_END -->