### PR TITLE
[python] Check if file exists before vendoring.

### DIFF
--- a/.changeset/red-parrots-cough.md
+++ b/.changeset/red-parrots-cough.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Check if file exists before mirroring into vendor

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -442,6 +442,10 @@ export async function mirrorPackagesIntoVendor({
           continue;
         }
         const srcFsPath = join(dir, filePath);
+        // Skip files listed in RECORD but missing on disk (e.g. deleted by a custom install command)
+        if (!fs.existsSync(srcFsPath)) {
+          continue;
+        }
         const bundlePath = join(vendorDirName, filePath).replace(/\\/g, '/');
         vendorFiles[bundlePath] = new FileFsRef({ fsPath: srcFsPath });
       }


### PR DESCRIPTION
If a file is listed in the `.dist-info/RECORD` but doesn't exist, don't mirror it.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a defensive file existence check before mirroring files into vendor directory, preventing errors when files listed in RECORD are missing from disk.
> 
> - Adds `fs.existsSync` check to skip missing files during vendoring
> - Changeset documents patch for @vercel/python package
>
> <sup>Risk assessment for [commit fa72d7f](https://github.com/vercel/vercel/commit/fa72d7f12e512c2273c1547519188c2cf5af5029).</sup>
<!-- VADE_RISK_END -->