### PR TITLE
feat(cli): skip inline terms for integrations requiring browser install

### DIFF
--- a/.changeset/cli-aws-browser-terms.md
+++ b/.changeset/cli-aws-browser-terms.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(cli): skip inline terms for integrations requiring browser install

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -162,7 +162,14 @@ export async function addAutoProvision(
   let acceptedPolicies: AcceptedPolicies = {};
   let browserInstallationId: string | undefined;
   if (!teamInstallation) {
-    if (client.isAgent || !client.stdin.isTTY) {
+    if (
+      // AI agent mode — cannot interact with terminal prompts
+      client.isAgent ||
+      // Non-interactive terminal (CI/scripts) — no TTY for prompts
+      !client.stdin.isTTY ||
+      // Server declares browser install required (e.g. needs device fingerprint)
+      integration.capabilities?.requiresBrowserInstall
+    ) {
       // Browser flow: open browser for terms acceptance, poll for installation
       const browserInstallation = await acceptTermsViaBrowser(
         client,

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -111,6 +111,9 @@ export interface Integration {
   products?: IntegrationProduct[];
   eulaDocUri?: string;
   privacyDocUri?: string;
+  capabilities?: {
+    requiresBrowserInstall?: boolean;
+  };
 }
 
 export interface IntegrationInstallation {

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -269,6 +269,9 @@ const integrations: Record<string, Integration> = {
     id: 'aws-apg',
     name: 'Aurora Postgres',
     slug: 'aws-apg',
+    capabilities: {
+      requiresBrowserInstall: true,
+    },
     products: [
       {
         id: 'aws-apg-product',


### PR DESCRIPTION
## Summary
- When an integration has `capabilities.requiresBrowserInstall`, skip inline CLI terms prompts and go directly to browser-based terms acceptance
- Prevents double prompting: previously users would accept terms inline, server would reject (missing device fingerprint), then redirect to browser to accept again

## Changes
- Added `capabilities?: { requiresBrowserInstall?: boolean }` to CLI's `Integration` type
- Added `integration.capabilities?.requiresBrowserInstall` check in the terms decision logic in `add-auto-provision.ts`
- Added mock integration with the new capability
- Added test verifying browser flow triggers for `requiresBrowserInstall`
- Updated existing test that used `aws-apg` for inline terms to use `acme-prepayment` instead

## Companion PR
API: https://github.com/vercel/api/pull/62040 (exposes the capability)

## Test plan

### Unit Tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/add-auto-provision.test.ts

 ✓ test/unit/commands/integration/add-auto-provision.test.ts (27 tests) 310ms

 Test Files  1 passed (1)
      Tests  27 passed (27)
```

### Manual Testing

Tested with companion API PR fully deployed (API returns `requiresBrowserInstall: true` for applicable integrations).

| Test | Integration | Team | Expected | Result |
|------|-------------|------|----------|--------|
| `requiresBrowserInstall`, no installation | `aws/aws-apg` | bare team | Browser flow | ✅ "Opening browser for terms acceptance" — URL: `.../accept-terms/aws?source=cli` |
| No `requiresBrowserInstall` | `neon` | bare team | Inline/auto-provision | ✅ Auto-provisioned directly (201) — no browser flow |
| `requiresBrowserInstall`, with installation | `aws/aws-dsql` | bare team (now installed) | Skip terms → provision | ✅ Straight to provisioning |

### Code paths covered

| Path | Expected | Tested by |
|------|----------|-----------|
| `requiresBrowserInstall` + no installation → browser flow | Opens browser, polls for installation | Unit + manual |
| `requiresBrowserInstall` + existing installation → skip terms | Straight to provisioning | Unit + manual |
| No `requiresBrowserInstall` + `isAgent` → browser flow | Opens browser (unchanged behavior) | Unit |
| No `requiresBrowserInstall` + `!isTTY` → browser flow | Opens browser (unchanged behavior) | Unit |
| No `requiresBrowserInstall` + TTY → inline terms | Inline prompts (unchanged behavior) | Unit + manual |

Fixes: [MKT-3020](https://linear.app/vercel/issue/MKT-3020/redirected-to-accept-terms-page-after-aws-integration)

*🤖 Written by Claude Code on behalf of @tonypan2*

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new condition that forces browser-based terms acceptance when an integration requires it, which is a defensive change that ensures proper device fingerprinting rather than bypassing security.
> 
> - Adds `requiresBrowserInstall` capability check to force browser flow for terms acceptance
> - New optional type field `capabilities?.requiresBrowserInstall` on Integration interface
> - Test updates and new test for browser flow trigger
>
> <sup>Risk assessment for [commit 7aa1b8a](https://github.com/vercel/vercel/commit/7aa1b8a354f51e58250174ad76aaf2faef9aa856).</sup>
<!-- VADE_RISK_END -->