### PR TITLE
Fix punctuation: i.e., to i.e.

### DIFF
--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -416,7 +416,7 @@ export async function ensureRepoLink(
 
 /**
  * Adds additional projects to an existing `repo.json` file.
- * Requires that `repo.json` already exists (i.e., the repo has been linked
+ * Requires that `repo.json` already exists (i.e. the repo has been linked
  * with `vc link --repo`). Runs the same project discovery flow and merges
  * the resulting projects into the existing config, deduplicating by project ID.
  */


### PR DESCRIPTION
Fixes #14766. Removes redundant comma in i.e. abbreviation.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR contains only a comment punctuation fix, changing "i.e.," to "i.e." in a JSDoc comment with no code changes.
> 
> - Comment-only punctuation fix in JSDoc
>
> <sup>Risk assessment for [commit 6b87ebe](https://github.com/vercel/vercel/commit/6b87ebe1ba727bf23d283be10a67f9dc1e6a24a7).</sup>
<!-- VADE_RISK_END -->