### PR TITLE
Add functionFailoverRegion per function to next builder

### DIFF
--- a/.changeset/rare-moons-love.md
+++ b/.changeset/rare-moons-love.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Add support for funcitonFailoverRegions in next builder

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1833,12 +1833,6 @@ export const build: BuildV2 = async buildOptions => {
       isApiLambda: boolean;
       lambdaIdentifier: string;
       lambdaCombinedBytes: number;
-      memory?: number;
-      maxDuration?: number;
-      regions?: string[];
-      functionFailoverRegions?: string[];
-      supportsCancellation?: boolean;
-      experimentalTriggers?: NodejsLambda['experimentalTriggers'];
     };
     const apiLambdaGroups: Array<LambdaGroup> = [];
     const pageLambdaGroups: Array<LambdaGroup> = [];
@@ -1970,12 +1964,6 @@ export const build: BuildV2 = async buildOptions => {
                   routeIsApi ? 'API' : 'PAGE'
                 }_LAMBDA_${lambdaGroupIndex}`
               ),
-              memory: group.memory,
-              maxDuration: group.maxDuration,
-              regions: group.regions,
-              functionFailoverRegions: group.functionFailoverRegions,
-              supportsCancellation: group.supportsCancellation,
-              experimentalTriggers: group.experimentalTriggers,
             };
           }
 
@@ -2369,12 +2357,6 @@ export const build: BuildV2 = async buildOptions => {
                 operationType,
                 runtime: nodeVersion.runtime,
                 nextVersion,
-                memory: group.memory,
-                maxDuration: group.maxDuration,
-                regions: group.regions,
-                functionFailoverRegions: group.functionFailoverRegions,
-                supportsCancellation: group.supportsCancellation,
-                experimentalTriggers: group.experimentalTriggers,
               });
           }
         )

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1833,6 +1833,12 @@ export const build: BuildV2 = async buildOptions => {
       isApiLambda: boolean;
       lambdaIdentifier: string;
       lambdaCombinedBytes: number;
+      memory?: number;
+      maxDuration?: number;
+      regions?: string[];
+      functionFailoverRegions?: string[];
+      supportsCancellation?: boolean;
+      experimentalTriggers?: NodejsLambda['experimentalTriggers'];
     };
     const apiLambdaGroups: Array<LambdaGroup> = [];
     const pageLambdaGroups: Array<LambdaGroup> = [];
@@ -1964,6 +1970,12 @@ export const build: BuildV2 = async buildOptions => {
                   routeIsApi ? 'API' : 'PAGE'
                 }_LAMBDA_${lambdaGroupIndex}`
               ),
+              memory: group.memory,
+              maxDuration: group.maxDuration,
+              regions: group.regions,
+              functionFailoverRegions: group.functionFailoverRegions,
+              supportsCancellation: group.supportsCancellation,
+              experimentalTriggers: group.experimentalTriggers,
             };
           }
 
@@ -2357,6 +2369,12 @@ export const build: BuildV2 = async buildOptions => {
                 operationType,
                 runtime: nodeVersion.runtime,
                 nextVersion,
+                memory: group.memory,
+                maxDuration: group.maxDuration,
+                regions: group.regions,
+                functionFailoverRegions: group.functionFailoverRegions,
+                supportsCancellation: group.supportsCancellation,
+                experimentalTriggers: group.experimentalTriggers,
               });
           }
         )

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1426,6 +1426,7 @@ export async function serverBuild({
         operationType,
         memory: group.memory,
         regions: group.regions,
+        functionFailoverRegions: group.functionFailoverRegions,
         runtime: nodeVersion.runtime,
         maxDuration: group.maxDuration,
         supportsCancellation: group.supportsCancellation,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1877,6 +1877,7 @@ export type LambdaGroup = {
   memory?: number;
   maxDuration?: number;
   regions?: string[];
+  functionFailoverRegions?: string[];
   supportsCancellation?: boolean;
   isAppRouter?: boolean;
   isAppRouteHandler?: boolean;
@@ -1961,6 +1962,7 @@ export async function getPageLambdaGroups({
       memory?: number;
       maxDuration?: number;
       regions?: string[];
+      functionFailoverRegions?: string[];
       experimentalTriggers?: NodejsLambda['experimentalTriggers'];
       supportsCancellation?: boolean;
     } = {};
@@ -2047,6 +2049,10 @@ export async function getPageLambdaGroups({
             group.maxDuration === opts.maxDuration &&
             group.memory === opts.memory &&
             compareRegions(group.regions, opts.regions) &&
+            compareRegions(
+              group.functionFailoverRegions,
+              opts.functionFailoverRegions
+            ) &&
             group.isPrerenders === isPrerenderRoute &&
             group.isExperimentalPPR === isExperimentalPPR &&
             JSON.stringify(group.experimentalTriggers) ===

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -951,6 +951,7 @@ describe('vercel.json functions regions', () => {
     expect(lambda).toBeDefined();
     expect(lambda.type).toBe('Lambda');
     expect(lambda.regions).toEqual(['iad1', 'sfo1']);
+    expect(lambda.functionFailoverRegions).toEqual(['dub1', 'hnd1']);
   });
 
   it('should ignore preferredRegion and regions from route config when no vercel.json functions config', () => {
@@ -958,6 +959,7 @@ describe('vercel.json functions regions', () => {
     expect(lambda).toBeDefined();
     expect(lambda.type).toBe('Lambda');
     expect(lambda.regions).toBeUndefined();
+    expect(lambda.functionFailoverRegions).toBeUndefined();
   });
 
   it('should not set regions on routes without any config', () => {

--- a/packages/next/test/integration/vercel-json-regions/vercel.json
+++ b/packages/next/test/integration/vercel-json-regions/vercel.json
@@ -8,7 +8,8 @@
   ],
   "functions": {
     "app/api-route/route.js": {
-      "regions": ["iad1", "sfo1"]
+      "regions": ["iad1", "sfo1"],
+      "functionFailoverRegions": ["dub1", "hnd1"]
     }
   }
 }


### PR DESCRIPTION
Adds support for functionFailoverRegion to functions in vercel json in the next builder

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new optional configuration property (functionFailoverRegions) to the Next.js builder, passing it through existing data structures with corresponding test coverage.
> 
> - Adds functionFailoverRegions property to LambdaGroup type and opts object
> - Extends region comparison logic to include failover regions in group matching
> - Adds integration tests verifying new property behavior
>
> <sup>Risk assessment for [commit 0153726](https://github.com/vercel/vercel/commit/015372613c1d380b2126728726ceeed0ccb52592).</sup>
<!-- VADE_RISK_END -->