### PR TITLE
trace: add span around builder install with packages and error tags

### DIFF
--- a/.changeset/heavy-dragons-visit.md
+++ b/.changeset/heavy-dragons-visit.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add tracing when installing builders

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -831,6 +831,8 @@ async function doBuild(
 
       const builderSpan = span.child('vc.builder', {
         name: builderPkg.name,
+        version: builderPkg.version,
+        dynamicallyInstalled: String(builderWithPkg.dynamicallyInstalled),
       });
 
       const serviceRoutePrefix = build.config?.routePrefix;

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -620,7 +620,7 @@ async function doBuild(
 
   const builderSpecs = new Set(builds.map(b => b.use));
 
-  const buildersWithPkgs = await importBuilders(builderSpecs, cwd);
+  const buildersWithPkgs = await importBuilders(builderSpecs, cwd, span);
 
   // Populate Files -> FileFsRef mapping
   const filesMap: Files = {};

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -14,7 +14,7 @@ import * as staticBuilder from './static-builder';
 import { VERCEL_DIR } from '../projects/link';
 import { isErrnoException } from '@vercel/error-utils';
 import output from '../../output-manager';
-import { tracedInstallBuilders } from './install-builders';
+import { installBuilders, tracedInstallBuilders } from './install-builders';
 
 export interface BuilderWithPkg {
   /**
@@ -51,16 +51,14 @@ export async function importBuilders(
 
   if ('buildersToAdd' in importResult) {
     const { buildersToAdd } = importResult;
-    const installResult = await tracedInstallBuilders(
-      span,
-      buildersDir,
-      buildersToAdd
-    );
+    const installResult = span
+      ? await tracedInstallBuilders(buildersDir, buildersToAdd, span)
+      : await installBuilders(buildersDir, buildersToAdd);
 
     importResult = await resolveBuilders(
       buildersDir,
       builderSpecs,
-      installResult.resolvedSpecs
+      installResult
     );
 
     if ('buildersToAdd' in importResult) {

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -14,7 +14,7 @@ import * as staticBuilder from './static-builder';
 import { VERCEL_DIR } from '../projects/link';
 import { isErrnoException } from '@vercel/error-utils';
 import output from '../../output-manager';
-import { installBuilders, tracedInstallBuilders } from './install-builders';
+import { installBuilders, untracedInstallBuilders } from './install-builders';
 
 export interface BuilderWithPkg {
   /**
@@ -52,8 +52,8 @@ export async function importBuilders(
   if ('buildersToAdd' in importResult) {
     const { buildersToAdd } = importResult;
     const installResult = span
-      ? await tracedInstallBuilders(buildersDir, buildersToAdd, span)
-      : await installBuilders(buildersDir, buildersToAdd);
+      ? await installBuilders(buildersDir, buildersToAdd, span)
+      : await untracedInstallBuilders(buildersDir, buildersToAdd);
 
     importResult = await resolveBuilders(
       buildersDir,

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -1,22 +1,20 @@
-import { URL } from 'url';
-import plural from 'pluralize';
 import npa from 'npm-package-arg';
 import { satisfies } from 'semver';
 import { dirname, join } from 'path';
 import { createRequire } from 'module';
-import { mkdirp, outputJSON, readJSON, symlink } from 'fs-extra';
+import { readJSON } from 'fs-extra';
 import { isStaticRuntime } from '@vercel/fs-detectors';
-import type { BuilderV2, BuilderV3, PackageJson } from '@vercel/build-utils';
-import execa from 'execa';
+import type {
+  BuilderV2,
+  BuilderV3,
+  PackageJson,
+  Span,
+} from '@vercel/build-utils';
 import * as staticBuilder from './static-builder';
 import { VERCEL_DIR } from '../projects/link';
-import readJSONFile from '../read-json-file';
-import { CantParseJSONFile } from '../errors-ts';
-import { isErrnoException, isError } from '@vercel/error-utils';
-import cmd from '../output/cmd';
-import code from '../output/code';
-import type { Writable } from 'stream';
+import { isErrnoException } from '@vercel/error-utils';
 import output from '../../output-manager';
+import { tracedInstallBuilders } from './install-builders';
 
 export interface BuilderWithPkg {
   /**
@@ -44,16 +42,19 @@ const require_ = createRequire(__filename);
  */
 export async function importBuilders(
   builderSpecs: Set<string>,
-  cwd: string
+  cwd: string,
+  span?: Span
 ): Promise<Map<string, BuilderWithPkg>> {
   const buildersDir = join(cwd, VERCEL_DIR, 'builders');
 
   let importResult = await resolveBuilders(buildersDir, builderSpecs);
 
   if ('buildersToAdd' in importResult) {
-    const installResult = await installBuilders(
+    const { buildersToAdd } = importResult;
+    const installResult = await tracedInstallBuilders(
+      span,
       buildersDir,
-      importResult.buildersToAdd
+      buildersToAdd
     );
 
     importResult = await resolveBuilders(
@@ -168,7 +169,6 @@ export async function resolveBuilders(
       }
 
       // TODO: handle `parsed.type === 'tag'` ("latest" vs. anything else?)
-
       const path = join(dirname(pkgPath), builderPkg.main || 'index.js');
 
       const builder = require_(path);
@@ -203,117 +203,4 @@ export async function resolveBuilders(
   }
 
   return { builders };
-}
-
-async function installBuilders(
-  buildersDir: string,
-  buildersToAdd: Set<string>
-) {
-  const resolvedSpecs = new Map<string, string>();
-  const buildersPkgPath = join(buildersDir, 'package.json');
-  try {
-    const emptyPkgJson = {
-      private: true,
-      license: 'UNLICENSED',
-    };
-    await outputJSON(buildersPkgPath, emptyPkgJson, {
-      flag: 'wx',
-    });
-  } catch (err: any) {
-    if (err.code !== 'EEXIST') throw err;
-  }
-
-  output.log(
-    `Installing ${plural('Builder', buildersToAdd.size)}: ${Array.from(
-      buildersToAdd
-    ).join(', ')}`
-  );
-  try {
-    const { stderr } = await execa(
-      'npm',
-      ['install', '@vercel/build-utils', ...buildersToAdd],
-      {
-        cwd: buildersDir,
-        stdio: 'pipe',
-        reject: true,
-      }
-    );
-    stderr
-      .split('/\r?\n/')
-      .filter(line => line.includes('npm WARN deprecated'))
-      .forEach(line => {
-        output.warn(line);
-      });
-  } catch (err: unknown) {
-    if (isError(err)) {
-      const execaMessage = err.message;
-      let message = getErrorMessage(err, execaMessage);
-      if (execaMessage.startsWith('Command failed with ENOENT')) {
-        // `npm` is not installed
-        message = `Please install ${cmd('npm')} before continuing`;
-      } else {
-        const notFound = /GET (.*) - Not found/.exec(message);
-        if (notFound) {
-          const url = new URL(notFound[1]);
-          const packageName = decodeURIComponent(url.pathname.slice(1));
-          message = `The package ${code(
-            packageName
-          )} is not published on the npm registry`;
-        }
-      }
-      err.message = message;
-      (err as any).link =
-        'https://vercel.link/builder-dependencies-install-failed';
-    }
-    throw err;
-  }
-
-  // Symlink `@now/build-utils` -> `@vercel/build-utils` to support legacy Builders
-  const nowScopePath = join(buildersDir, 'node_modules/@now');
-  await mkdirp(nowScopePath);
-
-  try {
-    await symlink('../@vercel/build-utils', join(nowScopePath, 'build-utils'));
-  } catch (err: unknown) {
-    if (!isErrnoException(err) || err.code !== 'EEXIST') {
-      // Throw unless the error is due to the symlink already existing
-      throw err;
-    }
-  }
-
-  // Cross-reference any builderSpecs from the saved `package.json` file,
-  // in case they were installed from a URL
-  const buildersPkg = await readJSONFile<PackageJson>(buildersPkgPath);
-  if (buildersPkg instanceof CantParseJSONFile) throw buildersPkg;
-  if (!buildersPkg) {
-    throw new Error(`Failed to load "${buildersPkgPath}"`);
-  }
-  for (const spec of buildersToAdd) {
-    for (const [name, version] of Object.entries(
-      buildersPkg.dependencies || {}
-    )) {
-      if (version === spec) {
-        output.debug(`Resolved Builder spec "${spec}" to name "${name}"`);
-        resolvedSpecs.set(spec, name);
-      }
-    }
-  }
-
-  return { resolvedSpecs };
-}
-
-type BonusError = Error & {
-  stderr?: string | Writable;
-};
-
-function getErrorMessage(err: BonusError, execaMessage: string) {
-  if (!err || !('stderr' in err)) {
-    return execaMessage;
-  }
-
-  if (typeof err.stderr === 'string') {
-    return err.stderr;
-  }
-
-  return execaMessage;
 }

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -27,6 +27,11 @@ export interface BuilderWithPkg {
   pkgPath: string;
   builder: BuilderV2 | BuilderV3;
   pkg: PackageJson & { name: string };
+  /**
+   * true if the builder was installed into `.vercel/builders` (e.g. via npm);
+   * false if resolved from CLI dependencies or built-in (e.g. @vercel/static).
+   */
+  dynamicallyInstalled: boolean;
 }
 
 type ResolveBuildersResult =
@@ -103,6 +108,7 @@ export async function resolveBuilders(
         pkg: { name },
         path: '',
         pkgPath: '',
+        dynamicallyInstalled: false,
       });
       continue;
     }
@@ -171,6 +177,8 @@ export async function resolveBuilders(
 
       const builder = require_(path);
 
+      const dynamicallyInstalled = pkgPath.startsWith(buildersDir);
+
       builders.set(spec, {
         builder,
         pkg: {
@@ -179,6 +187,7 @@ export async function resolveBuilders(
         },
         path,
         pkgPath,
+        dynamicallyInstalled,
       });
       output.debug(`Imported Builder "${name}" from "${dirname(pkgPath)}"`);
     } catch (err: any) {

--- a/packages/cli/src/util/build/install-builders.ts
+++ b/packages/cli/src/util/build/install-builders.ts
@@ -28,7 +28,7 @@ function getErrorMessage(err: BonusError, execaMessage: string) {
   return execaMessage;
 }
 
-export async function installBuilders(
+export async function untracedInstallBuilders(
   buildersDir: string,
   buildersToAdd: Set<string>
 ): Promise<Map<string, string>> {
@@ -125,7 +125,7 @@ export async function installBuilders(
   return resolvedSpecs;
 }
 
-export async function tracedInstallBuilders(
+export async function installBuilders(
   buildersDir: string,
   buildersToAdd: Set<string>,
   span: Span
@@ -135,7 +135,7 @@ export async function tracedInstallBuilders(
   });
   return installSpan.trace(async s => {
     try {
-      return await installBuilders(buildersDir, buildersToAdd);
+      return await untracedInstallBuilders(buildersDir, buildersToAdd);
     } catch (err) {
       s.setAttributes({
         error: isError(err) ? err.message : String(err),

--- a/packages/cli/src/util/build/install-builders.ts
+++ b/packages/cli/src/util/build/install-builders.ts
@@ -1,0 +1,153 @@
+import { URL } from 'url';
+import plural from 'pluralize';
+import { join } from 'path';
+import { mkdirp, outputJSON, symlink } from 'fs-extra';
+import type { PackageJson, Span } from '@vercel/build-utils';
+import execa from 'execa';
+import readJSONFile from '../read-json-file';
+import { CantParseJSONFile } from '../errors-ts';
+import { isErrnoException, isError } from '@vercel/error-utils';
+import cmd from '../output/cmd';
+import code from '../output/code';
+import type { Writable } from 'stream';
+import output from '../../output-manager';
+
+export interface InstallBuildersResult {
+  resolvedSpecs: Map<string, string>;
+}
+
+type BonusError = Error & {
+  stderr?: string | Writable;
+};
+
+function getErrorMessage(err: BonusError, execaMessage: string) {
+  if (!err || !('stderr' in err)) {
+    return execaMessage;
+  }
+
+  if (typeof err.stderr === 'string') {
+    return err.stderr;
+  }
+
+  return execaMessage;
+}
+
+export async function installBuilders(
+  buildersDir: string,
+  buildersToAdd: Set<string>
+): Promise<InstallBuildersResult> {
+  const resolvedSpecs = new Map<string, string>();
+  const buildersPkgPath = join(buildersDir, 'package.json');
+  try {
+    const emptyPkgJson = {
+      private: true,
+      license: 'UNLICENSED',
+    };
+    await outputJSON(buildersPkgPath, emptyPkgJson, {
+      flag: 'wx',
+    });
+  } catch (err: any) {
+    if (err.code !== 'EEXIST') throw err;
+  }
+
+  output.log(
+    `Installing ${plural('Builder', buildersToAdd.size)}: ${Array.from(
+      buildersToAdd
+    ).join(', ')}`
+  );
+  try {
+    const { stderr } = await execa(
+      'npm',
+      ['install', '@vercel/build-utils', ...buildersToAdd],
+      {
+        cwd: buildersDir,
+        stdio: 'pipe',
+        reject: true,
+      }
+    );
+    stderr
+      .split('/\r?\n/')
+      .filter(line => line.includes('npm WARN deprecated'))
+      .forEach(line => {
+        output.warn(line);
+      });
+  } catch (err: unknown) {
+    if (isError(err)) {
+      const execaMessage = err.message;
+      let message = getErrorMessage(err, execaMessage);
+      if (execaMessage.startsWith('Command failed with ENOENT')) {
+        // `npm` is not installed
+        message = `Please install ${cmd('npm')} before continuing`;
+      } else {
+        const notFound = /GET (.*) - Not found/.exec(message);
+        if (notFound) {
+          const url = new URL(notFound[1]);
+          const packageName = decodeURIComponent(url.pathname.slice(1));
+          message = `The package ${code(
+            packageName
+          )} is not published on the npm registry`;
+        }
+      }
+      err.message = message;
+      (err as any).link =
+        'https://vercel.link/builder-dependencies-install-failed';
+    }
+    throw err;
+  }
+
+  // Symlink `@now/build-utils` -> `@vercel/build-utils` to support legacy Builders
+  const nowScopePath = join(buildersDir, 'node_modules/@now');
+  await mkdirp(nowScopePath);
+
+  try {
+    await symlink('../@vercel/build-utils', join(nowScopePath, 'build-utils'));
+  } catch (err: unknown) {
+    if (!isErrnoException(err) || err.code !== 'EEXIST') {
+      // Throw unless the error is due to the symlink already existing
+      throw err;
+    }
+  }
+
+  // Cross-reference any builderSpecs from the saved `package.json` file,
+  // in case they were installed from a URL
+  const buildersPkg = await readJSONFile<PackageJson>(buildersPkgPath);
+  if (buildersPkg instanceof CantParseJSONFile) throw buildersPkg;
+  if (!buildersPkg) {
+    throw new Error(`Failed to load "${buildersPkgPath}"`);
+  }
+  for (const spec of buildersToAdd) {
+    for (const [name, version] of Object.entries(
+      buildersPkg.dependencies || {}
+    )) {
+      if (version === spec) {
+        output.debug(`Resolved Builder spec "${spec}" to name "${name}"`);
+        resolvedSpecs.set(spec, name);
+      }
+    }
+  }
+
+  return { resolvedSpecs };
+}
+
+export async function tracedInstallBuilders(
+  span: Span | undefined,
+  buildersDir: string,
+  buildersToAdd: Set<string>
+): Promise<InstallBuildersResult> {
+  const installSpan = span?.child('vc.installBuilders', {
+    packages: Array.from(buildersToAdd).join(','),
+  });
+  if (installSpan) {
+    return installSpan.trace(async s => {
+      try {
+        return await installBuilders(buildersDir, buildersToAdd);
+      } catch (err) {
+        s.setAttributes({
+          error: isError(err) ? err.message : String(err),
+        });
+        throw err;
+      }
+    });
+  }
+  return installBuilders(buildersDir, buildersToAdd);
+}


### PR DESCRIPTION
## Summary
- Add `tracedInstallBuilders(span, buildersDir, buildersToAdd)` with `vc.installBuilders` span, `packages` tag, and `error` tag on failure
- Move `installBuilders` and `tracedInstallBuilders` to new `install-builders.ts`
- `importBuilders` accepts optional `span` and passes it to `tracedInstallBuilders`
- Build command passes `span` into `importBuilders`

Made with [Cursor](https://cursor.com)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds tracing/observability instrumentation around builder installation with span creation and error tags, plus refactors code into a new file - no security, auth, or business logic changes.
> 
> - Adds `vc.installBuilders` span with `packages` and `error` tags for tracing
> - Moves `installBuilders` to new `install-builders.ts` file with traced/untraced variants
> - Adds `dynamicallyInstalled` boolean property to `BuilderWithPkg` interface
>
> <sup>Risk assessment for [commit e4c58a4](https://github.com/vercel/vercel/commit/e4c58a40ce0107322e8dea4dba4f68fd0b51ace5).</sup>
<!-- VADE_RISK_END -->