### PR TITLE
fix(cli): fix missing planId in non-subscription plan web fallback

### DIFF
--- a/.changeset/fix-plan-fallback-web-ui.md
+++ b/.changeset/fix-plan-fallback-web-ui.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): fix missing planId in non-subscription plan web fallback

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -457,7 +457,7 @@ async function provisionResourceViaCLI(
         projectLink.value,
         name,
         metadata,
-        billingPlanId
+        billingPlan.id
       );
     }
 


### PR DESCRIPTION
## Summary
- When a user interactively selects a non-subscription billing plan in `vercel integration add`, the web checkout fallback was passing `billingPlanId` (the raw `--plan` flag, `undefined` when not passed) instead of `billingPlan.id` (the actually-selected plan)
- This meant the Vercel Dashboard checkout wouldn't pre-select the plan the user just chose in the CLI

## Root cause

Introduced in #14965 ("Add --plan flag to vercel integration add"). When threading `billingPlanId` through the non-subscription web fallback in `provisionResourceViaCLI`, the wrong variable was passed:

```ts
// Before (bug): passes raw --plan flag value, undefined when not provided
provisionResourceViaWebUI(..., billingPlanId);

// After (fix): passes the plan the user actually selected
provisionResourceViaWebUI(..., billingPlan.id);
```

**Why TypeScript didn't catch it:** Both `billingPlanId` (`flags['--plan']`) and `billingPlan.id` are `string | undefined`, so the type checker sees them as interchangeable.

**Why the existing unit test didn't catch it:** The test at `add.test.ts:1399` only exercises `--plan pro` (explicit flag), where `billingPlanId === billingPlan.id`. There was no test for the interactive selection path (no `--plan` flag) where `billingPlanId` is `undefined` but `billingPlan.id` is the selected plan.

| Scenario | `billingPlanId` | `billingPlan.id` | Bug visible? |
|---|---|---|---|
| `--plan pro` (tested) | `"pro"` | `"pro"` | No — same value |
| Interactive selection (untested) | `undefined` | `"pro"` | **Yes** — `planId` param missing from URL |

## Test plan

### Unit tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/add.test.ts

 ✓ test/unit/commands/integration/add.test.ts  (75 tests) 4284ms

 Test Files  1 passed (1)
      Tests  75 passed (75)
```

New test added: "should include planId in web UI URL for non-subscription plan selected interactively"
- Exercises the interactive billing plan selection with `acme-prepayment` (no `--plan` flag)
- Asserts `planId=pro` is present in the URL passed to `open()`
- **On main (without fix):** fails with `expected null to deeply equal 'pro'` — confirms the bug
- **With fix:** passes — `planId=pro` present in URL

### Manual testing

The non-subscription billing plan → web fallback path is **unit-only** because no available real integration has prepayment-type plans on the test team. Verified by testing:

- **Prisma** (`vc integration add prisma --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV`): has billing plans (Free, Starter, Pro, Business) but all are `subscription` type → goes to CLI provisioning, never hits the web fallback
- **Upstash** (`vc integration add upstash/upstash-kv --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV`): unsupported wizard → browser fallback (different code path, no billing plan selection)
- **Neon** (`vc integration add neon --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV`): unsupported wizard → browser fallback (different code path)

### Code paths covered

| Path | Verified by |
|---|---|
| Interactive plan selection → non-subscription → web fallback (the bug) | Unit test (new) |
| `--plan` flag → non-subscription → web fallback (regression) | Unit test (existing, line 1399) |
| Interactive plan selection → subscription → CLI provisioning | Manual (prisma) |
| Unsupported wizard → browser fallback | Manual (neon, upstash) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Simple bug fix changing a variable reference from `billingPlanId` to `billingPlan.id` to pass the correct plan ID, with corresponding test coverage added.
> 
> - Single-line fix: passes `billingPlan.id` instead of `billingPlanId` in web fallback
> - Adds unit test for interactive plan selection path
>
> <sup>Risk assessment for [commit ebed50f](https://github.com/vercel/vercel/commit/ebed50f138e91c47e5fc2d552846d2e6a7807fc6).</sup>
<!-- VADE_RISK_END -->