### PR TITLE
[python] fix relative import at workPath package in python-runtime

### DIFF
--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -16,6 +16,7 @@ import socket
 import sys
 import time
 import traceback
+import types
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from importlib import util
 from typing import TYPE_CHECKING, Any, Literal, Never, TextIO
@@ -518,15 +519,58 @@ if os.path.exists(_runtime_config_path):
 
 # Import relative path
 # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+
+
+def _resolve_user_module_import_name() -> tuple[str, str | None]:
+    """
+    Resolve the module name used to load the user entrypoint.
+
+    For root entrypoints like "main.py" in a package root (directory contains
+    "__init__.py"), importing as plain "main" breaks explicit relative imports
+    (e.g. "from .utils import ...") because there is no parent package.
+
+    In that case we create a synthetic package that points to the entrypoint
+    directory and import the module as "<synthetic>.main", while also aliasing
+    it back to the original module name for compatibility.
+    """
+    if "." in _entrypoint_modname:
+        return _entrypoint_modname, None
+
+    entrypoint_dir = os.path.dirname(_entrypoint_abs)
+    package_init = os.path.join(entrypoint_dir, "__init__.py")
+    if not os.path.isfile(package_init):
+        return _entrypoint_modname, None
+
+    package_name = "__vc_root_package__"
+    if package_name not in sys.modules:
+        package = types.ModuleType(package_name)
+        package.__file__ = package_init
+        package.__package__ = package_name
+        package.__path__ = [entrypoint_dir]  # type: ignore[attr-defined]
+        package.__spec__ = util.spec_from_file_location(
+            package_name,
+            package_init,
+            submodule_search_locations=[entrypoint_dir],
+        )
+        sys.modules[package_name] = package
+
+    return f"{package_name}.{_entrypoint_modname}", _entrypoint_modname
+
+
 try:
+    __vc_import_name, __vc_declared_module_alias = (
+        _resolve_user_module_import_name()
+    )
     __vc_spec = util.spec_from_file_location(
-        _entrypoint_modname,
+        __vc_import_name,
         _entrypoint_abs,
     )
     if __vc_spec is None or __vc_spec.loader is None:
         _fatal(f"Could not load module spec for {_entrypoint_rel}")
     __vc_module = util.module_from_spec(__vc_spec)
-    sys.modules[_entrypoint_modname] = __vc_module
+    sys.modules[__vc_import_name] = __vc_module
+    if __vc_declared_module_alias is not None:
+        sys.modules[__vc_declared_module_alias] = __vc_module
     __vc_spec.loader.exec_module(__vc_module)
     __vc_variables = dir(__vc_module)
 except Exception:

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -546,7 +546,7 @@ def _resolve_user_module_import_name() -> tuple[str, str | None]:
         package = types.ModuleType(package_name)
         package.__file__ = package_init
         package.__package__ = package_name
-        package.__path__ = [entrypoint_dir]  # type: ignore[attr-defined]
+        package.__path__ = [entrypoint_dir]
         package.__spec__ = util.spec_from_file_location(
             package_name,
             package_init,

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -60,8 +60,7 @@ def _make_root_relative_import_entrypoint(
     """
     (tmp_path / "__init__.py").write_text("", encoding="utf-8")
     (tmp_path / "utils.py").write_text(
-        "def build_body(path: str) -> str:\n"
-        "    return f'relative:{path}'\n",
+        "def build_body(path: str) -> str:\n    return f'relative:{path}'\n",
         encoding="utf-8",
     )
     entrypoint = tmp_path / "main.py"

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -47,6 +47,42 @@ def _make_entrypoint(
     return dst, fixture_name, fixture_name.removesuffix(".py")
 
 
+def _make_root_relative_import_entrypoint(
+    tmp_path: pathlib.Path,
+) -> tuple[pathlib.Path, str, str]:
+    """
+    Create a root entrypoint that relies on explicit relative imports.
+
+    Layout:
+      __init__.py
+      utils.py
+      main.py  (from .utils import build_body)
+    """
+    (tmp_path / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "utils.py").write_text(
+        "def build_body(path: str) -> str:\n"
+        "    return f'relative:{path}'\n",
+        encoding="utf-8",
+    )
+    entrypoint = tmp_path / "main.py"
+    entrypoint.write_text(
+        "from .utils import build_body\n"
+        "\n"
+        "async def app(scope, receive, send):\n"
+        "    if scope.get('type') != 'http':\n"
+        "        return\n"
+        "    body = build_body(scope.get('path', '/')).encode()\n"
+        "    await send({\n"
+        "        'type': 'http.response.start',\n"
+        "        'status': 200,\n"
+        "        'headers': [(b'content-type', b'text/plain')],\n"
+        "    })\n"
+        "    await send({'type': 'http.response.body', 'body': body})\n",
+        encoding="utf-8",
+    )
+    return entrypoint, "main.py", "main"
+
+
 def _coverage_active() -> bool:
     """Check if coverage collection is active in this process."""
     try:
@@ -467,6 +503,25 @@ class TestASGIApp(_RuntimeTestCase):
             sock.close()
             self.assertIn(b"200", data)
 
+    async def test_root_entrypoint_relative_import(self) -> None:
+        ep_abs, ep_rel, mod = _make_root_relative_import_entrypoint(
+            self.tmp_path
+        )
+        async with _run_runtime(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            ipc_socket_path=self.n1.socket_path,
+        ):
+            ss = await self.n1.wait_for_message(
+                ServerStartedMessage, timeout=10.0
+            )
+            port = ss.payload.http_port
+
+            resp = await _http_get(port, "/relative")
+            self.assertEqual(resp.status, 200)
+            self.assertEqual(resp.read().decode(), "relative:/relative")
+
 
 class TestLogging(_RuntimeTestCase):
     """Tests for IPC log message forwarding."""
@@ -749,6 +804,20 @@ class TestLambdaASGI(_LambdaTestCase):
             ),
         )
         self.assertEqual(result["statusCode"], 200)
+
+    async def test_root_entrypoint_relative_import(self) -> None:
+        ep_abs, ep_rel, mod = _make_root_relative_import_entrypoint(
+            self.tmp_path
+        )
+        result = await _invoke_lambda(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            event=_lambda_event("GET", "/relative"),
+        )
+        self.assertEqual(result["statusCode"], 200)
+        body = base64.b64decode(result["body"]).decode()
+        self.assertEqual(body, "relative:/relative")
 
 
 class TestLambdaErrorPaths(_LambdaTestCase):


### PR DESCRIPTION
Fixes the following issue when your rootDir/workPath is itself a Python package and you attempt to import from a relative path:
```
ImportError: attempted relative import with no known parent package
```

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a synthetic package mechanism to fix Python relative imports by manipulating sys.modules, which is runtime behavior change but does not affect auth, security, or database schema.
> 
> - Adds synthetic package creation for root entrypoints with __init__.py
> - Modifies sys.modules registration to support relative imports
> - Adds comprehensive test coverage for new import behavior
>
> <sup>Risk assessment for [commit 78317b6](https://github.com/vercel/vercel/commit/78317b64ce80f4f0a76459d757f27a030cf7f36d).</sup>
<!-- VADE_RISK_END -->