### PR TITLE
Rename fetch to nodeFetch when importing from node-fetch

### DIFF
--- a/.changeset/clean-dolphins-jam.md
+++ b/.changeset/clean-dolphins-jam.md
@@ -1,0 +1,9 @@
+---
+'@vercel/frameworks': patch
+'@vercel/python': patch
+'@vercel/next': patch
+'@vercel/node': patch
+'vercel': patch
+---
+
+Migrate from node-fetch to fetch directly in tests

--- a/.changeset/clean-dolphins-jam.md
+++ b/.changeset/clean-dolphins-jam.md
@@ -6,4 +6,4 @@
 'vercel': patch
 ---
 
-Migrate from node-fetch to fetch directly in tests
+Rename fetch to nodeFetch when importing from node-fetch

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { execCli } from './helpers/exec';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import { apiFetch } from './helpers/api-fetch';
 import fs from 'fs-extra';
 import sleep from '../src/util/sleep';
@@ -187,7 +187,7 @@ test('default command should work with --cwd option', async () => {
 
   const url = stdout;
 
-  const deploymentResult = await fetch(`${url}/README.md`);
+  const deploymentResult = await nodeFetch(`${url}/README.md`);
   const body = await deploymentResult.text();
   expect(body).toEqual(
     'readme contents for deploy-default-with-conflicting-sub-directory'
@@ -216,7 +216,7 @@ test('should allow deploying a directory that was built with a target environmen
 
   const url = stdout;
 
-  const deploymentResult = await fetch(`${url}/README.md`);
+  const deploymentResult = await nodeFetch(`${url}/README.md`);
   const body = await deploymentResult.text();
   expect(body).toEqual(
     'readme contents for deploy-default-with-prebuilt-preview'
@@ -243,7 +243,7 @@ test('should allow deploying a directory that was prebuilt, but has no builds.js
 
   const url = stdout;
 
-  const deploymentResult = await fetch(`${url}/README.md`);
+  const deploymentResult = await nodeFetch(`${url}/README.md`);
   const body = await deploymentResult.text();
   expect(body).toEqual('readme contents for build-output-api-raw');
 });
@@ -305,7 +305,7 @@ test('deploy using only now.json with `redirects` defined', async () => {
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
 
   const url = stdout;
-  const res = await fetch(`${url}/foo/bar`, { redirect: 'manual' });
+  const res = await nodeFetch(`${url}/foo/bar`, { redirect: 'manual' });
   const location = res.headers.get('location');
   expect(location).toBe('https://example.com/foo/bar');
 });
@@ -328,18 +328,18 @@ test('deploy using --local-config flag v2', async () => {
   const { host } = new URL(stdout);
   expect(host).toMatch(/secondary/gm);
 
-  const testRes = await fetch(`https://${host}/test-${team.slug}.html`);
+  const testRes = await nodeFetch(`https://${host}/test-${team.slug}.html`);
   const testText = await testRes.text();
   expect(testText).toBe('<h1>hello test</h1>');
 
-  const anotherTestRes = await fetch(`https://${host}/another-test`);
+  const anotherTestRes = await nodeFetch(`https://${host}/another-test`);
   const anotherTestText = await anotherTestRes.text();
   expect(anotherTestText).toBe(testText);
 
-  const mainRes = await fetch(`https://${host}/main-${team.slug}.html`);
+  const mainRes = await nodeFetch(`https://${host}/main-${team.slug}.html`);
   expect(mainRes.status).toBe(404);
 
-  const anotherMainRes = await fetch(`https://${host}/another-main`);
+  const anotherMainRes = await nodeFetch(`https://${host}/another-main`);
   expect(anotherMainRes.status).toBe(404);
 });
 
@@ -450,11 +450,11 @@ test('deploy using --local-config flag above target', async () => {
 
   const { host } = new URL(stdout);
 
-  const testRes = await fetch(`https://${host}/index.html`);
+  const testRes = await nodeFetch(`https://${host}/index.html`);
   const testText = await testRes.text();
   expect(testText).toBe('<h1>hello index</h1>');
 
-  const anotherTestRes = await fetch(`https://${host}/another.html`);
+  const anotherTestRes = await nodeFetch(`https://${host}/another.html`);
   const anotherTestText = await anotherTestRes.text();
   expect(anotherTestText).toBe('<h1>hello another</h1>');
 
@@ -648,13 +648,13 @@ test.skip('deploy `api-env` fixture and test `vercel env` command', async () => 
     const { host } = new URL(stdout);
 
     const apiUrl = `https://${host}/api/get-env`;
-    const apiRes = await fetch(apiUrl);
+    const apiRes = await nodeFetch(apiUrl);
     expect(apiRes.status, apiUrl).toBe(200);
     const apiJson = await apiRes.json();
     expect(apiJson[promptEnvVar]).toBe('my plaintext value');
 
     const homeUrl = `https://${host}`;
-    const homeRes = await fetch(homeUrl);
+    const homeRes = await nodeFetch(homeUrl);
     expect(homeRes.status, homeUrl).toBe(200);
     const homeJson = await homeRes.json();
     expect(homeJson[promptEnvVar]).toBe('my plaintext value');
@@ -667,7 +667,7 @@ test.skip('deploy `api-env` fixture and test `vercel env` command', async () => 
 
     const localhost = await getLocalhost(vc);
     const apiUrl = `${localhost[0]}/api/get-env`;
-    const apiRes = await fetch(apiUrl);
+    const apiRes = await nodeFetch(apiUrl);
 
     expect(apiRes.status).toBe(200);
 
@@ -677,7 +677,7 @@ test.skip('deploy `api-env` fixture and test `vercel env` command', async () => 
 
     const homeUrl = localhost[0];
 
-    const homeRes = await fetch(homeUrl);
+    const homeRes = await nodeFetch(homeUrl);
     const homeJson = await homeRes.json();
     expect(homeJson[promptEnvVar]).toBe('my plaintext value');
 
@@ -696,7 +696,7 @@ test.skip('deploy `api-env` fixture and test `vercel env` command', async () => 
 
     const localhost = await getLocalhost(vc);
     const apiUrl = `${localhost[0]}/api/get-env`;
-    const apiRes = await fetch(apiUrl);
+    const apiRes = await nodeFetch(apiUrl);
     expect(apiRes.status).toBe(200);
 
     const apiJson = await apiRes.json();
@@ -704,7 +704,7 @@ test.skip('deploy `api-env` fixture and test `vercel env` command', async () => 
     expect(apiJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
 
     const homeUrl = localhost[0];
-    const homeRes = await fetch(homeUrl);
+    const homeRes = await nodeFetch(homeUrl);
     const homeJson = await homeRes.json();
     expect(homeJson[promptEnvVar]).toBe('my plaintext value');
     expect(homeJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
@@ -768,7 +768,7 @@ test.skip('deploy `api-env` fixture and test `vercel env` command', async () => 
 
     const localhost = await getLocalhost(vc);
     const apiUrl = `${localhost[0]}/api/get-env`;
-    const apiRes = await fetch(apiUrl);
+    const apiRes = await nodeFetch(apiUrl);
 
     const localhostNoProtocol = localhost[0].slice('http://'.length);
 
@@ -783,7 +783,7 @@ test.skip('deploy `api-env` fixture and test `vercel env` command', async () => 
     expect(apiJson['VERCEL_REGION']).toBe('dev1');
 
     const homeUrl = localhost[0];
-    const homeRes = await fetch(homeUrl);
+    const homeRes = await nodeFetch(homeUrl);
     const homeJson = await homeRes.json();
     expect(homeJson['VERCEL']).toBe('1');
     expect(homeJson['VERCEL_URL']).toBe(localhostNoProtocol);

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { URL } from 'url';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import express from 'express';
 import { createServer } from 'http';
 import { listen } from 'async-listen';
@@ -237,7 +237,7 @@ test.skip('should show prompts to set up project during first deploy', async () 
   const { href } = new URL(output.stdout);
 
   // Send a test request to the deployment
-  const response = await fetch(href);
+  const response = await nodeFetch(href);
   const text = await response.text();
   expect(text).toContain('<h1>custom hello</h1>');
 
@@ -263,7 +263,7 @@ test.skip('should show prompts to set up project during first deploy', async () 
       });
     });
 
-    const res2 = await fetch(`http://localhost:${port}/`);
+    const res2 = await nodeFetch(`http://localhost:${port}/`);
     const text2 = await res2.text();
     expect(text2).toContain('<h1>custom hello</h1>');
   } finally {
@@ -477,12 +477,12 @@ test('use `rootDirectory` from project when deploying', async () => {
 
   const { href } = new URL(secondResult.stdout);
 
-  const pageResponse1 = await fetch(href);
+  const pageResponse1 = await nodeFetch(href);
   expect(pageResponse1.status).toBe(200);
   expect(await pageResponse1.text()).toMatch(/I am a website/gm);
 
   // Ensures that the `now.json` file has been applied
-  const pageResponse2 = await fetch(`${secondResult.stdout}/i-do-exist`);
+  const pageResponse2 = await nodeFetch(`${secondResult.stdout}/i-do-exist`);
   expect(pageResponse2.status).toBe(200);
   expect(await pageResponse2.text()).toMatch(/I am a website/gm);
 
@@ -795,7 +795,7 @@ test('deploys with only now.json and README.md', async () => {
 
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
   const { host } = new URL(stdout);
-  const res = await fetch(`https://${host}/README.md`);
+  const res = await nodeFetch(`https://${host}/README.md`);
   const text = await res.text();
   expect(text).toMatch(/readme contents/);
 });
@@ -822,7 +822,7 @@ test('deploys with only vercel.json and README.md', async () => {
   );
 
   const { host } = new URL(stdout);
-  const res = await fetch(`https://${host}/README.md`);
+  const res = await nodeFetch(`https://${host}/README.md`);
   const text = await res.text();
   expect(text).toMatch(/readme contents/);
 });
@@ -922,14 +922,14 @@ test.skip('deploy pnpm twice using pnp and symlink=false', async () => {
   let { exitCode, stdout, stderr } = await firstDeploy;
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
 
-  let page = await fetch(stdout);
+  let page = await nodeFetch(stdout);
   let text = await page.text();
   expect(text).toBe('no cache\n');
 
   ({ exitCode, stdout, stderr } = await deploy());
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
 
-  page = await fetch(stdout);
+  page = await nodeFetch(stdout);
   text = await page.text();
 
   expect(text).toContain('cache exists\n');
@@ -1073,7 +1073,7 @@ test('[vc dev] should show prompts to set up project', async () => {
 
   // Ensure that `vc dev` also works
   try {
-    const response = await fetch(`http://localhost:${port}/`);
+    const response = await nodeFetch(`http://localhost:${port}/`);
     const text = await response.text();
     expect(text).toContain('<h1>custom hello</h1>');
   } finally {
@@ -1164,7 +1164,7 @@ test('[vc dev] should send the platform proxy request headers to frontend dev se
 
   // Ensure that `vc dev` also works
   try {
-    const response = await fetch(`http://localhost:${port}/`);
+    const response = await nodeFetch(`http://localhost:${port}/`);
     const body = await response.json();
     expect(body.headers['x-vercel-deployment-url']).toBe(`localhost:${port}`);
     expect(body.env.NOW_REGION).toBe('dev1');
@@ -1312,7 +1312,7 @@ test.skip('vercel.json configuration overrides in a new project prompt user and 
   const deployment = await vc;
   expect(deployment.exitCode, formatOutput(deployment)).toBe(0);
   // assert the command were executed
-  const page = await fetch(deployment.stdout);
+  const page = await nodeFetch(deployment.stdout);
   const text = await page.text();
   expect(text).toBe('1\n');
   // Since this test asserts that we can create a new project based on the folder name, delete it after the test
@@ -1348,7 +1348,7 @@ test('vercel.json configuration overrides in an existing project do not prompt u
   let deployment = await deploy(true);
 
   const { href } = new URL(deployment.stdout);
-  let page = await fetch(href);
+  let page = await nodeFetch(href);
   let text = await page.text();
   expect(text).toBe('0');
 
@@ -1367,7 +1367,7 @@ test('vercel.json configuration overrides in an existing project do not prompt u
   );
 
   deployment = await deploy();
-  page = await fetch(deployment.stdout);
+  page = await nodeFetch(deployment.stdout);
   text = await page.text();
   expect(text).toBe('1\n');
 
@@ -1400,7 +1400,7 @@ test('vercel.json configuration overrides in an existing project do not prompt u
   );
 
   deployment = await deploy();
-  page = await fetch(deployment.stdout);
+  page = await nodeFetch(deployment.stdout);
   text = await page.text();
   expect(text).toMatch(/Next\.js Test/);
 });
@@ -1465,7 +1465,7 @@ test.each([
     const { href } = new URL(output.stdout);
 
     // Send a test request to the deployment
-    const response = await fetch(href);
+    const response = await nodeFetch(href);
     expect(response.status).toBe(expectedStatus);
 
     const projectResponse = await apiFetch(`/projects/${projectName}`, {

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -8,7 +8,7 @@ import { homedir } from 'os';
 import { runNpmInstall } from '@vercel/build-utils';
 import { execCli } from './helpers/exec';
 import type { RequestInfo } from 'node-fetch';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import fs from 'fs-extra';
 import { logo } from '../src/util/pkg-name';
 import sleep from '../src/util/sleep';
@@ -45,7 +45,7 @@ const waitForDeployment = async (href: RequestInfo) => {
 
   // eslint-disable-next-line
   while (true) {
-    const response = await fetch(href, { redirect: 'manual' });
+    const response = await nodeFetch(href, { redirect: 'manual' });
     const text = await response.text();
     if (
       response.status === 200 &&
@@ -174,10 +174,10 @@ test.skip('ignore files specified in .nowignore', async () => {
   });
 
   const { host } = new URL(targetCall.stdout);
-  const ignoredFile = await fetch(`https://${host}/ignored.txt`);
+  const ignoredFile = await nodeFetch(`https://${host}/ignored.txt`);
   expect(ignoredFile.status).toBe(404);
 
-  const presentFile = await fetch(`https://${host}/index.txt`);
+  const presentFile = await nodeFetch(`https://${host}/index.txt`);
   expect(presentFile.status).toBe(200);
 });
 
@@ -192,10 +192,10 @@ test.skip('ignore files specified in .nowignore via allowlist', async () => {
   });
 
   const { host } = new URL(targetCall.stdout);
-  const ignoredFile = await fetch(`https://${host}/ignored.txt`);
+  const ignoredFile = await nodeFetch(`https://${host}/ignored.txt`);
   expect(ignoredFile.status).toBe(404);
 
-  const presentFile = await fetch(`https://${host}/index.txt`);
+  const presentFile = await nodeFetch(`https://${host}/index.txt`);
   expect(presentFile.status).toBe(200);
 });
 
@@ -317,7 +317,7 @@ test.skip('ensure we render a warning for deployments with no files', async () =
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
 
   // Send a test request to the deployment
-  const res = await fetch(href);
+  const res = await nodeFetch(href);
   expect(res.status).toBe(404);
 });
 
@@ -364,7 +364,7 @@ test('ensure the `scope` property works with email', async () => {
   expect(host.split('-')[0]).toBe(session);
 
   // Send a test request to the deployment
-  const response = await fetch(href);
+  const response = await nodeFetch(href);
   const contentType = response.headers.get('content-type');
 
   expect(contentType).toBe('text/html; charset=utf-8');
@@ -394,7 +394,7 @@ test('ensure the `scope` property works with username', async () => {
   expect(host.split('-')[0]).toBe(session);
 
   // Send a test request to the deployment
-  const response = await fetch(href);
+  const response = await nodeFetch(href);
   const contentType = response.headers.get('content-type');
 
   expect(contentType).toBe('text/html; charset=utf-8');
@@ -808,7 +808,7 @@ test('deploy a Lambda with 128MB of memory', async () => {
   expect(output.exitCode, formatOutput(output)).toBe(0);
 
   const { host: url } = new URL(output.stdout);
-  const response = await fetch('https://' + url + '/api/memory');
+  const response = await nodeFetch('https://' + url + '/api/memory');
 
   expect(response.status).toBe(200);
 
@@ -839,12 +839,12 @@ test.skip('deploy a Lambda with 3 seconds of maxDuration', async () => {
 
   // Should time out
   url.pathname = '/api/wait-for/5';
-  const response1 = await fetch(url.href);
+  const response1 = await nodeFetch(url.href);
   expect(response1.status).toBe(504);
 
   // Should not time out
   url.pathname = '/api/wait-for/1';
-  const response2 = await fetch(url.href);
+  const response2 = await nodeFetch(url.href);
   expect(response2.status).toBe(200);
 });
 
@@ -875,7 +875,7 @@ test('deploy a Lambda with a specific runtime', async () => {
   expect(output.exitCode, formatOutput(output)).toBe(0);
 
   const url = new URL(output.stdout);
-  const res = await fetch(`${url}/api/test`);
+  const res = await nodeFetch(`${url}/api/test`);
   const text = await res.text();
   expect(text).toBe('Hello from PHP');
 });
@@ -909,7 +909,7 @@ test('use build-env', async () => {
   await waitForDeployment(href);
 
   // get the content
-  const response = await fetch(href);
+  const response = await nodeFetch(href);
   const content = await response.text();
   expect(content.trim()).toBe('bar');
 });

--- a/packages/cli/test/unit/util/error.test.ts
+++ b/packages/cli/test/unit/util/error.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import { listen } from 'async-listen';
 import type { IncomingMessage, Server, ServerResponse } from 'http';
 import { createServer } from 'http';
@@ -36,7 +36,7 @@ describe('responseError()', () => {
       send(res, 404, {});
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res, 'Failed to load data');
     expect(formatted.message).toEqual('Failed to load data (404)');
   });
@@ -46,7 +46,7 @@ describe('responseError()', () => {
       send(res, 404, {});
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('Response Error (404)');
   });
@@ -56,7 +56,7 @@ describe('responseError()', () => {
       send(res, 500, '');
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('Response Error (500)');
   });
@@ -70,7 +70,7 @@ describe('responseError()', () => {
       });
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('The request is not correct (400)');
   });
@@ -80,7 +80,7 @@ describe('responseError()', () => {
       send(res, 500, 'This is a malformed error');
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res, 'Failed to process data');
     expect(formatted.message).toEqual('Failed to process data (500)');
   });
@@ -92,7 +92,7 @@ describe('responseError()', () => {
       });
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res, 'Failed to process data');
     expect(formatted.message).toEqual('Failed to process data (500)');
   });
@@ -102,7 +102,7 @@ describe('responseError()', () => {
       send(res, 403, `32puuuh2332`);
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseErrorMessage(res, 'Not authenticated');
     expect(formatted).toEqual('Not authenticated (403)');
   });
@@ -116,7 +116,7 @@ describe('responseError()', () => {
       });
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseErrorMessage(res);
     expect(formatted).toEqual('This is a test (403)');
   });
@@ -130,7 +130,7 @@ describe('responseError()', () => {
       });
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseErrorMessage(res);
     expect(formatted).toEqual('Response Error (500)');
   });
@@ -140,7 +140,7 @@ describe('responseError()', () => {
       send(res, 403, `122{"sss"`);
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res, 'Not authenticated');
     expect(formatted.message).toEqual('Not authenticated (403)');
   });
@@ -155,7 +155,7 @@ describe('responseError()', () => {
       });
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('The request is not correct (403)');
     expect(formatted.additionalProperty).toEqual('test');
@@ -172,7 +172,7 @@ describe('responseError()', () => {
       });
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('You were rate limited (429)');
     expect(formatted.retryAfterMs).toEqual(20000);
@@ -187,7 +187,7 @@ describe('responseError()', () => {
       });
     };
 
-    const res = await fetch(url);
+    const res = await nodeFetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('You were rate limited (429)');
     // We default to 0 in this case so callers still know to retry

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -3,7 +3,7 @@ import assert from 'assert';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { isString } from 'util';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import { URL, URLSearchParams } from 'url';
 import frameworkList from '../src/frameworks';
 
@@ -209,7 +209,7 @@ const Schema = {
 async function getDeployment(host: string) {
   const query = new URLSearchParams();
   query.set('url', host);
-  const res = await fetch(
+  const res = await nodeFetch(
     `https://api.vercel.com/v11/deployments/get?${query}`
   );
   const body = await res.json();

--- a/packages/next/test/fixtures/00-trailing-slash-add/index.test.js
+++ b/packages/next/test/fixtures/00-trailing-slash-add/index.test.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const nodeFetch = require('node-fetch');
 const path = require('path');
 const { deployAndTest, waitFor } = require('../../utils');
 
@@ -16,7 +16,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
     // request _next/data until we get the revalidated content
     for (let i = 0; i < 10; i++) {
-      const dataRes = await fetch(
+      const dataRes = await nodeFetch(
         `${ctx.deploymentUrl}/_next/data/build-TfctsWXpff2fKS/index.json`
       );
       expect(dataRes.status).toBe(200);
@@ -34,7 +34,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
     // ensure the HTML response is actually HTML after revalidating
     // via the _next/data endpoint
-    const htmlRes = await fetch(ctx.deploymentUrl);
+    const htmlRes = await nodeFetch(ctx.deploymentUrl);
     expect(htmlRes.status).toBe(200);
     expect(htmlRes.headers.get('content-type')).toContain('text/html');
 

--- a/packages/next/test/fixtures/00-trailing-slash-middleware-add/index.test.js
+++ b/packages/next/test/fixtures/00-trailing-slash-middleware-add/index.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
-const fetch = require('node-fetch');
+const nodeFetch = require('node-fetch');
 const { deployAndTest, waitFor } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
@@ -33,7 +33,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
     // request _next/data until we get the revalidated content
     for (let i = 0; i < 10; i++) {
-      const dataRes = await fetch(
+      const dataRes = await nodeFetch(
         `${ctx.deploymentUrl}/_next/data/build-TfctsWXpff2fKS/index.json`
       );
       expect(dataRes.status).toBe(200);
@@ -51,7 +51,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
     // ensure the HTML response is actually HTML after revalidating
     // via the _next/data endpoint
-    const htmlRes = await fetch(ctx.deploymentUrl);
+    const htmlRes = await nodeFetch(ctx.deploymentUrl);
     expect(htmlRes.status).toBe(200);
     expect(htmlRes.headers.get('content-type')).toContain('text/html');
 

--- a/packages/node/test/fixtures/06-ts-esm/api/proxy.ts
+++ b/packages/node/test/fixtures/06-ts-esm/api/proxy.ts
@@ -1,11 +1,11 @@
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 export default async function handler(
   _request: IncomingMessage,
   response: ServerResponse
 ) {
-  const res = await fetch('https://example.vercel.sh');
+  const res = await nodeFetch('https://example.vercel.sh');
   const text = await res.text();
   return response.end(text);
 }

--- a/packages/node/test/unit/dev.test.ts
+++ b/packages/node/test/unit/dev.test.ts
@@ -4,7 +4,6 @@ import { resolve, extname } from 'path';
 import { createServer, request } from 'http';
 import { listen } from 'async-listen';
 import { once } from 'node:events';
-import { fetch } from 'undici';
 import { promisify } from 'util';
 import { setTimeout } from 'timers/promises';
 

--- a/test/lib/deployment/fetch-retry.js
+++ b/test/lib/deployment/fetch-retry.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const nodeFetch = require('node-fetch');
 const retryBailByDefault = require('./retry-bail-by-default.js');
 
 const ABSOLUTE_URL_PATTERN = /^https?:\/\//i;
@@ -13,7 +13,7 @@ async function fetchRetry(url, ...rest) {
       try {
         const requestIds = [];
         for (let i = 60; i >= 0; i--) {
-          const res = await fetch(url, ...rest);
+          const res = await nodeFetch(url, ...rest);
 
           if (res.status === 401) {
             const clonedRes = res.clone();


### PR DESCRIPTION
# Overview

Migrate tests from node-fetch to fetch.


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR contains only test file refactoring that renames the import alias from `fetch` to `nodeFetch` when importing from node-fetch, with no changes to production code logic or behavior.
> 
> - Renames import alias `fetch` → `nodeFetch` across multiple test files
> - Removes unused `fetch` import from undici in one test file
> - Adds changeset documentation for the rename
>
> <sup>Risk assessment for [commit de07bbc](https://github.com/vercel/vercel/commit/de07bbc39edc87c09f8979f8f8857d45b4d86d35).</sup>
<!-- VADE_RISK_END -->