### PR TITLE
fix(cli): add `integration-resource` command to `vc --help` output

### DIFF
--- a/.changeset/add-integration-resource-to-help.md
+++ b/.changeset/add-integration-resource-to-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): add `integration-resource` command to `vc --help` output

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -30,6 +30,7 @@ export const help = () => `
       inspect              [id]        Displays information related to a deployment
       i | install          [name]      Install an integration from the Marketplace
       integration          [cmd]       Manages your Marketplace integrations
+      ir | integration-resource [cmd]  Manages your Marketplace integration resources
       link                 [path]      Link local directory to a Vercel Project
       ls | list            [app]       Lists deployments
       login                [email]     Logs into your account or creates a new one

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -21,6 +21,7 @@ exports[`base level help output > help 1`] = `
       inspect              [id]        Displays information related to a deployment
       i | install          [name]      Install an integration from the Marketplace
       integration          [cmd]       Manages your Marketplace integrations
+      ir | integration-resource [cmd]  Manages your Marketplace integration resources
       link                 [path]      Link local directory to a Vercel Project
       ls | list            [app]       Lists deployments
       login                [email]     Logs into your account or creates a new one


### PR DESCRIPTION
## Summary
- The `integration-resource` command (alias `ir`) was registered and functional but **not listed in `vc --help`**, making it invisible to users
- Added it to the Basic section of the top-level help template, right after the `integration` entry
- Updated the corresponding snapshot test

## Test plan
- [x] `fix` passes (format, lint, typecheck, cleanup)
- [x] Snapshot test (`args.test.ts`) updated and passes
- [ ] Manual verification: `node packages/cli/dist/index.js --help` shows `integration-resource`

Fixes: [MKT-2908](https://linear.app/vercel/issue/MKT-2908/cant-see-the-integration-resource-command-listed-in-vc-help)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a missing CLI command entry to the help text output and updates the corresponding test snapshot, with no logic or security changes.
> 
> - Added `integration-resource` command to CLI help template
> - Updated test snapshot to match new help output
>
> <sup>Risk assessment for [commit f868ae7](https://github.com/vercel/vercel/commit/f868ae721993f705815df001d4feb1ac2860513f).</sup>
<!-- VADE_RISK_END -->