### PR TITLE
Pass `v0` meta to project creation

### DIFF
--- a/.changeset/three-elephants-jog.md
+++ b/.changeset/three-elephants-jog.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Pass v0 meta to project creation

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -245,6 +245,9 @@ async function handleInitDeployment(
     );
   }
 
+  const cliMeta = parseMeta(parsedArguments.flags['--meta']);
+  const isV0 = cliMeta.v0 === 'true';
+
   const link = await ensureLink('deploy', client, cwd, {
     autoConfirm,
     setupMsg: 'Set up and deploy',
@@ -253,6 +256,7 @@ async function handleInitDeployment(
       nowConfig: localConfig,
       paths,
     }),
+    v0: isV0,
   });
   if (typeof link === 'number') {
     return link;
@@ -351,11 +355,7 @@ async function handleInitDeployment(
     }
   }
 
-  const meta = Object.assign(
-    {},
-    parseMeta(localConfig.meta),
-    parseMeta(parsedArguments.flags['--meta'])
-  );
+  const meta = Object.assign({}, parseMeta(localConfig.meta), cliMeta);
 
   const gitMetadata = await createGitMeta(cwd, project);
 
@@ -792,6 +792,9 @@ async function handleDefaultDeploy(
     );
   }
 
+  const cliMeta = parseMeta(parsedArguments.flags['--meta']);
+  const isV0 = cliMeta.v0 === 'true';
+
   const link = await ensureLink('deploy', client, cwd, {
     autoConfirm,
     setupMsg: 'Set up and deploy',
@@ -800,6 +803,7 @@ async function handleDefaultDeploy(
       nowConfig: localConfig,
       paths,
     }),
+    v0: isV0,
   });
   if (typeof link === 'number') {
     return link;
@@ -956,11 +960,7 @@ async function handleDefaultDeploy(
   }
 
   // #region Meta
-  const meta = Object.assign(
-    {},
-    parseMeta(localConfig.meta),
-    parseMeta(parsedArguments.flags['--meta'])
-  );
+  const meta = Object.assign({}, parseMeta(localConfig.meta), cliMeta);
 
   const gitMetadata = await createGitMeta(cwd, project);
   // #endregion

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -60,6 +60,8 @@ export interface SetupAndLinkOptions {
   /** When true, avoid prompts and return action_required payload when scope/project choice is needed */
   nonInteractive?: boolean;
   pullEnv?: boolean;
+  /** When true, indicates the project is being created from v0 (grants V0Builder permissions) */
+  v0?: boolean;
 }
 
 export default async function setupAndLink(
@@ -74,6 +76,7 @@ export default async function setupAndLink(
     projectName = basename(path),
     nonInteractive = false,
     pullEnv = true,
+    v0,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
   const { config } = client;
@@ -267,6 +270,7 @@ export default async function setupAndLink(
       ...settings,
       name: newProjectName,
       vercelAuth: vercelAuthSetting,
+      v0,
     });
 
     await linkFolderToProject(

--- a/packages/cli/src/util/projects/create-project.ts
+++ b/packages/cli/src/util/projects/create-project.ts
@@ -3,9 +3,13 @@ import type { Project, ProjectSettings } from '@vercel-internals/types';
 
 export default async function createProject(
   client: Client,
-  settings: ProjectSettings & { name: string; vercelAuth?: 'none' | 'standard' }
+  settings: ProjectSettings & {
+    name: string;
+    vercelAuth?: 'none' | 'standard';
+    v0?: boolean;
+  }
 ) {
-  const { vercelAuth, ...rest } = settings;
+  const { vercelAuth, v0, ...rest } = settings;
   const project = await client.fetch<Project>('/v1/projects', {
     method: 'POST',
     body: {
@@ -15,6 +19,7 @@ export default async function createProject(
        * vercelAuth used to be called ssoProtection.
        */
       ...(vercelAuth === 'none' ? { ssoProtection: null } : undefined),
+      ...(v0 ? { v0: true } : undefined),
     },
   });
   return project;


### PR DESCRIPTION
This param getting set on the project is required to enable [v0 roles](https://v0.app/docs/enterprise#choosing-the-right-role) for users, so that they can manage the project (deploy, link git repo, set env vars, etc) even if they don't have a sufficient Vercel role.


<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR adds a new `v0` parameter that grants V0Builder permissions during project creation, which is a permission/authorization change that could affect who can manage projects.
> 
> - Adds `v0` flag to project creation API that grants V0Builder permissions
> - New permission path controlled by CLI `--meta v0=true` flag
> - Propagates v0 flag through ensureLink → setupAndLink → createProject
>
> <sup>Risk assessment for [commit 8838ba6](https://github.com/vercel/vercel/commit/8838ba64e95d57476fede5c294252f347c61e150).</sup>
<!-- VADE_RISK_END -->