### PR TITLE
fix(cli): error when multiple installations found in auto-provision path

### DIFF
--- a/.changeset/fix-auto-provision-multi-install.md
+++ b/.changeset/fix-auto-provision-multi-install.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): error when multiple installations found in auto-provision path

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -124,9 +124,18 @@ export async function addAutoProvision(
   );
 
   // 3b. Check if integration is installed on this team
-  const teamInstallation = installations.find(
+  const teamInstallations = installations.filter(
     i => i.ownerId === team.id && i.installationType === 'marketplace'
   );
+
+  if (teamInstallations.length > 1) {
+    output.error(
+      `Found more than one existing installation of ${integration.name}. Please contact Vercel Support at https://vercel.com/help`
+    );
+    return 1;
+  }
+
+  const teamInstallation = teamInstallations[0];
 
   let acceptedPolicies: AcceptedPolicies = {};
   if (!teamInstallation) {


### PR DESCRIPTION
## Summary
- Auto-provision path silently picked the first installation when multiple existed for the same team
- Standard path at `add.ts:186` correctly errored in this case
- Now both paths consistently error with guidance to contact Vercel Support

## Test plan
- [ ] `vercel integration add <slug>` with multiple installations shows error
- [ ] Single installation continues to work normally

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a defensive error check that rejects ambiguous states when multiple installations exist, making the auto-provision path consistent with the standard path's existing validation.
> 
> - Adds validation to error when multiple team installations found
> - Changes `.find()` to `.filter()` to detect multiple installations
> - Returns early with error message and support link
>
> <sup>Risk assessment for [commit 892babc](https://github.com/vercel/vercel/commit/892babcd971bff7617d6b6b10db54bdf87cc3ef4).</sup>
<!-- VADE_RISK_END -->