### PR TITLE
fix(cli): destroy HTTP agent on exit to prevent process hang

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1046,5 +1046,6 @@ Run ${chalk.cyan(cmd(await getUpdateCommand()))} to update.${errorMsg}`
     }
 
     process.exitCode = exitCode;
+    client?.agent?.destroy();
   })
   .catch(handleUnexpected);


### PR DESCRIPTION
## Summary

- Destroy the HTTP agent after the command finishes so the Node process can exit cleanly
- Fixes `vc integration add <slug> --help` (and potentially other commands) hanging indefinitely after printing output

## Root Cause

The CLI creates an `HttpsAgent({ keepAlive: true })` at startup (`src/index.ts:367`). After a command returns, the main flow sets `process.exitCode = exitCode` but never calls `process.exit()` — it relies on the event loop draining naturally. The keepAlive sockets never close, so the process hangs forever.

Most commands aren't affected because they either call `process.exit(1)` on errors or don't make API calls on clean exit paths. The `--help` dynamic path (which fetches integration data and billing plans) is the first clean `return 0` path that exposes this.

## Fix

One line: `client?.agent?.destroy()` after `process.exitCode = exitCode`.

## Repro

```
$ vc integration add neon --help
# ... output prints correctly ...
# process hangs, never exits (Ctrl+C required)
```

## Test plan

```bash
# Build and test locally
pnpm --filter vercel build
FF_AUTO_PROVISION_INSTALL=1 timeout 15 node packages/cli/dist/index.js integration add neon --help
# Should print help and exit with code 0 (previously hung until timeout)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a single line to destroy the HTTP agent on CLI exit to prevent process hang, which is a straightforward resource cleanup fix with no security implications.
> 
> - Adds `client?.agent?.destroy()` call after setting exit code
> - Fixes keepAlive socket preventing clean process termination
>
> <sup>Risk assessment for [commit 99eef12](https://github.com/vercel/vercel/commit/99eef12155dea36c381be0eb446e37bf078f4ac5).</sup>
<!-- VADE_RISK_END -->