### PR TITLE
[python] workers: allow topic filter in subscribe()

### DIFF
--- a/.changeset/tasty-icons-turn.md
+++ b/.changeset/tasty-icons-turn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-workers': patch
+---
+
+[python] workers: allow topic filter in subscribe()

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -70,8 +70,20 @@ class SendMessageResult(TypedDict):
 @dataclass
 class _Subscription:
     func: WorkerCallable
-    topic: str | None = None
+    topic_filter: Callable[[str | None], bool] | None = None
+    topic_desc: str | None = None
     consumer: str | None = None
+
+    def matches(
+        self, topic: str | None, consumer: str | None = None, *, ignore_consumer: bool = False
+    ) -> bool:
+        if self.topic_filter is not None:
+            if not self.topic_filter(topic):
+                return False
+        if not ignore_consumer and self.consumer is not None:
+            if self.consumer != consumer:
+                return False
+        return True
 
 
 _subscriptions: list[_Subscription] = []
@@ -80,7 +92,7 @@ _subscriptions: list[_Subscription] = []
 def subscribe(
     _func: WorkerCallable | None = None,
     *,
-    topic: str | None = None,
+    topic: str | tuple[str, Callable[[str | None], bool]] | None = None,
     consumer: str | None = None,
 ) -> Callable[[WorkerCallable], WorkerCallable] | WorkerCallable:
     """
@@ -93,10 +105,26 @@ def subscribe(
 
         @subscribe(topic="events", consumer="billing")
         def billing_worker(message, metadata): ...
+
+        @subscribe(topic=("user-*", lambda t: t.startswith("user-")))
+        def user_worker(message, metadata): ...
     """
 
+    if isinstance(topic, str):
+        topic_filter = lambda t, expected=topic: t == expected
+        topic_desc = topic
+    elif isinstance(topic, tuple):
+        topic_desc, topic_filter = topic
+    else:
+        topic_filter = None
+        topic_desc = None
+
     def decorator(func: WorkerCallable) -> WorkerCallable:
-        _subscriptions.append(_Subscription(func=func, topic=topic, consumer=consumer))
+        _subscriptions.append(
+            _Subscription(
+                func=func, topic_filter=topic_filter, topic_desc=topic_desc, consumer=consumer
+            )
+        )
 
         @wraps(func)
         def wrapper(message: Any, metadata: MessageMetadata) -> Any:
@@ -141,10 +169,7 @@ def _select_subscriptions(
 ) -> Iterable[_Subscription]:
     # Match by topic and consumer (unless consumer is ignored).
     explicit_matches = [
-        s
-        for s in _subscriptions
-        if (s.topic is None or s.topic == topic)
-        and (ignore_consumer or s.consumer is None or s.consumer == consumer)
+        s for s in _subscriptions if s.matches(topic, consumer, ignore_consumer=ignore_consumer)
     ]
     return explicit_matches
 
@@ -204,10 +229,10 @@ def _send_in_process(queue_name: str, payload: Any) -> SendMessageResult:
     # In dev mode, surface a clear error when there are worker functions but none of
     # them are subscribed to the requested topic. This helps catch mismatches between
     # the queue name used in send() and the topics configured via @subscribe.
-    matching_for_topic = [s for s in _subscriptions if s.topic is None or s.topic == queue_name]
+    matching_for_topic = [s for s in _subscriptions if s.matches(queue_name, ignore_consumer=True)]
     if not matching_for_topic:
         available_topics = sorted(
-            {s.topic for s in _subscriptions if s.topic is not None},
+            {s.topic_desc for s in _subscriptions if s.topic_desc is not None},
         )
         raise RuntimeError(
             "No worker subscriptions found for topic "

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -92,12 +92,14 @@ _subscriptions: list[_Subscription] = []
 @overload
 def subscribe(_func: WorkerCallable) -> WorkerCallable: ...
 
+
 @overload
 def subscribe(
     *,
     topic: str | tuple[str, Callable[[str | None], bool]] | None = None,
     consumer: str | None = None,
 ) -> Callable[[WorkerCallable], WorkerCallable]: ...
+
 
 def subscribe(
     _func: WorkerCallable | None = None,
@@ -122,6 +124,7 @@ def subscribe(
 
     topic_filter: Callable[[str | None], bool] | None
     if isinstance(topic, str):
+
         def topic_filter(t: str | None) -> bool:
             return t == topic
 

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -110,8 +110,11 @@ def subscribe(
         def user_worker(message, metadata): ...
     """
 
+    topic_filter: Callable[[str | None], bool] | None
     if isinstance(topic, str):
-        topic_filter = lambda t, expected=topic: t == expected
+        def topic_filter(t: str | None) -> bool:
+            return t == topic
+
         topic_desc = topic
     elif isinstance(topic, tuple):
         topic_desc, topic_filter = topic

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import wraps
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol, TypedDict, overload
 from uuid import uuid4
 
 import httpx
@@ -88,6 +88,16 @@ class _Subscription:
 
 _subscriptions: list[_Subscription] = []
 
+
+@overload
+def subscribe(_func: WorkerCallable) -> WorkerCallable: ...
+
+@overload
+def subscribe(
+    *,
+    topic: str | tuple[str, Callable[[str | None], bool]] | None = None,
+    consumer: str | None = None,
+) -> Callable[[WorkerCallable], WorkerCallable]: ...
 
 def subscribe(
     _func: WorkerCallable | None = None,


### PR DESCRIPTION
This allows `subscribe()` to take a `(str, Callable)` in addition to `str | None` only, so as to support custom topic filtering.

Refs vercel/vqs#42 
Port of vercel/vqs-py#11
Closes vercel/vqs-py#11

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds support for custom topic filtering in the subscribe() decorator by extending the topic parameter to accept a tuple with a filter function, which is a feature enhancement with no security implications.
> 
> - Extends `topic` parameter type from `str | None` to `str | tuple[str, Callable] | None`
> - Adds `matches()` method to `_Subscription` dataclass for topic/consumer filtering
> - Refactors topic matching logic to use new `topic_filter` callable
>
> <sup>Risk assessment for [commit eee79fe](https://github.com/vercel/vercel/commit/eee79fea6e44c2c030cc30622e6ce1e06c83f240).</sup>
<!-- VADE_RISK_END -->