### PR TITLE
Revert "Support per function regions from vercel.json (#15149)"

### DIFF
--- a/.changeset/giant-pugs-try.md
+++ b/.changeset/giant-pugs-try.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Revert per function builder support

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1427,8 +1427,6 @@ export async function serverBuild({
         memory: group.memory,
         runtime: nodeVersion.runtime,
         maxDuration: group.maxDuration,
-        regions: group.regions,
-        functionFailoverRegions: group.functionFailoverRegions,
         supportsCancellation: group.supportsCancellation,
         isStreaming: group.isStreaming,
         nextVersion,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1872,24 +1872,10 @@ export function addLocaleOrDefault(
     : pathname;
 }
 
-function regionsArrayEqual(
-  a: string[] | undefined,
-  b: string[] | undefined
-): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  if (a.length !== b.length) return false;
-  const sortedA = [...a].sort();
-  const sortedB = [...b].sort();
-  return sortedA.every((val, i) => val === sortedB[i]);
-}
-
 export type LambdaGroup = {
   pages: string[];
   memory?: number;
   maxDuration?: number;
-  regions?: string[];
-  functionFailoverRegions?: string[];
   supportsCancellation?: boolean;
   isAppRouter?: boolean;
   isAppRouteHandler?: boolean;
@@ -1961,8 +1947,6 @@ export async function getPageLambdaGroups({
       architecture?: NodejsLambda['architecture'];
       memory?: number;
       maxDuration?: number;
-      regions?: string[];
-      functionFailoverRegions?: string[];
       experimentalTriggers?: NodejsLambda['experimentalTriggers'];
       supportsCancellation?: boolean;
     } = {};
@@ -2042,11 +2026,6 @@ export async function getPageLambdaGroups({
           const matches =
             group.maxDuration === opts.maxDuration &&
             group.memory === opts.memory &&
-            regionsArrayEqual(group.regions, opts.regions) &&
-            regionsArrayEqual(
-              group.functionFailoverRegions,
-              opts.functionFailoverRegions
-            ) &&
             group.isPrerenders === isPrerenderRoute &&
             group.isExperimentalPPR === isExperimentalPPR &&
             JSON.stringify(group.experimentalTriggers) ===

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -5,12 +5,6 @@
       "use": "@vercel/next",
       "config": {
         "functions": {
-          "app/dashboard/page.js": {
-            "maxDuration": 5,
-            "memory": 512,
-            "regions": ["iad1", "sfo1"],
-            "functionFailoverRegions": ["pdx1"]
-          },
           "app/**/*": {
             "maxDuration": 5,
             "memory": 512

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -135,13 +135,6 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
     expect(buildResult.output['dashboard'].fallback.fsPath).toMatch(
       /server\/app\/dashboard\.html$/
     );
-    expect(buildResult.output['dashboard'].lambda.regions).toEqual([
-      'iad1',
-      'sfo1',
-    ]);
-    expect(
-      buildResult.output['dashboard'].lambda.functionFailoverRegions
-    ).toEqual(['pdx1']);
     expect(buildResult.output['dashboard.rsc'].type).toBe('Prerender');
     expect(buildResult.output['dashboard.rsc'].fallback.fsPath).toMatch(
       /server\/app\/dashboard\.rsc$/


### PR DESCRIPTION
This reverts commit 5d1f55af04d0fdba7e7ac86f9eeda44316f54f5b.

Vercel build system does not properly support per function regions yet, so revert this PR temporarily while we land more robust support there.