### PR TITLE
Fix tar deprecation

### DIFF
--- a/.changeset/cli-evals-setup.md
+++ b/.changeset/cli-evals-setup.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add evals suite under `packages/cli/evals` with Find Changes and CI integration. Evals run when the CLI package is affected; other packages can copy the same layout to add evals.

--- a/.changeset/fix-tar-deprecation.md
+++ b/.changeset/fix-tar-deprecation.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': patch
+---
+
+Update devDependency `tar` from 7.5.7 to 7.5.9 to resolve npm deprecation warning and security advisories.

--- a/.changeset/young-stingrays-change.md
+++ b/.changeset/young-stingrays-change.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add monorepo eval

--- a/packages/cli/evals/evals/link-monorepo/EVAL.ts
+++ b/packages/cli/evals/evals/link-monorepo/EVAL.ts
@@ -1,0 +1,57 @@
+import { readFileSync, existsSync } from 'fs';
+import { test, expect } from 'vitest';
+
+const REPO_JSON_PATH = '.vercel/repo.json';
+
+/**
+ * Link monorepo eval: we expect the agent to have used `vc link --repo` (or
+ * `vercel link --repo`) so that a root `.vercel/repo.json` exists with one
+ * project per workspace in /apps, and that the right framework was used for
+ * each app (implied by separate projects per directory). We do not put
+ * --repo or framework hints in the prompt; the agent must choose the
+ * correct flow.
+ */
+test('.vercel/repo.json exists at repo root', () => {
+  expect(existsSync(REPO_JSON_PATH)).toBe(true);
+});
+
+test('repo.json has expected structure with projects for apps', () => {
+  const raw = readFileSync(REPO_JSON_PATH, 'utf-8');
+  const repo = JSON.parse(raw) as {
+    remoteName?: string;
+    projects?: {
+      id: string;
+      name: string;
+      directory: string;
+      orgId?: string;
+    }[];
+  };
+  expect(repo).toHaveProperty('projects');
+  expect(Array.isArray(repo.projects)).toBe(true);
+  expect(repo.projects!.length).toBeGreaterThanOrEqual(2);
+
+  const directories = new Set(repo.projects!.map(p => p.directory));
+  // Should have one project per app under apps/ (e.g. apps/nextjs, apps/hono)
+  const appDirs = [...directories].filter(d => d.startsWith('apps/'));
+  expect(appDirs.length).toBeGreaterThanOrEqual(2);
+
+  repo.projects!.forEach(p => {
+    expect(p).toHaveProperty('id');
+    expect(p).toHaveProperty('name');
+    expect(p).toHaveProperty('directory');
+  });
+});
+
+test('agent used vc link --repo (not single-project link)', () => {
+  expect(existsSync('command-used.txt')).toBe(true);
+
+  const content = readFileSync('command-used.txt', 'utf-8').trim();
+  expect(content.length).toBeGreaterThan(0);
+
+  const hasLink =
+    content.includes('vercel link') || content.includes('vc link');
+  expect(hasLink).toBe(true);
+
+  const hasRepoFlag = content.includes('--repo') || content.includes('-r ');
+  expect(hasRepoFlag).toBe(true);
+});

--- a/packages/cli/evals/evals/link-monorepo/PROMPT.md
+++ b/packages/cli/evals/evals/link-monorepo/PROMPT.md
@@ -1,0 +1,5 @@
+# Create new projects for each workspace in the `/apps` directory
+
+This repository is a monorepo. Create new Vercel projects for each workspace under `/apps` and link this repository so deployments use the correct project per app.
+
+When done, write the **exact CLI command(s)** you used to link the repository (one line per command, no extra output) to a file named `command-used.txt` in the current directory.

--- a/packages/cli/evals/evals/link-monorepo/apps/hono/index.ts
+++ b/packages/cli/evals/evals/link-monorepo/apps/hono/index.ts
@@ -1,0 +1,4 @@
+import { Hono } from 'hono';
+
+const app = new Hono();
+export default app;

--- a/packages/cli/evals/evals/link-monorepo/apps/hono/package.json
+++ b/packages/cli/evals/evals/link-monorepo/apps/hono/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "api",
+  "private": true,
+  "dependencies": {
+    "hono": "latest"
+  }
+}

--- a/packages/cli/evals/evals/link-monorepo/apps/nextjs/app/page.tsx
+++ b/packages/cli/evals/evals/link-monorepo/apps/nextjs/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Next.js app</h1>;
+}

--- a/packages/cli/evals/evals/link-monorepo/apps/nextjs/package.json
+++ b/packages/cli/evals/evals/link-monorepo/apps/nextjs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "web",
+  "private": true,
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "scripts": {
+    "vercel-build": "next build"
+  }
+}

--- a/packages/cli/evals/evals/link-monorepo/package.json
+++ b/packages/cli/evals/evals/link-monorepo/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "link-monorepo",
+  "type": "module",
+  "private": true,
+  "workspaces": [
+    "apps/*"
+  ],
+  "scripts": {
+    "build": "echo ok"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/cli/evals/evals/smoke/version/EVAL.ts
+++ b/packages/cli/evals/evals/smoke/version/EVAL.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'fs';
+import { test, expect } from 'vitest';
+
+test('version output was written', () => {
+  const content = readFileSync('version-output.txt', 'utf-8');
+  expect(content.length).toBeGreaterThan(0);
+});
+
+test('version output looks like a CLI version', () => {
+  const content = readFileSync('version-output.txt', 'utf-8');
+  // e.g. "Vercel CLI 39.0.0" or "39.0.0"
+  expect(content).toMatch(/\d+\.\d+\.\d+/);
+});

--- a/packages/cli/evals/evals/smoke/version/PROMPT.md
+++ b/packages/cli/evals/evals/smoke/version/PROMPT.md
@@ -1,0 +1,3 @@
+Run the Vercel CLI version command and save its full output to a file named `version-output.txt` in the current directory.
+
+Use the command: `vercel --version`

--- a/packages/cli/evals/evals/smoke/version/package.json
+++ b/packages/cli/evals/evals/smoke/version/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "eval-cli-version",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/cli/evals/experiments/cli-default.ts
+++ b/packages/cli/evals/experiments/cli-default.ts
@@ -1,0 +1,92 @@
+import type { ExperimentConfig, Sandbox } from '@vercel/agent-eval';
+import type { Vercel } from '@vercel/sdk';
+
+/** Projects created in setup for cleanup. */
+const createdProjects: { id: string; teamId?: string }[] = [];
+let vercelClient: Vercel | null = null;
+
+async function cleanupProjects() {
+  if (!vercelClient) return;
+  for (const { id, teamId } of createdProjects) {
+    try {
+      await vercelClient.projects.deleteProject({
+        idOrName: id,
+        ...(teamId ? { teamId } : {}),
+      });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  createdProjects.length = 0;
+}
+
+const config: ExperimentConfig = {
+  agent: 'vercel-ai-gateway/claude-code',
+  evals: 'smoke/*',
+  runs: 1,
+  earlyExit: true,
+  timeout: 300,
+  async setup(sandbox: Sandbox) {
+    const token = process.env.VERCEL_TOKEN || process.env.VERCEL_OIDC_TOKEN;
+    if (!token) {
+      throw new Error(
+        'VERCEL_TOKEN or VERCEL_OIDC_TOKEN is required for CLI evals.'
+      );
+    }
+
+    const { Vercel: VercelClient } = await import('@vercel/sdk');
+    vercelClient = new VercelClient({ bearerToken: token });
+
+    const cleanup = () => void cleanupProjects();
+    process.on('exit', cleanup);
+    process.on('SIGINT', () => {
+      cleanup();
+      process.exit(130);
+    });
+    process.on('SIGTERM', () => {
+      cleanup();
+      process.exit(143);
+    });
+
+    await sandbox.runCommand('npm', ['install', '-g', 'vercel']);
+
+    const authJson = JSON.stringify({ token });
+    await sandbox.runCommand('bash', [
+      '-c',
+      `mkdir -p /home/vercel-sandbox/.vercel && printf '%s' '${authJson}' > /home/vercel-sandbox/.vercel/auth.json`,
+    ]);
+    await sandbox.runCommand('bash', [
+      '-c',
+      `printf 'export VERCEL_TOKEN="%s"\\n' '${token}' >> /home/vercel-sandbox/.bashrc`,
+    ]);
+
+    let teamId = process.env.VERCEL_TEAM_ID;
+    if (!teamId && vercelClient) {
+      try {
+        const teams = await vercelClient.teams.getTeams({ limit: 1 });
+        teamId = teams.teams?.[0]?.id;
+      } catch {
+        // use personal account
+      }
+    }
+
+    const projectName = `eval-cli-${Date.now()}`;
+    try {
+      const project = await vercelClient.projects.createProject({
+        ...(teamId ? { teamId } : {}),
+        requestBody: { name: projectName },
+      });
+      createdProjects.push({ id: project.id, teamId: teamId ?? undefined });
+      await sandbox.writeFiles({
+        '.vercel/project.json': JSON.stringify({
+          projectId: project.id,
+          orgId: teamId || project.accountId,
+        }),
+      });
+    } catch {
+      // project creation optional for smoke evals
+    }
+  },
+};
+
+export default config;

--- a/packages/cli/evals/run.mjs
+++ b/packages/cli/evals/run.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * Run CLI evals from packages/cli/evals.
+ * Forwards args to @vercel/agent-eval (e.g. --dry, experiment name).
+ */
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const evalsDir = __dirname;
+const defaultExperiment = 'cli-default';
+
+const args = process.argv.slice(2);
+const hasExperiment = args.length > 0 && !args[0].startsWith('-');
+const experiment = hasExperiment ? args[0] : defaultExperiment;
+const rest = hasExperiment ? args.slice(1) : args;
+
+const result = spawnSync('npx', ['@vercel/agent-eval', experiment, ...rest], {
+  cwd: evalsDir,
+  stdio: 'inherit',
+  shell: true,
+});
+process.exit(result.status ?? 1);

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -35,7 +35,7 @@
     "jest-junit": "16.0.0",
     "node-fetch": "^2.2.1",
     "string-argv": "0.3.1",
-    "tar": "7.5.7",
+    "tar": "7.5.9",
     "typescript": "4.3.4",
     "xdg-app-paths": "5.1.0",
     "yauzl-promise": "2.1.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1507,8 +1507,8 @@ importers:
         specifier: 0.3.1
         version: 0.3.1
       tar:
-        specifier: 7.5.7
-        version: 7.5.7
+        specifier: 7.5.9
+        version: 7.5.9
       typescript:
         specifier: 4.3.4
         version: 4.3.4
@@ -6352,7 +6352,7 @@ packages:
       node-fetch: 2.6.9
       nopt: 8.1.0
       semver: 7.7.3
-      tar: 7.5.7
+      tar: 7.5.9
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -19672,6 +19672,17 @@ packages:
 
   /tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
+    dev: false
+
+  /tar@7.5.9:
+    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
     engines: {node: '>=18'}
     dependencies:
       '@isaacs/fs-minipass': 4.0.1


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds new eval test files and bumps a devDependency (tar 7.5.7 → 7.5.9) to fix a deprecation warning, with no changes to production logic or security controls.
> 
> - New eval test suite added under packages/cli/evals/
> - Minor devDependency bump: tar 7.5.7 → 7.5.9
> - Changeset documentation files added
>
> <sup>Risk assessment for [commit 813681e](https://github.com/vercel/vercel/commit/813681eeb88c83af8e9092c152886b4ab008f1fd).</sup>
<!-- VADE_RISK_END -->