### PR TITLE
[services] strip services route prefix in ruby runtime

### DIFF
--- a/.changeset/lucky-jeans-drum.md
+++ b/.changeset/lucky-jeans-drum.md
@@ -1,0 +1,6 @@
+---
+"@vercel/fs-detectors": patch
+"@vercel/ruby": patch
+---
+
+[services] strip services route prefix in ruby runtime by mounting the app at `SCRIPT_NAME` when service route prefix is auto configured

--- a/packages/fs-detectors/src/services/auto-detect.ts
+++ b/packages/fs-detectors/src/services/auto-detect.ts
@@ -19,6 +19,12 @@ const BACKEND_DIR = 'backend';
 const SERVICES_DIR = 'services';
 
 const FRONTEND_LOCATIONS = [FRONTEND_DIR, APPS_WEB_DIR];
+// Runtime frameworks, e.g. Python, Node, Ruby, etc. are currently marked experimental,
+// but service auto-detection should still consider them.
+const DETECTION_FRAMEWORKS = frameworkList.filter(
+  (framework: Framework) =>
+    !framework.experimental || framework.runtimeFramework
+);
 
 /**
  * Auto-detect services when experimentalServices is not configured.
@@ -268,7 +274,8 @@ async function detectServiceInDir(
   const serviceFs = fs.chdir(dirPath);
   const frameworks = await detectFrameworks({
     fs: serviceFs,
-    frameworkList,
+    frameworkList: DETECTION_FRAMEWORKS,
+    useExperimentalFrameworks: true,
   });
 
   if (frameworks.length > 1) {

--- a/packages/fs-detectors/src/services/utils.ts
+++ b/packages/fs-detectors/src/services/utils.ts
@@ -65,9 +65,10 @@ export function isRouteOwningBuilder(service: ResolvedService): boolean {
  *
  * Priority (highest to lowest):
  * 1. Explicit runtime (user specified in config)
- * 2. Framework detection (fastapi → python, express → node)
- * 3. Builder detection (@vercel/python → python)
- * 4. Entrypoint extension (.py → python, .ts → node)
+ * 2. Runtime framework slug (ruby → ruby, go → go)
+ * 3. Framework detection (fastapi → python, express → node)
+ * 4. Builder detection (@vercel/python → python)
+ * 5. Entrypoint extension (.py → python, .ts → node)
  *
  * @returns The inferred runtime, or undefined if none can be determined.
  */
@@ -80,6 +81,11 @@ export function inferServiceRuntime(config: {
   // Explicit runtime takes priority
   if (config.runtime && config.runtime in RUNTIME_BUILDERS) {
     return config.runtime as ServiceRuntime;
+  }
+
+  // Runtime framework slug maps directly to runtime name.
+  if (config.framework && config.framework in RUNTIME_BUILDERS) {
+    return config.framework as ServiceRuntime;
   }
 
   // Infer from framework

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/.gitignore
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/.gitignore
@@ -1,0 +1,7 @@
+.vercel
+
+node_modules
+.next
+
+backend/vendor
+backend/.bundle

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/backend/Gemfile
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/backend/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'sinatra', '~> 4.0'
+gem 'rack', '~> 3.0'
+gem 'rackup', '~> 2.0'

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/backend/app.rb
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/backend/app.rb
@@ -1,0 +1,20 @@
+require 'sinatra'
+require 'json'
+
+set :show_exceptions, false
+
+get '/' do
+  content_type :json
+  JSON.generate(message: 'Hello from Sinatra')
+end
+
+get '/health' do
+  content_type :json
+  JSON.generate(status: 'ok')
+end
+
+not_found do
+  content_type :json
+  status 404
+  JSON.generate(detail: '404 from Sinatra')
+end

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/backend/config.ru
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/backend/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/api/route.js
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/api/route.js
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ message: 'Hello from Next API' });
+}

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/backend-from-env/page.js
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/backend-from-env/page.js
@@ -1,0 +1,19 @@
+export const dynamic = 'force-dynamic';
+
+export default async function BackendFromEnvPage() {
+  const serviceUrl = process.env.BACKEND_URL;
+
+  let response = 'backend-status:missing';
+
+  if (serviceUrl) {
+    try {
+      const res = await fetch(`${serviceUrl}/health`, { cache: 'no-store' });
+      const body = await res.json();
+      response = `backend-status:${body.status || 'unknown'}`;
+    } catch {
+      response = 'backend-status:error';
+    }
+  }
+
+  return `service-url:${serviceUrl || 'missing'} ${response}`;
+}

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/layout.js
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/not-found.js
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return '404 from Next.js';
+}

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/page.js
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'Hello from Next.js';
+}

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "scripts": {
+    "vercel-build": "next build"
+  }
+}

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/probes.json
@@ -1,0 +1,64 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "Hello from Next.js"
+    },
+    {
+      "path": "/api",
+      "status": 200,
+      "mustContain": "Hello from Next API"
+    },
+    {
+      "path": "/_/backend",
+      "status": 200,
+      "mustContain": "Hello from Sinatra"
+    },
+    {
+      "path": "/_/backend/health",
+      "status": 200,
+      "mustContain": "ok"
+    },
+    {
+      "path": "/backend-from-env",
+      "status": 200,
+      "mustContain": "backend-status:ok"
+    },
+    {
+      "path": "/backend-from-env",
+      "status": 200,
+      "mustContain": "service-url:https://"
+    },
+    {
+      "path": "/backend-from-env",
+      "status": 200,
+      "mustContain": "/_/backend"
+    },
+    {
+      "path": "/does-not-exist",
+      "status": 404,
+      "mustContain": "404 from Next.js"
+    },
+    {
+      "path": "/api/does-not-exist",
+      "status": 404,
+      "mustContain": "404 from Next.js"
+    },
+    {
+      "path": "/_/backend/does-not-exist",
+      "status": 404,
+      "mustContain": "404 from Sinatra"
+    },
+    {
+      "path": "/backend",
+      "status": 404,
+      "mustContain": "404 from Next.js"
+    },
+    {
+      "path": "/backend/index",
+      "status": 404,
+      "mustContain": "404 from Next.js"
+    }
+  ]
+}

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/vercel.json
@@ -1,0 +1,6 @@
+{
+  "uploadNowJson": true,
+  "projectSettings": {
+    "framework": "services"
+  }
+}

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -57,8 +57,17 @@ describe('detectServices', () => {
         name: 'backend',
         workspace: 'backend',
         framework: 'ruby',
+        runtime: 'ruby',
         routePrefix: '/_/backend',
         routePrefixSource: 'generated',
+      });
+
+      const backendRoute = findMatchingRoute(
+        result.routes.rewrites,
+        '/_/backend/ping'
+      );
+      expect(backendRoute).toMatchObject({
+        dest: '/_svc/backend/index',
       });
     });
   });

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -36,6 +36,31 @@ describe('detectServices', () => {
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0].code).toBe('NO_SERVICES_CONFIGURED');
     });
+
+    it('should auto-detect a Ruby backend service in backend/', async () => {
+      const fs = new VirtualFilesystem({
+        'frontend/package.json': JSON.stringify({
+          dependencies: {
+            next: '15.0.0',
+          },
+        }),
+        'backend/Gemfile': 'source "https://rubygems.org"',
+        'backend/config.ru': 'run Sinatra::Application',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(2);
+
+      const backend = result.services.find(s => s.name === 'backend');
+      expect(backend).toMatchObject({
+        name: 'backend',
+        workspace: 'backend',
+        framework: 'ruby',
+        routePrefix: '/_/backend',
+        routePrefixSource: 'generated',
+      });
+    });
   });
 
   describe('with vercel.json without experimentalServices', () => {

--- a/packages/ruby/package.json
+++ b/packages/ruby/package.json
@@ -8,7 +8,8 @@
   "files": [
     "dist",
     "vc_init.rb",
-    "vc_init_dev.rb"
+    "vc_init_dev.rb",
+    "vc_utils.rb"
   ],
   "repository": {
     "type": "git",

--- a/packages/ruby/src/index.ts
+++ b/packages/ruby/src/index.ts
@@ -261,7 +261,7 @@ export const build: BuildV3 = async ({
   // in order to allow the user to have `server.rb`, we need our `server.rb` to be called
   // something else
   const handlerRbFilename = 'vc__handler__ruby';
-  const utilsRbFilename = 'vc_utils.rb';
+  const utilsRbFilename = 'vc__utils__ruby.rb';
 
   // Apply predefined default excludes similar to Python runtime
   const predefinedExcludes = [

--- a/packages/ruby/src/index.ts
+++ b/packages/ruby/src/index.ts
@@ -246,6 +246,8 @@ export const build: BuildV3 = async ({
 
   const originalRbPath = join(__dirname, '..', 'vc_init.rb');
   const originalHandlerRbContents = await readFile(originalRbPath, 'utf8');
+  const originalUtilsRbPath = join(__dirname, '..', 'vc_utils.rb');
+  const originalUtilsRbContents = await readFile(originalUtilsRbPath, 'utf8');
 
   // will be used on `require_relative '$here'` or for loading rack config.ru file
   // for example, `require_relative 'api/users'`
@@ -259,6 +261,7 @@ export const build: BuildV3 = async ({
   // in order to allow the user to have `server.rb`, we need our `server.rb` to be called
   // something else
   const handlerRbFilename = 'vc__handler__ruby';
+  const utilsRbFilename = 'vc_utils.rb';
 
   // Apply predefined default excludes similar to Python runtime
   const predefinedExcludes = [
@@ -281,6 +284,9 @@ export const build: BuildV3 = async ({
   outputFiles[`${handlerRbFilename}.rb`] = new FileBlob({
     data: nowHandlerRbContents,
   });
+  outputFiles[utilsRbFilename] = new FileBlob({
+    data: originalUtilsRbContents,
+  });
 
   // static analysis is impossible with ruby.
   // instead, provide `includeFiles` and `excludeFiles` config options to reduce bundle size.
@@ -298,7 +304,10 @@ export const build: BuildV3 = async ({
       }
 
       // whitelist handler
-      if (excludedPaths[i] === `${handlerRbFilename}.rb`) {
+      if (
+        excludedPaths[i] === `${handlerRbFilename}.rb` ||
+        excludedPaths[i] === utilsRbFilename
+      ) {
         continue;
       }
 

--- a/packages/ruby/src/start-dev-server.ts
+++ b/packages/ruby/src/start-dev-server.ts
@@ -106,7 +106,7 @@ function createDevRubyShim(
     const vercelRubyDir = join(workPath, '.vercel', 'ruby');
     mkdirSync(vercelRubyDir, { recursive: true });
     const shimPath = join(vercelRubyDir, `vc_init_dev.rb`);
-    const utilsPath = join(vercelRubyDir, 'vc_utils.rb');
+    const utilsPath = join(vercelRubyDir, 'vc__utils__ruby.rb');
     const templatePath = join(__dirname, '..', 'vc_init_dev.rb');
     const utilsTemplatePath = join(__dirname, '..', 'vc_utils.rb');
     const template = readFileSync(templatePath, 'utf8');

--- a/packages/ruby/src/start-dev-server.ts
+++ b/packages/ruby/src/start-dev-server.ts
@@ -106,10 +106,14 @@ function createDevRubyShim(
     const vercelRubyDir = join(workPath, '.vercel', 'ruby');
     mkdirSync(vercelRubyDir, { recursive: true });
     const shimPath = join(vercelRubyDir, `vc_init_dev.rb`);
+    const utilsPath = join(vercelRubyDir, 'vc_utils.rb');
     const templatePath = join(__dirname, '..', 'vc_init_dev.rb');
+    const utilsTemplatePath = join(__dirname, '..', 'vc_utils.rb');
     const template = readFileSync(templatePath, 'utf8');
+    const utilsTemplate = readFileSync(utilsTemplatePath, 'utf8');
     const shimSource = template.replace(/__VC_DEV_ENTRYPOINT__/g, entrypoint);
     writeFileSync(shimPath, shimSource, 'utf8');
+    writeFileSync(utilsPath, utilsTemplate, 'utf8');
     debug(`Prepared Ruby dev shim at ${shimPath}`);
     return shimPath;
   } catch (err: any) {

--- a/packages/ruby/vc_init.rb
+++ b/packages/ruby/vc_init.rb
@@ -3,7 +3,7 @@ require 'webrick'
 require 'net/http'
 require 'base64'
 require 'json'
-require_relative 'vc_utils'
+require_relative 'vc__utils__ruby'
 
 $entrypoint = '__VC_HANDLER_FILENAME'
 

--- a/packages/ruby/vc_init.rb
+++ b/packages/ruby/vc_init.rb
@@ -3,7 +3,7 @@ require 'webrick'
 require 'net/http'
 require 'base64'
 require 'json'
-require 'uri'
+require_relative 'vc_utils'
 
 $entrypoint = '__VC_HANDLER_FILENAME'
 
@@ -11,99 +11,8 @@ ENV['RAILS_ENV'] ||= 'production'
 ENV['RACK_ENV'] ||= 'production'
 ENV['RAILS_LOG_TO_STDOUT'] ||= '1'
 
-# Returns an empty string when unset/blank/root ("/"), otherwise:
-# - always starts with "/"
-# - has no trailing slash
-def normalize_service_route_prefix(raw_prefix)
-  return '' if raw_prefix.nil?
 
-  prefix = raw_prefix.strip
-  return '' if prefix.empty?
-
-  prefix = "/#{prefix}" unless prefix.start_with?('/')
-
-  if prefix != '/'
-    prefix = prefix.sub(%r{/+\z}, '')
-    prefix = '/' if prefix.empty?
-  end
-
-  prefix == '/' ? '' : prefix
-end
-
-def service_route_prefix_strip_enabled?
-  raw = ENV['VERCEL_SERVICE_ROUTE_PREFIX_STRIP']
-  return false if raw.nil? || raw.empty?
-
-  %w[1 true].include?(raw.downcase)
-end
-
-# Split an HTTP request-target into [path, query].
-#
-# Supports:
-# - origin-form: "/a/b?x=1"
-# - absolute-form: "https://example.com/a/b?x=1"
-# - asterisk-form: "*"
-def split_request_target(target)
-  return ['/', ''] if target.nil? || target.empty?
-
-  begin
-    parsed = URI.parse(target)
-    if parsed.scheme && parsed.host
-      path = parsed.path.nil? || parsed.path.empty? ? '/' : parsed.path
-      return [path, parsed.query.to_s]
-    end
-  rescue URI::InvalidURIError
-  end
-
-  return ['*', ''] if target == '*'
-
-  path, query = target.split('?', 2)
-  path = '/' if path.nil? || path.empty?
-  path = "/#{path}" unless path.start_with?('/')
-  [path, query.to_s]
-end
-
-# Strip the configured service route prefix from a request path.
-#
-# Returns:
-# - stripped path passed to the user app
-# - matched mount prefix (empty when no prefix matched)
-def strip_service_route_prefix(path)
-  return [path, ''] if path == '*'
-
-  normalized_path = path.nil? || path.empty? ? '/' : path
-  normalized_path = "/#{normalized_path}" unless normalized_path.start_with?('/')
-
-  prefix = $service_route_prefix
-  return [normalized_path, ''] if prefix.empty?
-
-  return ['/', prefix] if normalized_path == prefix
-
-  if normalized_path.start_with?("#{prefix}/")
-    stripped = normalized_path[prefix.length..]
-    return [stripped.nil? || stripped.empty? ? '/' : stripped, prefix]
-  end
-
-  [normalized_path, '']
-end
-
-# Apply service-prefix stripping to a full request-target.
-#
-# Returns:
-# - updated request-target (path + optional query)
-# - matched mount prefix for Rack SCRIPT_NAME (or "")
-def apply_service_route_prefix_to_target(target)
-  path, query = split_request_target(target)
-  path, script_name = strip_service_route_prefix(path)
-  updated = query.empty? ? path : "#{path}?#{query}"
-  [updated, script_name]
-end
-
-$service_route_prefix = if service_route_prefix_strip_enabled?
-  normalize_service_route_prefix(ENV['VERCEL_SERVICE_ROUTE_PREFIX'])
-else
-  ''
-end
+$service_route_prefix = resolve_service_route_prefix
 
 def rack_handler(httpMethod, path, body, headers, script_name = '')
   require 'rack'
@@ -192,7 +101,10 @@ def vc__handler(event:, context:)
     body = Base64.decode64(body)
   end
 
-  path, script_name = apply_service_route_prefix_to_target(path)
+  path, script_name = apply_service_route_prefix_to_target(
+    path,
+    $service_route_prefix
+  )
 
   if $entrypoint.end_with? '.ru'
     return rack_handler(httpMethod, path, body, headers, script_name)

--- a/packages/ruby/vc_init_dev.rb
+++ b/packages/ruby/vc_init_dev.rb
@@ -10,7 +10,7 @@ require 'rack'
 require 'rack/handler/webrick'
 require 'webrick'
 require 'socket'
-require_relative 'vc_utils'
+require_relative 'vc__utils__ruby'
 
 $stdout.sync = true
 $stderr.sync = true

--- a/packages/ruby/vc_init_dev.rb
+++ b/packages/ruby/vc_init_dev.rb
@@ -17,6 +17,52 @@ $stderr.sync = true
 USER_ENTRYPOINT = "__VC_DEV_ENTRYPOINT__"
 PUBLIC_DIR = 'public'
 
+def normalize_service_route_prefix(raw_prefix)
+  return '' if raw_prefix.nil?
+
+  prefix = raw_prefix.strip
+  return '' if prefix.empty?
+
+  prefix = "/#{prefix}" unless prefix.start_with?('/')
+
+  if prefix != '/'
+    prefix = prefix.sub(%r{/+\z}, '')
+    prefix = '/' if prefix.empty?
+  end
+
+  prefix == '/' ? '' : prefix
+end
+
+def service_route_prefix_strip_enabled?
+  raw = ENV['VERCEL_SERVICE_ROUTE_PREFIX_STRIP']
+  return false if raw.nil? || raw.empty?
+
+  %w[1 true].include?(raw.downcase)
+end
+
+SERVICE_ROUTE_PREFIX = if service_route_prefix_strip_enabled?
+  normalize_service_route_prefix(ENV['VERCEL_SERVICE_ROUTE_PREFIX'])
+else
+  ''
+end
+
+def strip_service_route_prefix(path_info)
+  normalized_path = path_info.nil? || path_info.empty? ? '/' : path_info
+  normalized_path = "/#{normalized_path}" unless normalized_path.start_with?('/')
+
+  prefix = SERVICE_ROUTE_PREFIX
+  return [normalized_path, ''] if prefix.empty?
+
+  return ['/', prefix] if normalized_path == prefix
+
+  if normalized_path.start_with?("#{prefix}/")
+    stripped = normalized_path[prefix.length..]
+    return [stripped.nil? || stripped.empty? ? '/' : stripped, prefix]
+  end
+
+  [normalized_path, '']
+end
+
 def build_user_app
   if USER_ENTRYPOINT.end_with?('.ru')
     app, _ = Rack::Builder.parse_file(USER_ENTRYPOINT)
@@ -36,17 +82,32 @@ class StaticThenApp
   end
 
   def call(env)
-    req_path = env['PATH_INFO'] || '/'
+    effective_env = env.dup
+    req_path, matched_prefix = strip_service_route_prefix(
+      effective_env['PATH_INFO'] || '/'
+    )
+    effective_env['PATH_INFO'] = req_path
+
+    unless matched_prefix.empty?
+      script_name = effective_env['SCRIPT_NAME'] || ''
+      if !script_name.empty? && script_name != '/'
+        script_name = script_name.sub(%r{/+\z}, '')
+      else
+        script_name = ''
+      end
+      effective_env['SCRIPT_NAME'] = "#{script_name}#{matched_prefix}"
+    end
+
     # Normalize path and guard against traversal
     safe = req_path.sub(/^\//, '')
     full = File.expand_path(safe, @base)
 
     if full.start_with?(@base + File::SEPARATOR) && File.file?(full)
       # Delegate to Rack::File which handles HEAD/GET correctly
-      return @file_server.call(env)
+      return @file_server.call(effective_env)
     end
 
-    @app.call(env)
+    @app.call(effective_env)
   end
 end
 

--- a/packages/ruby/vc_utils.rb
+++ b/packages/ruby/vc_utils.rb
@@ -1,0 +1,101 @@
+require 'uri'
+
+# Normalize a configured service prefix into canonical mount-path form.
+#
+# Returns an empty string when unset/blank/root ("/"), otherwise:
+# - always starts with "/"
+# - has no trailing slash
+def normalize_service_route_prefix(raw_prefix)
+  return '' if raw_prefix.nil?
+
+  prefix = raw_prefix.strip
+  return '' if prefix.empty?
+
+  prefix = "/#{prefix}" unless prefix.start_with?('/')
+
+  if prefix != '/'
+    prefix = prefix.sub(%r{/+\z}, '')
+    prefix = '/' if prefix.empty?
+  end
+
+  prefix == '/' ? '' : prefix
+end
+
+# Return whether service-prefix stripping is explicitly enabled.
+#
+# Stripping is gated behind a dedicated env var so manually configured
+# route prefixes can be preserved by default.
+def service_route_prefix_strip_enabled?
+  raw = ENV['VERCEL_SERVICE_ROUTE_PREFIX_STRIP']
+  return false if raw.nil? || raw.empty?
+
+  %w[1 true].include?(raw.downcase)
+end
+
+def resolve_service_route_prefix
+  return '' unless service_route_prefix_strip_enabled?
+
+  normalize_service_route_prefix(ENV['VERCEL_SERVICE_ROUTE_PREFIX'])
+end
+
+# Split an HTTP request-target into [path, query].
+#
+# Supports:
+# - origin-form: "/a/b?x=1"
+# - absolute-form: "https://example.com/a/b?x=1"
+# - asterisk-form: "*"
+def split_request_target(target)
+  return ['/', ''] if target.nil? || target.empty?
+
+  begin
+    parsed = URI.parse(target)
+    if parsed.scheme && parsed.host
+      path = parsed.path.nil? || parsed.path.empty? ? '/' : parsed.path
+      return [path, parsed.query.to_s]
+    end
+  rescue URI::InvalidURIError
+  end
+
+  return ['*', ''] if target == '*'
+
+  path, query = target.split('?', 2)
+  path = '/' if path.nil? || path.empty?
+  path = "/#{path}" unless path.start_with?('/')
+  [path, query.to_s]
+end
+
+# Strip the configured service route prefix from a request path.
+#
+# Returns:
+# - stripped path passed to the user app
+# - matched mount prefix (empty when no prefix matched)
+def strip_service_route_prefix(path, prefix)
+  return [path, ''] if path == '*'
+
+  normalized_path = path.nil? || path.empty? ? '/' : path
+  normalized_path = "/#{normalized_path}" unless normalized_path.start_with?('/')
+
+  normalized_prefix = prefix.to_s
+  return [normalized_path, ''] if normalized_prefix.empty?
+
+  return ['/', normalized_prefix] if normalized_path == normalized_prefix
+
+  if normalized_path.start_with?("#{normalized_prefix}/")
+    stripped = normalized_path[normalized_prefix.length..]
+    return [stripped.nil? || stripped.empty? ? '/' : stripped, normalized_prefix]
+  end
+
+  [normalized_path, '']
+end
+
+# Apply service-prefix stripping to a full request-target.
+#
+# Returns:
+# - updated request-target (path + optional query)
+# - matched mount prefix for Rack SCRIPT_NAME (or "")
+def apply_service_route_prefix_to_target(target, prefix)
+  path, query = split_request_target(target)
+  path, script_name = strip_service_route_prefix(path, prefix)
+  updated = query.empty? ? path : "#{path}?#{query}"
+  [updated, script_name]
+end


### PR DESCRIPTION
Strip service route prefix in ruby runtime by setting `SCRIPT_NAME` when services are auto-detected so app sees /ping instead of /_/backend/ping.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds Ruby runtime support for service route prefix stripping by setting SCRIPT_NAME, consisting of new utility functions, test fixtures, and framework detection changes with no security-sensitive modifications.
> 
> - Adds new `vc_utils.rb` with route prefix normalization/stripping helpers
> - Extends framework detection to include experimental runtime frameworks
> - Adds e2e test fixture for Ruby backend service auto-detection
>
> <sup>Risk assessment for [commit f00fb05](https://github.com/vercel/vercel/commit/f00fb055c45e4b0d4c36f3194c1adc4abd7c0c3d).</sup>
<!-- VADE_RISK_END -->