### PR TITLE
[python]Disable runtime dependency installs for projects with custom build/install commands

### DIFF
--- a/.changeset/cyan-cougars-sniff.md
+++ b/.changeset/cyan-cougars-sniff.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Disable runtime dependency installs for projects with custom build/install commands

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -125,6 +125,8 @@ export class PythonDependencyExternalizer {
           `To resolve this, either:\n` +
           `  1. Remove the custom build/install command and let Vercel manage dependencies automatically\n` +
           `  2. Reduce your dependency footprint to fit within the ${limitMB} MB limit`,
+        link: 'https://vercel.com/docs/functions/runtimes/python#controlling-what-gets-bundled',
+        action: 'Learn More',
       });
     }
 
@@ -172,6 +174,8 @@ export class PythonDependencyExternalizer {
           `packages must fit within the ${ephemeralLimitMB} MB ephemeral storage available ` +
           `to Lambda functions. Consider removing unused dependencies or splitting your ` +
           `application into smaller functions.`,
+        link: 'https://vercel.com/docs/functions/runtimes/python#controlling-what-gets-bundled',
+        action: 'Learn More',
       });
     }
 
@@ -397,6 +401,8 @@ export class PythonDependencyExternalizer {
           `deferring public packages to runtime installation. This usually means your ` +
           `private packages or source code are too large. Consider reducing the size of ` +
           `private dependencies or splitting your application.`,
+        link: 'https://vercel.com/docs/functions/runtimes/python#controlling-what-gets-bundled',
+        action: 'Learn More',
       });
     }
   }

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -113,9 +113,14 @@ export class PythonDependencyExternalizer {
 
     const runtimeInstallEnabled = this.shouldEnableRuntimeInstall();
 
+    const pythonOnHiveEnabled =
+      process.env.VERCEL_PYTHON_ON_HIVE === '1' ||
+      process.env.VERCEL_PYTHON_ON_HIVE === 'true';
+
     if (
       this.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES &&
-      this.hasCustomCommand
+      this.hasCustomCommand &&
+      !pythonOnHiveEnabled
     ) {
       const limitMB = (LAMBDA_SIZE_THRESHOLD_BYTES / (1024 * 1024)).toFixed(0);
       throw new NowBuildError({

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -93,7 +93,7 @@ export class PythonDependencyExternalizer {
    * Must be called before generateBundle().
    */
   async analyze(files: Files): Promise<{
-    overLambdaLimit: boolean;
+    runtimeInstallEnabled: boolean;
     allVendorFiles: Files;
   }> {
     this.allVendorFiles = await mirrorPackagesIntoVendor({
@@ -111,9 +111,12 @@ export class PythonDependencyExternalizer {
     const totalBundleSizeMB = (this.totalBundleSize / (1024 * 1024)).toFixed(2);
     debug(`Total bundle size: ${totalBundleSizeMB} MB`);
 
-    const overLambdaLimit = this.shouldEnableRuntimeInstall();
+    const runtimeInstallEnabled = this.shouldEnableRuntimeInstall();
 
-    if (overLambdaLimit && this.hasCustomCommand) {
+    if (
+      this.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES &&
+      this.hasCustomCommand
+    ) {
       const limitMB = (LAMBDA_SIZE_THRESHOLD_BYTES / (1024 * 1024)).toFixed(0);
       throw new NowBuildError({
         code: 'LAMBDA_SIZE_EXCEEDED',
@@ -130,7 +133,7 @@ export class PythonDependencyExternalizer {
       });
     }
 
-    return { overLambdaLimit, allVendorFiles: this.allVendorFiles };
+    return { runtimeInstallEnabled, allVendorFiles: this.allVendorFiles };
   }
 
   /**

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -38,6 +38,7 @@ interface PythonDependencyExternalizerOptions {
   projectName: string | undefined;
   noBuildCheckFailed: boolean;
   pythonPath: string;
+  hasCustomCommand: boolean;
 }
 
 export class PythonDependencyExternalizer {
@@ -49,6 +50,7 @@ export class PythonDependencyExternalizer {
   private projectName: string | undefined;
   private noBuildCheckFailed: boolean;
   private pythonPath: string;
+  private hasCustomCommand: boolean;
 
   // Populated by analyze()
   private allVendorFiles: Files = {};
@@ -64,6 +66,25 @@ export class PythonDependencyExternalizer {
     this.projectName = options.projectName;
     this.noBuildCheckFailed = options.noBuildCheckFailed;
     this.pythonPath = options.pythonPath;
+    this.hasCustomCommand = options.hasCustomCommand;
+  }
+
+  shouldEnableRuntimeInstall(): boolean {
+    if (this.hasCustomCommand) {
+      return false;
+    }
+    const pythonOnHiveEnabled =
+      process.env.VERCEL_PYTHON_ON_HIVE === '1' ||
+      process.env.VERCEL_PYTHON_ON_HIVE === 'true';
+    if (pythonOnHiveEnabled) {
+      return false;
+    } else if (
+      this.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES &&
+      this.uvLockPath !== null
+    ) {
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -90,10 +111,22 @@ export class PythonDependencyExternalizer {
     const totalBundleSizeMB = (this.totalBundleSize / (1024 * 1024)).toFixed(2);
     debug(`Total bundle size: ${totalBundleSizeMB} MB`);
 
-    const overLambdaLimit = shouldEnableRuntimeInstall({
-      totalBundleSize: this.totalBundleSize,
-      uvLockPath: this.uvLockPath,
-    });
+    const overLambdaLimit = this.shouldEnableRuntimeInstall();
+
+    if (overLambdaLimit && this.hasCustomCommand) {
+      const limitMB = (LAMBDA_SIZE_THRESHOLD_BYTES / (1024 * 1024)).toFixed(0);
+      throw new NowBuildError({
+        code: 'LAMBDA_SIZE_EXCEEDED',
+        message:
+          `Total bundle size (${totalBundleSizeMB} MB) exceeds the Lambda size limit (${limitMB} MB).\n\n` +
+          `Runtime dependency installation is not available for projects that use a custom ` +
+          `build or install command, because custom commands may install dependencies that ` +
+          `are not tracked in uv.lock.\n\n` +
+          `To resolve this, either:\n` +
+          `  1. Remove the custom build/install command and let Vercel manage dependencies automatically\n` +
+          `  2. Reduce your dependency footprint to fit within the ${limitMB} MB limit`,
+      });
+    }
 
     return { overLambdaLimit, allVendorFiles: this.allVendorFiles };
   }
@@ -370,27 +403,6 @@ export class PythonDependencyExternalizer {
 }
 
 // Utility functions
-export function shouldEnableRuntimeInstall({
-  totalBundleSize,
-  uvLockPath,
-}: {
-  totalBundleSize: number;
-  uvLockPath: string | null;
-}): boolean {
-  const pythonOnHiveEnabled =
-    process.env.VERCEL_PYTHON_ON_HIVE === '1' ||
-    process.env.VERCEL_PYTHON_ON_HIVE === 'true';
-  if (pythonOnHiveEnabled) {
-    return false;
-  } else if (
-    totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES &&
-    uvLockPath !== null
-  ) {
-    return true;
-  }
-  return false;
-}
-
 /**
  * Mirror packages from site-packages into the _vendor directory.
  *

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -551,10 +551,10 @@ from vercel_runtime.vc_init import vc_handler
     hasCustomCommand,
   });
 
-  const { overLambdaLimit, allVendorFiles } =
+  const { runtimeInstallEnabled, allVendorFiles } =
     await depExternalizer.analyze(files);
 
-  if (overLambdaLimit) {
+  if (runtimeInstallEnabled) {
     await depExternalizer.generateBundle(files);
   } else {
     // Bundle all dependencies since we're not doing runtime installation

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -86,6 +86,10 @@ export const build: BuildV3 = async ({
   let spawnEnv: NodeJS.ProcessEnv | undefined;
   // Custom install command from dashboard/project settings, if any.
   let projectInstallCommand: string | undefined;
+  // Track whether a custom build or install command was used.
+  // When true, runtime dependency installation is disabled because
+  // custom commands may install dependencies not tracked in uv.lock.
+  let hasCustomCommand = false;
 
   debug(`workPath: ${workPath}`);
 
@@ -150,12 +154,16 @@ export const build: BuildV3 = async ({
         env: spawnEnv,
         cwd: workPath,
       });
+      hasCustomCommand = true;
     } else {
-      await runPyprojectScript(
+      const ranBuildScript = await runPyprojectScript(
         workPath,
         ['vercel-build', 'now-build', 'build'],
         spawnEnv
       );
+      if (ranBuildScript) {
+        hasCustomCommand = true;
+      }
     }
   }
 
@@ -333,6 +341,7 @@ export const build: BuildV3 = async ({
       cwd: workPath,
     });
     assumeDepsInstalled = true;
+    hasCustomCommand = true;
   } else {
     // Check and run a custom vercel install command from project manifest.
     // This will return `false` if no script was ran.
@@ -342,6 +351,9 @@ export const build: BuildV3 = async ({
       pythonEnv,
       /* useUserVirtualEnv */ false
     );
+    if (assumeDepsInstalled) {
+      hasCustomCommand = true;
+    }
   }
 
   let uv: UvRunner;
@@ -536,6 +548,7 @@ from vercel_runtime.vc_init import vc_handler
     projectName,
     noBuildCheckFailed,
     pythonPath: pythonVersion.pythonPath,
+    hasCustomCommand,
   });
 
   const { overLambdaLimit, allVendorFiles } =


### PR DESCRIPTION
For now, produce a helpful error message when someone tries to deploy a python function >250MB and its using a custom build or install command.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Adds defensive validation that disables runtime dependency installs for custom build commands and throws a helpful error when bundle size exceeds limits, which restricts functionality rather than loosening it.
> 
> - Adds `hasCustomCommand` flag to disable runtime dependency installation for custom builds
> - Throws `NowBuildError` with actionable guidance when bundle exceeds Lambda size limit with custom commands
> - Updates tests to cover new `hasCustomCommand` behavior
>
> <sup>Risk assessment for [commit fb1e5af](https://github.com/vercel/vercel/commit/fb1e5af618f8047bb191fd7e42578594a3931255).</sup>
<!-- VADE_RISK_END -->