### PR TITLE
[python] Allow specifying filepath:variable in vercel.json builds src.

### DIFF
--- a/.changeset/two-dingos-change.md
+++ b/.changeset/two-dingos-change.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Allow specifying filepath:variable in vercel.json builds src.

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -84,6 +84,15 @@ export const build: BuildV3 = async ({
 }) => {
   const framework = config?.framework;
 
+  // Parse "filepath:variable" syntax in entrypoint (from vercel.json builds src).
+  // e.g. "myapp/wsgi.py:application" -> entrypoint="myapp/wsgi.py", entrypointVariable="application"
+  let entrypointVariable: string | null = null;
+  const colonIdx = entrypoint.indexOf(':');
+  if (colonIdx !== -1) {
+    entrypointVariable = entrypoint.slice(colonIdx + 1) || null;
+    entrypoint = entrypoint.slice(0, colonIdx);
+  }
+
   let spawnEnv: NodeJS.ProcessEnv | undefined;
   // Custom install command from dashboard/project settings, if any.
   let projectInstallCommand: string | undefined;
@@ -169,8 +178,6 @@ export const build: BuildV3 = async ({
   }
 
   let fsFiles = await glob('**', workPath);
-
-  let entrypointVariable: string | null = null;
 
   // Zero config entrypoint discovery
   if (

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1502,6 +1502,69 @@ describe('pyproject.toml entrypoint detection', () => {
   });
 });
 
+describe('filepath:variable syntax in vercel.json builds src', () => {
+  let workPath: string;
+
+  beforeEach(() => {
+    workPath = path.join(tmpdir(), `python-colon-syntax-${Date.now()}`);
+    fs.mkdirSync(workPath, { recursive: true });
+    makeMockPython('3.9');
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('sets __VC_HANDLER_VARIABLE_NAME from "filepath:variable" in entrypoint', async () => {
+    const files = {
+      'myapp/wsgi.py': new FileBlob({
+        data: 'application = lambda env, start: None\n',
+      }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath,
+      files,
+      entrypoint: 'myapp/wsgi.py:application',
+      meta: { isDev: false },
+      config: {},
+      repoRootPath: workPath,
+    });
+
+    const handler = result.output.files?.['vc__handler__python.py'];
+    if (!handler || !('data' in handler)) {
+      throw new Error('handler bootstrap not found');
+    }
+    const content = handler.data.toString();
+    expect(content).toContain('"__VC_HANDLER_VARIABLE_NAME": "application"');
+    expect(content).toContain('os.path.join(_here, "myapp/wsgi.py")');
+  });
+
+  it('leaves __VC_HANDLER_VARIABLE_NAME empty when no variable is specified', async () => {
+    const files = {
+      'myapp/wsgi.py': new FileBlob({
+        data: 'application = lambda env, start: None\n',
+      }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath,
+      files,
+      entrypoint: 'myapp/wsgi.py',
+      meta: { isDev: false },
+      config: {},
+      repoRootPath: workPath,
+    });
+
+    const handler = result.output.files?.['vc__handler__python.py'];
+    if (!handler || !('data' in handler)) {
+      throw new Error('handler bootstrap not found');
+    }
+    const content = handler.data.toString();
+    expect(content).toContain('"__VC_HANDLER_VARIABLE_NAME": ""');
+  });
+});
+
 describe('python version fallback logging', () => {
   let mockWorkPath: string;
   let consoleLogSpy: MockInstance;


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds support for parsing "filepath:variable" syntax in Python build entrypoints, with corresponding unit tests - a straightforward feature addition with no security, auth, or schema changes.
> 
> - New parsing logic for colon-separated entrypoint syntax in build function
> - Unit tests added for filepath:variable parsing behavior
> - Changeset file for minor version bump
>
> <sup>Risk assessment for [commit 20f5474](https://github.com/vercel/vercel/commit/20f5474cd611aca4e6899a51f4a900d2ab47a8fb).</sup>
<!-- VADE_RISK_END -->