### PR TITLE
feat(cli): open browser for terms acceptance in agent/non-TTY mode

### DIFF
--- a/.changeset/mkt-2912-browser-terms-acceptance.md
+++ b/.changeset/mkt-2912-browser-terms-acceptance.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+feat(cli): open browser for terms acceptance when running as AI agent or non-TTY

--- a/packages/cli/src/util/integration/accept-terms-via-browser.ts
+++ b/packages/cli/src/util/integration/accept-terms-via-browser.ts
@@ -1,0 +1,67 @@
+import open from 'open';
+import output from '../../output-manager';
+import sleep from '../sleep';
+import type Client from '../client';
+import type { Integration, IntegrationInstallation } from './types';
+import { fetchInstallations } from './fetch-installations';
+
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 300_000; // 5 minutes
+
+/**
+ * Opens a browser window for the user to accept terms and conditions,
+ * then polls for the installation to appear.
+ *
+ * Used when the CLI is running in a non-interactive context (AI agent or non-TTY)
+ * where interactive terminal prompts are not possible.
+ */
+export async function acceptTermsViaBrowser(
+  client: Client,
+  teamId: string,
+  integration: Integration
+): Promise<IntegrationInstallation | null> {
+  const url = new URL('/api/marketplace/cli', 'https://vercel.com');
+  url.searchParams.set('cmd', 'accept-terms');
+  url.searchParams.set('integrationId', integration.id);
+  url.searchParams.set('source', 'cli');
+
+  output.log(
+    `Opening browser to accept terms for ${integration.name}...`
+  );
+  output.log(
+    'Please accept the terms and conditions in your browser to continue.'
+  );
+
+  output.debug(`Opening URL: ${url.href}`);
+  open(url.href).catch((err: unknown) =>
+    output.debug(`Failed to open browser: ${err}`)
+  );
+
+  output.spinner('Waiting for terms acceptance in browser...');
+
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < POLL_TIMEOUT_MS) {
+    await sleep(POLL_INTERVAL_MS);
+
+    try {
+      const installations = await fetchInstallations(client, integration);
+      const teamInstallation = installations.find(
+        i => i.ownerId === teamId && i.installationType === 'marketplace'
+      );
+
+      if (teamInstallation) {
+        output.stopSpinner();
+        output.success('Terms accepted successfully.');
+        return teamInstallation;
+      }
+    } catch {
+      // Keep polling on transient errors
+      output.debug('Polling for installation failed, retrying...');
+    }
+  }
+
+  output.stopSpinner();
+  output.error('Timed out waiting for terms acceptance. Please try again.');
+  return null;
+}


### PR DESCRIPTION
## Summary
- When an AI agent or non-TTY environment tries to install a Marketplace integration that requires terms acceptance, instead of failing with an error, the CLI now opens a browser window for the user to accept terms
- Polls for the installation to appear (every 2s, up to 5 min timeout), then continues with provisioning
- Both legacy and auto-provision code paths are supported

## New file
- `packages/cli/src/util/integration/accept-terms-via-browser.ts` — Opens browser to `/api/marketplace/cli?cmd=accept-terms`, polls `fetchInstallations()` until installation appears

## Modified files
- `packages/cli/src/commands/integration/add.ts` — Route agent/non-TTY to browser flow instead of `promptForTermAcceptance()`
- `packages/cli/src/commands/integration/add-auto-provision.ts` — Same change for auto-provision path

## Test plan
- [ ] Agent detection: Run with `CLAUDECODE=1` env var, verify browser opens for terms
- [ ] Non-TTY: Pipe command (`echo | vercel integration add supabase`), verify browser opens
- [ ] TTY: Run normally in terminal, verify interactive prompts still work
- [ ] Already installed: Verify terms step is skipped entirely (existing behavior preserved)
- [ ] Timeout: Verify graceful timeout message after 5 minutes without acceptance

## Companion PR
- Front: https://github.com/vercel/front/pull/62920

Fixes: [MKT-2912](https://linear.app/vercel/issue/MKT-2912/explore-opening-a-browser-window-to-accept-terms-and-conditions-when)