### PR TITLE
cli(metrics): align schema with query engine and rename incomingRequest to edgeRequest on CLI

### DIFF
--- a/.changeset/align-metrics-schema.md
+++ b/.changeset/align-metrics-schema.md
@@ -1,0 +1,10 @@
+---
+'vercel': patch
+---
+
+cli(metrics): align schema with query engine and rename incomingRequest to edgeRequest
+
+- Remove `tokens` unit type (now `count`), drop `unique` aggregation, add `p50`
+- Remove unsupported events: `analyticsEvent`, `analyticsPageview`, `blobStoreState`, `dataCacheState`
+- Update dimensions, measures, and `filterOnly` flags across all events
+- Rename `incomingRequest` to `edgeRequest` with query engine aliasing for agent understanding

--- a/packages/cli/src/commands/metrics/command.ts
+++ b/packages/cli/src/commands/metrics/command.ts
@@ -77,7 +77,7 @@ export const metricsCommand = {
       type: String,
       deprecated: false,
       description:
-        'Aggregation function (default: sum for counts/bytes/tokens, avg for durations/memory/ratios)',
+        'Aggregation function (default: sum for counts/bytes/currency, avg for durations/memory/ratios)',
       argument: 'FN',
     },
     {

--- a/packages/cli/src/commands/metrics/command.ts
+++ b/packages/cli/src/commands/metrics/command.ts
@@ -28,7 +28,7 @@ export const schemaSubcommand = {
     },
     {
       name: 'Schema as JSON for agents',
-      value: `${packageName} metrics schema -e incomingRequest --format=json`,
+      value: `${packageName} metrics schema -e edgeRequest --format=json`,
     },
   ],
 } as const;
@@ -59,8 +59,7 @@ export const metricsCommand = {
       shorthand: 'e',
       type: String,
       deprecated: false,
-      description:
-        'Event type to query (e.g., incomingRequest, functionExecution)',
+      description: 'Event type to query (e.g., edgeRequest, functionExecution)',
       argument: 'NAME',
     },
     {
@@ -158,15 +157,11 @@ export const metricsCommand = {
   examples: [
     {
       name: '5xx errors by error code in the last hour',
-      value: `${packageName} metrics -e incomingRequest -f "httpStatus ge 500" --group-by errorCode --since 1h`,
+      value: `${packageName} metrics -e functionExecution -f "httpStatus ge 500" --group-by errorCode --since 1h`,
     },
     {
-      name: 'P95 latency by route over 24 hours',
-      value: `${packageName} metrics -e incomingRequest -m requestDurationMs -a p95 --group-by route --since 24h`,
-    },
-    {
-      name: 'Traffic by HTTP status code',
-      value: `${packageName} metrics -e incomingRequest --group-by httpStatus --since 6h`,
+      name: 'Function invocations by HTTP status code',
+      value: `${packageName} metrics -e functionExecution --group-by httpStatus --since 6h`,
     },
     {
       name: 'Function duration by route',
@@ -185,16 +180,16 @@ export const metricsCommand = {
       value: `${packageName} metrics schema`,
     },
     {
-      name: 'Requests matching a path pattern',
-      value: `${packageName} metrics -e incomingRequest -f "contains(requestPath, '/api')" --group-by route --since 1h`,
+      name: 'Function executions matching a path pattern',
+      value: `${packageName} metrics -e functionExecution -f "contains(requestPath, '/api')" --group-by route --since 1h`,
     },
     {
       name: 'Show schema for an event',
-      value: `${packageName} metrics schema -e incomingRequest`,
+      value: `${packageName} metrics schema -e edgeRequest`,
     },
     {
-      name: 'Team-wide traffic by project',
-      value: `${packageName} metrics --all -e incomingRequest --group-by projectName --since 24h`,
+      name: 'Team-wide function executions by project',
+      value: `${packageName} metrics --all -e functionExecution --group-by projectId --since 24h`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -13,7 +13,7 @@ import {
   validateGroupBy,
   validateMutualExclusivity,
 } from './validation';
-import { getDefaultAggregation } from './schema-data';
+import { getDefaultAggregation, getQueryEngineEventName } from './schema-data';
 import {
   formatQueryJson,
   formatErrorJson,
@@ -304,7 +304,7 @@ export default async function query(
   const body: MetricsQueryRequest = {
     reason: 'agent' as const,
     scope,
-    event,
+    event: getQueryEngineEventName(event),
     rollups: { [rollupColumn]: { measure, aggregation } },
     startTime: rounded.start.toISOString(),
     endTime: rounded.end.toISOString(),

--- a/packages/cli/src/commands/metrics/schema-data.ts
+++ b/packages/cli/src/commands/metrics/schema-data.ts
@@ -12,6 +12,8 @@ export interface MeasureSchema {
 
 export interface EventSchema {
   description: string;
+  /** If set, this name is sent to the query engine instead of the schema key. */
+  queryEngineEvent?: string;
   dimensions: DimensionSchema[];
   measures: MeasureSchema[];
 }
@@ -431,8 +433,9 @@ export const SCHEMA = {
       },
     ],
   },
-  incomingRequest: {
+  edgeRequest: {
     description: 'Edge Requests',
+    queryEngineEvent: 'incomingRequest',
     dimensions: [
       { name: 'asnId', label: 'AS Number', filterOnly: false },
       { name: 'asnName', label: 'AS Name', filterOnly: false },
@@ -781,6 +784,11 @@ export function getEventNames(): string[] {
 
 export function getEvent(name: string): EventSchema | undefined {
   return (SCHEMA as Record<string, EventSchema>)[name];
+}
+
+export function getQueryEngineEventName(name: string): string {
+  const event = getEvent(name);
+  return event?.queryEngineEvent ?? name;
 }
 
 export function getDimensions(eventName: string): DimensionSchema[] {

--- a/packages/cli/src/commands/metrics/schema-data.ts
+++ b/packages/cli/src/commands/metrics/schema-data.ts
@@ -25,12 +25,12 @@ const VALUE_AGGREGATIONS = [
   'avg',
   'min',
   'max',
+  'p50',
   'p75',
   'p90',
   'p95',
   'p99',
   'stddev',
-  'unique',
 ] as const;
 
 export type CountAggregation = (typeof COUNT_AGGREGATIONS)[number];
@@ -82,17 +82,17 @@ export const SCHEMA = {
       {
         name: 'cacheCreationInputTokens',
         label: 'Cache Creation Tokens',
-        unit: 'tokens',
+        unit: 'count',
       },
       {
         name: 'cachedInputTokens',
         label: 'Cached Input Tokens',
-        unit: 'tokens',
+        unit: 'count',
       },
       { name: 'cost', label: 'Cost', unit: 'US dollars' },
       { name: 'count', label: 'Count', unit: 'count' },
-      { name: 'inputTokens', label: 'Input Tokens', unit: 'tokens' },
-      { name: 'outputTokens', label: 'Output Tokens', unit: 'tokens' },
+      { name: 'inputTokens', label: 'Input Tokens', unit: 'count' },
+      { name: 'outputTokens', label: 'Output Tokens', unit: 'count' },
       {
         name: 'timeToFirstTokenMs',
         label: 'Time to First Token',
@@ -845,7 +845,6 @@ export function getDefaultAggregation(
   switch (measure.unit) {
     case 'count':
     case 'bytes':
-    case 'tokens':
     case 'US dollars':
       return 'sum';
     case 'milliseconds':

--- a/packages/cli/src/commands/metrics/schema-data.ts
+++ b/packages/cli/src/commands/metrics/schema-data.ts
@@ -40,30 +40,31 @@ export type MetricsAggregation = ValueAggregation;
 // Measures with "cannot be used in rollups" are excluded since the CLI only supports aggregated queries.
 export const SCHEMA = {
   aiGatewayRequest: {
-    description: 'AI Gateway request events for tracking AI model API usage',
+    description: 'AI Gateway Requests',
     dimensions: [
       {
         name: 'aiGatewayModelId',
         label: 'AI Gateway Model ID',
-        filterOnly: false,
+        filterOnly: true,
       },
       { name: 'aiModel', label: 'AI Model', filterOnly: false },
       { name: 'aiModelType', label: 'AI Model Type', filterOnly: false },
       { name: 'aiProvider', label: 'AI Provider', filterOnly: false },
       {
-        name: 'cachedInputTokensCurrency',
-        label: 'Cached Input Tokens Currency',
+        name: 'cacheCreationInputTokensCurrency',
+        label: 'Cache Creation Input Tokens Currency',
         filterOnly: true,
       },
       {
-        name: 'cacheCreationInputTokensCurrency',
-        label: 'Cache Creation Input Tokens Currency',
+        name: 'cachedInputTokensCurrency',
+        label: 'Cached Input Tokens Currency',
         filterOnly: true,
       },
       { name: 'costCurrency', label: 'Currency', filterOnly: true },
       { name: 'deploymentId', label: 'Deployment ID', filterOnly: false },
       { name: 'environment', label: 'Environment', filterOnly: false },
       { name: 'httpStatus', label: 'HTTP Status', filterOnly: false },
+      { name: 'isByok', label: 'BYOK', filterOnly: false },
       { name: 'keyId', label: 'Key ID', filterOnly: true },
       { name: 'keyName', label: 'Key Name', filterOnly: true },
       {
@@ -72,6 +73,13 @@ export const SCHEMA = {
         filterOnly: true,
       },
       { name: 'projectId', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
+      {
+        name: 'videoAspectRatio',
+        label: 'Video Aspect Ratio',
+        filterOnly: false,
+      },
+      { name: 'videoResolution', label: 'Video Resolution', filterOnly: false },
     ],
     measures: [
       {
@@ -98,6 +106,13 @@ export const SCHEMA = {
         label: 'Time to First Token',
         unit: 'milliseconds',
       },
+      { name: 'videoCount', label: 'Video Count', unit: 'count' },
+      {
+        name: 'videoDurationSeconds',
+        label: 'Video Duration',
+        unit: 'seconds',
+      },
+      { name: 'videoFps', label: 'Video FPS', unit: 'count' },
       { name: 'webSearchCallCount', label: 'Web Search Calls', unit: 'count' },
     ],
   },
@@ -127,7 +142,7 @@ export const SCHEMA = {
       { name: 'requestMethod', label: 'Request Method', filterOnly: false },
       { name: 'requestPath', label: 'Request Path', filterOnly: false },
       { name: 'storeId', label: 'Store ID', filterOnly: true },
-      { name: 'storeName', label: 'Store', filterOnly: false },
+      { name: 'storeName', label: 'Store', filterOnly: true },
     ],
     measures: [
       { name: 'bdtOutBytes', label: 'Blob Data Transfer', unit: 'bytes' },
@@ -144,12 +159,12 @@ export const SCHEMA = {
       },
       { name: 'blobOperationType', label: 'Operation', filterOnly: true },
       { name: 'storeId', label: 'Store ID', filterOnly: true },
-      { name: 'storeName', label: 'Store', filterOnly: false },
+      { name: 'storeName', label: 'Store', filterOnly: true },
     ],
     measures: [{ name: 'count', label: 'Count', unit: 'count' }],
   },
   blockedConnection: {
-    description: 'Connections blocked by firewall rules',
+    description: 'Blocked Connections',
     dimensions: [
       { name: 'asnId', label: 'AS Number', filterOnly: false },
       { name: 'asnName', label: 'AS Name', filterOnly: false },
@@ -162,7 +177,7 @@ export const SCHEMA = {
         filterOnly: false,
       },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       { name: 'requestHostname', label: 'Request Hostname', filterOnly: false },
       { name: 'requestPath', label: 'Request Path', filterOnly: false },
       { name: 'route', label: 'Route', filterOnly: false },
@@ -172,7 +187,7 @@ export const SCHEMA = {
     measures: [{ name: 'count', label: 'Count', unit: 'count' }],
   },
   botIdCheck: {
-    description: 'Bot identification check results',
+    description: 'BotID Checks',
     dimensions: [
       { name: 'asnId', label: 'AS Number', filterOnly: false },
       { name: 'asnName', label: 'AS Name', filterOnly: false },
@@ -187,7 +202,7 @@ export const SCHEMA = {
         filterOnly: false,
       },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       { name: 'referrerUrl', label: 'Referrer URL', filterOnly: false },
       { name: 'requestHostname', label: 'Request Hostname', filterOnly: false },
       { name: 'requestPath', label: 'Request Path', filterOnly: false },
@@ -211,7 +226,7 @@ export const SCHEMA = {
       {
         name: 'entryRevalidateSeconds',
         label: 'Entry Revalidate Lifetime',
-        filterOnly: false,
+        filterOnly: true,
       },
       { name: 'environment', label: 'Environment', filterOnly: false },
       { name: 'projectId', label: 'Project', filterOnly: false },
@@ -221,7 +236,7 @@ export const SCHEMA = {
     measures: [{ name: 'count', label: 'Count', unit: 'count' }],
   },
   firewallAction: {
-    description: 'Firewall actions including blocks challenges and allows',
+    description: 'Firewall Actions',
     dimensions: [
       { name: 'asnId', label: 'AS Number', filterOnly: false },
       { name: 'asnName', label: 'AS Name', filterOnly: false },
@@ -235,7 +250,7 @@ export const SCHEMA = {
         filterOnly: false,
       },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       { name: 'requestHostname', label: 'Request Hostname', filterOnly: false },
       { name: 'requestPath', label: 'Request Path', filterOnly: false },
       { name: 'route', label: 'Route', filterOnly: false },
@@ -245,9 +260,11 @@ export const SCHEMA = {
     measures: [{ name: 'count', label: 'Count', unit: 'count' }],
   },
   functionExecution: {
-    description: 'Serverless function execution details',
+    description: 'Function Executions',
     dimensions: [
       { name: 'cause', label: 'Cause', filterOnly: false },
+      { name: 'clientIp', label: 'IP Address', filterOnly: false },
+      { name: 'clientUserAgent', label: 'User Agent', filterOnly: false },
       { name: 'deploymentId', label: 'Deployment ID', filterOnly: false },
       {
         name: 'edgeNetworkRegion',
@@ -257,6 +274,11 @@ export const SCHEMA = {
       { name: 'environment', label: 'Environment', filterOnly: false },
       { name: 'errorCode', label: 'Error Code', filterOnly: false },
       { name: 'functionRegion', label: 'Function Region', filterOnly: false },
+      {
+        name: 'functionStartType',
+        label: 'Function Start Type',
+        filterOnly: false,
+      },
       { name: 'httpStatus', label: 'HTTP Status', filterOnly: false },
       {
         name: 'middlewareAction',
@@ -270,7 +292,7 @@ export const SCHEMA = {
       },
       { name: 'pathType', label: 'Path Type', filterOnly: false },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       { name: 'provider', label: 'Provider', filterOnly: true },
       {
         name: 'referrerHostname',
@@ -306,8 +328,11 @@ export const SCHEMA = {
         label: 'Active CPU Time',
         unit: 'milliseconds',
       },
-      { name: 'functionDurationMs', label: 'Duration', unit: 'milliseconds' },
-      { name: 'peakMemoryMb', label: 'Peak Memory', unit: 'megabytes' },
+      {
+        name: 'functionDurationMs',
+        label: 'Duration',
+        unit: 'milliseconds',
+      },
       {
         name: 'provisionedMemoryMb',
         label: 'Provisioned Memory',
@@ -322,14 +347,9 @@ export const SCHEMA = {
     ],
   },
   imageTransformation: {
-    description: 'Successful image optimization operations',
+    description: 'Image Transformations',
     dimensions: [
       { name: 'deploymentId', label: 'Deployment ID', filterOnly: false },
-      {
-        name: 'edgeFunctionInvocation',
-        label: 'Edge Function Invocations',
-        filterOnly: true,
-      },
       { name: 'environment', label: 'Environment', filterOnly: false },
       { name: 'httpStatus', label: 'HTTP Status', filterOnly: false },
       {
@@ -341,7 +361,7 @@ export const SCHEMA = {
       { name: 'optimizedQuality', label: 'Quality', filterOnly: false },
       { name: 'optimizedWidthPixels', label: 'Width', filterOnly: false },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       { name: 'sourceImage', label: 'Source Image', filterOnly: true },
       {
         name: 'sourceImageHash',
@@ -373,7 +393,7 @@ export const SCHEMA = {
     ],
   },
   imageTransformationFailure: {
-    description: 'Failed image optimization operations',
+    description: 'Image Transformation Failures',
     dimensions: [
       { name: 'deploymentId', label: 'Deployment ID', filterOnly: false },
       { name: 'environment', label: 'Environment', filterOnly: false },
@@ -389,7 +409,7 @@ export const SCHEMA = {
       { name: 'optimizedQuality', label: 'Quality', filterOnly: false },
       { name: 'optimizedWidthPixels', label: 'Width', filterOnly: false },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       { name: 'sourceImage', label: 'Source Image', filterOnly: true },
       {
         name: 'sourceImageHostname',
@@ -402,10 +422,17 @@ export const SCHEMA = {
         filterOnly: true,
       },
     ],
-    measures: [{ name: 'count', label: 'Count', unit: 'count' }],
+    measures: [
+      { name: 'count', label: 'Count', unit: 'count' },
+      {
+        name: 'requestDurationMs',
+        label: 'Request Duration',
+        unit: 'milliseconds',
+      },
+    ],
   },
   incomingRequest: {
-    description: 'All incoming HTTP requests to your deployments',
+    description: 'Edge Requests',
     dimensions: [
       { name: 'asnId', label: 'AS Number', filterOnly: false },
       { name: 'asnName', label: 'AS Name', filterOnly: false },
@@ -450,6 +477,11 @@ export const SCHEMA = {
         filterOnly: true,
       },
       {
+        name: 'microfrontendsDefaultAppProjectId',
+        label: 'Microfrontends Default App Project ID',
+        filterOnly: true,
+      },
+      {
         name: 'microfrontendsMatchedPath',
         label: 'Microfrontends Matched Path',
         filterOnly: false,
@@ -462,7 +494,7 @@ export const SCHEMA = {
       { name: 'pathType', label: 'Path Type', filterOnly: false },
       { name: 'pathTypeVariant', label: 'Path Type Variant', filterOnly: true },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       {
         name: 'redirectLocation',
         label: 'Redirect Location',
@@ -525,22 +557,25 @@ export const SCHEMA = {
         label: 'Fast Data Transfer (Total)',
         unit: 'bytes',
       },
-      { name: 'isrReadUnits', label: 'Read Units', unit: 'count' },
-      { name: 'isrWriteUnits', label: 'Write Units', unit: 'count' },
       {
         name: 'requestDurationMs',
-        label: 'Request Duration',
+        label: 'Edge Request Duration',
         unit: 'milliseconds',
       },
     ],
   },
   isrOperation: {
-    description: 'Incremental Static Regeneration operations',
+    description: 'ISR Operations',
     dimensions: [
       { name: 'cacheHitLevel', label: 'Cache Hit Level', filterOnly: true },
       { name: 'cacheHitState', label: 'Cache Hit State', filterOnly: true },
       { name: 'cacheResult', label: 'Cache Result', filterOnly: false },
       { name: 'deploymentId', label: 'Deployment ID', filterOnly: false },
+      {
+        name: 'edgeNetworkRegion',
+        label: 'Edge Network Region',
+        filterOnly: false,
+      },
       { name: 'environment', label: 'Environment', filterOnly: false },
       { name: 'errorCode', label: 'Error Code', filterOnly: false },
       { name: 'httpStatus', label: 'HTTP Status', filterOnly: false },
@@ -548,7 +583,7 @@ export const SCHEMA = {
       { name: 'isrCacheRegion', label: 'ISR Cache Region', filterOnly: false },
       { name: 'pathType', label: 'Path Type', filterOnly: false },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       {
         name: 'referrerHostname',
         label: 'Referrer Hostname',
@@ -561,7 +596,6 @@ export const SCHEMA = {
       { name: 'route', label: 'Route', filterOnly: false },
     ],
     measures: [
-      { name: 'count', label: 'Count', unit: 'count' },
       { name: 'isrReadBytes', label: 'Read Bandwidth', unit: 'bytes' },
       { name: 'isrReadUnits', label: 'Read Units', unit: 'count' },
       { name: 'isrWriteBytes', label: 'Write Bandwidth', unit: 'bytes' },
@@ -569,12 +603,11 @@ export const SCHEMA = {
     ],
   },
   middlewareInvocation: {
-    description: 'Middleware function invocations',
+    description: 'Middleware Invocations',
     dimensions: [
       { name: 'clientIp', label: 'IP Address', filterOnly: false },
       { name: 'clientUserAgent', label: 'User Agent', filterOnly: false },
       { name: 'deploymentId', label: 'Deployment ID', filterOnly: false },
-      { name: 'durationMs', label: 'Duration', filterOnly: true },
       {
         name: 'edgeNetworkRegion',
         label: 'Edge Network Region',
@@ -604,7 +637,7 @@ export const SCHEMA = {
         filterOnly: false,
       },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       {
         name: 'referrerHostname',
         label: 'Referrer Hostname',
@@ -638,24 +671,12 @@ export const SCHEMA = {
         label: 'Active CPU Time',
         unit: 'milliseconds',
       },
-      {
-        name: 'functionDurationGbhr',
-        label: 'Duration (Gb-hrs)',
-        unit: 'gigabyte hours',
-      },
-      { name: 'peakMemoryMb', label: 'Peak Memory', unit: 'megabytes' },
-      {
-        name: 'provisionedMemoryMb',
-        label: 'Provisioned Memory',
-        unit: 'megabytes',
-      },
       { name: 'ttfbMs', label: 'Time to First Byte', unit: 'milliseconds' },
     ],
   },
   outgoingRequest: {
-    description: 'External API calls made from your functions',
+    description: 'External APIs',
     dimensions: [
-      { name: 'cacheApi', label: 'Cache API', filterOnly: true },
       { name: 'cacheHostname', label: 'Cache Hostname', filterOnly: true },
       { name: 'cachePath', label: 'Cache Path', filterOnly: true },
       { name: 'deploymentId', label: 'Deployment ID', filterOnly: false },
@@ -670,7 +691,7 @@ export const SCHEMA = {
       { name: 'originPath', label: 'Function Path', filterOnly: false },
       { name: 'originRoute', label: 'Function Route', filterOnly: false },
       { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'projectName', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       {
         name: 'reason',
         label: 'Reason of failure for outgoing requests',
@@ -705,8 +726,8 @@ export const SCHEMA = {
       { name: 'environment', label: 'Environment', filterOnly: false },
       { name: 'eventType', label: 'Queue Event Type', filterOnly: true },
       { name: 'messageId', label: 'Message ID', filterOnly: true },
-      { name: 'notificationUrl', label: 'Notification URL', filterOnly: true },
       { name: 'projectId', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       { name: 'queueName', label: 'Queue Name', filterOnly: true },
     ],
     measures: [{ name: 'count', label: 'Count', unit: 'count' }],
@@ -714,12 +735,12 @@ export const SCHEMA = {
   speedInsightsMetric: {
     description: 'Core Web Vitals and performance metrics',
     dimensions: [
-      { name: 'browserName', label: 'Browser', filterOnly: false },
+      { name: 'browserName', label: 'Browser', filterOnly: true },
       { name: 'country', label: 'Country', filterOnly: true },
       { name: 'deploymentId', label: 'Deployment ID', filterOnly: false },
       { name: 'deviceType', label: 'Device Type', filterOnly: true },
       { name: 'environment', label: 'Environment', filterOnly: false },
-      { name: 'osName', label: 'Operating System', filterOnly: false },
+      { name: 'osName', label: 'Operating System', filterOnly: true },
       { name: 'projectId', label: 'Project', filterOnly: false },
       { name: 'requestHostname', label: 'Request Hostname', filterOnly: false },
       { name: 'requestPath', label: 'Request Path', filterOnly: false },
@@ -736,10 +757,11 @@ export const SCHEMA = {
     ],
   },
   workflowOperation: {
-    description: 'Workflow execution operations',
+    description: 'Workflow Operations',
     dimensions: [
       { name: 'environment', label: 'Environment', filterOnly: false },
       { name: 'projectId', label: 'Project', filterOnly: false },
+      { name: 'projectName', label: 'Project', filterOnly: true },
       { name: 'stepRunId', label: 'Step Run ID', filterOnly: false },
       { name: 'workflowEventType', label: 'Event Type', filterOnly: false },
       { name: 'workflowName', label: 'Workflow Name', filterOnly: false },

--- a/packages/cli/src/commands/metrics/schema-data.ts
+++ b/packages/cli/src/commands/metrics/schema-data.ts
@@ -603,6 +603,7 @@ export const SCHEMA = {
       { name: 'isrReadUnits', label: 'Read Units', unit: 'count' },
       { name: 'isrWriteBytes', label: 'Write Bandwidth', unit: 'bytes' },
       { name: 'isrWriteUnits', label: 'Write Units', unit: 'count' },
+      { name: 'count', label: 'Count', unit: 'count' },
     ],
   },
   middlewareInvocation: {

--- a/packages/cli/src/commands/metrics/schema-data.ts
+++ b/packages/cli/src/commands/metrics/schema-data.ts
@@ -101,48 +101,6 @@ export const SCHEMA = {
       { name: 'webSearchCallCount', label: 'Web Search Calls', unit: 'count' },
     ],
   },
-  analyticsEvent: {
-    description: 'Web Analytics custom event tracking',
-    dimensions: [
-      { name: 'browserName', label: 'Browser', filterOnly: false },
-      { name: 'country', label: 'Country', filterOnly: true },
-      { name: 'deploymentId', label: 'Deployment ID', filterOnly: true },
-      { name: 'deviceId', label: 'Device Id', filterOnly: true },
-      { name: 'deviceType', label: 'Device Type', filterOnly: true },
-      { name: 'environment', label: 'Environment', filterOnly: false },
-      { name: 'eventName', label: 'Analytics event name', filterOnly: true },
-      { name: 'osName', label: 'Operating System', filterOnly: false },
-      { name: 'projectId', label: 'Project', filterOnly: false },
-      {
-        name: 'referrerHostname',
-        label: 'Referrer Hostname',
-        filterOnly: false,
-      },
-      { name: 'requestPath', label: 'Request Path', filterOnly: false },
-    ],
-    measures: [{ name: 'count', label: 'Count', unit: 'count' }],
-  },
-  analyticsPageview: {
-    description: 'Web Analytics pageview tracking',
-    dimensions: [
-      { name: 'browserName', label: 'Browser', filterOnly: false },
-      { name: 'country', label: 'Country', filterOnly: true },
-      { name: 'deploymentId', label: 'Deployment ID', filterOnly: true },
-      { name: 'deviceId', label: 'Device Id', filterOnly: true },
-      { name: 'deviceType', label: 'Device Type', filterOnly: true },
-      { name: 'environment', label: 'Environment', filterOnly: false },
-      { name: 'osName', label: 'Operating System', filterOnly: false },
-      { name: 'projectId', label: 'Project', filterOnly: false },
-      {
-        name: 'referrerHostname',
-        label: 'Referrer Hostname',
-        filterOnly: false,
-      },
-      { name: 'requestPath', label: 'Request Path', filterOnly: false },
-      { name: 'route', label: 'Route', filterOnly: false },
-    ],
-    measures: [{ name: 'count', label: 'Count', unit: 'count' }],
-  },
   blobDataTransfer: {
     description: 'Blob store data transfer operations',
     dimensions: [
@@ -189,16 +147,6 @@ export const SCHEMA = {
       { name: 'storeName', label: 'Store', filterOnly: false },
     ],
     measures: [{ name: 'count', label: 'Count', unit: 'count' }],
-  },
-  blobStoreState: {
-    description: 'Blob store state metrics including size and object count',
-    dimensions: [
-      { name: 'environment', label: 'Environment', filterOnly: false },
-      { name: 'projectId', label: 'Project', filterOnly: false },
-      { name: 'storeId', label: 'Store ID', filterOnly: true },
-      { name: 'storeName', label: 'Store', filterOnly: false },
-    ],
-    measures: [],
   },
   blockedConnection: {
     description: 'Connections blocked by firewall rules',
@@ -271,15 +219,6 @@ export const SCHEMA = {
       { name: 'requestId', label: 'Request ID', filterOnly: true },
     ],
     measures: [{ name: 'count', label: 'Count', unit: 'count' }],
-  },
-  dataCacheState: {
-    description: 'Vercel Data Cache state metrics',
-    dimensions: [
-      { name: 'cacheApi', label: 'Cache API', filterOnly: true },
-      { name: 'environment', label: 'Environment', filterOnly: false },
-      { name: 'projectId', label: 'Project', filterOnly: false },
-    ],
-    measures: [],
   },
   firewallAction: {
     description: 'Firewall actions including blocks challenges and allows',

--- a/packages/cli/src/commands/metrics/text-output.ts
+++ b/packages/cli/src/commands/metrics/text-output.ts
@@ -85,7 +85,7 @@ const MAX_SPARKLINE_LENGTH = 120;
 type TableAlignment = 'l' | 'c' | 'r';
 type StatColumn = 'total' | 'avg' | 'min' | 'max';
 
-const COUNT_UNITS = new Set(['count', 'tokens', 'us dollars', 'dollars']);
+const COUNT_UNITS = new Set(['count', 'us dollars', 'dollars']);
 const DURATION_UNITS = new Set(['milliseconds', 'seconds']);
 const BYTES_UNITS = new Set([
   'bytes',
@@ -332,7 +332,7 @@ function buildExpectedTimestamps(
 
 /**
  * Classifies a schema unit into formatting behavior:
- * - `count`: count/tokens/USD-like values (integer totals for `sum`)
+ * - `count`: count/USD-like values (integer totals for `sum`)
  * - `duration`: time units (ms/s)
  * - `bytes`: storage/bandwidth-like units
  * - `ratio`: percentages/ratios and unknown units (safe decimal fallback)

--- a/packages/cli/test/unit/commands/metrics/output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/output.test.ts
@@ -24,7 +24,7 @@ describe('output', () => {
   describe('formatQueryJson', () => {
     it('should format full JSON response', () => {
       const query: QueryMetadata = {
-        event: 'incomingRequest',
+        event: 'edgeRequest',
         measure: 'count',
         aggregation: 'sum',
         groupBy: [],

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -81,7 +81,7 @@ describe('query', () => {
       const output = client.stdout.getFullOutput();
       const parsed = JSON.parse(output);
       expect(parsed.error.code).toBe('UNKNOWN_EVENT');
-      expect(parsed.error.allowedValues).toContain('incomingRequest');
+      expect(parsed.error.allowedValues).toContain('edgeRequest');
     });
   });
 
@@ -92,7 +92,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--measure',
         'bogus'
       );
@@ -113,7 +113,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--measure',
         'count',
         '--aggregation',
@@ -137,7 +137,7 @@ describe('query', () => {
         res.json({ data: [], summary: [], statistics: {} });
       });
       mockLinkedProject();
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -182,7 +182,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--measure',
         'fdtOutBytes'
       );
@@ -202,7 +202,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--group-by',
         'bogus'
       );
@@ -243,7 +243,7 @@ describe('query', () => {
         res.json({ data: [], summary: [], statistics: {} });
       });
       mockLinkedProject();
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -266,7 +266,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--project',
         'other-app'
       );
@@ -288,7 +288,7 @@ describe('query', () => {
         res.json({ data: [], summary: [], statistics: {} });
       });
       mockTeamScope('my-team');
-      client.setArgv('metrics', '--event', 'incomingRequest', '--all');
+      client.setArgv('metrics', '--event', 'edgeRequest', '--all');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -304,7 +304,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--all',
         '--project',
         'my-app'
@@ -324,7 +324,7 @@ describe('query', () => {
         org: null as any,
         project: null as any,
       });
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -337,7 +337,7 @@ describe('query', () => {
         status: 'error',
         exitCode: 1,
       });
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -350,7 +350,7 @@ describe('query', () => {
         team: null,
         user: { id: 'user_dummy' } as any,
       });
-      client.setArgv('metrics', '--event', 'incomingRequest', '--all');
+      client.setArgv('metrics', '--event', 'edgeRequest', '--all');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -368,7 +368,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--project',
         'my-app'
       );
@@ -391,7 +391,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--project',
         'other-app'
       );
@@ -420,7 +420,7 @@ describe('query', () => {
         });
       });
       mockLinkedProject();
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -454,7 +454,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--group-by',
         'httpStatus'
       );
@@ -473,7 +473,7 @@ describe('query', () => {
         res.json({ data: [], summary: [], statistics: {} });
       });
       mockLinkedProject();
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -499,7 +499,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--format=json'
       );
 
@@ -508,7 +508,7 @@ describe('query', () => {
       expect(exitCode).toBe(0);
       const output = client.stdout.getFullOutput();
       const parsed = JSON.parse(output);
-      expect(parsed.query.event).toBe('incomingRequest');
+      expect(parsed.query.event).toBe('edgeRequest');
       expect(parsed.data).toHaveLength(1);
       expect(parsed.summary).toHaveLength(1);
       expect(parsed.statistics).toBeDefined();
@@ -527,7 +527,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--limit',
         '50'
       );
@@ -551,7 +551,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--order-by',
         'value:asc'
       );
@@ -575,7 +575,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--filter',
         'httpStatus ge 500'
       );
@@ -593,7 +593,7 @@ describe('query', () => {
         res.status(402).json({ error: { code: 'PAYMENT_REQUIRED' } });
       });
       mockLinkedProject();
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -608,7 +608,7 @@ describe('query', () => {
         res.status(403).json({ error: { code: 'FORBIDDEN' } });
       });
       mockLinkedProject();
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -621,7 +621,7 @@ describe('query', () => {
         res.status(500).json({ error: { code: 'INTERNAL_ERROR' } });
       });
       mockLinkedProject();
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -636,7 +636,7 @@ describe('query', () => {
           .json({ error: { code: 'BAD_REQUEST', message: 'Invalid query' } });
       });
       mockLinkedProject();
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -653,7 +653,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--format=json'
       );
 
@@ -670,12 +670,12 @@ describe('query', () => {
     it('should track event option', async () => {
       mockApiSuccess();
       mockLinkedProject();
-      client.setArgv('metrics', '--event', 'incomingRequest');
+      client.setArgv('metrics', '--event', 'edgeRequest');
 
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
       ]);
     });
 
@@ -686,7 +686,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--measure',
         'requestDurationMs'
       );
@@ -694,7 +694,7 @@ describe('query', () => {
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
         { key: 'option:measure', value: 'requestDurationMs' },
       ]);
     });
@@ -706,7 +706,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--measure',
         'requestDurationMs',
         '--aggregation',
@@ -716,7 +716,7 @@ describe('query', () => {
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
         { key: 'option:measure', value: 'requestDurationMs' },
         { key: 'option:aggregation', value: 'p95' },
       ]);
@@ -729,7 +729,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--group-by',
         'httpStatus'
       );
@@ -737,7 +737,7 @@ describe('query', () => {
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
         { key: 'option:group-by', value: 'httpStatus' },
       ]);
     });
@@ -749,7 +749,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--limit',
         '50'
       );
@@ -757,7 +757,7 @@ describe('query', () => {
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
         { key: 'option:limit', value: '[REDACTED]' },
       ]);
     });
@@ -769,7 +769,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--filter',
         'httpStatus ge 500'
       );
@@ -777,7 +777,7 @@ describe('query', () => {
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
         { key: 'option:filter', value: '[REDACTED]' },
       ]);
     });
@@ -785,12 +785,12 @@ describe('query', () => {
     it('should track --all flag', async () => {
       mockApiSuccess();
       mockTeamScope();
-      client.setArgv('metrics', '--event', 'incomingRequest', '--all');
+      client.setArgv('metrics', '--event', 'edgeRequest', '--all');
 
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
         { key: 'flag:all', value: 'TRUE' },
       ]);
     });
@@ -802,14 +802,14 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--format=json'
       );
 
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
         { key: 'option:format', value: 'json' },
       ]);
     });
@@ -821,7 +821,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--granularity',
         '5m'
       );
@@ -829,7 +829,7 @@ describe('query', () => {
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
         { key: 'option:granularity', value: '5m' },
       ]);
     });
@@ -841,7 +841,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--project',
         'my-app'
       );
@@ -849,7 +849,7 @@ describe('query', () => {
       await query(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
         { key: 'option:project', value: '[REDACTED]' },
       ]);
     });
@@ -867,7 +867,7 @@ describe('query', () => {
         'metrics',
         'query',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--measure',
         'requestDurationMs',
         '--aggregation',

--- a/packages/cli/test/unit/commands/metrics/schema-data.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema-data.test.ts
@@ -63,7 +63,8 @@ describe('schema-data', () => {
     expect(aggs).toContain('avg');
     expect(aggs).toContain('min');
     expect(aggs).toContain('max');
-    expect(aggs).toContain('unique');
+    expect(aggs).toContain('p50');
+    expect(aggs).not.toContain('unique');
   });
 
   it('should return empty aggregations for unknown event', () => {
@@ -138,16 +139,10 @@ describe('schema-data', () => {
       ).toBe('avg');
     });
 
-    it('should return sum for tokens unit', () => {
+    it('should return sum for count unit', () => {
       expect(getDefaultAggregation('aiGatewayRequest', 'inputTokens')).toBe(
         'sum'
       );
-    });
-
-    it('should return avg for gigabyte hours unit', () => {
-      expect(
-        getDefaultAggregation('middlewareInvocation', 'functionDurationGbhr')
-      ).toBe('avg');
     });
 
     it('should return avg for percent unit', () => {

--- a/packages/cli/test/unit/commands/metrics/schema-data.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema-data.test.ts
@@ -96,8 +96,7 @@ describe('schema-data', () => {
     expect(measureNames).toContain('functionDurationMs');
   });
 
-  it('should have empty measures for events with no rollup-able measures', () => {
-    // blobStoreState only has measures that cannot be used in rollups
+  it('should have empty measures for unknown events', () => {
     expect(getMeasures('blobStoreState')).toEqual([]);
     expect(getMeasures('dataCacheState')).toEqual([]);
   });

--- a/packages/cli/test/unit/commands/metrics/schema-data.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema-data.test.ts
@@ -18,9 +18,7 @@ describe('schema-data', () => {
   it('should return correct event for known event', () => {
     const event = getEvent('incomingRequest');
     expect(event).toBeDefined();
-    expect(event!.description).toBe(
-      'All incoming HTTP requests to your deployments'
-    );
+    expect(event!.description).toBe('Edge Requests');
   });
 
   it('should return undefined for unknown event', () => {
@@ -127,9 +125,9 @@ describe('schema-data', () => {
     });
 
     it('should return avg for megabytes unit', () => {
-      expect(getDefaultAggregation('functionExecution', 'peakMemoryMb')).toBe(
-        'avg'
-      );
+      expect(
+        getDefaultAggregation('functionExecution', 'provisionedMemoryMb')
+      ).toBe('avg');
     });
 
     it('should return avg for ratio unit', () => {
@@ -142,6 +140,12 @@ describe('schema-data', () => {
       expect(getDefaultAggregation('aiGatewayRequest', 'inputTokens')).toBe(
         'sum'
       );
+    });
+
+    it('should return avg for seconds unit', () => {
+      expect(
+        getDefaultAggregation('aiGatewayRequest', 'videoDurationSeconds')
+      ).toBe('avg');
     });
 
     it('should return avg for percent unit', () => {

--- a/packages/cli/test/unit/commands/metrics/schema-data.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema-data.test.ts
@@ -16,7 +16,7 @@ describe('schema-data', () => {
   });
 
   it('should return correct event for known event', () => {
-    const event = getEvent('incomingRequest');
+    const event = getEvent('edgeRequest');
     expect(event).toBeDefined();
     expect(event!.description).toBe('Edge Requests');
   });
@@ -26,7 +26,7 @@ describe('schema-data', () => {
   });
 
   it('should return dimensions with correct shape', () => {
-    const dims = getDimensions('incomingRequest');
+    const dims = getDimensions('edgeRequest');
     expect(dims.length).toBeGreaterThan(0);
     for (const dim of dims) {
       expect(dim).toHaveProperty('name');
@@ -46,7 +46,7 @@ describe('schema-data', () => {
   });
 
   it('should return count aggregations for count measure', () => {
-    const aggs = getAggregations('incomingRequest', 'count');
+    const aggs = getAggregations('edgeRequest', 'count');
     expect(aggs).toContain('sum');
     expect(aggs).toContain('persecond');
     expect(aggs).toContain('percent');
@@ -55,7 +55,7 @@ describe('schema-data', () => {
   });
 
   it('should return value aggregations for non-count measure', () => {
-    const aggs = getAggregations('incomingRequest', 'requestDurationMs');
+    const aggs = getAggregations('edgeRequest', 'requestDurationMs');
     expect(aggs).toContain('sum');
     expect(aggs).toContain('p95');
     expect(aggs).toContain('avg');
@@ -70,7 +70,7 @@ describe('schema-data', () => {
   });
 
   it('should return empty aggregations for unknown measure', () => {
-    expect(getAggregations('incomingRequest', 'bogus')).toEqual([]);
+    expect(getAggregations('edgeRequest', 'bogus')).toEqual([]);
   });
 
   it('should mark filter-only dimensions correctly', () => {
@@ -94,7 +94,8 @@ describe('schema-data', () => {
     expect(measureNames).toContain('functionDurationMs');
   });
 
-  it('should have empty measures for unknown events', () => {
+  it('should have empty measures for events with no rollup-able measures', () => {
+    // blobStoreState only has measures that cannot be used in rollups
     expect(getMeasures('blobStoreState')).toEqual([]);
     expect(getMeasures('dataCacheState')).toEqual([]);
   });
@@ -109,7 +110,7 @@ describe('schema-data', () => {
 
   describe('getDefaultAggregation', () => {
     it('should return sum for count measure', () => {
-      expect(getDefaultAggregation('incomingRequest', 'count')).toBe('sum');
+      expect(getDefaultAggregation('edgeRequest', 'count')).toBe('sum');
     });
 
     it('should return avg for milliseconds unit', () => {
@@ -119,9 +120,7 @@ describe('schema-data', () => {
     });
 
     it('should return sum for bytes unit', () => {
-      expect(getDefaultAggregation('incomingRequest', 'fdtOutBytes')).toBe(
-        'sum'
-      );
+      expect(getDefaultAggregation('edgeRequest', 'fdtOutBytes')).toBe('sum');
     });
 
     it('should return avg for megabytes unit', () => {
@@ -163,7 +162,7 @@ describe('schema-data', () => {
     });
 
     it('should return sum for unknown measure', () => {
-      expect(getDefaultAggregation('incomingRequest', 'bogus')).toBe('sum');
+      expect(getDefaultAggregation('edgeRequest', 'bogus')).toBe('sum');
     });
   });
 });

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -30,7 +30,7 @@ describe('schema', () => {
       expect(stderrOutput).toContain('Events found');
       expect(stderrOutput).toContain('Event');
       expect(stderrOutput).toContain('Description');
-      expect(stderrOutput).toContain('incomingRequest');
+      expect(stderrOutput).toContain('edgeRequest');
     });
 
     it('should output JSON list with --format=json', async () => {
@@ -49,13 +49,13 @@ describe('schema', () => {
 
   describe('event detail', () => {
     it('should output table detail for a known event', async () => {
-      client.setArgv('metrics', 'schema', '--event', 'incomingRequest');
+      client.setArgv('metrics', 'schema', '--event', 'edgeRequest');
 
       const exitCode = await schema(client, new MockTelemetry());
 
       expect(exitCode).toBe(0);
       const stderrOutput = client.stderr.getFullOutput();
-      expect(stderrOutput).toContain('Event: incomingRequest');
+      expect(stderrOutput).toContain('Event: edgeRequest');
       expect(stderrOutput).toContain('Dimension');
       expect(stderrOutput).toContain('Label');
       expect(stderrOutput).toContain('Groupable');
@@ -68,7 +68,7 @@ describe('schema', () => {
         'metrics',
         'schema',
         '--event',
-        'incomingRequest',
+        'edgeRequest',
         '--format=json'
       );
 
@@ -77,7 +77,7 @@ describe('schema', () => {
       expect(exitCode).toBe(0);
       const output = client.stdout.getFullOutput();
       const parsed = JSON.parse(output);
-      expect(parsed.event).toBe('incomingRequest');
+      expect(parsed.event).toBe('edgeRequest');
       expect(parsed.description).toBeDefined();
       expect(parsed.dimensions).toBeDefined();
       expect(parsed.measures).toBeDefined();
@@ -105,18 +105,18 @@ describe('schema', () => {
       const output = client.stdout.getFullOutput();
       const parsed = JSON.parse(output);
       expect(parsed.error.code).toBe('UNKNOWN_EVENT');
-      expect(parsed.error.allowedValues).toContain('incomingRequest');
+      expect(parsed.error.allowedValues).toContain('edgeRequest');
     });
   });
 
   describe('telemetry', () => {
     it('should track event option', async () => {
-      client.setArgv('metrics', 'schema', '--event', 'incomingRequest');
+      client.setArgv('metrics', 'schema', '--event', 'edgeRequest');
 
       await schema(client, new MockTelemetry());
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:event', value: 'incomingRequest' },
+        { key: 'option:event', value: 'edgeRequest' },
       ]);
     });
 

--- a/packages/cli/test/unit/commands/metrics/text-output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/text-output.test.ts
@@ -216,7 +216,7 @@ describe('text-output', () => {
   describe('section formatters', () => {
     it('should render usage-style metadata fields', () => {
       const metadata = formatMetadataHeader({
-        event: 'incomingRequest',
+        event: 'edgeRequest',
         measure: 'requestDurationMs',
         aggregation: 'avg',
         periodStart: '2026-02-19T10:00:00.000Z',
@@ -273,7 +273,7 @@ describe('text-output', () => {
       };
 
       const output = formatText(response, {
-        event: 'incomingRequest',
+        event: 'edgeRequest',
         measure: 'count',
         aggregation: 'sum',
         groupBy: [],
@@ -292,7 +292,7 @@ describe('text-output', () => {
         .join('\n');
 
       expect(normalized).toMatchInlineSnapshot(`
-        "> Metric: incomingRequest / count sum
+        "> Metric: edgeRequest / count sum
         > Period: 2026-02-19 10:00 to 2026-02-19 10:15
         > Interval: 5m
         > Project: my-project (my-team)
@@ -378,7 +378,7 @@ describe('text-output', () => {
           statistics: {},
         },
         {
-          event: 'incomingRequest',
+          event: 'edgeRequest',
           measure: 'count',
           aggregation: 'sum',
           groupBy: [],
@@ -400,7 +400,7 @@ describe('text-output', () => {
           statistics: {},
         },
         {
-          event: 'incomingRequest',
+          event: 'edgeRequest',
           measure: 'count',
           aggregation: 'sum',
           groupBy: [],

--- a/packages/cli/test/unit/commands/metrics/text-output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/text-output.test.ts
@@ -26,9 +26,9 @@ const projectScope: Scope = {
 
 describe('text-output', () => {
   describe('number formatting', () => {
-    it('should classify measure types from schema units', () => {
+    it('should classify measure types from schema units and fallback units', () => {
       expect(getMeasureType('count')).toBe('count');
-      expect(getMeasureType('tokens')).toBe('count');
+      expect(getMeasureType('unknown_unit')).toBe('ratio');
       expect(getMeasureType('US dollars')).toBe('count');
       expect(getMeasureType('milliseconds')).toBe('duration');
       expect(getMeasureType('bytes')).toBe('bytes');

--- a/packages/cli/test/unit/commands/metrics/validation.test.ts
+++ b/packages/cli/test/unit/commands/metrics/validation.test.ts
@@ -11,7 +11,7 @@ import {
 describe('validation', () => {
   describe('validateEvent', () => {
     it('should pass for known event', () => {
-      expect(validateEvent('incomingRequest')).toEqual({ valid: true });
+      expect(validateEvent('edgeRequest')).toEqual({ valid: true });
     });
 
     it('should fail for unknown event with available list', () => {
@@ -20,7 +20,7 @@ describe('validation', () => {
       if (!result.valid) {
         expect(result.code).toBe('UNKNOWN_EVENT');
         expect(result.message).toContain('"bogus"');
-        expect(result.allowedValues).toContain('incomingRequest');
+        expect(result.allowedValues).toContain('edgeRequest');
         expect(result.allowedValues).toContain('functionExecution');
       }
     });
@@ -28,24 +28,24 @@ describe('validation', () => {
 
   describe('validateMeasure', () => {
     it('should pass for valid measure', () => {
-      expect(validateMeasure('incomingRequest', 'count')).toEqual({
+      expect(validateMeasure('edgeRequest', 'count')).toEqual({
         valid: true,
       });
     });
 
     it('should pass for non-count measure', () => {
-      expect(validateMeasure('incomingRequest', 'requestDurationMs')).toEqual({
+      expect(validateMeasure('edgeRequest', 'requestDurationMs')).toEqual({
         valid: true,
       });
     });
 
     it('should fail for unknown measure with available list', () => {
-      const result = validateMeasure('incomingRequest', 'latency');
+      const result = validateMeasure('edgeRequest', 'latency');
       expect(result.valid).toBe(false);
       if (!result.valid) {
         expect(result.code).toBe('UNKNOWN_MEASURE');
         expect(result.message).toContain('"latency"');
-        expect(result.message).toContain('"incomingRequest"');
+        expect(result.message).toContain('"edgeRequest"');
         expect(result.allowedValues).toContain('count');
         expect(result.allowedValues).toContain('requestDurationMs');
       }
@@ -54,7 +54,7 @@ describe('validation', () => {
 
   describe('validateAggregation', () => {
     it('should pass for valid aggregation on count', () => {
-      expect(validateAggregation('incomingRequest', 'count', 'sum')).toEqual({
+      expect(validateAggregation('edgeRequest', 'count', 'sum')).toEqual({
         valid: true,
         value: 'sum',
       });
@@ -62,12 +62,12 @@ describe('validation', () => {
 
     it('should pass for p95 on duration measure', () => {
       expect(
-        validateAggregation('incomingRequest', 'requestDurationMs', 'p95')
+        validateAggregation('edgeRequest', 'requestDurationMs', 'p95')
       ).toEqual({ valid: true, value: 'p95' });
     });
 
     it('should fail for p95 on count measure', () => {
-      const result = validateAggregation('incomingRequest', 'count', 'p95');
+      const result = validateAggregation('edgeRequest', 'count', 'p95');
       expect(result.valid).toBe(false);
       if (!result.valid) {
         expect(result.code).toBe('INVALID_AGGREGATION');
@@ -80,7 +80,7 @@ describe('validation', () => {
 
     it('should fail for completely invalid aggregation', () => {
       const result = validateAggregation(
-        'incomingRequest',
+        'edgeRequest',
         'requestDurationMs',
         'bogus'
       );
@@ -95,13 +95,13 @@ describe('validation', () => {
 
   describe('validateGroupBy', () => {
     it('should pass for valid dimensions', () => {
-      expect(
-        validateGroupBy('incomingRequest', ['httpStatus', 'route'])
-      ).toEqual({ valid: true });
+      expect(validateGroupBy('edgeRequest', ['httpStatus', 'route'])).toEqual({
+        valid: true,
+      });
     });
 
     it('should fail for unknown dimension with available list', () => {
-      const result = validateGroupBy('incomingRequest', ['bogus']);
+      const result = validateGroupBy('edgeRequest', ['bogus']);
       expect(result.valid).toBe(false);
       if (!result.valid) {
         expect(result.code).toBe('UNKNOWN_DIMENSION');
@@ -121,7 +121,7 @@ describe('validation', () => {
     });
 
     it('should pass for empty dimensions', () => {
-      expect(validateGroupBy('incomingRequest', [])).toEqual({
+      expect(validateGroupBy('edgeRequest', [])).toEqual({
         valid: true,
       });
     });
@@ -159,9 +159,9 @@ describe('validation', () => {
 
   describe('validateRequiredEvent', () => {
     it('should pass when event is provided', () => {
-      expect(validateRequiredEvent('incomingRequest')).toEqual({
+      expect(validateRequiredEvent('edgeRequest')).toEqual({
         valid: true,
-        value: 'incomingRequest',
+        value: 'edgeRequest',
       });
     });
 


### PR DESCRIPTION
## Summary

  - Remove the `tokens` unit type (replaced with `count`), drop the `unique` aggregation, and add `p50` percentile support
  - Remove events that are not supported by the query engine: `analyticsEvent`, `analyticsPageview`, `blobStoreState`, `dataCacheState`
  - Align remaining event schemas with the query engine: add/remove dimensions and measures, update `filterOnly` flags, shorten event descriptions
  - Rename `incomingRequest` to `edgeRequest` with a `queryEngineEvent` alias so the CLI uses the new user-facing name while still sending `incomingRequest` to the API.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR renames CLI event types, updates schema definitions (dimensions/measures/filterOnly flags), and removes unsupported events - all changes are to static CLI schema data and documentation, not database structure or security controls.
> 
> - Rename `incomingRequest` to `edgeRequest` with `queryEngineEvent` alias for API compatibility
> - Remove unsupported events (`analyticsEvent`, `analyticsPageview`, `blobStoreState`, `dataCacheState`) and update schema dimensions/measures
> - Update CLI examples, descriptions, and test assertions to use new event names
>
> <sup>Risk assessment for [commit b702e61](https://github.com/vercel/vercel/commit/b702e61506173ba5a3c8706254d777d855bdd5dd).</sup>
<!-- VADE_RISK_END -->