### PR TITLE
feat(cli): extend ls to multiple projects

### DIFF
--- a/.changeset/list-command-all-projects.md
+++ b/.changeset/list-command-all-projects.md
@@ -1,0 +1,10 @@
+---
+'vercel': minor
+---
+
+Add `--all` flag to `vercel ls` command and improve behavior when not linked to a project
+
+- `vercel ls` no longer requires a linked project. When not linked, it now lists all deployments across all projects in the current scope
+- Added `--all` flag to explicitly list deployments across all projects, even when linked to a specific project
+- Added "Project" column to the deployment table output to show which project each deployment belongs to
+- JSON output (`--format json`) is unchanged and continues to include the `name` field for project name

--- a/packages/cli/src/commands/list/command.ts
+++ b/packages/cli/src/commands/list/command.ts
@@ -1,5 +1,6 @@
 import { packageName } from '../../util/pkg-name';
 import {
+  allOption,
   confirmOption,
   formatOption,
   nextOption,
@@ -9,7 +10,7 @@ import {
 export const listCommand = {
   name: 'list',
   aliases: ['ls'],
-  description: 'List app deployments for an app.',
+  description: 'List deployments.',
   arguments: [
     {
       name: 'app',
@@ -17,6 +18,7 @@ export const listCommand = {
     },
   ],
   options: [
+    allOption,
     {
       name: 'meta',
       description:
@@ -65,7 +67,11 @@ export const listCommand = {
       value: `${packageName} list`,
     },
     {
-      name: 'List all deployments for the project `my-app` in the team of the currently linked project',
+      name: 'List all deployments across all projects',
+      value: `${packageName} list --all`,
+    },
+    {
+      name: 'List all deployments for the project `my-app`',
       value: `${packageName} list my-app`,
     },
     {

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -150,3 +150,11 @@ export const nonInteractiveOption = {
   description:
     'Run without interactive prompts; when an agent is detected this is the default',
 } as const;
+
+export const allOption = {
+  name: 'all',
+  shorthand: 'a',
+  type: Boolean,
+  deprecated: false,
+  description: 'List resources across all projects',
+} as const;

--- a/packages/cli/src/util/telemetry/commands/list/index.ts
+++ b/packages/cli/src/util/telemetry/commands/list/index.ts
@@ -6,6 +6,12 @@ export class ListTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof listCommand>
 {
+  trackCliFlagAll(all: boolean | undefined) {
+    if (all) {
+      this.trackCliFlag('all');
+    }
+  }
+
   trackCliOptionMeta(meta: string[] | undefined) {
     if (meta && meta.length > 0) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3661,10 +3661,14 @@ exports[`help command > list help output snapshots > list help column width 40 1
 "
   ▲ vercel list [app] [options]
 
-  List app deployments for an app.      
+  List deployments.                     
 
   Options:
 
+  -a,  --all                   List       
+                               resources  
+                               across all 
+                               projects   
        --environment <TARGET>             
   -F,  --format <FORMAT>       Specify the
                                output     
@@ -3763,7 +3767,11 @@ exports[`help command > list help output snapshots > list help column width 40 1
 
     $ vercel list
 
-  - List all deployments for the project \`my-app\` in the team of the currently linked project
+  - List all deployments across all projects
+
+    $ vercel list --all
+
+  - List all deployments for the project \`my-app\`
 
     $ vercel list my-app
 
@@ -3790,10 +3798,11 @@ exports[`help command > list help output snapshots > list help column width 80 1
 "
   ▲ vercel list [app] [options]
 
-  List app deployments for an app.                                              
+  List deployments.                                                             
 
   Options:
 
+  -a,  --all                   List resources across all projects                 
        --environment <TARGET>                                                     
   -F,  --format <FORMAT>       Specify the output format (json)                   
   -m,  --meta <KEY=VALUE>      Filter deployments by metadata (e.g.: \`-m          
@@ -3830,7 +3839,11 @@ exports[`help command > list help output snapshots > list help column width 80 1
 
     $ vercel list
 
-  - List all deployments for the project \`my-app\` in the team of the currently linked project
+  - List all deployments across all projects
+
+    $ vercel list --all
+
+  - List all deployments for the project \`my-app\`
 
     $ vercel list my-app
 
@@ -3857,10 +3870,11 @@ exports[`help command > list help output snapshots > list help column width 120 
 "
   ▲ vercel list [app] [options]
 
-  List app deployments for an app.                                                                                      
+  List deployments.                                                                                                     
 
   Options:
 
+  -a,  --all                   List resources across all projects                                                         
        --environment <TARGET>                                                                                             
   -F,  --format <FORMAT>       Specify the output format (json)                                                           
   -m,  --meta <KEY=VALUE>      Filter deployments by metadata (e.g.: \`-m KEY=value\`). Can appear many times.              
@@ -3892,7 +3906,11 @@ exports[`help command > list help output snapshots > list help column width 120 
 
     $ vercel list
 
-  - List all deployments for the project \`my-app\` in the team of the currently linked project
+  - List all deployments across all projects
+
+    $ vercel list --all
+
+  - List all deployments for the project \`my-app\`
 
     $ vercel list my-app
 


### PR DESCRIPTION
Add `--all` flag to `vercel ls` command and improve behavior when not linked to a project

- `vercel ls` no longer requires a linked project. When not linked, it now lists all deployments across all projects in the current scope
- Added `--all` flag to explicitly list deployments across all projects, even when linked to a specific project
- Added "Project" column to the deployment table output to show which project each deployment belongs to
- JSON output (`--format json`) is unchanged and continues to include the `name` field for project name


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new `--all` flag to the CLI `ls` command with corresponding tests, telemetry tracking, and documentation - a feature addition with no security, auth, or data integrity implications.
> 
> - Adds `--all` flag option to list deployments across all projects
> - Changes behavior when not linked to project to default to showing all deployments
> - Adds Project column to deployment table output
>
> <sup>Risk assessment for [commit 3dac273](https://github.com/vercel/vercel/commit/3dac273bb75b8117aeca9002758d543fb8591db4).</sup>
<!-- VADE_RISK_END -->