### PR TITLE
running evals on cron

### DIFF
--- a/.changeset/cli-evals-hourly-cron.md
+++ b/.changeset/cli-evals-hourly-cron.md
@@ -1,0 +1,5 @@
+---
+---
+
+Add an hourly GitHub Actions cron to run CLI evals.
+

--- a/.github/workflows/cli-evals.yml
+++ b/.github/workflows/cli-evals.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     paths:
       - 'packages/cli/evals/**'
+  schedule:
+    # Run hourly to track eval health over time.
+    - cron: '0 * * * *'
 
 jobs:
   evals:


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds an hourly cron schedule to an existing GitHub Actions workflow for running CLI evals, with no changes to security, auth, or business logic.
> 
> - Adds hourly cron trigger to cli-evals.yml workflow
> - Adds changeset documentation file
>
> <sup>Risk assessment for [commit 459f042](https://github.com/vercel/vercel/commit/459f042a5ef26567384ae829c2295171d47f3982).</sup>
<!-- VADE_RISK_END -->