### PR TITLE
[python] Look for django entrypoint from setting file's from sibling imports.

### DIFF
--- a/.changeset/shaggy-shrimps-chew.md
+++ b/.changeset/shaggy-shrimps-chew.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python-analysis': minor
+'@vercel/build-utils': minor
+---
+
+Look for django entrypoint from setting file's from sibling imports.

--- a/packages/build-utils/src/python.ts
+++ b/packages/build-utils/src/python.ts
@@ -1,8 +1,9 @@
 import fs from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import {
   containsAppOrHandler,
   getStringConstant,
+  getStringConstantOrImport,
   parseDjangoSettingsModule,
 } from '@vercel/python-analysis';
 import debug from './debug';
@@ -55,6 +56,9 @@ export async function getDjangoSettingsModule(
  * DJANGO_SETTINGS_MODULE from manage.py, loading that settings file, and
  * returning the file path for ASGI_APPLICATION or WSGI_APPLICATION (e.g.
  * 'myapp.asgi.application' -> 'myapp/asgi.py'). Returns null if any step fails.
+ *
+ * When the settings file does not define the application constant directly,
+ * sibling imports are followed one level deep.
  */
 export async function getDjangoEntrypoint(
   workPath: string
@@ -65,30 +69,42 @@ export async function getDjangoEntrypoint(
     workPath,
     `${settingsModule.replace(/\./g, '/')}.py`
   );
+  let settingsContent: string;
   try {
-    const settingsContent = await fs.promises.readFile(settingsPath, 'utf-8');
-    const asgiApplication = await getStringConstant(
-      settingsContent,
-      'ASGI_APPLICATION'
-    );
-    if (asgiApplication) {
-      const modulePath = asgiApplication.split('.').slice(0, -1).join('/');
-      const asgiPath = `${modulePath}.py`;
-      debug(`Django ASGI entrypoint from ${settingsModule}: ${asgiPath}`);
-      return asgiPath;
-    }
-    const wsgiApplication = await getStringConstant(
-      settingsContent,
-      'WSGI_APPLICATION'
-    );
-    if (wsgiApplication) {
-      const modulePath = wsgiApplication.split('.').slice(0, -1).join('/');
-      const wsgiPath = `${modulePath}.py`;
-      debug(`Django WSGI entrypoint from ${settingsModule}: ${wsgiPath}`);
-      return wsgiPath;
-    }
+    settingsContent = await fs.promises.readFile(settingsPath, 'utf-8');
   } catch {
-    debug(`Failed to read or parse settings file: ${settingsPath}`);
+    debug(`Failed to read settings file: ${settingsPath}`);
+    return null;
   }
+
+  for (const appKey of ['ASGI_APPLICATION', 'WSGI_APPLICATION'] as const) {
+    const result = await getStringConstantOrImport(settingsContent, appKey);
+    if (!result) continue;
+
+    if (result.type === 'value') {
+      const appPath = `${result.value.split('.').slice(0, -1).join('/')}.py`;
+      debug(`Django ${appKey} entrypoint from ${settingsModule}: ${appPath}`);
+      return appPath;
+    }
+
+    // Follow sibling imports one level deep.
+    for (const siblingName of result.imports) {
+      const siblingPath = join(dirname(settingsPath), `${siblingName}.py`);
+      try {
+        const siblingContent = await fs.promises.readFile(siblingPath, 'utf-8');
+        const value = await getStringConstant(siblingContent, appKey);
+        if (value) {
+          const appPath = `${value.split('.').slice(0, -1).join('/')}.py`;
+          debug(
+            `Django ${appKey} entrypoint from ${settingsModule}/${siblingName}: ${appPath}`
+          );
+          return appPath;
+        }
+      } catch {
+        debug(`Failed to read sibling settings: ${siblingPath}`);
+      }
+    }
+  }
+
   return null;
 }

--- a/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
@@ -79,16 +79,90 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
     false
 }
 
-/// Extract the string value of a top-level constant with the given name.
-/// Only considers simple assignments (`NAME = "string"`) and annotated assignments
-/// (`NAME: str = "string"`) at module level. Returns the first matching string
-/// value, or None if not found or the value is not a string literal.
-pub(crate) fn get_string_constant_impl(source: &str, name: &str) -> Option<String> {
+/// The result of `get_string_constant_or_import_impl`: either a directly-assigned
+/// string value, or a list of sibling module names to follow.
+pub(crate) enum StringConstantOrImport {
+    /// A string literal was directly assigned: `NAME = "value"`
+    Value(String),
+    /// No direct assignment found; these are sibling module names
+    /// (e.g. `"base"`, `"common"`) that may define the constant.
+    Imports(Vec<String>),
+}
+
+/// Like `get_string_constant_impl`, but when no explicit assignment is found,
+/// falls back to scanning relative (sibling) imports at module level.
+/// If multiple statements match, the last one is used.
+///
+/// Priority:
+/// 1. Direct string assignment → `StringConstantOrImport::Value`
+/// 2. Explicit named sibling import (`from .base import NAME`) →
+///    `StringConstantOrImport::Imports(["base"])`
+/// 3. Wildcard sibling imports (`from .base import *`) →
+///    `StringConstantOrImport::Imports(["common", "base", …])`
+///
+/// Non-relative (absolute) imports and bare-package imports (`from . import X`)
+/// are ignored. Returns `None` if none of the above are found.
+pub(crate) fn get_string_constant_or_import_impl(
+    source: &str,
+    name: &str,
+) -> Option<StringConstantOrImport> {
     let parsed = match parse_module(source) {
         Ok(parsed) => parsed,
         Err(_) => return None,
     };
-    for stmt in parsed.suite() {
+    let stmts = parsed.suite();
+
+    // 1. Check for a direct string assignment first.
+    if let Some(s) = _get_string_constant_impl(stmts, name) {
+        return Some(StringConstantOrImport::Value(s));
+    }
+
+    // 2. No direct assignment — scan for relative (sibling) imports.
+    let mut wildcard_imports: Vec<String> = Vec::new();
+
+    for stmt in stmts.iter().rev() {
+        if let Stmt::ImportFrom(import_from) = stmt {
+            // Only consider relative imports (level > 0 means at least one leading dot).
+            if import_from.level == 0 {
+                continue;
+            }
+            // Skip bare-package imports like `from . import X` (no module name).
+            let module_name = match &import_from.module {
+                Some(m) => m.as_str(),
+                None => continue,
+            };
+
+            let module_path = module_name.to_string();
+
+            // Wildcard import: `from .base import *`
+            let is_wildcard = import_from.names.len() == 1
+                && import_from.names[0].name.as_str() == "*";
+
+            if is_wildcard {
+                wildcard_imports.push(module_path);
+            } else {
+                // If we find a matching import, return immediately.
+                for alias in &import_from.names {
+                    let imported_as = alias
+                        .asname
+                        .as_ref()
+                        .map(|id| id.as_str())
+                        .unwrap_or_else(|| alias.name.as_str());
+                    if imported_as == name {
+                        return Some(StringConstantOrImport::Imports(vec![module_path]));
+                    }
+                }
+            }
+        }
+    }
+
+    (!wildcard_imports.is_empty()).then_some(StringConstantOrImport::Imports(wildcard_imports))
+}
+
+/// Inner implementation of string-constant extraction that works on already-parsed stmts.
+/// If multiple assignments exist, the last one is used.
+fn _get_string_constant_impl(stmts: &[Stmt], name: &str) -> Option<String> {
+    for stmt in stmts.iter().rev() {
         match stmt {
             Stmt::Assign(assign) => {
                 if assign.targets.len() == 1 && is_name_expr(&assign.targets[0], name) {
@@ -110,6 +184,18 @@ pub(crate) fn get_string_constant_impl(source: &str, name: &str) -> Option<Strin
         }
     }
     None
+}
+
+/// Extract the string value of a top-level constant with the given name.
+/// Only considers simple assignments (`NAME = "string"`) and annotated assignments
+/// (`NAME: str = "string"`) at module level. If multiple assignments exist, the last
+/// one is used. Returns None if not found or the value is not a string literal.
+pub(crate) fn get_string_constant_impl(source: &str, name: &str) -> Option<String> {
+    let parsed = match parse_module(source) {
+        Ok(parsed) => parsed,
+        Err(_) => return None,
+    };
+    _get_string_constant_impl(parsed.suite(), name)
 }
 
 fn is_name_expr(expr: &Expr, name: &str) -> bool {
@@ -306,6 +392,137 @@ def create():
     return app
 "#;
         assert!(!contains_app_or_handler_impl(source));
+    }
+
+    // -------------------------------------------------------------------------
+    // get_string_constant_or_import_impl
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_gsci_direct_assignment() {
+        let source = r#"WSGI_APPLICATION = "myapp.wsgi.application""#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(matches!(result, Some(StringConstantOrImport::Value(s)) if s == "myapp.wsgi.application"));
+    }
+
+    #[test]
+    fn test_gsci_annotated_assignment() {
+        let source = r#"WSGI_APPLICATION: str = "myapp.wsgi.application""#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(matches!(result, Some(StringConstantOrImport::Value(s)) if s == "myapp.wsgi.application"));
+    }
+
+    #[test]
+    fn test_gsci_explicit_named_import() {
+        let source = r#"from .base import WSGI_APPLICATION"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(matches!(
+            result,
+            Some(StringConstantOrImport::Imports(paths)) if paths == vec!["base"]
+        ));
+    }
+
+    #[test]
+    fn test_gsci_explicit_named_import_aliased() {
+        // `from .base import WSGI as WSGI_APPLICATION` — the alias resolves to our name
+        let source = r#"from .base import WSGI as WSGI_APPLICATION"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(matches!(
+            result,
+            Some(StringConstantOrImport::Imports(paths)) if paths == vec!["base"]
+        ));
+    }
+
+    #[test]
+    fn test_gsci_explicit_import_returns_last_only() {
+        // Two explicit sibling imports — the last one takes priority.
+        let source = r#"
+from .base import WSGI_APPLICATION
+from .prod import WSGI_APPLICATION
+"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(matches!(
+            result,
+            Some(StringConstantOrImport::Imports(paths)) if paths == vec!["prod"]
+        ));
+    }
+
+    #[test]
+    fn test_gsci_wildcard_imports() {
+        // Wildcards are returned last-first.
+        let source = r#"
+from .base import *
+from .common import *
+"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(matches!(
+            result,
+            Some(StringConstantOrImport::Imports(paths)) if paths == vec!["common", "base"]
+        ));
+    }
+
+    #[test]
+    fn test_gsci_explicit_import_takes_priority_over_wildcard() {
+        // Even if wildcard imports appear first, an explicit named import wins.
+        let source = r#"
+from .base import *
+from .prod import WSGI_APPLICATION
+"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(matches!(
+            result,
+            Some(StringConstantOrImport::Imports(paths)) if paths == vec!["prod"]
+        ));
+    }
+
+    #[test]
+    fn test_gsci_ignores_absolute_imports() {
+        let source = r#"from django.conf import WSGI_APPLICATION"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_gsci_ignores_bare_package_import() {
+        // `from . import WSGI_APPLICATION` (level=1, module=None) is skipped.
+        let source = r#"from . import WSGI_APPLICATION"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_gsci_direct_assignment_beats_import() {
+        // Assignment takes priority even if imports also appear.
+        let source = r#"
+from .base import *
+WSGI_APPLICATION = "myapp.wsgi.application"
+"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(matches!(result, Some(StringConstantOrImport::Value(s)) if s == "myapp.wsgi.application"));
+    }
+
+    #[test]
+    fn test_gsci_double_dot_relative_import() {
+        let source = r#"from ..base import WSGI_APPLICATION"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(matches!(
+            result,
+            Some(StringConstantOrImport::Imports(paths)) if paths == vec!["base"]
+        ));
+    }
+
+    #[test]
+    fn test_gsci_not_found() {
+        let source = r#"DEBUG = True"#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_gsci_invalid_syntax() {
+        let source = r#"from .base import "#;
+        let result = get_string_constant_or_import_impl(source, "WSGI_APPLICATION");
+        assert!(result.is_none());
     }
 
     // -------------------------------------------------------------------------

--- a/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
@@ -10,11 +10,13 @@ bindings::export!(PythonAnalyzer with_types_in bindings);
 
 struct PythonAnalyzer;
 
-use crate::bindings::{DistMetadata, DirectUrlInfo, RecordEntry};
+use crate::bindings::{DistMetadata, DirectUrlInfo, RecordEntry, StringConstantOrImport};
 use crate::entrypoint::{
     contains_app_or_handler_impl,
     get_string_constant_impl,
+    get_string_constant_or_import_impl,
     parse_django_settings_module_impl,
+    StringConstantOrImport as StringConstantOrImportImpl,
 };
 
 impl crate::bindings::Guest for PythonAnalyzer {
@@ -31,10 +33,22 @@ impl crate::bindings::Guest for PythonAnalyzer {
 
     /// Extract the string value of a top-level constant with the given name.
     /// Only considers simple assignments (`NAME = "string"`) and annotated assignments
-    /// (`NAME: str = "string"`) at module level. Returns the first matching string
-    /// value, or None if not found or the value is not a string literal.
+    /// (`NAME: str = "string"`) at module level. If multiple assignments exist, the last
+    /// one is used. Returns None if not found or the value is not a string literal.
     fn get_string_constant(source: String, name: String) -> Option<String> {
         get_string_constant_impl(&source, &name)
+    }
+
+    /// Like `get_string_constant`, but when no direct assignment is found, returns
+    /// relative sibling module paths from which the constant may be imported.
+    fn get_string_constant_or_import(
+        source: String,
+        name: String,
+    ) -> Option<StringConstantOrImport> {
+        get_string_constant_or_import_impl(&source, &name).map(|r| match r {
+            StringConstantOrImportImpl::Value(s) => StringConstantOrImport::Value(s),
+            StringConstantOrImportImpl::Imports(paths) => StringConstantOrImport::Imports(paths),
+        })
     }
 
     /// Extract the default value from `os.environ.setdefault('DJANGO_SETTINGS_MODULE', '...')`

--- a/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
+++ b/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
@@ -12,8 +12,27 @@ world python-analysis {
     export contains-app-or-handler: func(source: string) -> bool;
 
     /// Extract the string value of a top-level constant with the given name.
-    /// Only considers simple or annotated assignments at module level whose value is a string literal.
+    /// Only considers simple or annotated assignments at module level whose value is a
+    /// string literal. If multiple assignments exist, the last one is used.
     export get-string-constant: func(source: string, name: string) -> option<string>;
+
+    /// Like get-string-constant, but when no direct assignment is found, returns the
+    /// sibling module names from which the constant may be imported instead.
+    /// If multiple statements match, the last one is used.
+    ///
+    /// Priority:
+    ///   1. Direct string assignment → value(string)
+    ///   2. Explicit named sibling import (`from .base import NAME`) →
+    ///      imports(["base"])
+    ///   3. Wildcard sibling imports (`from .base import *`) →
+    ///      imports(["common", "base", …])
+    ///
+    /// Non-relative and bare-package imports are ignored. Returns none if nothing found.
+    variant string-constant-or-import {
+        value(string),
+        imports(list<string>),
+    }
+    export get-string-constant-or-import: func(source: string, name: string) -> option<string-constant-or-import>;
 
     /// Extract the default value from os.environ.setdefault('DJANGO_SETTINGS_MODULE', '...')
     /// in Python source (e.g. manage.py). Returns the second argument (e.g. 'app.settings')

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -14,8 +14,11 @@
 export {
   containsAppOrHandler,
   getStringConstant,
+  getStringConstantOrImport,
   parseDjangoSettingsModule,
 } from './semantic/entrypoints';
+
+export type { StringConstantOrImport } from './semantic/entrypoints';
 
 // =============================================================================
 // Installed package analysis (WASM-based .dist-info parsing)

--- a/packages/python-analysis/src/semantic/entrypoints.ts
+++ b/packages/python-analysis/src/semantic/entrypoints.ts
@@ -46,8 +46,8 @@ export async function containsAppOrHandler(source: string): Promise<boolean> {
 /**
  * Extract the string value of a top-level constant with the given name.
  * Only considers simple assignments (NAME = "string") and annotated assignments
- * (NAME: str = "string") at module level. Returns the first matching string
- * value, or null if not found or the value is not a string literal.
+ * (NAME: str = "string") at module level. If multiple assignments exist, the last
+ * one is used. Returns null if not found or the value is not a string literal.
  *
  * @param source - Python source code
  * @param name - Constant name (e.g. "VERSION", "APP_NAME")
@@ -59,6 +59,45 @@ export async function getStringConstant(
 ): Promise<string | null> {
   const mod = await importWasmModule();
   return mod.getStringConstant(source, name) ?? null;
+}
+
+/**
+ * Result of `getStringConstantOrImport`: either a directly-assigned string
+ * value, or a list of sibling module names to follow.
+ */
+export type StringConstantOrImport =
+  | { type: 'value'; value: string }
+  | { type: 'imports'; imports: string[] };
+
+/**
+ * Like `getStringConstant`, but when no direct assignment is found, returns
+ * the sibling module names (e.g. `"base"`, `"common"`) from which the constant
+ * may be imported instead. If multiple statements match, the last one is used.
+ *
+ * Priority:
+ * 1. Direct string assignment → `{ type: 'value', value: string }`
+ * 2. Explicit named sibling import (`from .base import NAME`) →
+ *    `{ type: 'imports', imports: ['base'] }`
+ * 3. Wildcard sibling imports (`from .base import *`) →
+ *    `{ type: 'imports', imports: ['common', 'base', …] }`
+ *
+ * Non-relative and bare-package imports are ignored.
+ * Returns `null` if nothing is found.
+ *
+ * @param source - Python source code
+ * @param name - Constant name (e.g. "WSGI_APPLICATION")
+ */
+export async function getStringConstantOrImport(
+  source: string,
+  name: string
+): Promise<StringConstantOrImport | null> {
+  const mod = await importWasmModule();
+  const result = mod.getStringConstantOrImport(source, name);
+  if (!result) return null;
+  if (result.tag === 'value') {
+    return { type: 'value', value: result.val as string };
+  }
+  return { type: 'imports', imports: result.val as string[] };
 }
 
 /** Simple check for DJANGO_SETTINGS_MODULE presence so we can skip WASM when absent */


### PR DESCRIPTION
A common pattern is:

`hello/settings/dev.py`:
```py
from .common import *
...
```

`hello/settings/common.py`
```py
...
WSGI_APPLICATION = hello.wsgi.application
...
```

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new feature to follow sibling imports when looking for Django entrypoints, consisting of new Rust parsing logic, TypeScript wrappers, and comprehensive tests with no security, auth, or schema changes.
> 
> - New `getStringConstantOrImport` function in Rust/TS to follow sibling imports
> - Refactored `getDjangoEntrypoint` to check sibling settings files one level deep
> - Added 14 unit tests for new import-following logic
>
> <sup>Risk assessment for [commit 4153a3a](https://github.com/vercel/vercel/commit/4153a3a7dc147718da4bd458eec80e62557010cd).</sup>
<!-- VADE_RISK_END -->