### PR TITLE
[python] Consolidate Python version resolution into `python-analysis`

### DIFF
--- a/.changeset/chilled-gifts-worry.md
+++ b/.changeset/chilled-gifts-worry.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python-analysis': patch
+'@vercel/python': patch
+---
+
+Consolidate Python version resolution into `python-analysis`

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -85,8 +85,11 @@ export {
 // Python selection (runtime + types)
 // =============================================================================
 
-export type { PythonSelectionResult } from './manifest/python-selector';
-export { selectPython } from './manifest/python-selector';
+export type {
+  PythonSelectionResult,
+  PythonVersionSelectionResult,
+} from './manifest/python-selector';
+export { selectPython, selectPythonVersion } from './manifest/python-selector';
 
 // =============================================================================
 // Errors

--- a/packages/python-analysis/src/manifest/package.ts
+++ b/packages/python-analysis/src/manifest/package.ts
@@ -265,9 +265,12 @@ export async function discoverPythonPackage({
   let workspaceLockFile: PythonLockFile | undefined;
 
   if (manifests.length === 0) {
-    // No Python manifests detected in the repo
+    // No Python manifests detected in the repo, but .python-version
+    // may still specify a version constraint.
+    const requiresPython = computeRequiresPython(undefined, undefined, configs);
     return {
       configs,
+      requiresPython,
     };
   } else {
     entrypointManifest = manifests[0];
@@ -315,41 +318,50 @@ function computeRequiresPython(
 ): PythonConstraint[] {
   const constraints: PythonConstraint[] = [];
 
-  // Check for `.python-version` between manifest and workspace
+  // Check for `.python-version` between manifest and workspace.
+  // When present, it takes priority over `requires-python`.
+  let hasPythonVersionFile = false;
   for (const configSet of configs) {
     const pythonVersionConfig = configSet[PythonConfigKind.PythonVersion];
     if (pythonVersionConfig !== undefined) {
       constraints.push({
         request: pythonVersionConfig.data,
-        source: `${pythonVersionConfig.path}`,
+        source: pythonVersionConfig.path,
+        prettySource: pythonVersionConfig.path,
       });
+      hasPythonVersionFile = true;
       break;
     }
   }
 
-  // Check `requires-python` from nearest package pyproject.toml
-  const manifestRequiresPython = manifest?.data.project?.['requires-python'];
-  if (manifestRequiresPython) {
-    const parsed = parsePep440Constraint(manifestRequiresPython);
-    if (parsed?.length) {
-      const request = pythonRequestFromConstraint(parsed);
-      constraints.push({
-        request: [request],
-        source: `"requires-python" key in ${manifest.path}`,
-      });
-    }
-  } else {
-    // Check `requires-python` from workspace pyproject.toml
-    const workspaceRequiresPython =
-      workspaceManifest?.data.project?.['requires-python'];
-    if (workspaceRequiresPython) {
-      const parsed = parsePep440Constraint(workspaceRequiresPython);
+  // Check `requires-python` from nearest package pyproject.toml,
+  // but only if no `.python-version` file was found (it takes priority).
+  if (!hasPythonVersionFile) {
+    const manifestRequiresPython = manifest?.data.project?.['requires-python'];
+    if (manifestRequiresPython) {
+      const parsed = parsePep440Constraint(manifestRequiresPython);
       if (parsed?.length) {
         const request = pythonRequestFromConstraint(parsed);
         constraints.push({
           request: [request],
-          source: `"requires-python" key in ${workspaceManifest.path}`,
+          source: manifest.path,
+          prettySource: `"requires-python" key in ${manifest.path}`,
         });
+      }
+    } else {
+      // Check `requires-python` from workspace pyproject.toml
+      const workspaceRequiresPython =
+        workspaceManifest?.data.project?.['requires-python'];
+      if (workspaceRequiresPython) {
+        const parsed = parsePep440Constraint(workspaceRequiresPython);
+        if (parsed?.length) {
+          const request = pythonRequestFromConstraint(parsed);
+          constraints.push({
+            request: [request],
+            source: workspaceManifest.path,
+            prettySource: `"requires-python" key in ${workspaceManifest.path}`,
+          });
+        }
       }
     }
   }

--- a/packages/python-analysis/src/manifest/pipfile-parser.ts
+++ b/packages/python-analysis/src/manifest/pipfile-parser.ts
@@ -354,18 +354,27 @@ export function convertPipfileLockToPyprojectToml(
   const sources: Record<string, DependencySource[]> = {};
   const pyproject: PyProjectToml = {};
 
+  const pythonVersion = pipfileLock._meta?.requires?.python_version;
+
   // Process default (main) packages
   const deps: string[] = [];
   for (const dep of pipfileLockDepsToRequirements(pipfileLock.default || {})) {
     deps.push(formatPep508(dep));
     addDepSource(sources, dep);
   }
-  if (deps.length > 0) {
-    pyproject.project = {
+
+  if (deps.length > 0 || pythonVersion) {
+    const project: Record<string, unknown> = {
       name: 'app',
       version: '0.1.0',
-      dependencies: deps,
     };
+    if (pythonVersion) {
+      project['requires-python'] = `==${pythonVersion}.*`;
+    }
+    if (deps.length > 0) {
+      project.dependencies = deps;
+    }
+    pyproject.project = project as PyProjectToml['project'];
   }
 
   // Process develop (dev) packages

--- a/packages/python-analysis/src/manifest/python-selector.ts
+++ b/packages/python-analysis/src/manifest/python-selector.ts
@@ -143,12 +143,20 @@ export function selectPythonVersion({
   allBuilds,
   defaultBuild,
   majorMinorOnly,
+  legacyTildeEquals,
 }: {
   constraints?: PythonConstraint[];
   availableBuilds: PythonBuild[];
   allBuilds: PythonBuild[];
   defaultBuild: PythonBuild;
   majorMinorOnly?: boolean;
+  /**
+   * When true, treat 2-part compatible-release specifiers (`~=X.Y`) as
+   * pinning to exactly that minor version (`==X.Y.*`) rather than the
+   * PEP 440 correct `>=X.Y, <(X+1).0`.  This preserves the historical
+   * behaviour of the Python builder prior to the python-analysis migration.
+   */
+  legacyTildeEquals?: boolean;
 }): PythonVersionSelectionResult {
   const source = constraints?.[0]?.source;
 
@@ -156,12 +164,19 @@ export function selectPythonVersion({
     return { build: defaultBuild };
   }
 
-  const effectiveConstraints = majorMinorOnly
+  let effectiveConstraints = majorMinorOnly
     ? constraints.map(c => ({
         ...c,
         request: c.request.map(truncatePatchVersionsInRequest),
       }))
     : constraints;
+
+  if (legacyTildeEquals) {
+    effectiveConstraints = effectiveConstraints.map(c => ({
+      ...c,
+      request: c.request.map(legacyTildeEqualsTransform),
+    }));
+  }
 
   // First pass: try against available builds
   const result = selectPython(effectiveConstraints, availableBuilds);
@@ -287,6 +302,34 @@ function truncatePatchConstraint(c: Pep440Constraint): Pep440Constraint | null {
     default:
       return c;
   }
+}
+
+/**
+ * Transform 2-part `~=X.Y` into `==X.Y.*` to match the historical builder
+ * behaviour where `~=3.10` was interpreted as `>=3.10, <3.11` (i.e., pinned
+ * to the minor version) rather than the PEP 440 correct `>=3.10, <4.0`.
+ *
+ * 3-part `~=X.Y.Z` is unaffected — `truncatePatchConstraint` already
+ * converts it to `==X.Y.*`.
+ */
+function legacyTildeEqualsTransform(req: PythonRequest): PythonRequest {
+  if (!req.version?.constraint || req.version.constraint.length === 0) {
+    return req;
+  }
+
+  const newConstraints = req.version.constraint.map((c): Pep440Constraint => {
+    if (c.operator !== '~=') return c;
+    const parts = c.version.split('.');
+    if (parts.length === 2) {
+      return { operator: '==', version: c.version, prefix: '.*' };
+    }
+    return c;
+  });
+
+  return {
+    ...req,
+    version: { ...req.version, constraint: newConstraints },
+  };
 }
 
 /**

--- a/packages/python-analysis/src/manifest/python-selector.ts
+++ b/packages/python-analysis/src/manifest/python-selector.ts
@@ -6,6 +6,7 @@ import type {
   PythonRequest,
   PythonVariant,
   PythonVersion,
+  PythonVersionRequest,
 } from './python-specifiers';
 import { PythonImplementation } from './python-specifiers';
 
@@ -84,7 +85,9 @@ export function selectPython(
 
     // If some constraints have matches but no build satisfies all, they don't overlap
     if (constraintsWithMatches.length > 1) {
-      const sources = constraintsWithMatches.map(i => constraints[i].source);
+      const sources = constraintsWithMatches.map(
+        i => constraints[i].prettySource
+      );
       warnings.push(
         `Python version constraints may not overlap: ${sources.join(', ')}`
       );
@@ -92,7 +95,9 @@ export function selectPython(
   }
 
   // Build the error message
-  const constraintDescriptions = constraints.map(c => c.source).join(', ');
+  const constraintDescriptions = constraints
+    .map(c => c.prettySource)
+    .join(', ');
   errors.push(
     `No Python build satisfies all constraints: ${constraintDescriptions}`
   );
@@ -102,6 +107,186 @@ export function selectPython(
     errors,
     warnings: warnings.length > 0 ? warnings : undefined,
   };
+}
+
+/**
+ * Result of the higher-level selectPythonVersion function.
+ */
+export interface PythonVersionSelectionResult {
+  /** The selected build. Falls back to defaultBuild if no constraints match. */
+  build: PythonBuild;
+  /** Source file where the constraint originated (e.g. "pyproject.toml"). */
+  source?: string;
+  /** Diagnostic indicating the constraint was found but the build isn't in availableBuilds. */
+  notAvailable?: {
+    build: PythonBuild;
+    /** The version string of the unavailable build. */
+    version: string;
+  };
+  /** Diagnostic indicating no build matches the constraint at all. */
+  invalidConstraint?: {
+    /** Human-readable version string from the constraint. */
+    versionString: string;
+  };
+}
+
+/**
+ * Higher-level Python version selection with two-pass matching and diagnostics.
+ *
+ * First tries to match constraints against availableBuilds. If no match,
+ * tries against allBuilds to produce diagnostic information. Falls back
+ * to defaultBuild if no constraints are provided or no match is found.
+ */
+export function selectPythonVersion({
+  constraints,
+  availableBuilds,
+  allBuilds,
+  defaultBuild,
+  majorMinorOnly,
+}: {
+  constraints?: PythonConstraint[];
+  availableBuilds: PythonBuild[];
+  allBuilds: PythonBuild[];
+  defaultBuild: PythonBuild;
+  majorMinorOnly?: boolean;
+}): PythonVersionSelectionResult {
+  const source = constraints?.[0]?.source;
+
+  if (!constraints || constraints.length === 0) {
+    return { build: defaultBuild };
+  }
+
+  const effectiveConstraints = majorMinorOnly
+    ? constraints.map(c => ({
+        ...c,
+        request: c.request.map(truncatePatchVersionsInRequest),
+      }))
+    : constraints;
+
+  // First pass: try against available builds
+  const result = selectPython(effectiveConstraints, availableBuilds);
+  if (result.build) {
+    return { build: result.build, source };
+  }
+
+  // Second pass: try against all builds for diagnostics
+  const allResult = selectPython(effectiveConstraints, allBuilds);
+  if (allResult.build) {
+    const version = pythonVersionToString(allResult.build.version);
+    return {
+      build: defaultBuild,
+      source,
+      notAvailable: { build: allResult.build, version },
+    };
+  }
+
+  // No match at all — extract version string for error message
+  const versionString = extractConstraintVersionString(constraints);
+  return {
+    build: defaultBuild,
+    source,
+    invalidConstraint: { versionString },
+  };
+}
+
+/**
+ * Extract a human-readable version string from PythonConstraint objects
+ * for use in warning/error messages.
+ */
+function extractConstraintVersionString(
+  constraints: PythonConstraint[]
+): string {
+  for (const c of constraints) {
+    for (const req of c.request) {
+      if (req.version?.constraint && req.version.constraint.length > 0) {
+        const specs = req.version.constraint;
+        if (
+          specs.length === 1 &&
+          specs[0].operator === '==' &&
+          (!specs[0].prefix || specs[0].prefix === '.*')
+        ) {
+          return specs[0].version;
+        }
+        return pep440ConstraintsToString(specs);
+      }
+    }
+  }
+  return 'unknown';
+}
+
+/**
+ * Truncate patch versions in a PythonRequest's version constraints.
+ * Used by `majorMinorOnly` to transform constraints for major.minor-only matching.
+ */
+function truncatePatchVersionsInRequest(req: PythonRequest): PythonRequest {
+  if (!req.version?.constraint || req.version.constraint.length === 0) {
+    return req;
+  }
+
+  const newConstraints: Pep440Constraint[] = [];
+  for (const c of req.version.constraint) {
+    const result = truncatePatchConstraint(c);
+    if (result !== null) {
+      newConstraints.push(result);
+    }
+  }
+
+  const newVersion: PythonVersionRequest = {
+    ...req.version,
+    constraint: newConstraints,
+  };
+  return { ...req, version: newVersion };
+}
+
+/**
+ * Truncate a single PEP 440 constraint to major.minor level.
+ * Returns null if the constraint should be dropped entirely.
+ *
+ * Transformation rules for constraints with 3+ dot-separated version parts:
+ * - `==X.Y.Z` -> `==X.Y.*` (prefix match)
+ * - `!=X.Y.Z` -> dropped (trivially satisfied)
+ * - `~=X.Y.Z` -> `==X.Y.*` (compatible release at minor level)
+ * - `>=X.Y.Z` -> `>=X.Y` (drop patch)
+ * - `<=X.Y.Z` -> `<=X.Y` (drop patch)
+ * - `>X.Y.Z`  -> `>=X.Y` when Z>0, `>X.Y` when Z==0
+ * - `<X.Y.Z`  -> `<=X.Y` when Z>0, `<X.Y` when Z==0
+ */
+function truncatePatchConstraint(c: Pep440Constraint): Pep440Constraint | null {
+  // Skip arbitrary equality
+  if (c.operator === '===') {
+    return c;
+  }
+
+  const parts = c.version.split('.');
+  if (parts.length < 3) {
+    return c;
+  }
+
+  const majorMinor = parts.slice(0, 2).join('.');
+  const patch = parseInt(parts[2], 10);
+
+  switch (c.operator) {
+    case '==':
+      return { operator: '==', version: majorMinor, prefix: '.*' };
+    case '!=':
+      return null; // drop: X.Y != X.Y.Z is trivially true
+    case '~=':
+      return { operator: '==', version: majorMinor, prefix: '.*' };
+    case '>=':
+      return { operator: '>=', version: majorMinor, prefix: '' };
+    case '<=':
+      return { operator: '<=', version: majorMinor, prefix: '' };
+    case '>':
+      return patch === 0
+        ? { operator: '>', version: majorMinor, prefix: '' }
+        : { operator: '>=', version: majorMinor, prefix: '' };
+    case '<':
+      return patch === 0
+        ? { operator: '<', version: majorMinor, prefix: '' }
+        : { operator: '<=', version: majorMinor, prefix: '' };
+    default:
+      return c;
+  }
 }
 
 /**
@@ -142,7 +327,9 @@ export function pythonVersionToString(version: PythonVersion): string {
 export function pep440ConstraintsToString(
   constraints: Pep440Constraint[]
 ): string {
-  return constraints.map(c => `${c.operator}${c.prefix}${c.version}`).join(',');
+  return constraints
+    .map(c => `${c.operator}${c.version}${c.prefix ?? ''}`)
+    .join(',');
 }
 
 /**

--- a/packages/python-analysis/src/manifest/python-specifiers.ts
+++ b/packages/python-analysis/src/manifest/python-specifiers.ts
@@ -163,8 +163,10 @@ export interface PythonVersionRequest {
 export interface PythonConstraint {
   /** The Python version request(s) that define this constraint. */
   request: PythonRequest[];
-  /** Human-readable description of where this constraint came from. */
+  /** Config file name where this constraint originated (e.g. "pyproject.toml", ".python-version"). */
   source: string;
+  /** Human-readable description of where this constraint came from. */
+  prettySource: string;
 }
 
 export type PythonVersion = {

--- a/packages/python-analysis/test/package.test.ts
+++ b/packages/python-analysis/test/package.test.ts
@@ -329,7 +329,7 @@ describe('discoverPythonPackage', () => {
       expect(result.requiresPython).toBeDefined();
       expect(result.requiresPython?.length).toBeGreaterThan(0);
       const constraint = result.requiresPython?.find(c =>
-        c.source.includes('requires-python')
+        c.source.includes('pyproject.toml')
       );
       expect(constraint).toBeDefined();
     });

--- a/packages/python-analysis/test/python-selector.test.ts
+++ b/packages/python-analysis/test/python-selector.test.ts
@@ -1714,3 +1714,164 @@ describe('selectPythonVersion with majorMinorOnly', () => {
     expect(result.invalidConstraint).toBeDefined();
   });
 });
+
+describe('selectPythonVersion with legacyTildeEquals', () => {
+  const availableBuilds: PythonBuild[] = [
+    makeBuild({ version: { major: 3, minor: 10 } }),
+    makeBuild({ version: { major: 3, minor: 11 } }),
+    makeBuild({ version: { major: 3, minor: 12 } }),
+    makeBuild({ version: { major: 3, minor: 13 } }),
+    makeBuild({ version: { major: 3, minor: 14 } }),
+  ];
+
+  const allBuilds = availableBuilds;
+  const defaultBuild = availableBuilds[2]; // 3.12
+
+  function selectLegacy(constraints: PythonConstraint[]) {
+    return selectPythonVersion({
+      constraints,
+      availableBuilds,
+      allBuilds,
+      defaultBuild,
+      majorMinorOnly: true,
+      legacyTildeEquals: true,
+    });
+  }
+
+  it('~=X.Y pins to exactly X.Y (historical behavior)', () => {
+    const result = selectLegacy([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '~=', version: '3.10', prefix: '' }],
+            },
+          }),
+        ],
+        'pyproject.toml'
+      ),
+    ]);
+    // Historical: ~=3.10 → ==3.10.* → pins to 3.10
+    expect(result.build.version).toEqual({ major: 3, minor: 10 });
+  });
+
+  it('~=X.Y does not match higher minor versions', () => {
+    const result = selectLegacy([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '~=', version: '3.15', prefix: '' }],
+            },
+          }),
+        ],
+        'pyproject.toml'
+      ),
+    ]);
+    // 3.15 not in available or all builds → invalidConstraint
+    expect(result.invalidConstraint).toBeDefined();
+  });
+
+  it('~=X.Y.Z is unaffected (still becomes ==X.Y.* via majorMinorOnly)', () => {
+    const result = selectLegacy([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '~=', version: '3.11.5', prefix: '' }],
+            },
+          }),
+        ],
+        'pyproject.toml'
+      ),
+    ]);
+    // 3-part ~= is handled by majorMinorOnly, not legacyTildeEquals
+    expect(result.build.version).toEqual({ major: 3, minor: 11 });
+  });
+
+  it('without legacyTildeEquals, ~=X.Y uses PEP 440 semantics', () => {
+    const result = selectPythonVersion({
+      constraints: [
+        makeConstraint(
+          [
+            makeRequest({
+              version: {
+                constraint: [{ operator: '~=', version: '3.10', prefix: '' }],
+              },
+            }),
+          ],
+          'pyproject.toml'
+        ),
+      ],
+      availableBuilds,
+      allBuilds,
+      defaultBuild,
+      majorMinorOnly: true,
+      // legacyTildeEquals NOT set
+    });
+    // PEP 440: ~=3.10 → >=3.10, <4.0 → matches all; first is 3.10
+    expect(result.build.version).toEqual({ major: 3, minor: 10 });
+  });
+
+  it('without legacyTildeEquals, ~=3.13 selects 3.14 (PEP 440)', () => {
+    // Put 3.12 first (as default) to show the difference
+    const reorderedBuilds: PythonBuild[] = [
+      makeBuild({ version: { major: 3, minor: 12 } }), // default, first
+      makeBuild({ version: { major: 3, minor: 14 } }),
+      makeBuild({ version: { major: 3, minor: 13 } }),
+      makeBuild({ version: { major: 3, minor: 11 } }),
+      makeBuild({ version: { major: 3, minor: 10 } }),
+    ];
+    const result = selectPythonVersion({
+      constraints: [
+        makeConstraint(
+          [
+            makeRequest({
+              version: {
+                constraint: [{ operator: '~=', version: '3.13', prefix: '' }],
+              },
+            }),
+          ],
+          'pyproject.toml'
+        ),
+      ],
+      availableBuilds: reorderedBuilds,
+      allBuilds: reorderedBuilds,
+      defaultBuild: reorderedBuilds[0],
+      majorMinorOnly: true,
+    });
+    // PEP 440: ~=3.13 → >=3.13, <4.0 → 3.12 fails, 3.14 matches first
+    expect(result.build.version).toEqual({ major: 3, minor: 14 });
+  });
+
+  it('with legacyTildeEquals, ~=3.13 selects exactly 3.13', () => {
+    const reorderedBuilds: PythonBuild[] = [
+      makeBuild({ version: { major: 3, minor: 12 } }),
+      makeBuild({ version: { major: 3, minor: 14 } }),
+      makeBuild({ version: { major: 3, minor: 13 } }),
+      makeBuild({ version: { major: 3, minor: 11 } }),
+      makeBuild({ version: { major: 3, minor: 10 } }),
+    ];
+    const result = selectPythonVersion({
+      constraints: [
+        makeConstraint(
+          [
+            makeRequest({
+              version: {
+                constraint: [{ operator: '~=', version: '3.13', prefix: '' }],
+              },
+            }),
+          ],
+          'pyproject.toml'
+        ),
+      ],
+      availableBuilds: reorderedBuilds,
+      allBuilds: reorderedBuilds,
+      defaultBuild: reorderedBuilds[0],
+      majorMinorOnly: true,
+      legacyTildeEquals: true,
+    });
+    // Legacy: ~=3.13 → ==3.13.* → pins to 3.13
+    expect(result.build.version).toEqual({ major: 3, minor: 13 });
+  });
+});

--- a/packages/python-analysis/test/python-selector.test.ts
+++ b/packages/python-analysis/test/python-selector.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   selectPython,
+  selectPythonVersion,
   pythonVersionToString,
   pep440ConstraintsToString,
   implementationsMatch,
@@ -50,7 +51,7 @@ function makeConstraint(
   request: PythonRequest[],
   source: string
 ): PythonConstraint {
-  return { request, source };
+  return { request, source, prettySource: source };
 }
 
 describe('pythonVersionToString', () => {
@@ -106,9 +107,9 @@ describe('pep440ConstraintsToString', () => {
   it('handles constraint with prefix', () => {
     expect(
       pep440ConstraintsToString([
-        { operator: '==', version: '3.12', prefix: '!' },
+        { operator: '==', version: '3.11', prefix: '.*' },
       ])
-    ).toBe('==!3.12');
+    ).toBe('==3.11.*');
   });
 });
 
@@ -1459,5 +1460,257 @@ describe('PythonBuild', () => {
         'cpython-3.12+custom-linux-x86_64-gnu'
       );
     });
+  });
+});
+
+describe('selectPythonVersion with majorMinorOnly', () => {
+  const availableBuilds: PythonBuild[] = [
+    makeBuild({ version: { major: 3, minor: 10 } }),
+    makeBuild({ version: { major: 3, minor: 11 } }),
+    makeBuild({ version: { major: 3, minor: 12 } }),
+    makeBuild({ version: { major: 3, minor: 13 } }),
+  ];
+
+  const allBuilds = availableBuilds;
+  const defaultBuild = availableBuilds[2]; // 3.12
+
+  function selectMajorMinor(constraints: PythonConstraint[]) {
+    return selectPythonVersion({
+      constraints,
+      availableBuilds,
+      allBuilds,
+      defaultBuild,
+      majorMinorOnly: true,
+    });
+  }
+
+  it('==X.Y.Z becomes ==X.Y.* prefix match', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '==', version: '3.11.4', prefix: '' }],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    expect(result.build.version).toEqual({ major: 3, minor: 11 });
+  });
+
+  it('!=X.Y.Z is dropped (trivially satisfied)', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [
+                { operator: '>=', version: '3.12', prefix: '' },
+                { operator: '!=', version: '3.12.4', prefix: '' },
+              ],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    // != is dropped, so >=3.12 matches 3.12
+    expect(result.build.version).toEqual({ major: 3, minor: 12 });
+  });
+
+  it('~=X.Y.Z becomes ==X.Y.* prefix match', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '~=', version: '3.10.1', prefix: '' }],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    expect(result.build.version).toEqual({ major: 3, minor: 10 });
+  });
+
+  it('>=X.Y.Z becomes >=X.Y', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '>=', version: '3.10.1', prefix: '' }],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    // >=3.10 matches all; first available is 3.10
+    expect(result.build.version).toEqual({ major: 3, minor: 10 });
+  });
+
+  it('<=X.Y.Z becomes <=X.Y', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '<=', version: '3.11.4', prefix: '' }],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    // <=3.11 matches 3.10 and 3.11; first available is 3.10
+    expect(result.build.version).toEqual({ major: 3, minor: 10 });
+  });
+
+  it('>X.Y.Z (Z>0) becomes >=X.Y (widening)', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '>', version: '3.10.1', prefix: '' }],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    // >3.10.1 widens to >=3.10, so 3.10 matches
+    expect(result.build.version).toEqual({ major: 3, minor: 10 });
+  });
+
+  it('>X.Y.0 stays >X.Y (no widening)', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '>', version: '3.10.0', prefix: '' }],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    // >3.10 does NOT match 3.10, first match is 3.11
+    expect(result.build.version).toEqual({ major: 3, minor: 11 });
+  });
+
+  it('<X.Y.Z (Z>0) becomes <=X.Y (widening)', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '<', version: '3.12.1', prefix: '' }],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    // <3.12.1 widens to <=3.12, so 3.10, 3.11, 3.12 match; first is 3.10
+    expect(result.build.version).toEqual({ major: 3, minor: 10 });
+  });
+
+  it('<X.Y.0 stays <X.Y (no widening)', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '<', version: '3.12.0', prefix: '' }],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    // <3.12 matches 3.10, 3.11; first is 3.10
+    expect(result.build.version).toEqual({ major: 3, minor: 10 });
+    // And does NOT match 3.12
+    const result2 = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [
+                { operator: '<', version: '3.12.0', prefix: '' },
+                { operator: '>=', version: '3.12', prefix: '' },
+              ],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    expect(result2.invalidConstraint).toBeDefined();
+  });
+
+  it('=== is left unchanged', () => {
+    // === is arbitrary equality, not transformed
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [
+                { operator: '===', version: '3.12.99-custom', prefix: '' },
+              ],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    // Won't match any build, falls through to invalidConstraint
+    expect(result.invalidConstraint).toBeDefined();
+  });
+
+  it('constraints with only major.minor are not modified', () => {
+    const result = selectMajorMinor([
+      makeConstraint(
+        [
+          makeRequest({
+            version: {
+              constraint: [{ operator: '==', version: '3.12', prefix: '' }],
+            },
+          }),
+        ],
+        '.python-version'
+      ),
+    ]);
+    expect(result.build.version).toEqual({ major: 3, minor: 12 });
+  });
+
+  it('works without majorMinorOnly (no transformation)', () => {
+    // Without majorMinorOnly, ==3.11.4 should not match 3.11 (no patch on build)
+    const result = selectPythonVersion({
+      constraints: [
+        makeConstraint(
+          [
+            makeRequest({
+              version: {
+                constraint: [{ operator: '==', version: '3.11.4', prefix: '' }],
+              },
+            }),
+          ],
+          '.python-version'
+        ),
+      ],
+      availableBuilds,
+      allBuilds,
+      defaultBuild,
+    });
+    // 3.11.4 != 3.11, so falls through
+    expect(result.invalidConstraint).toBeDefined();
   });
 });

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import { promisify } from 'util';
 import { join, dirname, basename, parse } from 'path';
 import {
   VERCEL_RUNTIME_VERSION,
@@ -28,32 +27,20 @@ import {
   PythonFramework,
 } from '@vercel/build-utils';
 import {
+  discoverPackage,
   ensureUvProject,
   resolveVendorDir,
   installRequirementsFile,
   installRequirement,
 } from './install';
 import { PythonDependencyExternalizer } from './dependency-externalizer';
-import { detectInstallSource } from './install';
 import { UvRunner, getUvBinaryOrInstall } from './uv';
-import { readConfigFile } from '@vercel/build-utils';
-import {
-  getSupportedPythonVersion,
-  DEFAULT_PYTHON_VERSION,
-  parseVersionTuple,
-  compareTuples,
-} from './version';
+import { resolvePythonVersion, pythonVersionString } from './version';
 import { startDevServer } from './start-dev-server';
-import {
-  runPyprojectScript,
-  findDir,
-  ensureVenv,
-  createVenvEnv,
-} from './utils';
+import { runPyprojectScript, ensureVenv, createVenvEnv } from './utils';
 import { runQuirks } from './quirks';
 
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
+const writeFile = fs.promises.writeFile;
 
 import {
   PYTHON_CANDIDATE_ENTRYPOINTS,
@@ -157,132 +144,40 @@ export const build: BuildV3 = async ({
 
   const entryDirectory = dirname(entrypoint);
 
-  const pyprojectDir = findDir({
-    file: 'pyproject.toml',
-    entryDirectory,
-    workPath,
-    fsFiles,
-  });
+  const entrypointAbsDir = join(workPath, entryDirectory);
+  const rootDir = repoRootPath ?? workPath;
 
-  const pipfileLockDir = findDir({
-    file: 'Pipfile.lock',
-    entryDirectory,
-    workPath,
-    fsFiles,
-  });
+  const pythonPackage = await builderSpan
+    .child('vc.builder.python.discover')
+    .trace(() =>
+      discoverPackage({
+        entrypointDir: entrypointAbsDir,
+        rootDir,
+      })
+    );
 
-  const pythonVersionFileDir = findDir({
-    file: '.python-version',
-    entryDirectory,
-    workPath,
-    fsFiles,
-  });
-
-  // Determine Python version from .python-version, pyproject.toml, or Pipfile.lock if present.
-  const { pythonVersion, declaredPythonVersion } = await builderSpan
+  const { pythonVersion, pinVersionFilePath } = await builderSpan
     .child('vc.builder.python.version')
-    .trace(async versionSpan => {
-      let declared:
-        | {
-            version: string;
-            source: 'Pipfile.lock' | 'pyproject.toml' | '.python-version';
-          }
-        | undefined;
-
-      // .python-version is the highest priority because its what uv will use to select dependencies
-      if (pythonVersionFileDir) {
-        try {
-          const content = await readFile(
-            join(pythonVersionFileDir, '.python-version'),
-            'utf8'
-          );
-          const version = parsePythonVersionFile(content);
-          if (version) {
-            declared = { version, source: '.python-version' };
-            debug(`Found Python version ${version} in .python-version`);
-          }
-        } catch (err) {
-          debug('Failed to read .python-version file', err);
-        }
-      }
-
-      if (!declared && pyprojectDir) {
-        let requiresPython: string | undefined;
-        try {
-          const pyproject = await readConfigFile<{
-            project?: { ['requires-python']?: string };
-          }>(join(pyprojectDir, 'pyproject.toml'));
-          requiresPython = pyproject?.project?.['requires-python'];
-        } catch (err) {
-          debug('Failed to parse pyproject.toml', err);
-        }
-        if (typeof requiresPython === 'string' && requiresPython.trim()) {
-          declared = {
-            version: requiresPython.trim(),
-            source: 'pyproject.toml',
-          };
-          debug(`Found requires-python "${requiresPython}" in pyproject.toml`);
-        }
-      }
-
-      if (!declared && pipfileLockDir) {
-        let lock: {
-          _meta?: { requires?: { python_version?: string } };
-        } = {};
-        const pipfileLockPath = join(pipfileLockDir, 'Pipfile.lock');
-        try {
-          const pipfileLockContent = await readFile(pipfileLockPath, 'utf8');
-          try {
-            lock = JSON.parse(pipfileLockContent);
-          } catch (err) {
-            console.log(
-              `Failed to parse "Pipfile.lock". File content:\n${pipfileLockContent}`
-            );
-            throw err;
-          }
-        } catch (_err) {
-          throw new NowBuildError({
-            code: 'INVALID_PIPFILE_LOCK',
-            message: 'Unable to parse Pipfile.lock',
-          });
-        }
-        const pyFromLock = lock?._meta?.requires?.python_version;
-        if (pyFromLock) {
-          declared = { version: pyFromLock, source: 'Pipfile.lock' };
-          debug(`Found Python version ${pyFromLock} in Pipfile.lock`);
-        }
-      }
-
-      const resolved = getSupportedPythonVersion({
+    .trace(versionSpan => {
+      const resolution = resolvePythonVersion({
         isDev: meta.isDev,
-        declaredPythonVersion: declared,
+        pythonPackage,
+        rootDir,
       });
-
       versionSpan.setAttributes({
-        'python.version': resolved.version,
-        'python.versionSource': declared?.source,
+        'python.version': pythonVersionString(resolution.pythonVersion),
+        'python.versionSource': resolution.versionSource,
       });
-
-      return { pythonVersion: resolved, declaredPythonVersion: declared };
+      return resolution;
     });
 
-  // Write a .python-version file on behalf of the user when:
-  // no .python-version file exists and the required version in pyproject.toml
-  // is <= DEFAULT_PYTHON_VERSION
-  const selectedVersionTuple = parseVersionTuple(pythonVersion.version);
-  const defaultVersionTuple = parseVersionTuple(DEFAULT_PYTHON_VERSION);
-  if (
-    !pythonVersionFileDir &&
-    pyprojectDir &&
-    declaredPythonVersion?.source === 'pyproject.toml' &&
-    selectedVersionTuple &&
-    defaultVersionTuple &&
-    compareTuples(selectedVersionTuple, defaultVersionTuple) <= 0
-  ) {
-    const pythonVersionFilePath = join(pyprojectDir, '.python-version');
-    await writeFile(pythonVersionFilePath, `${pythonVersion.version}\n`);
+  if (pinVersionFilePath) {
     console.log(
-      `Writing .python-version file with version ${pythonVersion.version}`
+      `Writing .python-version file with version ${pythonVersionString(pythonVersion)}`
+    );
+    await writeFile(
+      pinVersionFilePath,
+      `${pythonVersionString(pythonVersion)}\n`
     );
   }
 
@@ -393,9 +288,9 @@ export const build: BuildV3 = async ({
         const { projectDir, lockPath, lockFileProvidedByUser } =
           await ensureUvProject({
             workPath,
-            entryDirectory,
-            repoRootPath,
-            pythonVersion: pythonVersion.version,
+            rootDir,
+            pythonPackage,
+            pythonVersion: pythonVersionString(pythonVersion),
             uv,
             generateLockFile: true,
             requireBinaryWheels: false,
@@ -404,13 +299,8 @@ export const build: BuildV3 = async ({
         uvLockPath = lockPath;
         uvProjectDir = projectDir;
 
-        // Get the project name from python-analysis for package classification
-        const installInfo = await detectInstallSource({
-          workPath,
-          entryDirectory,
-          repoRootPath,
-        });
-        projectName = installInfo.pythonPackage?.manifest?.data?.project?.name;
+        // Get the project name from the already-discovered package info
+        projectName = pythonPackage?.manifest?.data?.project?.name;
 
         // For user-provided lock files, check if all packages have binary wheels
         // available BEFORE running the actual sync. We track this result so we can
@@ -611,7 +501,7 @@ from vercel_runtime.vc_init import vc_handler
     pythonPath: pythonVersion.pythonPath,
     hasCustomCommand,
     alwaysBundlePackages: [
-      ...quirksResult.alwaysBundlePackages,
+      ...(quirksResult.alwaysBundlePackages ?? []),
       ...(shouldInstallVercelWorkers
         ? ['vercel-workers', 'vercel_workers']
         : []),
@@ -703,18 +593,6 @@ export const defaultShouldServe: ShouldServe = ({
 
 function hasProp(obj: { [path: string]: FileFsRef }, key: string): boolean {
   return Object.hasOwnProperty.call(obj, key);
-}
-
-// Parses a .python-version file and returns the first non-empty, non-comment line.
-// Supports both exact versions (e.g. "3.12") and version specifiers (e.g. ">=3.12").
-function parsePythonVersionFile(content: string): string | undefined {
-  const lines = content.split('\n');
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    return trimmed;
-  }
-  return undefined;
 }
 
 // internal only - expect breaking changes if other packages depend on these exports

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -13,7 +13,7 @@ import {
 } from '@vercel/python-analysis';
 import { getVenvPythonBin } from './utils';
 import { UvRunner, filterUnsafeUvPipArgs, getProtectedUvEnv } from './uv';
-import { DEFAULT_PYTHON_VERSION } from './version';
+import { DEFAULT_PYTHON_VERSION_STRING } from './version';
 
 const makeDependencyCheckCode = (dependency: string) => `
 from importlib import util
@@ -110,44 +110,19 @@ export function resolveVendorDir() {
   return vendorDir;
 }
 
-function toBuildError(error: PythonAnalysisError): NowBuildError {
-  return new NowBuildError({
-    code: error.code,
-    message: error.message,
-    link: error.link,
-    action: error.action,
-  });
-}
-
-export type ManifestType = 'uv.lock' | 'pylock.toml' | 'pyproject.toml' | null;
-
-export interface InstallSourceInfo {
-  manifestPath: string | null;
-  manifestType: ManifestType;
-  /** The discovered package info from python-analysis. */
-  pythonPackage?: PythonPackage;
-}
-
-interface DetectInstallSourceParams {
-  workPath: string;
-  entryDirectory: string;
-  repoRootPath?: string;
-}
-
-export async function detectInstallSource({
-  workPath,
-  entryDirectory,
-  repoRootPath,
-}: DetectInstallSourceParams): Promise<InstallSourceInfo> {
-  const entrypointDir = join(workPath, entryDirectory);
-  const rootDir = repoRootPath ?? workPath;
-
-  let pythonPackage: PythonPackage;
+/**
+ * Discover Python package metadata, converting PythonAnalysisError
+ * into NowBuildError with diagnostic logging.
+ */
+export async function discoverPackage({
+  entrypointDir,
+  rootDir,
+}: {
+  entrypointDir: string;
+  rootDir: string;
+}): Promise<PythonPackage> {
   try {
-    pythonPackage = await discoverPythonPackage({
-      entrypointDir,
-      rootDir,
-    });
+    return await discoverPythonPackage({ entrypointDir, rootDir });
   } catch (error: unknown) {
     if (error instanceof PythonAnalysisError) {
       if (
@@ -159,11 +134,30 @@ export async function detectInstallSource({
           `Failed to parse "${error.path}". File content:\n${error.fileContent}`
         );
       }
-      throw toBuildError(error);
+      throw new NowBuildError({
+        code: error.code,
+        message: error.message,
+        link: error.link,
+        action: error.action,
+      });
     }
     throw error;
   }
+}
 
+export type ManifestType = 'uv.lock' | 'pylock.toml' | 'pyproject.toml' | null;
+
+export interface InstallSourceInfo {
+  manifestPath: string | null;
+  manifestType: ManifestType;
+  /** The discovered package info from python-analysis. */
+  pythonPackage: PythonPackage;
+}
+
+export function detectInstallSource(
+  pythonPackage: PythonPackage,
+  rootDir: string
+): InstallSourceInfo {
   // Determine effective manifest type based on lock file and manifest presence
   let manifestType: ManifestType = null;
   let manifestPath: string | null = null;
@@ -199,7 +193,7 @@ export async function createPyprojectToml({
   dependencies: string[];
   pythonVersion?: string;
 }) {
-  const version = pythonVersion ?? DEFAULT_PYTHON_VERSION;
+  const version = pythonVersion ?? DEFAULT_PYTHON_VERSION_STRING;
   const requiresPython = `~=${version}.0`;
 
   const manifest = createMinimalManifest({
@@ -221,8 +215,8 @@ export interface UvProjectInfo {
 
 interface EnsureUvProjectParams {
   workPath: string;
-  entryDirectory: string;
-  repoRootPath?: string;
+  rootDir: string;
+  pythonPackage: PythonPackage;
   pythonVersion: string;
   uv: UvRunner;
   generateLockFile?: boolean;
@@ -236,22 +230,15 @@ interface EnsureUvProjectParams {
 
 export async function ensureUvProject({
   workPath,
-  entryDirectory,
-  repoRootPath,
+  rootDir,
+  pythonPackage,
   pythonVersion,
   uv,
   generateLockFile = false,
   requireBinaryWheels = false,
 }: EnsureUvProjectParams): Promise<UvProjectInfo> {
-  const rootDir = repoRootPath ?? workPath;
-
-  const installInfo = await detectInstallSource({
-    workPath,
-    entryDirectory,
-    repoRootPath,
-  });
-  const { manifestType, pythonPackage } = installInfo;
-  const manifest = pythonPackage?.manifest;
+  const { manifestType } = detectInstallSource(pythonPackage, rootDir);
+  const manifest = pythonPackage.manifest;
 
   let projectDir: string;
   let pyprojectPath: string;
@@ -263,7 +250,7 @@ export async function ensureUvProject({
     lockFileProvidedByUser = true;
     // Lock file exists - use it directly
     const lockFile =
-      pythonPackage?.manifest?.lockFile ?? pythonPackage?.workspaceLockFile;
+      pythonPackage.manifest?.lockFile ?? pythonPackage.workspaceLockFile;
     if (!lockFile) {
       throw new Error(
         `Expected lock file path to be resolved, but it was null`
@@ -304,9 +291,11 @@ export async function ensureUvProject({
 
     // If this is a converted manifest, write the pyproject.toml to disk
     if (manifest.origin) {
-      // Inject requires-python for the target version if not already set,
+      // Override requires-python to match the builder's selected Python version
       // so that `uv lock` and `uv sync` agree on the Python constraint.
-      if (manifest.data.project && !manifest.data.project['requires-python']) {
+      // For converted manifests the original constraint (e.g. from Pipfile.lock)
+      // may specify an older version that the builder has auto-upgraded.
+      if (manifest.data.project) {
         manifest.data.project['requires-python'] = `~=${pythonVersion}.0`;
       }
       const content = stringifyManifest(manifest.data);
@@ -316,7 +305,7 @@ export async function ensureUvProject({
     }
 
     // Check for workspace lock file
-    const workspaceLockFile = pythonPackage?.workspaceLockFile;
+    const workspaceLockFile = pythonPackage.workspaceLockFile;
     if (workspaceLockFile) {
       lockPath = join(rootDir, workspaceLockFile.path);
     } else {

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -19,7 +19,11 @@ import {
   getVenvBinDir,
 } from './utils';
 import { findUvBinary, getProtectedUvEnv } from './uv';
-import { detectInstallSource, type ManifestType } from './install';
+import {
+  discoverPackage,
+  detectInstallSource,
+  type ManifestType,
+} from './install';
 import { stringifyManifest } from '@vercel/python-analysis';
 
 const DEV_SERVER_STARTUP_TIMEOUT = 10_000;
@@ -121,13 +125,16 @@ async function syncDependencies({
   onStdout,
   onStderr,
 }: SyncDependenciesOptions): Promise<void> {
-  const installInfo = await detectInstallSource({
-    workPath,
-    entryDirectory: '.',
+  const pythonPackage = await discoverPackage({
+    entrypointDir: workPath,
+    rootDir: workPath,
   });
 
-  let { manifestType, manifestPath } = installInfo;
-  const manifest = installInfo.pythonPackage?.manifest;
+  const installInfo = detectInstallSource(pythonPackage, workPath);
+
+  const { manifestType } = installInfo;
+  let { manifestPath } = installInfo;
+  const manifest = pythonPackage.manifest;
 
   if (!manifestType || !manifestPath) {
     debug('No Python project manifest found, skipping dependency sync');

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -140,23 +140,3 @@ export async function runPyprojectScript(
   // No command string was provided for the found script name
   return false;
 }
-
-export function findDir({
-  file,
-  entryDirectory,
-  workPath,
-  fsFiles,
-}: {
-  file: string;
-  entryDirectory: string;
-  workPath: string;
-  fsFiles: Record<string, any>;
-}): string | null {
-  if (fsFiles[join(entryDirectory, file)]) {
-    return join(workPath, entryDirectory);
-  }
-  if (fsFiles[file]) {
-    return workPath;
-  }
-  return null;
-}

--- a/packages/python/src/version.ts
+++ b/packages/python/src/version.ts
@@ -217,6 +217,7 @@ export function resolvePythonVersion({
       allBuilds,
       defaultBuild,
       majorMinorOnly: true,
+      legacyTildeEquals: true,
     });
 
     source = result.source;

--- a/packages/python/src/version.ts
+++ b/packages/python/src/version.ts
@@ -1,67 +1,73 @@
+import { join, dirname } from 'path';
 import { NowBuildError } from '@vercel/build-utils';
+import { selectPythonVersion, PythonConfigKind } from '@vercel/python-analysis';
+import type { PythonBuild, PythonPackage } from '@vercel/python-analysis';
 import { UvRunner, findUvInPath } from './uv';
 
-interface PythonVersion {
-  version: string;
+export interface PythonVersion {
+  major: number;
+  minor: number;
   pipPath: string;
   pythonPath: string;
   runtime: string;
   discontinueDate?: Date;
 }
 
-export const DEFAULT_PYTHON_VERSION = '3.12';
+export interface PythonVersionResolution {
+  pythonVersion: PythonVersion;
+  pythonPackage: PythonPackage;
+  versionSource?: string;
+  /**
+   * When set, the builder should write a `.python-version` file at this
+   * absolute path with the selected version string.  This is returned when
+   * the version was inferred from `requires-python` in `pyproject.toml`,
+   * no `.python-version` already exists, and the resolved version is at or
+   * below DEFAULT_PYTHON_VERSION.
+   */
+  pinVersionFilePath?: string;
+}
+
+export function pythonVersionString(pv: PythonVersion): string {
+  return `${pv.major}.${pv.minor}`;
+}
+
+const DEFAULT_PYTHON_VERSION: PythonVersion = makePythonVersion(3, 12);
+export const DEFAULT_PYTHON_VERSION_STRING = pythonVersionString(
+  DEFAULT_PYTHON_VERSION
+);
+
+function makePythonVersion(
+  major: number,
+  minor: number,
+  discontinueDate?: Date
+): PythonVersion {
+  return {
+    major,
+    minor,
+    pipPath: `pip${major}.${minor}`,
+    pythonPath: `python${major}.${minor}`,
+    runtime: `python${major}.${minor}`,
+    discontinueDate,
+  };
+}
 
 // The order must be most recent first
 const allOptions: PythonVersion[] = [
-  {
-    version: '3.14',
-    pipPath: 'pip3.14',
-    pythonPath: 'python3.14',
-    runtime: 'python3.14',
-  },
-  {
-    version: '3.13',
-    pipPath: 'pip3.13',
-    pythonPath: 'python3.13',
-    runtime: 'python3.13',
-  },
-  {
-    version: '3.12',
-    pipPath: 'pip3.12',
-    pythonPath: 'python3.12',
-    runtime: 'python3.12',
-  },
-  {
-    version: '3.11',
-    pipPath: 'pip3.11',
-    pythonPath: 'python3.11',
-    runtime: 'python3.11',
-  },
-  {
-    version: '3.10',
-    pipPath: 'pip3.10',
-    pythonPath: 'python3.10',
-    runtime: 'python3.10',
-  },
-  {
-    version: '3.9',
-    pipPath: 'pip3.9',
-    pythonPath: 'python3.9',
-    runtime: 'python3.9',
-  },
-  {
-    version: '3.6',
-    pipPath: 'pip3.6',
-    pythonPath: 'python3.6',
-    runtime: 'python3.6',
-    discontinueDate: new Date('2022-07-18'),
-  },
+  makePythonVersion(3, 14),
+  makePythonVersion(3, 13),
+  makePythonVersion(3, 12),
+  makePythonVersion(3, 11),
+  makePythonVersion(3, 10),
+  makePythonVersion(3, 9),
+  makePythonVersion(3, 6, new Date('2022-07-18')),
 ];
 
 function getDevPythonVersion(): PythonVersion {
-  // Use the system-installed version of `python3` when running `vercel dev`
+  // Use the system-installed version of `python3` when running `vercel dev`.
+  // minor is set to 0 as a placeholder — it is not used in dev mode.
   return {
-    version: '3',
+    major: 3,
+    minor: 0,
     pipPath: 'pip3',
     pythonPath: 'python3',
     runtime: 'python3',
@@ -72,7 +78,6 @@ function getDevPythonVersion(): PythonVersion {
  * Select the appropriate Python version for production builds when no version is specified
  * or an unsupported version is requested.
  */
-
 export function getDefaultPythonVersion({
   isDev,
 }: {
@@ -82,9 +87,8 @@ export function getDefaultPythonVersion({
     return getDevPythonVersion();
   }
 
-  // When no version is explicitly specified use default version
   const defaultOption = allOptions.find(
-    opt => opt.version === DEFAULT_PYTHON_VERSION && isInstalled(opt)
+    opt => versionsEqual(opt, DEFAULT_PYTHON_VERSION) && isInstalled(opt)
   );
   if (defaultOption) {
     return defaultOption;
@@ -102,200 +106,210 @@ export function getDefaultPythonVersion({
   return selection;
 }
 
-/**
- * example: "3.10" -> [3, 10]
- */
-export function parseVersionTuple(input: string): [number, number] | null {
-  const cleaned = input.trim().replace(/\s+/g, '');
-  const m = cleaned.match(/^(\d+)(?:\.(\d+))?/);
-  if (!m) return null;
-  const major = Number(m[1]);
-  const minor = m[2] !== undefined ? Number(m[2]) : 0;
-  if (Number.isNaN(major) || Number.isNaN(minor)) return null;
-  return [major, minor];
+function versionsEqual(a: PythonVersion, b: PythonVersion): boolean {
+  return a.major === b.major && a.minor === b.minor;
 }
 
-export function compareTuples(
-  a: [number, number],
-  b: [number, number]
-): number {
-  if (a[0] !== b[0]) return a[0] - b[0];
-  return a[1] - b[1];
-}
-
-type SpecOp = '<' | '<=' | '>' | '>=' | '==' | '!=' | '~=';
-interface VersionSpecifier {
-  op: SpecOp;
-  ver: [number, number];
+function versionLessOrEqual(a: PythonVersion, b: PythonVersion): boolean {
+  if (a.major !== b.major) return a.major < b.major;
+  return a.minor <= b.minor;
 }
 
 /**
- * example: ">=3.10" -> { op: '>=', ver: [3, 10] }
+ * Convert a local PythonVersion entry to a python-analysis PythonBuild.
  */
-function parseSpecifier(spec: string): VersionSpecifier | null {
-  const s = spec.trim();
-  // Support operators: <=, >=, ==, !=, ~=, <, >
-  // Allow optional patch version (e.g., 3.11.4) which will be ignored (only major.minor used)
-  const m =
-    s.match(
-      /^(<=|>=|==|!=|~=|<|>)\s*([0-9]+(?:\.[0-9]+)?)(?:\.[0-9]+)?(?:\.\*)?$/
-    ) ||
-    // Bare version like "3.11" or "3.11.4" -> implied ==
-    s.match(/^()([0-9]+(?:\.[0-9]+)?)(?:\.[0-9]+)?(?:\.\*)?$/);
-  if (!m) return null;
-  const op = (m[1] || '==') as SpecOp;
-  const vt = parseVersionTuple(m[2]);
-  if (!vt) return null;
-  return { op, ver: vt };
+function toPythonBuild(opt: PythonVersion): PythonBuild {
+  return {
+    version: { major: opt.major, minor: opt.minor },
+    implementation: 'cpython',
+    variant: 'default',
+    os: 'linux',
+    architecture: 'x86_64',
+    libc: 'gnu',
+  };
 }
 
 /**
- * example: [3, 10] satisfies ">=3.10" -> true
- * example: [3, 9] satisfies ">=3.10" -> false
+ * Build the list of available Python builds for selectPythonVersion().
+ *
+ * Ordered with DEFAULT_PYTHON_VERSION first, then remaining versions in
+ * descending order. Only includes installed, non-discontinued versions.
+ * This preserves the "3.12 preferred" behavior since selectPythonVersion
+ * returns the first match.
  */
-function satisfies(
-  candidate: [number, number],
-  spec: VersionSpecifier
-): boolean {
-  const cmp = compareTuples(candidate, spec.ver);
-  switch (spec.op) {
-    case '==':
-      return cmp === 0;
-    case '!=':
-      return cmp !== 0;
-    case '<':
-      return cmp < 0;
-    case '<=':
-      return cmp <= 0;
-    case '>':
-      return cmp > 0;
-    case '>=':
-      return cmp >= 0;
-    case '~=': {
-      // Compatible release, e.g. ~=3.10 means >=3.10 and <3.11
-      const lowerOk = cmp >= 0;
-      const upper: [number, number] = [spec.ver[0], spec.ver[1] + 1];
-      return lowerOk && compareTuples(candidate, upper) < 0;
-    }
-    default:
-      return false;
-  }
-}
-
-function selectFromRequiresPython(expr: string): PythonVersion | undefined {
-  const raw = expr.trim();
-  if (!raw) return undefined;
-  const parts = raw
-    .split(',')
-    .map(p => p.trim())
-    .filter(Boolean);
-  const specifiers: VersionSpecifier[] = [];
-  for (const p of parts) {
-    const sp = parseSpecifier(p);
-    if (sp) specifiers.push(sp);
-  }
-  if (specifiers.length === 0) {
-    // Try direct exact match with the raw string (e.g. "3.11")
-    return allOptions.find(o => o.version === raw);
-  }
-  // Filter all supported options by the specifiers (intersection semantics)
-  const matches = allOptions.filter(opt => {
-    const vt = parseVersionTuple(opt.version)!;
-    return specifiers.every(sp => satisfies(vt, sp));
-  });
-  if (matches.length === 0) return undefined;
-
-  // Prefer DEFAULT_PYTHON_VERSION (3.12) if it satisfies the constraints.
-  // This makes Python 3.13+ opt-in only - users must explicitly require
-  const defaultMatch = matches.find(
-    opt => opt.version === DEFAULT_PYTHON_VERSION && isInstalled(opt)
+function getAvailablePythonBuilds(): PythonBuild[] {
+  const installed = allOptions.filter(
+    opt => !isDiscontinued(opt) && isInstalled(opt)
   );
-  if (defaultMatch) {
-    return defaultMatch;
-  }
-
-  // If DEFAULT_PYTHON_VERSION doesn't match constraints, fall back to
-  // the latest installed version that matches
-  const installedMatch = matches.find(isInstalled);
-  return installedMatch ?? matches[0];
+  const defaultOpt = installed.find(opt =>
+    versionsEqual(opt, DEFAULT_PYTHON_VERSION)
+  );
+  const rest = installed.filter(
+    opt => !versionsEqual(opt, DEFAULT_PYTHON_VERSION)
+  );
+  const ordered = defaultOpt ? [defaultOpt, ...rest] : rest;
+  return ordered.map(toPythonBuild);
 }
 
-export function getSupportedPythonVersion({
+/**
+ * Build the list of ALL known Python builds (including discontinued
+ * and not-installed), used for producing better error diagnostics.
+ */
+function getAllPythonBuilds(): PythonBuild[] {
+  return allOptions.map(toPythonBuild);
+}
+
+/**
+ * Map a python-analysis PythonBuild back to a local PythonVersion entry.
+ */
+function getPythonVersionForBuild(
+  build: PythonBuild
+): PythonVersion | undefined {
+  return allOptions.find(
+    opt =>
+      opt.major === build.version.major && opt.minor === build.version.minor
+  );
+}
+
+/**
+ * Resolve Python version from an already-discovered PythonPackage.
+ *
+ * Handles isDev early return, delegates constraint matching to
+ * python-analysis selectPythonVersion, and applies builder-specific
+ * logging, warnings, and error handling.
+ */
+export function resolvePythonVersion({
   isDev,
-  declaredPythonVersion,
+  pythonPackage,
+  rootDir,
 }: {
   isDev?: boolean;
-  declaredPythonVersion?: {
-    version: string;
-    source: 'Pipfile.lock' | 'pyproject.toml' | '.python-version';
-  };
-}): PythonVersion {
+  pythonPackage: PythonPackage;
+  rootDir: string;
+}): PythonVersionResolution {
   if (isDev) {
-    return getDevPythonVersion();
+    return {
+      pythonVersion: getDevPythonVersion(),
+      pythonPackage,
+    };
   }
 
-  let selection = getDefaultPythonVersion({ isDev: false });
+  const constraints = pythonPackage.requiresPython;
+  const defaultPv = getDefaultPythonVersion({ isDev: false });
 
-  if (declaredPythonVersion) {
-    const { version, source } = declaredPythonVersion;
-    let requested: PythonVersion | undefined;
-    if (source === 'pyproject.toml' || source === '.python-version') {
-      // Support both exact versions and version specifiers (e.g. ">=3.12")
-      requested = selectFromRequiresPython(version);
-    } else {
-      // For Pipfile.lock, do exact match
-      requested = allOptions.find(o => o.version === version);
-    }
-    if (requested) {
-      // If a discontinued version is explicitly requested, error even if not installed
-      if (isDiscontinued(requested)) {
+  let selection: PythonVersion;
+  let source: string | undefined;
+  let autoUpgraded = false;
+
+  if (!constraints || constraints.length === 0) {
+    console.log(
+      `No Python version specified in .python-version, pyproject.toml, or Pipfile.lock. Using python version: ${pythonVersionString(defaultPv)}`
+    );
+    selection = defaultPv;
+  } else {
+    const defaultBuild = toPythonBuild(defaultPv);
+    const availableBuilds = getAvailablePythonBuilds();
+    const allBuilds = getAllPythonBuilds();
+
+    const result = selectPythonVersion({
+      constraints,
+      availableBuilds,
+      allBuilds,
+      defaultBuild,
+      majorMinorOnly: true,
+    });
+
+    source = result.source;
+    selection = getPythonVersionForBuild(result.build) ?? defaultPv;
+
+    // Auto-upgrade: when the constraint comes from a converted manifest
+    // (e.g. Pipfile.lock) and resolves to a version below the default,
+    // upgrade to the default.  Legacy projects often pin old versions
+    // that are incompatible with the builder's runtime requirements.
+    if (
+      pythonPackage.manifest?.origin &&
+      !result.notAvailable &&
+      !result.invalidConstraint &&
+      !versionLessOrEqual(defaultPv, selection)
+    ) {
+      const originalVersion = pythonVersionString(selection);
+      selection = defaultPv;
+      autoUpgraded = true;
+      console.log(
+        `Python version ${originalVersion} detected in ${source} is below the minimum supported version. Using python version: ${pythonVersionString(selection)}`
+      );
+    } else if (result.notAvailable) {
+      const npv = getPythonVersionForBuild(result.notAvailable.build);
+      if (npv && isDiscontinued(npv)) {
         throw new NowBuildError({
           code: 'BUILD_UTILS_PYTHON_VERSION_DISCONTINUED',
           link: 'https://vercel.link/python-version',
-          message: `Python version "${requested.version}" detected in ${source} is discontinued and must be upgraded.`,
+          message: `Python version "${pythonVersionString(npv)}" detected in ${source} is discontinued and must be upgraded.`,
         });
       }
-      // Otherwise, prefer the requested version if installed; fall back to latest installed
-      if (isInstalled(requested)) {
-        selection = requested;
-        console.log(`Using Python ${selection.version} from ${source}`);
-      } else {
+      if (npv) {
         console.warn(
-          `Warning: Python version "${version}" detected in ${source} is not installed and will be ignored. https://vercel.link/python-version`
+          `Warning: Python version "${pythonVersionString(npv)}" detected in ${source} is not installed and will be ignored. https://vercel.link/python-version`
         );
-        console.log(`Using python version: ${selection.version}`);
       }
-    } else {
+      console.log(`Using python version: ${pythonVersionString(selection)}`);
+    } else if (result.invalidConstraint) {
       console.warn(
-        `Warning: Python version "${version}" detected in ${source} is invalid and will be ignored. https://vercel.link/python-version`
+        `Warning: Python version "${result.invalidConstraint.versionString}" detected in ${source} is invalid and will be ignored. https://vercel.link/python-version`
       );
-      console.log(`Using python version: ${selection.version}`);
+      console.log(`Using python version: ${pythonVersionString(selection)}`);
+    } else {
+      console.log(
+        `Using Python ${pythonVersionString(selection)} from ${source}`
+      );
     }
-  } else {
-    console.log(
-      `No Python version specified in .python-version, pyproject.toml, or Pipfile.lock. Using python version: ${selection.version}`
-    );
   }
 
   if (isDiscontinued(selection)) {
     throw new NowBuildError({
       code: 'BUILD_UTILS_PYTHON_VERSION_DISCONTINUED',
       link: 'https://vercel.link/python-version',
-      message: `Python version "${selection.version}" declared in project configuration is discontinued and must be upgraded.`,
+      message: `Python version "${pythonVersionString(selection)}" declared in project configuration is discontinued and must be upgraded.`,
     });
   }
 
   if (selection.discontinueDate) {
     const d = selection.discontinueDate.toISOString().split('T')[0];
-    const srcSuffix = declaredPythonVersion
-      ? `detected in ${declaredPythonVersion.source}`
-      : 'selected by runtime';
+    const srcSuffix = source ? `detected in ${source}` : 'selected by runtime';
     console.warn(
-      `Error: Python version "${selection.version}" ${srcSuffix} has reached End-of-Life. Deployments created on or after ${d} will fail to build. https://vercel.link/python-version`
+      `Error: Python version "${pythonVersionString(selection)}" ${srcSuffix} has reached End-of-Life. Deployments created on or after ${d} will fail to build. https://vercel.link/python-version`
     );
   }
 
-  return selection;
+  let pinVersionFilePath: string | undefined;
+  const hasPythonVersionFile =
+    pythonPackage.configs?.some(
+      configSet => configSet[PythonConfigKind.PythonVersion] !== undefined
+    ) ?? false;
+
+  if (
+    !hasPythonVersionFile &&
+    pythonPackage.manifest &&
+    versionLessOrEqual(selection, defaultPv)
+  ) {
+    // Pin .python-version when:
+    // - The version was auto-upgraded from a converted manifest (Pipfile.lock, etc.)
+    // - Or the version came from requires-python in a native pyproject.toml
+    if (
+      autoUpgraded ||
+      (!pythonPackage.manifest.origin && source?.endsWith('pyproject.toml'))
+    ) {
+      const manifestDir = join(rootDir, dirname(pythonPackage.manifest.path));
+      pinVersionFilePath = join(manifestDir, '.python-version');
+    }
+  }
+
+  return {
+    pythonVersion: selection,
+    pythonPackage,
+    versionSource: source,
+    pinVersionFilePath,
+  };
 }
 
 function isDiscontinued({ discontinueDate }: PythonVersion): boolean {
@@ -332,10 +346,10 @@ export function resetInstalledPythonsCache(): void {
   installedPythonsCache = null;
 }
 
-function isInstalled({ version }: PythonVersion): boolean {
+function isInstalled(pv: PythonVersion): boolean {
   try {
     const installed = getInstalledPythons();
-    return installed.has(version);
+    return installed.has(pythonVersionString(pv));
   } catch (err) {
     throw new NowBuildError({
       code: 'UV_ERROR',

--- a/packages/python/test/fixtures/47-python314/pyproject.toml
+++ b/packages/python/test/fixtures/47-python314/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fixture-python314"
 version = "0.0.1"
-requires-python = "~=3.14.0"
+requires-python = "~=3.14"
 dependencies = [
   "fastapi",
 ]

--- a/packages/python/test/fixtures/47-python314/pyproject.toml
+++ b/packages/python/test/fixtures/47-python314/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fixture-python314"
 version = "0.0.1"
-requires-python = "~=3.14"
+requires-python = "~=3.14.0"
 dependencies = [
   "fastapi",
 ]

--- a/packages/python/test/integration-setup.js
+++ b/packages/python/test/integration-setup.js
@@ -11,7 +11,7 @@ jest.setTimeout(4 * 60 * 1000);
 module.exports = function setupTests(groupIndex) {
   const fixturesPath = path.resolve(__dirname, 'fixtures');
   const testsThatFailToBuild = new Map([
-    ['30-fail-build-invalid-pipfile', 'Unable to parse Pipfile.lock'],
+    ['30-fail-build-invalid-pipfile', 'Could not parse config file'],
     [
       '31-fail-build-invalid-python36',
       'Python version "3.6" detected in Pipfile.lock is discontinued and must be upgraded.',
@@ -40,7 +40,7 @@ module.exports = function setupTests(groupIndex) {
         } catch (err) {
           expect(err).toBeTruthy();
           expect(err.deployment).toBeTruthy();
-          expect(err.deployment.errorMessage).toBe(errMsg);
+          expect(err.deployment.errorMessage).toContain(errMsg);
         }
       });
       continue; //eslint-disable-line

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -39,10 +39,11 @@ vi.mock('../src/install', async () => {
 
 // Imports after mocks are set up (vitest hoists vi.mock calls)
 import {
-  getSupportedPythonVersion,
-  DEFAULT_PYTHON_VERSION,
+  resolvePythonVersion,
+  DEFAULT_PYTHON_VERSION_STRING,
   resetInstalledPythonsCache,
 } from '../src/version';
+import type { PythonConstraint, PythonPackage } from '@vercel/python-analysis';
 import { build } from '../src/index';
 import { createVenvEnv, getVenvBinDir } from '../src/utils';
 import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
@@ -50,6 +51,55 @@ import { VERCEL_WORKERS_VERSION } from '../src/package-versions';
 import { createPyprojectToml } from '../src/install';
 import { detectDjangoPythonEntrypoint } from '../src/entrypoint';
 import { FileBlob } from '@vercel/build-utils';
+
+/**
+ * Build a PythonConstraint from a PEP 440 version specifier string.
+ * Handles exact versions ("3.9"), specifiers (">=3.10,<3.12"), and
+ * compatible releases ("~=3.10.0").
+ */
+function makeConstraint(version: string, source: string): PythonConstraint {
+  const specs = version
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  const constraint = specs.map(spec => {
+    const match = spec.match(/^(<=|>=|==|!=|~=|===|<|>)?\s*(.+)$/);
+    return {
+      operator: match?.[1] || '==',
+      version: match?.[2] || spec,
+      prefix: '',
+    };
+  });
+  return {
+    request: [
+      {
+        implementation: 'cpython' as const,
+        version: {
+          constraint,
+          variant: 'default' as const,
+        },
+      },
+    ],
+    source,
+    prettySource: source,
+  };
+}
+
+function makePackage(constraints?: PythonConstraint[]): PythonPackage {
+  return { requiresPython: constraints };
+}
+
+function selectVersion(opts: {
+  constraints?: PythonConstraint[];
+  isDev?: boolean;
+}) {
+  return resolvePythonVersion({
+    isDev: opts.isDev,
+    pythonPackage: makePackage(opts.constraints),
+    rootDir: '/tmp',
+  });
+}
+
 let warningMessages: string[];
 const originalConsoleWarn = console.warn;
 const realDateNow = Date.now.bind(global.Date);
@@ -107,30 +157,30 @@ afterEach(() => {
 
 it('should only match supported versions, otherwise throw an error', () => {
   makeMockPython('3.9');
-  const result = getSupportedPythonVersion({
-    declaredPythonVersion: { version: '3.9', source: 'Pipfile.lock' },
+  const { pythonVersion: result } = selectVersion({
+    constraints: [makeConstraint('3.9', 'Pipfile.lock')],
   });
   expect(result).toHaveProperty('runtime', 'python3.9');
 });
 
 it('should ignore minor version in vercel dev', () => {
   expect(
-    getSupportedPythonVersion({
-      declaredPythonVersion: { version: '3.9', source: 'Pipfile.lock' },
+    selectVersion({
+      constraints: [makeConstraint('3.9', 'Pipfile.lock')],
       isDev: true,
-    })
+    }).pythonVersion
   ).toHaveProperty('runtime', 'python3');
   expect(
-    getSupportedPythonVersion({
-      declaredPythonVersion: { version: '3.6', source: 'Pipfile.lock' },
+    selectVersion({
+      constraints: [makeConstraint('3.6', 'Pipfile.lock')],
       isDev: true,
-    })
+    }).pythonVersion
   ).toHaveProperty('runtime', 'python3');
   expect(
-    getSupportedPythonVersion({
-      declaredPythonVersion: { version: '999', source: 'Pipfile.lock' },
+    selectVersion({
+      constraints: [makeConstraint('999', 'Pipfile.lock')],
       isDev: true,
-    })
+    }).pythonVersion
   ).toHaveProperty('runtime', 'python3');
   expect(warningMessages).toStrictEqual([]);
 });
@@ -139,11 +189,8 @@ describe('requires-python range parsing', () => {
   it('selects latest installed within range ">=3.10,<3.12"', () => {
     makeMockPython('3.10');
     makeMockPython('3.11');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.10,<3.12',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.10,<3.12', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.11');
   });
@@ -151,23 +198,17 @@ describe('requires-python range parsing', () => {
   it('selects highest allowed when upper bound inclusive (>=3.10,<=3.12)', () => {
     makeMockPython('3.11');
     makeMockPython('3.12');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.10,<=3.12',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.10,<=3.12', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.12');
   });
 
-  it('respects compatible release "~=3.10" (>=3.10,<3.11)', () => {
+  it('respects compatible release "~=3.10.0" (>=3.10.0,<3.11.0)', () => {
     makeMockPython('3.10');
     makeMockPython('3.11');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '~=3.10',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('~=3.10.0', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.10');
   });
@@ -177,11 +218,8 @@ describe('Python 3.13 and 3.14 support', () => {
   it('selects Python 3.13 when specified in requires-python', () => {
     makeMockPython('3.12');
     makeMockPython('3.13');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.13',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.13', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.13');
   });
@@ -189,26 +227,20 @@ describe('Python 3.13 and 3.14 support', () => {
   it('selects Python 3.14 when specified in requires-python', () => {
     makeMockPython('3.13');
     makeMockPython('3.14');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.14',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.14', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.14');
   });
 
-  it('prefers DEFAULT_PYTHON_VERSION (3.12) when range allows it', () => {
+  it('prefers DEFAULT_PYTHON_VERSION_STRING (3.12) when range allows it', () => {
     // Even though 3.13 and 3.14 are installed and match >=3.12,
     // we prefer 3.12 to make 3.13+ opt-in only
     makeMockPython('3.12');
     makeMockPython('3.13');
     makeMockPython('3.14');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.12',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.12', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.12');
   });
@@ -218,35 +250,26 @@ describe('Python 3.13 and 3.14 support', () => {
     makeMockPython('3.12');
     makeMockPython('3.13');
     makeMockPython('3.14');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.12,<3.14',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.12,<3.14', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.12');
   });
 
-  it('respects compatible release "~=3.13" (>=3.13,<3.14)', () => {
+  it('respects compatible release "~=3.13.0" (>=3.13.0,<3.14.0)', () => {
     makeMockPython('3.13');
     makeMockPython('3.14');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '~=3.13',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('~=3.13.0', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.13');
   });
 
-  it('respects compatible release "~=3.14" (>=3.14,<3.15)', () => {
+  it('respects compatible release "~=3.14.0" (>=3.14.0,<3.15.0)', () => {
     makeMockPython('3.13');
     makeMockPython('3.14');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '~=3.14',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('~=3.14.0', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.14');
   });
@@ -258,11 +281,8 @@ describe('Python 3.13 and 3.14 support', () => {
     makeMockPython('3.11');
     makeMockPython('3.12');
     makeMockPython('3.13');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.9',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.9', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.12');
   });
@@ -272,11 +292,8 @@ describe('Python 3.13 and 3.14 support', () => {
     makeMockPython('3.11');
     makeMockPython('3.12');
     makeMockPython('3.13');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.11,<=3.13',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.11,<=3.13', 'pyproject.toml')],
     });
     expect(result).toHaveProperty('runtime', 'python3.12');
   });
@@ -286,11 +303,8 @@ describe('Python 3.13 and 3.14 support', () => {
     makeMockPython('3.13');
     makeMockPython('3.14');
     // Note: NOT installing 3.12
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.12',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.12', 'pyproject.toml')],
     });
     // Should fall back to 3.14 (latest installed that matches)
     expect(result).toHaveProperty('runtime', 'python3.14');
@@ -301,11 +315,8 @@ describe('.python-version file support', () => {
   it('selects Python version from .python-version source', () => {
     makeMockPython('3.11');
     makeMockPython('3.12');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '3.11',
-        source: '.python-version',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('3.11', '.python-version')],
     });
     expect(result).toHaveProperty('runtime', 'python3.11');
   });
@@ -314,11 +325,8 @@ describe('.python-version file support', () => {
     makeMockPython('3.10');
     makeMockPython('3.11');
     makeMockPython('3.12');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '3.10',
-        source: '.python-version',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('3.10', '.python-version')],
     });
     // Should match exactly 3.10, not pick the latest
     expect(result).toHaveProperty('runtime', 'python3.10');
@@ -328,24 +336,18 @@ describe('.python-version file support', () => {
     makeMockPython('3.12');
     makeMockPython('3.13');
     // Request 3.9 which is not installed
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '3.9',
-        source: '.python-version',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('3.9', '.python-version')],
     });
     // Should fall back to default
     expect(result).toHaveProperty('runtime', 'python3.12');
     expect(warningMessages[0]).toContain('not installed and will be ignored');
   });
 
-  it('warns and falls back when .python-version specifies invalid version', () => {
+  it('warns and falls back when .python-version specifies unrecognized version', () => {
     makeMockPython('3.12');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: 'invalid',
-        source: '.python-version',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('999', '.python-version')],
     });
     // Should fall back to default
     expect(result).toHaveProperty('runtime', 'python3.12');
@@ -357,11 +359,8 @@ describe('.python-version file support', () => {
     // Spy on console.log to verify the message
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      getSupportedPythonVersion({
-        declaredPythonVersion: {
-          version: '3.11',
-          source: '.python-version',
-        },
+      selectVersion({
+        constraints: [makeConstraint('3.11', '.python-version')],
       });
       expect(logSpy).toHaveBeenCalledWith(
         expect.stringContaining('Using Python 3.11 from .python-version')
@@ -373,59 +372,62 @@ describe('.python-version file support', () => {
 });
 
 describe('default Python version behavior', () => {
-  it('uses DEFAULT_PYTHON_VERSION when no version specified and default is installed', () => {
+  it('uses DEFAULT_PYTHON_VERSION_STRING when no version specified and default is installed', () => {
     makeMockPython('3.13');
     makeMockPython('3.14');
-    makeMockPython(DEFAULT_PYTHON_VERSION);
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: undefined,
+    makeMockPython(DEFAULT_PYTHON_VERSION_STRING);
+    const { pythonVersion: result } = selectVersion({
+      constraints: undefined,
     });
-    expect(result).toHaveProperty('runtime', `python${DEFAULT_PYTHON_VERSION}`);
+    expect(result).toHaveProperty(
+      'runtime',
+      `python${DEFAULT_PYTHON_VERSION_STRING}`
+    );
   });
 
   it('falls back to latest installed when default is not installed', () => {
     makeMockPython('3.13');
     makeMockPython('3.14');
-    // Note: NOT installing DEFAULT_PYTHON_VERSION (3.12)
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: undefined,
+    // Note: NOT installing DEFAULT_PYTHON_VERSION_STRING (3.12)
+    const { pythonVersion: result } = selectVersion({
+      constraints: undefined,
     });
     // Should pick 3.14 as the latest installed
     expect(result).toHaveProperty('runtime', 'python3.14');
   });
 
   it('respects explicit version even when default is installed', () => {
-    makeMockPython(DEFAULT_PYTHON_VERSION);
+    makeMockPython(DEFAULT_PYTHON_VERSION_STRING);
     makeMockPython('3.13');
     makeMockPython('3.14');
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: {
-        version: '>=3.14',
-        source: 'pyproject.toml',
-      },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('>=3.14', 'pyproject.toml')],
     });
     // Should pick 3.14 because it was explicitly requested
     expect(result).toHaveProperty('runtime', 'python3.14');
   });
 
-  it('DEFAULT_PYTHON_VERSION constant is exported and has expected value', () => {
-    expect(DEFAULT_PYTHON_VERSION).toBe('3.12');
+  it('DEFAULT_PYTHON_VERSION_STRING constant is exported and has expected value', () => {
+    expect(DEFAULT_PYTHON_VERSION_STRING).toBe('3.12');
   });
 });
 
 describe('fallback behavior when requested version is not installed', () => {
-  it('falls back to DEFAULT_PYTHON_VERSION when Pipfile.lock requests unavailable version', () => {
+  it('falls back to DEFAULT_PYTHON_VERSION_STRING when Pipfile.lock requests unavailable version', () => {
     // Setup: 3.14, 3.13, 3.12 are installed, but NOT 3.9
     makeMockPython('3.14');
     makeMockPython('3.13');
-    makeMockPython(DEFAULT_PYTHON_VERSION); // 3.12
+    makeMockPython(DEFAULT_PYTHON_VERSION_STRING); // 3.12
 
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: { version: '3.9', source: 'Pipfile.lock' },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('3.9', 'Pipfile.lock')],
     });
 
     // Should fall back to 3.12 (the default), NOT 3.14 (the latest)
-    expect(result).toHaveProperty('runtime', `python${DEFAULT_PYTHON_VERSION}`);
+    expect(result).toHaveProperty(
+      'runtime',
+      `python${DEFAULT_PYTHON_VERSION_STRING}`
+    );
     expect(warningMessages[0]).toContain('not installed and will be ignored');
   });
 
@@ -435,8 +437,8 @@ describe('fallback behavior when requested version is not installed', () => {
     makeMockPython('3.13');
     // Note: NOT installing 3.12 (default) or 3.9 (requested)
 
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: { version: '3.9', source: 'Pipfile.lock' },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('3.9', 'Pipfile.lock')],
     });
 
     // Should fall back to 3.14 (latest installed) since 3.12 is also unavailable
@@ -444,24 +446,27 @@ describe('fallback behavior when requested version is not installed', () => {
     expect(warningMessages[0]).toContain('not installed and will be ignored');
   });
 
-  it('falls back to DEFAULT_PYTHON_VERSION when pyproject.toml requests unavailable version', () => {
+  it('falls back to DEFAULT_PYTHON_VERSION_STRING when pyproject.toml requests unavailable version', () => {
     // Setup: 3.14, 3.13, 3.12 are installed, but NOT 3.9
     makeMockPython('3.14');
     makeMockPython('3.13');
-    makeMockPython(DEFAULT_PYTHON_VERSION); // 3.12
+    makeMockPython(DEFAULT_PYTHON_VERSION_STRING); // 3.12
 
-    const result = getSupportedPythonVersion({
-      declaredPythonVersion: { version: '==3.9', source: 'pyproject.toml' },
+    const { pythonVersion: result } = selectVersion({
+      constraints: [makeConstraint('==3.9', 'pyproject.toml')],
     });
 
     // Should fall back to 3.12 (the default), NOT 3.14 (the latest)
-    expect(result).toHaveProperty('runtime', `python${DEFAULT_PYTHON_VERSION}`);
+    expect(result).toHaveProperty(
+      'runtime',
+      `python${DEFAULT_PYTHON_VERSION_STRING}`
+    );
     expect(warningMessages[0]).toContain('not installed and will be ignored');
   });
 });
 
 describe('createPyprojectToml', () => {
-  it('sets requires-python to compatible release of DEFAULT_PYTHON_VERSION when no pythonVersion provided', async () => {
+  it('sets requires-python to compatible release of DEFAULT_PYTHON_VERSION_STRING when no pythonVersion provided', async () => {
     const tempDir = path.join(tmpdir(), `pyproject-test-${Date.now()}`);
     fs.mkdirSync(tempDir, { recursive: true });
     const pyprojectPath = path.join(tempDir, 'pyproject.toml');
@@ -475,7 +480,7 @@ describe('createPyprojectToml', () => {
 
       const content = fs.readFileSync(pyprojectPath, 'utf8');
       expect(content).toContain(
-        `requires-python = "~=${DEFAULT_PYTHON_VERSION}.0"`
+        `requires-python = "~=${DEFAULT_PYTHON_VERSION_STRING}.0"`
       );
     } finally {
       if (fs.existsSync(tempDir)) {
@@ -509,8 +514,8 @@ describe('createPyprojectToml', () => {
 
 it('should select default or latest installed version when no Piplock detected', () => {
   makeMockPython('3.10');
-  const result = getSupportedPythonVersion({
-    declaredPythonVersion: undefined,
+  const { pythonVersion: result } = selectVersion({
+    constraints: undefined,
   });
   expect(result).toHaveProperty('runtime');
   // When default version isn't installed, falls back to latest available
@@ -520,8 +525,8 @@ it('should select default or latest installed version when no Piplock detected',
 
 it('should select latest supported installed version and warn when invalid Piplock detected', () => {
   makeMockPython('3.10');
-  const result = getSupportedPythonVersion({
-    declaredPythonVersion: { version: '999', source: 'Pipfile.lock' },
+  const { pythonVersion: result } = selectVersion({
+    constraints: [makeConstraint('999', 'Pipfile.lock')],
   });
   expect(result).toHaveProperty('runtime');
   expect(result.runtime).toMatch(/^python3\.\d+$/);
@@ -532,8 +537,8 @@ it('should select latest supported installed version and warn when invalid Piplo
 
 it('should throw if uv not found', () => {
   expect(() =>
-    getSupportedPythonVersion({
-      declaredPythonVersion: { version: '3.6', source: 'Pipfile.lock' },
+    selectVersion({
+      constraints: [makeConstraint('3.6', 'Pipfile.lock')],
     })
   ).toThrow('uv is required but was not found in PATH.');
   expect(warningMessages).toStrictEqual([]);
@@ -553,8 +558,8 @@ it('should throw if no python versions installed', () => {
   process.env.PATH = `${tmpPythonDir}${path.delimiter}${process.env.PATH}`;
 
   expect(() =>
-    getSupportedPythonVersion({
-      declaredPythonVersion: { version: '3.6', source: 'Pipfile.lock' },
+    selectVersion({
+      constraints: [makeConstraint('3.6', 'Pipfile.lock')],
     })
   ).toThrow('Unable to find any supported Python versions.');
   expect(warningMessages).toStrictEqual([]);
@@ -565,8 +570,8 @@ it('should throw for discontinued versions', () => {
   makeMockPython('3.6');
 
   expect(() =>
-    getSupportedPythonVersion({
-      declaredPythonVersion: { version: '3.6', source: 'Pipfile.lock' },
+    selectVersion({
+      constraints: [makeConstraint('3.6', 'Pipfile.lock')],
     })
   ).toThrow(
     'Python version "3.6" detected in Pipfile.lock is discontinued and must be upgraded.'
@@ -579,9 +584,9 @@ it('should warn for deprecated versions, soon to be discontinued', () => {
   makeMockPython('3.6');
 
   expect(
-    getSupportedPythonVersion({
-      declaredPythonVersion: { version: '3.6', source: 'Pipfile.lock' },
-    })
+    selectVersion({
+      constraints: [makeConstraint('3.6', 'Pipfile.lock')],
+    }).pythonVersion
   ).toHaveProperty('runtime', 'python3.6');
   expect(warningMessages).toStrictEqual([
     'Error: Python version "3.6" detected in Pipfile.lock has reached End-of-Life. Deployments created on or after 2022-07-18 will fail to build. https://vercel.link/python-version',


### PR DESCRIPTION
Replace ad-hoc version parsing and file discovery in the Python builder
with the structured APIs from `@vercel/python-analysis`.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR refactors Python version resolution logic by consolidating ad-hoc parsing into the python-analysis package, with no changes to authentication, authorization, database schema, or security controls.
> 
> - Refactors version selection from inline parsing to structured `selectPythonVersion` API
> - Adds new exports and helper functions in python-analysis package
> - Extensive test coverage added for version selection scenarios
>
> <sup>Risk assessment for [commit ad04692](https://github.com/vercel/vercel/commit/ad04692e96f13405a4c4dac212277fed52a08f96).</sup>
<!-- VADE_RISK_END -->