### PR TITLE
[config] Convert path-to-regexp patterns to regex in Route output

### DIFF
--- a/.changeset/witty-dogs-move.md
+++ b/.changeset/witty-dogs-move.md
@@ -1,0 +1,5 @@
+---
+'@vercel/config': patch
+---
+
+Fix rewrite regexp conversion when header transforms are present

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -41,6 +41,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@vercel/routing-utils": "workspace:*",
     "pretty-cache-header": "^1.0.0",
     "zod": "^3.22.0"
   },

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -388,7 +388,7 @@ describe('Router', () => {
       );
 
       expect(route).toMatchObject({
-        src: '/users/:userId',
+        src: '^\\/users(?:\\/([^\\/]+?))$',
         dest: 'https://api.example.com/users/$1',
         transforms: [
           {
@@ -437,7 +437,7 @@ describe('Router', () => {
       );
 
       expect(route).toMatchObject({
-        src: '/api/(.*)',
+        src: '^\\/api(?:\\/(.*))$',
         dest: 'https://backend.example.com/$1',
         respectOriginCacheControl: false,
       });
@@ -472,7 +472,7 @@ describe('Router', () => {
       }));
 
       expect(route).toMatchObject({
-        src: '/old',
+        src: '^\\/old$',
         dest: '/new',
         status: 308,
         transforms: [

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -1,6 +1,26 @@
 import { cacheHeader } from 'pretty-cache-header';
+import { sourceToRegex } from '@vercel/routing-utils';
 import { validateRegexPattern, parseCronExpression } from './utils/validation';
 import type { Redirect, Rewrite } from './types';
+
+/**
+ * Convert a destination string from path-to-regexp format to use capture group references.
+ * Replaces :paramName with $index based on the segments array.
+ */
+function convertDestination(destination: string, segments: string[]): string {
+  let result = destination;
+  segments.forEach((segment, index) => {
+    const patterns = [
+      new RegExp(`:${segment}\\*`, 'g'),
+      new RegExp(`:${segment}\\+`, 'g'),
+      new RegExp(`:${segment}(?![a-zA-Z0-9_])`, 'g'),
+    ];
+    for (const pattern of patterns) {
+      result = result.replace(pattern, `$${index + 1}`);
+    }
+  });
+  return result;
+}
 
 /**
  * Type utility to extract path parameter names from a route pattern string.
@@ -826,9 +846,13 @@ export class Router {
         }
       }
 
+      // Convert path-to-regexp patterns to regex for routes format
+      const { src: regexSrc, segments } = sourceToRegex(source);
+      const convertedDest = convertDestination(destination, segments);
+
       const route: Route = {
-        src: source,
-        dest: destination,
+        src: regexSrc,
+        dest: convertedDest,
         transforms,
       };
       if (has) route.has = has;
@@ -851,9 +875,13 @@ export class Router {
 
     if (destEnvVars.length > 0) {
       // Need Route format to include env field
+      // Convert path-to-regexp patterns to regex for routes format
+      const { src: regexSrc, segments } = sourceToRegex(source);
+      const convertedDest = convertDestination(destination, segments);
+
       const route: Route = {
-        src: source,
-        dest: destination,
+        src: regexSrc,
+        dest: convertedDest,
         env: destEnvVars,
       };
       if (has) route.has = has;
@@ -998,9 +1026,13 @@ export class Router {
         transforms.push(transform);
       }
 
+      // Convert path-to-regexp patterns to regex for routes format
+      const { src: regexSrc, segments } = sourceToRegex(source);
+      const convertedDest = convertDestination(destination, segments);
+
       const route: Route = {
-        src: source,
-        dest: destination,
+        src: regexSrc,
+        dest: convertedDest,
         status: statusCode || (permanent ? 308 : 307),
         transforms,
       };
@@ -1022,9 +1054,13 @@ export class Router {
 
     if (destEnvVars.length > 0) {
       // Need Route format to include env field
+      // Convert path-to-regexp patterns to regex for routes format
+      const { src: regexSrc, segments } = sourceToRegex(source);
+      const convertedDest = convertDestination(destination, segments);
+
       const route: Route = {
-        src: source,
-        dest: destination,
+        src: regexSrc,
+        dest: convertedDest,
         status: statusCode || (permanent ? 308 : 307),
         env: destEnvVars,
       };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,6 +1026,9 @@ importers:
 
   packages/config:
     dependencies:
+      '@vercel/routing-utils':
+        specifier: workspace:*
+        version: link:../routing-utils
       pretty-cache-header:
         specifier: ^1.0.0
         version: 1.0.0


### PR DESCRIPTION
I was digging into [a customer-reported issue](https://linear.app/vercel/issue/BLD-3607/rewrites-with-requestheaders-returning-404-errors-oror-00976315) where a customer's rewrites stopped working when they added a header transform using vercel.ts.

After digging on it I realized that when we don't convert path-to-regexp patterns to proper regex when compiling `routes.rewrite()` to the `routes` format. So it gets compiled to this:

```
{
  "src": "^/api/proxy/:path*$",
  "dest": "https://api.example.com/:path*",
  "transforms": [...]
}
```

When it should look like this:

```
{
  "src": "^/api/proxy(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?$",
  "dest": "https://api.example.com/$1",
}
```

So the route returns a 404 because it's trying to literally serve `:path`. This isn't an issue for rewrites defined in the `rewrites` property of vercel.json because those use the path-to-regexp format. I didn't realize that this differed when writing the logic to convert to `routes`.

The fix converts patterns using `sourceToRegex()` from routing-utils when returning `routes` format.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR fixes a bug in route pattern conversion by properly transforming path-to-regexp patterns to regex format, which is a correctness fix for routing behavior rather than a security-sensitive change.
> 
> - Adds `sourceToRegex()` conversion for route source patterns in rewrite/redirect logic
> - New `convertDestination()` helper replaces named params with capture group references
> - Test expectations updated to reflect proper regex output format
>
> <sup>Risk assessment for [commit 312e2c8](https://github.com/vercel/vercel/commit/312e2c8c02928531ff52b91a0121ed73f1e58acb).</sup>
<!-- VADE_RISK_END -->