### PR TITLE
chore(fs-detectors): upgrade glob to ^10

### DIFF
--- a/.changeset/upgrade-glob-v10.md
+++ b/.changeset/upgrade-glob-v10.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Upgrade glob from v8 to v10 to resolve deprecation warnings

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -24,14 +24,13 @@
     "@vercel/error-utils": "workspace:*",
     "@vercel/frameworks": "workspace:*",
     "@vercel/routing-utils": "workspace:*",
-    "glob": "8.0.3",
+    "glob": "10.3.10",
     "js-yaml": "4.1.0",
     "json5": "2.2.2",
     "minimatch": "3.1.2",
     "semver": "6.3.1"
   },
   "devDependencies": {
-    "@types/glob": "7.2.0",
     "@types/jest": "27.5.1",
     "@types/js-yaml": "4.0.5",
     "@types/minimatch": "3.0.5",

--- a/packages/fs-detectors/src/workspaces/get-glob-fs.ts
+++ b/packages/fs-detectors/src/workspaces/get-glob-fs.ts
@@ -1,7 +1,5 @@
-import fs from 'fs';
+import type { Dirent, Stats } from 'fs';
 import { DetectorFilesystem } from '../detectors/filesystem';
-
-type GlobFs = typeof fs;
 
 function removeWindowsPrefix(path: string) {
   // on windows, this will return a path like
@@ -12,74 +10,91 @@ function removeWindowsPrefix(path: string) {
   return path.replace(/^[a-zA-Z]:/, '');
 }
 
+/**
+ * Subset of FSOption from path-scurry used by glob.
+ * Defined inline to avoid depending on path-scurry directly.
+ */
+interface GlobFs {
+  readdir: (
+    path: string,
+    options: { withFileTypes: true },
+    cb: (er: NodeJS.ErrnoException | null, entries?: Dirent[]) => void
+  ) => void;
+  lstatSync: (path: string) => Stats;
+  promises: {
+    lstat: (path: string) => Promise<Stats>;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+
+function makeStats(isPathAFile: boolean): Stats {
+  return {
+    ino: 0,
+    mode: 0,
+    nlink: 0,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    size: 0,
+    blksize: 0,
+    blocks: 0,
+    atimeMs: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    atime: new Date(),
+    mtime: new Date(),
+    ctime: new Date(),
+    birthtime: new Date(),
+    dev: 0,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isDirectory: () => !isPathAFile,
+    isFIFO: () => false,
+    isFile: () => isPathAFile,
+    isSocket: () => false,
+    isSymbolicLink: () => false,
+  };
+}
+
 export function getGlobFs(_fs: DetectorFilesystem): GlobFs {
-  const readdir = (
-    path: fs.PathLike,
-    callback: (err: NodeJS.ErrnoException | null, files: string[]) => void
-  ): void => {
-    _fs
-      .readdir(removeWindowsPrefix(String(path)))
-      .then(stats =>
-        callback(
-          null,
-          stats.map(stat => stat.name)
-        )
-      )
-      .catch(err => callback(err, []));
-  };
-
-  const stat = (
-    path: fs.PathLike,
-    callback: (
-      err: NodeJS.ErrnoException | null,
-      stats: fs.Stats | null
-    ) => void
-  ): void => {
-    _fs
-      .isFile(removeWindowsPrefix(String(path)))
-      .then(isPathAFile => {
-        callback(null, {
-          ino: 0,
-          mode: 0,
-          nlink: 0,
-          uid: 0,
-          gid: 0,
-          rdev: 0,
-          size: 0,
-          blksize: 0,
-          blocks: 0,
-          atimeMs: 0,
-          mtimeMs: 0,
-          ctimeMs: 0,
-          birthtimeMs: 0,
-          atime: new Date(),
-          mtime: new Date(),
-          ctime: new Date(),
-          birthtime: new Date(),
-          dev: 0,
-          isBlockDevice: () => false,
-          isCharacterDevice: () => false,
-          isDirectory: () => !isPathAFile,
-          isFIFO: () => false,
-          isFile: () => isPathAFile,
-          isSocket: () => false,
-          isSymbolicLink: () => false,
-        });
-      })
-      .catch(err => callback(err, null));
-  };
-
-  return new Proxy(fs, {
-    get(_target, prop) {
-      switch (prop) {
-        case 'readdir':
-          return readdir;
-        case 'lstat':
-        case 'stat':
-          return stat;
-        default:
-          throw new Error('Not Implemented');
-      }
+  return {
+    readdir(
+      path: string,
+      _options: { withFileTypes: true },
+      cb: (er: NodeJS.ErrnoException | null, entries?: Dirent[]) => void
+    ): void {
+      _fs
+        .readdir(removeWindowsPrefix(path))
+        .then(stats => {
+          const dirents = stats.map(stat => {
+            return {
+              name: stat.name,
+              isFile: () => stat.type === 'file',
+              isDirectory: () => stat.type === 'dir',
+              isBlockDevice: () => false,
+              isCharacterDevice: () => false,
+              isFIFO: () => false,
+              isSocket: () => false,
+              isSymbolicLink: () => false,
+              path: removeWindowsPrefix(stat.path),
+              parentPath: removeWindowsPrefix(stat.path),
+            } as Dirent;
+          });
+          cb(null, dirents);
+        })
+        .catch(err => cb(err));
     },
-  });
+    lstatSync(_path: string): Stats {
+      throw new Error('Not Implemented');
+    },
+    promises: {
+      lstat(path: string): Promise<Stats> {
+        return _fs
+          .isFile(removeWindowsPrefix(path))
+          .then(isPathAFile => makeStats(isPathAFile));
+      },
+    },
+  };
 }

--- a/packages/fs-detectors/src/workspaces/get-glob-fs.ts
+++ b/packages/fs-detectors/src/workspaces/get-glob-fs.ts
@@ -86,7 +86,7 @@ export function getGlobFs(_fs: DetectorFilesystem): GlobFs {
         })
         .catch(err => cb(err));
     },
-    lstatSync(_path: string): Stats {
+    lstatSync(): Stats {
       throw new Error('Not Implemented');
     },
     promises: {

--- a/packages/fs-detectors/src/workspaces/get-workspace-package-paths.ts
+++ b/packages/fs-detectors/src/workspaces/get-workspace-package-paths.ts
@@ -1,6 +1,6 @@
 import _path from 'path';
 import yaml from 'js-yaml';
-import glob from 'glob';
+import { glob } from 'glob';
 import json5 from 'json5';
 import { DetectorFilesystem } from '../detectors/filesystem';
 import { Workspace } from './get-workspaces';
@@ -79,21 +79,11 @@ async function getPackagePaths(
 ): Promise<string[]> {
   return (
     await Promise.all(
-      packages.map(
-        packageGlob =>
-          new Promise<string[]>((resolve, reject) => {
-            glob(
-              normalizePath(posixPath.join(packageGlob, 'package.json')),
-              {
-                cwd: '/',
-                fs: getGlobFs(fs),
-              },
-              (err, matches) => {
-                if (err) reject(err);
-                else resolve(matches);
-              }
-            );
-          })
+      packages.map(packageGlob =>
+        glob(normalizePath(posixPath.join(packageGlob, 'package.json')), {
+          cwd: '/',
+          fs: getGlobFs(fs),
+        })
       )
     )
   ).flat();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1320,8 +1320,8 @@ importers:
         specifier: workspace:*
         version: link:../routing-utils
       glob:
-        specifier: 8.0.3
-        version: 8.0.3
+        specifier: 10.3.10
+        version: 10.3.10
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
@@ -1335,9 +1335,6 @@ importers:
         specifier: 6.3.1
         version: 6.3.1
     devDependencies:
-      '@types/glob':
-        specifier: 7.2.0
-        version: 7.2.0
       '@types/jest':
         specifier: 27.5.1
         version: 27.5.1
@@ -6093,7 +6090,6 @@ packages:
       strip-ansi-cjs: /strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: true
 
   /@isaacs/cliui@9.0.0:
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
@@ -6938,7 +6934,6 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
     requiresBuild: true
-    dev: true
     optional: true
 
   /@pkgr/core@0.2.4:
@@ -11018,12 +11013,10 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /ansi-regex@6.1.0:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansi-sequence-parser@1.1.3:
     resolution: {integrity: sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==}
@@ -11046,7 +11039,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
@@ -11056,7 +11048,6 @@ packages:
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansis@3.17.0:
     resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
@@ -12172,7 +12163,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -12180,7 +12170,6 @@ packages:
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -12843,7 +12832,6 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
 
   /edge-runtime@2.5.9:
     resolution: {integrity: sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==}
@@ -12905,11 +12893,9 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
 
   /empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -14472,7 +14458,6 @@ packages:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-    dev: true
 
   /form-data@3.0.3:
     resolution: {integrity: sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==}
@@ -14583,6 +14568,7 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
 
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -14772,6 +14758,19 @@ packages:
       path-scurry: 1.11.1
     dev: true
 
+  /glob@10.3.10:
+    resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 2.3.6
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      path-scurry: 1.11.1
+    dev: false
+
   /glob@10.3.16:
     resolution: {integrity: sha512-JDKXl1DiuuHJ6fVS2FXjownaavciiHNUU4mOvV/B793RLh05vZL1rcPnCSaOgv1hDT6RDlY7AB7ZUvFYAtPgAw==}
     engines: {node: '>=16 || 14 >=14.18'}
@@ -14792,7 +14791,7 @@ packages:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.1
+      minimatch: 10.1.1
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
@@ -14829,6 +14828,7 @@ packages:
       inherits: 2.0.4
       minimatch: 5.0.1
       once: 1.4.0
+    dev: true
 
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -15278,6 +15278,7 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    dev: true
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -15502,7 +15503,6 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
@@ -15842,7 +15842,6 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-    dev: true
 
   /jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -16836,7 +16835,6 @@ packages:
 
   /lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-    dev: true
 
   /lru-cache@11.2.2:
     resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
@@ -17119,7 +17117,6 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -18005,7 +18002,6 @@ packages:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-    dev: true
 
   /path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
@@ -19383,7 +19379,6 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-    dev: true
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -19721,7 +19716,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: true
 
   /string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
@@ -19730,7 +19724,6 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-    dev: true
 
   /string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -19853,14 +19846,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: true
 
   /strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.1.0
-    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -21694,7 +21685,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
@@ -21703,7 +21693,6 @@ packages:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-    dev: true
 
   /wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}


### PR DESCRIPTION
Installing fs-detectors (or something that depends on it) triggers this warning:

>  npm warn deprecated glob@8.0.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me

This PR upgrades to glob@10, which has a promise-based API and native types. The `get-glob-fs` had to be changed significantly to be compatible with glob@10 and `DetectorFilesystem`.

## Changes

**package.json:**
- Updated glob from 8.0.3 to 10.3.10
- Removed @types/glob from devDependencies (glob 10 ships its own types)

**src/workspaces/get-workspace-package-paths.ts:**
- Changed import glob from 'glob' to import { glob } from 'glob' (named export in v10)
- Replaced the callback-based API wrapped in new Promise() with glob 10's native promise-based API, simplifying the code significantly

**src/workspaces/get-glob-fs.ts (rewritten):**
- Updated to implement glob 10's FSOption interface (from path-scurry) instead of the old fs-like interface
- readdir now returns Dirent[] objects (with withFileTypes: true) instead of string[]
- Added promises.lstat which glob 10 uses for async file verification
- Kept lstatSync as a stub since only async paths are used
- Defined GlobFs type inline to avoid a direct dependency on path-scurry
- Preserved the Windows path prefix stripping logic


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR upgrades the glob dependency from v8 to v10 and refactors the filesystem adapter to use the new promise-based API, with no changes to security, authentication, or database schemas.
> 
> - Dependency upgrade: glob 8.0.3 → 10.3.10, removed @types/glob
> - Refactored get-glob-fs.ts to implement glob v10's FSOption interface with Dirent objects
> - Simplified get-workspace-package-paths.ts by replacing callback-based Promise wrapper with native async API
>
> <sup>Risk assessment for [commit 17871e2](https://github.com/vercel/vercel/commit/17871e22e48f7bc022b3d70abc1a24423cd022dc).</sup>
<!-- VADE_RISK_END -->