### PR TITLE
[fs-detectors] skip auto-detection for root-only projects

### DIFF
--- a/.changeset/wise-days-juggle.md
+++ b/.changeset/wise-days-juggle.md
@@ -1,0 +1,6 @@
+---
+'@vercel/fs-detectors': patch
+'vercel': patch
+---
+
+[fs-detectors] skip auto-detection for root-only projects

--- a/packages/cli/test/unit/util/projects/detect-services.test.ts
+++ b/packages/cli/test/unit/util/projects/detect-services.test.ts
@@ -31,6 +31,16 @@ describe('tryDetectServices()', () => {
     expect(result).toBeNull();
   });
 
+  it('should return null for root-only project with no backend', async () => {
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({ dependencies: { next: '14.0.0' } })
+    );
+
+    const result = await tryDetectServices(tempDir);
+    expect(result).toBeNull();
+  });
+
   it('should return null when vercel.json has no experimentalServices and no service found', async () => {
     await writeFile(
       join(tempDir, 'vercel.json'),

--- a/packages/fs-detectors/src/services/auto-detect.ts
+++ b/packages/fs-detectors/src/services/auto-detect.ts
@@ -143,6 +143,9 @@ async function detectServicesAtRoot(
   if (backendResult.error) {
     return { services: null, errors: [backendResult.error] };
   }
+  if (Object.keys(backendResult.services).length === 0) {
+    return { services: null, errors: [] };
+  }
   Object.assign(services, backendResult.services);
 
   return { services, errors: [] };

--- a/packages/fs-detectors/test/unit.auto-detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.auto-detect-services.test.ts
@@ -30,7 +30,7 @@ describe('autoDetectServices', () => {
       });
     });
 
-    it('should detect only Next.js at root with no backend', async () => {
+    it('should return null for root-only Next.js with no backend', async () => {
       const fs = new VirtualFilesystem({
         'package.json': JSON.stringify({
           dependencies: {
@@ -42,12 +42,7 @@ describe('autoDetectServices', () => {
       const result = await autoDetectServices({ fs });
 
       expect(result.errors).toEqual([]);
-      expect(result.services).not.toBeNull();
-      expect(result.services!.frontend).toMatchObject({
-        framework: 'nextjs',
-        routePrefix: '/',
-      });
-      expect(result.services!.backend).toBeUndefined();
+      expect(result.services).toBeNull();
     });
 
     it('should not add backend service if backend/ dir exists but has no framework', async () => {
@@ -63,12 +58,7 @@ describe('autoDetectServices', () => {
       const result = await autoDetectServices({ fs });
 
       expect(result.errors).toEqual([]);
-      expect(result.services).not.toBeNull();
-      expect(result.services!.frontend).toMatchObject({
-        framework: 'nextjs',
-        routePrefix: '/',
-      });
-      expect(result.services!.backend).toBeUndefined();
+      expect(result.services).toBeNull();
     });
   });
 
@@ -461,7 +451,7 @@ describe('detectServices with auto-detection', () => {
   });
 
   describe('auto-detection fallback', () => {
-    it('should auto-detect services when no experimentalServices configured', async () => {
+    it('should return no services for root-only project without experimentalServices', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({
           buildCommand: 'npm run build',
@@ -475,19 +465,18 @@ describe('detectServices with auto-detection', () => {
 
       const result = await detectServices({ fs });
 
-      expect(result.errors).toEqual([]);
-      expect(result.warnings).toHaveLength(0);
       expect(result.source).toBe('auto-detected');
-      expect(result.services).toHaveLength(1);
-      expect(result.services[0]).toMatchObject({
-        name: 'frontend',
-        framework: 'nextjs',
-        routePrefix: '/',
-      });
-      expect(result.services[0].routePrefixSource).toBe('generated');
+      expect(result.services).toHaveLength(0);
+      expect(result.errors).toEqual([
+        {
+          code: 'NO_SERVICES_CONFIGURED',
+          message:
+            'No services configured. Add `experimentalServices` to vercel.json.',
+        },
+      ]);
     });
 
-    it('should auto-detect services when vercel.json does not exist', async () => {
+    it('should return no services for root-only project without vercel.json', async () => {
       const fs = new VirtualFilesystem({
         'package.json': JSON.stringify({
           dependencies: {
@@ -498,16 +487,15 @@ describe('detectServices with auto-detection', () => {
 
       const result = await detectServices({ fs });
 
-      expect(result.errors).toEqual([]);
-      expect(result.warnings).toHaveLength(0);
       expect(result.source).toBe('auto-detected');
-      expect(result.services).toHaveLength(1);
-      expect(result.services[0]).toMatchObject({
-        name: 'frontend',
-        framework: 'nextjs',
-        routePrefix: '/',
-      });
-      expect(result.services[0].routePrefixSource).toBe('generated');
+      expect(result.services).toHaveLength(0);
+      expect(result.errors).toEqual([
+        {
+          code: 'NO_SERVICES_CONFIGURED',
+          message:
+            'No services configured. Add `experimentalServices` to vercel.json.',
+        },
+      ]);
     });
 
     it('should mark prefixed auto-detected services as generated', async () => {


### PR DESCRIPTION
Single root-only framework projects should not be auto-detected as services

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a condition to skip auto-detection for root-only projects without backends, which is a logic change in the fs-detectors service detection but does not affect security, auth, or database schemas.
> 
> - Adds early return when no backend services detected in auto-detect.ts
> - Updates tests to expect null/empty services for root-only projects
> - Changeset for patch version bump
>
> <sup>Risk assessment for [commit 15893de](https://github.com/vercel/vercel/commit/15893dea0003d9b4ea49420dd18999d302e777c8).</sup>
<!-- VADE_RISK_END -->