### PR TITLE
[client] Add inlined file deployment for small HTML-only projects

### DIFF
--- a/.changeset/red-boats-behave.md
+++ b/.changeset/red-boats-behave.md
@@ -1,0 +1,5 @@
+---
+"@vercel/client": patch
+---
+
+[client] Add inlined file deployment for small HTML-only projects

--- a/packages/client/src/deploy.ts
+++ b/packages/client/src/deploy.ts
@@ -5,6 +5,7 @@ import { checkDeploymentStatus } from './check-deployment-status';
 import {
   fetch,
   prepareFiles,
+  shouldUseInlineFiles,
   createDebug,
   getApiDeploymentsUrl,
 } from './utils';
@@ -26,8 +27,15 @@ async function* postDeployment(
   link?: string;
 }> {
   const debug = createDebug(clientOptions.debug);
+  const useInline = shouldUseInlineFiles(files);
   const preparedFiles = prepareFiles(files, clientOptions);
   const apiDeployments = getApiDeploymentsUrl();
+
+  if (useInline) {
+    debug(
+      `Using inlined file deployment (${preparedFiles.length} HTML files)`
+    );
+  }
 
   if (deploymentOptions?.builds && !deploymentOptions.functions) {
     clientOptions.skipAutoDetectionConfirmation = true;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,7 +1,7 @@
 import buildCreateDeployment from './create-deployment';
 
 export { checkDeploymentStatus } from './check-deployment-status';
-export { getVercelIgnore, buildFileTree } from './utils/index';
+export { getVercelIgnore, buildFileTree, shouldUseInlineFiles } from './utils/index';
 export const createDeployment = buildCreateDeployment();
 export * from './errors';
 export * from './types';

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -373,7 +373,8 @@ export interface PreparedFile {
   file: string;
   sha?: string;
   size?: number;
-  mode: number;
+  /** File mode/permissions (not used for inlined files) */
+  mode?: number;
   /** Inlined file content (utf-8 or base64 encoded) */
   data?: string;
   /** Encoding of the inlined data */
@@ -440,19 +441,24 @@ export const prepareFiles = (
 
       const normalizedFileName = isWin ? fileName.replace(/\\/g, '/') : fileName;
 
-      const preparedFile: PreparedFile = {
-        file: normalizedFileName,
-        size: file.data?.byteLength || file.data?.length,
-        mode: file.mode,
-      };
+      let preparedFile: PreparedFile;
 
       if (useInline && file.data) {
         // Inline the file content - HTML files use utf-8 encoding
-        preparedFile.data = file.data.toString('utf-8');
-        preparedFile.encoding = 'utf-8';
+        // Inlined files only accept: file, data, encoding (no size, mode, or sha)
+        preparedFile = {
+          file: normalizedFileName,
+          data: file.data.toString('utf-8'),
+          encoding: 'utf-8',
+        };
       } else {
         // Use SHA reference for separate upload
-        preparedFile.sha = sha || undefined;
+        preparedFile = {
+          file: normalizedFileName,
+          size: file.data?.byteLength || file.data?.length,
+          mode: file.mode,
+          sha: sha || undefined,
+        };
       }
 
       preparedFiles.push(preparedFile);

--- a/packages/client/tests/unit.utils.test.ts
+++ b/packages/client/tests/unit.utils.test.ts
@@ -379,7 +379,10 @@ describe('prepareFiles() with inline files', () => {
     expect(prepared[0].file).toBe('index.html');
     expect(prepared[0].data).toBe('<html><body>Hello</body></html>');
     expect(prepared[0].encoding).toBe('utf-8');
+    // Inlined files should NOT have sha, size, or mode (API rejects additional properties)
     expect(prepared[0].sha).toBeUndefined();
+    expect(prepared[0].size).toBeUndefined();
+    expect(prepared[0].mode).toBeUndefined();
   });
 
   it('should use SHA reference for non-HTML files', () => {


### PR DESCRIPTION
## Summary

- Adds support for inlined file deployments when the source directory contains only HTML files (fewer than 10)
- Files are sent directly in the deployment API request body instead of being uploaded separately to `/v2/files`
- This optimization reduces deployment latency for simple static HTML sites

## Changes

- **`packages/client/src/utils/index.ts`**: 
  - Extended `PreparedFile` interface with `data` and `encoding` fields
  - Added `shouldUseInlineFiles()` function to detect when inline deployment should be used
  - Modified `prepareFiles()` to conditionally include file content

- **`packages/client/src/deploy.ts`**: Added debug logging when using inline deployment

- **`packages/client/src/index.ts`**: Exported `shouldUseInlineFiles` for external use

- **`packages/client/tests/unit.utils.test.ts`**: Added comprehensive unit tests

## Test plan

- [ ] Verify unit tests pass for `shouldUseInlineFiles()` and `prepareFiles()`
- [ ] Test deployment with a directory containing < 10 HTML files only
- [ ] Test deployment with mixed file types (should use SHA upload)
- [ ] Test deployment with >= 10 HTML files (should use SHA upload)
- [ ] Verify debug output shows "Using inlined file deployment" when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a performance optimization for small HTML-only deployments by inlining file content in the API request, with no security or authorization changes.
> 
> - New `shouldUseInlineFiles()` function checks for <10 HTML-only files
> - Modified `prepareFiles()` to conditionally include file data with utf-8 encoding
> - Comprehensive unit tests added for inline file detection and preparation
>
> <sup>Risk assessment for [commit 8e5a6ae](https://github.com/vercel/vercel/commit/8e5a6aec7ef8abf59cf4f639f3a72196b1c9c97c).</sup>
<!-- VADE_RISK_END -->