### PR TITLE
[cli] Fix --help exit code for metrics command

### DIFF
--- a/.changeset/fix-metrics-help-exit-code.md
+++ b/.changeset/fix-metrics-help-exit-code.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `--help` flag to return exit code 0 instead of 2 for the `metrics` command, aligning with standard CLI conventions.

--- a/packages/cli/src/commands/metrics/index.ts
+++ b/packages/cli/src/commands/metrics/index.ts
@@ -43,7 +43,7 @@ export default async function metrics(client: Client): Promise<number> {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('metrics', subcommand);
     output.print(help(metricsCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printSubHelp(command: Command) {
@@ -60,7 +60,7 @@ export default async function metrics(client: Client): Promise<number> {
       if (needHelp) {
         telemetry.trackCliFlagHelp('metrics', subcommandOriginal);
         printSubHelp(schemaSubcommand);
-        return 2;
+        return 0;
       }
       telemetry.trackCliSubcommandSchema(subcommandOriginal);
       const schemaFn = (await import('./schema')).default;
@@ -70,7 +70,7 @@ export default async function metrics(client: Client): Promise<number> {
       if (needHelp) {
         telemetry.trackCliFlagHelp('metrics', subcommandOriginal);
         output.print(help(metricsCommand, { columns: client.stderr.columns }));
-        return 2;
+        return 0;
       }
       // Show help if --event is not provided (required for query)
       if (!parsedArgs.flags['--event']) {

--- a/packages/cli/test/unit/commands/metrics/index.test.ts
+++ b/packages/cli/test/unit/commands/metrics/index.test.ts
@@ -9,12 +9,12 @@ describe('metrics', () => {
   });
 
   describe('--help', () => {
-    it('should print help and return 2', async () => {
+    it('should print help and return 0', async () => {
       client.setArgv('metrics', '--help');
 
       const exitCode = await metrics(client);
 
-      expect(exitCode).toBe(2);
+      expect(exitCode).toBe(0);
       const output = client.stderr.getFullOutput();
       // Shows schema subcommand
       expect(output).toContain('schema');


### PR DESCRIPTION
Return exit code 0 instead of 2 when --help flag is used, aligning with standard CLI conventions (git, npm, docker) and the root `vercel --help` behavior.

This follows the same fix applied in #13780 and #14834 for other commands.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR changes the exit code from 2 to 0 when --help flag is used for the metrics CLI command, which is a standard CLI convention fix with no security implications.
> 
> - Exit code changed from 2 to 0 for --help flag in three places
> - Test updated to expect exit code 0 instead of 2
> - Changeset added documenting the patch
>
> <sup>Risk assessment for [commit 0fc2575](https://github.com/vercel/vercel/commit/0fc2575eff6fa3e4d02fa897b9a4fa8035d1a384).</sup>
<!-- VADE_RISK_END -->