### PR TITLE
feat(cli): fix headless login browser error

### DIFF
--- a/.changeset/sharp-poets-grin.md
+++ b/.changeset/sharp-poets-grin.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix headless login browser error

--- a/packages/cli/scripts/Dockerfile.headless
+++ b/packages/cli/scripts/Dockerfile.headless
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+
+# Copy and install the packed tarball
+COPY vercel-*.tgz /app/
+RUN npm install -g /app/vercel-*.tgz
+
+CMD ["sh"]

--- a/packages/cli/scripts/test-headless.sh
+++ b/packages/cli/scripts/test-headless.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Test the CLI in a headless Docker environment (no browser, no TTY)
+# Usage: ./scripts/test-headless.sh [command]
+# Example: ./scripts/test-headless.sh login --debug
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI_DIR="$(dirname "$SCRIPT_DIR")"
+IMAGE_NAME="vercel-cli-test"
+
+cd "$CLI_DIR"
+
+# Build the CLI
+echo "Building CLI..."
+pnpm build
+
+# Pack the CLI
+echo "Packing CLI..."
+rm -f vercel-*.tgz
+pnpm pack
+
+# Build Docker image
+echo "Building Docker image..."
+docker build -t "$IMAGE_NAME" -f scripts/Dockerfile.headless .
+
+# Run the container
+if [ $# -eq 0 ]; then
+  echo "Starting interactive shell..."
+  echo "Run 'vercel <command>' to test the CLI"
+  docker run --rm -it "$IMAGE_NAME"
+else
+  echo "Running: vercel $*"
+  docker run --rm -it "$IMAGE_NAME" vercel "$@"
+fi

--- a/packages/cli/src/commands/login/future.ts
+++ b/packages/cli/src/commands/login/future.ts
@@ -67,7 +67,11 @@ export async function login(
   // Open browser automatically unless we're in CI (excluding Cursor)
   if (!shouldSkipBrowser) {
     try {
-      await open.default(verification_uri_complete);
+      const browserProcess = await open.default(verification_uri_complete);
+      browserProcess.on('error', (error: Error) => {
+        // ignore errors if this fails and prompt user to open browser manually
+        o.debug(`Failed to open browser: ${error}`);
+      });
     } catch (error) {
       // Fail gracefully if browser can't be opened
       o.debug(`Failed to open browser: ${error}`);


### PR DESCRIPTION
open uses a subprocess so we need to catch errors via an event. Also add a script for easy testing in the future. 

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds error handling for subprocess browser opening in CLI login and includes test infrastructure scripts, with no security-sensitive changes.
> 
> - Adds error event handler for browser subprocess to gracefully handle failures
> - New Dockerfile and shell script for headless CLI testing
> - Changeset for patch version bump
>
> <sup>Risk assessment for [commit f272f42](https://github.com/vercel/vercel/commit/f272f42cdae1b5f822bfb103d16b80af83bb6963).</sup>
<!-- VADE_RISK_END -->