### PR TITLE
refactor(cli): use formatted tables for `metrics schema` output

### DIFF
--- a/.changeset/metrics-schema-table-output.md
+++ b/.changeset/metrics-schema-table-output.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Use formatted tables for `metrics schema` output, matching the convention used by other list commands

--- a/packages/cli/test/unit/commands/metrics/index.test.ts
+++ b/packages/cli/test/unit/commands/metrics/index.test.ts
@@ -41,8 +41,8 @@ describe('metrics', () => {
 
       // schema lists events, exit 0
       expect(exitCode).toBe(0);
-      const output = client.stdout.getFullOutput();
-      expect(output).toContain('event,description');
+      const stderrOutput = client.stderr.getFullOutput();
+      expect(stderrOutput).toContain('Events found');
     });
 
     it('should route to query as default subcommand', async () => {

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -20,16 +20,17 @@ describe('schema', () => {
   });
 
   describe('event list', () => {
-    it('should output CSV list of events', async () => {
+    it('should output table list of events', async () => {
       client.setArgv('metrics', 'schema');
 
       const exitCode = await schema(client, new MockTelemetry());
 
       expect(exitCode).toBe(0);
-      const output = client.stdout.getFullOutput();
-      expect(output).toContain('event,description');
-      expect(output).toContain('incomingRequest');
-      expect(output).toContain('functionExecution');
+      const stderrOutput = client.stderr.getFullOutput();
+      expect(stderrOutput).toContain('Events found');
+      expect(stderrOutput).toContain('Event');
+      expect(stderrOutput).toContain('Description');
+      expect(stderrOutput).toContain('incomingRequest');
     });
 
     it('should output JSON list with --format=json', async () => {
@@ -47,16 +48,19 @@ describe('schema', () => {
   });
 
   describe('event detail', () => {
-    it('should output CSV detail for a known event', async () => {
+    it('should output table detail for a known event', async () => {
       client.setArgv('metrics', 'schema', '--event', 'incomingRequest');
 
       const exitCode = await schema(client, new MockTelemetry());
 
       expect(exitCode).toBe(0);
-      const stdoutOutput = client.stdout.getFullOutput();
-      // Should have two blocks separated by blank line
-      expect(stdoutOutput).toContain('dimension,label,filterOnly');
-      expect(stdoutOutput).toContain('measure,label,unit');
+      const stderrOutput = client.stderr.getFullOutput();
+      expect(stderrOutput).toContain('Event: incomingRequest');
+      expect(stderrOutput).toContain('Dimension');
+      expect(stderrOutput).toContain('Label');
+      expect(stderrOutput).toContain('Groupable');
+      expect(stderrOutput).toContain('Measure');
+      expect(stderrOutput).toContain('Unit');
     });
 
     it('should output JSON detail with --format=json', async () => {


### PR DESCRIPTION
Replace raw CSV output with formatted tables using formatTable, matching the convention used by other list commands (domains ls, env ls, dns ls). Human-readable output now goes to stderr; JSON output remains on stdout.

<img width="759" height="475" alt="Screenshot 2026-02-19 at 12 24 06" src="https://github.com/user-attachments/assets/2624a9c2-99c1-4770-96bf-d518dcb31288" />
<img width="756" height="559" alt="Screenshot 2026-02-19 at 12 23 56" src="https://github.com/user-attachments/assets/89fefc9d-699c-4f06-ae7d-82b45d4ce027" />


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR refactors CLI output formatting from CSV to formatted tables for the metrics schema command, with no security, auth, or business logic changes.
> 
> - Replaces CSV output with formatTable for human-readable display
> - Adds helper functions for formatting events, dimensions, and measures tables
> - Updates tests to verify new table output format on stderr
>
> <sup>Risk assessment for [commit f5989a6](https://github.com/vercel/vercel/commit/f5989a6bee609650dd405d8ee2255410e5341cb8).</sup>
<!-- VADE_RISK_END -->