### PR TITLE
Support per function regions from vercel.json

### DIFF
--- a/.changeset/add-regions-function-config.md
+++ b/.changeset/add-regions-function-config.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Added support for `regions` and `functionFailoverRegions` in per-function configuration from `vercel.json` for Next.js projects.

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1427,6 +1427,8 @@ export async function serverBuild({
         memory: group.memory,
         runtime: nodeVersion.runtime,
         maxDuration: group.maxDuration,
+        regions: group.regions,
+        functionFailoverRegions: group.functionFailoverRegions,
         supportsCancellation: group.supportsCancellation,
         isStreaming: group.isStreaming,
         nextVersion,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1876,6 +1876,8 @@ export type LambdaGroup = {
   pages: string[];
   memory?: number;
   maxDuration?: number;
+  regions?: string[];
+  functionFailoverRegions?: string[];
   supportsCancellation?: boolean;
   isAppRouter?: boolean;
   isAppRouteHandler?: boolean;
@@ -1947,6 +1949,8 @@ export async function getPageLambdaGroups({
       architecture?: NodejsLambda['architecture'];
       memory?: number;
       maxDuration?: number;
+      regions?: string[];
+      functionFailoverRegions?: string[];
       experimentalTriggers?: NodejsLambda['experimentalTriggers'];
       supportsCancellation?: boolean;
     } = {};
@@ -2026,6 +2030,9 @@ export async function getPageLambdaGroups({
           const matches =
             group.maxDuration === opts.maxDuration &&
             group.memory === opts.memory &&
+            JSON.stringify(group.regions) === JSON.stringify(opts.regions) &&
+            JSON.stringify(group.functionFailoverRegions) ===
+              JSON.stringify(opts.functionFailoverRegions) &&
             group.isPrerenders === isPrerenderRoute &&
             group.isExperimentalPPR === isExperimentalPPR &&
             JSON.stringify(group.experimentalTriggers) ===

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1872,6 +1872,18 @@ export function addLocaleOrDefault(
     : pathname;
 }
 
+function regionsArrayEqual(
+  a: string[] | undefined,
+  b: string[] | undefined
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((val, i) => val === sortedB[i]);
+}
+
 export type LambdaGroup = {
   pages: string[];
   memory?: number;
@@ -2030,9 +2042,11 @@ export async function getPageLambdaGroups({
           const matches =
             group.maxDuration === opts.maxDuration &&
             group.memory === opts.memory &&
-            JSON.stringify(group.regions) === JSON.stringify(opts.regions) &&
-            JSON.stringify(group.functionFailoverRegions) ===
-              JSON.stringify(opts.functionFailoverRegions) &&
+            regionsArrayEqual(group.regions, opts.regions) &&
+            regionsArrayEqual(
+              group.functionFailoverRegions,
+              opts.functionFailoverRegions
+            ) &&
             group.isPrerenders === isPrerenderRoute &&
             group.isExperimentalPPR === isExperimentalPPR &&
             JSON.stringify(group.experimentalTriggers) ===

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -5,6 +5,12 @@
       "use": "@vercel/next",
       "config": {
         "functions": {
+          "app/dashboard/page.js": {
+            "maxDuration": 5,
+            "memory": 512,
+            "regions": ["iad1", "sfo1"],
+            "functionFailoverRegions": ["pdx1"]
+          },
           "app/**/*": {
             "maxDuration": 5,
             "memory": 512

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -135,6 +135,13 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
     expect(buildResult.output['dashboard'].fallback.fsPath).toMatch(
       /server\/app\/dashboard\.html$/
     );
+    expect(buildResult.output['dashboard'].lambda.regions).toEqual([
+      'iad1',
+      'sfo1',
+    ]);
+    expect(
+      buildResult.output['dashboard'].lambda.functionFailoverRegions
+    ).toEqual(['pdx1']);
     expect(buildResult.output['dashboard.rsc'].type).toBe('Prerender');
     expect(buildResult.output['dashboard.rsc'].fallback.fsPath).toMatch(
       /server\/app\/dashboard\.rsc$/


### PR DESCRIPTION
Update next builder to allow per function regions from vercel.json

Enables vercel.json below to be mapped into build output API lambdas
```
  "regions": ["fra1"],
  "functions": {
    "src/app/api/v3/**/cle1/route.ts": {
      "regions": ["cle1"],
      "functionFailoverRegions": ["pdx1"]
    },
    "src/app/api/v3/**/iad1/route.ts": {
      "regions": ["iad1"],
      "functionFailoverRegions": ["pdx1"]
    }
  },
```

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds support for passing through regions and functionFailoverRegions configuration from vercel.json to lambda build output, a straightforward feature addition with no security implications.
> 
> - Adds regions and functionFailoverRegions properties to LambdaGroup type
> - Passes region config through to lambda build output in server-build.ts
> - Adds helper function regionsArrayEqual for comparing region arrays in grouping logic
>
> <sup>Risk assessment for [commit 2c3a826](https://github.com/vercel/vercel/commit/2c3a826fd26f595101c411d7262c0e92e8af9b36).</sup>
<!-- VADE_RISK_END -->