### PR TITLE
[release] Re-add `environment: release` to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: release # Must be kept for trusted publishing on PyPI
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Inadvertent change from #15091


<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR re-adds the `environment: release` configuration to the GitHub Actions release workflow, which is an infrastructure/deployment change affecting trusted publishing to PyPI.
> 
> - Adds `environment: release` to GitHub Actions workflow for PyPI trusted publishing
> - Infrastructure change affecting release/deployment pipeline
>
> <sup>Risk assessment for [commit 5d5a253](https://github.com/vercel/vercel/commit/5d5a253ec2cbb5bbd00ef12987bab7d204bf8dc1).</sup>
<!-- VADE_RISK_END -->