### PR TITLE
[services] make the `experimentalServices` config the primary marker for the services flow

### DIFF
--- a/.changeset/rude-seals-poke.md
+++ b/.changeset/rude-seals-poke.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+[services] make the `experimentalServices` config the primary marker for the services flow

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -23,10 +23,7 @@ import {
 } from '../../util/agent-output';
 import type { DevTelemetryClient } from '../../util/telemetry/commands/dev';
 import { VERCEL_OIDC_TOKEN } from '../../util/env/constants';
-import {
-  tryDetectServices,
-  isExperimentalServicesEnabled,
-} from '../../util/projects/detect-services';
+import { tryDetectServices } from '../../util/projects/detect-services';
 import { displayDetectedServices } from '../../util/input/display-services';
 import { acquireDevLock, releaseDevLock } from '../../util/dev/dev-lock';
 import { resolveProjectCwd } from '../../util/projects/find-project-root';
@@ -129,16 +126,15 @@ export default async function dev(
   }
 
   let services: ResolvedService[] | undefined;
-  if (isExperimentalServicesEnabled()) {
-    const result = await tryDetectServices(cwd);
-    if (result && result.services.length > 0) {
-      displayDetectedServices(result.services);
-      services = result.services;
-    }
+  const servicesResult = await tryDetectServices(cwd);
+  const foundServices = servicesResult && servicesResult.services.length > 0;
+  if (foundServices) {
+    displayDetectedServices(servicesResult.services);
+    services = servicesResult.services;
   }
 
   let lockAcquired = false;
-  if (isExperimentalServicesEnabled()) {
+  if (foundServices) {
     const port = typeof listen[0] === 'number' ? listen[0] : 0;
     const lockResult = await acquireDevLock(cwd, port);
 

--- a/packages/cli/src/util/projects/detect-services.ts
+++ b/packages/cli/src/util/projects/detect-services.ts
@@ -1,29 +1,50 @@
+import { join } from 'path';
 import {
   detectServices,
   LocalFileSystemDetector,
   type DetectServicesResult,
 } from '@vercel/fs-detectors';
+import readJSONFile from '../read-json-file';
 
-export function isExperimentalServicesEnabled(): boolean {
+/**
+ * Check if vercel.json in the given directory has experimentalServices configured
+ * or VERCEL_USE_EXPERIMENTAL_SERVICES environment variable is set.
+ */
+export async function isExperimentalServicesEnabled(
+  cwd: string
+): Promise<boolean> {
   return (
     process.env.VERCEL_USE_EXPERIMENTAL_SERVICES === '1' ||
-    process.env.VERCEL_USE_EXPERIMENTAL_SERVICES?.toLowerCase() === 'true'
+    process.env.VERCEL_USE_EXPERIMENTAL_SERVICES?.toLowerCase() === 'true' ||
+    (await hasExperimentalServicesConfig(cwd))
+  );
+}
+
+async function hasExperimentalServicesConfig(cwd: string): Promise<boolean> {
+  const config = await readJSONFile<Record<string, unknown>>(
+    join(cwd, 'vercel.json')
+  );
+  if (!config || config instanceof Error) return false;
+  return (
+    config.experimentalServices != null &&
+    typeof config.experimentalServices === 'object'
   );
 }
 
 /**
  * Detect services if experimental services are enabled.
  *
- * Returns the detection result if:
- * - VERCEL_USE_EXPERIMENTAL_SERVICES=1 env var is set
+ * Returns the detection result if any of the following is true:
  * - vercel.json contains experimentalServices with valid services
+ * - VERCEL_USE_EXPERIMENTAL_SERVICES env var is set (enables auto-detection of services)
  *
  * Returns null otherwise.
  */
 export async function tryDetectServices(
   cwd: string
 ): Promise<DetectServicesResult | null> {
-  if (!isExperimentalServicesEnabled()) {
+  const isServicesEnabled = await isExperimentalServicesEnabled(cwd);
+  if (!isServicesEnabled) {
     return null;
   }
 

--- a/packages/cli/test/unit/util/projects/find-project-root.test.ts
+++ b/packages/cli/test/unit/util/projects/find-project-root.test.ts
@@ -29,8 +29,8 @@ vi.mock('fs-extra', async () => {
 });
 
 vi.mock('../../../../src/util/projects/detect-services', () => ({
-  isExperimentalServicesEnabled: vi.fn(() => false),
-  tryDetectServices: vi.fn(() => null),
+  isExperimentalServicesEnabled: vi.fn(async () => false),
+  tryDetectServices: vi.fn(async () => null),
 }));
 
 describe('findProjectRoot', () => {
@@ -105,7 +105,7 @@ describe('resolveProjectCwd', () => {
 
   beforeEach(() => {
     vol.reset();
-    mockedIsEnabled.mockReturnValue(false);
+    mockedIsEnabled.mockResolvedValue(false);
     mockedTryDetect.mockResolvedValue(null);
   });
 
@@ -114,7 +114,7 @@ describe('resolveProjectCwd', () => {
   });
 
   it('should return cwd unchanged when feature flag is off', async () => {
-    mockedIsEnabled.mockReturnValue(false);
+    mockedIsEnabled.mockResolvedValue(false);
 
     const result = await resolveProjectCwd('/project/services/api');
 
@@ -122,7 +122,7 @@ describe('resolveProjectCwd', () => {
   });
 
   it('should return project root when flag is on and services detected', async () => {
-    mockedIsEnabled.mockReturnValue(true);
+    mockedIsEnabled.mockResolvedValue(true);
     mockedTryDetect.mockResolvedValue({
       services: [{ name: 'api', slug: 'api', directory: 'services/api' }],
     } as any);
@@ -138,7 +138,7 @@ describe('resolveProjectCwd', () => {
   });
 
   it('should return original cwd when flag is on but no services found', async () => {
-    mockedIsEnabled.mockReturnValue(true);
+    mockedIsEnabled.mockResolvedValue(true);
     mockedTryDetect.mockResolvedValue({
       services: [],
     } as any);
@@ -154,7 +154,7 @@ describe('resolveProjectCwd', () => {
   });
 
   it('should return original cwd when no project root found', async () => {
-    mockedIsEnabled.mockReturnValue(true);
+    mockedIsEnabled.mockResolvedValue(true);
 
     vol.fromJSON({
       '/some/deep/path/package.json': '{}',


### PR DESCRIPTION
If a user specifies `experimentalServices` in `vercel.json`, the CLI shouldn't require `VERCEL_USE_EXPERIMENTAL_SERVICES` env var to be set, because `experimentalServices` performs essentially the same function. Thus, `VERCEL_USE_EXPERIMENTAL_SERVICES` should be used to enable auto-discovery of services

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR refactors how experimental services are enabled, changing from requiring an env var to also accepting vercel.json config, which is a feature flag behavior change but does not affect security, auth, or data schemas.
> 
> - Removes env var gate for service detection, now also checks vercel.json for experimentalServices config
> - Changes `isExperimentalServicesEnabled` from sync to async function that reads vercel.json
> - Adds comprehensive unit tests for new config-based detection behavior
>
> <sup>Risk assessment for [commit 1c34a24](https://github.com/vercel/vercel/commit/1c34a24f0d892d4d805e238186c3dc231cb97e8a).</sup>
<!-- VADE_RISK_END -->