### PR TITLE
feat(cli): Add vercel buy pro subcommand

### DIFF
--- a/.changeset/buy-addons-support.md
+++ b/.changeset/buy-addons-support.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Support add-on purchasing in `vercel buy` CLI
+Support add-on and pro plan purchasing in `vercel buy` CLI

--- a/.changeset/buy-addons-support.md
+++ b/.changeset/buy-addons-support.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Support add-on and pro plan purchasing in `vercel buy` CLI
+Support add-on purchasing in `vercel buy` CLI

--- a/.changeset/buy-pro-support.md
+++ b/.changeset/buy-pro-support.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel buy pro` subcommand for purchasing Pro plan

--- a/packages/cli/src/commands/buy/command.ts
+++ b/packages/cli/src/commands/buy/command.ts
@@ -92,11 +92,22 @@ export const proSubcommand = {
   aliases: [],
   description: 'Purchase a Vercel Pro subscription for your team',
   arguments: [],
-  options: [],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt',
+    },
+    formatOption,
+    jsonOption,
+  ],
   examples: [
     {
       name: 'Upgrade your team to Vercel Pro',
       value: `${packageName} buy pro`,
+    },
+    {
+      name: 'Upgrade without confirmation prompt',
+      value: `${packageName} buy pro --yes`,
     },
   ],
 } as const;

--- a/packages/cli/src/util/buy/types.ts
+++ b/packages/cli/src/util/buy/types.ts
@@ -3,7 +3,7 @@ import type { CreditType, AddonAlias } from '../../commands/buy/command';
 export type PurchaseItem =
   | { type: 'credits'; creditType: CreditType; amount: number }
   | { type: 'addon'; productAlias: AddonAlias; quantity: number }
-  | { type: 'pro' }
+  | { type: 'subscription'; planSlug: 'pro' }
   | { type: 'v0' };
 
 export interface BuyResponse {

--- a/packages/cli/test/unit/commands/buy/pro.test.ts
+++ b/packages/cli/test/unit/commands/buy/pro.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { client } from '../../../mocks/client';
+import buy from '../../../../src/commands/buy';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+
+function useBuyEndpoint(handler?: (req: any, res: any) => void) {
+  client.scenario.post('/v1/billing/buy', (req, res) => {
+    if (handler) {
+      handler(req, res);
+    } else {
+      res.json({
+        subscriptionIntent: {
+          id: 'subint_test_123',
+          status: 'succeeded',
+        },
+      });
+    }
+  });
+}
+
+function setupTeam() {
+  useUser();
+  const team = useTeam();
+  client.config.currentTeam = team.id;
+  return team;
+}
+
+describe('buy pro', () => {
+  describe('--yes', () => {
+    it('skips confirmation and purchases successfully', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+    });
+
+    it('errors in non-TTY mode without --yes', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'pro');
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Use --yes');
+    });
+  });
+
+  describe('confirmation prompt', () => {
+    it('aborts when user declines', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'pro');
+
+      const exitCodePromise = buy(client);
+      await expect(client.stderr).toOutput('Upgrade team');
+      client.stdin.write('n\n');
+
+      expect(await exitCodePromise).toBe(0);
+    });
+
+    it('proceeds when user confirms', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'pro');
+
+      const exitCodePromise = buy(client);
+      await expect(client.stderr).toOutput('Upgrade team');
+      client.stdin.write('y\n');
+
+      expect(await exitCodePromise).toBe(0);
+    });
+  });
+
+  describe('API errors', () => {
+    it('handles missing_stripe_customer error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'missing_stripe_customer',
+            message: 'No payment method',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('payment method');
+    });
+
+    it('handles payment_failed error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(402).json({
+          error: {
+            code: 'payment_failed',
+            message: 'Payment failed',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Payment failed');
+    });
+  });
+
+  describe('--format=json', () => {
+    it('outputs JSON on success', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'pro', '--yes', '--format=json');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const parsed = JSON.parse(stdoutOutput);
+      expect(parsed.team).toBeDefined();
+      expect(parsed.subscriptionIntent.id).toBe('subint_test_123');
+    });
+  });
+
+  describe('--help', () => {
+    it('shows help and returns 2', async () => {
+      client.setArgv('buy', 'pro', '--help');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(2);
+    });
+
+    it('tracks telemetry', async () => {
+      client.setArgv('buy', 'pro', '--help');
+      await buy(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'buy:pro',
+        },
+      ]);
+    });
+  });
+
+  describe('telemetry', () => {
+    it('tracks pro subcommand', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'pro', '--yes');
+      await buy(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:pro',
+          value: 'pro',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Add vercel buy pro subcommand

- Implement `vercel buy pro` to upgrade a team to Vercel Pro via the billing API
- Add `--yes`, `--format`, and `--json` flag support
- Add tests for confirmation prompts, API errors, JSON output, and telemetry

```bash
# Buy Pro subscription with default payment method
vercel buy pro
```

<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> New CLI subcommand for purchasing Pro subscriptions involves billing/payment flow, which is critical business logic affecting money.
> 
> - Billing: implements `vercel buy pro` calling billing API to purchase subscriptions
> - Adds confirmation prompt with --yes bypass for non-interactive mode
> - Comprehensive test coverage for purchase flow, errors, and telemetry
>
> <sup>Risk assessment for [commit 40fe0da](https://github.com/vercel/vercel/commit/40fe0dafe13f6c25852e3abd61c235ee3e6493e4).</sup>
<!-- VADE_RISK_END -->