### PR TITLE
fix(cli): pass teamId explicitly in fetchInstallations

### DIFF
--- a/.changeset/fix-fetch-installations-teamid.md
+++ b/.changeset/fix-fetch-installations-teamid.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): pass teamId explicitly in fetchInstallations to fix missing installation detection

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -91,7 +91,7 @@ export async function addAutoProvision(
   // Select product and check installations in parallel
   const [productResult, installationsResult] = await Promise.allSettled([
     selectProduct(client, integration.products, options.productSlug),
-    fetchInstallations(client, integration),
+    fetchInstallations(client, integration, team.id),
   ]);
 
   if (productResult.status === 'rejected') {

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -149,7 +149,7 @@ export async function add(
 
   const [productResult, installationsResult] = await Promise.allSettled([
     selectProduct(client, integration.products, productSlug),
-    fetchInstallations(client, integration),
+    fetchInstallations(client, integration, team.id),
   ]);
 
   if (productResult.status === 'rejected') {

--- a/packages/cli/src/util/integration/fetch-installations.ts
+++ b/packages/cli/src/util/integration/fetch-installations.ts
@@ -3,16 +3,19 @@ import type { Integration, IntegrationInstallation } from './types';
 
 export async function fetchInstallations(
   client: Client,
-  integration: Integration
+  integration: Integration,
+  teamId: string
 ) {
   const searchParams = new URLSearchParams();
   searchParams.set('view', 'account');
   searchParams.set('installationType', 'marketplace');
   searchParams.set('integrationIdOrSlug', integration.id);
+  searchParams.set('teamId', teamId);
   return client.fetch<IntegrationInstallation[]>(
     `/v2/integrations/configurations?${searchParams}`,
     {
       json: true,
+      useCurrentTeam: false,
     }
   );
 }


### PR DESCRIPTION
## Summary

- `fetchInstallations` relied on `client.fetch` auto-appending `teamId` from `client.config.currentTeam`, but for Northstar users `currentTeam` isn't set — `getScope` resolves the team via `user.defaultTeamId` instead
- The configurations request went out without `teamId`, returned empty results, and the CLI incorrectly concluded there was no existing installation
- This caused unnecessary term acceptance prompts followed by a 409 "Integration already installed" error
- Pass `teamId` explicitly (matching how `fetchMarketplaceIntegrations` already works)

## Test plan
- [x] `vitest run packages/cli/test/unit/commands/integration/add.test.ts` — 75 tests pass
- [x] `vitest run packages/cli/test/unit/commands/integration/add-auto-provision.test.ts` — 73 tests pass
- [ ] Manual: `vc-dev integration add neon` on a Northstar account that already has Neon installed — should skip terms and detect existing installation

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds explicit teamId parameter passing to fix installation detection for Northstar users, a straightforward bug fix with no security implications.
> 
> - Adds teamId parameter to fetchInstallations function signature and API call
> - Sets useCurrentTeam: false to prevent auto-appending behavior
> - Changeset added for patch release
>
> <sup>Risk assessment for [commit 124dca3](https://github.com/vercel/vercel/commit/124dca34c08e91e497fe202ea7d6e14a80709bb9).</sup>
<!-- VADE_RISK_END -->