### PR TITLE
feat(cli): add --json flag to deploy command

### DIFF
--- a/.changeset/deploy-json-flag.md
+++ b/.changeset/deploy-json-flag.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add --json flag to `vc deploy` for machine-readable output

--- a/packages/cli/src/commands/deploy/command.ts
+++ b/packages/cli/src/commands/deploy/command.ts
@@ -1,4 +1,10 @@
-import { confirmOption, forceOption, yesOption } from '../../util/arg-common';
+import {
+  confirmOption,
+  forceOption,
+  formatOption,
+  jsonOption,
+  yesOption,
+} from '../../util/arg-common';
 
 export const deprecatedArchiveSplitTgz = 'split-tgz';
 
@@ -288,6 +294,8 @@ export const deployCommand = {
       deprecated: false,
       description: 'Specify the target deployment environment',
     },
+    formatOption,
+    jsonOption,
     confirmOption,
   ],
   examples: [

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -1253,7 +1253,7 @@ async function handleDefaultDeploy(
       id: deployment.id,
       url: `https://${deployment.url}`,
       inspectorUrl: deployment.inspectorUrl ?? null,
-      deploymentApiUrl: `https://api.vercel.com/v13/deployments/${deployment.id}`,
+      deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deployment.id}`,
     };
     client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
     return 0;

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -81,6 +81,7 @@ import { ensureLink } from '../../util/link/ensure-link';
 import { UploadErrorMissingArchive } from '../../util/deploy/process-deployment';
 import { displayBuildLogsUntilFinalError } from '../../util/logs';
 import { determineAgent } from '@vercel/detect-agent';
+import { validateJsonOutput } from '../../util/output-format';
 
 const COMMAND_CONFIG = {
   init: getCommandAliases(initSubcommand),
@@ -670,6 +671,15 @@ async function handleDefaultDeploy(
   telemetryClient.trackCliFlagGuidance(parsedArguments.flags['--guidance']);
   telemetryClient.trackCliFlagForce(parsedArguments.flags['--force']);
   telemetryClient.trackCliFlagWithCache(parsedArguments.flags['--with-cache']);
+  telemetryClient.trackCliFlagJson(parsedArguments.flags['--json']);
+  telemetryClient.trackCliOptionFormat(parsedArguments.flags['--format']);
+
+  const formatResult = validateJsonOutput(parsedArguments.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
 
   if ('--confirm' in parsedArguments.flags) {
     telemetryClient.trackCliFlagConfirm(parsedArguments.flags['--confirm']);
@@ -1235,6 +1245,18 @@ async function handleDefaultDeploy(
 
     printError(err);
     return 1;
+  }
+
+  if (asJson) {
+    output.stopSpinner();
+    const jsonOutput = {
+      id: deployment.id,
+      url: `https://${deployment.url}`,
+      inspectorUrl: deployment.inspectorUrl ?? null,
+      deploymentApiUrl: `https://api.vercel.com/v13/deployments/${deployment.id}`,
+    };
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
   }
 
   const { isAgent } = await determineAgent();

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -1253,6 +1253,8 @@ async function handleDefaultDeploy(
       id: deployment.id,
       url: `https://${deployment.url}`,
       inspectorUrl: deployment.inspectorUrl ?? null,
+      readyState: deployment.readyState,
+      target: deployment.target ?? null,
       deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deployment.id}`,
     };
     client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -156,6 +156,19 @@ export class DeployTelemetryClient
       this.trackCliFlag('yes');
     }
   }
+  trackCliFlagJson(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('json');
+    }
+  }
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
 
   trackDeploymentId(id: string | undefined) {
     if (id) {

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -753,7 +753,7 @@ exports[`help command > certs help output snapshots > certs remove help output s
 `;
 
 exports[`help command > deploy help output snapshots > deploy help column width 40 1`] = `
-"
+
   ▲ vercel deploy [project-path] [options]
 
   Deploy your project to Vercel. The    
@@ -800,6 +800,11 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 nothing 
                                 has     
                                 changed 
+  -F,  --format <FORMAT>        Specify 
+                                the     
+                                output  
+                                format  
+                                (json)  
        --guidance               Receive 
                                 command 
                                 suggest…
@@ -964,11 +969,11 @@ exports[`help command > deploy help output snapshots > deploy help column width 
 
     $ vercel > deployment-url.txt
 
-"
+
 `;
 
 exports[`help command > deploy help output snapshots > deploy help column width 80 1`] = `
-"
+
   ▲ vercel deploy [project-path] [options]
 
   Deploy your project to Vercel. The \`deploy\` command is the default command    
@@ -985,6 +990,7 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 (e.g. \`-e KEY1=value1 -e KEY2=value2\`)          
   -f,  --force                  Force a new deployment even if nothing has      
                                 changed                                         
+  -F,  --format <FORMAT>        Specify the output format (json)                
        --guidance               Receive command suggestions once deployment is  
                                 complete                                        
   -l,  --logs                   Print the build logs                            
@@ -1045,11 +1051,11 @@ exports[`help command > deploy help output snapshots > deploy help column width 
 
     $ vercel > deployment-url.txt
 
-"
+
 `;
 
 exports[`help command > deploy help output snapshots > deploy help column width 120 1`] = `
-"
+
   ▲ vercel deploy [project-path] [options]
 
   Deploy your project to Vercel. The \`deploy\` command is the default command for the Vercel CLI, and can be omitted     
@@ -1061,6 +1067,7 @@ exports[`help command > deploy help output snapshots > deploy help column width 
   -b,  --build-env <KEY=VALUE>  Specify environment variables during build-time (e.g. \`-b KEY1=value1 -b KEY2=value2\`)  
   -e,  --env <KEY=VALUE>        Specify environment variables during run-time (e.g. \`-e KEY1=value1 -e KEY2=value2\`)    
   -f,  --force                  Force a new deployment even if nothing has changed                                      
+  -F,  --format <FORMAT>        Specify the output format (json)                                                        
        --guidance               Receive command suggestions once deployment is complete                                 
   -l,  --logs                   Print the build logs                                                                    
   -m,  --meta <KEY=VALUE>       Specify metadata for the deployment (e.g. \`-m KEY1=value1 -m KEY2=value2\`)              
@@ -1113,7 +1120,7 @@ exports[`help command > deploy help output snapshots > deploy help column width 
 
     $ vercel > deployment-url.txt
 
-"
+
 `;
 
 exports[`help command > dev help output snapshots > dev --help > outputs help 1`] = `

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -753,7 +753,7 @@ exports[`help command > certs help output snapshots > certs remove help output s
 `;
 
 exports[`help command > deploy help output snapshots > deploy help column width 40 1`] = `
-
+"
   ▲ vercel deploy [project-path] [options]
 
   Deploy your project to Vercel. The    
@@ -969,11 +969,11 @@ exports[`help command > deploy help output snapshots > deploy help column width 
 
     $ vercel > deployment-url.txt
 
-
+"
 `;
 
 exports[`help command > deploy help output snapshots > deploy help column width 80 1`] = `
-
+"
   ▲ vercel deploy [project-path] [options]
 
   Deploy your project to Vercel. The \`deploy\` command is the default command    
@@ -1051,11 +1051,11 @@ exports[`help command > deploy help output snapshots > deploy help column width 
 
     $ vercel > deployment-url.txt
 
-
+"
 `;
 
 exports[`help command > deploy help output snapshots > deploy help column width 120 1`] = `
-
+"
   ▲ vercel deploy [project-path] [options]
 
   Deploy your project to Vercel. The \`deploy\` command is the default command for the Vercel CLI, and can be omitted     
@@ -1120,7 +1120,7 @@ exports[`help command > deploy help output snapshots > deploy help column width 
 
     $ vercel > deployment-url.txt
 
-
+"
 `;
 
 exports[`help command > dev help output snapshots > dev --help > outputs help 1`] = `

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1671,4 +1671,110 @@ describe('deploy', () => {
       expect(stderrOutput).not.toContain('Aliased:');
     });
   });
+
+  describe('--json', () => {
+    const deploymentUrl = 'my-app-abc123.vercel.app';
+    const deploymentId = 'dpl_json_test';
+    const inspectorUrl = 'https://vercel.com/team/project/dpl_json_test';
+
+    beforeEach(() => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.post(`/v13/deployments`, (req, res) => {
+        res.json({
+          creator: {
+            uid: user.id,
+            username: user.username,
+          },
+          id: deploymentId,
+          url: deploymentUrl,
+          inspectorUrl,
+          readyState: 'READY',
+        });
+      });
+      client.scenario.get(`/v13/deployments/${deploymentId}`, (req, res) => {
+        res.json({
+          creator: {
+            uid: user.id,
+            username: user.username,
+          },
+          id: deploymentId,
+          url: deploymentUrl,
+          inspectorUrl,
+          readyState: 'READY',
+          aliasAssigned: true,
+          alias: [],
+        });
+      });
+    });
+
+    it('should output deployment as JSON to stdout with --json', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--json');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const json = JSON.parse(stdoutOutput);
+
+      expect(json).toEqual({
+        id: deploymentId,
+        url: `https://${deploymentUrl}`,
+        inspectorUrl,
+        deploymentApiUrl: `https://api.vercel.com/v13/deployments/${deploymentId}`,
+      });
+    });
+
+    it('should output deployment as JSON to stdout with --format=json', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--format', 'json');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const json = JSON.parse(stdoutOutput);
+
+      expect(json).toEqual({
+        id: deploymentId,
+        url: `https://${deploymentUrl}`,
+        inspectorUrl,
+        deploymentApiUrl: `https://api.vercel.com/v13/deployments/${deploymentId}`,
+      });
+    });
+
+    it('should track --json flag telemetry', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--json');
+      await deploy(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:json', value: 'TRUE' },
+        { key: 'output:deployment-id', value: deploymentId },
+      ]);
+    });
+
+    it('should track --format telemetry', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--format', 'json');
+      await deploy(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'option:format', value: 'json' },
+        { key: 'output:deployment-id', value: deploymentId },
+      ]);
+    });
+
+    it('should return error for invalid format', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--format', 'xml');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(1);
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1696,6 +1696,7 @@ describe('deploy', () => {
           url: deploymentUrl,
           inspectorUrl,
           readyState: 'READY',
+          target: 'production',
         });
       });
       client.scenario.get(`/v13/deployments/${deploymentId}`, (req, res) => {
@@ -1708,6 +1709,7 @@ describe('deploy', () => {
           url: deploymentUrl,
           inspectorUrl,
           readyState: 'READY',
+          target: 'production',
           aliasAssigned: true,
           alias: [],
         });
@@ -1727,7 +1729,9 @@ describe('deploy', () => {
         id: deploymentId,
         url: `https://${deploymentUrl}`,
         inspectorUrl,
-        deploymentApiUrl: `https://api.vercel.com/v13/deployments/${deploymentId}`,
+        readyState: 'READY',
+        target: 'production',
+        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
       });
     });
 
@@ -1744,7 +1748,9 @@ describe('deploy', () => {
         id: deploymentId,
         url: `https://${deploymentUrl}`,
         inspectorUrl,
-        deploymentApiUrl: `https://api.vercel.com/v13/deployments/${deploymentId}`,
+        readyState: 'READY',
+        target: 'production',
+        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
       });
     });
 


### PR DESCRIPTION
## Summary
- Adds `--json` and `--format=json` flags to `vc deploy`
- When used, outputs deployment details as JSON to stdout instead of human-readable output
- JSON output includes `id`, `url`, `inspectorUrl`, and `deploymentApiUrl`
- Adds telemetry tracking for both flags
- Adds unit tests for JSON output, telemetry, and invalid format handling

## Example

```sh
$ vc deploy --json
{
  "id": "dpl_abc123",
  "url": "https://my-app-abc123.vercel.app",
  "inspectorUrl": "https://vercel.com/team/project/dpl_abc123",
  "deploymentApiUrl": "https://api.vercel.com/v13/deployments/dpl_abc123"
}
```

## Context

I was writing a script that would test a bunch of deployments in serial and wanted to then look at the deployment record. Parsing json output is easier than stdout and stderr

## Test plan
- [x] Unit tests for `--json` flag output format
- [x] Unit tests for `--format=json` flag output format
- [x] Unit tests for telemetry tracking (`flag:json`, `option:format`)
- [x] Unit test for invalid format error handling
- [x] All 56 deploy tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new --json flag to the CLI deploy command for machine-readable output, with proper validation and comprehensive unit tests - no security, auth, or database changes.
> 
> - Adds --json and --format flags to deploy command with validation via validateJsonOutput
> - Outputs deployment details (id, url, inspectorUrl, readyState, target) as JSON when flag is set
> - Adds telemetry tracking and unit tests for new flags
>
> <sup>Risk assessment for [commit d3f8767](https://github.com/vercel/vercel/commit/d3f87677338732aca29170d781c2bc3d3361e2ac).</sup>
<!-- VADE_RISK_END -->