### PR TITLE
[services] run framework detection with file entrypoints

### DIFF
--- a/.changeset/strong-days-grin.md
+++ b/.changeset/strong-days-grin.md
@@ -1,0 +1,5 @@
+---
+"@vercel/fs-detectors": patch
+---
+
+[services] run framework detection with file entrypoints

--- a/.changeset/vercel-workers-v3-redesign.md
+++ b/.changeset/vercel-workers-v3-redesign.md
@@ -1,5 +1,0 @@
----
----
-
-Rebuilt `python/vercel-workers` around Queue API v3 with typed models, explicit sync/async clients, a thin public API, and `_internal` queue/http layers aligned with `vercel-py` design patterns.
-

--- a/.changeset/vercel-workers-v3-redesign.md
+++ b/.changeset/vercel-workers-v3-redesign.md
@@ -1,0 +1,5 @@
+---
+---
+
+Rebuilt `python/vercel-workers` around Queue API v3 with typed models, explicit sync/async clients, a thin public API, and `_internal` queue/http layers aligned with `vercel-py` design patterns.
+

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -150,15 +150,24 @@ async function detectFrameworkFromWorkspace({
   fs,
   workspace,
   serviceName,
+  runtime,
 }: {
   fs: DetectorFilesystem;
   workspace: string;
   serviceName: string;
+  runtime?: ServiceRuntime;
 }): Promise<{ framework?: string; error?: ServiceDetectionError }> {
   const serviceFs = workspace === '.' ? fs : fs.chdir(workspace);
+  const frameworkCandidates = runtime
+    ? frameworkList.filter(
+        framework =>
+          framework.slug != null &&
+          inferServiceRuntime({ framework: framework.slug }) === runtime
+      )
+    : frameworkList;
   const frameworks = await detectFrameworks({
     fs: serviceFs,
-    frameworkList,
+    frameworkList: frameworkCandidates,
   });
 
   if (frameworks.length > 1) {
@@ -517,31 +526,61 @@ export async function resolveAllConfiguredServices(
     let resolvedConfig = serviceConfig;
 
     const shouldDetectFramework =
-      !serviceConfig.framework && Boolean(resolvedEntrypoint?.isDirectory);
+      !serviceConfig.framework && Boolean(resolvedEntrypoint);
 
-    if (shouldDetectFramework) {
-      const workspace = resolvedEntrypoint!.normalized;
-      const { framework, error } = await detectFrameworkFromWorkspace({
-        fs,
-        workspace,
-        serviceName: name,
-      });
-      if (error) {
-        errors.push(error);
-        continue;
-      }
-      if (!framework) {
-        errors.push({
-          code: 'MISSING_SERVICE_FRAMEWORK',
-          message: `Service "${name}" uses directory entrypoint "${serviceConfig.entrypoint}" but no framework could be detected in "${workspace}". Specify "framework" explicitly or use a file entrypoint.`,
+    if (shouldDetectFramework && resolvedEntrypoint) {
+      if (resolvedEntrypoint.isDirectory) {
+        const workspace = resolvedEntrypoint.normalized;
+        const { framework, error } = await detectFrameworkFromWorkspace({
+          fs,
+          workspace,
           serviceName: name,
         });
-        continue;
+        if (error) {
+          errors.push(error);
+          continue;
+        }
+        if (!framework) {
+          errors.push({
+            code: 'MISSING_SERVICE_FRAMEWORK',
+            message: `Service "${name}" uses directory entrypoint "${serviceConfig.entrypoint}" but no framework could be detected in "${workspace}". Specify "framework" explicitly or use a file entrypoint.`,
+            serviceName: name,
+          });
+          continue;
+        }
+        resolvedConfig = {
+          ...resolvedConfig,
+          framework,
+        };
+      } else {
+        const inferredRuntime = inferServiceRuntime({
+          ...serviceConfig,
+          entrypoint: resolvedEntrypoint.normalized,
+        });
+
+        if (inferredRuntime) {
+          const inferredWorkspace = await inferWorkspaceFromNearestManifest({
+            fs,
+            entrypoint: resolvedEntrypoint.normalized,
+            runtime: inferredRuntime,
+          });
+          const workspace =
+            inferredWorkspace ??
+            posixPath.dirname(resolvedEntrypoint.normalized);
+          const detection = await detectFrameworkFromWorkspace({
+            fs,
+            workspace,
+            serviceName: name,
+            runtime: inferredRuntime,
+          });
+          if (detection.framework) {
+            resolvedConfig = {
+              ...resolvedConfig,
+              framework: detection.framework,
+            };
+          }
+        }
       }
-      resolvedConfig = {
-        ...serviceConfig,
-        framework,
-      };
     }
 
     const service = await resolveConfiguredService({

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -13,8 +13,10 @@ import {
   RUNTIME_MANIFESTS,
 } from './types';
 import {
+  filterFrameworksByRuntime,
   getBuilderForRuntime,
   hasFile,
+  inferRuntimeFromFramework,
   inferServiceRuntime,
   INTERNAL_SERVICE_PREFIX,
 } from './utils';
@@ -158,13 +160,7 @@ async function detectFrameworkFromWorkspace({
   runtime?: ServiceRuntime;
 }): Promise<{ framework?: string; error?: ServiceDetectionError }> {
   const serviceFs = workspace === '.' ? fs : fs.chdir(workspace);
-  const frameworkCandidates = runtime
-    ? frameworkList.filter(
-        framework =>
-          framework.slug != null &&
-          inferServiceRuntime({ framework: framework.slug }) === runtime
-      )
-    : frameworkList;
+  const frameworkCandidates = filterFrameworksByRuntime(frameworkList, runtime);
   const frameworks = await detectFrameworks({
     fs: serviceFs,
     frameworkList: frameworkCandidates,
@@ -268,6 +264,16 @@ export function validateServiceConfig(
       message: `Service "${name}" has invalid framework "${config.framework}".`,
       serviceName: name,
     };
+  }
+  if (config.runtime && config.framework) {
+    const frameworkRuntime = inferRuntimeFromFramework(config.framework);
+    if (frameworkRuntime && frameworkRuntime !== config.runtime) {
+      return {
+        code: 'RUNTIME_FRAMEWORK_MISMATCH',
+        message: `Service "${name}" has conflicting runtime/framework: runtime "${config.runtime}" is incompatible with framework "${config.framework}" (runtime "${frameworkRuntime}").`,
+        serviceName: name,
+      };
+    }
   }
 
   const hasFramework = Boolean(config.framework);
@@ -525,10 +531,7 @@ export async function resolveAllConfiguredServices(
 
     let resolvedConfig = serviceConfig;
 
-    const shouldDetectFramework =
-      !serviceConfig.framework && Boolean(resolvedEntrypoint);
-
-    if (shouldDetectFramework && resolvedEntrypoint) {
+    if (!serviceConfig.framework && resolvedEntrypoint) {
       if (resolvedEntrypoint.isDirectory) {
         const workspace = resolvedEntrypoint.normalized;
         const { framework, error } = await detectFrameworkFromWorkspace({

--- a/packages/fs-detectors/src/services/utils.ts
+++ b/packages/fs-detectors/src/services/utils.ts
@@ -61,6 +61,49 @@ export function isRouteOwningBuilder(service: ResolvedService): boolean {
 }
 
 /**
+ * Infer runtime from a framework slug.
+ *
+ * Examples:
+ * - `python` -> `python`
+ * - `fastapi` -> `python`
+ * - `express` -> `node`
+ */
+export function inferRuntimeFromFramework(
+  framework: string | null | undefined
+): ServiceRuntime | undefined {
+  if (!framework) {
+    return undefined;
+  }
+
+  // Runtime framework slug maps directly to runtime name.
+  if (framework in RUNTIME_BUILDERS) {
+    return framework as ServiceRuntime;
+  }
+
+  if (isPythonFramework(framework)) {
+    return 'python';
+  }
+  if (isBackendFramework(framework)) {
+    return 'node';
+  }
+
+  return undefined;
+}
+
+export function filterFrameworksByRuntime<T extends { slug?: string | null }>(
+  frameworks: readonly T[],
+  runtime?: ServiceRuntime
+): T[] {
+  if (!runtime) {
+    return [...frameworks];
+  }
+
+  return frameworks.filter(
+    framework => inferRuntimeFromFramework(framework.slug) === runtime
+  );
+}
+
+/**
  * Infer runtime from available service configuration.
  *
  * Priority (highest to lowest):
@@ -83,17 +126,9 @@ export function inferServiceRuntime(config: {
     return config.runtime as ServiceRuntime;
   }
 
-  // Runtime framework slug maps directly to runtime name.
-  if (config.framework && config.framework in RUNTIME_BUILDERS) {
-    return config.framework as ServiceRuntime;
-  }
-
-  // Infer from framework
-  if (isPythonFramework(config.framework)) {
-    return 'python';
-  }
-  if (isBackendFramework(config.framework)) {
-    return 'node';
+  const frameworkRuntime = inferRuntimeFromFramework(config.framework);
+  if (frameworkRuntime) {
+    return frameworkRuntime;
   }
 
   // Infer from builder

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -200,6 +200,74 @@ describe('detectServices', () => {
       expect(result.routes.defaults).toHaveLength(0);
     });
 
+    it('should auto-detect FastAPI for backend file entrypoint in configured services', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            frontend: {
+              entrypoint: 'frontend',
+              routePrefix: '/',
+              framework: 'nextjs',
+            },
+            backend: {
+              entrypoint: 'backend/main.py',
+              routePrefix: '/svc/api',
+            },
+          },
+        }),
+        'frontend/package.json': JSON.stringify({
+          dependencies: {
+            next: '15.0.0',
+          },
+        }),
+        'backend/pyproject.toml': '[project]\ndependencies = ["fastapi"]\n',
+        'backend/main.py': 'from fastapi import FastAPI\napp = FastAPI()\n',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.source).toBe('configured');
+      expect(result.services).toHaveLength(2);
+
+      const frontend = result.services.find(s => s.name === 'frontend');
+      expect(frontend).toMatchObject({
+        name: 'frontend',
+        framework: 'nextjs',
+        workspace: 'frontend',
+        routePrefix: '/',
+        routePrefixSource: 'configured',
+      });
+      expect(frontend?.builder.use).toBe('@vercel/next');
+
+      const backend = result.services.find(s => s.name === 'backend');
+      expect(backend).toMatchObject({
+        name: 'backend',
+        framework: 'fastapi',
+        runtime: 'python',
+        workspace: 'backend',
+        entrypoint: 'main.py',
+        routePrefix: '/svc/api',
+        routePrefixSource: 'configured',
+      });
+      expect(backend?.builder).toMatchObject({
+        src: 'backend/main.py',
+        use: '@vercel/python',
+        config: {
+          zeroConfig: true,
+          routePrefix: 'svc/api',
+          workspace: 'backend',
+          framework: 'fastapi',
+        },
+      });
+
+      expect(result.routes.rewrites).toContainEqual({
+        src: '^(?=/svc/api(?:/|$))(?:/svc/api(?:/.*)?$)',
+        dest: '/_svc/backend/index',
+        check: true,
+      });
+      expect(result.routes.defaults).toEqual([]);
+    });
+
     it('should default type to web', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({
@@ -297,6 +365,62 @@ describe('detectServices', () => {
       expect(result.services[0].builder.config).toMatchObject({
         workspace: 'services/fastapi-api',
       });
+    });
+
+    it('should auto-detect framework for Python file entrypoint when omitted', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            api: {
+              entrypoint: 'backend/main.py',
+              routePrefix: '/api',
+            },
+          },
+        }),
+        'backend/pyproject.toml': '[project]\ndependencies = ["fastapi"]\n',
+        'backend/main.py': 'from fastapi import FastAPI\napp = FastAPI()\n',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0]).toMatchObject({
+        name: 'api',
+        framework: 'fastapi',
+        runtime: 'python',
+        workspace: 'backend',
+        entrypoint: 'main.py',
+        routePrefix: '/api',
+      });
+      expect(result.services[0].builder.use).toBe('@vercel/python');
+    });
+
+    it('should keep runtime-only resolution when file entrypoint framework detection is ambiguous', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            api: {
+              entrypoint: 'backend/main.py',
+              routePrefix: '/api',
+            },
+          },
+        }),
+        'backend/requirements.txt': 'fastapi\nflask\n',
+        'backend/main.py': 'from fastapi import FastAPI\napp = FastAPI()\n',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0]).toMatchObject({
+        name: 'api',
+        runtime: 'python',
+        workspace: 'backend',
+        entrypoint: 'main.py',
+        routePrefix: '/api',
+      });
+      expect(result.services[0].framework).toBeUndefined();
+      expect(result.services[0].builder.use).toBe('@vercel/python');
     });
 
     it('should infer Ruby workspace from nearest Gemfile when workspace is omitted', async () => {


### PR DESCRIPTION
Since `framework` is now an optional field, runs framework detection when `entrypoint` is a file. Previously we were only inferring the framework if entrypoint was a directory

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds framework detection logic for file entrypoints in service resolution, including new utility functions and validation, with corresponding test coverage.
> 
> - Adds `filterFrameworksByRuntime` and `inferRuntimeFromFramework` utility functions
> - Extends `detectFrameworkFromWorkspace` to accept optional runtime parameter for filtering
> - Adds validation for runtime/framework mismatch in `validateServiceConfig`
>
> <sup>Risk assessment for [commit bdb94fc](https://github.com/vercel/vercel/commit/bdb94fce0d5fae4195bd7851f85e29dfae737d04).</sup>
<!-- VADE_RISK_END -->