### PR TITLE
feat(cli): Support add-on purchasing in vercel buy CLI

### DIFF
--- a/.changeset/buy-addons-support.md
+++ b/.changeset/buy-addons-support.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Support add-on purchasing in `vercel buy` CLI

--- a/packages/cli/src/commands/buy/addon.ts
+++ b/packages/cli/src/commands/buy/addon.ts
@@ -1,14 +1,25 @@
+import chalk from 'chalk';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { addonSubcommand } from './command';
+import {
+  addonSubcommand,
+  SUPPORTED_ADDON_ALIASES,
+  ADDON_LABELS,
+  type AddonAlias,
+} from './command';
 import output from '../../output-manager';
 import getScope from '../../util/get-scope';
+import { getCommandName } from '../../util/pkg-name';
+import stamp from '../../util/output/stamp';
+import { createPurchase } from '../../util/buy/create-purchase';
+import { handlePurchaseError } from '../../util/buy/handle-purchase-error';
+import { validateJsonOutput } from '../../util/output-format';
 
 export default async function addon(client: Client, argv: string[]) {
-  let parsedArgs;
   const flagsSpecification = getFlagsSpecification(addonSubcommand.options);
+  let parsedArgs;
   try {
     parsedArgs = parseArguments(argv, flagsSpecification);
   } catch (error) {
@@ -16,8 +27,52 @@ export default async function addon(client: Client, argv: string[]) {
     return 1;
   }
 
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
   const { args } = parsedArgs;
-  const [addonName] = args;
+  const [addonName, quantityStr] = args;
+
+  // Validate addon name argument
+  if (!addonName) {
+    output.error(
+      `Missing addon name. Supported addons: ${SUPPORTED_ADDON_ALIASES.join(', ')}`
+    );
+    output.log(`Run ${getCommandName('buy addon --help')} for usage.`);
+    return 1;
+  }
+
+  if (!SUPPORTED_ADDON_ALIASES.includes(addonName as AddonAlias)) {
+    output.error(
+      `Invalid addon "${addonName}". Supported addons: ${SUPPORTED_ADDON_ALIASES.join(', ')}`
+    );
+    return 1;
+  }
+
+  // Validate quantity argument
+  if (!quantityStr) {
+    output.error('Missing quantity. Please specify the number of units.');
+    output.log(`Run ${getCommandName('buy addon --help')} for usage.`);
+    return 1;
+  }
+
+  const quantity = Number(quantityStr);
+  if (!Number.isInteger(quantity)) {
+    output.error(
+      `Invalid quantity "${quantityStr}". Please specify a whole number.`
+    );
+    return 1;
+  }
+  if (quantity <= 0) {
+    output.error(
+      `Invalid quantity "${quantityStr}". Please specify a positive number.`
+    );
+    return 1;
+  }
 
   // Ensure we have a team scope
   const { team, contextName } = await getScope(client);
@@ -29,13 +84,65 @@ export default async function addon(client: Client, argv: string[]) {
     return 1;
   }
 
-  if (addonName) {
-    output.log(`Purchasing addon "${addonName}" for team ${contextName}...`);
-  } else {
-    output.log(`Browsing available addons for team ${contextName}...`);
+  const typedAddonAlias = addonName as AddonAlias;
+  const label = ADDON_LABELS[typedAddonAlias];
+  const yes = parsedArgs.flags['--yes'];
+
+  // Confirm purchase
+  if (!yes) {
+    if (!client.stdin.isTTY) {
+      output.error(
+        'Confirmation required. Use --yes to skip the confirmation prompt in non-interactive mode.'
+      );
+      return 1;
+    }
+    if (
+      !(await client.input.confirm(
+        `Purchase ${chalk.bold(quantity)} unit${quantity === 1 ? '' : 's'} of ${label} for team ${chalk.bold(contextName)}?`,
+        false
+      ))
+    ) {
+      return 0;
+    }
   }
 
-  // TODO: Implement addon purchase flow when API is available
-  output.error('Addon purchases are not yet available via the CLI.');
-  return 1;
+  const purchaseStamp = stamp();
+  output.spinner('Processing purchase');
+
+  try {
+    const result = await createPurchase(client, {
+      type: 'addon',
+      productAlias: typedAddonAlias,
+      quantity,
+    });
+
+    output.stopSpinner();
+
+    if (asJson) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            productAlias: typedAddonAlias,
+            quantity,
+            team: contextName,
+            subscriptionIntent: result.subscriptionIntent,
+          },
+          null,
+          2
+        )}\n`
+      );
+    } else {
+      output.success(
+        `Purchased ${chalk.bold(quantity)} unit${quantity === 1 ? '' : 's'} of ${label} for ${chalk.bold(contextName)} ${purchaseStamp()}`
+      );
+      if (result.subscriptionIntent) {
+        output.debug(`Subscription intent: ${result.subscriptionIntent.id}`);
+      }
+    }
+
+    return 0;
+  } catch (err: unknown) {
+    output.stopSpinner();
+    return handlePurchaseError(err, contextName);
+  }
 }

--- a/packages/cli/src/commands/buy/command.ts
+++ b/packages/cli/src/commands/buy/command.ts
@@ -48,6 +48,15 @@ export const creditsSubcommand = {
   ],
 } as const;
 
+// TODO(mingchungx): Add other addons
+export const SUPPORTED_ADDON_ALIASES = ['siem'] as const;
+export type AddonAlias = (typeof SUPPORTED_ADDON_ALIASES)[number];
+
+// TODO(mingchungx): Add other labels
+export const ADDON_LABELS: Record<AddonAlias, string> = {
+  siem: 'SIEM',
+};
+
 export const addonSubcommand = {
   name: 'addon',
   aliases: ['addons'],
@@ -55,18 +64,25 @@ export const addonSubcommand = {
   arguments: [
     {
       name: 'addon-name',
-      required: false,
+      required: true,
+    },
+    {
+      name: 'quantity',
+      required: true,
     },
   ],
-  options: [],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt',
+    },
+    formatOption,
+    jsonOption,
+  ],
   examples: [
     {
-      name: 'Browse and purchase available addons',
-      value: `${packageName} buy addon`,
-    },
-    {
-      name: 'Purchase a specific addon',
-      value: `${packageName} buy addon <addon-name>`,
+      name: 'Purchase 1 unit of the SIEM addon',
+      value: `${packageName} buy addon siem 1`,
     },
   ],
 } as const;
@@ -137,8 +153,8 @@ export const buyCommand = {
       value: `${packageName} buy credits v0 100`,
     },
     {
-      name: 'Purchase an addon',
-      value: `${packageName} buy addon`,
+      name: 'Purchase the SIEM addon',
+      value: `${packageName} buy addon siem 1`,
     },
     {
       name: 'Upgrade to Pro',

--- a/packages/cli/src/commands/buy/credits.ts
+++ b/packages/cli/src/commands/buy/credits.ts
@@ -144,7 +144,9 @@ export default async function credits(client: Client, argv: string[]) {
       output.success(
         `Purchased ${chalk.bold(`$${amount}`)} of ${label} credits for ${chalk.bold(contextName)} ${purchaseStamp()}`
       );
-      output.debug(`Purchase intent: ${result.purchaseIntent.id}`);
+      if (result.purchaseIntent) {
+        output.debug(`Purchase intent: ${result.purchaseIntent.id}`);
+      }
     }
 
     return 0;

--- a/packages/cli/src/util/buy/handle-purchase-error.ts
+++ b/packages/cli/src/util/buy/handle-purchase-error.ts
@@ -13,6 +13,16 @@ const getBillingUrl = (teamSlug: string) =>
  */
 export function handlePurchaseError(err: unknown, teamSlug?: string): number {
   if (isAPIError(err)) {
+    if (err.code === 'invalid_plan_iteration') {
+      output.error('Your team must be on the Flex plan to purchase add-ons.');
+      return 1;
+    }
+    if (err.code === 'missing_subscription') {
+      output.error(
+        'Your team does not have an active subscription. Please contact support.'
+      );
+      return 1;
+    }
     if (err.code === 'missing_stripe_customer') {
       const dashboardHint = teamSlug
         ? ` Please add one: ${output.link(getBillingUrl(teamSlug), getBillingUrl(teamSlug))}`

--- a/packages/cli/src/util/buy/types.ts
+++ b/packages/cli/src/util/buy/types.ts
@@ -1,13 +1,17 @@
-import type { CreditType } from '../../commands/buy/command';
+import type { CreditType, AddonAlias } from '../../commands/buy/command';
 
 export type PurchaseItem =
   | { type: 'credits'; creditType: CreditType; amount: number }
-  | { type: 'addon'; addonName: string }
+  | { type: 'addon'; productAlias: AddonAlias; quantity: number }
   | { type: 'pro' }
   | { type: 'v0' };
 
 export interface BuyResponse {
-  purchaseIntent: {
+  purchaseIntent?: {
+    id: string;
+    status: string;
+  };
+  subscriptionIntent?: {
     id: string;
     status: string;
   };

--- a/packages/cli/test/unit/commands/buy/addon.test.ts
+++ b/packages/cli/test/unit/commands/buy/addon.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import { client } from '../../../mocks/client';
+import buy from '../../../../src/commands/buy';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+
+function useBuyEndpoint(handler?: (req: any, res: any) => void) {
+  client.scenario.post('/v1/billing/buy', (req, res) => {
+    if (handler) {
+      handler(req, res);
+    } else {
+      res.json({
+        subscriptionIntent: {
+          id: 'subint_test_123',
+          status: 'succeeded',
+        },
+      });
+    }
+  });
+}
+
+function setupTeam() {
+  useUser();
+  const team = useTeam();
+  client.config.currentTeam = team.id;
+  return team;
+}
+
+describe('buy addon', () => {
+  describe('validation', () => {
+    it('errors when addon name is missing', async () => {
+      client.setArgv('buy', 'addon');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Missing addon name');
+    });
+
+    it('errors when addon name is invalid', async () => {
+      client.setArgv('buy', 'addon', 'invalid', '1');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid addon "invalid"');
+    });
+
+    it('errors when quantity is missing', async () => {
+      client.setArgv('buy', 'addon', 'siem');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Missing quantity');
+    });
+
+    it('errors when quantity is not a number', async () => {
+      client.setArgv('buy', 'addon', 'siem', 'abc');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid quantity "abc"');
+    });
+
+    it('errors when quantity is zero', async () => {
+      client.setArgv('buy', 'addon', 'siem', '0');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('positive number');
+    });
+
+    it('errors when quantity is negative', async () => {
+      client.setArgv('buy', 'addon', 'siem', '-1');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('unknown or unexpected option');
+    });
+
+    it('errors when quantity is a decimal', async () => {
+      client.setArgv('buy', 'addon', 'siem', '1.5');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid quantity "1.5"');
+    });
+  });
+
+  describe('--yes', () => {
+    it('skips confirmation and purchases successfully', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'addon', 'siem', '1', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+    });
+
+    it('errors in non-TTY mode without --yes', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'addon', 'siem', '1');
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Use --yes');
+    });
+  });
+
+  describe('confirmation prompt', () => {
+    it('aborts when user declines', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'addon', 'siem', '1');
+
+      const exitCodePromise = buy(client);
+      await expect(client.stderr).toOutput('Purchase');
+      client.stdin.write('n\n');
+
+      expect(await exitCodePromise).toBe(0);
+    });
+
+    it('proceeds when user confirms', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'addon', 'siem', '1');
+
+      const exitCodePromise = buy(client);
+      await expect(client.stderr).toOutput('Purchase');
+      client.stdin.write('y\n');
+
+      expect(await exitCodePromise).toBe(0);
+    });
+  });
+
+  describe('API errors', () => {
+    it('handles missing_stripe_customer error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'missing_stripe_customer',
+            message: 'No payment method',
+          },
+        });
+      });
+      client.setArgv('buy', 'addon', 'siem', '1', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('payment method');
+    });
+
+    it('handles payment_failed error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(402).json({
+          error: {
+            code: 'payment_failed',
+            message: 'Payment failed',
+          },
+        });
+      });
+      client.setArgv('buy', 'addon', 'siem', '1', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Payment failed');
+    });
+
+    it('handles invalid_plan_iteration error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'invalid_plan_iteration',
+            message: 'Team must be on flex plan',
+          },
+        });
+      });
+      client.setArgv('buy', 'addon', 'siem', '1', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Flex plan');
+    });
+
+    it('handles missing_subscription error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'missing_subscription',
+            message: 'No subscription found',
+          },
+        });
+      });
+      client.setArgv('buy', 'addon', 'siem', '1', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('active subscription');
+    });
+  });
+
+  describe('--format=json', () => {
+    it('outputs JSON on success', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'addon', 'siem', '1', '--yes', '--format=json');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const parsed = JSON.parse(stdoutOutput);
+      expect(parsed.productAlias).toBe('siem');
+      expect(parsed.quantity).toBe(1);
+      expect(parsed.subscriptionIntent.id).toBe('subint_test_123');
+    });
+  });
+
+  describe('--help', () => {
+    it('shows help and returns 2', async () => {
+      client.setArgv('buy', 'addon', '--help');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(2);
+    });
+
+    it('tracks telemetry', async () => {
+      client.setArgv('buy', 'addon', '--help');
+      await buy(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'buy:addon',
+        },
+      ]);
+    });
+  });
+
+  describe('telemetry', () => {
+    it('tracks addon subcommand', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'addon', 'siem', '1', '--yes');
+      await buy(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:addon',
+          value: 'addon',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
#  Support add-on purchasing in vercel buy CLI

Support add-on purchasing via `vercel buy` CLI. The basic heuristic is:

```sh
vercel buy addon <addon> <quantity>
```

Note that `<quantity>` is a "set" quantity, _not_ incremental.

### Example

```sh
# Buy SIEM Integration add on (quantity 1)
vercel buy addon siem 1
```

<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR adds new CLI functionality for purchasing add-ons via `vercel buy addon` command with proper input validation, confirmation prompts, and error handling - a new feature addition with billing implications but includes defensive checks.
> 
> - New billing feature: CLI add-on purchasing via `createPurchase` API call
> - Input validation for addon name and quantity (must be positive integer)
> - Confirmation prompt required unless `--yes` flag provided
>
> <sup>Risk assessment for [commit fa08aba](https://github.com/vercel/vercel/commit/fa08abae6686041a907b55f93a9bb0dd2f67002a).</sup>
<!-- VADE_RISK_END -->