### PR TITLE
fix(cli): handle browser open error in login flow

### DIFF
--- a/.changeset/fix-login-browser-open.md
+++ b/.changeset/fix-login-browser-open.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix login crash when browser opener is unavailable in headless environments


### PR DESCRIPTION
## Summary
- Fixes a crash in headless/non-interactive environments (e.g. sandboxes) where `xdg-open` is unavailable
- The `open` package (v8.4.0) with `wait:false` (default) returns a `ChildProcess` directly, not a `Promise`. The previous `await` + `try/catch` did not catch the spawn `ENOENT` error because it fires as a ChildProcess `'error'` event via `process.nextTick`, which runs before Promise microtasks
- Fix attaches the error handler synchronously on the ChildProcess to properly catch and handle the error

Fixes the regression from #15050 where non-interactive login broke:
```
Error: An unexpected error occurred!
Error: spawn xdg-open ENOENT
```

## Test plan
- [ ] Verify `vercel whoami` works in a headless Linux environment without `xdg-open`
- [ ] Verify browser still opens correctly on macOS/Linux with a desktop environment
- [ ] Verify CI environments still skip browser opening


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR improves error handling for browser opening in CLI login flow by attaching a synchronous error handler to catch spawn errors in headless environments - no security or auth logic changes.
> 
> - Adds synchronous error handler on ChildProcess to catch browser spawn failures
> - Moves user-facing warning message from catch block to error event handler
> - Changeset added for patch version bump
>
> <sup>Risk assessment for [commit 0593768](https://github.com/vercel/vercel/commit/05937688b7914744a39f3386111d50a21d1f8f06).</sup>
<!-- VADE_RISK_END -->