### PR TITLE
[CLI-Evals] feat: continue on failures so we don't block for now

### DIFF
--- a/.github/workflows/cli-evals.yml
+++ b/.github/workflows/cli-evals.yml
@@ -9,6 +9,8 @@ jobs:
   evals:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # TODO: Remove continue-on-error when evals should block PR merge.
+    continue-on-error: true
     # Evals use separate secrets (EVAL_*) so you can point to a dedicated evals team.
     # Same pattern as test.yml / test-e2e.yml: VERCEL_TOKEN + team/project IDs; add EVAL_AI_GATEWAY_API_KEY for the agent.
     steps:


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds continue-on-error to CI workflow, allowing eval failures to not block PR merges - a deliberate relaxation of CI gates with explicit TODO to re-enable later.
> 
> - CI: adds `continue-on-error: true` to evals job, allowing failures to pass
> - Includes TODO comment indicating temporary change
>
> <sup>Risk assessment for [commit 7e2ba6e](https://github.com/vercel/vercel/commit/7e2ba6e3326b5cad7ed07fb50f4e1e360e4d4f53).</sup>
<!-- VADE_RISK_END -->