### PR TITLE
fix(cli): add integration field to list JSON + fix --integration filter for multi-product

### DIFF
--- a/.changeset/fix-list-json-integration-field.md
+++ b/.changeset/fix-list-json-integration-field.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): add integration field to list JSON and fix --integration filter for multi-product

--- a/packages/cli/src/commands/integration/list.ts
+++ b/packages/cli/src/commands/integration/list.ts
@@ -111,9 +111,12 @@ export async function list(client: Client) {
 
   function filterOnIntegration(resource: Resource): boolean {
     if (!filterIntegration) return true;
-    const match = filterIntegration === resource.product?.slug;
+    const productSlug = resource.product?.slug?.toLocaleLowerCase();
+    const match =
+      productSlug === filterIntegration ||
+      productSlug?.startsWith(`${filterIntegration}-`);
     if (match) knownIntegration = true;
-    return match;
+    return !!match;
   }
 
   function filterOnProject(resource: Resource): boolean {
@@ -157,6 +160,7 @@ export async function list(client: Client) {
       name: result.name,
       status: result.status,
       product: result.product,
+      integration: result.integration,
       installationId: result.configurationId,
       projects: result.projects,
     }));

--- a/packages/cli/test/unit/commands/integration/list.test.ts
+++ b/packages/cli/test/unit/commands/integration/list.test.ts
@@ -409,13 +409,14 @@ describe('integration', () => {
           expect(jsonOutput.resources[0]).toMatchObject({
             name: 'store-acme-connected-project',
             product: 'Acme',
+            integration: 'acme',
             projects: ['connected-project'],
           });
-          expect(jsonOutput.resources[0]).not.toHaveProperty('integration');
           expect(jsonOutput.resources[0]).toHaveProperty('installationId');
           expect(jsonOutput.resources[1]).toMatchObject({
             name: 'store-foo-bar-both-projects',
             product: 'Foo Bar',
+            integration: 'foo-bar',
             projects: ['connected-project', 'other-project'],
           });
         });


### PR DESCRIPTION
## Summary
- JSON output from `integration list --format=json` was missing the `integration` slug field shown in table output
- `--integration` flag filtered on exact product slug match only, so `--integration upstash` matched nothing (products are `upstash-kv`, `upstash-vector`, etc.)
- Filter now also matches when product slug starts with the filter value + hyphen

## Test plan
- [ ] `vercel integration list --format=json` includes `integration` field
- [ ] `vercel integration list -i upstash` shows all Upstash products
- [ ] `vercel integration list -i neon` still works (exact match)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a missing field to JSON output and relaxes a CLI filter to match product slugs by prefix, with no security, auth, or data integrity implications.
> 
> - Adds `integration` field to JSON output for `integration list` command
> - Expands `--integration` filter to match product slugs starting with filter value + hyphen
> - Updates unit tests to verify new JSON field inclusion
>
> <sup>Risk assessment for [commit d9d6f02](https://github.com/vercel/vercel/commit/d9d6f02a8082868cc8e71d40d0a4501b96bc5ae9).</sup>
<!-- VADE_RISK_END -->