### PR TITLE
Rename fetch to fetchApi to more easily migrate to fetch underlying

### DIFF
--- a/.changeset/grumpy-fans-exercise.md
+++ b/.changeset/grumpy-fans-exercise.md
@@ -1,0 +1,6 @@
+---
+'@vercel/client': patch
+---
+
+rename fetch to fetchApi
+

--- a/packages/client/src/check-deployment-status.ts
+++ b/packages/client/src/check-deployment-status.ts
@@ -1,5 +1,5 @@
 import sleep from 'sleep-promise';
-import { fetch, getApiDeploymentsUrl } from './utils';
+import { fetchApi, getApiDeploymentsUrl } from './utils';
 import { getPollingDelay } from './utils/get-polling-delay';
 import {
   isDone,
@@ -92,7 +92,7 @@ export async function* checkDeploymentStatus(
     let deploymentResponse: any;
     let retriesLeft = RETRY_COUNT;
     while (true) {
-      deploymentResponse = await fetch(
+      deploymentResponse = await fetchApi(
         `${apiDeployments}/${deployment.id || deployment.deploymentId}${
           teamId ? `?teamId=${teamId}` : ''
         }`,

--- a/packages/client/src/continue.ts
+++ b/packages/client/src/continue.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import type { Agent } from 'http';
 import type { Deployment, DeploymentEventType } from './types';
 import { checkDeploymentStatus } from './check-deployment-status';
-import { fetch, buildFileTree, createDebug, prepareFiles } from './utils';
+import { fetchApi, buildFileTree, createDebug, prepareFiles } from './utils';
 import { hashes, mapToObject, FilesMap } from './utils/hashes';
 import { isReady, isAliasAssigned } from './utils/ready-state';
 import { uploadFiles, UploadProgress } from './upload';
@@ -180,7 +180,7 @@ async function postContinue(options: {
   const debug = createDebug(options.debug);
 
   debug(`Calling continue deployment endpoint for ${options.deploymentId}`);
-  const response = await fetch(
+  const response = await fetchApi(
     `/deployments/${options.deploymentId}/continue${
       options.teamId ? `?teamId=${options.teamId}` : ''
     }`,

--- a/packages/client/src/deploy.ts
+++ b/packages/client/src/deploy.ts
@@ -3,7 +3,7 @@ import { generateQueryString } from './utils/query-string';
 import { isReady, isAliasAssigned } from './utils/ready-state';
 import { checkDeploymentStatus } from './check-deployment-status';
 import {
-  fetch,
+  fetchApi,
   prepareFiles,
   createDebug,
   getApiDeploymentsUrl,
@@ -47,7 +47,7 @@ async function* postDeployment(
 
   debug('Sending deployment creation API request');
   try {
-    const response = await fetch(
+    const response = await fetchApi(
       `${apiDeployments}${generateQueryString(clientOptions)}`,
       clientOptions.token,
       {

--- a/packages/client/src/upload.ts
+++ b/packages/client/src/upload.ts
@@ -6,7 +6,7 @@ import retry from 'async-retry';
 import { Sema } from 'async-sema';
 
 import { DeploymentFile, FilesMap } from './utils/hashes';
-import { fetch, API_FILES, createDebug } from './utils';
+import { fetchApi, API_FILES, createDebug } from './utils';
 import { DeploymentError } from './errors';
 import { deploy } from './deploy';
 import type { Agent } from 'http';
@@ -200,7 +200,7 @@ export async function* uploadFiles(options: {
         abortControllers.add(abortController);
 
         try {
-          const res = await fetch(
+          const res = await fetchApi(
             API_FILES,
             options.token,
             {

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -324,7 +324,7 @@ interface FetchOpts extends RequestInit {
   userAgent?: string;
 }
 
-export const fetch = async (
+export const fetchApi = async (
   url: string,
   token: string,
   opts: FetchOpts = {},

--- a/packages/client/tests/unit.check-deployment-status.test.ts
+++ b/packages/client/tests/unit.check-deployment-status.test.ts
@@ -9,7 +9,7 @@ vi.mock('../src/utils', async () => {
   const actual = await vi.importActual('../src/utils');
   return {
     ...actual,
-    fetch: mockFetch,
+    fetchApi: mockFetch,
   };
 });
 

--- a/packages/client/tests/unit.manual-deployment.test.ts
+++ b/packages/client/tests/unit.manual-deployment.test.ts
@@ -19,7 +19,7 @@ vi.mock('../src/utils', async () => {
   const actual = await vi.importActual('../src/utils');
   return {
     ...actual,
-    fetch: mockFetch,
+    fetchApi: mockFetch,
     buildFileTree: mockBuildFileTree,
   };
 });


### PR DESCRIPTION
# Overview 

Rename `fetch` to `fetchApi` in `packages/client` to remove confusion over API naming vs. built in fetch


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR is a straightforward rename of the `fetch` function to `fetchApi` across multiple files with no logic changes, only identifier renaming.
> 
> - Renames `fetch` to `fetchApi` in utils and all call sites
> - Updates test mocks to use new function name
> - Adds changeset for patch version bump
>
> <sup>Risk assessment for [commit 794bd2b](https://github.com/vercel/vercel/commit/794bd2b8a2228ec12b7c1a32d13842a8caa8c63d).</sup>
<!-- VADE_RISK_END -->