### PR TITLE
[python] regression test fixture for relative imports

### DIFF
--- a/packages/python/test/fixtures/50-workpath-relative-imports/.gitignore
+++ b/packages/python/test/fixtures/50-workpath-relative-imports/.gitignore
@@ -1,0 +1,7 @@
+.vercel/
+.venv/
+venv/
+__pycache__/
+.Python
+.DS_Store
+.env*

--- a/packages/python/test/fixtures/50-workpath-relative-imports/README.md
+++ b/packages/python/test/fixtures/50-workpath-relative-imports/README.md
@@ -1,0 +1,15 @@
+## Relative Import Repro
+
+This fixture reproduces a Python package-root entrypoint that uses a relative import:
+
+- `main.py` imports `from .utils import ...`
+- `__init__.py` marks `workPath` as a package
+- `pyproject.toml` exposes `app = "main:app"`
+
+Deploy from this directory and hit:
+
+- `/`
+- `/api/relative/<name>`
+
+If package context is resolved correctly, both routes return JSON with
+`"import_marker":"relative-import-ok"`.

--- a/packages/python/test/fixtures/50-workpath-relative-imports/__init__.py
+++ b/packages/python/test/fixtures/50-workpath-relative-imports/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for workPath relative import repro."""

--- a/packages/python/test/fixtures/50-workpath-relative-imports/main.py
+++ b/packages/python/test/fixtures/50-workpath-relative-imports/main.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+
+from .utils import IMPORT_MARKER, build_message
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {
+        "ok": True,
+        "import_marker": IMPORT_MARKER,
+        "message": build_message("world"),
+        "module": __name__,
+        "package": __package__,
+    }
+
+
+@app.get("/api/relative/{name}")
+def read_relative(name: str):
+    return {
+        "ok": True,
+        "import_marker": IMPORT_MARKER,
+        "message": build_message(name),
+        "module": __name__,
+        "package": __package__,
+    }

--- a/packages/python/test/fixtures/50-workpath-relative-imports/probes.json
+++ b/packages/python/test/fixtures/50-workpath-relative-imports/probes.json
@@ -1,0 +1,17 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "\"import_marker\":\"relative-import-ok\""
+    },
+    {
+      "path": "/api/relative/RANDOMNESS_PLACEHOLDER",
+      "status": 200,
+      "mustContain": "\"message\":\"hello RANDOMNESS_PLACEHOLDER from relative import\""
+    },
+    {
+      "logMustContain": "Using Python 3.12 from pyproject.toml"
+    }
+  ]
+}

--- a/packages/python/test/fixtures/50-workpath-relative-imports/pyproject.toml
+++ b/packages/python/test/fixtures/50-workpath-relative-imports/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "fixture-workpath-relative-imports"
+version = "0.0.1"
+requires-python = ">=3.12"
+dependencies = [
+  "fastapi>=0.118,<1",
+]
+
+[project.scripts]
+app = "main:app"

--- a/packages/python/test/fixtures/50-workpath-relative-imports/utils.py
+++ b/packages/python/test/fixtures/50-workpath-relative-imports/utils.py
@@ -1,0 +1,5 @@
+IMPORT_MARKER = "relative-import-ok"
+
+
+def build_message(name: str) -> str:
+    return f"hello {name} from relative import"


### PR DESCRIPTION
Regression test fixture for relative imports when workPath is a python package

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new test fixture directory with Python files, config, and test probes to reproduce relative import behavior - purely test infrastructure with no production code changes.
> 
> - New test fixture for Python relative imports regression testing
> - Contains .gitignore, README, Python source files, and probe definitions
> - All files under packages/python/test/fixtures/ path
>
> <sup>Risk assessment for [commit 3d47c0f](https://github.com/vercel/vercel/commit/3d47c0f0e2555ed387d1a6a1670deb4f2ee9363e).</sup>
<!-- VADE_RISK_END -->