### PR TITLE
[CODEOWNERS] Add @vercel/team-python to go, ruby, and rust builders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,9 @@
 /packages/static-build                   @vercel/ci-cd
 /packages/edge                           @vercel/ci-cd @vercel/compute
 /packages/functions                      @vercel/ci-cd @vercel/compute @kldavis4
-/packages/rust                           @vercel/ci-cd @vercel/compute @ecklf
+/packages/go                             @vercel/ci-cd @vercel/team-python
+/packages/ruby                           @vercel/ci-cd @vercel/team-python
+/packages/rust                           @vercel/ci-cd @vercel/team-python @vercel/compute @ecklf
 /crates                                  @vercel/ci-cd @vercel/compute @ecklf
 /Cargo.*                                 @vercel/ci-cd @vercel/compute @ecklf
 /packages/firewall                       @vercel/ci-cd @cramforce @sueplex @quuu @ctgowrie


### PR DESCRIPTION
Adds @vercel/team-python to go, ruby, and rust builders