### PR TITLE
feat(cli): add --format=json to integration add (auto-provision)

### DIFF
--- a/.changeset/cli-integration-add-json-output.md
+++ b/.changeset/cli-integration-add-json-output.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(cli): add --format=json support to `integration add` (auto-provision)

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -35,6 +35,7 @@ export interface AddAutoProvisionOptions extends PostProvisionOptions {
   billingPlanId?: string;
   installationId?: string;
   commandName?: 'integration add' | 'install';
+  asJson?: boolean;
 }
 
 export async function addAutoProvision(
@@ -57,6 +58,7 @@ export async function addAutoProvision(
   telemetry.trackCliOptionInstallationId(options.installationId);
   telemetry.trackCliOptionEnvironment(options.environments);
   telemetry.trackCliOptionPrefix(options.prefix);
+  telemetry.trackCliOptionFormat(options.asJson ? 'json' : undefined);
 
   // Get team context
   const { contextName, team } = await getScope(client);
@@ -382,7 +384,7 @@ export async function addAutoProvision(
   );
 
   // Post-provision: dashboard URL, connect, env pull
-  return postProvisionSetup(
+  const setupResult = await postProvisionSetup(
     client,
     resourceName,
     provisioned.resource.id,
@@ -406,4 +408,62 @@ export async function addAutoProvision(
       },
     }
   );
+
+  if (options.asJson) {
+    const warnings: string[] = [];
+    if (setupResult.connectError) {
+      warnings.push(
+        `Failed to connect to project: ${setupResult.connectError}`
+      );
+    }
+    if (setupResult.connected && !setupResult.envPulled && !options.noEnvPull) {
+      warnings.push(
+        'Failed to pull environment variables. You can run `vercel env pull` manually.'
+      );
+    }
+
+    const jsonOutput: Record<string, unknown> = {
+      resource: {
+        id: provisioned.resource.id,
+        name: provisioned.resource.name,
+        status: provisioned.resource.status,
+        externalResourceId: provisioned.resource.externalResourceId,
+      },
+      integration: {
+        id: provisioned.integration.id,
+        slug: provisioned.integration.slug,
+        name: provisioned.integration.name,
+      },
+      product: {
+        id: provisioned.product.id,
+        slug: provisioned.product.slug,
+        name: provisioned.product.name,
+      },
+      installation: {
+        id: provisioned.installation.id,
+      },
+      billingPlan: provisioned.billingPlan
+        ? {
+            id: provisioned.billingPlan.id,
+            name: provisioned.billingPlan.name,
+            type: provisioned.billingPlan.type,
+          }
+        : null,
+      dashboardUrl: setupResult.dashboardUrl,
+    };
+
+    if (setupResult.project) {
+      jsonOutput.project = setupResult.project;
+    }
+    jsonOutput.environments = setupResult.environments;
+    jsonOutput.envPulled = setupResult.envPulled;
+    jsonOutput.warnings = warnings;
+
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+
+    // Partial failures (connect/env-pull) still return 0 when resource was provisioned
+    return setupResult.connectError ? 0 : setupResult.exitCode;
+  }
+
+  return setupResult.exitCode;
 }

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -16,8 +16,10 @@ import type {
   AutoProvisionFallback,
   AutoProvisionResult,
 } from '../../util/integration/types';
+import { buildSSOLink } from '../../util/integration/build-sso-link';
 import { resolveResourceName } from '../../util/integration/generate-resource-name';
 import {
+  ENV_PULL_FAILED_MESSAGE,
   getLinkedProjectField,
   postProvisionSetup,
   type PostProvisionOptions,
@@ -417,9 +419,7 @@ export async function addAutoProvision(
       );
     }
     if (setupResult.connected && !setupResult.envPulled && !options.noEnvPull) {
-      warnings.push(
-        'Failed to pull environment variables. You can run `vercel env pull` manually.'
-      );
+      warnings.push(ENV_PULL_FAILED_MESSAGE);
     }
 
     const jsonOutput: Record<string, unknown> = {
@@ -450,14 +450,19 @@ export async function addAutoProvision(
           }
         : null,
       dashboardUrl: setupResult.dashboardUrl,
+      ssoUrl: {
+        integration: buildSSOLink(team, provisioned.installation.id),
+        resource: buildSSOLink(
+          team,
+          provisioned.installation.id,
+          provisioned.resource.externalResourceId
+        ),
+      },
+      project: setupResult.project ?? null,
+      environments: setupResult.environments,
+      envPulled: setupResult.envPulled,
+      warnings,
     };
-
-    if (setupResult.project) {
-      jsonOutput.project = setupResult.project;
-    }
-    jsonOutput.environments = setupResult.environments;
-    jsonOutput.envPulled = setupResult.envPulled;
-    jsonOutput.warnings = warnings;
 
     client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
 

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -137,7 +137,7 @@ export async function add(
 
   if (asJson) {
     output.error(
-      'The --format flag is only supported with auto-provision mode'
+      'The --format flag is not yet supported with the integration add command'
     );
     return 1;
   }

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -39,6 +39,7 @@ import { IntegrationAddTelemetryClient } from '../../util/telemetry/commands/int
 import { createAuthorization } from '../../util/integration/create-authorization';
 import sleep from '../../util/sleep';
 import { fetchAuthorization } from '../../util/integration/fetch-authorization';
+import { validateJsonOutput } from '../../util/output-format';
 
 import type { IntegrationAddFlags } from './command';
 
@@ -61,6 +62,14 @@ export async function add(
     return 1;
   }
   const installationId = flags['--installation-id'];
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
   const options: AddOptions = {
     noConnect: flags['--no-connect'],
     noEnvPull: flags['--no-env-pull'],
@@ -122,7 +131,15 @@ export async function add(
       environments: options.environments,
       prefix,
       commandName,
+      asJson,
     });
+  }
+
+  if (asJson) {
+    output.error(
+      'The --format flag is only supported with auto-provision mode'
+    );
+    return 1;
   }
 
   const telemetry = new IntegrationAddTelemetryClient({
@@ -734,5 +751,12 @@ async function provisionStorageProduct(
     `${product.name} successfully provisioned: ${chalk.bold(name)}`
   );
 
-  return postProvisionSetup(client, name, storeId, contextName, options);
+  const result = await postProvisionSetup(
+    client,
+    name,
+    storeId,
+    contextName,
+    options
+  );
+  return result.exitCode;
 }

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -21,6 +21,7 @@ export const addSubcommand = {
       deprecated: false,
       argument: 'NAME',
     },
+    formatOption,
     {
       name: 'metadata',
       description:
@@ -137,6 +138,10 @@ export const addSubcommand = {
     {
       name: 'Install with a prefix for environment variable names',
       value: `${packageName} integration add acme --prefix NEON2_`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} integration add acme --format=json`,
     },
     {
       name: 'Show available products for an integration',

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -21,7 +21,6 @@ export const addSubcommand = {
       deprecated: false,
       argument: 'NAME',
     },
-    formatOption,
     {
       name: 'metadata',
       description:
@@ -81,6 +80,7 @@ export const addSubcommand = {
       description:
         'Installation ID to use when multiple installations exist for the integration',
     },
+    formatOption,
   ],
   examples: [
     {

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -83,7 +83,7 @@ export default async function main(client: Client) {
         : {
             ...addSubcommand,
             options: addSubcommand.options.filter(
-              o => o.name !== 'installation-id'
+              o => o.name !== 'installation-id' && o.name !== 'format'
             ),
           };
 

--- a/packages/cli/src/util/integration/format-dynamic-examples.ts
+++ b/packages/cli/src/util/integration/format-dynamic-examples.ts
@@ -104,6 +104,14 @@ export function formatDynamicExamples(
     `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --prefix NEON2_`)}`
   );
 
+  // JSON output
+  lines.push('');
+  lines.push(`  ${chalk.dim('-')} Output as JSON`);
+  lines.push('');
+  lines.push(
+    `    ${chalk.cyan(`$ ${packageName} ${commandName} ${integrationSlug} --format=json`)}`
+  );
+
   // Installation ID (only when auto-provision FF is enabled)
   if (process.env.FF_AUTO_PROVISION_INSTALL === '1') {
     lines.push('');

--- a/packages/cli/src/util/integration/post-provision-setup.ts
+++ b/packages/cli/src/util/integration/post-provision-setup.ts
@@ -38,6 +38,16 @@ export function validateEnvironments(
   return { valid: true };
 }
 
+export interface PostProvisionSetupResult {
+  exitCode: number;
+  dashboardUrl: string;
+  project?: { id: string; name: string };
+  connected: boolean;
+  environments: string[];
+  envPulled: boolean;
+  connectError?: string;
+}
+
 /**
  * Handles post-provisioning setup: prints dashboard URL, auto-connects
  * resource to the linked project (all environments), and runs env pull.
@@ -51,22 +61,30 @@ export async function postProvisionSetup(
   resourceId: string,
   contextName: string,
   options: PostProvisionOptions = {}
-): Promise<number> {
+): Promise<PostProvisionSetupResult> {
   const dashboardUrl = `https://vercel.com/${contextName}/~/stores/integration/${resourceId}`;
   output.log(
     indent(`Dashboard: ${output.link(dashboardUrl, dashboardUrl)}`, 4)
   );
 
+  const baseResult: PostProvisionSetupResult = {
+    exitCode: 0,
+    dashboardUrl,
+    connected: false,
+    environments: [],
+    envPulled: false,
+  };
+
   if (options.noConnect) {
-    return 0;
+    return baseResult;
   }
 
   const linkedProject = await getLinkedProject(client);
   if (linkedProject.status === 'error') {
-    return linkedProject.exitCode;
+    return { ...baseResult, exitCode: linkedProject.exitCode };
   }
   if (linkedProject.status === 'not_linked') {
-    return 0;
+    return baseResult;
   }
 
   const { project } = linkedProject;
@@ -95,7 +113,13 @@ export async function postProvisionSetup(
     output.stopSpinner();
     options.onProjectConnectFailed?.(project.id, error as Error);
     output.error(`Failed to connect: ${(error as Error).message}`);
-    return 1;
+    return {
+      ...baseResult,
+      exitCode: 1,
+      project: { id: project.id, name: project.name },
+      environments,
+      connectError: (error as Error).message,
+    };
   }
   output.stopSpinner();
 
@@ -105,6 +129,7 @@ export async function postProvisionSetup(
 
   options.onProjectConnected?.(project.id);
 
+  let envPulled = false;
   if (!options.noEnvPull) {
     const pullExitCode = await pull(
       client,
@@ -115,10 +140,18 @@ export async function postProvisionSetup(
       output.warn(
         'Failed to pull environment variables. You can run `vercel env pull` manually.'
       );
+    } else {
+      envPulled = true;
     }
   }
 
-  return 0;
+  return {
+    ...baseResult,
+    project: { id: project.id, name: project.name },
+    connected: true,
+    environments,
+    envPulled,
+  };
 }
 
 /**

--- a/packages/cli/src/util/integration/post-provision-setup.ts
+++ b/packages/cli/src/util/integration/post-provision-setup.ts
@@ -12,6 +12,9 @@ export const VALID_ENVIRONMENTS = [
   'development',
 ] as const;
 
+export const ENV_PULL_FAILED_MESSAGE =
+  'Failed to pull environment variables. You can run `vercel env pull` manually.';
+
 export interface PostProvisionOptions {
   noConnect?: boolean;
   noEnvPull?: boolean;
@@ -137,9 +140,7 @@ export async function postProvisionSetup(
       'vercel-cli:integration:add'
     );
     if (pullExitCode !== 0) {
-      output.warn(
-        'Failed to pull environment variables. You can run `vercel env pull` manually.'
-      );
+      output.warn(ENV_PULL_FAILED_MESSAGE);
     } else {
       envPulled = true;
     }

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -2304,6 +2304,13 @@ describe('integration add (auto-provision)', () => {
       expect(jsonOutput.dashboardUrl).toContain(
         'stores/integration/resource_123'
       );
+      expect(jsonOutput.ssoUrl.integration).toContain(
+        'integrationConfigurationId=install_123'
+      );
+      expect(jsonOutput.ssoUrl.resource).toContain(
+        'resource_id=ext_resource_123'
+      );
+      expect(jsonOutput.project).toBeNull();
       expect(jsonOutput.environments).toEqual([]);
       expect(jsonOutput.envPulled).toBe(false);
       expect(jsonOutput.warnings).toEqual([]);

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -2269,4 +2269,146 @@ describe('integration add (auto-provision)', () => {
       );
     });
   });
+
+  describe('--format=json', () => {
+    beforeEach(() => {
+      useAutoProvision({ responseKey: 'provisioned' });
+      // Restore pull mock implementation (vi.restoreAllMocks in afterEach clears it)
+      pullMock.mockResolvedValue(0);
+    });
+
+    it('should output valid JSON to stdout on success without project', async () => {
+      client.setArgv('integration', 'add', 'acme', '--format=json');
+      const exitCode = await integrationCommand(client);
+
+      expect(exitCode).toEqual(0);
+      const jsonOutput = JSON.parse(client.stdout.getFullOutput());
+      expect(jsonOutput.resource).toEqual({
+        id: 'resource_123',
+        name: 'test-resource',
+        status: 'available',
+        externalResourceId: 'ext_resource_123',
+      });
+      expect(jsonOutput.integration).toEqual({
+        id: 'acme',
+        slug: 'acme',
+        name: 'Acme Integration',
+      });
+      expect(jsonOutput.product).toEqual({
+        id: 'acme-product',
+        slug: 'acme',
+        name: 'Acme Product',
+      });
+      expect(jsonOutput.installation).toEqual({ id: 'install_123' });
+      expect(jsonOutput.billingPlan).toBeNull();
+      expect(jsonOutput.dashboardUrl).toContain(
+        'stores/integration/resource_123'
+      );
+      expect(jsonOutput.environments).toEqual([]);
+      expect(jsonOutput.envPulled).toBe(false);
+      expect(jsonOutput.warnings).toEqual([]);
+    });
+
+    it('should include project and environments in JSON when connected', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'vercel-integration-add',
+        name: 'vercel-integration-add',
+      });
+      const cwd = setupUnitFixture('vercel-integration-add');
+      client.cwd = cwd;
+      client.setArgv('integration', 'add', 'acme', '--format=json');
+      const exitCode = await integrationCommand(client);
+
+      expect(exitCode).toEqual(0);
+      const jsonOutput = JSON.parse(client.stdout.getFullOutput());
+      expect(jsonOutput.project).toEqual({
+        id: 'vercel-integration-add',
+        name: 'vercel-integration-add',
+      });
+      expect(jsonOutput.environments).toEqual([
+        'production',
+        'preview',
+        'development',
+      ]);
+      expect(jsonOutput.envPulled).toBe(true);
+      expect(jsonOutput.warnings).toEqual([]);
+    });
+
+    it('should output JSON with warnings when connect fails', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'vercel-integration-add',
+        name: 'vercel-integration-add',
+      });
+      const cwd = setupUnitFixture('vercel-integration-add');
+      client.cwd = cwd;
+      connectMock.mockRejectedValueOnce(new Error('Connection refused'));
+      client.setArgv('integration', 'add', 'acme', '--format=json');
+      const exitCode = await integrationCommand(client);
+
+      // Exit code 0 because resource was provisioned (primary action succeeded)
+      expect(exitCode).toEqual(0);
+      const jsonOutput = JSON.parse(client.stdout.getFullOutput());
+      expect(jsonOutput.resource.id).toBe('resource_123');
+      expect(jsonOutput.warnings).toEqual([
+        'Failed to connect to project: Connection refused',
+      ]);
+    });
+
+    it('should output JSON with env pull warning when pull fails', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'vercel-integration-add',
+        name: 'vercel-integration-add',
+      });
+      const cwd = setupUnitFixture('vercel-integration-add');
+      client.cwd = cwd;
+      pullMock.mockResolvedValue(1);
+      client.setArgv('integration', 'add', 'acme', '--format=json');
+      const exitCode = await integrationCommand(client);
+
+      expect(exitCode).toEqual(0);
+      const jsonOutput = JSON.parse(client.stdout.getFullOutput());
+      expect(jsonOutput.project).toEqual({
+        id: 'vercel-integration-add',
+        name: 'vercel-integration-add',
+      });
+      expect(jsonOutput.envPulled).toBe(false);
+      expect(jsonOutput.warnings).toContainEqual(
+        expect.stringContaining('Failed to pull environment variables')
+      );
+    });
+
+    it('should not output JSON to stdout on pre-provisioning error', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'nonexistent-integration',
+        '--format=json'
+      );
+      const exitCode = await integrationCommand(client);
+
+      expect(exitCode).toEqual(1);
+      // stdout should be empty - no JSON
+      expect(client.stdout.getFullOutput()).toBe('');
+    });
+
+    it('should error on invalid --format value', async () => {
+      client.setArgv('integration', 'add', 'acme', '--format=xml');
+      const exitCode = await integrationCommand(client);
+
+      expect(exitCode).toEqual(1);
+      expect(client.stdout.getFullOutput()).toBe('');
+    });
+
+    it('should not output JSON when --format is not specified', async () => {
+      client.setArgv('integration', 'add', 'acme');
+      const exitCode = await integrationCommand(client);
+
+      expect(exitCode).toEqual(0);
+      // No JSON on stdout
+      expect(client.stdout.getFullOutput()).toBe('');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `--format=json` support to `vercel integration add` for the auto-provision path (`FF_AUTO_PROVISION_INSTALL=1`)
- On success, writes structured JSON to **stdout** with resource, integration, product, installation, billing plan, dashboard URL, SSO URLs, project connection status, and warnings
- Refactors `postProvisionSetup` to return a `PostProvisionSetupResult` object instead of just an exit code

## How agents use this (stream separation)

The Vercel CLI already separates streams per Unix convention:
- **stdout** (fd 1): primary data — JSON result
- **stderr** (fd 2): everything else — spinners, status messages, errors, prompts

When a human runs the command, they see both streams interleaved on the terminal. When an agent runs it, it captures them separately:

```bash
# Agent captures stdout (JSON) and stderr (diagnostics) separately
output=$(vercel integration add neon --format=json 2>/tmp/stderr.log)
exit_code=$?

if [ $exit_code -eq 0 ]; then
  echo "$output" | jq .resource.id    # parse JSON from stdout
else
  cat /tmp/stderr.log                  # read error details from stderr
fi
```

The agent determines success/failure from the **exit code** (0 = success, 1 = error), not by parsing output. Intermediate messages (spinners, "Installing...", "Provisioning...") go to stderr and don't interfere with the JSON on stdout.

### Output contract

| Exit code | stdout | stderr |
|-----------|--------|--------|
| `0` | JSON result | progress/status messages |
| `0` | JSON with non-empty `warnings` array | progress + warning messages (partial failure: resource provisioned but connect/env-pull failed) |
| `1` | *(empty)* | error message |

### Example JSON output

```json
{
  "resource": {
    "id": "res_xxx",
    "name": "neon-blue-river",
    "status": "available",
    "externalResourceId": "ext_xxx"
  },
  "integration": { "id": "int_xxx", "slug": "neon", "name": "Neon" },
  "product": { "id": "prod_xxx", "slug": "neon-postgres", "name": "Neon Postgres" },
  "installation": { "id": "inst_xxx" },
  "billingPlan": { "id": "plan_xxx", "name": "Free", "type": "subscription" },
  "dashboardUrl": "https://vercel.com/team/~/stores/integration/res_xxx",
  "ssoUrl": {
    "integration": "https://vercel.com/api/marketplace/sso?teamId=...&integrationConfigurationId=inst_xxx",
    "resource": "https://vercel.com/api/marketplace/sso?teamId=...&integrationConfigurationId=inst_xxx&resource_id=ext_xxx"
  },
  "project": { "id": "prj_xxx", "name": "my-app" },
  "environments": ["production", "preview", "development"],
  "envPulled": true,
  "warnings": []
}
```

All top-level keys are always present — `billingPlan` and `project` are `null` (not omitted) when absent.

## Design decisions

1. **Errors to stderr, not stdout** — consistent with Unix convention and all other `integration` subcommands (`list`, `open`, `balance`, `remove`, `discover`)
2. **Partial failures return exit code 0 with warnings** — if the resource was provisioned (the primary action), that's success. Connection or env-pull failures are reported in the `warnings` array
3. **Terms acceptance works normally in JSON mode** — terms browser flow writes to stderr, doesn't interfere with JSON on stdout
4. **Legacy path rejects `--format`** — only the auto-provision code path supports JSON; the legacy flow errors with a clear message
5. **SSO URLs included** — both integration-level and resource-level SSO links via `buildSSOLink()`, no extra API calls needed
6. **Shared env pull warning constant** — `ENV_PULL_FAILED_MESSAGE` used by both `postProvisionSetup` and the JSON warnings builder

## Test plan

- [x] `--format=json` outputs valid JSON to stdout on success (no project context)
- [x] JSON includes `project: null` when no project is linked
- [x] JSON includes project, environments, envPulled when connected to a project
- [x] JSON includes `ssoUrl.integration` and `ssoUrl.resource`
- [x] Partial failure: connect fails → JSON with warnings, exit code 0
- [x] Partial failure: env pull fails → JSON with warning, exit code 0
- [x] Pre-provisioning error → no JSON on stdout, exit code 1
- [x] Invalid `--format=xml` → error, exit code 1
- [x] Without `--format`, behavior unchanged (no JSON on stdout)
- [x] `--format` filtered from help when auto-provision FF is off
- [x] All 277 tests pass (including `formatDynamicExamples` coverage test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)