### PR TITLE
feat(cli): add --installation-id flag for auto-provision with multiple installations

### DIFF
--- a/.changeset/cli-installation-id-flag.md
+++ b/.changeset/cli-installation-id-flag.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(cli): add `--installation-id` flag for `integration add` / `install` to handle multiple installations

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -47,7 +47,8 @@ type AddOptions = PostProvisionOptions;
 export async function add(
   client: Client,
   args: string[],
-  flags: IntegrationAddFlags
+  flags: IntegrationAddFlags,
+  commandName?: 'integration add' | 'install'
 ) {
   const resourceNameArg = flags['--name'];
   const metadataFlags = flags['--metadata'];
@@ -59,6 +60,7 @@ export async function add(
     );
     return 1;
   }
+  const installationId = flags['--installation-id'];
   const options: AddOptions = {
     noConnect: flags['--no-connect'],
     noEnvPull: flags['--no-env-pull'],
@@ -114,10 +116,12 @@ export async function add(
       productSlug,
       metadata: metadataFlags,
       billingPlanId,
+      installationId,
       noConnect: options.noConnect,
       noEnvPull: options.noEnvPull,
       environments: options.environments,
       prefix,
+      commandName,
     });
   }
 

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -71,6 +71,15 @@ export const addSubcommand = {
       description:
         'Prefix for environment variable names (e.g., --prefix NEON2_ creates NEON2_DATABASE_URL instead of DATABASE_URL)',
     },
+    {
+      name: 'installation-id',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      argument: 'ID',
+      description:
+        'Installation ID to use when multiple installations exist for the integration',
+    },
   ],
   examples: [
     {

--- a/packages/cli/src/util/integration/auto-provision-resource.ts
+++ b/packages/cli/src/util/integration/auto-provision-resource.ts
@@ -29,7 +29,8 @@ export async function autoProvisionResource(
   name: string,
   metadata: Metadata,
   acceptedPolicies: AcceptedPolicies,
-  billingPlanId?: string
+  billingPlanId?: string,
+  installationId?: string
 ): Promise<AutoProvisionResult> {
   const endpoint = `/v1/integrations/integration/${encodeURIComponent(integrationSlug)}/marketplace/auto-provision/${encodeURIComponent(productSlug)}`;
   const body = {
@@ -38,6 +39,7 @@ export async function autoProvisionResource(
     acceptedPolicies,
     source: 'cli',
     ...(billingPlanId ? { billingPlanId } : {}),
+    ...(installationId ? { installationId } : {}),
   };
   output.debug(`Auto-provision request: POST ${endpoint}`);
   output.debug(`Auto-provision body: ${JSON.stringify(body, null, 2)}`);

--- a/packages/cli/src/util/integration/format-dynamic-examples.ts
+++ b/packages/cli/src/util/integration/format-dynamic-examples.ts
@@ -104,6 +104,16 @@ export function formatDynamicExamples(
     `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --prefix NEON2_`)}`
   );
 
+  // Installation ID (only when auto-provision FF is enabled)
+  if (process.env.FF_AUTO_PROVISION_INSTALL === '1') {
+    lines.push('');
+    lines.push(`  ${chalk.dim('-')} Install using a specific installation`);
+    lines.push('');
+    lines.push(
+      `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --installation-id <id>`)}`
+    );
+  }
+
   lines.push('');
 
   return lines.join('\n');

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -226,6 +226,13 @@ export interface AutoProvisionedResponse {
   billingPlan: BillingPlan | null;
 }
 
+export interface AutoProvisionInstallationInfo {
+  id: string;
+  type?: 'marketplace' | 'external';
+  externalId?: string;
+  status?: string;
+}
+
 export interface AutoProvisionFallback {
   kind: string;
   reason?: string;
@@ -234,6 +241,7 @@ export interface AutoProvisionFallback {
   integration: AutoProvisionIntegration;
   product: AutoProvisionProduct;
   installation?: { id: string };
+  installations?: AutoProvisionInstallationInfo[];
 }
 
 export type AutoProvisionResult =

--- a/packages/cli/src/util/telemetry/commands/integration/add.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/add.ts
@@ -63,6 +63,15 @@ export class IntegrationAddTelemetryClient
     }
   }
 
+  trackCliOptionInstallationId(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'installation-id',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackMarketplaceEvent(event: string, props: Record<string, unknown>) {
     this.trackCommandOutput({
       key: event,

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -1029,6 +1029,22 @@ const autoProvisionResponses: Record<
     integration: autoProvisionIntegration,
     product: autoProvisionProduct,
   },
+  multiple_installations: {
+    kind: 'unknown',
+    reason: 'multiple_installations',
+    url: 'https://vercel.com/acme/~/integrations/checkout/acme?productSlug=acme',
+    integration: autoProvisionIntegration,
+    product: autoProvisionProduct,
+    installations: [
+      { id: 'icfg_marketplace_1', type: 'marketplace', status: 'active' },
+      {
+        id: 'icfg_external_1',
+        type: 'external',
+        externalId: 'aws-account-123',
+        status: 'active',
+      },
+    ],
+  },
 };
 
 const discoverIntegrations = [
@@ -1383,6 +1399,17 @@ export function useAutoProvision(opts?: {
     '/v1/integrations/integration/:integrationSlug/marketplace/auto-provision/:productSlug',
     (req, res) => {
       requestBodies.push(req.body);
+
+      // When installationId is provided and responseKey is multiple_installations,
+      // simulate the server accepting the selection and provisioning successfully
+      if (
+        req.body.installationId &&
+        opts?.responseKey === 'multiple_installations'
+      ) {
+        res.status(201);
+        res.json(autoProvisionResponses['provisioned']);
+        return;
+      }
 
       const response =
         autoProvisionResponses[opts?.responseKey ?? 'provisioned'];

--- a/packages/cli/test/unit/util/integration/format-dynamic-examples.test.ts
+++ b/packages/cli/test/unit/util/integration/format-dynamic-examples.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { formatDynamicExamples } from '../../../../src/util/integration/format-dynamic-examples';
 import { addSubcommand } from '../../../../src/commands/integration/command';
 import type { IntegrationProduct } from '../../../../src/util/integration/types';
@@ -31,6 +31,14 @@ const productWithSchema: IntegrationProduct[] = [
 ];
 
 describe('formatDynamicExamples', () => {
+  beforeEach(() => {
+    process.env.FF_AUTO_PROVISION_INSTALL = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.FF_AUTO_PROVISION_INSTALL;
+  });
+
   it('should include an example for every addSubcommand option', () => {
     const output = stripAnsi(
       formatDynamicExamples('test-integration', productWithSchema)


### PR DESCRIPTION
## Summary
- Adds `--installation-id` flag to `vc integration add` / `vc install`
- When the auto-provision API returns `multiple_installations`, prints a helpful error listing each installation (id, type, externalId, status) and a suggested re-run command
- When `--installation-id` is provided, passes it in the API request body so the server uses that specific installation

## Test plan

### Unit Tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/add-auto-provision.test.ts test/unit/commands/integration/add.test.ts

 ✓ test/unit/commands/integration/add-auto-provision.test.ts  (78 tests)
 ✓ test/unit/commands/integration/add.test.ts  (75 tests)

 Test Files  2 passed (2)
      Tests  153 passed (153)
```

### Manual Testing

| Test | Command | Result |
|------|---------|--------|
| `--help` shows new flag | `vc integration add --help` | `--installation-id <ID>  Installation ID to use when multiple installations exist` |
| `--installation-id` requires value | `vc integration add prisma --installation-id` | `Error: option requires argument: --installation-id` |
| `installationId` sent in POST body | `FF=1 vc integration add neon --installation-id fake_test_id_12345 --debug` | Body contains `"installationId": "fake_test_id_12345"`. API returned `Installation fake_test_id_12345 is not eligible for provisioning (400)` — confirms passthrough. |
| Normal provision (no regression) | `FF=1 vc integration add neon` | `Success! Neon successfully provisioned: neon-citron-drum` |
| `multiple_installations` error | N/A | Unit only — requires team with duplicate installations (unusual admin state). |

**Debug log evidence** (`--installation-id fake_test_id_12345`):
```
> [debug] Auto-provision request: POST /v1/integrations/integration/neon/marketplace/auto-provision/neon
> [debug] Auto-provision body: {
  "name": "neon-ancient-snow",
  "metadata": {},
  "acceptedPolicies": {},
  "source": "cli",
  "installationId": "fake_test_id_12345"
}
> [debug] Auto-provision error: Error: Installation fake_test_id_12345 is not eligible for provisioning (400)
```

**Debug log evidence** (without `--installation-id` — no `installationId` in body):
```
> [debug] Auto-provision request: POST /v1/integrations/integration/neon/marketplace/auto-provision/neon
> [debug] Auto-provision body: {
  "name": "neon-citron-drum",
  "metadata": {},
  "acceptedPolicies": {},
  "source": "cli"
}
> [debug] #7 ← 201 Created
```

### Code Paths Covered

| Path | Verified by |
|------|------------|
| Flag parsed by arg parser | Manual (`--help`, missing-value error) |
| `installationId` in POST body | Manual (neon `--debug`) + Unit |
| `installationId` absent when flag not passed | Manual (neon `--debug`) |
| `multiple_installations` → error with installation list | Unit |
| List includes type, externalId, status | Unit |
| Suggested command includes product slug for `slug/product` | Unit |
| `--installation-id` resolves multi-install → provisions | Unit |
| Telemetry tracks `--installation-id` | Unit |

Fixes: [MKT-2711](https://linear.app/vercel/issue/MKT-2711/investigate-what-happens-when-multiple-installations-exist-for-an)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new CLI flag (--installation-id) for handling multiple installations, with feature flag gating, error handling, and comprehensive tests - no security, auth, or data changes.
> 
> - Adds `--installation-id` CLI flag gated behind `FF_AUTO_PROVISION_INSTALL` feature flag
> - Handles `multiple_installations` API response with helpful error message listing installations
> - Extensive unit tests covering flag parsing, FF gating, and error messages
>
> <sup>Risk assessment for [commit d8c88c4](https://github.com/vercel/vercel/commit/d8c88c4fb2ea12b5078cd9a4a064cc008cb6e2eb).</sup>
<!-- VADE_RISK_END -->