### PR TITLE
perf(cli): skip redundant getUser call in selectOrg non-interactive mode

### DIFF
--- a/.changeset/fast-scope-resolve.md
+++ b/.changeset/fast-scope-resolve.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+Skip redundant `getUser` API call in `selectOrg` non-interactive mode when scope is already known
+
+When running in non-interactive mode (e.g. AI agent detected) with `--scope`/`--team` provided, `selectOrg` now resolves the team from `getTeams` alone, skipping the unnecessary `getUser` call. This eliminates a redundant `/v2/user` request that the global scope resolution in `index.ts` already performed.

--- a/packages/cli/src/util/input/select-org.ts
+++ b/packages/cli/src/util/input/select-org.ts
@@ -94,8 +94,19 @@ export default async function selectOrg(
     0
   );
 
-  // Non-interactive without a resolved scope: output choices and exit
+  // Non-interactive: the fast path above only checked teams.  If the user
+  // passed --scope/--team pointing at their personal account (non-northstar),
+  // currentTeam was cleared by index.ts and the fast path missed it.  Check
+  // the full choices list (which includes the personal account) before giving up.
   if (client.nonInteractive) {
+    const targetScope = currentTeam || getScopeOrTeamFromArgv(client.argv);
+    if (targetScope) {
+      const match = choices.find(
+        c => c.value.id === targetScope || c.value.slug === targetScope
+      );
+      if (match) return match.value;
+    }
+
     const actionRequired: ActionRequiredPayload = {
       status: 'action_required',
       reason: 'missing_scope',

--- a/packages/cli/src/util/input/select-org.ts
+++ b/packages/cli/src/util/input/select-org.ts
@@ -41,22 +41,38 @@ export default async function selectOrg(
     config: { currentTeam },
   } = client;
 
-  // Fast path: when non-interactive and the scope is already known we only
-  // need the teams list (skip getUser) to resolve the Org value.  This avoids
-  // a redundant /v2/user call that the global scope resolution in index.ts
-  // already made.
+  // Non-interactive fast path: when the scope is already known, try to
+  // resolve from teams alone (skip getUser).  This avoids a redundant
+  // /v2/user round-trip that the global scope resolution in index.ts
+  // already performed.
   if (client.nonInteractive) {
     const targetScope = currentTeam || getScopeOrTeamFromArgv(client.argv);
     if (targetScope) {
       const teams = await getTeams(client);
-      const match = teams.find(
+      const teamMatch = teams.find(
         t => t.id === targetScope || t.slug === targetScope
       );
-      if (match) {
-        return { type: 'team', id: match.id, slug: match.slug };
+      if (teamMatch) {
+        return { type: 'team', id: teamMatch.id, slug: teamMatch.slug };
       }
-      // targetScope didn't match any team — fall through to the full flow
-      // so the action_required payload includes the complete choices list.
+
+      // Scope didn't match a team — it may be a personal account
+      // (non-northstar).  Fetch user to check before falling through to
+      // the action_required error.
+      const user = await getUser(client);
+      if (
+        user.version !== 'northstar' &&
+        (user.id === targetScope ||
+          user.email === targetScope ||
+          user.username === targetScope)
+      ) {
+        return { type: 'user', id: user.id, slug: user.username };
+      }
+
+      // Scope is invalid — build the full choices list for the error payload
+      const choices = buildChoices(user, teams);
+      outputMissingScopeError(client, choices);
+      process.exit(1);
     }
   }
 
@@ -69,60 +85,16 @@ export default async function selectOrg(
     output.stopSpinner();
   }
 
-  const personalAccountChoice =
-    user.version === 'northstar'
-      ? []
-      : [
-          {
-            name: user.name || user.username,
-            value: { type: 'user', id: user.id, slug: user.username },
-          } as const,
-        ];
-
-  const choices: Choice[] = [
-    ...personalAccountChoice,
-    ...teams
-      .sort(a => (a.id === user.defaultTeamId ? -1 : 1))
-      .map<Choice>(team => ({
-        name: team.name || team.slug,
-        value: { type: 'team', id: team.id, slug: team.slug },
-      })),
-  ];
+  const choices = buildChoices(user, teams);
 
   const defaultChoiceIndex = Math.max(
     choices.findIndex(choice => choice.value.id === currentTeam),
     0
   );
 
-  // Non-interactive: the fast path above only checked teams.  If the user
-  // passed --scope/--team pointing at their personal account (non-northstar),
-  // currentTeam was cleared by index.ts and the fast path missed it.  Check
-  // the full choices list (which includes the personal account) before giving up.
+  // Non-interactive without a target scope: output choices and exit
   if (client.nonInteractive) {
-    const targetScope = currentTeam || getScopeOrTeamFromArgv(client.argv);
-    if (targetScope) {
-      const match = choices.find(
-        c => c.value.id === targetScope || c.value.slug === targetScope
-      );
-      if (match) return match.value;
-    }
-
-    const actionRequired: ActionRequiredPayload = {
-      status: 'action_required',
-      reason: 'missing_scope',
-      message:
-        choices.length > 0
-          ? 'Provide --scope or --team explicitly. No default is applied in non-interactive mode.'
-          : 'No scopes available.',
-      choices: choices.map(c => ({
-        id: c.value.id,
-        name: c.value.slug,
-      })),
-      next: choices.map(c => ({
-        command: `${packageName} link --scope ${c.value.slug}`,
-      })),
-    };
-    outputActionRequired(client, actionRequired);
+    outputMissingScopeError(client, choices);
     process.exit(1);
   }
 
@@ -135,4 +107,45 @@ export default async function selectOrg(
     choices,
     default: choices[defaultChoiceIndex].value,
   });
+}
+
+function buildChoices(user: User, teams: Team[]): Choice[] {
+  const personalAccountChoice =
+    user.version === 'northstar'
+      ? []
+      : [
+          {
+            name: user.name || user.username,
+            value: { type: 'user', id: user.id, slug: user.username },
+          } as const,
+        ];
+
+  return [
+    ...personalAccountChoice,
+    ...teams
+      .sort(a => (a.id === user.defaultTeamId ? -1 : 1))
+      .map<Choice>(team => ({
+        name: team.name || team.slug,
+        value: { type: 'team', id: team.id, slug: team.slug },
+      })),
+  ];
+}
+
+function outputMissingScopeError(client: Client, choices: Choice[]): void {
+  const actionRequired: ActionRequiredPayload = {
+    status: 'action_required',
+    reason: 'missing_scope',
+    message:
+      choices.length > 0
+        ? 'Provide --scope or --team explicitly. No default is applied in non-interactive mode.'
+        : 'No scopes available.',
+    choices: choices.map(c => ({
+      id: c.value.id,
+      name: c.value.slug,
+    })),
+    next: choices.map(c => ({
+      command: `${packageName} link --scope ${c.value.slug}`,
+    })),
+  };
+  outputActionRequired(client, actionRequired);
 }


### PR DESCRIPTION
## Summary

When running in non-interactive mode with `--scope`/`--team` provided (or `currentTeam` already set by the global scope resolution), `selectOrg` now resolves the team from `getTeams` alone, skipping the unnecessary `getUser` call.

This eliminates a redundant `/v2/user` round-trip that the global scope resolution in `index.ts` already performed — saving one API call on every non-interactive CLI invocation with a known scope.

### Changes

**`packages/cli/src/util/input/select-org.ts`**

Added a fast path at the top of the non-interactive branch:
1. Determine `targetScope` from `currentTeam` or `--scope`/`--team` argv
2. If known, fetch only `getTeams` (skip `getUser`)
3. Find the matching team by ID or slug and return early
4. If no match (e.g. personal account scope or invalid), fall through to the full flow that fetches both `getUser` + `getTeams` and builds the `action_required` choices list

### Before / After

| Scenario | Before | After |
|---|---|---|
| Non-interactive + `--scope team-slug` | `getUser` + `getTeams` (2 calls) | `getTeams` only (1 call) |
| Non-interactive + no scope | `getUser` + `getTeams` | `getUser` + `getTeams` (unchanged) |
| Interactive mode | `getUser` + `getTeams` | `getUser` + `getTeams` (unchanged) |

Fixes #15125
Related: #15068 #15077

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR is a performance optimization that adds a fast path to skip a redundant API call in non-interactive mode, with no changes to authorization logic or security controls.
> 
> - Adds early return path in non-interactive mode when scope already known
> - Refactors existing code into `buildChoices` and `outputMissingScopeError` helper functions
> - Changeset documentation for patch release
>
> <sup>Risk assessment for [commit 694640d](https://github.com/vercel/vercel/commit/694640deaa601daf3bc654829ca1c479cf386408).</sup>
<!-- VADE_RISK_END -->