### PR TITLE
[cli] Send cache tags as array with comma encoding in invalidate and dangerously-delete commands

### DIFF
--- a/.changeset/cli-cache-tag-encoding.md
+++ b/.changeset/cli-cache-tag-encoding.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Send cache tags as an array instead of a comma-separated string in `cache invalidate` and `cache dangerously-delete` CLI commands, encoding commas with `!` for consistency with `@vercel/functions`.

--- a/packages/cli/src/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/commands/cache/dangerously-delete.ts
@@ -66,11 +66,12 @@ export default async function dangerouslyDelete(
   let postUrl = '';
   let postBody = {};
   if (tag) {
-    itemName = plural('tag', tag.split(',').length, false);
+    const tags = tag.split(',').map((t: string) => t.replace(/,/g, '!'));
+    itemName = plural('tag', tags.length, false);
     itemValue = tag;
     flag = '--tag';
     postUrl = '/v1/edge-cache/dangerously-delete-by-tags';
-    postBody = { tags: tag, revalidationDeadlineSeconds: revalidate };
+    postBody = { tags, revalidationDeadlineSeconds: revalidate };
   } else if (srcimg) {
     itemName = 'source image';
     itemValue = srcimg;

--- a/packages/cli/src/commands/cache/invalidate.ts
+++ b/packages/cli/src/commands/cache/invalidate.ts
@@ -64,11 +64,12 @@ export default async function invalidate(
   let postUrl = '';
   let postBody = {};
   if (tag) {
-    itemName = plural('tag', tag.split(',').length, false);
+    const tags = tag.split(',').map((t: string) => t.replace(/,/g, '!'));
+    itemName = plural('tag', tags.length, false);
     itemValue = tag;
     flag = '--tag';
     postUrl = '/v1/edge-cache/invalidate-by-tags';
-    postBody = { tags: tag };
+    postBody = { tags };
   } else if (srcimg) {
     itemName = 'source image';
     itemValue = srcimg;

--- a/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
+++ b/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
@@ -56,7 +56,7 @@ describe('cache dangerously-delete', () => {
       `/v1/edge-cache/dangerously-delete-by-tags`,
       (req, res) => {
         expect(req.body).toEqual({
-          tags: 'foo',
+          tags: ['foo'],
         });
         res.end();
       }
@@ -74,7 +74,7 @@ describe('cache dangerously-delete', () => {
       `/v1/edge-cache/dangerously-delete-by-tags`,
       (req, res) => {
         expect(req.body).toEqual({
-          tags: 'foo,bar,baz',
+          tags: ['foo', 'bar', 'baz'],
         });
         res.end();
       }
@@ -92,7 +92,7 @@ describe('cache dangerously-delete', () => {
       `/v1/edge-cache/dangerously-delete-by-tags`,
       (req, res) => {
         expect(req.body).toEqual({
-          tags: 'foo',
+          tags: ['foo'],
           revalidationDeadlineSeconds: 60,
         });
         res.end();

--- a/packages/cli/test/unit/commands/cache/invalidate.test.ts
+++ b/packages/cli/test/unit/commands/cache/invalidate.test.ts
@@ -51,7 +51,7 @@ describe('cache invalidate', () => {
   it('should succeed with --tag', async () => {
     client.scenario.post(`/v1/edge-cache/invalidate-by-tags`, (req, res) => {
       expect(req.body).toEqual({
-        tags: 'foo',
+        tags: ['foo'],
       });
       res.end();
     });
@@ -66,7 +66,7 @@ describe('cache invalidate', () => {
   it('should succeed with multiple tags', async () => {
     client.scenario.post(`/v1/edge-cache/invalidate-by-tags`, (req, res) => {
       expect(req.body).toEqual({
-        tags: 'foo,bar,baz',
+        tags: ['foo', 'bar', 'baz'],
       });
       res.end();
     });


### PR DESCRIPTION
### TL;DR

Modified cache invalidation and deletion commands to send tags as arrays instead of comma-separated strings to the API.

### What changed?

The `cache invalidate` and `cache dangerously-delete` commands now parse comma-separated tag strings into arrays before sending them to the API endpoints. The tag processing logic splits on commas and replaces any remaining commas with exclamation marks to handle edge cases.

### How to test?

Run the cache commands with single and multiple tags:
- `vercel cache invalidate --tag foo`
- `vercel cache invalidate --tag foo,bar,baz`
- `vercel cache dangerously-delete --tag foo`
- `vercel cache dangerously-delete --tag foo,bar,baz --revalidate 60`

Verify that the API receives the tags as an array format instead of a string.

### Why make this change?

This change aligns the CLI with the expected API format where tags should be sent as an array rather than a comma-separated string, ensuring proper communication between the client and server.