### PR TITLE
Fix tar deprecation

### DIFF
--- a/.changeset/fix-tar-deprecation.md
+++ b/.changeset/fix-tar-deprecation.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': patch
+---
+
+Update devDependency `tar` from 7.5.7 to 7.5.9 to resolve npm deprecation warning and security advisories.

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -35,7 +35,7 @@
     "jest-junit": "16.0.0",
     "node-fetch": "^2.2.1",
     "string-argv": "0.3.1",
-    "tar": "7.5.7",
+    "tar": "7.5.9",
     "typescript": "4.3.4",
     "xdg-app-paths": "5.1.0",
     "yauzl-promise": "2.1.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1507,8 +1507,8 @@ importers:
         specifier: 0.3.1
         version: 0.3.1
       tar:
-        specifier: 7.5.7
-        version: 7.5.7
+        specifier: 7.5.9
+        version: 7.5.9
       typescript:
         specifier: 4.3.4
         version: 4.3.4
@@ -6352,7 +6352,7 @@ packages:
       node-fetch: 2.6.9
       nopt: 8.1.0
       semver: 7.7.3
-      tar: 7.5.7
+      tar: 7.5.9
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -19672,6 +19672,17 @@ packages:
 
   /tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
+    dev: false
+
+  /tar@7.5.9:
+    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
     engines: {node: '>=18'}
     dependencies:
       '@isaacs/fs-minipass': 4.0.1


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Minor patch version bump of devDependency `tar` from 7.5.7 to 7.5.9 to resolve deprecation warning and security advisories.
> 
> - Dependency bump: `tar` 7.5.7 → 7.5.9 (devDependency)
> - Changeset added for patch release
>
> <sup>Risk assessment for [commit da08f17](https://github.com/vercel/vercel/commit/da08f17e2f6ba4904d74a900cfe311dcd471524f).</sup>
<!-- VADE_RISK_END -->