### PR TITLE
feat(cli): integration add improvements

### DIFF
--- a/.changeset/bright-phones-hide.md
+++ b/.changeset/bright-phones-hide.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Suggest `vercel integration guide` after successful provisioning, use deeplink format for dashboard URL, and mention `integration discover` in `integration guide` help

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -406,6 +406,8 @@ export async function addAutoProvision(
     contextName,
     {
       ...options,
+      integrationSlug: integration.slug,
+      installationId: provisioned.installation.id,
       onProjectConnected: (projectId: string) => {
         telemetry.trackMarketplaceEvent('marketplace_project_connected', {
           ...baseProps,

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -4,6 +4,7 @@ import open from 'open';
 import output from '../../output-manager';
 import type Client from '../../util/client';
 import getScope from '../../util/get-scope';
+import indent from '../../util/output/indent';
 import { autoProvisionResource } from '../../util/integration/auto-provision-resource';
 import { fetchIntegrationWithTelemetry } from '../../util/integration/fetch-integration';
 import { fetchInstallations } from '../../util/integration/fetch-installations';
@@ -385,6 +386,18 @@ export async function addAutoProvision(
     `${product.name} successfully provisioned: ${chalk.bold(resourceName)}`
   );
 
+  const guideSlug =
+    integration.products.length > 1
+      ? `${integration.slug}/${product.slug}`
+      : integration.slug;
+  const guideCommand = `vercel integration guide ${guideSlug}`;
+  output.log(
+    indent(
+      `Guide: Run ${chalk.cyan(`\`${guideCommand}\``)} for getting started guides and code snippets`,
+      4
+    )
+  );
+
   // Post-provision: dashboard URL, connect, env pull
   const setupResult = await postProvisionSetup(
     client,
@@ -461,6 +474,7 @@ export async function addAutoProvision(
       project: setupResult.project ?? null,
       environments: setupResult.environments,
       envPulled: setupResult.envPulled,
+      guideCommand,
       warnings,
     };
 

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -526,6 +526,7 @@ async function provisionResourceViaCLI(
       metadata,
       billingPlan,
       authorizationId,
+      integration.slug,
       contextName,
       options
     );
@@ -723,6 +724,7 @@ async function provisionStorageProduct(
   metadata: Metadata,
   billingPlan: BillingPlan,
   authorizationId: string,
+  integrationSlug: string,
   contextName: string,
   options: AddOptions = {}
 ) {
@@ -751,12 +753,10 @@ async function provisionStorageProduct(
     `${product.name} successfully provisioned: ${chalk.bold(name)}`
   );
 
-  const result = await postProvisionSetup(
-    client,
-    name,
-    storeId,
-    contextName,
-    options
-  );
+  const result = await postProvisionSetup(client, name, storeId, contextName, {
+    ...options,
+    integrationSlug,
+    installationId: installation.id,
+  });
   return result.exitCode;
 }

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -386,6 +386,10 @@ export const guideSubcommand = {
       name: 'Show the Next.js guide without prompts (useful for CI/agents)',
       value: `${packageName} integration guide neon --framework nextjs`,
     },
+    {
+      name: 'Discover available integrations and product slugs',
+      value: `${packageName} integration discover`,
+    },
   ],
 } as const;
 

--- a/packages/cli/src/util/integration/post-provision-setup.ts
+++ b/packages/cli/src/util/integration/post-provision-setup.ts
@@ -22,6 +22,8 @@ export interface PostProvisionOptions {
   onProjectConnected?: (projectId: string) => void;
   onProjectConnectFailed?: (projectId: string, error: Error) => void;
   prefix?: string;
+  integrationSlug?: string;
+  installationId?: string;
 }
 
 /**
@@ -65,9 +67,15 @@ export async function postProvisionSetup(
   contextName: string,
   options: PostProvisionOptions = {}
 ): Promise<PostProvisionSetupResult> {
-  const dashboardUrl = `https://vercel.com/${contextName}/~/stores/integration/${resourceId}`;
+  const dashboardUrl =
+    options.integrationSlug && options.installationId
+      ? `https://vercel.com/d/dashboard/integrations/${options.integrationSlug}/${options.installationId}/resources/${resourceId}`
+      : `https://vercel.com/${contextName}/~/stores/integration/${resourceId}`;
   output.log(
-    indent(`Dashboard: ${output.link(dashboardUrl, dashboardUrl)}`, 4)
+    indent(
+      `Dashboard: ${output.link(dashboardUrl, dashboardUrl, { fallback: false })}`,
+      4
+    )
   );
 
   const baseResult: PostProvisionSetupResult = {

--- a/packages/cli/src/util/integration/post-provision-setup.ts
+++ b/packages/cli/src/util/integration/post-provision-setup.ts
@@ -23,6 +23,7 @@ export interface PostProvisionOptions {
   onProjectConnectFailed?: (projectId: string, error: Error) => void;
   prefix?: string;
   integrationSlug?: string;
+  /** Resolved installation ID used for the dashboard deeplink URL. Not the same as the CLI `--installation-id` flag. */
   installationId?: string;
 }
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2959,6 +2959,10 @@ exports[`help command > integration help output snapshots > integration guide su
 
     $ vercel integration guide neon --framework nextjs
 
+  - Discover available integrations and product slugs
+
+    $ vercel integration discover
+
 "
 `;
 

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -2300,7 +2300,7 @@ describe('integration add (auto-provision)', () => {
       expect(jsonOutput.installation).toEqual({ id: 'install_123' });
       expect(jsonOutput.billingPlan).toBeNull();
       expect(jsonOutput.dashboardUrl).toContain(
-        'stores/integration/resource_123'
+        '/d/dashboard/integrations/acme/install_123/resources/resource_123'
       );
       expect(jsonOutput.ssoUrl.integration).toContain(
         'integrationConfigurationId=install_123'


### PR DESCRIPTION
## Summary

- **Suggest `integration guide` after provisioning**: After a successful `vercel integration add`, show a hint to run `vercel integration guide <slug>` for getting started guides and code snippets. Included in both regular and `--format=json` output (as `guideCommand`).
- **Use deeplink format for dashboard URL**: Switch the post-provisioning dashboard URL from the old `~/stores/integration/{id}` path to the new deeplink format `/d/dashboard/integrations/{slug}/{installationId}/resources/{id}`. This is team-slug-independent and resolves via server redirect. Also fixes duplicate URL display in terminals that don't support hyperlinks.
- **Mention `integration discover` in `integration guide` help**: Add an example to the `integration guide` help output so users know they can run `vercel integration discover` to find available integration and product slugs.

## Linear Issues

- [MKT-2765: Update create resource links with new deep-linking path](https://linear.app/vercel/issue/MKT-2765/update-create-resource-links-with-new-deep-linking-path)
- [MKT-2846: Suggest guide command upon successful provisioning of resource](https://linear.app/vercel/issue/MKT-2846/suggest-guide-command-upon-successful-provisioning-of-resource)
- [MKT-2892: `vc integration guide --help`: can we show either a list of integrations/products or direct user to use `discover`?](https://linear.app/vercel/issue/MKT-2892/vc-integration-guide-help-can-we-show-either-a-list-of)

## Test plan

- [x] All 275 integration command tests pass
- [x] Help snapshot tests updated and passing
- [x] Manual test: `vercel integration add <slug>` shows guide suggestion and new deeplink dashboard URL
- [x] Manual test: `vercel integration add <slug> --format=json` includes `guideCommand` field
- [x] Manual test: `vercel integration guide --help` shows `vercel integration discover` example

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI UX improvements adding guide command suggestions, updating dashboard URL format to deeplinks, and adding help text examples - no security, auth, or data schema changes.
> 
> - Adds guide command suggestion after successful resource provisioning
> - Changes dashboard URL format from `/~/stores/integration/{id}` to deeplink `/d/dashboard/integrations/{slug}/{installationId}/resources/{id}`
> - Adds `integration discover` example to help output
>
> <sup>Risk assessment for [commit 62bbc87](https://github.com/vercel/vercel/commit/62bbc8762f7e8d38ab7f8d49ec7b240c6d206e34).</sup>
<!-- VADE_RISK_END -->