### PR TITLE
[services] service path prefix env vars

### DIFF
--- a/.changeset/selfish-teachers-tan.md
+++ b/.changeset/selfish-teachers-tan.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[services] inject `VERCEL_SERVICE_ROUTE_PREFIX` env vars

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -312,6 +312,7 @@ export class ServicesOrchestrator {
 
     if (service.routePrefix && service.routePrefix !== '/') {
       env.VERCEL_SERVICE_BASE_PATH = service.routePrefix;
+      env.VERCEL_SERVICE_ROUTE_PREFIX = service.routePrefix;
     }
 
     // Try to use builder's startDevServer if available

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -311,7 +311,6 @@ export class ServicesOrchestrator {
     );
 
     if (service.routePrefix && service.routePrefix !== '/') {
-      env.VERCEL_SERVICE_BASE_PATH = service.routePrefix;
       env.VERCEL_SERVICE_ROUTE_PREFIX = service.routePrefix;
     }
 


### PR DESCRIPTION
Injects `VERCEL_SERVICE_ROUTE_PREFIX` env vars

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new function to inject environment variables into Lambda functions and renames an existing env var, which are straightforward configuration changes with no security implications.
> 
> - Adds `injectServiceEnvVars` helper to set `VERCEL_SERVICE_ROUTE_PREFIX` on Lambda outputs
> - Renames env var from `VERCEL_SERVICE_BASE_PATH` to `VERCEL_SERVICE_ROUTE_PREFIX` in services-orchestrator
> - Passes `service` parameter through build result writers
>
> <sup>Risk assessment for [commit 877857b](https://github.com/vercel/vercel/commit/877857b31f804c2264e68b9389d8d177a6d14146).</sup>
<!-- VADE_RISK_END -->