### PR TITLE
[next]: fix segment routing to not collide with user-defined params

### DIFF
--- a/.changeset/fuzzy-planets-repeat.md
+++ b/.changeset/fuzzy-planets-repeat.md
@@ -2,4 +2,7 @@
 '@vercel/next': patch
 ---
 
-Avoid segment prefetch route token collisions for dynamic params that include `segment` (for example `[...segments]`) by remapping the internal segment suffix capture token before generating rewrite destinations.
+Avoid route token collisions for dynamic params that overlap with internal segment-cache capture names (for example `[...segments]`) by:
+
+- remapping the internal segment suffix capture token before generating prefetch segment rewrite destinations, and
+- normalizing conflicting `routeKeys` from `routes-manifest.json` before generating dynamic route rewrites and prerender `allowQuery` metadata.

--- a/.changeset/fuzzy-planets-repeat.md
+++ b/.changeset/fuzzy-planets-repeat.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Avoid segment prefetch route token collisions for dynamic params that include `segment` (for example `[...segments]`) by remapping the internal segment suffix capture token before generating rewrite destinations.

--- a/.changeset/fuzzy-planets-repeat.md
+++ b/.changeset/fuzzy-planets-repeat.md
@@ -5,4 +5,4 @@
 Avoid route token collisions for dynamic params that overlap with internal segment-cache capture names (for example `[...segments]`) by:
 
 - remapping the internal segment suffix capture token before generating prefetch segment rewrite destinations, and
-- normalizing conflicting `routeKeys` from `routes-manifest.json` before generating dynamic route rewrites and prerender `allowQuery` metadata.
+- preserving `routeKeys` from `routes-manifest.json` so Next.js receives the original dynamic param names.

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -364,181 +364,6 @@ type RoutesManifestV4 = Omit<RoutesManifestOld, 'dynamicRoutes' | 'version'> & {
 
 export type RoutesManifest = RoutesManifestV4 | RoutesManifestOld;
 
-const ROUTE_KEY_VALUE_SUFFIX = 'Param';
-const RESERVED_INTERNAL_ROUTE_PARAM_NAMES = new Set([
-  'path',
-  'segment',
-  'segments',
-  'segmentPath',
-  'rscSuffix',
-  'nxtSegmentSuffix',
-]);
-
-function shouldNormalizeRouteKeyValue(routeKeyValue: string): boolean {
-  if (!routeKeyValue.startsWith('nxtP')) {
-    return false;
-  }
-
-  return RESERVED_INTERNAL_ROUTE_PARAM_NAMES.has(routeKeyValue.slice(4));
-}
-
-function getRouteKeyRenames(
-  routeKeys?: Record<string, string>
-): Map<string, string> {
-  const routeKeyRenames = new Map<string, string>();
-
-  if (!routeKeys) {
-    return routeKeyRenames;
-  }
-
-  const usedRouteKeyValues = new Set(Object.values(routeKeys));
-
-  for (const routeKeyValue of Object.values(routeKeys)) {
-    if (!shouldNormalizeRouteKeyValue(routeKeyValue)) {
-      continue;
-    }
-
-    if (routeKeyRenames.has(routeKeyValue)) {
-      continue;
-    }
-
-    let normalizedRouteKeyValue = `${routeKeyValue}${ROUTE_KEY_VALUE_SUFFIX}`;
-    while (usedRouteKeyValues.has(normalizedRouteKeyValue)) {
-      normalizedRouteKeyValue += ROUTE_KEY_VALUE_SUFFIX;
-    }
-
-    routeKeyRenames.set(routeKeyValue, normalizedRouteKeyValue);
-    usedRouteKeyValues.add(normalizedRouteKeyValue);
-  }
-
-  return routeKeyRenames;
-}
-
-function applyRouteKeyRenamesToMap(
-  routeKeys: Record<string, string> | undefined,
-  routeKeyRenames: ReadonlyMap<string, string>
-): Record<string, string> | undefined {
-  if (!routeKeys || routeKeyRenames.size === 0) {
-    return routeKeys;
-  }
-
-  return Object.fromEntries(
-    Object.entries(routeKeys).map(([key, value]) => [
-      routeKeyRenames.get(key) ?? key,
-      routeKeyRenames.get(value) ?? value,
-    ])
-  );
-}
-
-function applyRouteKeyRenamesToString(
-  value: string | undefined,
-  routeKeyRenames: ReadonlyMap<string, string>
-): string | undefined {
-  if (!value || routeKeyRenames.size === 0) {
-    return value;
-  }
-
-  let normalizedValue = value;
-  for (const [routeKeyValue, normalizedRouteKeyValue] of routeKeyRenames) {
-    const escapedRouteKeyValue = escapeStringRegexp(routeKeyValue);
-
-    normalizedValue = normalizedValue
-      .replace(
-        new RegExp(`\\(\\?<${escapedRouteKeyValue}>`, 'g'),
-        `(?<${normalizedRouteKeyValue}>`
-      )
-      .replace(
-        new RegExp(`\\\\k<${escapedRouteKeyValue}>`, 'g'),
-        `\\k<${normalizedRouteKeyValue}>`
-      )
-      .replace(
-        new RegExp(`\\$${escapedRouteKeyValue}(?=[^a-zA-Z0-9_]|$)`, 'g'),
-        `$${normalizedRouteKeyValue}`
-      )
-      .replace(
-        new RegExp(`([?&])${escapedRouteKeyValue}(?==)`, 'g'),
-        `$1${normalizedRouteKeyValue}`
-      );
-  }
-
-  return normalizedValue;
-}
-
-function mergeRouteKeyRenames(
-  ...routeKeyRenamesList: ReadonlyMap<string, string>[]
-): Map<string, string> {
-  const mergedRouteKeyRenames = new Map<string, string>();
-  for (const routeKeyRenames of routeKeyRenamesList) {
-    for (const [key, value] of routeKeyRenames.entries()) {
-      mergedRouteKeyRenames.set(key, value);
-    }
-  }
-  return mergedRouteKeyRenames;
-}
-
-function normalizeRoutesManifestRouteKeys(routesManifest: RoutesManifest) {
-  for (const route of routesManifest.dynamicRoutes || []) {
-    if (!('routeKeys' in route)) {
-      continue;
-    }
-
-    const routeKeyRenames = getRouteKeyRenames(route.routeKeys);
-
-    route.routeKeys = applyRouteKeyRenamesToMap(
-      route.routeKeys,
-      routeKeyRenames
-    );
-    route.regex =
-      applyRouteKeyRenamesToString(route.regex, routeKeyRenames) || route.regex;
-    route.namedRegex =
-      applyRouteKeyRenamesToString(route.namedRegex, routeKeyRenames) ||
-      route.namedRegex;
-
-    for (const prefetchSegmentDataRoute of route.prefetchSegmentDataRoutes ||
-      []) {
-      const prefetchRouteKeyRenames = getRouteKeyRenames(
-        prefetchSegmentDataRoute.routeKeys
-      );
-      const allRouteKeyRenames = mergeRouteKeyRenames(
-        routeKeyRenames,
-        prefetchRouteKeyRenames
-      );
-
-      prefetchSegmentDataRoute.routeKeys = applyRouteKeyRenamesToMap(
-        prefetchSegmentDataRoute.routeKeys,
-        prefetchRouteKeyRenames
-      );
-      prefetchSegmentDataRoute.source =
-        applyRouteKeyRenamesToString(
-          prefetchSegmentDataRoute.source,
-          allRouteKeyRenames
-        ) || prefetchSegmentDataRoute.source;
-      prefetchSegmentDataRoute.destination =
-        applyRouteKeyRenamesToString(
-          prefetchSegmentDataRoute.destination,
-          allRouteKeyRenames
-        ) || prefetchSegmentDataRoute.destination;
-    }
-  }
-
-  for (const route of routesManifest.dataRoutes || []) {
-    const routeKeyRenames = getRouteKeyRenames(route.routeKeys);
-
-    route.routeKeys = applyRouteKeyRenamesToMap(
-      route.routeKeys,
-      routeKeyRenames
-    );
-    route.dataRouteRegex =
-      applyRouteKeyRenamesToString(route.dataRouteRegex, routeKeyRenames) ||
-      route.dataRouteRegex;
-    route.namedDataRouteRegex =
-      applyRouteKeyRenamesToString(
-        route.namedDataRouteRegex,
-        routeKeyRenames
-      ) || route.namedDataRouteRegex;
-  }
-}
-
 export async function getRoutesManifest(
   entryPath: string,
   outputDirectory: string,
@@ -588,7 +413,6 @@ export async function getRoutesManifest(
       delete route.namedRegex;
     }
   }
-  normalizeRoutesManifestRouteKeys(routesManifest);
 
   return routesManifest;
 }
@@ -618,19 +442,40 @@ function getDestinationForSegmentRoute(
 const PREFETCH_SEGMENT_SUFFIX_CAPTURE = 'segment';
 const PREFETCH_SEGMENT_SUFFIX_CAPTURE_SAFE = 'nxtSegmentSuffix';
 
+function getSafePrefetchSegmentSuffixCaptureName(
+  prefetchSegmentDataRoute: PrefetchSegmentDataRoute
+): string {
+  let name = PREFETCH_SEGMENT_SUFFIX_CAPTURE_SAFE;
+  let suffix = 0;
+
+  while (
+    prefetchSegmentDataRoute.source.includes(`(?<${name}>`) ||
+    prefetchSegmentDataRoute.source.includes(`\\k<${name}>`) ||
+    prefetchSegmentDataRoute.destination.includes(`$${name}`)
+  ) {
+    suffix += 1;
+    name = `${PREFETCH_SEGMENT_SUFFIX_CAPTURE_SAFE}${suffix}`;
+  }
+
+  return name;
+}
+
 function normalizePrefetchSegmentDataRoute(
   prefetchSegmentDataRoute: PrefetchSegmentDataRoute
 ): PrefetchSegmentDataRoute {
   // The runtime destination replacement for "$segment" can also match the
   // "$segment" prefix in literals like "$segments". Remap the capture name to
   // avoid accidental partial replacements.
+  const safeCaptureName = getSafePrefetchSegmentSuffixCaptureName(
+    prefetchSegmentDataRoute
+  );
   const source = prefetchSegmentDataRoute.source.replace(
     `(?<${PREFETCH_SEGMENT_SUFFIX_CAPTURE}>`,
-    `(?<${PREFETCH_SEGMENT_SUFFIX_CAPTURE_SAFE}>`
+    `(?<${safeCaptureName}>`
   );
   const destination = prefetchSegmentDataRoute.destination.replace(
     new RegExp(`\\$${PREFETCH_SEGMENT_SUFFIX_CAPTURE}(?=\\?|$)`),
-    `$${PREFETCH_SEGMENT_SUFFIX_CAPTURE_SAFE}`
+    `$${safeCaptureName}`
   );
 
   return {

--- a/packages/next/test/fixtures/00-app-dir-segment-cache/app/catch/[...segments]/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-segment-cache/app/catch/[...segments]/page.jsx
@@ -1,0 +1,8 @@
+export async function generateStaticParams() {
+  return [{ segments: ['foobar', 'one'] }];
+}
+
+export default async function Page({ params }) {
+  const { segments = [] } = await params;
+  return <div>Catch Result: {segments.join('/')}</div>;
+}

--- a/packages/next/test/fixtures/00-app-dir-segment-cache/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-segment-cache/index.test.js
@@ -1,12 +1,47 @@
 /* eslint-env jest */
 const path = require('path');
 const { deployAndTest } = require('../../utils');
+const fetch = require('../../../../../test/lib/deployment/fetch-retry');
+const { setTimeout } = require('timers/promises');
 
 const ctx = {};
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  beforeAll(async () => {
     const info = await deployAndTest(__dirname);
     Object.assign(ctx, info);
+  });
+
+  it('should cache prefetch segment routes for catch-all params named "segments"', async () => {
+    const assertCached = async (rsc, segmentPrefetchValue) => {
+      const prefetchUrl = `${ctx.deploymentUrl}/catch/foobar/one?_rsc=${rsc}`;
+      const headers = {
+        RSC: '1',
+        'Next-Router-Prefetch': '1',
+        'Next-Router-Segment-Prefetch': segmentPrefetchValue,
+      };
+
+      let secondCacheStatus;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const first = await fetch(prefetchUrl, { headers });
+        expect(first.status).toBe(200);
+
+        const second = await fetch(prefetchUrl, { headers });
+        expect(second.status).toBe(200);
+
+        secondCacheStatus = second.headers.get('x-vercel-cache');
+        if (secondCacheStatus && secondCacheStatus !== 'MISS') {
+          return;
+        }
+
+        await setTimeout(500 * (attempt + 1));
+      }
+
+      expect(secondCacheStatus).toBeTruthy();
+      expect(secondCacheStatus).not.toBe('MISS');
+    };
+
+    await assertCached('segcache1', '/catch/$c$segments');
+    await assertCached('segcache2', '/catch/$c$segments/__PAGE__');
   });
 });

--- a/packages/next/test/unit/dynamic-routes.test.ts
+++ b/packages/next/test/unit/dynamic-routes.test.ts
@@ -1,0 +1,85 @@
+import { getDynamicRoutes } from '../../src/utils';
+
+const prerenderManifest = {
+  fallbackRoutes: {},
+  blockingFallbackRoutes: {},
+  omittedRoutes: {},
+} as any;
+
+async function getPrefetchSegmentRoute({
+  page,
+  source,
+  destination,
+  routeKey,
+}: {
+  page: string;
+  source: string;
+  destination: string;
+  routeKey: string;
+}) {
+  const routes = await getDynamicRoutes({
+    entryPath: '/',
+    entryDirectory: '',
+    dynamicPages: [page],
+    routesManifest: {
+      version: 4,
+      dynamicRoutes: [
+        {
+          page,
+          regex: '^/catch/(.+?)(?:/)?$',
+          namedRegex: `^/catch/(?<${routeKey}>.+?)(?:/)?$`,
+          routeKeys: { [routeKey]: routeKey },
+          prefetchSegmentDataRoutes: [
+            {
+              source,
+              destination,
+              routeKeys: { [routeKey]: routeKey },
+            },
+          ],
+        },
+      ],
+    } as any,
+    isAppPPREnabled: true,
+    isAppClientSegmentCacheEnabled: true,
+    isAppClientParamParsingEnabled: true,
+    prerenderManifest,
+  });
+
+  const prefetchRoute = routes.find(route =>
+    route.src.includes('\\.segments/catch/')
+  );
+  expect(prefetchRoute).toBeDefined();
+  return prefetchRoute!;
+}
+
+describe('getDynamicRoutes', () => {
+  it('remaps the segment suffix capture for params named "segments"', async () => {
+    const route = await getPrefetchSegmentRoute({
+      page: '/catch/[...segments]',
+      routeKey: 'nxtPsegments',
+      source:
+        '^/catch/(?<nxtPsegments>.+?)\\.segments/catch/\\$c\\$segments(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$',
+      destination: '/catch/[...segments].segments/catch/$c$segments$segment',
+    });
+
+    expect(route.src).toContain('(?<nxtSegmentSuffix>');
+    expect(route.dest).toBe(
+      '/catch/[...segments].segments/catch/$c$segments$nxtSegmentSuffix?nxtPsegments=$nxtPsegments'
+    );
+  });
+
+  it('only remaps the trailing "$segment" token when a literal "$segment" is present', async () => {
+    const route = await getPrefetchSegmentRoute({
+      page: '/catch/[...segment]',
+      routeKey: 'nxtPsegment',
+      source:
+        '^/catch/(?<nxtPsegment>.+?)\\.segments/catch/\\$c\\$segment(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$',
+      destination: '/catch/[...segment].segments/catch/$c$segment$segment',
+    });
+
+    expect(route.src).toContain('\\$c\\$segment(?<nxtSegmentSuffix>');
+    expect(route.dest).toBe(
+      '/catch/[...segment].segments/catch/$c$segment$nxtSegmentSuffix?nxtPsegment=$nxtPsegment'
+    );
+  });
+});

--- a/packages/next/test/unit/dynamic-routes.test.ts
+++ b/packages/next/test/unit/dynamic-routes.test.ts
@@ -82,4 +82,19 @@ describe('getDynamicRoutes', () => {
       '/catch/[...segment].segments/catch/$c$segment$nxtSegmentSuffix?nxtPsegment=$nxtPsegment'
     );
   });
+
+  it('uses a unique internal segment suffix capture name when "nxtSegmentSuffix" already exists', async () => {
+    const route = await getPrefetchSegmentRoute({
+      page: '/catch/[...segments]',
+      routeKey: 'nxtSegmentSuffix',
+      source:
+        '^/catch/(?<nxtSegmentSuffix>.+?)\\.segments/catch/\\$c\\$segments(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$',
+      destination: '/catch/[...segments].segments/catch/$c$segments$segment',
+    });
+
+    expect(route.src).toContain('(?<nxtSegmentSuffix1>');
+    expect(route.dest).toBe(
+      '/catch/[...segments].segments/catch/$c$segments$nxtSegmentSuffix1?nxtSegmentSuffix=$nxtSegmentSuffix'
+    );
+  });
 });

--- a/packages/next/test/unit/routes-manifest.test.ts
+++ b/packages/next/test/unit/routes-manifest.test.ts
@@ -1,0 +1,146 @@
+import fs from 'fs-extra';
+import { getRoutesManifest } from '../../src/utils';
+import { genDir } from '../utils';
+
+describe('getRoutesManifest', () => {
+  it('normalizes route keys for params named "segments"', async () => {
+    const entryPath = await genDir({
+      '.next/routes-manifest.json': JSON.stringify(
+        {
+          version: 4,
+          pages404: true,
+          basePath: '',
+          redirects: [],
+          rewrites: {
+            beforeFiles: [],
+            afterFiles: [],
+            fallback: [],
+          },
+          staticRoutes: [],
+          dynamicRoutes: [
+            {
+              page: '/catch/[...segments]',
+              regex: '^/catch/(?<nxtPsegments>.+?)(?:/)?$',
+              namedRegex: '^/catch/(?<nxtPsegments>.+?)(?:/)?$',
+              routeKeys: {
+                nxtPsegments: 'nxtPsegments',
+              },
+              prefetchSegmentDataRoutes: [
+                {
+                  source:
+                    '^/catch/(?<nxtPsegments>.+?)\\.segments/catch/\\$c\\$segments(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$',
+                  destination:
+                    '/catch/[...segments].segments/catch/$c$segments$segment?nxtPsegments=$nxtPsegments',
+                  routeKeys: {
+                    nxtPsegments: 'nxtPsegments',
+                  },
+                },
+              ],
+            },
+          ],
+          dataRoutes: [
+            {
+              page: '/catch/[...segments]',
+              dataRouteRegex:
+                '^/_next/data/buildId/catch/(?<nxtPsegments>.+?)\\.json$',
+              namedDataRouteRegex:
+                '^/_next/data/buildId/catch/(?<nxtPsegments>.+?)\\.json$',
+              routeKeys: {
+                nxtPsegments: 'nxtPsegments',
+              },
+            },
+          ],
+        },
+        null,
+        2
+      ),
+    });
+
+    try {
+      const routesManifest = await getRoutesManifest(
+        entryPath,
+        '.next',
+        '15.0.0'
+      );
+
+      expect(routesManifest).toBeDefined();
+      const dynamicRoute = routesManifest!.dynamicRoutes[0] as any;
+      const prefetchSegmentDataRoute =
+        dynamicRoute.prefetchSegmentDataRoutes[0];
+      const dataRoute = routesManifest!.dataRoutes![0];
+
+      expect(dynamicRoute.routeKeys).toEqual({
+        nxtPsegmentsParam: 'nxtPsegmentsParam',
+      });
+      expect(dynamicRoute.regex).toContain('(?<nxtPsegmentsParam>');
+      expect(dynamicRoute.namedRegex).toContain('(?<nxtPsegmentsParam>');
+
+      expect(prefetchSegmentDataRoute.routeKeys).toEqual({
+        nxtPsegmentsParam: 'nxtPsegmentsParam',
+      });
+      expect(prefetchSegmentDataRoute.source).toContain(
+        '(?<nxtPsegmentsParam>'
+      );
+      expect(prefetchSegmentDataRoute.destination).toContain(
+        'nxtPsegmentsParam=$nxtPsegmentsParam'
+      );
+
+      expect(dataRoute.routeKeys).toEqual({
+        nxtPsegmentsParam: 'nxtPsegmentsParam',
+      });
+      expect(dataRoute.dataRouteRegex).toContain('(?<nxtPsegmentsParam>');
+      expect(dataRoute.namedDataRouteRegex).toContain('(?<nxtPsegmentsParam>');
+    } finally {
+      await fs.remove(entryPath);
+    }
+  });
+
+  it('does not normalize non-reserved route keys', async () => {
+    const entryPath = await genDir({
+      '.next/routes-manifest.json': JSON.stringify(
+        {
+          version: 4,
+          pages404: true,
+          basePath: '',
+          redirects: [],
+          rewrites: {
+            beforeFiles: [],
+            afterFiles: [],
+            fallback: [],
+          },
+          staticRoutes: [],
+          dynamicRoutes: [
+            {
+              page: '/blog/[slug]',
+              regex: '^/blog/(?<nxtPslug>.+?)(?:/)?$',
+              namedRegex: '^/blog/(?<nxtPslug>.+?)(?:/)?$',
+              routeKeys: {
+                nxtPslug: 'nxtPslug',
+              },
+            },
+          ],
+        },
+        null,
+        2
+      ),
+    });
+
+    try {
+      const routesManifest = await getRoutesManifest(
+        entryPath,
+        '.next',
+        '15.0.0'
+      );
+
+      expect(routesManifest).toBeDefined();
+      const dynamicRoute = routesManifest!.dynamicRoutes[0] as any;
+      expect(dynamicRoute.routeKeys).toEqual({
+        nxtPslug: 'nxtPslug',
+      });
+      expect(dynamicRoute.regex).toContain('(?<nxtPslug>');
+      expect(dynamicRoute.namedRegex).toContain('(?<nxtPslug>');
+    } finally {
+      await fs.remove(entryPath);
+    }
+  });
+});

--- a/packages/next/test/unit/routes-manifest.test.ts
+++ b/packages/next/test/unit/routes-manifest.test.ts
@@ -3,7 +3,7 @@ import { getRoutesManifest } from '../../src/utils';
 import { genDir } from '../utils';
 
 describe('getRoutesManifest', () => {
-  it('normalizes route keys for params named "segments"', async () => {
+  it('preserves route keys for params named "segments"', async () => {
     const entryPath = await genDir({
       '.next/routes-manifest.json': JSON.stringify(
         {
@@ -70,26 +70,24 @@ describe('getRoutesManifest', () => {
       const dataRoute = routesManifest!.dataRoutes![0];
 
       expect(dynamicRoute.routeKeys).toEqual({
-        nxtPsegmentsParam: 'nxtPsegmentsParam',
+        nxtPsegments: 'nxtPsegments',
       });
-      expect(dynamicRoute.regex).toContain('(?<nxtPsegmentsParam>');
-      expect(dynamicRoute.namedRegex).toContain('(?<nxtPsegmentsParam>');
+      expect(dynamicRoute.regex).toContain('(?<nxtPsegments>');
+      expect(dynamicRoute.namedRegex).toContain('(?<nxtPsegments>');
 
       expect(prefetchSegmentDataRoute.routeKeys).toEqual({
-        nxtPsegmentsParam: 'nxtPsegmentsParam',
+        nxtPsegments: 'nxtPsegments',
       });
-      expect(prefetchSegmentDataRoute.source).toContain(
-        '(?<nxtPsegmentsParam>'
-      );
+      expect(prefetchSegmentDataRoute.source).toContain('(?<nxtPsegments>');
       expect(prefetchSegmentDataRoute.destination).toContain(
-        'nxtPsegmentsParam=$nxtPsegmentsParam'
+        'nxtPsegments=$nxtPsegments'
       );
 
       expect(dataRoute.routeKeys).toEqual({
-        nxtPsegmentsParam: 'nxtPsegmentsParam',
+        nxtPsegments: 'nxtPsegments',
       });
-      expect(dataRoute.dataRouteRegex).toContain('(?<nxtPsegmentsParam>');
-      expect(dataRoute.namedDataRouteRegex).toContain('(?<nxtPsegmentsParam>');
+      expect(dataRoute.dataRouteRegex).toContain('(?<nxtPsegments>');
+      expect(dataRoute.namedDataRouteRegex).toContain('(?<nxtPsegments>');
     } finally {
       await fs.remove(entryPath);
     }


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds internal route token collision avoidance logic for Next.js segment routing, with no security, auth, or data integrity changes - purely routing normalization with comprehensive test coverage.
> 
> - Adds `normalizePrefetchSegmentDataRoute` function to remap internal capture token names to avoid collisions
> - Extracts `PrefetchSegmentDataRoute` type for reuse across routing utilities
> - Adds unit and integration tests for segment cache routing with catch-all params
>
> <sup>Risk assessment for [commit c4114bd](https://github.com/vercel/vercel/commit/c4114bd51bdb04fe587a261ffa80aee91434c4b1).</sup>
<!-- VADE_RISK_END -->