### PR TITLE
feat(cli): add --cascade flag to integration remove

### DIFF
--- a/.changeset/cascade-remove-flag-v2.md
+++ b/.changeset/cascade-remove-flag-v2.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add a `--cascade` flag to `vercel integration remove` that opens the integration settings page in the browser so users can complete uninstall through the existing UI flow.

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -316,7 +316,7 @@ export const removeSubcommand = {
   name: 'remove',
   aliases: [],
   description:
-    'Uninstalls a marketplace integration. Resources must be removed first using `integration-resource remove`.',
+    'Uninstalls a marketplace integration. Remove resources first with `integration-resource remove`, or use `--cascade` to continue uninstall in the browser UI.',
   arguments: [
     {
       name: 'integration',
@@ -328,6 +328,14 @@ export const removeSubcommand = {
       ...yesOption,
       description:
         'Skip the confirmation prompt when uninstalling an integration',
+    },
+    {
+      name: 'cascade',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Open integration settings in your browser to uninstall using the UI flow (supports cascade deletion)',
     },
     formatOption,
   ],
@@ -342,6 +350,10 @@ export const removeSubcommand = {
     {
       name: 'Remove a resource before uninstalling',
       value: `${packageName} integration-resource remove <resource-name> --disconnect-all --yes`,
+    },
+    {
+      name: 'Open integration settings to uninstall using cascade UI flow',
+      value: `${packageName} integration remove acme --cascade`,
     },
     {
       name: 'Output as JSON',

--- a/packages/cli/src/commands/integration/remove-integration.ts
+++ b/packages/cli/src/commands/integration/remove-integration.ts
@@ -1,5 +1,6 @@
 import type { Team } from '@vercel-internals/types';
 import chalk from 'chalk';
+import open from 'open';
 import output from '../../output-manager';
 import type Client from '../../util/client';
 import { isAPIError } from '../../util/errors-ts';
@@ -40,9 +41,16 @@ export async function remove(client: Client) {
   const asJson = formatResult.jsonOutput;
 
   const skipConfirmation = !!parsedArguments.flags['--yes'];
+  const cascade = !!parsedArguments.flags['--cascade'];
 
   telemetry.trackCliFlagYes(skipConfirmation);
+  telemetry.trackCliFlagCascade(cascade);
   telemetry.trackCliOptionFormat(parsedArguments.flags['--format']);
+
+  if (asJson && cascade) {
+    output.error('--format=json cannot be used with --cascade');
+    return 1;
+  }
 
   if (asJson && !skipConfirmation) {
     output.error('--format=json requires --yes to skip confirmation prompts');
@@ -83,6 +91,26 @@ export async function remove(client: Client) {
     return 1;
   }
   telemetry.trackCliArgumentIntegration(integrationName, true);
+
+  if (cascade) {
+    const settingsUrl = buildIntegrationSettingsUrl(
+      team.slug,
+      integrationConfiguration.slug,
+      integrationConfiguration.id
+    );
+
+    output.log('Opening integration settings page to uninstall...');
+    output.log(
+      `In your browser, click ${chalk.bold('"Uninstall Integration"')} to continue with cascade deletion.`
+    );
+    output.log(`Visit this URL if the browser does not open: ${settingsUrl}`);
+
+    open(settingsUrl).catch((err: unknown) =>
+      output.debug(`Failed to open browser: ${err}`)
+    );
+
+    return 0;
+  }
 
   if (!skipConfirmation && !client.stdin.isTTY) {
     output.error(
@@ -198,6 +226,14 @@ export async function remove(client: Client) {
 
   output.success(`${chalk.bold(integrationName)} successfully removed.`);
   return 0;
+}
+
+function buildIntegrationSettingsUrl(
+  teamSlug: string,
+  integrationSlug: string,
+  configurationId: string
+): string {
+  return `https://vercel.com/${encodeURIComponent(teamSlug)}/~/integrations/${encodeURIComponent(integrationSlug)}/${encodeURIComponent(configurationId)}/settings?action=confirm_uninstall`;
 }
 
 async function confirmIntegrationRemoval(

--- a/packages/cli/src/util/telemetry/commands/integration/remove.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/remove.ts
@@ -20,4 +20,10 @@ export class IntegrationRemoveTelemetryClient
       this.trackCliFlag('yes');
     }
   }
+
+  trackCliFlagCascade(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('cascade');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/integration/remove.test.ts
+++ b/packages/cli/test/unit/commands/integration/remove.test.ts
@@ -1,9 +1,23 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import open from 'open';
 import integrationCommand from '../../../../src/commands/integration';
 import { client } from '../../../mocks/client';
 import { useConfiguration, useResources } from '../../../mocks/integration';
 import { type Team, useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
+
+vi.mock('open', () => {
+  return {
+    default: vi.fn(),
+  };
+});
+
+const openMock = vi.mocked(open);
+
+beforeEach(() => {
+  openMock.mockClear();
+  openMock.mockResolvedValue(undefined as any);
+});
 
 describe('integration', () => {
   describe('remove', () => {
@@ -56,6 +70,58 @@ describe('integration', () => {
         );
 
         await expect(exitCodePromise).resolves.toEqual(0);
+      });
+
+      it('opens integration settings for cascade uninstall and does not uninstall from CLI', async () => {
+        useConfiguration();
+        const integration = 'acme-no-projects';
+        let uninstallCalled = false;
+
+        client.scenario.post(
+          '/:version/integrations/installations/:integrationIdOrSlug/uninstall',
+          (_req, res) => {
+            uninstallCalled = true;
+            res.sendStatus(200);
+          }
+        );
+
+        client.setArgv('integration', 'remove', integration, '--cascade');
+        const exitCode = await integrationCommand(client);
+
+        expect(exitCode).toEqual(0);
+        expect(uninstallCalled).toEqual(false);
+        expect(openMock).toHaveBeenCalledWith(
+          `https://vercel.com/${encodeURIComponent(team.slug)}/~/integrations/${integration}/acme-first/settings?action=confirm_uninstall`
+        );
+        await expect(client.stderr).toOutput(
+          'Opening integration settings page to uninstall...'
+        );
+        await expect(client.stderr).toOutput('"Uninstall Integration"');
+        expect(client.stderr.getFullOutput()).not.toContain('Are you sure?');
+      });
+
+      it('tracks --cascade telemetry', async () => {
+        useConfiguration();
+        const integration = 'acme-no-projects';
+
+        client.setArgv('integration', 'remove', integration, '--cascade');
+        const exitCode = await integrationCommand(client);
+        expect(exitCode).toEqual(0);
+
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: 'subcommand:remove',
+            value: 'remove',
+          },
+          {
+            key: 'flag:cascade',
+            value: 'TRUE',
+          },
+          {
+            key: 'argument:integration',
+            value: integration,
+          },
+        ]);
       });
 
       it('exits gracefully when cancelling during confirmation for removing an integration', async () => {
@@ -187,6 +253,26 @@ describe('integration', () => {
         await expect(client.stderr).toOutput(
           'Error: --format=json requires --yes to skip confirmation prompts'
         );
+      });
+
+      it('should error when --format=json is used with --cascade', async () => {
+        useConfiguration();
+        const integration = 'acme-no-projects';
+
+        client.setArgv(
+          'integration',
+          'remove',
+          integration,
+          '--yes',
+          '--format=json',
+          '--cascade'
+        );
+        const exitCode = await integrationCommand(client);
+        expect(exitCode).toEqual(1);
+        await expect(client.stderr).toOutput(
+          'Error: --format=json cannot be used with --cascade'
+        );
+        expect(openMock).not.toHaveBeenCalled();
       });
 
       it('should track --format option in telemetry', async () => {


### PR DESCRIPTION
## Summary
- Adds a `--cascade` flag to `vercel integration remove` that opens the integration settings page in the browser so users can complete uninstall through the existing UI flow
- When an integration has resources attached, the CLI currently fails with 403. `--cascade` provides an escape hatch by handing off to the dashboard's cascade deletion UI
- The URL includes `?action=confirm_uninstall` which triggers the uninstall flyout to auto-open (companion PR in front repo)

## Changes
- `command.ts`: Added `--cascade` option definition and usage example
- `remove-integration.ts`: Parses flag, validates against `--format=json`, builds settings URL with query param, opens browser via `open` package
- `telemetry/remove.ts`: Added `trackCliFlagCascade` method
- `remove.test.ts`: 3 new tests (cascade opens browser + skips API uninstall, telemetry tracking, `--format=json` conflict error)

## Companion PR
- **Front**: Auto-open uninstall flyout when `?action=confirm_uninstall` is in URL (TBD - will link after creation)

## Test plan
- [x] `fix` passes
- [x] All 18 unit tests pass
- [ ] Manual test: `vercel integration remove <slug> --cascade` opens browser to correct settings URL
- [ ] Manual test: `--cascade` with `--format=json` returns error

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new --cascade CLI flag that opens a browser to the integration settings page for cascade deletion, with proper validation and telemetry - no security, auth, or database changes.
> 
> - New --cascade flag opens browser to integration settings URL for uninstall flow
> - Validates --cascade cannot be combined with --format=json
> - Adds telemetry tracking and 3 new unit tests
>
> <sup>Risk assessment for [commit 9b51aa0](https://github.com/vercel/vercel/commit/9b51aa018129d6dda4a42eab0add706635dd7b14).</sup>
<!-- VADE_RISK_END -->