### PR TITLE
[cli] Remove --order-by flag from metrics query

### DIFF
--- a/.changeset/remove-metrics-order-by.md
+++ b/.changeset/remove-metrics-order-by.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove `--order-by` flag from `metrics query` command; ordering is handled server-side.

--- a/packages/cli/src/commands/metrics/command.ts
+++ b/packages/cli/src/commands/metrics/command.ts
@@ -96,15 +96,6 @@ export const metricsCommand = {
       argument: 'N',
     },
     {
-      name: 'order-by',
-      shorthand: null,
-      type: String,
-      deprecated: false,
-      description:
-        'Order results by rollup:asc|desc (default: rollup value desc)',
-      argument: 'ROLLUP',
-    },
-    {
       name: 'filter',
       shorthand: 'f',
       type: String,

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -192,7 +192,6 @@ export default async function query(
   const aggregationFlag = flags['--aggregation'];
   const groupBy = flags['--group-by'] ?? [];
   const limit = flags['--limit'];
-  const orderBy = flags['--order-by'];
   const filter = flags['--filter'];
   const since = flags['--since'];
   const until = flags['--until'];
@@ -206,7 +205,6 @@ export default async function query(
   telemetry.trackCliOptionAggregation(aggregationFlag);
   telemetry.trackCliOptionGroupBy(groupBy.length > 0 ? groupBy : undefined);
   telemetry.trackCliOptionLimit(limit);
-  telemetry.trackCliOptionOrderBy(orderBy);
   telemetry.trackCliOptionFilter(filter);
   telemetry.trackCliOptionSince(since);
   telemetry.trackCliOptionUntil(until);
@@ -312,7 +310,6 @@ export default async function query(
     ...(groupBy.length > 0 ? { groupBy } : {}),
     ...(filter ? { filter } : {}),
     limit: limit ?? 10,
-    ...(orderBy ? { orderBy } : {}),
   };
 
   // Make API call

--- a/packages/cli/src/util/telemetry/commands/metrics/index.ts
+++ b/packages/cli/src/util/telemetry/commands/metrics/index.ts
@@ -69,15 +69,6 @@ export class MetricsTelemetryClient
     }
   }
 
-  trackCliOptionOrderBy(v: string | undefined) {
-    if (v) {
-      this.trackCliOption({
-        option: 'order-by',
-        value: this.redactedValue,
-      });
-    }
-  }
-
   trackCliOptionFilter(v: string | undefined) {
     if (v) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -539,30 +539,6 @@ describe('query', () => {
     });
   });
 
-  describe('--order-by flag', () => {
-    it('should send order-by to API', async () => {
-      let requestBody: any;
-      client.scenario.post('/api/observability/metrics', (req, res) => {
-        requestBody = req.body;
-        res.json({ data: [], summary: [], statistics: {} });
-      });
-      mockLinkedProject();
-      client.setArgv(
-        'metrics',
-        'query',
-        '--event',
-        'edgeRequest',
-        '--order-by',
-        'value:asc'
-      );
-
-      const exitCode = await query(client, new MockTelemetry());
-
-      expect(exitCode).toBe(0);
-      expect(requestBody.orderBy).toBe('value:asc');
-    });
-  });
-
   describe('--filter flag', () => {
     it('should pass filter string to API', async () => {
       let requestBody: any;


### PR DESCRIPTION
The orderBy field is no longer sent in the request body; the API handles ordering server-side. Removes the flag definition, telemetry tracking, and associated tests.

It's not working at all, and causing the agents to trip up.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR removes the --order-by CLI flag, its telemetry tracking, and associated tests from the metrics query command, which is a straightforward feature removal with no security or data implications.
> 
> - Removes --order-by flag definition from metricsCommand
> - Removes orderBy from API request body and telemetry tracking
> - Removes associated unit tests for --order-by flag
>
> <sup>Risk assessment for [commit 7862c81](https://github.com/vercel/vercel/commit/7862c8111efdf265190791cfffa5b3c668fe5618).</sup>
<!-- VADE_RISK_END -->