### PR TITLE
feat(cli): browser-based terms acceptance for non-interactive environments

### DIFF
--- a/.changeset/cli-browser-terms-acceptance.md
+++ b/.changeset/cli-browser-terms-acceptance.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(cli): open browser for terms acceptance in non-interactive environments

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -7,6 +7,7 @@ import getScope from '../../util/get-scope';
 import { autoProvisionResource } from '../../util/integration/auto-provision-resource';
 import { fetchIntegrationWithTelemetry } from '../../util/integration/fetch-integration';
 import { fetchInstallations } from '../../util/integration/fetch-installations';
+import { acceptTermsViaBrowser } from '../../util/integration/accept-terms-via-browser';
 import { promptForTermAcceptance } from '../../util/integration/prompt-for-terms';
 import { selectProduct } from '../../util/integration/select-product';
 import type {
@@ -155,15 +156,33 @@ export async function addAutoProvision(
 
   let acceptedPolicies: AcceptedPolicies = {};
   if (!teamInstallation) {
-    const policies = await promptForTermAcceptance(client, integration);
-    if (!policies) {
-      telemetry.trackMarketplaceEvent('marketplace_install_flow_dropped', {
-        ...baseProps,
-        reason: 'policy_declined',
-      });
-      return 1;
+    if (client.isAgent || !client.stdin.isTTY) {
+      // Browser flow: open browser for terms acceptance, poll for installation
+      const browserInstallation = await acceptTermsViaBrowser(
+        client,
+        integration,
+        team.id
+      );
+      if (!browserInstallation) {
+        telemetry.trackMarketplaceEvent('marketplace_install_flow_dropped', {
+          ...baseProps,
+          reason: 'browser_terms_timeout',
+        });
+        return 1;
+      }
+      // acceptedPolicies stays {} — installation already created with policies in browser
+    } else {
+      // Interactive TTY: keep existing prompt behavior
+      const policies = await promptForTermAcceptance(client, integration);
+      if (!policies) {
+        telemetry.trackMarketplaceEvent('marketplace_install_flow_dropped', {
+          ...baseProps,
+          reason: 'policy_declined',
+        });
+        return 1;
+      }
+      acceptedPolicies = policies;
     }
-    acceptedPolicies = policies;
   }
 
   // Validate metadata flags (if provided) BEFORE prompting for resource name

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -155,13 +155,15 @@ export async function addAutoProvision(
   );
 
   let acceptedPolicies: AcceptedPolicies = {};
+  let browserInstallationId: string | undefined;
   if (!teamInstallation) {
     if (client.isAgent || !client.stdin.isTTY) {
       // Browser flow: open browser for terms acceptance, poll for installation
       const browserInstallation = await acceptTermsViaBrowser(
         client,
         integration,
-        team.id
+        team.id,
+        contextName
       );
       if (!browserInstallation) {
         telemetry.trackMarketplaceEvent('marketplace_install_flow_dropped', {
@@ -170,7 +172,7 @@ export async function addAutoProvision(
         });
         return 1;
       }
-      // acceptedPolicies stays {} — installation already created with policies in browser
+      browserInstallationId = browserInstallation.id;
     } else {
       // Interactive TTY: keep existing prompt behavior
       const policies = await promptForTermAcceptance(client, integration);
@@ -259,7 +261,7 @@ export async function addAutoProvision(
       metadata,
       acceptedPolicies,
       options.billingPlanId,
-      options.installationId
+      browserInstallationId ?? options.installationId
     );
   } catch (error) {
     output.stopSpinner();

--- a/packages/cli/src/util/integration/accept-terms-via-browser.ts
+++ b/packages/cli/src/util/integration/accept-terms-via-browser.ts
@@ -22,7 +22,7 @@ export async function acceptTermsViaBrowser(
   output.log(
     'Opening browser for terms acceptance. Accept the terms to continue...'
   );
-  output.debug(`Opening URL: ${url.href}`);
+  output.log(`Visit this URL if the browser does not open: ${url.href}`);
 
   open(url.href).catch((err: unknown) =>
     output.debug(`Failed to open browser: ${err}`)

--- a/packages/cli/src/util/integration/accept-terms-via-browser.ts
+++ b/packages/cli/src/util/integration/accept-terms-via-browser.ts
@@ -12,11 +12,12 @@ export async function acceptTermsViaBrowser(
   client: Client,
   integration: Integration,
   teamId: string,
+  teamSlug: string,
   timeoutMs: number = DEFAULT_TIMEOUT_MS
 ): Promise<IntegrationInstallation | null> {
-  const url = new URL('https://vercel.com/api/marketplace/cli');
-  url.searchParams.set('cmd', 'accept-terms');
-  url.searchParams.set('integrationId', integration.id);
+  const url = new URL(
+    `https://vercel.com/${encodeURIComponent(teamSlug)}/~/integrations/accept-terms/${encodeURIComponent(integration.slug)}`
+  );
   url.searchParams.set('source', 'cli');
 
   output.log(

--- a/packages/cli/src/util/integration/accept-terms-via-browser.ts
+++ b/packages/cli/src/util/integration/accept-terms-via-browser.ts
@@ -1,0 +1,59 @@
+import open from 'open';
+import output from '../../output-manager';
+import sleep from '../sleep';
+import type Client from '../client';
+import { fetchInstallations } from './fetch-installations';
+import type { Integration, IntegrationInstallation } from './types';
+
+const POLL_INTERVAL_MS = 2000;
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+export async function acceptTermsViaBrowser(
+  client: Client,
+  integration: Integration,
+  teamId: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS
+): Promise<IntegrationInstallation | null> {
+  const url = new URL('https://vercel.com/api/marketplace/cli');
+  url.searchParams.set('cmd', 'accept-terms');
+  url.searchParams.set('integrationId', integration.id);
+  url.searchParams.set('source', 'cli');
+
+  output.log(
+    'Opening browser for terms acceptance. Accept the terms to continue...'
+  );
+  output.debug(`Opening URL: ${url.href}`);
+
+  open(url.href).catch((err: unknown) =>
+    output.debug(`Failed to open browser: ${err}`)
+  );
+
+  output.spinner('Waiting for terms acceptance in browser...');
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+
+    try {
+      const installations = await fetchInstallations(client, integration);
+      const teamInstallation = installations.find(
+        i => i.ownerId === teamId && i.installationType === 'marketplace'
+      );
+
+      if (teamInstallation) {
+        output.stopSpinner();
+        output.success('Terms accepted in browser.');
+        return teamInstallation;
+      }
+    } catch (error) {
+      output.debug(`Polling error (will retry): ${error}`);
+    }
+  }
+
+  output.stopSpinner();
+  output.error(
+    'Timed out waiting for terms acceptance. Please try again and accept terms in the browser within 5 minutes.'
+  );
+  return null;
+}

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -470,7 +470,7 @@ describe('integration add (auto-provision)', () => {
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
       expect(openMock).toHaveBeenCalledWith(
-        expect.stringContaining('cmd=accept-terms')
+        expect.stringContaining('/~/integrations/accept-terms/acme')
       );
     });
 
@@ -502,7 +502,7 @@ describe('integration add (auto-provision)', () => {
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
       expect(openMock).toHaveBeenCalledWith(
-        expect.stringContaining('cmd=accept-terms')
+        expect.stringContaining('/~/integrations/accept-terms/acme')
       );
     });
 
@@ -533,12 +533,13 @@ describe('integration add (auto-provision)', () => {
         client,
         { id: 'acme', slug: 'acme', name: 'Acme Integration' },
         t.id,
+        t.slug,
         100 // 100ms timeout — will expire almost immediately
       );
 
       expect(result).toBeNull();
       expect(openMock).toHaveBeenCalledWith(
-        expect.stringContaining('cmd=accept-terms')
+        expect.stringContaining('/~/integrations/accept-terms/acme')
       );
     });
 
@@ -594,8 +595,7 @@ describe('integration add (auto-provision)', () => {
 
       const calledUrl = openMock.mock.calls[0]?.[0] as string;
       const parsed = new URL(calledUrl);
-      expect(parsed.searchParams.get('cmd')).toEqual('accept-terms');
-      expect(parsed.searchParams.get('integrationId')).toEqual('acme');
+      expect(parsed.pathname).toContain('/~/integrations/accept-terms/acme');
       expect(parsed.searchParams.get('source')).toEqual('cli');
     });
 

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -442,33 +442,161 @@ describe('integration add (auto-provision)', () => {
       expect(exitCode).toEqual(1);
     });
 
-    it('should exit with code 1 in non-TTY mode when no installation exists', async () => {
+    it('should open browser for terms acceptance in non-TTY mode', async () => {
+      client.reset();
+      useUser();
+      const teams = useTeams('team_dummy');
+      const t = Array.isArray(teams) ? teams[0] : teams.teams[0];
+      client.config.currentTeam = t.id;
+      process.env.FF_AUTO_PROVISION_INSTALL = '1';
+      useAutoProvision({
+        responseKey: 'provisioned',
+        withInstallation: false,
+        installationAppearsAfterPolls: 1,
+      });
+
       client.stdin.isTTY = false;
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Term acceptance requires an interactive terminal.'
+        'Waiting for terms acceptance in browser...'
+      );
+      await expect(client.stderr).toOutput('Terms accepted in browser.');
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned: acme-gray-apple'
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(1);
+      expect(exitCode).toEqual(0);
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringContaining('cmd=accept-terms')
+      );
     });
 
-    it('should exit with code 1 when AI agent is detected (legal requirement)', async () => {
-      // Term acceptance must be performed by a human, not an AI agent.
-      // Agents running in a PTY can bypass the isTTY check, so we
-      // explicitly block detected agents from accepting terms.
+    it('should open browser for terms acceptance when AI agent detected', async () => {
+      client.reset();
+      useUser();
+      const teams = useTeams('team_dummy');
+      const t = Array.isArray(teams) ? teams[0] : teams.teams[0];
+      client.config.currentTeam = t.id;
+      process.env.FF_AUTO_PROVISION_INSTALL = '1';
+      useAutoProvision({
+        responseKey: 'provisioned',
+        withInstallation: false,
+        installationAppearsAfterPolls: 1,
+      });
+
       client.isAgent = true;
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Term acceptance cannot be performed by an AI agent.'
+        'Waiting for terms acceptance in browser...'
+      );
+      await expect(client.stderr).toOutput('Terms accepted in browser.');
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned: acme-gray-apple'
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(1);
+      expect(exitCode).toEqual(0);
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringContaining('cmd=accept-terms')
+      );
+    });
+
+    it('should exit with code 1 on browser terms timeout', async () => {
+      client.reset();
+      useUser();
+      const teams = useTeams('team_dummy');
+      const t = Array.isArray(teams) ? teams[0] : teams.teams[0];
+      client.config.currentTeam = t.id;
+      process.env.FF_AUTO_PROVISION_INSTALL = '1';
+      // Never return an installation — simulates user not accepting in browser
+      useAutoProvision({
+        responseKey: 'provisioned',
+        withInstallation: false,
+      });
+
+      // Mock sleep to be instant so the timeout loop completes quickly
+      vi.mock('../../../../src/util/sleep', () => ({
+        default: vi.fn().mockResolvedValue(undefined),
+      }));
+
+      // Import and call acceptTermsViaBrowser directly with a very short timeout
+      const { acceptTermsViaBrowser } = await import(
+        '../../../../src/util/integration/accept-terms-via-browser'
+      );
+
+      const result = await acceptTermsViaBrowser(
+        client,
+        { id: 'acme', slug: 'acme', name: 'Acme Integration' },
+        t.id,
+        100 // 100ms timeout — will expire almost immediately
+      );
+
+      expect(result).toBeNull();
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringContaining('cmd=accept-terms')
+      );
+    });
+
+    it('should skip browser when installation already exists (agent mode)', async () => {
+      // Need fresh mocks since beforeEach registered withInstallation: false
+      client.reset();
+      useUser();
+      const teams = useTeams('team_dummy');
+      const t = Array.isArray(teams) ? teams[0] : teams.teams[0];
+      client.config.currentTeam = t.id;
+      process.env.FF_AUTO_PROVISION_INSTALL = '1';
+      useAutoProvision({
+        responseKey: 'provisioned',
+        withInstallation: true,
+      });
+
+      client.isAgent = true;
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned: acme-gray-apple'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      // Browser should NOT be opened since installation already exists
+      expect(openMock).not.toHaveBeenCalled();
+    });
+
+    it('should include correct params in browser terms URL', async () => {
+      client.reset();
+      openMock.mockReset().mockResolvedValue(undefined as never);
+      useUser();
+      const teams = useTeams('team_dummy');
+      const t = Array.isArray(teams) ? teams[0] : teams.teams[0];
+      client.config.currentTeam = t.id;
+      process.env.FF_AUTO_PROVISION_INSTALL = '1';
+      useAutoProvision({
+        responseKey: 'provisioned',
+        withInstallation: false,
+        installationAppearsAfterPolls: 1,
+      });
+
+      client.isAgent = true;
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('Terms accepted in browser.');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      const calledUrl = openMock.mock.calls[0]?.[0] as string;
+      const parsed = new URL(calledUrl);
+      expect(parsed.searchParams.get('cmd')).toEqual('accept-terms');
+      expect(parsed.searchParams.get('integrationId')).toEqual('acme');
+      expect(parsed.searchParams.get('source')).toEqual('cli');
     });
 
     it('should reject --yes flag to prevent automated term bypass (legal requirement)', async () => {


### PR DESCRIPTION
## Summary

- When `vercel integration add` runs in auto-provision mode and the client is an AI agent or non-TTY terminal, the CLI now opens a browser for terms acceptance instead of erroring out
- The CLI polls for installation creation (every 2s, up to 5 min timeout) and continues the provisioning flow once terms are accepted in the browser
- Interactive TTY behavior remains unchanged

## Changes

- **New**: `packages/cli/src/util/integration/accept-terms-via-browser.ts` — utility that opens browser, shows spinner, and polls `fetchInstallations()` for the new installation
- **Modified**: `packages/cli/src/commands/integration/add-auto-provision.ts` — conditional browser/TTY flow based on `client.isAgent || !client.stdin.isTTY`
- **Modified**: test mocks and tests — updated existing non-TTY/agent tests to expect browser flow, added timeout/skip/URL-params tests

## Companion PR

- Frontend (accept-terms page + API route): https://github.com/vercel/front/pull/63048

## Test plan

- [x] All 77 unit tests pass (`vitest run packages/cli/test/unit/commands/integration/add-auto-provision.test.ts`)
- [ ] Manual E2E: run `vercel integration add <integration> --agent` and verify browser opens, terms page loads, and CLI continues after acceptance
- [ ] Verify interactive TTY flow is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new browser-based terms acceptance flow for non-interactive CLI environments (AI agents or non-TTY), which is a feature addition that maintains the existing interactive TTY behavior and doesn't weaken any security controls.
> 
> - New utility `accept-terms-via-browser.ts` opens browser and polls for installation creation
> - Conditional flow in `add-auto-provision.ts` routes non-TTY/agent clients to browser flow
> - Test updates verify browser flow behavior and timeout handling
>
> <sup>Risk assessment for [commit a7ceacd](https://github.com/vercel/vercel/commit/a7ceacdcebab0ff64dc5b72cad01ea90354df935).</sup>
<!-- VADE_RISK_END -->