### PR TITLE
Prefix stdout so we can filter on it

### DIFF
--- a/.changeset/pretty-bottles-sing.md
+++ b/.changeset/pretty-bottles-sing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Prefix stdout in test helpers

--- a/packages/cli/test/helpers/exec.ts
+++ b/packages/cli/test/helpers/exec.ts
@@ -1,4 +1,5 @@
 import execa from 'execa';
+import testLogger from './test-logger';
 
 const defaultOptions = {
   reject: false,
@@ -12,8 +13,7 @@ export function execCli(
   args: string[] = [],
   opts: execa.Options<string> & { token?: string | boolean } = {}
 ): execa.ExecaChildProcess<string> {
-  // eslint-disable-next-line no-console
-  console.log(`$ vercel ${args.join(' ')}`);
+  testLogger(`$ vercel ${args.join(' ')}`);
 
   if (!args.includes('--token') && opts.token !== false) {
     args.push(

--- a/packages/cli/test/helpers/get-global-dir.ts
+++ b/packages/cli/test/helpers/get-global-dir.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs, { ensureDirSync } from 'fs-extra';
 import XDGAppPaths from 'xdg-app-paths';
 import { getCachedTmpDir } from './get-tmp-dir';
+import testLogger from './test-logger';
 
 export default function getGlobalDir() {
   let globalDir: string;
@@ -13,8 +14,7 @@ export default function getGlobalDir() {
   }
 
   if (!fs.existsSync(globalDir)) {
-    // eslint-disable-next-line no-console
-    console.log('Creating global config directory ', globalDir);
+    testLogger('Creating global config directory ', globalDir);
     ensureDirSync(globalDir);
   }
 

--- a/packages/cli/test/helpers/test-logger.ts
+++ b/packages/cli/test/helpers/test-logger.ts
@@ -1,0 +1,49 @@
+import { format } from 'util';
+
+const testNameToShortId = new Map<string, string>();
+const testsThatLoggedMapping = new Set<string>();
+
+function getCurrentTestName(): string {
+  try {
+    const state = (globalThis as any).expect?.getState?.();
+    const current = state?.currentTestName;
+    if (current) return current;
+  } catch {
+    // not in Jest
+  }
+  return 'unknown-test';
+}
+
+/** Deterministic 4-char id from test name. Grep for [id] to get one test's logs. */
+function getShortId(): string {
+  const name = getCurrentTestName();
+  let id = testNameToShortId.get(name);
+  if (id) return id;
+  let h = 0;
+  for (let i = 0; i < name.length; i++)
+    h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+  id = Math.abs(h).toString(36).slice(0, 4);
+  testNameToShortId.set(name, id);
+  return id;
+}
+
+/**
+ * Same API as console.log, but each line is prefixed with [shortId] derived from
+ * the current test name so parallel test output is grep-able (e.g. grep '[a1x9]').
+ */
+function testLogger(...args: unknown[]): void {
+  const message = format(...args);
+  const shortId = getShortId();
+  const name = getCurrentTestName();
+  const prefix = `[${shortId}] `;
+  if (!testsThatLoggedMapping.has(name)) {
+    testsThatLoggedMapping.add(name);
+    process.stdout.write(prefix + `test: ${name}\n`);
+  }
+  const lines = message.split('\n');
+  for (const line of lines) {
+    process.stdout.write(prefix + line + '\n');
+  }
+}
+
+export default testLogger;

--- a/packages/cli/test/helpers/wait-for-prompt.ts
+++ b/packages/cli/test/helpers/wait-for-prompt.ts
@@ -1,4 +1,5 @@
 import stripAnsi from 'strip-ansi';
+import testLogger from './test-logger';
 import type { CLIProcess } from './types';
 
 function getPromptErrorDetails(
@@ -27,8 +28,7 @@ export default async function waitForPrompt(
   return new Promise<void>((resolve, reject) => {
     let mostRecentChunk = 'NO CHUNKS SO FAR';
 
-    // eslint-disable-next-line no-console
-    console.log('Waiting for prompt...');
+    testLogger('Waiting for prompt...');
     const handleTimeout = setTimeout(() => {
       cleanup();
       const promptErrorDetails = getPromptErrorDetails(
@@ -59,8 +59,7 @@ export default async function waitForPrompt(
       const chunk = stripAnsi(rawChunk.toString());
 
       mostRecentChunk = chunk;
-      // eslint-disable-next-line no-console
-      console.log('> ' + chunk);
+      testLogger('> ' + chunk);
       if (assertion(chunk)) {
         cleanup();
         resolve();


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR replaces console.log calls with a custom testLogger in test helper files to prefix stdout with test identifiers for filtering parallel test output.
> 
> - New test-logger utility adds prefixed stdout for grep-able test output
> - Replaces console.log with testLogger in 3 test helper files
> - Test infrastructure only - no production code changes
>
> <sup>Risk assessment for [commit 0e71824](https://github.com/vercel/vercel/commit/0e71824558547921f4e3c946669a9cd729fdb485).</sup>
<!-- VADE_RISK_END -->