### PR TITLE
fix(cli): return exit code 1 when integration/resource not found

### DIFF
--- a/.changeset/fix-exit-code-zero-on-error.md
+++ b/.changeset/fix-exit-code-zero-on-error.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): return exit code 1 when integration or resource not found

--- a/packages/cli/src/commands/integration-resource/disconnect.ts
+++ b/packages/cli/src/commands/integration-resource/disconnect.ts
@@ -89,7 +89,7 @@ export async function disconnect(client: Client) {
 
   if (!targetedResource) {
     output.error(`No resource ${chalk.bold(resourceName)} found.`);
-    return 0;
+    return 1;
   }
 
   if (parsedArguments.flags['--all']) {

--- a/packages/cli/src/commands/integration-resource/index.ts
+++ b/packages/cli/src/commands/integration-resource/index.ts
@@ -42,6 +42,7 @@ export default async function main(client: Client) {
   const needHelp = flags['--help'];
 
   if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('integration-resource');
     output.print(
       help(integrationResourceCommand, { columns: client.stderr.columns })
     );

--- a/packages/cli/src/commands/integration-resource/remove-resource.ts
+++ b/packages/cli/src/commands/integration-resource/remove-resource.ts
@@ -69,7 +69,7 @@ export async function remove(client: Client) {
 
   if (!targetedResource) {
     output.error(`No resource ${chalk.bold(resourceName)} found.`);
-    return 0;
+    return 1;
   }
 
   if (disconnectAll) {

--- a/packages/cli/src/commands/integration/remove-integration.ts
+++ b/packages/cli/src/commands/integration/remove-integration.ts
@@ -61,7 +61,7 @@ export async function remove(client: Client) {
   if (!integrationConfiguration) {
     output.error(`No integration ${chalk.bold(integrationName)} found.`);
     telemetry.trackCliArgumentIntegration(integrationName, false);
-    return 0;
+    return 1;
   }
   telemetry.trackCliArgumentIntegration(integrationName, true);
 

--- a/packages/cli/test/unit/commands/integration-resource/disconnect.test.ts
+++ b/packages/cli/test/unit/commands/integration-resource/disconnect.test.ts
@@ -104,7 +104,7 @@ describe('integration-resource', () => {
           `> Could not find project ${project} connected to resource ${resource}.`
         );
 
-        await expect(exitCodePromise).resolves.toEqual(0);
+        await expect(exitCodePromise).resolves.toEqual(1);
       });
 
       it('disconnects the resource from the current project when no project specified', async () => {

--- a/packages/cli/test/unit/commands/integration-resource/remove.test.ts
+++ b/packages/cli/test/unit/commands/integration-resource/remove.test.ts
@@ -74,7 +74,7 @@ describe('integration-resource', () => {
           `Error: No resource ${resource} found.`
         );
 
-        await expect(exitCodePromise).resolves.toEqual(0);
+        await expect(exitCodePromise).resolves.toEqual(1);
       });
 
       it('exits gracefully when cancelling confirmation for deleting a resource', async () => {

--- a/packages/cli/test/unit/commands/integration/remove.test.ts
+++ b/packages/cli/test/unit/commands/integration/remove.test.ts
@@ -89,7 +89,7 @@ describe('integration', () => {
           `No integration ${integration} found.`
         );
 
-        await expect(exitCodePromise).resolves.toEqual(0);
+        await expect(exitCodePromise).resolves.toEqual(1);
       });
     });
 


### PR DESCRIPTION
## Summary
- Fix 3 commands that returned exit code 0 after printing an error when the target was not found
- `integration remove`: `output.error()` + `return 0` → `return 1`
- `integration-resource remove`: same fix
- `integration-resource disconnect`: same fix
- Also added missing telemetry tracking for `integration-resource --help`

## Test plan
- [ ] `vercel integration remove nonexistent` returns exit code 1
- [ ] `vercel ir remove nonexistent` returns exit code 1
- [ ] `vercel ir disconnect nonexistent` returns exit code 1

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR fixes CLI exit codes to return 1 instead of 0 when resources are not found, which is a bug fix with no security implications.
> 
> - Changes `return 0` to `return 1` in 3 error handling paths for not-found resources
> - Adds telemetry tracking for `--help` flag on integration-resource command
> - Updates corresponding unit tests to expect exit code 1
>
> <sup>Risk assessment for [commit 57ad1f3](https://github.com/vercel/vercel/commit/57ad1f3b79f6139df32e7cd53d783a851f785f26).</sup>
<!-- VADE_RISK_END -->