### PR TITLE
python dev-server: check cache *before* doing entrypoint detection

### DIFF
--- a/.changeset/polite-glasses-search.md
+++ b/.changeset/polite-glasses-search.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Avoid doing entry point detection on every request to a python dev server

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -435,6 +435,32 @@ export const startDevServer: StartDevServer = async opts => {
 
   const framework = config?.framework;
 
+  // Check for an existing persistent server
+  const serverKey = `${workPath}::${framework}`;
+  const existing = PERSISTENT_SERVERS.get(serverKey);
+  if (existing) {
+    return {
+      port: existing.port,
+      pid: existing.pid,
+      shutdown: async () => {
+        // no-op so CLI does not kill persistent server per request
+      },
+    };
+  }
+
+  // Check for a pending start operation before spawning a new server
+  {
+    const pending = PENDING_STARTS.get(serverKey);
+    if (pending) {
+      const { port, pid } = await pending;
+      return {
+        port,
+        pid,
+        shutdown: async () => {},
+      };
+    }
+  }
+
   // No framework is defined, so most likely this is 'handler' class-based
   // serverless functions that should be served directly using vercel-runtime
   // instead of dev server.
@@ -465,32 +491,6 @@ export const startDevServer: StartDevServer = async opts => {
   const modulePath = entry.replace(/\.py$/i, '').replace(/[\\/]/g, '.');
 
   const env = { ...process.env, ...(meta.env || {}) } as NodeJS.ProcessEnv;
-
-  // Check for an existing persistent server
-  const serverKey = `${workPath}::${entry}::${framework}`;
-  const existing = PERSISTENT_SERVERS.get(serverKey);
-  if (existing) {
-    return {
-      port: existing.port,
-      pid: existing.pid,
-      shutdown: async () => {
-        // no-op so CLI does not kill persistent server per request
-      },
-    };
-  }
-
-  // Check for a pending start operation before spawning a new server
-  {
-    const pending = PENDING_STARTS.get(serverKey);
-    if (pending) {
-      const { port, pid } = await pending;
-      return {
-        port,
-        pid,
-        shutdown: async () => {},
-      };
-    }
-  }
 
   // Track child process and listeners
   let childProcess: ChildProcess | null = null;


### PR DESCRIPTION
The potential downside here is that if the entrypoint implicitly changes,
then we won't pick that up.

The upside is that we skip doing a bunch of work.

(Currently on one django repo I was looking at, it was 700ms! I'm
going to look into that and fix it but I expect it will remain at 10s
of ms, which is worth avoiding.)


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR reorders cache checks to run before entrypoint detection and changes the server cache key to exclude the entry parameter, which could cause incorrect server reuse if entrypoints change.
> 
> - Cache key changed from `workPath::entry::framework` to `workPath::framework`, removing entry from key
> - Cache lookup moved before entrypoint detection logic to skip work on subsequent requests
> - Potential for stale server reuse if entrypoint changes without framework/workPath change
>
> <sup>Risk assessment for [commit 924bb7d](https://github.com/vercel/vercel/commit/924bb7d1b5d82f4b45946658dcf6dac44593484f).</sup>
<!-- VADE_RISK_END -->