### PR TITLE
Update Next.js adapter version

### DIFF
--- a/.changeset/odd-bugs-move.md
+++ b/.changeset/odd-bugs-move.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Update Next.js adapter version

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.11",
+    "@next-community/adapter-vercel": "0.0.1-beta.12",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1716,8 +1716,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.11
-        version: 0.0.1-beta.11(next@16.1.6)
+        specifier: 0.0.1-beta.12
+        version: 0.0.1-beta.12(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6547,8 +6547,8 @@ packages:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  /@next-community/adapter-vercel@0.0.1-beta.11(next@16.1.6):
-    resolution: {integrity: sha512-4q+Yu31FZpuhiNvJ4OVSZpslumO5dTOymjSDfieGMGNrYCOkpbRgQGyJnLtPvLQcJ7Ku7mx2LH9cgPZ1C23CCQ==}
+  /@next-community/adapter-vercel@0.0.1-beta.12(next@16.1.6):
+    resolution: {integrity: sha512-pvINuPgfGWKA8YquGl3xwRp6aDnKvZDrlu3ZtbsnUiTt/CKPTgBmWJ1jpE4OCLSCM+frQUOl2FEZzUSdSUcs1A==}
     engines: {node: '>= 20.6.0'}
     peerDependencies:
       next: '>= 16.1.1-canary.18'


### PR DESCRIPTION
x-ref: https://github.com/nextjs/adapter-vercel/pull/38

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Minor patch version bump of a dev dependency from beta.11 to beta.12 with no code changes.
> 
> - Dev dependency bump: @next-community/adapter-vercel 0.0.1-beta.11 → beta.12
> - Changeset file added for patch release
>
> <sup>Risk assessment for [commit 83ae068](https://github.com/vercel/vercel/commit/83ae068c1d4f5e03f44b564a2eabd45191456b53).</sup>
<!-- VADE_RISK_END -->