### PR TITLE
[services] detected services source

### DIFF
--- a/.changeset/silly-hornets-whisper.md
+++ b/.changeset/silly-hornets-whisper.md
@@ -1,0 +1,5 @@
+---
+"@vercel/fs-detectors": patch
+---
+
+[services] adds source information to detected services

--- a/packages/fs-detectors/src/index.ts
+++ b/packages/fs-detectors/src/index.ts
@@ -24,6 +24,7 @@ export { getServicesBuilders } from './services/get-services-builders';
 export type {
   DetectServicesOptions,
   DetectServicesResult,
+  DetectServicesSource,
   ResolvedService,
   Service,
   ServicesRoutes,

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -40,6 +40,7 @@ export async function detectServices(
   if (configError) {
     return {
       services: [],
+      source: 'configured',
       routes: { rewrites: [], defaults: [], crons: [], workers: [] },
       errors: [configError],
       warnings: [],
@@ -57,6 +58,7 @@ export async function detectServices(
     if (autoResult.errors.length > 0) {
       return {
         services: [],
+        source: 'auto-detected',
         routes: { rewrites: [], defaults: [], crons: [], workers: [] },
         errors: autoResult.errors,
         warnings: [],
@@ -72,6 +74,7 @@ export async function detectServices(
       const routes = generateServicesRoutes(result.services);
       return {
         services: result.services,
+        source: 'auto-detected',
         routes,
         errors: result.errors,
         warnings: [],
@@ -80,6 +83,7 @@ export async function detectServices(
 
     return {
       services: [],
+      source: 'auto-detected',
       routes: { rewrites: [], defaults: [], crons: [], workers: [] },
       errors: [
         {
@@ -104,6 +108,7 @@ export async function detectServices(
 
   return {
     services: result.services,
+    source: 'configured',
     routes,
     errors: result.errors,
     warnings: [],

--- a/packages/fs-detectors/src/services/types.ts
+++ b/packages/fs-detectors/src/services/types.ts
@@ -55,11 +55,19 @@ export interface ServicesRoutes {
 
 export interface DetectServicesResult {
   services: Service[];
+  /**
+   * Source of service definitions:
+   * - `configured`: loaded from explicit project configuration (currently `vercel.json#experimentalServices`)
+   * - `auto-detected`: inferred from project structure
+   */
+  source: DetectServicesSource;
   /** Routing rules derived from services */
   routes: ServicesRoutes;
   errors: ServiceDetectionError[];
   warnings: ServiceDetectionWarning[];
 }
+
+export type DetectServicesSource = 'configured' | 'auto-detected';
 
 export interface ServiceDetectionWarning {
   code: string;

--- a/packages/fs-detectors/test/unit.auto-detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.auto-detect-services.test.ts
@@ -391,6 +391,7 @@ describe('detectServices with auto-detection', () => {
 
       expect(result.errors).toEqual([]);
       expect(result.warnings).toEqual([]);
+      expect(result.source).toBe('configured');
       expect(result.services).toHaveLength(1);
       expect(result.services[0].name).toBe('api');
       expect(result.services[0].routePrefix).toBe('/api');
@@ -476,6 +477,7 @@ describe('detectServices with auto-detection', () => {
 
       expect(result.errors).toEqual([]);
       expect(result.warnings).toHaveLength(0);
+      expect(result.source).toBe('auto-detected');
       expect(result.services).toHaveLength(1);
       expect(result.services[0]).toMatchObject({
         name: 'frontend',
@@ -498,6 +500,7 @@ describe('detectServices with auto-detection', () => {
 
       expect(result.errors).toEqual([]);
       expect(result.warnings).toHaveLength(0);
+      expect(result.source).toBe('auto-detected');
       expect(result.services).toHaveLength(1);
       expect(result.services[0]).toMatchObject({
         name: 'frontend',
@@ -522,6 +525,7 @@ describe('detectServices with auto-detection', () => {
 
       expect(result.errors).toEqual([]);
       expect(result.warnings).toHaveLength(0);
+      expect(result.source).toBe('auto-detected');
       expect(result.services).toHaveLength(2);
       const backend = result.services.find(
         service => service.name === 'backend'

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -33,6 +33,7 @@ describe('detectServices', () => {
       const result = await detectServices({ fs });
 
       expect(result.services).toEqual([]);
+      expect(result.source).toBe('auto-detected');
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0].code).toBe('NO_SERVICES_CONFIGURED');
     });
@@ -103,6 +104,7 @@ describe('detectServices', () => {
       const result = await detectServices({ fs });
 
       expect(result.services).toHaveLength(1);
+      expect(result.source).toBe('configured');
       expect(result.services[0]).toMatchObject({
         name: 'api',
         type: 'web',


### PR DESCRIPTION
Adds source information to detected services result 

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new 'source' field to the DetectServicesResult type to indicate whether services were configured or auto-detected, with corresponding test updates - a purely additive, non-breaking change.
> 
> - Adds new `source` property to `DetectServicesResult` interface
> - Exports new `DetectServicesSource` type from index
> - Test assertions added to verify source field values
>
> <sup>Risk assessment for [commit b9cb7be](https://github.com/vercel/vercel/commit/b9cb7be188f8af0fb6ccd0e1a0811f18166b2a57).</sup>
<!-- VADE_RISK_END -->