### PR TITLE
feat(cli): Flatten blob store commands, add --allow-overwrite and conditional headers

### DIFF
--- a/.changeset/blob-private-storage.md
+++ b/.changeset/blob-private-storage.md
@@ -4,7 +4,7 @@
 
 Add private Blob storage support:
 
-- Create private stores: `vercel blob store add my-store --access private`
+- Create private stores: `vercel blob create-store my-store --access private`
 - Upload to private stores: `vercel blob put file.txt --access private`
 - Download blobs with the new `blob get` command: `vercel blob get file.txt --access private` (works with both public and private stores)
 - Copy blobs: `vercel blob copy source.txt dest.txt --access private`

--- a/.changeset/flatten-blob-store-commands.md
+++ b/.changeset/flatten-blob-store-commands.md
@@ -1,0 +1,8 @@
+---
+'vercel': minor
+---
+
+Flatten blob store commands: `blob create-store`, `blob delete-store`, `blob get-store`.
+Rename `--force` to `--allow-overwrite`.
+Add conditional headers: `--if-match` for put/del/copy, `--if-none-match` for get.
+Old commands and options are deprecated but still work.

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -1,3 +1,23 @@
+const ifMatchOption = {
+  name: 'if-match',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+  description:
+    "Only perform the operation if the blob's ETag matches this value",
+  argument: 'STRING',
+} as const;
+
+const ifNoneMatchOption = {
+  name: 'if-none-match',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+  description:
+    "Only return content if the blob's ETag does not match this value (returns 304 if unchanged)",
+  argument: 'STRING',
+} as const;
+
 const accessOption = {
   name: 'access',
   shorthand: 'a',
@@ -109,13 +129,23 @@ export const putSubcommand = {
       argument: 'Number',
     },
     {
-      name: 'force',
-      shorthand: 'f',
+      name: 'allow-overwrite',
+      shorthand: null,
       type: Boolean,
       deprecated: false,
       description: 'Overwrite the file if it already exists (default: false)',
       argument: 'Boolean',
     },
+    {
+      name: 'force',
+      shorthand: 'f',
+      type: Boolean,
+      deprecated: true,
+      description:
+        'Overwrite the file if it already exists (deprecated, use --allow-overwrite)',
+      argument: 'Boolean',
+    },
+    ifMatchOption,
   ],
   examples: [],
 } as const;
@@ -130,7 +160,7 @@ export const delSubcommand = {
       required: true,
     },
   ],
-  options: [],
+  options: [ifMatchOption],
   examples: [],
 } as const;
 
@@ -176,6 +206,7 @@ export const copySubcommand = {
         'Max-age of the cache-control header directive (default: 2592000 = 30 days)',
       argument: 'Number',
     },
+    ifMatchOption,
   ],
   examples: [],
 } as const;
@@ -200,6 +231,7 @@ export const getSubcommand = {
       description: 'Save blob content to a file instead of stdout',
       argument: 'PATH',
     },
+    ifNoneMatchOption,
   ],
   examples: [],
 } as const;
@@ -270,6 +302,72 @@ export const getStoreSubcommand = {
   examples: [],
 } as const;
 
+export const createStoreSubcommand = {
+  name: 'create-store',
+  aliases: [],
+  description: 'Create a new Blob store',
+  arguments: [
+    {
+      name: 'name',
+      required: false,
+    },
+  ],
+  options: [
+    accessOption,
+    {
+      name: 'region',
+      shorthand: 'r',
+      type: String,
+      deprecated: false,
+      description:
+        'Region to create the Blob store in (default: "iad1"). See https://vercel.com/docs/edge-network/regions#region-list for all available regions',
+      argument: 'STRING',
+    },
+  ],
+  examples: [
+    {
+      name: 'Create a blob store (uses default region "iad1")',
+      value: 'vercel blob create-store my-store',
+    },
+    {
+      name: 'Create a blob store in a specific region',
+      value: 'vercel blob create-store my-store --region cdg1',
+    },
+    {
+      name: 'Create a private blob store',
+      value: 'vercel blob create-store my-private-store --access private',
+    },
+  ],
+} as const;
+
+export const deleteStoreSubcommand = {
+  name: 'delete-store',
+  aliases: [],
+  description: 'Delete a Blob store',
+  arguments: [
+    {
+      name: 'storeId',
+      required: false,
+    },
+  ],
+  options: [],
+  examples: [],
+} as const;
+
+export const getStoreInfoSubcommand = {
+  name: 'get-store',
+  aliases: [],
+  description: 'Get a Blob store',
+  arguments: [
+    {
+      name: 'storeId',
+      required: false,
+    },
+  ],
+  options: [],
+  examples: [],
+} as const;
+
 export const storeSubcommand = {
   name: 'store',
   aliases: [],
@@ -291,6 +389,9 @@ export const blobCommand = {
     getSubcommand,
     delSubcommand,
     copySubcommand,
+    createStoreSubcommand,
+    deleteStoreSubcommand,
+    getStoreInfoSubcommand,
     storeSubcommand,
   ],
   options: [

--- a/packages/cli/src/commands/blob/copy.ts
+++ b/packages/cli/src/commands/blob/copy.ts
@@ -46,6 +46,7 @@ export default async function copy(
       '--add-random-suffix': addRandomSuffix,
       '--content-type': contentType,
       '--cache-control-max-age': cacheControlMaxAge,
+      '--if-match': ifMatch,
     },
   } = parsedArgs;
 
@@ -58,6 +59,7 @@ export default async function copy(
   telemetryClient.trackCliFlagAddRandomSuffix(addRandomSuffix);
   telemetryClient.trackCliOptionContentType(contentType);
   telemetryClient.trackCliOptionCacheControlMaxAge(cacheControlMaxAge);
+  telemetryClient.trackCliOptionIfMatch(ifMatch);
 
   let result: blob.PutBlobResult;
   try {
@@ -71,6 +73,7 @@ export default async function copy(
       addRandomSuffix: addRandomSuffix ?? false,
       contentType,
       cacheControlMaxAge,
+      ifMatch,
     });
   } catch (err) {
     printError(err);

--- a/packages/cli/src/commands/blob/del.ts
+++ b/packages/cli/src/commands/blob/del.ts
@@ -37,15 +37,17 @@ export default async function del(
   }
 
   const { args } = parsedArgs;
+  const { '--if-match': ifMatch } = parsedArgs.flags;
 
   telemetryClient.trackCliArgumentUrlsOrPathnames(args[0]);
+  telemetryClient.trackCliOptionIfMatch(ifMatch);
 
   try {
     output.debug('Deleting blob');
 
     output.spinner('Deleting blob');
 
-    await blob.del(args, { token: rwToken });
+    await blob.del(args, { token: rwToken, ifMatch });
   } catch (err) {
     output.error(`Error deleting blob: ${err}`);
     return 1;

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -11,6 +11,9 @@ import {
   listSubcommand,
   putSubcommand,
   copySubcommand,
+  createStoreSubcommand,
+  deleteStoreSubcommand,
+  getStoreInfoSubcommand,
   storeSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -22,6 +25,9 @@ import get from './get';
 import del from './del';
 import copy from './copy';
 import { store } from './store';
+import addStore from './store-add';
+import removeStore from './store-remove';
+import getStore from './store-get';
 import { printError } from '../../util/error';
 import { getBlobRWToken } from '../../util/blob/token';
 
@@ -31,6 +37,9 @@ const COMMAND_CONFIG = {
   get: getCommandAliases(getSubcommand),
   del: getCommandAliases(delSubcommand),
   copy: getCommandAliases(copySubcommand),
+  'create-store': getCommandAliases(createStoreSubcommand),
+  'delete-store': getCommandAliases(deleteStoreSubcommand),
+  'get-store': getCommandAliases(getStoreInfoSubcommand),
   store: getCommandAliases(storeSubcommand),
 };
 
@@ -151,7 +160,50 @@ export default async function main(client: Client) {
       }
 
       return copy(client, args, token.token);
+    case 'create-store':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(createStoreSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandCreateStore(subcommandOriginal);
+
+      return addStore(client, args);
+    case 'delete-store':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(deleteStoreSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandDeleteStore(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
+      return removeStore(client, args, token);
+    case 'get-store':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(getStoreInfoSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandGetStore(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
+      return getStore(client, args, token);
     case 'store':
+      output.warn(
+        '`vercel blob store` is deprecated. Use `vercel blob create-store`, `vercel blob delete-store`, or `vercel blob get-store` instead.'
+      );
       telemetry.trackCliSubcommandStore(subcommandOriginal);
       return store(client, token);
     default:

--- a/packages/cli/src/commands/blob/put.ts
+++ b/packages/cli/src/commands/blob/put.ts
@@ -45,8 +45,14 @@ export default async function put(
     '--multipart': multipart,
     '--content-type': contentType,
     '--cache-control-max-age': cacheControlMaxAge,
+    '--allow-overwrite': allowOverwrite,
     '--force': force,
+    '--if-match': ifMatch,
   } = flags;
+
+  if (force) {
+    output.warn('--force is deprecated, use --allow-overwrite instead');
+  }
 
   const access = parseAccessFlag(accessFlag);
   if (!access) return 1;
@@ -61,7 +67,9 @@ export default async function put(
   telemetryClient.trackCliFlagMultipart(multipart);
   telemetryClient.trackCliOptionContentType(contentType);
   telemetryClient.trackCliOptionCacheControlMaxAge(cacheControlMaxAge);
+  telemetryClient.trackCliFlagAllowOverwrite(allowOverwrite);
   telemetryClient.trackCliFlagForce(force);
+  telemetryClient.trackCliOptionIfMatch(ifMatch);
 
   // ReadableStream works for both stdin and ReadStream
   let putBody: ReadableStream;
@@ -143,7 +151,8 @@ export default async function put(
       multipart: multipart ?? true,
       contentType,
       cacheControlMaxAge,
-      allowOverwrite: force ?? false,
+      allowOverwrite: allowOverwrite ?? force ?? false,
+      ifMatch,
     });
   } catch (err) {
     printError(err);

--- a/packages/cli/src/util/blob/token.ts
+++ b/packages/cli/src/util/blob/token.ts
@@ -10,8 +10,8 @@ import cmd from '../output/cmd';
 import listItem from '../output/list-item';
 
 const ErrorMessage = `No Vercel Blob token found. To fix this issue, choose one of the following options:
-${listItem(`Pass the token directly as an option: ${getCommandName('blob list --rw-token BLOB_TOKEN')}`, 1)}
-${listItem(`Set the Token as an environment variable: ${cmd(`BLOB_READ_WRITE_TOKEN=BLOB_TOKEN ${packageName} blob list`)}`, 2)}
+${listItem(`Pass the token directly as an option: ${getCommandName('blob list --rw-token BLOB_READ_WRITE_TOKEN')}`, 1)}
+${listItem(`Set the Token as an environment variable: ${cmd(`BLOB_READ_WRITE_TOKEN=BLOB_READ_WRITE_TOKEN ${packageName} blob list`)}`, 2)}
 ${listItem('Link your current folder to a Vercel Project that has a Vercel Blob store connected', 3)}`;
 
 export type BlobRWToken =

--- a/packages/cli/src/util/telemetry/commands/blob/copy.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/copy.ts
@@ -56,4 +56,13 @@ export class BlobCopyTelemetryClient
       });
     }
   }
+
+  trackCliOptionIfMatch(ifMatch: string | undefined) {
+    if (ifMatch) {
+      this.trackCliOption({
+        option: 'if-match',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/blob/del.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/del.ts
@@ -14,4 +14,13 @@ export class BlobDelTelemetryClient
       });
     }
   }
+
+  trackCliOptionIfMatch(ifMatch: string | undefined) {
+    if (ifMatch) {
+      this.trackCliOption({
+        option: 'if-match',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/blob/get.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/get.ts
@@ -32,4 +32,13 @@ export class BlobGetTelemetryClient
       });
     }
   }
+
+  trackCliOptionIfNoneMatch(ifNoneMatch: string | undefined) {
+    if (ifNoneMatch) {
+      this.trackCliOption({
+        option: 'if-none-match',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/blob/index.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/index.ts
@@ -41,6 +41,27 @@ export class BlobTelemetryClient
     });
   }
 
+  trackCliSubcommandCreateStore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'create-store',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandDeleteStore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'delete-store',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandGetStore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'get-store',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandStore(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'store',

--- a/packages/cli/src/util/telemetry/commands/blob/put.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/put.ts
@@ -70,9 +70,24 @@ export class BlobPutTelemetryClient
     }
   }
 
+  trackCliFlagAllowOverwrite(allowOverwrite: boolean | undefined) {
+    if (allowOverwrite) {
+      this.trackCliFlag('allow-overwrite');
+    }
+  }
+
   trackCliFlagForce(force: boolean | undefined) {
     if (force) {
       this.trackCliFlag('force');
+    }
+  }
+
+  trackCliOptionIfMatch(ifMatch: string | undefined) {
+    if (ifMatch) {
+      this.trackCliOption({
+        option: 'if-match',
+        value: this.redactedValue,
+      });
     }
   }
 }

--- a/packages/cli/test/unit/commands/blob/copy.test.ts
+++ b/packages/cli/test/unit/commands/blob/copy.test.ts
@@ -53,6 +53,7 @@ describe('blob copy', () => {
         addRandomSuffix: false,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
       expect(mockedOutput.spinner).toHaveBeenCalledWith('Copying blob');
       expect(mockedOutput.stopSpinner).toHaveBeenCalled();
@@ -106,6 +107,7 @@ describe('blob copy', () => {
         addRandomSuffix: true,
         contentType: 'image/png',
         cacheControlMaxAge: 86400,
+        ifMatch: undefined,
       });
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -145,6 +147,7 @@ describe('blob copy', () => {
         addRandomSuffix: false,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
     });
 
@@ -166,6 +169,59 @@ describe('blob copy', () => {
         contentType: undefined,
         cacheControlMaxAge: undefined,
       });
+    });
+  });
+
+  describe('--if-match option', () => {
+    it('should pass --if-match to blob.copy', async () => {
+      client.setArgv(
+        'blob',
+        'copy',
+        '--if-match',
+        '"some-etag"',
+        'source.txt',
+        'dest.txt'
+      );
+
+      const exitCode = await copy(
+        client,
+        ['--if-match', '"some-etag"', 'source.txt', 'dest.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.copy).toHaveBeenCalledWith('source.txt', 'dest.txt', {
+        token: testToken,
+        access: 'public',
+        addRandomSuffix: false,
+        contentType: undefined,
+        cacheControlMaxAge: undefined,
+        ifMatch: '"some-etag"',
+      });
+    });
+
+    it('should track --if-match telemetry', async () => {
+      const exitCode = await copy(
+        client,
+        ['--if-match', '"etag-value"', 'source.txt', 'dest.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:fromUrlOrPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'argument:toPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:if-match',
+          value: '[REDACTED]',
+        },
+      ]);
     });
   });
 
@@ -323,6 +379,7 @@ describe('blob copy', () => {
         addRandomSuffix: false,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -357,6 +414,7 @@ describe('blob copy', () => {
         addRandomSuffix: false,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
     });
 
@@ -374,6 +432,7 @@ describe('blob copy', () => {
         addRandomSuffix: true,
         contentType: undefined,
         cacheControlMaxAge: undefined,
+        ifMatch: undefined,
       });
     });
   });
@@ -479,6 +538,7 @@ describe('blob copy', () => {
           addRandomSuffix: true,
           contentType: 'application/pdf',
           cacheControlMaxAge: 7200,
+          ifMatch: undefined,
         }
       );
 

--- a/packages/cli/test/unit/commands/blob/del.test.ts
+++ b/packages/cli/test/unit/commands/blob/del.test.ts
@@ -38,6 +38,7 @@ describe('blob del', () => {
       expect(exitCode).toBe(0);
       expect(mockedBlob.del).toHaveBeenCalledWith(['test-file.txt'], {
         token: testToken,
+        ifMatch: undefined,
       });
       expect(mockedOutput.debug).toHaveBeenCalledWith('Deleting blob');
       expect(mockedOutput.spinner).toHaveBeenCalledWith('Deleting blob');
@@ -66,6 +67,7 @@ describe('blob del', () => {
         ['file1.txt', 'file2.txt', 'file3.txt'],
         {
           token: testToken,
+          ifMatch: undefined,
         }
       );
       expect(mockedOutput.success).toHaveBeenCalledWith('Blob deleted');
@@ -87,6 +89,7 @@ describe('blob del', () => {
       expect(exitCode).toBe(0);
       expect(mockedBlob.del).toHaveBeenCalledWith([blobUrl], {
         token: testToken,
+        ifMatch: undefined,
       });
     });
 
@@ -103,7 +106,52 @@ describe('blob del', () => {
       expect(exitCode).toBe(0);
       expect(mockedBlob.del).toHaveBeenCalledWith(args, {
         token: testToken,
+        ifMatch: undefined,
       });
+    });
+  });
+
+  describe('--if-match option', () => {
+    it('should pass --if-match to blob.del', async () => {
+      client.setArgv(
+        'blob',
+        'del',
+        '--if-match',
+        '"some-etag"',
+        'test-file.txt'
+      );
+
+      const exitCode = await del(
+        client,
+        ['--if-match', '"some-etag"', 'test-file.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.del).toHaveBeenCalledWith(['test-file.txt'], {
+        token: testToken,
+        ifMatch: '"some-etag"',
+      });
+    });
+
+    it('should track --if-match telemetry', async () => {
+      const exitCode = await del(
+        client,
+        ['--if-match', '"etag-value"', 'test-file.txt'],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:urlsOrPathnames',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:if-match',
+          value: '[REDACTED]',
+        },
+      ]);
     });
   });
 

--- a/packages/cli/test/unit/commands/blob/put.test.ts
+++ b/packages/cli/test/unit/commands/blob/put.test.ts
@@ -62,6 +62,7 @@ describe('blob put', () => {
           contentType: undefined,
           cacheControlMaxAge: undefined,
           allowOverwrite: false,
+          ifMatch: undefined,
         }
       );
       expect(mockedOutput.debug).toHaveBeenCalledWith('Uploading blob');
@@ -125,6 +126,7 @@ describe('blob put', () => {
           contentType: 'text/plain',
           cacheControlMaxAge: 3600,
           allowOverwrite: true,
+          ifMatch: undefined,
         }
       );
 
@@ -176,6 +178,7 @@ describe('blob put', () => {
           contentType: undefined,
           cacheControlMaxAge: undefined,
           allowOverwrite: false,
+          ifMatch: undefined,
         }
       );
     });
@@ -357,6 +360,69 @@ describe('blob put', () => {
       ]);
     });
 
+    it('should handle --allow-overwrite flag', async () => {
+      const testFile = getFixturePath('test-file.txt');
+      const exitCode = await put(
+        client,
+        ['--allow-overwrite', testFile],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.put).toHaveBeenCalledWith(
+        'test-file.txt',
+        expect.any(ReadStream),
+        expect.objectContaining({ allowOverwrite: true })
+      );
+    });
+
+    it('should show deprecation warning when --force is used', async () => {
+      const testFile = getFixturePath('test-file.txt');
+      const exitCode = await put(client, ['--force', testFile], testToken);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOutput.warn).toHaveBeenCalledWith(
+        '--force is deprecated, use --allow-overwrite instead'
+      );
+      expect(mockedBlob.put).toHaveBeenCalledWith(
+        'test-file.txt',
+        expect.any(ReadStream),
+        expect.objectContaining({ allowOverwrite: true })
+      );
+    });
+
+    it('should prefer --allow-overwrite over --force', async () => {
+      const testFile = getFixturePath('test-file.txt');
+      const exitCode = await put(
+        client,
+        ['--allow-overwrite', '--force', testFile],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.put).toHaveBeenCalledWith(
+        'test-file.txt',
+        expect.any(ReadStream),
+        expect.objectContaining({ allowOverwrite: true })
+      );
+    });
+
+    it('should handle --if-match option', async () => {
+      const testFile = getFixturePath('test-file.txt');
+      const exitCode = await put(
+        client,
+        ['--if-match', '"some-etag"', testFile],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.put).toHaveBeenCalledWith(
+        'test-file.txt',
+        expect.any(ReadStream),
+        expect.objectContaining({ ifMatch: '"some-etag"' })
+      );
+    });
+
     it('should handle --multipart flag (enabled by default)', async () => {
       const testFile = getFixturePath('test-file.txt');
       const exitCode = await put(client, ['--multipart', testFile], testToken);
@@ -526,6 +592,7 @@ describe('blob put', () => {
           contentType: undefined,
           cacheControlMaxAge: undefined,
           allowOverwrite: false,
+          ifMatch: undefined,
         }
       );
       expect(mockedOutput.success).toHaveBeenCalledWith(
@@ -572,6 +639,7 @@ describe('blob put', () => {
           contentType: 'text/plain',
           cacheControlMaxAge: 3600,
           allowOverwrite: true,
+          ifMatch: undefined,
         }
       );
     });


### PR DESCRIPTION
## Summary

- Flatten blob store commands: `blob create-store`, `blob delete-store`, `blob get-store` (old `blob store add/remove/get` deprecated but still works)
- Rename `--force` to `--allow-overwrite` (old flag deprecated with warning)
- Add `--if-match` to `put`, `del`, `copy` and `--if-none-match` to `get` for conditional operations
- Handle 304 Not Modified response in `blob get`

Docs PR: https://github.com/vercel/front/pull/62530

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI feature additions for blob store commands including new subcommands, renamed flags with deprecation warnings, and conditional header options - all changes are additive with no security or authorization logic modifications.
> 
> - New flattened blob store commands: create-store, delete-store, get-store
> - Renamed --force to --allow-overwrite with deprecation warning for old flag
> - Added conditional header options (--if-match, --if-none-match) and 304 response handling
>
> <sup>Risk assessment for [commit 0551b4d](https://github.com/vercel/vercel/commit/0551b4d7756af3ad446550de11a6c2497cc277c2).</sup>
<!-- VADE_RISK_END -->