### PR TITLE
fix(cli): prefer team over personal account when --scope slug is ambiguous

### DIFF
--- a/.changeset/fix-scope-slug-disambiguation.md
+++ b/.changeset/fix-scope-slug-disambiguation.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+fix(cli): prefer team over personal account when `--scope` slug is ambiguous
+
+When a personal account username and a team slug are identical, `--scope <slug>` now resolves to the team instead of erroring with "You cannot set your Personal Account as the scope." This fixes both the global `--scope` flag and `vercel teams switch <slug>`.

--- a/packages/cli/src/commands/teams/switch.ts
+++ b/packages/cli/src/commands/teams/switch.ts
@@ -124,37 +124,38 @@ export default async function change(client: Client, argv: string[]) {
     return 0;
   }
 
-  if (desiredSlug === user.username || desiredSlug === user.email) {
-    if (user.version === 'northstar') {
-      output.error('You cannot set your Personal Account as the scope.');
-      return 1;
-    }
-
-    // Switch to user's personal account
-    if (personalScopeSelected) {
-      output.log('No changes made');
-      return 0;
-    }
-
-    if (user.limited) {
-      await client.reauthenticate({
-        scope: user.username,
-        teamId: null,
-      });
-    }
-
-    updateCurrentTeam(config);
-
-    output.success(
-      `Your account (${chalk.bold(user.username)}) is now active!`
-    );
-    return 0;
-  }
-
-  // Switch to selected team
+  // Switch to selected team (check teams first so a team slug takes priority
+  // over a personal-account username when they collide)
   const newTeam = teams.find(team => team.slug === desiredSlug);
 
   if (!newTeam) {
+    if (desiredSlug === user.username || desiredSlug === user.email) {
+      if (user.version === 'northstar') {
+        output.error('You cannot set your Personal Account as the scope.');
+        return 1;
+      }
+
+      // Switch to user's personal account
+      if (personalScopeSelected) {
+        output.log('No changes made');
+        return 0;
+      }
+
+      if (user.limited) {
+        await client.reauthenticate({
+          scope: user.username,
+          teamId: null,
+        });
+      }
+
+      updateCurrentTeam(config);
+
+      output.success(
+        `Your account (${chalk.bold(user.username)}) is now active!`
+      );
+      return 0;
+    }
+
     output.error(
       `You do not have permission to access scope ${chalk.bold(desiredSlug)}.`
     );

--- a/packages/cli/test/unit/commands/switch/switch.test.ts
+++ b/packages/cli/test/unit/commands/switch/switch.test.ts
@@ -82,5 +82,27 @@ describe('switch', () => {
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "switch"').toEqual(1);
     });
+
+    it('should prefer team when slug matches both personal username and team slug', async () => {
+      const user = useUser({ version: 'northstar' });
+      const matchingTeam = {
+        id: 'team_matching',
+        slug: user.username,
+        name: 'Matching Team',
+        creatorId: 'creator-id',
+        created: '2017-04-29T17:21:54.514Z',
+        avatar: null,
+      };
+      client.scenario.get('/v1/teams', (_req: any, res: any) => {
+        res.json({ teams: [matchingTeam] });
+      });
+
+      const exitCodePromise = teamsSwitch(client, [user.username]);
+      const exitCode = await exitCodePromise;
+      expect(exitCode, 'exit code for "switch"').toEqual(0);
+      await expect(client.stderr).toOutput(
+        `The team Matching Team (${user.username}) is now active!`
+      );
+    });
   });
 });

--- a/packages/cli/test/unit/commands/teams/switch.test.ts
+++ b/packages/cli/test/unit/commands/teams/switch.test.ts
@@ -96,5 +96,27 @@ describe('teams switch', () => {
       );
       await expect(exitCodePromise).resolves.toEqual(1);
     });
+
+    it('should prefer team when slug matches both personal username and team slug', async () => {
+      const user = useUser({ version: 'northstar' });
+      const matchingTeam = {
+        id: 'team_matching',
+        slug: user.username,
+        name: 'Matching Team',
+        creatorId: 'creator-id',
+        created: '2017-04-29T17:21:54.514Z',
+        avatar: null,
+      };
+      client.scenario.get('/v1/teams', (_req: any, res: any) => {
+        res.json({ teams: [matchingTeam] });
+      });
+
+      client.setArgv('teams', 'switch', user.username);
+      const exitCodePromise = teams(client);
+      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(client.stderr).toOutput(
+        `The team Matching Team (${user.username}) is now active!`
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

When a personal account username and a team slug are identical, `--scope <slug>` always resolved to the personal account, making it impossible to target the team via the CLI.

Fixes #15062

## The Bug

In `packages/cli/src/index.ts`, the scope resolution logic checks `user.id === scope || user.email === scope || user.username === scope` **before** fetching teams. If the scope matches the username, it immediately errors with "You cannot set your Personal Account as the scope" (northstar) or clears the team — it never checks whether a team has that slug.

The same bug exists in `packages/cli/src/commands/teams/switch.ts` (line 127), where `desiredSlug === user.username` is checked before `teams.find(team => team.slug === desiredSlug)`.

## The Fix

**`index.ts`**: Always fetch teams, even when scope matches the personal account. Prefer team match over personal account — since `--scope` on a personal account is meaningless (northstar users cannot use it, non-northstar users do not need it).

**`teams/switch.ts`**: Move the `teams.find(...)` lookup before the username/email check. Only fall through to the personal account logic when no team matches.

## Trade-off

This adds one extra API call (`GET /v1/teams`) when the scope matches the personal username. Previously it short-circuited. This is negligible — it is a one-time CLI startup cost.

## Tests

- **Existing tests preserved**: The "should not allow setting user as scope" test still passes — when no team has the matching slug, the personal account error still fires.
- **New tests added**:
  - `northstar.test.ts`: 3 new integration tests (team preferred over username, team by ID, nonexistent scope error)
  - `switch.test.ts` + `teams/switch.test.ts`: 1 new unit test each verifying team takes priority when slug collides with username

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR changes scope resolution order to prefer team matches over personal account matches when slugs collide, which is a defensive change that fixes a bug where users couldn't target teams with matching slugs.
> 
> - Reorders scope resolution: team lookup now happens before personal account check in both `index.ts` and `switch.ts`
> - Always fetches teams list even when scope matches personal username
> - Adds 5 new tests covering team-preferred disambiguation scenarios
>
> <sup>Risk assessment for [commit c8e583a](https://github.com/vercel/vercel/commit/c8e583a7e0ab378ca5875f793b7751599e4b74a5).</sup>
<!-- VADE_RISK_END -->