### PR TITLE
[cli] Surface not_prepayment error in balance command

### DIFF
--- a/packages/cli/src/util/integration/fetch-installation-prepayment-info.ts
+++ b/packages/cli/src/util/integration/fetch-installation-prepayment-info.ts
@@ -1,6 +1,7 @@
 import output from '../../output-manager';
 import type Client from '../client';
 import type { InstallationBalancesAndThresholds } from './types';
+import { isAPIError } from '../errors-ts';
 
 export async function fetchInstallationPrepaymentInfo(
   client: Client,
@@ -41,6 +42,10 @@ export async function getBalanceInformation(
     return prepaymentInfo;
   } catch (error) {
     output.stopSpinner();
+    if (isAPIError(error) && error.code === 'not_prepayment') {
+      output.error(error.serverMessage);
+      return;
+    }
     output.error(`Failed to fetch balance info: ${(error as Error).message}`);
     return;
   }

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -1128,6 +1128,18 @@ export function usePrepayment(responseKey: string) {
         return;
       }
 
+      if (responseKey === 'not-prepayment') {
+        res.status(400);
+        res.json({
+          error: {
+            code: 'not_prepayment',
+            message:
+              'Balance information is only available for integrations that support prepayment billing.',
+          },
+        });
+        return;
+      }
+
       const prepaymentInfo = configurationPrepaymentInformation[responseKey];
 
       if (!prepaymentInfo) {

--- a/packages/cli/test/unit/commands/integration/balance.test.ts
+++ b/packages/cli/test/unit/commands/integration/balance.test.ts
@@ -226,6 +226,22 @@ describe('integration', () => {
     });
 
     describe('errors', () => {
+      it('should error when integration does not support prepayment billing', async () => {
+        const teams = useTeams('team_dummy');
+        const team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+        client.config.currentTeam = team.id;
+        useConfiguration();
+        useResources();
+        usePrepayment('not-prepayment');
+
+        client.setArgv('integration', 'balance', 'acme-prepayment');
+        const exitCode = await integrationCommand(client);
+        expect(exitCode, 'exit code for "integration"').toEqual(1);
+        await expect(client.stderr).toOutput(
+          'Error: Balance information is only available for integrations that support prepayment billing.'
+        );
+      });
+
       it('should error when there is no team', async () => {
         client.setArgv('integration', 'balance', 'acme');
         const exitCode = await integrationCommand(client);


### PR DESCRIPTION
## Summary
- When the API returns a 400 with error code `not_prepayment`, the `vercel integration balance` command now shows the error message directly instead of a generic fetch failure:
  ```
  Error: Balance information is only available for integrations that support prepayment billing.
  ```
- Uses `isAPIError` to detect the specific error code and surfaces `serverMessage` cleanly

## Context
Companion to the API-side PR on vercel/api (`bhrigu/balance-prepayment-check`) which adds the `not_prepayment` error to the balance endpoints.

Addresses the review feedback from https://github.com/vercel/vercel/pull/15115#discussion_r2829537684

## Test plan
- [ ] New test: `should error when integration does not support prepayment billing`
- [ ] All existing balance tests continue to pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds specific error handling for a `not_prepayment` API error code in the CLI balance command, surfacing a cleaner error message instead of a generic failure, with corresponding test coverage.
> 
> - Adds specific error handling for `not_prepayment` error code in catch block
> - New mock response for `not-prepayment` test scenario
> - New test case verifying error message output
>
> <sup>Risk assessment for [commit 7195162](https://github.com/vercel/vercel/commit/71951625d981b4b0652850388f2778deb3546a06).</sup>
<!-- VADE_RISK_END -->