### PR TITLE
Use npm token for dd reporting

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,10 +8,11 @@ on:
   pull_request:
 
 env:
-  VERCEL_TELEMETRY_DISABLED: '1'
-  TURBO_REMOTE_ONLY: 'true'
-  TURBO_TEAM: 'vercel'
+  VERCEL_TELEMETRY_DISABLED: "1"
+  TURBO_REMOTE_ONLY: "true"
+  TURBO_TEAM: "vercel"
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -196,7 +197,7 @@ jobs:
       - name: Build ${{matrix.packageName}} and all its dependencies
         run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...
         env:
-          FORCE_COLOR: '1'
+          FORCE_COLOR: "1"
       - name: Resolve Python wheel URLs
         run: |
           DEPLOYMENT_URL="${{ needs.setup.outputs.dplUrl }}"
@@ -231,8 +232,8 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          FORCE_COLOR: '1'
-      - name: 'Determine Turbo HIT or MISS'
+          FORCE_COLOR: "1"
+      - name: "Determine Turbo HIT or MISS"
         if: ${{ !cancelled() }}
         id: turbo-summary
         shell: bash
@@ -240,9 +241,9 @@ jobs:
           TURBO_MISS_COUNT=`node utils/determine-turbo-hit-or-miss.js`
           echo "MISS COUNT: $TURBO_MISS_COUNT"
           echo "misses=$TURBO_MISS_COUNT" >> $GITHUB_OUTPUT
-      - name: 'Upload Test Report to Datadog'
+      - name: "Upload Test Report to Datadog"
         if: ${{ steps['turbo-summary'].outputs.misses != '0' && !cancelled() }}
-        run: 'pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports'
+        run: "pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports"
         env:
           DATADOG_API_KEY: ${{secrets.DATADOG_API_KEY_CLI}}
           DD_ENV: ci

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,9 +8,9 @@ on:
   pull_request:
 
 env:
-  VERCEL_TELEMETRY_DISABLED: "1"
-  TURBO_REMOTE_ONLY: "true"
-  TURBO_TEAM: "vercel"
+  VERCEL_TELEMETRY_DISABLED: '1'
+  TURBO_REMOTE_ONLY: 'true'
+  TURBO_TEAM: 'vercel'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
@@ -197,7 +197,7 @@ jobs:
       - name: Build ${{matrix.packageName}} and all its dependencies
         run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...
         env:
-          FORCE_COLOR: "1"
+          FORCE_COLOR: '1'
       - name: Resolve Python wheel URLs
         run: |
           DEPLOYMENT_URL="${{ needs.setup.outputs.dplUrl }}"
@@ -232,8 +232,8 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          FORCE_COLOR: "1"
-      - name: "Determine Turbo HIT or MISS"
+          FORCE_COLOR: '1'
+      - name: 'Determine Turbo HIT or MISS'
         if: ${{ !cancelled() }}
         id: turbo-summary
         shell: bash
@@ -241,9 +241,9 @@ jobs:
           TURBO_MISS_COUNT=`node utils/determine-turbo-hit-or-miss.js`
           echo "MISS COUNT: $TURBO_MISS_COUNT"
           echo "misses=$TURBO_MISS_COUNT" >> $GITHUB_OUTPUT
-      - name: "Upload Test Report to Datadog"
+      - name: 'Upload Test Report to Datadog'
         if: ${{ steps['turbo-summary'].outputs.misses != '0' && !cancelled() }}
-        run: "pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports"
+        run: 'pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports'
         env:
           DATADOG_API_KEY: ${{secrets.DATADOG_API_KEY_CLI}}
           DD_ENV: ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
 
 env:
-  VERCEL_TELEMETRY_DISABLED: "1"
-  TURBO_REMOTE_ONLY: "true"
-  TURBO_TEAM: "vercel"
+  VERCEL_TELEMETRY_DISABLED: '1'
+  TURBO_REMOTE_ONLY: 'true'
+  TURBO_TEAM: 'vercel'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
@@ -325,7 +325,7 @@ jobs:
       - name: Build ${{matrix.packageName}} and all its dependencies
         run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...
         env:
-          FORCE_COLOR: "1"
+          FORCE_COLOR: '1'
       - name: Test ${{matrix.packageName}}
         run: node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}
         shell: bash
@@ -335,8 +335,8 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          FORCE_COLOR: "1"
-      - name: "Determine Turbo HIT or MISS"
+          FORCE_COLOR: '1'
+      - name: 'Determine Turbo HIT or MISS'
         if: ${{ !cancelled() }}
         id: turbo-summary
         shell: bash
@@ -344,9 +344,9 @@ jobs:
           TURBO_MISS_COUNT=`node utils/determine-turbo-hit-or-miss.js`
           echo "MISS COUNT: $TURBO_MISS_COUNT"
           echo "misses=$TURBO_MISS_COUNT" >> $GITHUB_OUTPUT
-      - name: "Upload Test Report to Datadog"
+      - name: 'Upload Test Report to Datadog'
         if: ${{ steps['turbo-summary'].outputs.misses != '0' && !cancelled() }}
-        run: "pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports"
+        run: 'pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports'
         env:
           DATADOG_API_KEY: ${{secrets.DATADOG_API_KEY_CLI}}
           DD_ENV: ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
 
 env:
-  VERCEL_TELEMETRY_DISABLED: '1'
-  TURBO_REMOTE_ONLY: 'true'
-  TURBO_TEAM: 'vercel'
+  VERCEL_TELEMETRY_DISABLED: "1"
+  TURBO_REMOTE_ONLY: "true"
+  TURBO_TEAM: "vercel"
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -324,7 +325,7 @@ jobs:
       - name: Build ${{matrix.packageName}} and all its dependencies
         run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...
         env:
-          FORCE_COLOR: '1'
+          FORCE_COLOR: "1"
       - name: Test ${{matrix.packageName}}
         run: node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}
         shell: bash
@@ -334,8 +335,8 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          FORCE_COLOR: '1'
-      - name: 'Determine Turbo HIT or MISS'
+          FORCE_COLOR: "1"
+      - name: "Determine Turbo HIT or MISS"
         if: ${{ !cancelled() }}
         id: turbo-summary
         shell: bash
@@ -343,9 +344,9 @@ jobs:
           TURBO_MISS_COUNT=`node utils/determine-turbo-hit-or-miss.js`
           echo "MISS COUNT: $TURBO_MISS_COUNT"
           echo "misses=$TURBO_MISS_COUNT" >> $GITHUB_OUTPUT
-      - name: 'Upload Test Report to Datadog'
+      - name: "Upload Test Report to Datadog"
         if: ${{ steps['turbo-summary'].outputs.misses != '0' && !cancelled() }}
-        run: 'pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports'
+        run: "pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports"
         env:
           DATADOG_API_KEY: ${{secrets.DATADOG_API_KEY_CLI}}
           DD_ENV: ci


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR adds an elevated NPM token environment variable to CI workflows, which is an infrastructure/deployment configuration change that could affect build security and access.
> 
> - Adds NPM_TOKEN_ELEVATED secret to test-e2e.yml workflow
> - Adds same elevated token to test.yml workflow
> - Infrastructure: CI environment variable changes with elevated permissions
>
> <sup>Risk assessment for [commit 4de8849](https://github.com/vercel/vercel/commit/4de8849f50935dc92eda719bd8ea603e6af98856).</sup>
<!-- VADE_RISK_END -->