### PR TITLE
fix(cli): unify teamId scoping for all marketplace integration commands

### DIFF
--- a/.changeset/unify-marketplace-teamid-scoping.md
+++ b/.changeset/unify-marketplace-teamid-scoping.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): unify teamId scoping for all marketplace integration commands

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 /packages/cli/src/commands/integration-resource/ @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
 /packages/cli/src/commands/flags         @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/flags
 /packages/cli/src/util/integration/      @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
+/packages/cli/src/util/integration-resource/ @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
 /packages/cli/src/util/telemetry/commands/integration/ @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
 /packages/cli/test/mocks/integration.ts  @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace
 /packages/cli/test/unit/commands/install/      @vercel/ci-cd @vercel/vercel-cli-approvers @vercel/marketplace

--- a/packages/cli/src/commands/integration-resource/create-threshold.ts
+++ b/packages/cli/src/commands/integration-resource/create-threshold.ts
@@ -58,10 +58,11 @@ export async function createThreshold(client: Client) {
     output.error('Team not found.');
     return 1;
   }
+  client.config.currentTeam = team.id;
 
   // Fetch Resource
   output.spinner('Retrieving resource…', 500);
-  const resources = await getResources(client, team.id);
+  const resources = await getResources(client);
   const targetedResource = resources.find(
     resource => resource.name === resourceName
   );
@@ -112,8 +113,7 @@ export async function createThreshold(client: Client) {
   // Fetch prepayment info
   const prepaymentInfo = await getBalanceInformation(
     client,
-    targetedResource.product.integrationConfigurationId,
-    team
+    targetedResource.product.integrationConfigurationId
   );
   if (prepaymentInfo === undefined) {
     return 1;

--- a/packages/cli/src/commands/integration-resource/disconnect.ts
+++ b/packages/cli/src/commands/integration-resource/disconnect.ts
@@ -61,6 +61,7 @@ export async function disconnect(client: Client) {
     output.error('Team not found.');
     return 1;
   }
+  client.config.currentTeam = team.id;
 
   const isMissingResourceOrIntegration = parsedArguments.args.length < 2;
   if (isMissingResourceOrIntegration) {
@@ -97,7 +98,7 @@ export async function disconnect(client: Client) {
   telemetry.trackCliFlagAll(shouldDisconnectAll);
 
   output.spinner('Retrieving resource…', 500);
-  const resources = await getResources(client, team.id);
+  const resources = await getResources(client);
   const targetedResource = resources.find(
     resource => resource.name === resourceName
   );

--- a/packages/cli/src/commands/integration-resource/remove-resource.ts
+++ b/packages/cli/src/commands/integration-resource/remove-resource.ts
@@ -1,4 +1,3 @@
-import type { Team } from '@vercel-internals/types';
 import chalk from 'chalk';
 import output from '../../output-manager';
 import type Client from '../../util/client';
@@ -56,6 +55,7 @@ export async function remove(client: Client) {
     output.error('Team not found.');
     return 1;
   }
+  client.config.currentTeam = team.id;
 
   const isMissingResourceOrIntegration = parsedArguments.args.length < 2;
   if (isMissingResourceOrIntegration) {
@@ -77,7 +77,7 @@ export async function remove(client: Client) {
   telemetry.trackCliFlagYes(skipConfirmation);
 
   output.spinner('Retrieving resource…', 500);
-  const resources = await getResources(client, team.id);
+  const resources = await getResources(client);
   const targetedResource = resources.find(
     resource => resource.name === resourceName
   );
@@ -109,7 +109,7 @@ export async function remove(client: Client) {
     }
   }
 
-  return await handleDeleteResource(client, team, targetedResource, {
+  return await handleDeleteResource(client, targetedResource, {
     skipConfirmation,
     skipProjectCheck: disconnectAll,
     asJson,
@@ -118,7 +118,6 @@ export async function remove(client: Client) {
 
 async function handleDeleteResource(
   client: Client,
-  team: Team,
   resource: Resource,
   options?: {
     skipConfirmation: boolean;
@@ -145,7 +144,7 @@ async function handleDeleteResource(
 
   try {
     output.spinner('Deleting resource…', 500);
-    await _deleteResource(client, resource, team);
+    await _deleteResource(client, resource);
   } catch (error) {
     output.error(
       `A problem occurred when attempting to delete ${chalk.bold(resource.name)}: ${(error as Error).message}`

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -55,6 +55,7 @@ export async function addAutoProvision(
     output.error('Team not found');
     return 1;
   }
+  client.config.currentTeam = team.id;
 
   // 2. Fetch integration
   const integration = await fetchIntegrationWithTelemetry(

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -130,6 +130,7 @@ export async function add(
     output.error('Team not found');
     return 1;
   }
+  client.config.currentTeam = team.id;
 
   const integration = await fetchIntegrationWithTelemetry(
     client,

--- a/packages/cli/src/commands/integration/balance.ts
+++ b/packages/cli/src/commands/integration/balance.ts
@@ -62,11 +62,11 @@ export async function balance(client: Client) {
     output.error('Team not found.');
     return 1;
   }
+  client.config.currentTeam = team.id;
 
   const installation = await getBalanceInstallationId(
     client,
     integrationSlug,
-    team.id,
     telemetry
   );
   if (installation === undefined) {
@@ -74,20 +74,12 @@ export async function balance(client: Client) {
   }
   const installationId = installation.id;
 
-  const resources = await getResourcesForInstallation(
-    client,
-    installationId,
-    team
-  );
+  const resources = await getResourcesForInstallation(client, installationId);
   if (resources === undefined) {
     return 1;
   }
 
-  const prepaymentInfo = await getBalanceInformation(
-    client,
-    installationId,
-    team
-  );
+  const prepaymentInfo = await getBalanceInformation(client, installationId);
   if (prepaymentInfo === undefined) {
     return 1;
   }
@@ -111,17 +103,12 @@ export async function balance(client: Client) {
 async function getBalanceInstallationId(
   client: Client,
   integrationSlug: string,
-  teamId: string,
   telemetry: IntegrationBalanceTelemetryClient
 ) {
   let knownIntegrationSlug = false;
   output.spinner('Retrieving installation…', 500);
   try {
-    const installation = await getFirstConfiguration(
-      client,
-      integrationSlug,
-      teamId
-    );
+    const installation = await getFirstConfiguration(client, integrationSlug);
 
     if (!installation) {
       output.stopSpinner();
@@ -145,12 +132,11 @@ async function getBalanceInstallationId(
 
 async function getResourcesForInstallation(
   client: Client,
-  installationId: string,
-  team: { id: string }
+  installationId: string
 ) {
   output.spinner('Retrieving resources…', 500);
   try {
-    const resources = (await getResources(client, team.id)).filter(
+    const resources = (await getResources(client)).filter(
       resource =>
         resource.product?.integrationConfigurationId === installationId
     );

--- a/packages/cli/src/commands/integration/list.ts
+++ b/packages/cli/src/commands/integration/list.ts
@@ -74,6 +74,7 @@ export async function list(client: Client) {
     output.error('Team not found.');
     return 1;
   }
+  client.config.currentTeam = team.id;
 
   if (!project && !parsedArguments.flags['--all']) {
     project = await getLinkedProject(client).then(result => {
@@ -94,7 +95,7 @@ export async function list(client: Client) {
 
   try {
     output.spinner('Retrieving resources…', 500);
-    resources = await getResources(client, team.id);
+    resources = await getResources(client);
   } catch (error) {
     output.error(`Failed to fetch resources: ${(error as Error).message}`);
     return 1;

--- a/packages/cli/src/commands/integration/open-integration.ts
+++ b/packages/cli/src/commands/integration/open-integration.ts
@@ -61,16 +61,13 @@ export async function openIntegration(client: Client, subArgs: string[]) {
     output.error('Team not found');
     return 1;
   }
+  client.config.currentTeam = team.id;
 
   let configuration: Configuration | undefined;
   let knownIntegrationSlug = false;
 
   try {
-    configuration = await getFirstConfiguration(
-      client,
-      integrationSlug,
-      team.id
-    );
+    configuration = await getFirstConfiguration(client, integrationSlug);
     knownIntegrationSlug = !!configuration;
   } catch (error) {
     output.error(
@@ -97,7 +94,7 @@ export async function openIntegration(client: Client, subArgs: string[]) {
   if (resourceName) {
     let resources;
     try {
-      resources = await getResources(client, team.id);
+      resources = await getResources(client);
     } catch (error) {
       output.error(`Failed to fetch resources: ${(error as Error).message}`);
       return 1;

--- a/packages/cli/src/commands/integration/remove-integration.ts
+++ b/packages/cli/src/commands/integration/remove-integration.ts
@@ -51,6 +51,7 @@ export async function remove(client: Client) {
     output.error('Team not found.');
     return 1;
   }
+  client.config.currentTeam = team.id;
 
   const isMissingResourceOrIntegration = parsedArguments.args.length < 2;
   if (isMissingResourceOrIntegration) {
@@ -69,8 +70,7 @@ export async function remove(client: Client) {
   output.spinner('Retrieving integration…', 500);
   const integrationConfiguration = await getFirstConfiguration(
     client,
-    integrationName,
-    team.id
+    integrationName
   );
   output.stopSpinner();
 
@@ -96,7 +96,7 @@ export async function remove(client: Client) {
 
   try {
     output.spinner('Uninstalling integration…', 1000);
-    await removeIntegration(client, integrationConfiguration, team);
+    await removeIntegration(client, integrationConfiguration);
   } catch (error) {
     output.error(
       chalk.red(

--- a/packages/cli/src/util/integration-resource/delete-resource.ts
+++ b/packages/cli/src/util/integration-resource/delete-resource.ts
@@ -1,19 +1,9 @@
 import type Client from '../client';
 import type { Resource } from '../integration-resource/types';
-import type { Team } from '@vercel-internals/types';
 
-export async function deleteResource(
-  client: Client,
-  resource: Resource,
-  team: Team
-) {
-  const params = new URLSearchParams();
-  params.set('teamId', team.id);
-  return client.fetch(
-    `/v1/storage/stores/integration/${resource.id}?${params}`,
-    {
-      json: true,
-      method: 'DELETE',
-    }
-  );
+export async function deleteResource(client: Client, resource: Resource) {
+  return client.fetch(`/v1/storage/stores/integration/${resource.id}`, {
+    json: true,
+    method: 'DELETE',
+  });
 }

--- a/packages/cli/src/util/integration-resource/get-resources.ts
+++ b/packages/cli/src/util/integration-resource/get-resources.ts
@@ -1,15 +1,9 @@
 import type Client from '../client';
 import type { Resource } from './types';
 
-export async function getResources(
-  client: Client,
-  teamId: string
-): Promise<Resource[]> {
-  const searchParams = new URLSearchParams();
-  searchParams.set('teamId', teamId);
-
+export async function getResources(client: Client): Promise<Resource[]> {
   const storesResponse = await client.fetch<{ stores: Resource[] }>(
-    `/v1/storage/stores?${searchParams}`,
+    `/v1/storage/stores`,
     {
       json: true,
     }

--- a/packages/cli/src/util/integration/fetch-installation-prepayment-info.ts
+++ b/packages/cli/src/util/integration/fetch-installation-prepayment-info.ts
@@ -4,14 +4,10 @@ import type { InstallationBalancesAndThresholds } from './types';
 
 export async function fetchInstallationPrepaymentInfo(
   client: Client,
-  teamId: string,
   installationId: string
 ): Promise<InstallationBalancesAndThresholds> {
-  const searchParams = new URLSearchParams();
-  searchParams.set('teamId', teamId);
-
   return await client.fetch<InstallationBalancesAndThresholds>(
-    `/v1/integrations/installations/${installationId}/billing/balance?${searchParams}`,
+    `/v1/integrations/installations/${installationId}/billing/balance`,
     {
       json: true,
     }
@@ -20,14 +16,12 @@ export async function fetchInstallationPrepaymentInfo(
 
 export async function getBalanceInformation(
   client: Client,
-  installationId: string,
-  team: { id: string }
+  installationId: string
 ) {
   output.spinner('Retrieving balance info…', 500);
   try {
     const prepaymentInfo = await fetchInstallationPrepaymentInfo(
       client,
-      team.id,
       installationId
     );
 

--- a/packages/cli/src/util/integration/fetch-marketplace-integrations.ts
+++ b/packages/cli/src/util/integration/fetch-marketplace-integrations.ts
@@ -3,32 +3,27 @@ import type { Configuration } from './types';
 
 export async function fetchMarketplaceIntegrations(
   client: Client,
-  slug: string,
-  teamId: string
+  slug: string
 ) {
   const searchParams = new URLSearchParams();
   searchParams.set('view', 'account');
   searchParams.set('installationType', 'marketplace');
   searchParams.set('integrationIdOrSlug', slug);
-  searchParams.set('teamId', teamId);
   return await client.fetch<Configuration[]>(
     `/v2/integrations/configurations?${searchParams}`,
     {
       json: true,
-      useCurrentTeam: false,
     }
   );
 }
 
 export async function getFirstConfiguration(
   client: Client,
-  integrationSlug: string,
-  teamId: string
+  integrationSlug: string
 ) {
   const configurations = await fetchMarketplaceIntegrations(
     client,
-    integrationSlug,
-    teamId
+    integrationSlug
   );
   return configurations.length > 0 ? configurations[0] : undefined;
 }

--- a/packages/cli/src/util/integration/remove-integration.ts
+++ b/packages/cli/src/util/integration/remove-integration.ts
@@ -1,16 +1,12 @@
 import type Client from '../client';
 import type { Configuration } from './types';
-import type { Team } from '@vercel-internals/types';
 
 export async function removeIntegration(
   client: Client,
-  configuration: Configuration,
-  team: Team
+  configuration: Configuration
 ) {
-  const params = new URLSearchParams();
-  params.set('teamId', team.id);
   return client.fetch(
-    `/v2/integrations/installations/${configuration.id}/uninstall?${params}`,
+    `/v2/integrations/installations/${configuration.id}/uninstall`,
     {
       json: true,
       body: {},

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -1122,7 +1122,12 @@ export function useIntegrationDiscover(opts?: {
 
 export function useConfiguration() {
   client.scenario.get('/:version/integrations/configurations', (req, res) => {
-    const { integrationIdOrSlug } = req.query;
+    const { integrationIdOrSlug, teamId } = req.query;
+
+    if (!teamId) {
+      res.status(400).json({ error: 'teamId is required' });
+      return;
+    }
 
     if (integrationIdOrSlug === 'error') {
       res.status(500);

--- a/packages/cli/test/unit/util/integration/fetch-installation-prepayment-info.test.ts
+++ b/packages/cli/test/unit/util/integration/fetch-installation-prepayment-info.test.ts
@@ -2,18 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { fetchInstallationPrepaymentInfo } from '../../../../src/util/integration/fetch-installation-prepayment-info';
 
 describe('fetchInstallationPrepaymentInfo', () => {
-  it('constructs URL with correct teamId query parameter', async () => {
+  it('constructs URL with correct installationId', async () => {
     const mockFetch = vi.fn().mockResolvedValue({});
     const mockClient = { fetch: mockFetch } as any;
 
-    await fetchInstallationPrepaymentInfo(
-      mockClient,
-      'team_dummy',
-      'install_123'
-    );
+    await fetchInstallationPrepaymentInfo(mockClient, 'install_123');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      '/v1/integrations/installations/install_123/billing/balance?teamId=team_dummy',
+      '/v1/integrations/installations/install_123/billing/balance',
       { json: true }
     );
   });


### PR DESCRIPTION
## Summary

For Northstar users, `getScope()` resolves the team via `user.defaultTeamId` but does **not** set `client.config.currentTeam`. This meant `client.fetch()` never auto-appended `teamId`, causing API calls to scope to the wrong context — returning empty results or 409 "already installed" errors.

Previously each utility tried to fix this independently by accepting explicit `teamId` params (e.g. #15054 for `fetchMarketplaceIntegrations`). This was whack-a-mole — other utilities like `fetchInstallations`, `fetchInstallationPrepaymentInfo`, and `getResources` had the same bug.

**This PR unifies the pattern:** every integration/integration-resource command now sets `client.config.currentTeam = team.id` after `getScope()`, matching the established pattern used by ~13 other CLI commands (`env`, `flags`, `deploy`, etc.). All downstream utilities rely on auto-append and no longer accept explicit `teamId`/`team` params.

### Changes

**9 commands — add `currentTeam` assignment after `getScope`:**
- `integration add`, `integration add` (auto-provision), `integration balance`
- `integration list`, `integration open`, `integration remove`
- `integration-resource disconnect`, `integration-resource create-threshold`, `integration-resource remove`

**5 utilities — remove explicit `teamId` params:**
- `fetch-marketplace-integrations.ts` (reverts #15054 utility-level fix)
- `fetch-installation-prepayment-info.ts`
- `get-resources.ts`
- `remove-integration.ts`
- `delete-resource.ts`

**Implicitly fixed utilities** (already relied on auto-append, but `currentTeam` was never set for Northstar users before this PR):
- `fetchInstallations` — called from `add.ts` and `add-auto-provision.ts`
- `disconnectResourceFromProject`, `provisionStoreResource`, `createAuthorization`, `fetchBillingPlans`

**Net effect:** -31 lines, simpler utility signatures, one consistent pattern.

## Test plan

### Unit Tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/add.test.ts test/unit/commands/integration/add-auto-provision.test.ts test/unit/commands/integration/balance.test.ts test/unit/util/integration/fetch-installation-prepayment-info.test.ts

 ✓ test/unit/util/integration/fetch-installation-prepayment-info.test.ts  (1 test)
 ✓ test/unit/commands/integration/balance.test.ts  (16 tests)
 ✓ test/unit/commands/integration/add.test.ts  (75 tests)
 ✓ test/unit/commands/integration/add-auto-provision.test.ts  (73 tests)

 Test Files  4 passed (4)
      Tests  165 passed (165)
```

- [x] Northstar fallback test in balance.test.ts validates teamId is present via auto-append
- [x] Mock `useConfiguration` validates `teamId` query param is present (400 if missing)

### Manual Testing

All commands tested with `--debug` to verify `teamId` auto-injection in every API URL:

| Command | API endpoints hit | teamId present | Result |
|---|---|---|---|
| `vc integration list` | `/v1/storage/stores` | ✅ | Listed resources correctly |
| `vc integration balance upstash` | `/v2/integrations/configurations`, `/v1/storage/stores`, `/v1/integrations/installations/.../billing/balance` | ✅ (all 3) | Retrieved balance info |
| `vc integration open upstash` | `/v2/integrations/configurations` | ✅ | Printed SSO URL with correct teamId |
| `vc integration add upstash` (legacy) | `/v2/integrations/integration/upstash`, `/v2/integrations/configurations` | ✅ (both) | Reached product selection prompt |
| `FF=1 vc integration add upstash/upstash-kv` (auto-provision) | `/v2/integrations/integration/upstash`, `/v2/integrations/configurations` | ✅ (both) | Reached wizard prompts |
| `vc integration remove upstash` | `/v2/integrations/configurations` | ✅ | Confirmation prompt appeared |
| `vc integration-resource disconnect` | `/v1/storage/stores` | ✅ | Reached resource lookup |

### Code paths covered

| Utility function | Old behavior | New behavior | Verified by |
|---|---|---|---|
| `getResources()` | Manual `teamId` query param | Auto-injected via `currentTeam` | Manual (list, balance, disconnect) + unit |
| `fetchMarketplaceIntegrations()` | Manual `teamId` + `useCurrentTeam: false` | Auto-injected (removed opt-out) | Manual (balance, open, remove, add) + unit |
| `deleteResource()` | Manual `teamId` from `team` param | Auto-injected | Unit only (destructive) |
| `removeIntegration()` | Manual `teamId` from `team` param | Auto-injected | Unit only (destructive) |
| `fetchInstallationPrepaymentInfo()` | Manual `teamId` query param | Auto-injected | Manual (balance) + unit |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Refactors CLI commands to set currentTeam config after getScope() and removes explicit teamId parameters from utility functions, relying on auto-append behavior - a pattern change that could affect API scoping if currentTeam is not properly set.
> 
> - Adds `client.config.currentTeam = team.id` assignment in 9 integration commands
> - Removes explicit `teamId` params from 5 utility functions (getResources, fetchMarketplaceIntegrations, etc.)
> - Removes `useCurrentTeam: false` flag from fetchMarketplaceIntegrations
>
> <sup>Risk assessment for [commit 7e1035f](https://github.com/vercel/vercel/commit/7e1035f32fda1e28e796819b516db3459e00f268).</sup>
<!-- VADE_RISK_END -->