### PR TITLE
feat(cli): add optional search query to `integration discover`

### DIFF
--- a/.changeset/cli-integration-discover-search.md
+++ b/.changeset/cli-integration-discover-search.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(cli): add optional search query to `vercel integration discover`

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -271,12 +271,24 @@ export const discoverSubcommand = {
   name: 'discover',
   aliases: [],
   description: 'Discover available marketplace integrations',
-  arguments: [],
+  arguments: [
+    {
+      name: 'query',
+      required: false,
+    },
+  ],
   options: [formatOption, jsonOption],
   examples: [
     {
       name: 'Discover marketplace integrations',
       value: [`${packageName} integration discover`],
+    },
+    {
+      name: 'Search for integrations matching a query',
+      value: [
+        `${packageName} integration discover postgres`,
+        `${packageName} integration discover aws`,
+      ],
     },
     {
       name: 'Discover marketplace integrations as JSON',

--- a/packages/cli/src/util/telemetry/commands/integration/discover.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/discover.ts
@@ -11,4 +11,13 @@ export class IntegrationDiscoverTelemetryClient
       this.trackCliFlag('json');
     }
   }
+
+  trackCliArgumentQuery(v: string | undefined) {
+    if (v) {
+      this.trackCliArgument({
+        arg: 'query',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2917,6 +2917,49 @@ exports[`help command > integration help output snapshots > integration balance 
 "
 `;
 
+exports[`help command > integration help output snapshots > integration discover subcommand > integration discover subcommand help column width 120 1`] = `
+"
+  ▲ vercel integration discover [query] [options]
+
+  Discover available marketplace integrations                                                                           
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Discover marketplace integrations
+
+    $ vercel integration discover
+
+  - Search for integrations matching a query
+
+    $ vercel integration discover postgres
+    $ vercel integration discover aws
+
+  - Discover marketplace integrations as JSON
+
+    $ vercel integration discover --format=json
+
+"
+`;
+
 exports[`help command > integration help output snapshots > integration guide subcommand > integration guide subcommand help column width 120 1`] = `
 "
   ▲ vercel integration guide integration [options]
@@ -2990,7 +3033,7 @@ exports[`help command > integration help output snapshots > integration help col
                              specif…
                              market…
                              integr…
-  discover                   Discov…
+  discover  [query]          Discov…
                              availa…
                              market…
                              integr…
@@ -3101,7 +3144,7 @@ exports[`help command > integration help output snapshots > integration help col
   add       integration      Installs a marketplace integration             
   balance   integration      Shows the balances and thresholds of a         
                              specified marketplace integration              
-  discover                   Discover available marketplace integrations    
+  discover  [query]          Discover available marketplace integrations    
   guide     integration      Show getting started guides and code snippets  
                              for a marketplace integration                  
   list      [project]        List resources from marketplace integrations   
@@ -3148,7 +3191,7 @@ exports[`help command > integration help output snapshots > integration help col
 
   add       integration      Installs a marketplace integration                                                     
   balance   integration      Shows the balances and thresholds of a specified marketplace integration               
-  discover                   Discover available marketplace integrations                                            
+  discover  [query]          Discover available marketplace integrations                                            
   guide     integration      Show getting started guides and code snippets for a marketplace integration            
   list      [project]        List resources from marketplace integrations for the current project                   
   open      name [resource]  Opens a marketplace integration's or resource's dashboard via SSO                      

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -461,6 +461,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('integration discover subcommand', () => {
+      it('integration discover subcommand help column width 120', () => {
+        expect(
+          help(integration.discoverSubcommand, {
+            columns: 120,
+            parent: integration.integrationCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('integration-resource help output snapshots', () => {


### PR DESCRIPTION
## Summary
- Adds an optional `[query]` argument to `vercel integration discover` to filter marketplace integrations by a search term
- Matching is case-insensitive substring search across product name, slug, provider, description, and tags
- Without a query, the command behaves exactly as before (lists all integrations)

## Examples
```sh
vercel integration discover postgres
> Available marketplace products:
Product Name                Slug                                       Provider     Description                       
Amazon Aurora PostgreSQL    aws/aws-apg                                AWS          Full PostgreSQL compatibility     
Amazon Aurora DSQL          aws/aws-dsql                               AWS          Serverless PostgreSQL             
Prisma Postgres             prisma/prisma-postgres                     Prisma       Instant Serverless Postgres       
Nile                        nile                                       Nile         Postgres re-engineered for B2B    
ACME                        aws-marketplace-integration-demo/vector    ACME Corp    ACME Databases                    
Supabase                    supabase                                   Supabase     Postgres backend                  
Neon                        neon                                       Neon         Serverless Postgres
```


```sh
vc-dev integration discover kv --format=json
{
  "products": [
    {
      "name": "Amazon DynamoDB",
      "slug": "aws/aws-dynamodb",
      "provider": "AWS",
      "description": "Serverless distributed NoSQL",
      "tags": [
        "Storage",
        "Kv"
      ]
    },
    {
      "name": "Redis",
      "slug": "redis",
      "provider": "Redis",
      "description": "Serverless Redis",
      "tags": [
        "Storage",
        "Vector",
        "Redis",
        "Kv"
      ]
    },
    {
      "name": "Upstash for Redis",
      "slug": "upstash/upstash-kv",
      "provider": "Upstash",
      "description": "Redis Compatible Database ",
      "tags": [
        "Storage",
        "Searching",
        "Workflow",
        "Kv"
      ]
    }
  ]
}
```



## Test plan
- [x] Unit tests pass for filtering by name, provider, description, tag, and case-insensitivity
- [x] Test for "no matches" message when query has no results
- [x] Test for too-many-arguments error
- [x] Telemetry tracking test for the new argument
- [x] Help snapshot tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds an optional search query argument to a CLI command for filtering marketplace integrations, with no changes to authentication, authorization, database schema, or security controls.
> 
> - Adds optional `query` argument to `integration discover` CLI command
> - Implements case-insensitive substring filtering across product fields
> - Adds comprehensive unit tests and telemetry tracking for new argument
>
> <sup>Risk assessment for [commit 4a60ab6](https://github.com/vercel/vercel/commit/4a60ab6fe733615c49ad531639d858763dffaabd).</sup>
<!-- VADE_RISK_END -->