### PR TITLE
fix(cli): populate top-level orgId in repo.json when all projects share the same org

### DIFF
--- a/.changeset/fix-repo-json-top-level-org-id.md
+++ b/.changeset/fix-repo-json-top-level-org-id.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): populate top-level orgId in repo.json when all projects share the same org

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -382,8 +382,13 @@ export async function ensureRepoLink(
       return;
     }
 
+    // Include top-level orgId when all projects share the same org so that
+    // tools reading the deprecated top-level field (e.g. @vercel/toolbar) still
+    // resolve the owner correctly. See https://github.com/vercel/vercel/issues/15286
+    const orgIds = new Set(result.projects.map(p => p.orgId).filter(Boolean));
     repoConfig = {
       remoteName: result.remoteName,
+      ...(orgIds.size === 1 ? { orgId: [...orgIds][0] } : {}),
       projects: result.projects,
     };
     await outputJSON(repoConfigPath, repoConfig, { spaces: 2 });


### PR DESCRIPTION
## Summary

`vercel link --repo` stores `orgId` per-project inside the `projects[]` array of `.vercel/repo.json`. However, some tools — most notably `@vercel/toolbar` — read the **deprecated top-level `orgId`** field to identify the project owner. When that top-level field is absent, those tools silently fail (toolbar never appears in local dev).

## Root Cause

In `ensureRepoLink` (`packages/cli/src/util/link/repo.ts`), the written `repoConfig` object only included `remoteName` and `projects`. No top-level `orgId` was set, even though the interface already declares it (with a `@deprecated` note for backward compat).

## Fix

After collecting linked projects, compute the set of distinct `orgId` values. When all projects belong to the **same org** (the common case), also write that `orgId` at the top level. If projects span multiple orgs the top-level field is omitted — reading tools must fall back to per-project values in that case anyway.

This is a purely additive change: the per-project `orgId` structure is unchanged, and existing parsers that already handle per-project `orgId` are unaffected.

Fixes #15286

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a top-level orgId field to repo.json for backward compatibility when all projects share the same org, a purely additive change to CLI configuration output with no security or schema implications.
> 
> - Adds top-level orgId to repo.json when all projects share same org
> - Changeset file added for patch release
>
> <sup>Risk assessment for [commit 40d214e](https://github.com/vercel/vercel/commit/40d214effd046df1c8214d0f3dfafb3c8a1945fd).</sup>
<!-- VADE_RISK_END -->