### PR TITLE
[python-runtime] Fix legacy invocation ASGI lifespan support

### DIFF
--- a/.changeset/hungry-shirts-greet.md
+++ b/.changeset/hungry-shirts-greet.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-runtime': patch
+---
+
+fix ASGI lifecycle events in non-IPC codepath

--- a/python/vercel-runtime/tests/fixtures/asgi_lifespan_app.py
+++ b/python/vercel-runtime/tests/fixtures/asgi_lifespan_app.py
@@ -1,0 +1,39 @@
+"""ASGI app that uses lifespan to set state before handling requests."""
+
+_started = False
+
+
+async def app(scope, receive, send):
+    global _started  # noqa: PLW0603
+
+    if scope["type"] == "lifespan":
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                _started = True
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+        return
+
+    if scope["type"] != "http":
+        return
+
+    status = 200 if _started else 503
+    body = b"started" if _started else b"not started"
+
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [(b"content-type", b"text/plain")],
+        }
+    )
+    await send(
+        {
+            "type": "http.response.body",
+            "body": body,
+            "more_body": False,
+        }
+    )

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -751,6 +751,25 @@ class TestLambdaASGI(_LambdaTestCase):
         self.assertEqual(result["statusCode"], 200)
 
 
+class TestLambdaASGILifespan(_LambdaTestCase):
+    """Lambda mode with ASGI lifespan protocol."""
+
+    async def test_lifespan_startup_runs_before_request(self) -> None:
+        ep_abs, ep_rel, mod = _make_entrypoint(
+            "asgi_lifespan_app.py", self.tmp_path
+        )
+        result = await _invoke_lambda(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            event=_lambda_event("GET", "/"),
+        )
+        # The app returns 200 only if lifespan startup ran.
+        self.assertEqual(result["statusCode"], 200)
+        body = base64.b64decode(result["body"]).decode()
+        self.assertEqual(body, "started")
+
+
 class TestLambdaErrorPaths(_LambdaTestCase):
     """Legacy Lambda mode error paths."""
 


### PR DESCRIPTION
The non-N1 ASGI code path in `vc_init.py` never sent lifespan
events, so frameworks like FastAPI that depend on startup hooks
(e.g. `prisma.connect()` in a lifespan context manager) failed
with `ClientNotConnectedError` at request time.

Add a persistent event loop shared between the lifespan task and
per-request `ASGICycle` invocations, with an `atexit` handler for
clean shutdown.

Found this when testing functions with `vd invoke` in legacy mode.


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds ASGI lifespan protocol support to the Python runtime's legacy code path, implementing proper startup/shutdown event handling with a persistent event loop - a bug fix with no security, auth, or schema implications.
> 
> - Adds ASGI lifespan startup/shutdown handling with asyncio.Runner for persistent event loop
> - Removes legacy per-request event loop creation in favor of shared runner
> - Adds test fixture and test case for lifespan protocol verification
>
> <sup>Risk assessment for [commit 2f64826](https://github.com/vercel/vercel/commit/2f648261fb2150900bc83217481b921e6580a102).</sup>
<!-- VADE_RISK_END -->