### PR TITLE
fix(cli): handle null resource in auto-provision response

### DIFF
--- a/.changeset/fix-installed-response.md
+++ b/.changeset/fix-installed-response.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): handle `kind:installed` auto-provision response for installation-only integrations

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -237,6 +237,15 @@ export async function addAutoProvision(
   );
   output.debug(`Installation: ${JSON.stringify(result.installation, null, 2)}`);
   output.debug(`Billing plan: ${JSON.stringify(result.billingPlan, null, 2)}`);
+
+  // Installation-only integrations (e.g. Sentry) return resource: null
+  if (!result.resource) {
+    output.success(
+      `${product.name} by ${chalk.bold(integration.name)} is already installed`
+    );
+    return 0;
+  }
+
   output.success(
     `${product.name} successfully provisioned: ${chalk.bold(resourceName)}`
   );

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -222,7 +222,7 @@ export interface AutoProvisionedResponse {
   integration: AutoProvisionIntegration;
   product: AutoProvisionProduct;
   installation: { id: string };
-  resource: AutoProvisionResource;
+  resource: AutoProvisionResource | null;
   billingPlan: BillingPlan | null;
 }
 

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -1011,6 +1011,14 @@ const autoProvisionResponses: Record<
     integration: autoProvisionIntegration,
     product: autoProvisionProduct,
   },
+  installed: {
+    kind: 'provisioned',
+    integration: autoProvisionIntegration,
+    product: autoProvisionProduct,
+    installation: { id: 'install_123' },
+    resource: null,
+    billingPlan: null,
+  },
 };
 
 const discoverIntegrations = [
@@ -1356,8 +1364,9 @@ export function useAutoProvision(opts?: {
         res.status(422);
         res.json(response);
       } else {
-        // 201 for successful provisioning
-        res.status(201);
+        // 200 for installation-only (no resource), 201 for resource provisioning
+        const provisioned = response as AutoProvisionedResponse;
+        res.status(provisioned.resource ? 201 : 200);
         res.json(response);
       }
     }

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -787,6 +787,22 @@ describe('integration add (auto-provision)', () => {
     });
   });
 
+  describe('installation-only integrations', () => {
+    it('should succeed with "already installed" message when resource is null', async () => {
+      useAutoProvision({ responseKey: 'installed' });
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Acme Product by Acme Integration is already installed'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+  });
+
   describe('--name flag', () => {
     beforeEach(() => {
       useAutoProvision({ responseKey: 'provisioned' });


### PR DESCRIPTION
## Summary

- The auto-provision API returns `kind: 'provisioned'` with `resource: null` for installation-only integrations (like Sentry) that are already installed (see [vercel/api#61372](https://github.com/vercel/api/pull/61372))
- Make `resource` nullable on `AutoProvisionedResponse` and handle null gracefully — show "already installed" message and exit 0 instead of crashing on `result.resource.id`

## Test plan

- [x] All 74 auto-provision tests pass (73 existing + 1 new)
- [x] New test: provisioned response with `resource: null` shows "already installed" and exits 0

## Dependencies

- Requires API change: [vercel/api#61372](https://github.com/vercel/api/pull/61372)

Fixes: [MKT-2913](https://linear.app/vercel/issue/MKT-2913/update-selectbillingplan-method-for-correct-endpoint-usage)