### PR TITLE
feat(cli): add `--prefix` flag to `integration add` for env var prefix

### DIFF
--- a/.changeset/add-prefix-flag.md
+++ b/.changeset/add-prefix-flag.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(cli): add `--prefix` flag to `integration add` for env var namespacing

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -125,7 +125,7 @@ export default async function addStore(
         link.project.id,
         storeId,
         environments,
-        link.org.id
+        { accountId: link.org.id }
       );
 
       output.success(

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -51,6 +51,7 @@ export async function addAutoProvision(
   telemetry.trackCliFlagNoEnvPull(options.noEnvPull);
   telemetry.trackCliOptionPlan(options.billingPlanId);
   telemetry.trackCliOptionEnvironment(options.environments);
+  telemetry.trackCliOptionPrefix(options.prefix);
 
   // Get team context
   const { contextName, team } = await getScope(client);
@@ -182,7 +183,6 @@ export async function addAutoProvision(
       });
       return 1;
     }
-    // Validate all required fields are present
     if (!validateAndPrintRequiredMetadata(parsed, product.metadataSchema)) {
       telemetry.trackMarketplaceEvent('marketplace_install_flow_dropped', {
         ...baseProps,

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -52,10 +52,18 @@ export async function add(
   const resourceNameArg = flags['--name'];
   const metadataFlags = flags['--metadata'];
   const billingPlanId = flags['--plan'];
+  const prefix = flags['--prefix'];
+  if (prefix !== undefined && !/^[a-zA-Z][a-zA-Z0-9_]*$/.test(prefix)) {
+    output.error(
+      'Invalid --prefix value. It must start with a letter and contain only letters, digits, and underscores.'
+    );
+    return 1;
+  }
   const options: AddOptions = {
     noConnect: flags['--no-connect'],
     noEnvPull: flags['--no-env-pull'],
     environments: flags['--environment'],
+    prefix,
   };
   if (args.length > 1) {
     output.error('Cannot install more than one integration at a time');
@@ -109,6 +117,7 @@ export async function add(
       noConnect: options.noConnect,
       noEnvPull: options.noEnvPull,
       environments: options.environments,
+      prefix,
     });
   }
 
@@ -123,6 +132,7 @@ export async function add(
   telemetry.trackCliFlagNoConnect(options.noConnect);
   telemetry.trackCliFlagNoEnvPull(options.noEnvPull);
   telemetry.trackCliOptionEnvironment(options.environments);
+  telemetry.trackCliOptionPrefix(prefix);
 
   const { contextName, team } = await getScope(client);
 

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -62,6 +62,15 @@ export const addSubcommand = {
       description:
         'Environment to connect (can be repeated: production, preview, development). Defaults to all.',
     },
+    {
+      name: 'prefix',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      argument: 'PREFIX',
+      description:
+        'Prefix for environment variable names (e.g., --prefix NEON2_ creates NEON2_DATABASE_URL instead of DATABASE_URL)',
+    },
   ],
   examples: [
     {
@@ -115,6 +124,10 @@ export const addSubcommand = {
     {
       name: 'Install without pulling environment variables',
       value: `${packageName} integration add acme --no-env-pull`,
+    },
+    {
+      name: 'Install with a prefix for environment variable names',
+      value: `${packageName} integration add acme --prefix NEON2_`,
     },
     {
       name: 'Show available products for an integration',

--- a/packages/cli/src/util/integration-resource/connect-resource-to-project.ts
+++ b/packages/cli/src/util/integration-resource/connect-resource-to-project.ts
@@ -1,11 +1,16 @@
 import type Client from '../client';
 
+interface ConnectResourceOptions {
+  accountId?: string;
+  envVarPrefix?: string;
+}
+
 export async function connectResourceToProject(
   client: Client,
   projectId: string,
   storeId: string,
   environments: string[],
-  accountId?: string
+  options?: ConnectResourceOptions
 ) {
   return client.fetch(`/v1/storage/stores/${storeId}/connections`, {
     json: true,
@@ -14,7 +19,10 @@ export async function connectResourceToProject(
       envVarEnvironments: environments,
       projectId,
       type: 'integration',
+      ...(options?.envVarPrefix !== undefined
+        ? { envVarPrefix: options.envVarPrefix }
+        : {}),
     },
-    accountId,
+    accountId: options?.accountId,
   });
 }

--- a/packages/cli/src/util/integration/format-dynamic-examples.ts
+++ b/packages/cli/src/util/integration/format-dynamic-examples.ts
@@ -94,6 +94,16 @@ export function formatDynamicExamples(
     `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --no-env-pull`)}`
   );
 
+  // Prefix
+  lines.push('');
+  lines.push(
+    `  ${chalk.dim('-')} Install with a prefix for environment variable names`
+  );
+  lines.push('');
+  lines.push(
+    `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --prefix NEON2_`)}`
+  );
+
   lines.push('');
 
   return lines.join('\n');

--- a/packages/cli/src/util/integration/post-provision-setup.ts
+++ b/packages/cli/src/util/integration/post-provision-setup.ts
@@ -18,6 +18,7 @@ export interface PostProvisionOptions {
   environments?: string[];
   onProjectConnected?: (projectId: string) => void;
   onProjectConnectFailed?: (projectId: string, error: Error) => void;
+  prefix?: string;
 }
 
 /**
@@ -87,7 +88,8 @@ export async function postProvisionSetup(
       client,
       project.id,
       resourceId,
-      environments
+      environments,
+      options.prefix ? { envVarPrefix: options.prefix } : undefined
     );
   } catch (error) {
     output.stopSpinner();

--- a/packages/cli/src/util/telemetry/commands/integration/add.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/add.ts
@@ -69,4 +69,13 @@ export class IntegrationAddTelemetryClient
       value: JSON.stringify(props),
     });
   }
+
+  trackCliOptionPrefix(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'prefix',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -1293,6 +1293,8 @@ export function useIntegration({
     });
   });
 
+  const connectionRequestBodies: unknown[] = [];
+
   client.scenario.post(
     '/v1/storage/stores/:storeId/connections',
     (req, res) => {
@@ -1302,6 +1304,7 @@ export function useIntegration({
         return;
       }
 
+      connectionRequestBodies.push(req.body);
       res.status(200);
       res.end();
     }
@@ -1324,7 +1327,7 @@ export function useIntegration({
     }
   );
 
-  return { installRequestBodies };
+  return { installRequestBodies, connectionRequestBodies };
 }
 
 export function useAutoProvision(opts?: {

--- a/packages/cli/test/unit/commands/blob/store-add.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-add.test.ts
@@ -220,7 +220,7 @@ describe('blob store add', () => {
         'proj_123',
         'store_test123',
         ['production', 'preview', 'development'],
-        'org_123'
+        { accountId: 'org_123' }
       );
       expect(mockedOutput.success).toHaveBeenCalledWith(
         'Blob store created: test-store (store_test123)'
@@ -255,7 +255,7 @@ describe('blob store add', () => {
         'proj_123',
         'store_test123',
         ['production'],
-        'org_123'
+        { accountId: 'org_123' }
       );
     });
 


### PR DESCRIPTION
## Summary
- Adds `--prefix` flag to `vc integration add` (and `vc install`) that sends `envVarPrefix` in the `POST /v1/storage/stores/{storeId}/connections` request body
- Validates prefix format: must start with a letter, contain only letters, digits, and underscores
- Threads prefix through both legacy and auto-provision code paths: `add.ts` → `postProvisionSetup()` → `connectResourceToProject()`
- Refactors `connectResourceToProject` to use an options object (`{ accountId?, envVarPrefix? }`) instead of positional params
- Includes telemetry tracking via `trackCliOptionPrefix()`

## Test plan

### Unit Tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/add.test.ts test/unit/commands/integration/add-auto-provision.test.ts

 ✓ test/unit/commands/integration/add.test.ts  (81 tests) 4371ms
 ✓ test/unit/commands/integration/add-auto-provision.test.ts  (77 tests) 3678ms

 Test Files  2 passed (2)
      Tests  158 passed (158)
```

### Manual Testing

**`--help` shows `--prefix` flag:**
```
$ vc integration add --help
       --prefix <PREFIX>       …
  - Install with a prefix for environment variable names
    $ vercel integration add acme --prefix NEON2_
```

**Prefix validation:**
```
$ vc integration add acme --prefix 2NEON
Error: Invalid --prefix value. It must start with a letter and contain only letters, digits, and underscores.

$ vc integration add acme --prefix NEO-N
Error: Invalid --prefix value. It must start with a letter and contain only letters, digits, and underscores.
```

**Legacy path with `--prefix UPSTASH2_`:**
```
$ vc integration add upstash --prefix UPSTASH2_ --debug
> Installing Upstash QStash/Workflow by Upstash under acme-marketplace-team-vtest314
> Success! Upstash QStash/Workflow successfully provisioned: upstash-qstash-yellow-coin
> upstash-qstash-yellow-coin successfully connected to cli-test

Changes:
+ UPSTASH2__QSTASH_CURRENT_SIGNING_KEY
+ UPSTASH2__QSTASH_NEXT_SIGNING_KEY
+ UPSTASH2__QSTASH_TOKEN
+ UPSTASH2__QSTASH_URL
```
✅ All env vars prefixed with `UPSTASH2_`. Server-side `envVarPrefix` support confirmed working.

**`vc install` forwards `--prefix`:**
```
$ vc install acme --prefix 2BAD
Error: Invalid --prefix value. It must start with a letter and contain only letters, digits, and underscores.

$ vc install --help | grep prefix
       --prefix <PREFIX>       …
```

### Code Paths Covered

| Path | Expected | Tested by |
|------|----------|-----------|
| `--help` shows `--prefix` | Flag in help output | Manual |
| Invalid `--prefix` (digit start, special chars, empty) | Early validation error | Manual + Unit |
| Valid `--prefix` accepted | Proceeds to provisioning | Manual + Unit |
| Legacy + `--prefix` + project | `envVarPrefix` in connection request body | Manual (upstash) + Unit |
| Legacy without `--prefix` + project | No `envVarPrefix` in body | Unit |
| Auto-provision + `--prefix` + project | `envVarPrefix` sent via `connectResourceToProject` | Unit |
| Auto-provision without `--prefix` + project | No `envVarPrefix` | Unit |
| Auto-provision + `--prefix` + `--environment` | Both prefix and environment sent | Unit |
| `vc install --prefix` forwarding | Delegates to `add()` with prefix | Manual + Unit |
| Telemetry tracking for `--prefix` | `option:prefix` event with `[REDACTED]` | Unit (both paths) |

Fixes: [MKT-2900](https://linear.app/vercel/issue/MKT-2900/vc-test-integration-add-neon-fails-because-env-var-already-exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new `--prefix` CLI flag with input validation that restricts values to valid identifier format, refactors a function signature to use an options object, and includes comprehensive tests - all low-risk changes.
> 
> - Adds `--prefix` flag with regex validation: `/^[a-zA-Z][a-zA-Z0-9_]*$/`
> - Refactors `connectResourceToProject` to use options object instead of positional params
> - Extensive unit test coverage for new flag and validation
>
> <sup>Risk assessment for [commit a45864a](https://github.com/vercel/vercel/commit/a45864a8622af49ceaa27fe177c1e4667b2b006f).</sup>
<!-- VADE_RISK_END -->