### PR TITLE
fix(cli): fix create-threshold help example and decimal parsing

### DIFF
--- a/.changeset/fix-threshold-parse-and-example.md
+++ b/.changeset/fix-threshold-parse-and-example.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): fix create-threshold help example, decimal parsing, exit code, error message, and balance mapping

--- a/packages/cli/src/commands/integration-resource/command.ts
+++ b/packages/cli/src/commands/integration-resource/command.ts
@@ -131,8 +131,8 @@ export const createThresholdSubcommand = {
       name: 'create threshold',
       value: [
         `${packageName} integration-resource create-threshold <resource> <minimum> <spend> <limit> [options]`,
-        `${packageName} integration-resource create-threshold my-acme-resource 100 50 2000`,
-        `${packageName} integration-resource create-threshold my-acme-resource 100 50 2000 --yes`,
+        `${packageName} integration-resource create-threshold my-acme-resource 50 100 2000`,
+        `${packageName} integration-resource create-threshold my-acme-resource 50 100 2000 --yes`,
       ],
     },
   ],

--- a/packages/cli/src/commands/integration-resource/create-threshold.ts
+++ b/packages/cli/src/commands/integration-resource/create-threshold.ts
@@ -69,8 +69,8 @@ export async function createThreshold(client: Client) {
 
   // Assert resource is valid
   if (!targetedResource) {
-    output.log(`The resource ${chalk.bold(resourceName)} was not found.`);
-    return 0;
+    output.error(`The resource ${chalk.bold(resourceName)} was not found.`);
+    return 1;
   }
 
   if (!targetedResource.product?.integrationConfigurationId) {
@@ -165,12 +165,12 @@ function parseCreateThresholdArguments(
   telemetry.trackCliArgumentLimit(args[3]);
 
   const resourceName = args[0];
-  const minimum = Number.parseFloat(args[1]) * 100;
-  const spend = Number.parseInt(args[2]) * 100;
-  const limit = Number.parseInt(args[3]) * 100;
+  const minimum = Math.round(Number.parseFloat(args[1]) * 100);
+  const spend = Math.round(Number.parseFloat(args[2]) * 100);
+  const limit = Math.round(Number.parseFloat(args[3]) * 100);
   if (isNaN(minimum)) {
     throw new Error(
-      'Minimum is an invalid number format. Spend must be a positive number (ex. "5.75")'
+      'Minimum is an invalid number format. Minimum must be a positive number (ex. "5.75")'
     );
   }
   if (isNaN(spend)) {

--- a/packages/cli/src/commands/integration/balance.ts
+++ b/packages/cli/src/commands/integration/balance.ts
@@ -173,7 +173,10 @@ function outputBalanceInformation(
         ? (resources.find(r => r.externalResourceId === threshold.resourceId)
             ?.name ?? threshold.resourceId)
         : 'installation';
-      mappings[resourceName] = { threshold, resourceName };
+      mappings[threshold.resourceId ?? 'installation'] = {
+        threshold,
+        resourceName,
+      };
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix help text example `100 50 2000` → `50 100 2000` — the old example violated the command's own `minimum <= spend` validation and would always error
- Fix `spend` and `limit` argument parsing to use `parseFloat` instead of `parseInt`, which was silently truncating decimal values (e.g., `10.99` → `10`) despite error messages implying decimals are valid
- Add `Math.round` after `parseFloat * 100` to prevent floating point precision issues (e.g., `10.10 * 100 = 1010.0000000000001`)

## Test plan
- [ ] `vercel integration-resource create-threshold --help` shows correct example
- [ ] `vercel ir create-threshold res 50.50 100.99 2000` correctly parses decimal spend/limit values
- [ ] `10.10` as input produces exactly `1010` cents (not `1010.0000000000001`)
- [ ] Existing unit tests pass

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR contains CLI bug fixes including correcting help text examples, fixing decimal parsing with parseFloat/Math.round, and fixing error handling to return proper exit codes.
> 
> - Fix help text example to use valid argument order (50 100 2000)
> - Change parseInt to parseFloat with Math.round for decimal value parsing
> - Fix error handling: return exit code 1 instead of 0 when resource not found
>
> <sup>Risk assessment for [commit 090daa7](https://github.com/vercel/vercel/commit/090daa75d9070087b404a4001f0e68720c35bb24).</sup>
<!-- VADE_RISK_END -->