### PR TITLE
fix(cli): handle sigint on update prompt

### DIFF
--- a/.changeset/fix-upgrade-sigint.md
+++ b/.changeset/fix-upgrade-sigint.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): Handle SIGINT during upgrade prompt without showing a stacktrace

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1012,15 +1012,26 @@ main()
             `Changelog: ${output.link(changelog, changelog, { fallback: false })}\n`
           );
 
-          const shouldUpgrade = await client.input.confirm(
-            'Would you like to upgrade now?',
-            true
-          );
+          try {
+            const shouldUpgrade = await client.input.confirm(
+              'Would you like to upgrade now?',
+              true
+            );
 
-          if (shouldUpgrade) {
-            const upgradeExitCode = await executeUpgrade();
-            process.exitCode = upgradeExitCode;
-            return;
+            if (shouldUpgrade) {
+              const upgradeExitCode = await executeUpgrade();
+              process.exitCode = upgradeExitCode;
+              return;
+            }
+          } catch (err: unknown) {
+            if (
+              err instanceof Error &&
+              err.message.includes('User force closed the prompt')
+            ) {
+              // User pressed Ctrl+C to dismiss the prompt
+            } else {
+              throw err;
+            }
           }
         } else {
           const errorMsg =


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a try/catch to gracefully handle SIGINT (Ctrl+C) during an upgrade prompt, silently catching a specific error message while re-throwing other errors - a defensive UX improvement with no security implications.
> 
> - Wraps upgrade prompt in try/catch to suppress stacktrace on Ctrl+C
> - Only catches errors with specific 'User force closed the prompt' message
> - Re-throws all other errors to preserve existing error handling
>
> <sup>Risk assessment for [commit cefb70e](https://github.com/vercel/vercel/commit/cefb70e14297109e9411f9070f989a1b4688eeee).</sup>
<!-- VADE_RISK_END -->