### PR TITLE
fix(cli): return exit code 1 when integration add falls back to browser

### DIFF
--- a/.changeset/fix-auto-provision-exit-code.md
+++ b/.changeset/fix-auto-provision-exit-code.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Fix `integration add` auto-provision to exit 1 when browser fallback is triggered instead of falsely reporting success. Add `.catch()` to all `open()` calls to prevent unhandled promise rejections in headless/CI environments.

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -245,8 +245,10 @@ export async function addAutoProvision(
       url.searchParams.set('planId', options.billingPlanId);
     }
     output.debug(`Opening URL: ${url.href}`);
-    open(url.href);
-    return 0;
+    open(url.href).catch((err: unknown) =>
+      output.debug(`Failed to open browser: ${err}`)
+    );
+    return 1;
   }
 
   // 9. Success!

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -237,7 +237,7 @@ export async function add(
       );
     }
 
-    return 0;
+    return 1;
   }
 
   return await provisionResourceViaCLI(
@@ -284,7 +284,9 @@ function provisionResourceViaWebUI(
   url.searchParams.set('cmd', 'add');
   output.print('Opening the Vercel Dashboard to continue the installation...');
   output.debug(`Opening URL: ${url.href}`);
-  open(url.href);
+  open(url.href).catch((err: unknown) =>
+    output.debug(`Failed to open browser: ${err}`)
+  );
 }
 
 async function provisionResourceViaCLI(
@@ -401,7 +403,7 @@ async function provisionResourceViaCLI(
       );
     }
 
-    return 0;
+    return 1;
   }
 
   const confirmed = await confirmProductSelection(
@@ -618,7 +620,9 @@ function handleManualVerificationAction(
   url.searchParams.set('cmd', 'authorize');
   output.print('Opening the Vercel Dashboard to continue the installation...');
   output.debug(`Opening URL: ${url.href}`);
-  open(url.href);
+  open(url.href).catch((err: unknown) =>
+    output.debug(`Failed to open browser: ${err}`)
+  );
 }
 
 async function provisionStorageProduct(

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -12,7 +12,7 @@ import { useUser } from '../../../mocks/user';
 
 vi.mock('open', () => {
   return {
-    default: vi.fn(),
+    default: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -36,7 +36,7 @@ const pullMock = vi.mocked(pull);
 const connectMock = vi.mocked(connectResourceToProject);
 
 beforeEach(() => {
-  openMock.mockClear();
+  openMock.mockReset().mockResolvedValue(undefined as never);
   pullMock.mockClear();
   connectMock.mockClear();
   // Enable auto-provision feature flag
@@ -348,7 +348,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       expect(openMock).toHaveBeenCalledWith(
         expect.stringContaining(
           'https://vercel.com/acme/~/integrations/checkout/acme'
@@ -383,7 +383,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       const calledUrl = openMock.mock.calls[0]?.[0] as string;
       const parsed = new URL(calledUrl);
       expect(parsed.searchParams.get('metadata')).toEqual(
@@ -412,7 +412,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       const calledUrl = openMock.mock.calls[0]?.[0] as string;
       const parsed = new URL(calledUrl);
       expect(parsed.searchParams.get('defaultResourceName')).toEqual('my-db');
@@ -434,7 +434,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       expect(openMock).toHaveBeenCalled();
       // No --metadata flags, so metadata should NOT be in the URL
       expect(openMock).toHaveBeenCalledWith(
@@ -459,7 +459,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       const calledUrl = openMock.mock.calls[0]?.[0] as string;
       const parsed = new URL(calledUrl);
       expect(parsed.searchParams.get('metadata')).toEqual(
@@ -496,7 +496,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       const calledUrl = openMock.mock.calls[0]?.[0] as string;
       const parsed = new URL(calledUrl);
       expect(parsed.searchParams.get('metadata')).toEqual(
@@ -525,7 +525,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       expect(openMock).toHaveBeenCalledWith(
         expect.not.stringMatching(/metadata=/)
       );
@@ -550,7 +550,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       // Verify all three URL parameters are present
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/defaultResourceName=acme-gray-apple/)
@@ -582,7 +582,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       // Verify defaultResourceName and source are present, but not projectSlug
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/defaultResourceName=acme-gray-apple/)
@@ -607,7 +607,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/defaultResourceName=my-custom-db/)
       );
@@ -635,7 +635,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/defaultResourceName=my-proj-db/)
       );
@@ -673,7 +673,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/defaultResourceName=my-nolink-db/)
       );
@@ -827,7 +827,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/planId=pro/)
       );
@@ -847,7 +847,7 @@ describe('integration add (auto-provision)', () => {
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(1);
       expect(openMock).toHaveBeenCalledWith(
         expect.not.stringMatching(/planId=/)
       );

--- a/packages/cli/test/unit/commands/integration/add.test.ts
+++ b/packages/cli/test/unit/commands/integration/add.test.ts
@@ -14,7 +14,7 @@ import { useUser } from '../../../mocks/user';
 
 vi.mock('open', () => {
   return {
-    default: vi.fn(),
+    default: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -28,7 +28,7 @@ const openMock = vi.mocked(open);
 const pullMock = vi.mocked(pull);
 
 beforeEach(() => {
-  openMock.mockClear();
+  openMock.mockReset().mockResolvedValue(undefined as never);
   pullMock.mockClear();
   // Mock Math.random to get predictable resource names (gray-apple suffix)
   vi.spyOn(Math, 'random').mockReturnValue(0);
@@ -174,7 +174,7 @@ describe('integration', () => {
           );
           client.stdin.write('y\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
           expect(openMock).toHaveBeenCalledWith(
             'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&projectId=vercel-integration-add&defaultResourceName=acme-gray-apple&cmd=add'
           );
@@ -198,7 +198,7 @@ describe('integration', () => {
           );
           client.stdin.write('y\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
           expect(openMock).toHaveBeenCalledWith(
             'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&defaultResourceName=acme-gray-apple&cmd=add'
           );
@@ -215,7 +215,7 @@ describe('integration', () => {
           );
           client.stdin.write('y\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
           expect(openMock).toHaveBeenCalledWith(
             'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&defaultResourceName=acme-gray-apple&cmd=add'
           );
@@ -228,7 +228,7 @@ describe('integration', () => {
             'Terms have not been accepted. Open Vercel Dashboard? (Y/n)'
           );
           client.stdin.write('y\n');
-          await expect(exitCodePromise).resolves.toEqual(0);
+          await expect(exitCodePromise).resolves.toEqual(1);
 
           expect(client.telemetryEventStore).toHaveTelemetryEvents([
             {
@@ -259,7 +259,7 @@ describe('integration', () => {
           );
           client.stdin.write('y\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
           expect(openMock).toHaveBeenCalledWith(
             'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&defaultResourceName=my-custom-db&cmd=add'
           );
@@ -282,7 +282,7 @@ describe('integration', () => {
           );
           client.stdin.write('y\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
           const calledUrl = openMock.mock.calls[0]?.[0] as string;
           const parsed = new URL(calledUrl);
           expect(parsed.searchParams.get('metadata')).toEqual(
@@ -310,7 +310,7 @@ describe('integration', () => {
           );
           client.stdin.write('y\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
           expect(openMock).toHaveBeenCalledWith(
             'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&projectId=vercel-integration-add&defaultResourceName=my-proj-db&cmd=add'
           );
@@ -341,7 +341,7 @@ describe('integration', () => {
           );
           client.stdin.write('y\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
           expect(openMock).toHaveBeenCalledWith(
             'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&defaultResourceName=my-nolink-db&cmd=add'
           );
@@ -578,7 +578,7 @@ describe('integration', () => {
             'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
           );
           client.stdin.write('Y\n');
-          await expect(exitCodePromise).resolves.toEqual(0);
+          await expect(exitCodePromise).resolves.toEqual(1);
           expect(openMock).toHaveBeenCalledWith(
             'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&projectId=vercel-integration-add&defaultResourceName=acme-gray-apple&cmd=add'
           );
@@ -601,7 +601,7 @@ describe('integration', () => {
             'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
           );
           client.stdin.write('n\n');
-          await expect(exitCodePromise).resolves.toEqual(0);
+          await expect(exitCodePromise).resolves.toEqual(1);
           expect(openMock).not.toHaveBeenCalled();
         });
 
@@ -630,7 +630,7 @@ describe('integration', () => {
             'You have selected a plan that cannot be provisioned through the CLI. Open \nVercel Dashboard?'
           );
           client.stdin.write('Y\n');
-          await expect(exitCodePromise).resolves.toEqual(0);
+          await expect(exitCodePromise).resolves.toEqual(1);
           const calledUrl = openMock.mock.calls[0]?.[0] as string;
           const parsed = new URL(calledUrl);
           expect(parsed.searchParams.get('teamId')).toEqual('team_dummy');
@@ -825,7 +825,7 @@ describe('integration', () => {
           );
           client.stdin.write('n\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(1);
         });
 
         it('should error when product slug is not found', async () => {
@@ -866,7 +866,7 @@ describe('integration', () => {
           );
           client.stdin.write('n\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(1);
         });
       });
 
@@ -1056,7 +1056,7 @@ describe('integration', () => {
             );
             client.stdin.write('y\n');
             const exitCode = await exitCodePromise;
-            expect(exitCode).toEqual(0);
+            expect(exitCode).toEqual(1);
             expect(openMock).toHaveBeenCalledWith(
               'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&defaultResourceName=acme-gray-apple&planId=pro&cmd=add'
             );
@@ -1070,7 +1070,7 @@ describe('integration', () => {
             );
             client.stdin.write('y\n');
             const exitCode = await exitCodePromise;
-            expect(exitCode).toEqual(0);
+            expect(exitCode).toEqual(1);
             expect(openMock).toHaveBeenCalledWith(
               expect.not.stringMatching(/planId=/)
             );
@@ -1193,7 +1193,7 @@ describe('integration', () => {
             );
             client.stdin.write('y\n');
             const exitCode = await exitCodePromise;
-            expect(exitCode).toEqual(0);
+            expect(exitCode).toEqual(1);
             expect(openMock).toHaveBeenCalledWith(
               expect.stringMatching(/planId=pro/)
             );
@@ -1517,7 +1517,7 @@ describe('integration', () => {
           );
           client.stdin.write('y\n');
           const exitCode = await exitCodePromise;
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(1);
           const calledUrl = openMock.mock.calls[0]?.[0] as string;
           const parsed = new URL(calledUrl);
           expect(parsed.searchParams.get('metadata')).toEqual(


### PR DESCRIPTION
## Summary
- Fix `vercel integration add` to return exit code 1 (instead of 0) whenever the CLI falls back to opening the browser — across **both** the legacy path and the auto-provision path
- The resource was NOT provisioned by the CLI in any of these cases — returning 0 falsely signals success
- In CI environments, `open()` fails silently and pipelines incorrectly treat provisioning as complete

## Before / After

Same command, same input, same API response — only the exit code changes:

**Auto-provision path (inngest, `kind: unknown` fallback):**

Before (main):
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add inngest --no-connect
> Installing Inngest by Inngest under acme-marketplace-team-vtest314
> Additional setup required. Opening browser...
$ echo $?
0        # ← BUG: claims success, but resource was NOT provisioned
```

After (this PR):
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add inngest --no-connect
> Installing Inngest by Inngest under acme-marketplace-team-vtest314
> Additional setup required. Opening browser...
$ echo $?
1        # ← Correctly signals provisioning did not complete
```

**Legacy path (neon, unsupported wizard → browser):**

Before (main):
```
$ vc integration add neon --no-connect
> Installing Neon by Neon under acme-marketplace-team-vtest314
? This resource must be provisioned through the Web UI. Open Vercel Dashboard? yes
Opening the Vercel Dashboard to continue the installation...
$ echo $?
0        # ← BUG: claims success, but resource was NOT provisioned
```

After (this PR):
```
$ vc integration add neon --no-connect
> Installing Neon by Neon under acme-marketplace-team-vtest314
? This resource must be provisioned through the Web UI. Open Vercel Dashboard? yes
Opening the Vercel Dashboard to continue the installation...
$ echo $?
1        # ← Correctly signals provisioning did not complete
```

**Provisioned path (neon, auto-provision) — unchanged:**
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add neon --no-connect
> Installing Neon by Neon under acme-marketplace-team-vtest314
> Success! Neon successfully provisioned: neon-cyan-flower
$ echo $?
0        # ← Correct: resource was provisioned
```

## Changes

**Source (3 `return 0` → `return 1`):**
- `packages/cli/src/commands/integration/add.ts:240` — legacy path: no installation or unsupported wizard → browser fallback
- `packages/cli/src/commands/integration/add.ts:404` — legacy path: non-subscription billing plan → browser fallback
- `packages/cli/src/commands/integration/add-auto-provision.ts:235` — auto-provision path: `kind !== 'provisioned'` → browser fallback

**Tests (31 assertions updated):**
- `packages/cli/test/unit/commands/integration/add.test.ts` — 17 assertions for legacy browser fallback scenarios
- `packages/cli/test/unit/commands/integration/add-auto-provision.test.ts` — 14 assertions for auto-provision browser fallback scenarios

## Test plan

### Unit tests

```
$ pnpm vitest run packages/cli/test/unit/commands/integration/add.test.ts packages/cli/test/unit/commands/integration/add-auto-provision.test.ts

 ✓ packages/cli/test/unit/commands/integration/add-auto-provision.test.ts  (59 tests) 3740ms
 ✓ packages/cli/test/unit/commands/integration/add.test.ts  (64 tests) 4304ms

 Test Files  2 passed (2)
      Tests  123 passed (123)
```

### Manual testing

| Path | Command | Exit code | Result |
|------|---------|-----------|--------|
| Legacy, neon (unsupported wizard → browser) | `vc integration add neon --no-connect` | **Before: 0, After: 1** | ✅ Browser fallback now correctly exits 1 |
| FF=1, inngest (fallback `kind: unknown`) | `FF_AUTO_PROVISION_INSTALL=1 vc integration add inngest --no-connect` | **Before: 0, After: 1** | ✅ Browser fallback now correctly exits 1 |
| FF=1, neon (provisioned 201) | `FF_AUTO_PROVISION_INSTALL=1 vc integration add neon --no-connect` | **0 (unchanged)** | ✅ Successful provisioning still exits 0 |

### Code paths covered

| Path | Expected | Verified by |
|------|----------|-------------|
| **Auto-provision path** | | |
| → provisioned (201) | Exit 0, no browser | Unit + manual (neon) |
| → `kind: unknown` fallback | Exit 1, opens browser | Unit + manual (inngest) |
| → `kind: metadata` fallback | Exit 1, opens browser | Unit |
| → policy retry → fallback | Exit 1, opens browser | Unit |
| → fallback with --plan | Exit 1, planId in URL | Unit |
| → fallback with --name | Exit 1, name in URL | Unit |
| → fallback with --no-connect | Exit 1, no projectSlug | Unit |
| → fallback with project linked | Exit 1, projectSlug in URL | Unit |
| **Legacy path** | | |
| → no installation → browser | Exit 1, opens browser | Unit + manual (neon) |
| → unsupported wizard → browser | Exit 1, opens browser | Unit + manual (neon) |
| → user declines browser open | Exit 1, no browser | Unit |
| → non-subscription plan → browser | Exit 1, opens browser | Unit |
| → with --name → browser | Exit 1, name in URL | Unit |
| → with --metadata → browser | Exit 1, metadata in URL | Unit |
| → with --plan → browser | Exit 1, planId in URL | Unit |
| → with --no-connect → browser | Exit 1, no projectId | Unit |
| → successful CLI provision | Exit 0 (unchanged) | Unit |

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR changes CLI exit codes from 0 to 1 for browser fallback scenarios to correctly signal incomplete provisioning, with corresponding test updates - a bug fix that improves error signaling without affecting security or access controls.
> 
> - Exit code changes: `return 0` → `return 1` in 3 browser fallback paths
> - Added `.catch()` handlers to `open()` calls for CI environments
> - Test updates: 31 assertions changed from `expect(exitCode).toEqual(0)` to `expect(exitCode).toEqual(1)`
>
> <sup>Risk assessment for [commit b73871e](https://github.com/vercel/vercel/commit/b73871eff3e875e66d50d67d07aed33cb3a3c6b1).</sup>
<!-- VADE_RISK_END -->