### PR TITLE
[functions] Scope cache tag encoding to commas only and add encoding to purge calls

### DIFF
--- a/.changeset/fix-cache-tag-encoding.md
+++ b/.changeset/fix-cache-tag-encoding.md
@@ -2,4 +2,4 @@
 '@vercel/functions': patch
 ---
 
-fix(functions): scope cache tag encoding to commas only instead of full `encodeURIComponent` to avoid breaking tags containing colons, ampersands, and other non-comma special characters. Also encode commas in `invalidateByTag`, `dangerouslyDeleteByTag`, and `addCacheTag` for consistency.
+fix(functions): scope cache tag encoding to commas only instead of full `encodeURIComponent` to avoid breaking tags containing colons, ampersands, and other non-comma special characters. Commas are replaced with `!`. Also encode commas in `invalidateByTag`, `dangerouslyDeleteByTag`, and `addCacheTag` for consistency.

--- a/.changeset/fix-cache-tag-encoding.md
+++ b/.changeset/fix-cache-tag-encoding.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+fix(functions): scope cache tag encoding to commas only instead of full `encodeURIComponent` to avoid breaking tags containing colons, ampersands, and other non-comma special characters. Also encode commas in `invalidateByTag`, `dangerouslyDeleteByTag`, and `addCacheTag` for consistency.

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -78,7 +78,7 @@ A promise that resolves when the tag is added.
 
 #### Defined in
 
-[packages/functions/src/addcachetag/index.ts:3](https://github.com/vercel/vercel/blob/main/packages/functions/src/addcachetag/index.ts#L3)
+[packages/functions/src/addcachetag/index.ts:4](https://github.com/vercel/vercel/blob/main/packages/functions/src/addcachetag/index.ts#L4)
 
 ---
 
@@ -133,7 +133,7 @@ attachDatabasePool(pgPool);
 
 #### Defined in
 
-[packages/functions/src/purge/index.ts:28](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L28)
+[packages/functions/src/purge/index.ts:29](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L29)
 
 ---
 
@@ -154,7 +154,7 @@ attachDatabasePool(pgPool);
 
 #### Defined in
 
-[packages/functions/src/purge/index.ts:12](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L12)
+[packages/functions/src/purge/index.ts:13](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L13)
 
 ---
 
@@ -261,7 +261,7 @@ An instance of the Vercel Runtime Cache.
 
 #### Defined in
 
-[packages/functions/src/cache/index.ts:55](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L55)
+[packages/functions/src/cache/index.ts:48](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L48)
 
 ---
 
@@ -331,7 +331,7 @@ https://vercel.com/docs/projects/environment-variables/system-environment-variab
 
 #### Defined in
 
-[packages/functions/src/purge/index.ts:23](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L23)
+[packages/functions/src/purge/index.ts:24](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L24)
 
 ---
 
@@ -351,7 +351,7 @@ https://vercel.com/docs/projects/environment-variables/system-environment-variab
 
 #### Defined in
 
-[packages/functions/src/purge/index.ts:4](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L4)
+[packages/functions/src/purge/index.ts:5](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L5)
 
 ---
 

--- a/packages/functions/src/addcachetag/index.ts
+++ b/packages/functions/src/addcachetag/index.ts
@@ -1,9 +1,10 @@
 import { getContext } from '../get-context';
+import { encodeTag } from '../encode-tag';
 
 export const addCacheTag = (tag: string | string[]) => {
   const addCacheTag = getContext().addCacheTag;
   if (addCacheTag) {
-    return addCacheTag(tag);
+    return addCacheTag(encodeTag(tag));
   }
   return Promise.resolve();
 };

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -1,4 +1,5 @@
 import { getContext } from '../get-context';
+import { encodeTag, encodeTags } from '../encode-tag';
 import { CacheOptions, RuntimeCache } from './types';
 import { InMemoryCache } from './in-memory-cache';
 import { BuildCache } from './build-client';
@@ -12,14 +13,6 @@ const defaultKeyHashFunction = (key: string) => {
 };
 
 const defaultNamespaceSeparator = '$';
-
-function encodeTags(tags: string[]): string[] {
-  return tags.map(encodeURIComponent);
-}
-
-function encodeTag(tag: string | string[]): string | string[] {
-  return Array.isArray(tag) ? encodeTags(tag) : encodeURIComponent(tag);
-}
 
 function encodeOptions(options?: {
   name?: string;

--- a/packages/functions/src/encode-tag.ts
+++ b/packages/functions/src/encode-tag.ts
@@ -1,5 +1,5 @@
 function encodeComma(tag: string): string {
-  return tag.replaceAll(',', '%2C');
+  return tag.replace(/,/g, '!');
 }
 
 export function encodeTags(tags: string[]): string[] {

--- a/packages/functions/src/encode-tag.ts
+++ b/packages/functions/src/encode-tag.ts
@@ -1,0 +1,11 @@
+function encodeComma(tag: string): string {
+  return tag.replaceAll(',', '%2C');
+}
+
+export function encodeTags(tags: string[]): string[] {
+  return tags.map(encodeComma);
+}
+
+export function encodeTag(tag: string | string[]): string | string[] {
+  return Array.isArray(tag) ? encodeTags(tag) : encodeComma(tag);
+}

--- a/packages/functions/src/purge/index.ts
+++ b/packages/functions/src/purge/index.ts
@@ -1,10 +1,11 @@
 import { getContext } from '../get-context';
+import { encodeTag } from '../encode-tag';
 import { DangerouslyDeleteOptions } from './types';
 
 export const invalidateByTag = (tag: string | string[]) => {
   const api = getContext().purge;
   if (api) {
-    return api.invalidateByTag(tag);
+    return api.invalidateByTag(encodeTag(tag));
   }
   return Promise.resolve();
 };
@@ -15,7 +16,7 @@ export const dangerouslyDeleteByTag = (
 ) => {
   const api = getContext().purge;
   if (api) {
-    return api.dangerouslyDeleteByTag(tag, options);
+    return api.dangerouslyDeleteByTag(encodeTag(tag), options);
   }
   return Promise.resolve();
 };

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -116,7 +116,7 @@ describe('getCache', () => {
       tags: ['tag with spaces', 'tag&special=chars', 'tag,with,commas'],
     });
     expect(mockCache.set).toHaveBeenCalledWith('b876d32', 'value', {
-      tags: ['tag with spaces', 'tag&special=chars', 'tag%2Cwith%2Ccommas'],
+      tags: ['tag with spaces', 'tag&special=chars', 'tag!with!commas'],
     });
   });
 
@@ -124,7 +124,7 @@ describe('getCache', () => {
     vitest.spyOn(mockCache, 'expireTag');
     const cache = getCache();
     await cache.expireTag('tag,special');
-    expect(mockCache.expireTag).toHaveBeenCalledWith('tag%2Cspecial');
+    expect(mockCache.expireTag).toHaveBeenCalledWith('tag!special');
   });
 
   test('should not encode non-comma characters in expireTag', async () => {
@@ -138,6 +138,6 @@ describe('getCache', () => {
     vitest.spyOn(mockCache, 'expireTag');
     const cache = getCache();
     await cache.expireTag(['tag,one', 'tag&two']);
-    expect(mockCache.expireTag).toHaveBeenCalledWith(['tag%2Cone', 'tag&two']);
+    expect(mockCache.expireTag).toHaveBeenCalledWith(['tag!one', 'tag&two']);
   });
 });

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -110,34 +110,34 @@ describe('getCache', () => {
     expect(mockCache.get).toHaveBeenCalledWith(`${namespace}$b876d32`);
   });
 
-  test('should URL encode tags in set', async () => {
+  test('should encode commas in tags in set', async () => {
     const cache = getCache();
     await cache.set('key', 'value', {
       tags: ['tag with spaces', 'tag&special=chars', 'tag,with,commas'],
     });
     expect(mockCache.set).toHaveBeenCalledWith('b876d32', 'value', {
-      tags: [
-        'tag%20with%20spaces',
-        'tag%26special%3Dchars',
-        'tag%2Cwith%2Ccommas',
-      ],
+      tags: ['tag with spaces', 'tag&special=chars', 'tag%2Cwith%2Ccommas'],
     });
   });
 
-  test('should URL encode tags in expireTag with string', async () => {
+  test('should encode commas in expireTag with string', async () => {
     vitest.spyOn(mockCache, 'expireTag');
     const cache = getCache();
-    await cache.expireTag('tag&special');
-    expect(mockCache.expireTag).toHaveBeenCalledWith('tag%26special');
+    await cache.expireTag('tag,special');
+    expect(mockCache.expireTag).toHaveBeenCalledWith('tag%2Cspecial');
   });
 
-  test('should URL encode tags in expireTag with array', async () => {
+  test('should not encode non-comma characters in expireTag', async () => {
     vitest.spyOn(mockCache, 'expireTag');
     const cache = getCache();
-    await cache.expireTag(['tag one', 'tag&two']);
-    expect(mockCache.expireTag).toHaveBeenCalledWith([
-      'tag%20one',
-      'tag%26two',
-    ]);
+    await cache.expireTag('key:id');
+    expect(mockCache.expireTag).toHaveBeenCalledWith('key:id');
+  });
+
+  test('should encode commas in expireTag with array', async () => {
+    vitest.spyOn(mockCache, 'expireTag');
+    const cache = getCache();
+    await cache.expireTag(['tag,one', 'tag&two']);
+    expect(mockCache.expireTag).toHaveBeenCalledWith(['tag%2Cone', 'tag&two']);
   });
 });


### PR DESCRIPTION
# Problem

A customer reported that after the encodeURIComponent change in https://github.com/vercel/vercel/pull/14749, their tags containing colons (e.g. "key:id") stopped working with invalidateByTag. The tag was being stored as "key%3Aid" in the cache but the purge API was sending "key:id", causing a mismatch. The original change was only meant to support commas in tags (since commas are used as tag delimiters), but encodeURIComponent encoded far more characters than necessary, creating a breaking change in a minor release.

Because the [Purge](https://github.com/vercel/functions/blob/main/packages/purge/src/purge.ts) class already does encodeURIComponent on the whole joined tag string in getInvalidateUrl (line 102) for URL safety. If we also encodeURIComponent in the client wrapper, the tag value gets double-encoded — "key:id" → "key%3Aid" → "key%253Aid" in the URL. That happens to work (server decodes once to "key%3Aid" which matches the stored value), but it's fragile and means the encoding behavior depends on two separate layers both encoding in a specific way. If the Purge class ever changes its encoding, everything breaks.

More importantly, it doesn't fix the root issue — encodeURIComponent encodes characters like `:`, `&`, `=` that were never a problem. The only character that actually breaks things is `,` because it's used as the tag delimiter in both the `x-vercel-cache-tags` header and the `?tags=` query parameter. Scoping to commas solves the actual problem without changing the semantics of tags that were already working.

# Solution

This change modifies cache tag encoding to only encode commas (`%2C`) instead of using full `encodeURIComponent`, preserving special characters like colons and ampersands in cache tags. The encoding is now consistently applied to both cache operations and purge functions (`invalidateByTag` and `dangerouslyDeleteByTag`).

**Changes:**
- Replaced `encodeURIComponent` with comma-specific encoding in cache functions
- Added comma encoding to `invalidateByTag` and `dangerouslyDeleteByTag` purge operations
- Updated tests to verify comma encoding while preserving other special characters

**The net change here from prior to #14749 is to revert the excessive encoding of tags and ensure all tag calls now encode just commas, which should solve this customer's issue and continue to solve the original customer's issue.**

---
changeset

<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> Changes cache tag encoding from full encodeURIComponent to comma-only replacement, affecting how cache tags are stored and matched across cache operations and purge functions - a breaking change in encoding behavior that could cause cache mismatches if not deployed consistently.
> 
> - Replaces `encodeURIComponent` with comma-to-exclamation replacement for cache tags
> - Applies new encoding to `invalidateByTag`, `dangerouslyDeleteByTag`, and `addCacheTag`
> - Encoding change affects cache key matching - mismatch could cause purge failures
>
> <sup>Risk assessment for [commit b9367d2](https://github.com/vercel/vercel/commit/b9367d2d13740be2c01e5b5d40c5539c5914b05e).</sup>
<!-- VADE_RISK_END -->