### PR TITLE
[python] Add --no-install-project to the uv sync command for large lambdas.

### DIFF
--- a/.changeset/metal-crabs-taste.md
+++ b/.changeset/metal-crabs-taste.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Add no install project flag to the predeploy uv sync command

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -394,6 +394,7 @@ export const build: BuildV3 = async ({
           projectDir,
           frozen: true,
           noBuild: true,
+          noInstallProject: true,
         });
       } catch (err) {
         // Note the failure but don't error yet - we only need wheels

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -96,8 +96,10 @@ export class UvRunner {
     locked?: boolean;
     frozen?: boolean;
     noBuild?: boolean;
+    noInstallProject?: boolean;
   }): Promise<void> {
-    const { venvPath, projectDir, locked, frozen, noBuild } = options;
+    const { venvPath, projectDir, locked, frozen, noBuild, noInstallProject } =
+      options;
     const args = ['sync', '--active', '--no-dev', '--link-mode', 'copy'];
     if (frozen) {
       args.push('--frozen');
@@ -106,6 +108,9 @@ export class UvRunner {
     }
     if (noBuild) {
       args.push('--no-build');
+    }
+    if (noInstallProject) {
+      args.push('--no-install-project');
     }
     args.push('--no-editable');
     await this.runUvCmd(args, projectDir, venvPath);


### PR DESCRIPTION
Fixes bug where projects using a local, editable build dep fail to pass the runtime dependency installation pre deploy check.

For example if a customer is using a dep like this, it will never have a wheel but it shouldn't fail the check since we always include private packages in the lambda zip.

```toml
[[package]]
name = "foo-bar"
version = "0.1.0"
source = { editable = "." }
```

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new optional flag to the uv sync command for Python lambda builds, which is a straightforward feature addition with no security, auth, or schema implications.
> 
> - Adds `noInstallProject` option to UvRunner sync method
> - Passes `--no-install-project` flag to uv CLI when option is set
> - Changeset for patch version bump
>
> <sup>Risk assessment for [commit 39a6401](https://github.com/vercel/vercel/commit/39a64014f5968524f7976208b8add97ea38d5d24).</sup>
<!-- VADE_RISK_END -->