### PR TITLE
feat(cli): `integration open` resource support and `--format=json` output

### DIFF
--- a/.changeset/integration-open-resource-print-only.md
+++ b/.changeset/integration-open-resource-print-only.md
@@ -2,4 +2,4 @@
 "vercel": patch
 ---
 
-feat(cli): `integration open` now supports opening resource dashboards and `--print-only` flag
+feat(cli): `integration open` now supports opening resource dashboards and JSON output via `--format=json`

--- a/.changeset/integration-open-resource-print-only.md
+++ b/.changeset/integration-open-resource-print-only.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+feat(cli): `integration open` now supports opening resource dashboards and `--print-only` flag

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -158,7 +158,7 @@ export const openSubcommand = {
       required: false,
     },
   ],
-  options: [formatOption, jsonOption],
+  options: [formatOption],
   examples: [
     {
       name: "Open a marketplace integration's dashboard",

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -146,20 +146,47 @@ export type IntegrationAddFlags = {
 export const openSubcommand = {
   name: 'open',
   aliases: [],
-  description: "Opens a marketplace integration's dashboard",
+  description:
+    "Opens a marketplace integration's or resource's dashboard via SSO",
   arguments: [
     {
       name: 'name',
       required: true,
     },
+    {
+      name: 'resource',
+      required: false,
+    },
   ],
-  options: [],
+  options: [
+    {
+      name: 'print-only',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Print the SSO link to stdout instead of opening it',
+    },
+  ],
   examples: [
     {
       name: "Open a marketplace integration's dashboard",
       value: [
         `${packageName} integration open <integration-name>`,
         `${packageName} integration open acme`,
+      ],
+    },
+    {
+      name: "Open a resource's dashboard within an integration",
+      value: [
+        `${packageName} integration open <integration-name> <resource-name>`,
+        `${packageName} integration open acme my-acme-store`,
+      ],
+    },
+    {
+      name: 'Print the SSO link without opening',
+      value: [
+        `${packageName} integration open acme --print-only`,
+        `${packageName} integration open acme my-acme-store --print-only`,
       ],
     },
   ],

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -160,11 +160,11 @@ export const openSubcommand = {
   ],
   options: [
     {
-      name: 'print-only',
+      name: 'json',
       shorthand: null,
       type: Boolean,
       deprecated: false,
-      description: 'Print the SSO link to stdout instead of opening it',
+      description: 'Output the SSO link as JSON',
     },
   ],
   examples: [
@@ -183,10 +183,10 @@ export const openSubcommand = {
       ],
     },
     {
-      name: 'Print the SSO link without opening',
+      name: 'Get the SSO link as JSON',
       value: [
-        `${packageName} integration open acme --print-only`,
-        `${packageName} integration open acme my-acme-store --print-only`,
+        `${packageName} integration open acme --json`,
+        `${packageName} integration open acme my-acme-store --json`,
       ],
     },
   ],

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -158,15 +158,7 @@ export const openSubcommand = {
       required: false,
     },
   ],
-  options: [
-    {
-      name: 'json',
-      shorthand: null,
-      type: Boolean,
-      deprecated: false,
-      description: 'Output the SSO link as JSON',
-    },
-  ],
+  options: [formatOption, jsonOption],
   examples: [
     {
       name: "Open a marketplace integration's dashboard",
@@ -185,8 +177,8 @@ export const openSubcommand = {
     {
       name: 'Get the SSO link as JSON',
       value: [
-        `${packageName} integration open acme --json`,
-        `${packageName} integration open acme my-acme-store --json`,
+        `${packageName} integration open acme --format=json`,
+        `${packageName} integration open acme my-acme-store --format=json`,
       ],
     },
   ],

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -207,18 +207,7 @@ export default async function main(client: Client) {
         return 0;
       }
       telemetry.trackCliSubcommandOpen(subcommandOriginal);
-
-      const openFlagsSpec = getFlagsSpecification(openSubcommand.options);
-      let openParsedArgs;
-      try {
-        openParsedArgs = parseArguments(subArgs, openFlagsSpec);
-      } catch (error) {
-        printError(error);
-        return 1;
-      }
-      const asJson = openParsedArgs.flags['--json'] as boolean | undefined;
-
-      return openIntegration(client, openParsedArgs.args, asJson);
+      return openIntegration(client, subArgs);
     }
     case 'remove': {
       if (needHelp) {

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -216,11 +216,9 @@ export default async function main(client: Client) {
         printError(error);
         return 1;
       }
-      const printOnly = openParsedArgs.flags['--print-only'] as
-        | boolean
-        | undefined;
+      const asJson = openParsedArgs.flags['--json'] as boolean | undefined;
 
-      return openIntegration(client, openParsedArgs.args, printOnly);
+      return openIntegration(client, openParsedArgs.args, asJson);
     }
     case 'remove': {
       if (needHelp) {

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -207,7 +207,20 @@ export default async function main(client: Client) {
         return 0;
       }
       telemetry.trackCliSubcommandOpen(subcommandOriginal);
-      return openIntegration(client, subArgs);
+
+      const openFlagsSpec = getFlagsSpecification(openSubcommand.options);
+      let openParsedArgs;
+      try {
+        openParsedArgs = parseArguments(subArgs, openFlagsSpec);
+      } catch (error) {
+        printError(error);
+        return 1;
+      }
+      const printOnly = openParsedArgs.flags['--print-only'] as
+        | boolean
+        | undefined;
+
+      return openIntegration(client, openParsedArgs.args, printOnly);
     }
     case 'remove': {
       if (needHelp) {

--- a/packages/cli/src/commands/integration/open-integration.ts
+++ b/packages/cli/src/commands/integration/open-integration.ts
@@ -98,7 +98,7 @@ export async function openIntegration(
     );
 
     if (printOnly) {
-      output.print(`${link}\n`);
+      client.stdout.write(`${link}\n`);
     } else {
       output.print(
         `Opening the ${chalk.bold(resourceName)} resource dashboard...`
@@ -113,7 +113,7 @@ export async function openIntegration(
   const link = buildSSOLink(team, configurationId);
 
   if (printOnly) {
-    output.print(`${link}\n`);
+    client.stdout.write(`${link}\n`);
   } else {
     output.print(`Opening the ${chalk.bold(integrationSlug)} dashboard...`);
     open(link);

--- a/packages/cli/src/commands/integration/open-integration.ts
+++ b/packages/cli/src/commands/integration/open-integration.ts
@@ -77,7 +77,14 @@ export async function openIntegration(
 
   // If a resource name is provided, look it up and build SSO link with resource_id
   if (resourceName) {
-    const resources = await getResources(client, team.id);
+    let resources;
+    try {
+      resources = await getResources(client, team.id);
+    } catch (error) {
+      output.error(`Failed to fetch resources: ${(error as Error).message}`);
+      return 1;
+    }
+
     const resource = resources.find(
       r =>
         r.name === resourceName &&

--- a/packages/cli/src/commands/integration/open-integration.ts
+++ b/packages/cli/src/commands/integration/open-integration.ts
@@ -73,13 +73,15 @@ export async function openIntegration(
     return 1;
   }
 
+  const configurationId = configuration.id;
+
   // If a resource name is provided, look it up and build SSO link with resource_id
   if (resourceName) {
     const resources = await getResources(client, team.id);
     const resource = resources.find(
       r =>
         r.name === resourceName &&
-        r.product?.integrationConfigurationId === configuration.id
+        r.product?.integrationConfigurationId === configurationId
     );
 
     if (!resource) {
@@ -91,7 +93,7 @@ export async function openIntegration(
 
     const link = buildSSOLink(
       team,
-      configuration.id,
+      configurationId,
       resource.externalResourceId
     );
 
@@ -108,7 +110,7 @@ export async function openIntegration(
   }
 
   // No resource specified — open the integration dashboard
-  const link = buildSSOLink(team, configuration.id);
+  const link = buildSSOLink(team, configurationId);
 
   if (printOnly) {
     output.print(`${link}\n`);

--- a/packages/cli/src/commands/integration/open-integration.ts
+++ b/packages/cli/src/commands/integration/open-integration.ts
@@ -38,7 +38,6 @@ export async function openIntegration(client: Client, subArgs: string[]) {
   }
   const asJson = formatResult.jsonOutput;
 
-  telemetry.trackCliFlagJson(parsedArguments.flags['--json']);
   telemetry.trackCliOptionFormat(parsedArguments.flags['--format']);
 
   if (args.length > 2) {

--- a/packages/cli/src/util/integration/build-sso-link.ts
+++ b/packages/cli/src/util/integration/build-sso-link.ts
@@ -1,8 +1,15 @@
 import type { Team } from '@vercel-internals/types';
 
-export function buildSSOLink(team: Team, configurationId: string) {
+export function buildSSOLink(
+  team: Team,
+  configurationId: string,
+  resourceExternalId?: string
+) {
   const url = new URL('/api/marketplace/sso', 'https://vercel.com');
   url.searchParams.set('teamId', team.id);
   url.searchParams.set('integrationConfigurationId', configurationId);
+  if (resourceExternalId) {
+    url.searchParams.set('resource_id', resourceExternalId);
+  }
   return url.href;
 }

--- a/packages/cli/src/util/telemetry/commands/integration/open.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/open.ts
@@ -21,10 +21,4 @@ export class IntegrationOpenTelemetryClient
       });
     }
   }
-
-  trackCliFlagJson(v: boolean | undefined) {
-    if (v) {
-      this.trackCliFlag('json');
-    }
-  }
 }

--- a/packages/cli/src/util/telemetry/commands/integration/open.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/open.ts
@@ -12,4 +12,19 @@ export class IntegrationOpenTelemetryClient
       value: known ? v : this.redactedValue,
     });
   }
+
+  trackCliArgumentResource(v: string | undefined) {
+    if (v) {
+      this.trackCliArgument({
+        arg: 'resource',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagPrintOnly(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('print-only');
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/integration/open.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/open.ts
@@ -22,9 +22,9 @@ export class IntegrationOpenTelemetryClient
     }
   }
 
-  trackCliFlagPrintOnly(v: boolean | undefined) {
+  trackCliFlagJson(v: boolean | undefined) {
     if (v) {
-      this.trackCliFlag('print-only');
+      this.trackCliFlag('json');
     }
   }
 }

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -1133,7 +1133,7 @@ export function useConfiguration() {
     const foundConfigs =
       configurations[(integrationIdOrSlug ?? 'acme-no-results') as string];
 
-    res.json(foundConfigs);
+    res.json(foundConfigs ?? []);
   });
 }
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2901,6 +2901,51 @@ exports[`help command > integration help output snapshots > integration balance 
 "
 `;
 
+exports[`help command > integration help output snapshots > integration guide subcommand > integration guide subcommand help column width 120 1`] = `
+"
+  ▲ vercel integration guide integration [options]
+
+  Show getting started guides and code snippets for a marketplace integration                                           
+
+  Options:
+
+  -f,  --framework <FRAMEWORK>  Select a framework guide without interactive prompt (e.g., nextjs, remix, astro, nuxtjs,
+                                sveltekit)                                                                              
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Show guides for a single-product integration
+
+    $ vercel integration guide <integration-name>
+    $ vercel integration guide neon
+
+  - Show guides for a specific product of a multi-product integration
+
+    $ vercel integration guide <integration>/<product>
+    $ vercel integration guide aws/aws-dynamodb
+
+  - Show the Next.js guide without prompts (useful for CI/agents)
+
+    $ vercel integration guide neon --framework nextjs
+
+"
+`;
+
 exports[`help command > integration help output snapshots > integration help column width 40 1`] = `
 "
   ▲ vercel integration command
@@ -2922,6 +2967,20 @@ exports[`help command > integration help output snapshots > integration help col
                              specif…
                              market…
                              integr…
+  discover                   Discov…
+                             availa…
+                             market…
+                             integr…
+  guide     integration      Show   
+                             getting
+                             started
+                             guides 
+                             and    
+                             code   
+                             snippe…
+                             for a  
+                             market…
+                             integr…
   list      [project]        List   
                              resour…
                              from   
@@ -2930,10 +2989,6 @@ exports[`help command > integration help output snapshots > integration help col
                              for the
                              current
                              project
-  discover                   Discov…
-                             availa…
-                             market…
-                             integr…
   open      name [resource]  Opens a
                              market…
                              integr…
@@ -3015,9 +3070,11 @@ exports[`help command > integration help output snapshots > integration help col
   add       integration      Installs a marketplace integration             
   balance   integration      Shows the balances and thresholds of a         
                              specified marketplace integration              
+  discover                   Discover available marketplace integrations    
+  guide     integration      Show getting started guides and code snippets  
+                             for a marketplace integration                  
   list      [project]        List resources from marketplace integrations   
                              for the current project                        
-  discover                   Discover available marketplace integrations    
   open      name [resource]  Opens a marketplace integration's or resource's
                              dashboard via SSO                              
   remove    integration      Uninstalls a marketplace integration           
@@ -3058,8 +3115,9 @@ exports[`help command > integration help output snapshots > integration help col
 
   add       integration      Installs a marketplace integration                                                     
   balance   integration      Shows the balances and thresholds of a specified marketplace integration               
-  list      [project]        List resources from marketplace integrations for the current project                   
   discover                   Discover available marketplace integrations                                            
+  guide     integration      Show getting started guides and code snippets for a marketplace integration            
+  list      [project]        List resources from marketplace integrations for the current project                   
   open      name [resource]  Opens a marketplace integration's or resource's dashboard via SSO                      
   remove    integration      Uninstalls a marketplace integration                                                   
 
@@ -3665,10 +3723,14 @@ exports[`help command > list help output snapshots > list help column width 40 1
 "
   ▲ vercel list [app] [options]
 
-  List app deployments for an app.      
+  List deployments.                     
 
   Options:
 
+  -a,  --all                   List       
+                               resources  
+                               across all 
+                               projects   
        --environment <TARGET>             
   -F,  --format <FORMAT>       Specify the
                                output     
@@ -3767,7 +3829,11 @@ exports[`help command > list help output snapshots > list help column width 40 1
 
     $ vercel list
 
-  - List all deployments for the project \`my-app\` in the team of the currently linked project
+  - List all deployments across all projects
+
+    $ vercel list --all
+
+  - List all deployments for the project \`my-app\`
 
     $ vercel list my-app
 
@@ -3794,10 +3860,11 @@ exports[`help command > list help output snapshots > list help column width 80 1
 "
   ▲ vercel list [app] [options]
 
-  List app deployments for an app.                                              
+  List deployments.                                                             
 
   Options:
 
+  -a,  --all                   List resources across all projects                 
        --environment <TARGET>                                                     
   -F,  --format <FORMAT>       Specify the output format (json)                   
   -m,  --meta <KEY=VALUE>      Filter deployments by metadata (e.g.: \`-m          
@@ -3834,7 +3901,11 @@ exports[`help command > list help output snapshots > list help column width 80 1
 
     $ vercel list
 
-  - List all deployments for the project \`my-app\` in the team of the currently linked project
+  - List all deployments across all projects
+
+    $ vercel list --all
+
+  - List all deployments for the project \`my-app\`
 
     $ vercel list my-app
 
@@ -3861,10 +3932,11 @@ exports[`help command > list help output snapshots > list help column width 120 
 "
   ▲ vercel list [app] [options]
 
-  List app deployments for an app.                                                                                      
+  List deployments.                                                                                                     
 
   Options:
 
+  -a,  --all                   List resources across all projects                                                         
        --environment <TARGET>                                                                                             
   -F,  --format <FORMAT>       Specify the output format (json)                                                           
   -m,  --meta <KEY=VALUE>      Filter deployments by metadata (e.g.: \`-m KEY=value\`). Can appear many times.              
@@ -3896,7 +3968,11 @@ exports[`help command > list help output snapshots > list help column width 120 
 
     $ vercel list
 
-  - List all deployments for the project \`my-app\` in the team of the currently linked project
+  - List all deployments across all projects
+
+    $ vercel list --all
+
+  - List all deployments for the project \`my-app\`
 
     $ vercel list my-app
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2901,51 +2901,6 @@ exports[`help command > integration help output snapshots > integration balance 
 "
 `;
 
-exports[`help command > integration help output snapshots > integration guide subcommand > integration guide subcommand help column width 120 1`] = `
-"
-  ▲ vercel integration guide integration [options]
-
-  Show getting started guides and code snippets for a marketplace integration                                           
-
-  Options:
-
-  -f,  --framework <FRAMEWORK>  Select a framework guide without interactive prompt (e.g., nextjs, remix, astro, nuxtjs,
-                                sveltekit)                                                                              
-
-
-  Global Options:
-
-       --cwd <DIR>            Sets the current working directory for a single run of a command                          
-  -d,  --debug                Debug mode (default off)                                                                  
-  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
-  -h,  --help                 Output usage information                                                                  
-  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
-       --no-color             No color mode (default off)                                                               
-       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
-  -S,  --scope                Set a custom scope                                                                        
-  -t,  --token <TOKEN>        Login token                                                                               
-  -v,  --version              Output the version number                                                                 
-
-
-  Examples:
-
-  - Show guides for a single-product integration
-
-    $ vercel integration guide <integration-name>
-    $ vercel integration guide neon
-
-  - Show guides for a specific product of a multi-product integration
-
-    $ vercel integration guide <integration>/<product>
-    $ vercel integration guide aws/aws-dynamodb
-
-  - Show the Next.js guide without prompts (useful for CI/agents)
-
-    $ vercel integration guide neon --framework nextjs
-
-"
-`;
-
 exports[`help command > integration help output snapshots > integration help column width 40 1`] = `
 "
   ▲ vercel integration command
@@ -2954,48 +2909,42 @@ exports[`help command > integration help output snapshots > integration help col
 
   Commands:
 
-  add       integration  Installs
-                         a       
-                         marketp…
-                         integra…
-  balance   integration  Shows   
-                         the     
-                         balances
-                         and     
-                         thresho…
-                         of a    
-                         specifi…
-                         marketp…
-                         integra…
-  discover               Discover
-                         availab…
-                         marketp…
-                         integra…
-  guide     integration  Show    
-                         getting 
-                         started 
-                         guides  
-                         and code
-                         snippets
-                         for a   
-                         marketp…
-                         integra…
-  list      [project]    List    
-                         resourc…
-                         from    
-                         marketp…
-                         integra…
-                         for the 
-                         current 
-                         project 
-  open      name         Opens a 
-                         marketp…
-                         integra…
-                         dashboa…
-  remove    integration  Uninsta…
-                         a       
-                         marketp…
-                         integra…
+  add       integration      Instal…
+                             a      
+                             market…
+                             integr…
+  balance   integration      Shows  
+                             the    
+                             balanc…
+                             and    
+                             thresh…
+                             of a   
+                             specif…
+                             market…
+                             integr…
+  list      [project]        List   
+                             resour…
+                             from   
+                             market…
+                             integr…
+                             for the
+                             current
+                             project
+  discover                   Discov…
+                             availa…
+                             market…
+                             integr…
+  open      name [resource]  Opens a
+                             market…
+                             integr…
+                             or     
+                             resour…
+                             dashbo…
+                             via SSO
+  remove    integration      Uninst…
+                             a      
+                             market…
+                             integr…
 
 
   Global Options:
@@ -3063,16 +3012,15 @@ exports[`help command > integration help output snapshots > integration help col
 
   Commands:
 
-  add       integration  Installs a marketplace integration              
-  balance   integration  Shows the balances and thresholds of a specified
-                         marketplace integration                         
-  discover               Discover available marketplace integrations     
-  guide     integration  Show getting started guides and code snippets   
-                         for a marketplace integration                   
-  list      [project]    List resources from marketplace integrations for
-                         the current project                             
-  open      name         Opens a marketplace integration's dashboard     
-  remove    integration  Uninstalls a marketplace integration            
+  add       integration      Installs a marketplace integration             
+  balance   integration      Shows the balances and thresholds of a         
+                             specified marketplace integration              
+  list      [project]        List resources from marketplace integrations   
+                             for the current project                        
+  discover                   Discover available marketplace integrations    
+  open      name [resource]  Opens a marketplace integration's or resource's
+                             dashboard via SSO                              
+  remove    integration      Uninstalls a marketplace integration           
 
 
   Global Options:
@@ -3108,13 +3056,12 @@ exports[`help command > integration help output snapshots > integration help col
 
   Commands:
 
-  add       integration  Installs a marketplace integration                                                      
-  balance   integration  Shows the balances and thresholds of a specified marketplace integration                
-  discover               Discover available marketplace integrations                                             
-  guide     integration  Show getting started guides and code snippets for a marketplace integration             
-  list      [project]    List resources from marketplace integrations for the current project                    
-  open      name         Opens a marketplace integration's dashboard                                             
-  remove    integration  Uninstalls a marketplace integration                                                    
+  add       integration      Installs a marketplace integration                                                     
+  balance   integration      Shows the balances and thresholds of a specified marketplace integration               
+  list      [project]        List resources from marketplace integrations for the current project                   
+  discover                   Discover available marketplace integrations                                            
+  open      name [resource]  Opens a marketplace integration's or resource's dashboard via SSO                      
+  remove    integration      Uninstalls a marketplace integration                                                   
 
 
   Global Options:
@@ -3718,14 +3665,10 @@ exports[`help command > list help output snapshots > list help column width 40 1
 "
   ▲ vercel list [app] [options]
 
-  List deployments.                     
+  List app deployments for an app.      
 
   Options:
 
-  -a,  --all                   List       
-                               resources  
-                               across all 
-                               projects   
        --environment <TARGET>             
   -F,  --format <FORMAT>       Specify the
                                output     
@@ -3824,11 +3767,7 @@ exports[`help command > list help output snapshots > list help column width 40 1
 
     $ vercel list
 
-  - List all deployments across all projects
-
-    $ vercel list --all
-
-  - List all deployments for the project \`my-app\`
+  - List all deployments for the project \`my-app\` in the team of the currently linked project
 
     $ vercel list my-app
 
@@ -3855,11 +3794,10 @@ exports[`help command > list help output snapshots > list help column width 80 1
 "
   ▲ vercel list [app] [options]
 
-  List deployments.                                                             
+  List app deployments for an app.                                              
 
   Options:
 
-  -a,  --all                   List resources across all projects                 
        --environment <TARGET>                                                     
   -F,  --format <FORMAT>       Specify the output format (json)                   
   -m,  --meta <KEY=VALUE>      Filter deployments by metadata (e.g.: \`-m          
@@ -3896,11 +3834,7 @@ exports[`help command > list help output snapshots > list help column width 80 1
 
     $ vercel list
 
-  - List all deployments across all projects
-
-    $ vercel list --all
-
-  - List all deployments for the project \`my-app\`
+  - List all deployments for the project \`my-app\` in the team of the currently linked project
 
     $ vercel list my-app
 
@@ -3927,11 +3861,10 @@ exports[`help command > list help output snapshots > list help column width 120 
 "
   ▲ vercel list [app] [options]
 
-  List deployments.                                                                                                     
+  List app deployments for an app.                                                                                      
 
   Options:
 
-  -a,  --all                   List resources across all projects                                                         
        --environment <TARGET>                                                                                             
   -F,  --format <FORMAT>       Specify the output format (json)                                                           
   -m,  --meta <KEY=VALUE>      Filter deployments by metadata (e.g.: \`-m KEY=value\`). Can appear many times.              
@@ -3963,11 +3896,7 @@ exports[`help command > list help output snapshots > list help column width 120 
 
     $ vercel list
 
-  - List all deployments across all projects
-
-    $ vercel list --all
-
-  - List all deployments for the project \`my-app\`
+  - List all deployments for the project \`my-app\` in the team of the currently linked project
 
     $ vercel list my-app
 

--- a/packages/cli/test/unit/commands/integration/open-integration.test.ts
+++ b/packages/cli/test/unit/commands/integration/open-integration.test.ts
@@ -165,6 +165,63 @@ describe('integration', () => {
           });
         });
 
+        describe('--format=json', () => {
+          it('should output SSO link as JSON without opening browser', async () => {
+            useProject({
+              ...defaultProject,
+              id: 'vercel-integration-open',
+              name: 'vercel-integration-open',
+            });
+            client.setArgv('integration', 'open', 'acme', '--format=json');
+            const exitCode = await integrationCommand(client);
+            expect(exitCode, 'exit code for "integration"').toEqual(0);
+            expect(openMock).not.toHaveBeenCalled();
+            await expect(client.stdout).toOutput(
+              '"url": "https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1"'
+            );
+          });
+
+          it('should track --format telemetry', async () => {
+            useProject({
+              ...defaultProject,
+              id: 'vercel-integration-open',
+              name: 'vercel-integration-open',
+            });
+            client.setArgv('integration', 'open', 'acme', '--format=json');
+            const exitCode = await integrationCommand(client);
+            expect(exitCode).toEqual(0);
+
+            expect(client.telemetryEventStore).toHaveTelemetryEvents([
+              {
+                key: 'subcommand:open',
+                value: 'open',
+              },
+              {
+                key: 'option:format',
+                value: 'json',
+              },
+              {
+                key: 'argument:name',
+                value: 'acme',
+              },
+            ]);
+          });
+
+          it('should error for invalid format value', async () => {
+            useProject({
+              ...defaultProject,
+              id: 'vercel-integration-open',
+              name: 'vercel-integration-open',
+            });
+            client.setArgv('integration', 'open', 'acme', '--format=xml');
+            const exitCode = await integrationCommand(client);
+            expect(exitCode, 'exit code for "integration"').toEqual(1);
+            await expect(client.stderr).toOutput(
+              'Error: Invalid output format: "xml"'
+            );
+          });
+        });
+
         describe('non-TTY stdout', () => {
           it('should write raw URL to stdout when piped', async () => {
             useProject({
@@ -230,6 +287,27 @@ describe('integration', () => {
             'acme',
             'store-acme-connected-project',
             '--json'
+          );
+          const exitCode = await integrationCommand(client);
+          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          expect(openMock).not.toHaveBeenCalled();
+          await expect(client.stdout).toOutput(
+            '"url": "https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1&resource_id=ext_store_1"'
+          );
+        });
+
+        it('should output resource SSO link as JSON with --format=json', async () => {
+          useProject({
+            ...defaultProject,
+            id: 'vercel-integration-open',
+            name: 'vercel-integration-open',
+          });
+          client.setArgv(
+            'integration',
+            'open',
+            'acme',
+            'store-acme-connected-project',
+            '--format=json'
           );
           const exitCode = await integrationCommand(client);
           expect(exitCode, 'exit code for "integration"').toEqual(0);

--- a/packages/cli/test/unit/commands/integration/open-integration.test.ts
+++ b/packages/cli/test/unit/commands/integration/open-integration.test.ts
@@ -362,6 +362,28 @@ describe('integration', () => {
           const exitCode = await exitCodePromise;
           expect(exitCode, 'exit code for "integration"').toEqual(1);
         });
+
+        it('should error when the resources API responds erroneously', async () => {
+          const teams = useTeams('team_dummy');
+          const team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+          client.config.currentTeam = team.id;
+          useConfiguration();
+          useResources(500);
+
+          client.setArgv(
+            'integration',
+            'open',
+            'acme',
+            'store-acme-connected-project'
+          );
+          const exitCodePromise = integrationCommand(client);
+          await expect(client.stderr).toOutput(
+            'Error: Failed to fetch resources:',
+            20000
+          );
+          const exitCode = await exitCodePromise;
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
+        });
       });
     });
   });

--- a/packages/cli/test/unit/commands/integration/open-integration.test.ts
+++ b/packages/cli/test/unit/commands/integration/open-integration.test.ts
@@ -133,7 +133,7 @@ describe('integration', () => {
             const exitCode = await integrationCommand(client);
             expect(exitCode, 'exit code for "integration"').toEqual(0);
             expect(openMock).not.toHaveBeenCalled();
-            await expect(client.stderr).toOutput(
+            await expect(client.stdout).toOutput(
               'https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1'
             );
           });
@@ -216,7 +216,7 @@ describe('integration', () => {
           const exitCode = await integrationCommand(client);
           expect(exitCode, 'exit code for "integration"').toEqual(0);
           expect(openMock).not.toHaveBeenCalled();
-          await expect(client.stderr).toOutput(
+          await expect(client.stdout).toOutput(
             'https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1&resource_id=ext_store_1'
           );
         });

--- a/packages/cli/test/unit/commands/integration/open-integration.test.ts
+++ b/packages/cli/test/unit/commands/integration/open-integration.test.ts
@@ -122,29 +122,29 @@ describe('integration', () => {
           ]);
         });
 
-        describe('--print-only', () => {
-          it('should print SSO link without opening browser for integration', async () => {
+        describe('--json', () => {
+          it('should output SSO link as JSON without opening browser', async () => {
             useProject({
               ...defaultProject,
               id: 'vercel-integration-open',
               name: 'vercel-integration-open',
             });
-            client.setArgv('integration', 'open', 'acme', '--print-only');
+            client.setArgv('integration', 'open', 'acme', '--json');
             const exitCode = await integrationCommand(client);
             expect(exitCode, 'exit code for "integration"').toEqual(0);
             expect(openMock).not.toHaveBeenCalled();
             await expect(client.stdout).toOutput(
-              'https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1'
+              '"url": "https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1"'
             );
           });
 
-          it('should track --print-only telemetry', async () => {
+          it('should track --json telemetry', async () => {
             useProject({
               ...defaultProject,
               id: 'vercel-integration-open',
               name: 'vercel-integration-open',
             });
-            client.setArgv('integration', 'open', 'acme', '--print-only');
+            client.setArgv('integration', 'open', 'acme', '--json');
             const exitCode = await integrationCommand(client);
             expect(exitCode).toEqual(0);
 
@@ -154,7 +154,7 @@ describe('integration', () => {
                 value: 'open',
               },
               {
-                key: 'flag:print-only',
+                key: 'flag:json',
                 value: 'TRUE',
               },
               {
@@ -162,6 +162,24 @@ describe('integration', () => {
                 value: 'acme',
               },
             ]);
+          });
+        });
+
+        describe('non-TTY stdout', () => {
+          it('should write raw URL to stdout when piped', async () => {
+            useProject({
+              ...defaultProject,
+              id: 'vercel-integration-open',
+              name: 'vercel-integration-open',
+            });
+            client.setArgv('integration', 'open', 'acme');
+            (client.stdout as any).isTTY = false;
+            const exitCode = await integrationCommand(client);
+            expect(exitCode, 'exit code for "integration"').toEqual(0);
+            expect(openMock).not.toHaveBeenCalled();
+            await expect(client.stdout).toOutput(
+              'https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1'
+            );
           });
         });
       });
@@ -200,7 +218,7 @@ describe('integration', () => {
           );
         });
 
-        it('should print resource SSO link with --print-only', async () => {
+        it('should output resource SSO link as JSON with --json', async () => {
           useProject({
             ...defaultProject,
             id: 'vercel-integration-open',
@@ -211,13 +229,13 @@ describe('integration', () => {
             'open',
             'acme',
             'store-acme-connected-project',
-            '--print-only'
+            '--json'
           );
           const exitCode = await integrationCommand(client);
           expect(exitCode, 'exit code for "integration"').toEqual(0);
           expect(openMock).not.toHaveBeenCalled();
           await expect(client.stdout).toOutput(
-            'https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1&resource_id=ext_store_1'
+            '"url": "https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1&resource_id=ext_store_1"'
           );
         });
 

--- a/packages/cli/test/unit/commands/integration/open-integration.test.ts
+++ b/packages/cli/test/unit/commands/integration/open-integration.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import open from 'open';
 import integrationCommand from '../../../../src/commands/integration';
 import { client } from '../../../mocks/client';
-import { useConfiguration } from '../../../mocks/integration';
+import { useConfiguration, useResources } from '../../../mocks/integration';
 import { defaultProject, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
@@ -121,25 +121,187 @@ describe('integration', () => {
             },
           ]);
         });
+
+        describe('--print-only', () => {
+          it('should print SSO link without opening browser for integration', async () => {
+            useProject({
+              ...defaultProject,
+              id: 'vercel-integration-open',
+              name: 'vercel-integration-open',
+            });
+            client.setArgv('integration', 'open', 'acme', '--print-only');
+            const exitCode = await integrationCommand(client);
+            expect(exitCode, 'exit code for "integration"').toEqual(0);
+            expect(openMock).not.toHaveBeenCalled();
+            await expect(client.stderr).toOutput(
+              'https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1'
+            );
+          });
+
+          it('should track --print-only telemetry', async () => {
+            useProject({
+              ...defaultProject,
+              id: 'vercel-integration-open',
+              name: 'vercel-integration-open',
+            });
+            client.setArgv('integration', 'open', 'acme', '--print-only');
+            const exitCode = await integrationCommand(client);
+            expect(exitCode).toEqual(0);
+
+            expect(client.telemetryEventStore).toHaveTelemetryEvents([
+              {
+                key: 'subcommand:open',
+                value: 'open',
+              },
+              {
+                key: 'flag:print-only',
+                value: 'TRUE',
+              },
+              {
+                key: 'argument:name',
+                value: 'acme',
+              },
+            ]);
+          });
+        });
+      });
+
+      describe('found resources', () => {
+        const teamId = 'team_dummy';
+
+        beforeEach(() => {
+          const teams = useTeams(teamId);
+          const team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+          client.config.currentTeam = team.id;
+
+          useConfiguration();
+          useResources();
+        });
+
+        it('should open resource dashboard with resource_id in SSO link', async () => {
+          useProject({
+            ...defaultProject,
+            id: 'vercel-integration-open',
+            name: 'vercel-integration-open',
+          });
+          client.setArgv(
+            'integration',
+            'open',
+            'acme',
+            'store-acme-connected-project'
+          );
+          const exitCode = await integrationCommand(client);
+          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          await expect(client.stderr).toOutput(
+            'Opening the store-acme-connected-project resource dashboard...'
+          );
+          expect(openMock).toHaveBeenCalledWith(
+            'https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1&resource_id=ext_store_1'
+          );
+        });
+
+        it('should print resource SSO link with --print-only', async () => {
+          useProject({
+            ...defaultProject,
+            id: 'vercel-integration-open',
+            name: 'vercel-integration-open',
+          });
+          client.setArgv(
+            'integration',
+            'open',
+            'acme',
+            'store-acme-connected-project',
+            '--print-only'
+          );
+          const exitCode = await integrationCommand(client);
+          expect(exitCode, 'exit code for "integration"').toEqual(0);
+          expect(openMock).not.toHaveBeenCalled();
+          await expect(client.stderr).toOutput(
+            'https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1&resource_id=ext_store_1'
+          );
+        });
+
+        it('should track resource argument in telemetry', async () => {
+          useProject({
+            ...defaultProject,
+            id: 'vercel-integration-open',
+            name: 'vercel-integration-open',
+          });
+          client.setArgv(
+            'integration',
+            'open',
+            'acme',
+            'store-acme-connected-project'
+          );
+          const exitCode = await integrationCommand(client);
+          expect(exitCode).toEqual(0);
+
+          expect(client.telemetryEventStore).toHaveTelemetryEvents([
+            {
+              key: 'subcommand:open',
+              value: 'open',
+            },
+            {
+              key: 'argument:name',
+              value: 'acme',
+            },
+            {
+              key: 'argument:resource',
+              value: '[REDACTED]',
+            },
+          ]);
+        });
+
+        it('should not match a resource belonging to a different integration', async () => {
+          useProject({
+            ...defaultProject,
+            id: 'vercel-integration-open',
+            name: 'vercel-integration-open',
+          });
+          // store-foo-bar-both-projects belongs to foo-bar, not acme
+          client.setArgv(
+            'integration',
+            'open',
+            'acme',
+            'store-foo-bar-both-projects'
+          );
+          const exitCode = await integrationCommand(client);
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
+          await expect(client.stderr).toOutput(
+            'Error: Resource "store-foo-bar-both-projects" not found for integration "acme".'
+          );
+        });
+
+        it('should error when resource name is not found', async () => {
+          useProject({
+            ...defaultProject,
+            id: 'vercel-integration-open',
+            name: 'vercel-integration-open',
+          });
+          client.setArgv('integration', 'open', 'acme', 'nonexistent-resource');
+          const exitCode = await integrationCommand(client);
+          expect(exitCode, 'exit code for "integration"').toEqual(1);
+          await expect(client.stderr).toOutput(
+            'Error: Resource "nonexistent-resource" not found for integration "acme".'
+          );
+        });
       });
 
       describe('errors', () => {
-        it('should error when no integration arugment is passed', async () => {
+        it('should error when no argument is passed', async () => {
           client.setArgv('integration', 'open');
           const exitCode = await integrationCommand(client);
           expect(exitCode, 'exit code for "integration"').toEqual(1);
           await expect(client.stderr).toOutput(
-            'Error: You must pass an integration slug'
+            'Error: You must pass an integration name'
           );
         });
 
-        it('should error when more than one integration arugment is passed', async () => {
-          client.setArgv('integration', 'open', 'acme', 'foobar');
+        it('should error when too many arguments are passed', async () => {
+          client.setArgv('integration', 'open', 'acme', 'resource', 'extra');
           const exitCode = await integrationCommand(client);
           expect(exitCode, 'exit code for "integration"').toEqual(1);
-          await expect(client.stderr).toOutput(
-            'Error: Cannot open more than one dashboard at a time'
-          );
+          await expect(client.stderr).toOutput('Error: Too many arguments');
         });
 
         it('should error when no team is present', async () => {

--- a/packages/cli/test/unit/commands/integration/open-integration.test.ts
+++ b/packages/cli/test/unit/commands/integration/open-integration.test.ts
@@ -122,49 +122,6 @@ describe('integration', () => {
           ]);
         });
 
-        describe('--json', () => {
-          it('should output SSO link as JSON without opening browser', async () => {
-            useProject({
-              ...defaultProject,
-              id: 'vercel-integration-open',
-              name: 'vercel-integration-open',
-            });
-            client.setArgv('integration', 'open', 'acme', '--json');
-            const exitCode = await integrationCommand(client);
-            expect(exitCode, 'exit code for "integration"').toEqual(0);
-            expect(openMock).not.toHaveBeenCalled();
-            await expect(client.stdout).toOutput(
-              '"url": "https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1"'
-            );
-          });
-
-          it('should track --json telemetry', async () => {
-            useProject({
-              ...defaultProject,
-              id: 'vercel-integration-open',
-              name: 'vercel-integration-open',
-            });
-            client.setArgv('integration', 'open', 'acme', '--json');
-            const exitCode = await integrationCommand(client);
-            expect(exitCode).toEqual(0);
-
-            expect(client.telemetryEventStore).toHaveTelemetryEvents([
-              {
-                key: 'subcommand:open',
-                value: 'open',
-              },
-              {
-                key: 'flag:json',
-                value: 'TRUE',
-              },
-              {
-                key: 'argument:name',
-                value: 'acme',
-              },
-            ]);
-          });
-        });
-
         describe('--format=json', () => {
           it('should output SSO link as JSON without opening browser', async () => {
             useProject({
@@ -272,27 +229,6 @@ describe('integration', () => {
           );
           expect(openMock).toHaveBeenCalledWith(
             'https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1&resource_id=ext_store_1'
-          );
-        });
-
-        it('should output resource SSO link as JSON with --json', async () => {
-          useProject({
-            ...defaultProject,
-            id: 'vercel-integration-open',
-            name: 'vercel-integration-open',
-          });
-          client.setArgv(
-            'integration',
-            'open',
-            'acme',
-            'store-acme-connected-project',
-            '--json'
-          );
-          const exitCode = await integrationCommand(client);
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
-          expect(openMock).not.toHaveBeenCalled();
-          await expect(client.stdout).toOutput(
-            '"url": "https://vercel.com/api/marketplace/sso?teamId=team_dummy&integrationConfigurationId=acme-1&resource_id=ext_store_1"'
           );
         });
 


### PR DESCRIPTION
## Summary

- Extends `vercel integration open` to accept an optional `[resource]` positional argument, allowing users to SSO directly into a specific resource's dashboard: `vercel integration open <integration> <resource>`
- Adds `--format=json` flag to output the SSO link as JSON to stdout instead of opening the browser, useful for CI/scripts
- In non-TTY environments (piped output), the raw SSO URL is written to stdout without opening the browser
- Resources are matched by name **and** integration configuration ID to prevent cross-integration collisions (e.g. two integrations having a resource with the same name)
- Uses the standard `formatOption` + `validateJsonOutput` pattern; only `--format=json` is accepted (no deprecated `--json` alias)

[MKT-2664: command to give sso login link](https://linear.app/vercel/issue/MKT-2664/command-to-give-sso-login-link)

## Examples

#### JSON output (integration)
```sh
vercel integration open redis --format=json
{
  "url": "https://vercel.com/api/marketplace/sso?teamId=team_xxx&integrationConfigurationId=icfg_xxx"
}
```

#### JSON output (resource)
```sh
vercel integration open redis redis-new-db --format=json
{
  "url": "https://vercel.com/api/marketplace/sso?teamId=team_xxx&integrationConfigurationId=icfg_xxx&resource_id=xxx"
}
```

#### Piped output (non-TTY)
```sh
vercel integration open redis | pbcopy
# Copies raw SSO URL to clipboard
```

#### Non-existent resource
```sh
vercel integration open redis non-existent
Error: Resource "non-existent" not found for integration "redis".
```

## Test plan

- [x] All 21 tests in `open-integration.test.ts` pass
- [x] TypeScript type check passes cleanly (no new errors)
- [x] Help snapshots up to date
- [x] `--format=json` outputs JSON to stdout without opening browser
- [x] `--format=xml` (invalid) returns proper error message
- [x] Non-TTY stdout writes raw URL without opening browser
- [x] TTY stdout opens browser with message
- [x] Resource lookup scoped to integration's configuration ID
- [x] Telemetry tracks `--format` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds CLI feature enhancements for the `integration open` command including a new resource argument and JSON output format, with no security-sensitive changes - only new optional parameters, output formatting, and comprehensive test coverage.
> 
> - Adds optional `resource` positional argument and `--format=json` flag to CLI command
> - Extends `buildSSOLink` to include optional `resource_id` parameter
> - Adds 21 new test cases covering resource lookup, JSON output, and error handling
>
> <sup>Risk assessment for [commit 25ac042](https://github.com/vercel/vercel/commit/25ac0429a06f34a9c95cbddbf3a7136f0a0f1d39).</sup>
<!-- VADE_RISK_END -->