### PR TITLE
[next] vary fallback allowQuery for partial fallback shells

### DIFF
--- a/.changeset/fifty-buckets-play.md
+++ b/.changeset/fifty-buckets-play.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+vary fallback `allowQuery` by params for partial fallback shells

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3038,6 +3038,12 @@ export const onPrerenderRoute =
         };
       }
 
+      const partialFallback =
+        isAppPathRoute &&
+        renderingMode === RenderingMode.PARTIALLY_STATIC &&
+        isFallback &&
+        Boolean(postponedState);
+
       // If this is a fallback page with PPR enabled, we should not have the
       // cache key vary based on the route parameters to ensure that we always
       // have a HIT for the fallback page.
@@ -3063,20 +3069,15 @@ export const onPrerenderRoute =
         }
         // We additionally vary based on if there's a postponed prerender
         // because if there isn't, then that means that we generated an
-        // empty shell, and producing an empty RSC shell would be a waste.
-        // If there is a postponed prerender, then the RSC shell would be
-        // non-empty, and it would be valuable to also generate an empty
-        // RSC shell.
+        // empty shell. For partial fallbacks when cache components are enabled,
+        // we still want to vary the HTML by params so the route shell can be
+        // cached per-param. Otherwise, keep the fallback shell shared across
+        // params.
         else if (postponedPrerender) {
-          htmlAllowQuery = [];
+          htmlAllowQuery =
+            partialFallback && isAppClientParamParsingEnabled ? allowQuery : [];
         }
       }
-
-      const partialFallback =
-        isAppPathRoute &&
-        renderingMode === RenderingMode.PARTIALLY_STATIC &&
-        isFallback &&
-        Boolean(postponedState);
 
       // If this is a static metadata file that should output FileRef instead of Prerender
       const staticMetadataFile = getSourceFileRefOfStaticMetadata(


### PR DESCRIPTION
Based on #14703

This updates only `allowQuery` for fallback HTML when the route is a true `partialFallback` (PPR fallback with postponed state) and cache components is enabled. For all other fallback cases, behavior stays the same as today (allowQuery is cleared to [] for shared fallback caching).

This change is needed because partial-fallback shells can be param-specific, so collapsing them to one shared fallback cache key can serve the wrong shell across params and block correct upgrade behavior. Gating this behind `partialFallback` lets us roll out the new behavior safely and independently, without changing legacy fallback semantics for non-partial paths.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR modifies caching behavior for partial fallback shells by conditionally varying the allowQuery parameter, which is a Next.js build/rendering optimization change rather than a security or data schema change.
> 
> - Adds conditional logic for `htmlAllowQuery` based on `partialFallback` and `isAppClientParamParsingEnabled`
> - Moves `partialFallback` variable declaration earlier in function
> - Updates comments explaining fallback caching behavior
>
> <sup>Risk assessment for [commit 0fc83c1](https://github.com/vercel/vercel/commit/0fc83c1231498eecad58db950cd0bfcb166004e4).</sup>
<!-- VADE_RISK_END -->