### PR TITLE
[python] Add `diagnostics` callback to produce `project-manifest.json`

### DIFF
--- a/.changeset/kind-lobsters-relax.md
+++ b/.changeset/kind-lobsters-relax.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python-analysis': patch
+'@vercel/python': patch
+---
+
+Add `diagnostics` callback to produce package-manifest.json

--- a/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
@@ -5,6 +5,7 @@ mod bindings {
 }
 mod dist_metadata;
 mod entrypoint;
+mod pep508;
 mod requirements_txt;
 
 bindings::export!(PythonAnalyzer with_types_in bindings);
@@ -15,7 +16,7 @@ use std::future::Future;
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
 
-use crate::bindings::{DirectUrlInfo, DistMetadata, ParsedRequirementsTxt, RecordEntry};
+use crate::bindings::{DirectUrlInfo, DistMetadata, ParsedReqEntry, ParsedRequirementsTxt, RecordEntry};
 use crate::entrypoint::{
     contains_app_or_handler_impl, contains_top_level_callable_impl, get_string_constant_impl,
 };
@@ -82,6 +83,10 @@ impl crate::bindings::Guest for PythonAnalyzer {
         filename: Option<String>,
     ) -> Result<ParsedRequirementsTxt, String> {
         requirements_txt::parse_requirements_txt(&content, working_dir, filename)
+    }
+
+    fn parse_pep508(dep: String) -> Result<ParsedReqEntry, String> {
+        pep508::parse_pep508(&dep)
     }
 
     fn is_wheel_compatible(

--- a/packages/python-analysis/crates/vercel_python_analysis/src/pep508.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/pep508.rs
@@ -1,0 +1,68 @@
+//! PEP 508 dependency string parsing via `uv-pep508`.
+//!
+//! This module provides direct parsing of individual PEP 508 dependency
+//! specifiers without the overhead of the full requirements.txt machinery.
+
+use std::str::FromStr;
+
+use crate::bindings::{ParsedReqEntry, ParsedVcsInfo};
+
+/// Extract VCS (Git) information from a parsed URL.
+pub(crate) fn extract_vcs_info(parsed_url: &uv_pypi_types::ParsedUrl) -> Option<ParsedVcsInfo> {
+    match parsed_url {
+        uv_pypi_types::ParsedUrl::Git(git) => {
+            let url = git.url.repository().to_string();
+            let rev = git.url.reference().as_str().map(String::from);
+            Some(ParsedVcsInfo { url, rev })
+        }
+        _ => None,
+    }
+}
+
+/// Convert a `uv_pep508::VersionOrUrl` into its component parts:
+/// `(version_spec, url, editable, vcs, given_url)`.
+pub(crate) fn convert_version_or_url(
+    version_or_url: &Option<uv_pep508::VersionOrUrl<uv_pypi_types::VerbatimParsedUrl>>,
+) -> (Option<String>, Option<String>, bool, Option<ParsedVcsInfo>, Option<String>) {
+    match version_or_url {
+        Some(uv_pep508::VersionOrUrl::VersionSpecifier(spec)) => {
+            (Some(spec.to_string()), None, false, None, None)
+        }
+        Some(uv_pep508::VersionOrUrl::Url(verbatim_url)) => {
+            let given = verbatim_url.verbatim.given().map(String::from);
+            let url_str = verbatim_url.verbatim.to_string();
+            let editable = verbatim_url.parsed_url.is_editable();
+            let vcs = extract_vcs_info(&verbatim_url.parsed_url);
+            (None, Some(url_str), editable, vcs, given)
+        }
+        None => (None, None, false, None, None),
+    }
+}
+
+/// Parse a single PEP 508 dependency string directly using `uv-pep508`.
+///
+/// This is much lighter than `parse_requirements_txt` because it avoids
+/// the `uv-requirements-txt` machinery (client builder, cache, file I/O).
+pub(crate) fn parse_pep508(dep: &str) -> Result<ParsedReqEntry, String> {
+    let req = uv_pep508::Requirement::<uv_pypi_types::VerbatimParsedUrl>::from_str(dep)
+        .map_err(|e| e.to_string())?;
+
+    let pep508 = req.to_string();
+    let name = Some(req.name.to_string());
+    let extras: Vec<String> = req.extras.iter().map(|e| e.to_string()).collect();
+    let markers = req.marker.contents().map(|m| m.to_string());
+    let (version_spec, url, editable, vcs, given_url) = convert_version_or_url(&req.version_or_url);
+
+    Ok(ParsedReqEntry {
+        name,
+        pep508,
+        extras,
+        markers,
+        version_spec,
+        url,
+        hashes: Vec::new(),
+        editable,
+        vcs,
+        given_url,
+    })
+}

--- a/packages/python-analysis/crates/vercel_python_analysis/src/requirements_txt.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/requirements_txt.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use crate::bindings::{ParsedReqEntry, ParsedRequirementsTxt, ParsedVcsInfo};
 use crate::block_on;
+use crate::pep508::{convert_version_or_url, extract_vcs_info};
 
 pub(crate) fn parse_requirements_txt(
     content: &str,
@@ -88,19 +89,8 @@ fn convert_requirement(
             let name = Some(named.name.to_string());
             let extras: Vec<String> = named.extras.iter().map(|e| e.to_string()).collect();
             let markers = named.marker.contents().map(|m| m.to_string());
-            let (version_spec, url, editable, vcs, given_url) = match &named.version_or_url {
-                Some(uv_pep508::VersionOrUrl::VersionSpecifier(spec)) => {
-                    (Some(spec.to_string()), None, false, None, None)
-                }
-                Some(uv_pep508::VersionOrUrl::Url(verbatim_url)) => {
-                    let given = verbatim_url.verbatim.given().map(String::from);
-                    let url_str = verbatim_url.verbatim.to_string();
-                    let editable = verbatim_url.parsed_url.is_editable();
-                    let vcs = extract_vcs_info(&verbatim_url.parsed_url);
-                    (None, Some(url_str), editable, vcs, given)
-                }
-                None => (None, None, false, None, None),
-            };
+            let (version_spec, url, editable, vcs, given_url) =
+                convert_version_or_url(&named.version_or_url);
             ConvertedReq {
                 pep508,
                 name,
@@ -138,17 +128,6 @@ fn convert_requirement(
                 given_url: given,
             }
         }
-    }
-}
-
-fn extract_vcs_info(parsed_url: &uv_pypi_types::ParsedUrl) -> Option<ParsedVcsInfo> {
-    match parsed_url {
-        uv_pypi_types::ParsedUrl::Git(git) => {
-            let url = git.url.repository().to_string();
-            let rev = git.url.reference().as_str().map(String::from);
-            Some(ParsedVcsInfo { url, rev })
-        }
-        _ => None,
     }
 }
 

--- a/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
+++ b/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
@@ -171,6 +171,16 @@ world python-analysis {
     export parse-requirements-txt: func(content: string, working-dir: option<string>, filename: option<string>) -> result<parsed-requirements-txt, string>;
 
     // =========================================================================
+    // PEP 508 parsing
+    // =========================================================================
+
+    /// Parse a single PEP 508 dependency string
+    /// (e.g. "flask[async]>=2.0 ; python_version >= '3.8'")
+    /// into a structured requirement entry.
+    /// Returns an error string if the input is not a valid PEP 508 specifier.
+    export parse-pep508: func(dep: string) -> result<parsed-req-entry, string>;
+
+    // =========================================================================
     // Wheel compatibility checking
     // =========================================================================
 

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -124,6 +124,8 @@ export {
 
 // PyProject types (from source of truth)
 export type {
+  DependencyGroupEntry,
+  DependencyGroupInclude,
   License,
   LicenseObject,
   Person,
@@ -183,6 +185,9 @@ export type {
   HashDigest,
   NormalizedRequirement,
 } from './manifest/requirement/types';
+
+// PEP 508 parsing and formatting
+export { parsePep508 } from './manifest/pep508';
 
 // =============================================================================
 // Python specifier types (no schemas - internal types)

--- a/packages/python-analysis/src/manifest/package.ts
+++ b/packages/python-analysis/src/manifest/package.ts
@@ -127,6 +127,8 @@ export interface PythonVersionConfig {
   path: RelPath;
   /** Parsed Python version requests from the file. */
   data: PythonRequest[];
+  /** Raw version string from the file (e.g. "3.12", ">=3.12,<3.13"). */
+  specifier: string;
 }
 
 /**
@@ -328,6 +330,7 @@ function computeRequiresPython(
         request: pythonVersionConfig.data,
         source: pythonVersionConfig.path,
         prettySource: pythonVersionConfig.path,
+        specifier: pythonVersionConfig.specifier,
       });
       hasPythonVersionFile = true;
       break;
@@ -346,6 +349,7 @@ function computeRequiresPython(
           request: [request],
           source: manifest.path,
           prettySource: `"requires-python" key in ${manifest.path}`,
+          specifier: manifestRequiresPython,
         });
       }
     } else {
@@ -360,6 +364,7 @@ function computeRequiresPython(
             request: [request],
             source: workspaceManifest.path,
             prettySource: `"requires-python" key in ${workspaceManifest.path}`,
+            specifier: workspaceRequiresPython,
           });
         }
       }
@@ -724,5 +729,6 @@ async function maybeLoadPythonRequest(
     kind: PythonConfigKind.PythonVersion,
     path: dotPythonVersionRelPath,
     data: pyreq,
+    specifier: data.trim(),
   };
 }

--- a/packages/python-analysis/src/manifest/pep508.ts
+++ b/packages/python-analysis/src/manifest/pep508.ts
@@ -13,6 +13,8 @@
  */
 
 import type { NormalizedRequirement } from './requirement/types';
+import type { ParsedReqEntry } from '#wasm/vercel_python_analysis.js';
+import { importWasmModule } from '../wasm/load';
 
 /**
  * Regular expression to extract extras from a package name.
@@ -119,4 +121,74 @@ export function mergeExtras(
   }
 
   return result.size > 0 ? Array.from(result) : undefined;
+}
+
+/**
+ * Convert a WASM-parsed PEP 508 entry to a NormalizedRequirement.
+ */
+function wasmEntryToRequirement(entry: ParsedReqEntry): NormalizedRequirement {
+  const req: NormalizedRequirement = {
+    name: entry.name || '',
+  };
+
+  if (entry.versionSpec) {
+    req.version = entry.versionSpec;
+  }
+
+  if (entry.extras.length > 0) {
+    req.extras = entry.extras;
+  }
+
+  if (entry.markers) {
+    req.markers = entry.markers;
+  }
+
+  if (entry.url) {
+    req.url = entry.url;
+  }
+
+  return req;
+}
+
+/**
+ * Parse a single PEP 508 dependency string into a NormalizedRequirement.
+ *
+ * Uses the uv-pep508 Rust crate via WASM for spec-compliant parsing.
+ *
+ * @param dep - A PEP 508 dependency string (e.g., "flask[async]>=2.0 ; python_version >= '3.8'")
+ * @returns The parsed requirement, or null if parsing fails
+ */
+export async function parsePep508(
+  dep: string
+): Promise<NormalizedRequirement | null>;
+/**
+ * Parse multiple PEP 508 dependency strings in a single batch.
+ *
+ * Loads the WASM module once and parses all strings synchronously,
+ * avoiding per-item async overhead.
+ *
+ * @param deps - Array of PEP 508 dependency strings
+ * @returns Array of parsed requirements (null for entries that fail to parse)
+ */
+export async function parsePep508(
+  deps: string[]
+): Promise<(NormalizedRequirement | null)[]>;
+export async function parsePep508(
+  depOrDeps: string | string[]
+): Promise<NormalizedRequirement | null | (NormalizedRequirement | null)[]> {
+  const wasm = await importWasmModule();
+  if (Array.isArray(depOrDeps)) {
+    return depOrDeps.map(dep => {
+      try {
+        return wasmEntryToRequirement(wasm.parsePep508(dep));
+      } catch {
+        return null;
+      }
+    });
+  }
+  try {
+    return wasmEntryToRequirement(wasm.parsePep508(depOrDeps));
+  } catch {
+    return null;
+  }
 }

--- a/packages/python-analysis/src/manifest/pyproject/schema.zod.ts
+++ b/packages/python-analysis/src/manifest/pyproject/schema.zod.ts
@@ -47,7 +47,18 @@ export const pyProjectProjectSchema = z.object({
   entry_points: z.record(z.record(z.string())).optional(),
 });
 
-export const pyProjectDependencyGroupsSchema = z.record(z.array(z.string()));
+export const dependencyGroupIncludeSchema = z.object({
+  'include-group': z.string(),
+});
+
+export const dependencyGroupEntrySchema = z.union([
+  z.string(),
+  dependencyGroupIncludeSchema,
+]);
+
+export const pyProjectDependencyGroupsSchema = z.record(
+  z.array(dependencyGroupEntrySchema)
+);
 
 export const pyProjectToolSectionSchema = z.object({
   uv: uvConfigSchema.optional(),

--- a/packages/python-analysis/src/manifest/pyproject/types.ts
+++ b/packages/python-analysis/src/manifest/pyproject/types.ts
@@ -80,9 +80,21 @@ export interface PyProjectProject {
 }
 
 /**
- * [dependency-groups].
+ * PEP 735 include-group directive: `{include-group: "other-group"}`.
  */
-export type PyProjectDependencyGroups = Record<string, string[]>;
+export interface DependencyGroupInclude {
+  'include-group': string;
+}
+
+/**
+ * A single entry in a dependency group: either a PEP 508 string or an include directive.
+ */
+export type DependencyGroupEntry = string | DependencyGroupInclude;
+
+/**
+ * [dependency-groups] per PEP 735.
+ */
+export type PyProjectDependencyGroups = Record<string, DependencyGroupEntry[]>;
 
 /**
  * [tool.FOO] section.

--- a/packages/python-analysis/src/manifest/python-specifiers.ts
+++ b/packages/python-analysis/src/manifest/python-specifiers.ts
@@ -167,6 +167,8 @@ export interface PythonConstraint {
   source: string;
   /** Human-readable description of where this constraint came from. */
   prettySource: string;
+  /** Raw version specifier string from the source file (e.g. ">=3.12", "3.12"). */
+  specifier?: string;
 }
 
 export type PythonVersion = {

--- a/packages/python-analysis/src/manifest/uv-config/schema.zod.ts
+++ b/packages/python-analysis/src/manifest/uv-config/schema.zod.ts
@@ -22,4 +22,5 @@ export const uvConfigSchema = z.object({
     .optional(),
   index: z.array(uvIndexEntrySchema).optional(),
   workspace: uvConfigWorkspaceSchema.optional(),
+  'dev-dependencies': z.array(z.string()).optional(),
 });

--- a/packages/python-analysis/src/manifest/uv-config/types.ts
+++ b/packages/python-analysis/src/manifest/uv-config/types.ts
@@ -51,4 +51,9 @@ export interface UvConfig {
    * Workspace configuration.
    */
   workspace?: UvConfigWorkspace;
+  /**
+   * Legacy dev dependencies (pre-PEP 735).
+   * Equivalent to `[dependency-groups].dev`.
+   */
+  'dev-dependencies'?: string[];
 }

--- a/packages/python-analysis/src/manifest/uv-lock-parser.ts
+++ b/packages/python-analysis/src/manifest/uv-lock-parser.ts
@@ -29,6 +29,7 @@ export interface UvLockPackage {
   version: string;
   source?: UvLockPackageSource;
   wheels: UvLockWheel[];
+  dependencies?: Array<{ name: string }>;
 }
 
 /**
@@ -49,6 +50,7 @@ interface UvLockToml {
     version: string;
     source?: UvLockPackageSource;
     wheels?: Array<{ url: string }>;
+    dependencies?: Array<{ name: string }>;
   }>;
 }
 
@@ -78,6 +80,7 @@ export function parseUvLock(content: string, path?: string): UvLockFile {
       version: pkg.version,
       source: pkg.source,
       wheels: (pkg.wheels ?? []).map(w => ({ url: w.url })),
+      ...(pkg.dependencies ? { dependencies: pkg.dependencies } : {}),
     }));
 
   return { version: parsed.version, packages };

--- a/packages/python-analysis/test/package.test.ts
+++ b/packages/python-analysis/test/package.test.ts
@@ -332,6 +332,7 @@ describe('discoverPythonPackage', () => {
         c.source.includes('pyproject.toml')
       );
       expect(constraint).toBeDefined();
+      expect(constraint?.specifier).toBe('>=3.10');
     });
 
     it('extracts requires-python from .python-version file', async () => {
@@ -346,6 +347,22 @@ describe('discoverPythonPackage', () => {
         c.source.includes('.python-version')
       );
       expect(constraint).toBeDefined();
+      expect(constraint?.specifier).toBe('3.12');
+    });
+
+    it('preserves specifier from nested .python-version', async () => {
+      const root = fixtureRoot('python-version-nested');
+      const entrypoint = path.join(root, 'api');
+      const result = await discoverPythonPackage({
+        entrypointDir: entrypoint,
+        rootDir: root,
+      });
+
+      const constraint = result.requiresPython?.find(c =>
+        c.source.includes('.python-version')
+      );
+      expect(constraint).toBeDefined();
+      expect(constraint?.specifier).toBe('3.12');
     });
 
     it('uses workspace requires-python when package does not specify', async () => {

--- a/packages/python-analysis/test/pep508.test.ts
+++ b/packages/python-analysis/test/pep508.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { parsePep508 } from '../src/manifest/pep508';
+
+describe('parsePep508', () => {
+  it('parses a simple package name', async () => {
+    const result = await parsePep508('flask');
+    expect(result).toEqual({ name: 'flask' });
+  });
+
+  it('parses a package with version specifier', async () => {
+    const result = await parsePep508('flask>=2.0');
+    expect(result).toEqual({ name: 'flask', version: '>=2.0' });
+  });
+
+  it('parses a package with compound version specifiers', async () => {
+    const result = await parsePep508('django>=4.0,<5.0');
+    expect(result).toEqual({ name: 'django', version: '>=4.0, <5.0' });
+  });
+
+  it('parses a package with extras', async () => {
+    const result = await parsePep508('requests[security,socks]');
+    expect(result).toEqual({
+      name: 'requests',
+      extras: ['security', 'socks'],
+    });
+  });
+
+  it('parses a package with extras and version', async () => {
+    const result = await parsePep508('uvicorn[standard]>=0.20');
+    expect(result).toEqual({
+      name: 'uvicorn',
+      version: '>=0.20',
+      extras: ['standard'],
+    });
+  });
+
+  it('parses a package with environment markers', async () => {
+    const result = await parsePep508('pywin32>=300 ; sys_platform == "win32"');
+    expect(result).toEqual({
+      name: 'pywin32',
+      version: '>=300',
+      markers: "sys_platform == 'win32'",
+    });
+  });
+
+  it('parses full PEP 508 with extras, version, and markers', async () => {
+    const result = await parsePep508(
+      'flask[async]>=2.0 ; python_version >= "3.8"'
+    );
+    expect(result).toEqual({
+      name: 'flask',
+      version: '>=2.0',
+      extras: ['async'],
+      // uv normalizes python_version to python_full_version and quotes to single
+      markers: "python_full_version >= '3.8'",
+    });
+  });
+
+  it('parses URL-based dependency', async () => {
+    const result = await parsePep508(
+      'mypackage @ https://example.com/pkg.tar.gz'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('mypackage');
+    expect(result!.url).toContain('https://example.com/pkg.tar.gz');
+  });
+
+  it('returns null for invalid input', async () => {
+    const result = await parsePep508('!!!invalid');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty string', async () => {
+    const result = await parsePep508('');
+    expect(result).toBeNull();
+  });
+
+  it('normalizes package name casing', async () => {
+    const result = await parsePep508('Flask>=2.0');
+    expect(result).not.toBeNull();
+    // uv-pep508 normalizes names per PEP 503
+    expect(result!.name).toBe('flask');
+  });
+
+  it('parses compatible release version', async () => {
+    const result = await parsePep508('numpy~=1.24.0');
+    expect(result).toEqual({ name: 'numpy', version: '~=1.24.0' });
+  });
+
+  it('parses exact version', async () => {
+    const result = await parsePep508('requests==2.28.0');
+    expect(result).toEqual({ name: 'requests', version: '==2.28.0' });
+  });
+
+  it('parses a batch of dependency strings', async () => {
+    const results = await parsePep508([
+      'flask>=2.0',
+      '!!!invalid',
+      'requests[security]',
+    ]);
+    expect(results).toEqual([
+      { name: 'flask', version: '>=2.0' },
+      null,
+      { name: 'requests', extras: ['security'] },
+    ]);
+  });
+
+  it('returns empty array for empty batch', async () => {
+    const results = await parsePep508([]);
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/python/src/diagnostics.ts
+++ b/packages/python/src/diagnostics.ts
@@ -1,0 +1,332 @@
+import fs from 'fs';
+import { join, dirname } from 'path';
+import {
+  FileBlob,
+  debug,
+  type BuildOptions,
+  type Files,
+} from '@vercel/build-utils';
+import {
+  parseUvLock,
+  normalizePackageName,
+  parsePep508,
+  type DependencyGroupEntry,
+  type PyProjectDependencyGroups,
+  type PythonPackage,
+  type UvLockPackageSource,
+} from '@vercel/python-analysis';
+import type { PythonVersion } from './version';
+import { pythonVersionString } from './version';
+
+export const MANIFEST_FILENAME = 'package-manifest.json';
+
+export const DIAGNOSTICS_PATH = join('.vercel', 'python', MANIFEST_FILENAME);
+
+interface DependencyEntry {
+  name: string;
+  type: 'direct' | 'transitive';
+  scopes: string[];
+  requested?: string;
+  resolved?: string;
+  source?: string;
+  sourceUrl?: string;
+}
+
+const MANIFEST_VERSION = '20260304';
+
+interface ProjectManifest {
+  version: string;
+  runtime: string;
+  runtimeVersion: {
+    requested?: string;
+    requestedSource?: string;
+    resolved: string;
+  };
+  dependencies: DependencyEntry[];
+}
+
+function isDependencyGroupInclude(
+  entry: DependencyGroupEntry
+): entry is { 'include-group': string } {
+  return typeof entry === 'object' && 'include-group' in entry;
+}
+
+/**
+ * Resolve a dependency group, recursively following `{include-group: "..."}` references.
+ * Cycle detection via `ancestors` prevents infinite recursion.
+ */
+function resolveDependencyGroup(
+  groupName: string,
+  allGroups: PyProjectDependencyGroups,
+  ancestors: Set<string> = new Set()
+): string[] {
+  if (ancestors.has(groupName)) return [];
+  const entries = allGroups[groupName];
+  if (!Array.isArray(entries)) return [];
+
+  ancestors.add(groupName);
+  const result: string[] = [];
+  for (const entry of entries) {
+    if (typeof entry === 'string') {
+      result.push(entry);
+    } else if (isDependencyGroupInclude(entry)) {
+      result.push(
+        ...resolveDependencyGroup(entry['include-group'], allGroups, ancestors)
+      );
+    }
+  }
+  ancestors.delete(groupName);
+  return result;
+}
+
+function mapSource(src: UvLockPackageSource | undefined): {
+  source?: string;
+  sourceUrl?: string;
+} {
+  if (!src) return {};
+  if (src.virtual) return {};
+  if (src.registry) {
+    try {
+      const url = new URL(src.registry);
+      return { source: 'registry', sourceUrl: url.origin };
+    } catch {
+      return { source: 'registry', sourceUrl: src.registry };
+    }
+  }
+  if (src.git) return { source: 'git', sourceUrl: src.git };
+  if (src.url) return { source: 'url', sourceUrl: src.url };
+  if (src.editable) return { source: 'editable', sourceUrl: src.editable };
+  if (src.path) return { source: 'path', sourceUrl: src.path };
+  return {};
+}
+
+/**
+ * Generate and write the project manifest to `.vercel/python/package-manifest.json`.
+ * Called during build() so data is collected while it's already available.
+ */
+export async function generateProjectManifest({
+  workPath,
+  pythonPackage,
+  pythonVersion,
+  uvLockPath,
+}: {
+  workPath: string;
+  pythonPackage: PythonPackage;
+  pythonVersion: PythonVersion;
+  uvLockPath: string;
+}): Promise<void> {
+  const resolved = pythonVersionString(pythonVersion);
+  const constraint = pythonPackage.requiresPython?.[0];
+  const requested = constraint?.specifier;
+
+  const project = pythonPackage.manifest?.data?.project;
+  const pyprojectData = pythonPackage.manifest?.data;
+
+  // Track direct dependency names and their scopes.
+  // A package can appear in multiple groups, so we collect all scopes.
+  const directScopesMap = new Map<string, Set<string>>();
+  const directRequested = new Map<string, string>();
+
+  // Collect all raw dependency strings paired with their scope first,
+  // then parse them in a single batch to avoid repeated WASM calls.
+  const allRawDeps: { dep: string; scope: string }[] = [];
+
+  // 1. project.dependencies → scope "main"
+  if (project?.dependencies && Array.isArray(project.dependencies)) {
+    for (const dep of project.dependencies) {
+      allRawDeps.push({ dep, scope: 'main' });
+    }
+  }
+
+  // 2. project.optional-dependencies → scope = group key
+  const optDeps = project?.['optional-dependencies'];
+  if (optDeps) {
+    for (const [group, deps] of Object.entries(optDeps)) {
+      if (Array.isArray(deps)) {
+        for (const dep of deps) {
+          allRawDeps.push({ dep, scope: group });
+        }
+      }
+    }
+  }
+
+  // 3. dependency-groups → scope = group key
+  // Supports PEP 735 include-group references via recursive resolution.
+  const depGroups = pyprojectData?.['dependency-groups'];
+  if (depGroups) {
+    for (const group of Object.keys(depGroups)) {
+      const groupDeps = resolveDependencyGroup(group, depGroups);
+      for (const dep of groupDeps) {
+        allRawDeps.push({ dep, scope: group });
+      }
+    }
+  }
+
+  // 4. tool.uv.dev-dependencies → scope "dev" (legacy, pre-PEP 735)
+  const uvDevDeps = pyprojectData?.tool?.uv?.['dev-dependencies'];
+  if (uvDevDeps && Array.isArray(uvDevDeps)) {
+    for (const dep of uvDevDeps) {
+      allRawDeps.push({ dep, scope: 'dev' });
+    }
+  }
+
+  // Parse all dependency strings in a single batch.
+  const allParsed = await parsePep508(allRawDeps.map(d => d.dep));
+  for (let i = 0; i < allRawDeps.length; i++) {
+    const parsed = allParsed[i];
+    if (!parsed) continue;
+    const { dep, scope } = allRawDeps[i];
+    const normalized = normalizePackageName(parsed.name);
+    let scopes = directScopesMap.get(normalized);
+    if (!scopes) {
+      scopes = new Set();
+      directScopesMap.set(normalized, scopes);
+    }
+    scopes.add(scope);
+    // Keep the first requested string we see for this package
+    if (!directRequested.has(normalized)) {
+      directRequested.set(normalized, dep);
+    }
+  }
+
+  // Resolve versions and source info from the lock file
+  const directEntries: DependencyEntry[] = [];
+  const transitiveEntries: DependencyEntry[] = [];
+
+  {
+    const content = await fs.promises.readFile(uvLockPath, 'utf-8');
+    const uvLock = parseUvLock(content, uvLockPath);
+    const projectName = project?.name;
+    const excludeSet = new Set(
+      projectName ? [normalizePackageName(projectName)] : []
+    );
+
+    // Build maps from the lock file
+    const lockMap = new Map<
+      string,
+      { version: string; source?: UvLockPackageSource }
+    >();
+    // Forward dependency graph: package → set of packages it depends on
+    const depGraph = new Map<string, Set<string>>();
+
+    for (const pkg of uvLock.packages) {
+      const normalized = normalizePackageName(pkg.name);
+      if (excludeSet.has(normalized)) continue;
+      if (pkg.source?.virtual) continue;
+      lockMap.set(normalized, { version: pkg.version, source: pkg.source });
+      if (pkg.dependencies) {
+        const deps = new Set<string>();
+        for (const d of pkg.dependencies) {
+          deps.add(normalizePackageName(d.name));
+        }
+        depGraph.set(normalized, deps);
+      }
+    }
+
+    // Propagate scopes from direct deps through the dependency graph.
+    // BFS from each direct dep: every reachable transitive package
+    // inherits the scopes of the direct dep.
+    const transitiveScopesMap = new Map<string, Set<string>>();
+
+    for (const [name, scopes] of directScopesMap) {
+      const queue = [name];
+      let head = 0;
+      const visited = new Set<string>();
+      while (head < queue.length) {
+        const current = queue[head++];
+        if (visited.has(current)) continue;
+        visited.add(current);
+        const children = depGraph.get(current);
+        if (!children) continue;
+        for (const child of children) {
+          if (excludeSet.has(child)) continue;
+          if (!directScopesMap.has(child)) {
+            let childScopes = transitiveScopesMap.get(child);
+            if (!childScopes) {
+              childScopes = new Set();
+              transitiveScopesMap.set(child, childScopes);
+            }
+            for (const s of scopes) {
+              childScopes.add(s);
+            }
+          }
+          if (!visited.has(child)) {
+            queue.push(child);
+          }
+        }
+      }
+    }
+
+    // Build direct entries
+    for (const [name, scopes] of directScopesMap) {
+      const info = lockMap.get(name);
+      const entry: DependencyEntry = {
+        name,
+        type: 'direct',
+        scopes: [...scopes].sort(),
+        requested: directRequested.get(name),
+      };
+      if (info) {
+        entry.resolved = info.version;
+        const src = mapSource(info.source);
+        if (src.source) entry.source = src.source;
+        if (src.sourceUrl) entry.sourceUrl = src.sourceUrl;
+      }
+      directEntries.push(entry);
+    }
+
+    // Build transitive entries (only include packages reachable from a direct dep)
+    for (const [normalized, info] of lockMap) {
+      if (directScopesMap.has(normalized)) continue;
+      const scopes = transitiveScopesMap.get(normalized);
+      if (!scopes || scopes.size === 0) continue;
+      const src = mapSource(info.source);
+      transitiveEntries.push({
+        name: normalized,
+        type: 'transitive',
+        scopes: [...scopes].sort(),
+        resolved: info.version,
+        ...(src.source ? { source: src.source } : {}),
+        ...(src.sourceUrl ? { sourceUrl: src.sourceUrl } : {}),
+      });
+    }
+  }
+
+  const manifest: ProjectManifest = {
+    version: MANIFEST_VERSION,
+    runtime: 'python',
+    runtimeVersion: {
+      ...(requested ? { requested } : {}),
+      ...(constraint?.source ? { requestedSource: constraint.source } : {}),
+      resolved,
+    },
+    dependencies: [
+      ...directEntries.sort((a, b) => a.name.localeCompare(b.name)),
+      ...transitiveEntries.sort((a, b) => a.name.localeCompare(b.name)),
+    ],
+  };
+
+  const outPath = join(workPath, DIAGNOSTICS_PATH);
+  await fs.promises.mkdir(dirname(outPath), { recursive: true });
+  await fs.promises.writeFile(outPath, JSON.stringify(manifest, null, 2));
+}
+
+/**
+ * Diagnostics callback — returns the project manifest cached during build().
+ */
+export const diagnostics = async ({
+  workPath,
+}: BuildOptions): Promise<Files> => {
+  try {
+    const manifestPath = join(workPath, DIAGNOSTICS_PATH);
+    const data = await fs.promises.readFile(manifestPath, 'utf-8');
+    return {
+      [MANIFEST_FILENAME]: new FileBlob({ data }),
+    };
+  } catch (err) {
+    debug(
+      `Diagnostics: no cached manifest found: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return {};
+  }
+};

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -36,6 +36,7 @@ import {
 import { PythonDependencyExternalizer } from './dependency-externalizer';
 import { UvRunner, getUvBinaryOrInstall } from './uv';
 import { resolvePythonVersion, pythonVersionString } from './version';
+import { generateProjectManifest } from './diagnostics';
 import { startDevServer } from './start-dev-server';
 import { runPyprojectScript, ensureVenv, createVenvEnv } from './utils';
 import { runQuirks } from './quirks';
@@ -690,6 +691,23 @@ from vercel_runtime.vc_init import vc_handler
     supportsResponseStreaming: true,
   });
 
+  // Write project manifest for diagnostics (best-effort, never fails the build).
+  // Requires uv.lock to resolve versions and dependency graph.
+  if (uvLockPath) {
+    try {
+      await generateProjectManifest({
+        workPath,
+        pythonPackage,
+        pythonVersion,
+        uvLockPath,
+      });
+    } catch (err) {
+      debug(
+        `Failed to write project manifest: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
   return { output };
 };
 
@@ -732,6 +750,8 @@ export const defaultShouldServe: ShouldServe = ({
 function hasProp(obj: { [path: string]: FileFsRef }, key: string): boolean {
   return Object.hasOwnProperty.call(obj, key);
 }
+
+export { diagnostics } from './diagnostics';
 
 // internal only - expect breaking changes if other packages depend on these exports
 export { installRequirement, installRequirementsFile };

--- a/packages/python/test/diagnostics.test.ts
+++ b/packages/python/test/diagnostics.test.ts
@@ -1,0 +1,784 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import { tmpdir } from 'os';
+import { FileBlob } from '@vercel/build-utils';
+import type {
+  DependencyGroupEntry,
+  PythonPackage,
+} from '@vercel/python-analysis';
+import type { PythonVersion } from '../src/version';
+import {
+  generateProjectManifest,
+  diagnostics,
+  DIAGNOSTICS_PATH,
+  MANIFEST_FILENAME,
+} from '../src/diagnostics';
+
+const pythonVersion: PythonVersion = {
+  major: 3,
+  minor: 12,
+  pipPath: 'pip3.12',
+  pythonPath: 'python3.12',
+  runtime: 'python3.12',
+};
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(tmpdir(), 'vc-diag-test-'));
+}
+
+function writeUvLock(
+  dir: string,
+  packages: {
+    name: string;
+    version: string;
+    source?: string;
+    dependencies?: string[];
+  }[]
+): string {
+  const lockPath = path.join(dir, 'uv.lock');
+  const entries = packages
+    .map(p => {
+      let block = `[[package]]\nname = "${p.name}"\nversion = "${p.version}"`;
+      if (p.source) {
+        block += `\n${p.source}`;
+      }
+      if (p.dependencies && p.dependencies.length > 0) {
+        const depEntries = p.dependencies
+          .map(d => `    { name = "${d}" }`)
+          .join(',\n');
+        block += `\ndependencies = [\n${depEntries},\n]`;
+      }
+      return block;
+    })
+    .join('\n\n');
+  fs.writeFileSync(
+    lockPath,
+    `version = 1\nrequires-python = ">=3.10"\n\n${entries}\n`
+  );
+  return lockPath;
+}
+
+function makePackage(opts: {
+  name?: string;
+  dependencies?: string[];
+  optionalDependencies?: Record<string, string[]>;
+  dependencyGroups?: Record<string, DependencyGroupEntry[]>;
+  uvDevDependencies?: string[];
+  requiresPython?: string;
+  requiresPythonSource?: string;
+}): PythonPackage {
+  const pkg: PythonPackage = {
+    manifest: {
+      path: 'pyproject.toml',
+      data: {
+        project: {
+          name: opts.name ?? 'test-app',
+          ...(opts.dependencies ? { dependencies: opts.dependencies } : {}),
+          ...(opts.requiresPython
+            ? { 'requires-python': opts.requiresPython }
+            : {}),
+          ...(opts.optionalDependencies
+            ? { 'optional-dependencies': opts.optionalDependencies }
+            : {}),
+        },
+        ...(opts.dependencyGroups
+          ? { 'dependency-groups': opts.dependencyGroups }
+          : {}),
+        ...(opts.uvDevDependencies
+          ? { tool: { uv: { 'dev-dependencies': opts.uvDevDependencies } } }
+          : {}),
+      },
+    },
+  };
+
+  if (opts.requiresPython) {
+    pkg.requiresPython = [
+      {
+        request: [],
+        source: opts.requiresPythonSource ?? 'pyproject.toml',
+        prettySource: `"requires-python" key in pyproject.toml`,
+        specifier: opts.requiresPython,
+      },
+    ];
+  }
+
+  return pkg;
+}
+
+describe('generateProjectManifest', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('generates manifest with direct and transitive deps from uv.lock', async () => {
+    const pkg = makePackage({
+      dependencies: ['flask>=2.0', 'requests'],
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      {
+        name: 'flask',
+        version: '3.1.0',
+        dependencies: ['werkzeug', 'jinja2'],
+      },
+      { name: 'requests', version: '2.32.0' },
+      { name: 'werkzeug', version: '3.0.0' },
+      { name: 'jinja2', version: '3.1.4' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifestPath = path.join(tempDir, DIAGNOSTICS_PATH);
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.version).toBe('20260304');
+    expect(manifest.runtime).toBe('python');
+    expect(manifest.runtimeVersion.resolved).toBe('3.12');
+
+    // Direct deps should have resolved versions from lock
+    const directDeps = manifest.dependencies.filter(
+      (d: any) => d.type === 'direct'
+    );
+    expect(directDeps).toEqual([
+      {
+        name: 'flask',
+        type: 'direct',
+        scopes: ['main'],
+        requested: 'flask>=2.0',
+        resolved: '3.1.0',
+      },
+      {
+        name: 'requests',
+        type: 'direct',
+        scopes: ['main'],
+        requested: 'requests',
+        resolved: '2.32.0',
+      },
+    ]);
+
+    // Transitive deps should inherit scope from direct dep
+    const werkzeug = manifest.dependencies.find(
+      (d: any) => d.name === 'werkzeug'
+    );
+    expect(werkzeug.type).toBe('transitive');
+    expect(werkzeug.scopes).toEqual(['main']);
+
+    const transitiveNames = manifest.dependencies
+      .filter((d: any) => d.type === 'transitive')
+      .map((d: any) => d.name);
+    expect(transitiveNames).toContain('werkzeug');
+    expect(transitiveNames).toContain('jinja2');
+    expect(transitiveNames).not.toContain('flask');
+    expect(transitiveNames).not.toContain('requests');
+  });
+
+  it('generates manifest with no dependencies', async () => {
+    const pkg = makePackage({});
+    const uvLockPath = writeUvLock(tempDir, []);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.dependencies).toEqual([]);
+  });
+
+  it('includes requested python version from constraint', async () => {
+    const pkg = makePackage({
+      requiresPython: '>=3.10',
+      requiresPythonSource: 'pyproject.toml',
+    });
+    const uvLockPath = writeUvLock(tempDir, []);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.runtimeVersion).toEqual({
+      requested: '>=3.10',
+      requestedSource: 'pyproject.toml',
+      resolved: '3.12',
+    });
+  });
+
+  it('omits requested when no python version constraint', async () => {
+    const pkg: PythonPackage = {
+      manifest: {
+        path: 'pyproject.toml',
+        data: { project: { name: 'test-app' } },
+      },
+    };
+    const uvLockPath = writeUvLock(tempDir, []);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.runtimeVersion).toEqual({ resolved: '3.12' });
+  });
+
+  it('excludes project itself from transitive deps', async () => {
+    const pkg = makePackage({
+      name: 'my-app',
+      dependencies: ['flask'],
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'my-app', version: '0.1.0', dependencies: ['flask'] },
+      { name: 'flask', version: '3.1.0', dependencies: ['werkzeug'] },
+      { name: 'werkzeug', version: '3.0.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    const allNames = manifest.dependencies.map((d: any) => d.name);
+    expect(allNames).not.toContain('my-app');
+  });
+
+  it('handles extras and markers in dependencies', async () => {
+    const pkg = makePackage({
+      dependencies: ['uvicorn[standard]>=0.20 ; python_version >= "3.8"'],
+    });
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'uvicorn', version: '0.30.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.dependencies).toEqual([
+      {
+        name: 'uvicorn',
+        type: 'direct',
+        scopes: ['main'],
+        requested: 'uvicorn[standard]>=0.20 ; python_version >= "3.8"',
+        resolved: '0.30.0',
+      },
+    ]);
+  });
+
+  it('collects optional-dependencies with correct scopes', async () => {
+    const pkg = makePackage({
+      dependencies: ['flask'],
+      optionalDependencies: {
+        mypy: ['mypy>=1.0', 'types-requests'],
+        test: ['pytest'],
+      },
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'flask', version: '3.1.0' },
+      { name: 'mypy', version: '1.8.0' },
+      { name: 'types-requests', version: '2.31.0' },
+      { name: 'pytest', version: '8.0.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    const directDeps = manifest.dependencies.filter(
+      (d: any) => d.type === 'direct'
+    );
+    expect(directDeps).toEqual([
+      {
+        name: 'flask',
+        type: 'direct',
+        scopes: ['main'],
+        requested: 'flask',
+        resolved: '3.1.0',
+      },
+      {
+        name: 'mypy',
+        type: 'direct',
+        scopes: ['mypy'],
+        requested: 'mypy>=1.0',
+        resolved: '1.8.0',
+      },
+      {
+        name: 'pytest',
+        type: 'direct',
+        scopes: ['test'],
+        requested: 'pytest',
+        resolved: '8.0.0',
+      },
+      {
+        name: 'types-requests',
+        type: 'direct',
+        scopes: ['mypy'],
+        requested: 'types-requests',
+        resolved: '2.31.0',
+      },
+    ]);
+  });
+
+  it('collects dependency-groups with correct scopes', async () => {
+    const pkg = makePackage({
+      dependencies: ['flask'],
+      dependencyGroups: {
+        dev: ['ruff>=0.1.0', 'black'],
+      },
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'flask', version: '3.1.0' },
+      { name: 'ruff', version: '0.3.0' },
+      { name: 'black', version: '24.1.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    const devDeps = manifest.dependencies.filter((d: any) =>
+      d.scopes.includes('dev')
+    );
+    expect(devDeps).toEqual([
+      {
+        name: 'black',
+        type: 'direct',
+        scopes: ['dev'],
+        requested: 'black',
+        resolved: '24.1.0',
+      },
+      {
+        name: 'ruff',
+        type: 'direct',
+        scopes: ['dev'],
+        requested: 'ruff>=0.1.0',
+        resolved: '0.3.0',
+      },
+    ]);
+  });
+
+  it('collects tool.uv.dev-dependencies with dev scope', async () => {
+    const pkg = makePackage({
+      dependencies: ['flask'],
+      uvDevDependencies: ['ruff>=0.1.0', 'black'],
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'flask', version: '3.1.0' },
+      { name: 'ruff', version: '0.3.0' },
+      { name: 'black', version: '24.1.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    const devDeps = manifest.dependencies.filter((d: any) =>
+      d.scopes.includes('dev')
+    );
+    expect(devDeps).toEqual([
+      {
+        name: 'black',
+        type: 'direct',
+        scopes: ['dev'],
+        requested: 'black',
+        resolved: '24.1.0',
+      },
+      {
+        name: 'ruff',
+        type: 'direct',
+        scopes: ['dev'],
+        requested: 'ruff>=0.1.0',
+        resolved: '0.3.0',
+      },
+    ]);
+  });
+
+  it('resolves include-group references in dependency-groups', async () => {
+    const pkg = makePackage({
+      dependencies: ['flask'],
+      dependencyGroups: {
+        test: ['pytest'],
+        dev: ['ruff', { 'include-group': 'test' }],
+      },
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'flask', version: '3.1.0' },
+      { name: 'pytest', version: '8.0.0' },
+      { name: 'ruff', version: '0.3.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    const pytest = manifest.dependencies.find((d: any) => d.name === 'pytest');
+    // pytest is in "test" directly and included in "dev" via include-group
+    expect(pytest.type).toBe('direct');
+    expect(pytest.scopes).toEqual(['dev', 'test']);
+
+    const ruff = manifest.dependencies.find((d: any) => d.name === 'ruff');
+    expect(ruff.type).toBe('direct');
+    expect(ruff.scopes).toEqual(['dev']);
+  });
+
+  it('handles circular include-group references without looping', async () => {
+    const pkg = makePackage({
+      dependencyGroups: {
+        a: ['requests', { 'include-group': 'b' }],
+        b: ['flask', { 'include-group': 'a' }],
+      },
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'requests', version: '2.32.0' },
+      { name: 'flask', version: '3.1.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    const names = manifest.dependencies.map((d: any) => d.name);
+    expect(names).toContain('requests');
+    expect(names).toContain('flask');
+  });
+
+  it('skips non-existent include-group targets gracefully', async () => {
+    const pkg = makePackage({
+      dependencyGroups: {
+        dev: ['ruff', { 'include-group': 'nonexistent' }],
+      },
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'ruff', version: '0.3.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    expect(manifest.dependencies).toEqual([
+      {
+        name: 'ruff',
+        type: 'direct',
+        scopes: ['dev'],
+        requested: 'ruff',
+        resolved: '0.3.0',
+      },
+    ]);
+  });
+
+  it('includes source info from lock file', async () => {
+    const pkg = makePackage({
+      dependencies: ['flask', 'my-lib'],
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      {
+        name: 'flask',
+        version: '3.1.0',
+        source: '[package.source]\nregistry = "https://pypi.org/simple"',
+      },
+      {
+        name: 'my-lib',
+        version: '0.1.0',
+        source: '[package.source]\ngit = "https://github.com/org/my-lib.git"',
+      },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    const flask = manifest.dependencies.find((d: any) => d.name === 'flask');
+    expect(flask.source).toBe('registry');
+    expect(flask.sourceUrl).toBe('https://pypi.org');
+
+    const myLib = manifest.dependencies.find((d: any) => d.name === 'my-lib');
+    expect(myLib.source).toBe('git');
+    expect(myLib.sourceUrl).toBe('https://github.com/org/my-lib.git');
+  });
+
+  it('skips virtual source packages', async () => {
+    const pkg = makePackage({
+      name: 'my-app',
+      dependencies: ['flask'],
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      {
+        name: 'my-app',
+        version: '0.1.0',
+        source: '[package.source]\nvirtual = "."',
+      },
+      { name: 'flask', version: '3.1.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    const allNames = manifest.dependencies.map((d: any) => d.name);
+    expect(allNames).not.toContain('my-app');
+    expect(allNames).toContain('flask');
+  });
+
+  it('transitive deps inherit scopes from their dependents', async () => {
+    const pkg = makePackage({
+      dependencies: ['flask'],
+      dependencyGroups: {
+        dev: ['pytest'],
+      },
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      {
+        name: 'flask',
+        version: '3.1.0',
+        dependencies: ['werkzeug', 'jinja2'],
+      },
+      {
+        name: 'pytest',
+        version: '8.0.0',
+        dependencies: ['pluggy'],
+      },
+      { name: 'werkzeug', version: '3.0.0' },
+      { name: 'jinja2', version: '3.1.4', dependencies: ['markupsafe'] },
+      { name: 'markupsafe', version: '2.1.5' },
+      { name: 'pluggy', version: '1.4.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    const werkzeug = manifest.dependencies.find(
+      (d: any) => d.name === 'werkzeug'
+    );
+    expect(werkzeug.type).toBe('transitive');
+    expect(werkzeug.scopes).toEqual(['main']);
+
+    // markupsafe is transitively pulled in via flask → jinja2 → markupsafe
+    const markupsafe = manifest.dependencies.find(
+      (d: any) => d.name === 'markupsafe'
+    );
+    expect(markupsafe.type).toBe('transitive');
+    expect(markupsafe.scopes).toEqual(['main']);
+
+    // pluggy is pulled in by pytest (dev scope)
+    const pluggy = manifest.dependencies.find((d: any) => d.name === 'pluggy');
+    expect(pluggy.type).toBe('transitive');
+    expect(pluggy.scopes).toEqual(['dev']);
+  });
+
+  it('transitive deps can have multiple scopes', async () => {
+    const pkg = makePackage({
+      dependencies: ['flask'],
+      dependencyGroups: {
+        dev: ['pytest'],
+      },
+    });
+
+    // Both flask and pytest depend on markupsafe
+    const uvLockPath = writeUvLock(tempDir, [
+      {
+        name: 'flask',
+        version: '3.1.0',
+        dependencies: ['markupsafe'],
+      },
+      {
+        name: 'pytest',
+        version: '8.0.0',
+        dependencies: ['markupsafe'],
+      },
+      { name: 'markupsafe', version: '2.1.5' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    const markupsafe = manifest.dependencies.find(
+      (d: any) => d.name === 'markupsafe'
+    );
+    expect(markupsafe.type).toBe('transitive');
+    expect(markupsafe.scopes).toEqual(['dev', 'main']);
+  });
+
+  it('direct dep in multiple groups gets all scopes', async () => {
+    const pkg = makePackage({
+      dependencies: ['requests'],
+      optionalDependencies: {
+        test: ['requests'],
+      },
+    });
+
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'requests', version: '2.32.0' },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tempDir, DIAGNOSTICS_PATH), 'utf-8')
+    );
+
+    const requests = manifest.dependencies.find(
+      (d: any) => d.name === 'requests'
+    );
+    expect(requests.type).toBe('direct');
+    expect(requests.scopes).toEqual(['main', 'test']);
+  });
+});
+
+describe('diagnostics callback', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('returns manifest file when present', async () => {
+    // Write a manifest as generateProjectManifest would
+    const manifestPath = path.join(tempDir, DIAGNOSTICS_PATH);
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    const content = JSON.stringify({ version: '20260304', test: true });
+    fs.writeFileSync(manifestPath, content);
+
+    const files = await diagnostics({ workPath: tempDir } as any);
+
+    expect(files).toHaveProperty(MANIFEST_FILENAME);
+    const blob = files[MANIFEST_FILENAME] as FileBlob;
+    expect(blob).toBeInstanceOf(FileBlob);
+    expect(JSON.parse(blob.data as string)).toEqual({
+      version: '20260304',
+      test: true,
+    });
+  });
+
+  it('returns empty object when no manifest exists', async () => {
+    const files = await diagnostics({ workPath: tempDir } as any);
+    expect(files).toEqual({});
+  });
+});


### PR DESCRIPTION
Introduce a `diagnostics` export to the Python builder that returns a `package-manifest.json` file containing structured project metadata: runtime, resolved Python version, and a full dependency inventory.

`generateProjectManifest` collects dependencies from all `pyproject.toml` sources (`project.dependencies`, `optional-dependencies`, `dependency-groups`), classifies each as direct or transitive, and resolves versions and source info (registry, git, path, etc.) from the `uv.lock` file.

Transitive dependencies inherit scopes from their direct dependents via BFS through the lock file's dependency graph. A dependency that appears in multiple groups (e.g. both `main` and `dev`) accumulates all scopes.

The manifest is only generated when a `uv.lock` file is available; builds without one (e.g. custom install commands) skip manifest creation.

The `diagnostics` callback is wired into the builder contract so the build system can collect the manifest after the build completes.

Example `package-manifest.json`:

```json
{
  "version": "20260304",
  "runtime": "python",
  "runtimeVersion": {
    "requested": ">=3.10",
    "requestedSource": "pyproject.toml",
    "resolved": "3.12"
  },
  "dependencies": [
    {
      "name": "flask",
      "type": "direct",
      "scopes": ["main"],
      "requested": "flask>=2.0",
      "resolved": "3.1.0",
      "source": "registry",
      "sourceUrl": "https://pypi.org"
    },
    {
      "name": "werkzeug",
      "type": "transitive",
      "scopes": ["main"],
      "resolved": "3.0.0"
    }
  ]
}
```

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new diagnostics feature to generate a project manifest JSON file containing dependency metadata; it only adds new code paths for metadata collection without modifying existing build logic, auth, or database schemas.
> 
> - New `diagnostics.ts` file with `generateProjectManifest` function to produce metadata JSON
> - Exports `parsePep508` and adds `specifier` field to existing types for version tracking
> - Comprehensive test coverage added in `diagnostics.test.ts`
>
> <sup>Risk assessment for [commit 218f4e8](https://github.com/vercel/vercel/commit/218f4e8bd8252ea15d6d8592fc10a9250832b0f1).</sup>
<!-- VADE_RISK_END -->