### PR TITLE
feat(cli): ellipsize long group values in metrics text output

### DIFF
--- a/.changeset/ellipsize-metrics-group-values.md
+++ b/.changeset/ellipsize-metrics-group-values.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Ellipsize long group values in `metrics` text output to prevent excessively wide tables. Values exceeding 60 characters are truncated by keeping equal start/end portions with `…` in the middle.

--- a/packages/cli/test/unit/commands/metrics/text-output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/text-output.test.ts
@@ -12,6 +12,7 @@ import {
   formatMetadataHeader,
   formatSparklineSection,
   formatText,
+  ellipsizeMiddle,
 } from '../../../../src/commands/metrics/text-output';
 import type {
   MetricsQueryResponse,
@@ -52,6 +53,40 @@ describe('text-output', () => {
       expect(formatDecimal(0.87)).toBe('0.87');
       expect(formatDecimal(0.042)).toBe('0.042');
       expect(formatDecimal(0.003)).toBe('0.003');
+    });
+  });
+
+  describe('ellipsizeMiddle', () => {
+    it('should return the string unchanged when within max length', () => {
+      expect(ellipsizeMiddle('short', 60)).toBe('short');
+      expect(ellipsizeMiddle('/api/status', 60)).toBe('/api/status');
+    });
+
+    it('should return the string unchanged when exactly at max length', () => {
+      const str = 'a'.repeat(60);
+      expect(ellipsizeMiddle(str, 60)).toBe(str);
+    });
+
+    it('should ellipsize long strings with equal start/end portions', () => {
+      const result = ellipsizeMiddle('a'.repeat(100), 60);
+      expect(result).toHaveLength(60);
+      expect(result).toContain('…');
+      // With maxLength=60: endLength=29, startLength=30
+      expect(result).toBe('a'.repeat(30) + '…' + 'a'.repeat(29));
+    });
+
+    it('should handle odd max length correctly', () => {
+      const result = ellipsizeMiddle('abcdefghij', 5);
+      // endLength=2, startLength=2
+      expect(result).toBe('ab…ij');
+      expect(result).toHaveLength(5);
+    });
+
+    it('should handle even max length correctly', () => {
+      const result = ellipsizeMiddle('abcdefghij', 6);
+      // endLength=2, startLength=3
+      expect(result).toBe('abc…ij');
+      expect(result).toHaveLength(6);
     });
   });
 


### PR DESCRIPTION
Long group values (e.g., route names) caused the metrics table to be excessively wide. Values exceeding 60 characters are now truncated by keeping equal start/end portions with a … in the middle.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a cosmetic string truncation utility for CLI text output formatting, with no changes to security, auth, data, or business logic.
> 
> - New `ellipsizeMiddle` helper truncates strings over 60 chars for display
> - Applied to group values in summary table and sparkline section formatting
> - Unit tests added for ellipsize function edge cases
>
> <sup>Risk assessment for [commit 096f53b](https://github.com/vercel/vercel/commit/096f53b3698da5b5962b0054adb7535c146f3c15).</sup>
<!-- VADE_RISK_END -->