### PR TITLE
feat(cli): add private Blob storage support

### DIFF
--- a/.changeset/blob-private-storage.md
+++ b/.changeset/blob-private-storage.md
@@ -4,7 +4,7 @@
 
 Add private Blob storage support:
 
-- Create private stores: `vercel blob store add my-store --access private`
+- Create private stores: `vercel blob create-store my-store --access private`
 - Upload to private stores: `vercel blob put file.txt --access private`
 - Download blobs with the new `blob get` command: `vercel blob get file.txt --access private` (works with both public and private stores)
 - Copy blobs: `vercel blob copy source.txt dest.txt --access private`

--- a/.changeset/blob-private-storage.md
+++ b/.changeset/blob-private-storage.md
@@ -2,4 +2,12 @@
 'vercel': minor
 ---
 
-Add private Blob storage support: new `blob get` command for downloading blobs, `--access` flag on `put`, `copy`, `get`, and `store add` commands (defaults to `public` for backward compatibility), and display access type in `store get` output
+Add private Blob storage support:
+
+- Create private stores: `vercel blob store add my-store --access private`
+- Upload to private stores: `vercel blob put file.txt --access private`
+- Download blobs with the new `blob get` command: `vercel blob get file.txt --access private` (works with both public and private stores)
+- Copy blobs: `vercel blob copy source.txt dest.txt --access private`
+- Display access type (Public/Private) in `vercel blob store get` output
+
+The `--access` flag defaults to `public` for backward compatibility.

--- a/.changeset/blob-private-storage.md
+++ b/.changeset/blob-private-storage.md
@@ -11,3 +11,8 @@ Add private Blob storage support:
 - Display access type (Public/Private) in `vercel blob store get` output
 
 The `--access` flag defaults to `public` for backward compatibility.
+
+Flatten blob store commands: `blob create-store`, `blob delete-store`, `blob get-store`.
+Rename `--force` to `--allow-overwrite`.
+Add conditional headers: `--if-match` for put/del/copy, `--if-none-match` for get.
+Old commands and options are deprecated but still work.

--- a/.changeset/blob-private-storage.md
+++ b/.changeset/blob-private-storage.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add private Blob storage support: new `blob get` command for downloading blobs, `--access` flag on `put`, `copy`, `get`, and `store add` commands (defaults to `public` for backward compatibility), and display access type in `store get` output

--- a/.changeset/flatten-blob-store-commands.md
+++ b/.changeset/flatten-blob-store-commands.md
@@ -1,0 +1,8 @@
+---
+'vercel': minor
+---
+
+Flatten blob store commands: `blob create-store`, `blob delete-store`, `blob get-store`.
+Rename `--force` to `--allow-overwrite`.
+Add conditional headers: `--if-match` for put/del/copy, `--if-none-match` for get.
+Old commands and options are deprecated but still work.

--- a/.changeset/flatten-blob-store-commands.md
+++ b/.changeset/flatten-blob-store-commands.md
@@ -1,8 +1,0 @@
----
-'vercel': minor
----
-
-Flatten blob store commands: `blob create-store`, `blob delete-store`, `blob get-store`.
-Rename `--force` to `--allow-overwrite`.
-Add conditional headers: `--if-match` for put/del/copy, `--if-none-match` for get.
-Old commands and options are deprecated but still work.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
     "node": ">= 18"
   },
   "dependencies": {
-    "@vercel/blob": "1.0.2",
+    "@vercel/blob": "2.3.0-cc8f7be-20260217140255",
     "@vercel/build-utils": "workspace:*",
     "@vercel/detect-agent": "workspace:*",
     "@vercel/fun": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
     "node": ">= 18"
   },
   "dependencies": {
-    "@vercel/blob": "2.3.0-cc8f7be-20260217140255",
+    "@vercel/blob": "2.3.0",
     "@vercel/build-utils": "workspace:*",
     "@vercel/detect-agent": "workspace:*",
     "@vercel/fun": "1.3.0",

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -1,3 +1,23 @@
+const ifMatchOption = {
+  name: 'if-match',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+  description:
+    "Only perform the operation if the blob's ETag matches this value",
+  argument: 'STRING',
+} as const;
+
+const ifNoneMatchOption = {
+  name: 'if-none-match',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+  description:
+    "Only return content if the blob's ETag does not match this value (returns 304 if unchanged)",
+  argument: 'STRING',
+} as const;
+
 const accessOption = {
   name: 'access',
   shorthand: 'a',
@@ -109,13 +129,23 @@ export const putSubcommand = {
       argument: 'Number',
     },
     {
-      name: 'force',
-      shorthand: 'f',
+      name: 'allow-overwrite',
+      shorthand: null,
       type: Boolean,
       deprecated: false,
       description: 'Overwrite the file if it already exists (default: false)',
       argument: 'Boolean',
     },
+    {
+      name: 'force',
+      shorthand: 'f',
+      type: Boolean,
+      deprecated: true,
+      description:
+        'Overwrite the file if it already exists (deprecated, use --allow-overwrite)',
+      argument: 'Boolean',
+    },
+    ifMatchOption,
   ],
   examples: [],
 } as const;
@@ -130,7 +160,7 @@ export const delSubcommand = {
       required: true,
     },
   ],
-  options: [],
+  options: [ifMatchOption],
   examples: [],
 } as const;
 
@@ -176,6 +206,7 @@ export const copySubcommand = {
         'Max-age of the cache-control header directive (default: 2592000 = 30 days)',
       argument: 'Number',
     },
+    ifMatchOption,
   ],
   examples: [],
 } as const;
@@ -200,6 +231,7 @@ export const getSubcommand = {
       description: 'Save blob content to a file instead of stdout',
       argument: 'PATH',
     },
+    ifNoneMatchOption,
   ],
   examples: [],
 } as const;
@@ -270,6 +302,72 @@ export const getStoreSubcommand = {
   examples: [],
 } as const;
 
+export const createStoreSubcommand = {
+  name: 'create-store',
+  aliases: [],
+  description: 'Create a new Blob store',
+  arguments: [
+    {
+      name: 'name',
+      required: false,
+    },
+  ],
+  options: [
+    accessOption,
+    {
+      name: 'region',
+      shorthand: 'r',
+      type: String,
+      deprecated: false,
+      description:
+        'Region to create the Blob store in (default: "iad1"). See https://vercel.com/docs/edge-network/regions#region-list for all available regions',
+      argument: 'STRING',
+    },
+  ],
+  examples: [
+    {
+      name: 'Create a blob store (uses default region "iad1")',
+      value: 'vercel blob create-store my-store',
+    },
+    {
+      name: 'Create a blob store in a specific region',
+      value: 'vercel blob create-store my-store --region cdg1',
+    },
+    {
+      name: 'Create a private blob store',
+      value: 'vercel blob create-store my-private-store --access private',
+    },
+  ],
+} as const;
+
+export const deleteStoreSubcommand = {
+  name: 'delete-store',
+  aliases: [],
+  description: 'Delete a Blob store',
+  arguments: [
+    {
+      name: 'storeId',
+      required: false,
+    },
+  ],
+  options: [],
+  examples: [],
+} as const;
+
+export const getStoreInfoSubcommand = {
+  name: 'get-store',
+  aliases: [],
+  description: 'Get a Blob store',
+  arguments: [
+    {
+      name: 'storeId',
+      required: false,
+    },
+  ],
+  options: [],
+  examples: [],
+} as const;
+
 export const storeSubcommand = {
   name: 'store',
   aliases: [],
@@ -291,6 +389,9 @@ export const blobCommand = {
     getSubcommand,
     delSubcommand,
     copySubcommand,
+    createStoreSubcommand,
+    deleteStoreSubcommand,
+    getStoreInfoSubcommand,
     storeSubcommand,
   ],
   options: [

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -55,6 +55,16 @@ export const putSubcommand = {
   ],
   options: [
     {
+      name: 'access',
+      shorthand: 'a',
+      type: String,
+      deprecated: false,
+      description:
+        'Access level for the blob: public or private (default: public)',
+      argument: 'String',
+      choices: ['public', 'private'],
+    },
+    {
       name: 'add-random-suffix',
       shorthand: 'r',
       type: Boolean,
@@ -139,6 +149,16 @@ export const copySubcommand = {
   ],
   options: [
     {
+      name: 'access',
+      shorthand: 'a',
+      type: String,
+      deprecated: false,
+      description:
+        'Access level for the blob: public or private (default: public)',
+      argument: 'String',
+      choices: ['public', 'private'],
+    },
+    {
       name: 'add-random-suffix',
       shorthand: 'r',
       type: Boolean,
@@ -168,6 +188,39 @@ export const copySubcommand = {
   examples: [],
 } as const;
 
+export const getSubcommand = {
+  name: 'get',
+  aliases: [],
+  description: 'Download a blob by URL or pathname',
+  arguments: [
+    {
+      name: 'urlOrPathname',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'access',
+      shorthand: 'a',
+      type: String,
+      deprecated: false,
+      description:
+        'Access level for the blob: public or private (default: public)',
+      argument: 'String',
+      choices: ['public', 'private'],
+    },
+    {
+      name: 'output',
+      shorthand: 'o',
+      type: String,
+      deprecated: false,
+      description: 'Save blob content to a file instead of stdout',
+      argument: 'PATH',
+    },
+  ],
+  examples: [],
+} as const;
+
 export const addStoreSubcommand = {
   name: 'add',
   aliases: [],
@@ -179,6 +232,16 @@ export const addStoreSubcommand = {
     },
   ],
   options: [
+    {
+      name: 'access',
+      shorthand: 'a',
+      type: String,
+      deprecated: false,
+      description:
+        'Access level for the Blob store: public or private (default: public)',
+      argument: 'String',
+      choices: ['public', 'private'],
+    },
     {
       name: 'region',
       shorthand: 'r',
@@ -197,6 +260,10 @@ export const addStoreSubcommand = {
     {
       name: 'Create a blob store in a specific region',
       value: 'vercel blob store add my-store --region cdg1',
+    },
+    {
+      name: 'Create a private blob store',
+      value: 'vercel blob store add my-private-store --access private',
     },
   ],
 } as const;
@@ -247,6 +314,7 @@ export const blobCommand = {
   subcommands: [
     listSubcommand,
     putSubcommand,
+    getSubcommand,
     delSubcommand,
     copySubcommand,
     storeSubcommand,

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -1,3 +1,13 @@
+const accessOption = {
+  name: 'access',
+  shorthand: 'a',
+  type: String,
+  deprecated: false,
+  description: 'Access level for the blob: public or private (default: public)',
+  argument: 'String',
+  choices: ['public', 'private'],
+} as const;
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -54,16 +64,7 @@ export const putSubcommand = {
     },
   ],
   options: [
-    {
-      name: 'access',
-      shorthand: 'a',
-      type: String,
-      deprecated: false,
-      description:
-        'Access level for the blob: public or private (default: public)',
-      argument: 'String',
-      choices: ['public', 'private'],
-    },
+    accessOption,
     {
       name: 'add-random-suffix',
       shorthand: 'r',
@@ -148,16 +149,7 @@ export const copySubcommand = {
     },
   ],
   options: [
-    {
-      name: 'access',
-      shorthand: 'a',
-      type: String,
-      deprecated: false,
-      description:
-        'Access level for the blob: public or private (default: public)',
-      argument: 'String',
-      choices: ['public', 'private'],
-    },
+    accessOption,
     {
       name: 'add-random-suffix',
       shorthand: 'r',
@@ -199,16 +191,7 @@ export const getSubcommand = {
     },
   ],
   options: [
-    {
-      name: 'access',
-      shorthand: 'a',
-      type: String,
-      deprecated: false,
-      description:
-        'Access level for the blob: public or private (default: public)',
-      argument: 'String',
-      choices: ['public', 'private'],
-    },
+    accessOption,
     {
       name: 'output',
       shorthand: 'o',
@@ -232,16 +215,7 @@ export const addStoreSubcommand = {
     },
   ],
   options: [
-    {
-      name: 'access',
-      shorthand: 'a',
-      type: String,
-      deprecated: false,
-      description:
-        'Access level for the Blob store: public or private (default: public)',
-      argument: 'String',
-      choices: ['public', 'private'],
-    },
+    accessOption,
     {
       name: 'region',
       shorthand: 'r',

--- a/packages/cli/src/commands/blob/copy.ts
+++ b/packages/cli/src/commands/blob/copy.ts
@@ -46,6 +46,7 @@ export default async function copy(
       '--add-random-suffix': addRandomSuffix,
       '--content-type': contentType,
       '--cache-control-max-age': cacheControlMaxAge,
+      '--if-match': ifMatch,
     },
   } = parsedArgs;
 
@@ -58,6 +59,7 @@ export default async function copy(
   telemetryClient.trackCliFlagAddRandomSuffix(addRandomSuffix);
   telemetryClient.trackCliOptionContentType(contentType);
   telemetryClient.trackCliOptionCacheControlMaxAge(cacheControlMaxAge);
+  telemetryClient.trackCliOptionIfMatch(ifMatch);
 
   let result: blob.PutBlobResult;
   try {
@@ -71,6 +73,7 @@ export default async function copy(
       addRandomSuffix: addRandomSuffix ?? false,
       contentType,
       cacheControlMaxAge,
+      ifMatch,
     });
   } catch (err) {
     printError(err);

--- a/packages/cli/src/commands/blob/copy.ts
+++ b/packages/cli/src/commands/blob/copy.ts
@@ -7,7 +7,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { copySubcommand } from './command';
 import { BlobCopyTelemetryClient } from '../../util/telemetry/commands/blob/copy';
 import { getCommandName } from '../../util/pkg-name';
-import { isAccess } from '../../util/blob/access';
+import { parseAccessFlag } from '../../util/blob/access';
 
 export default async function copy(
   client: Client,
@@ -49,13 +49,8 @@ export default async function copy(
     },
   } = parsedArgs;
 
-  const access = accessFlag ?? 'public';
-  if (!isAccess(access)) {
-    output.error(
-      `Invalid access value: '${access}'. Must be 'public' or 'private'.`
-    );
-    return 1;
-  }
+  const access = parseAccessFlag(accessFlag);
+  if (!access) return 1;
 
   telemetryClient.trackCliArgumentFromUrlOrPathname(fromUrl);
   telemetryClient.trackCliArgumentToPathname(toPathname);

--- a/packages/cli/src/commands/blob/del.ts
+++ b/packages/cli/src/commands/blob/del.ts
@@ -37,15 +37,17 @@ export default async function del(
   }
 
   const { args } = parsedArgs;
+  const { '--if-match': ifMatch } = parsedArgs.flags;
 
   telemetryClient.trackCliArgumentUrlsOrPathnames(args[0]);
+  telemetryClient.trackCliOptionIfMatch(ifMatch);
 
   try {
     output.debug('Deleting blob');
 
     output.spinner('Deleting blob');
 
-    await blob.del(args, { token: rwToken });
+    await blob.del(args, { token: rwToken, ifMatch });
   } catch (err) {
     output.error(`Error deleting blob: ${err}`);
     return 1;

--- a/packages/cli/src/commands/blob/get.ts
+++ b/packages/cli/src/commands/blob/get.ts
@@ -71,12 +71,12 @@ export default async function get(
       access,
     });
 
-    if (!result) {
+    if (!result || !result.stream) {
       output.error(`Blob not found: ${urlOrPathname}`);
       return 1;
     }
 
-    const nodeStream = Readable.fromWeb(result.body as NodeWebReadableStream);
+    const nodeStream = Readable.fromWeb(result.stream as NodeWebReadableStream);
 
     if (outputPath) {
       const writeStream = createWriteStream(outputPath);
@@ -84,10 +84,10 @@ export default async function get(
 
       output.stopSpinner();
 
-      const sizeInfo = result.contentLength
-        ? ` (${bytes(result.contentLength)})`
+      const sizeInfo = result.blob.size ? ` (${bytes(result.blob.size)})` : '';
+      const typeInfo = result.blob.contentType
+        ? `, ${result.blob.contentType}`
         : '';
-      const typeInfo = result.contentType ? `, ${result.contentType}` : '';
       output.success(`Saved to ${outputPath}${sizeInfo}${typeInfo}`);
     } else {
       await pipeline(nodeStream, client.stdout, { end: false });

--- a/packages/cli/src/commands/blob/get.ts
+++ b/packages/cli/src/commands/blob/get.ts
@@ -1,0 +1,101 @@
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import * as blob from '@vercel/blob';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { getSubcommand } from './command';
+import { getCommandName } from '../../util/pkg-name';
+import { BlobGetTelemetryClient } from '../../util/telemetry/commands/blob/get';
+import { printError } from '../../util/error';
+import { isAccess } from '../../util/blob/access';
+import { createWriteStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import type { ReadableStream as NodeWebReadableStream } from 'node:stream/web';
+import { pipeline } from 'node:stream/promises';
+import bytes from 'bytes';
+
+export default async function get(
+  client: Client,
+  argv: string[],
+  rwToken: string
+): Promise<number> {
+  const telemetryClient = new BlobGetTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(getSubcommand.options);
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const {
+    flags,
+    args: [urlOrPathname],
+  } = parsedArgs;
+  const { '--access': accessFlag, '--output': outputPath } = flags;
+
+  if (!urlOrPathname) {
+    output.error(
+      `Missing required argument. Usage: ${getCommandName('blob get <urlOrPathname>')}`
+    );
+    return 1;
+  }
+
+  const access = accessFlag ?? 'public';
+  if (!isAccess(access)) {
+    output.error(
+      `Invalid access value: '${access}'. Must be 'public' or 'private'.`
+    );
+    return 1;
+  }
+
+  telemetryClient.trackCliArgumentUrlOrPathname(urlOrPathname);
+  telemetryClient.trackCliOptionAccess(accessFlag);
+  telemetryClient.trackCliOptionOutput(outputPath);
+
+  try {
+    output.debug('Downloading blob');
+
+    if (outputPath) {
+      output.spinner('Downloading blob');
+    }
+
+    const result = await blob.get(urlOrPathname, {
+      token: rwToken,
+      access,
+    });
+
+    if (!result) {
+      output.error(`Blob not found: ${urlOrPathname}`);
+      return 1;
+    }
+
+    const nodeStream = Readable.fromWeb(result.body as NodeWebReadableStream);
+
+    if (outputPath) {
+      const writeStream = createWriteStream(outputPath);
+      await pipeline(nodeStream, writeStream);
+
+      output.stopSpinner();
+
+      const sizeInfo = result.contentLength
+        ? ` (${bytes(result.contentLength)})`
+        : '';
+      const typeInfo = result.contentType ? `, ${result.contentType}` : '';
+      output.success(`Saved to ${outputPath}${sizeInfo}${typeInfo}`);
+    } else {
+      await pipeline(nodeStream, client.stdout, { end: false });
+    }
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/blob/get.ts
+++ b/packages/cli/src/commands/blob/get.ts
@@ -93,6 +93,7 @@ export default async function get(
       await pipeline(nodeStream, client.stdout, { end: false });
     }
   } catch (err) {
+    output.stopSpinner();
     printError(err);
     return 1;
   }

--- a/packages/cli/src/commands/blob/get.ts
+++ b/packages/cli/src/commands/blob/get.ts
@@ -7,7 +7,7 @@ import { getSubcommand } from './command';
 import { getCommandName } from '../../util/pkg-name';
 import { BlobGetTelemetryClient } from '../../util/telemetry/commands/blob/get';
 import { printError } from '../../util/error';
-import { isAccess } from '../../util/blob/access';
+import { parseAccessFlag } from '../../util/blob/access';
 import { createWriteStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import type { ReadableStream as NodeWebReadableStream } from 'node:stream/web';
@@ -47,13 +47,8 @@ export default async function get(
     return 1;
   }
 
-  const access = accessFlag ?? 'public';
-  if (!isAccess(access)) {
-    output.error(
-      `Invalid access value: '${access}'. Must be 'public' or 'private'.`
-    );
-    return 1;
-  }
+  const access = parseAccessFlag(accessFlag);
+  if (!access) return 1;
 
   telemetryClient.trackCliArgumentUrlOrPathname(urlOrPathname);
   telemetryClient.trackCliOptionAccess(accessFlag);

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -11,6 +11,9 @@ import {
   listSubcommand,
   putSubcommand,
   copySubcommand,
+  createStoreSubcommand,
+  deleteStoreSubcommand,
+  getStoreInfoSubcommand,
   storeSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -22,6 +25,9 @@ import get from './get';
 import del from './del';
 import copy from './copy';
 import { store } from './store';
+import addStore from './store-add';
+import removeStore from './store-remove';
+import getStore from './store-get';
 import { printError } from '../../util/error';
 import { getBlobRWToken } from '../../util/blob/token';
 
@@ -31,6 +37,9 @@ const COMMAND_CONFIG = {
   get: getCommandAliases(getSubcommand),
   del: getCommandAliases(delSubcommand),
   copy: getCommandAliases(copySubcommand),
+  'create-store': getCommandAliases(createStoreSubcommand),
+  'delete-store': getCommandAliases(deleteStoreSubcommand),
+  'get-store': getCommandAliases(getStoreInfoSubcommand),
   store: getCommandAliases(storeSubcommand),
 };
 
@@ -151,7 +160,50 @@ export default async function main(client: Client) {
       }
 
       return copy(client, args, token.token);
+    case 'create-store':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(createStoreSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandCreateStore(subcommandOriginal);
+
+      return addStore(client, args);
+    case 'delete-store':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(deleteStoreSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandDeleteStore(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
+      return removeStore(client, args, token);
+    case 'get-store':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(getStoreInfoSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandGetStore(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
+      return getStore(client, args, token);
     case 'store':
+      output.warn(
+        '`vercel blob store` is deprecated. Use `vercel blob create-store`, `vercel blob delete-store`, or `vercel blob get-store` instead.'
+      );
       telemetry.trackCliSubcommandStore(subcommandOriginal);
       return store(client, token);
     default:

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -7,6 +7,7 @@ import list from './list';
 import {
   blobCommand,
   delSubcommand,
+  getSubcommand,
   listSubcommand,
   putSubcommand,
   copySubcommand,
@@ -17,6 +18,7 @@ import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { BlobTelemetryClient } from '../../util/telemetry/commands/blob';
 import put from './put';
+import get from './get';
 import del from './del';
 import copy from './copy';
 import { store } from './store';
@@ -26,6 +28,7 @@ import { getBlobRWToken } from '../../util/blob/token';
 const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
   put: getCommandAliases(putSubcommand),
+  get: getCommandAliases(getSubcommand),
   del: getCommandAliases(delSubcommand),
   copy: getCommandAliases(copySubcommand),
   store: getCommandAliases(storeSubcommand),
@@ -103,6 +106,21 @@ export default async function main(client: Client) {
       }
 
       return put(client, args, token.token);
+    case 'get':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(getSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandGet(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
+      return get(client, args, token.token);
     case 'del':
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob', subcommandOriginal);

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -1,7 +1,7 @@
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import getInvalidSubcommand from '../../util/get-invalid-subcommand';
-import getSubcommand from '../../util/get-subcommand';
+import resolveSubcommand from '../../util/get-subcommand';
 import { type Command, help } from '../help';
 import list from './list';
 import {
@@ -53,7 +53,7 @@ export default async function main(client: Client) {
   }
 
   const subArgs = parsedArgs.args.slice(1);
-  const { subcommand, args, subcommandOriginal } = getSubcommand(
+  const { subcommand, args, subcommandOriginal } = resolveSubcommand(
     subArgs,
     COMMAND_CONFIG
   );

--- a/packages/cli/src/commands/blob/put.ts
+++ b/packages/cli/src/commands/blob/put.ts
@@ -45,8 +45,14 @@ export default async function put(
     '--multipart': multipart,
     '--content-type': contentType,
     '--cache-control-max-age': cacheControlMaxAge,
+    '--allow-overwrite': allowOverwrite,
     '--force': force,
+    '--if-match': ifMatch,
   } = flags;
+
+  if (force) {
+    output.warn('--force is deprecated, use --allow-overwrite instead');
+  }
 
   const access = parseAccessFlag(accessFlag);
   if (!access) return 1;
@@ -61,7 +67,9 @@ export default async function put(
   telemetryClient.trackCliFlagMultipart(multipart);
   telemetryClient.trackCliOptionContentType(contentType);
   telemetryClient.trackCliOptionCacheControlMaxAge(cacheControlMaxAge);
+  telemetryClient.trackCliFlagAllowOverwrite(allowOverwrite);
   telemetryClient.trackCliFlagForce(force);
+  telemetryClient.trackCliOptionIfMatch(ifMatch);
 
   // ReadableStream works for both stdin and ReadStream
   let putBody: ReadableStream;
@@ -143,7 +151,8 @@ export default async function put(
       multipart: multipart ?? true,
       contentType,
       cacheControlMaxAge,
-      allowOverwrite: force ?? false,
+      allowOverwrite: allowOverwrite ?? force ?? false,
+      ifMatch,
     });
   } catch (err) {
     printError(err);

--- a/packages/cli/src/commands/blob/put.ts
+++ b/packages/cli/src/commands/blob/put.ts
@@ -12,7 +12,7 @@ import { getCommandName } from '../../util/pkg-name';
 import chalk from 'chalk';
 import { BlobPutTelemetryClient } from '../../util/telemetry/commands/blob/put';
 import { printError } from '../../util/error';
-import { isAccess } from '../../util/blob/access';
+import { parseAccessFlag } from '../../util/blob/access';
 
 export default async function put(
   client: Client,
@@ -48,13 +48,8 @@ export default async function put(
     '--force': force,
   } = flags;
 
-  const access = accessFlag ?? 'public';
-  if (!isAccess(access)) {
-    output.error(
-      `Invalid access value: '${access}'. Must be 'public' or 'private'.`
-    );
-    return 1;
-  }
+  const access = parseAccessFlag(accessFlag);
+  if (!access) return 1;
 
   // Only track file path if one was provided
   if (filePath) {

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -9,7 +9,7 @@ import { parseArguments } from '../../util/get-args';
 import { addStoreSubcommand } from './command';
 import { BlobAddStoreTelemetryClient } from '../../util/telemetry/commands/blob/store-add';
 import { printError } from '../../util/error';
-import { isAccess } from '../../util/blob/access';
+import { parseAccessFlag } from '../../util/blob/access';
 
 export default async function addStore(
   client: Client,
@@ -37,13 +37,8 @@ export default async function addStore(
   } = parsedArgs;
 
   const accessFlag = flags['--access'];
-  const access = accessFlag ?? 'public';
-  if (!isAccess(access)) {
-    output.error(
-      `Invalid access value: '${access}'. Must be 'public' or 'private'.`
-    );
-    return 1;
-  }
+  const access = parseAccessFlag(accessFlag);
+  if (!access) return 1;
 
   const region = flags['--region'] || 'iad1';
 

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -73,7 +73,11 @@ export default async function addStore(
 
     output.spinner('Creating new blob store');
 
-    const requestBody: { name: string; region: string; access: string } = {
+    const requestBody: {
+      name: string;
+      region: string;
+      access: 'public' | 'private';
+    } = {
       name,
       region,
       access,

--- a/packages/cli/src/commands/blob/store-get.ts
+++ b/packages/cli/src/commands/blob/store-get.ts
@@ -86,9 +86,7 @@ export default async function getStore(
       ? `\nRegion: ${store.store.region}`
       : '';
 
-    const accessInfo = store.store.access
-      ? `\nAccess: ${store.store.access === 'private' ? 'Private' : 'Public'}`
-      : '';
+    const accessInfo = `\nAccess: ${store.store.access === 'private' ? 'Private' : 'Public'}`;
 
     output.print(
       `Blob Store: ${chalk.bold(store.store.name)} (${chalk.dim(store.store.id)})

--- a/packages/cli/src/commands/blob/store-get.ts
+++ b/packages/cli/src/commands/blob/store-get.ts
@@ -73,6 +73,7 @@ export default async function getStore(
         billingState: string;
         size: number;
         region?: string;
+        access?: string;
       };
     }>(`/v1/storage/stores/${storeId}`, {
       method: 'GET',
@@ -85,6 +86,10 @@ export default async function getStore(
       ? `\nRegion: ${store.store.region}`
       : '';
 
+    const accessInfo = store.store.access
+      ? `\nAccess: ${store.store.access === 'private' ? 'Private' : 'Public'}`
+      : '';
+
     output.print(
       `Blob Store: ${chalk.bold(store.store.name)} (${chalk.dim(store.store.id)})
 Billing State: ${
@@ -92,7 +97,7 @@ Billing State: ${
           ? chalk.green('Active')
           : chalk.red('Inactive')
       }
-Size: ${bytes(store.store.size)}${regionInfo}
+Size: ${bytes(store.store.size)}${regionInfo}${accessInfo}
 Created At: ${format(new Date(store.store.createdAt), dateTimeFormat)}
 Updated At: ${format(new Date(store.store.updatedAt), dateTimeFormat)}\n`
     );

--- a/packages/cli/src/util/blob/access.ts
+++ b/packages/cli/src/util/blob/access.ts
@@ -1,0 +1,7 @@
+const VALID_ACCESS_VALUES = ['public', 'private'] as const;
+
+type BlobAccess = (typeof VALID_ACCESS_VALUES)[number];
+
+export function isAccess(value: string): value is BlobAccess {
+  return (VALID_ACCESS_VALUES as readonly string[]).includes(value);
+}

--- a/packages/cli/src/util/blob/access.ts
+++ b/packages/cli/src/util/blob/access.ts
@@ -1,7 +1,26 @@
+import output from '../../output-manager';
+
 const VALID_ACCESS_VALUES = ['public', 'private'] as const;
 
 type BlobAccess = (typeof VALID_ACCESS_VALUES)[number];
 
-export function isAccess(value: string): value is BlobAccess {
+function isAccess(value: string): value is BlobAccess {
   return (VALID_ACCESS_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Parses and validates an --access flag value, defaulting to 'public'.
+ * Returns the validated access value, or null if invalid (with error printed).
+ */
+export function parseAccessFlag(
+  accessFlag: string | undefined
+): BlobAccess | null {
+  const access = accessFlag ?? 'public';
+  if (!isAccess(access)) {
+    output.error(
+      `Invalid access value: '${access}'. Must be 'public' or 'private'.`
+    );
+    return null;
+  }
+  return access;
 }

--- a/packages/cli/src/util/blob/token.ts
+++ b/packages/cli/src/util/blob/token.ts
@@ -10,8 +10,8 @@ import cmd from '../output/cmd';
 import listItem from '../output/list-item';
 
 const ErrorMessage = `No Vercel Blob token found. To fix this issue, choose one of the following options:
-${listItem(`Pass the token directly as an option: ${getCommandName('blob list --rw-token BLOB_TOKEN')}`, 1)}
-${listItem(`Set the Token as an environment variable: ${cmd(`BLOB_READ_WRITE_TOKEN=BLOB_TOKEN ${packageName} blob list`)}`, 2)}
+${listItem(`Pass the token directly as an option: ${getCommandName('blob list --rw-token BLOB_READ_WRITE_TOKEN')}`, 1)}
+${listItem(`Set the Token as an environment variable: ${cmd(`BLOB_READ_WRITE_TOKEN=BLOB_READ_WRITE_TOKEN ${packageName} blob list`)}`, 2)}
 ${listItem('Link your current folder to a Vercel Project that has a Vercel Blob store connected', 3)}`;
 
 export type BlobRWToken =

--- a/packages/cli/src/util/telemetry/commands/blob/copy.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/copy.ts
@@ -56,4 +56,13 @@ export class BlobCopyTelemetryClient
       });
     }
   }
+
+  trackCliOptionIfMatch(ifMatch: string | undefined) {
+    if (ifMatch) {
+      this.trackCliOption({
+        option: 'if-match',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/blob/copy.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/copy.ts
@@ -6,6 +6,15 @@ export class BlobCopyTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof copySubcommand>
 {
+  trackCliOptionAccess(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'access',
+        value,
+      });
+    }
+  }
+
   trackCliArgumentFromUrlOrPathname(value: string | undefined) {
     if (value) {
       this.trackCliArgument({

--- a/packages/cli/src/util/telemetry/commands/blob/del.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/del.ts
@@ -14,4 +14,13 @@ export class BlobDelTelemetryClient
       });
     }
   }
+
+  trackCliOptionIfMatch(ifMatch: string | undefined) {
+    if (ifMatch) {
+      this.trackCliOption({
+        option: 'if-match',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/blob/get.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/get.ts
@@ -32,4 +32,13 @@ export class BlobGetTelemetryClient
       });
     }
   }
+
+  trackCliOptionIfNoneMatch(ifNoneMatch: string | undefined) {
+    if (ifNoneMatch) {
+      this.trackCliOption({
+        option: 'if-none-match',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/blob/get.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/get.ts
@@ -1,0 +1,35 @@
+import { TelemetryClient } from '../..';
+import type { getSubcommand } from '../../../../commands/blob/command';
+import type { TelemetryMethods } from '../../types';
+
+export class BlobGetTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof getSubcommand>
+{
+  trackCliArgumentUrlOrPathname(value: string | undefined) {
+    if (value) {
+      this.trackCliArgument({
+        arg: 'urlOrPathname',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionAccess(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'access',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionOutput(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'output',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/blob/index.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/index.ts
@@ -41,6 +41,27 @@ export class BlobTelemetryClient
     });
   }
 
+  trackCliSubcommandCreateStore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'create-store',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandDeleteStore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'delete-store',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandGetStore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'get-store',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandStore(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'store',

--- a/packages/cli/src/util/telemetry/commands/blob/index.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/index.ts
@@ -20,6 +20,13 @@ export class BlobTelemetryClient
     });
   }
 
+  trackCliSubcommandGet(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'get',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandDel(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'del',

--- a/packages/cli/src/util/telemetry/commands/blob/put.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/put.ts
@@ -70,9 +70,24 @@ export class BlobPutTelemetryClient
     }
   }
 
+  trackCliFlagAllowOverwrite(allowOverwrite: boolean | undefined) {
+    if (allowOverwrite) {
+      this.trackCliFlag('allow-overwrite');
+    }
+  }
+
   trackCliFlagForce(force: boolean | undefined) {
     if (force) {
       this.trackCliFlag('force');
+    }
+  }
+
+  trackCliOptionIfMatch(ifMatch: string | undefined) {
+    if (ifMatch) {
+      this.trackCliOption({
+        option: 'if-match',
+        value: this.redactedValue,
+      });
     }
   }
 }

--- a/packages/cli/src/util/telemetry/commands/blob/put.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/put.ts
@@ -6,6 +6,15 @@ export class BlobPutTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof putSubcommand>
 {
+  trackCliOptionAccess(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'access',
+        value,
+      });
+    }
+  }
+
   trackCliArgumentPathToFile(pathToFile: string | undefined) {
     if (pathToFile) {
       this.trackCliArgument({

--- a/packages/cli/src/util/telemetry/commands/blob/store-add.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-add.ts
@@ -6,6 +6,15 @@ export class BlobAddStoreTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof addStoreSubcommand>
 {
+  trackCliOptionAccess(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'access',
+        value,
+      });
+    }
+  }
+
   trackCliArgumentName(value: string | undefined) {
     if (value) {
       this.trackCliArgument({

--- a/packages/cli/test/helpers/exec.ts
+++ b/packages/cli/test/helpers/exec.ts
@@ -34,9 +34,10 @@ export function execCli(
   combinedOptions.env = combinedOptions.env ?? {};
 
   // Force color to be off. We can test color in unit tests.
+  // Explicitly set FORCE_COLOR=0 to override CI's FORCE_COLOR=1,
+  // which takes precedence over NO_COLOR in chalk.
   combinedOptions.env['NO_COLOR'] = '1';
-  delete combinedOptions.env['FORCE_COLOR'];
-  delete process.env['FORCE_COLOR']; // this is inherited by execa
+  combinedOptions.env['FORCE_COLOR'] = '0';
 
   return execa(file, args, combinedOptions);
 }

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -535,9 +535,8 @@ test('create a production deployment', async () => {
 });
 
 test('try to deploy non-existing path', async () => {
-  const goal = `Error: Could not find “${humanizePath(
-    path.join(process.cwd(), session)
-  )}”`;
+  const goal = `Could not find`;
+  const expectedPath = humanizePath(path.join(process.cwd(), session));
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     session,
@@ -545,7 +544,11 @@ test('try to deploy non-existing path', async () => {
   ]);
 
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
-  expect(stderr.trim().endsWith(goal), `should end with "${goal}"`).toBe(true);
+  // Strip ANSI codes before checking — chalk colors and Node.js
+  // deprecation warnings can pollute stderr in CI.
+  const plain = stderr.replace(/\u001b\[[0-9;]*m/g, '');
+  expect(plain).toContain(goal);
+  expect(plain).toContain(expectedPath);
 });
 
 test('try to deploy with non-existing team', async () => {

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -535,8 +535,9 @@ test('create a production deployment', async () => {
 });
 
 test('try to deploy non-existing path', async () => {
-  const goal = `Could not find`;
-  const expectedPath = humanizePath(path.join(process.cwd(), session));
+  const goal = `Error: Could not find “${humanizePath(
+    path.join(process.cwd(), session)
+  )}”`;
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     session,
@@ -544,11 +545,7 @@ test('try to deploy non-existing path', async () => {
   ]);
 
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
-  // Strip ANSI codes before checking — chalk colors and Node.js
-  // deprecation warnings can pollute stderr in CI.
-  const plain = stderr.replace(/\u001b\[[0-9;]*m/g, '');
-  expect(plain).toContain(goal);
-  expect(plain).toContain(expectedPath);
+  expect(stderr.trim().endsWith(goal), `should end with "${goal}"`).toBe(true);
 });
 
 test('try to deploy with non-existing team', async () => {

--- a/packages/cli/test/unit/commands/blob/copy.test.ts
+++ b/packages/cli/test/unit/commands/blob/copy.test.ts
@@ -53,6 +53,7 @@ describe('blob copy', () => {
         addRandomSuffix: false,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
       expect(mockedOutput.spinner).toHaveBeenCalledWith('Copying blob');
       expect(mockedOutput.stopSpinner).toHaveBeenCalled();
@@ -106,6 +107,7 @@ describe('blob copy', () => {
         addRandomSuffix: true,
         contentType: 'image/png',
         cacheControlMaxAge: 86400,
+        ifMatch: undefined,
       });
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -145,6 +147,7 @@ describe('blob copy', () => {
         addRandomSuffix: false,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
     });
 
@@ -166,6 +169,59 @@ describe('blob copy', () => {
         contentType: undefined,
         cacheControlMaxAge: undefined,
       });
+    });
+  });
+
+  describe('--if-match option', () => {
+    it('should pass --if-match to blob.copy', async () => {
+      client.setArgv(
+        'blob',
+        'copy',
+        '--if-match',
+        '"some-etag"',
+        'source.txt',
+        'dest.txt'
+      );
+
+      const exitCode = await copy(
+        client,
+        ['--if-match', '"some-etag"', 'source.txt', 'dest.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.copy).toHaveBeenCalledWith('source.txt', 'dest.txt', {
+        token: testToken,
+        access: 'public',
+        addRandomSuffix: false,
+        contentType: undefined,
+        cacheControlMaxAge: undefined,
+        ifMatch: '"some-etag"',
+      });
+    });
+
+    it('should track --if-match telemetry', async () => {
+      const exitCode = await copy(
+        client,
+        ['--if-match', '"etag-value"', 'source.txt', 'dest.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:fromUrlOrPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'argument:toPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:if-match',
+          value: '[REDACTED]',
+        },
+      ]);
     });
   });
 
@@ -323,6 +379,7 @@ describe('blob copy', () => {
         addRandomSuffix: false,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -357,6 +414,7 @@ describe('blob copy', () => {
         addRandomSuffix: false,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
     });
 
@@ -374,6 +432,7 @@ describe('blob copy', () => {
         addRandomSuffix: true,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
     });
   });
@@ -479,6 +538,7 @@ describe('blob copy', () => {
           addRandomSuffix: true,
           contentType: 'application/pdf',
           cacheControlMaxAge: 7200,
+          ifMatch: undefined,
         }
       );
 

--- a/packages/cli/test/unit/commands/blob/copy.test.ts
+++ b/packages/cli/test/unit/commands/blob/copy.test.ts
@@ -32,6 +32,7 @@ describe('blob copy', () => {
       pathname: 'copied-file.txt',
       contentType: 'text/plain',
       contentDisposition: 'attachment; filename="copied-file.txt"',
+      etag: 'test-etag',
     });
   });
 

--- a/packages/cli/test/unit/commands/blob/copy.test.ts
+++ b/packages/cli/test/unit/commands/blob/copy.test.ts
@@ -298,6 +298,49 @@ describe('blob copy', () => {
     });
   });
 
+  describe('access option', () => {
+    it('should handle --access private option', async () => {
+      client.setArgv(
+        'blob',
+        'copy',
+        '--access',
+        'private',
+        'source.txt',
+        'dest.txt'
+      );
+
+      const exitCode = await copy(
+        client,
+        ['--access', 'private', 'source.txt', 'dest.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.copy).toHaveBeenCalledWith('source.txt', 'dest.txt', {
+        token: testToken,
+        access: 'private',
+        addRandomSuffix: false,
+        contentType: undefined,
+        cacheControlMaxAge: undefined,
+      });
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:fromUrlOrPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'argument:toPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:access',
+          value: 'private',
+        },
+      ]);
+    });
+  });
+
   describe('flag variations', () => {
     it('should handle addRandomSuffix flag correctly when false', async () => {
       const exitCode = await copy(

--- a/packages/cli/test/unit/commands/blob/del.test.ts
+++ b/packages/cli/test/unit/commands/blob/del.test.ts
@@ -38,6 +38,7 @@ describe('blob del', () => {
       expect(exitCode).toBe(0);
       expect(mockedBlob.del).toHaveBeenCalledWith(['test-file.txt'], {
         token: testToken,
+        ifMatch: undefined,
       });
       expect(mockedOutput.debug).toHaveBeenCalledWith('Deleting blob');
       expect(mockedOutput.spinner).toHaveBeenCalledWith('Deleting blob');
@@ -66,6 +67,7 @@ describe('blob del', () => {
         ['file1.txt', 'file2.txt', 'file3.txt'],
         {
           token: testToken,
+          ifMatch: undefined,
         }
       );
       expect(mockedOutput.success).toHaveBeenCalledWith('Blob deleted');
@@ -87,6 +89,7 @@ describe('blob del', () => {
       expect(exitCode).toBe(0);
       expect(mockedBlob.del).toHaveBeenCalledWith([blobUrl], {
         token: testToken,
+        ifMatch: undefined,
       });
     });
 
@@ -103,7 +106,52 @@ describe('blob del', () => {
       expect(exitCode).toBe(0);
       expect(mockedBlob.del).toHaveBeenCalledWith(args, {
         token: testToken,
+        ifMatch: undefined,
       });
+    });
+  });
+
+  describe('--if-match option', () => {
+    it('should pass --if-match to blob.del', async () => {
+      client.setArgv(
+        'blob',
+        'del',
+        '--if-match',
+        '"some-etag"',
+        'test-file.txt'
+      );
+
+      const exitCode = await del(
+        client,
+        ['--if-match', '"some-etag"', 'test-file.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.del).toHaveBeenCalledWith(['test-file.txt'], {
+        token: testToken,
+        ifMatch: '"some-etag"',
+      });
+    });
+
+    it('should track --if-match telemetry', async () => {
+      const exitCode = await del(
+        client,
+        ['--if-match', '"etag-value"', 'test-file.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:urlsOrPathnames',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:if-match',
+          value: '[REDACTED]',
+        },
+      ]);
     });
   });
 

--- a/packages/cli/test/unit/commands/blob/get.test.ts
+++ b/packages/cli/test/unit/commands/blob/get.test.ts
@@ -1,0 +1,283 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import get from '../../../../src/commands/blob/get';
+import * as blobModule from '@vercel/blob';
+import output from '../../../../src/output-manager';
+import { Readable } from 'node:stream';
+import * as fs from 'node:fs';
+import * as streamPromises from 'node:stream/promises';
+
+// Mock the external dependencies
+vi.mock('@vercel/blob');
+vi.mock('../../../../src/output-manager');
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    createWriteStream: vi.fn(),
+  };
+});
+vi.mock('node:stream/promises', async () => {
+  const actual = await vi.importActual('node:stream/promises');
+  return {
+    ...actual,
+    pipeline: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const mockedBlob = vi.mocked(blobModule);
+const mockedOutput = vi.mocked(output);
+const mockedCreateWriteStream = vi.mocked(fs.createWriteStream);
+const mockedPipeline = vi.mocked(streamPromises.pipeline);
+
+function createMockGetResult(body?: string) {
+  const content = body ?? 'file content here';
+  const readable = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(content));
+      controller.close();
+    },
+  });
+
+  return {
+    url: 'https://example.com/test-file.txt',
+    downloadUrl: 'https://example.com/test-file.txt',
+    pathname: 'test-file.txt',
+    contentType: 'text/plain',
+    contentDisposition: 'attachment; filename="test-file.txt"',
+    contentLength: content.length,
+    body: readable,
+  };
+}
+
+describe('blob get', () => {
+  const testToken = 'vercel_blob_rw_test_token_123';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+
+    mockedBlob.get.mockResolvedValue(createMockGetResult());
+    mockedPipeline.mockResolvedValue(undefined);
+  });
+
+  describe('successful download', () => {
+    it('should stream blob content to stdout by default', async () => {
+      client.setArgv('blob', 'get', 'test-file.txt');
+
+      const exitCode = await get(client, ['test-file.txt'], testToken);
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.get).toHaveBeenCalledWith('test-file.txt', {
+        token: testToken,
+        access: 'public',
+      });
+      expect(mockedPipeline).toHaveBeenCalledWith(
+        expect.any(Readable),
+        client.stdout,
+        { end: false }
+      );
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:urlOrPathname',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+
+    it('should save blob content to file with --output', async () => {
+      const mockWriteStream = {} as fs.WriteStream;
+      mockedCreateWriteStream.mockReturnValue(mockWriteStream);
+
+      client.setArgv('blob', 'get', 'test-file.txt', '--output', './local.txt');
+
+      const exitCode = await get(
+        client,
+        ['test-file.txt', '--output', './local.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.get).toHaveBeenCalledWith('test-file.txt', {
+        token: testToken,
+        access: 'public',
+      });
+      expect(mockedCreateWriteStream).toHaveBeenCalledWith('./local.txt');
+      expect(mockedPipeline).toHaveBeenCalledWith(
+        expect.any(Readable),
+        mockWriteStream
+      );
+      expect(mockedOutput.stopSpinner).toHaveBeenCalled();
+      expect(mockedOutput.success).toHaveBeenCalledWith(
+        'Saved to ./local.txt (17B), text/plain'
+      );
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:urlOrPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:output',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+
+    it('should use --access private', async () => {
+      client.setArgv('blob', 'get', 'private-file.txt', '--access', 'private');
+
+      const exitCode = await get(
+        client,
+        ['private-file.txt', '--access', 'private'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.get).toHaveBeenCalledWith('private-file.txt', {
+        token: testToken,
+        access: 'private',
+      });
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:urlOrPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:access',
+          value: 'private',
+        },
+      ]);
+    });
+
+    it('should handle URL as argument', async () => {
+      const blobUrl = 'https://example.com/my-blob.txt';
+      client.setArgv('blob', 'get', blobUrl);
+
+      const exitCode = await get(client, [blobUrl], testToken);
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.get).toHaveBeenCalledWith(blobUrl, {
+        token: testToken,
+        access: 'public',
+      });
+    });
+
+    it('should show spinner only when --output is used', async () => {
+      // Without --output: no spinner
+      client.setArgv('blob', 'get', 'test-file.txt');
+      await get(client, ['test-file.txt'], testToken);
+      expect(mockedOutput.spinner).not.toHaveBeenCalled();
+
+      vi.clearAllMocks();
+      mockedBlob.get.mockResolvedValue(createMockGetResult());
+      mockedPipeline.mockResolvedValue(undefined);
+      const mockWriteStream = {} as fs.WriteStream;
+      mockedCreateWriteStream.mockReturnValue(mockWriteStream);
+
+      // With --output: show spinner
+      client.setArgv('blob', 'get', 'test-file.txt', '--output', 'out.txt');
+      await get(client, ['test-file.txt', '--output', 'out.txt'], testToken);
+      expect(mockedOutput.spinner).toHaveBeenCalledWith('Downloading blob');
+    });
+  });
+
+  describe('error cases', () => {
+    it('should return 1 when no arguments are provided', async () => {
+      const exitCode = await get(client, [], testToken);
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.error).toHaveBeenCalledWith(
+        expect.stringContaining('Missing required argument')
+      );
+      expect(mockedBlob.get).not.toHaveBeenCalled();
+    });
+
+    it('should return 1 when blob is not found', async () => {
+      mockedBlob.get.mockResolvedValue(null);
+
+      const exitCode = await get(client, ['nonexistent.txt'], testToken);
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.error).toHaveBeenCalledWith(
+        'Blob not found: nonexistent.txt'
+      );
+    });
+
+    it('should return 1 when blob.get fails', async () => {
+      mockedBlob.get.mockRejectedValue(new Error('Download failed'));
+
+      const exitCode = await get(client, ['test-file.txt'], testToken);
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should return 1 with invalid --access value', async () => {
+      const exitCode = await get(
+        client,
+        ['test-file.txt', '--access', 'invalid'],
+        testToken
+      );
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.error).toHaveBeenCalledWith(
+        "Invalid access value: 'invalid'. Must be 'public' or 'private'."
+      );
+      expect(mockedBlob.get).not.toHaveBeenCalled();
+    });
+
+    it('should return 1 when argument parsing fails', async () => {
+      const exitCode = await get(client, ['--invalid-flag'], testToken);
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  describe('telemetry tracking', () => {
+    it('should track all provided options', async () => {
+      const mockWriteStream = {} as fs.WriteStream;
+      mockedCreateWriteStream.mockReturnValue(mockWriteStream);
+
+      const exitCode = await get(
+        client,
+        ['test-file.txt', '--access', 'private', '--output', 'out.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:urlOrPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:access',
+          value: 'private',
+        },
+        {
+          key: 'option:output',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+
+    it('should not track optional flags when not provided', async () => {
+      const exitCode = await get(client, ['test-file.txt'], testToken);
+
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).not.toHaveTelemetryEvents([
+        {
+          key: 'option:access',
+          value: expect.any(String),
+        },
+      ]);
+      expect(client.telemetryEventStore).not.toHaveTelemetryEvents([
+        {
+          key: 'option:output',
+          value: expect.any(String),
+        },
+      ]);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/blob/list.test.ts
+++ b/packages/cli/test/unit/commands/blob/list.test.ts
@@ -37,6 +37,7 @@ describe('blob list', () => {
           pathname: 'file1.txt',
           size: 1024,
           uploadedAt: new Date('2023-01-01T12:00:00Z'),
+          etag: 'test-etag-1',
         },
         {
           url: 'https://example.com/file2.jpg',
@@ -44,6 +45,7 @@ describe('blob list', () => {
           pathname: 'folder/file2.jpg',
           size: 2048,
           uploadedAt: new Date('2023-01-02T12:00:00Z'),
+          etag: 'test-etag-2',
         },
       ],
       cursor: undefined,
@@ -219,6 +221,7 @@ describe('blob list', () => {
             pathname: 'file1.txt',
             size: 1024,
             uploadedAt: new Date('2023-01-01T12:00:00Z'),
+            etag: 'test-etag',
           },
         ],
         cursor: 'next_cursor_123',
@@ -242,6 +245,7 @@ describe('blob list', () => {
             pathname: 'file1.txt',
             size: 1024,
             uploadedAt: new Date('2023-01-01T12:00:00Z'),
+            etag: 'test-etag',
           },
         ],
         cursor: undefined,
@@ -489,6 +493,7 @@ describe('blob list', () => {
         uploadedAt: new Date(
           `2023-01-${String((i % 30) + 1).padStart(2, '0')}T12:00:00Z`
         ),
+        etag: `test-etag-${i}`,
       }));
 
       mockedBlob.list.mockResolvedValue({

--- a/packages/cli/test/unit/commands/blob/put.test.ts
+++ b/packages/cli/test/unit/commands/blob/put.test.ts
@@ -62,6 +62,7 @@ describe('blob put', () => {
           contentType: undefined,
           cacheControlMaxAge: undefined,
           allowOverwrite: false,
+          ifMatch: undefined,
         }
       );
       expect(mockedOutput.debug).toHaveBeenCalledWith('Uploading blob');
@@ -125,6 +126,7 @@ describe('blob put', () => {
           contentType: 'text/plain',
           cacheControlMaxAge: 3600,
           allowOverwrite: true,
+          ifMatch: undefined,
         }
       );
 
@@ -176,6 +178,7 @@ describe('blob put', () => {
           contentType: undefined,
           cacheControlMaxAge: undefined,
           allowOverwrite: false,
+          ifMatch: undefined,
         }
       );
     });
@@ -357,6 +360,69 @@ describe('blob put', () => {
       ]);
     });
 
+    it('should handle --allow-overwrite flag', async () => {
+      const testFile = getFixturePath('test-file.txt');
+      const exitCode = await put(
+        client,
+        ['--allow-overwrite', testFile],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.put).toHaveBeenCalledWith(
+        'test-file.txt',
+        expect.any(ReadStream),
+        expect.objectContaining({ allowOverwrite: true })
+      );
+    });
+
+    it('should show deprecation warning when --force is used', async () => {
+      const testFile = getFixturePath('test-file.txt');
+      const exitCode = await put(client, ['--force', testFile], testToken);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOutput.warn).toHaveBeenCalledWith(
+        '--force is deprecated, use --allow-overwrite instead'
+      );
+      expect(mockedBlob.put).toHaveBeenCalledWith(
+        'test-file.txt',
+        expect.any(ReadStream),
+        expect.objectContaining({ allowOverwrite: true })
+      );
+    });
+
+    it('should prefer --allow-overwrite over --force', async () => {
+      const testFile = getFixturePath('test-file.txt');
+      const exitCode = await put(
+        client,
+        ['--allow-overwrite', '--force', testFile],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.put).toHaveBeenCalledWith(
+        'test-file.txt',
+        expect.any(ReadStream),
+        expect.objectContaining({ allowOverwrite: true })
+      );
+    });
+
+    it('should handle --if-match option', async () => {
+      const testFile = getFixturePath('test-file.txt');
+      const exitCode = await put(
+        client,
+        ['--if-match', '"some-etag"', testFile],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.put).toHaveBeenCalledWith(
+        'test-file.txt',
+        expect.any(ReadStream),
+        expect.objectContaining({ ifMatch: '"some-etag"' })
+      );
+    });
+
     it('should handle --multipart flag (enabled by default)', async () => {
       const testFile = getFixturePath('test-file.txt');
       const exitCode = await put(client, ['--multipart', testFile], testToken);
@@ -526,6 +592,7 @@ describe('blob put', () => {
           contentType: undefined,
           cacheControlMaxAge: undefined,
           allowOverwrite: false,
+          ifMatch: undefined,
         }
       );
       expect(mockedOutput.success).toHaveBeenCalledWith(
@@ -572,6 +639,7 @@ describe('blob put', () => {
           contentType: 'text/plain',
           cacheControlMaxAge: 3600,
           allowOverwrite: true,
+          ifMatch: undefined,
         }
       );
     });

--- a/packages/cli/test/unit/commands/blob/put.test.ts
+++ b/packages/cli/test/unit/commands/blob/put.test.ts
@@ -329,6 +329,33 @@ describe('blob put', () => {
       );
     });
 
+    it('should handle --access private option', async () => {
+      const testFile = getFixturePath('test-file.txt');
+      const exitCode = await put(
+        client,
+        ['--access', 'private', testFile],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.put).toHaveBeenCalledWith(
+        'test-file.txt',
+        expect.any(ReadStream),
+        expect.objectContaining({ access: 'private' })
+      );
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:pathToFile',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:access',
+          value: 'private',
+        },
+      ]);
+    });
+
     it('should handle --multipart flag (enabled by default)', async () => {
       const testFile = getFixturePath('test-file.txt');
       const exitCode = await put(client, ['--multipart', testFile], testToken);

--- a/packages/cli/test/unit/commands/blob/put.test.ts
+++ b/packages/cli/test/unit/commands/blob/put.test.ts
@@ -39,6 +39,7 @@ describe('blob put', () => {
       pathname: 'uploaded-file.txt',
       contentType: 'text/plain',
       contentDisposition: 'attachment; filename="uploaded-file.txt"',
+      etag: 'test-etag',
     });
   });
 

--- a/packages/cli/test/unit/commands/blob/store-add.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-add.test.ts
@@ -64,7 +64,11 @@ describe('blob store add', () => {
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'my-test-store', region: 'iad1' }),
+        body: JSON.stringify({
+          name: 'my-test-store',
+          region: 'iad1',
+          access: 'public',
+        }),
         accountId: 'org_123',
       });
       expect(mockedOutput.debug).toHaveBeenCalledWith(
@@ -109,7 +113,11 @@ describe('blob store add', () => {
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'my-test-store', region: 'sfo1' }),
+        body: JSON.stringify({
+          name: 'my-test-store',
+          region: 'sfo1',
+          access: 'public',
+        }),
         accountId: 'org_123',
       });
       expect(mockedOutput.success).toHaveBeenCalledWith(
@@ -137,7 +145,11 @@ describe('blob store add', () => {
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'default-region-store', region: 'iad1' }),
+        body: JSON.stringify({
+          name: 'default-region-store',
+          region: 'iad1',
+          access: 'public',
+        }),
         accountId: 'org_123',
       });
 
@@ -176,7 +188,11 @@ describe('blob store add', () => {
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'test-store-name', region: 'iad1' }),
+        body: JSON.stringify({
+          name: 'test-store-name',
+          region: 'iad1',
+          access: 'public',
+        }),
         accountId: 'org_123',
       });
     });
@@ -256,7 +272,11 @@ describe('blob store add', () => {
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'standalone-store', region: 'iad1' }),
+        body: JSON.stringify({
+          name: 'standalone-store',
+          region: 'iad1',
+          access: 'public',
+        }),
         accountId: undefined,
       });
       expect(client.input.confirm).not.toHaveBeenCalled();
@@ -361,7 +381,11 @@ describe('blob store add', () => {
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'linked-store', region: 'iad1' }),
+        body: JSON.stringify({
+          name: 'linked-store',
+          region: 'iad1',
+          access: 'public',
+        }),
         accountId: 'org_123',
       });
     });
@@ -379,7 +403,11 @@ describe('blob store add', () => {
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'unlinked-store', region: 'iad1' }),
+        body: JSON.stringify({
+          name: 'unlinked-store',
+          region: 'iad1',
+          access: 'public',
+        }),
         accountId: undefined,
       });
     });

--- a/packages/cli/test/unit/commands/blob/store-get.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-get.test.ts
@@ -182,7 +182,7 @@ describe('blob store get', () => {
       expect(exitCode).toBe(0);
       expect(mockedOutput.print).toHaveBeenCalledWith(
         expect.stringContaining(
-          'Blob Store: Display Test Store (store_display_test_123)\nBilling State: Active\nSize: 2MB\nCreated At: 2022-01-01T00:00:00.000Z\nUpdated At: 2023-01-01T00:00:00.000Z'
+          'Blob Store: Display Test Store (store_display_test_123)\nBilling State: Active\nSize: 2MB\nAccess: Public\nCreated At: 2022-01-01T00:00:00.000Z\nUpdated At: 2023-01-01T00:00:00.000Z'
         )
       );
       expect(formatSpy).toHaveBeenCalledWith(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,8 +433,8 @@ importers:
         specifier: workspace:*
         version: link:../backends
       '@vercel/blob':
-        specifier: 1.0.2
-        version: 1.0.2
+        specifier: 2.3.0-cc8f7be-20260217140255
+        version: 2.3.0-cc8f7be-20260217140255
       '@vercel/build-utils':
         specifier: workspace:*
         version: link:../build-utils
@@ -10125,15 +10125,15 @@ packages:
       - supports-color
     dev: true
 
-  /@vercel/blob@1.0.2:
-    resolution: {integrity: sha512-Im/KeFH4oPx7UsM+QiteimnE07bIUD7JK6CBafI9Z0jRFogaialTBMiZj8EKk/30ctUYsrpIIyP9iIY1YxWnUQ==}
-    engines: {node: '>=16.14'}
+  /@vercel/blob@2.3.0-cc8f7be-20260217140255:
+    resolution: {integrity: sha512-VJioq3lwcz09K+XpALFiMHbUs75Irthv+DBU+9wQKUpMwun8JDkW7TzOLNtH8fTJphehmRtrh4LGvqMLrHw2vQ==}
+    engines: {node: '>=20.0.0'}
     dependencies:
       async-retry: 1.3.3
       is-buffer: 2.0.5
       is-node-process: 1.2.0
       throttleit: 2.1.0
-      undici: 5.28.4
+      undici: 6.23.0
     dev: false
 
   /@vercel/fun@1.3.0:
@@ -20592,6 +20592,11 @@ packages:
     resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
     engines: {node: '>=18.17'}
     dev: true
+
+  /undici@6.23.0:
+    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
+    engines: {node: '>=18.17'}
+    dev: false
 
   /undici@7.22.0:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,8 +433,8 @@ importers:
         specifier: workspace:*
         version: link:../backends
       '@vercel/blob':
-        specifier: 2.3.0-cc8f7be-20260217140255
-        version: 2.3.0-cc8f7be-20260217140255
+        specifier: 2.3.0
+        version: 2.3.0
       '@vercel/build-utils':
         specifier: workspace:*
         version: link:../build-utils
@@ -10125,8 +10125,8 @@ packages:
       - supports-color
     dev: true
 
-  /@vercel/blob@2.3.0-cc8f7be-20260217140255:
-    resolution: {integrity: sha512-VJioq3lwcz09K+XpALFiMHbUs75Irthv+DBU+9wQKUpMwun8JDkW7TzOLNtH8fTJphehmRtrh4LGvqMLrHw2vQ==}
+  /@vercel/blob@2.3.0:
+    resolution: {integrity: sha512-oYWiJbWRQ7gz9Mj0X/NHFJ3OcLMOBzq/2b3j6zeNrQmtFo6dHwU8FAwNpxVIYddVMd+g8eqEi7iRueYx8FtM0Q==}
     engines: {node: '>=20.0.0'}
     dependencies:
       async-retry: 1.3.3


### PR DESCRIPTION
## Summary

- New `blob get` command that downloads blobs by URL or pathname — streams content to stdout by default (pipeable), supports `--output` flag to save to file
- `--access` flag (`public` | `private`) on `put`, `copy`, `get`, and `create-store` commands — defaults to `public` for backward compatibility
- Display `Access: Public/Private` in `get-store` output
- Bump `@vercel/blob` to `2.3.0-cc8f7be-20260217140255` prerelease with private storage SDK support (`get()` method, `access: 'private'`)
- Shared `parseAccessFlag()` helper in `src/util/blob/access.ts`

Replaces #14614 with a clean implementation addressing review feedback:
- `--access` defaults to `public` (no breaking change to existing `vercel blob put file.txt` workflows)
- `blob get` streams content to stdout instead of only printing metadata
- `parseAccessFlag()` helper is shared, not duplicated across files
- Proper type import instead of type assertion hack

## Test plan

- [x] All existing blob tests pass (`npx vitest run packages/cli/test/unit/commands/blob/`)
- [x] New tests for `blob get` command (stdout streaming, `--output` file save, `--access private`, error cases, telemetry)
- [x] Updated `create-store` test assertions to include `access` in request body
- [ ] Manual testing with a real store:
  - `vercel blob put test-file.txt` (backward compat, no --access)
  - `vercel blob put test-file.txt --access private`
  - `vercel blob get test-file.txt --access private`
  - `vercel blob get test-file.txt --access private --output ./downloaded.txt`
  - `vercel blob get test-file.txt --access private | head -c 100`
  - `vercel blob create-store my-store --access private`
  - `vercel blob get-store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds new CLI commands and options for private blob storage support with a major dependency bump, but defaults to 'public' access for backward compatibility and adds proper validation.
> 
> - Major version bump of @vercel/blob from 1.0.2 to 2.3.0 prerelease
> - New `blob get` command and `--access` flag across multiple subcommands
> - Access flag defaults to 'public' with validation via parseAccessFlag helper
>
> <sup>Risk assessment for [commit 2f8ab76](https://github.com/vercel/vercel/commit/2f8ab76edc03626c597bd115dc30cda3981188be).</sup>
<!-- VADE_RISK_END -->