### PR TITLE
feat(cli): Add vercel buy v0 plans subcommands

### DIFF
--- a/packages/cli/src/commands/buy/command.ts
+++ b/packages/cli/src/commands/buy/command.ts
@@ -1,6 +1,8 @@
 import { packageName } from '../../util/pkg-name';
 import { yesOption, formatOption, jsonOption } from '../../util/arg-common';
 
+export type PlanSlug = 'pro' | 'v0-free' | 'v0-premium' | 'v0-team';
+
 export const SUPPORTED_CREDIT_TYPES = ['v0', 'gateway', 'agent'] as const;
 export type CreditType = (typeof SUPPORTED_CREDIT_TYPES)[number];
 
@@ -112,16 +114,47 @@ export const proSubcommand = {
   ],
 } as const;
 
+export const SUPPORTED_V0_PLANS = ['free', 'premium', 'team'] as const;
+export type V0Plan = (typeof SUPPORTED_V0_PLANS)[number];
+
+export const V0_PLAN_LABELS: Record<V0Plan, string> = {
+  free: 'v0 Free',
+  premium: 'v0 Premium',
+  team: 'v0 Team',
+};
+
+export const V0_PLAN_TO_SLUG: Record<V0Plan, PlanSlug> = {
+  free: 'v0-free',
+  premium: 'v0-premium',
+  team: 'v0-team',
+};
+
 export const v0Subcommand = {
   name: 'v0',
   aliases: [],
   description: 'Purchase a v0 subscription for your team',
-  arguments: [],
-  options: [],
+  arguments: [
+    {
+      name: 'plan',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt',
+    },
+    formatOption,
+    jsonOption,
+  ],
   examples: [
     {
-      name: 'Purchase v0 for your team',
-      value: `${packageName} buy v0`,
+      name: 'Purchase v0 Premium for your team',
+      value: `${packageName} buy v0 premium`,
+    },
+    {
+      name: 'Purchase v0 Team for your team',
+      value: `${packageName} buy v0 team`,
     },
   ],
 } as const;
@@ -172,8 +205,8 @@ export const buyCommand = {
       value: `${packageName} buy pro`,
     },
     {
-      name: 'Purchase v0',
-      value: `${packageName} buy v0`,
+      name: 'Purchase v0 Premium',
+      value: `${packageName} buy v0 premium`,
     },
     {
       name: 'Purchase a domain',

--- a/packages/cli/src/commands/buy/v0.ts
+++ b/packages/cli/src/commands/buy/v0.ts
@@ -1,19 +1,56 @@
+import chalk from 'chalk';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { v0Subcommand } from './command';
+import {
+  v0Subcommand,
+  SUPPORTED_V0_PLANS,
+  V0_PLAN_LABELS,
+  V0_PLAN_TO_SLUG,
+  type V0Plan,
+} from './command';
 import output from '../../output-manager';
 import getScope from '../../util/get-scope';
+import { getCommandName } from '../../util/pkg-name';
+import stamp from '../../util/output/stamp';
+import { createPurchase } from '../../util/buy/create-purchase';
+import { handlePurchaseError } from '../../util/buy/handle-purchase-error';
+import { validateJsonOutput } from '../../util/output-format';
 
 export default async function v0(client: Client, argv: string[]) {
   const flagsSpecification = getFlagsSpecification(v0Subcommand.options);
   let parsedArgs;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     parsedArgs = parseArguments(argv, flagsSpecification);
   } catch (error) {
     printError(error);
+    return 1;
+  }
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const { args } = parsedArgs;
+  const [plan] = args;
+
+  // Validate plan argument
+  if (!plan) {
+    output.error(
+      `Missing plan. Supported plans: ${SUPPORTED_V0_PLANS.join(', ')}`
+    );
+    output.log(`Run ${getCommandName('buy v0 --help')} for usage.`);
+    return 1;
+  }
+
+  if (!SUPPORTED_V0_PLANS.includes(plan as V0Plan)) {
+    output.error(
+      `Invalid plan "${plan}". Supported plans: ${SUPPORTED_V0_PLANS.join(', ')}`
+    );
     return 1;
   }
 
@@ -27,9 +64,65 @@ export default async function v0(client: Client, argv: string[]) {
     return 1;
   }
 
-  output.log(`Purchasing v0 subscription for team ${contextName}...`);
+  const typedPlan = plan as V0Plan;
+  const label = V0_PLAN_LABELS[typedPlan];
+  const planSlug = V0_PLAN_TO_SLUG[typedPlan];
+  const yes = parsedArgs.flags['--yes'];
 
-  // TODO: Implement v0 subscription purchase flow when API is available
-  output.error('v0 subscription purchase is not yet available via the CLI.');
-  return 1;
+  // Confirm purchase
+  if (!yes) {
+    if (!client.stdin.isTTY) {
+      output.error(
+        'Confirmation required. Use --yes to skip the confirmation prompt in non-interactive mode.'
+      );
+      return 1;
+    }
+    if (
+      !(await client.input.confirm(
+        `Purchase ${chalk.bold(label)} for team ${chalk.bold(contextName)}?`,
+        false
+      ))
+    ) {
+      return 0;
+    }
+  }
+
+  const purchaseStamp = stamp();
+  output.spinner('Processing purchase');
+
+  try {
+    const result = await createPurchase(client, {
+      type: 'subscription',
+      planSlug,
+    });
+
+    output.stopSpinner();
+
+    if (asJson) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            plan: typedPlan,
+            planSlug,
+            team: contextName,
+            purchaseIntent: result.purchaseIntent,
+          },
+          null,
+          2
+        )}\n`
+      );
+    } else {
+      output.success(
+        `Purchased ${chalk.bold(label)} for ${chalk.bold(contextName)} ${purchaseStamp()}`
+      );
+      if (result.purchaseIntent) {
+        output.debug(`Purchase intent: ${result.purchaseIntent.id}`);
+      }
+    }
+
+    return 0;
+  } catch (err: unknown) {
+    output.stopSpinner();
+    return handlePurchaseError(err, contextName);
+  }
 }

--- a/packages/cli/src/util/buy/handle-purchase-error.ts
+++ b/packages/cli/src/util/buy/handle-purchase-error.ts
@@ -38,6 +38,23 @@ export function handlePurchaseError(err: unknown, teamSlug?: string): number {
       );
       return 1;
     }
+    if (err.code === 'plan_not_found') {
+      output.error(
+        'The requested plan was not found. Please check the plan name and try again.'
+      );
+      return 1;
+    }
+    if (err.code === 'invalid_plan') {
+      output.error(err.message || 'Your team is not eligible for this plan.');
+      return 1;
+    }
+    if (err.code === 'has_subscription') {
+      output.error(
+        err.message ||
+          'Your team already has an active subscription for this product.'
+      );
+      return 1;
+    }
     if (
       err.code === 'purchase_create_failed' ||
       err.code === 'purchase_confirm_failed' ||

--- a/packages/cli/src/util/buy/types.ts
+++ b/packages/cli/src/util/buy/types.ts
@@ -1,10 +1,13 @@
-import type { CreditType, AddonAlias } from '../../commands/buy/command';
+import type {
+  CreditType,
+  AddonAlias,
+  PlanSlug,
+} from '../../commands/buy/command';
 
 export type PurchaseItem =
   | { type: 'credits'; creditType: CreditType; amount: number }
   | { type: 'addon'; productAlias: AddonAlias; quantity: number }
-  | { type: 'subscription'; planSlug: 'pro' }
-  | { type: 'v0' };
+  | { type: 'subscription'; planSlug: PlanSlug };
 
 export interface BuyResponse {
   purchaseIntent?: {

--- a/packages/cli/test/unit/commands/buy/v0.test.ts
+++ b/packages/cli/test/unit/commands/buy/v0.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest';
+import { client } from '../../../mocks/client';
+import buy from '../../../../src/commands/buy';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+
+function useBuyEndpoint(handler?: (req: any, res: any) => void) {
+  client.scenario.post('/v1/billing/buy', (req, res) => {
+    if (handler) {
+      handler(req, res);
+    } else {
+      res.json({
+        purchaseIntent: {
+          id: 'pi_test_123',
+          status: 'succeeded',
+        },
+      });
+    }
+  });
+}
+
+function setupTeam() {
+  useUser();
+  const team = useTeam();
+  client.config.currentTeam = team.id;
+  return team;
+}
+
+describe('buy v0', () => {
+  describe('validation', () => {
+    it('errors when plan is missing', async () => {
+      client.setArgv('buy', 'v0');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Missing plan');
+    });
+
+    it('errors when plan is invalid', async () => {
+      client.setArgv('buy', 'v0', 'invalid');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid plan "invalid"');
+    });
+  });
+
+  describe('--yes', () => {
+    it('skips confirmation and purchases premium successfully', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'v0', 'premium', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+    });
+
+    it('skips confirmation and purchases free successfully', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'v0', 'free', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+    });
+
+    it('skips confirmation and purchases team successfully', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'v0', 'team', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+    });
+
+    it('errors in non-TTY mode without --yes', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'v0', 'premium');
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Use --yes');
+    });
+  });
+
+  describe('confirmation prompt', () => {
+    it('aborts when user declines', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'v0', 'premium');
+
+      const exitCodePromise = buy(client);
+      await expect(client.stderr).toOutput('Purchase');
+      client.stdin.write('n\n');
+
+      expect(await exitCodePromise).toBe(0);
+    });
+
+    it('proceeds when user confirms', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'v0', 'premium');
+
+      const exitCodePromise = buy(client);
+      await expect(client.stderr).toOutput('Purchase');
+      client.stdin.write('y\n');
+
+      expect(await exitCodePromise).toBe(0);
+    });
+  });
+
+  describe('API errors', () => {
+    it('handles missing_stripe_customer error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'missing_stripe_customer',
+            message: 'No payment method',
+          },
+        });
+      });
+      client.setArgv('buy', 'v0', 'premium', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('payment method');
+    });
+
+    it('handles has_subscription error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'has_subscription',
+            message: 'Team already has an active v0 subscription',
+          },
+        });
+      });
+      client.setArgv('buy', 'v0', 'premium', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('active v0 subscription');
+    });
+
+    it('handles invalid_plan error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'invalid_plan',
+            message: 'Enterprise teams cannot purchase v0 subscriptions',
+          },
+        });
+      });
+      client.setArgv('buy', 'v0', 'premium', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Enterprise teams cannot purchase');
+    });
+
+    it('handles plan_not_found error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'plan_not_found',
+            message: 'No v0 plan found',
+          },
+        });
+      });
+      client.setArgv('buy', 'v0', 'premium', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('plan was not found');
+    });
+  });
+
+  describe('--format=json', () => {
+    it('outputs JSON on success', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'v0', 'premium', '--yes', '--format=json');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const parsed = JSON.parse(stdoutOutput);
+      expect(parsed.plan).toBe('premium');
+      expect(parsed.planSlug).toBe('v0-premium');
+      expect(parsed.purchaseIntent.id).toBe('pi_test_123');
+    });
+  });
+
+  describe('--help', () => {
+    it('shows help and returns 2', async () => {
+      client.setArgv('buy', 'v0', '--help');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(2);
+    });
+
+    it('tracks telemetry', async () => {
+      client.setArgv('buy', 'v0', '--help');
+      await buy(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'buy:v0',
+        },
+      ]);
+    });
+  });
+
+  describe('telemetry', () => {
+    it('tracks v0 subcommand', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'v0', 'premium', '--yes');
+      await buy(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:v0',
+          value: 'v0',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Add vercel buy v0 plans subcommands

- Implement `vercel buy v0 <plan>` to purchase v0 subscriptions (`free`, `premium`, `team`)
- Unify pro and v0 purchase types under `{ type: 'subscription', planSlug }` to match the billing API
- Add error handling for `plan_not_found`, `invalid_plan`, and `has_subscription` API errors
- Add `--yes`, `--format`, `--json` flag support for both `buy pro` and `buy v0`


**Example:**
```bash
vercel buy v0 premium --yes
```


<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR adds new CLI subcommands for purchasing v0 subscriptions, involving billing/payment logic changes that could affect money if the purchase flow has bugs.
> 
> - Billing: implements v0 subscription purchase flow via createPurchase API
> - Unifies purchase types under subscription model, removing separate v0 type
> - Adds error handling for plan_not_found, invalid_plan, has_subscription errors
>
> <sup>Risk assessment for [commit ce2b739](https://github.com/vercel/vercel/commit/ce2b73965f766b03f4a1add73c3fdf6f09144c48).</sup>
<!-- VADE_RISK_END -->