### PR TITLE
[cli] Send deviceFingerprint in auto-provision requests

### DIFF
--- a/packages/cli/src/util/integration/auto-provision-resource.ts
+++ b/packages/cli/src/util/integration/auto-provision-resource.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import output from '../../output-manager';
 import type Client from '../client';
 import { APIError } from '../errors-ts';
@@ -7,6 +8,21 @@ import type {
   AutoProvisionResult,
   Metadata,
 } from './types';
+
+function generateDeviceFingerprint() {
+  return {
+    userAgent: `vercel-cli/${process.env.npm_package_version ?? 'unknown'}`,
+    operatingSystem: `${os.platform()}-${os.arch()}`,
+    timezone:
+      Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC',
+    acceptedLanguage: process.env.LANG?.split('.')[0] ?? 'en-US',
+    acceptedCharset: 'utf-8',
+    capabilitiesJsWebgl: false,
+    gpuVendor: 'none',
+    gpuModel: 'none',
+    plugins: 'none',
+  };
+}
 
 function isAutoProvisionFallback(
   error: unknown
@@ -39,6 +55,7 @@ export async function autoProvisionResource(
     metadata,
     acceptedPolicies,
     source: 'cli',
+    deviceFingerprint: generateDeviceFingerprint(),
     ...(billingPlanId ? { billingPlanId } : {}),
   };
   output.debug(`Auto-provision request: POST ${endpoint}`);


### PR DESCRIPTION
## Summary
- Generate and include a `deviceFingerprint` when calling the auto-provision API endpoint
- AWS integrations require this for account creation fraud prevention — without it, provisioning fails with `"fingerprint_required"`
- Companion API PR: https://github.com/vercel/api/pull/61152

## Test plan
- [ ] Verify `vercel integration add` for AWS products (DynamoDB, DSQL, RDS) provisions successfully
- [ ] Verify fingerprint is included in the request body (check debug output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a device fingerprint generation function and includes it in auto-provision API requests for fraud prevention, which is a straightforward data addition with no security or validation changes.
> 
> - Adds generateDeviceFingerprint() function collecting OS, timezone, and CLI version info
> - Includes deviceFingerprint in auto-provision request body
>
> <sup>Risk assessment for [commit 3cc186c](https://github.com/vercel/vercel/commit/3cc186c358a2b0639c09fe73b46d0566f169f122).</sup>
<!-- VADE_RISK_END -->