### PR TITLE
[python-runtime] Report fatal init errors via IPC `unrecoverable-error` message

### DIFF
--- a/.changeset/new-falcons-reply.md
+++ b/.changeset/new-falcons-reply.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-runtime': patch
+---
+
+Report fatal init errors via IPC `unrecoverable-error` message

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -41,7 +41,31 @@ def _stderr(message: str) -> None:
 
 def _fatal(message: str) -> Never:
     _stderr(message)
+    _send_unrecoverable_error(message)
     sys.exit(1)
+
+
+def _fatal_exc(label: str) -> Never:
+    """Report a fatal exception (with traceback) and exit."""
+    _fatal(f"{label}:\n{traceback.format_exc()}")
+
+
+def _send_unrecoverable_error(message: str) -> None:
+    """Send an ``unrecoverable-error`` IPC message to the functions runtime.
+
+    This is the only message type (besides ``server-started``) that the
+    functions runtime accepts before the handshake completes, so it is the
+    correct way to report fatal errors during module import.
+    """
+    send_message(
+        {
+            "type": "unrecoverable-error",
+            "payload": {
+                "exitCode": 1,
+                "message": message,
+            },
+        }
+    )
 
 
 def _must_getenv(varname: str) -> str:
@@ -374,6 +398,20 @@ def enqueue_or_send_message(msg: _IpcMessage) -> None:
             _original_stderr.write(decoded + "\n")
 
 
+def _flush_init_log_buf() -> None:
+    """Flush buffered init logs through IPC and mark the channel as ready.
+
+    Called once the ``server-started`` handshake is complete so the functions
+    runtime will accept ``log`` messages.
+    """
+    global _ipc_ready, _init_log_buf_bytes  # noqa: PLW0603
+    _ipc_ready = True
+    for m in _init_log_buf:
+        send_message(m)
+    _init_log_buf.clear()
+    _init_log_buf_bytes = 0
+
+
 def flush_init_log_buf_to_stderr() -> None:
     global _init_log_buf_bytes  # noqa: PLW0603
     try:
@@ -535,9 +573,7 @@ try:
     __vc_spec.loader.exec_module(__vc_module)
     __vc_variables = dir(__vc_module)
 except Exception:
-    _stderr(f"Error importing {_entrypoint_rel}:")
-    _stderr(traceback.format_exc())
-    exit(1)
+    _fatal_exc(f'could not import "{_entrypoint_rel}"')
 
 _use_legacy_asyncio = sys.version_info < (3, 10)
 
@@ -822,11 +858,10 @@ if "VERCEL_IPC_PATH" in os.environ:
             else __vc_module.Handler
         )
         if not issubclass(base, BaseHTTPRequestHandler):
-            _stderr("Handler must inherit from BaseHTTPRequestHandler")
-            _stderr(
+            _fatal(
+                "Handler must inherit from BaseHTTPRequestHandler\n"
                 "See the docs: https://vercel.com/docs/functions/serverless-functions/runtimes/python"
             )
-            exit(1)
 
         class Handler(BaseHandler, base):  # type: ignore[valid-type,misc]
             def handle_request(self) -> None:
@@ -970,12 +1005,7 @@ if "VERCEL_IPC_PATH" in os.environ:
                     },
                 }
             )
-
-            # Mark IPC as ready and flush any buffered init logs
-            _ipc_ready = True
-            for m in _init_log_buf:
-                send_message(m)
-            _init_log_buf.clear()
+            _flush_init_log_buf()
 
             # Run the server (blocking)
             server.run()
@@ -993,18 +1023,13 @@ if "VERCEL_IPC_PATH" in os.environ:
                 },
             }
         )
-        # Mark IPC as ready and flush any buffered init logs
-        _ipc_ready = True
-        for m in _init_log_buf:
-            send_message(m)
-        _init_log_buf.clear()
+        _flush_init_log_buf()
         server.serve_forever()  # type: ignore[attr-defined]
 
-    _stderr(f'Missing variable `handler` or `app` in file "{_entrypoint_rel}".')
-    _stderr(
+    _fatal(
+        f'Missing variable `handler` or `app` in file "{_entrypoint_rel}".\n'
         "See the docs: https://vercel.com/docs/functions/serverless-functions/runtimes/python"
     )
-    exit(1)
 
 if "handler" in __vc_variables or "Handler" in __vc_variables:
     base = (
@@ -1013,11 +1038,10 @@ if "handler" in __vc_variables or "Handler" in __vc_variables:
         else __vc_module.Handler
     )
     if not issubclass(base, BaseHTTPRequestHandler):
-        _stderr("Handler must inherit from BaseHTTPRequestHandler")
-        _stderr(
+        _fatal(
+            "Handler must inherit from BaseHTTPRequestHandler\n"
             "See the docs: https://vercel.com/docs/functions/serverless-functions/runtimes/python"
         )
-        exit(1)
 
     _stderr("using HTTP Handler")
     import _thread  # noqa: PLC2701
@@ -1438,11 +1462,8 @@ elif "app" in __vc_variables or "application" in __vc_variables:
             return response
 
 else:
-    _stderr(
+    _fatal(
         f"Missing variable `handler`, `app`, or `application` "
-        f'in file "{_entrypoint_rel}".'
-    )
-    _stderr(
+        f'in file "{_entrypoint_rel}".\n'
         "See the docs: https://vercel.com/docs/functions/serverless-functions/runtimes/python"
     )
-    exit(1)

--- a/python/vercel-runtime/tests/_n1_mock.py
+++ b/python/vercel-runtime/tests/_n1_mock.py
@@ -58,6 +58,14 @@ class EndPayload:
 
 
 @attrs.frozen
+class UnrecoverableErrorPayload:
+    """Payload for ``unrecoverable-error``."""
+
+    exit_code: int
+    message: str
+
+
+@attrs.frozen
 class MetricPayload:
     """Payload for ``metric``."""
 
@@ -101,6 +109,14 @@ class EndMessage:
 
     type: Literal["end"]
     payload: EndPayload
+
+
+@attrs.frozen
+class UnrecoverableErrorMessage:
+    """``unrecoverable-error`` message."""
+
+    type: Literal["unrecoverable-error"]
+    payload: UnrecoverableErrorPayload
 
 
 @attrs.frozen
@@ -169,6 +185,15 @@ def _parse_message(raw: dict[str, Any]) -> N1Message:
             ),
         )
 
+    if msg_type == "unrecoverable-error":
+        return UnrecoverableErrorMessage(
+            type="unrecoverable-error",
+            payload=UnrecoverableErrorPayload(
+                exit_code=payload.get("exitCode", 0),
+                message=payload.get("message", ""),
+            ),
+        )
+
     if msg_type == "metric":
         return MetricMessage(
             type="metric",
@@ -187,6 +212,7 @@ N1Message = (
     | HandlerStartedMessage
     | LogMessage
     | EndMessage
+    | UnrecoverableErrorMessage
     | MetricMessage
     | UnknownMessage
 )

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -27,6 +27,7 @@ from tests._n1_mock import (
     LogMessage,
     N1Mock,
     ServerStartedMessage,
+    UnrecoverableErrorMessage,
     create_n1_mock,
 )
 
@@ -546,6 +547,11 @@ class TestErrorPaths(_RuntimeTestCase):
             module_name=mod,
             ipc_socket_path=self.n1.socket_path,
         ) as proc:
+            msg = await self.n1.wait_for_message(
+                UnrecoverableErrorMessage, timeout=10.0
+            )
+            self.assertEqual(msg.payload.exit_code, 1)
+            self.assertIn("Missing variable", msg.payload.message)
             async with asyncio.timeout(10.0):
                 returncode = await proc.wait()
             self.assertEqual(returncode, 1)
@@ -560,6 +566,14 @@ class TestErrorPaths(_RuntimeTestCase):
             module_name=mod,
             ipc_socket_path=self.n1.socket_path,
         ) as proc:
+            msg = await self.n1.wait_for_message(
+                UnrecoverableErrorMessage, timeout=10.0
+            )
+            self.assertEqual(msg.payload.exit_code, 1)
+            self.assertIn(
+                "Handler must inherit from BaseHTTPRequestHandler",
+                msg.payload.message,
+            )
             async with asyncio.timeout(10.0):
                 returncode = await proc.wait()
             self.assertEqual(returncode, 1)
@@ -594,11 +608,17 @@ class TestErrorPaths(_RuntimeTestCase):
             module_name="nonexistent",
             ipc_socket_path=self.n1.socket_path,
         ) as proc:
+            msg = await self.n1.wait_for_message(
+                UnrecoverableErrorMessage, timeout=10.0
+            )
+            self.assertEqual(msg.payload.exit_code, 1)
+            self.assertIn("could not import", msg.payload.message)
+            self.assertIn("nonexistent.py", msg.payload.message)
             async with asyncio.timeout(10.0):
                 returncode = await proc.wait()
             self.assertEqual(returncode, 1)
             stderr = await _read_stderr(proc)
-            self.assertIn("Error importing", stderr)
+            self.assertIn("could not import", stderr)
 
 
 class _LambdaTestCase(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Before this change, fatal errors during module import (missing handler,
import failures) were written to stderr and lost — SFR never saw them
because the functions runtime only forwards IPC messages.

`_fatal()` now sends an `unrecoverable-error` IPC message before
exiting, which is one of the two message types the functions runtime
accepts before the `server-started` handshake.

While here:

- Add `_fatal_exc()` helper for fatal-with-traceback (used for import
  errors)
- Replace all `_stderr(); exit(1)` patterns with `_fatal()`
- Extract `_flush_init_log_buf()` to deduplicate the IPC-ready +
  buffer flush sequence


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR improves error reporting in the Python runtime by sending IPC messages for fatal errors instead of only writing to stderr, with no changes to security, authentication, or database schemas.
> 
> - Adds `_send_unrecoverable_error()` to send IPC messages before exit on fatal errors
> - Refactors `_stderr(); exit(1)` patterns to use unified `_fatal()` helper
> - Adds test coverage for new `UnrecoverableErrorMessage` IPC message type
>
> <sup>Risk assessment for [commit 46cc231](https://github.com/vercel/vercel/commit/46cc23103db2ade80b2300e980d639eb7848d2a6).</sup>
<!-- VADE_RISK_END -->