### PR TITLE
fix: Add Path=/ to __vdpl Skew Protection cookie

### DIFF
--- a/packages/react-router/edge/entry.server.ts
+++ b/packages/react-router/edge/entry.server.ts
@@ -50,7 +50,7 @@ export async function handleRequest(
   if (vercelSkewProtectionEnabled && vercelDeploymentId) {
     responseHeaders.append(
       'Set-Cookie',
-      `__vdpl=${vercelDeploymentId}; HttpOnly`
+      `__vdpl=${vercelDeploymentId}; Path=/; HttpOnly`
     );
   }
 

--- a/packages/react-router/entry.server.ts
+++ b/packages/react-router/entry.server.ts
@@ -60,7 +60,7 @@ export function handleRequest(
           if (vercelSkewProtectionEnabled && vercelDeploymentId) {
             responseHeaders.append(
               'Set-Cookie',
-              `__vdpl=${vercelDeploymentId}; HttpOnly`
+              `__vdpl=${vercelDeploymentId}; Path=/; HttpOnly`
             );
           }
 


### PR DESCRIPTION
The `__vdpl` cookie is set without a `Path` attribute in both `entry.server.js` and `edge/entry.server.js`:

```js
responseHeaders.append('Set-Cookie', `__vdpl=${vercelDeploymentId}; HttpOnly`);
```

Per [RFC 6265 Section 5.1.4](https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4), when `Path` is omitted the browser computes a default path from the request URI (everything up to the last `/`). This means:

| Page loaded | Cookie path | Sent on `/assets/*`? |
|--------|--------|--------|
| `/dashboard` | `/` | Yes |
| `/dashboard/clients` | `/dashboard` | No |
| `/dashboard/clients/abc` | `/dashboard/clients` | No |

When a user lands on a deep URL, the `__vdpl` cookie is not sent on subsequent requests for `/assets/*.js` files. After a new deployment, the browser tries to lazy-load old content-hashed chunks, but the asset requests don’t include the cookie, resulting in 404s.

We observed this in production: the browser had accumulated multiple `__vdpl` cookies with different paths pointing to different deployment IDs:

| Deployment ID | Path |
|--------|--------|
| `dpl_825k59...` | `/dashboard/clients/prod...` |
| `dpl_H583YD...` | `/` |
| `dpl_8V9bE7...` | `/assets` | 

Vercel logs showed asset requests hitting the serverless function (`/*` route, 404) instead of being served from the CDN, consistent with the cookie not being sent and Skew Protection not kicking in.

Every other Vercel framework adapter sets `Path=/`:

- Next.js (`next/dist/lib/load-custom-routes.js`):

```js
value: `__vdpl=${config.deploymentId}; Path=/; HttpOnly`
```

- SvelteKit (`@sveltejs/adapter-vercel`):

```js
'Set-Cookie': `__vdpl=${process.env.VERCEL_DEPLOYMENT_ID}; Path=${builder.config.kit.paths.base}/; SameSite=Strict; ...`
```

- Qwik (`@builder.io/qwik`):

```js
cookies.set(VERCEL_COOKIE, deploymentId, { path: baseUrl, ... });
```

The fix adds `Path=/` to the `Set-Cookie` header in both the Node and Edge entry servers, consistent with all other framework implementations.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds Path=/ attribute to an existing cookie for Vercel Skew Protection, which is a defensive fix ensuring the cookie is sent on all requests rather than being scoped to deep paths.
> 
> - Adds Path=/ to __vdpl cookie in both Node and Edge entry servers
> - Fixes cookie scoping bug where deep URLs caused cookie to not be sent on asset requests
>
> <sup>Risk assessment for [commit dc27ebb](https://github.com/vercel/vercel/commit/dc27ebb877745d2aad1f2aad120151f38bfcca2f).</sup>
<!-- VADE_RISK_END -->