### PR TITLE
fix(cli): use namespaced vc.builder span attributes for Datadog

### DIFF
--- a/.changeset/namespaced-builder-span-attributes.md
+++ b/.changeset/namespaced-builder-span-attributes.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Use namespaced vc.builder span attributes (builder.name, builder.version, builder.dynamicallyInstalled) so they appear correctly in Datadog and don't conflict with reserved `version` tag

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -830,9 +830,11 @@ async function doBuild(
       }
 
       const builderSpan = span.child('vc.builder', {
-        name: builderPkg.name,
-        version: builderPkg.version,
-        dynamicallyInstalled: String(builderWithPkg.dynamicallyInstalled),
+        'builder.name': builderPkg.name,
+        'builder.version': builderPkg.version,
+        'builder.dynamicallyInstalled': String(
+          builderWithPkg.dynamicallyInstalled
+        ),
       });
 
       const serviceRoutePrefix = build.config?.routePrefix;


### PR DESCRIPTION
Use `builder.name`, `builder.version`, and `builder.dynamicallyInstalled` on vc.builder spans so they show up in Datadog and don't conflict with the reserved `version` (service version) tag in Unified Service Tagging.

Made with [Cursor](https://cursor.com)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR renames span attribute keys from unprefixed names to namespaced versions (e.g., 'name' to 'builder.name') for Datadog compatibility, with no logic or security changes.
> 
> - Renames telemetry span attributes to use 'builder.' namespace prefix
> - Adds changeset documentation for the patch
>
> <sup>Risk assessment for [commit 3418fcc](https://github.com/vercel/vercel/commit/3418fcc0d3a766e91393f5726c282a17cd41783f).</sup>
<!-- VADE_RISK_END -->