### PR TITLE
feat(fs-detectors): add VERCEL_DISABLE_API_404 env var to skip implicit api 404 route

### DIFF
--- a/.changeset/disable-api-404-route.md
+++ b/.changeset/disable-api-404-route.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Add `VERCEL_DISABLE_API_404` environment variable to disable the implicit 404 route for the `/api` directory.

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -1142,11 +1142,16 @@ function getRouteResult(
       const hasApiBuild = apiBuilders.find(builder => {
         return builder.src?.startsWith('api/');
       });
-      if (typeof ignoreRuntimes === 'undefined' && hasApiBuild) {
+      if (
+        typeof ignoreRuntimes === 'undefined' &&
+        hasApiBuild &&
+        process.env.VERCEL_DISABLE_API_404 !== '1'
+      ) {
         // This route is only necessary to hide the directory listing
         // to avoid enumerating serverless function names.
         // But it causes issues in `vc dev` for frameworks that handle
         // their own functions such as redwood, so we ignore.
+        // Can be disabled by setting VERCEL_DISABLE_API_404=1.
         rewriteRoutes.push({
           src: '^/api(/.*)?$',
           status: 404,

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -2812,6 +2812,35 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
     });
   });
 
+  it('VERCEL_DISABLE_API_404 omits the api 404 route', async () => {
+    const originalEnv = process.env.VERCEL_DISABLE_API_404;
+    process.env.VERCEL_DISABLE_API_404 = '1';
+    try {
+      const featHandleMiss = true;
+      const files = ['api/user.go', 'api/team.js', 'api/package.json'];
+
+      const { rewriteRoutes } = await invokeDetectBuildersAndThrow(
+        files,
+        null,
+        {
+          featHandleMiss,
+        }
+      );
+      // The 404 route for /api should not be present
+      expect(
+        rewriteRoutes.find(
+          (r: any) => r.src === '^/api(/.*)?$' && r.status === 404
+        )
+      ).toBeUndefined();
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.VERCEL_DISABLE_API_404;
+      } else {
+        process.env.VERCEL_DISABLE_API_404 = originalEnv;
+      }
+    }
+  });
+
   it('conflicting file path with same name', async () => {
     const featHandleMiss = true;
     const files = ['api/user.go', 'api/user.js'];


### PR DESCRIPTION
## Summary

- Adds a `VERCEL_DISABLE_API_404` environment variable that, when set to `"1"`, prevents the implicit `{ "src": "^/api(/.*)?$", "status": 404 }` route from being generated for the `/api` directory
- This allows unmatched `/api/*` requests to fall through to a frontend framework's catch-all handler instead of returning a hard 404

## Background

When using the top-level `api/` directory to define serverless functions, Vercel automatically adds a catch-all 404 route in the `filesystem` phase to prevent directory listing enumeration of serverless function names. Certain frameworks (Remix, SvelteKit, Redwood, etc.) already bypass this via the `ignoreRuntimes` mechanism, but there was no user-facing way to opt out for other setups.

## Changes

- **`packages/fs-detectors/src/detect-builders.ts`**: Added `process.env.VERCEL_DISABLE_API_404 !== '1'` check to the condition that generates the 404 route
- **`packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts`**: Added test verifying the route is omitted when the env var is set
- **`.changeset/disable-api-404-route.md`**: Changeset for `@vercel/fs-detectors` (patch)

## Usage

Set `VERCEL_DISABLE_API_404=1` in your environment (e.g., Vercel project settings, `.env`, or shell) to disable the implicit API 404 route.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Adds environment variable to disable implicit 404 route for /api directory, which could allow unmatched API requests to fall through instead of returning 404 - this is an intentional feature to support certain framework setups but changes routing behavior.
> 
> - New env var `VERCEL_DISABLE_API_404` bypasses 404 route generation for /api paths
> - Changes routing behavior: unmatched /api/* requests can fall through instead of hard 404
> - Test added to verify route omission when env var is set
>
> <sup>Risk assessment for [commit 38c4427](https://github.com/vercel/vercel/commit/38c4427cbd13f38b9deb240bd66fc1340801794c).</sup>
<!-- VADE_RISK_END -->