### PR TITLE
[python] run build command after install commands

### DIFF
--- a/.changeset/long-dots-brake.md
+++ b/.changeset/long-dots-brake.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Run Python build commands _after_ install commands and in the virtual env

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -118,56 +118,6 @@ export const build: BuildV3 = async ({
     throw err;
   }
 
-  // For Python frameworks, also honor project install/build commands (vercel.json/dashboard)
-  if (isPythonFramework(framework)) {
-    const {
-      cliType,
-      lockfileVersion,
-      packageJsonPackageManager,
-      turboSupportsCorepackHome,
-    } = await scanParentDirs(workPath, true);
-    spawnEnv = getEnvForPackageManager({
-      cliType,
-      lockfileVersion,
-      packageJsonPackageManager,
-      env: process.env,
-      turboSupportsCorepackHome,
-      projectCreatedAt: config?.projectSettings?.createdAt,
-    });
-
-    const installCommand = config?.projectSettings?.installCommand;
-    if (typeof installCommand === 'string') {
-      const trimmed = installCommand.trim();
-      if (trimmed) {
-        projectInstallCommand = trimmed;
-      } else {
-        console.log('Skipping "install" command...');
-      }
-    }
-
-    const projectBuildCommand =
-      config?.projectSettings?.buildCommand ??
-      // fallback if provided directly on config (some callers set this)
-      (config as any)?.buildCommand;
-    if (projectBuildCommand) {
-      console.log(`Running "${projectBuildCommand}"`);
-      await execCommand(projectBuildCommand, {
-        env: spawnEnv,
-        cwd: workPath,
-      });
-      hasCustomCommand = true;
-    } else {
-      const ranBuildScript = await runPyprojectScript(
-        workPath,
-        ['vercel-build', 'now-build', 'build'],
-        spawnEnv
-      );
-      if (ranBuildScript) {
-        hasCustomCommand = true;
-      }
-    }
-  }
-
   let fsFiles = await glob('**', workPath);
 
   // Zero config entrypoint discovery
@@ -326,6 +276,34 @@ export const build: BuildV3 = async ({
     venvPath,
   });
 
+  // For Python frameworks, set up the env and extract the install command (vercel.json/dashboard)
+  if (isPythonFramework(framework)) {
+    const {
+      cliType,
+      lockfileVersion,
+      packageJsonPackageManager,
+      turboSupportsCorepackHome,
+    } = await scanParentDirs(workPath, true);
+    spawnEnv = getEnvForPackageManager({
+      cliType,
+      lockfileVersion,
+      packageJsonPackageManager,
+      env: process.env,
+      turboSupportsCorepackHome,
+      projectCreatedAt: config?.projectSettings?.createdAt,
+    });
+
+    const installCommand = config?.projectSettings?.installCommand;
+    if (typeof installCommand === 'string') {
+      const trimmed = installCommand.trim();
+      if (trimmed) {
+        projectInstallCommand = trimmed;
+      } else {
+        console.log('Skipping "install" command...');
+      }
+    }
+  }
+
   const baseEnv = spawnEnv || process.env;
   const pythonEnv = createVenvEnv(venvPath, baseEnv);
 
@@ -437,6 +415,27 @@ export const build: BuildV3 = async ({
       frozen: lockFileProvidedByUser,
       locked: !lockFileProvidedByUser,
     });
+  }
+
+  // Run the project build command (if any) AFTER dependencies are installed.
+  if (isPythonFramework(framework)) {
+    const projectBuildCommand =
+      config?.projectSettings?.buildCommand ??
+      // fallback if provided directly on config (some callers set this)
+      (config as any)?.buildCommand;
+    if (projectBuildCommand) {
+      console.log(`Running "${projectBuildCommand}"`);
+      await execCommand(projectBuildCommand, {
+        env: pythonEnv,
+        cwd: workPath,
+      });
+    } else {
+      await runPyprojectScript(
+        workPath,
+        ['vercel-build', 'now-build', 'build'],
+        pythonEnv
+      );
+    }
   }
 
   // Ensure correct version of vercel-runtime is installed.

--- a/packages/python/test/fixtures/33-uv-lock/vercel.json
+++ b/packages/python/test/fixtures/33-uv-lock/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "python3 -c 'import fastapi'  # check installation"
+}

--- a/packages/python/test/fixtures/44-custom-install/vercel.json
+++ b/packages/python/test/fixtures/44-custom-install/vercel.json
@@ -1,3 +1,4 @@
 {
-  "installCommand": "pip install -r requirements-vercel.txt"
+  "installCommand": "pip install -r requirements-vercel.txt",
+  "buildCommand": "python3 -c 'import fastapi'  # check installation"
 }


### PR DESCRIPTION
Previously the project build command ran before dependencies were
installed, which meant build scripts couldn't import installed
packages, and which was inconsistent with our other builders.

Move the env setup and install command extraction closer
to where they're used, and run the build command after uv sync
completes. And now that the venv is created before the build,
run the build in the env also.

Support for python `buildCommand`/`installCommand` was added
in #14244, and they ran in the correct order but not I think in the
virtual env. The `installCommand` was made to run in the venv in #14418,
but this resulted in it running *after* `buildCommand`.
I think that we also broke putting `pip install` in buildCommand at some point,
because of it needing `--break-system-packages`

TODO:
- [x] Tests
- [x] Develop more confidence about how breaking this might be


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR reorders Python build/install command execution and changes the environment from spawnEnv to pythonEnv for build commands, which is a build process logic change but fixes incorrect ordering rather than introducing new risk.
> 
> - Moves build command execution to run after dependency installation
> - Changes build command environment from spawnEnv to pythonEnv (virtual env)
> - Adds test fixtures to verify build commands can import installed packages
>
> <sup>Risk assessment for [commit 20b7f05](https://github.com/vercel/vercel/commit/20b7f057963644d4a39ce85d84fbc37d81daa08c).</sup>
<!-- VADE_RISK_END -->