### PR TITLE
fix(node): apply module/moduleResolution defaults after tsconfig extends resolution

### DIFF
--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -428,6 +428,17 @@ export function register(opts: Options = {}): Register {
       configFileName
     );
 
+    // Apply module defaults after extends resolution so that values
+    // inherited from base tsconfigs are respected. Previously these
+    // defaults were set in fixConfig() before parseJsonConfigFileContent,
+    // which caused them to override values from the extends chain.
+    if (configResult.options.module === undefined) {
+      configResult.options.module = ts.ModuleKind.NodeNext;
+      configResult.options.moduleResolution =
+        ts.ModuleResolutionKind.NodeNext;
+      configResult.options.strict = false;
+    }
+
     if (configFileName) {
       const configDiagnosticList = filterDiagnostics(
         configResult.errors,
@@ -503,14 +514,6 @@ export function fixConfig(
   // This is useful when no `tsconfig.json` is supplied.
   if (config.compilerOptions.esModuleInterop === undefined) {
     config.compilerOptions.esModuleInterop = true;
-  }
-
-  // nodenext will defer to the package.json#type field
-  // but still respect .mts and .cts files
-  if (config.compilerOptions.module === undefined) {
-    config.compilerOptions.module = 'NodeNext';
-    config.compilerOptions.moduleResolution = 'NodeNext';
-    config.compilerOptions.strict = false;
   }
 
   return config;

--- a/packages/node/test/unit/tsconfig-extends.test.ts
+++ b/packages/node/test/unit/tsconfig-extends.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+import { build } from '../../src';
+import { prepareFilesystem } from './test-utils';
+
+describe.skipIf(process.platform === 'win32')('tsconfig extends chain', () => {
+  test('should respect module/moduleResolution inherited from base tsconfig', async () => {
+    const filesystem = await prepareFilesystem({
+      'package.json': JSON.stringify({
+        type: 'module',
+        dependencies: {
+          '@types/node': '*',
+        },
+      }),
+      'tsconfig.base.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'Bundler',
+          esModuleInterop: true,
+          strict: true,
+          skipLibCheck: true,
+        },
+      }),
+      // Only extends — no direct module/moduleResolution
+      'tsconfig.json': JSON.stringify({
+        extends: './tsconfig.base.json',
+        include: ['*.ts'],
+      }),
+      'utils.ts': `
+          export const greet = (name: string): string => \`Hello, \${name}!\`;
+        `,
+      // Extensionless import: valid under "Bundler", fails with TS2835 under "NodeNext"
+      'index.ts': `
+          import { IncomingMessage, ServerResponse } from 'http';
+          import { greet } from './utils';
+
+          export default (req: IncomingMessage, res: ServerResponse) => {
+            res.end(greet('World'));
+          };
+        `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'index.ts',
+      config: {},
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+
+    const files =
+      buildResult.output.type === 'Lambda' ? buildResult.output.files : {};
+    expect(files).toHaveProperty('index.js');
+    expect(files).toHaveProperty('utils.js');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `fixConfig()` in `packages/node/src/typescript.ts` applying `module: 'NodeNext'`, `moduleResolution: 'NodeNext'`, `strict: false` defaults **before** `ts.parseJsonConfigFileContent` resolves the `extends` chain
- Move these defaults to after extends resolution, checking the resolved `configResult.options` instead of the raw JSON
- Projects using shared base tsconfigs (common in monorepos) now get their intended `module`/`moduleResolution`/`strict` values

## Problem

When a tsconfig uses `extends` to inherit `module`/`moduleResolution` from a base config:

```json
// tsconfig.base.json
{ "compilerOptions": { "module": "ESNext", "moduleResolution": "Bundler" } }

// tsconfig.json
{ "extends": "./tsconfig.base.json", "include": ["src/**/*.ts"] }
```

`fixConfig()` checks `config.compilerOptions.module === undefined` on the **raw JSON** (before extends), sees it as undefined, and injects `NodeNext`. Since `parseJsonConfigFileContent` gives precedence to the direct config over extended bases, the inherited values are silently overridden.

This causes:
- **TS2835** errors (extensionless imports rejected under `NodeNext`)
- **TS2339** errors (generic inference changes under `strict: false`)
- Behavior mismatch between local `tsc` and Vercel builds

## Fix

Move the conditional defaults from `fixConfig()` (pre-extends) to after `parseJsonConfigFileContent` (post-extends), checking the **resolved** options:

```ts
const configResult = ts.parseJsonConfigFileContent(config, ts.sys, basePath, undefined, configFileName);

if (configResult.options.module === undefined) {
  configResult.options.module = ts.ModuleKind.NodeNext;
  configResult.options.moduleResolution = ts.ModuleResolutionKind.NodeNext;
  configResult.options.strict = false;
}
```

Projects without any `module` set (anywhere in the extends chain) still get `NodeNext` defaults. Projects that DO set `module` (in any config in the chain) now have their settings respected.

## Test plan

- [ ] Projects with `module` in base tsconfig via `extends` — should use inherited value, not `NodeNext`
- [ ] Projects with `module` set directly in tsconfig — should use direct value (unchanged behavior)
- [ ] Projects with no `module` anywhere — should still get `NodeNext` default (unchanged behavior)
- [ ] Projects with no tsconfig — should still get `NodeNext` default (unchanged behavior)

Fixes #15332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR moves TypeScript module/moduleResolution/strict defaults from pre-extends resolution to post-extends resolution, fixing a bug where inherited tsconfig values were being overridden; the logic and default values remain identical, just applied at a different point in the config resolution flow.
> 
> - Moves default application from `fixConfig()` to after `parseJsonConfigFileContent`
> - Same conditional logic and default values, different timing in config resolution
> - Adds test for tsconfig extends chain behavior
>
> <sup>Risk assessment for [commit 3938d45](https://github.com/vercel/vercel/commit/3938d4530ce6a2d51d6afc36c31fbe95c985e6d4).</sup>
<!-- VADE_RISK_END -->