### PR TITLE
fix(cli): read all stdin chunks in readStandardInput

### DIFF
--- a/.changeset/fix-stdin-multiline.md
+++ b/.changeset/fix-stdin-multiline.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+Fix `vercel env add` truncating multiline values piped via stdin
+
+`readStandardInput` used `stdin.once('data', resolve)` which only captured the first chunk of piped input. Multiline values (e.g. PEM private keys) were silently truncated to the first line. Now reads all chunks until the stream ends.

--- a/packages/cli/src/util/input/read-standard-input.ts
+++ b/packages/cli/src/util/input/read-standard-input.ts
@@ -4,14 +4,23 @@ export default async function readStandardInput(
   stdin: ReadableTTY
 ): Promise<string> {
   return new Promise<string>(resolve => {
-    setTimeout(() => resolve(''), 500);
-
     if (stdin.isTTY) {
       // found tty so we know there is nothing piped to stdin
       resolve('');
     } else {
+      // Guard: if no data arrives within 500ms, assume nothing was piped.
+      // Once data starts flowing, cancel the timeout and read everything.
+      const timer = setTimeout(() => resolve(''), 500);
       stdin.setEncoding('utf8');
-      stdin.once('data', resolve);
+      const chunks: string[] = [];
+      stdin.on('data', (chunk: string) => {
+        clearTimeout(timer);
+        chunks.push(chunk);
+      });
+      stdin.on('end', () => {
+        clearTimeout(timer);
+        resolve(chunks.join(''));
+      });
     }
   });
 }

--- a/packages/cli/test/unit/util/input/read-standard-input.test.ts
+++ b/packages/cli/test/unit/util/input/read-standard-input.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { PassThrough } from 'node:stream';
+import readStandardInput from '../../../../src/util/input/read-standard-input';
+
+function createMockStdin({ isTTY = false }: { isTTY?: boolean } = {}) {
+  const stream = new PassThrough() as PassThrough & { isTTY: boolean };
+  stream.isTTY = isTTY;
+  return stream;
+}
+
+describe('readStandardInput', () => {
+  it('returns empty string for TTY stdin', async () => {
+    const stdin = createMockStdin({ isTTY: true });
+    const result = await readStandardInput(stdin as any);
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when no data arrives within timeout', async () => {
+    const stdin = createMockStdin();
+    const result = await readStandardInput(stdin as any);
+    expect(result).toBe('');
+  }, 2000);
+
+  it('reads single-line input', async () => {
+    const stdin = createMockStdin();
+    const promise = readStandardInput(stdin as any);
+    stdin.end('hello world\n');
+    const result = await promise;
+    expect(result).toBe('hello world\n');
+  });
+
+  it('reads multiline input from a single chunk', async () => {
+    const stdin = createMockStdin();
+    const promise = readStandardInput(stdin as any);
+    const multiline =
+      '-----BEGIN PRIVATE KEY-----\nMIIEvQIBA...\n-----END PRIVATE KEY-----\n';
+    stdin.end(multiline);
+    const result = await promise;
+    expect(result).toBe(multiline);
+  });
+
+  it('reads multiline input split across multiple chunks', async () => {
+    const stdin = createMockStdin();
+    const promise = readStandardInput(stdin as any);
+    stdin.write('line1\n');
+    stdin.write('line2\n');
+    stdin.write('line3\n');
+    stdin.end();
+    const result = await promise;
+    expect(result).toBe('line1\nline2\nline3\n');
+  });
+});


### PR DESCRIPTION
## Summary

`vercel env add` silently truncates multiline values (e.g. PEM private keys) when piped via stdin. Only the first line is captured; everything after the first newline is dropped.

### Root cause

`readStandardInput` used `stdin.once('data', resolve)` which resolves the promise on the **first chunk** of data. Node.js streams may deliver piped input across multiple chunks, especially for multiline content.

### Fix

Replace `once('data')` with `on('data')` + `on('end')` to collect all chunks before resolving. The 500ms timeout guard (for detecting when nothing is piped) is preserved but cleared once data starts flowing.

### Before / After

| Input | Before | After |
|---|---|---|
| `echo "one line" \| vercel env add ...` | ✅ Works | ✅ Works |
| `cat key.pem \| vercel env add ...` | ❌ Truncated to first line | ✅ Full value |
| `vercel env add ...` (interactive) | ✅ Works | ✅ Works |

### Tests

Added `read-standard-input.test.ts` covering:
- TTY stdin → empty string
- No data timeout → empty string
- Single-line pipe
- Multiline single chunk
- Multiline multiple chunks

Fixes #14972

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR fixes a bug in stdin reading by collecting all data chunks instead of only the first one, with no security implications - purely a data completeness fix for CLI input handling.
> 
> - Replaces `stdin.once('data')` with `stdin.on('data')` + `on('end')` to collect all chunks
> - Adds timeout guard that clears once data starts flowing
> - New unit tests covering TTY, timeout, single-line, and multiline input scenarios
>
> <sup>Risk assessment for [commit aee3511](https://github.com/vercel/vercel/commit/aee35110621d3bc5a813a41f5fe1c5d4d7381248).</sup>
<!-- VADE_RISK_END -->