### PR TITLE
Move framework-helpers from build-utils to @vercel/frameworks.

### DIFF
--- a/.changeset/framework-helpers-to-frameworks.md
+++ b/.changeset/framework-helpers-to-frameworks.md
@@ -1,0 +1,6 @@
+---
+'@vercel/frameworks': minor
+'@vercel/build-utils': patch
+---
+
+Move framework-helpers from build-utils to @vercel/frameworks. Add Python framework checks (isPythonFramework, PYTHON_FRAMEWORKS, isRuntimeFramework). build-utils re-exports from @vercel/frameworks for backward compatibility.

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -19,6 +19,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@vercel/frameworks": "workspace:*",
     "@vercel/python-analysis": "workspace:*"
   },
   "devDependencies": {

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -156,6 +156,8 @@ export {
   PYTHON_FRAMEWORKS,
   PythonFramework,
   isPythonFramework,
-} from './framework-helpers';
+  isRuntimeFramework,
+  BuilderLike,
+} from '@vercel/frameworks';
 
 export * from './python';

--- a/packages/frameworks/src/framework-helpers.ts
+++ b/packages/frameworks/src/framework-helpers.ts
@@ -1,5 +1,3 @@
-import { Builder } from '.';
-
 /**
  * List of backend frameworks supported by the experimental backends feature
  */
@@ -13,6 +11,10 @@ export const BACKEND_FRAMEWORKS = [
   'elysia',
 ] as const;
 
+/**
+ * List of Python frameworks (for runtime inference and experimental features).
+ * Includes FastAPI, Flask, and the generic Python preset.
+ */
 export const PYTHON_FRAMEWORKS = [
   'fastapi',
   'flask',
@@ -44,20 +46,33 @@ export type BackendFramework = (typeof BACKEND_FRAMEWORKS)[number];
 export type PythonFramework = (typeof PYTHON_FRAMEWORKS)[number];
 
 /**
- * Checks if the given framework is a backend framework
+ * Checks if the given framework is a backend framework (Node.js)
  */
 export function isBackendFramework(
   framework: string | null | undefined
 ): framework is BackendFramework {
   if (!framework) return false;
+  if (isPythonFramework(framework)) return true;
   return BACKEND_FRAMEWORKS.includes(framework as BackendFramework);
 }
 
+/**
+ * Checks if the given framework is a Python framework (FastAPI, Flask, or generic Python)
+ */
 export function isPythonFramework(
   framework: string | null | undefined
 ): framework is (typeof PYTHON_FRAMEWORKS)[number] {
   if (!framework) return false;
   return PYTHON_FRAMEWORKS.includes(framework as PythonFramework);
+}
+
+/**
+ * Checks if the given framework is either a backend framework or a Python framework
+ */
+export function isRuntimeFramework(
+  framework: string | null | undefined
+): boolean {
+  return isBackendFramework(framework) || isPythonFramework(framework);
 }
 
 // Opt builds into experimental builder, but don't introspect the app
@@ -75,7 +90,14 @@ export function isExperimentalBackendsEnabled(): boolean {
   );
 }
 
-export function isBackendBuilder(builder: Builder | null | undefined): boolean {
+/** Builder-like object with at least a `use` property (e.g. from @vercel/build-utils Builder) */
+export interface BuilderLike {
+  use?: string;
+}
+
+export function isBackendBuilder(
+  builder: BuilderLike | null | undefined
+): boolean {
   if (!builder) return false;
   if (builder.use === UNIFIED_BACKEND_BUILDER) return true;
   const use = builder.use as (typeof BACKEND_BUILDERS)[number];

--- a/packages/frameworks/src/framework-helpers.ts
+++ b/packages/frameworks/src/framework-helpers.ts
@@ -52,7 +52,6 @@ export function isBackendFramework(
   framework: string | null | undefined
 ): framework is BackendFramework {
   if (!framework) return false;
-  if (isPythonFramework(framework)) return true;
   return BACKEND_FRAMEWORKS.includes(framework as BackendFramework);
 }
 

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -5,6 +5,7 @@ import { Framework } from './types';
 import { readConfigFile } from './read-config-file';
 
 export * from './types';
+export * from './framework-helpers';
 
 const { readdir, readFile, unlink } = promises;
 

--- a/packages/fs-detectors/src/services/utils.ts
+++ b/packages/fs-detectors/src/services/utils.ts
@@ -1,7 +1,4 @@
-import {
-  isBackendFramework,
-  isPythonFramework,
-} from '@vercel/build-utils/dist/framework-helpers';
+import { isBackendFramework, isPythonFramework } from '@vercel/frameworks';
 import type { DetectorFilesystem } from '../detectors/filesystem';
 import type {
   ServiceRuntime,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
 
   packages/build-utils:
     dependencies:
+      '@vercel/frameworks':
+        specifier: workspace:*
+        version: link:../frameworks
       '@vercel/python-analysis':
         specifier: workspace:*
         version: link:../python-analysis


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR moves framework-helpers code between packages and adds new utility functions for framework detection, with no changes to security, auth, or business logic.
> 
> - Relocates framework-helpers from build-utils to @vercel/frameworks package
> - Adds new isRuntimeFramework() utility combining backend and Python framework checks
> - Updates import paths in fs-detectors to use new package location
>
> <sup>Risk assessment for [commit 2222437](https://github.com/vercel/vercel/commit/22224378aa84b2d72e426ce0cf4e68b770bf6740).</sup>
<!-- VADE_RISK_END -->