### PR TITLE
Add allowedFunctionRegions route param

### DIFF
--- a/.changeset/add-allowed-function-regions.md
+++ b/.changeset/add-allowed-function-regions.md
@@ -1,0 +1,6 @@
+---
+'@vercel/routing-utils': patch
+'@vercel/config': patch
+---
+
+Add `allowedFunctionRegions` route field to restrict which regions a serverless function can execute in.

--- a/.changeset/add-allowed-function-regions.md
+++ b/.changeset/add-allowed-function-regions.md
@@ -1,6 +1,0 @@
----
-'@vercel/routing-utils': patch
-'@vercel/config': patch
----
-
-Add `allowedFunctionRegions` route field to restrict which regions a serverless function can execute in.

--- a/.changeset/quick-lobsters-own.md
+++ b/.changeset/quick-lobsters-own.md
@@ -1,0 +1,6 @@
+---
+'@vercel/routing-utils': patch
+'@vercel/config': patch
+---
+
+Adds a new allowedFunctionRegions routing parameter

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -349,6 +349,8 @@ export interface Route {
    * When false, caching is disabled for this rewrite.
    */
   respectOriginCacheControl?: boolean;
+  /** An array of region identifiers to restrict which regions a serverless function can execute in */
+  allowedFunctionRegions?: string[];
 }
 
 /**
@@ -534,6 +536,8 @@ export interface RewriteRule {
    * When false, caching is disabled for this rewrite.
    */
   respectOriginCacheControl?: boolean;
+  /** An array of region identifiers to restrict which regions a serverless function can execute in */
+  allowedFunctionRegions?: string[];
 }
 
 /**

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -259,6 +259,7 @@ export interface Rewrite {
   has?: Condition[];
   missing?: Condition[];
   respectOriginCacheControl?: boolean;
+  allowedFunctionRegions?: string[];
 }
 
 /**

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -478,6 +478,16 @@ export const routesSchema = {
               'When set to true (default), external rewrites will respect the Cache-Control header from the origin. When false, caching is disabled for this rewrite.',
             type: 'boolean',
           },
+          allowedFunctionRegions: {
+            description:
+              'An array of region identifiers to restrict which regions a serverless function can execute in.',
+            type: 'array',
+            maxItems: 64,
+            items: {
+              type: 'string',
+              maxLength: 32,
+            },
+          },
         },
       },
       {
@@ -541,6 +551,16 @@ export const rewritesSchema = {
         description:
           'When set to true (default), external rewrites will respect the Cache-Control header from the origin. When false, caching is disabled for this rewrite.',
         type: 'boolean',
+      },
+      allowedFunctionRegions: {
+        description:
+          'An array of region identifiers to restrict which regions a serverless function can execute in.',
+        type: 'array',
+        maxItems: 64,
+        items: {
+          type: 'string',
+          maxLength: 32,
+        },
       },
     },
   },

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -99,6 +99,7 @@ export type RouteWithSrc = {
    */
   middleware?: number;
   respectOriginCacheControl?: boolean;
+  allowedFunctionRegions?: string[];
 };
 
 export type RouteWithHandle = {
@@ -143,6 +144,7 @@ export interface Rewrite {
   statusCode?: number;
   env?: string[];
   respectOriginCacheControl?: boolean;
+  allowedFunctionRegions?: string[];
 }
 
 export interface Redirect {


### PR DESCRIPTION
## Add `allowedFunctionRegions` route field

Adds a new `allowedFunctionRegions` field to routes and rewrites that restricts which regions a serverless function can execute in.

### Usage

```json
{
  "src": "/api/eu/(.*)",
  "dest": "/api/$1",
  "allowedFunctionRegions": ["fra1", "cdg1"]
}
```

When specified, only regions in the intersection of `allowedFunctionRegions` and the function's `deployedTo` regions will be considered. This enables use cases like:

- Routing EU traffic to EU-only regions for data residency
- Forcing specific regions for compliance requirements

### Changes

- **@vercel/routing-utils**: Added `allowedFunctionRegions` to `RouteWithSrc` type, `Rewrite` interface, and corresponding JSON schemas
- **@vercel/config**: Added `allowedFunctionRegions` to `Route`, `RewriteRule`, and `Rewrite` interfaces
- Added tests for schema validation

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new optional `allowedFunctionRegions` field to routing types and schemas with proper validation constraints (maxItems: 64, maxLength: 32), which is a defensive feature addition that restricts function execution regions.
> 
> - New optional `allowedFunctionRegions` field added to Route, RewriteRule, and Rewrite interfaces
> - JSON schema validation added with maxItems: 64 and string maxLength: 32 constraints
> - Test coverage added for valid usage and error cases
>
> <sup>Risk assessment for [commit 6a89d80](https://github.com/vercel/vercel/commit/6a89d803d33fb44dd9f56dcf37d750fc6f154089).</sup>
<!-- VADE_RISK_END -->