### PR TITLE
[CLI] feat: non-interactive, allow scope arg

### DIFF
--- a/.changeset/wild-hotels-collect.md
+++ b/.changeset/wild-hotels-collect.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+non-interactive mode should allow scope argument

--- a/packages/cli/src/util/input/select-org.ts
+++ b/packages/cli/src/util/input/select-org.ts
@@ -11,6 +11,27 @@ import {
 
 type Choice = { name: string; value: Org };
 
+function getScopeOrTeamFromArgv(argv: string[]): string | null {
+  const args = argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--scope' || arg === '--team' || arg === '-S' || arg === '-T') {
+      const next = args[i + 1];
+      if (typeof next === 'string' && !next.startsWith('-')) {
+        return next;
+      }
+      continue;
+    }
+    if (arg.startsWith('--scope=')) {
+      return arg.slice('--scope='.length);
+    }
+    if (arg.startsWith('--team=')) {
+      return arg.slice('--team='.length);
+    }
+  }
+  return null;
+}
+
 export default async function selectOrg(
   client: Client,
   question: string,
@@ -54,12 +75,21 @@ export default async function selectOrg(
     0
   );
 
-  // Non-interactive: if user already passed --scope/--team (currentTeam set), use it; otherwise output choices and exit
+  // Non-interactive: if user already passed --scope/--team (currentTeam set or via argv), use it; otherwise output choices and exit
   if (client.nonInteractive) {
     if (currentTeam) {
       const match = choices.find(c => c.value.id === currentTeam);
       if (match) return match.value;
     }
+
+    const explicitScope = getScopeOrTeamFromArgv(client.argv);
+    if (explicitScope) {
+      const match = choices.find(
+        c => c.value.id === explicitScope || c.value.slug === explicitScope
+      );
+      if (match) return match.value;
+    }
+
     const actionRequired: ActionRequiredPayload = {
       status: 'action_required',
       reason: 'missing_scope',

--- a/packages/cli/test/unit/util/input/select-org.test.ts
+++ b/packages/cli/test/unit/util/input/select-org.test.ts
@@ -139,6 +139,30 @@ describe('selectOrg', () => {
       logSpy.mockRestore();
     });
 
+    it('returns org when --scope flag is present in argv (non-interactive, no currentTeam)', async () => {
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: number) => {
+          throw new Error(`process.exit(${code})`);
+        });
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      client.setArgv('deploy', '--scope', firstTeam.slug);
+
+      const result = await selectOrg(client, 'Which scope?', false);
+      expect(result).toEqual({
+        type: 'team',
+        id: firstTeam.id,
+        slug: firstTeam.slug,
+      });
+
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
+    });
+
     it('outputs action_required and exits even with single scope (no defaulting)', async () => {
       // Single team only (northstar user + one team)
       user = useUser({ version: 'northstar' });


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new code path in non-interactive mode that allows scope/team selection via argv parsing, which is a feature addition that still validates against existing choices rather than bypassing authorization.
> 
> - Adds `getScopeOrTeamFromArgv` helper to parse --scope/--team flags from argv
> - Extends non-interactive flow to match explicit scope against valid choices list
> - Includes unit test for new --scope flag behavior
>
> <sup>Risk assessment for [commit fcd789e](https://github.com/vercel/vercel/commit/fcd789eb5f022104be1439367c447379c2f542c0).</sup>
<!-- VADE_RISK_END -->