### PR TITLE
Update Next.js adapter version

### DIFF
--- a/.changeset/tasty-bikes-drop.md
+++ b/.changeset/tasty-bikes-drop.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Update Next.js adapter version

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "https://adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz",
+    "@next-community/adapter-vercel": "0.0.1-beta.10",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.9",
+    "@next-community/adapter-vercel": "https://adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/packages/next/test/fixtures/00-fallback-false-preview/index.test.js
+++ b/packages/next/test/fixtures/00-fallback-false-preview/index.test.js
@@ -38,11 +38,13 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     expect(res.status).toBe(200);
 
     const $ = cheerio.load(await res.text());
-    const srcset = $('img[alt="Vercel Logo"]').attr('srcset') || '';
-    const match = srcset.match(/\/_next\/static\/media\/vercel\.[^&\s"]+/);
-    expect(match).toBeTruthy();
+    const imgSrc = $('img[alt="Vercel Logo"]').attr('src');
+    expect(imgSrc).toBeTruthy();
 
-    const staticImagePath = match[0];
+    const imgUrl = new URL(imgSrc, ctx.deploymentUrl);
+    const staticImagePath = imgUrl.searchParams.get('url');
+    expect(staticImagePath).toMatch(/\/_next\/static\/media\/vercel\./);
+
     const imageRes = await fetch(
       `${ctx.deploymentUrl}/_next/image?url=${encodeURIComponent(staticImagePath)}&w=256&q=75`
     );

--- a/packages/next/test/fixtures/00-fallback-false-preview/index.test.js
+++ b/packages/next/test/fixtures/00-fallback-false-preview/index.test.js
@@ -33,6 +33,25 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     Object.assign(ctx, info);
   });
 
+  it('should serve _next/image for static imported image with immutable cache', async () => {
+    const res = await fetch(`${ctx.deploymentUrl}/`);
+    expect(res.status).toBe(200);
+
+    const $ = cheerio.load(await res.text());
+    const srcset = $('img[alt="Vercel Logo"]').attr('srcset') || '';
+    const match = srcset.match(/\/_next\/static\/media\/vercel\.[^&\s"]+/);
+    expect(match).toBeTruthy();
+
+    const staticImagePath = match[0];
+    const imageRes = await fetch(
+      `${ctx.deploymentUrl}/_next/image?url=${encodeURIComponent(staticImagePath)}&w=256&q=75`
+    );
+    expect(imageRes.status).toBe(200);
+    expect(imageRes.headers.get('cache-control')).toMatch(
+      /public,\s*max-age=31536000,\s*immutable/
+    );
+  });
+
   it('should revalidate content properly from /blog', async () => {
     const dataRes = await fetch(
       `${ctx.deploymentUrl}/_next/data/build-TfctsWXpff2fKS/blog.json`

--- a/packages/next/test/fixtures/00-fallback-false-preview/vercel.json
+++ b/packages/next/test/fixtures/00-fallback-false-preview/vercel.json
@@ -24,13 +24,6 @@
       }
     },
     {
-      "path": "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Fvercel.db942267.png&w=256&q=75",
-      "status": 200,
-      "responseHeaders": {
-        "cache-control": "public,max-age=31536000,immutable"
-      }
-    },
-    {
       "path": "/blog/test-123",
       "status": 200,
       "mustContain": "blog fallback rewrite"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1716,8 +1716,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.9
-        version: 0.0.1-beta.9(next@16.1.6)
+        specifier: https://adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz
+        version: '@adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz(next@16.1.6)'
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6547,15 +6547,6 @@ packages:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  /@next-community/adapter-vercel@0.0.1-beta.9(next@16.1.6):
-    resolution: {integrity: sha512-9PSiC/PztojB49ZssbQ1NGkPJeYRyMSFWR7XTzCpgdVfLNnVOPgZ7UFLvMbMhmxMx16878v9BWNp/gzQa1YU3A==}
-    engines: {node: '>= 20.6.0'}
-    peerDependencies:
-      next: '>= 16.1.1-canary.18'
-    dependencies:
-      next: 16.1.6(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
-    dev: true
-
   /@next/env@11.1.2:
     resolution: {integrity: sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA==}
     dev: true
@@ -10463,7 +10454,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.24.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.24.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.24.0)
@@ -10510,7 +10501,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -10557,7 +10548,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -10604,7 +10595,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -13322,7 +13313,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -13351,7 +13342,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.24.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -13377,7 +13368,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.35.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -13387,7 +13378,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
+  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13408,11 +13399,11 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
       debug: 3.2.7
-      eslint: 8.35.0
+      eslint: 8.24.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13439,7 +13430,7 @@ packages:
       ignore: 5.3.2
     dev: true
 
-  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
+  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13450,16 +13441,16 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.35.0
+      eslint: 8.24.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -21872,3 +21863,15 @@ packages:
   /zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
     dev: false
+
+  '@adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz(next@16.1.6)':
+    resolution: {tarball: https://adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz}
+    id: '@adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz'
+    name: '@next-community/adapter-vercel'
+    version: 0.0.1-beta.9
+    engines: {node: '>= 20.6.0'}
+    peerDependencies:
+      next: '>= 16.1.1-canary.18'
+    dependencies:
+      next: 16.1.6(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
+    dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1716,8 +1716,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: https://adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz
-        version: '@adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz(next@16.1.6)'
+        specifier: 0.0.1-beta.10
+        version: 0.0.1-beta.10(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6546,6 +6546,15 @@ packages:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  /@next-community/adapter-vercel@0.0.1-beta.10(next@16.1.6):
+    resolution: {integrity: sha512-H/EryVKaxWngEv+P94kZQQ7BnYTSGKXNsYfO8lONPtYf3w6MX6lsD6kkf7D/zHcBSxnfzVD+/gt77v5rh+cfAw==}
+    engines: {node: '>= 20.6.0'}
+    peerDependencies:
+      next: '>= 16.1.1-canary.18'
+    dependencies:
+      next: 16.1.6(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
+    dev: true
 
   /@next/env@11.1.2:
     resolution: {integrity: sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA==}
@@ -21863,15 +21872,3 @@ packages:
   /zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
     dev: false
-
-  '@adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz(next@16.1.6)':
-    resolution: {tarball: https://adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz}
-    id: '@adapter-vercel-adapter-6jjwbp7ym.vercel.app/adapter.tgz'
-    name: '@next-community/adapter-vercel'
-    version: 0.0.1-beta.9
-    engines: {node: '>= 20.6.0'}
-    peerDependencies:
-      next: '>= 16.1.1-canary.18'
-    dependencies:
-      next: 16.1.6(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
-    dev: true


### PR DESCRIPTION
x-ref: https://github.com/nextjs/adapter-vercel/pull/34

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR contains a minor dev dependency version bump (beta.9 to beta.10) and associated test updates with no changes to production code, auth, or schema.
> 
> - Dev dependency bump: @next-community/adapter-vercel 0.0.1-beta.9 → beta.10
> - Added test for _next/image cache-control header verification
> - Removed hardcoded test fixture path in vercel.json
>
> <sup>Risk assessment for [commit 4aa9960](https://github.com/vercel/vercel/commit/4aa9960ceee1b9c0535dab99cb7725c198ce42b0).</sup>
<!-- VADE_RISK_END -->