### PR TITLE
[ci:release] Integrate Python runtime release properly

### DIFF
--- a/.changeset/rotten-apricots-wonder.md
+++ b/.changeset/rotten-apricots-wonder.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-runtime': patch
+---
+
+fix PyPI publication integration in release flow

--- a/.github/workflows/comment-cli-tarball.yml
+++ b/.github/workflows/comment-cli-tarball.yml
@@ -58,6 +58,23 @@ jobs:
             message += '}\n';
             message += '```\n';
 
+            // Check if a Python runtime wheel was built
+            try {
+              const resp = await fetch(`${deploymentUrl}/tarballs/vercel-runtime-wheel.json`);
+              if (resp.ok) {
+                const { filename } = await resp.json();
+                const wheelUrl = `${deploymentUrl}/tarballs/${filename}`;
+                message += '\n### Python Runtime Wheel\n\n';
+                message += 'A Python runtime wheel was also built for this PR.\n';
+                message += 'To use in your Python project builds, also set this environment variable:\n\n';
+                message += '```\n';
+                message += `VERCEL_RUNTIME_PYTHON="vercel-runtime @ ${wheelUrl}"\n`;
+                message += '```\n';
+              }
+            } catch {
+              // No wheel available, skip
+            }
+
             // Find existing comment to update
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/release-python-runtime.yml
+++ b/.github/workflows/release-python-runtime.yml
@@ -1,10 +1,6 @@
 name: Release Python Runtime Package
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'python/vercel-runtime/**'
   workflow_dispatch:
     inputs:
       force:
@@ -14,48 +10,7 @@ on:
         type: boolean
 
 jobs:
-  check-version:
-    runs-on: ubuntu-latest
-
-    outputs:
-      version_changed: ${{ steps.check.outputs.version_changed }}
-      version: ${{ steps.check.outputs.version }}
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
-
-      - name: Check if version has changed
-        id: check
-        run: |
-          CURRENT_VERSION=$(grep -Po '(?<=^version = ")[^"]+' python/vercel-runtime/pyproject.toml)
-          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-
-          # For workflow_dispatch with force=true, skip version check
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force }}" = "true" ]; then
-            echo "version_changed=true" >> $GITHUB_OUTPUT
-            echo "Force publish requested - proceeding with publish"
-            exit 0
-          fi
-
-          # Get the version from the previous commit
-          PREVIOUS_VERSION=$(
-            git show HEAD^:python/vercel-runtime/pyproject.toml 2>/dev/null \
-              | grep -Po '(?<=^version = ")[^"]+' || echo ""
-          )
-
-          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
-            echo "version_changed=true" >> $GITHUB_OUTPUT
-            echo "Version changed from '$PREVIOUS_VERSION' to '$CURRENT_VERSION'"
-          else
-            echo "version_changed=false" >> $GITHUB_OUTPUT
-            echo "Version unchanged at '$CURRENT_VERSION'"
-          fi
-
   publish:
-    needs: check-version
-    if: needs.check-version.outputs.version_changed == 'true'
     runs-on: ubuntu-latest
 
     environment:
@@ -63,14 +18,18 @@ jobs:
 
     permissions:
       id-token: write
-      attestations: write
       contents: write
-      deployments: write
 
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 2
           persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -78,22 +37,9 @@ jobs:
           python-version-file: 'pyproject.toml'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
           version: '0.9.22'
 
-      - name: Build
-        run: uv build --package vercel-runtime --out-dir python/vercel-runtime/dist/
-
-      - name: Smoke test (wheel)
-        run: |
-          uv run --isolated --no-project --with python/vercel-runtime/dist/*.whl \
-            python/vercel-runtime/tests/release_smoke_test.py
-
-      - name: Smoke test (source distribution)
-        run: |
-          uv run --isolated --no-project --with python/vercel-runtime/dist/*.tar.gz \
-            python/vercel-runtime/tests/release_smoke_test.py
-
       - name: Publish
-        run: uv publish --directory python/vercel-runtime/
+        run: node python/vercel-runtime/publish.mjs ${{ inputs.force == true && '--force' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.event.head_commit.message, 'Version Packages')
+    environment: release
     permissions:
       contents: write
       id-token: write
@@ -39,6 +40,16 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-wasip2
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: 'pyproject.toml'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.9.22'
 
       - name: install npm@9
         run: npm i -g npm@9
@@ -74,26 +85,6 @@ jobs:
           script: |
             const script = require('./utils/trigger-update-workflow.js')
             await script({ github, context })
-
-      - name: Trigger Python Runtime Release (if @vercel/python-runtime changed)
-        if: steps.changesets.outputs.published == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
-          script: |
-            const publishedPackages = JSON.parse('${{ steps.changesets.outputs.publishedPackages }}' || '[]');
-            const pythonRuntimePublished = publishedPackages.some(pkg => pkg.name === '@vercel/python-runtime');
-            if (pythonRuntimePublished) {
-              console.log('@vercel/python-runtime was published, triggering Python runtime release workflow');
-              await github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'release-python-runtime.yml',
-                ref: 'main',
-              });
-            } else {
-              console.log('@vercel/python-runtime was not in the published packages, skipping Python release');
-            }
 
       - name: Set latest Release to `vercel` (if a Publish Happened)
         if: steps.changesets.outputs.published == 'true'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -207,12 +207,22 @@ jobs:
           fi
         env:
           FORCE_COLOR: '1'
+      - name: Resolve Python runtime wheel URL
+        id: python-wheel
+        run: |
+          WHEEL_NAME=$(curl -sf "${{ needs.setup.outputs.dplUrl }}/tarballs/vercel-runtime-wheel.json" | jq -r '.filename' || echo "")
+          if [ -n "$WHEEL_NAME" ]; then
+            echo "spec=vercel-runtime @ ${{ needs.setup.outputs.dplUrl }}/tarballs/$WHEEL_NAME" >> $GITHUB_OUTPUT
+          else
+            echo "spec=" >> $GITHUB_OUTPUT
+          fi
       - name: Test ${{matrix.packageName}}
         run: node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}
         shell: bash
         env:
           JEST_JUNIT_OUTPUT_FILE: ${{github.workspace}}/.junit-reports/${{matrix.scriptName}}-${{matrix.packageName}}-${{matrix.chunkNumber}}-${{ matrix.runner }}.xml
           VERCEL_CLI_VERSION: ${{ needs.setup.outputs.dplUrl }}/tarballs/vercel.tgz
+          VERCEL_RUNTIME_PYTHON: ${{ steps.python-wheel.outputs.spec }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prepare": "husky install",
     "pack": "cd utils && node -r ts-eager/register ./pack.ts",
     "ci:version": "changeset version && node utils/sync-python-version.js && pnpm install --no-frozen-lockfile",
-    "ci:publish": "pnpm publish -r && node utils/update-canary-tags.mjs && changeset tag",
+    "ci:publish": "node utils/publish-runtimes.mjs && pnpm publish -r && node utils/update-canary-tags.mjs && changeset tag",
     "type-check": "turbo type-check --concurrency=12 --output-logs=errors-only --summarize --continue"
   },
   "lint-staged": {

--- a/packages/python/turbo.json
+++ b/packages/python/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test-e2e": {
+      "env": ["VERCEL_RUNTIME_PYTHON"]
+    }
+  }
+}

--- a/python/vercel-runtime/publish.mjs
+++ b/python/vercel-runtime/publish.mjs
@@ -1,0 +1,120 @@
+/**
+ * Publish vercel-runtime on PyPI.
+ *
+ * Should be called by `ci:publish` via `publish-runtimes.mjs` before
+ * `pnpm publish -r` so that if PyPI publication fails the npm publish
+ * never happens.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, rmSync, readdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PYPROJECT_PATH = 'python/vercel-runtime/pyproject.toml';
+
+function getVersion(tomlContent) {
+  const match = tomlContent.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error(`Could not parse version from pyproject.toml`);
+  }
+  return match[1];
+}
+
+// Current version on disk
+const currentToml = readFileSync(resolve(__dirname, 'pyproject.toml'), 'utf8');
+const currentVersion = getVersion(currentToml);
+
+// Previous version from parent commit
+let previousVersion = '';
+try {
+  const previousToml = execFileSync(
+    'git',
+    ['show', `HEAD^:${PYPROJECT_PATH}`],
+    { encoding: 'utf8' }
+  );
+  previousVersion = getVersion(previousToml);
+} catch {
+  // First commit or file didn't exist - treat as changed
+  previousVersion = '';
+}
+
+const force = process.argv.includes('--force');
+
+if (currentVersion === previousVersion && !force) {
+  console.log(
+    `Python vercel-runtime version unchanged (${currentVersion}), skipping PyPI publication.`
+  );
+  process.exit(0);
+}
+
+console.log(
+  `Python vercel-runtime version changed: ${previousVersion || '(none)'} -> ${currentVersion}`
+);
+
+function run(cmd, args) {
+  const cmdline = `${cmd} ${args.join(' ')}`;
+  console.log(`$ ${cmdline}`);
+  try {
+    execFileSync(cmd, args, { stdio: 'inherit' });
+  } catch (err) {
+    const code = err.status ?? 1;
+    console.error(`command failed with exit code ${code}: ${cmdline}`);
+    process.exit(code);
+  }
+}
+
+// Sanity check: the version we're about to publish must match what
+// @vercel/python will request when building projects.
+const runtimeVersionTs = readFileSync(
+  resolve(__dirname, '..', '..', 'packages', 'python', 'src', 'runtime-version.ts'),
+  'utf8'
+);
+const pinnedMatch = runtimeVersionTs.match(/VERCEL_RUNTIME_VERSION\s*=\s*'([^']+)'/);
+if (!pinnedMatch) {
+  throw new Error('Could not parse VERCEL_RUNTIME_VERSION from packages/python/src/runtime-version.ts');
+}
+if (pinnedMatch[1] !== currentVersion) {
+  throw new Error(
+    `Version mismatch: pyproject.toml has ${currentVersion} but ` +
+    `packages/python/src/runtime-version.ts pins ${pinnedMatch[1]}`
+  );
+}
+
+// Clean stale artifacts so globs match exactly one wheel
+const distDir = resolve(__dirname, 'dist');
+rmSync(distDir, { recursive: true, force: true });
+
+// Build
+run('uv', [
+  'build',
+  '--package',
+  'vercel-runtime',
+  '--out-dir',
+  'python/vercel-runtime/dist/',
+]);
+
+// Verify exactly one wheel was produced
+const wheels = readdirSync(distDir).filter(f => f.endsWith('.whl'));
+if (wheels.length !== 1) {
+  throw new Error(
+    `Expected exactly 1 wheel in dist/, found ${wheels.length}: ${wheels.join(', ')}`
+  );
+}
+const wheelPath = join(distDir, wheels[0]);
+
+// Smoke test the wheel
+run('uv', [
+  'run',
+  '--isolated',
+  '--no-project',
+  '--with',
+  wheelPath,
+  'python/vercel-runtime/tests/release_smoke_test.py',
+]);
+
+// Publish to PyPI (relies on OIDC trusted publishing env set up by the release.yml workflow)
+run('uv', ['publish', '--directory', 'python/vercel-runtime/']);
+
+console.log(`Successfully published vercel-runtime ${currentVersion} on PyPI.`);

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -38,6 +38,7 @@ async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
     VERCEL_FORCE_PYTHON_STREAMING,
     VERCEL_FORCE_BUILD_IN_HIVE,
     VERCEL_BUILD_CONTAINER_VERSION,
+    VERCEL_RUNTIME_PYTHON,
   } = process.env;
 
   // Warn if using custom build container configuration
@@ -80,6 +81,7 @@ async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
         VERCEL_FORCE_PYTHON_STREAMING,
         VERCEL_FORCE_BUILD_IN_HIVE,
         VERCEL_BUILD_CONTAINER_VERSION,
+        VERCEL_RUNTIME_PYTHON,
         NEXT_TELEMETRY_DISABLED: '1',
       },
     },

--- a/utils/publish-runtimes.mjs
+++ b/utils/publish-runtimes.mjs
@@ -1,0 +1,23 @@
+/**
+ * Publish non-npm runtime packages before pnpm publish.
+ *
+ * Currently delegates to:
+ *   - python/vercel-runtime/publish.mjs  (PyPI)
+ *
+ * Called by ci:publish so that if any runtime publish fails,
+ * npm publish never happens.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function run(script) {
+  console.log(`\n--- Running ${script} ---`);
+  execFileSync('node', [resolve(root, script)], { stdio: 'inherit' });
+}
+
+run('python/vercel-runtime/publish.mjs');


### PR DESCRIPTION
Currently the vercel-runtime Python package gets pushed to PyPI _after_
all e2e and npm publishing was done via workflow dispatch to
`release-python-runtime.yml`.  This is problematic because the Python
builder pins the runtime version _exactly_ and would fail to find the
yet-unreleased package version on PyPI when running e2e tests.

A simple fix would be to publish to PyPI before e2e, but that defeats
the purpose of pre-release testing.  Instead, here we follow the
JavaScript package procedure where we push artifacts to Vercel and test
on those.  For Python this means that we inject `VERCEL_RUNTIME_PYTHON`
pointing to `vercel-runtime @ ${{ dplUrl }}/tarballs/vercel-runtime.whl`
alongside `VERCEL_CLI_VERSION`.

The remaining issue is to make sure that PyPI publication succeeds
_before_ we proceed with the main CLI publication, otherwise we will
release a broken build.  Achieve this by moving the PyPI publication step
into `ci:publish` so it runs before `pnpm publish`.

Specific changes:

  - Add `python/vercel-runtime/publish.mjs` (version check, build, smoke
    test, publish)
  - Add `utils/publish-runtimes.mjs` which gets called from `ci:publish`
    for dispatch (mostly just generalizing non-JS publication here).
  - Remove async `workflow_dispatch` trigger and `push` trigger from
    `release-python-runtime.yml` (`workflow_dispatch` kept for now for
    manual publication if we need it).
  - `api/_lib/script/build.ts` learns to scan and copy
    `python/**/dist/*.whl` so they are accessible in pre-release e2e.


<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR modifies CI/CD release workflows and publishing scripts to integrate Python runtime publication before npm publish, which is infrastructure/deployment configuration affecting the release process.
> 
> - Modifies `ci:publish` script to run Python runtime publish before npm publish
> - Changes release workflow to add `environment: release` and Python setup steps
> - Adds new publish scripts for PyPI publication with version validation
>
> <sup>Risk assessment for [commit 478d73d](https://github.com/vercel/vercel/commit/478d73de694b165f257fcd9b167fd104820951c8).</sup>
<!-- VADE_RISK_END -->