### PR TITLE
[python] Get python entrypoint from Procfile.

### DIFF
--- a/.changeset/lovely-roses-own.md
+++ b/.changeset/lovely-roses-own.md
@@ -1,0 +1,6 @@
+---
+'@vercel/build-utils': minor
+'@vercel/python': minor
+---
+
+Add error message when no entrypoint is found, but Procfile is detected.

--- a/packages/build-utils/src/python.ts
+++ b/packages/build-utils/src/python.ts
@@ -115,7 +115,7 @@ export async function getDjangoEntrypoint(
  */
 export async function getProcfileWebEntrypoint(
   workPath: string
-): Promise<string | null> {
+): Promise<[string, string | null] | null> {
   try {
     const procfilePath = join(workPath, 'Procfile');
     const procfileContent = await fs.promises.readFile(procfilePath, 'utf-8');
@@ -134,9 +134,9 @@ export async function getProcfileWebEntrypoint(
 const PY_ID = '[A-Za-z_][A-Za-z0-9_]*';
 const APP_SPEC_PATTERN = `${PY_ID}(?:\\.${PY_ID})*(?::${PY_ID})?`;
 
-function moduleSpecToPath(appSpec: string): string {
-  const modulePath = appSpec.split(':')[0];
-  return `${modulePath.replace(/\./g, '/')}.py`;
+function moduleSpecToPath(appSpec: string): [string, string | null] {
+  const [modulePart, attr] = appSpec.split(':');
+  return [`${modulePart.replace(/\./g, '/')}.py`, attr ?? null];
 }
 
 /**
@@ -149,7 +149,7 @@ function moduleSpecToPath(appSpec: string): string {
 async function parseProcfileWebGunicorn(
   workPath: string,
   procfileContent: string
-): Promise<string | null> {
+): Promise<[string, string | null] | null> {
   const webGunicornMatch = procfileContent.match(/web:\s*gunicorn\s*(.*)/);
   if (!webGunicornMatch) return null;
   const args = webGunicornMatch[1].trim().split(/\s+/);
@@ -273,7 +273,9 @@ function getGunicornConfigPath(args: string[]): string {
  * Parse Procfile content for "web: uvicorn <module>" or "web: uvicorn <module>:<attr>".
  * Returns the corresponding .py path or null.
  */
-function parseProcfileWebUvicorn(procfileContent: string): string | null {
+function parseProcfileWebUvicorn(
+  procfileContent: string
+): [string, string | null] | null {
   const match = procfileContent.match(
     new RegExp(`web:\\s*uvicorn\\s+(${APP_SPEC_PATTERN})`)
   );
@@ -288,7 +290,7 @@ function parseProcfileWebUvicorn(procfileContent: string): string | null {
 async function parseProcfileWebUwsgiIni(
   workPath: string,
   procfileContent: string
-): Promise<string | null> {
+): Promise<[string, string | null] | null> {
   const uwsgiMatch = procfileContent.match(/web:\s*uwsgi\s+(\S+\.ini)/);
   if (!uwsgiMatch) return null;
   const iniPath = join(workPath, uwsgiMatch[1]);

--- a/packages/build-utils/src/python.ts
+++ b/packages/build-utils/src/python.ts
@@ -105,3 +105,201 @@ export async function getDjangoEntrypoint(
   }
   return null;
 }
+
+/**
+ * Read Procfile at workPath and parse the web process. Supports:
+ * - web: gunicorn <module> or <module>:<attr>
+ * - web: uvicorn <module> or <module>:<attr>
+ * - web: uwsgi <settings>.ini (reads module = <appModule> from the INI)
+ * Returns the corresponding Python file path or null.
+ */
+export async function getProcfileWebEntrypoint(
+  workPath: string
+): Promise<string | null> {
+  try {
+    const procfilePath = join(workPath, 'Procfile');
+    const procfileContent = await fs.promises.readFile(procfilePath, 'utf-8');
+    const gunicorn = await parseProcfileWebGunicorn(workPath, procfileContent);
+    if (gunicorn) return gunicorn;
+    const uvicorn = parseProcfileWebUvicorn(procfileContent);
+    if (uvicorn) return uvicorn;
+    const uwsgiIni = await parseProcfileWebUwsgiIni(workPath, procfileContent);
+    if (uwsgiIni) return uwsgiIni;
+  } catch {
+    debug('Procfile not found or unreadable, skipping Procfile web entrypoint');
+  }
+  return null;
+}
+
+const PY_ID = '[A-Za-z_][A-Za-z0-9_]*';
+const APP_SPEC_PATTERN = `${PY_ID}(?:\\.${PY_ID})*(?::${PY_ID})?`;
+
+function moduleSpecToPath(appSpec: string): string {
+  const modulePath = appSpec.split(':')[0];
+  return `${modulePath.replace(/\./g, '/')}.py`;
+}
+
+/**
+ * Parse Procfile content for "web: gunicorn [OPTIONS] [APP_MODULE]".
+ *
+ * If APP_MODULE is provided, use it to determine the Python file path.
+ * Otherwise look for the app in the config file: -c / --config path, or default
+ * to gunicorn.conf.py. The config file may set wsgi_app = "module:attr".
+ */
+async function parseProcfileWebGunicorn(
+  workPath: string,
+  procfileContent: string
+): Promise<string | null> {
+  const webGunicornMatch = procfileContent.match(/web:\s*gunicorn\s*(.*)/);
+  if (!webGunicornMatch) return null;
+  const args = webGunicornMatch[1].trim().split(/\s+/);
+  const appSpecRe = new RegExp(`^${APP_SPEC_PATTERN}$`);
+  const lastIsOptionArg =
+    args.length >= 2 && GUNICORN_OPTIONS_WITH_ARG.has(args[args.length - 2]);
+  if (
+    args.length > 0 &&
+    !lastIsOptionArg &&
+    appSpecRe.test(args[args.length - 1])
+  ) {
+    const wsgiApp = args[args.length - 1];
+    debug(`Gunicorn app as command line argument: ${wsgiApp}`);
+    return moduleSpecToPath(wsgiApp);
+  }
+
+  const configPath = getGunicornConfigPath(args);
+  const configFullPath = join(workPath, configPath);
+  try {
+    const configContent = await fs.promises.readFile(configFullPath, 'utf-8');
+    const wsgiApp = await getStringConstant(configContent, 'wsgi_app');
+    debug(`Gunicorn app from config file: ${wsgiApp}`);
+    return wsgiApp ? moduleSpecToPath(wsgiApp) : null;
+  } catch {
+    debug(`Gunicorn config not found or unreadable: ${configFullPath}`);
+    return null;
+  }
+}
+
+/** Gunicorn CLI flags that take an argument (per docs.gunicorn.org/reference/settings) */
+const GUNICORN_OPTIONS_WITH_ARG = new Set([
+  '-c',
+  '--config',
+  '--control-socket',
+  '--control-socket-mode',
+  '--reload-engine',
+  '--reload-extra-file',
+  '--dirty-app',
+  '--dirty-workers',
+  '--dirty-timeout',
+  '--dirty-threads',
+  '--dirty-graceful-timeout',
+  '--http-protocols',
+  '--http2-max-concurrent-streams',
+  '--http2-initial-window-size',
+  '--http2-max-frame-size',
+  '--http2-max-header-list-size',
+  '--access-logfile',
+  '--access-logformat',
+  '--error-logfile',
+  '--log-file',
+  '--log-level',
+  '--logger-class',
+  '--log-config',
+  '--log-config-json',
+  '--log-syslog-to',
+  '--log-syslog-prefix',
+  '--log-syslog-facility',
+  '--statsd-host',
+  '--dogstatsd-tags',
+  '--statsd-prefix',
+  '-n',
+  '--name',
+  '--keyfile',
+  '--certfile',
+  '--ca-certs',
+  '--limit-request-line',
+  '--limit-request-fields',
+  '--limit-request-field_size',
+  '--chdir',
+  '-e',
+  '--env',
+  '-p',
+  '--pid',
+  '--worker-tmp-dir',
+  '-u',
+  '--user',
+  '-g',
+  '--group',
+  '-m',
+  '--umask',
+  '--forwarded-allow-ips',
+  '--pythonpath',
+  '--paste',
+  '--paster',
+  '--proxy-protocol',
+  '--protocol',
+  '--paste-global',
+  '--root-path',
+  '-b',
+  '--bind',
+  '--backlog',
+  '-w',
+  '--workers',
+  '-k',
+  '--worker-class',
+  '--threads',
+  '--worker-connections',
+  '--max-requests',
+  '--max-requests-jitter',
+  '-t',
+  '--timeout',
+  '--graceful-timeout',
+  '--keep-alive',
+  '--asgi-loop',
+  '--asgi-lifespan',
+  '--asgi-disconnect-grace-period',
+]);
+
+/** Extract config path from gunicorn args (-c / --config / --config=). */
+function getGunicornConfigPath(args: string[]): string {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '-c' || args[i] === '--config')
+      return args[i + 1] ?? 'gunicorn.conf.py';
+    if (args[i].startsWith('--config=')) return args[i].slice(9);
+  }
+  return 'gunicorn.conf.py';
+}
+
+/**
+ * Parse Procfile content for "web: uvicorn <module>" or "web: uvicorn <module>:<attr>".
+ * Returns the corresponding .py path or null.
+ */
+function parseProcfileWebUvicorn(procfileContent: string): string | null {
+  const match = procfileContent.match(
+    new RegExp(`web:\\s*uvicorn\\s+(${APP_SPEC_PATTERN})`)
+  );
+  return match ? moduleSpecToPath(match[1]) : null;
+}
+
+/**
+ * Parse Procfile content for "web: uwsgi <settings>.ini", then read the INI
+ * and extract "module = <appModule>" or "module = <appModule>:<attr>".
+ * Returns the corresponding .py path or null.
+ */
+async function parseProcfileWebUwsgiIni(
+  workPath: string,
+  procfileContent: string
+): Promise<string | null> {
+  const uwsgiMatch = procfileContent.match(/web:\s*uwsgi\s+(\S+\.ini)/);
+  if (!uwsgiMatch) return null;
+  const iniPath = join(workPath, uwsgiMatch[1]);
+  try {
+    const iniContent = await fs.promises.readFile(iniPath, 'utf-8');
+    const match = iniContent.match(
+      new RegExp(`^\\s*module\\s*=\\s*(${APP_SPEC_PATTERN})\\s*$`, 'm')
+    );
+    return match ? moduleSpecToPath(match[1]) : null;
+  } catch {
+    debug(`uWSGI config not found or unreadable: ${iniPath}`);
+    return null;
+  }
+}

--- a/packages/build-utils/test/unit.python.test.ts
+++ b/packages/build-utils/test/unit.python.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import { tmpdir } from 'os';
+import { getProcfileWebEntrypoint } from '../src';
+
+describe('Procfile web entrypoint discovery', () => {
+  async function writeFiles(
+    workPath: string,
+    files: Record<string, string>
+  ): Promise<void> {
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(workPath, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+  }
+
+  it('resolves Procfile entrypoint (web: gunicorn module:attr)', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: gunicorn myapp.wsgi:application',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('myapp/wsgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Procfile entrypoint (web: gunicorn module only)', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-module-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: gunicorn project.wsgi',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('project/wsgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Procfile entrypoint (web: gunicorn -c myconf.py myapp.wsgi)', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-gunicorn-config-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: gunicorn -c myconf.py myapp.wsgi',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('myapp/wsgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Procfile entrypoint (web: gunicorn -c config, wsgi_app in config)', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-gunicorn-wsgi-app-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: gunicorn -c gunicorn.conf.py',
+      'gunicorn.conf.py': 'wsgi_app = "myproject.wsgi:application"',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('myproject/wsgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Procfile entrypoint (web: gunicorn, default config gunicorn.conf.py with wsgi_app)', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-gunicorn-default-config-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: gunicorn',
+      'gunicorn.conf.py': 'wsgi_app = "myproject.wsgi:application"',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('myproject/wsgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Procfile entrypoint (web: gunicorn -c config with app on command line; command line takes precedence)', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-gunicorn-cmdline-precedence-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: gunicorn -c gunicorn.conf.py myapp.wsgi',
+      'gunicorn.conf.py': 'wsgi_app = "other.wsgi:application"',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('myapp/wsgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Procfile entrypoint (web: uvicorn module:attr)', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-uvicorn-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: uvicorn myproject.asgi:application',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('myproject/asgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Procfile entrypoint (web: uvicorn module only)', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-uvicorn-module-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: uvicorn app.asgi',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('app/asgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Procfile entrypoint (web: uwsgi .ini)', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-uwsgi-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: uwsgi uwsgi.ini',
+      'uwsgi.ini': '[uwsgi]\nmodule = myproject.wsgi:application\n',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('myproject/wsgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('returns path from Procfile even when file does not exist on disk', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-skip-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'web: gunicorn nonexistent.wsgi:application',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBe('nonexistent/wsgi.py');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('returns null when Procfile has no web process line', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-django-procfile-no-web-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+
+    await writeFiles(workPath, {
+      Procfile: 'worker: python worker.py\nrelease: python migrate.py',
+    });
+
+    const result = await getProcfileWebEntrypoint(workPath);
+    expect(result).toBeNull();
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+});

--- a/packages/build-utils/test/unit.python.test.ts
+++ b/packages/build-utils/test/unit.python.test.ts
@@ -28,7 +28,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('myapp/wsgi.py');
+    expect(result).toEqual(['myapp/wsgi.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -45,7 +45,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('project/wsgi.py');
+    expect(result).toEqual(['project/wsgi.py', null]);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -62,7 +62,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('myapp/wsgi.py');
+    expect(result).toEqual(['myapp/wsgi.py', null]);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -80,7 +80,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('myproject/wsgi.py');
+    expect(result).toEqual(['myproject/wsgi.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -98,7 +98,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('myproject/wsgi.py');
+    expect(result).toEqual(['myproject/wsgi.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -116,7 +116,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('myapp/wsgi.py');
+    expect(result).toEqual(['myapp/wsgi.py', null]);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -133,7 +133,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('myproject/asgi.py');
+    expect(result).toEqual(['myproject/asgi.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -150,7 +150,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('app/asgi.py');
+    expect(result).toEqual(['app/asgi.py', null]);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -168,7 +168,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('myproject/wsgi.py');
+    expect(result).toEqual(['myproject/wsgi.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -185,7 +185,7 @@ describe('Procfile web entrypoint discovery', () => {
     });
 
     const result = await getProcfileWebEntrypoint(workPath);
-    expect(result).toBe('nonexistent/wsgi.py');
+    expect(result).toEqual(['nonexistent/wsgi.py', 'application']);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -13,6 +13,7 @@ import {
   scanParentDirs,
   getEnvForPackageManager,
   isPythonFramework,
+  getProcfileWebEntrypoint,
   type BuildOptions,
   type GlobOptions,
   type BuildV3,
@@ -197,6 +198,19 @@ export const build: BuildV3 = async ({
       entrypoint = detectedModule;
       entrypointVariable = detectedEntryVar;
     } else {
+      const procfileEntry = await getProcfileWebEntrypoint(workPath);
+      if (procfileEntry) {
+        const [procfilePath, procfileVar] = procfileEntry;
+        const suggestedSrc = procfileVar
+          ? `${procfilePath}:${procfileVar}`
+          : procfilePath;
+        throw new NowBuildError({
+          code: `${framework.toUpperCase()}_ENTRYPOINT_NOT_FOUND`,
+          message: `No ${framework} entrypoint found. A Procfile was detected at "${suggestedSrc}". Set the entrypoint explicitly in vercel.json: { "builds": [{ "src": "${suggestedSrc}", "use": "@vercel/python" }] }`,
+          link: `https://vercel.com/docs/frameworks/backend/${framework}#exporting-the-${framework}-application`,
+          action: 'Learn More',
+        });
+      }
       const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
       throw new NowBuildError({
         code: `${framework.toUpperCase()}_ENTRYPOINT_NOT_FOUND`,

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1314,6 +1314,62 @@ describe('Django entrypoint discovery', () => {
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
+
+  it('build() throws a Procfile hint error when no entrypoint is found but Procfile is present', async () => {
+    const mockWorkPath = path.join(
+      tmpdir(),
+      `python-django-procfile-hint-${Date.now()}`
+    );
+    fs.mkdirSync(mockWorkPath, { recursive: true });
+    makeMockPython('3.9');
+
+    const files = {
+      Procfile: new FileBlob({ data: 'web: uvicorn myapp.asgi:app' }),
+    } as Record<string, FileBlob>;
+
+    await expect(
+      build({
+        workPath: mockWorkPath,
+        files,
+        entrypoint: 'main.py',
+        meta: { isDev: true },
+        config: { framework: 'django' },
+        repoRootPath: mockWorkPath,
+      })
+    ).rejects.toThrow(/Procfile.*myapp\/asgi\.py:app.*Set the entrypoint/i);
+
+    if (fs.existsSync(mockWorkPath)) {
+      fs.removeSync(mockWorkPath);
+    }
+  });
+
+  it('build() suggests file path without variable when Procfile has no explicit attr', async () => {
+    const mockWorkPath = path.join(
+      tmpdir(),
+      `python-django-procfile-hint-no-var-${Date.now()}`
+    );
+    fs.mkdirSync(mockWorkPath, { recursive: true });
+    makeMockPython('3.9');
+
+    const files = {
+      Procfile: new FileBlob({ data: 'web: gunicorn myapp.wsgi' }),
+    } as Record<string, FileBlob>;
+
+    await expect(
+      build({
+        workPath: mockWorkPath,
+        files,
+        entrypoint: 'main.py',
+        meta: { isDev: true },
+        config: { framework: 'django' },
+        repoRootPath: mockWorkPath,
+      })
+    ).rejects.toThrow(/Procfile.*"myapp\/wsgi\.py".*Set the entrypoint/i);
+
+    if (fs.existsSync(mockWorkPath)) {
+      fs.removeSync(mockWorkPath);
+    }
+  });
 });
 
 describe('getPyprojectEntrypoint - pyproject.toml [project.scripts] discovery', () => {


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds new Procfile parsing functionality to detect Python entrypoints and provide helpful error messages, with no changes to authentication, authorization, database schemas, or security controls.
> 
> - Adds Procfile parsing for gunicorn/uvicorn/uwsgi web entrypoint detection
> - Throws descriptive error with Procfile hint when no entrypoint found
> - Adds comprehensive unit tests for Procfile parsing scenarios
>
> <sup>Risk assessment for [commit 6a9b575](https://github.com/vercel/vercel/commit/6a9b575b331eeb87bc9b7c2bbbd6f22a4ca98183).</sup>
<!-- VADE_RISK_END -->