### PR TITLE
[python] Parse entrypoint variable name.

### DIFF
--- a/.changeset/little-wasps-wonder.md
+++ b/.changeset/little-wasps-wonder.md
@@ -1,0 +1,8 @@
+---
+'@vercel/python-analysis': minor
+'@vercel/python-runtime': minor
+'@vercel/build-utils': minor
+'@vercel/python': minor
+---
+
+Use specified entrypoint variable for python when available.

--- a/packages/build-utils/src/python.ts
+++ b/packages/build-utils/src/python.ts
@@ -17,14 +17,24 @@ import FileFsRef from './file-fs-ref';
 export async function isPythonEntrypoint(
   file: FileFsRef | { fsPath?: string }
 ): Promise<boolean> {
+  return (await getGenericEntrypointVariable(file)) !== null;
+}
+
+/**
+ * Returns the entrypoint variable name for a Python entrypoint file,
+ * or null if the file is not a valid entrypoint.
+ */
+export async function getGenericEntrypointVariable(
+  file: FileFsRef | { fsPath?: string }
+): Promise<string | null> {
   try {
     const fsPath = (file as FileFsRef).fsPath;
-    if (!fsPath) return false;
+    if (!fsPath) return null;
     const content = await fs.promises.readFile(fsPath, 'utf-8');
-    return (await parseEntrypointVariable(content)) !== null;
+    return await parseEntrypointVariable(content);
   } catch (err) {
     debug(`Failed to check Python entrypoint: ${err}`);
-    return false;
+    return null;
   }
 }
 
@@ -53,12 +63,13 @@ export async function getDjangoSettingsModule(
 /**
  * For Django projects: resolve the ASGI or WSGI application entrypoint by reading
  * DJANGO_SETTINGS_MODULE from manage.py, loading that settings file, and
- * returning the file path for ASGI_APPLICATION or WSGI_APPLICATION (e.g.
- * 'myapp.asgi.application' -> 'myapp/asgi.py'). Returns null if any step fails.
+ * returning [modulePath, variableName] for ASGI_APPLICATION or WSGI_APPLICATION
+ * (e.g. 'myapp.wsgi.application' -> ['myapp/wsgi.py', 'application']).
+ * Returns null if any step fails.
  */
 export async function getDjangoEntrypoint(
   workPath: string
-): Promise<string | null> {
+): Promise<[string, string] | null> {
   const settingsModule = await getDjangoSettingsModule(workPath);
   if (!settingsModule) return null;
   const settingsPath = join(
@@ -72,20 +83,22 @@ export async function getDjangoEntrypoint(
       'ASGI_APPLICATION'
     );
     if (asgiApplication) {
-      const modulePath = asgiApplication.split('.').slice(0, -1).join('/');
-      const asgiPath = `${modulePath}.py`;
+      const parts = asgiApplication.split('.');
+      const varName = parts[parts.length - 1];
+      const asgiPath = `${parts.slice(0, -1).join('/')}.py`;
       debug(`Django ASGI entrypoint from ${settingsModule}: ${asgiPath}`);
-      return asgiPath;
+      return [asgiPath, varName];
     }
     const wsgiApplication = await getStringConstant(
       settingsContent,
       'WSGI_APPLICATION'
     );
     if (wsgiApplication) {
-      const modulePath = wsgiApplication.split('.').slice(0, -1).join('/');
-      const wsgiPath = `${modulePath}.py`;
+      const parts = wsgiApplication.split('.');
+      const varName = parts[parts.length - 1];
+      const wsgiPath = `${parts.slice(0, -1).join('/')}.py`;
       debug(`Django WSGI entrypoint from ${settingsModule}: ${wsgiPath}`);
-      return wsgiPath;
+      return [wsgiPath, varName];
     }
   } catch {
     debug(`Failed to read or parse settings file: ${settingsPath}`);

--- a/packages/build-utils/src/python.ts
+++ b/packages/build-utils/src/python.ts
@@ -21,7 +21,7 @@ export async function isPythonEntrypoint(
     const fsPath = (file as FileFsRef).fsPath;
     if (!fsPath) return false;
     const content = await fs.promises.readFile(fsPath, 'utf-8');
-    return await containsAppOrHandler(content);
+    return (await containsAppOrHandler(content)) !== null;
   } catch (err) {
     debug(`Failed to check Python entrypoint: ${err}`);
     return false;

--- a/packages/build-utils/src/python.ts
+++ b/packages/build-utils/src/python.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { join } from 'path';
 import {
-  containsAppOrHandler,
+  parseEntrypointVariable,
   getStringConstant,
   parseDjangoSettingsModule,
 } from '@vercel/python-analysis';
@@ -21,7 +21,7 @@ export async function isPythonEntrypoint(
     const fsPath = (file as FileFsRef).fsPath;
     if (!fsPath) return false;
     const content = await fs.promises.readFile(fsPath, 'utf-8');
-    return (await containsAppOrHandler(content)) !== null;
+    return (await parseEntrypointVariable(content)) !== null;
   } catch (err) {
     debug(`Failed to check Python entrypoint: ${err}`);
     return false;

--- a/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
@@ -9,10 +9,10 @@ use ruff_python_ast::visitor::{walk_body, walk_expr, Visitor};
 use ruff_python_ast::{Expr, Stmt};
 use ruff_python_parser::parse_module;
 
-pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
+pub(crate) fn contains_app_or_handler_impl(source: &str) -> Option<String> {
     let parsed = match parse_module(source) {
         Ok(parsed) => parsed,
-        Err(_) => return false, // Couldn't parse
+        Err(_) => return None, // Couldn't parse
     };
 
     // Iterate over top-level statements
@@ -22,8 +22,8 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
             // e.g., app = Sanic() or app = Flask(__name__) or app = create_app()
             Stmt::Assign(assign) => {
                 for target in &assign.targets {
-                    if is_name_expr(target, "app") || is_name_expr(target, "application") {
-                        return true;
+                    if let Some(id @ ("app" | "application")) = get_name_expr_id(target) {
+                        return Some(id.to_string());
                     }
                 }
             }
@@ -31,8 +31,8 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
             // Check for annotated assignment to 'app' or 'application'
             // e.g., app: Sanic = Sanic()
             Stmt::AnnAssign(ann_assign) => {
-                if is_name_expr(&ann_assign.target, "app") || is_name_expr(&ann_assign.target, "application") {
-                    return true;
+                if let Some(id @ ("app" | "application")) = get_name_expr_id(&ann_assign.target) {
+                    return Some(id.to_string());
                 }
             }
 
@@ -40,8 +40,9 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
             // e.g., def app(environ, start_response): ...
             // e.g., async def app(scope, receive, send): ...
             Stmt::FunctionDef(func_def) => {
-                if func_def.name.as_str() == "app" || func_def.name.as_str() == "application" {
-                    return true;
+                let name = func_def.name.as_str();
+                if name == "app" || name == "application" {
+                    return Some(name.to_string());
                 }
             }
 
@@ -58,7 +59,7 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
                         .map(|id| id.as_str())
                         .unwrap_or_else(|| alias.name.as_str());
                     if imported_as == "app" || imported_as == "application" {
-                        return true;
+                        return Some(imported_as.to_string());
                     }
                 }
             }
@@ -67,7 +68,7 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
             // e.g., class handler(BaseHTTPRequestHandler):
             Stmt::ClassDef(class_def) => {
                 if class_def.name.as_str().eq_ignore_ascii_case("handler") {
-                    return true;
+                    return Some(class_def.name.as_str().to_string());
                 }
             }
 
@@ -76,7 +77,7 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
         }
     }
 
-    false
+    None
 }
 
 /// Extract the string value of a top-level constant with the given name.
@@ -91,14 +92,14 @@ pub(crate) fn get_string_constant_impl(source: &str, name: &str) -> Option<Strin
     for stmt in parsed.suite() {
         match stmt {
             Stmt::Assign(assign) => {
-                if assign.targets.len() == 1 && is_name_expr(&assign.targets[0], name) {
+                if assign.targets.len() == 1 && get_name_expr_id(&assign.targets[0]) == Some(name) {
                     if let Some(s) = expr_to_string_literal(&assign.value) {
                         return Some(s);
                     }
                 }
             }
             Stmt::AnnAssign(ann_assign) => {
-                if is_name_expr(&ann_assign.target, name) {
+                if get_name_expr_id(&ann_assign.target) == Some(name) {
                     if let Some(value) = &ann_assign.value {
                         if let Some(s) = expr_to_string_literal(value) {
                             return Some(s);
@@ -112,17 +113,17 @@ pub(crate) fn get_string_constant_impl(source: &str, name: &str) -> Option<Strin
     None
 }
 
-fn is_name_expr(expr: &Expr, name: &str) -> bool {
+fn get_name_expr_id<'a>(expr: &'a Expr) -> Option<&'a str> {
     match expr {
-        Expr::Name(name_expr) => name_expr.id.as_str() == name,
-        _ => false,
+        Expr::Name(name_expr) => Some(name_expr.id.as_str()),
+        _ => None,
     }
 }
 
 fn is_name_or_attribute_expr(expr: &Expr, path: &[&str]) -> bool {
     match path {
         [] => false,
-        [single] => matches!(expr, Expr::Name(n) if n.id.as_str() == *single),
+        [single] => get_name_expr_id(expr) == Some(*single),
         _ => {
             let (last, rest) = path.split_last().unwrap();
             match expr {
@@ -205,7 +206,7 @@ mod tests {
 from flask import Flask
 app = Flask(__name__)
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -214,7 +215,7 @@ app = Flask(__name__)
 from fastapi import FastAPI
 app = FastAPI()
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -223,7 +224,16 @@ app = FastAPI()
 from sanic import Sanic
 app: Sanic = Sanic()
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+    }
+
+    #[test]
+    fn test_application() {
+        let source = r#"
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
+"#;
+        assert_eq!(contains_app_or_handler_impl(source), Some("application".to_string()));
     }
 
     #[test]
@@ -232,7 +242,7 @@ app: Sanic = Sanic()
 def app(environ, start_response):
     pass
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -241,7 +251,7 @@ def app(environ, start_response):
 async def app(scope, receive, send):
     pass
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -249,7 +259,7 @@ async def app(scope, receive, send):
         let source = r#"
 from server import app
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -257,7 +267,7 @@ from server import app
         let source = r#"
 from server import application as app
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -267,7 +277,7 @@ from http.server import BaseHTTPRequestHandler
 class handler(BaseHTTPRequestHandler):
     pass
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("handler".to_string()));
     }
 
     #[test]
@@ -277,7 +287,7 @@ from http.server import BaseHTTPRequestHandler
 class Handler(BaseHTTPRequestHandler):
     pass
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("Handler".to_string()));
     }
 
     #[test]
@@ -286,7 +296,7 @@ class Handler(BaseHTTPRequestHandler):
 def main():
     print("Hello")
 "#;
-        assert!(!contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), None);
     }
 
     #[test]
@@ -294,7 +304,7 @@ def main():
         let source = r#"
 def invalid(
 "#;
-        assert!(!contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), None);
     }
 
     #[test]
@@ -305,7 +315,7 @@ def create():
     app = Flask(__name__)
     return app
 "#;
-        assert!(!contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), None);
     }
 
     // -------------------------------------------------------------------------

--- a/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
@@ -9,7 +9,7 @@ use ruff_python_ast::visitor::{walk_body, walk_expr, Visitor};
 use ruff_python_ast::{Expr, Stmt};
 use ruff_python_parser::parse_module;
 
-pub(crate) fn contains_app_or_handler_impl(source: &str) -> Option<String> {
+pub(crate) fn parse_entrypoint_variable_impl(source: &str) -> Option<String> {
     let parsed = match parse_module(source) {
         Ok(parsed) => parsed,
         Err(_) => return None, // Couldn't parse
@@ -206,7 +206,7 @@ mod tests {
 from flask import Flask
 app = Flask(__name__)
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -215,7 +215,7 @@ app = Flask(__name__)
 from fastapi import FastAPI
 app = FastAPI()
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -224,7 +224,7 @@ app = FastAPI()
 from sanic import Sanic
 app: Sanic = Sanic()
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -233,7 +233,7 @@ app: Sanic = Sanic()
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("application".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("application".to_string()));
     }
 
     #[test]
@@ -242,7 +242,7 @@ application = get_wsgi_application()
 def app(environ, start_response):
     pass
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -251,7 +251,7 @@ def app(environ, start_response):
 async def app(scope, receive, send):
     pass
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -259,7 +259,7 @@ async def app(scope, receive, send):
         let source = r#"
 from server import app
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -267,7 +267,7 @@ from server import app
         let source = r#"
 from server import application as app
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -277,7 +277,7 @@ from http.server import BaseHTTPRequestHandler
 class handler(BaseHTTPRequestHandler):
     pass
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("handler".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("handler".to_string()));
     }
 
     #[test]
@@ -287,7 +287,7 @@ from http.server import BaseHTTPRequestHandler
 class Handler(BaseHTTPRequestHandler):
     pass
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("Handler".to_string()));
+        assert_eq!(parse_entrypoint_variable_impl(source), Some("Handler".to_string()));
     }
 
     #[test]
@@ -296,7 +296,7 @@ class Handler(BaseHTTPRequestHandler):
 def main():
     print("Hello")
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), None);
+        assert_eq!(parse_entrypoint_variable_impl(source), None);
     }
 
     #[test]
@@ -304,7 +304,7 @@ def main():
         let source = r#"
 def invalid(
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), None);
+        assert_eq!(parse_entrypoint_variable_impl(source), None);
     }
 
     #[test]
@@ -315,7 +315,7 @@ def create():
     app = Flask(__name__)
     return app
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), None);
+        assert_eq!(parse_entrypoint_variable_impl(source), None);
     }
 
     // -------------------------------------------------------------------------

--- a/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
@@ -23,9 +23,9 @@ impl crate::bindings::Guest for PythonAnalyzer {
     /// - A top-level 'application' callable (e.g., Django)
     /// - A top-level 'handler' class (e.g., BaseHTTPRequestHandler subclass)
     ///
-    /// Returns true if found, false otherwise.
-    /// Returns false for invalid Python syntax.
-    fn contains_app_or_handler(source: String) -> bool {
+    /// Returns the variable name (e.g. "app", "application", "handler") if found, None otherwise.
+    /// Returns None for invalid Python syntax.
+    fn contains_app_or_handler(source: String) -> Option<String> {
         contains_app_or_handler_impl(&source)
     }
 

--- a/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
@@ -12,7 +12,7 @@ struct PythonAnalyzer;
 
 use crate::bindings::{DistMetadata, DirectUrlInfo, RecordEntry};
 use crate::entrypoint::{
-    contains_app_or_handler_impl,
+    parse_entrypoint_variable_impl,
     get_string_constant_impl,
     parse_django_settings_module_impl,
 };
@@ -25,8 +25,8 @@ impl crate::bindings::Guest for PythonAnalyzer {
     ///
     /// Returns the variable name (e.g. "app", "application", "handler") if found, None otherwise.
     /// Returns None for invalid Python syntax.
-    fn contains_app_or_handler(source: String) -> Option<String> {
-        contains_app_or_handler_impl(&source)
+    fn parse_entrypoint_variable(source: String) -> Option<String> {
+        parse_entrypoint_variable_impl(&source)
     }
 
     /// Extract the string value of a top-level constant with the given name.

--- a/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
+++ b/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
@@ -9,7 +9,7 @@ world python-analysis {
     ///
     /// Returns the variable name (e.g. "app", "application", "handler") if found, none otherwise.
     /// Returns none for invalid Python syntax.
-    export contains-app-or-handler: func(source: string) -> option<string>;
+    export parse-entrypoint-variable: func(source: string) -> option<string>;
 
     /// Extract the string value of a top-level constant with the given name.
     /// Only considers simple or annotated assignments at module level whose value is a string literal.

--- a/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
+++ b/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
@@ -7,9 +7,9 @@ world python-analysis {
     /// - A top-level 'application' callable (e.g., Django)
     /// - A top-level 'handler' class (e.g., BaseHTTPRequestHandler subclass)
     ///
-    /// Returns true if found, false otherwise.
-    /// Returns false for invalid Python syntax.
-    export contains-app-or-handler: func(source: string) -> bool;
+    /// Returns the variable name (e.g. "app", "application", "handler") if found, none otherwise.
+    /// Returns none for invalid Python syntax.
+    export contains-app-or-handler: func(source: string) -> option<string>;
 
     /// Extract the string value of a top-level constant with the given name.
     /// Only considers simple or annotated assignments at module level whose value is a string literal.

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -12,7 +12,7 @@
 // =============================================================================
 
 export {
-  containsAppOrHandler,
+  parseEntrypointVariable,
   getStringConstant,
   parseDjangoSettingsModule,
 } from './semantic/entrypoints';

--- a/packages/python-analysis/src/semantic/entrypoints.ts
+++ b/packages/python-analysis/src/semantic/entrypoints.ts
@@ -15,21 +15,23 @@ import { importWasmModule } from '../wasm/load';
  * accurate AST analysis without requiring a Python runtime.
  *
  * @param source - The Python source code to analyze
- * @returns Promise that resolves to true if an app or handler is found, false otherwise.
- *          Returns false for invalid Python syntax.
+ * @returns Promise that resolves to the variable name (e.g. "app", "application", "handler") if found, null otherwise.
+ *          Returns null for invalid Python syntax.
  *
  * @example
  * ```typescript
  * import { containsAppOrHandler } from '@vercel/python-analysis';
  *
- * const hasApp = await containsAppOrHandler(`
+ * const varName = await containsAppOrHandler(`
  * from flask import Flask
  * app = Flask(__name__)
  * `);
- * console.log(hasApp); // true
+ * console.log(varName); // "app"
  * ```
  */
-export async function containsAppOrHandler(source: string): Promise<boolean> {
+export async function containsAppOrHandler(
+  source: string
+): Promise<string | null> {
   // Skip parsing if file doesn't contain {app|application|[Hh]andler}
   if (
     !source.includes('app') &&
@@ -37,10 +39,10 @@ export async function containsAppOrHandler(source: string): Promise<boolean> {
     !source.includes('handler') &&
     !source.includes('Handler')
   ) {
-    return false;
+    return null;
   }
   const mod = await importWasmModule();
-  return mod.containsAppOrHandler(source);
+  return mod.containsAppOrHandler(source) ?? null;
 }
 
 /**

--- a/packages/python-analysis/src/semantic/entrypoints.ts
+++ b/packages/python-analysis/src/semantic/entrypoints.ts
@@ -20,16 +20,16 @@ import { importWasmModule } from '../wasm/load';
  *
  * @example
  * ```typescript
- * import { containsAppOrHandler } from '@vercel/python-analysis';
+ * import { parseEntrypointVariable } from '@vercel/python-analysis';
  *
- * const varName = await containsAppOrHandler(`
+ * const varName = await parseEntrypointVariable(`
  * from flask import Flask
  * app = Flask(__name__)
  * `);
  * console.log(varName); // "app"
  * ```
  */
-export async function containsAppOrHandler(
+export async function parseEntrypointVariable(
   source: string
 ): Promise<string | null> {
   // Skip parsing if file doesn't contain {app|application|[Hh]andler}
@@ -42,7 +42,7 @@ export async function containsAppOrHandler(
     return null;
   }
   const mod = await importWasmModule();
-  return mod.containsAppOrHandler(source) ?? null;
+  return mod.parseEntrypointVariable(source) ?? null;
 }
 
 /**

--- a/packages/python-analysis/test/semantic.test.ts
+++ b/packages/python-analysis/test/semantic.test.ts
@@ -8,7 +8,7 @@ describe('containsAppOrHandler', () => {
 from flask import Flask
 app = Flask(__name__)
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects FastAPI app assignment', async () => {
@@ -16,7 +16,7 @@ app = Flask(__name__)
 from fastapi import FastAPI
 app = FastAPI()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects Sanic app with type annotation', async () => {
@@ -24,14 +24,14 @@ app = FastAPI()
 from sanic import Sanic
 app: Sanic = Sanic()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects app created via factory function', async () => {
       const source = `
 app = create_app()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects WSGI function named app', async () => {
@@ -39,7 +39,7 @@ app = create_app()
 def app(environ, start_response):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects ASGI async function named app', async () => {
@@ -47,7 +47,7 @@ def app(environ, start_response):
 async def app(scope, receive, send):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects Django WSGI application', async () => {
@@ -55,7 +55,7 @@ async def app(scope, receive, send):
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('application');
     });
 
     it('detects Django ASGI application', async () => {
@@ -63,35 +63,35 @@ application = get_wsgi_application()
 from django.core.asgi import get_asgi_application
 application = get_asgi_application()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('application');
     });
 
     it('detects imported app', async () => {
       const source = `
 from server import app
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects aliased import as app', async () => {
       const source = `
 from server import application as app
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects imported application', async () => {
       const source = `
 from server import application as app
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects aliased import as application', async () => {
       const source = `
 from server import callable as application
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('application');
     });
 
     it('does not detect nested app assignment', async () => {
@@ -100,7 +100,7 @@ def create():
     app = Flask(__name__)
     return app
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app in class method', async () => {
@@ -110,7 +110,7 @@ class Factory:
         app = FastAPI()
         return app
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
   });
 
@@ -121,7 +121,7 @@ from http.server import BaseHTTPRequestHandler
 class handler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('handler');
     });
 
     it('detects Handler class (capitalized)', async () => {
@@ -130,7 +130,7 @@ from http.server import BaseHTTPRequestHandler
 class Handler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('Handler');
     });
 
     it('detects HANDLER class (uppercase)', async () => {
@@ -139,7 +139,7 @@ from http.server import BaseHTTPRequestHandler
 class HANDLER(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('HANDLER');
     });
 
     it('does not detect nested handler class', async () => {
@@ -149,16 +149,16 @@ def create_handler():
         pass
     return handler
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
   });
 
   describe('negative cases', () => {
-    it('returns false for empty file', async () => {
-      expect(await containsAppOrHandler('')).toBe(false);
+    it('returns null for empty file', async () => {
+      expect(await containsAppOrHandler('')).toBeNull();
     });
 
-    it('returns false for file without app or handler', async () => {
+    it('returns null for file without app or handler', async () => {
       const source = `
 def main():
     print("Hello, world!")
@@ -166,14 +166,14 @@ def main():
 if __name__ == "__main__":
     main()
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
-    it('returns false for invalid Python syntax', async () => {
+    it('returns null for invalid Python syntax', async () => {
       const source = `
 def invalid(
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect other class names', async () => {
@@ -181,29 +181,29 @@ def invalid(
 class MyHandler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not match app in comments', async () => {
       const source = `
 # app = Flask(__name__)
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not match app in strings', async () => {
       const source = `
 code = "app = Flask(__name__)"
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
-    it('returns false for file with only comments', async () => {
+    it('returns null for file with only comments', async () => {
       const source = `
 # just a comment
 # another comment
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app as function parameter', async () => {
@@ -211,7 +211,7 @@ code = "app = Flask(__name__)"
 def process(app):
     return app.run()
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect handler function (only class)', async () => {
@@ -219,7 +219,7 @@ def process(app):
 def handler(request):
     return response
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app in decorator', async () => {
@@ -228,14 +228,14 @@ def handler(request):
 def index():
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app as attribute access', async () => {
       const source = `
 result = server.app.run()
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
   });
 });

--- a/packages/python-analysis/test/semantic.test.ts
+++ b/packages/python-analysis/test/semantic.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { containsAppOrHandler, parseDjangoSettingsModule } from '../src';
+import { parseEntrypointVariable, parseDjangoSettingsModule } from '../src';
 
-describe('containsAppOrHandler', () => {
+describe('parseEntrypointVariable', () => {
   describe('app detection', () => {
     it('detects Flask app assignment', async () => {
       const source = `
 from flask import Flask
 app = Flask(__name__)
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await parseEntrypointVariable(source)).toBe('app');
     });
 
     it('detects FastAPI app assignment', async () => {
@@ -16,7 +16,7 @@ app = Flask(__name__)
 from fastapi import FastAPI
 app = FastAPI()
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await parseEntrypointVariable(source)).toBe('app');
     });
 
     it('detects Sanic app with type annotation', async () => {
@@ -24,14 +24,14 @@ app = FastAPI()
 from sanic import Sanic
 app: Sanic = Sanic()
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await parseEntrypointVariable(source)).toBe('app');
     });
 
     it('detects app created via factory function', async () => {
       const source = `
 app = create_app()
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await parseEntrypointVariable(source)).toBe('app');
     });
 
     it('detects WSGI function named app', async () => {
@@ -39,7 +39,7 @@ app = create_app()
 def app(environ, start_response):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await parseEntrypointVariable(source)).toBe('app');
     });
 
     it('detects ASGI async function named app', async () => {
@@ -47,7 +47,7 @@ def app(environ, start_response):
 async def app(scope, receive, send):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await parseEntrypointVariable(source)).toBe('app');
     });
 
     it('detects Django WSGI application', async () => {
@@ -55,7 +55,7 @@ async def app(scope, receive, send):
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
 `;
-      expect(await containsAppOrHandler(source)).toBe('application');
+      expect(await parseEntrypointVariable(source)).toBe('application');
     });
 
     it('detects Django ASGI application', async () => {
@@ -63,35 +63,35 @@ application = get_wsgi_application()
 from django.core.asgi import get_asgi_application
 application = get_asgi_application()
 `;
-      expect(await containsAppOrHandler(source)).toBe('application');
+      expect(await parseEntrypointVariable(source)).toBe('application');
     });
 
     it('detects imported app', async () => {
       const source = `
 from server import app
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await parseEntrypointVariable(source)).toBe('app');
     });
 
     it('detects aliased import as app', async () => {
       const source = `
 from server import application as app
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await parseEntrypointVariable(source)).toBe('app');
     });
 
     it('detects imported application', async () => {
       const source = `
 from server import application as app
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await parseEntrypointVariable(source)).toBe('app');
     });
 
     it('detects aliased import as application', async () => {
       const source = `
 from server import callable as application
 `;
-      expect(await containsAppOrHandler(source)).toBe('application');
+      expect(await parseEntrypointVariable(source)).toBe('application');
     });
 
     it('does not detect nested app assignment', async () => {
@@ -100,7 +100,7 @@ def create():
     app = Flask(__name__)
     return app
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('does not detect app in class method', async () => {
@@ -110,7 +110,7 @@ class Factory:
         app = FastAPI()
         return app
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
   });
 
@@ -121,7 +121,7 @@ from http.server import BaseHTTPRequestHandler
 class handler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('handler');
+      expect(await parseEntrypointVariable(source)).toBe('handler');
     });
 
     it('detects Handler class (capitalized)', async () => {
@@ -130,7 +130,7 @@ from http.server import BaseHTTPRequestHandler
 class Handler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('Handler');
+      expect(await parseEntrypointVariable(source)).toBe('Handler');
     });
 
     it('detects HANDLER class (uppercase)', async () => {
@@ -139,7 +139,7 @@ from http.server import BaseHTTPRequestHandler
 class HANDLER(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('HANDLER');
+      expect(await parseEntrypointVariable(source)).toBe('HANDLER');
     });
 
     it('does not detect nested handler class', async () => {
@@ -149,13 +149,13 @@ def create_handler():
         pass
     return handler
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
   });
 
   describe('negative cases', () => {
     it('returns null for empty file', async () => {
-      expect(await containsAppOrHandler('')).toBeNull();
+      expect(await parseEntrypointVariable('')).toBeNull();
     });
 
     it('returns null for file without app or handler', async () => {
@@ -166,14 +166,14 @@ def main():
 if __name__ == "__main__":
     main()
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('returns null for invalid Python syntax', async () => {
       const source = `
 def invalid(
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('does not detect other class names', async () => {
@@ -181,21 +181,21 @@ def invalid(
 class MyHandler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('does not match app in comments', async () => {
       const source = `
 # app = Flask(__name__)
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('does not match app in strings', async () => {
       const source = `
 code = "app = Flask(__name__)"
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('returns null for file with only comments', async () => {
@@ -203,7 +203,7 @@ code = "app = Flask(__name__)"
 # just a comment
 # another comment
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('does not detect app as function parameter', async () => {
@@ -211,7 +211,7 @@ code = "app = Flask(__name__)"
 def process(app):
     return app.run()
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('does not detect handler function (only class)', async () => {
@@ -219,7 +219,7 @@ def process(app):
 def handler(request):
     return response
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('does not detect app in decorator', async () => {
@@ -228,14 +228,14 @@ def handler(request):
 def index():
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
 
     it('does not detect app as attribute access', async () => {
       const source = `
 result = server.app.run()
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await parseEntrypointVariable(source)).toBeNull();
     });
   });
 });

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -33,7 +33,7 @@ function getCandidateEntrypointsInDirs(dirs: string[]) {
 
 export async function getPyprojectEntrypoint(
   workPath: string
-): Promise<string | null> {
+): Promise<[string, string | null] | null> {
   const pyprojectData = await readConfigFile<{
     project?: { scripts?: Record<string, unknown> };
   }>(join(workPath, 'pyproject.toml'));
@@ -52,6 +52,7 @@ export async function getPyprojectEntrypoint(
   const match = appScript.match(/([A-Za-z_][\w.]*)\s*:\s*([A-Za-z_][\w]*)/);
   if (!match) return null;
   const modulePath = match[1];
+  const varName = match[2];
   const relPath = modulePath.replace(/\./g, '/');
 
   // Prefer an existing file match if present; otherwise fall back to "<module>.py".
@@ -59,7 +60,7 @@ export async function getPyprojectEntrypoint(
     const fsFiles = await glob('**', workPath);
     const candidates = [`${relPath}.py`, `${relPath}/__init__.py`];
     for (const candidate of candidates) {
-      if (fsFiles[candidate]) return candidate;
+      if (fsFiles[candidate]) return [candidate, varName];
     }
     return null;
   } catch {
@@ -71,13 +72,13 @@ export async function getPyprojectEntrypoint(
 async function findValidEntrypoint(
   fsFiles: Record<string, FileFsRef>,
   candidates: string[]
-): Promise<string | null> {
+): Promise<[string, string | null] | null> {
   for (const candidate of candidates) {
     if (fsFiles[candidate]) {
       const isValid = await isPythonEntrypoint(fsFiles[candidate] as FileFsRef);
       if (isValid) {
         debug(`Detected Python entrypoint: ${candidate}`);
-        return candidate;
+        return [candidate, null];
       }
     }
   }
@@ -90,7 +91,7 @@ async function findValidEntrypoint(
 export async function detectGenericPythonEntrypoint(
   workPath: string,
   configuredEntrypoint: string
-): Promise<string | null> {
+): Promise<[string, string | null] | null> {
   const entry = configuredEntrypoint.endsWith('.py')
     ? configuredEntrypoint
     : `${configuredEntrypoint}.py`;
@@ -103,7 +104,7 @@ export async function detectGenericPythonEntrypoint(
       const isValid = await isPythonEntrypoint(fsFiles[entry] as FileFsRef);
       if (isValid) {
         debug(`Using configured Python entrypoint: ${entry}`);
-        return entry;
+        return [entry, null];
       }
     }
 
@@ -126,7 +127,7 @@ export async function detectGenericPythonEntrypoint(
 export async function detectDjangoPythonEntrypoint(
   workPath: string,
   configuredEntrypoint: string
-): Promise<string | null> {
+): Promise<[string, string | null] | null> {
   const entry = configuredEntrypoint.endsWith('.py')
     ? configuredEntrypoint
     : `${configuredEntrypoint}.py`;
@@ -139,7 +140,7 @@ export async function detectDjangoPythonEntrypoint(
       const isValid = await isPythonEntrypoint(fsFiles[entry] as FileFsRef);
       if (isValid) {
         debug(`Using configured Python entrypoint: ${entry}`);
-        return entry;
+        return [entry, null];
       }
     }
 
@@ -167,7 +168,7 @@ export async function detectDjangoPythonEntrypoint(
         const fullWsgiEntry = pathPosix.join(rootDir, wsgiEntry);
         if (fsFiles[fullWsgiEntry]) {
           debug(`Using Django WSGI entrypoint: ${fullWsgiEntry}`);
-          return fullWsgiEntry;
+          return [fullWsgiEntry, null];
         }
       }
     }
@@ -190,11 +191,11 @@ export async function detectPythonEntrypoint(
   framework: PythonFramework,
   workPath: string,
   configuredEntrypoint: string
-): Promise<string | null> {
-  const entrypoint =
+): Promise<[string, string | null] | null> {
+  const result =
     framework === 'django'
       ? await detectDjangoPythonEntrypoint(workPath, configuredEntrypoint)
       : await detectGenericPythonEntrypoint(workPath, configuredEntrypoint);
-  if (entrypoint) return entrypoint;
+  if (result) return result;
   return await getPyprojectEntrypoint(workPath);
 }

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -4,7 +4,7 @@ import {
   glob,
   debug,
   isDirectory,
-  isPythonEntrypoint,
+  getGenericEntrypointVariable,
   getDjangoEntrypoint,
 } from '@vercel/build-utils';
 import { readConfigFile } from '@vercel/build-utils';
@@ -52,7 +52,7 @@ export async function getPyprojectEntrypoint(
   const match = appScript.match(/([A-Za-z_][\w.]*)\s*:\s*([A-Za-z_][\w]*)/);
   if (!match) return null;
   const modulePath = match[1];
-  const varName = match[2];
+  const entryVar = match[2];
   const relPath = modulePath.replace(/\./g, '/');
 
   // Prefer an existing file match if present; otherwise fall back to "<module>.py".
@@ -60,7 +60,7 @@ export async function getPyprojectEntrypoint(
     const fsFiles = await glob('**', workPath);
     const candidates = [`${relPath}.py`, `${relPath}/__init__.py`];
     for (const candidate of candidates) {
-      if (fsFiles[candidate]) return [candidate, varName];
+      if (fsFiles[candidate]) return [candidate, entryVar];
     }
     return null;
   } catch {
@@ -75,10 +75,12 @@ async function findValidEntrypoint(
 ): Promise<[string, string | null] | null> {
   for (const candidate of candidates) {
     if (fsFiles[candidate]) {
-      const isValid = await isPythonEntrypoint(fsFiles[candidate] as FileFsRef);
-      if (isValid) {
+      const entryVar = await getGenericEntrypointVariable(
+        fsFiles[candidate] as FileFsRef
+      );
+      if (entryVar) {
         debug(`Detected Python entrypoint: ${candidate}`);
-        return [candidate, null];
+        return [candidate, entryVar];
       }
     }
   }
@@ -101,10 +103,12 @@ export async function detectGenericPythonEntrypoint(
 
     // If the configured entrypoint exists and is valid, use it
     if (fsFiles[entry]) {
-      const isValid = await isPythonEntrypoint(fsFiles[entry] as FileFsRef);
-      if (isValid) {
+      const entryVar = await getGenericEntrypointVariable(
+        fsFiles[entry] as FileFsRef
+      );
+      if (entryVar) {
         debug(`Using configured Python entrypoint: ${entry}`);
-        return [entry, null];
+        return [entry, entryVar];
       }
     }
 
@@ -137,10 +141,12 @@ export async function detectDjangoPythonEntrypoint(
 
     // If the configured entrypoint exists and is valid, use it
     if (fsFiles[entry]) {
-      const isValid = await isPythonEntrypoint(fsFiles[entry] as FileFsRef);
-      if (isValid) {
+      const entryVar = await getGenericEntrypointVariable(
+        fsFiles[entry] as FileFsRef
+      );
+      if (entryVar) {
         debug(`Using configured Python entrypoint: ${entry}`);
-        return [entry, null];
+        return [entry, entryVar];
       }
     }
 
@@ -165,10 +171,11 @@ export async function detectDjangoPythonEntrypoint(
       const currPath = join(workPath, rootDir);
       const wsgiEntry = await getDjangoEntrypoint(currPath);
       if (wsgiEntry) {
-        const fullWsgiEntry = pathPosix.join(rootDir, wsgiEntry);
+        const [wsgiPath, wsgiVar] = wsgiEntry;
+        const fullWsgiEntry = pathPosix.join(rootDir, wsgiPath);
         if (fsFiles[fullWsgiEntry]) {
           debug(`Using Django WSGI entrypoint: ${fullWsgiEntry}`);
-          return [fullWsgiEntry, null];
+          return [fullWsgiEntry, wsgiVar];
         }
       }
     }

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -33,7 +33,7 @@ function getCandidateEntrypointsInDirs(dirs: string[]) {
 
 export async function getPyprojectEntrypoint(
   workPath: string
-): Promise<[string, string | null] | null> {
+): Promise<[string, string] | null> {
   const pyprojectData = await readConfigFile<{
     project?: { scripts?: Record<string, unknown> };
   }>(join(workPath, 'pyproject.toml'));
@@ -72,7 +72,7 @@ export async function getPyprojectEntrypoint(
 async function findValidEntrypoint(
   fsFiles: Record<string, FileFsRef>,
   candidates: string[]
-): Promise<[string, string | null] | null> {
+): Promise<[string, string] | null> {
   for (const candidate of candidates) {
     if (fsFiles[candidate]) {
       const entryVar = await getGenericEntrypointVariable(
@@ -93,7 +93,7 @@ async function findValidEntrypoint(
 export async function detectGenericPythonEntrypoint(
   workPath: string,
   configuredEntrypoint: string
-): Promise<[string, string | null] | null> {
+): Promise<[string, string] | null> {
   const entry = configuredEntrypoint.endsWith('.py')
     ? configuredEntrypoint
     : `${configuredEntrypoint}.py`;
@@ -131,7 +131,7 @@ export async function detectGenericPythonEntrypoint(
 export async function detectDjangoPythonEntrypoint(
   workPath: string,
   configuredEntrypoint: string
-): Promise<[string, string | null] | null> {
+): Promise<[string, string] | null> {
   const entry = configuredEntrypoint.endsWith('.py')
     ? configuredEntrypoint
     : `${configuredEntrypoint}.py`;
@@ -198,7 +198,7 @@ export async function detectPythonEntrypoint(
   framework: PythonFramework,
   workPath: string,
   configuredEntrypoint: string
-): Promise<[string, string | null] | null> {
+): Promise<[string, string] | null> {
   const result =
     framework === 'django'
       ? await detectDjangoPythonEntrypoint(workPath, configuredEntrypoint)

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -170,6 +170,8 @@ export const build: BuildV3 = async ({
 
   let fsFiles = await glob('**', workPath);
 
+  let entrypointVariable: string | null = null;
+
   // Zero config entrypoint discovery
   if (
     isPythonFramework(framework) &&
@@ -181,11 +183,12 @@ export const build: BuildV3 = async ({
       entrypoint
     );
     if (detected) {
-      const [detectedModule] = detected;
+      const [detectedModule, detectedEntryVar] = detected;
       debug(
         `Resolved Python entrypoint to "${detectedModule}" (configured "${entrypoint}" not found).`
       );
       entrypoint = detectedModule;
+      entrypointVariable = detectedEntryVar;
     } else {
       const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
       throw new NowBuildError({
@@ -497,6 +500,7 @@ os.environ.update({
   "__VC_HANDLER_ENTRYPOINT": "${entrypointWithSuffix}",
   "__VC_HANDLER_ENTRYPOINT_ABS": os.path.join(_here, "${entrypointWithSuffix}"),
   "__VC_HANDLER_VENDOR_DIR": "${vendorDir}",
+  "__VC_HANDLER_VARIABLE_NAME": "${entrypointVariable ?? ''}",
 })
 
 _vendor_rel = '${vendorDir}'

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -181,10 +181,11 @@ export const build: BuildV3 = async ({
       entrypoint
     );
     if (detected) {
+      const [detectedModule] = detected;
       debug(
-        `Resolved Python entrypoint to "${detected}" (configured "${entrypoint}" not found).`
+        `Resolved Python entrypoint to "${detectedModule}" (configured "${entrypoint}" not found).`
       );
-      entrypoint = detected;
+      entrypoint = detectedModule;
     } else {
       const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
       throw new NowBuildError({

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -421,12 +421,12 @@ export const startDevServer: StartDevServer = async opts => {
   // Silence Node warnings and install cleanup handlers once
   if (!restoreWarnings) restoreWarnings = silenceNodeWarnings();
   installGlobalCleanupHandlers();
-  const entry = await detectPythonEntrypoint(
+  const detected = await detectPythonEntrypoint(
     framework as PythonFramework,
     workPath,
     rawEntrypoint
   );
-  if (!entry) {
+  if (!detected) {
     const searched = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
     throw new NowBuildError({
       code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
@@ -435,6 +435,7 @@ export const startDevServer: StartDevServer = async opts => {
       action: 'Learn More',
     });
   }
+  const [entry, _entryVariable] = detected;
 
   // Convert to module path, e.g. "src/app.py" -> "src.app"
   const modulePath = entry.replace(/\.py$/i, '').replace(/[\\/]/g, '.');

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1140,7 +1140,7 @@ describe('Django entrypoint discovery', () => {
       workPath,
       'hello/world.py'
     );
-    expect(result).toBe('hello/world.py');
+    expect(result).toEqual(['hello/world.py', null]);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1156,7 +1156,7 @@ describe('Django entrypoint discovery', () => {
     });
 
     const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
-    expect(result).toBe('hello/wsgi.py');
+    expect(result).toEqual(['hello/wsgi.py', null]);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1173,7 +1173,7 @@ describe('Django entrypoint discovery', () => {
     });
 
     const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
-    expect(result).toBe('src/app.py');
+    expect(result).toEqual(['src/app.py', null]);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1193,7 +1193,7 @@ describe('Django entrypoint discovery', () => {
     // WSGI_APPLICATION value does not refer to a valid file
 
     const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
-    expect(result).toBe('src/app.py');
+    expect(result).toEqual(['src/app.py', null]);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1213,7 +1213,7 @@ describe('Django entrypoint discovery', () => {
     });
 
     const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
-    expect(result).toBe('mysite/config/wsgi.py');
+    expect(result).toEqual(['mysite/config/wsgi.py', null]);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1260,6 +1260,25 @@ describe('Django entrypoint discovery', () => {
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
 
+  it('uses variable name from WSGI_APPLICATION when it differs from "application"', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-wsgi-var-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      'manage.py': `os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hello.settings')`,
+      'hello/settings.py': `WSGI_APPLICATION = 'hello.wsgi.wsgi_app'`,
+      'hello/wsgi.py': `wsgi_app = lambda env, start: None`,
+    });
+
+    const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
+    expect(result).toEqual(['hello/wsgi.py', 'wsgi_app']);
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
   it('build() discovers Django entrypoint from WSGI_APPLICATION when configured entrypoint is missing', async () => {
     const workPath = path.join(tmpdir(), `python-django-build-${Date.now()}`);
     fs.mkdirSync(workPath, { recursive: true });

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -47,7 +47,10 @@ import { build } from '../src/index';
 import { createVenvEnv, getVenvBinDir } from '../src/utils';
 import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
 import { createPyprojectToml } from '../src/install';
-import { detectDjangoPythonEntrypoint } from '../src/entrypoint';
+import {
+  detectDjangoPythonEntrypoint,
+  getPyprojectEntrypoint,
+} from '../src/entrypoint';
 import { FileBlob } from '@vercel/build-utils';
 let warningMessages: string[];
 const originalConsoleWarn = console.warn;
@@ -1140,7 +1143,7 @@ describe('Django entrypoint discovery', () => {
       workPath,
       'hello/world.py'
     );
-    expect(result).toEqual(['hello/world.py', null]);
+    expect(result).toEqual(['hello/world.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1156,7 +1159,46 @@ describe('Django entrypoint discovery', () => {
     });
 
     const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
-    expect(result).toEqual(['hello/wsgi.py', null]);
+    expect(result).toEqual(['hello/wsgi.py', 'application']);
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Django entrypoint from ASGI_APPLICATION', async () => {
+    const workPath = path.join(tmpdir(), `python-django-asgi-${Date.now()}`);
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      'manage.py': `os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hello.settings')`,
+      'hello/settings.py': `ASGI_APPLICATION = 'hello.asgi.application'`,
+      'hello/asgi.py': `application = lambda scope, receive, send: None`,
+    });
+
+    const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
+    expect(result).toEqual(['hello/asgi.py', 'application']);
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('prefers ASGI_APPLICATION over WSGI_APPLICATION', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-asgi-wsgi-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      'manage.py': `os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hello.settings')`,
+      'hello/settings.py': [
+        `ASGI_APPLICATION = 'hello.asgi.application'`,
+        `WSGI_APPLICATION = 'hello.wsgi.application'`,
+      ].join('\n'),
+      'hello/asgi.py': `application = lambda scope, receive, send: None`,
+      'hello/wsgi.py': `application = lambda env, start: None`,
+    });
+
+    const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
+    expect(result).toEqual(['hello/asgi.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1173,7 +1215,7 @@ describe('Django entrypoint discovery', () => {
     });
 
     const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
-    expect(result).toEqual(['src/app.py', null]);
+    expect(result).toEqual(['src/app.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1193,7 +1235,7 @@ describe('Django entrypoint discovery', () => {
     // WSGI_APPLICATION value does not refer to a valid file
 
     const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
-    expect(result).toEqual(['src/app.py', null]);
+    expect(result).toEqual(['src/app.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1213,7 +1255,7 @@ describe('Django entrypoint discovery', () => {
     });
 
     const result = await detectDjangoPythonEntrypoint(workPath, 'missing.py');
-    expect(result).toEqual(['mysite/config/wsgi.py', null]);
+    expect(result).toEqual(['mysite/config/wsgi.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1250,6 +1292,52 @@ describe('Django entrypoint discovery', () => {
     }
     const content = handler.data.toString();
     expect(content).toContain('os.path.join(_here, "hello/world.py")');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+});
+
+describe('getPyprojectEntrypoint - pyproject.toml [project.scripts] discovery', () => {
+  async function writeFiles(
+    workPath: string,
+    files: Record<string, string>
+  ): Promise<void> {
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(workPath, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+  }
+
+  it('returns [filePath, varName] when pyproject.toml has app script', async () => {
+    const workPath = path.join(tmpdir(), `python-pyproject-ep-${Date.now()}`);
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      'pyproject.toml': '[project.scripts]\napp = "mymodule:myapp"\n',
+      'mymodule.py': 'from flask import Flask\nmyapp = Flask(__name__)\n',
+    });
+
+    const result = await getPyprojectEntrypoint(workPath);
+    expect(result).toEqual(['mymodule.py', 'myapp']);
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('returns null when pyproject.toml has no app script', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-pyproject-ep-noapp-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      'pyproject.toml': '[project.scripts]\nstart = "mymodule:main"\n',
+      'mymodule.py': 'def main(): pass\n',
+    });
+
+    const result = await getPyprojectEntrypoint(workPath);
+    expect(result).toBeNull();
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -532,16 +532,15 @@ try:
     __vc_variables = dir(__vc_module)
     __vc_app_variable = (
         _entry_variable
-        if _entry_variable and _entry_variable in __vc_variables
-        else "handler"
-        if "handler" in __vc_variables
-        else "Handler"
-        if "Handler" in __vc_variables
-        else "app"
-        if "app" in __vc_variables
-        else "application"
-        if "application" in __vc_variables
-        else None
+        if _entry_variable in __vc_variables
+        else next(
+            (
+                v
+                for v in __vc_variables
+                if v.lower() == "handler" or v in ("app", "application")
+            ),
+            None,
+        )
     )
 except Exception:
     _stderr(f"Error importing {_entrypoint_rel}:")
@@ -824,7 +823,7 @@ if "VERCEL_IPC_PATH" in os.environ:
                     }
                 )
 
-    if __vc_app_variable in ("handler", "Handler"):
+    if __vc_app_variable and __vc_app_variable.lower() == "handler":
         base = getattr(__vc_module, __vc_app_variable)
         if not issubclass(base, BaseHTTPRequestHandler):
             _stderr("Handler must inherit from BaseHTTPRequestHandler")
@@ -1007,7 +1006,7 @@ if "VERCEL_IPC_PATH" in os.environ:
     )
     exit(1)
 
-if __vc_app_variable in ("handler", "Handler"):
+if __vc_app_variable and __vc_app_variable.lower() == "handler":
     base = getattr(__vc_module, __vc_app_variable)
     if not issubclass(base, BaseHTTPRequestHandler):
         _stderr("Handler must inherit from BaseHTTPRequestHandler")

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -55,6 +55,7 @@ _here = os.path.dirname(__file__)
 _entrypoint_rel = _must_getenv("__VC_HANDLER_ENTRYPOINT")
 _entrypoint_abs = _must_getenv("__VC_HANDLER_ENTRYPOINT_ABS")
 _entrypoint_modname = _must_getenv("__VC_HANDLER_MODULE_NAME")
+_entry_variable = os.environ.get("__VC_HANDLER_VARIABLE_NAME") or ""
 
 
 def _normalize_service_route_prefix(raw_prefix: str | None) -> str:
@@ -529,6 +530,19 @@ try:
     sys.modules[_entrypoint_modname] = __vc_module
     __vc_spec.loader.exec_module(__vc_module)
     __vc_variables = dir(__vc_module)
+    __vc_app_variable = (
+        _entry_variable
+        if _entry_variable and _entry_variable in __vc_variables
+        else "handler"
+        if "handler" in __vc_variables
+        else "Handler"
+        if "Handler" in __vc_variables
+        else "app"
+        if "app" in __vc_variables
+        else "application"
+        if "application" in __vc_variables
+        else None
+    )
 except Exception:
     _stderr(f"Error importing {_entrypoint_rel}:")
     _stderr(traceback.format_exc())
@@ -810,12 +824,8 @@ if "VERCEL_IPC_PATH" in os.environ:
                     }
                 )
 
-    if "handler" in __vc_variables or "Handler" in __vc_variables:
-        base = (
-            __vc_module.handler
-            if "handler" in __vc_variables
-            else __vc_module.Handler
-        )
+    if __vc_app_variable in ("handler", "Handler"):
+        base = getattr(__vc_module, __vc_app_variable)
         if not issubclass(base, BaseHTTPRequestHandler):
             _stderr("Handler must inherit from BaseHTTPRequestHandler")
             _stderr(
@@ -836,12 +846,8 @@ if "VERCEL_IPC_PATH" in os.environ:
                 method()
                 self.wfile.flush()
 
-    elif "app" in __vc_variables or "application" in __vc_variables:
-        app: Any = getattr(  # pyright: ignore[reportRedeclaration]
-            __vc_module,
-            "app",
-            getattr(__vc_module, "application", None),
-        )
+    elif __vc_app_variable is not None:
+        app: Any = getattr(__vc_module, __vc_app_variable)  # pyright: ignore[reportRedeclaration]
         if not inspect.iscoroutinefunction(
             app
         ) and not inspect.iscoroutinefunction(app.__call__):
@@ -1001,12 +1007,8 @@ if "VERCEL_IPC_PATH" in os.environ:
     )
     exit(1)
 
-if "handler" in __vc_variables or "Handler" in __vc_variables:
-    base = (
-        __vc_module.handler
-        if "handler" in __vc_variables
-        else __vc_module.Handler
-    )
+if __vc_app_variable in ("handler", "Handler"):
+    base = getattr(__vc_module, __vc_app_variable)
     if not issubclass(base, BaseHTTPRequestHandler):
         _stderr("Handler must inherit from BaseHTTPRequestHandler")
         _stderr(
@@ -1060,12 +1062,8 @@ if "handler" in __vc_variables or "Handler" in __vc_variables:
 
         return return_dict
 
-elif "app" in __vc_variables or "application" in __vc_variables:
-    app: Any = getattr(  # type: ignore[no-redef]
-        __vc_module,
-        "app",
-        getattr(__vc_module, "application", None),
-    )
+elif __vc_app_variable is not None:
+    app: Any = getattr(__vc_module, __vc_app_variable)  # type: ignore[no-redef]
     if not inspect.iscoroutinefunction(app) and not inspect.iscoroutinefunction(
         app.__call__
     ):


### PR DESCRIPTION
Python entrypoint detection methods may find a variable other than `app`, `application` or `handler`. We should use it in `vc_init` when available.

Not sure what to do about `start-dev-server.ts` though...

Also, maybe we should support `app.py:run` as an explicit entrypoint format.

<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR changes Python entrypoint detection logic from boolean checks to returning variable names, modifying how the runtime resolves and loads application handlers - a change to critical build/runtime infrastructure that could affect all Python deployments.
> 
> - Changes entrypoint detection from boolean to returning variable name across multiple packages
> - Modifies vc_init.py runtime logic for resolving app/handler variables
> - Alters return types of entrypoint detection functions from string to [string, string] tuples
>
> <sup>Risk assessment for [commit 73df0ea](https://github.com/vercel/vercel/commit/73df0ea5ad6bafd8222726165a06cb016958fdea).</sup>
<!-- VADE_RISK_END -->