### PR TITLE
fix(cli): make `install --help` show same dynamic help as `integration add --help`

### DIFF
--- a/.changeset/fix-install-help-alias.md
+++ b/.changeset/fix-install-help-alias.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): make `install --help` show same dynamic help as `integration add --help`

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -4,6 +4,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { help } from '../help';
 import { add } from '../integration/add';
+import { printAddDynamicHelp } from '../integration/add-help';
 import { addSubcommand } from '../integration/command';
 import { installCommand } from './command';
 import output from '../../output-manager';
@@ -27,7 +28,19 @@ export default async function install(client: Client) {
 
   if (flags['--help']) {
     telemetry.trackCliFlagHelp('install');
-    output.print(help(installCommand, { columns: client.stderr.columns }));
+
+    const printed = await printAddDynamicHelp(
+      client,
+      args[1],
+      installCommand,
+      cmd => output.print(help(cmd, { columns: client.stderr.columns })),
+      'install'
+    );
+
+    if (!printed) {
+      output.print(help(installCommand, { columns: client.stderr.columns }));
+    }
+
     return 0;
   }
 

--- a/packages/cli/src/commands/integration/add-help.ts
+++ b/packages/cli/src/commands/integration/add-help.ts
@@ -1,0 +1,85 @@
+import type Client from '../../util/client';
+import type { Command } from '../help';
+import output from '../../output-manager';
+import { fetchIntegration } from '../../util/integration/fetch-integration';
+import { formatProductHelp } from '../../util/integration/format-product-help';
+import { formatBillingPlansHelp } from '../../util/integration/format-billing-plans-help';
+import { formatDynamicExamples } from '../../util/integration/format-dynamic-examples';
+import { formatMetadataSchemaHelp } from '../../util/integration/format-schema-help';
+import { fetchBillingPlans } from '../../util/integration/fetch-billing-plans';
+
+/**
+ * Prints dynamic, integration-specific help for the `integration add` / `install` command.
+ * If a slug is provided and the integration can be fetched, prints dynamic help
+ * (examples, products, metadata schemas, billing plans) and returns true.
+ * Otherwise returns false, and the caller should print static help as a fallback.
+ */
+export async function printAddDynamicHelp(
+  client: Client,
+  rawArg: string | undefined,
+  baseCommand: Command,
+  printHelp: (command: Command) => void,
+  commandName: string
+): Promise<boolean> {
+  if (!rawArg) {
+    return false;
+  }
+
+  const integrationSlug = rawArg.split('/')[0];
+  const productSlug = rawArg.includes('/') ? rawArg.split('/')[1] : undefined;
+
+  try {
+    const integration = await fetchIntegration(client, integrationSlug);
+    const products = integration.products ?? [];
+
+    // Print help without static examples — we'll show dynamic ones instead
+    printHelp({ ...baseCommand, examples: [] });
+    output.print(formatDynamicExamples(integrationSlug, products, commandName));
+
+    if (products.length > 1) {
+      output.print(formatProductHelp(integrationSlug, products, commandName));
+    }
+
+    // Show metadata schema for ALL products
+    for (const product of products) {
+      if (product.metadataSchema) {
+        // For single-product integrations, don't show product slug
+        // For multi-product integrations, show product slug for slash syntax
+        const metadataProductSlug =
+          products.length > 1 ? product.slug : undefined;
+        output.print(
+          formatMetadataSchemaHelp(
+            product.metadataSchema,
+            integrationSlug,
+            metadataProductSlug
+          )
+        );
+      }
+    }
+
+    // Show billing plans for each product (or just the specified one)
+    const productsToShow = productSlug
+      ? products.filter(p => p.slug === productSlug)
+      : products;
+    for (const product of productsToShow) {
+      try {
+        const { plans } = await fetchBillingPlans(
+          client,
+          integration,
+          product,
+          {}
+        );
+        output.print(formatBillingPlansHelp(product.name, plans));
+      } catch (err: unknown) {
+        output.debug(
+          `Failed to fetch billing plans for ${product.slug}: ${err}`
+        );
+      }
+    }
+
+    return true;
+  } catch (err: unknown) {
+    output.debug(`Failed to fetch integration for dynamic help: ${err}`);
+    return false;
+  }
+}

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -25,12 +25,7 @@ import { openIntegration } from './open-integration';
 import { remove } from './remove-integration';
 import { discover } from './discover';
 import { guide } from './guide';
-import { fetchIntegration } from '../../util/integration/fetch-integration';
-import { formatProductHelp } from '../../util/integration/format-product-help';
-import { formatBillingPlansHelp } from '../../util/integration/format-billing-plans-help';
-import { formatDynamicExamples } from '../../util/integration/format-dynamic-examples';
-import { formatMetadataSchemaHelp } from '../../util/integration/format-schema-help';
-import { fetchBillingPlans } from '../../util/integration/fetch-billing-plans';
+import { printAddDynamicHelp } from './add-help';
 
 const COMMAND_CONFIG = {
   add: getCommandAliases(addSubcommand),
@@ -85,70 +80,18 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration', subcommandOriginal);
 
-        // Dynamic help: if an integration slug is provided, fetch and show integration-specific help
-        const rawArg = subArgs[0];
-        if (rawArg) {
-          // Strip product slug if slash syntax was used (e.g. "upstash/upstash-kv" → "upstash")
-          const integrationSlug = rawArg.split('/')[0];
-          const productSlug = rawArg.includes('/')
-            ? rawArg.split('/')[1]
-            : undefined;
-          try {
-            const integration = await fetchIntegration(client, integrationSlug);
-            const products = integration.products ?? [];
+        const printed = await printAddDynamicHelp(
+          client,
+          subArgs[0],
+          addSubcommand,
+          cmd => printHelp(cmd),
+          'integration add'
+        );
 
-            // Print help without static examples — we'll show dynamic ones instead
-            printHelp({ ...addSubcommand, examples: [] });
-            output.print(formatDynamicExamples(integrationSlug, products));
-
-            if (products.length > 1) {
-              output.print(formatProductHelp(integrationSlug, products));
-            }
-            // Show metadata schema for ALL products
-            for (const product of products) {
-              if (product.metadataSchema) {
-                // For single-product integrations, don't show product slug
-                // For multi-product integrations, show product slug for slash syntax
-                const metadataProductSlug =
-                  products.length > 1 ? product.slug : undefined;
-                output.print(
-                  formatMetadataSchemaHelp(
-                    product.metadataSchema,
-                    integrationSlug,
-                    metadataProductSlug
-                  )
-                );
-              }
-            }
-            // Show billing plans for each product (or just the specified one)
-            const productsToShow = productSlug
-              ? products.filter(p => p.slug === productSlug)
-              : products;
-            for (const product of productsToShow) {
-              try {
-                const { plans } = await fetchBillingPlans(
-                  client,
-                  integration,
-                  product,
-                  {}
-                );
-                output.print(formatBillingPlansHelp(product.name, plans));
-              } catch (err: unknown) {
-                output.debug(
-                  `Failed to fetch billing plans for ${product.slug}: ${err}`
-                );
-              }
-            }
-            return 0;
-          } catch (err: unknown) {
-            output.debug(
-              `Failed to fetch integration for dynamic help: ${err}`
-            );
-          }
+        if (!printed) {
+          printHelp(addSubcommand);
         }
 
-        // Fallback: no integration slug provided, or fetch failed — show static help
-        printHelp(addSubcommand);
         return 0;
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);

--- a/packages/cli/src/util/integration/format-dynamic-examples.ts
+++ b/packages/cli/src/util/integration/format-dynamic-examples.ts
@@ -9,7 +9,8 @@ import type { IntegrationProduct } from './types';
  */
 export function formatDynamicExamples(
   integrationSlug: string,
-  products: IntegrationProduct[]
+  products: IntegrationProduct[],
+  commandName = 'integration add'
 ): string {
   const lines: string[] = [];
   lines.push('');
@@ -20,7 +21,7 @@ export function formatDynamicExamples(
   lines.push(`  ${chalk.dim('-')} Install ${integrationSlug}`);
   lines.push('');
   lines.push(
-    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug}`)}`
+    `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug}`)}`
   );
 
   // Slash syntax for multi-product
@@ -30,7 +31,7 @@ export function formatDynamicExamples(
     lines.push(`  ${chalk.dim('-')} Install a specific product`);
     lines.push('');
     lines.push(
-      `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug}/${firstProduct.slug}`)}`
+      `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug}/${firstProduct.slug}`)}`
     );
   }
 
@@ -39,11 +40,15 @@ export function formatDynamicExamples(
   lines.push(`  ${chalk.dim('-')} Install with a custom resource name`);
   lines.push('');
   lines.push(
-    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} --name my-resource`)}`
+    `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --name my-resource`)}`
   );
 
   // Metadata example — pick the first product with a schema and build a real example
-  const metadataExample = buildMetadataExample(integrationSlug, products);
+  const metadataExample = buildMetadataExample(
+    integrationSlug,
+    products,
+    commandName
+  );
   if (metadataExample) {
     lines.push('');
     lines.push(`  ${chalk.dim('-')} Install with metadata`);
@@ -56,7 +61,7 @@ export function formatDynamicExamples(
   lines.push(`  ${chalk.dim('-')} Install with a specific billing plan`);
   lines.push('');
   lines.push(
-    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} --plan pro`)}`
+    `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --plan pro`)}`
   );
 
   // Environment
@@ -66,7 +71,7 @@ export function formatDynamicExamples(
   );
   lines.push('');
   lines.push(
-    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} -e production -e preview`)}`
+    `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} -e production -e preview`)}`
   );
 
   // No-connect
@@ -76,7 +81,7 @@ export function formatDynamicExamples(
   );
   lines.push('');
   lines.push(
-    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} --no-connect`)}`
+    `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --no-connect`)}`
   );
 
   // No-env-pull
@@ -86,7 +91,7 @@ export function formatDynamicExamples(
   );
   lines.push('');
   lines.push(
-    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} --no-env-pull`)}`
+    `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --no-env-pull`)}`
   );
 
   lines.push('');
@@ -96,7 +101,8 @@ export function formatDynamicExamples(
 
 function buildMetadataExample(
   integrationSlug: string,
-  products: IntegrationProduct[]
+  products: IntegrationProduct[],
+  commandName: string
 ): string | undefined {
   // Find first product with a schema that has visible fields
   for (const product of products) {
@@ -132,7 +138,7 @@ function buildMetadataExample(
         products.length > 1
           ? `${integrationSlug}/${product.slug}`
           : integrationSlug;
-      return `${packageName} integration add ${slug} ${flags.join(' ')}`;
+      return `${packageName} ${commandName} ${slug} ${flags.join(' ')}`;
     }
   }
 

--- a/packages/cli/src/util/integration/format-product-help.ts
+++ b/packages/cli/src/util/integration/format-product-help.ts
@@ -8,7 +8,8 @@ import type { IntegrationProduct } from './types';
  */
 export function formatProductHelp(
   integrationSlug: string,
-  products: IntegrationProduct[]
+  products: IntegrationProduct[],
+  commandName = 'integration add'
 ): string {
   const lines: string[] = [];
   lines.push('');
@@ -29,7 +30,7 @@ export function formatProductHelp(
   lines.push(`  ${chalk.dim('Usage:')}`);
   lines.push('');
   lines.push(
-    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug}/<product-slug>`)}`
+    `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug}/<product-slug>`)}`
   );
   lines.push('');
 

--- a/packages/cli/test/unit/commands/install/index.test.ts
+++ b/packages/cli/test/unit/commands/install/index.test.ts
@@ -53,6 +53,35 @@ describe('install', () => {
         },
       ]);
     });
+
+    it('shows dynamic help with integration slug', async () => {
+      useUser();
+      const teams = useTeams('team_dummy');
+      const team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+      client.config.currentTeam = team.id;
+      useIntegration({ withInstallation: true, ownerId: team.id });
+
+      client.setArgv('install', 'acme', '--help');
+      const exitCode = await install(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.getFullOutput();
+      // Dynamic examples should use "install" not "integration add"
+      expect(output).toContain('$ vercel install acme');
+      expect(output).not.toContain('$ vercel integration add');
+      // Should show metadata and billing plan info
+      expect(output).toContain('Metadata options for "acme"');
+      expect(output).toContain('Available billing plans for');
+    });
+
+    it('falls back to static help without a slug', async () => {
+      client.setArgv('install', '--help');
+      const exitCode = await install(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.getFullOutput();
+      expect(output).toContain('vercel install');
+    });
   });
 
   describe('[integration]', () => {

--- a/packages/cli/test/unit/util/integration/format-dynamic-examples.test.ts
+++ b/packages/cli/test/unit/util/integration/format-dynamic-examples.test.ts
@@ -49,4 +49,13 @@ describe('formatDynamicExamples', () => {
       ).toBe(true);
     }
   });
+
+  it('should use custom commandName in examples', () => {
+    const output = stripAnsi(
+      formatDynamicExamples('test-integration', productWithSchema, 'install')
+    );
+
+    expect(output).toContain('$ vercel install test-integration');
+    expect(output).not.toContain('integration add');
+  });
 });

--- a/packages/cli/test/unit/util/integration/format-product-help.test.ts
+++ b/packages/cli/test/unit/util/integration/format-product-help.test.ts
@@ -49,4 +49,12 @@ describe('formatProductHelp', () => {
     expect(result).toContain('Available products for "my-integration"');
     expect(result).toContain('my-integration/<product-slug>');
   });
+
+  it('should use custom commandName in usage example', () => {
+    const products = [makeProduct({ slug: 'prod-a', name: 'Product A' })];
+    const result = stripAnsi(formatProductHelp('acme', products, 'install'));
+
+    expect(result).toContain('$ vercel install acme/<product-slug>');
+    expect(result).not.toContain('integration add');
+  });
 });


### PR DESCRIPTION
Closes MKT-2881

## Summary

`vc install` is a 100% alias for `vc integration add`, but their `--help` output was completely different:

- `vc install neon --help` — static stub with 2 generic "acme" examples, ignored the integration slug, no API calls
- `vc integration add neon --help` — dynamic help fetching real integration data, showing products, metadata schemas, billing plans, and slug-specific examples

This PR fixes the disparity:

- Extracts the dynamic help logic into a shared `printAddDynamicHelp()` function in `add-help.ts`
- Both `install` and `integration add` now call this shared function
- Format functions (`formatDynamicExamples`, `formatProductHelp`) accept a `commandName` parameter so examples show `vercel install <slug>` vs `vercel integration add <slug>` as appropriate

## Test plan

### Unit Tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/install/index.test.ts test/unit/commands/integration/add.test.ts test/unit/util/integration/format-product-help.test.ts

 ✓ test/unit/util/integration/format-product-help.test.ts  (5 tests) 2ms
 ✓ test/unit/commands/install/index.test.ts  (13 tests) 123ms
 ✓ test/unit/commands/integration/add.test.ts  (74 tests) 4307ms

 Test Files  3 passed (3)
      Tests  92 passed (92)
```

New tests added:
- `install --help` with integration slug shows dynamic help using `vercel install` (not `vercel integration add`) in examples
- `install --help` without slug falls back to static help
- `formatProductHelp` with custom `commandName` parameter

### Manual Testing

`--help` works without auth (the `fetchIntegration` endpoint is public):

```
$ vc install neon --help     # Now shows dynamic help with products, metadata, billing plans
$ vc integration add neon --help  # Unchanged behavior
```

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR refactors CLI help output logic by extracting shared dynamic help functionality into a reusable function, with no changes to authentication, authorization, or security-sensitive code paths.
> 
> - Extracts `printAddDynamicHelp()` function to share help formatting between `install` and `integration add` commands
> - Adds `commandName` parameter to format functions for correct command display in examples
> - Adds unit tests for new dynamic help behavior and custom command name formatting
>
> <sup>Risk assessment for [commit d1454e3](https://github.com/vercel/vercel/commit/d1454e3155ae8f2318b0da836583327f82d34104).</sup>
<!-- VADE_RISK_END -->