### PR TITLE
fix(cli): Require product slug for multi-product integrations in non-TTY

### DIFF
--- a/.changeset/remove-interactive-product-select.md
+++ b/.changeset/remove-interactive-product-select.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Require slash syntax for multi-product integrations in non-TTY mode, keep interactive product selector for TTY

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -70,7 +70,21 @@ export async function addAutoProvision(
     return 1;
   }
 
-  // 3. Select product (by slug, single auto-select, or interactive prompt)
+  // 3. Select product (by slug, single auto-select, or interactive prompt in TTY)
+  if (
+    !options.productSlug &&
+    integration.products.length > 1 &&
+    !client.stdin.isTTY
+  ) {
+    const choices = integration.products
+      .map(p => `  ${integrationSlug}/${p.slug}`)
+      .join('\n');
+    output.error(
+      `Integration "${integrationSlug}" has multiple products. Specify one with:\n\n${choices}\n\nExample: vercel integration add ${integrationSlug}/${integration.products[0].slug}`
+    );
+    return 1;
+  }
+
   const product = await selectProduct(
     client,
     integration.products,


### PR DESCRIPTION
Fixes: [MKT-2775](https://linear.app/vercel/issue/MKT-2775/remove-interactive-product-selection-from-cli)

## Summary

- In the auto-provision path (`add-auto-provision.ts`), require a product slug for multi-product integrations in **non-TTY** mode (CI, agents) — error with actionable guidance listing available products in slash syntax
- In **TTY** mode (human terminal), keep the interactive product selector so humans can still pick interactively
- Legacy `add` path is unchanged

### Non-TTY (agents/CI): actionable error

```
$ echo "" | FF_AUTO_PROVISION_INSTALL=1 vc integration add upstash
Error: Integration "upstash" has multiple products. Specify one with:

  upstash/upstash-qstash
  upstash/upstash-search
  upstash/upstash-vector
  upstash/upstash-kv

Example: vercel integration add upstash/upstash-qstash
```

### TTY (humans): interactive selector preserved

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add upstash
? Select a product (Use arrow keys)
❯ Upstash QStash/Workflow
  Upstash Search
  Upstash Vector
  Upstash for Redis
```

## Test plan

### Unit tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/add-auto-provision.test.ts

 ✓ test/unit/commands/integration/add-auto-provision.test.ts  (60 tests) 3535ms

 Test Files  1 passed (1)
      Tests  60 passed (60)
```

### Manual testing

| Scenario | Command | Expected | Actual |
|----------|---------|----------|--------|
| FF=1, multi-product, no slug, TTY | `FF_AUTO_PROVISION_INSTALL=1 vc integration add upstash` | Interactive product selector | ✅ `Select a product` prompt shown with 4 products |
| FF=1, multi-product, no slug, non-TTY | `echo "" \| FF_AUTO_PROVISION_INSTALL=1 vc integration add upstash` | Error with product list | ✅ Error with slash syntax choices |
| FF=1, multi-product, slash syntax | `FF_AUTO_PROVISION_INSTALL=1 vc integration add upstash/upstash-kv` | Selects product, proceeds | ✅ `Installing Upstash for Redis by Upstash...` |

### Code paths covered

| Path | Verified by |
|------|------------|
| Auto-provision: multiple products + no slug + non-TTY → error | Unit + manual |
| Auto-provision: multiple products + no slug + TTY → interactive selector | Unit + manual |
| Auto-provision: multiple products + slash syntax → direct select | Unit + manual |
| Auto-provision: single product + no slug → auto-select | Unit |
| Legacy: multiple products → interactive prompt (unchanged) | Unit |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a defensive check that rejects multi-product integrations in non-TTY mode when no product slug is specified, requiring explicit user input rather than allowing ambiguous behavior.
> 
> - Adds non-TTY check to error out when multiple products exist without explicit slug
> - Error message lists available products in slash syntax format
> - Test updates verify new non-TTY error behavior
>
> <sup>Risk assessment for [commit 4acdc8d](https://github.com/vercel/vercel/commit/4acdc8d5993ad0ad990d1ea935adff4d1c4a1b3b).</sup>
<!-- VADE_RISK_END -->