### PR TITLE
[next] fix: lower max uncompressed lambda size to leave headroom for primitives

### DIFF
--- a/.changeset/odd-trainers-greet.md
+++ b/.changeset/odd-trainers-greet.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+lower max uncompressed lambda size to leave headroom for primitives

--- a/packages/next/src/constants.ts
+++ b/packages/next/src/constants.ts
@@ -8,9 +8,10 @@ export const MIB = 1024 * KIB;
 export const EDGE_FUNCTION_SIZE_LIMIT = 4 * MIB;
 
 /**
- * The maximum size of an uncompressed function.
+ * The maximum size of an uncompressed function (250MB).
+ * It's 10 MiB smaller than the actual Lambda limit to leave room for other primitives that affect function size e.g. layers
  */
-export const DEFAULT_MAX_UNCOMPRESSED_LAMBDA_SIZE = 250 * MIB;
+export const DEFAULT_MAX_UNCOMPRESSED_LAMBDA_SIZE = 240 * MIB;
 
 /**
  * The maximum size of an uncompressed function using Bun. It's 100 MiB smaller

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -175,7 +175,7 @@ it.skip('Should not exceed function limit for large dependencies (server build)'
   // this assertion is unstable as `next-server`'s size can change up and down
   // on canary so skipping to prevent random failures.
   // expect(logs).toContain(
-  //   'Warning: Max serverless function size of 50 MB compressed or 250 MB uncompressed almost reached'
+  //   'Warning: Max serverless function size of 50 MB compressed or 240 MB uncompressed almost reached'
   // );
 
   expect(logs).toContain('node_modules/chrome-aws-lambda/bin');
@@ -227,7 +227,7 @@ it.skip('Should not exceed function limit for large dependencies (shared lambda)
   expect(lambdas.size).toBe(3);
 
   expect(logs).toContain(
-    'Warning: Max serverless function size of 50 MB compressed or 250 MB uncompressed almost reached'
+    'Warning: Max serverless function size of 50 MB compressed or 240 MB uncompressed almost reached'
   );
   expect(logs).toContain('node_modules/chrome-aws-lambda/bin');
 });
@@ -255,7 +255,7 @@ it('Should provide lambda info when limit is hit (server build)', async () => {
     'Max serverless function size was exceeded for 2 functions'
   );
   expect(logs).toContain(
-    'Max serverless function size of 250 MB uncompressed reached'
+    'Max serverless function size of 240 MB uncompressed reached'
   );
   expect(logs).toContain(`Serverless Function's page: api/both.js`);
   expect(logs).toMatch(/Large Dependencies.*?Uncompressed size/);
@@ -285,7 +285,7 @@ it('Should provide lambda info when limit is hit for internal pages (server buil
   console.log = origLog;
 
   expect(logs).toContain(
-    'Max serverless function size of 250 MB uncompressed reached'
+    'Max serverless function size of 240 MB uncompressed reached'
   );
   // expect(logs).toContain(`Serverless Function's page: api/firebase.js`);
   expect(logs).toContain(`Serverless Function's page: api/chrome.js`);
@@ -320,7 +320,7 @@ it('Should provide lambda info when limit is hit (uncompressed)', async () => {
     'Max serverless function size was exceeded for 1 function'
   );
   expect(logs).toContain(
-    'Max serverless function size of 250 MB uncompressed reached'
+    'Max serverless function size of 240 MB uncompressed reached'
   );
   expect(logs).toContain(`Serverless Function's page: api/hello.js`);
   expect(logs).toMatch(/Large Dependencies.*?Uncompressed size/);

--- a/packages/next/test/integration/legacy/integration-legacy.test.js
+++ b/packages/next/test/integration/legacy/integration-legacy.test.js
@@ -274,7 +274,7 @@ it('Should provide lambda info when limit is hit (shared lambdas)', async () => 
     'Max serverless function size was exceeded for 1 function'
   );
   expect(logs).toContain(
-    'Max serverless function size of 250 MB uncompressed reached'
+    'Max serverless function size of 240 MB uncompressed reached'
   );
   expect(logs).toContain(`Serverless Function's page: api/both.js`);
   expect(logs).toMatch(/Large Dependencies.*?Uncompressed size/);

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/next.config.js
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/next.config.js
@@ -21,7 +21,7 @@ assert(
 );
 
 // generate large text file which will be traced in `/api/hello`
-// which when combined with the 404 HTML files will push us over the 250MB
+// which when combined with the 404 HTML files will push us over the 240MB
 // uncompressed limit
 fs.writeFileSync('data.txt', Buffer.alloc(200 * 1024 * 1024));
 

--- a/packages/next/test/unit/utils.test.ts
+++ b/packages/next/test/unit/utils.test.ts
@@ -450,10 +450,10 @@ describe('getMaxUncompressedLambdaSize', () => {
   });
 
   it.each(['provided.al2023', 'nodejs22.x'])(
-    'should return 250 MiB for %s runtime',
+    'should return 240 MiB for %s runtime',
     runtime => {
       const size = getMaxUncompressedLambdaSize(runtime);
-      expect(size).toBe(250 * 1024 * 1024);
+      expect(size).toBe(240 * 1024 * 1024);
     }
   );
 


### PR DESCRIPTION
We can run into the following error on Vercel deployments.

> [vc] (patchBuild) ungraceful error was thrown: A Serverless Function has exceeded the unzipped maximum size of 250 MB.

This happens because other Lambda primitives like layers add to the 250MB limit.

Fix: Lowering the limit to 240MB for bundling so we leave some headroom.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR reduces a Lambda size limit constant from 250MB to 240MB and updates corresponding test assertions, which is a defensive change that tightens constraints.
> 
> - Constant change: reduces DEFAULT_MAX_UNCOMPRESSED_LAMBDA_SIZE from 250 to 240 MiB
> - Test updates: adjusts expected warning/error messages to reflect new limit
> - Changeset added for patch release
>
> <sup>Risk assessment for [commit 8720b4f](https://github.com/vercel/vercel/commit/8720b4f874496c996a29e535dafd4f5576c72e41).</sup>
<!-- VADE_RISK_END -->