### PR TITLE
Revert "[python] run build command after install commands (#15171)"

### DIFF
--- a/.changeset/long-dots-brake.md
+++ b/.changeset/long-dots-brake.md
@@ -1,5 +1,0 @@
----
-'@vercel/python': minor
----
-
-Run Python build commands _after_ install commands and in the virtual env

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -118,6 +118,56 @@ export const build: BuildV3 = async ({
     throw err;
   }
 
+  // For Python frameworks, also honor project install/build commands (vercel.json/dashboard)
+  if (isPythonFramework(framework)) {
+    const {
+      cliType,
+      lockfileVersion,
+      packageJsonPackageManager,
+      turboSupportsCorepackHome,
+    } = await scanParentDirs(workPath, true);
+    spawnEnv = getEnvForPackageManager({
+      cliType,
+      lockfileVersion,
+      packageJsonPackageManager,
+      env: process.env,
+      turboSupportsCorepackHome,
+      projectCreatedAt: config?.projectSettings?.createdAt,
+    });
+
+    const installCommand = config?.projectSettings?.installCommand;
+    if (typeof installCommand === 'string') {
+      const trimmed = installCommand.trim();
+      if (trimmed) {
+        projectInstallCommand = trimmed;
+      } else {
+        console.log('Skipping "install" command...');
+      }
+    }
+
+    const projectBuildCommand =
+      config?.projectSettings?.buildCommand ??
+      // fallback if provided directly on config (some callers set this)
+      (config as any)?.buildCommand;
+    if (projectBuildCommand) {
+      console.log(`Running "${projectBuildCommand}"`);
+      await execCommand(projectBuildCommand, {
+        env: spawnEnv,
+        cwd: workPath,
+      });
+      hasCustomCommand = true;
+    } else {
+      const ranBuildScript = await runPyprojectScript(
+        workPath,
+        ['vercel-build', 'now-build', 'build'],
+        spawnEnv
+      );
+      if (ranBuildScript) {
+        hasCustomCommand = true;
+      }
+    }
+  }
+
   let fsFiles = await glob('**', workPath);
 
   // Zero config entrypoint discovery
@@ -276,34 +326,6 @@ export const build: BuildV3 = async ({
     venvPath,
   });
 
-  // For Python frameworks, set up the env and extract the install command (vercel.json/dashboard)
-  if (isPythonFramework(framework)) {
-    const {
-      cliType,
-      lockfileVersion,
-      packageJsonPackageManager,
-      turboSupportsCorepackHome,
-    } = await scanParentDirs(workPath, true);
-    spawnEnv = getEnvForPackageManager({
-      cliType,
-      lockfileVersion,
-      packageJsonPackageManager,
-      env: process.env,
-      turboSupportsCorepackHome,
-      projectCreatedAt: config?.projectSettings?.createdAt,
-    });
-
-    const installCommand = config?.projectSettings?.installCommand;
-    if (typeof installCommand === 'string') {
-      const trimmed = installCommand.trim();
-      if (trimmed) {
-        projectInstallCommand = trimmed;
-      } else {
-        console.log('Skipping "install" command...');
-      }
-    }
-  }
-
   const baseEnv = spawnEnv || process.env;
   const pythonEnv = createVenvEnv(venvPath, baseEnv);
 
@@ -415,27 +437,6 @@ export const build: BuildV3 = async ({
       frozen: lockFileProvidedByUser,
       locked: !lockFileProvidedByUser,
     });
-  }
-
-  // Run the project build command (if any) AFTER dependencies are installed.
-  if (isPythonFramework(framework)) {
-    const projectBuildCommand =
-      config?.projectSettings?.buildCommand ??
-      // fallback if provided directly on config (some callers set this)
-      (config as any)?.buildCommand;
-    if (projectBuildCommand) {
-      console.log(`Running "${projectBuildCommand}"`);
-      await execCommand(projectBuildCommand, {
-        env: pythonEnv,
-        cwd: workPath,
-      });
-    } else {
-      await runPyprojectScript(
-        workPath,
-        ['vercel-build', 'now-build', 'build'],
-        pythonEnv
-      );
-    }
   }
 
   // Ensure correct version of vercel-runtime is installed.

--- a/packages/python/test/fixtures/33-uv-lock/vercel.json
+++ b/packages/python/test/fixtures/33-uv-lock/vercel.json
@@ -1,3 +1,0 @@
-{
-  "buildCommand": "python3 -c 'import fastapi'  # check installation"
-}

--- a/packages/python/test/fixtures/44-custom-install/vercel.json
+++ b/packages/python/test/fixtures/44-custom-install/vercel.json
@@ -1,4 +1,3 @@
 {
-  "installCommand": "pip install -r requirements-vercel.txt",
-  "buildCommand": "python3 -c 'import fastapi'  # check installation"
+  "installCommand": "pip install -r requirements-vercel.txt"
 }


### PR DESCRIPTION
This reverts commit 90238372d2bd0df7b9c0b31331106c242179d526.

This caused CI breakage.


<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This revert changes the execution order of Python build commands - moving them to run BEFORE dependencies are installed instead of AFTER, which is a significant change to build logic that could cause build failures or unexpected behavior.
> 
> - Build command execution moved from after dependency install to before
> - Environment changed from pythonEnv (venv) to spawnEnv for build command execution
> - Reverts CI-breaking change per PR description
>
> <sup>Risk assessment for [commit 840a2c0](https://github.com/vercel/vercel/commit/840a2c03a6f3967faa3efa71597a15af642dd18c).</sup>
<!-- VADE_RISK_END -->