### PR TITLE
fix(node): fix TypeError for unsupported HTTP methods with web handler

### DIFF
--- a/packages/node/src/serverless-functions/helpers-web.ts
+++ b/packages/node/src/serverless-functions/helpers-web.ts
@@ -40,7 +40,7 @@ export const createWebExportsHandler = (awaiter: Awaiter) => {
 
     return (req: IncomingMessage, res: ServerResponse) => {
       const method = req.method ?? 'GET';
-      handlerByMethod[method](req, res);
+      (handlerByMethod[method] ?? defaultHttpHandler)(req, res);
     };
   }
 

--- a/packages/node/test/unit/serverless-functions/helpers-web.test.ts
+++ b/packages/node/test/unit/serverless-functions/helpers-web.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+import { createWebExportsHandler } from '../../../src/serverless-functions/helpers-web';
+
+describe('serverless-functions/helpers-web', () => {
+  it('returns 405 for unsupported methods', () => {
+    const getWebExportsHandler = createWebExportsHandler({
+      waitUntil: () => {},
+    } as any);
+
+    const handler = getWebExportsHandler(
+      {
+        GET: () => new Response('ok'),
+      },
+      ['GET']
+    );
+
+    const end = vi.fn();
+    const response = {
+      statusCode: 200,
+      end,
+    } as unknown as ServerResponse;
+
+    expect(() =>
+      handler(
+        {
+          method: 'CONNECT',
+        } as IncomingMessage,
+        response
+      )
+    ).not.toThrow();
+    expect(response.statusCode).toBe(405);
+    expect(end).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a fallback to a default HTTP handler for unsupported methods, preventing TypeError crashes and returning 405 status - a defensive change that improves error handling.
> 
> - Adds null-coalescing fallback to defaultHttpHandler for unsupported HTTP methods
> - New test file verifies 405 response for unsupported methods like CONNECT
>
> <sup>Risk assessment for [commit 9fcdb7b](https://github.com/vercel/vercel/commit/9fcdb7bc5a8eb5b9f9d1dc4ead9049419ff8c8f9).</sup>
<!-- VADE_RISK_END -->