### PR TITLE
[config] Add helper functions for has/missing conditions

### DIFF
--- a/.changeset/large-birds-report.md
+++ b/.changeset/large-birds-report.md
@@ -1,0 +1,5 @@
+---
+'@vercel/config': patch
+---
+
+Add a new `matchers` export that exposes helpers to make matching against headers, query params, cookies, and host simpler to write.

--- a/packages/config/example/vercel.ts
+++ b/packages/config/example/vercel.ts
@@ -17,8 +17,6 @@ import {
   matchers,
 } from '@vercel/config/v1';
 
-const { header, cookie, host } = matchers;
-
 export const config: VercelConfig = {
   buildCommand: 'pnpm run generate-config',
   installCommand: 'pnpm install --no-frozen-lockfile',
@@ -69,7 +67,7 @@ export const config: VercelConfig = {
         { key: 'x-content-type-options', value: 'nosniff' },
       ],
       {
-        has: [host('secure.example.com')],
+        has: [matchers.host('secure.example.com')],
       }
     ),
   ],
@@ -132,8 +130,8 @@ export const config: VercelConfig = {
     // Only rewrites if user has admin/moderator role AND secure session cookie
     routes.rewrite('/admin/(.*)', 'https://admin.backend.com/$1', {
       has: [
-        header('x-user-role', { inc: ['admin', 'moderator'] }),
-        cookie('session', { pre: 'secure-' }),
+        matchers.header('x-user-role', { inc: ['admin', 'moderator'] }),
+        matchers.cookie('session', { pre: 'secure-' }),
       ],
     }),
 
@@ -144,10 +142,10 @@ export const config: VercelConfig = {
       'https://premium-api.backend.com/$1',
       {
         has: [
-          header('x-api-version', { gte: 2 }),
-          header('authorization', { pre: 'Bearer ' }),
+          matchers.header('x-api-version', { gte: 2 }),
+          matchers.header('authorization', { pre: 'Bearer ' }),
         ],
-        missing: [header('x-legacy-auth')],
+        missing: [matchers.header('x-legacy-auth')],
       }
     ),
   ],
@@ -168,12 +166,12 @@ export const config: VercelConfig = {
 
     // Conditional redirect - redirect to login if no auth token
     routes.redirect('/dashboard/(.*)', '/login', {
-      missing: [cookie('auth-token')],
+      missing: [matchers.cookie('auth-token')],
     }),
 
     // Host-based redirect - redirect non-www to www
     routes.redirect('/(.*)', 'https://www.example.com/$1', {
-      has: [host('example.com')],
+      has: [matchers.host('example.com')],
     }),
   ],
 };

--- a/packages/config/example/vercel.ts
+++ b/packages/config/example/vercel.ts
@@ -14,10 +14,10 @@ import {
   VercelConfig,
   routes,
   deploymentEnv,
-  header,
-  cookie,
-  host,
+  matchers,
 } from '@vercel/config/v1';
+
+const { header, cookie, host } = matchers;
 
 export const config: VercelConfig = {
   buildCommand: 'pnpm run generate-config',

--- a/packages/config/example/vercel.ts
+++ b/packages/config/example/vercel.ts
@@ -10,7 +10,14 @@
  * - Cache control headers with pretty-cache-header syntax
  */
 
-import { VercelConfig, routes, deploymentEnv } from '@vercel/config/v1';
+import {
+  VercelConfig,
+  routes,
+  deploymentEnv,
+  header,
+  cookie,
+  host,
+} from '@vercel/config/v1';
 
 export const config: VercelConfig = {
   buildCommand: 'pnpm run generate-config',
@@ -62,7 +69,7 @@ export const config: VercelConfig = {
         { key: 'x-content-type-options', value: 'nosniff' },
       ],
       {
-        has: [{ type: 'host', value: 'secure.example.com' }],
+        has: [host('secure.example.com')],
       }
     ),
   ],
@@ -125,8 +132,8 @@ export const config: VercelConfig = {
     // Only rewrites if user has admin/moderator role AND secure session cookie
     routes.rewrite('/admin/(.*)', 'https://admin.backend.com/$1', {
       has: [
-        { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] },
-        { type: 'cookie', key: 'session', pre: 'secure-' },
+        header('x-user-role', { inc: ['admin', 'moderator'] }),
+        cookie('session', { pre: 'secure-' }),
       ],
     }),
 
@@ -137,10 +144,10 @@ export const config: VercelConfig = {
       'https://premium-api.backend.com/$1',
       {
         has: [
-          { type: 'header', key: 'x-api-version', gte: 2 },
-          { type: 'header', key: 'authorization', pre: 'Bearer ' },
+          header('x-api-version', { gte: 2 }),
+          header('authorization', { pre: 'Bearer ' }),
         ],
-        missing: [{ type: 'header', key: 'x-legacy-auth' }],
+        missing: [header('x-legacy-auth')],
       }
     ),
   ],
@@ -161,12 +168,12 @@ export const config: VercelConfig = {
 
     // Conditional redirect - redirect to login if no auth token
     routes.redirect('/dashboard/(.*)', '/login', {
-      missing: [{ type: 'cookie', key: 'auth-token' }],
+      missing: [cookie('auth-token')],
     }),
 
     // Host-based redirect - redirect non-www to www
     routes.redirect('/(.*)', 'https://www.example.com/$1', {
-      has: [{ type: 'host', value: 'example.com' }],
+      has: [host('example.com')],
     }),
   ],
 };

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -1,13 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import {
-  createRoutes,
-  Router,
-  deploymentEnv,
-  header,
-  cookie,
-  query,
-  host,
-} from './router';
+import { createRoutes, Router, deploymentEnv, matchers } from './router';
+
+const { header, cookie, query, host } = matchers;
 import { cacheHeader } from 'pretty-cache-header';
 
 describe('Router', () => {

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { createRoutes, Router, deploymentEnv } from './router';
+import {
+  createRoutes,
+  Router,
+  deploymentEnv,
+  header,
+  cookie,
+  query,
+  host,
+} from './router';
 import { cacheHeader } from 'pretty-cache-header';
 
 describe('Router', () => {
@@ -186,6 +194,189 @@ describe('Router', () => {
     it('deploymentEnv() should return $ prefixed string', () => {
       expect(deploymentEnv('BEARER_TOKEN')).toBe('$BEARER_TOKEN');
       expect(deploymentEnv('API_KEY')).toBe('$API_KEY');
+    });
+  });
+
+  describe('condition helpers', () => {
+    describe('header()', () => {
+      it('should create a presence-only condition', () => {
+        expect(header('x-admin-token')).toEqual({
+          type: 'header',
+          key: 'x-admin-token',
+        });
+      });
+
+      it('should create a regex value condition', () => {
+        expect(header('accept', '(.*)text/markdown(.*)')).toEqual({
+          type: 'header',
+          key: 'accept',
+          value: '(.*)text/markdown(.*)',
+        });
+      });
+
+      it('should create an operator-based condition', () => {
+        expect(header('x-user-role', { inc: ['admin', 'moderator'] })).toEqual({
+          type: 'header',
+          key: 'x-user-role',
+          inc: ['admin', 'moderator'],
+        });
+      });
+
+      it('should support all operator types', () => {
+        expect(header('x-version', { eq: 2 })).toEqual({
+          type: 'header',
+          key: 'x-version',
+          eq: 2,
+        });
+        expect(header('x-version', { neq: 'beta' })).toEqual({
+          type: 'header',
+          key: 'x-version',
+          neq: 'beta',
+        });
+        expect(header('x-version', { gte: 2 })).toEqual({
+          type: 'header',
+          key: 'x-version',
+          gte: 2,
+        });
+        expect(header('x-version', { gt: 1 })).toEqual({
+          type: 'header',
+          key: 'x-version',
+          gt: 1,
+        });
+        expect(header('x-version', { lt: 5 })).toEqual({
+          type: 'header',
+          key: 'x-version',
+          lt: 5,
+        });
+        expect(header('x-version', { lte: 5 })).toEqual({
+          type: 'header',
+          key: 'x-version',
+          lte: 5,
+        });
+        expect(header('x-auth', { pre: 'Bearer ' })).toEqual({
+          type: 'header',
+          key: 'x-auth',
+          pre: 'Bearer ',
+        });
+        expect(header('x-auth', { suf: '-token' })).toEqual({
+          type: 'header',
+          key: 'x-auth',
+          suf: '-token',
+        });
+        expect(header('x-role', { ninc: ['guest'] })).toEqual({
+          type: 'header',
+          key: 'x-role',
+          ninc: ['guest'],
+        });
+      });
+    });
+
+    describe('cookie()', () => {
+      it('should create a presence-only condition', () => {
+        expect(cookie('session')).toEqual({
+          type: 'cookie',
+          key: 'session',
+        });
+      });
+
+      it('should create a regex value condition', () => {
+        expect(cookie('theme', 'dark|light')).toEqual({
+          type: 'cookie',
+          key: 'theme',
+          value: 'dark|light',
+        });
+      });
+
+      it('should create an operator-based condition', () => {
+        expect(cookie('session', { pre: 'secure-' })).toEqual({
+          type: 'cookie',
+          key: 'session',
+          pre: 'secure-',
+        });
+      });
+    });
+
+    describe('query()', () => {
+      it('should create a presence-only condition', () => {
+        expect(query('debug')).toEqual({
+          type: 'query',
+          key: 'debug',
+        });
+      });
+
+      it('should create a regex value condition', () => {
+        expect(query('format', 'markdown')).toEqual({
+          type: 'query',
+          key: 'format',
+          value: 'markdown',
+        });
+      });
+
+      it('should create an operator-based condition', () => {
+        expect(query('page', { gte: 1 })).toEqual({
+          type: 'query',
+          key: 'page',
+          gte: 1,
+        });
+      });
+    });
+
+    describe('host()', () => {
+      it('should create a host value condition', () => {
+        expect(host('example.com')).toEqual({
+          type: 'host',
+          value: 'example.com',
+        });
+      });
+
+      it('should create a host operator condition', () => {
+        expect(host({ suf: '.example.com' })).toEqual({
+          type: 'host',
+          suf: '.example.com',
+        });
+      });
+    });
+
+    describe('end-to-end with router', () => {
+      it('should work in rewrite has/missing arrays', () => {
+        const rewrite = router.rewrite(
+          '/admin/(.*)',
+          'https://admin.backend.com/$1',
+          {
+            has: [
+              header('x-user-role', { inc: ['admin', 'moderator'] }),
+              cookie('session', { pre: 'secure-' }),
+            ],
+            missing: [header('x-legacy-auth')],
+          }
+        );
+        expect(rewrite).toEqual({
+          source: '/admin/(.*)',
+          destination: 'https://admin.backend.com/$1',
+          has: [
+            { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] },
+            { type: 'cookie', key: 'session', pre: 'secure-' },
+          ],
+          missing: [{ type: 'header', key: 'x-legacy-auth' }],
+        });
+      });
+
+      it('should mix helpers with raw Condition objects', () => {
+        const rewrite = router.rewrite('/api/(.*)', 'https://backend.com/$1', {
+          has: [
+            header('authorization', { pre: 'Bearer ' }),
+            { type: 'header', key: 'x-api-version', gte: 2 },
+          ],
+        });
+        expect(rewrite).toEqual({
+          source: '/api/(.*)',
+          destination: 'https://backend.com/$1',
+          has: [
+            { type: 'header', key: 'authorization', pre: 'Bearer ' },
+            { type: 'header', key: 'x-api-version', gte: 2 },
+          ],
+        });
+      });
     });
   });
 

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -231,6 +231,32 @@ export interface Condition extends ConditionOperators {
   value?: string;
 }
 
+function createKeyedConditionHelper(type: 'header' | 'cookie' | 'query') {
+  return (key: string, value?: string | ConditionOperators): Condition => {
+    if (value === undefined) {
+      return { type, key };
+    }
+    if (typeof value === 'string') {
+      return { type, key, value };
+    }
+    return { type, key, ...value };
+  };
+}
+
+function createKeylessConditionHelper(type: 'host') {
+  return (value: string | ConditionOperators): Condition => {
+    if (typeof value === 'string') {
+      return { type, value };
+    }
+    return { type, ...value };
+  };
+}
+
+export const header = createKeyedConditionHelper('header');
+export const cookie = createKeyedConditionHelper('cookie');
+export const query = createKeyedConditionHelper('query');
+export const host = createKeylessConditionHelper('host');
+
 /**
  * Transform type specifies the scope of what the transform will apply to.
  * - 'request.query': Transform query parameters in the request

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -252,10 +252,12 @@ function createKeylessConditionHelper(type: 'host') {
   };
 }
 
-export const header = createKeyedConditionHelper('header');
-export const cookie = createKeyedConditionHelper('cookie');
-export const query = createKeyedConditionHelper('query');
-export const host = createKeylessConditionHelper('host');
+export const matchers = {
+  header: createKeyedConditionHelper('header'),
+  cookie: createKeyedConditionHelper('cookie'),
+  query: createKeyedConditionHelper('query'),
+  host: createKeylessConditionHelper('host'),
+};
 
 /**
  * Transform type specifies the scope of what the transform will apply to.


### PR DESCRIPTION
## Summary

- Adds `matchers.header()`, `matchers.cookie()`, `matchers.query()`, and `matchers.host()` factory functions to `@vercel/config` that reduce boilerplate when writing `has`/`missing` conditions
- Updates example to use the new helpers
- Fully backward compatible — raw `Condition` objects still work in the same arrays

**Before:**
```typescript
routes.rewrite('/admin/(.*)', 'https://admin.backend.com/$1', {
  has: [
    { type: 'header', key: 'authorization' },
    { type: 'cookie', key: 'auth-token' },
    { type: 'query', key: 'format', value: 'json' },
    { type: 'host', value: 'api.example.com' },
  ],
  missing: [{ type: 'header', key: 'x-legacy-auth' }],
})
```

**After:**
```typescript
import { routes, matchers } from '@vercel/config/v1';

routes.rewrite('/admin/(.*)', 'https://admin.backend.com/$1', {
  has: [
    matchers.header('authorization'),
    matchers.cookie('auth-token'),
    matchers.query('format', 'json'),
    matchers.host('api.example.com'),
  ],
  missing: [matchers.header('x-legacy-auth')],
})
```

Each helper supports up to three calling styles:
- Presence check: `matchers.header('x-admin-token')`
- Regex match: `matchers.header('accept', '(.*)text/markdown(.*)')`
- Operator match: `matchers.cookie('session', { pre: 'secure-' })`

## Test plan

- [x] All existing tests pass
- [x] New tests cover all 4 helpers (presence, string value, operator-based)
- [x] End-to-end tests verify helpers produce correct output through `rewrite()`
- [x] TypeScript type checking passes

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds helper factory functions (matchers.header, matchers.cookie, matchers.query, matchers.host) that produce the same Condition objects as before, purely reducing boilerplate with no changes to security logic or validation.
> 
> - Adds `matchers` export with 4 helper functions that return Condition objects
> - Updates example file to use new helpers instead of raw objects
> - Adds comprehensive tests for all helper variations
>
> <sup>Risk assessment for [commit 4db2efc](https://github.com/vercel/vercel/commit/4db2efc739f14bbb8ba05c046fbd239c36aea5ea).</sup>
<!-- VADE_RISK_END -->