### PR TITLE
fix(cli): always print fallback URLs so headless users can copy them

### DIFF
--- a/.changeset/fix-print-fallback-urls.md
+++ b/.changeset/fix-print-fallback-urls.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): always print fallback URLs so headless users can copy them

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -224,6 +224,7 @@ export async function addAutoProvision(
     if (options.billingPlanId) {
       url.searchParams.set('planId', options.billingPlanId);
     }
+    output.log(url.href);
     output.debug(`Opening URL: ${url.href}`);
     open(url.href).catch((err: unknown) =>
       output.debug(`Failed to open browser: ${err}`)

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -326,6 +326,7 @@ function provisionResourceViaWebUI(
   }
   url.searchParams.set('cmd', 'add');
   output.print('Opening the Vercel Dashboard to continue the installation...');
+  output.log(url.href);
   output.debug(`Opening URL: ${url.href}`);
   open(url.href).catch((err: unknown) =>
     output.debug(`Failed to open browser: ${err}`)
@@ -677,6 +678,7 @@ function handleManualVerificationAction(
   url.searchParams.set('source', 'cli');
   url.searchParams.set('cmd', 'authorize');
   output.print('Opening the Vercel Dashboard to continue the installation...');
+  output.log(url.href);
   output.debug(`Opening URL: ${url.href}`);
   open(url.href).catch((err: unknown) =>
     output.debug(`Failed to open browser: ${err}`)

--- a/packages/cli/src/commands/integration/open-integration.ts
+++ b/packages/cli/src/commands/integration/open-integration.ts
@@ -62,7 +62,11 @@ export async function openIntegration(client: Client, args: string[]) {
 
   output.print(`Opening the ${chalk.bold(integrationSlug)} dashboard...`);
 
-  open(buildSSOLink(team, configuration.id));
+  const url = buildSSOLink(team, configuration.id);
+  output.log(url);
+  open(url).catch((err: unknown) =>
+    output.debug(`Failed to open browser: ${err}`)
+  );
 
   return 0;
 }

--- a/packages/cli/test/unit/commands/integration/open-integration.test.ts
+++ b/packages/cli/test/unit/commands/integration/open-integration.test.ts
@@ -9,7 +9,7 @@ import { useUser } from '../../../mocks/user';
 
 vi.mock('open', () => {
   return {
-    default: vi.fn(),
+    default: vi.fn().mockResolvedValue(undefined),
   };
 });
 


### PR DESCRIPTION
## Summary
- Browser fallback URLs were only visible with `--debug`, invisible to headless users
- Now all `open()` calls also print the URL via `output.log()` (to stderr)
- Fixed `integration open` missing `.catch()` on `open()`

## Test plan
- [ ] Web fallback in `integration add` prints the URL
- [ ] Auto-provision fallback prints the URL
- [ ] `integration open` prints SSO URL and handles browser failure

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds logging of URLs to stderr for headless users and adds missing error handling on browser open calls - no security, auth, or critical logic changes.
> 
> - Adds `output.log(url.href)` calls to print URLs before opening browser
> - Adds missing `.catch()` handler on `open()` in open-integration.ts
> - Updates test mock to return resolved promise
>
> <sup>Risk assessment for [commit 9c507c2](https://github.com/vercel/vercel/commit/9c507c2d8bd2cac3801355a92cde2ba1e0ebabf9).</sup>
<!-- VADE_RISK_END -->