### PR TITLE
feat: CLI evals setup/destroy hooks and auto-provision as default

### DIFF
--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -35,7 +35,7 @@ export const inspectSubcommand = {
       required: false,
     },
   ],
-  options: [yesOption],
+  options: [jsonOption],
   examples: [
     {
       name: 'Inspect the linked project from the current directory',

--- a/packages/cli/src/commands/project/inspect.ts
+++ b/packages/cli/src/commands/project/inspect.ts
@@ -7,11 +7,14 @@ import { inspectSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
 import { formatProject } from '../../util/projects/format-project';
 import stamp from '../../util/output/stamp';
 import getTeamById from '../../util/teams/get-team-by-id';
 import formatDate from '../../util/format-date';
+import { validateJsonOutput } from '../../util/output-format';
+import { getLinkedProject } from '../../util/projects/link';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
 import type Client from '../../util/client';
 
 export default async function inspect(
@@ -32,11 +35,11 @@ export default async function inspect(
     printError(error);
     return 1;
   }
-  const { args } = parsedArgs;
+  const { args, flags } = parsedArgs;
 
   const name = args[0];
   telemetry.trackCliArgumentName(name);
-  telemetry.trackCliFlagYes(parsedArgs.flags['--yes']);
+  telemetry.trackCliFlagJson(flags['--json']);
 
   if (args.length !== 0 && args.length !== 1) {
     output.error(
@@ -47,15 +50,63 @@ export default async function inspect(
     return 2;
   }
 
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const jsonOutput = formatResult.jsonOutput;
+
   const inspectStamp = stamp();
-  const project = await getProjectByCwdOrLink({
-    autoConfirm: parsedArgs.flags['--yes'],
-    client,
-    commandName: 'project inspect',
-    projectNameOrId: name,
-  });
+
+  let project;
+  if (name) {
+    const result = await getProjectByNameOrId(client, name);
+    if (result instanceof ProjectNotFound) {
+      output.error(`Project not found: ${name}`);
+      return 1;
+    }
+    project = result;
+  } else {
+    const link = await getLinkedProject(client, client.cwd);
+    if (link.status === 'not_linked') {
+      output.error(
+        `No project found in the current directory. Run ${chalk.cyan(getCommandName('link'))} to link a project, or provide a project name.`
+      );
+      return 1;
+    }
+    if (link.status === 'error') {
+      return link.exitCode;
+    }
+    project = link.project;
+  }
 
   const org = await getTeamById(client, project.accountId);
+
+  if (jsonOutput) {
+    const framework = frameworkList.find(f => f.slug === project.framework);
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          id: project.id,
+          name: project.name,
+          owner: org.name,
+          ownerSlug: org.slug,
+          createdAt: project.createdAt,
+          rootDirectory: project.rootDirectory ?? '.',
+          nodeVersion: project.nodeVersion,
+          framework: framework?.name ?? null,
+          buildCommand: project.buildCommand ?? null,
+          outputDirectory: project.outputDirectory ?? null,
+          installCommand: project.installCommand ?? null,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
   const projectSlugLink = formatProject(org.slug, project.name);
 
   output.log(`Found Project ${projectSlugLink} ${chalk.gray(inspectStamp())}`);

--- a/packages/cli/src/util/telemetry/commands/project/inspect.ts
+++ b/packages/cli/src/util/telemetry/commands/project/inspect.ts
@@ -15,9 +15,9 @@ export class ProjectInspectTelemetryClient
     }
   }
 
-  trackCliFlagYes(yes: boolean | undefined) {
-    if (yes) {
-      this.trackCliFlag('yes');
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
     }
   }
 }

--- a/packages/cli/test/unit/commands/project/inspect.test.ts
+++ b/packages/cli/test/unit/commands/project/inspect.test.ts
@@ -135,4 +135,41 @@ describe('inspect', () => {
     line = await lines.next();
     expect(line.value).toEqual('');
   });
+
+  it('should output JSON when --json flag is provided', async () => {
+    useUser();
+    const teams = useTeams('team_dummy');
+    assert(Array.isArray(teams));
+    const [team] = teams;
+    const { project } = useProject({
+      ...defaultProject,
+      name: 'test_project',
+      accountId: team.id,
+      rootDirectory: 'src',
+      nodeVersion: '20.x',
+      framework: 'nextjs',
+      buildCommand: 'npm run build',
+      installCommand: 'npm install',
+    });
+
+    client.setArgv('project', 'inspect', project.name!, '--json');
+    const exitCode = await projects(client);
+
+    expect(exitCode).toEqual(0);
+    await expect(client.stdout).toOutput('"id"');
+    await expect(client.stdout).toOutput('"name"');
+    await expect(client.stdout).toOutput('"owner"');
+    await expect(client.stdout).toOutput('"framework"');
+  });
+
+  it('should error when project name is not found', async () => {
+    useUser();
+    useTeams('team_dummy');
+
+    client.setArgv('project', 'inspect', 'nonexistent-project');
+    const exitCode = await projects(client);
+
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Project not found');
+  });
 });


### PR DESCRIPTION
## Changes

### CLI Evals Improvements
- **Setup/Destroy Hooks**: Added `setup()` and `destroy()` functions in `hooks.ts` to manage project lifecycle during eval runs
- **Project Mode Variants**: Implemented `getProjectModeVariantsFromEnv()` to support matrix testing with different project configurations (auto, linked-project, no-linked-project)
- **Ephemeral Projects**: When `CLI_EVAL_PROJECT_ID` is not set, evals now automatically create and clean up ephemeral projects
- **Enhanced Auth Setup**: Improved `setupAuthAndConfig()` to write auth to both `~/.local/share/com.vercel.cli/` and `~/.vercel/` directories
- **Result Upload**: Added `transform-agent-eval-to-canonical.js` script to upload eval results to centralized evals app
- **CI Improvements**: Increased timeout to 45 minutes, added memory limit for Node, and set proper fetch depth for release workflow

### Auto-Provision as Default
- Changed `FF_AUTO_PROVISION_INSTALL` from opt-in (`=1`) to opt-out (`!=0`)
- Applied to both `vercel install` and `vercel integration add` commands
- Flag now acts as a kill-switch (set `=0` to revert to legacy flow)

### Project Inspect Command
- Added `--json` flag support for structured output
- Removed `--yes` flag (no longer prompts for project creation)
- Returns project metadata: id, name, owner, framework, build settings, etc.
- Non-interactive when project name is provided or project is linked

### Testing
- Added comprehensive test suite for setup/destroy hooks in `hooks.test.ts`
- Updated integration tests to explicitly set `FF_AUTO_PROVISION_INSTALL=1` where needed
- Added test coverage for project inspect with `--json` flag

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a --json flag to the project inspect command, replacing the --yes flag, with no security-sensitive changes visible in the diff.
> 
> - CLI: replaced --yes flag with --json flag for project inspect command
> - Added JSON output format support with structured project metadata
> - Added unit tests for --json flag and error handling
>
> <sup>Risk assessment for [commit 702c5bb](https://github.com/vercel/vercel/commit/702c5bbb71195df63c45896a5932d17bb9646583).</sup>
<!-- VADE_RISK_END -->