### PR TITLE
Bump waitForPrompt test util

### DIFF
--- a/.changeset/tricky-plums-taste.md
+++ b/.changeset/tricky-plums-taste.md
@@ -1,0 +1,4 @@
+---
+---
+
+Bump waitForPrompt test util

--- a/packages/cli/test/helpers/wait-for-prompt.ts
+++ b/packages/cli/test/helpers/wait-for-prompt.ts
@@ -13,7 +13,7 @@ function getPromptErrorDetails(
 export default async function waitForPrompt(
   cp: CLIProcess,
   rawAssertion: string | RegExp | ((chunk: string) => boolean),
-  timeout = 3000
+  timeout = 5000
 ) {
   let assertion: (chunk: string) => boolean;
   if (typeof rawAssertion === 'string') {


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR only increases a test utility timeout from 3000ms to 5000ms, a trivial test infrastructure change with no production impact.
> 
> - Test util: increased default timeout from 3000 to 5000ms
> - Changeset file added for version bump
>
> <sup>Risk assessment for [commit a5f2e4a](https://github.com/vercel/vercel/commit/a5f2e4af10bafdcb280c2a71d6ef3fefee0878b8).</sup>
<!-- VADE_RISK_END -->