### PR TITLE
fix(cli): suppress stdout URL when using --json in deploy

### DIFF
--- a/.changeset/fix-deploy-json-stdout.md
+++ b/.changeset/fix-deploy-json-stdout.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vc deploy --json` to output only valid JSON to stdout when piped

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -436,7 +436,6 @@ async function handleInitDeployment(
       withFullLogs: false,
       autoAssignCustomDomains,
       manual: true,
-      jsonOutput: asJson,
     };
 
     if (!localConfig.builds || localConfig.builds.length === 0) {

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -436,6 +436,7 @@ async function handleInitDeployment(
       withFullLogs: false,
       autoAssignCustomDomains,
       manual: true,
+      jsonOutput: asJson,
     };
 
     if (!localConfig.builds || localConfig.builds.length === 0) {
@@ -1056,6 +1057,7 @@ async function handleDefaultDeploy(
       withFullLogs,
       autoAssignCustomDomains,
       agentName: client.agentName,
+      jsonOutput: asJson,
     };
 
     if (!localConfig.builds || localConfig.builds.length === 0) {

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -51,6 +51,7 @@ export default async function processDeployment({
   withFullLogs,
   agent,
   manual,
+  jsonOutput,
   ...args
 }: {
   now: Now;
@@ -74,6 +75,7 @@ export default async function processDeployment({
   agent?: Agent;
   bulkRedirectsPath?: string | null;
   manual?: boolean;
+  jsonOutput?: boolean;
 }) {
   const {
     now,
@@ -216,7 +218,7 @@ export default async function processDeployment({
           ) + `\n`
         );
 
-        if (quiet || process.env.FORCE_TTY === '1') {
+        if (!jsonOutput && (quiet || process.env.FORCE_TTY === '1')) {
           process.stdout.write(`https://${event.payload.url}`);
         }
 

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -55,6 +55,7 @@ export interface CreateOptions {
   autoAssignCustomDomains?: boolean;
   agentName?: string;
   manual?: boolean;
+  jsonOutput?: boolean;
 }
 
 export interface RemoveOptions {
@@ -132,6 +133,7 @@ export default class Now {
       autoAssignCustomDomains,
       agentName,
       manual,
+      jsonOutput = false,
     }: CreateOptions,
     org: Org,
     isSettingUpProject: boolean,
@@ -183,6 +185,7 @@ export default class Now {
       withFullLogs,
       bulkRedirectsPath: nowConfig.bulkRedirectsPath,
       manual,
+      jsonOutput,
     });
 
     if (deployment && deployment.warnings) {

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1782,5 +1782,26 @@ describe('deploy', () => {
       const exitCode = await deploy(client);
       expect(exitCode).toEqual(1);
     });
+
+    it('should output only valid JSON to stdout when piped (non-TTY)', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--json');
+      // Simulate piped stdout (non-TTY) like `vc deploy --json | jq`
+      client.stdout.isTTY = false;
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      // Should be valid JSON parseable by jq
+      const json = JSON.parse(stdoutOutput);
+      expect(json).toEqual({
+        id: deploymentId,
+        url: `https://${deploymentUrl}`,
+        inspectorUrl,
+        readyState: 'READY',
+        target: 'production',
+        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- When running `vc deploy --json | jq`, the output was invalid JSON because `process.stdout.write` in `process-deployment.ts` wrote the bare deployment URL to stdout alongside the JSON output
- Added a `jsonOutput` flag that flows through `CreateOptions` → `now.create()` → `processDeployment()` to skip the bare URL stdout write when JSON output is requested
- Added a test verifying that stdout contains only valid JSON when `isTTY` is false (simulating pipe)

## Test plan
- [x] Existing `--json` tests pass
- [x] New test: `should output only valid JSON to stdout when piped (non-TTY)` verifies `JSON.parse(stdoutOutput)` succeeds with non-TTY stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a flag to suppress bare URL stdout output when --json is used in CLI deploy command, a straightforward output formatting fix with no security or data implications.
> 
> - Adds `jsonOutput` boolean flag threaded through CreateOptions → Now.create() → processDeployment()
> - Conditionally skips `process.stdout.write` of bare URL when JSON output requested
> - New unit test verifies stdout contains only valid JSON in non-TTY mode
>
> <sup>Risk assessment for [commit 7653e7d](https://github.com/vercel/vercel/commit/7653e7d4944846c673a494ed5aedc4e353a67dbe).</sup>
<!-- VADE_RISK_END -->