### PR TITLE
fix(config): convert path-to-regexp patterns to regex in getConfig()

### DIFF
--- a/.changeset/fix-404-getconfig-conversion.md
+++ b/.changeset/fix-404-getconfig-conversion.md
@@ -1,0 +1,5 @@
+---
+"@vercel/config": patch
+---
+
+Fix path-to-regexp pattern conversion in getConfig() when converting redirects, rewrites, and headers to routes format

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -544,4 +544,53 @@ describe('Router', () => {
       expect(route.transforms[0].env).toEqual(['REGION', 'DATACENTER']);
     });
   });
+
+  describe('getConfig', () => {
+    it('should return routes when route() is used', () => {
+      router.route({
+        src: '^\\/test$',
+        dest: '/dest',
+      });
+
+      const config = router.getConfig();
+      expect(config.routes).toBeDefined();
+      expect(config.routes).toHaveLength(1);
+      expect(config.routes?.[0].src).toBe('^\\/test$');
+    });
+
+    it('should include rewrites with transforms as routes', () => {
+      const route = router.rewrite(
+        '/api/:path*',
+        'https://backend.example.com/$1',
+        {
+          requestHeaders: {
+            authorization: deploymentEnv('API_KEY'),
+          },
+        }
+      );
+
+      // The rewrite should already have the converted regex
+      expect(route).toMatchObject({
+        src: '^\\/api(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
+        dest: 'https://backend.example.com/$1',
+      });
+    });
+
+    it('should convert destination params correctly when route uses path params', () => {
+      const route = router.rewrite(
+        '/users/:userId/posts/:postId',
+        'https://api.example.com/users/$1/posts/$2',
+        ({ userId }) => ({
+          requestHeaders: {
+            'x-user-id': userId,
+          },
+        })
+      );
+
+      expect(route).toMatchObject({
+        src: '^\\/users(?:\\/([^\\/]+?))\\/posts(?:\\/([^\\/]+?))$',
+        dest: 'https://api.example.com/users/$1/posts/$2',
+      });
+    });
+  });
 });

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -1212,9 +1212,13 @@ export class Router {
 
     // Convert rewrites to routes
     const routesFromRewrites: Route[] = rewritesNeedingRoutes.map(rewrite => {
+      // Convert path-to-regexp patterns to regex for routes format
+      const { src: regexSrc, segments } = sourceToRegex(rewrite.source);
+      const convertedDest = convertDestination(rewrite.destination, segments);
+
       const route: Route = {
-        src: rewrite.source,
-        dest: rewrite.destination,
+        src: regexSrc,
+        dest: convertedDest,
       };
       if (rewrite.transforms) route.transforms = rewrite.transforms;
       if (rewrite.methods) route.methods = rewrite.methods;
@@ -1233,9 +1237,18 @@ export class Router {
       // Convert standalone redirects to routes
       const routesFromRedirects: Route[] = this.redirectRules.map(
         redirectRule => {
+          // Convert path-to-regexp patterns to regex for routes format
+          const { src: regexSrc, segments } = sourceToRegex(
+            redirectRule.source
+          );
+          const convertedDest = convertDestination(
+            redirectRule.destination,
+            segments
+          );
+
           const route: Route = {
-            src: redirectRule.source,
-            dest: redirectRule.destination,
+            src: regexSrc,
+            dest: convertedDest,
             status:
               redirectRule.statusCode || (redirectRule.permanent ? 308 : 307),
           };
@@ -1247,9 +1260,13 @@ export class Router {
 
       // Convert legacy rewrites (without transforms) to routes
       const routesFromLegacyRewrites: Route[] = legacyRewrites.map(rewrite => {
+        // Convert path-to-regexp patterns to regex for routes format
+        const { src: regexSrc, segments } = sourceToRegex(rewrite.source);
+        const convertedDest = convertDestination(rewrite.destination, segments);
+
         const route: Route = {
-          src: rewrite.source,
-          dest: rewrite.destination,
+          src: regexSrc,
+          dest: convertedDest,
         };
         if (rewrite.has) route.has = rewrite.has;
         if (rewrite.missing) route.missing = rewrite.missing;
@@ -1266,6 +1283,9 @@ export class Router {
           return !isCachingHeader;
         })
         .map(headerRule => {
+          // Convert path-to-regexp patterns to regex for routes format
+          const { src: regexSrc } = sourceToRegex(headerRule.source);
+
           const transforms: Transform[] = headerRule.headers.map(header => ({
             type: 'response.headers' as TransformType,
             op: 'set' as TransformOp,
@@ -1274,7 +1294,7 @@ export class Router {
           }));
 
           const route: Route = {
-            src: headerRule.source,
+            src: regexSrc,
             transforms,
           };
           if (headerRule.has) route.has = headerRule.has;


### PR DESCRIPTION
The previous fix (#15134) only addressed pattern conversion when rewrite() and redirect() methods returned Route objects with transforms or env vars. This fix extends the conversion to the getConfig() method, which converts redirects, rewrites, and headers to routes format when routes are present.

Without this fix, patterns like `:path*` would be passed through literally instead of being converted to proper regex, causing 404 errors.

https://claude.ai/code/session_01CeTsDHjUb1wrKjMEBCsv87