### PR TITLE
[python] Detect django framework when manage.py is found.

### DIFF
--- a/.changeset/tidy-geckos-own.md
+++ b/.changeset/tidy-geckos-own.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': minor
+---
+
+Detect django framework when manage.py is found.

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2240,6 +2240,9 @@ export const frameworks = [
           path: 'Pipfile',
           matchContent: '[Dd]jango',
         },
+        {
+          path: 'manage.py',
+        },
       ],
     },
     settings: {


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a simple framework detection rule for Django by checking for manage.py file presence, which is a minor additive change to framework detection logic.
> 
> - Adds manage.py as detection path for Django framework
> - Changeset file documents minor version bump for @vercel/frameworks
>
> <sup>Risk assessment for [commit 5e07d95](https://github.com/vercel/vercel/commit/5e07d952c9d0338ce5a15a8245e8478a78d0646d).</sup>
<!-- VADE_RISK_END -->