### PR TITLE
Update Next.js adapter version

### DIFF
--- a/.changeset/funny-cooks-move.md
+++ b/.changeset/funny-cooks-move.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Update Next.js adapter version

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.10",
+    "@next-community/adapter-vercel": "0.0.1-beta.11",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1716,8 +1716,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.10
-        version: 0.0.1-beta.10(next@16.1.6)
+        specifier: 0.0.1-beta.11
+        version: 0.0.1-beta.11(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6547,8 +6547,8 @@ packages:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  /@next-community/adapter-vercel@0.0.1-beta.10(next@16.1.6):
-    resolution: {integrity: sha512-H/EryVKaxWngEv+P94kZQQ7BnYTSGKXNsYfO8lONPtYf3w6MX6lsD6kkf7D/zHcBSxnfzVD+/gt77v5rh+cfAw==}
+  /@next-community/adapter-vercel@0.0.1-beta.11(next@16.1.6):
+    resolution: {integrity: sha512-4q+Yu31FZpuhiNvJ4OVSZpslumO5dTOymjSDfieGMGNrYCOkpbRgQGyJnLtPvLQcJ7Ku7mx2LH9cgPZ1C23CCQ==}
     engines: {node: '>= 20.6.0'}
     peerDependencies:
       next: '>= 16.1.1-canary.18'


### PR DESCRIPTION
x-ref: https://github.com/nextjs/adapter-vercel/pull/36

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR contains only a minor patch version bump of a dev dependency from beta.10 to beta.11 with an accompanying changeset file.
> 
> - Dev dependency bump: @next-community/adapter-vercel 0.0.1-beta.10 → 0.0.1-beta.11
> - Changeset file added for patch release
>
> <sup>Risk assessment for [commit cf95b21](https://github.com/vercel/vercel/commit/cf95b2138b01f8a81f07d95400ad72045d6b38e4).</sup>
<!-- VADE_RISK_END -->