### PR TITLE
Fix spans for backends builder

### DIFF
--- a/.changeset/neat-teachers-yawn.md
+++ b/.changeset/neat-teachers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Fix `detectBuilders` so projects using experimental backends still add `@vercel/static` for `public/**/*` files.

--- a/.changeset/perfect-ways-build.md
+++ b/.changeset/perfect-ways-build.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Fix spans

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -118,7 +118,7 @@ export const build: BuildV2 = async args => {
       ignoreNodeModules: false,
       ignore: args.config.excludeFiles,
       conditions: isBun ? ['bun'] : undefined,
-      span: buildSpan,
+      span: buildSpan.child('vc.builder.backends.nodeModuleNft'),
     });
 
     const baseDir = args.repoRootPath || args.workPath;

--- a/packages/backends/src/rolldown/index.ts
+++ b/packages/backends/src/rolldown/index.ts
@@ -314,7 +314,9 @@ module.exports = requireFromContext('${pkgName}');
     ...args,
     localBuildFiles,
     files,
-    span: rolldownSpan ?? new Span({ name: 'vc.builder.backends.nft' }),
+    span: (
+      rolldownSpan ?? new Span({ name: 'vc.builder.backends.rolldown' })
+    ).child('vc.builder.backends.sourceCodeNft'),
     ignoreNodeModules: true,
     ignore: args.config.excludeFiles,
   });

--- a/packages/backends/src/rolldown/nft.ts
+++ b/packages/backends/src/rolldown/nft.ts
@@ -16,8 +16,6 @@ export const nft = async (
     conditions?: string[];
   }
 ) => {
-  const nftSpan = args.span.child('vc.builder.backends.nft');
-
   const runNft = async () => {
     const ignorePatterns = [
       ...(args.ignoreNodeModules ? ['**/node_modules/**'] : []),
@@ -90,7 +88,7 @@ export const nft = async (
     }
   };
 
-  await nftSpan.trace(runNft);
+  await args.span.trace(runNft);
 };
 const isTypeScriptFile = (fsPath: string) => {
   return (

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -367,12 +367,13 @@ export async function detectBuilders(
   if (frontendBuilder) {
     // Add @vercel/static build for public files for server-based frameworks
     // so that files in `public/` are served from the root path, e.g. `/logo.svg`.
-    // This applies to Express, Hono, Go, and Python-based server frameworks.
+    // This applies to Express, Hono, Go, Python, and experimental backends.
     if (
-      frontendBuilder?.use === '@vercel/express' ||
-      frontendBuilder?.use === '@vercel/hono' ||
-      frontendBuilder?.use === '@vercel/python' ||
-      frontendBuilder?.use === '@vercel/go'
+      isOfficialRuntime('express', frontendBuilder?.use) ||
+      isOfficialRuntime('hono', frontendBuilder?.use) ||
+      isOfficialRuntime('python', frontendBuilder?.use) ||
+      isOfficialRuntime('go', frontendBuilder?.use) ||
+      isOfficialRuntime('backends', frontendBuilder?.use)
     ) {
       builders.push({
         src: 'public/**/*',

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -243,6 +243,36 @@ describe('Test `detectBuilders`', () => {
     expect(builders.length).toBe(2);
   });
 
+  it('framework + public with experimental backends', async () => {
+    const previousExperimentalBackends =
+      process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+    process.env.VERCEL_EXPERIMENTAL_BACKENDS = '1';
+
+    try {
+      const files = ['package.json', 'public/logo.svg'];
+      const pkg = {
+        dependencies: { hono: '4.10.1' },
+      };
+
+      const { builders } = await invokeDetectBuildersAndThrow(files, pkg, {
+        projectSettings: {
+          framework: 'hono',
+        },
+      });
+
+      expect(builders.length).toBe(2);
+      expect(builders[0].use).toBe('@vercel/static');
+      expect(builders[0].src).toBe('public/**/*');
+      expect(builders[1].use).toBe('@vercel/backends');
+    } finally {
+      if (previousExperimentalBackends === undefined) {
+        delete process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+      } else {
+        process.env.VERCEL_EXPERIMENTAL_BACKENDS = previousExperimentalBackends;
+      }
+    }
+  });
+
   it('api go with test files', async () => {
     const files = [
       'api/index.go',
@@ -1483,6 +1513,37 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders.length).toBe(2);
     expect(errorRoutes.length).toBe(1);
     expect((errorRoutes[0] as Source).status).toBe(404);
+  });
+
+  it('framework + public with experimental backends', async () => {
+    const previousExperimentalBackends =
+      process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+    process.env.VERCEL_EXPERIMENTAL_BACKENDS = '1';
+
+    try {
+      const files = ['package.json', 'public/logo.svg'];
+      const pkg = {
+        dependencies: { hono: '4.10.1' },
+      };
+
+      const { builders } = await invokeDetectBuildersAndThrow(files, pkg, {
+        projectSettings: {
+          framework: 'hono',
+        },
+        featHandleMiss,
+      });
+
+      expect(builders.length).toBe(2);
+      expect(builders[0].use).toBe('@vercel/static');
+      expect(builders[0].src).toBe('public/**/*');
+      expect(builders[1].use).toBe('@vercel/backends');
+    } finally {
+      if (previousExperimentalBackends === undefined) {
+        delete process.env.VERCEL_EXPERIMENTAL_BACKENDS;
+      } else {
+        process.env.VERCEL_EXPERIMENTAL_BACKENDS = previousExperimentalBackends;
+      }
+    }
   });
 
   it('api go with test files', async () => {


### PR DESCRIPTION
There was an NFT-sized gap in the span reporting

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR fixes span naming for tracing/telemetry in the backends builder and extends static file detection to include experimental backends, with no security or schema changes.
> 
> - Refactors span naming hierarchy for NFT tracing in backends builder
> - Adds `@vercel/backends` to list of runtimes that get `@vercel/static` for public files
> - Adds unit tests for experimental backends with public directory detection
>
> <sup>Risk assessment for [commit aed2325](https://github.com/vercel/vercel/commit/aed23251b40e3fd0c8b3550d40b9c01492e21f3e).</sup>
<!-- VADE_RISK_END -->