### PR TITLE
fix(cli): stop showing region as required in help since server handles region selection

### DIFF
--- a/.changeset/region-auto-detected-help.md
+++ b/.changeset/region-auto-detected-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): stop showing region as required in help since server handles region selection

--- a/packages/cli/src/util/integration/format-schema-help.ts
+++ b/packages/cli/src/util/integration/format-schema-help.ts
@@ -84,6 +84,14 @@ function generateExample(
 }
 
 /**
+ * Whether a field uses a vercel-region control where the server handles region selection.
+ */
+export function isServerHandledRegion(prop: MetadataSchemaProperty): boolean {
+  const control = prop['ui:control'];
+  return control === 'vercel-region' || control === 'multi-vercel-region';
+}
+
+/**
  * Format metadata schema as help text for CLI display
  * @param schema The metadata schema to format
  * @param integrationName The integration slug/name
@@ -117,7 +125,10 @@ export function formatMetadataSchemaHelp(
     }
 
     const isRequired = required.has(key);
-    const requiredSuffix = isRequired ? chalk.red(' (required)') : '';
+    const requiredSuffix =
+      isRequired && !isServerHandledRegion(prop)
+        ? chalk.red(' (required)')
+        : '';
 
     const typeHint =
       prop.type === 'boolean'

--- a/packages/cli/src/util/integration/parse-metadata.ts
+++ b/packages/cli/src/util/integration/parse-metadata.ts
@@ -1,5 +1,9 @@
 import output from '../../output-manager';
-import { getAllOptionValues, isHiddenOnCreate } from './format-schema-help';
+import {
+  getAllOptionValues,
+  isServerHandledRegion,
+  isHiddenOnCreate,
+} from './format-schema-help';
 import type { Metadata, MetadataSchema } from './types';
 
 export interface ParseMetadataResult {
@@ -147,6 +151,8 @@ export function parseMetadataFlags(
 
 /**
  * Validate that all required metadata fields are provided.
+ * Region fields (vercel-region / multi-vercel-region) are always skipped
+ * because the server handles region selection automatically.
  */
 export function validateRequiredMetadata(
   metadata: Metadata,
@@ -160,6 +166,11 @@ export function validateRequiredMetadata(
 
     // Skip hidden fields (they use defaults server-side)
     if (propSchema && isHiddenOnCreate(propSchema)) {
+      continue;
+    }
+
+    // Skip vercel-region fields (server handles region selection)
+    if (propSchema && isServerHandledRegion(propSchema)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Region metadata fields (`vercel-region` / `multi-vercel-region`) no longer show `(required)` in `--help` output and are no longer validated as required — the server handles region selection via `suggestRegionsForMissingFields()`
- This applies unconditionally (no feature flag gating) since the legacy code path is being deprecated
- Shared `isServerHandledRegion()` helper centralizes the `vercel-region` / `multi-vercel-region` control check, matching the same logic used server-side in `auto-provision-resource.ts`

## Test plan
- [x] Unit tests for `validateRequiredMetadata` region skipping (3 tests: skips region fields, still requires non-region, doesn't skip non-region select)
- [x] Unit tests for `formatMetadataSchemaHelp` region display (2 tests: omits required for region, still shows for non-region)
- [x] Manual: `supabase --help` — `region` has no `(required)` suffix
- [x] Manual: `upstash --help` — `primaryRegion` has no `(required)` suffix, `indexType (required)` still shown

### Manual test evidence

**supabase `--help`** (region no longer shows `(required)`):
```
    region
      Primary region where your database will be hosted
      Options: sfo1, iad1, ca-central-1, dub1, lhr1, fra1, ...
      Default: iad1
      Example: -m region=sfo1
```

**upstash `--help`** (non-region field still shows `(required)`):
```
    primaryRegion
      Choose the region where your index will reside in.
      Options: iad1, dub1, us-central1
      Example: -m primaryRegion=iad1

    indexType (required)
      Options: DENSE, SPARSE, HYBRID
      Example: -m indexType=DENSE
```

Fixes: [MKT-2904](https://linear.app/vercel/issue/MKT-2904/supabase-confusing-that-region-is-required-metadata-in-help-since)
Also fixes: [MKT-2903](https://linear.app/vercel/issue/MKT-2903/aws-help-says-region-is-required-but-actually-has-default)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR modifies CLI help text display and validation to skip region fields when auto-provision feature flag is enabled, with no security or authorization changes.
> 
> - Adds `skipAutoRegion` option to skip vercel-region validation when auto-provision is enabled
> - Modifies help text formatting to omit `(required)` suffix for auto-detected region fields
> - Adds unit tests for new validation and help formatting behavior
>
> <sup>Risk assessment for [commit 3b74d6d](https://github.com/vercel/vercel/commit/3b74d6d122b16f987c2b22475c5686b05f70f44a).</sup>
<!-- VADE_RISK_END -->