### PR TITLE
feat(cli): add --resource flag to integration remove

### DIFF
--- a/.changeset/resource-flag-integration-remove.md
+++ b/.changeset/resource-flag-integration-remove.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add `--resource` flag to `vc integration remove` to remove integration resources, and `--disconnect-all` to disconnect projects before removal. Fix exit code for not-found from 0 to 1.

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -225,18 +225,33 @@ export const balanceSubcommand = {
 export const removeSubcommand = {
   name: 'remove',
   aliases: [],
-  description: 'Uninstalls a marketplace integration',
+  description: 'Uninstalls a marketplace integration or removes a resource',
   arguments: [
     {
-      name: 'integration',
-      required: true,
+      name: 'name',
+      required: false,
     },
   ],
   options: [
     {
       ...yesOption,
+      description: 'Skip the confirmation prompt',
+    },
+    {
+      name: 'resource',
+      shorthand: null,
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+      description: 'Remove a resource by name instead of an integration',
+    },
+    {
+      name: 'disconnect-all',
+      shorthand: 'a',
+      type: Boolean,
+      deprecated: false,
       description:
-        'Skip the confirmation prompt when uninstalling an integration',
+        'Disconnect all projects from the resource before removing it (requires --resource)',
     },
   ],
   examples: [
@@ -245,6 +260,19 @@ export const removeSubcommand = {
       value: [
         `${packageName} integration remove <integration>`,
         `${packageName} integration remove acme`,
+      ],
+    },
+    {
+      name: 'Remove a resource',
+      value: [
+        `${packageName} integration remove --resource <name>`,
+        `${packageName} integration remove --resource my-db`,
+      ],
+    },
+    {
+      name: 'Disconnect all projects from a resource, then remove it',
+      value: [
+        `${packageName} integration remove --resource my-db --disconnect-all`,
       ],
     },
   ],

--- a/packages/cli/src/commands/integration/remove-integration.ts
+++ b/packages/cli/src/commands/integration/remove-integration.ts
@@ -8,6 +8,13 @@ import getScope from '../../util/get-scope';
 import { printError } from '../../util/error';
 import { getFirstConfiguration } from '../../util/integration/fetch-marketplace-integrations';
 import { removeIntegration } from '../../util/integration/remove-integration';
+import { getResources } from '../../util/integration-resource/get-resources';
+import { handleDeleteResource } from '../../util/integration-resource/handle-delete-resource';
+import {
+  CancelledError,
+  FailedError,
+} from '../../util/integration-resource/types';
+import { handleDisconnectAllProjects } from '../integration-resource/disconnect';
 import { removeSubcommand } from './command';
 import { IntegrationRemoveTelemetryClient } from '../../util/telemetry/commands/integration/remove';
 
@@ -34,8 +41,38 @@ export async function remove(client: Client) {
     return 1;
   }
 
-  const isMissingResourceOrIntegration = parsedArguments.args.length < 2;
-  if (isMissingResourceOrIntegration) {
+  const resourceName = parsedArguments.flags['--resource'];
+  const isResource = typeof resourceName === 'string';
+  const skipConfirmation = !!parsedArguments.flags['--yes'];
+  const disconnectAll = !!parsedArguments.flags['--disconnect-all'];
+
+  telemetry.trackCliFlagYes(skipConfirmation);
+  telemetry.trackCliOptionResource(resourceName);
+  telemetry.trackCliFlagDisconnectAll(disconnectAll);
+
+  if (disconnectAll && !isResource) {
+    output.error(
+      'The `--disconnect-all` flag can only be used with `--resource`.'
+    );
+    return 1;
+  }
+
+  if (!skipConfirmation && !client.stdin.isTTY) {
+    output.error(
+      'Confirmation required. Use `--yes` to skip confirmation in non-interactive mode.'
+    );
+    return 1;
+  }
+
+  if (isResource) {
+    return removeResource(client, team, resourceName, telemetry, {
+      skipConfirmation,
+      disconnectAll,
+    });
+  }
+
+  const integrationName = parsedArguments.args[1];
+  if (!integrationName) {
     output.error('You must specify an integration. See `--help` for details.');
     return 1;
   }
@@ -46,10 +83,72 @@ export async function remove(client: Client) {
     return 1;
   }
 
-  const integrationName = parsedArguments.args[1];
-  const skipConfirmation = !!parsedArguments.flags['--yes'];
-  telemetry.trackCliFlagYes(skipConfirmation);
+  return removeInstallation(
+    client,
+    team,
+    integrationName,
+    skipConfirmation,
+    telemetry
+  );
+}
 
+async function removeResource(
+  client: Client,
+  team: Team,
+  resourceName: string,
+  telemetry: IntegrationRemoveTelemetryClient,
+  options: {
+    skipConfirmation: boolean;
+    disconnectAll: boolean;
+  }
+): Promise<number> {
+  output.spinner('Retrieving resource…', 500);
+  const resources = await getResources(client, team.id);
+  const targetedResource = resources.find(
+    resource => resource.name === resourceName
+  );
+  output.stopSpinner();
+
+  if (!targetedResource) {
+    output.error(`No resource ${chalk.bold(resourceName)} found.`);
+    telemetry.trackCliArgumentName(resourceName, false);
+    return 1;
+  }
+  telemetry.trackCliArgumentName(resourceName, true);
+
+  if (options.disconnectAll) {
+    try {
+      await handleDisconnectAllProjects(
+        client,
+        targetedResource,
+        options.skipConfirmation
+      );
+    } catch (error) {
+      if (error instanceof CancelledError) {
+        output.log(error.message);
+        return 0;
+      }
+      if (error instanceof FailedError) {
+        output.error(error.message);
+        return 1;
+      }
+      throw error;
+    }
+  }
+
+  return await handleDeleteResource(client, team, targetedResource, {
+    skipConfirmation: options.skipConfirmation,
+    skipProjectCheck: options.disconnectAll,
+  });
+}
+
+async function removeInstallation(
+  client: Client,
+  team: Team,
+  integrationName: string,
+  skipConfirmation: boolean,
+  telemetry: IntegrationRemoveTelemetryClient
+): Promise<number> {
   output.spinner('Retrieving integration…', 500);
   const integrationConfiguration = await getFirstConfiguration(
     client,
@@ -59,11 +158,13 @@ export async function remove(client: Client) {
   output.stopSpinner();
 
   if (!integrationConfiguration) {
-    output.error(`No integration ${chalk.bold(integrationName)} found.`);
-    telemetry.trackCliArgumentIntegration(integrationName, false);
-    return 0;
+    output.error(
+      `No integration ${chalk.bold(integrationName)} found. To remove a resource, use the \`--resource\` flag.`
+    );
+    telemetry.trackCliArgumentName(integrationName, false);
+    return 1;
   }
-  telemetry.trackCliArgumentIntegration(integrationName, true);
+  telemetry.trackCliArgumentName(integrationName, true);
 
   const userDidNotConfirm =
     !skipConfirmation &&

--- a/packages/cli/src/util/integration-resource/handle-delete-resource.ts
+++ b/packages/cli/src/util/integration-resource/handle-delete-resource.ts
@@ -1,0 +1,54 @@
+import type { Team } from '@vercel-internals/types';
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../client';
+import { deleteResource } from './delete-resource';
+import type { Resource } from './types';
+
+export async function handleDeleteResource(
+  client: Client,
+  team: Team,
+  resource: Resource,
+  options?: {
+    skipConfirmation: boolean;
+    skipProjectCheck: boolean;
+  }
+): Promise<number> {
+  const hasProjects =
+    resource.projectsMetadata && resource.projectsMetadata.length > 0;
+  if (!options?.skipProjectCheck && hasProjects) {
+    output.error(
+      `Cannot delete resource ${chalk.bold(resource.name)} while it has connected projects. Please disconnect any projects using this resource first or use the \`--disconnect-all\` flag.`
+    );
+    return 1;
+  }
+
+  if (
+    !options?.skipConfirmation &&
+    !(await confirmDeleteResource(client, resource))
+  ) {
+    output.log('Canceled');
+    return 0;
+  }
+
+  try {
+    output.spinner('Deleting resource…', 500);
+    await deleteResource(client, resource, team);
+    output.success(`${chalk.bold(resource.name)} successfully deleted.`);
+  } catch (error) {
+    output.error(
+      `A problem occurred when attempting to delete ${chalk.bold(resource.name)}: ${(error as Error).message}`
+    );
+    return 1;
+  }
+
+  return 0;
+}
+
+async function confirmDeleteResource(
+  client: Client,
+  resource: Resource
+): Promise<boolean> {
+  output.log(`${chalk.bold(resource.name)} will be deleted permanently.`);
+  return client.input.confirm(`${chalk.red('Are you sure?')}`, false);
+}

--- a/packages/cli/src/util/telemetry/commands/integration/remove.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/remove.ts
@@ -6,10 +6,10 @@ export class IntegrationRemoveTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof removeSubcommand>
 {
-  trackCliArgumentIntegration(v: string | undefined, known?: boolean) {
+  trackCliArgumentName(v: string | undefined, known?: boolean) {
     if (v) {
       this.trackCliArgument({
-        arg: 'integration',
+        arg: 'name',
         value: known ? v : this.redactedValue,
       });
     }
@@ -18,6 +18,21 @@ export class IntegrationRemoveTelemetryClient
   trackCliFlagYes(v: boolean | undefined) {
     if (v) {
       this.trackCliFlag('yes');
+    }
+  }
+
+  trackCliOptionResource(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'resource',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagDisconnectAll(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('disconnect-all');
     }
   }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2938,10 +2938,14 @@ exports[`help command > integration help output snapshots > integration help col
                          marketp…
                          integra…
                          dashboa…
-  remove    integration  Uninsta…
+  remove    [name]       Uninsta…
                          a       
                          marketp…
                          integra…
+                         or      
+                         removes 
+                         a       
+                         resource
 
 
   Global Options:
@@ -3016,7 +3020,8 @@ exports[`help command > integration help output snapshots > integration help col
                          the current project                             
   discover               Discover available marketplace integrations     
   open      name         Opens a marketplace integration's dashboard     
-  remove    integration  Uninstalls a marketplace integration            
+  remove    [name]       Uninstalls a marketplace integration or removes 
+                         a resource                                      
 
 
   Global Options:
@@ -3057,7 +3062,7 @@ exports[`help command > integration help output snapshots > integration help col
   list      [project]    List resources from marketplace integrations for the current project                    
   discover               Discover available marketplace integrations                                             
   open      name         Opens a marketplace integration's dashboard                                             
-  remove    integration  Uninstalls a marketplace integration                                                    
+  remove    [name]       Uninstalls a marketplace integration or removes a resource                              
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/integration-resource/remove.test.ts
+++ b/packages/cli/test/unit/commands/integration-resource/remove.test.ts
@@ -62,7 +62,7 @@ describe('integration-resource', () => {
         await expect(exitCodePromise).resolves.toEqual(0);
       });
 
-      it('exits gracefully when no resource is found to delete', async () => {
+      it('returns 1 when no resource is found to delete', async () => {
         useResources();
         const resource = 'not-a-real-project-to-find';
 
@@ -74,7 +74,7 @@ describe('integration-resource', () => {
           `Error: No resource ${resource} found.`
         );
 
-        await expect(exitCodePromise).resolves.toEqual(0);
+        await expect(exitCodePromise).resolves.toEqual(1);
       });
 
       it('exits gracefully when cancelling confirmation for deleting a resource', async () => {
@@ -303,6 +303,20 @@ describe('integration-resource', () => {
           const exitCodePromise = integrationResourceCommand(client);
           await expect(client.stderr).toOutput(
             'Cannot specify more than one resource at a time.'
+          );
+          await expect(exitCodePromise).resolves.toEqual(1);
+        });
+
+        it('should error in non-TTY without `--yes`', async () => {
+          (client.stdin as { isTTY?: boolean }).isTTY = false;
+          client.setArgv(
+            'integration-resource',
+            'remove',
+            'store-acme-no-projects'
+          );
+          const exitCodePromise = integrationResourceCommand(client);
+          await expect(client.stderr).toOutput(
+            'Error: Confirmation required. Use `--yes` to skip confirmation in non-interactive mode.'
           );
           await expect(exitCodePromise).resolves.toEqual(1);
         });


### PR DESCRIPTION
## Summary
- Add `--resource <NAME>` option to `vc integration remove` so it can also remove integration resources, eliminating the need to know about the separate `vc integration-resource remove` command
- Add `--disconnect-all` flag to disconnect all projects from a resource before removing it
- Fix exit code when integration/resource not found (was `0`, now `1`)
- Add nudge message suggesting `--resource` when integration lookup fails
- Non-TTY guard: requires `--yes` in non-interactive mode instead of hanging
- Clean up telemetry: unified `trackCliArgumentName` with `known` after lookup in both paths

## Test plan

### Unit tests
```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/remove.test.ts

 ✓ packages/cli/test/unit/commands/integration/remove.test.ts  (18 tests) 71ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
```

### Manual tests

**Remove resource with `--yes`:**
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add neon --name remove-test-1 --no-connect
> Installing Neon by Neon under acme-marketplace-team-vtest314
> Success! Neon successfully provisioned: remove-test-1

$ vc integration remove --resource remove-test-1 --yes
Retrieving resource…
> Success! remove-test-1 successfully deleted.
```

**Remove resource with `--disconnect-all --yes`:**
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add braintrust --name remove-test-2
> Installing Braintrust by Braintrust under acme-marketplace-team-vtest314
> Success! Braintrust successfully provisioned: remove-test-2

$ vc integration remove --resource remove-test-2 --disconnect-all --yes
Retrieving resource…
> remove-test-2 has no projects to disconnect.
> Success! remove-test-2 successfully deleted.
```

**Interactive confirmation (no `--yes`):**
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add neon --name remove-test-3 --no-connect
> Success! Neon successfully provisioned: remove-test-3

$ vc integration remove --resource remove-test-3
Retrieving resource…
> remove-test-3 will be deleted permanently.
? Are you sure? yes
> Success! remove-test-3 successfully deleted.
```

**Error: resource not found:**
```
$ vc integration remove --resource nonexistent-resource --yes
Retrieving resource…
Error: No resource nonexistent-resource found.
```

**Error: `--disconnect-all` without `--resource`:**
```
$ vc integration remove something --disconnect-all
Error: The `--disconnect-all` flag can only be used with `--resource`.
```

**Error: integration not found (with nudge):**
```
$ vc integration remove nonexistent-integration --yes
Retrieving integration…
Error: No integration nonexistent-integration found. To remove a resource, use the `--resource` flag.
```

**Help output:**
```
$ vc integration remove --help
  ▲ vercel integration remove [name] [options]
  Uninstalls a marketplace integration or removes a resource
  Options:
  -a,  --disconnect-all   Disconnect all projects from the resource before removing it (requires --resource)
       --resource <NAME>  Remove a resource by name instead of an integration
  -y,  --yes              Skip the confirmation prompt
  Examples:
  - Uninstall an integration
    $ vercel integration remove <integration>
    $ vercel integration remove acme
  - Remove a resource
    $ vercel integration remove --resource <name>
    $ vercel integration remove --resource my-db
  - Disconnect all projects from a resource, then remove it
    $ vercel integration remove --resource my-db --disconnect-all
```

### Code paths covered

| Path | Expected | Tested by |
|------|----------|-----------|
| `--resource <NAME> --yes` | Retrieve → delete → success | Unit + manual (neon) |
| `--resource <NAME>` interactive | Retrieve → confirm → delete → success | Unit + manual (neon) |
| `--resource <NAME> --disconnect-all --yes` | Retrieve → disconnect → delete → success | Unit + manual (braintrust) |
| `--resource <NAME>` not found | Error: No resource found | Unit + manual |
| `--resource <NAME>` has connected projects, no `--disconnect-all` | Error: Cannot delete | Unit |
| `--resource <NAME>` cancel confirmation | Canceled, exit 0 | Unit |
| `--disconnect-all` without `--resource` | Error: only with --resource | Unit + manual |
| No args, no `--resource` | Error: must specify integration | Unit |
| Integration not found | Error with nudge to use --resource | Unit + manual |
| Non-TTY without `--yes` | Error: use --yes | Unit |

Fixes: [MKT-2764](https://linear.app/vercel/issue/MKT-2764/agent-lacks-knowledge-of-vc-integration-resource-remove-command)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI feature addition with new flags for integration remove command; changes are defensive (adding non-TTY guard requiring --yes) and fix incorrect exit codes from 0 to 1 for not-found errors.
> 
> - Adds `--resource` and `--disconnect-all` flags to `vc integration remove` command
> - Adds non-TTY guard requiring `--yes` flag for non-interactive mode
> - Fixes exit code from 0 to 1 when integration/resource not found
>
> <sup>Risk assessment for [commit 4dd4b1c](https://github.com/vercel/vercel/commit/4dd4b1ce1d2e57cda510b3c6e924c75af77c3bd9).</sup>
<!-- VADE_RISK_END -->