### PR TITLE
chore(release): update uv.lock during release version sync for Python runtime

### DIFF
--- a/.github/workflows/release-version-pr-sync.yml
+++ b/.github/workflows/release-version-pr-sync.yml
@@ -40,6 +40,11 @@ jobs:
       - name: install npm@9
         run: npm i -g npm@9
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.9.22'
+
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prettier-check": "prettier --check .",
     "prepare": "husky install",
     "pack": "cd utils && node -r ts-eager/register ./pack.ts",
-    "ci:version": "changeset version && node utils/sync-python-version.js && pnpm install --no-frozen-lockfile",
+    "ci:version": "changeset version && node utils/sync-python-version.js && uv lock && pnpm install --no-frozen-lockfile",
     "ci:publish": "node utils/publish-runtimes.mjs && pnpm publish -r && node utils/update-canary-tags.mjs && changeset tag",
     "type-check": "turbo type-check --concurrency=12 --output-logs=errors-only --summarize --continue"
   },


### PR DESCRIPTION
## Summary

The `ci:version` script bumps `python/vercel-runtime/pyproject.toml` via `sync-python-version.js` but never updates the root `uv.lock`, causing Python runtime CI to fail on Version Packages PRs with:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

- Add `uv lock` to the `ci:version` script chain in `package.json`
- Install `uv` in `release-version-pr-sync.yml` (`release.yml` already had it)

## Test plan

- [x] Verified the fix matches the `uv` setup already used in `release.yml` (same action hash and version)
- [ ] Next time `Release Version PR Sync` runs, `uv.lock` should be updated automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds uv tool setup to CI workflow and adds `uv lock` command to the version script chain to keep lockfile in sync - a straightforward CI/build fix with no security implications.
> 
> - Adds `uv lock` step to `ci:version` script in package.json
> - Installs uv tool in release-version-pr-sync.yml workflow
>
> <sup>Risk assessment for [commit da9863a](https://github.com/vercel/vercel/commit/da9863a6759aed6fc79378ea16644c4ef4b75514).</sup>
<!-- VADE_RISK_END -->