### PR TITLE
feat(cli): easier agentic login

### DIFF
--- a/.changeset/shaggy-weeks-brake.md
+++ b/.changeset/shaggy-weeks-brake.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Support easier auth from cursor / claude


### PR DESCRIPTION
Support better login experience from cursor / claude

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR modifies CLI login UX to auto-open browser for authentication instead of waiting for user input, which is a flow change but does not alter authentication security - the same device authorization flow is used.
> 
> - Removes manual [ENTER] prompt, auto-opens browser for device auth flow
> - Adds Cursor agent detection to control browser-opening behavior in CI
> - Graceful fallback with instructions when browser fails to open
>
> <sup>Risk assessment for [commit 265367b](https://github.com/vercel/vercel/commit/265367b4bc1c8ac0a658080a147da04e192d13fb).</sup>
<!-- VADE_RISK_END -->