### PR TITLE
Add flags reference to vercel-cli skill

### DIFF
--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -50,6 +50,7 @@ Use this to route to the correct reference file:
 - **Node.js backends (Express, Hono, etc.)** → `references/node-backends.md`
 - **Monorepos (Turborepo, Nx, workspaces)** → `references/monorepos.md`
 - **Bun runtime** → `references/bun.md`
+- **Feature flags** → `references/flags.md`
 - **Advanced (API, webhooks)** → `references/advanced.md`
 - **Global flags** → `references/global-options.md`
 - **First-time setup** → `references/getting-started.md`

--- a/skills/vercel-cli/references/flags.md
+++ b/skills/vercel-cli/references/flags.md
@@ -1,0 +1,40 @@
+# Feature Flags
+
+`vercel flags` manages [Vercel Flags](https://vercel.com/docs/flags/vercel-flags) — create, inspect, enable, disable, archive, and delete feature flags, plus manage SDK keys.
+
+## Managing Flags
+
+```bash
+vercel flags list                                        # list active flags
+vercel flags list --state archived                       # list archived flags
+vercel flags inspect my-feature                        # show flag details
+vercel flags add my-feature                            # create boolean flag
+vercel flags add my-feature --kind string --description "My flag"  # string flag with description
+vercel flags archive my-feature --yes                  # archive (skip prompt)
+vercel flags rm my-feature --yes                       # delete (must be archived first)
+```
+
+Flag kinds: `boolean` (default), `string`, `number`. Each kind gets default variants automatically.
+
+## Enable / Disable
+
+Only works with **boolean** flags. Controls whether a flag evaluates rules in an environment.
+
+```bash
+vercel flags enable my-feature -e production           # start evaluating rules
+vercel flags disable my-feature -e production          # stop evaluating rules
+vercel flags disable my-feature -e production --variant off  # serve specific variant while disabled
+```
+
+Environments: `production`, `preview`, `development`. Omit `-e` to choose interactively.
+
+## SDK Keys
+
+SDK keys authenticate your application when evaluating flags. The full key value is only shown at creation time.
+
+```bash
+vercel flags sdk-keys ls                               # list SDK keys
+vercel flags sdk-keys add -e production                # create key
+vercel flags sdk-keys add -e preview --label "Preview App"  # with label
+vercel flags sdk-keys rm <hash-key> --yes              # delete key
+```


### PR DESCRIPTION
## Summary

- Adds `skills/vercel-cli/references/flags.md` covering all `vercel flags` subcommands (list, inspect, add, archive, rm, enable, disable) and SDK key management (sdk-keys ls, add, rm)
- Adds a "Feature flags" entry to the decision tree in `skills/vercel-cli/SKILL.md` so flag-related queries route to the new reference


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds documentation files only - a new reference markdown file for vercel-cli flags and a routing entry in the skill decision tree.
> 
> - New documentation file `skills/vercel-cli/references/flags.md` with CLI usage examples
> - Single line addition to decision tree in `SKILL.md` for routing flag queries
>
> <sup>Risk assessment for [commit 39d65a4](https://github.com/vercel/vercel/commit/39d65a4a3f19682c90f879d2084e460d91a242db).</sup>
<!-- VADE_RISK_END -->