### PR TITLE
feat(cli): add --search option to vc logs

### DIFF
--- a/.changeset/dirty-rings-lie.md
+++ b/.changeset/dirty-rings-lie.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add a `--search` option to `vc logs` that passes the raw query through to the request logs API, while preserving existing `--query` behavior.

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -112,6 +112,14 @@ export const logsCommand = {
       description: 'Full-text search query',
     },
     {
+      name: 'search',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Raw search query passed to the API (supports filter syntax)',
+    },
+    {
       name: 'request-id',
       shorthand: null,
       type: String,
@@ -169,6 +177,10 @@ export const logsCommand = {
     {
       name: 'Search logs and pipe to jq',
       value: `${packageName} logs --query "timeout" --json | jq '.message'`,
+    },
+    {
+      name: 'Pass a raw search query with filters',
+      value: `${packageName} logs --search "status:500 error" --json | jq '.message'`,
     },
     {
       name: 'Display production logs only',

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -117,7 +117,7 @@ export const logsCommand = {
       type: String,
       deprecated: false,
       description:
-        'Raw search query passed to the API (supports filter syntax)',
+        'Advanced search query (supports filter syntax, e.g. "status:500 error")',
     },
     {
       name: 'request-id',
@@ -179,7 +179,7 @@ export const logsCommand = {
       value: `${packageName} logs --query "timeout" --json | jq '.message'`,
     },
     {
-      name: 'Pass a raw search query with filters',
+      name: 'Use advanced search query with filters',
       value: `${packageName} logs --search "status:500 error" --json | jq '.message'`,
     },
     {

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -180,7 +180,7 @@ export const logsCommand = {
     },
     {
       name: 'Use advanced search query with filters',
-      value: `${packageName} logs --search "status:500 error" --json | jq '.message'`,
+      value: `${packageName} logs --search 'status:500 error' --json | jq '.message'`,
     },
     {
       name: 'Display production logs only',

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -245,6 +245,7 @@ export default async function logs(client: Client) {
   const limitOption = parsedArguments.flags['--limit'];
   const jsonOption = parsedArguments.flags['--json'];
   const queryOption = parsedArguments.flags['--query'];
+  const searchOption = parsedArguments.flags['--search'];
   const requestIdOption = parsedArguments.flags['--request-id'];
   const expandOption = parsedArguments.flags['--expand'];
   const branchFlagValue = parsedArguments.flags['--branch'];
@@ -269,6 +270,7 @@ export default async function logs(client: Client) {
   telemetry.trackCliFlagJson(jsonOption);
   telemetry.trackCliFlagFollow(followOption);
   telemetry.trackCliOptionQuery(queryOption);
+  telemetry.trackCliOptionSearch(searchOption);
   telemetry.trackCliOptionRequestId(requestIdOption);
   telemetry.trackCliFlagExpand(expandOption);
   telemetry.trackCliOptionBranch(branchFlagValue);
@@ -283,6 +285,7 @@ export default async function logs(client: Client) {
       { flag: '--until', value: untilOption },
       { flag: '--limit', value: limitOption },
       { flag: '--query', value: queryOption },
+      { flag: '--search', value: searchOption },
       { flag: '--request-id', value: requestIdOption },
     ];
 
@@ -516,7 +519,7 @@ export default async function logs(client: Client) {
       since: sinceOption,
       until: untilOption,
       limit,
-      search: queryOption,
+      search: searchOption ?? queryOption,
       requestId: requestIdOption,
       branch: branchOption,
     })) {

--- a/packages/cli/src/util/telemetry/commands/logs/index.ts
+++ b/packages/cli/src/util/telemetry/commands/logs/index.ts
@@ -139,6 +139,15 @@ export class LogsTelemetryClient
     }
   }
 
+  trackCliOptionSearch(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'search',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliOptionRequestId(v: string | undefined) {
     if (v) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -587,6 +587,51 @@ describe('logs', () => {
     });
   });
 
+  describe('--search option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logstest',
+        name: 'logs-test-project',
+      });
+    });
+
+    it('should pass raw search query to the API', async () => {
+      let receivedSearch: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedSearch = req.query.search as string;
+        res.json({
+          rows: [createMockLog({ message: 'status:500 error' })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--search', 'status:500 error');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedSearch).toEqual('status:500 error');
+    });
+
+    it('should track telemetry for --search option', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--search', 'status:500 error');
+      await logs(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:search',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
+
   describe('--deployment option', () => {
     beforeEach(() => {
       useUser();
@@ -868,6 +913,22 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput('Remove: --query');
+    });
+
+    it('should error when --follow is used with --search', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv(
+        'logs',
+        '--follow',
+        '--deployment',
+        'dpl_test',
+        '--search',
+        'status:500 error'
+      );
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Remove: --search');
     });
 
     it('should error when --follow is used with multiple incompatible flags', async () => {


### PR DESCRIPTION
Add a `--search` option to `vc logs` as a thin passthrough to the request logs API `search` query parameter.

- adds `--search` to command help/examples
- forwards the raw `--search` value to the API without extra parsing, while keeping existing `--query` behavior
- adds telemetry and unit tests for `--search`, including `--follow` incompatibility handling

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new --search CLI option to the logs command, forwarding it to an existing API parameter, with corresponding telemetry and unit tests.
> 
> - New --search CLI flag added to logs command with passthrough to API
> - Telemetry tracking added for --search option with redacted values
> - Unit tests added for --search functionality and --follow incompatibility
>
> <sup>Risk assessment for [commit 2062d16](https://github.com/vercel/vercel/commit/2062d16e3a6c14ae35a84d87d5ce0657d72986d3).</sup>
<!-- VADE_RISK_END -->