### PR TITLE
[python] vercel-workers changeset

### DIFF
--- a/.changeset/green-pugs-melt.md
+++ b/.changeset/green-pugs-melt.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-workers': patch
+---
+
+Add a version bump for `@vercel/python-workers` so previously merged changes are included in the next release.


### PR DESCRIPTION
Adds version bump for `vercel-workers`

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR only adds a changeset file for a patch version bump with no code changes.
> 
> - Adds changeset markdown file for version bump
> - No code, schema, or logic changes
>
> <sup>Risk assessment for [commit 1f8df54](https://github.com/vercel/vercel/commit/1f8df5446bfdc88802d343a54fc619af4cff9936).</sup>
<!-- VADE_RISK_END -->