### PR TITLE
feat(cli): add --environment flag to integration add

### DIFF
--- a/.changeset/add-environment-flag.md
+++ b/.changeset/add-environment-flag.md
@@ -1,0 +1,7 @@
+---
+'vercel': minor
+---
+
+Add `--environment` repeatable flag to `vercel integration add`
+
+Allows specifying which environments to connect a resource to (e.g., `--environment production --environment preview`). Defaults to all three environments (production, preview, development) when not specified, preserving backward compatibility.

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -45,6 +45,7 @@ export async function addAutoProvision(
   telemetry.trackCliFlagNoConnect(options.noConnect);
   telemetry.trackCliFlagNoEnvPull(options.noEnvPull);
   telemetry.trackCliOptionPlan(options.billingPlanId);
+  telemetry.trackCliOptionEnvironment(options.environments);
 
   // 1. Get team context
   const { contextName, team } = await getScope(client);

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -8,6 +8,8 @@ import indent from '../../util/output/indent';
 import {
   getLinkedProjectField,
   postProvisionSetup,
+  VALID_ENVIRONMENTS,
+  validateEnvironments,
   type PostProvisionOptions,
 } from '../../util/integration/post-provision-setup';
 import type {
@@ -75,6 +77,17 @@ export async function add(
     integrationSlug = rawArg;
   }
 
+  // Validate --environment values early (before any network requests)
+  if (options.environments?.length) {
+    const envValidation = validateEnvironments(options.environments);
+    if (!envValidation.valid) {
+      output.error(
+        `Invalid environment value: ${envValidation.invalid.map(e => `"${e}"`).join(', ')}. Must be one of: ${VALID_ENVIRONMENTS.join(', ')}`
+      );
+      return 1;
+    }
+  }
+
   // Note: Resource name validation happens after product selection
   // to apply product-specific validation rules
 
@@ -86,6 +99,7 @@ export async function add(
       billingPlanId,
       noConnect: options.noConnect,
       noEnvPull: options.noEnvPull,
+      environments: options.environments,
     });
   }
 
@@ -99,6 +113,7 @@ export async function add(
   telemetry.trackCliOptionPlan(billingPlanId);
   telemetry.trackCliFlagNoConnect(options.noConnect);
   telemetry.trackCliFlagNoEnvPull(options.noEnvPull);
+  telemetry.trackCliOptionEnvironment(options.environments);
 
   const { contextName, team } = await getScope(client);
 
@@ -657,7 +672,9 @@ async function provisionStorageProduct(
   } finally {
     output.stopSpinner();
   }
-  output.log(`${product.name} successfully provisioned: ${chalk.bold(name)}`);
+  output.success(
+    `${product.name} successfully provisioned: ${chalk.bold(name)}`
+  );
 
   return postProvisionSetup(client, name, storeId, contextName, options);
 }

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -53,6 +53,15 @@ export const addSubcommand = {
       deprecated: false,
       description: 'Skip running env pull after provisioning',
     },
+    {
+      name: 'environment',
+      shorthand: 'e',
+      type: [String],
+      deprecated: false,
+      argument: 'ENV',
+      description:
+        'Environment to connect (can be repeated: production, preview, development). Defaults to all.',
+    },
   ],
   examples: [
     {
@@ -91,6 +100,21 @@ export const addSubcommand = {
         `${packageName} integration add acme --plan pro`,
         `${packageName} integration add acme -p pro`,
       ],
+    },
+    {
+      name: 'Install and connect to specific environments only',
+      value: [
+        `${packageName} integration add acme --environment production`,
+        `${packageName} integration add acme -e production -e preview`,
+      ],
+    },
+    {
+      name: 'Install without connecting to the current project',
+      value: `${packageName} integration add acme --no-connect`,
+    },
+    {
+      name: 'Install without pulling environment variables',
+      value: `${packageName} integration add acme --no-env-pull`,
     },
     {
       name: 'Show available products for an integration',

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -170,6 +170,9 @@ export default async function main(client: Client) {
       const noEnvPull = addParsedArgs.flags['--no-env-pull'] as
         | boolean
         | undefined;
+      const environmentFlags = addParsedArgs.flags['--environment'] as
+        | string[]
+        | undefined;
 
       return add(
         client,
@@ -180,6 +183,7 @@ export default async function main(client: Client) {
         {
           noConnect,
           noEnvPull,
+          environments: environmentFlags,
         }
       );
     }

--- a/packages/cli/src/util/integration/format-dynamic-examples.ts
+++ b/packages/cli/src/util/integration/format-dynamic-examples.ts
@@ -51,6 +51,44 @@ export function formatDynamicExamples(
     lines.push(`    ${chalk.cyan(`$ ${metadataExample}`)}`);
   }
 
+  // Billing plan
+  lines.push('');
+  lines.push(`  ${chalk.dim('-')} Install with a specific billing plan`);
+  lines.push('');
+  lines.push(
+    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} --plan pro`)}`
+  );
+
+  // Environment
+  lines.push('');
+  lines.push(
+    `  ${chalk.dim('-')} Install and connect to specific environments only`
+  );
+  lines.push('');
+  lines.push(
+    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} -e production -e preview`)}`
+  );
+
+  // No-connect
+  lines.push('');
+  lines.push(
+    `  ${chalk.dim('-')} Install without connecting to the current project`
+  );
+  lines.push('');
+  lines.push(
+    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} --no-connect`)}`
+  );
+
+  // No-env-pull
+  lines.push('');
+  lines.push(
+    `  ${chalk.dim('-')} Install without pulling environment variables`
+  );
+  lines.push('');
+  lines.push(
+    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} --no-env-pull`)}`
+  );
+
   lines.push('');
 
   return lines.join('\n');

--- a/packages/cli/src/util/telemetry/commands/integration/add.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/add.ts
@@ -53,4 +53,13 @@ export class IntegrationAddTelemetryClient
       this.trackCliFlag('no-env-pull');
     }
   }
+
+  trackCliOptionEnvironment(v: string[] | undefined) {
+    if (v?.length) {
+      this.trackCliOption({
+        option: 'environment',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/util/integration/format-dynamic-examples.test.ts
+++ b/packages/cli/test/unit/util/integration/format-dynamic-examples.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { formatDynamicExamples } from '../../../../src/util/integration/format-dynamic-examples';
+import { addSubcommand } from '../../../../src/commands/integration/command';
+import type { IntegrationProduct } from '../../../../src/util/integration/types';
+
+// Strip ANSI codes so we can match plain text
+function stripAnsi(str: string): string {
+  return str.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+// Product with a metadataSchema so the metadata example is generated
+const productWithSchema: IntegrationProduct[] = [
+  {
+    id: 'iap_test',
+    slug: 'test-product',
+    name: 'Test Product',
+    shortDescription: 'A test product',
+    type: 'storage',
+    metadataSchema: {
+      type: 'object',
+      properties: {
+        region: {
+          type: 'string',
+          'ui:control': 'vercel-region',
+          'ui:options': ['iad1', 'sfo1'],
+        },
+      },
+      required: ['region'],
+    },
+  },
+];
+
+describe('formatDynamicExamples', () => {
+  it('should include an example for every addSubcommand option', () => {
+    const output = stripAnsi(
+      formatDynamicExamples('test-integration', productWithSchema)
+    );
+
+    for (const option of addSubcommand.options) {
+      const longFlag = `--${option.name}`;
+      const shortFlag = option.shorthand ? `-${option.shorthand}` : null;
+      const hasLong = output.includes(longFlag);
+      const hasShort = shortFlag ? output.includes(shortFlag) : false;
+
+      expect(
+        hasLong || hasShort,
+        `Dynamic examples missing flag "${longFlag}"${shortFlag ? ` / "${shortFlag}"` : ''}. ` +
+          `Add an example to formatDynamicExamples() for this option.`
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Added `--environment` / `-e` repeatable flag to `vercel integration add` (both auto-provision and legacy flows).
- Previously, resource connections were hardcoded to all 3 environments (production, preview, development).
- Now agents/CI can specify which environments to connect: `vercel integration add acme -e production -e preview`.
- Defaults to all 3 when flag is not provided (backward compatible).
- Early validation rejects invalid environment values with a clear error message.
- `VALID_ENVIRONMENTS` is the single source of truth — fallback, error messages, and help text all reference it (with a guard test).
- Fixed `formatDynamicExamples` to include examples for all `addSubcommand` flags (`--plan`, `--environment`, `--no-connect`, `--no-env-pull` were missing from dynamic help). Added a guard test that fails if a new flag is added without a dynamic example.
- Added telemetry tracking (`trackCliOptionEnvironment`) in both auto-provision and legacy paths.
- Changed success message in legacy path from `output.log` to `output.success` to match auto-provision path.

Fixes: [MKT-2750](https://linear.app/vercel/issue/MKT-2750/in-vc-integration-add-allow-connecting-only-certain-environments)

## Test Plan

### Unit Tests

```
$ cd packages/cli && pnpm vitest run test/unit/util/integration/format-dynamic-examples.test.ts test/unit/commands/integration/add.test.ts test/unit/commands/integration/add-auto-provision.test.ts

 ✓ test/unit/util/integration/format-dynamic-examples.test.ts  (1 test) 1ms
 ✓ test/unit/commands/integration/add-auto-provision.test.ts  (66 tests) 3565ms
 ✓ test/unit/commands/integration/add.test.ts  (69 tests) 4224ms

 Test Files  3 passed (3)
      Tests  136 passed (136)
```

### Manual Testing (auto-provision path, `FF_AUTO_PROVISION_INSTALL=1`)

Tested against `acme-marketplace-team-vtest314` (`team_ZrswwWlkgu3cRre7Tk7Rr0HV`) with braintrust (auto-provisions with 201).

**`--environment production` — single env, full flow:**
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add braintrust --environment production --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV
> Installing Braintrust by Braintrust under acme-marketplace-team-vtest314
⠋ Provisioning resource...
> Success! Braintrust successfully provisioned: braintrust-blue-school
>     Dashboard: https://vercel.com/acme-marketplace-team-vtest314/~/stores/integration/ir_3ZuQaKZIn8ob70wF
⠋ Connecting braintrust-blue-school to cli-test...
> braintrust-blue-school successfully connected to cli-test
> Overwriting existing .env.local file
> Downloading `development` Environment Variables for acme-marketplace-team-vtest314/cli-test
✅  Updated .env.local file
```
✅ Full flow: provision → dashboard → connect to project → env pull. Connected with `["production"]` only.

**`-e production -e preview` — multiple envs:**
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add braintrust -e production -e preview --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV
> Installing Braintrust by Braintrust under acme-marketplace-team-vtest314
⠋ Provisioning resource...
> Success! Braintrust successfully provisioned: braintrust-indigo-ocean
>     Dashboard: https://vercel.com/acme-marketplace-team-vtest314/~/stores/integration/ir_VTuV7RmrifPL0LFC
Error: Failed to connect: This project already has an existing environment variable with name BRAINTRUST_API_KEY in one of the chosen environments (400)
```
✅ Provisioned correctly. Connect returned 400 because production env var already existed from previous test — confirms both environments (`["production", "preview"]`) were passed to the connect API.

**`--environment staging` — invalid value:**
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add braintrust --environment staging --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV
Error: Invalid environment value: "staging". Must be one of: production, preview, development
```
✅ Validation rejects before any API calls.

**`--environment production --no-connect` — skip connect:**
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add braintrust --environment production --no-connect --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV
> Installing Braintrust by Braintrust under acme-marketplace-team-vtest314
⠋ Provisioning resource...
> Success! Braintrust successfully provisioned: braintrust-gray-zebra
>     Dashboard: https://vercel.com/acme-marketplace-team-vtest314/~/stores/integration/ir_qmSsuFBkyRYWsCvm
```
✅ Provisioned, dashboard shown, no connect attempt (skipped correctly).

### Code Paths Covered

| Path | Expected | Tested by |
|------|----------|-----------|
| Invalid `--environment` value | Error before API calls | Unit + manual (`staging`) |
| Multiple invalid values | All listed in error | Unit + manual |
| `--environment production` (single) | Connect with `["production"]` | Unit (asserts `connectMock` args) + manual (full flow with connect + env pull) |
| `-e production -e preview` (multi) | Connect with `["production", "preview"]` | Unit (asserts `connectMock` args) + manual (400 confirms both envs passed) |
| No `--environment` flag (default) | Connect with all 3 envs | Unit (asserts `connectMock` args) |
| `-e` shorthand | Same as `--environment` | Unit + manual |
| `--environment` + `--no-connect` | Skip connect, environments irrelevant | Unit + manual |
| Static `--help` shows flag | Option, description, examples visible | Manual |
| Dynamic `--help` shows flag | All flags have dynamic examples | Unit (guard test) |
| `VALID_ENVIRONMENTS` ↔ help description sync | Help text mentions every valid env | Unit (guard test) |
| Dynamic examples cover all flags | Every `addSubcommand` option has an example | Unit (guard test) |
| Legacy path + `--environment` | Environments forwarded to `postProvisionSetup` | Unit |
| Auto-provision path + `--environment` | Environments forwarded to `postProvisionSetup` | Unit + manual (braintrust) |
| Telemetry tracking | `trackCliOptionEnvironment` called in both paths | Unit (type-checked via `TelemetryMethods` interface) |

> **Note:** Legacy path manual testing was not done for `--environment` specifically because the legacy flow uses interactive prompts (region, billing plan, confirmation) that are orthogonal to the `--environment` flag. The `--environment` flag is processed identically in both paths — it's passed through `options` to `postProvisionSetup`, which is the same function in both cases. Unit tests verify both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new --environment flag to the CLI integration add command with proper input validation that RESTRICTS invalid values, includes comprehensive tests, and maintains backward compatibility by defaulting to all environments.
> 
> - New CLI flag `--environment` with early validation rejecting invalid values
> - Telemetry tracking and help text updates for new flag
> - Extensive unit tests covering validation, deduplication, and both code paths
>
> <sup>Risk assessment for [commit 81f396b](https://github.com/vercel/vercel/commit/81f396b5f341ade0c2e4dd84a303851cc48f0dcb).</sup>
<!-- VADE_RISK_END -->