### PR TITLE
fix(cli): show actionable error when removing integration with existing resources

### DIFF
--- a/.changeset/fix-remove-integration-resources-error.md
+++ b/.changeset/fix-remove-integration-resources-error.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): show actionable error when removing integration with existing resources

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -824,7 +824,11 @@ const resources: { stores: Resource[] } = {
       type: 'integration',
       name: 'store-acme-other-project',
       status: 'available',
-      product: { name: 'Acme', slug: 'acme' },
+      product: {
+        name: 'Acme',
+        slug: 'acme',
+        integrationConfigurationId: 'acme-first',
+      },
       projectsMetadata: [
         {
           id: 'spc_2',
@@ -862,7 +866,11 @@ const resources: { stores: Resource[] } = {
       type: 'integration',
       name: 'store-acme-no-projects',
       status: 'available',
-      product: { name: 'Acme', slug: 'acme' },
+      product: {
+        name: 'Acme',
+        slug: 'acme',
+        integrationConfigurationId: 'acme-first',
+      },
       projectsMetadata: [],
       externalResourceId: 'ext_store_4',
     },
@@ -1085,11 +1093,21 @@ export function useResources(returnError?: number) {
       return;
     }
 
-    const { teamId } = req.query;
+    const { teamId, integrationConfigurationId } = req.query;
 
     if (!teamId) {
       res.status(500);
       res.end();
+      return;
+    }
+
+    if (integrationConfigurationId) {
+      res.json({
+        stores: resources.stores.filter(
+          s =>
+            s.product?.integrationConfigurationId === integrationConfigurationId
+        ),
+      });
       return;
     }
 


### PR DESCRIPTION
Closes [MKT-2909](https://linear.app/vercel/issue/MKT-2909/supabase-improve-error-message-when-running-integration-removeand)

## Summary
- When `vc integration remove` fails because the integration still has resources, the old error was a generic `Failed to remove supabase: Cannot uninstall integration with resources (403)`
- Now catches the 403, fetches the integration's resources using `integrationConfigurationId` with `skip-metadata=true` (server-side filtering, avoids N+1 provider requests), and lists them by name
- Shows actionable commands to remove the resources and retry
- When running as an agent (`isAgent`), shows a warning to get user approval before running resource removal commands

## Before
```
Error: Failed to remove supabase: Cannot uninstall integration with resources (403)
```

## After
```
Error: Cannot uninstall supabase because it still has resources.

> Resources that must be removed first:
>   - supabase-fuchsia-window
>   - supabase-violet-chair
>   - supabase-violet-school
>   ...
>
> AGENT: You must get user approval before running any resource removal commands.
> Remove and disconnect all resources first with: vercel integration-resource remove <resource-name> --disconnect-all
> Then retry: vercel integration remove supabase
```

## Test plan

### Unit tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/remove.test.ts

 ✓ test/unit/commands/integration/remove.test.ts  (14 tests) 241ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

### Manual testing

| # | Test | Command | Result |
|---|------|---------|--------|
| 1 | Integration with resources | `vc integration remove supabase --yes` | 43 resources listed, actionable commands shown |
| 2 | Integration not found | `vc integration remove nonexistent-xyz --yes` | `Error: No integration nonexistent-xyz found.` |
| 3 | User cancels confirmation | `vc integration remove supabase` → 'n' | `> Canceled` |
| 4 | `skip-metadata=true` verified | `vc integration remove supabase --yes --debug` | `GET /v1/storage/stores?...&skip-metadata=true` |
| 5 | Agent warning shown | `vc integration remove supabase --yes` (from agent shell) | `AGENT: You must get user approval...` shown |
| 6 | No agent warning (non-agent) | Unit test with `client.isAgent=false` | Warning absent |

### Code paths covered

| Path | Verified by |
|------|------------|
| 403 + "resources" → resource list shown | Manual #1 + unit |
| 403 + "resources" → `skip-metadata=true` in fetch | Manual #4 (--debug) |
| 403 + "resources" → agent warning shown | Manual #5 + unit |
| 403 + "resources" → no agent warning (non-agent) | Unit (`isAgent=false`) |
| 403 + "resources" → stores fetch fails (catch) | Unit only |
| Successful removal (interactive + --yes) | Unit |
| User cancels confirmation | Manual #3 + unit |
| Integration not found | Manual #2 + unit |
| Non-403 error (generic) | Unit only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI error handling improvement that catches a 403 error and displays more helpful error messages with resource names and actionable commands - no security, auth, or data changes.
> 
> - Adds catch block for 403 error to show resource list and removal instructions
> - Adds agent-specific warning message when `client.isAgent` is true
> - Test and mock updates for new error handling behavior
>
> <sup>Risk assessment for [commit 995d440](https://github.com/vercel/vercel/commit/995d440bdda51912eda97d1ee76e31177e5e7c64).</sup>
<!-- VADE_RISK_END -->