### PR TITLE
[@vercel/build-utils] fix uncaught exception in streamToBuffer when stream exceeds max Buffer size

### DIFF
--- a/.changeset/lovely-pens-battle.md
+++ b/.changeset/lovely-pens-battle.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[@vercel/build-utils] fix uncaught exception in streamToBuffer when stream exceeds max Buffer size

--- a/packages/build-utils/src/fs/stream-to-buffer.ts
+++ b/packages/build-utils/src/fs/stream-to-buffer.ts
@@ -13,15 +13,19 @@ export default function streamToBuffer(
         reject(err);
         return;
       }
-      switch (buffers.length) {
-        case 0:
-          resolve(Buffer.allocUnsafe(0));
-          break;
-        case 1:
-          resolve(buffers[0]);
-          break;
-        default:
-          resolve(Buffer.concat(buffers));
+      try {
+        switch (buffers.length) {
+          case 0:
+            resolve(Buffer.allocUnsafe(0));
+            break;
+          case 1:
+            resolve(buffers[0]);
+            break;
+          default:
+            resolve(Buffer.concat(buffers));
+        }
+      } catch (concatErr) {
+        reject(concatErr);
       }
     });
   });

--- a/packages/build-utils/test/unit.stream-to-buffer.test.ts
+++ b/packages/build-utils/test/unit.stream-to-buffer.test.ts
@@ -1,8 +1,45 @@
 import { it, describe, expect } from 'vitest';
-import { streamToBufferChunks } from '../src/fs/stream-to-buffer';
-import { Readable } from 'stream';
+import streamToBuffer, {
+  streamToBufferChunks,
+} from '../src/fs/stream-to-buffer';
+import { Readable, PassThrough } from 'stream';
 
 const MB = 1024 * 1024;
+
+describe('streamToBuffer', () => {
+  it('resolves with the concatenated buffer for a normal stream', async () => {
+    const stream = Readable.from([Buffer.from('hello'), Buffer.from('world')]);
+    const result = await streamToBuffer(stream);
+    expect(result.toString()).toBe('helloworld');
+  });
+
+  it('rejects when Buffer.concat throws (e.g. exceeds max Buffer size)', async () => {
+    // When accumulated stream data exceeds buffer.constants.MAX_LENGTH,
+    // Buffer.concat throws a RangeError inside the end-of-stream
+    // callback. This must become a Promise rejection so callers can
+    // catch it — otherwise it escapes as an uncaught exception and
+    // crashes the process.
+    const originalConcat = Buffer.concat;
+    const stream = new PassThrough();
+
+    Buffer.concat = () => {
+      throw new RangeError(
+        'The value of "size" is out of range. It must be >= 0 && <= 4294967296. Received 5000000000'
+      );
+    };
+
+    // Two chunks are needed so buffers.length > 1, which triggers the
+    // Buffer.concat code path (single-chunk streams return buffers[0] directly)
+    stream.write(Buffer.from('chunk1'));
+    stream.end(Buffer.from('chunk2'));
+
+    try {
+      await expect(streamToBuffer(stream)).rejects.toThrow(RangeError);
+    } finally {
+      Buffer.concat = originalConcat;
+    }
+  });
+});
 
 describe('streamToBufferChunks', () => {
   it("returns 1 buffer when the total volume doesn't exceed 100mb", async () => {


### PR DESCRIPTION
## Summary

- Wraps the `eos` callback body in `streamToBuffer` with try/catch so that errors from `Buffer.concat` (or `Buffer.allocUnsafe`) become proper Promise rejections instead of uncaught exceptions
- Without this, any stream large enough to exceed Node's max Buffer size crashes the process — callers' `try/catch` around `await streamToBuffer(...)` never fires because the error is thrown inside an async event handler, bypassing the Promise chain entirely

`streamToBuffer` collects chunks from a stream and calls `Buffer.concat(buffers)` inside the `end-of-stream` callback. When the total data exceeds `buffer.constants.MAX_LENGTH` (~4 GiB on Node 20), `Buffer.concat` throws a `RangeError`. Because this happens inside an event callback rather than the Promise executor, the error escapes as an uncaught exception and the Promise never settles.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds defensive error handling by wrapping Buffer operations in try/catch to convert uncaught exceptions into proper Promise rejections, improving error handling without changing any security or business logic.
> 
> - Adds try/catch around Buffer.concat to properly reject Promise on error
> - New unit tests verify RangeError becomes Promise rejection
> - Changeset file for patch version bump
>
> <sup>Risk assessment for [commit 027a686](https://github.com/vercel/vercel/commit/027a6864e5958cb59a24c1a699b8c8f9a5ed3b55).</sup>
<!-- VADE_RISK_END -->