### PR TITLE
Update to latest Next.js adapter version

### DIFF
--- a/.changeset/happy-plums-judge.md
+++ b/.changeset/happy-plums-judge.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Update to latest Next.js adapter version'

--- a/.changeset/mean-fans-relax.md
+++ b/.changeset/mean-fans-relax.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Add `NEXT_BUILDER_INTEGRATION` env to all `packages/next` vercel.json fixtures.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.7",
+    "@next-community/adapter-vercel": "0.0.1-beta.8",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.8",
+    "@next-community/adapter-vercel": "https://adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "https://adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz",
+    "@next-community/adapter-vercel": "0.0.1-beta.9",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/packages/next/test/fixtures/00-absolute-output-directory/vercel.json
+++ b/packages/next/test/fixtures/00-absolute-output-directory/vercel.json
@@ -16,5 +16,8 @@
       "status": 200,
       "mustContain": "\"hello\":\"world\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-actions-streaming-index-handling/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-actions-streaming-index-handling/vercel.json
@@ -5,5 +5,8 @@
       "use": "@vercel/next"
     }
   ],
-  "probes": []
+  "probes": [],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-actions-streaming/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-actions-streaming/vercel.json
@@ -5,5 +5,8 @@
       "use": "@vercel/next"
     }
   ],
-  "probes": []
+  "probes": [],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-actions/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-actions/vercel.json
@@ -5,5 +5,8 @@
       "use": "@vercel/next"
     }
   ],
-  "probes": []
+  "probes": [],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
@@ -219,5 +219,8 @@
       "mustContain": ":{",
       "mustNotContain": "<html"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-catchall-index-handling/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-catchall-index-handling/vercel.json
@@ -23,5 +23,8 @@
         "rsc": "1"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-dynamic-404/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-404/vercel.json
@@ -4,5 +4,8 @@
       "src": "package.json",
       "use": "@vercel/next"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/vercel.json
@@ -17,5 +17,8 @@
     {
       "logMustNotContain": "WARNING: Unable to find source file"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-edge-404/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/vercel.json
@@ -16,5 +16,8 @@
       "status": 404,
       "mustContain": "This Is The Not Found Page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-edge/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-edge/vercel.json
@@ -54,5 +54,8 @@
         "content-type": "text/x-component"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
@@ -95,5 +95,8 @@
       "status": 200,
       "mustContain": "sentinel:dynamic"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-middleware/vercel.json
@@ -78,5 +78,8 @@
       "mustContain": ":{",
       "mustNotContain": "<html"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -517,5 +517,8 @@
         "next-router-prefetch": "1"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-not-found-pages-interop/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-not-found-pages-interop/vercel.json
@@ -24,5 +24,8 @@
       "status": 200,
       "mustContain": "pages router page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-not-found/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-not-found/vercel.json
@@ -21,5 +21,8 @@
       "status": 404,
       "mustContain": "404"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/vercel.json
@@ -21,5 +21,8 @@
         "Content-Type": "text/html; charset=utf-8"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
@@ -399,5 +399,8 @@
       "mustContain": ":{",
       "mustNotContain": "<html"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-root-catch-all/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-root-catch-all/vercel.json
@@ -82,5 +82,8 @@
       "mustNotContain": "<html",
       "mustContain": "catch-all"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-segment-cache/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-segment-cache/vercel.json
@@ -19,5 +19,8 @@
       },
       "mustContain": "foobar-1"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-segment-options/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-segment-options/vercel.json
@@ -4,5 +4,8 @@
       "src": "package.json",
       "use": "@vercel/next"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/vercel.json
@@ -18,5 +18,8 @@
         "x-matched-path": "/dynamic.prefetch.rsc"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-segment-prefetch/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-segment-prefetch/vercel.json
@@ -84,5 +84,8 @@
       },
       "mustNotContain": "Dynamic Component"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-static/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-static/vercel.json
@@ -68,5 +68,8 @@
       "mustContain": ":{",
       "mustNotContain": "<html"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/vercel.json
@@ -58,5 +58,8 @@
         "x-matched-path": "/about.segments/_tree.segment.rsc"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
@@ -189,5 +189,8 @@
       "mustContain": ":{",
       "mustNotContain": "<html"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-base-path-index-revalidate/vercel.json
+++ b/packages/next/test/fixtures/00-base-path-index-revalidate/vercel.json
@@ -5,5 +5,8 @@
       "use": "@vercel/next"
     }
   ],
-  "probes": []
+  "probes": [],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-build-time-traces/vercel.json
+++ b/packages/next/test/fixtures/00-build-time-traces/vercel.json
@@ -11,5 +11,8 @@
       "status": 200,
       "mustContain": "index page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-bun-runtime/vercel.json
+++ b/packages/next/test/fixtures/00-bun-runtime/vercel.json
@@ -14,5 +14,8 @@
       "path": "/",
       "mustContain": "\"runtime\":\"bun\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-cached-build/vercel.json
+++ b/packages/next/test/fixtures/00-cached-build/vercel.json
@@ -26,5 +26,8 @@
       "status": 200,
       "mustContain": "ssp page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-fallback-false-preview/vercel.json
+++ b/packages/next/test/fixtures/00-fallback-false-preview/vercel.json
@@ -35,5 +35,8 @@
       "status": 200,
       "mustContain": "blog fallback rewrite"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-404-lambda/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-404-lambda/vercel.json
@@ -69,5 +69,8 @@
       "status": 200,
       "mustContain": "hello public"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-404-revalidate/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-404-revalidate/vercel.json
@@ -1,6 +1,11 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }],
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
   "probes": [
     {
       "path": "/non-existent",
@@ -22,7 +27,6 @@
       "status": 404,
       "mustContain": "lang=\"fr\""
     },
-
     {
       "path": "/",
       "status": 200,
@@ -33,7 +37,6 @@
       "status": 200,
       "mustContain": "index page"
     },
-
     {
       "path": "/another",
       "status": 200,
@@ -44,5 +47,8 @@
       "status": 200,
       "mustContain": "another page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/vercel.json
@@ -97,5 +97,8 @@
       "status": 200,
       "mustContain": "\"rest\":\"hello/world\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-basepath/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-basepath/vercel.json
@@ -85,5 +85,8 @@
       "status": 200,
       "mustContain": "\"rest\":\"hello/world\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-gssp-latest/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-gssp-latest/vercel.json
@@ -95,5 +95,8 @@
       "status": 200,
       "mustContain": "locale\":\"nl\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-gssp/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-gssp/vercel.json
@@ -140,5 +140,8 @@
       "status": 200,
       "mustContain": "Example Domain"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-support-no-locale-detection-rewrite-flag/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-support-no-locale-detection-rewrite-flag/vercel.json
@@ -536,5 +536,8 @@
       "status": 200,
       "mustContain": "\"catchall\":\"yes\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-support-no-locale-detection/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-support-no-locale-detection/vercel.json
@@ -521,5 +521,8 @@
       "status": 200,
       "mustContain": "\"catchall\":\"yes\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-support-no-shared-lambdas/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-support-no-shared-lambdas/vercel.json
@@ -355,5 +355,8 @@
       "status": 200,
       "mustContain": "slug\":\"first\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-support-root-catchall/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-support-root-catchall/vercel.json
@@ -188,5 +188,8 @@
       "status": 200,
       "mustContain": ">nl-NL<"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-i18n-support/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-support/vercel.json
@@ -958,5 +958,8 @@
       "status": 200,
       "mustContain": "no\":\"revalidate"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-index-dynamic-revalidate/vercel.json
+++ b/packages/next/test/fixtures/00-index-dynamic-revalidate/vercel.json
@@ -36,5 +36,8 @@
       "status": 200,
       "mustContain": "index page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-index-isr/vercel.json
+++ b/packages/next/test/fixtures/00-index-isr/vercel.json
@@ -123,5 +123,8 @@
       "status": 200,
       "mustContain": "one-more"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-initial-notfound-revalidate-i18n-previous/vercel.json
+++ b/packages/next/test/fixtures/00-initial-notfound-revalidate-i18n-previous/vercel.json
@@ -49,5 +49,8 @@
       "status": 404,
       "mustContain": "This page could not be found"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-initial-notfound-revalidate-i18n/vercel.json
+++ b/packages/next/test/fixtures/00-initial-notfound-revalidate-i18n/vercel.json
@@ -51,5 +51,8 @@
       "status": 404,
       "mustContain": "This page could not be found"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-initial-notfound-revalidate/vercel.json
+++ b/packages/next/test/fixtures/00-initial-notfound-revalidate/vercel.json
@@ -27,5 +27,8 @@
       "retries": 3,
       "retryDelay": 5000
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-isr-catchall-rewrite/vercel.json
+++ b/packages/next/test/fixtures/00-isr-catchall-rewrite/vercel.json
@@ -49,5 +49,8 @@
       "retries": 3,
       "retryDelay": 2000
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-legacy-mono-repo-server-mode/vercel.json
+++ b/packages/next/test/fixtures/00-legacy-mono-repo-server-mode/vercel.json
@@ -48,5 +48,8 @@
       "status": 200,
       "mustContain": "\"slug\":\"two\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-legacy-monorepo-index-route/vercel.json
+++ b/packages/next/test/fixtures/00-legacy-monorepo-index-route/vercel.json
@@ -38,5 +38,8 @@
       "status": 200,
       "mustContain": "blog slug page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-legacy-routes-nested/vercel.json
+++ b/packages/next/test/fixtures/00-legacy-routes-nested/vercel.json
@@ -24,5 +24,8 @@
       "status": 200,
       "mustContain": "another page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-middleware-base-path/vercel.json
+++ b/packages/next/test/fixtures/00-middleware-base-path/vercel.json
@@ -125,5 +125,8 @@
       "mustNotContain": "<html",
       "mustContain": "\"site\":\"subdomain-1\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-middleware-i18n/vercel.json
+++ b/packages/next/test/fixtures/00-middleware-i18n/vercel.json
@@ -106,5 +106,8 @@
       "mustNotContain": "<html>",
       "mustContain": "\"site\":\"subdomain-1\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-middleware-nested/vercel.json
+++ b/packages/next/test/fixtures/00-middleware-nested/vercel.json
@@ -12,5 +12,8 @@
         "redirect": "manual"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-middleware/vercel.json
@@ -121,5 +121,8 @@
       "mustNotContain": "<html>",
       "mustContain": "\"site\":\"subdomain-1\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-mixed-dynamic-routes/vercel.json
+++ b/packages/next/test/fixtures/00-mixed-dynamic-routes/vercel.json
@@ -32,5 +32,8 @@
       "status": 200,
       "mustContain": "[...slug] page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-nested-app-dir/vercel.json
+++ b/packages/next/test/fixtures/00-nested-app-dir/vercel.json
@@ -25,5 +25,8 @@
       "status": 200,
       "mustContain": "gsspData"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-nested-build/vercel.json
+++ b/packages/next/test/fixtures/00-nested-build/vercel.json
@@ -15,5 +15,8 @@
       "status": 200,
       "mustContain": "index page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-next-image-base-path/vercel.json
+++ b/packages/next/test/fixtures/00-next-image-base-path/vercel.json
@@ -23,5 +23,8 @@
         "content-type": "image/png"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-node-middleware-base-path/vercel.json
+++ b/packages/next/test/fixtures/00-node-middleware-base-path/vercel.json
@@ -14,5 +14,8 @@
         "x-from-proxy": "true"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-node-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-node-middleware/vercel.json
@@ -129,5 +129,8 @@
     {
       "logMustNotContain": "Unable to find source file for page middleware with"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-node-proxy/vercel.json
+++ b/packages/next/test/fixtures/00-node-proxy/vercel.json
@@ -129,5 +129,8 @@
     {
       "logMustNotContain": "Unable to find source file for page proxy with"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-non-server-build/vercel.json
+++ b/packages/next/test/fixtures/00-non-server-build/vercel.json
@@ -116,5 +116,8 @@
       "status": 200,
       "mustContain": "slug\":\"second\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-optional-fallback-revalidate/vercel.json
+++ b/packages/next/test/fixtures/00-optional-fallback-revalidate/vercel.json
@@ -5,5 +5,8 @@
       "src": "package.json",
       "use": "@vercel/next"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-public-dir-output-dir/vercel.json
+++ b/packages/next/test/fixtures/00-public-dir-output-dir/vercel.json
@@ -35,5 +35,8 @@
       "status": 200,
       "mustContain": "data!!"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-root-optional-revalidate/vercel.json
+++ b/packages/next/test/fixtures/00-root-optional-revalidate/vercel.json
@@ -11,5 +11,8 @@
       "path": "/non-existent",
       "status": 404
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-server-build-auto-export-dynamic/vercel.json
+++ b/packages/next/test/fixtures/00-server-build-auto-export-dynamic/vercel.json
@@ -28,5 +28,8 @@
       "path": "/another/invite/hello",
       "mustContain": "hello from /[teamSlug]/[project]/[id]"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-server-build-gsp-404/vercel.json
+++ b/packages/next/test/fixtures/00-server-build-gsp-404/vercel.json
@@ -27,5 +27,8 @@
       "status": 404,
       "mustContain": "custom 404"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-server-build-initial/vercel.json
+++ b/packages/next/test/fixtures/00-server-build-initial/vercel.json
@@ -134,5 +134,8 @@
       "status": 404,
       "mustContain": "custom 404"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-server-build-invalid-node-env/vercel.json
+++ b/packages/next/test/fixtures/00-server-build-invalid-node-env/vercel.json
@@ -7,7 +7,8 @@
     }
   ],
   "env": {
-    "NODE_ENV": "development"
+    "NODE_ENV": "development",
+    "NEXT_BUILDER_INTEGRATION": "1"
   },
   "probes": [
     {

--- a/packages/next/test/fixtures/00-server-build-legacy-monorepo/vercel.json
+++ b/packages/next/test/fixtures/00-server-build-legacy-monorepo/vercel.json
@@ -23,5 +23,8 @@
       "status": 200,
       "mustContain": "hello api"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-server-build-root-directory-output-dir/vercel.json
+++ b/packages/next/test/fixtures/00-server-build-root-directory-output-dir/vercel.json
@@ -26,5 +26,8 @@
       "status": 200,
       "mustContain": "hello api"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-server-build-root-directory/vercel.json
+++ b/packages/next/test/fixtures/00-server-build-root-directory/vercel.json
@@ -25,5 +25,8 @@
       "status": 200,
       "mustContain": "hello api"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-server-build/vercel.json
+++ b/packages/next/test/fixtures/00-server-build/vercel.json
@@ -213,5 +213,8 @@
       "status": 404,
       "mustContain": "custom 404"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-shared-lambdas-invalid-node-env/vercel.json
+++ b/packages/next/test/fixtures/00-shared-lambdas-invalid-node-env/vercel.json
@@ -7,7 +7,8 @@
     }
   ],
   "env": {
-    "NODE_ENV": "development"
+    "NODE_ENV": "development",
+    "NEXT_BUILDER_INTEGRATION": "1"
   },
   "probes": [
     {

--- a/packages/next/test/fixtures/00-shared-lambdas/vercel.json
+++ b/packages/next/test/fixtures/00-shared-lambdas/vercel.json
@@ -34,5 +34,8 @@
     {
       "logMustNotContain": "WARNING: Your application is being opted out of \"@vercel/next\" optimized lambdas mode due to `functions` config"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-static-metadata-test/vercel.json
+++ b/packages/next/test/fixtures/00-static-metadata-test/vercel.json
@@ -126,5 +126,8 @@
         "content-type": "image/svg+xml"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-test-limit-server-build/vercel.json
+++ b/packages/next/test/fixtures/00-test-limit-server-build/vercel.json
@@ -162,5 +162,8 @@
       "status": 200,
       "mustContain": "index page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-test-limit-shared-lambdas/vercel.json
+++ b/packages/next/test/fixtures/00-test-limit-shared-lambdas/vercel.json
@@ -162,5 +162,8 @@
       "status": 200,
       "mustContain": "index page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-trailing-slash-add-export/vercel.json
+++ b/packages/next/test/fixtures/00-trailing-slash-add-export/vercel.json
@@ -22,5 +22,8 @@
       "fetchOptions": { "redirect": "manual" },
       "mustContain": "oops 404"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-trailing-slash-remove/vercel.json
+++ b/packages/next/test/fixtures/00-trailing-slash-remove/vercel.json
@@ -34,5 +34,8 @@
       "status": 200,
       "mustContain": "this is a file"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/00-vercel-404/vercel.json
+++ b/packages/next/test/fixtures/00-vercel-404/vercel.json
@@ -17,5 +17,8 @@
       "status": 404,
       "mustContain": "custom 404"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/01-app-dir-static/vercel.json
+++ b/packages/next/test/fixtures/01-app-dir-static/vercel.json
@@ -19,5 +19,8 @@
       "status": 404,
       "mustContain": "404"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/01-cache-headers/vercel.json
+++ b/packages/next/test/fixtures/01-cache-headers/vercel.json
@@ -1,6 +1,11 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }],
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
   "probes": [
     {
       "path": "/_next/__NEXT_SCRIPT__(/)",
@@ -62,5 +67,8 @@
       "status": 200,
       "mustContain": "hi from final route"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/03-next-8/vercel.json
+++ b/packages/next/test/fixtures/03-next-8/vercel.json
@@ -4,5 +4,8 @@
   "probes": [
     { "path": "/hello1", "mustContain": "Hello World 1" },
     { "path": "/nested/hello2", "mustContain": "Hello World 2" }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/05-spr-support/vercel.json
+++ b/packages/next/test/fixtures/05-spr-support/vercel.json
@@ -187,5 +187,8 @@
         "x-vercel-cache": "PRERENDER"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/06-lambda-with-memory/vercel.json
+++ b/packages/next/test/fixtures/06-lambda-with-memory/vercel.json
@@ -61,5 +61,8 @@
     {
       "logMustNotContain": "WARNING: Your application is being opted out of \"@vercel/next\" optimized lambdas mode due to `functions` config"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/07-custom-routes/vercel.json
+++ b/packages/next/test/fixtures/07-custom-routes/vercel.json
@@ -89,5 +89,8 @@
       "status": 200,
       "mustContain": "hello from my-file"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/08-custom-routes-catchall/vercel.json
+++ b/packages/next/test/fixtures/08-custom-routes-catchall/vercel.json
@@ -10,5 +10,8 @@
       "path": "/something",
       "mustContain": "something"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/09-yarn-workspaces/vercel.json
+++ b/packages/next/test/fixtures/09-yarn-workspaces/vercel.json
@@ -11,5 +11,8 @@
     {
       "logMustContain": "WARNING: your application is being opted out of @vercel/next's optimized lambdas mode due to legacy routes"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/10-export-cache-headers/vercel.json
+++ b/packages/next/test/fixtures/10-export-cache-headers/vercel.json
@@ -18,5 +18,8 @@
       "path": "/",
       "mustContain": "nextExport\":true"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/11-export-clean-urls/vercel.json
+++ b/packages/next/test/fixtures/11-export-clean-urls/vercel.json
@@ -14,5 +14,8 @@
       "path": "/",
       "mustContain": "nextExport\":true"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/12-no-export-auto/vercel.json
+++ b/packages/next/test/fixtures/12-no-export-auto/vercel.json
@@ -14,5 +14,8 @@
       "path": "/",
       "mustNotContain": "nextExport\":true"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/13-export-custom-routes/vercel.json
+++ b/packages/next/test/fixtures/13-export-custom-routes/vercel.json
@@ -14,5 +14,8 @@
       "path": "/",
       "mustContain": "nextExport\":true"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/16-base-path/vercel.json
+++ b/packages/next/test/fixtures/16-base-path/vercel.json
@@ -76,5 +76,8 @@
       "status": 200,
       "mustContain": "\"post\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/17-static-404/vercel.json
+++ b/packages/next/test/fixtures/17-static-404/vercel.json
@@ -24,5 +24,8 @@
       "path": "/_errors/404",
       "mustContain": "__next"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/19-pages-404/vercel.json
+++ b/packages/next/test/fixtures/19-pages-404/vercel.json
@@ -34,5 +34,8 @@
       "path": "/404",
       "status": 404
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/20-pages-404-lambda/vercel.json
+++ b/packages/next/test/fixtures/20-pages-404-lambda/vercel.json
@@ -14,5 +14,8 @@
       "path": "/non-existent",
       "mustContain": "__next"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/21-server-props/vercel.json
+++ b/packages/next/test/fixtures/21-server-props/vercel.json
@@ -160,5 +160,8 @@
       "status": 200,
       "mustContain": "post-1337"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/22-ssg-v2-catchall/vercel.json
+++ b/packages/next/test/fixtures/22-ssg-v2-catchall/vercel.json
@@ -36,5 +36,8 @@
       "path": "/_next/data/build-TfctsWXpff2fKS/one-more.json",
       "mustNotContain": "<html>"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/22-ssg-v2-multi-payload/vercel.json
+++ b/packages/next/test/fixtures/22-ssg-v2-multi-payload/vercel.json
@@ -182,5 +182,8 @@
     {
       "logMustNotContain": "WARNING: Your application is being opted out of \"@vercel/next\" optimized lambdas mode due to `functions` config"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/22-ssg-v2/vercel.json
+++ b/packages/next/test/fixtures/22-ssg-v2/vercel.json
@@ -182,5 +182,8 @@
     {
       "logMustNotContain": "WARNING: Your application is being opted out of \"@vercel/next\" optimized lambdas mode due to `functions` config"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/23-custom-routes-verbose/vercel.json
+++ b/packages/next/test/fixtures/23-custom-routes-verbose/vercel.json
@@ -243,5 +243,8 @@
       "status": 200,
       "mustContain": "hello/world"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/24-custom-output-dir/vercel.json
+++ b/packages/next/test/fixtures/24-custom-output-dir/vercel.json
@@ -35,5 +35,8 @@
       "status": 200,
       "mustContain": "\"slug\":\"third\""
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/25-index-routes/vercel.json
+++ b/packages/next/test/fixtures/25-index-routes/vercel.json
@@ -38,5 +38,8 @@
       "path": "/api/sub/another",
       "mustContain": "hi from sub id"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/25-mono-repo-404/vercel.json
+++ b/packages/next/test/fixtures/25-mono-repo-404/vercel.json
@@ -2,7 +2,11 @@
   "version": 2,
   "uploadNowJson": true,
   "routes": [
-    { "src": "/(.*)", "dest": "/packages/webapp/$1", "continue": true }
+    {
+      "src": "/(.*)",
+      "dest": "/packages/webapp/$1",
+      "continue": true
+    }
   ],
   "builds": [
     {
@@ -36,5 +40,8 @@
     {
       "logMustContain": "WARNING: your application is being opted out of @vercel/next's optimized lambdas mode due to legacy routes"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/26-mono-repo-404-lambda/vercel.json
+++ b/packages/next/test/fixtures/26-mono-repo-404-lambda/vercel.json
@@ -30,5 +30,8 @@
     {
       "logMustContain": "WARNING: your application is being opted out of @vercel/next's optimized lambdas mode due to legacy routes"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/27-non-word-param/vercel.json
+++ b/packages/next/test/fixtures/27-non-word-param/vercel.json
@@ -48,5 +48,8 @@
       "path": "/_next/data/build-TfctsWXpff2fKS/one-more.json",
       "mustNotContain": "<html>"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/27-preview-mode/vercel.json
+++ b/packages/next/test/fixtures/27-preview-mode/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/28-nested-public/vercel.json
+++ b/packages/next/test/fixtures/28-nested-public/vercel.json
@@ -1,6 +1,11 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }],
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
   "probes": [
     {
       "path": "/",
@@ -12,5 +17,8 @@
       "status": 200,
       "mustContain": "hello world"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/29-ssg-all-static-custom-404/vercel.json
+++ b/packages/next/test/fixtures/29-ssg-all-static-custom-404/vercel.json
@@ -109,5 +109,8 @@
     {
       "logMustNotContain": "Compressed shared serverless function files"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/29-ssg-all-static/vercel.json
+++ b/packages/next/test/fixtures/29-ssg-all-static/vercel.json
@@ -104,5 +104,8 @@
     {
       "logMustNotContain": "Compressed shared serverless function files"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/30-monorepo-no-script/vercel.json
+++ b/packages/next/test/fixtures/30-monorepo-no-script/vercel.json
@@ -27,5 +27,8 @@
     {
       "logMustNotContain": "Compressed shared serverless function files"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/31-blocking-fallback/vercel.json
+++ b/packages/next/test/fixtures/31-blocking-fallback/vercel.json
@@ -58,5 +58,8 @@
         "x-vercel-cache": "/HIT|STALE/"
       }
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/32-custom-install-command/vercel.json
+++ b/packages/next/test/fixtures/32-custom-install-command/vercel.json
@@ -16,5 +16,8 @@
       "status": 200,
       "mustContain": "installCommand"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/33-base-path-gsp-404/vercel.json
+++ b/packages/next/test/fixtures/33-base-path-gsp-404/vercel.json
@@ -27,5 +27,8 @@
       "status": 404,
       "mustContain": "404 - Page Not Found Custom"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/35-esm-package/vercel.json
+++ b/packages/next/test/fixtures/35-esm-package/vercel.json
@@ -17,5 +17,8 @@
       "status": 200,
       "mustContain": "John Doe"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/fixtures/37-bundled-server/vercel.json
+++ b/packages/next/test/fixtures/37-bundled-server/vercel.json
@@ -3,5 +3,8 @@
     "env": {
       "VERCEL_NEXT_BUNDLED_SERVER": "1"
     }
+  },
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
   }
 }

--- a/packages/next/test/fixtures/500-getstaticprops-i18n/vercel.json
+++ b/packages/next/test/fixtures/500-getstaticprops-i18n/vercel.json
@@ -12,5 +12,8 @@
       "status": 500,
       "mustContain": "500 page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/404-getstaticprops-i18n/vercel.json
+++ b/packages/next/test/integration/404-getstaticprops-i18n/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/app-router-basepath/vercel.json
+++ b/packages/next/test/integration/app-router-basepath/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/custom-error-lambda/vercel.json
+++ b/packages/next/test/integration/custom-error-lambda/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/edge-app-dir-basepath/vercel.json
+++ b/packages/next/test/integration/edge-app-dir-basepath/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/initial-before-files-rewrite/vercel.json
+++ b/packages/next/test/integration/initial-before-files-rewrite/vercel.json
@@ -5,5 +5,8 @@
       "src": "package.json",
       "use": "@vercel/next"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -1,3 +1,4 @@
+process.env.NEXT_BUILDER_INTEGRATION = '1';
 process.env.NEXT_TELEMETRY_DISABLED = '1';
 
 const path = require('path');

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -1,3 +1,4 @@
+process.env.NEXT_BUILDER_INTEGRATION = '1';
 process.env.NEXT_TELEMETRY_DISABLED = '1';
 
 const path = require('path');

--- a/packages/next/test/integration/legacy-monorepo-basepath/vercel.json
+++ b/packages/next/test/integration/legacy-monorepo-basepath/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "app/package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "app/package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/middleware-dynamic/vercel.json
+++ b/packages/next/test/integration/middleware-dynamic/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/middleware-eval/vercel.json
+++ b/packages/next/test/integration/middleware-eval/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/ppr-basepath/vercel.json
+++ b/packages/next/test/integration/ppr-basepath/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/ppr-gsp/vercel.json
+++ b/packages/next/test/integration/ppr-gsp/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/ppr-legacy-basepath/vercel.json
+++ b/packages/next/test/integration/ppr-legacy-basepath/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/ppr-legacy/vercel.json
+++ b/packages/next/test/integration/ppr-legacy/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/ppr-root-params/vercel.json
+++ b/packages/next/test/integration/ppr-root-params/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/ppr/vercel.json
+++ b/packages/next/test/integration/ppr/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/rewrite-headers-with-rewrite/vercel.json
+++ b/packages/next/test/integration/rewrite-headers-with-rewrite/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/rewrite-headers/vercel.json
+++ b/packages/next/test/integration/rewrite-headers/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/segment-cache-cc.test.js
+++ b/packages/next/test/integration/segment-cache-cc.test.js
@@ -1,3 +1,4 @@
+process.env.NEXT_BUILDER_INTEGRATION = '1';
 process.env.NEXT_TELEMETRY_DISABLED = '1';
 
 const path = require('path');

--- a/packages/next/test/integration/segment-cache-cc/vercel.json
+++ b/packages/next/test/integration/segment-cache-cc/vercel.json
@@ -4,5 +4,8 @@
       "src": "package.json",
       "use": "@vercel/next"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/static-metadata.test.js
+++ b/packages/next/test/integration/static-metadata.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+process.env.NEXT_BUILDER_INTEGRATION = '1';
 process.env.NEXT_TELEMETRY_DISABLED = '1';
 
 const path = require('path');

--- a/packages/next/test/integration/static-site/vercel.json
+++ b/packages/next/test/integration/static-site/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/vercel.json
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/vercel.json
@@ -5,5 +5,8 @@
       "src": "package.json",
       "use": "@vercel/next"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/test-limit-exceeded-internal-files-server-build/vercel.json
+++ b/packages/next/test/integration/test-limit-exceeded-internal-files-server-build/vercel.json
@@ -22,5 +22,8 @@
       "status": 200,
       "mustContain": "index page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/test-limit-exceeded-server-build/vercel.json
+++ b/packages/next/test/integration/test-limit-exceeded-server-build/vercel.json
@@ -22,5 +22,8 @@
       "status": 200,
       "mustContain": "index page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/test-limit-exceeded-shared-lambdas/vercel.json
+++ b/packages/next/test/integration/test-limit-exceeded-shared-lambdas/vercel.json
@@ -22,5 +22,8 @@
       "status": 200,
       "mustContain": "index page"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/test-limit-large-uncompressed-files/vercel.json
+++ b/packages/next/test/integration/test-limit-large-uncompressed-files/vercel.json
@@ -5,5 +5,8 @@
       "src": "package.json",
       "use": "@vercel/next"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/packages/next/test/integration/use-cache/vercel.json
+++ b/packages/next/test/integration/use-cache/vercel.json
@@ -1,4 +1,12 @@
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_BUILDER_INTEGRATION": "1"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1707,8 +1707,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: https://adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz
-        version: '@adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz(next@16.1.6)'
+        specifier: 0.0.1-beta.9
+        version: 0.0.1-beta.9(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6399,6 +6399,15 @@ packages:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  /@next-community/adapter-vercel@0.0.1-beta.9(next@16.1.6):
+    resolution: {integrity: sha512-9PSiC/PztojB49ZssbQ1NGkPJeYRyMSFWR7XTzCpgdVfLNnVOPgZ7UFLvMbMhmxMx16878v9BWNp/gzQa1YU3A==}
+    engines: {node: '>= 20.6.0'}
+    peerDependencies:
+      next: '>= 16.1.1-canary.18'
+    dependencies:
+      next: 16.1.6(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
+    dev: true
 
   /@next/env@11.1.2:
     resolution: {integrity: sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA==}
@@ -21437,15 +21446,3 @@ packages:
   /zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
     dev: false
-
-  '@adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz(next@16.1.6)':
-    resolution: {tarball: https://adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz}
-    id: '@adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz'
-    name: '@next-community/adapter-vercel'
-    version: 0.0.1-beta.8
-    engines: {node: '>= 20.6.0'}
-    peerDependencies:
-      next: '>= 16.1.1-canary.18'
-    dependencies:
-      next: 16.1.6(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
-    dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1707,8 +1707,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.8
-        version: 0.0.1-beta.8(next@16.1.6)
+        specifier: https://adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz
+        version: '@adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz(next@16.1.6)'
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6399,15 +6399,6 @@ packages:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
-
-  /@next-community/adapter-vercel@0.0.1-beta.8(next@16.1.6):
-    resolution: {integrity: sha512-cxh4Ed3PhadigkQE/amtyieB+u+Z6dD8Kz3EKUQN1VS71tw1cdSzDfJG55ch+D1v4qxhsu1ISKdfyIimfZOa8A==}
-    engines: {node: '>= 20.6.0'}
-    peerDependencies:
-      next: '>= 16.1.1-canary.18'
-    dependencies:
-      next: 16.1.6(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
-    dev: true
 
   /@next/env@11.1.2:
     resolution: {integrity: sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA==}
@@ -21446,3 +21437,15 @@ packages:
   /zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
     dev: false
+
+  '@adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz(next@16.1.6)':
+    resolution: {tarball: https://adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz}
+    id: '@adapter-vercel-adapt-git-00df10-vtest314-next-adapter-e2e-tests.vercel.app/adapter.tgz'
+    name: '@next-community/adapter-vercel'
+    version: 0.0.1-beta.8
+    engines: {node: '>= 20.6.0'}
+    peerDependencies:
+      next: '>= 16.1.1-canary.18'
+    dependencies:
+      next: 16.1.6(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
+    dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1707,8 +1707,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.7
-        version: 0.0.1-beta.7(next@16.1.6)
+        specifier: 0.0.1-beta.8
+        version: 0.0.1-beta.8(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6400,8 +6400,8 @@ packages:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  /@next-community/adapter-vercel@0.0.1-beta.7(next@16.1.6):
-    resolution: {integrity: sha512-IDzM2kL+OBRP7vzSppt88DqTblZhfyib7Z63dQlxP6WBRlwKMuTy5OGHPTTuC5O/Ios+0w23IQrujVFJiFztgQ==}
+  /@next-community/adapter-vercel@0.0.1-beta.8(next@16.1.6):
+    resolution: {integrity: sha512-cxh4Ed3PhadigkQE/amtyieB+u+Z6dD8Kz3EKUQN1VS71tw1cdSzDfJG55ch+D1v4qxhsu1ISKdfyIimfZOa8A==}
     engines: {node: '>= 20.6.0'}
     peerDependencies:
       next: '>= 16.1.1-canary.18'


### PR DESCRIPTION
x-ref: https://github.com/nextjs/adapter-vercel/pull/31

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Minor dev dependency bump from beta.7 to beta.9 and adding test fixture environment variable across multiple vercel.json files.
> 
> - Dev dependency bump: @next-community/adapter-vercel 0.0.1-beta.7 → 0.0.1-beta.9
> - Adds NEXT_BUILDER_INTEGRATION env var to ~80 test fixture vercel.json files
>
> <sup>Risk assessment for [commit c970054](https://github.com/vercel/vercel/commit/c9700545d93e43f927dc03ab8f18ea9a42c399db).</sup>
<!-- VADE_RISK_END -->