### PR TITLE
feat(detect-agent): check AGENT env var for generic agent detection

### DIFF
--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -61,6 +61,16 @@ export async function determineAgent(): Promise<AgentResult> {
     }
   }
 
+  if (process.env.AGENT) {
+    const name = process.env.AGENT.trim();
+    if (name) {
+      return {
+        isAgent: true,
+        agent: { name: name as KnownAgentNames },
+      };
+    }
+  }
+
   if (process.env.CURSOR_TRACE_ID) {
     return { isAgent: true, agent: { name: CURSOR } };
   }

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -348,7 +348,7 @@ describe('determineAgent', () => {
       });
     });
 
-    it('CURSOR_TRACE_ID takes priority over other agents (except AI_AGENT)', async () => {
+    it('CURSOR_TRACE_ID takes priority over other agents (except AI_AGENT and AGENT)', async () => {
       vi.stubEnv('CURSOR_TRACE_ID', 'some-uuid');
       vi.stubEnv('CURSOR_AGENT', '1');
       vi.stubEnv('GEMINI_CLI', '1');

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -8,6 +8,7 @@ describe('determineAgent', () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
     vi.stubEnv('AI_AGENT', '');
+    vi.stubEnv('AGENT', '');
     vi.stubEnv('CURSOR_TRACE_ID', '');
     vi.stubEnv('CURSOR_AGENT', '');
     vi.stubEnv('GEMINI_CLI', '');
@@ -42,6 +43,29 @@ describe('determineAgent', () => {
         expect(result).toEqual({
           isAgent: true,
           agent: { name: 'custom-agent' },
+        });
+      });
+    });
+  });
+
+  describe('custom agent detection from `AGENT`', () => {
+    describe('AGENT not set', () => {
+      it('returns no agent', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({ isAgent: false });
+      });
+    });
+
+    describe('AGENT set', () => {
+      beforeEach(() => {
+        vi.stubEnv('AGENT', 'goose');
+      });
+
+      it('detects custom agent', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({
+          isAgent: true,
+          agent: { name: 'goose' },
         });
       });
     });
@@ -275,6 +299,7 @@ describe('determineAgent', () => {
   describe('priority order detection', () => {
     it('AI_AGENT takes highest priority over all other environment variables', async () => {
       vi.stubEnv('AI_AGENT', 'custom-priority');
+      vi.stubEnv('AGENT', 'goose');
       vi.stubEnv('CURSOR_TRACE_ID', 'some-uuid');
       vi.stubEnv('CURSOR_AGENT', '1');
       vi.stubEnv('GEMINI_CLI', '1');
@@ -293,6 +318,33 @@ describe('determineAgent', () => {
       expect(result).toEqual({
         isAgent: true,
         agent: { name: 'custom-priority' },
+      });
+    });
+
+    it('AGENT takes second priority — after AI_AGENT, before tool-specific vars', async () => {
+      vi.stubEnv('AGENT', 'goose');
+      vi.stubEnv('CURSOR_TRACE_ID', 'some-uuid');
+      vi.stubEnv('CURSOR_AGENT', '1');
+      vi.stubEnv('GEMINI_CLI', '1');
+      vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
+      vi.stubEnv('AUGMENT_AGENT', '1');
+      vi.stubEnv('OPENCODE_CLIENT', 'opencode');
+      vi.stubEnv('CLAUDE_CODE', '1');
+      vi.stubEnv('REPL_ID', '1');
+      mockFs({ '/opt/.devin': mockFs.directory({ mode: 0o755 }) });
+
+      const result = await determineAgent();
+      expect(result).toEqual({ isAgent: true, agent: { name: 'goose' } });
+    });
+
+    it('AI_AGENT still takes highest priority over AGENT', async () => {
+      vi.stubEnv('AI_AGENT', 'custom-override');
+      vi.stubEnv('AGENT', 'goose');
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: 'custom-override' },
       });
     });
 
@@ -374,6 +426,24 @@ describe('determineAgent', () => {
         isAgent: true,
         agent: { name: 'custom-agent' },
       });
+    });
+
+    it('handles whitespace-only values for AGENT', async () => {
+      vi.stubEnv('AGENT', '   ');
+      const result = await determineAgent();
+      expect(result).toEqual({ isAgent: false });
+    });
+
+    it('trims leading and trailing whitespace from AGENT', async () => {
+      vi.stubEnv('AGENT', '  amp  ');
+      const result = await determineAgent();
+      expect(result).toEqual({ isAgent: true, agent: { name: 'amp' } });
+    });
+
+    it('handles special characters in AGENT value', async () => {
+      vi.stubEnv('AGENT', 'bun@1.2');
+      const result = await determineAgent();
+      expect(result).toEqual({ isAgent: true, agent: { name: 'bun@1.2' } });
     });
 
     it('handles file system errors gracefully for devin detection', async () => {


### PR DESCRIPTION
## Summary

Add `AGENT` env var detection to `@vercel/detect-agent`, checked after `AI_AGENT` and before tool-specific vars.

An emerging convention uses `AGENT=<agent-name>` to signal agent presence:
- **Goose** ships `AGENT=goose` ([PR](https://github.com/block/goose/pull/7017))
- **Amp** ships `AGENT=amp` ([docs](https://ampcode.com/manual/appendix#permissions-delegation))
- **Bun** checks `AGENT=1` ([PR #21135](https://github.com/oven-sh/bun/pull/21135))
- Community proposal: https://github.com/agentsmd/agents.md/issues/136

### Changes
- `src/index.ts`: Add `AGENT` check (position 2, after `AI_AGENT`, before tool-specific vars)
- `test/unit/determine-agent.test.ts`: Add detection, edge case, and priority tests

Closes #15336

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new environment variable check (AGENT) for agent detection, which is a straightforward feature addition with proper validation (trim and empty check) and comprehensive test coverage.
> 
> - Adds AGENT env var detection after AI_AGENT, before tool-specific vars
> - Includes whitespace trimming and empty string validation
> - Comprehensive test coverage for detection, priority, and edge cases
>
> <sup>Risk assessment for [commit f017c0c](https://github.com/vercel/vercel/commit/f017c0c71de57960781b8f4f5c5864bd07d51151).</sup>
<!-- VADE_RISK_END -->