### PR TITLE
[services] service-level build install commands

### DIFF
--- a/.changeset/thick-phones-smash.md
+++ b/.changeset/thick-phones-smash.md
@@ -1,0 +1,7 @@
+---
+"vercel": patch
+"@vercel/node": patch
+"@vercel/python": patch
+---
+
+[services] Adds support for service-level build install commands

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -591,6 +591,23 @@ async function doBuild(
     // these env vars are baked into the client bundle so they can be accessed in the client code.
     // User-defined env vars take precedence and won't be overwritten.
     if (detectedServices && detectedServices.length > 0) {
+      if (
+        typeof projectSettings.buildCommand === 'string' &&
+        projectSettings.buildCommand.trim()
+      ) {
+        output.warn(
+          'Project-level `buildCommand` is ignored when services are configured. Configure a service-level `buildCommand` in `experimentalServices.<service>.buildCommand`.'
+        );
+      }
+      if (
+        typeof projectSettings.installCommand === 'string' &&
+        projectSettings.installCommand.trim()
+      ) {
+        output.warn(
+          'Project-level `installCommand` is ignored when services are configured. Configure a service-level `installCommand` in `experimentalServices.<service>.installCommand`.'
+        );
+      }
+
       const serviceUrlEnvVars = getServiceUrlEnvVars({
         services: detectedServices,
         frameworkList,
@@ -853,8 +870,7 @@ async function doBuild(
         config: buildConfig,
         meta,
         span: builderSpan,
-        ...(typeof serviceRoutePrefix === 'string' ||
-        typeof serviceWorkspace === 'string'
+        ...(service
           ? {
               service: {
                 routePrefix:
@@ -864,7 +880,7 @@ async function doBuild(
                 workspace:
                   typeof serviceWorkspace === 'string'
                     ? serviceWorkspace
-                    : undefined,
+                    : service.workspace,
               },
             }
           : undefined),

--- a/packages/cli/test/fixtures/unit/commands/build/services-project-settings-warning/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/services-project-settings-warning/.vercel/project.json
@@ -1,0 +1,9 @@
+{
+  "orgId": ".",
+  "projectId": ".",
+  "settings": {
+    "framework": "services",
+    "buildCommand": "echo project-build",
+    "installCommand": "echo project-install"
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/services-project-settings-warning/api/index.js
+++ b/packages/cli/test/fixtures/unit/commands/build/services-project-settings-warning/api/index.js
@@ -1,0 +1,3 @@
+module.exports = (_req, res) => {
+  res.end('ok');
+};

--- a/packages/cli/test/fixtures/unit/commands/build/services-project-settings-warning/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/services-project-settings-warning/vercel.json
@@ -1,0 +1,10 @@
+{
+  "experimentalServices": {
+    "api": {
+      "entrypoint": "api/index.js",
+      "routePrefix": "/",
+      "buildCommand": "echo service-build",
+      "installCommand": "echo service-install"
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1027,6 +1027,22 @@ describe.skipIf(flakey)('build', () => {
     expect(contents.trim()).toEqual('3');
   });
 
+  it('should warn that project-level commands are ignored for services builds', async () => {
+    const cwd = fixture('services-project-settings-warning');
+    client.cwd = cwd;
+
+    const exitCodePromise = build(client);
+    await expect(client.stderr).toOutput(
+      '`buildCommand` is ignored when services are configured.'
+    );
+    await expect(client.stderr).toOutput(
+      '`installCommand` is ignored when services are configured.'
+    );
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode).toEqual(0);
+  });
+
   it('should set VERCEL_PROJECT_SETTINGS_ environment variables', async () => {
     const cwd = fixture('project-settings-env-vars');
     const output = join(cwd, '.vercel/output');

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -33,6 +33,7 @@ import {
   isBunVersion,
 } from '@vercel/build-utils';
 import type {
+  BuildOptions,
   File,
   Files,
   Meta,
@@ -57,6 +58,7 @@ interface DownloadOptions {
   workPath: string;
   config: Config;
   meta: Meta;
+  service?: BuildOptions['service'];
   considerBuildCommand: boolean;
 }
 
@@ -71,6 +73,7 @@ async function downloadInstallAndBundle({
   workPath,
   config,
   meta,
+  service,
   considerBuildCommand,
 }: DownloadOptions) {
   const downloadedFiles = await download(files, workPath, meta);
@@ -98,7 +101,9 @@ async function downloadInstallAndBundle({
     projectCreatedAt: config.projectSettings?.createdAt,
   });
 
-  const installCommand = config.projectSettings?.installCommand;
+  const installCommand = service
+    ? config.installCommand
+    : config.projectSettings?.installCommand;
   if (typeof installCommand === 'string' && considerBuildCommand) {
     if (installCommand.trim()) {
       console.log(`Running "install" command: \`${installCommand}\`...`);
@@ -414,6 +419,7 @@ export const build = async ({
   repoRootPath,
   config = {},
   meta = {},
+  service,
   considerBuildCommand = false,
   entrypointCallback,
   checks = () => {},
@@ -428,6 +434,7 @@ export const build = async ({
   entrypointCallback?: () => Promise<string>;
   checks?: (project: { config: Config; isBun: boolean }) => void;
 }): Promise<BuildResultV3> => {
+  const shouldConsiderBuildCommand = considerBuildCommand || Boolean(service);
   const baseDir = repoRootPath || workPath;
   const awsLambdaHandler = getAWSLambdaHandler(entrypoint, config);
 
@@ -442,17 +449,20 @@ export const build = async ({
     workPath,
     config,
     meta,
-    considerBuildCommand,
+    service,
+    considerBuildCommand: shouldConsiderBuildCommand,
   });
 
   let entrypointPath = _entrypointPath;
 
-  const projectBuildCommand = config.projectSettings?.buildCommand;
+  const projectBuildCommand = service
+    ? config.buildCommand
+    : config.projectSettings?.buildCommand;
 
   // For traditional api-folder builds, the `build` script or project build command isn't used.
   // but we're reusing the node builder for hono and express, where they should be treated as the
   // primary builder
-  if (projectBuildCommand && considerBuildCommand) {
+  if (projectBuildCommand && shouldConsiderBuildCommand) {
     await execCommand(projectBuildCommand, {
       // Yarn v2 PnP mode may be activated, so force
       // "node-modules" linker style
@@ -464,7 +474,7 @@ export const build = async ({
       cwd: workPath,
     });
   } else {
-    const possibleScripts = considerBuildCommand
+    const possibleScripts = shouldConsiderBuildCommand
       ? ['vercel-build', 'now-build', 'build']
       : ['vercel-build', 'now-build'];
 

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -81,8 +81,11 @@ export const build: BuildV3 = async ({
   entrypoint,
   meta = {},
   config,
+  service,
 }) => {
   const framework = config?.framework;
+  const isPythonFrameworkBuild = isPythonFramework(framework);
+  const isServiceBuild = Boolean(service);
   let spawnEnv: NodeJS.ProcessEnv | undefined;
   // Custom install command from dashboard/project settings, if any.
   let projectInstallCommand: string | undefined;
@@ -113,8 +116,9 @@ export const build: BuildV3 = async ({
     throw err;
   }
 
-  // For Python frameworks, also honor project install/build commands (vercel.json/dashboard)
-  if (isPythonFramework(framework)) {
+  // For Python framework and services builds, honor project install/build commands
+  // from vercel.json/dashboard.
+  if (isPythonFrameworkBuild || isServiceBuild) {
     const {
       cliType,
       lockfileVersion,
@@ -130,7 +134,10 @@ export const build: BuildV3 = async ({
       projectCreatedAt: config?.projectSettings?.createdAt,
     });
 
-    const installCommand = config?.projectSettings?.installCommand;
+    // In services mode, only honor service-level commands.
+    const installCommand = isServiceBuild
+      ? config?.installCommand
+      : config?.projectSettings?.installCommand;
     if (typeof installCommand === 'string') {
       const trimmed = installCommand.trim();
       if (trimmed) {
@@ -140,10 +147,11 @@ export const build: BuildV3 = async ({
       }
     }
 
-    const projectBuildCommand =
-      config?.projectSettings?.buildCommand ??
-      // fallback if provided directly on config (some callers set this)
-      (config as any)?.buildCommand;
+    const projectBuildCommand = isServiceBuild
+      ? config?.buildCommand
+      : (config?.projectSettings?.buildCommand ??
+        // fallback if provided directly on config (some callers set this)
+        (config as any)?.buildCommand);
     if (projectBuildCommand) {
       console.log(`Running "${projectBuildCommand}"`);
       await execCommand(projectBuildCommand, {

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1776,6 +1776,105 @@ describe('custom install hooks', () => {
     );
   });
 
+  it('uses service-level build/install commands for services framework', async () => {
+    const mockExecCommand = vi.fn(async () => {});
+    const mockEnsureUvProject = vi.fn(async () => ({
+      projectDir: '/mock/project',
+      pyprojectPath: '/mock/project/pyproject.toml',
+      lockPath: '/mock/project/uv.lock',
+    }));
+
+    const realBuildUtils = await vi.importActual<
+      typeof import('@vercel/build-utils')
+    >('@vercel/build-utils');
+    vi.doMock('@vercel/build-utils', () => ({
+      ...realBuildUtils,
+      execCommand: mockExecCommand,
+    }));
+
+    const realInstall =
+      await vi.importActual<typeof import('../src/install')>('../src/install');
+    vi.doMock('../src/install', () => ({
+      ...realInstall,
+      ensureUvProject: mockEnsureUvProject,
+      getVenvSitePackagesDirs: vi.fn(async () => []),
+    }));
+
+    const realUtils =
+      await vi.importActual<typeof import('../src/utils')>('../src/utils');
+    vi.doMock('../src/utils', () => ({
+      ...realUtils,
+      ensureVenv: vi.fn(async () => {}),
+    }));
+
+    const realUv =
+      await vi.importActual<typeof import('../src/uv')>('../src/uv');
+    vi.doMock('../src/uv', () => ({
+      ...realUv,
+      getUvBinaryOrInstall: vi.fn(async () => '/mock/uv'),
+      UvRunner: createMockUvRunner(),
+    }));
+
+    // Import after mocks are configured
+    const { build: buildWithMocks } = await import('../src/index');
+
+    const workPath = path.join(tmpdir(), `python-service-hooks-${Date.now()}`);
+    fs.mkdirSync(workPath, { recursive: true });
+
+    const files = {
+      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+    } as Record<string, FileBlob>;
+
+    try {
+      await buildWithMocks({
+        workPath,
+        files,
+        entrypoint: 'handler.py',
+        meta: { isDev: false },
+        config: {
+          framework: 'services',
+          buildCommand: 'echo service-build',
+          installCommand: 'echo service-install',
+          projectSettings: {
+            buildCommand: 'echo project-build',
+            installCommand: 'echo project-install',
+          },
+        },
+        service: {
+          routePrefix: '/api',
+          workspace: '.',
+        },
+        repoRootPath: workPath,
+      });
+    } finally {
+      if (fs.existsSync(workPath)) fs.removeSync(workPath);
+    }
+
+    expect(mockEnsureUvProject).not.toHaveBeenCalled();
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      'echo service-build',
+      expect.objectContaining({
+        cwd: workPath,
+        env: expect.any(Object),
+      })
+    );
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      'echo service-install',
+      expect.objectContaining({
+        cwd: workPath,
+        env: expect.any(Object),
+      })
+    );
+    expect(mockExecCommand).not.toHaveBeenCalledWith(
+      'echo project-build',
+      expect.anything()
+    );
+    expect(mockExecCommand).not.toHaveBeenCalledWith(
+      'echo project-install',
+      expect.anything()
+    );
+  });
+
   it('uses pyproject.toml install script when no projectSettings.installCommand', async () => {
     const mockExecCommand = vi.fn(async () => {});
     const mockEnsureUvProject = vi.fn(async () => ({


### PR DESCRIPTION
When multiple services are configured:
* Ignore project-level build/install commands
* Forward the service-scoped build/install commands to the respective builder

Service-scoped build/install commands are defined as follows:
```json
{
  "experimentalServices": {
    "frontend": {
      "entrypoint": "apps/web",
      "routePrefix": "/",
      "installCommand": "pnpm install --filter web...",
      "buildCommand": "pnpm --filter web build"
    },
    "api": {
      "entrypoint": "services/api/main.py",
      "routePrefix": "/api",
      "installCommand": "pip install -r services/api/requirements-vercel.txt",
      "buildCommand": "python services/api/scripts/build.py"
    }
  }
}
```

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds service-level build/install command support with new conditional logic to prefer service-scoped commands over project-level commands, which is a feature addition with appropriate test coverage and no security implications.
> 
> - Adds warnings when project-level build/install commands are ignored for services builds
> - Modifies Node and Python builders to use service-level commands via `config.installCommand` and `config.buildCommand`
> - Includes test fixtures and unit tests for new service command behavior
>
> <sup>Risk assessment for [commit 5cc610c](https://github.com/vercel/vercel/commit/5cc610c6eefb6428667d1c5b8d3d326d99dc58bf).</sup>
<!-- VADE_RISK_END -->