### PR TITLE
[CLI-Evals] faet: reducing eval calls

### DIFF
--- a/.github/workflows/cli-evals.yml
+++ b/.github/workflows/cli-evals.yml
@@ -1,9 +1,11 @@
 name: CLI Evals
 
-# Disabled for automatic runs to control AI gateway costs. Run manually via "Run workflow" in the Actions tab.
-# To re-enable on PRs (e.g. only when evals change): add pull_request with paths: ['packages/cli/evals/**'].
+# Runs on PRs only when evals change (to limit AI gateway cost). Also runnable manually via "Run workflow".
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packages/cli/evals/**'
 
 jobs:
   evals:

--- a/.github/workflows/cli-evals.yml
+++ b/.github/workflows/cli-evals.yml
@@ -1,9 +1,9 @@
 name: CLI Evals
 
+# Disabled for automatic runs to control AI gateway costs. Run manually via "Run workflow" in the Actions tab.
+# To re-enable on PRs (e.g. only when evals change): add pull_request with paths: ['packages/cli/evals/**'].
 on:
-  pull_request:
-    paths:
-      - 'packages/cli/**'
+  workflow_dispatch:
 
 jobs:
   evals:


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR narrows the CI trigger path from all CLI changes to only eval-specific changes, reducing workflow runs - a low-risk CI configuration change.
> 
> - CI: narrows trigger path from `packages/cli/**` to `packages/cli/evals/**`
> - Adds `workflow_dispatch` for manual runs
> - Comment documents cost-reduction rationale
>
> <sup>Risk assessment for [commit dbb6ea3](https://github.com/vercel/vercel/commit/dbb6ea36597c8881d5a549e4e7a4403096ca4ec3).</sup>
<!-- VADE_RISK_END -->