### PR TITLE
[Python] Remove experimental flag from django framework.

### DIFF
--- a/.changeset/tame-rockets-speak.md
+++ b/.changeset/tame-rockets-speak.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': minor
+---
+
+Remove experimental flag from django framework.

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2217,7 +2217,6 @@ export const frameworks = [
   {
     name: 'Django',
     slug: 'django',
-    experimental: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/django.svg',
     tagline:
       'Django is a high-level Python web framework that encourages rapid development and clean, pragmatic design. ',


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR removes the experimental flag from the Django framework configuration, promoting it from experimental to stable status - a minor configuration change with no security or data implications.
> 
> - Removes `experimental: true` flag from Django framework definition
> - Adds changeset file documenting minor version bump
>
> <sup>Risk assessment for [commit 4fd2116](https://github.com/vercel/vercel/commit/4fd211649b1e2252f22ac5bbcf10fc83e4f6c774).</sup>
<!-- VADE_RISK_END -->