### PR TITLE
feat(cli): add marketplace funnel telemetry to integration add command

### DIFF
--- a/.changeset/cli-marketplace-telemetry.md
+++ b/.changeset/cli-marketplace-telemetry.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(cli): add marketplace funnel telemetry to integration add command

--- a/packages/cli/src/util/integration/auto-provision-resource.ts
+++ b/packages/cli/src/util/integration/auto-provision-resource.ts
@@ -15,9 +15,7 @@ function isAutoProvisionFallback(
     typeof error === 'object' &&
     error !== null &&
     'kind' in error &&
-    ['metadata', 'unknown'].includes(
-      (error as { kind: unknown }).kind as string
-    ) &&
+    (error as { kind: unknown }).kind !== 'provisioned' &&
     'url' in error &&
     'integration' in error &&
     'product' in error

--- a/packages/cli/src/util/integration/post-provision-setup.ts
+++ b/packages/cli/src/util/integration/post-provision-setup.ts
@@ -16,6 +16,8 @@ export interface PostProvisionOptions {
   noConnect?: boolean;
   noEnvPull?: boolean;
   environments?: string[];
+  onProjectConnected?: (projectId: string) => void;
+  onProjectConnectFailed?: (projectId: string, error: Error) => void;
 }
 
 /**
@@ -89,6 +91,7 @@ export async function postProvisionSetup(
     );
   } catch (error) {
     output.stopSpinner();
+    options.onProjectConnectFailed?.(project.id, error as Error);
     output.error(`Failed to connect: ${(error as Error).message}`);
     return 1;
   }
@@ -97,6 +100,8 @@ export async function postProvisionSetup(
   output.log(
     `${chalk.bold(resourceName)} successfully connected to ${chalk.bold(project.name)}`
   );
+
+  options.onProjectConnected?.(project.id);
 
   if (!options.noEnvPull) {
     const pullExitCode = await pull(

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -227,7 +227,9 @@ export interface AutoProvisionedResponse {
 }
 
 export interface AutoProvisionFallback {
-  kind: 'metadata' | 'unknown';
+  kind: string;
+  reason?: string;
+  error_message?: string;
   url: string;
   integration: AutoProvisionIntegration;
   product: AutoProvisionProduct;

--- a/packages/cli/src/util/telemetry/commands/integration/add.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/add.ts
@@ -62,4 +62,11 @@ export class IntegrationAddTelemetryClient
       });
     }
   }
+
+  trackMarketplaceEvent(event: string, props: Record<string, unknown>) {
+    this.trackCommandOutput({
+      key: event,
+      value: JSON.stringify(props),
+    });
+  }
 }

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -1001,12 +1001,22 @@ const autoProvisionResponses: Record<
   },
   metadata: {
     kind: 'metadata',
+    reason: 'invalid_metadata_schema',
+    error_message: 'Metadata field "region" is required',
     url: 'https://vercel.com/acme/~/integrations/checkout/acme?productSlug=acme',
     integration: autoProvisionIntegration,
     product: autoProvisionProduct,
   },
   unknown: {
     kind: 'unknown',
+    reason: 'unexpected_error',
+    error_message: 'An unexpected error occurred during provisioning',
+    url: 'https://vercel.com/acme/~/integrations/checkout/acme?productSlug=acme',
+    integration: autoProvisionIntegration,
+    product: autoProvisionProduct,
+  },
+  install: {
+    kind: 'install',
     url: 'https://vercel.com/acme/~/integrations/checkout/acme?productSlug=acme',
     integration: autoProvisionIntegration,
     product: autoProvisionProduct,
@@ -1356,7 +1366,7 @@ export function useAutoProvision(opts?: {
       const response =
         autoProvisionResponses[opts?.responseKey ?? 'provisioned'];
 
-      if (response.kind === 'metadata' || response.kind === 'unknown') {
+      if (response.kind !== 'provisioned') {
         // 422 responses for fallback cases
         res.status(422);
         res.json(response);


### PR DESCRIPTION
## Summary

Adds marketplace funnel telemetry events to the auto-provision path of `vercel integration add` (`FF_AUTO_PROVISION_INSTALL=1`). The legacy path is not instrumented — it will be removed.

**Events tracked (9):**
- `marketplace_install_flow_started`
- `marketplace_checkout_plan_selected` — includes `plan_selection_method` (cli_flag / server_default)
- `marketplace_checkout_provisioning_started`
- `marketplace_checkout_provisioning_completed` — includes `resource_id`
- `marketplace_checkout_provisioning_failed` — includes `error_message`
- `marketplace_project_connected` — includes `project_id`, `resource_id`
- `marketplace_project_connect_failed` — includes `project_id`, `resource_id`, `error_message`
- `marketplace_install_flow_web_fallback` — reason passed through from server response
- `marketplace_install_flow_dropped` — input validation failures after funnel entry (metadata_parse_error, metadata_validation_failed, resource_name_invalid)

All events carry base props: `integration_id`, `integration_slug`, `integration_name`, `product_id`, `product_slug`, `team_id`, `source: "cli"`, `is_auto_provision: true`

**Web fallback events** include pass-through fields from the auto-provision API response: `auto_provision_result_kind`, `auto_provision_result_reason`, `auto_provision_error_message`. No client-side interpretation — server values forwarded as-is.

## Implementation

- One generic telemetry method: `trackMarketplaceEvent(event, props)` — no per-event interfaces or typed wrappers
- Base props built once, spread into each event call
- `AutoProvisionFallback.kind` and `.reason` typed as `string` for forward-compatibility with new API responses
- `onProjectConnected` callback added to `PostProvisionOptions` to decouple telemetry from post-provision setup
- Fallback reason: `fallback.reason ?? fallback.kind` — pure pass-through from server
- Every post-`flow_started` exit has a terminal event — no silent funnel drops

### Fallback guard fix

`isAutoProvisionFallback` changed from allowlist (`['metadata', 'unknown'].includes(kind)`) to denylist (`kind !== 'provisioned'`). This is a behavioral change beyond telemetry:

- **Bug fix:** The old allowlist missed `kind: 'install'` (returned when policies not accepted) — would have thrown an unhandled error instead of falling back to the browser
- **Forward-compatible:** New API `kind` values (e.g. `multiple_installations` from https://github.com/vercel/api/pull/61258) are automatically handled as browser fallbacks
- **Safe:** The structural checks (`url`, `integration`, `product` fields present + HTTP 422) are the real guard, ensuring only actual step responses are caught

The API currently returns 4 `kind` values: `provisioned` (201 success), `install`, `metadata`, `unknown` (all 422 fallbacks). The denylist ensures the CLI doesn't need updating each time the API adds a new fallback reason.

## Event Lifecycle

### Happy Path

```
 ① flow_started
       │
 ② plan_selected (cli_flag | server_default)
       │
 ③ provisioning_started
       │
 ④ provisioning_completed
       │
 ⑤ project_connected (if project linked)
```

### Unhappy Paths

```
PATH 1: Policy Declined
───────────────────────
 ① flow_started
 ✖ flow_dropped (reason: policy_declined)
 → EXIT

PATH 2: Input Validation Failure
─────────────────────────────────
 ① flow_started
 ✖ flow_dropped (reason: metadata_parse_error
                       | metadata_validation_failed
                       | resource_name_invalid)
 → EXIT

PATH 3: Server Fallback
───────────────────────
 ① flow_started
 ② plan_selected
 ③ provisioning_started
 ✖ web_fallback (reason: server kind/reason)
 → Open browser fallback → EXIT

PATH 4: Provisioning API Error
──────────────────────────────
 ① flow_started
 ② plan_selected
 ③ provisioning_started
 ✖ provisioning_failed
 → EXIT
```

### Terminal Events by Exit Type

| Exit Point | Event | Reason |
|---|---|---|
| Terms declined | `flow_dropped` | `policy_declined` |
| Metadata parse error | `flow_dropped` | `metadata_parse_error` |
| Metadata validation failed | `flow_dropped` | `metadata_validation_failed` |
| Resource name invalid | `flow_dropped` | `resource_name_invalid` |
| Server non-provisioned | `web_fallback` | server `kind`/`reason` |
| Provisioning API error | `provisioning_failed` | — |

## Dependency

- **Depends on:** https://github.com/vercel/api/pull/60858 (adds `reason` field to auto-provision responses) — **merged and deployed**
- Without the API PR: CLI uses fallback `kind` value as the telemetry reason
- With the API PR: CLI reads the specific `reason` for full funnel specificity

## Test plan
- [x] 73/73 auto-provision tests passing
- [x] 75/75 legacy path tests passing (no changes to legacy path)
- [x] Telemetry events asserted for happy path
- [x] TypeScript compiles cleanly
- [ ] CI passes

Fixes: [MKT-2615](https://linear.app/vercel/issue/MKT-2615/cli-instrumentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds telemetry instrumentation to a CLI command with one behavioral change: the fallback guard logic changed from an allowlist to a denylist, which is a bug fix that handles additional API response kinds as browser fallbacks rather than throwing errors.
> 
> - Telemetry: adds 9 marketplace funnel events throughout auto-provision flow
> - Behavioral change: `isAutoProvisionFallback` now uses denylist (`kind !== 'provisioned'`) instead of allowlist
> - Adds callbacks `onProjectConnected` and `onProjectConnectFailed` to `PostProvisionOptions`
>
> <sup>Risk assessment for [commit 87e2258](https://github.com/vercel/vercel/commit/87e2258350446d768484cee81c5ea6a45acdb952).</sup>
<!-- VADE_RISK_END -->