### PR TITLE
[python] Add litellm proxy support

### DIFF
--- a/.changeset/sixty-ladybugs-draw.md
+++ b/.changeset/sixty-ladybugs-draw.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+add litellm proxy support

--- a/packages/python/src/quirks/index.ts
+++ b/packages/python/src/quirks/index.ts
@@ -4,6 +4,7 @@ import {
   scanDistributions,
 } from '@vercel/python-analysis';
 import { getVenvSitePackagesDirs } from '../install';
+import { litellmQuirk } from './litellm';
 import { prismaQuirk } from './prisma';
 
 export interface QuirkContext {
@@ -30,7 +31,7 @@ export interface Quirk {
   run(ctx: QuirkContext): Promise<QuirkResult>;
 }
 
-const quirks: Quirk[] = [prismaQuirk];
+const quirks: Quirk[] = [litellmQuirk, prismaQuirk];
 
 /**
  * Topologically sort activated quirks based on runsBefore/runsAfter edges.

--- a/packages/python/src/quirks/litellm.ts
+++ b/packages/python/src/quirks/litellm.ts
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import { join } from 'path';
+import { debug } from '@vercel/build-utils';
+import { getVenvSitePackagesDirs } from '../install';
+import type { Quirk, QuirkContext, QuirkResult } from './index';
+
+const LAMBDA_ROOT = '/var/task';
+
+const CONFIG_CANDIDATES = [
+  'litellm_config.yaml',
+  'litellm_config.yml',
+  'litellm.yaml',
+  'litellm.yml',
+];
+
+/** Find a litellm config file in workPath. Returns the basename if found. */
+async function findConfigFile(workPath: string): Promise<string | null> {
+  for (const name of CONFIG_CANDIDATES) {
+    const candidate = join(workPath, name);
+    try {
+      await fs.promises.access(candidate);
+      return name;
+    } catch {
+      // try next
+    }
+  }
+  return null;
+}
+
+export const litellmQuirk: Quirk = {
+  dependency: 'litellm',
+  runsBefore: ['prisma'],
+  async run(ctx: QuirkContext): Promise<QuirkResult> {
+    const buildEnv: Record<string, string> = {};
+    const env: Record<string, string> = {};
+
+    // 1. Find Prisma schema bundled with litellm
+    const sitePackagesDirs = await getVenvSitePackagesDirs(ctx.venvPath);
+    for (const sitePackages of sitePackagesDirs) {
+      const schemaPath = join(
+        sitePackages,
+        'litellm',
+        'proxy',
+        'schema.prisma'
+      );
+      try {
+        await fs.promises.access(schemaPath);
+        debug(`LiteLLM quirk: found schema at ${schemaPath}`);
+        buildEnv.PRISMA_SCHEMA_PATH = schemaPath;
+        break;
+      } catch {
+        // try next site-packages directory
+      }
+    }
+
+    if (!buildEnv.PRISMA_SCHEMA_PATH) {
+      debug('LiteLLM quirk: schema.prisma not found in any site-packages');
+    }
+
+    // 2. Set CONFIG_FILE_PATH if not already set
+    if (!process.env.CONFIG_FILE_PATH) {
+      const configName = await findConfigFile(ctx.workPath);
+      if (configName) {
+        debug(`LiteLLM quirk: found config at ${configName}`);
+        buildEnv.CONFIG_FILE_PATH = join(ctx.workPath, configName);
+        env.CONFIG_FILE_PATH = join(LAMBDA_ROOT, configName);
+      }
+    } else {
+      debug(
+        `LiteLLM quirk: CONFIG_FILE_PATH already set to ${process.env.CONFIG_FILE_PATH}`
+      );
+    }
+
+    return { buildEnv, env };
+  },
+};

--- a/packages/python/test/fixtures/51-litellm/app.py
+++ b/packages/python/test/fixtures/51-litellm/app.py
@@ -1,1 +1,3 @@
-from litellm.proxy.proxy_server import app  # noqa: F401
+from litellm.proxy import proxy_server
+
+app = proxy_server.app

--- a/packages/python/test/fixtures/51-litellm/app.py
+++ b/packages/python/test/fixtures/51-litellm/app.py
@@ -1,0 +1,1 @@
+from litellm.proxy.proxy_server import app  # noqa: F401

--- a/packages/python/test/fixtures/51-litellm/litellm_config.yaml
+++ b/packages/python/test/fixtures/51-litellm/litellm_config.yaml
@@ -1,0 +1,1 @@
+model_list: []

--- a/packages/python/test/fixtures/51-litellm/probes.json
+++ b/packages/python/test/fixtures/51-litellm/probes.json
@@ -1,0 +1,9 @@
+{
+  "probes": [
+    {
+      "path": "/health/liveliness",
+      "status": 200,
+      "mustContain": "I'm alive!"
+    }
+  ]
+}

--- a/packages/python/test/fixtures/51-litellm/pyproject.toml
+++ b/packages/python/test/fixtures/51-litellm/pyproject.toml
@@ -2,4 +2,4 @@
 name = "litellm-fixture"
 version = "0.0.0"
 requires-python = "~=3.13.0"
-dependencies = ["litellm[proxy]"]
+dependencies = ["litellm[proxy]", "fastapi<1.0.0"]

--- a/packages/python/test/fixtures/51-litellm/pyproject.toml
+++ b/packages/python/test/fixtures/51-litellm/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "litellm-fixture"
+version = "0.0.0"
+requires-python = "~=3.13.0"
+dependencies = ["litellm[proxy]"]


### PR DESCRIPTION
The `litellm` support is in a form of a new quirk that informs the
`prisma` quirk added earlier about the location of litellm's persistence
schema.  Other than that, the litellm proxy works out of the box with no
additional configuration other than placing `litellm_config.yaml` at the
root of the project (configurable with `CONFIG_FILE_PATH` env var).
Other litellm env vars are naturally supported, refer to upstream
documentation.


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new litellm proxy support feature with a new quirk module, test fixtures, and comprehensive test coverage - no security, auth, schema, or critical business logic changes.
> 
> - New litellm quirk module for build-time config detection
> - Test fixtures and extensive unit tests for litellm integration
> - Changeset documentation for patch release
>
> <sup>Risk assessment for [commit c4e1a8c](https://github.com/vercel/vercel/commit/c4e1a8c6ec905ba1181de0fe971df1197082affb).</sup>
<!-- VADE_RISK_END -->