### PR TITLE
fix(cli): show auto-detected region fields in integration add --help

### DIFF
--- a/.changeset/mkt-2904-auto-detected-region-help.md
+++ b/.changeset/mkt-2904-auto-detected-region-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): show "(auto-detected)" instead of "(required)" for region fields in `integration add --help` when auto-provision is active

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -155,8 +155,12 @@ export async function addAutoProvision(
       }
       return 1;
     }
-    // Validate all required fields are present
-    if (!validateAndPrintRequiredMetadata(parsed, product.metadataSchema)) {
+    // Validate all required fields are present (skip region — auto-detected by server)
+    if (
+      !validateAndPrintRequiredMetadata(parsed, product.metadataSchema, {
+        skipAutoRegion: true,
+      })
+    ) {
       return 1;
     }
     metadata = parsed;

--- a/packages/cli/src/commands/integration/add-help.ts
+++ b/packages/cli/src/commands/integration/add-help.ts
@@ -51,7 +51,10 @@ export async function printAddDynamicHelp(
           formatMetadataSchemaHelp(
             product.metadataSchema,
             integrationSlug,
-            metadataProductSlug
+            metadataProductSlug,
+            {
+              autoRegion: process.env.FF_AUTO_PROVISION_INSTALL === '1',
+            }
           )
         );
       }

--- a/packages/cli/src/util/integration/format-schema-help.ts
+++ b/packages/cli/src/util/integration/format-schema-help.ts
@@ -84,15 +84,31 @@ function generateExample(
 }
 
 /**
+ * Whether a field uses a vercel-region control that is auto-detected
+ * by the auto-provision API endpoint.
+ */
+export function isAutoDetectedRegion(prop: MetadataSchemaProperty): boolean {
+  const control = prop['ui:control'];
+  return control === 'vercel-region' || control === 'multi-vercel-region';
+}
+
+export interface FormatMetadataSchemaHelpOptions {
+  /** When true, vercel-region fields show "(auto-detected)" instead of "(required)" */
+  autoRegion?: boolean;
+}
+
+/**
  * Format metadata schema as help text for CLI display
  * @param schema The metadata schema to format
  * @param integrationName The integration slug/name
  * @param productSlug Optional product slug (for multi-product integrations, shown as integration/product)
+ * @param options Optional formatting options
  */
 export function formatMetadataSchemaHelp(
   schema: MetadataSchema,
   integrationName: string,
-  productSlug?: string
+  productSlug?: string,
+  options?: FormatMetadataSchemaHelpOptions
 ): string {
   const lines: string[] = [];
   lines.push('');
@@ -117,7 +133,13 @@ export function formatMetadataSchemaHelp(
     }
 
     const isRequired = required.has(key);
-    const requiredSuffix = isRequired ? chalk.red(' (required)') : '';
+    const isRegionAuto =
+      isRequired && options?.autoRegion && isAutoDetectedRegion(prop);
+    const requiredSuffix = isRequired
+      ? isRegionAuto
+        ? chalk.dim(' (auto-detected)')
+        : chalk.red(' (required)')
+      : '';
 
     const typeHint =
       prop.type === 'boolean'


### PR DESCRIPTION
When the auto-provision flow is active (FF_AUTO_PROVISION_INSTALL=1),
vercel-region and multi-vercel-region metadata fields now display
"(auto-detected)" instead of "(required)" in --help output, since the
server handles region selection automatically. Validation also skips
these fields in auto-provision mode.

Fixes MKT-2904

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>