### PR TITLE
chore(ci): add biome to ci as not required

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -52,6 +52,10 @@ jobs:
       - run: pnpm install
       - run: pnpm run lint
       - run: pnpm run prettier-check
+      # Non-blocking while we fix existing violations (~244 remaining).
+      # Remove `|| true` once clean to make this a required check.
+      - name: Biome check (informational)
+        run: pnpm run biome:check || true
       - name: Check dependency versions
         run: pnpm exec syncpack lint
       - run: pnpm run build

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -40,6 +40,9 @@
     "rules": {
       "recommended": true,
 
+      // Disable all a11y rules — not enforced by ESLint
+      "a11y": "off",
+
       "correctness": {
         // Matches @typescript-eslint/no-unused-vars: 2
         "noUnusedVariables": "error",
@@ -49,6 +52,24 @@
         "noUnusedFunctionParameters": "off",
         // Not enforced by ESLint
         "noInnerDeclarations": "off",
+        // Not enforced by ESLint
+        "noInvalidUseBeforeDeclaration": "off",
+        // Not enforced by ESLint
+        "noSwitchDeclarations": "off",
+        // Not enforced by ESLint
+        "useValidTypeof": "off",
+        // Not enforced by ESLint
+        "useParseIntRadix": "off",
+        // Not enforced by ESLint
+        "noVoidTypeReturn": "off",
+        // Not enforced by ESLint
+        "noConstantCondition": "off",
+        // Not enforced by ESLint
+        "noUnreachable": "off",
+        // Not enforced by ESLint — CSS rule
+        "noUnknownMediaFeatureName": "off",
+        // Not enforced by ESLint — CSS rule
+        "noInvalidDirectionInLinearGradient": "off",
       },
 
       "suspicious": {
@@ -76,6 +97,34 @@
         "noPrototypeBuiltins": "off",
         // Not enforced by ESLint
         "noRedeclare": "off",
+        // Not enforced by ESLint
+        "useIterableCallbackReturn": "off",
+        // Not enforced by ESLint
+        "noRedundantUseStrict": "off",
+        // Not enforced by ESLint
+        "noShadowRestrictedNames": "off",
+        // Not enforced by ESLint
+        "noControlCharactersInRegex": "off",
+        // Not enforced by ESLint
+        "noThenProperty": "off",
+        // Not enforced by ESLint
+        "noTemplateCurlyInString": "off",
+        // Not enforced by ESLint
+        "noUselessEscapeInString": "off",
+        // Not enforced by ESLint
+        "noShorthandPropertyOverrides": "off",
+        // Not enforced by ESLint
+        "noConstEnum": "off",
+        // Not enforced by ESLint
+        "noArrayIndexKey": "off",
+        // Not enforced by ESLint
+        "useAdjacentOverloadSignatures": "off",
+        // Not enforced by ESLint
+        "noDuplicateParameters": "off",
+        // Not enforced by ESLint
+        "noDuplicateFontNames": "off",
+        // Not enforced by ESLint
+        "noNonNullAssertedOptionalChain": "off",
       },
 
       "style": {
@@ -89,6 +138,10 @@
         "useTemplate": "off",
         // Not enforced by ESLint
         "useImportType": "off",
+        // Not enforced by ESLint
+        "useShorthandFunctionType": "off",
+        // Not enforced by ESLint
+        "useExportType": "off",
       },
 
       "complexity": {
@@ -106,7 +159,39 @@
         "noArguments": "off",
         // Not enforced by ESLint
         "noUselessUndefinedInitialization": "off",
+        // Not enforced by ESLint
+        "noUselessEscapeInRegex": "off",
+        // Not enforced by ESLint
+        "useRegexLiterals": "off",
+        // Not enforced by ESLint
+        "noUselessContinue": "off",
+        // Not enforced by ESLint
+        "noImportantStyles": "off",
+        // Not enforced by ESLint
+        "noUselessLoneBlockStatements": "off",
+        // Not enforced by ESLint
+        "noUselessFragments": "off",
+        // Not enforced by ESLint
+        "noUselessSwitchCase": "off",
+        // Not enforced by ESLint
+        "noUselessCatch": "off",
+        // Not enforced by ESLint
+        "useFlatMap": "off",
+        // Not enforced by ESLint
+        "useDateNow": "off",
+        // Not enforced by ESLint
+        "noUselessTernary": "off",
+        // Not enforced by ESLint
+        "noUselessRename": "off",
+        // Not enforced by ESLint
+        "noUselessConstructor": "off",
       },
+
+      // Not enforced by ESLint
+      "performance": "off",
+
+      // Not enforced by ESLint
+      "security": "off",
     },
   },
   "overrides": [

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -7,15 +7,23 @@
     "useIgnoreFile": true,
   },
   "files": {
-    // Allowlist of directories to process (avoids examples/ which has its own biome.json)
+    // Allowlist source directories, exclude examples/ (has its own biome.json)
+    // and test fixtures (contain intentionally broken files that cause parse errors).
     "includes": [
-      "api/**",
-      "internals/**",
-      "packages/**",
-      "test/**",
-      "utils/**",
+      "api/**/*.{js,ts,mjs,cjs,jsx,tsx,json,css}",
+      "internals/**/*.{js,ts,mjs,cjs,jsx,tsx,json,css}",
+      "packages/**/*.{js,ts,mjs,cjs,jsx,tsx,json,css}",
+      "!packages/**/test/fixtures/**",
+      "!packages/**/test/fixtures-*/**",
+      "!packages/**/test/dev/fixtures/**",
+      "!packages/**/test/build-fixtures/**",
+      "!packages/**/test/cache-fixtures/**",
+      "!packages/cli/types/**",
+      "test/**/*.{js,ts,mjs,cjs,jsx,tsx,json,css}",
+      "utils/**/*.{js,ts,mjs,cjs,jsx,tsx,json,css}",
       "*.js",
       "*.ts",
+      "*.mjs",
     ],
   },
   // Formatter settings match the existing Prettier configuration
@@ -33,6 +41,14 @@
       "trailingCommas": "es5",
       // Matches Prettier: arrowParens: "avoid"
       "arrowParentheses": "asNeeded",
+    },
+  },
+  // Disable import sorting — not enforced by ESLint
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "off",
+      },
     },
   },
   "linter": {


### PR DESCRIPTION
Start running biome in CI (not required to pass), and also update rules so we can start off passing, and then burn down after merge

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a non-blocking Biome linter check to CI and updates Biome configuration rules, which are purely CI/tooling changes with no impact on application code or security.
> 
> - Adds informational Biome check to CI workflow with `|| true` to prevent blocking
> - Updates biome.jsonc to exclude test fixtures and disable rules not enforced by ESLint
> - Configuration-only changes to linter tooling
>
> <sup>Risk assessment for [commit 83916fa](https://github.com/vercel/vercel/commit/83916fae4d9286e08b181107953eafcc445e2ff3).</sup>
<!-- VADE_RISK_END -->