### PR TITLE
Revert "[functions] URL encode cache tags"

### DIFF
--- a/.changeset/revert-url-encode.md
+++ b/.changeset/revert-url-encode.md
@@ -1,0 +1,6 @@
+---
+'@vercel/functions': patch
+---
+
+[functions] Revert "[functions] URL encode cache tags"
+

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -261,7 +261,7 @@ An instance of the Vercel Runtime Cache.
 
 #### Defined in
 
-[packages/functions/src/cache/index.ts:55](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L55)
+[packages/functions/src/cache/index.ts:33](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L33)
 
 ---
 

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -13,28 +13,6 @@ const defaultKeyHashFunction = (key: string) => {
 
 const defaultNamespaceSeparator = '$';
 
-function encodeTags(tags: string[]): string[] {
-  return tags.map(encodeURIComponent);
-}
-
-function encodeTag(tag: string | string[]): string | string[] {
-  return Array.isArray(tag) ? encodeTags(tag) : encodeURIComponent(tag);
-}
-
-function encodeOptions(options?: {
-  name?: string;
-  tags?: string[];
-  ttl?: number;
-}): { name?: string; tags?: string[]; ttl?: number } | undefined {
-  if (!options) {
-    return undefined;
-  }
-  if (options.tags && options.tags.length > 0) {
-    return { ...options, tags: encodeTags(options.tags) };
-  }
-  return options;
-}
-
 let inMemoryCacheInstance: InMemoryCache | null = null;
 let buildCacheInstance: BuildCache | null = null;
 
@@ -97,17 +75,13 @@ function wrapWithKeyTransformation(
       value: unknown,
       options?: { name?: string; tags?: string[]; ttl?: number }
     ) => {
-      const encodedOptions = encodeOptions(options);
-      if (encodedOptions) {
-        return resolveCache().set(makeKey(key), value, encodedOptions);
-      }
-      return resolveCache().set(makeKey(key), value);
+      return resolveCache().set(makeKey(key), value, options);
     },
     delete: (key: string) => {
       return resolveCache().delete(makeKey(key));
     },
     expireTag: (tag: string | string[]) => {
-      return resolveCache().expireTag(encodeTag(tag));
+      return resolveCache().expireTag(tag);
     },
   };
 }

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -35,8 +35,8 @@ describe('getCache', () => {
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
-    expect(mockCache.set).toHaveBeenCalledWith('b876d32', 'value');
-    expect(mockCache.get).toHaveBeenCalledWith('b876d32');
+    expect(mockCache.set).toHaveBeenCalledWith('b876d32', 'value', undefined);
+    expect(mockCache.get).toHaveBeenCalledWith('b876d32', undefined);
   });
 
   test('should return the same cache instance for multiple calls to getCache when no context cache is available', async () => {
@@ -77,7 +77,11 @@ describe('getCache', () => {
     });
     await cache.set('key', 'value');
     expect(customHashFunction).toHaveBeenCalledWith('key');
-    expect(mockCache.set).toHaveBeenCalledWith('custom-key', 'value');
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'custom-key',
+      'value',
+      undefined
+    );
   });
 
   test('should use the default key hash function if none is provided', async () => {
@@ -85,7 +89,7 @@ describe('getCache', () => {
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
-    expect(mockCache.get).toHaveBeenCalledWith('b876d32');
+    expect(mockCache.get).toHaveBeenCalledWith('b876d32', undefined);
   });
 
   test('should use the provided namespace and separator', async () => {
@@ -96,8 +100,12 @@ describe('getCache', () => {
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
-    expect(mockCache.set).toHaveBeenCalledWith('test:b876d32', 'value');
-    expect(mockCache.get).toHaveBeenCalledWith('test:b876d32');
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'test:b876d32',
+      'value',
+      undefined
+    );
+    expect(mockCache.get).toHaveBeenCalledWith('test:b876d32', undefined);
   });
 
   test('should use the default namespace separator if none is provided', async () => {
@@ -106,38 +114,14 @@ describe('getCache', () => {
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
-    expect(mockCache.set).toHaveBeenCalledWith(`${namespace}$b876d32`, 'value');
-    expect(mockCache.get).toHaveBeenCalledWith(`${namespace}$b876d32`);
-  });
-
-  test('should URL encode tags in set', async () => {
-    const cache = getCache();
-    await cache.set('key', 'value', {
-      tags: ['tag with spaces', 'tag&special=chars', 'tag,with,commas'],
-    });
-    expect(mockCache.set).toHaveBeenCalledWith('b876d32', 'value', {
-      tags: [
-        'tag%20with%20spaces',
-        'tag%26special%3Dchars',
-        'tag%2Cwith%2Ccommas',
-      ],
-    });
-  });
-
-  test('should URL encode tags in expireTag with string', async () => {
-    vitest.spyOn(mockCache, 'expireTag');
-    const cache = getCache();
-    await cache.expireTag('tag&special');
-    expect(mockCache.expireTag).toHaveBeenCalledWith('tag%26special');
-  });
-
-  test('should URL encode tags in expireTag with array', async () => {
-    vitest.spyOn(mockCache, 'expireTag');
-    const cache = getCache();
-    await cache.expireTag(['tag one', 'tag&two']);
-    expect(mockCache.expireTag).toHaveBeenCalledWith([
-      'tag%20one',
-      'tag%26two',
-    ]);
+    expect(mockCache.set).toHaveBeenCalledWith(
+      `${namespace}$b876d32`,
+      'value',
+      undefined
+    );
+    expect(mockCache.get).toHaveBeenCalledWith(
+      `${namespace}$b876d32`,
+      undefined
+    );
   });
 });


### PR DESCRIPTION
Reverts vercel/vercel#14749 since this caused a regression when using `:` and other characters in tags.

The expected behavior is that commas split into multiple tags.

<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> Revert removes URL encoding of cache tags, which could allow special characters like commas to be interpreted as tag delimiters, potentially affecting cache invalidation behavior.
> 
> - Removes encodeURIComponent from cache tags in set() and expireTag()
> - Tags with special characters (commas, spaces, ampersands) now passed through unencoded
> - Removes associated URL encoding tests
>
> <sup>Risk assessment for [commit 83d1d76](https://github.com/vercel/vercel/commit/83d1d7601b8ecaf69a01e90cdd612dcd5aeaea30).</sup>
<!-- VADE_RISK_END -->