### PR TITLE
fix(cli): allow `integration open` to accept a resource name directly

### DIFF
--- a/.changeset/fix-integration-open-resource-name.md
+++ b/.changeset/fix-integration-open-resource-name.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): allow `integration open` to accept a resource name directly

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -62,6 +62,15 @@ export const addSubcommand = {
       description:
         'Environment to connect (can be repeated: production, preview, development). Defaults to all.',
     },
+    {
+      name: 'prefix',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      argument: 'PREFIX',
+      description:
+        'Prefix for environment variable names (e.g., --prefix NEON2_ creates NEON2_DATABASE_URL instead of DATABASE_URL)',
+    },
   ],
   examples: [
     {
@@ -117,6 +126,10 @@ export const addSubcommand = {
       value: `${packageName} integration add acme --no-env-pull`,
     },
     {
+      name: 'Install with a prefix for environment variable names',
+      value: `${packageName} integration add acme --prefix NEON2_`,
+    },
+    {
       name: 'Show available products for an integration',
       value: `${packageName} integration add acme --help`,
     },
@@ -160,6 +173,13 @@ export const openSubcommand = {
   ],
   options: [formatOption],
   examples: [
+    {
+      name: "Open a resource's dashboard by resource name",
+      value: [
+        `${packageName} integration open <resource-name>`,
+        `${packageName} integration open my-acme-store`,
+      ],
+    },
     {
       name: "Open a marketplace integration's dashboard",
       value: [


### PR DESCRIPTION
## Summary
- `vc integration open <resource-name>` now works without needing to also pass the integration slug
- When the first argument doesn't match an integration slug and no second argument is provided, the CLI falls back to looking up the argument as a resource name
- Uses the resource's `product.integrationConfigurationId` to build the SSO link

**Before:** `vc integration open supabase-byzantium-lighthouse` → `Error: No configuration found`
**After:** `vc integration open supabase-byzantium-lighthouse` → Opens resource dashboard

The two-argument form (`vc integration open supabase supabase-byzantium-lighthouse`) still works as before.

## Test plan
- [x] Resource name as sole argument opens correct SSO link
- [x] Resource name with `--format=json` outputs correct JSON
- [x] Non-marketplace resource gives clear error
- [x] Unknown name (neither integration nor resource) gives clear error
- [x] Two-argument form still works
- [x] All 25 existing + new tests pass

Fixes: [MKT-2907](https://linear.app/vercel/issue/MKT-2907/supabase-cant-open-a-resources-sso-link)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI enhancement adds fallback logic to look up resource names when integration slug not found, with proper error handling and validation - no security-sensitive changes.
> 
> - Adds fallback resource lookup when integration slug not matched
> - New --prefix option for environment variable naming
> - Comprehensive test coverage for new resource name argument handling
>
> <sup>Risk assessment for [commit a99e351](https://github.com/vercel/vercel/commit/a99e351024adcdf1d4b2151492fe1c78e19b85da).</sup>
<!-- VADE_RISK_END -->