### PR TITLE
fix(cli): add recovery guidance when resource delete fails after disconnect-all

### DIFF
--- a/.changeset/fix-remove-resource-recovery-msg.md
+++ b/.changeset/fix-remove-resource-recovery-msg.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): add recovery guidance when resource delete fails after disconnect-all

--- a/packages/cli/src/commands/integration-resource/remove-resource.ts
+++ b/packages/cli/src/commands/integration-resource/remove-resource.ts
@@ -13,6 +13,7 @@ import {
   FailedError,
   type Resource,
 } from '../../util/integration-resource/types';
+import { packageName } from '../../util/pkg-name';
 import { IntegrationResourceRemoveTelemetryClient } from '../../util/telemetry/commands/integration-resource/remove';
 import { removeSubcommand } from './command';
 import { handleDisconnectAllProjects } from './disconnect';
@@ -132,6 +133,17 @@ async function handleDeleteResource(
     output.error(
       `A problem occurred when attempting to delete ${chalk.bold(resource.name)}: ${(error as Error).message}`
     );
+    if (options?.skipProjectCheck) {
+      output.log(
+        `The resource has been disconnected from all projects but could not be deleted.`
+      );
+      output.log(
+        `To delete it manually, visit: ${chalk.cyan(`https://vercel.com/${team.slug}/~/stores/integration/${resource.id}`)}`
+      );
+      output.log(
+        `Or retry with: ${chalk.cyan(`${packageName} integration-resource remove ${resource.name}`)}`
+      );
+    }
     return 1;
   }
 


### PR DESCRIPTION
## Summary
- When `integration-resource remove --disconnect-all` disconnects successfully but delete fails, user was left with an orphaned resource and no guidance
- Now shows: dashboard URL to delete manually + retry command

## Test plan
- [ ] Delete failure after disconnect-all shows recovery guidance with correct URLs
- [ ] Delete failure without disconnect-all shows base error only
- [ ] New tests pass

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds user-facing error recovery guidance (dashboard URL and retry command) when a resource delete fails after disconnect-all, with no changes to security, validation, or authorization logic.
> 
> - Adds informational output messages with recovery URLs in error handling path
> - New unit tests verify recovery guidance appears only after disconnect-all failure
> - Changeset file for patch release
>
> <sup>Risk assessment for [commit 1805549](https://github.com/vercel/vercel/commit/1805549c48bc9dd1d61afd2b68241796f5f990dc).</sup>
<!-- VADE_RISK_END -->