### PR TITLE
Replace deprecated url.parse() with WHATWG URL API

### DIFF
--- a/.changeset/neat-teachers-yawn.md
+++ b/.changeset/neat-teachers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Fix `detectBuilders` so projects using experimental backends still add `@vercel/static` for `public/**/*` files.

--- a/packages/cli/src/util/dev/router.ts
+++ b/packages/cli/src/util/dev/router.ts
@@ -1,4 +1,3 @@
-import url from 'url';
 import PCRE from 'pcre-to-regexp';
 
 import isURL from './is-url';
@@ -57,9 +56,10 @@ export async function devRouter(
   phase?: HandleValue | null
 ): Promise<RouteResult> {
   let result: RouteResult | undefined;
+  const _parsedReqUrl = new URL(reqUrl, 'http://localhost');
   // eslint-disable-next-line prefer-const
-  let { pathname: reqPathname, search: reqSearch } = url.parse(reqUrl);
-  reqPathname = reqPathname || '/';
+  let reqPathname = _parsedReqUrl.pathname || '/';
+  const reqSearch = _parsedReqUrl.search || null;
   const reqQuery = parseQueryString(reqSearch);
   const combinedHeaders: HttpHeadersConfig = { ...previousHeaders };
   let status: number | undefined;
@@ -132,8 +132,7 @@ export async function devRouter(
           phase !== 'hit' &&
           !isDestUrl
         ) {
-          let { pathname } = url.parse(destPath);
-          pathname = pathname || '/';
+          let pathname = new URL(destPath, 'http://localhost').pathname || '/';
           const hasDestFile = await devServer.hasFilesystem(
             pathname,
             vercelConfig
@@ -189,10 +188,10 @@ export async function devRouter(
           if (!destPath.startsWith('/')) {
             destPath = `/${destPath}`;
           }
+          const _parsedDestPath = new URL(destPath, 'http://localhost');
           // eslint-disable-next-line prefer-const
-          let { pathname: destPathname, search: destSearch } =
-            url.parse(destPath);
-          destPathname = destPathname || '/';
+          let destPathname = _parsedDestPath.pathname || '/';
+          const destSearch = _parsedDestPath.search || null;
           const destQuery = parseQueryString(destSearch);
           Object.assign(destQuery, reqQuery);
           result = {

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1,4 +1,4 @@
-import url, { URL } from 'url';
+import { URL } from 'url';
 import http from 'http';
 import fs from 'fs-extra';
 import ms from 'ms';
@@ -1009,7 +1009,7 @@ export default class DevServer {
       await this.startPromise;
 
       if (this.orchestrator) {
-        const pathname = url.parse(req.url || '/').pathname || '/';
+        const pathname = new URL(req.url || '/', 'http://localhost').pathname || '/';
         const service = this.orchestrator.getServiceForRoute(pathname);
         if (service) {
           const target = `http://${service.host}:${service.port}`;
@@ -1433,7 +1433,7 @@ export default class DevServer {
 
     // If there is a double-slash present in the URL,
     // then perform a redirect to make it "clean".
-    const parsed = url.parse(req.url || '/');
+    const parsed = new URL(req.url || '/', 'http://localhost');
     if (typeof parsed.pathname === 'string' && parsed.pathname.includes('//')) {
       let location = parsed.pathname.replace(/\/+/g, '/');
       if (parsed.search) {
@@ -1483,11 +1483,10 @@ export default class DevServer {
     const getReqUrl = (rr: RouteResult): string | undefined => {
       if (rr.dest) {
         if (rr.query) {
-          const destParsed = url.parse(rr.dest);
-          const destQuery = parseQueryString(destParsed.search);
+          const destParsed = new URL(rr.dest, 'http://localhost');
+          const destQuery = parseQueryString(destParsed.search || null);
           Object.assign(destQuery, rr.query);
-          destParsed.search = formatQueryString(destQuery);
-          return url.format(destParsed);
+          return destParsed.pathname + (formatQueryString(destQuery) || '');
         }
         return rr.dest;
       }
@@ -1552,7 +1551,7 @@ export default class DevServer {
           }
 
           const middlewareRes = await nodeFetch(
-            `http://127.0.0.1:${port}${parsed.path}`,
+            `http://127.0.0.1:${port}${parsed.pathname}${parsed.search}`,
             {
               headers: middlewareReqHeaders,
               method: req.method,
@@ -1644,9 +1643,9 @@ export default class DevServer {
               }
             } else {
               // Retain orginal pathname, but override query parameters from the rewrite
-              const rewriteUrlParsed = url.parse(beforeRewriteUrl);
-              rewriteUrlParsed.search = url.parse(rewritePath).search;
-              req.url = url.format(rewriteUrlParsed);
+              const rewriteUrlParsed = new URL(beforeRewriteUrl, 'http://localhost');
+              rewriteUrlParsed.search = new URL(rewritePath, 'http://localhost').search;
+              req.url = rewriteUrlParsed.pathname + rewriteUrlParsed.search;
             }
 
             debug(
@@ -1710,11 +1709,11 @@ export default class DevServer {
 
       if (routeResult.isDestUrl) {
         // Mix the `routes` result dest query params into the req path
-        const destParsed = url.parse(routeResult.dest);
-        const destQuery = parseQueryString(destParsed.search);
+        const destParsed = new URL(routeResult.dest);
+        const destQuery = parseQueryString(destParsed.search || null);
         Object.assign(destQuery, routeResult.query);
-        destParsed.search = formatQueryString(destQuery);
-        const destUrl = url.format(destParsed);
+        destParsed.search = formatQueryString(destQuery) || '';
+        const destUrl = destParsed.href;
 
         debug(`ProxyPass: ${destUrl}`);
         this.setResponseHeaders(res, requestId);
@@ -1890,12 +1889,12 @@ export default class DevServer {
         }
 
         this.setResponseHeaders(res, requestId);
-        const origUrl = url.parse(req.url || '/');
-        const origQuery = parseQueryString(origUrl.search);
+        const origUrl = new URL(req.url || '/', 'http://localhost');
+        const origQuery = parseQueryString(origUrl.search || null);
         origUrl.pathname = dest;
         Object.assign(origQuery, query);
-        origUrl.search = formatQueryString(origQuery);
-        req.url = url.format(origUrl);
+        origUrl.search = formatQueryString(origQuery) || '';
+        req.url = origUrl.pathname + origUrl.search;
         return proxyPass(req, res, upstream, this, requestId, false);
       }
 
@@ -1916,12 +1915,12 @@ export default class DevServer {
       Array.isArray(buildResult.routes) &&
       buildResult.routes.length > 0
     ) {
-      const origUrl = url.parse(req.url || '/');
-      const origQuery = parseQueryString(origUrl.search);
+      const origUrl = new URL(req.url || '/', 'http://localhost');
+      const origQuery = parseQueryString(origUrl.search || null);
       origUrl.pathname = dest;
       Object.assign(origQuery, query);
-      origUrl.search = formatQueryString(origQuery);
-      const newUrl = url.format(origUrl);
+      origUrl.search = formatQueryString(origQuery) || '';
+      const newUrl = origUrl.pathname + origUrl.search;
       debug(
         `Checking build result's ${buildResult.routes.length} \`routes\` to match ${newUrl}`
       );
@@ -2018,14 +2017,11 @@ export default class DevServer {
         );
 
         // Mix in the routing based query parameters
-        const origUrl = url.parse(req.url || '/');
-        const origQuery = parseQueryString(origUrl.search);
+        const origUrl = new URL(req.url || '/', 'http://localhost');
+        const origQuery = parseQueryString(origUrl.search || null);
         Object.assign(origQuery, query);
-        origUrl.search = formatQueryString(origQuery);
-        req.url = url.format({
-          pathname: origUrl.pathname,
-          search: origUrl.search,
-        });
+        origUrl.search = formatQueryString(origQuery) || '';
+        req.url = origUrl.pathname + origUrl.search;
 
         // Add the Vercel platform proxy request headers
         const headers = this.getProxyHeaders(req, requestId, false);
@@ -2133,14 +2129,11 @@ export default class DevServer {
         requestId = generateRequestId(this.podId, true);
 
         // Mix the `routes` result dest query params into the req path
-        const origUrl = url.parse(req.url || '/');
-        const origQuery = parseQueryString(origUrl.search);
+        const origUrl = new URL(req.url || '/', 'http://localhost');
+        const origQuery = parseQueryString(origUrl.search || null);
         Object.assign(origQuery, query);
-        origUrl.search = formatQueryString(origQuery);
-        const path = url.format({
-          pathname: origUrl.pathname,
-          search: origUrl.search,
-        });
+        origUrl.search = formatQueryString(origQuery) || '';
+        const path = origUrl.pathname + origUrl.search;
 
         const body = await rawBody(req);
         const payload: InvokePayload = {

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -367,12 +367,13 @@ export async function detectBuilders(
   if (frontendBuilder) {
     // Add @vercel/static build for public files for server-based frameworks
     // so that files in `public/` are served from the root path, e.g. `/logo.svg`.
-    // This applies to Express, Hono, Go, and Python-based server frameworks.
+    // This applies to Express, Hono, Go, Python, and experimental backends.
     if (
-      frontendBuilder?.use === '@vercel/express' ||
-      frontendBuilder?.use === '@vercel/hono' ||
-      frontendBuilder?.use === '@vercel/python' ||
-      frontendBuilder?.use === '@vercel/go'
+      isOfficialRuntime('express', frontendBuilder?.use) ||
+      isOfficialRuntime('hono', frontendBuilder?.use) ||
+      isOfficialRuntime('python', frontendBuilder?.use) ||
+      isOfficialRuntime('go', frontendBuilder?.use) ||
+      isOfficialRuntime('backends', frontendBuilder?.use)
     ) {
       builders.push({
         src: 'public/**/*',

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -243,6 +243,36 @@ describe('Test `detectBuilders`', () => {
     expect(builders.length).toBe(2);
   });
 
+  it('framework + public with experimental backends', async () => {
+    const previousExperimentalBackends =
+      process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+    process.env.VERCEL_EXPERIMENTAL_BACKENDS = '1';
+
+    try {
+      const files = ['package.json', 'public/logo.svg'];
+      const pkg = {
+        dependencies: { hono: '4.10.1' },
+      };
+
+      const { builders } = await invokeDetectBuildersAndThrow(files, pkg, {
+        projectSettings: {
+          framework: 'hono',
+        },
+      });
+
+      expect(builders.length).toBe(2);
+      expect(builders[0].use).toBe('@vercel/static');
+      expect(builders[0].src).toBe('public/**/*');
+      expect(builders[1].use).toBe('@vercel/backends');
+    } finally {
+      if (previousExperimentalBackends === undefined) {
+        delete process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+      } else {
+        process.env.VERCEL_EXPERIMENTAL_BACKENDS = previousExperimentalBackends;
+      }
+    }
+  });
+
   it('api go with test files', async () => {
     const files = [
       'api/index.go',
@@ -1483,6 +1513,37 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders.length).toBe(2);
     expect(errorRoutes.length).toBe(1);
     expect((errorRoutes[0] as Source).status).toBe(404);
+  });
+
+  it('framework + public with experimental backends', async () => {
+    const previousExperimentalBackends =
+      process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+    process.env.VERCEL_EXPERIMENTAL_BACKENDS = '1';
+
+    try {
+      const files = ['package.json', 'public/logo.svg'];
+      const pkg = {
+        dependencies: { hono: '4.10.1' },
+      };
+
+      const { builders } = await invokeDetectBuildersAndThrow(files, pkg, {
+        projectSettings: {
+          framework: 'hono',
+        },
+        featHandleMiss,
+      });
+
+      expect(builders.length).toBe(2);
+      expect(builders[0].use).toBe('@vercel/static');
+      expect(builders[0].src).toBe('public/**/*');
+      expect(builders[1].use).toBe('@vercel/backends');
+    } finally {
+      if (previousExperimentalBackends === undefined) {
+        delete process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+      } else {
+        process.env.VERCEL_EXPERIMENTAL_BACKENDS = previousExperimentalBackends;
+      }
+    }
   });
 
   it('api go with test files', async () => {


### PR DESCRIPTION
## Changes

- **CLI Router & Server**: Migrated from Node.js `url.parse()` and `url.format()` to the WHATWG `URL` API throughout the dev server implementation
- **FS Detectors**: Fixed `detectBuilders` to properly handle public static assets for experimental backends using `isOfficialRuntime()` helper instead of hardcoded builder checks
- **Tests**: Added comprehensive test coverage for public static asset handling with experimental backends in both standard and `featHandleMiss` modes

## Motivation

Replaces deprecated Node.js URL utilities with the standardized WHATWG URL API. Fixes a bug where projects using experimental backends were not adding `@vercel/static` builder for `public/**/*` files.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR replaces deprecated Node.js url.parse() with WHATWG URL API throughout dev server code and adds support for experimental backends in build detection, with no security-sensitive changes.
> 
> - Migrates url.parse()/url.format() to WHATWG URL API in router.ts and server.ts
> - Adds experimental backends support to detectBuilders for public static assets
> - Adds test coverage for experimental backends in both standard and featHandleMiss modes
>
> <sup>Risk assessment for [commit 7d3a80f](https://github.com/vercel/vercel/commit/7d3a80ff544f4b5158a22c29cc48dbfdb39bd240).</sup>
<!-- VADE_RISK_END -->