### PR TITLE
remame fetch to nodeFetch in packages

### DIFF
--- a/.changeset/happy-comics-smash.md
+++ b/.changeset/happy-comics-smash.md
@@ -1,0 +1,8 @@
+---
+'@vercel/static-build': patch
+'@vercel/build-utils': patch
+'vercel': patch
+'@vercel/go': patch
+---
+
+Rename fetch to nodeFetch in cases where it is an import from node-fetch

--- a/api/_lib/examples/github-repo-info.ts
+++ b/api/_lib/examples/github-repo-info.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import { Repo } from '../types';
 import { getExampleList } from './example-list';
 
@@ -7,14 +7,17 @@ import { getExampleList } from './example-list';
  * @param {object} repo parsed by the `parse-github-url` package
  */
 export async function getGitHubRepoInfo(repo: Repo) {
-  const response = await fetch(`https://api.github.com/repos/${repo.repo}`, {
-    headers: {
-      Accept: 'application/vnd.github.machine-man-preview+json',
-      // If we don't use a personal access token,
-      // it will get rate limited very easily.
-      Authorization: `Bearer ${process.env.GITHUB_ACCESS_TOKEN}`,
-    },
-  });
+  const response = await nodeFetch(
+    `https://api.github.com/repos/${repo.repo}`,
+    {
+      headers: {
+        Accept: 'application/vnd.github.machine-man-preview+json',
+        // If we don't use a personal access token,
+        // it will get rate limited very easily.
+        Authorization: `Bearer ${process.env.GITHUB_ACCESS_TOKEN}`,
+      },
+    }
+  );
 
   if (response.status !== 200) {
     console.log(`Non-200 response code from GitHub: ${response.status}`);

--- a/api/_lib/examples/gitlab-repo-info.ts
+++ b/api/_lib/examples/gitlab-repo-info.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 
 interface Repo {
   repo: string;
@@ -14,7 +14,7 @@ interface Repo {
  * @param {object} repo parsed by the `parse-github-url` package
  */
 export async function getGitLabRepoInfo(repo: Repo) {
-  const response = await fetch(
+  const response = await nodeFetch(
     `https://gitlab.com/api/v4/projects/${encodeURIComponent(repo.repo)}`
   );
 

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import multiStream from 'multistream';
 import retry from 'async-retry';
 import Sema from 'async-sema';
@@ -106,7 +106,7 @@ export default class FileRef implements FileBase {
     try {
       return await retry(
         async () => {
-          const resp = await fetch(url);
+          const resp = await nodeFetch(url);
           if (!resp.ok) {
             const error = new BailableError(
               `download: ${resp.status} ${resp.statusText} for ${url}`

--- a/packages/cli/src/commands/build/emit-flags-datafiles.ts
+++ b/packages/cli/src/commands/build/emit-flags-datafiles.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { NowBuildError } from '@vercel/build-utils';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import output from '../../output-manager';
 import pkg from '../../util/pkg';
 
@@ -152,7 +152,7 @@ export async function emitFlagsDatafiles(
         headers['x-vercel-region'] = env.VERCEL_REGION;
       }
 
-      const res = await fetch(`${FLAGS_HOST}/v1/datafile`, { headers });
+      const res = await nodeFetch(`${FLAGS_HOST}/v1/datafile`, { headers });
 
       if (!res.ok) {
         throw new NowBuildError({

--- a/packages/cli/src/commands/telemetry/flush.ts
+++ b/packages/cli/src/commands/telemetry/flush.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import type Client from '../../util/client';
 
 export default async function flush(_client: Client, args: string[]) {
@@ -9,7 +9,7 @@ export default async function flush(_client: Client, args: string[]) {
   try {
     // Use node-fetch directly instead of client.fetch because the client's
     // HTTP agent may be HTTPS-only, but the bridge URL can be http:// in tests.
-    const res = await fetch(url, {
+    const res = await nodeFetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -3,7 +3,7 @@ import http from 'http';
 import fs from 'fs-extra';
 import ms from 'ms';
 import chalk from 'chalk';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import plural from 'pluralize';
 import rawBody from 'raw-body';
 import { listen } from 'async-listen';
@@ -1551,7 +1551,7 @@ export default class DevServer {
             middlewareReqHeaders.set(name, value);
           }
 
-          const middlewareRes = await fetch(
+          const middlewareRes = await nodeFetch(
             `http://127.0.0.1:${port}${parsed.path}`,
             {
               headers: middlewareReqHeaders,

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -2,7 +2,7 @@ import qs from 'querystring';
 import { parse as parseUrl } from 'url';
 import retry from 'async-retry';
 import ms from 'ms';
-import fetch, { Headers } from 'node-fetch';
+import nodeFetch, { Headers } from 'node-fetch';
 import bytes from 'bytes';
 import chalk from 'chalk';
 import ua from './ua';
@@ -377,7 +377,7 @@ export default class Now {
 
     const res = await output.time(
       `${opts.method || 'GET'} ${this._apiUrl}${_url} ${opts.body || ''}`,
-      fetch(`${this._apiUrl}${_url}`, { ...opts, body })
+      nodeFetch(`${this._apiUrl}${_url}`, { ...opts, body })
     );
     printIndications(res);
     return res;

--- a/packages/cli/src/util/oauth.ts
+++ b/packages/cli/src/util/oauth.ts
@@ -1,4 +1,4 @@
-import fetch, { type Response } from 'node-fetch';
+import nodeFetch, { type Response } from 'node-fetch';
 import ua from './ua';
 import { hostname } from 'os';
 
@@ -38,7 +38,7 @@ export async function as(): Promise<AuthorizationServerMetadata> {
  * @see https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest
  */
 async function discoveryEndpointRequest(issuer: URL): Promise<Response> {
-  return await fetch(new URL('.well-known/openid-configuration', issuer), {
+  return await nodeFetch(new URL('.well-known/openid-configuration', issuer), {
     headers: { 'Content-Type': 'application/json', 'user-agent': userAgent },
   });
 }
@@ -97,7 +97,7 @@ async function processDiscoveryEndpointResponse(
  * @see https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
  */
 export async function deviceAuthorizationRequest(): Promise<Response> {
-  return await fetch((await as()).device_authorization_endpoint, {
+  return await nodeFetch((await as()).device_authorization_endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -204,7 +204,7 @@ export async function deviceAccessTokenRequest(options: {
   try {
     return [
       null,
-      await fetch((await as()).token_endpoint, {
+      await nodeFetch((await as()).token_endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
@@ -285,7 +285,7 @@ export async function processTokenResponse(
 export async function revocationRequest(options: {
   token: string;
 }): Promise<Response> {
-  return await fetch((await as()).revocation_endpoint, {
+  return await nodeFetch((await as()).revocation_endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -317,7 +317,7 @@ export async function processRevocationResponse(
 export async function refreshTokenRequest(options: {
   refresh_token: string;
 }): Promise<Response> {
-  return await fetch((await as()).token_endpoint, {
+  return await nodeFetch((await as()).token_endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -408,7 +408,7 @@ function canParseURL(url: string) {
  * @see https://datatracker.ietf.org/doc/html/rfc7662#section-2.1
  */
 export async function inspectTokenRequest(token: string): Promise<Response> {
-  return fetch((await as()).introspection_endpoint, {
+  return nodeFetch((await as()).introspection_endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/packages/cli/test/dev/integration-1.test.ts
+++ b/packages/cli/test/dev/integration-1.test.ts
@@ -7,12 +7,12 @@ import stripAnsi from 'strip-ansi';
 import { createServer } from 'http';
 import {
   exec,
-  fetch,
   fixture,
   testFixture,
   testFixtureStdio,
   validateResponseHeaders,
 } from './utils';
+import nodeFetch from 'node-fetch';
 
 test('[verdel dev] should support serverless functions', async () => {
   const dir = fixture('serverless-function');
@@ -20,7 +20,7 @@ test('[verdel dev] should support serverless functions', async () => {
 
   try {
     await readyResolver;
-    const res = await fetch(`http://localhost:${port}/api?foo=bar`);
+    const res = await nodeFetch(`http://localhost:${port}/api?foo=bar`);
     validateResponseHeaders(res);
     const payload = await res.json();
     expect(payload).toMatchObject({ url: '/api?foo=bar', method: 'GET' });
@@ -43,7 +43,7 @@ test('[vercel dev] should support edge functions', async () => {
 
     const body = { hello: 'world' };
 
-    const res = await fetch(`http://localhost:${port}/api/edge-success`, {
+    const res = await nodeFetch(`http://localhost:${port}/api/edge-success`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -87,7 +87,7 @@ test('[vercel dev] edge functions support WebAssembly files', async () => {
       { number: 2, result: 3 },
       { number: 12, result: 13 },
     ]) {
-      const res = await fetch(
+      const res = await nodeFetch(
         `http://localhost:${port}/api/webassembly?number=${number}`
       );
       validateResponseHeaders(res);
@@ -114,7 +114,9 @@ test('[vercel dev] throws an error when an edge function has no response', async
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/api/edge-no-response`);
+    const res = await nodeFetch(
+      `http://localhost:${port}/api/edge-no-response`
+    );
     validateResponseHeaders(res);
 
     const { stdout } = await dev.kill();
@@ -138,13 +140,16 @@ test('[vercel dev] should support edge functions returning intentional 500 respo
 
     const body = { hello: 'world' };
 
-    const res = await fetch(`http://localhost:${port}/api/edge-500-response`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
+    const res = await nodeFetch(
+      `http://localhost:${port}/api/edge-500-response`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      }
+    );
     validateResponseHeaders(res);
 
     expect(await res.status).toBe(500);
@@ -163,13 +168,16 @@ test('[vercel dev] should handle runtime errors thrown in edge functions', async
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/api/edge-error-runtime`, {
-      method: 'GET',
-      headers: {
-        Accept:
-          'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      },
-    });
+    const res = await nodeFetch(
+      `http://localhost:${port}/api/edge-error-runtime`,
+      {
+        method: 'GET',
+        headers: {
+          Accept:
+            'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        },
+      }
+    );
     validateResponseHeaders(res);
 
     const { stdout } = await dev.kill();
@@ -192,13 +200,16 @@ test('[vercel dev] should handle config errors thrown in edge functions', async 
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/api/edge-error-config`, {
-      method: 'GET',
-      headers: {
-        Accept:
-          'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      },
-    });
+    const res = await nodeFetch(
+      `http://localhost:${port}/api/edge-error-config`,
+      {
+        method: 'GET',
+        headers: {
+          Accept:
+            'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        },
+      }
+    );
     validateResponseHeaders(res);
 
     const { stderr } = await dev.kill();
@@ -221,13 +232,16 @@ test('[vercel dev] should handle startup errors thrown in edge functions', async
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/api/edge-error-startup`, {
-      method: 'GET',
-      headers: {
-        Accept:
-          'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      },
-    });
+    const res = await nodeFetch(
+      `http://localhost:${port}/api/edge-error-startup`,
+      {
+        method: 'GET',
+        headers: {
+          Accept:
+            'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        },
+      }
+    );
     validateResponseHeaders(res);
 
     const { stderr } = await dev.kill();
@@ -249,13 +263,16 @@ test('[vercel dev] should handle syntax errors thrown in edge functions', async 
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/api/edge-error-syntax`, {
-      method: 'GET',
-      headers: {
-        Accept:
-          'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      },
-    });
+    const res = await nodeFetch(
+      `http://localhost:${port}/api/edge-error-syntax`,
+      {
+        method: 'GET',
+        headers: {
+          Accept:
+            'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        },
+      }
+    );
     validateResponseHeaders(res);
 
     const { stderr } = await dev.kill();
@@ -277,7 +294,7 @@ test('[vercel dev] should handle import errors thrown in edge functions', async 
   try {
     await readyResolver;
 
-    const res = await fetch(
+    const res = await nodeFetch(
       `http://localhost:${port}/api/edge-error-unknown-import`,
       {
         method: 'GET',
@@ -309,7 +326,7 @@ test('[vercel dev] should handle missing handler errors thrown in edge functions
   try {
     await readyResolver;
 
-    const res = await fetch(
+    const res = await nodeFetch(
       `http://localhost:${port}/api/edge-error-no-handler`,
       {
         method: 'GET',
@@ -344,7 +361,7 @@ test('[vercel dev] should handle invalid middleware config', async () => {
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/api/whatever`, {
+    const res = await nodeFetch(`http://localhost:${port}/api/whatever`, {
       method: 'GET',
       headers: {
         Accept:
@@ -376,7 +393,7 @@ test('[vercel dev] should support request body', async () => {
     const body = { hello: 'world' };
 
     // Test that `req.body` works in dev
-    let res = await fetch(`http://localhost:${port}/api/req-body`, {
+    let res = await nodeFetch(`http://localhost:${port}/api/req-body`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -387,7 +404,7 @@ test('[vercel dev] should support request body', async () => {
     expect(await res.json()).toMatchObject({ body, readBody: body });
 
     // Test that `req` "data" events work in dev
-    res = await fetch(`http://localhost:${port}/api/data-events`, {
+    res = await nodeFetch(`http://localhost:${port}/api/data-events`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -406,7 +423,9 @@ test('[vercel dev] should maintain query when invoking serverless function', asy
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/something?url-param=a`);
+    const res = await nodeFetch(
+      `http://localhost:${port}/something?url-param=a`
+    );
     validateResponseHeaders(res);
 
     const text = await res.text();
@@ -434,7 +453,7 @@ test('[vercel dev] should maintain query when proxy passing', async () => {
       throw new Error('Unexpected HTTP address');
     }
 
-    const res = await fetch(
+    const res = await nodeFetch(
       `http://localhost:${port}/${destAddr.port}?url-param=a`
     );
     validateResponseHeaders(res);
@@ -457,7 +476,7 @@ test('[vercel dev] should maintain query when dev server defines routes', async 
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/test?url-param=a`);
+    const res = await nodeFetch(`http://localhost:${port}/test?url-param=a`);
     validateResponseHeaders(res);
 
     const text = await res.text();
@@ -487,7 +506,7 @@ test('[vercel dev] should allow `cache-control` to be overwritten', async () => 
   try {
     await readyResolver;
 
-    const res = await fetch(
+    const res = await nodeFetch(
       `http://localhost:${port}/?name=cache-control&value=immutable`
     );
     expect(res.headers.get('cache-control')).toEqual('immutable');
@@ -503,7 +522,7 @@ test('[vercel dev] should send `etag` header for static files', async () => {
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/foo.txt`);
+    const res = await nodeFetch(`http://localhost:${port}/foo.txt`);
     const expected = 'd263af8ab880c0b97eb6c5c125b5d44f9e5addd9';
     expect(res.headers.get('etag')).toEqual(`"${expected}"`);
     const body = await res.text();
@@ -522,23 +541,23 @@ test.skip('[vercel dev] should frontend dev server and routes', async () => {
   try {
     await readyResolver;
 
-    let res = await fetch(`http://localhost:${port}/`);
+    let res = await nodeFetch(`http://localhost:${port}/`);
     validateResponseHeaders(res);
     const podId = res.headers.get('x-vercel-id')!.match(/:(\w+)-/)![1];
     let body = await res.text();
     expect(body).toContain('hello, this is the frontend');
 
-    res = await fetch(`http://localhost:${port}/api/users`);
+    res = await nodeFetch(`http://localhost:${port}/api/users`);
     validateResponseHeaders(res, podId);
     body = await res.text();
     expect(body).toEqual('users');
 
-    res = await fetch(`http://localhost:${port}/api/users/1`);
+    res = await nodeFetch(`http://localhost:${port}/api/users/1`);
     validateResponseHeaders(res, podId);
     body = await res.text();
     expect(body).toEqual('users/1');
 
-    res = await fetch(`http://localhost:${port}/api/welcome`);
+    res = await nodeFetch(`http://localhost:${port}/api/welcome`);
     validateResponseHeaders(res, podId);
     body = await res.text();
     expect(body).toEqual('hello and welcome');
@@ -554,7 +573,7 @@ test('[vercel dev] should support `@vercel/static` routing', async () => {
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/`);
+    const res = await nodeFetch(`http://localhost:${port}/`);
     expect(res.status).toEqual(200);
     const body = await res.text();
     expect(body.trim()).toEqual('<body>Hello!</body>');
@@ -570,7 +589,7 @@ test('[vercel dev] should support `@vercel/static-build` routing', async () => {
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/api/date`);
+    const res = await nodeFetch(`http://localhost:${port}/api/date`);
     expect(res.status).toEqual(200);
     const body = await res.text();
     expect(body).toMatch(/^The current date/);
@@ -587,25 +606,25 @@ test('[vercel dev] should support directory listing', async () => {
     await readyResolver;
 
     // Get directory listing
-    let res = await fetch(`http://localhost:${port}/`);
+    let res = await nodeFetch(`http://localhost:${port}/`);
     let body = await res.text();
     expect(res.status).toEqual(200);
     expect(body).toContain('Index of');
 
     // Get a file
-    res = await fetch(`http://localhost:${port}/file.txt`);
+    res = await nodeFetch(`http://localhost:${port}/file.txt`);
     body = await res.text();
     expect(res.status).toEqual(200);
     expect(body.trim()).toEqual('Hello from file!');
 
     // Invoke a lambda
-    res = await fetch(`http://localhost:${port}/lambda.js`);
+    res = await nodeFetch(`http://localhost:${port}/lambda.js`);
     body = await res.text();
     expect(res.status).toEqual(200);
     expect(body).toEqual('Hello from Lambda!');
 
     // Trigger a 404
-    res = await fetch(`http://localhost:${port}/does-not-exist`);
+    res = await nodeFetch(`http://localhost:${port}/does-not-exist`);
     expect(res.status).toEqual(404);
   } finally {
     await dev.kill();
@@ -620,7 +639,7 @@ test('[vercel dev] should respond with 404 listing with Accept header support', 
     await readyResolver;
 
     // HTML response
-    let res = await fetch(`http://localhost:${port}/does-not-exist`, {
+    let res = await nodeFetch(`http://localhost:${port}/does-not-exist`, {
       headers: {
         Accept: 'text/html',
       },
@@ -631,7 +650,7 @@ test('[vercel dev] should respond with 404 listing with Accept header support', 
     expect(body).toMatch(/^<!DOCTYPE html>/);
 
     // JSON response
-    res = await fetch(`http://localhost:${port}/does-not-exist`, {
+    res = await nodeFetch(`http://localhost:${port}/does-not-exist`, {
       headers: {
         Accept: 'application/json',
       },
@@ -644,7 +663,7 @@ test('[vercel dev] should respond with 404 listing with Accept header support', 
     );
 
     // Plain text response
-    res = await fetch(`http://localhost:${port}/does-not-exist`);
+    res = await nodeFetch(`http://localhost:${port}/does-not-exist`);
     expect(res.status).toEqual(404);
     body = await res.text();
     expect(res.headers.get('content-type')).toEqual(
@@ -663,11 +682,11 @@ test('[vercel dev] should support `public` directory with zero config', async ()
   try {
     await readyResolver;
 
-    let res = await fetch(`http://localhost:${port}/api/user`);
+    let res = await nodeFetch(`http://localhost:${port}/api/user`);
     let body = await res.text();
     expect(body).toEqual('hello:user');
 
-    res = await fetch(`http://localhost:${port}/`);
+    res = await nodeFetch(`http://localhost:${port}/`);
     body = await res.text();
     expect(body).toMatch(/^<h1>hello world<\/h1>/);
   } finally {
@@ -682,11 +701,11 @@ test('[vercel dev] should support static files with zero config', async () => {
   try {
     await readyResolver;
 
-    let res = await fetch(`http://localhost:${port}/api/user`);
+    let res = await nodeFetch(`http://localhost:${port}/api/user`);
     let body = await res.text();
     expect(body).toEqual('bye:user');
 
-    res = await fetch(`http://localhost:${port}/`);
+    res = await nodeFetch(`http://localhost:${port}/`);
     expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8');
     body = await res.text();
     expect(body).toMatch(/^<h1>goodbye world<\/h1>/);
@@ -703,19 +722,19 @@ test('[vercel dev] should support custom 404 routes', async () => {
     await readyResolver;
 
     // Test custom 404 with static dest
-    let res = await fetch(`http://localhost:${port}/error.html`);
+    let res = await nodeFetch(`http://localhost:${port}/error.html`);
     expect(res.status).toEqual(404);
     let body = await res.text();
     expect(body.trim()).toEqual('<div>Custom 404 page</div>');
 
     // Test custom 404 with lambda dest
-    res = await fetch(`http://localhost:${port}/error.js`);
+    res = await nodeFetch(`http://localhost:${port}/error.js`);
     expect(res.status).toEqual(404);
     body = await res.text();
     expect(body).toEqual('Custom 404 Lambda\n');
 
     // Test regular 404 still works
-    res = await fetch(`http://localhost:${port}/does-not-exist`);
+    res = await nodeFetch(`http://localhost:${port}/does-not-exist`);
     expect(res.status).toEqual(404);
     body = await res.text();
     expect(body).toEqual('The page could not be found.\n\nNOT_FOUND\n');
@@ -746,7 +765,7 @@ test('[vercel dev] `vercel.json` should be invalidated if deleted', async () => 
 
     {
       // Env var should be set from `vercel.json`
-      const res = await fetch(`http://localhost:${port}/api`);
+      const res = await nodeFetch(`http://localhost:${port}/api`);
       const body = await res.json();
       expect(body.FOO).toBe('bar');
     }
@@ -755,7 +774,7 @@ test('[vercel dev] `vercel.json` should be invalidated if deleted', async () => 
       // Env var should not be set after `vercel.json` is deleted
       await fs.remove(configPath);
 
-      const res = await fetch(`http://localhost:${port}/api`);
+      const res = await nodeFetch(`http://localhost:${port}/api`);
       const body = await res.json();
       expect(body.FOO).toBe(undefined);
     }
@@ -776,7 +795,7 @@ test('[vercel dev] reflects changes to config and env without restart', async ()
 
     {
       // Node.js helpers should be available by default
-      const res = await fetch(`http://localhost:${port}/?foo=bar`);
+      const res = await nodeFetch(`http://localhost:${port}/?foo=bar`);
       const body = await res.json();
       expect(body.hasHelpers).toBe(true);
       expect(body.query.foo).toBe('bar');
@@ -797,7 +816,7 @@ test('[vercel dev] reflects changes to config and env without restart', async ()
       };
       await fs.writeJSON(configPath, config);
 
-      const res = await fetch(`http://localhost:${port}/?foo=bar`);
+      const res = await nodeFetch(`http://localhost:${port}/?foo=bar`);
       const body = await res.json();
       expect(body.hasHelpers).toBe(false);
       expect(body.query).toBe(undefined);
@@ -818,7 +837,7 @@ test('[vercel dev] reflects changes to config and env without restart', async ()
       };
       await fs.writeJSON(configPath, config);
 
-      const res = await fetch(`http://localhost:${port}/?foo=baz`);
+      const res = await nodeFetch(`http://localhost:${port}/?foo=baz`);
       const body = await res.json();
       expect(body.hasHelpers).toBe(true);
       expect(body.query.foo).toBe('baz');
@@ -836,7 +855,7 @@ test('[vercel dev] reflects changes to config and env without restart', async ()
       };
       await fs.writeJSON(configPath, config);
 
-      const res = await fetch(`http://localhost:${port}/?foo=baz`);
+      const res = await nodeFetch(`http://localhost:${port}/?foo=baz`);
       const body = await res.json();
       expect(body.hasHelpers).toBe(false);
       expect(body.query).toBe(undefined);
@@ -854,7 +873,7 @@ test('[vercel dev] reflects changes to config and env without restart', async ()
       };
       await fs.writeJSON(configPath, config);
 
-      const res = await fetch(`http://localhost:${port}/?foo=boo`);
+      const res = await nodeFetch(`http://localhost:${port}/?foo=boo`);
       const body = await res.json();
       expect(body.hasHelpers).toBe(true);
       expect(body.query.foo).toBe('boo');
@@ -885,7 +904,7 @@ test('[vercel dev] `@vercel/node` TypeScript should be resolved by default', asy
   try {
     await readyResolver;
 
-    const res = await fetch(`http://localhost:${port}/api/hello`);
+    const res = await nodeFetch(`http://localhost:${port}/api/hello`);
     const body = await res.text();
     expect(body).toBe('world');
   } finally {

--- a/packages/cli/test/dev/integration-3.test.ts
+++ b/packages/cli/test/dev/integration-3.test.ts
@@ -5,12 +5,12 @@ import {
   sleep,
   shouldSkip,
   fetchWithRetry,
-  fetch,
   fixture,
   testFixture,
   testFixtureStdio,
   validateResponseHeaders,
 } from './utils';
+import nodeFetch from 'node-fetch';
 
 // Angular has `engines: { node: "10.x" }` in its `package.json`
 test('[vercel dev] 02-angular-node', async () => {
@@ -218,7 +218,7 @@ test(
     '01-node',
     async (_testPath: any, port: any) => {
       {
-        const res = await fetch(`http://localhost:${port}////?foo=bar`, {
+        const res = await nodeFetch(`http://localhost:${port}////?foo=bar`, {
           redirect: 'manual',
         });
 
@@ -233,10 +233,13 @@ test(
       }
 
       {
-        const res = await fetch(`http://localhost:${port}///api////date.js`, {
-          method: 'POST',
-          redirect: 'manual',
-        });
+        const res = await nodeFetch(
+          `http://localhost:${port}///api////date.js`,
+          {
+            method: 'POST',
+            redirect: 'manual',
+          }
+        );
 
         validateResponseHeaders(res);
 

--- a/packages/cli/test/dev/integration-4.test.ts
+++ b/packages/cli/test/dev/integration-4.test.ts
@@ -1,8 +1,7 @@
 import fs from 'fs-extra';
 import { join } from 'path';
-import type { Response } from 'node-fetch';
+import nodeFetch, { type Response } from 'node-fetch';
 import {
-  fetch,
   fixture,
   testFixture,
   testFixtureStdio,
@@ -191,21 +190,23 @@ test('[vercel dev] Middleware rewrites with same origin', async () => {
     dev.unref();
     await readyResolver;
 
-    let response = await fetch(
+    let response = await nodeFetch(
       `http://localhost:${port}?to=http://localhost:${port}`
     );
     validateResponseHeaders(response);
     expect(response.status).toBe(200);
     expect(await response.text()).toMatch(/<h1>Index<\/h1>/);
 
-    response = await fetch(
+    response = await nodeFetch(
       `http://localhost:${port}?to=http://127.0.0.1:${port}`
     );
     validateResponseHeaders(response);
     expect(response.status).toBe(200);
     expect(await response.text()).toMatch(/<h1>Index<\/h1>/);
 
-    response = await fetch(`http://localhost:${port}?to=http://[::1]:${port}`);
+    response = await nodeFetch(
+      `http://localhost:${port}?to=http://[::1]:${port}`
+    );
     validateResponseHeaders(response);
     expect(response.status).toBe(200);
     expect(await response.text()).toMatch(/<h1>Index<\/h1>/);
@@ -316,7 +317,7 @@ test(
       const originalVercelJson = await fs.readJSON(vercelJsonPath);
 
       try {
-        const originalResponse = await fetch(
+        const originalResponse = await nodeFetch(
           `http://localhost:${port}/index.txt`
         );
         validateResponseHeaders(originalResponse);
@@ -328,7 +329,7 @@ test(
           devCommand: 'serve -p $PORT overridden',
         });
 
-        const overriddenResponse = await fetch(
+        const overriddenResponse = await nodeFetch(
           `http://localhost:${port}/index.txt`
         );
         validateResponseHeaders(overriddenResponse);

--- a/packages/cli/test/dev/integration-5.test.ts
+++ b/packages/cli/test/dev/integration-5.test.ts
@@ -3,13 +3,13 @@ import ms from 'ms';
 import fs, { mkdirp } from 'fs-extra';
 import {
   sleep,
-  fetch,
   fixture,
   testFixture,
   testFixtureStdio,
   validateResponseHeaders,
 } from './utils';
 import assert from 'assert';
+import nodeFetch from 'node-fetch';
 
 test(
   '[vercel dev] temporary directory listing',
@@ -21,7 +21,7 @@ test(
 
       await sleep(ms('20s'));
 
-      const firstResponse = await fetch(`http://localhost:${port}`);
+      const firstResponse = await nodeFetch(`http://localhost:${port}`);
       validateResponseHeaders(firstResponse);
       const body = await firstResponse.text();
       // eslint-disable-next-line no-console
@@ -31,7 +31,7 @@ test(
       await fs.writeFile(join(directory, 'index.txt'), 'hello');
 
       for (let i = 0; i < 20; i++) {
-        const response = await fetch(`http://localhost:${port}`);
+        const response = await nodeFetch(`http://localhost:${port}`);
         validateResponseHeaders(response);
 
         if (response.status === 200) {
@@ -59,7 +59,7 @@ test('[vercel dev] add a `package.json` to trigger `@vercel/static-build`', asyn
     'trigger-static-build',
     async (_testPath: any, port: any) => {
       {
-        const response = await fetch(`http://localhost:${port}`);
+        const response = await nodeFetch(`http://localhost:${port}`);
         validateResponseHeaders(response);
         const body = await response.text();
         expect(body.trim()).toBe('hello:index.txt');
@@ -77,7 +77,7 @@ test('[vercel dev] add a `package.json` to trigger `@vercel/static-build`', asyn
       await sleep(ms('2s'));
 
       {
-        const response = await fetch(`http://localhost:${port}`);
+        const response = await nodeFetch(`http://localhost:${port}`);
         validateResponseHeaders(response);
         const body = await response.text();
         expect(body.trim()).toBe(rnd);
@@ -146,7 +146,7 @@ test('[vercel dev] render warning for empty cwd dir', async () => {
 
     // Issue a request to ensure a 404 response
     await sleep(ms('3s'));
-    const response = await fetch(`http://localhost:${port}`);
+    const response = await nodeFetch(`http://localhost:${port}`);
     validateResponseHeaders(response);
     expect(response.status).toBe(404);
   } finally {
@@ -180,7 +180,7 @@ test('[vercel dev] do not rebuild for changes in the output directory', async ()
       }
     }
 
-    const resp1 = await fetch(`http://localhost:${port}`);
+    const resp1 = await nodeFetch(`http://localhost:${port}`);
     const text1 = await resp1.text();
     expect(text1.trim()).toBe('hello first');
 
@@ -188,7 +188,7 @@ test('[vercel dev] do not rebuild for changes in the output directory', async ()
 
     await sleep(ms('3s'));
 
-    const resp2 = await fetch(`http://localhost:${port}`);
+    const resp2 = await nodeFetch(`http://localhost:${port}`);
     const text2 = await resp2.text();
     expect(text2.trim()).toBe('hello second');
   } finally {
@@ -397,7 +397,9 @@ test(
 
     try {
       {
-        const response = await fetch(`http://localhost:${port}/api/new-file`);
+        const response = await nodeFetch(
+          `http://localhost:${port}/api/new-file`
+        );
         validateResponseHeaders(response);
         expect(response.status).toBe(404);
       }
@@ -419,7 +421,9 @@ test(
       await sleep(ms('1s'));
 
       {
-        const response = await fetch(`http://localhost:${port}/api/new-file`);
+        const response = await nodeFetch(
+          `http://localhost:${port}/api/new-file`
+        );
         validateResponseHeaders(response);
         const body = await response.text();
         expect(body.trim()).toBe('from new file');
@@ -436,12 +440,12 @@ describe('[vercel dev] Express', () => {
     testFixtureStdio(
       'express-no-export',
       async (_testPath: any, port: any) => {
-        const res = await fetch(`http://localhost:${port}`);
+        const res = await nodeFetch(`http://localhost:${port}`);
         validateResponseHeaders(res);
         const json = await res.json();
         expect(json).toHaveProperty('message', 'Hello Express!');
 
-        const res2 = await fetch(`http://localhost:${port}/test.json`);
+        const res2 = await nodeFetch(`http://localhost:${port}/test.json`);
         validateResponseHeaders(res2);
         const json2 = await res2.json();
         expect(json2).toHaveProperty('message', 'Hello Express!');
@@ -457,7 +461,7 @@ describe('[vercel dev] ESM edge functions', () => {
     testFixtureStdio(
       'esm-js-edge-module',
       async (_testPath: any, port: any) => {
-        const res = await fetch(`http://localhost:${port}/api/data`);
+        const res = await nodeFetch(`http://localhost:${port}/api/data`);
         validateResponseHeaders(res);
         const json = await res.json();
         expect(json).toHaveProperty('isLeapYear');
@@ -471,7 +475,7 @@ describe('[vercel dev] ESM edge functions', () => {
     testFixtureStdio(
       'esm-ts-edge-module',
       async (_testPath: any, port: any) => {
-        const res = await fetch(`http://localhost:${port}/api/data`);
+        const res = await nodeFetch(`http://localhost:${port}/api/data`);
         validateResponseHeaders(res);
         const json = await res.json();
         expect(json).toHaveProperty('isLeapYear');
@@ -485,7 +489,7 @@ describe('[vercel dev] ESM edge functions', () => {
     testFixtureStdio(
       'esm-js-edge-no-module',
       async (_testPath: any, port: any) => {
-        const res = await fetch(`http://localhost:${port}/api/data`);
+        const res = await nodeFetch(`http://localhost:${port}/api/data`);
         validateResponseHeaders(res);
         const json = await res.json();
         expect(json).toHaveProperty('isLeapYear');
@@ -499,7 +503,7 @@ describe('[vercel dev] ESM edge functions', () => {
     testFixtureStdio(
       'esm-ts-edge-no-module',
       async (_testPath: any, port: any) => {
-        const res = await fetch(`http://localhost:${port}/api/data`);
+        const res = await nodeFetch(`http://localhost:${port}/api/data`);
         validateResponseHeaders(res);
         const json = await res.json();
         expect(json).toHaveProperty('isLeapYear');
@@ -515,7 +519,7 @@ describe('[vercel dev] ESM serverless functions', () => {
     testFixtureStdio(
       'esm-js-nodejs-module',
       async (_testPath: any, port: any) => {
-        const res = await fetch(`http://localhost:${port}/api/data`);
+        const res = await nodeFetch(`http://localhost:${port}/api/data`);
         validateResponseHeaders(res);
         const json = await res.json();
         expect(json).toHaveProperty('isLeapYear');
@@ -529,7 +533,7 @@ describe('[vercel dev] ESM serverless functions', () => {
     testFixtureStdio(
       'esm-ts-nodejs-module',
       async (_testPath: any, port: any) => {
-        const res = await fetch(`http://localhost:${port}/api/data`);
+        const res = await nodeFetch(`http://localhost:${port}/api/data`);
         validateResponseHeaders(res);
         const json = await res.json();
         expect(json).toHaveProperty('isLeapYear');
@@ -543,7 +547,7 @@ describe('[vercel dev] ESM serverless functions', () => {
     testFixtureStdio(
       'esm-js-nodejs-no-module',
       async (_testPath: any, port: any) => {
-        const res = await fetch(`http://localhost:${port}/api/data`);
+        const res = await nodeFetch(`http://localhost:${port}/api/data`);
         validateResponseHeaders(res);
         const json = await res.json();
         expect(json).toHaveProperty('isLeapYear');
@@ -557,7 +561,7 @@ describe('[vercel dev] ESM serverless functions', () => {
     testFixtureStdio(
       'esm-ts-nodejs-no-module',
       async (_testPath: any, port: any) => {
-        const res = await fetch(`http://localhost:${port}/api/data`);
+        const res = await nodeFetch(`http://localhost:${port}/api/data`);
         validateResponseHeaders(res);
         const json = await res.json();
         expect(json).toHaveProperty('isLeapYear');
@@ -571,7 +575,7 @@ describe('[vercel dev] ESM serverless functions', () => {
     testFixtureStdio(
       'vercel-ts-test',
       async (_testPath: any, port: number) => {
-        const res = await fetch(`http://localhost:${port}/api/test`);
+        const res = await nodeFetch(`http://localhost:${port}/api/test`);
         validateResponseHeaders(res);
         const text = await res.text();
         expect(text).toEqual('Hello, Batman!');
@@ -587,7 +591,7 @@ describe('[vercel dev] Hono', () => {
     testFixtureStdio(
       'hono-no-export',
       async (_testPath: any, port: number) => {
-        const res = await fetch(`http://localhost:${port}/test.json`);
+        const res = await nodeFetch(`http://localhost:${port}/test.json`);
         validateResponseHeaders(res);
         const json2 = await res.json();
         expect(json2).toHaveProperty('message', 'Hello Hono!');

--- a/packages/cli/test/dev/utils.ts
+++ b/packages/cli/test/dev/utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import { join, resolve } from 'path';
 import type { ExecaChildProcess } from 'execa';
 import _execa, { type Options } from 'execa';
-import fetch, { type RequestInit, type Response } from 'node-fetch';
+import nodeFetch, { type RequestInit, type Response } from 'node-fetch';
 import retry from 'async-retry';
 import { satisfies } from 'semver';
 import stripAnsi from 'strip-ansi';
@@ -56,7 +56,7 @@ type FetchOptions = RequestInit & {
 export function fetchWithRetry(url: string, opts: FetchOptions = {}) {
   return retry(
     async () => {
-      const res = await fetch(url, opts);
+      const res = await nodeFetch(url, opts);
 
       if (res.status !== opts.status) {
         const text = await res.text();
@@ -655,5 +655,3 @@ afterEach(async () => {
     })
   );
 });
-
-export { fetch };

--- a/packages/cli/test/helpers/api-fetch.ts
+++ b/packages/cli/test/helpers/api-fetch.ts
@@ -1,5 +1,5 @@
 import type { RequestInit } from 'node-fetch';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 
 export const apiFetch = (
   path: string,

--- a/packages/cli/test/helpers/api-fetch.ts
+++ b/packages/cli/test/helpers/api-fetch.ts
@@ -9,7 +9,7 @@ export const apiFetch = (
   if (process.env.VERCEL_TEAM_ID) {
     url.searchParams.set('teamId', process.env.VERCEL_TEAM_ID);
   }
-  return fetch(url, {
+  return nodeFetch(url, {
     headers: {
       Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
       ...(headers || {}),

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
 import { extract } from 'tar';
 import execa from 'execa';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import {
   createWriteStream,
   mkdirp,
@@ -392,7 +392,7 @@ export async function createGo({
 async function download({ dest, version }: { dest: string; version: string }) {
   const { filename, url } = getGoUrl(version);
   console.log(`Downloading go: ${url}`);
-  const res = await fetch(url);
+  const res = await nodeFetch(url);
 
   if (!res.ok) {
     throw new Error(`Failed to download: ${url} (${res.status})`);

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -1,6 +1,6 @@
 import ms from 'ms';
 import path from 'path';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import getPort from 'get-port';
 import isPortReachable from 'is-port-reachable';
 import frameworks, { Framework } from '@vercel/frameworks';
@@ -294,7 +294,7 @@ async function fetchBinary(
   version: string,
   dest = '/usr/local/bin'
 ) {
-  const res = await fetch(url);
+  const res = await nodeFetch(url);
   if (res.status === 404) {
     throw new NowBuildError({
       code: 'STATIC_BUILD_BINARY_NOT_FOUND',

--- a/packages/static-build/src/utils/hugo.ts
+++ b/packages/static-build/src/utils/hugo.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import { NowBuildError } from '@vercel/build-utils';
 
 export async function getHugoUrl(
@@ -34,7 +34,7 @@ export async function getHugoUrl(
   }
 
   const checksumsUrl = `https://github.com/gohugoio/hugo/releases/download/v${version}/hugo_${version}_checksums.txt`;
-  const checksumsRes = await fetch(checksumsUrl);
+  const checksumsRes = await nodeFetch(checksumsUrl);
   if (checksumsRes.status === 404) {
     throw new NowBuildError({
       code: 'STATIC_BUILD_BINARY_NOT_FOUND',


### PR DESCRIPTION
# Overview 

Migrate from node-fetch to fetch for CLI usage


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR is a pure refactor that renames the `fetch` import to `nodeFetch` across multiple files without changing any logic, behavior, or functionality.
> 
> - Renames `fetch` import to `nodeFetch` in ~20 source and test files
> - No changes to function calls, parameters, or behavior
> - Changeset describes patch-level rename only
>
> <sup>Risk assessment for [commit 3a52b62](https://github.com/vercel/vercel/commit/3a52b6219bca1dc37ebc5bb6e68b231d6a339ef8).</sup>
<!-- VADE_RISK_END -->