### PR TITLE
fix(cli): improve agent discoverability of integration-resource commands

### DIFF
--- a/.changeset/cli-integration-remove-json-resources.md
+++ b/.changeset/cli-integration-remove-json-resources.md
@@ -1,0 +1,8 @@
+---
+'vercel': patch
+---
+
+fix(cli): improve agent discoverability of integration-resource commands
+
+- Add `integration-resource` cross-references in `integration --help` and `integration remove --help`
+- Emit structured JSON with resource names and next commands when `integration remove --format=json --yes` fails because resources still exist

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -315,7 +315,8 @@ export const balanceSubcommand = {
 export const removeSubcommand = {
   name: 'remove',
   aliases: [],
-  description: 'Uninstalls a marketplace integration',
+  description:
+    'Uninstalls a marketplace integration. Resources must be removed first using `integration-resource remove`.',
   arguments: [
     {
       name: 'integration',
@@ -337,6 +338,10 @@ export const removeSubcommand = {
         `${packageName} integration remove <integration>`,
         `${packageName} integration remove acme`,
       ],
+    },
+    {
+      name: 'Remove a resource before uninstalling',
+      value: `${packageName} integration-resource remove <resource-name> --disconnect-all --yes`,
     },
     {
       name: 'Output as JSON',
@@ -392,7 +397,8 @@ export const guideSubcommand = {
 export const integrationCommand = {
   name: 'integration',
   aliases: [],
-  description: 'Manage marketplace integrations',
+  description:
+    'Manage marketplace integrations. To manage individual resources (disconnect, remove), see `integration-resource`.',
   options: [],
   arguments: [],
   subcommands: [

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2966,7 +2966,10 @@ exports[`help command > integration help output snapshots > integration help col
 "
   ▲ vercel integration command
 
-  Manage marketplace integrations       
+  Manage marketplace integrations. To   
+  manage individual resources           
+  (disconnect, remove), see             
+  \`integration-resource\`.               
 
   Commands:
 
@@ -3016,6 +3019,13 @@ exports[`help command > integration help output snapshots > integration help col
                              a      
                              market…
                              integr…
+                             Resour…
+                             must be
+                             removed
+                             first  
+                             using  
+                             \`integ…
+                             remove…
 
 
   Global Options:
@@ -3079,7 +3089,8 @@ exports[`help command > integration help output snapshots > integration help col
 "
   ▲ vercel integration command
 
-  Manage marketplace integrations                                               
+  Manage marketplace integrations. To manage individual resources (disconnect,  
+  remove), see \`integration-resource\`.                                          
 
   Commands:
 
@@ -3093,7 +3104,9 @@ exports[`help command > integration help output snapshots > integration help col
                              for the current project                        
   open      name [resource]  Opens a marketplace integration's or resource's
                              dashboard via SSO                              
-  remove    integration      Uninstalls a marketplace integration           
+  remove    integration      Uninstalls a marketplace integration. Resources
+                             must be removed first using                    
+                             \`integration-resource remove\`.                 
 
 
   Global Options:
@@ -3125,7 +3138,7 @@ exports[`help command > integration help output snapshots > integration help col
 "
   ▲ vercel integration command
 
-  Manage marketplace integrations                                                                                       
+  Manage marketplace integrations. To manage individual resources (disconnect, remove), see \`integration-resource\`.     
 
   Commands:
 
@@ -3135,7 +3148,8 @@ exports[`help command > integration help output snapshots > integration help col
   guide     integration      Show getting started guides and code snippets for a marketplace integration            
   list      [project]        List resources from marketplace integrations for the current project                   
   open      name [resource]  Opens a marketplace integration's or resource's dashboard via SSO                      
-  remove    integration      Uninstalls a marketplace integration                                                   
+  remove    integration      Uninstalls a marketplace integration. Resources must be removed first using            
+                             \`integration-resource remove\`.                                                         
 
 
   Global Options:


### PR DESCRIPTION
Closes [MKT-2764](https://linear.app/vercel/issue/MKT-2764/agent-lacks-knowledge-of-vc-integration-resource-remove-command)

## Summary
- Add cross-reference to `integration-resource` in `vc integration` description and `vc integration remove` description so agents can discover resource management commands
- Add "Remove a resource before uninstalling" example in `vc integration remove --help`
- When `integration remove --format=json --yes` fails because resources still exist (403), emit structured JSON with resource names, per-resource removal commands (`next[]`), and a retry command — so agents can parse and execute the removal steps automatically instead of parsing human-readable text

## Before / After

### `vc integration --help`

| Before | After |
|--------|-------|
| `Manage marketplace integrations` | `Manage marketplace integrations. To manage individual resources (disconnect, remove), see integration-resource.` |

### `vc integration remove --help`

| Before | After |
|--------|-------|
| `Uninstalls a marketplace integration` | `Uninstalls a marketplace integration. Resources must be removed first using integration-resource remove.` |
| 1 example (uninstall) | 3 examples: uninstall, remove a resource before uninstalling, output as JSON |

### `vc integration remove neon --yes --format=json`

**Before:** No JSON output. Same text error goes to stderr. Agent must parse human text to find resource names and commands.

**After:** Structured JSON to stdout:
```json
{
  "integration": "neon",
  "removed": false,
  "error": "has_resources",
  "message": "Cannot uninstall neon because it still has resources.",
  "resources": [
    "neon-purple-river",
    "neon-copper-mirror",
    "neon-citron-drum"
  ],
  "next": [
    {
      "command": "vercel integration-resource remove neon-purple-river --disconnect-all --yes --format=json"
    },
    {
      "command": "vercel integration-resource remove neon-copper-mirror --disconnect-all --yes --format=json"
    },
    {
      "command": "vercel integration-resource remove neon-citron-drum --disconnect-all --yes --format=json"
    }
  ],
  "retry": "vercel integration remove neon --yes --format=json"
}
```

## Test plan

### Unit tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/remove.test.ts

 ✓ test/unit/commands/integration/remove.test.ts  (15 tests) 57ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
```

### Manual testing

| # | Test | Command | Result |
|---|------|---------|--------|
| 1 | `integration --help` | `vc integration --help` | Description now mentions `integration-resource` |
| 2 | `integration remove --help` | `vc integration remove --help` | Description mentions `integration-resource remove`, new example shown |
| 3 | 403 text output (no JSON) | `vc integration remove neon --yes` | 19 resources listed, actionable commands shown, AGENT warning — unchanged |
| 4 | 403 JSON output | `vc integration remove neon --yes --format=json` | Structured JSON with 19 resource names, 19 `next[]` commands, `retry` field |

### Code paths covered

| Path | Verified by |
|------|------------|
| 403 with resources, `--format=json` → structured JSON output | Unit + manual #4 |
| 403 with resources, no JSON → text error (unchanged) | Unit + manual #3 |
| 403 with resources, agent warning | Unit (`isAgent=true`) + manual #3 |
| 403 with resources, stores fetch fails → still shows guidance | Unit (catch block) |
| Successful removal with JSON output | Unit |
| Successful removal without JSON | Unit |
| Cancel confirmation | Unit |
| Integration not found | Unit |
| `--format=json` without `--yes` → error | Unit |