### PR TITLE
fix(cli): add missing `open` mock in login/future test

### DIFF
--- a/.changeset/fix-login-test-open-mock.md
+++ b/.changeset/fix-login-test-open-mock.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): add missing open mock in login/future test

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -12,6 +12,12 @@ vi.mock('node-fetch', async () => ({
   default: vi.fn(),
 }));
 
+vi.mock('open', () => {
+  return {
+    default: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
 function mockResponse(data: unknown, ok = true): Response {
   return {
     ok,


### PR DESCRIPTION
## Summary
- `packages/cli/test/unit/commands/login/future.test.ts` was missing a `vi.mock('open', ...)` declaration
- This caused running tests locally (without `process.env.CI`) to open browser tabs via the real `open` package when the login command's OAuth device flow fires
- Every other test file that exercises code paths touching `open` already has this mock — this was the only one missing

## Test plan
- [ ] `pnpm --filter vercel test test/unit/commands/login/future.test.ts` passes
- [ ] Running tests locally no longer opens browser tabs

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a missing test mock for the 'open' package to prevent browser tabs from opening during local test runs - purely a test infrastructure fix with no production code changes.
> 
> - Adds vi.mock('open', ...) to test file to match other test files
> - Changeset added for patch version bump
>
> <sup>Risk assessment for [commit 1ff7f4f](https://github.com/vercel/vercel/commit/1ff7f4f86071cb19f403918a3cba031bf3434235).</sup>
<!-- VADE_RISK_END -->