### PR TITLE
[services] pin next.js versions in e2e tests 

### DIFF
--- a/packages/fs-detectors/test/fixtures/e2e/03-services-frontend-backend/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/03-services-frontend-backend/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "16.1.6",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/fs-detectors/test/fixtures/e2e/04-services-vite-nextjs-prefixed-fastapi/apps/dashboard/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/04-services-vite-nextjs-prefixed-fastapi/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "16.1.6",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/fs-detectors/test/fixtures/e2e/05-services-root-nextjs-api-fastapi/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/05-services-root-nextjs-api-fastapi/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "16.1.6",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/fs-detectors/test/fixtures/e2e/06-services-multi-frontend-multi-runtime/apps/dashboard/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/06-services-multi-frontend-multi-runtime/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "16.1.6",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/fs-detectors/test/fixtures/e2e/06-services-multi-frontend-multi-runtime/apps/web/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/06-services-multi-frontend-multi-runtime/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "16.1.6",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/fs-detectors/test/fixtures/e2e/07-services-frontend-backend-zc/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/07-services-frontend-backend-zc/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "16.1.6",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "16.1.6",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/fs-detectors/test/fixtures/e2e/09-services-frontend-backend-go-zc/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/09-services-frontend-backend-go-zc/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "16.1.6",
     "react": "latest",
     "react-dom": "latest"
   },


### PR DESCRIPTION
It seems that fixture 05-services-multi-frontend-multi-runtime is failing on some PRs, pinning the Next.js version while investigating what is causing the failure:
https://github.com/vercel/vercel/actions/runs/22506430073/job/65206117619?pr=15314

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR pins Next.js version from "canary" to "16.1.6" in multiple e2e test fixture package.json files to stabilize failing tests.
> 
> - Dependency version pin in 8 e2e test fixture files
> - Changes confined to test/fixtures directory
>
> <sup>Risk assessment for [commit 3ce2577](https://github.com/vercel/vercel/commit/3ce2577b81e214125fef59ea4bd46e5d30cc4888).</sup>
<!-- VADE_RISK_END -->