### PR TITLE
fix(cli): filter empty strings from trailing commas in array metadata

### DIFF
--- a/.changeset/fix-metadata-trailing-comma.md
+++ b/.changeset/fix-metadata-trailing-comma.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): filter empty strings from trailing commas in array metadata

--- a/packages/cli/src/util/integration/parse-metadata.ts
+++ b/packages/cli/src/util/integration/parse-metadata.ts
@@ -28,8 +28,8 @@ export function parseMetadataFlags(
       continue;
     }
 
-    const key = item.slice(0, eqIndex);
-    const value = item.slice(eqIndex + 1);
+    const key = item.slice(0, eqIndex).trim();
+    const value = item.slice(eqIndex + 1).trim();
 
     const propSchema = schema.properties[key];
     if (!propSchema) {
@@ -69,7 +69,10 @@ export function parseMetadataFlags(
       }
       metadata[key] = num;
     } else if (propSchema.type === 'array') {
-      const items = value.split(',').map(v => v.trim());
+      const items = value
+        .split(',')
+        .map(v => v.trim())
+        .filter(v => v.length > 0);
       const itemType = propSchema.items?.type;
 
       if (itemType === 'number') {

--- a/packages/cli/test/unit/util/integration/parse-metadata.test.ts
+++ b/packages/cli/test/unit/util/integration/parse-metadata.test.ts
@@ -306,6 +306,24 @@ describe('parseMetadataFlags', () => {
         readRegions: ['sfo1', 'iad1', 'fra1'],
       });
     });
+
+    it('filters empty strings from trailing commas', () => {
+      const result = parseMetadataFlags(['tags=a,'], arraySchema);
+      expect(result.errors).toEqual([]);
+      expect(result.metadata).toEqual({ tags: ['a'] });
+    });
+
+    it('filters empty strings from leading commas', () => {
+      const result = parseMetadataFlags(['tags=,a'], arraySchema);
+      expect(result.errors).toEqual([]);
+      expect(result.metadata).toEqual({ tags: ['a'] });
+    });
+
+    it('filters empty strings from multiple consecutive commas', () => {
+      const result = parseMetadataFlags(['tags=a,,b'], arraySchema);
+      expect(result.errors).toEqual([]);
+      expect(result.metadata).toEqual({ tags: ['a', 'b'] });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Filter empty strings produced by trailing, leading, or consecutive commas in array metadata (e.g., `-m "regions=a,"` now produces `["a"]` instead of `["a", ""]`)
- Trim whitespace from metadata keys and values

## Test plan
- [x] Trailing comma: `tags=a,` → `["a"]`
- [x] Leading comma: `tags=,a` → `["a"]`
- [x] Consecutive commas: `tags=a,,b` → `["a", "b"]`
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds input sanitization by trimming whitespace and filtering empty strings from CLI metadata parsing, which tightens input validation rather than loosening it.
> 
> - Adds `.trim()` to metadata keys and values
> - Adds `.filter(v => v.length > 0)` to remove empty array items
> - Unit tests added for trailing/leading/consecutive comma handling
>
> <sup>Risk assessment for [commit 3baafdd](https://github.com/vercel/vercel/commit/3baafdd6655e0b47444610f7fbfb3e175c6e5d2b).</sup>
<!-- VADE_RISK_END -->