### PR TITLE
fix(ci): use npx instead of pnpm dlx for Datadog CI upload

### DIFF
--- a/.changeset/neat-teachers-yawn.md
+++ b/.changeset/neat-teachers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Fix `detectBuilders` so projects using experimental backends still add `@vercel/static` for `public/**/*` files.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -345,7 +345,7 @@ jobs:
           echo "misses=$TURBO_MISS_COUNT" >> $GITHUB_OUTPUT
       - name: 'Upload Test Report to Datadog'
         if: ${{ steps['turbo-summary'].outputs.misses != '0' && !cancelled() }}
-        run: 'pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports'
+        run: 'npx --yes @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports'
         env:
           DATADOG_API_KEY: ${{secrets.DATADOG_API_KEY_CLI}}
           DD_ENV: ci

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -367,12 +367,13 @@ export async function detectBuilders(
   if (frontendBuilder) {
     // Add @vercel/static build for public files for server-based frameworks
     // so that files in `public/` are served from the root path, e.g. `/logo.svg`.
-    // This applies to Express, Hono, Go, and Python-based server frameworks.
+    // This applies to Express, Hono, Go, Python, and experimental backends.
     if (
-      frontendBuilder?.use === '@vercel/express' ||
-      frontendBuilder?.use === '@vercel/hono' ||
-      frontendBuilder?.use === '@vercel/python' ||
-      frontendBuilder?.use === '@vercel/go'
+      isOfficialRuntime('express', frontendBuilder?.use) ||
+      isOfficialRuntime('hono', frontendBuilder?.use) ||
+      isOfficialRuntime('python', frontendBuilder?.use) ||
+      isOfficialRuntime('go', frontendBuilder?.use) ||
+      isOfficialRuntime('backends', frontendBuilder?.use)
     ) {
       builders.push({
         src: 'public/**/*',

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -243,6 +243,36 @@ describe('Test `detectBuilders`', () => {
     expect(builders.length).toBe(2);
   });
 
+  it('framework + public with experimental backends', async () => {
+    const previousExperimentalBackends =
+      process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+    process.env.VERCEL_EXPERIMENTAL_BACKENDS = '1';
+
+    try {
+      const files = ['package.json', 'public/logo.svg'];
+      const pkg = {
+        dependencies: { hono: '4.10.1' },
+      };
+
+      const { builders } = await invokeDetectBuildersAndThrow(files, pkg, {
+        projectSettings: {
+          framework: 'hono',
+        },
+      });
+
+      expect(builders.length).toBe(2);
+      expect(builders[0].use).toBe('@vercel/static');
+      expect(builders[0].src).toBe('public/**/*');
+      expect(builders[1].use).toBe('@vercel/backends');
+    } finally {
+      if (previousExperimentalBackends === undefined) {
+        delete process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+      } else {
+        process.env.VERCEL_EXPERIMENTAL_BACKENDS = previousExperimentalBackends;
+      }
+    }
+  });
+
   it('api go with test files', async () => {
     const files = [
       'api/index.go',
@@ -1483,6 +1513,37 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders.length).toBe(2);
     expect(errorRoutes.length).toBe(1);
     expect((errorRoutes[0] as Source).status).toBe(404);
+  });
+
+  it('framework + public with experimental backends', async () => {
+    const previousExperimentalBackends =
+      process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+    process.env.VERCEL_EXPERIMENTAL_BACKENDS = '1';
+
+    try {
+      const files = ['package.json', 'public/logo.svg'];
+      const pkg = {
+        dependencies: { hono: '4.10.1' },
+      };
+
+      const { builders } = await invokeDetectBuildersAndThrow(files, pkg, {
+        projectSettings: {
+          framework: 'hono',
+        },
+        featHandleMiss,
+      });
+
+      expect(builders.length).toBe(2);
+      expect(builders[0].use).toBe('@vercel/static');
+      expect(builders[0].src).toBe('public/**/*');
+      expect(builders[1].use).toBe('@vercel/backends');
+    } finally {
+      if (previousExperimentalBackends === undefined) {
+        delete process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+      } else {
+        process.env.VERCEL_EXPERIMENTAL_BACKENDS = previousExperimentalBackends;
+      }
+    }
   });
 
   it('api go with test files', async () => {


### PR DESCRIPTION
## Summary

- `pnpm dlx @datadog/datadog-ci@4.2.2` started failing in CI with a 403 from `registry.npmjs.org` when fetching `estraverse` (a transitive dep via `proxy-agent → pac-proxy-agent → pac-resolver → degenerator → escodegen → estraverse`)
- The error was `No authorization header was set for the request` — `pnpm dlx` runs in isolation and was unable to resolve auth for the public registry
- Switching to `npx --yes` uses npm's resolver directly and avoids the conflict

## Test plan

- [ ] Verify the Datadog CI upload step passes in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR contains a CI configuration fix switching from pnpm dlx to npx for Datadog uploads, plus a minor logic change to add experimental backends support with corresponding tests.
> 
> - CI: switch from `pnpm dlx` to `npx --yes` for Datadog CI upload
> - Logic: add `isOfficialRuntime('backends', ...)` check for experimental backends support
> - Tests: add two test cases for experimental backends with public files
>
> <sup>Risk assessment for [commit 0bf96a6](https://github.com/vercel/vercel/commit/0bf96a665c70e08b9e7adc409bff17dd9a61b3cc).</sup>
<!-- VADE_RISK_END -->