### PR TITLE
feat(cli): send cliVersion on resource provisioning requests

### DIFF
--- a/.changeset/cli-version-tracking.md
+++ b/.changeset/cli-version-tracking.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(cli): send cliVersion on resource provisioning requests

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -40,6 +40,7 @@ import { createAuthorization } from '../../util/integration/create-authorization
 import sleep from '../../util/sleep';
 import { fetchAuthorization } from '../../util/integration/fetch-authorization';
 import { validateJsonOutput } from '../../util/output-format';
+import pkg from '../../util/pkg';
 
 import type { IntegrationAddFlags } from './command';
 
@@ -374,7 +375,7 @@ async function installMarketplaceIntegration(
     {
       method: 'POST',
       json: true,
-      body: { acceptedPolicies, source: 'cli' },
+      body: { acceptedPolicies, source: 'cli', cliVersion: pkg.version },
     }
   );
 }

--- a/packages/cli/src/util/integration/auto-provision-resource.ts
+++ b/packages/cli/src/util/integration/auto-provision-resource.ts
@@ -1,6 +1,7 @@
 import output from '../../output-manager';
 import type Client from '../client';
 import { APIError } from '../errors-ts';
+import pkg from '../pkg';
 import type {
   AcceptedPolicies,
   AutoProvisionFallback,
@@ -38,6 +39,7 @@ export async function autoProvisionResource(
     metadata,
     acceptedPolicies,
     source: 'cli',
+    cliVersion: pkg.version,
     ...(billingPlanId ? { billingPlanId } : {}),
     ...(installationId ? { installationId } : {}),
   };

--- a/packages/cli/src/util/integration/provision-store-resource.ts
+++ b/packages/cli/src/util/integration/provision-store-resource.ts
@@ -1,4 +1,5 @@
 import type Client from '../client';
+import pkg from '../pkg';
 import type { Metadata } from './types';
 
 export async function provisionStoreResource(
@@ -23,6 +24,7 @@ export async function provisionStoreResource(
         name,
         authorizationId,
         source: 'cli',
+        cliVersion: pkg.version,
       },
     }
   );


### PR DESCRIPTION
## Summary
- Send `cliVersion: pkg.version` alongside `source: 'cli'` on provisioning API calls
- Applies to: auto-provision, provision-store, and install-marketplace endpoints

## Dependencies
- **Blocked by:** [api PR](https://github.com/vercel/api/pull/new/tonypan/cli-source-tracking) (must accept `cliVersion` first or the `additionalProperties: false` endpoints will 400)

## Changed files
| File | Change |
|------|--------|
| `util/integration/auto-provision-resource.ts` | Add `cliVersion: pkg.version` to body |
| `util/integration/provision-store-resource.ts` | Add `cliVersion: pkg.version` to body |
| `commands/integration/add.ts` | Add `cliVersion: pkg.version` to install body |

## Test plan
- [ ] CI passes
- [ ] Manual test: `vct integration add <slug>` sends `cliVersion` in request body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new `cliVersion` field to API request bodies for telemetry/tracking purposes, with no changes to authentication, authorization, or database schema.
> 
> - Adds `cliVersion: pkg.version` to 3 provisioning API request bodies
> - New changeset file for patch version bump
>
> <sup>Risk assessment for [commit 7c31d7b](https://github.com/vercel/vercel/commit/7c31d7bf64ad18b763317969f07da098de50acdb).</sup>
<!-- VADE_RISK_END -->