### PR TITLE
Update to latest Next.js adapter version

### DIFF
--- a/.changeset/fuzzy-pigs-act.md
+++ b/.changeset/fuzzy-pigs-act.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Update to latest Next.js adapter version

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.6",
+    "@next-community/adapter-vercel": "0.0.1-beta.7",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1701,8 +1701,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.6
-        version: 0.0.1-beta.6(next@16.1.6)
+        specifier: 0.0.1-beta.7
+        version: 0.0.1-beta.7(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6289,8 +6289,8 @@ packages:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  /@next-community/adapter-vercel@0.0.1-beta.6(next@16.1.6):
-    resolution: {integrity: sha512-mVljfbDjqHnv7p/BEsKTbBVLQh1Qw0JfbbPiZeCH7zEWHbFRV/m8MQWAJPRq8ZJfm71aCY0EddGNKp3r8/VKhg==}
+  /@next-community/adapter-vercel@0.0.1-beta.7(next@16.1.6):
+    resolution: {integrity: sha512-IDzM2kL+OBRP7vzSppt88DqTblZhfyib7Z63dQlxP6WBRlwKMuTy5OGHPTTuC5O/Ios+0w23IQrujVFJiFztgQ==}
     engines: {node: '>= 20.6.0'}
     peerDependencies:
       next: '>= 16.1.1-canary.18'


### PR DESCRIPTION
Adds handling for workflows/queue config manifest

x-ref: https://github.com/nextjs/adapter-vercel/pull/27

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR is a minor patch version bump of a dev dependency from beta.6 to beta.7 with no code logic changes.
> 
> - Dev dependency bump: @next-community/adapter-vercel 0.0.1-beta.6 → 0.0.1-beta.7
> - Changeset file added for patch release
>
> <sup>Risk assessment for [commit abf8892](https://github.com/vercel/vercel/commit/abf889253a7b113fdb262a89c948cc6abf1a3041).</sup>
<!-- VADE_RISK_END -->