### PR TITLE
[python] setup logging in vc_init_dev to route level<=WARNING to stdout and level>=ERROR to stderr

### DIFF
--- a/.changeset/hungry-peaches-judge.md
+++ b/.changeset/hungry-peaches-judge.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python': minor
+'vercel': patch
+---
+
+[python] setup logging in `vc_init_dev` to route records with level <= `WARNING` to `stdout` and with level >= `ERROR` to `stderr`.


### PR DESCRIPTION
By default, `uvicorn` emits all logs to `stderr` even if they are `INFO` level logs. This can cause issues for systems that treat messages in `stderr` as error sources. This change will configure logging for all web servers we use in `vc dev`, as well as the root logger, to output all entries equal to or below the `WARNING` level to `stdout`, and everything else to `stderr`.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds logging configuration to route log levels to appropriate streams (stdout/stderr) in Python dev server initialization, which is a non-security-related infrastructure change for local development tooling.
> 
> - Adds custom logging filter and config builders to route WARNING and below to stdout, ERROR and above to stderr
> - Patches fastapi_cli, uvicorn, hypercorn, and werkzeug logging configurations
> - Adds stream label prefix in debug mode for service orchestrator output
>
> <sup>Risk assessment for [commit 6c35312](https://github.com/vercel/vercel/commit/6c3531259f80473948646395a9fa06d9e0bb929a).</sup>
<!-- VADE_RISK_END -->