### PR TITLE
feat(cli): make metrics query default to text output

### DIFF
--- a/.changeset/serious-cows-cheat.md
+++ b/.changeset/serious-cows-cheat.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Change `vercel metrics` default query output from CSV to rich text with metadata, summary tables, sparklines, and optional raw values via `--raw-values`.

--- a/packages/cli/src/commands/metrics/output.ts
+++ b/packages/cli/src/commands/metrics/output.ts
@@ -1,41 +1,11 @@
 import type { EventSchema } from './schema-data';
-import type {
-  MetricsDataRow,
-  QueryMetadata,
-  MetricsQueryResponse,
-} from './types';
-
-export function escapeCsvValue(
-  value: string | number | boolean | null | undefined
-): string {
-  if (value === null || value === undefined) {
-    return '';
-  }
-  const str = String(value);
-  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
-    return `"${str.replace(/"/g, '""')}"`;
-  }
-  return str;
-}
+import type { QueryMetadata, MetricsQueryResponse } from './types';
 
 export function getRollupColumnName(
   measure: string,
   aggregation: string
 ): string {
   return `${measure}_${aggregation}`;
-}
-
-export function formatCsv(
-  data: MetricsDataRow[],
-  groupBy: string[],
-  rollupColumn: string
-): string {
-  const columns = ['timestamp', ...groupBy, rollupColumn];
-  const header = columns.join(',');
-  const rows = data.map(row =>
-    columns.map(col => escapeCsvValue(row[col])).join(',')
-  );
-  return header + '\n' + (rows.length > 0 ? rows.join('\n') + '\n' : '');
 }
 
 export function formatQueryJson(
@@ -52,37 +22,6 @@ export function formatQueryJson(
     null,
     2
   );
-}
-
-export function formatSchemaListCsv(
-  events: Array<{ name: string; description: string }>
-): string {
-  const header = 'event,description';
-  const rows = events.map(
-    e => `${escapeCsvValue(e.name)},${escapeCsvValue(e.description)}`
-  );
-  return header + '\n' + rows.join('\n') + '\n';
-}
-
-export function formatSchemaDetailCsv(
-  event: EventSchema & { name: string }
-): string {
-  // Dimensions table
-  const dimHeader = 'dimension,label,filterOnly';
-  const dimRows = event.dimensions.map(
-    d => `${escapeCsvValue(d.name)},${escapeCsvValue(d.label)},${d.filterOnly}`
-  );
-  const dimBlock = dimHeader + '\n' + dimRows.join('\n') + '\n';
-
-  // Measures table
-  const measureHeader = 'measure,label,unit';
-  const measureRows = event.measures.map(
-    m =>
-      `${escapeCsvValue(m.name)},${escapeCsvValue(m.label)},${escapeCsvValue(m.unit)}`
-  );
-  const measureBlock = measureHeader + '\n' + measureRows.join('\n') + '\n';
-
-  return dimBlock + '\n' + measureBlock;
 }
 
 export function formatSchemaDetailJson(

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -15,11 +15,11 @@ import {
 } from './validation';
 import { getDefaultAggregation } from './schema-data';
 import {
-  formatCsv,
   formatQueryJson,
   formatErrorJson,
   getRollupColumnName,
 } from './output';
+import { formatText } from './text-output';
 import {
   resolveTimeRange,
   computeGranularity,
@@ -359,7 +359,22 @@ export default async function query(
       )
     );
   } else {
-    client.stdout.write(formatCsv(response.data ?? [], groupBy, rollupColumn));
+    client.stdout.write(
+      formatText(response, {
+        event,
+        measure,
+        aggregation,
+        groupBy,
+        filter,
+        scope,
+        projectName:
+          scope.type === 'project-with-slug' ? scope.projectName : undefined,
+        teamName: scope.teamSlug,
+        periodStart: rounded.start.toISOString(),
+        periodEnd: rounded.end.toISOString(),
+        granularity: granResult.duration,
+      })
+    );
   }
 
   return 0;

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -27,7 +27,12 @@ import {
   toGranularityMsFromDuration,
 } from './time-utils';
 import type { MetricsTelemetryClient } from '../../util/telemetry/commands/metrics';
-import type { Scope, ValidationError, MetricsQueryResponse } from './types';
+import type {
+  Scope,
+  ValidationError,
+  MetricsQueryRequest,
+  MetricsQueryResponse,
+} from './types';
 import { getLinkedProject } from '../../util/projects/link';
 import getScope from '../../util/get-scope';
 import { isAPIError } from '../../util/errors-ts';
@@ -218,7 +223,8 @@ export default async function query(
   const event = requiredResult.value;
 
   // Compute aggregation after event is validated
-  const aggregation = aggregationFlag ?? getDefaultAggregation(event, measure);
+  const aggregationInput =
+    aggregationFlag ?? getDefaultAggregation(event, measure);
 
   // Validate event name
   const eventResult = validateEvent(event);
@@ -233,10 +239,11 @@ export default async function query(
   }
 
   // Validate aggregation
-  const aggResult = validateAggregation(event, measure, aggregation);
+  const aggResult = validateAggregation(event, measure, aggregationInput);
   if (!aggResult.valid) {
     return handleValidationError(aggResult, jsonOutput, client);
   }
+  const aggregation = aggResult.value;
 
   // Validate group-by dimensions
   const groupByResult = validateGroupBy(event, groupBy);
@@ -294,7 +301,7 @@ export default async function query(
 
   // Build request body
   const rollupColumn = getRollupColumnName(measure, aggregation);
-  const body = {
+  const body: MetricsQueryRequest = {
     reason: 'agent' as const,
     scope,
     event,

--- a/packages/cli/src/commands/metrics/schema-data.ts
+++ b/packages/cli/src/commands/metrics/schema-data.ts
@@ -33,6 +33,10 @@ const VALUE_AGGREGATIONS = [
   'unique',
 ] as const;
 
+export type CountAggregation = (typeof COUNT_AGGREGATIONS)[number];
+export type ValueAggregation = (typeof VALUE_AGGREGATIONS)[number];
+export type MetricsAggregation = ValueAggregation;
+
 // Measures with "cannot be used in rollups" are excluded since the CLI only supports aggregated queries.
 export const SCHEMA = {
   aiGatewayRequest: {
@@ -829,7 +833,7 @@ export function getMeasures(eventName: string): MeasureSchema[] {
 export function getDefaultAggregation(
   eventName: string,
   measureName: string
-): string {
+): MetricsAggregation {
   if (measureName === 'count') return 'sum';
 
   const event = getEvent(eventName);
@@ -859,7 +863,7 @@ export function getDefaultAggregation(
 export function getAggregations(
   eventName: string,
   measureName: string
-): readonly string[] {
+): readonly MetricsAggregation[] {
   const event = getEvent(eventName);
   if (!event) {
     return [];

--- a/packages/cli/src/commands/metrics/text-output.ts
+++ b/packages/cli/src/commands/metrics/text-output.ts
@@ -1,0 +1,776 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import indent from '../../util/output/indent';
+import { getMeasures } from './schema-data';
+import { getRollupColumnName } from './output';
+import { toGranularityMsFromDuration } from './time-utils';
+import type {
+  Granularity,
+  MetricsDataRow,
+  MetricsQueryResponse,
+  Scope,
+} from './types';
+
+export type MeasureType = 'count' | 'duration' | 'bytes' | 'ratio';
+
+export interface TimeSeriesPoint {
+  timestamp: string;
+  value: number | null;
+}
+
+export interface GroupStats {
+  total: number;
+  avg: number;
+  min: { value: number; timestamp: string };
+  max: { value: number; timestamp: string };
+  count: number;
+  allMissing: boolean;
+}
+
+export interface ExtractGroupedSeriesResult {
+  groups: string[];
+  series: Map<string, TimeSeriesPoint[]>;
+  groupValues: Map<string, string[]>;
+}
+
+interface SummaryTableRow {
+  groupValues: string[];
+  stats: GroupStats;
+}
+
+interface SummaryTableOptions {
+  rows: SummaryTableRow[];
+  groupByFields: string[];
+  measureType: MeasureType;
+  aggregation: string;
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+interface MetadataHeaderOptions {
+  event: string;
+  measure: string;
+  aggregation: string;
+  periodStart: string;
+  periodEnd: string;
+  granularity: Granularity;
+  filter?: string;
+  scope: Scope;
+  projectName?: string;
+  teamName?: string;
+  unit?: string;
+  groupCount?: number;
+}
+
+export interface FormatTextOptions {
+  event: string;
+  measure: string;
+  aggregation: string;
+  groupBy: string[];
+  filter?: string;
+  scope: Scope;
+  projectName?: string;
+  teamName?: string;
+  periodStart: string;
+  periodEnd: string;
+  granularity: Granularity;
+}
+
+// Use a non-printable delimiter so group keys remain stable without colliding
+// with user-visible values (which can contain common separators like "|" or ",").
+const GROUP_KEY_DELIMITER = '\u001f';
+const MAX_SPARKLINE_LENGTH = 120;
+
+const COUNT_UNITS = new Set(['count', 'tokens', 'us dollars', 'dollars']);
+const DURATION_UNITS = new Set(['milliseconds', 'seconds']);
+const BYTES_UNITS = new Set([
+  'bytes',
+  'megabytes',
+  'gigabyte hours',
+  'gigabyte_hours',
+]);
+const RATIO_UNITS = new Set(['ratio', 'percent']);
+
+export const BLOCKS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'] as const;
+export const MISSING_CHAR = '·';
+
+/** Normalizes schema unit strings to a stable lookup key. */
+function normalizeUnit(unit: string): string {
+  return unit
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, ' ');
+}
+
+/** Builds an internal map key from grouped dimension values. */
+function toGroupKey(groupValues: string[]): string {
+  if (groupValues.length === 0) {
+    return '';
+  }
+  return groupValues.join(GROUP_KEY_DELIMITER);
+}
+
+/** Left-pads a number to two digits. */
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** Left-pads a number to four digits. */
+function pad4(n: number): string {
+  return String(n).padStart(4, '0');
+}
+
+/** Formats a UTC date as YYYY-MM-DD HH:MM. */
+function formatHumanMinute(date: Date): string {
+  return `${pad4(date.getUTCFullYear())}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())} ${pad2(date.getUTCHours())}:${pad2(date.getUTCMinutes())}`;
+}
+
+/** Formats a period bound string for metadata, preserving invalid input as-is. */
+function formatPeriodBound(input: string): string {
+  const date = new Date(input);
+  if (isNaN(date.getTime())) {
+    return input;
+  }
+  // Keep metadata period compact and deterministic at minute precision.
+  return formatHumanMinute(date);
+}
+
+/** Renders granularity objects in short form (e.g. 5m, 1h, 1d). */
+function formatGranularity(granularity: Granularity): string {
+  if ('minutes' in granularity) {
+    return `${granularity.minutes}m`;
+  }
+  if ('hours' in granularity) {
+    return `${granularity.hours}h`;
+  }
+  return `${granularity.days}d`;
+}
+
+/** Converts verbose units to compact labels for metadata output. */
+function formatUnitLabel(unit: string): string {
+  switch (normalizeUnit(unit)) {
+    case 'milliseconds':
+      return 'ms';
+    case 'seconds':
+      return 's';
+    case 'us dollars':
+      return 'USD';
+    case 'gigabyte hours':
+      return 'GB-h';
+    default:
+      return unit;
+  }
+}
+
+/**
+ * Returns true only for total-count style output:
+ * - `measureType=count` and `aggregation=sum` -> integer display
+ * - everything else (`persecond`, `percent`, durations, ratios, bytes) -> decimal
+ */
+function isCountIntegerDisplay(
+  measureType: MeasureType,
+  aggregation: string
+): boolean {
+  // Count + sum should read like totals (integers), while count-persecond /
+  // count-percent stay decimal.
+  return measureType === 'count' && aggregation === 'sum';
+}
+
+/**
+ * Formats numbers by measure/aggregation with an optional override for count averages.
+ * Default behavior:
+ * - count+sum -> integer formatting via `formatCount()`
+ * - everything else -> decimal formatting via `formatDecimal()`
+ *
+ * When `preserveFractionalCountSum` is true, count+sum values like `1.5`
+ * stay decimal (used for `avg` only).
+ */
+function formatNumber(
+  value: number,
+  measureType: MeasureType,
+  aggregation: string,
+  opts?: { preserveFractionalCountSum?: boolean }
+): string {
+  if (isCountIntegerDisplay(measureType, aggregation)) {
+    if (opts?.preserveFractionalCountSum && !Number.isInteger(value)) {
+      return formatDecimal(value);
+    }
+    return formatCount(value);
+  }
+  return formatDecimal(value);
+}
+
+/** Chooses summary statistic columns for a given measure type. */
+function getStatColumns(measureType: MeasureType): string[] {
+  if (measureType === 'duration' || measureType === 'ratio') {
+    return ['avg', 'min', 'max'];
+  }
+  return ['total', 'avg', 'min', 'max'];
+}
+
+/** Parses API cell values into finite numbers or null for missing/invalid. */
+function toNumericValue(
+  value: string | number | null | undefined
+): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** Formats one summary statistic cell, including min/max timestamps. */
+function formatStatCell(
+  column: string,
+  stats: GroupStats,
+  measureType: MeasureType,
+  aggregation: string,
+  periodStart: Date,
+  periodEnd: Date
+): string {
+  switch (column) {
+    case 'total':
+      return formatNumber(stats.total, measureType, aggregation);
+    case 'avg':
+      return formatNumber(stats.avg, measureType, aggregation, {
+        preserveFractionalCountSum: true,
+      });
+    case 'min': {
+      const ts = formatMinMaxTimestamp(
+        new Date(stats.min.timestamp),
+        periodStart,
+        periodEnd
+      );
+      return `${formatNumber(stats.min.value, measureType, aggregation)} at ${ts}`;
+    }
+    case 'max': {
+      const ts = formatMinMaxTimestamp(
+        new Date(stats.max.timestamp),
+        periodStart,
+        periodEnd
+      );
+      return `${formatNumber(stats.max.value, measureType, aggregation)} at ${ts}`;
+    }
+    default:
+      return '--';
+  }
+}
+
+/** Builds expected timestamp buckets from period and granularity. */
+function buildExpectedTimestamps(
+  periodStart: string,
+  periodEnd: string,
+  granularityMs: number
+): string[] {
+  const start = Date.parse(periodStart);
+  const end = Date.parse(periodEnd);
+  if (isNaN(start) || isNaN(end) || granularityMs <= 0 || end <= start) {
+    return [];
+  }
+  const timestamps: string[] = [];
+  // Query output uses half-open bucket semantics: [start, end).
+  // Meaning:
+  // - include `start`
+  // - exclude `end`
+  //
+  // Example with 5m granularity:
+  // - start: 2026-02-19T10:00:00Z
+  // - end:   2026-02-19T10:15:00Z
+  // Buckets are: 10:00, 10:05, 10:10 (10:15 is not included).
+  //
+  // This avoids end-boundary off-by-one buckets and keeps adjacent ranges
+  // non-overlapping (the next query can start exactly at the previous end).
+  for (let current = start; current < end; current += granularityMs) {
+    timestamps.push(new Date(current).toISOString());
+  }
+  return timestamps;
+}
+
+/**
+ * Classifies a schema unit into formatting behavior:
+ * - `count`: count/tokens/USD-like values (integer totals for `sum`)
+ * - `duration`: time units (ms/s)
+ * - `bytes`: storage/bandwidth-like units
+ * - `ratio`: percentages/ratios and unknown units (safe decimal fallback)
+ */
+export function getMeasureType(unit: string): MeasureType {
+  const normalized = normalizeUnit(unit);
+  if (COUNT_UNITS.has(normalized)) {
+    return 'count';
+  }
+  if (DURATION_UNITS.has(normalized)) {
+    return 'duration';
+  }
+  if (BYTES_UNITS.has(normalized)) {
+    return 'bytes';
+  }
+  if (RATIO_UNITS.has(normalized)) {
+    return 'ratio';
+  }
+  return 'ratio';
+}
+
+/**
+ * Formats count-like values as rounded integers with `en-US` separators.
+ * Example: `17880.2 -> "17,880"`.
+ */
+export function formatCount(n: number): string {
+  return Math.round(n).toLocaleString('en-US');
+}
+
+/**
+ * Formats decimal values with explicit, stable rules:
+ * - `0` (or `-0`) -> `"0"`
+ * - `abs(n) >= 1` -> one decimal place (e.g. `42 -> "42.0"`)
+ * - `0 < abs(n) < 1` -> enough decimals to keep at least 2 significant digits
+ *   without trailing zero noise (e.g. `0.042 -> "0.042"`).
+ */
+export function formatDecimal(n: number): string {
+  if (!Number.isFinite(n)) {
+    return String(n);
+  }
+  if (n === 0 || Object.is(n, -0)) {
+    return '0';
+  }
+
+  const sign = n < 0 ? '-' : '';
+  const abs = Math.abs(n);
+
+  // Human-readable fixed precision for values >= 1.
+  if (abs >= 1) {
+    return `${sign}${abs.toFixed(1)}`;
+  }
+
+  // For fractional values, increase decimals until we have >=2 significant digits.
+  const exponent = Math.floor(Math.log10(abs));
+  const decimals = Math.min(20, Math.max(2, -exponent + 1));
+  const fixed = abs.toFixed(decimals);
+  const trimmed = fixed
+    .replace(/(\.\d*?[1-9])0+$/, '$1')
+    .replace(/\.0+$/, '')
+    .replace(/\.$/, '');
+
+  return `${sign}${trimmed}`;
+}
+
+/**
+ * Formats min/max timestamps based on queried period span (UTC):
+ * - same day: `HH:MM`
+ * - same year, different day: `MM-DD HH:MM`
+ * - cross-year: `YYYY-MM-DD HH:MM`
+ */
+export function formatMinMaxTimestamp(
+  date: Date,
+  periodStart: Date,
+  periodEnd: Date
+): string {
+  const sameDay =
+    periodStart.getUTCFullYear() === periodEnd.getUTCFullYear() &&
+    periodStart.getUTCMonth() === periodEnd.getUTCMonth() &&
+    periodStart.getUTCDate() === periodEnd.getUTCDate();
+
+  if (sameDay) {
+    return `${pad2(date.getUTCHours())}:${pad2(date.getUTCMinutes())}`;
+  }
+
+  const sameYear = periodStart.getUTCFullYear() === periodEnd.getUTCFullYear();
+  if (sameYear) {
+    return `${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())} ${pad2(date.getUTCHours())}:${pad2(date.getUTCMinutes())}`;
+  }
+
+  return `${pad4(date.getUTCFullYear())}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())} ${pad2(date.getUTCHours())}:${pad2(date.getUTCMinutes())}`;
+}
+
+/** Pivots flat API rows into complete per-group time series with null fills. */
+export function extractGroupedSeries(
+  data: MetricsDataRow[],
+  groupBy: string[],
+  rollupColumn: string,
+  periodStart: string,
+  periodEnd: string,
+  granularityMs: number
+): ExtractGroupedSeriesResult {
+  const expectedTimestamps = buildExpectedTimestamps(
+    periodStart,
+    periodEnd,
+    granularityMs
+  );
+  const groups: string[] = [];
+  const groupValues = new Map<string, string[]>();
+  const valueByGroup = new Map<string, Map<string, number | null>>();
+
+  for (const row of data) {
+    const values = groupBy.map(field => String(row[field] ?? ''));
+    const key = toGroupKey(values);
+    if (!valueByGroup.has(key)) {
+      // Preserve first-seen ordering from API response so output order is stable.
+      groups.push(key);
+      groupValues.set(key, values);
+      valueByGroup.set(key, new Map());
+    }
+    const timestamp = row.timestamp;
+    if (typeof timestamp !== 'string' || timestamp.length === 0) {
+      continue;
+    }
+
+    const numeric = toNumericValue(row[rollupColumn]);
+    valueByGroup.get(key)!.set(timestamp, numeric);
+  }
+
+  const series = new Map<string, TimeSeriesPoint[]>();
+  for (const key of groups) {
+    const byTimestamp = valueByGroup.get(key)!;
+    // Expand sparse API rows into complete series so every group aligns on time.
+    const points = expectedTimestamps.map(timestamp => ({
+      timestamp,
+      value: byTimestamp.has(timestamp) ? byTimestamp.get(timestamp)! : null,
+    }));
+    series.set(key, points);
+  }
+
+  return { groups, series, groupValues };
+}
+
+/**
+ * Computes summary stats from one group's series.
+ * Null points are treated as missing and excluded from total/avg/min/max.
+ * If all points are missing, returns `allMissing=true` and zero placeholders.
+ */
+export function computeGroupStats(points: TimeSeriesPoint[]): GroupStats {
+  const present = points.filter(point => point.value !== null) as Array<{
+    timestamp: string;
+    value: number;
+  }>;
+
+  if (present.length === 0) {
+    return {
+      total: 0,
+      avg: 0,
+      min: { value: 0, timestamp: '' },
+      max: { value: 0, timestamp: '' },
+      count: 0,
+      allMissing: true,
+    };
+  }
+
+  let total = 0;
+  let min = present[0];
+  let max = present[0];
+
+  for (const point of present) {
+    total += point.value;
+    if (point.value < min.value) {
+      min = point;
+    }
+    if (point.value > max.value) {
+      max = point;
+    }
+  }
+
+  return {
+    total,
+    avg: total / present.length,
+    min: { value: min.value, timestamp: min.timestamp },
+    max: { value: max.value, timestamp: max.timestamp },
+    count: present.length,
+    allMissing: false,
+  };
+}
+
+/**
+ * Reduces long series to `maxLen` buckets.
+ * Bucket rules:
+ * - all null -> null
+ * - more than 50% null -> null
+ * - otherwise -> average of present values
+ */
+export function downsample(
+  values: (number | null)[],
+  maxLen: number
+): (number | null)[] {
+  if (maxLen <= 0) {
+    return [];
+  }
+  if (values.length <= maxLen) {
+    return [...values];
+  }
+
+  const result: (number | null)[] = [];
+  for (let i = 0; i < maxLen; i++) {
+    const start = Math.floor((i * values.length) / maxLen);
+    const end = Math.floor(((i + 1) * values.length) / maxLen);
+    const bucket = values.slice(start, Math.max(start + 1, end));
+    const nullCount = bucket.filter(value => value === null).length;
+
+    // If missing dominates a bucket, keep it missing so gaps remain visible.
+    if (nullCount === bucket.length || nullCount > bucket.length / 2) {
+      result.push(null);
+      continue;
+    }
+
+    const present = bucket.filter(value => value !== null) as Array<number>;
+    const avg = present.reduce((sum, value) => sum + value, 0) / present.length;
+    result.push(avg);
+  }
+
+  return result;
+}
+
+/**
+ * Encodes a series as sparkline characters:
+ * - scales each series independently from its own min/max
+ * - null values become `·`
+ * - constant nonzero becomes `█`, constant zero becomes `▁`
+ */
+export function generateSparkline(values: (number | null)[]): string {
+  const sampled = downsample(values, MAX_SPARKLINE_LENGTH);
+  if (sampled.length === 0) {
+    return '';
+  }
+
+  const present = sampled.filter(value => value !== null) as number[];
+  if (present.length === 0) {
+    // Entire series missing: keep positional placeholders instead of empty output.
+    return sampled.map(() => MISSING_CHAR).join('');
+  }
+
+  const min = Math.min(...present);
+  const max = Math.max(...present);
+
+  if (min === max) {
+    // Constant series still conveys presence instead of shape:
+    // - [5, 5, 5] -> "███"
+    // - [0, 0, 0] -> "▁▁▁"
+    // - [5, null, 5] -> "█·█"
+    const block = min === 0 ? BLOCKS[0] : BLOCKS[BLOCKS.length - 1];
+    return sampled
+      .map(value => (value === null ? MISSING_CHAR : block))
+      .join('');
+  }
+
+  const range = max - min;
+  return sampled
+    .map(value => {
+      if (value === null) {
+        return MISSING_CHAR;
+      }
+      const ratio = (value - min) / range;
+      const index = Math.max(
+        0,
+        Math.min(BLOCKS.length - 1, Math.round(ratio * (BLOCKS.length - 1)))
+      );
+      return BLOCKS[index];
+    })
+    .join('');
+}
+
+/** Builds aligned metadata header lines shown above results. */
+export function formatMetadataHeader(opts: MetadataHeaderOptions): string {
+  const rows: Array<{ key: string; value: string }> = [
+    {
+      key: 'Metric',
+      value: `${opts.event} / ${opts.measure} ${opts.aggregation}`,
+    },
+    {
+      key: 'Period',
+      value: `${formatPeriodBound(opts.periodStart)} to ${formatPeriodBound(opts.periodEnd)}`,
+    },
+    {
+      key: 'Interval',
+      value: formatGranularity(opts.granularity),
+    },
+  ];
+
+  if (opts.filter) {
+    rows.push({ key: 'Filter', value: opts.filter });
+  }
+
+  if (opts.scope.type === 'project-with-slug') {
+    rows.push({
+      key: 'Project',
+      value: `${opts.projectName ?? opts.scope.projectName} (${opts.teamName ?? opts.scope.teamSlug})`,
+    });
+  } else {
+    rows.push({
+      key: 'Team',
+      value: `${opts.teamName ?? opts.scope.teamSlug} (all projects)`,
+    });
+  }
+
+  if (opts.unit && normalizeUnit(opts.unit) !== 'count') {
+    rows.push({ key: 'Units', value: formatUnitLabel(opts.unit) });
+  }
+
+  if (typeof opts.groupCount === 'number') {
+    rows.push({ key: 'Groups', value: String(opts.groupCount) });
+  }
+
+  // Match the usage command's metadata style with `>`-prefixed lines.
+  return rows
+    .map(row => `> ${chalk.gray(`${row.key}:`)} ${row.value}`)
+    .join('\n');
+}
+
+/** Renders the summary table section. */
+export function formatSummaryTable(opts: SummaryTableOptions): string {
+  const statColumns = getStatColumns(opts.measureType);
+  const header = [...opts.groupByFields, ...statColumns];
+  const rows: string[][] = [header.map(name => chalk.bold(chalk.cyan(name)))];
+
+  for (const row of opts.rows) {
+    const nextRow: string[] = [...row.groupValues];
+
+    if (row.stats.allMissing) {
+      nextRow.push(...statColumns.map(() => '--'));
+      rows.push(nextRow);
+      continue;
+    }
+
+    nextRow.push(
+      ...statColumns.map(column =>
+        formatStatCell(
+          column,
+          row.stats,
+          opts.measureType,
+          opts.aggregation,
+          opts.periodStart,
+          opts.periodEnd
+        )
+      )
+    );
+    rows.push(nextRow);
+  }
+
+  const centeredColumns = new Set(['min', 'max']);
+  const align = header.map(col => (centeredColumns.has(col) ? 'c' : 'r')) as (
+    | 'l'
+    | 'c'
+    | 'r'
+  )[];
+  return indent(
+    table(rows, {
+      align,
+      hsep: 2,
+    }),
+    2
+  );
+}
+
+/** Renders the `sparklines:` section for grouped or ungrouped output. */
+export function formatSparklineSection(
+  groupRows: string[][],
+  sparklines: string[],
+  groupByFields: string[]
+): string {
+  const lines = ['sparklines:'];
+
+  if (groupRows.length === 0) {
+    if (sparklines.length > 0) {
+      lines.push(indent(sparklines[0], 2));
+    }
+    return lines.join('\n');
+  }
+
+  const rows = [
+    [...groupByFields, 'sparkline'].map(name => chalk.bold(chalk.cyan(name))),
+    ...groupRows.map((groupValues, i) => [...groupValues, sparklines[i]]),
+  ];
+  lines.push(
+    indent(
+      table(rows, {
+        align: [...groupByFields.map<'r'>(() => 'r'), 'l'],
+        hsep: 2,
+      }),
+      2
+    )
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Composes final text output:
+ * metadata + summary table + sparklines.
+ * If there is no data, returns metadata and a deterministic `No data` line.
+ */
+export function formatText(
+  response: MetricsQueryResponse,
+  opts: FormatTextOptions
+): string {
+  const rollupColumn = getRollupColumnName(opts.measure, opts.aggregation);
+  const measureSchema = getMeasures(opts.event).find(
+    m => m.name === opts.measure
+  );
+  const measureUnit = measureSchema?.unit;
+  const measureType = getMeasureType(measureUnit ?? 'ratio');
+  const granularityMs = toGranularityMsFromDuration(opts.granularity);
+
+  const { groups, series, groupValues } = extractGroupedSeries(
+    response.data ?? [],
+    opts.groupBy,
+    rollupColumn,
+    opts.periodStart,
+    opts.periodEnd,
+    granularityMs
+  );
+
+  const metadata = formatMetadataHeader({
+    event: opts.event,
+    measure: opts.measure,
+    aggregation: opts.aggregation,
+    periodStart: opts.periodStart,
+    periodEnd: opts.periodEnd,
+    granularity: opts.granularity,
+    filter: opts.filter,
+    scope: opts.scope,
+    projectName: opts.projectName,
+    teamName: opts.teamName,
+    unit: measureUnit,
+    groupCount: opts.groupBy.length > 0 ? groups.length : undefined,
+  });
+
+  if (groups.length === 0) {
+    // Keep a minimal deterministic output when query returns no rows.
+    return `${metadata}\n\nNo data found for this period.\n`;
+  }
+
+  const summaryRows: SummaryTableRow[] = [];
+  const groupRows: string[][] = [];
+  const sparklineRows: string[] = [];
+
+  for (const key of groups) {
+    const points = series.get(key) ?? [];
+    const values = points.map(point => point.value);
+    const currentGroupValues = groupValues.get(key) ?? [];
+
+    summaryRows.push({
+      groupValues: currentGroupValues,
+      stats: computeGroupStats(points),
+    });
+    groupRows.push(currentGroupValues);
+    sparklineRows.push(generateSparkline(values));
+  }
+
+  const summaryTable = formatSummaryTable({
+    rows: summaryRows,
+    groupByFields: opts.groupBy,
+    measureType,
+    aggregation: opts.aggregation,
+    periodStart: new Date(opts.periodStart),
+    periodEnd: new Date(opts.periodEnd),
+  });
+
+  const groupedOutput = opts.groupBy.length > 0;
+  const sparklineSection = formatSparklineSection(
+    groupedOutput ? groupRows : [],
+    sparklineRows,
+    opts.groupBy
+  );
+
+  const sections = [metadata, summaryTable, sparklineSection];
+
+  return `${sections.join('\n\n')}\n`;
+}

--- a/packages/cli/src/commands/metrics/text-output.ts
+++ b/packages/cli/src/commands/metrics/text-output.ts
@@ -6,6 +6,7 @@ import { getRollupColumnName } from './output';
 import { toGranularityMsFromDuration } from './time-utils';
 import type {
   Granularity,
+  MetricsAggregation,
   MetricsDataRow,
   MetricsQueryResponse,
   Scope,
@@ -42,7 +43,7 @@ interface SummaryTableOptions {
   rows: SummaryTableRow[];
   groupByFields: string[];
   measureType: MeasureType;
-  aggregation: string;
+  aggregation: MetricsAggregation;
   periodStart: Date;
   periodEnd: Date;
 }
@@ -50,7 +51,7 @@ interface SummaryTableOptions {
 interface MetadataHeaderOptions {
   event: string;
   measure: string;
-  aggregation: string;
+  aggregation: MetricsAggregation;
   periodStart: string;
   periodEnd: string;
   granularity: Granularity;
@@ -65,7 +66,7 @@ interface MetadataHeaderOptions {
 export interface FormatTextOptions {
   event: string;
   measure: string;
-  aggregation: string;
+  aggregation: MetricsAggregation;
   groupBy: string[];
   filter?: string;
   scope: Scope;
@@ -80,6 +81,9 @@ export interface FormatTextOptions {
 // with user-visible values (which can contain common separators like "|" or ",").
 const GROUP_KEY_DELIMITER = '\u001f';
 const MAX_SPARKLINE_LENGTH = 120;
+
+type TableAlignment = 'l' | 'c' | 'r';
+type StatColumn = 'total' | 'avg' | 'min' | 'max';
 
 const COUNT_UNITS = new Set(['count', 'tokens', 'us dollars', 'dollars']);
 const DURATION_UNITS = new Set(['milliseconds', 'seconds']);
@@ -169,7 +173,7 @@ function formatUnitLabel(unit: string): string {
  */
 function isCountIntegerDisplay(
   measureType: MeasureType,
-  aggregation: string
+  aggregation: MetricsAggregation
 ): boolean {
   // Count + sum should read like totals (integers), while count-persecond /
   // count-percent stay decimal.
@@ -188,7 +192,7 @@ function isCountIntegerDisplay(
 function formatNumber(
   value: number,
   measureType: MeasureType,
-  aggregation: string,
+  aggregation: MetricsAggregation,
   opts?: { preserveFractionalCountSum?: boolean }
 ): string {
   if (isCountIntegerDisplay(measureType, aggregation)) {
@@ -201,7 +205,7 @@ function formatNumber(
 }
 
 /** Chooses summary statistic columns for a given measure type. */
-function getStatColumns(measureType: MeasureType): string[] {
+function getStatColumns(measureType: MeasureType): StatColumn[] {
   if (measureType === 'duration' || measureType === 'ratio') {
     return ['avg', 'min', 'max'];
   }
@@ -222,12 +226,51 @@ function toNumericValue(
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function isNonNullNumber(value: number | null): value is number {
+  return value !== null;
+}
+
+function isPointWithValue(
+  point: TimeSeriesPoint
+): point is { timestamp: string; value: number } {
+  return point.value !== null;
+}
+
+function getOrCreate<K, V>(map: Map<K, V>, key: K, make: () => V): V {
+  const existing = map.get(key);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const created = make();
+  map.set(key, created);
+  return created;
+}
+
+function getGroupFieldValue(row: MetricsDataRow, field: string): string {
+  const value = row[field];
+  return value == null || value === '' ? '(not set)' : String(value);
+}
+
+/**
+ * Canonicalizes API timestamps to ISO strings with millisecond precision.
+ * We build expected buckets via `toISOString()` (e.g. `...00.000Z`), while API
+ * rows may use equivalent forms like `...00Z`. Normalizing avoids false
+ * "missing" buckets caused by string-format differences.
+ */
+function normalizeTimestampToIso(timestamp: string): string | null {
+  const parsed = Date.parse(timestamp);
+  if (isNaN(parsed)) {
+    return null;
+  }
+  return new Date(parsed).toISOString();
+}
+
 /** Formats one summary statistic cell, including min/max timestamps. */
 function formatStatCell(
-  column: string,
+  column: StatColumn,
   stats: GroupStats,
   measureType: MeasureType,
-  aggregation: string,
+  aggregation: MetricsAggregation,
   periodStart: Date,
   periodEnd: Date
 ): string {
@@ -254,8 +297,6 @@ function formatStatCell(
       );
       return `${formatNumber(stats.max.value, measureType, aggregation)} at ${ts}`;
     }
-    default:
-      return '--';
   }
 }
 
@@ -403,33 +444,39 @@ export function extractGroupedSeries(
   const valueByGroup = new Map<string, Map<string, number | null>>();
 
   for (const row of data) {
-    const values = groupBy.map(field => {
-      const v = row[field];
-      return v == null || v === '' ? '(not set)' : String(v);
-    });
+    const values = groupBy.map(field => getGroupFieldValue(row, field));
     const key = toGroupKey(values);
-    if (!valueByGroup.has(key)) {
+    if (!groupValues.has(key)) {
       // Preserve first-seen ordering from API response so output order is stable.
       groups.push(key);
       groupValues.set(key, values);
-      valueByGroup.set(key, new Map());
     }
-    const timestamp = row.timestamp;
-    if (typeof timestamp !== 'string' || timestamp.length === 0) {
+    const groupMap = getOrCreate(valueByGroup, key, () => new Map());
+    const rawTimestamp = row.timestamp;
+    if (rawTimestamp.length === 0) {
+      continue;
+    }
+    const timestamp = normalizeTimestampToIso(rawTimestamp);
+    if (!timestamp) {
       continue;
     }
 
     const numeric = toNumericValue(row[rollupColumn]);
-    valueByGroup.get(key)!.set(timestamp, numeric);
+    groupMap.set(timestamp, numeric);
   }
 
   const series = new Map<string, TimeSeriesPoint[]>();
   for (const key of groups) {
-    const byTimestamp = valueByGroup.get(key)!;
+    const byTimestamp = valueByGroup.get(key);
+    if (!byTimestamp) {
+      continue;
+    }
     // Expand sparse API rows into complete series so every group aligns on time.
     const points = expectedTimestamps.map(timestamp => ({
       timestamp,
-      value: byTimestamp.has(timestamp) ? byTimestamp.get(timestamp)! : null,
+      value: byTimestamp.has(timestamp)
+        ? (byTimestamp.get(timestamp) ?? null)
+        : null,
     }));
     series.set(key, points);
   }
@@ -443,10 +490,7 @@ export function extractGroupedSeries(
  * If all points are missing, returns `allMissing=true` and zero placeholders.
  */
 export function computeGroupStats(points: TimeSeriesPoint[]): GroupStats {
-  const present = points.filter(point => point.value !== null) as Array<{
-    timestamp: string;
-    value: number;
-  }>;
+  const present = points.filter(isPointWithValue);
 
   if (present.length === 0) {
     return {
@@ -514,7 +558,7 @@ export function downsample(
       continue;
     }
 
-    const present = bucket.filter(value => value !== null) as Array<number>;
+    const present = bucket.filter(isNonNullNumber);
     const avg = present.reduce((sum, value) => sum + value, 0) / present.length;
     result.push(avg);
   }
@@ -534,7 +578,7 @@ export function generateSparkline(values: (number | null)[]): string {
     return '';
   }
 
-  const present = sampled.filter(value => value !== null) as number[];
+  const present = sampled.filter(isNonNullNumber);
   if (present.length === 0) {
     // Entire series missing: keep positional placeholders instead of empty output.
     return sampled.map(() => MISSING_CHAR).join('');
@@ -648,11 +692,9 @@ export function formatSummaryTable(opts: SummaryTableOptions): string {
   }
 
   const centeredColumns = new Set(['min', 'max']);
-  const align = header.map(col => (centeredColumns.has(col) ? 'c' : 'r')) as (
-    | 'l'
-    | 'c'
-    | 'r'
-  )[];
+  const align: TableAlignment[] = header.map(col =>
+    centeredColumns.has(col) ? 'c' : 'r'
+  );
   return indent(
     table(rows, {
       align,
@@ -671,20 +713,31 @@ export function formatSparklineSection(
   const lines = ['sparklines:'];
 
   if (groupRows.length === 0) {
-    if (sparklines.length > 0) {
-      lines.push(indent(sparklines[0], 2));
+    const sparkline = sparklines[0];
+    if (sparkline) {
+      lines.push(indent(sparkline, 2));
     }
     return lines.join('\n');
   }
 
+  const rowsWithSparklines = groupRows.map((groupValues, index) => ({
+    groupValues,
+    sparkline: sparklines[index] ?? '',
+  }));
+
   const rows = [
     [...groupByFields, 'sparkline'].map(name => chalk.bold(chalk.cyan(name))),
-    ...groupRows.map((groupValues, i) => [...groupValues, sparklines[i]]),
+    ...rowsWithSparklines.map(({ groupValues, sparkline }) => [
+      ...groupValues,
+      sparkline,
+    ]),
   ];
+  const align: TableAlignment[] = groupByFields.map(() => 'r');
+  align.push('l');
   lines.push(
     indent(
       table(rows, {
-        align: [...groupByFields.map<'r'>(() => 'r'), 'l'],
+        align,
         hsep: 2,
       }),
       2

--- a/packages/cli/src/commands/metrics/text-output.ts
+++ b/packages/cli/src/commands/metrics/text-output.ts
@@ -403,7 +403,10 @@ export function extractGroupedSeries(
   const valueByGroup = new Map<string, Map<string, number | null>>();
 
   for (const row of data) {
-    const values = groupBy.map(field => String(row[field] ?? ''));
+    const values = groupBy.map(field => {
+      const v = row[field];
+      return v == null || v === '' ? '(not set)' : String(v);
+    });
     const key = toGroupKey(values);
     if (!valueByGroup.has(key)) {
       // Preserve first-seen ordering from API response so output order is stable.

--- a/packages/cli/src/commands/metrics/types.ts
+++ b/packages/cli/src/commands/metrics/types.ts
@@ -1,3 +1,6 @@
+import type { MetricsAggregation } from './schema-data';
+export type { MetricsAggregation } from './schema-data';
+
 export interface ProjectScope {
   type: 'project-with-slug';
   teamSlug: string;
@@ -16,12 +19,30 @@ export type Granularity =
   | { hours: number }
   | { days: number };
 
-export type MetricsDataRow = Record<string, string | number | null>;
+export type MetricsApiDataCell = string | number | null;
+export type MetricsSummaryDataCell = string | number | null;
+
+export type MetricsDataRow = { timestamp: string } & Record<
+  string,
+  MetricsApiDataCell
+>;
+
+export type MetricsSummaryRow = Record<string, MetricsSummaryDataCell>;
+
+export interface MetricsQueryStatistics {
+  rowsRead?: number;
+  bytesRead?: number;
+  dbTimeSeconds?: number;
+  engineTimeSeconds?: number;
+  queryTable?: string;
+  cacheEngineTimeSeconds?: number;
+  cacheDbTimeSeconds?: number;
+}
 
 export interface QueryMetadata {
   event: string;
   measure: string;
-  aggregation: string;
+  aggregation: MetricsAggregation;
   groupBy: string[];
   filter: string | undefined;
   startTime: string;
@@ -33,7 +54,7 @@ export interface MetricsQueryRequest {
   reason: 'agent';
   scope: Scope;
   event: string;
-  rollups: Record<string, { measure: string; aggregation: string }>;
+  rollups: Record<string, { measure: string; aggregation: MetricsAggregation }>;
   startTime: string;
   endTime: string;
   granularity: Granularity;
@@ -45,13 +66,8 @@ export interface MetricsQueryRequest {
 
 export interface MetricsQueryResponse {
   data?: MetricsDataRow[];
-  summary?: MetricsDataRow[];
-  statistics: {
-    rowsRead?: number;
-    bytesRead?: number;
-    dbTimeSeconds?: number;
-    engineTimeSeconds?: number;
-  };
+  summary: MetricsSummaryRow[];
+  statistics: MetricsQueryStatistics;
 }
 
 export type ValidationError = {

--- a/packages/cli/src/commands/metrics/validation.ts
+++ b/packages/cli/src/commands/metrics/validation.ts
@@ -1,4 +1,5 @@
 import type { ValidationResult, ValidatedResult } from './types';
+import type { MetricsAggregation } from './schema-data';
 import {
   getEventNames,
   getEvent,
@@ -39,10 +40,11 @@ export function validateAggregation(
   event: string,
   measure: string,
   aggregation: string
-): ValidationResult {
+): ValidatedResult<MetricsAggregation> {
   const aggs = getAggregations(event, measure);
-  if (aggs.includes(aggregation)) {
-    return { valid: true };
+  const found = aggs.find(agg => agg === aggregation);
+  if (found) {
+    return { valid: true, value: found };
   }
   return {
     valid: false,

--- a/packages/cli/test/unit/commands/metrics/output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/output.test.ts
@@ -1,47 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
-  escapeCsvValue,
   getRollupColumnName,
-  formatCsv,
   formatQueryJson,
-  formatSchemaListCsv,
-  formatSchemaDetailCsv,
   formatSchemaDetailJson,
   formatSchemaListJson,
   formatErrorJson,
 } from '../../../../src/commands/metrics/output';
 
 describe('output', () => {
-  describe('escapeCsvValue', () => {
-    it('should return plain value as-is', () => {
-      expect(escapeCsvValue('hello')).toBe('hello');
-    });
-
-    it('should wrap value with comma in quotes', () => {
-      expect(escapeCsvValue('hello,world')).toBe('"hello,world"');
-    });
-
-    it('should escape double quotes', () => {
-      expect(escapeCsvValue('say "hi"')).toBe('"say ""hi"""');
-    });
-
-    it('should wrap value with newline in quotes', () => {
-      expect(escapeCsvValue('line1\nline2')).toBe('"line1\nline2"');
-    });
-
-    it('should return empty string for null', () => {
-      expect(escapeCsvValue(null)).toBe('');
-    });
-
-    it('should return empty string for undefined', () => {
-      expect(escapeCsvValue(undefined)).toBe('');
-    });
-
-    it('should convert numbers to string', () => {
-      expect(escapeCsvValue(42)).toBe('42');
-    });
-  });
-
   describe('getRollupColumnName', () => {
     it('should return default column name', () => {
       expect(getRollupColumnName('count', 'sum')).toBe('count_sum');
@@ -51,66 +17,6 @@ describe('output', () => {
       expect(getRollupColumnName('requestDurationMs', 'p95')).toBe(
         'requestDurationMs_p95'
       );
-    });
-  });
-
-  describe('formatCsv', () => {
-    it('should format ungrouped data', () => {
-      const data = [
-        { timestamp: '2025-01-15T10:00:00Z', count_sum: 89 },
-        { timestamp: '2025-01-15T10:05:00Z', count_sum: 102 },
-      ];
-      const result = formatCsv(data, [], 'count_sum');
-      expect(result).toBe(
-        'timestamp,count_sum\n' +
-          '2025-01-15T10:00:00Z,89\n' +
-          '2025-01-15T10:05:00Z,102\n'
-      );
-    });
-
-    it('should format grouped data', () => {
-      const data = [
-        {
-          timestamp: '2025-01-15T10:00:00Z',
-          httpStatus: '200',
-          count_sum: 4520,
-        },
-        {
-          timestamp: '2025-01-15T10:00:00Z',
-          httpStatus: '500',
-          count_sum: 89,
-        },
-      ];
-      const result = formatCsv(data, ['httpStatus'], 'count_sum');
-      expect(result).toBe(
-        'timestamp,httpStatus,count_sum\n' +
-          '2025-01-15T10:00:00Z,200,4520\n' +
-          '2025-01-15T10:00:00Z,500,89\n'
-      );
-    });
-
-    it('should format empty data with header only', () => {
-      const result = formatCsv([], [], 'count_sum');
-      expect(result).toBe('timestamp,count_sum\n');
-    });
-
-    it('should handle null values', () => {
-      const data = [{ timestamp: '2025-01-15T10:00:00Z', count_sum: null }];
-      const result = formatCsv(data, [], 'count_sum');
-      expect(result).toBe('timestamp,count_sum\n2025-01-15T10:00:00Z,\n');
-    });
-
-    it('should include multiple group-by columns in order', () => {
-      const data = [
-        {
-          timestamp: '2025-01-15T10:00:00Z',
-          httpStatus: '200',
-          route: '/api/users',
-          count_sum: 100,
-        },
-      ];
-      const result = formatCsv(data, ['httpStatus', 'route'], 'count_sum');
-      expect(result).toContain('timestamp,httpStatus,route,count_sum\n');
     });
   });
 
@@ -152,49 +58,6 @@ describe('output', () => {
       const result = JSON.parse(formatQueryJson(query, { statistics: {} }));
       expect(result.data).toEqual([]);
       expect(result.summary).toEqual([]);
-    });
-  });
-
-  describe('formatSchemaListCsv', () => {
-    it('should format event list', () => {
-      const events = [
-        { name: 'incomingRequest', description: 'HTTP requests' },
-        {
-          name: 'functionExecution',
-          description: 'Function executions',
-        },
-      ];
-      const result = formatSchemaListCsv(events);
-      expect(result).toBe(
-        'event,description\n' +
-          'incomingRequest,HTTP requests\n' +
-          'functionExecution,Function executions\n'
-      );
-    });
-  });
-
-  describe('formatSchemaDetailCsv', () => {
-    it('should output two blocks separated by blank line', () => {
-      const event = {
-        name: 'test',
-        description: 'Test event',
-        dimensions: [
-          { name: 'dim1', label: 'Dimension 1', filterOnly: false },
-          { name: 'dim2', label: 'Dimension 2', filterOnly: true },
-        ],
-        measures: [
-          { name: 'count', label: 'Count', unit: 'count' },
-          { name: 'durationMs', label: 'Duration', unit: 'milliseconds' },
-        ],
-      };
-      const result = formatSchemaDetailCsv(event);
-      const blocks = result.split('\n\n');
-      expect(blocks).toHaveLength(2);
-      expect(blocks[0]).toContain('dimension,label,filterOnly');
-      expect(blocks[0]).toContain('dim1,Dimension 1,false');
-      expect(blocks[0]).toContain('dim2,Dimension 2,true');
-      expect(blocks[1]).toContain('measure,label,unit');
-      expect(blocks[1]).toContain('count,Count,count');
     });
   });
 

--- a/packages/cli/test/unit/commands/metrics/output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/output.test.ts
@@ -6,6 +6,7 @@ import {
   formatSchemaListJson,
   formatErrorJson,
 } from '../../../../src/commands/metrics/output';
+import type { QueryMetadata } from '../../../../src/commands/metrics/types';
 
 describe('output', () => {
   describe('getRollupColumnName', () => {
@@ -22,7 +23,7 @@ describe('output', () => {
 
   describe('formatQueryJson', () => {
     it('should format full JSON response', () => {
-      const query = {
+      const query: QueryMetadata = {
         event: 'incomingRequest',
         measure: 'count',
         aggregation: 'sum',
@@ -45,7 +46,7 @@ describe('output', () => {
     });
 
     it('should handle missing optional fields', () => {
-      const query = {
+      const query: QueryMetadata = {
         event: 'test',
         measure: 'count',
         aggregation: 'sum',
@@ -55,7 +56,9 @@ describe('output', () => {
         endTime: '2025-01-15T11:00:00Z',
         granularity: { minutes: 1 } as const,
       };
-      const result = JSON.parse(formatQueryJson(query, { statistics: {} }));
+      const result = JSON.parse(
+        formatQueryJson(query, { summary: [], statistics: {} })
+      );
       expect(result.data).toEqual([]);
       expect(result.summary).toEqual([]);
     });

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -407,15 +407,15 @@ describe('query', () => {
     });
   });
 
-  describe('CSV output', () => {
-    it('should output ungrouped CSV', async () => {
+  describe('text output', () => {
+    it('should output ungrouped text', async () => {
       client.scenario.post('/api/observability/metrics', (_req, res) => {
         res.json({
           data: [
-            { timestamp: '2025-01-15T10:00:00Z', value: 89 },
-            { timestamp: '2025-01-15T10:05:00Z', value: 102 },
+            { timestamp: '2025-01-15T10:00:00Z', count_sum: 89 },
+            { timestamp: '2025-01-15T10:05:00Z', count_sum: 102 },
           ],
-          summary: [{ value: 191 }],
+          summary: [{ count_sum: 191 }],
           statistics: { rowsRead: 100 },
         });
       });
@@ -426,22 +426,23 @@ describe('query', () => {
 
       expect(exitCode).toBe(0);
       const output = client.stdout.getFullOutput();
-      expect(output).toContain('timestamp,count_sum');
+      expect(output).toContain('> Metric:');
+      expect(output).toContain('sparklines:');
     });
 
-    it('should output grouped CSV', async () => {
+    it('should output grouped text', async () => {
       client.scenario.post('/api/observability/metrics', (_req, res) => {
         res.json({
           data: [
             {
               timestamp: '2025-01-15T10:00:00Z',
               httpStatus: '200',
-              value: 4520,
+              count_sum: 4520,
             },
             {
               timestamp: '2025-01-15T10:00:00Z',
               httpStatus: '500',
-              value: 89,
+              count_sum: 89,
             },
           ],
           summary: [],
@@ -462,10 +463,12 @@ describe('query', () => {
 
       expect(exitCode).toBe(0);
       const output = client.stdout.getFullOutput();
-      expect(output).toContain('timestamp,httpStatus,count_sum');
+      expect(output).toContain('httpStatus');
+      expect(output).toContain('sparklines:');
+      expect(output).toContain('> Groups:');
     });
 
-    it('should output header only for empty data', async () => {
+    it('should output no-data message for empty data', async () => {
       client.scenario.post('/api/observability/metrics', (_req, res) => {
         res.json({ data: [], summary: [], statistics: {} });
       });
@@ -476,7 +479,9 @@ describe('query', () => {
 
       expect(exitCode).toBe(0);
       const output = client.stdout.getFullOutput();
-      expect(output).toContain('timestamp,count_sum');
+      expect(output).toContain('> Metric:');
+      expect(output).toContain('No data');
+      expect(output).not.toContain('sparklines:');
     });
   });
 

--- a/packages/cli/test/unit/commands/metrics/text-output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/text-output.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, it } from 'vitest';
+import stripAnsi from 'strip-ansi';
+import {
+  getMeasureType,
+  formatCount,
+  formatDecimal,
+  formatMinMaxTimestamp,
+  extractGroupedSeries,
+  computeGroupStats,
+  downsample,
+  generateSparkline,
+  formatMetadataHeader,
+  formatSparklineSection,
+  formatText,
+} from '../../../../src/commands/metrics/text-output';
+import type {
+  MetricsQueryResponse,
+  Scope,
+} from '../../../../src/commands/metrics/types';
+
+const projectScope: Scope = {
+  type: 'project-with-slug',
+  projectName: 'my-project',
+  teamSlug: 'my-team',
+};
+
+describe('text-output', () => {
+  describe('number formatting', () => {
+    it('should classify measure types from schema units', () => {
+      expect(getMeasureType('count')).toBe('count');
+      expect(getMeasureType('tokens')).toBe('count');
+      expect(getMeasureType('US dollars')).toBe('count');
+      expect(getMeasureType('milliseconds')).toBe('duration');
+      expect(getMeasureType('bytes')).toBe('bytes');
+      expect(getMeasureType('gigabyte hours')).toBe('bytes');
+      expect(getMeasureType('ratio')).toBe('ratio');
+      expect(getMeasureType('percent')).toBe('ratio');
+    });
+
+    it('should format count values with grouping', () => {
+      expect(formatCount(0)).toBe('0');
+      expect(formatCount(42)).toBe('42');
+      expect(formatCount(17880)).toBe('17,880');
+      expect(formatCount(724402795)).toBe('724,402,795');
+    });
+
+    it('should format decimal values with adaptive precision', () => {
+      expect(formatDecimal(0)).toBe('0');
+      expect(formatDecimal(42)).toBe('42.0');
+      expect(formatDecimal(4213.7)).toBe('4213.7');
+      expect(formatDecimal(1)).toBe('1.0');
+      expect(formatDecimal(0.87)).toBe('0.87');
+      expect(formatDecimal(0.042)).toBe('0.042');
+      expect(formatDecimal(0.003)).toBe('0.003');
+    });
+  });
+
+  describe('timestamp formatting', () => {
+    it('should format same-day period timestamps as HH:MM', () => {
+      const start = new Date('2026-02-17T15:00:00Z');
+      const end = new Date('2026-02-17T16:00:00Z');
+      const ts = new Date('2026-02-17T15:12:00Z');
+      expect(formatMinMaxTimestamp(ts, start, end)).toBe('15:12');
+    });
+
+    it('should format multi-day same-year timestamps as MM-DD HH:MM', () => {
+      const start = new Date('2026-02-18T14:00:00Z');
+      const end = new Date('2026-02-19T15:00:00Z');
+      const ts = new Date('2026-02-19T14:00:00Z');
+      expect(formatMinMaxTimestamp(ts, start, end)).toBe('02-19 14:00');
+    });
+
+    it('should format cross-year timestamps as YYYY-MM-DD HH:MM', () => {
+      const start = new Date('2025-12-28T00:00:00Z');
+      const end = new Date('2026-01-02T00:00:00Z');
+      const ts = new Date('2025-12-28T14:00:00Z');
+      expect(formatMinMaxTimestamp(ts, start, end)).toBe('2025-12-28 14:00');
+    });
+  });
+
+  describe('series extraction and stats', () => {
+    it('should extract grouped series and fill missing points with null', () => {
+      const result = extractGroupedSeries(
+        [
+          {
+            timestamp: '2026-02-19T10:00:00.000Z',
+            httpStatus: '200',
+            count_sum: 10,
+          },
+          {
+            timestamp: '2026-02-19T10:10:00.000Z',
+            httpStatus: '200',
+            count_sum: 30,
+          },
+        ],
+        ['httpStatus'],
+        'count_sum',
+        '2026-02-19T10:00:00.000Z',
+        '2026-02-19T10:15:00.000Z',
+        5 * 60 * 1000
+      );
+
+      expect(result.groups).toEqual(['200']);
+      expect(result.series.get('200')).toEqual([
+        { timestamp: '2026-02-19T10:00:00.000Z', value: 10 },
+        { timestamp: '2026-02-19T10:05:00.000Z', value: null },
+        { timestamp: '2026-02-19T10:10:00.000Z', value: 30 },
+      ]);
+    });
+
+    it('should use [start,end) semantics for expected timestamps', () => {
+      const result = extractGroupedSeries(
+        [
+          { timestamp: '2026-02-19T10:00:00.000Z', count_sum: 10 },
+          { timestamp: '2026-02-19T10:05:00.000Z', count_sum: 20 },
+          { timestamp: '2026-02-19T10:10:00.000Z', count_sum: 30 },
+          { timestamp: '2026-02-19T10:15:00.000Z', count_sum: 40 },
+        ],
+        [],
+        'count_sum',
+        '2026-02-19T10:00:00.000Z',
+        '2026-02-19T10:15:00.000Z',
+        5 * 60 * 1000
+      );
+
+      expect(result.groups).toEqual(['']);
+      expect(result.series.get('')!.map(point => point.timestamp)).toEqual([
+        '2026-02-19T10:00:00.000Z',
+        '2026-02-19T10:05:00.000Z',
+        '2026-02-19T10:10:00.000Z',
+      ]);
+      expect(result.series.get('')!.map(point => point.value)).toEqual([
+        10, 20, 30,
+      ]);
+    });
+
+    it('should compute stats excluding null values', () => {
+      const stats = computeGroupStats([
+        { timestamp: '2026-02-19T10:00:00.000Z', value: 10 },
+        { timestamp: '2026-02-19T10:05:00.000Z', value: null },
+        { timestamp: '2026-02-19T10:10:00.000Z', value: 30 },
+      ]);
+
+      expect(stats.total).toBe(40);
+      expect(stats.avg).toBe(20);
+      expect(stats.count).toBe(2);
+      expect(stats.min).toEqual({
+        value: 10,
+        timestamp: '2026-02-19T10:00:00.000Z',
+      });
+      expect(stats.max).toEqual({
+        value: 30,
+        timestamp: '2026-02-19T10:10:00.000Z',
+      });
+    });
+
+    it('should mark all-missing groups', () => {
+      const stats = computeGroupStats([
+        { timestamp: '2026-02-19T10:00:00.000Z', value: null },
+        { timestamp: '2026-02-19T10:05:00.000Z', value: null },
+      ]);
+
+      expect(stats.allMissing).toBe(true);
+      expect(stats.count).toBe(0);
+      expect(stats.total).toBe(0);
+    });
+  });
+
+  describe('sparkline generation', () => {
+    it('should render known sparkline patterns', () => {
+      expect(generateSparkline([1, 2, 3, 4, 5, 6, 7, 8])).toBe('▁▂▃▄▅▆▇█');
+      expect(generateSparkline([5, 5, 5, 5])).toBe('████');
+      expect(generateSparkline([0, 0, 0])).toBe('▁▁▁');
+      expect(generateSparkline([42])).toBe('█');
+      expect(generateSparkline([0])).toBe('▁');
+      expect(generateSparkline([1, null, 3])).toBe('▁·█');
+      expect(generateSparkline([null, null, null])).toBe('···');
+    });
+
+    it('should downsample values to max length', () => {
+      const values = Array.from({ length: 150 }, (_, i) => i + 1);
+      expect(generateSparkline(values).length).toBe(120);
+    });
+
+    it('should downsample with majority-null bucket rule', () => {
+      const result = downsample([1, null, null, 1, 2, null], 2);
+      expect(result).toEqual([null, 1.5]);
+    });
+  });
+
+  describe('section formatters', () => {
+    it('should render usage-style metadata fields', () => {
+      const metadata = formatMetadataHeader({
+        event: 'incomingRequest',
+        measure: 'requestDurationMs',
+        aggregation: 'avg',
+        periodStart: '2026-02-19T10:00:00.000Z',
+        periodEnd: '2026-02-19T10:15:00.000Z',
+        granularity: { minutes: 5 },
+        filter: 'httpStatus ge 500',
+        scope: projectScope,
+        unit: 'milliseconds',
+        groupCount: 2,
+      });
+
+      expect(metadata).toContain('> ');
+      expect(metadata).toContain('Metric:');
+      expect(metadata).toContain('Period:');
+      expect(metadata).toContain('Interval:');
+      expect(metadata).toContain('Filter:');
+      expect(metadata).toContain('Project:');
+      expect(metadata).toContain('Units:');
+      expect(metadata).toContain('Groups:');
+      expect(metadata).toContain('2026-02-19 10:00 to 2026-02-19 10:15');
+    });
+
+    it('should format grouped sparkline section', () => {
+      const sparklineSection = formatSparklineSection(
+        [
+          ['my-app', '200'],
+          ['shop-app', '500'],
+        ],
+        ['▁▂▃', '█▇▆'],
+        ['projectName', 'httpStatus']
+      );
+
+      expect(sparklineSection).toContain('sparklines:');
+      expect(sparklineSection).toContain('projectName');
+      expect(sparklineSection).toContain('httpStatus');
+      expect(sparklineSection).toContain('sparkline');
+      expect(sparklineSection).toContain('my-app');
+      expect(sparklineSection).toContain('shop-app');
+      expect(sparklineSection).toContain('▁▂▃');
+      expect(sparklineSection).toContain('█▇▆');
+    });
+  });
+
+  describe('formatText', () => {
+    it('should render ungrouped text output (snapshot)', () => {
+      const response: MetricsQueryResponse = {
+        data: [
+          { timestamp: '2026-02-19T10:00:00.000Z', count_sum: 10 },
+          { timestamp: '2026-02-19T10:05:00.000Z', count_sum: 20 },
+          { timestamp: '2026-02-19T10:10:00.000Z', count_sum: 30 },
+        ],
+        summary: [],
+        statistics: {},
+      };
+
+      const output = formatText(response, {
+        event: 'incomingRequest',
+        measure: 'count',
+        aggregation: 'sum',
+        groupBy: [],
+        scope: projectScope,
+        periodStart: '2026-02-19T10:00:00.000Z',
+        periodEnd: '2026-02-19T10:15:00.000Z',
+        granularity: { minutes: 5 },
+      });
+
+      const normalized = output
+        .split('\n')
+        .map(line => stripAnsi(line))
+        .join('\n')
+        .split('\n')
+        .map(line => line.trimEnd())
+        .join('\n');
+
+      expect(normalized).toMatchInlineSnapshot(`
+        "> Metric: incomingRequest / count sum
+        > Period: 2026-02-19 10:00 to 2026-02-19 10:15
+        > Interval: 5m
+        > Project: my-project (my-team)
+
+          total  avg      min          max
+             60   20  10 at 10:00  30 at 10:10
+
+        sparklines:
+          ▁▅█
+        "
+      `);
+    });
+
+    it('should render grouped duration output with units and raw values', () => {
+      const response: MetricsQueryResponse = {
+        data: [
+          {
+            timestamp: '2026-02-19T10:00:00.000Z',
+            projectName: 'my-app',
+            httpStatus: '200',
+            requestDurationMs_avg: 100,
+          },
+          {
+            timestamp: '2026-02-19T10:05:00.000Z',
+            projectName: 'my-app',
+            httpStatus: '200',
+            requestDurationMs_avg: 200,
+          },
+          {
+            timestamp: '2026-02-19T10:10:00.000Z',
+            projectName: 'my-app',
+            httpStatus: '200',
+            requestDurationMs_avg: 300,
+          },
+          {
+            timestamp: '2026-02-19T10:00:00.000Z',
+            projectName: 'my-app',
+            httpStatus: '500',
+            requestDurationMs_avg: 10,
+          },
+          {
+            timestamp: '2026-02-19T10:10:00.000Z',
+            projectName: 'my-app',
+            httpStatus: '500',
+            requestDurationMs_avg: 30,
+          },
+        ],
+        summary: [],
+        statistics: {},
+      };
+
+      const output = formatText(response, {
+        event: 'functionExecution',
+        measure: 'requestDurationMs',
+        aggregation: 'avg',
+        groupBy: ['projectName', 'httpStatus'],
+        scope: projectScope,
+        periodStart: '2026-02-19T10:00:00.000Z',
+        periodEnd: '2026-02-19T10:15:00.000Z',
+        granularity: { minutes: 5 },
+      });
+
+      expect(output).toContain('Units:');
+      expect(output).toContain('ms');
+      expect(output).toContain('Groups:');
+      expect(output).toContain('2');
+      expect(output).toContain('projectName');
+      expect(output).toContain('httpStatus');
+      expect(output).toContain('sparklines:');
+      expect(output).toContain('my-app');
+      expect(output).toContain('200');
+      expect(output).toContain('500');
+    });
+
+    it('should keep fractional average for count sum output', () => {
+      const output = formatText(
+        {
+          data: [
+            { timestamp: '2026-02-19T10:00:00.000Z', count_sum: 1 },
+            { timestamp: '2026-02-19T10:05:00.000Z', count_sum: 2 },
+          ],
+          summary: [],
+          statistics: {},
+        },
+        {
+          event: 'incomingRequest',
+          measure: 'count',
+          aggregation: 'sum',
+          groupBy: [],
+          scope: projectScope,
+          periodStart: '2026-02-19T10:00:00.000Z',
+          periodEnd: '2026-02-19T10:10:00.000Z',
+          granularity: { minutes: 5 },
+        }
+      );
+
+      expect(output).toContain('1.5');
+    });
+
+    it('should show no-data output when response has no rows', () => {
+      const output = formatText(
+        {
+          data: [],
+          summary: [],
+          statistics: {},
+        },
+        {
+          event: 'incomingRequest',
+          measure: 'count',
+          aggregation: 'sum',
+          groupBy: [],
+          scope: projectScope,
+          periodStart: '2026-02-19T10:00:00.000Z',
+          periodEnd: '2026-02-19T10:15:00.000Z',
+          granularity: { minutes: 5 },
+        }
+      );
+
+      expect(output).toContain('Metric:');
+      expect(output).toContain('No data found for this period.');
+      expect(output).not.toContain('sparklines:');
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/metrics/text-output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/text-output.test.ts
@@ -134,6 +134,31 @@ describe('text-output', () => {
       ]);
     });
 
+    it('should match API timestamps without milliseconds to expected buckets', () => {
+      const result = extractGroupedSeries(
+        [
+          { timestamp: '2026-02-19T10:00:00Z', count_sum: 10 },
+          { timestamp: '2026-02-19T10:05:00Z', count_sum: 20 },
+          { timestamp: '2026-02-19T10:10:00Z', count_sum: 30 },
+        ],
+        [],
+        'count_sum',
+        '2026-02-19T10:00:00.000Z',
+        '2026-02-19T10:15:00.000Z',
+        5 * 60 * 1000
+      );
+
+      expect(result.groups).toEqual(['']);
+      expect(result.series.get('')!.map(point => point.timestamp)).toEqual([
+        '2026-02-19T10:00:00.000Z',
+        '2026-02-19T10:05:00.000Z',
+        '2026-02-19T10:10:00.000Z',
+      ]);
+      expect(result.series.get('')!.map(point => point.value)).toEqual([
+        10, 20, 30,
+      ]);
+    });
+
     it('should compute stats excluding null values', () => {
       const stats = computeGroupStats([
         { timestamp: '2026-02-19T10:00:00.000Z', value: 10 },

--- a/packages/cli/test/unit/commands/metrics/validation.test.ts
+++ b/packages/cli/test/unit/commands/metrics/validation.test.ts
@@ -56,13 +56,14 @@ describe('validation', () => {
     it('should pass for valid aggregation on count', () => {
       expect(validateAggregation('incomingRequest', 'count', 'sum')).toEqual({
         valid: true,
+        value: 'sum',
       });
     });
 
     it('should pass for p95 on duration measure', () => {
       expect(
         validateAggregation('incomingRequest', 'requestDurationMs', 'p95')
-      ).toEqual({ valid: true });
+      ).toEqual({ valid: true, value: 'p95' });
     });
 
     it('should fail for p95 on count measure', () => {


### PR DESCRIPTION
Replace CSV as the default output format for `vercel metrics query` with a rich text format that includes:

- Metadata header showing metric, period, interval, scope, and units
- Summary table with total, avg, min (with timestamp), and max (with timestamp)
- Sparkline charts using Unicode block characters for at-a-glance trends
- Support for grouped series with per-group stats and sparklines
- Intelligent number formatting (integers for count sums, decimals for durations/ratios/bytes)
- Null-aware time series extraction with gap filling for missing buckets
- Downsampling for long series to fit terminal width

Remove the now-unused CSV formatting utilities (`escapeCsvValue`, `formatCsv`, `formatSchemaListCsv`, `formatSchemaDetailCsv`) from `output.ts` and their corresponding tests.

JSON output (`--format json`) is unchanged.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR replaces CSV output formatting with rich text output for a CLI metrics command, removing unused CSV utilities and adding new text formatting functions with comprehensive tests.
> 
> - Removes CSV formatting functions (`escapeCsvValue`, `formatCsv`, `formatSchemaListCsv`, `formatSchemaDetailCsv`) from output.ts
> - Adds new text-output.ts with sparkline generation, summary tables, and metadata formatting
> - Updates query.ts to use `formatText` instead of `formatCsv` for default output
>
> <sup>Risk assessment for [commit fa510a1](https://github.com/vercel/vercel/commit/fa510a10fece4b0466c8c3656920270d92741524).</sup>
<!-- VADE_RISK_END -->