### PR TITLE
fix(cli): use --format=json instead of deprecated --json in discover example

### DIFF
--- a/.changeset/fix-discover-json-example.md
+++ b/.changeset/fix-discover-json-example.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): use --format=json instead of deprecated --json in discover example

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -234,7 +234,7 @@ export const discoverSubcommand = {
     },
     {
       name: 'Discover marketplace integrations as JSON',
-      value: [`${packageName} integration discover --json`],
+      value: [`${packageName} integration discover --format=json`],
     },
   ],
 } as const;


### PR DESCRIPTION
## Summary
- Help text example for `integration discover` used deprecated `--json` flag
- Changed to `--format=json`

## Test plan
- [ ] `vercel integration discover --help` shows `--format=json` in example

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR updates a help text example string from deprecated --json flag to --format=json, a documentation-only change with no logic impact.
> 
> - Help text example string updated in CLI command definition
> - Changeset file added for patch release
>
> <sup>Risk assessment for [commit fd3b5c4](https://github.com/vercel/vercel/commit/fd3b5c4edb0c5ff83a559b1c9522195bca6899e6).</sup>
<!-- VADE_RISK_END -->