### PR TITLE
feat(cli): add blob list-stores, empty-store commands and UX improvements

### DIFF
--- a/.changeset/blob-breaking-changes.md
+++ b/.changeset/blob-breaking-changes.md
@@ -1,0 +1,17 @@
+---
+'vercel': major
+---
+
+feat(cli): blob command improvements and breaking changes
+
+**Breaking Changes:**
+- `--access` flag is now required for `put`, `copy`, `get`, and `create-store` (no longer defaults to `public`)
+- `--force` flag removed from `blob put` (use `--allow-overwrite` instead)
+- `blob store add|remove|get` subcommands removed (use `blob create-store`, `blob delete-store`, `blob get-store`)
+
+**New Features:**
+- `blob list-stores` (`ls-stores`): browse blob stores interactively or pipe as a table
+- `blob empty-store`: delete all blobs in a store with confirmation
+- `blob get-store` and `blob list-stores` now show a dashboard link
+- `blob create-store` interactive prompt now shows Private first with doc links
+- `blob delete-store` now shows connected projects in confirmation and auto-pulls `.env.local` after deletion

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -28,6 +28,8 @@ const accessOption = {
   choices: ['public', 'private'],
 } as const;
 
+import { yesOption } from '../../util/arg-common';
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -345,6 +347,15 @@ export const deleteStoreSubcommand = {
   examples: [],
 } as const;
 
+export const emptyStoreSubcommand = {
+  name: 'empty-store',
+  aliases: [],
+  description: 'Delete all blobs in a Blob store',
+  arguments: [],
+  options: [yesOption],
+  examples: [],
+} as const;
+
 export const getStoreInfoSubcommand = {
   name: 'get-store',
   aliases: [],
@@ -355,6 +366,15 @@ export const getStoreInfoSubcommand = {
       required: false,
     },
   ],
+  options: [],
+  examples: [],
+} as const;
+
+export const listStoresSubcommand = {
+  name: 'list-stores',
+  aliases: ['ls-stores'],
+  description: 'List all Blob stores',
+  arguments: [],
   options: [],
   examples: [],
 } as const;
@@ -373,6 +393,8 @@ export const blobCommand = {
     createStoreSubcommand,
     deleteStoreSubcommand,
     getStoreInfoSubcommand,
+    listStoresSubcommand,
+    emptyStoreSubcommand,
   ],
   options: [
     {

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -14,6 +14,8 @@ import {
   createStoreSubcommand,
   deleteStoreSubcommand,
   getStoreInfoSubcommand,
+  listStoresSubcommand,
+  emptyStoreSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
@@ -26,6 +28,8 @@ import copy from './copy';
 import addStore from './store-add';
 import removeStore from './store-remove';
 import getStore from './store-get';
+import listStores from './store-list';
+import emptyStore from './store-empty';
 import { printError } from '../../util/error';
 import { getBlobRWToken } from '../../util/blob/token';
 
@@ -38,6 +42,8 @@ const COMMAND_CONFIG = {
   'create-store': getCommandAliases(createStoreSubcommand),
   'delete-store': getCommandAliases(deleteStoreSubcommand),
   'get-store': getCommandAliases(getStoreInfoSubcommand),
+  'list-stores': getCommandAliases(listStoresSubcommand),
+  'empty-store': getCommandAliases(emptyStoreSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -176,11 +182,6 @@ export default async function main(client: Client) {
 
       telemetry.trackCliSubcommandDeleteStore(subcommandOriginal);
 
-      if (!token.success) {
-        printError(token.error);
-        return 1;
-      }
-
       return removeStore(client, args, token);
     case 'get-store':
       if (needHelp) {
@@ -191,12 +192,32 @@ export default async function main(client: Client) {
 
       telemetry.trackCliSubcommandGetStore(subcommandOriginal);
 
+      return getStore(client, args, token);
+    case 'list-stores':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(listStoresSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandListStores(subcommandOriginal);
+
+      return listStores(client, args);
+    case 'empty-store':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(emptyStoreSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandEmptyStore(subcommandOriginal);
+
       if (!token.success) {
         printError(token.error);
         return 1;
       }
 
-      return getStore(client, args, token);
+      return emptyStore(client, args, token.token, token);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(blobCommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -3,7 +3,7 @@ import output from '../../output-manager';
 import { getLinkedProject } from '../../util/projects/link';
 import { connectResourceToProject } from '../../util/integration-resource/connect-resource-to-project';
 import chalk from 'chalk';
-import { getCommandName } from '../../util/pkg-name';
+import { envPullCommandLogic } from '../env/pull';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { parseArguments } from '../../util/get-args';
 import { addStoreSubcommand } from './command';
@@ -36,7 +36,26 @@ export default async function addStore(
     flags,
   } = parsedArgs;
 
-  const accessFlag = flags['--access'];
+  let accessFlag = flags['--access'];
+  if (!accessFlag && client.stdin.isTTY) {
+    accessFlag = await client.input.select<'public' | 'private'>({
+      message: 'Choose the access type for the blob store',
+      choices: [
+        {
+          name: 'Private',
+          value: 'private',
+          description:
+            'For sensitive documents, user content, and apps with custom auth. https://vercel.com/docs/vercel-blob/private-storage',
+        },
+        {
+          name: 'Public',
+          value: 'public',
+          description:
+            'For images, videos, large media, and public assets. https://vercel.com/docs/vercel-blob/public-storage',
+        },
+      ],
+    });
+  }
   const access = parseAccessFlag(accessFlag);
   if (!access) return 1;
 
@@ -68,22 +87,12 @@ export default async function addStore(
 
     output.spinner('Creating new blob store');
 
-    const requestBody: {
-      name: string;
-      region: string;
-      access: 'public' | 'private';
-    } = {
-      name,
-      region,
-      access,
-    };
-
     const res = await client.fetch<{ store: { id: string; region?: string } }>(
       '/v1/storage/stores/blob',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody),
+        body: JSON.stringify({ name, region, access }),
         accountId: link.status === 'linked' ? link.org.id : undefined,
       }
     );
@@ -99,6 +108,11 @@ export default async function addStore(
 
   const regionInfo = storeRegion ? ` in ${storeRegion}` : '';
   output.success(`Blob store created: ${name} (${storeId})${regionInfo}`);
+  const docsUrl =
+    access === 'public'
+      ? 'https://vercel.com/docs/vercel-blob/public-storage'
+      : 'https://vercel.com/docs/vercel-blob/private-storage';
+  output.log(`Access: ${access}. Learn more: ${output.link(docsUrl, docsUrl)}`);
 
   if (link.status === 'linked') {
     const res = await client.input.confirm(
@@ -125,13 +139,27 @@ export default async function addStore(
         link.project.id,
         storeId,
         environments,
-        { accountId: link.org.id }
+        link.org.id
       );
 
       output.success(
         `Blob store ${chalk.bold(name)} linked to ${chalk.bold(
           link.project.name
-        )}. Make sure to pull the new environment variables using ${getCommandName('env pull')}`
+        )}`
+      );
+
+      client.config.currentTeam =
+        link.org.type === 'team' ? link.org.id : undefined;
+
+      await envPullCommandLogic(
+        client,
+        '.env.local',
+        true,
+        'development',
+        link,
+        undefined,
+        client.cwd,
+        'vercel-cli:blob:store-add'
       );
     }
   }

--- a/packages/cli/src/commands/blob/store-empty.ts
+++ b/packages/cli/src/commands/blob/store-empty.ts
@@ -1,0 +1,130 @@
+import type Client from '../../util/client';
+import { printError } from '../../util/error';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { emptyStoreSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import * as blob from '@vercel/blob';
+import type { BlobRWToken } from '../../util/blob/token';
+import { BlobEmptyStoreTelemetryClient } from '../../util/telemetry/commands/blob/store-empty';
+import { getLinkedProject } from '../../util/projects/link';
+import {
+  formatStoreLabel,
+  formatConnectedProjects,
+} from '../../util/blob/confirm';
+
+export default async function emptyStore(
+  client: Client,
+  argv: string[],
+  rwToken: string,
+  fullToken: BlobRWToken
+): Promise<number> {
+  const telemetryClient = new BlobEmptyStoreTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(
+    emptyStoreSubcommand.options
+  );
+
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const {
+    flags: { '--yes': yes },
+  } = parsedArgs;
+
+  telemetryClient.trackCliFlagYes(yes);
+
+  if (!fullToken.success) {
+    printError(fullToken.error);
+    return 1;
+  }
+
+  const [, , , id] = fullToken.token.split('_');
+  const storeId = `store_${id}`;
+
+  try {
+    const link = await getLinkedProject(client);
+    const accountId = link.status === 'linked' ? link.org.id : undefined;
+
+    const [storeResponse, connectionsResponse, initialList] = await Promise.all(
+      [
+        client.fetch<{ store: { name: string } }>(
+          `/v1/storage/stores/${storeId}`,
+          { method: 'GET', accountId }
+        ),
+        client.fetch<{
+          connections: { project: { name: string } }[];
+        }>(`/v1/storage/stores/${storeId}/connections`, {
+          method: 'GET',
+          accountId,
+        }),
+        blob.list({ token: rwToken, limit: 1 }),
+      ]
+    );
+
+    const { name } = storeResponse.store;
+    const { connections } = connectionsResponse;
+
+    if (initialList.blobs.length === 0) {
+      output.log('Store is already empty');
+      return 0;
+    }
+
+    const label = formatStoreLabel(name, storeId);
+    const projectsInfo = formatConnectedProjects(connections);
+    const message = `Are you sure you want to delete all files in ${label}?${projectsInfo} This action cannot be undone.`;
+
+    if (!yes) {
+      if (!client.stdin.isTTY) {
+        output.error(
+          'Missing --yes flag. This is a destructive operation, use --yes to confirm.'
+        );
+        return 1;
+      }
+
+      const confirmed = await client.input.confirm(message, false);
+      if (!confirmed) {
+        output.log('Canceled');
+        return 0;
+      }
+    }
+
+    let totalDeleted = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+      output.spinner(`Deleting blobs... (${totalDeleted} deleted)`);
+
+      const listResult = await blob.list({
+        token: rwToken,
+        limit: 1000,
+      });
+
+      if (listResult.blobs.length === 0) {
+        hasMore = false;
+        break;
+      }
+
+      const urls = listResult.blobs.map(b => b.url);
+      await blob.del(urls, { token: rwToken });
+      totalDeleted += urls.length;
+    }
+
+    output.stopSpinner();
+    output.success(`All blobs deleted (${totalDeleted} total)`);
+
+    return 0;
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/blob/store-list.ts
+++ b/packages/cli/src/commands/blob/store-list.ts
@@ -1,0 +1,165 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { printError } from '../../util/error';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import getScope from '../../util/get-scope';
+import { getLinkFromDir, getVercelDirectory } from '../../util/projects/link';
+import getProjectByIdOrName from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
+import { listStoresSubcommand } from './command';
+import { BlobListStoresTelemetryClient } from '../../util/telemetry/commands/blob/store-list';
+import {
+  formatStoreDetails,
+  type StoreDetails,
+} from '../../util/blob/format-store';
+import table from '../../util/output/table';
+
+interface StoreListItem {
+  id: string;
+  name: string;
+  projectsMetadata?: {
+    projectId: string;
+    name: string;
+    environments: string[];
+  }[];
+}
+
+export default async function listStores(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  new BlobListStoresTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(
+    listStoresSubcommand.options
+  );
+
+  try {
+    parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  try {
+    // Resolve team and optional project context without interactive prompts.
+    // Read the local project link file directly (non-interactive) instead of
+    // getLinkedProject which can prompt for project selection in monorepos.
+    let accountId: string;
+    let teamSlug: string | undefined;
+    let linkedProject: { id: string; name: string } | undefined;
+
+    const dirLink = await getLinkFromDir(getVercelDirectory(client.cwd));
+    if (dirLink) {
+      accountId = dirLink.orgId;
+      const project = await getProjectByIdOrName(
+        client,
+        dirLink.projectId,
+        dirLink.orgId
+      );
+      if (project && !(project instanceof ProjectNotFound)) {
+        linkedProject = { id: project.id, name: project.name };
+      }
+    } else {
+      const { team } = await getScope(client);
+      if (!team) {
+        output.error('Team not found.');
+        return 1;
+      }
+      accountId = team.id;
+      teamSlug = team.slug;
+    }
+
+    output.spinner('Fetching blob stores');
+
+    const response = await client.fetch<{ stores: StoreListItem[] }>(
+      '/v1/storage/stores',
+      {
+        method: 'GET',
+        accountId,
+      }
+    );
+
+    output.stopSpinner();
+
+    let stores = response.stores;
+
+    // Filter by linked project if applicable
+    if (linkedProject) {
+      const projectId = linkedProject.id;
+      stores = stores.filter(store =>
+        store.projectsMetadata?.some(
+          metadata => metadata.projectId === projectId
+        )
+      );
+    }
+
+    if (stores.length === 0) {
+      output.log('No blob stores found');
+      return 0;
+    }
+
+    const header = linkedProject
+      ? `Blob stores for project ${chalk.bold(linkedProject.name)}:`
+      : `Blob stores:`;
+    output.log(header);
+
+    // Non-TTY (piped output or non-interactive input): print table and exit
+    if (!client.stdin.isTTY || !client.stdout.isTTY) {
+      output.print(
+        table(
+          [
+            ['Name', 'Store ID'].map(h => chalk.dim(h)),
+            ...stores.map(store => [store.name, store.id]),
+          ],
+          { hsep: 4 }
+        ) + '\n'
+      );
+      return 0;
+    }
+
+    // TTY: interactive select then show details
+
+    const choices = [
+      ...stores.map(store => ({
+        name: `${store.name} (${chalk.dim(store.id)})`,
+        value: store.id,
+      })),
+      { name: 'Cancel', value: '' },
+    ];
+
+    const selected = await client.input.select<string>({
+      message: 'Select a store to view details',
+      choices,
+      pageSize: 15,
+    });
+
+    if (!selected) {
+      return 0;
+    }
+
+    output.spinner('Fetching store details');
+
+    const storeResponse = await client.fetch<{ store: StoreDetails }>(
+      `/v1/storage/stores/${selected}`,
+      {
+        method: 'GET',
+        accountId,
+      }
+    );
+
+    output.stopSpinner();
+    output.print('\n' + formatStoreDetails(storeResponse.store, teamSlug));
+
+    return 0;
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/util/blob/confirm.ts
+++ b/packages/cli/src/util/blob/confirm.ts
@@ -1,0 +1,24 @@
+export function formatStoreLabel(name: string, id: string): string {
+  return `${name} (${id})`;
+}
+
+export function formatConnectedProjects(
+  connections: { project: { name: string } }[]
+): string {
+  if (connections.length === 0) {
+    return '';
+  }
+
+  const MAX_SHOWN = 2;
+  const shown = connections
+    .slice(0, MAX_SHOWN)
+    .map(c => c.project.name)
+    .join(', ');
+  const remaining = connections.length - MAX_SHOWN;
+
+  if (remaining > 0) {
+    return ` This store is connected to ${shown} and ${remaining} other project${remaining > 1 ? 's' : ''}.`;
+  }
+
+  return ` This store is connected to ${shown}.`;
+}

--- a/packages/cli/src/util/blob/format-store.ts
+++ b/packages/cli/src/util/blob/format-store.ts
@@ -1,0 +1,65 @@
+import bytes from 'bytes';
+import chalk from 'chalk';
+import { format } from 'date-fns';
+import output from '../../output-manager';
+
+export interface StoreDetails {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  billingState: string;
+  size: number;
+  count?: number;
+  region?: string;
+  access?: string;
+}
+
+export function formatStoreDetails(
+  store: StoreDetails,
+  teamSlug?: string
+): string {
+  const dateTimeFormat = 'MM/DD/YYYY HH:mm:ss.SS';
+  const isPublic = store.access !== 'private';
+  const storeIdSuffix = store.id.replace('store_', '').toLowerCase();
+  const accessDomain = isPublic ? 'public' : 'private';
+  const billingState =
+    store.billingState === 'active'
+      ? chalk.green('Active')
+      : chalk.red('Inactive');
+
+  const lines: string[] = [
+    `Blob Store: ${chalk.bold(store.name)} (${chalk.dim(store.id)})`,
+    `Billing State: ${billingState}`,
+  ];
+
+  if (store.count !== undefined) {
+    lines.push(`Blob Count: ${store.count.toLocaleString()}`);
+  }
+
+  lines.push(`Size: ${bytes(store.size)}`);
+
+  if (store.region) {
+    lines.push(`Region: ${store.region}`);
+  }
+
+  lines.push(`Access: ${isPublic ? 'Public' : 'Private'}`);
+  lines.push(
+    `Base URL: ${storeIdSuffix}.${accessDomain}.blob.vercel-storage.com`
+  );
+
+  if (teamSlug) {
+    const dashboardUrl = `https://vercel.com/${teamSlug}/~/stores/blob/${store.id}`;
+    const link = output.link(dashboardUrl, dashboardUrl);
+    lines.push(`Dashboard: ${link || dashboardUrl}`);
+  }
+
+  lines.push(
+    `Created At: ${format(new Date(store.createdAt), dateTimeFormat)}`
+  );
+  lines.push(
+    `Updated At: ${format(new Date(store.updatedAt), dateTimeFormat)}`
+  );
+
+  return lines.join('\n') + '\n';
+}

--- a/packages/cli/src/util/env/get-env-records.ts
+++ b/packages/cli/src/util/env/get-env-records.ts
@@ -14,7 +14,9 @@ export type EnvRecordsSource =
   | 'vercel-cli:dev'
   | 'vercel-cli:pull'
   | 'vercel-cli:link'
-  | 'vercel-cli:integration:add';
+  | 'vercel-cli:integration:add'
+  | 'vercel-cli:blob:store-add'
+  | 'vercel-cli:blob:store-remove';
 
 export default async function getEnvRecords(
   client: Client,

--- a/packages/cli/src/util/telemetry/commands/blob/index.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/index.ts
@@ -62,6 +62,20 @@ export class BlobTelemetryClient
     });
   }
 
+  trackCliSubcommandEmptyStore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'empty-store',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandListStores(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list-stores',
+      value: actual,
+    });
+  }
+
   trackCliOptionRwToken() {
     this.trackCliOption({
       option: '--rw-token',

--- a/packages/cli/src/util/telemetry/commands/blob/store-empty.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-empty.ts
@@ -1,0 +1,14 @@
+import { TelemetryClient } from '../..';
+import type { emptyStoreSubcommand } from '../../../../commands/blob/command';
+import type { TelemetryMethods } from '../../types';
+
+export class BlobEmptyStoreTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof emptyStoreSubcommand>
+{
+  trackCliFlagYes(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/blob/store-list.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-list.ts
@@ -1,0 +1,7 @@
+import { TelemetryClient } from '../..';
+import type { listStoresSubcommand } from '../../../../commands/blob/command';
+import type { TelemetryMethods } from '../../types';
+
+export class BlobListStoresTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof listStoresSubcommand> {}

--- a/packages/cli/test/unit/commands/blob/store-add.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-add.test.ts
@@ -3,6 +3,7 @@ import { client } from '../../../mocks/client';
 import addStore from '../../../../src/commands/blob/store-add';
 import * as linkModule from '../../../../src/util/projects/link';
 import * as connectResourceModule from '../../../../src/util/integration-resource/connect-resource-to-project';
+import * as envPullModule from '../../../../src/commands/env/pull';
 import output from '../../../../src/output-manager';
 
 // Mock the external dependencies
@@ -11,11 +12,13 @@ vi.mock(
   '../../../../src/util/integration-resource/connect-resource-to-project'
 );
 vi.mock('../../../../src/output-manager');
+vi.mock('../../../../src/commands/env/pull');
 
 const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
 const mockedConnectResourceToProject = vi.mocked(
   connectResourceModule.connectResourceToProject
 );
+const mockedEnvPullCommandLogic = vi.mocked(envPullModule.envPullCommandLogic);
 const mockedOutput = vi.mocked(output);
 
 describe('blob store add', () => {
@@ -28,6 +31,9 @@ describe('blob store add', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     client.reset();
+
+    // Mock output.link to return the URL text
+    mockedOutput.link.mockImplementation((text: string) => text);
 
     // Default successful mocks
     client.fetch = vi.fn().mockResolvedValue({
@@ -52,13 +58,25 @@ describe('blob store add', () => {
     });
 
     mockedConnectResourceToProject.mockResolvedValue(undefined);
+    mockedEnvPullCommandLogic.mockResolvedValue(undefined);
   });
 
   describe('successful store creation', () => {
     it('should create store with provided name and track telemetry', async () => {
-      client.setArgv('blob', 'store', 'add', 'my-test-store');
+      client.setArgv(
+        'blob',
+        'store',
+        'add',
+        '--access',
+        'public',
+        'my-test-store'
+      );
 
-      const exitCode = await addStore(client, ['my-test-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'my-test-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
@@ -81,13 +99,65 @@ describe('blob store add', () => {
       expect(mockedOutput.success).toHaveBeenCalledWith(
         'Blob store created: my-test-store (store_test123)'
       );
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('Access: public. Learn more:')
+      );
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'https://vercel.com/docs/vercel-blob/public-storage'
+        )
+      );
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'argument:name',
           value: '[REDACTED]',
         },
+        {
+          key: 'option:access',
+          value: 'public',
+        },
       ]);
+    });
+
+    it('should show private access docs link for private stores', async () => {
+      client.setArgv(
+        'blob',
+        'store',
+        'add',
+        '--access',
+        'private',
+        'my-private-store'
+      );
+
+      const exitCode = await addStore(client, [
+        '--access',
+        'private',
+        'my-private-store',
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'my-private-store',
+          region: 'iad1',
+          access: 'private',
+        }),
+        accountId: 'org_123',
+      });
+      expect(mockedOutput.success).toHaveBeenCalledWith(
+        'Blob store created: my-private-store (store_test123)'
+      );
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('Access: private. Learn more:')
+      );
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'https://vercel.com/docs/vercel-blob/private-storage'
+        )
+      );
     });
 
     it('should create store with specified region and track telemetry', async () => {
@@ -95,6 +165,8 @@ describe('blob store add', () => {
         'blob',
         'store',
         'add',
+        '--access',
+        'public',
         'my-test-store',
         '--region',
         'sfo1'
@@ -104,6 +176,8 @@ describe('blob store add', () => {
       });
 
       const exitCode = await addStore(client, [
+        '--access',
+        'public',
         'my-test-store',
         '--region',
         'sfo1',
@@ -130,6 +204,10 @@ describe('blob store add', () => {
           value: '[REDACTED]',
         },
         {
+          key: 'option:access',
+          value: 'public',
+        },
+        {
           key: 'option:region',
           value: '[REDACTED]',
         },
@@ -137,9 +215,20 @@ describe('blob store add', () => {
     });
 
     it('should use default region when no region is specified', async () => {
-      client.setArgv('blob', 'store', 'add', 'default-region-store');
+      client.setArgv(
+        'blob',
+        'store',
+        'add',
+        '--access',
+        'public',
+        'default-region-store'
+      );
 
-      const exitCode = await addStore(client, ['default-region-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'default-region-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
@@ -158,16 +247,31 @@ describe('blob store add', () => {
           key: 'argument:name',
           value: '[REDACTED]',
         },
+        {
+          key: 'option:access',
+          value: 'public',
+        },
       ]);
     });
 
     it('should display region in success message when API returns region', async () => {
-      client.setArgv('blob', 'store', 'add', 'region-display-store');
+      client.setArgv(
+        'blob',
+        'store',
+        'add',
+        '--access',
+        'public',
+        'region-display-store'
+      );
       client.fetch = vi.fn().mockResolvedValue({
         store: { id: 'store_test123', region: 'iad1' },
       });
 
-      const exitCode = await addStore(client, ['region-display-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'region-display-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(mockedOutput.success).toHaveBeenCalledWith(
@@ -176,9 +280,9 @@ describe('blob store add', () => {
     });
 
     it('should prompt for name when not provided', async () => {
-      client.setArgv('blob', 'store', 'add');
+      client.setArgv('blob', 'store', 'add', '--access', 'public');
 
-      const exitCode = await addStore(client, []);
+      const exitCode = await addStore(client, ['--access', 'public']);
 
       expect(exitCode).toBe(0);
       expect(client.input.text).toHaveBeenCalledWith({
@@ -200,7 +304,11 @@ describe('blob store add', () => {
 
   describe('project linking', () => {
     it('should link store to project when confirmed', async () => {
-      const exitCode = await addStore(client, ['test-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'test-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(client.input.confirm).toHaveBeenCalledWith(
@@ -220,20 +328,36 @@ describe('blob store add', () => {
         'proj_123',
         'store_test123',
         ['production', 'preview', 'development'],
-        { accountId: 'org_123' }
+        'org_123'
       );
       expect(mockedOutput.success).toHaveBeenCalledWith(
         'Blob store created: test-store (store_test123)'
       );
       expect(mockedOutput.success).toHaveBeenCalledWith(
-        'Blob store test-store linked to my-project. Make sure to pull the new environment variables using `vercel env pull`'
+        'Blob store test-store linked to my-project'
+      );
+
+      // Should auto-pull env vars after linking
+      expect(mockedEnvPullCommandLogic).toHaveBeenCalledWith(
+        client,
+        '.env.local',
+        true,
+        'development',
+        expect.objectContaining({ status: 'linked' }),
+        undefined,
+        client.cwd,
+        'vercel-cli:blob:store-add'
       );
     });
 
     it('should not link store when user declines', async () => {
       client.input.confirm = vi.fn().mockResolvedValue(false);
 
-      const exitCode = await addStore(client, ['test-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'test-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(client.input.confirm).toHaveBeenCalledWith(
@@ -242,12 +366,17 @@ describe('blob store add', () => {
       );
       expect(client.input.checkbox).not.toHaveBeenCalled();
       expect(mockedConnectResourceToProject).not.toHaveBeenCalled();
+      expect(mockedEnvPullCommandLogic).not.toHaveBeenCalled();
     });
 
     it('should handle linking with selected environments', async () => {
       client.input.checkbox = vi.fn().mockResolvedValue(['production']);
 
-      const exitCode = await addStore(client, ['prod-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'prod-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(mockedConnectResourceToProject).toHaveBeenCalledWith(
@@ -255,7 +384,7 @@ describe('blob store add', () => {
         'proj_123',
         'store_test123',
         ['production'],
-        { accountId: 'org_123' }
+        'org_123'
       );
     });
 
@@ -266,7 +395,11 @@ describe('blob store add', () => {
         status: 'not_linked',
       });
 
-      const exitCode = await addStore(client, ['standalone-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'standalone-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
@@ -281,6 +414,7 @@ describe('blob store add', () => {
       });
       expect(client.input.confirm).not.toHaveBeenCalled();
       expect(mockedConnectResourceToProject).not.toHaveBeenCalled();
+      expect(mockedEnvPullCommandLogic).not.toHaveBeenCalled();
     });
   });
 
@@ -297,11 +431,61 @@ describe('blob store add', () => {
       expect(exitCode).toBe(1);
     });
 
+    it('should return 1 when --access flag is missing in non-TTY', async () => {
+      (client.stdin as any).isTTY = false;
+      const exitCode = await addStore(client, ['test-store']);
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.error).toHaveBeenCalledWith(
+        "Missing required --access flag. Must be 'public' or 'private'."
+      );
+    });
+
+    it('should prompt for access type when --access flag is missing in TTY', async () => {
+      const selectMock = vi.fn().mockResolvedValue('private');
+      client.input.select = selectMock;
+
+      const exitCode = await addStore(client, ['test-store']);
+
+      expect(exitCode).toBe(0);
+      expect(selectMock).toHaveBeenCalledWith({
+        message: 'Choose the access type for the blob store',
+        choices: [
+          {
+            name: 'Private',
+            value: 'private',
+            description:
+              'For sensitive documents, user content, and apps with custom auth. https://vercel.com/docs/vercel-blob/private-storage',
+          },
+          {
+            name: 'Public',
+            value: 'public',
+            description:
+              'For images, videos, large media, and public assets. https://vercel.com/docs/vercel-blob/public-storage',
+          },
+        ],
+      });
+      expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'test-store',
+          region: 'iad1',
+          access: 'private',
+        }),
+        accountId: 'org_123',
+      });
+    });
+
     it('should return 1 when store creation fails', async () => {
       const apiError = new Error('Store creation failed');
       client.fetch = vi.fn().mockRejectedValue(apiError);
 
-      const exitCode = await addStore(client, ['test-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'test-store',
+      ]);
 
       expect(exitCode).toBe(1);
       expect(mockedOutput.spinner).toHaveBeenCalledWith(
@@ -314,7 +498,11 @@ describe('blob store add', () => {
       const apiError = new Error('Network error');
       client.fetch = vi.fn().mockRejectedValue(apiError);
 
-      const exitCode = await addStore(client, ['failing-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'failing-store',
+      ]);
 
       expect(exitCode).toBe(1);
       expect(mockedOutput.success).not.toHaveBeenCalled();
@@ -325,9 +513,9 @@ describe('blob store add', () => {
       mockedConnectResourceToProject.mockRejectedValue(linkError);
 
       // This should still succeed even if linking fails
-      await expect(addStore(client, ['test-store'])).rejects.toThrow(
-        'Linking failed'
-      );
+      await expect(
+        addStore(client, ['--access', 'public', 'test-store'])
+      ).rejects.toThrow('Linking failed');
 
       // Store should still be created successfully
       expect(client.fetch).toHaveBeenCalled();
@@ -339,7 +527,11 @@ describe('blob store add', () => {
 
   describe('telemetry tracking', () => {
     it('should track name argument when provided', async () => {
-      const exitCode = await addStore(client, ['telemetry-test-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'telemetry-test-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -347,17 +539,25 @@ describe('blob store add', () => {
           key: 'argument:name',
           value: '[REDACTED]',
         },
+        {
+          key: 'option:access',
+          value: 'public',
+        },
       ]);
     });
 
     it('should track name argument even when prompted', async () => {
-      const exitCode = await addStore(client, []);
+      const exitCode = await addStore(client, ['--access', 'public']);
 
       expect(exitCode).toBe(0);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'argument:name',
           value: '[REDACTED]',
+        },
+        {
+          key: 'option:access',
+          value: 'public',
         },
       ]);
     });
@@ -366,16 +566,25 @@ describe('blob store add', () => {
       // Mock input to return undefined/empty
       client.input.text = vi.fn().mockResolvedValue('');
 
-      const exitCode = await addStore(client, []);
+      const exitCode = await addStore(client, ['--access', 'public']);
 
       expect(exitCode).toBe(0);
-      expect(client.telemetryEventStore).toHaveTelemetryEvents([]);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:access',
+          value: 'public',
+        },
+      ]);
     });
   });
 
   describe('API call behavior', () => {
     it('should include accountId when project is linked', async () => {
-      const exitCode = await addStore(client, ['linked-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'linked-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
@@ -397,7 +606,11 @@ describe('blob store add', () => {
         status: 'not_linked',
       });
 
-      const exitCode = await addStore(client, ['unlinked-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'unlinked-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
@@ -417,7 +630,11 @@ describe('blob store add', () => {
         store: { id: 'store_custom_id_456' },
       });
 
-      const exitCode = await addStore(client, ['custom-store']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'custom-store',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(mockedOutput.success).toHaveBeenCalledWith(
@@ -428,8 +645,8 @@ describe('blob store add', () => {
 
   describe('interactive prompt validation', () => {
     it('should validate store name length correctly', async () => {
-      client.setArgv('blob', 'store', 'add');
-      await addStore(client, []);
+      client.setArgv('blob', 'store', 'add', '--access', 'public');
+      await addStore(client, ['--access', 'public']);
 
       const textCall = textInputMock.mock.calls[0][0];
       const validateFn = textCall.validate;
@@ -461,7 +678,11 @@ describe('blob store add', () => {
         org: { id: 'org_456', slug: 'different-org', type: 'user' },
       });
 
-      const exitCode = await addStore(client, ['confirmation-test']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'confirmation-test',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(client.input.confirm).toHaveBeenCalledWith(
@@ -473,7 +694,11 @@ describe('blob store add', () => {
 
   describe('spinner and output behavior', () => {
     it('should show spinner during store creation and stop on success', async () => {
-      const exitCode = await addStore(client, ['spinner-test']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'spinner-test',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(mockedOutput.spinner).toHaveBeenCalledWith(
@@ -486,7 +711,11 @@ describe('blob store add', () => {
     });
 
     it('should show linking spinner when connecting to project', async () => {
-      const exitCode = await addStore(client, ['link-spinner-test']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'link-spinner-test',
+      ]);
 
       expect(exitCode).toBe(0);
       expect(mockedOutput.spinner).toHaveBeenCalledWith(
@@ -498,7 +727,11 @@ describe('blob store add', () => {
       const apiError = new Error('Creation failed');
       client.fetch = vi.fn().mockRejectedValue(apiError);
 
-      const exitCode = await addStore(client, ['error-test']);
+      const exitCode = await addStore(client, [
+        '--access',
+        'public',
+        'error-test',
+      ]);
 
       expect(exitCode).toBe(1);
       expect(mockedOutput.spinner).toHaveBeenCalledWith(

--- a/packages/cli/test/unit/commands/blob/store-empty.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-empty.test.ts
@@ -1,0 +1,417 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import emptyStore from '../../../../src/commands/blob/store-empty';
+import * as blobModule from '@vercel/blob';
+import * as linkModule from '../../../../src/util/projects/link';
+import output from '../../../../src/output-manager';
+import type { BlobRWToken } from '../../../../src/util/blob/token';
+
+vi.mock('@vercel/blob');
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/output-manager');
+
+const mockedBlob = vi.mocked(blobModule);
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedOutput = vi.mocked(output);
+
+describe('blob empty-store', () => {
+  const testToken = 'vercel_blob_rw_abc123_additional_data';
+  const fullToken: BlobRWToken = { success: true, token: testToken };
+  const storeId = 'store_abc123';
+
+  const confirmInputMock = vi.fn().mockResolvedValue(true);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+
+    client.input.confirm = confirmInputMock;
+    (client.stdin as any).isTTY = true;
+
+    mockedGetLinkedProject.mockResolvedValue({
+      status: 'linked',
+      project: {
+        id: 'proj_123',
+        name: 'my-project',
+        accountId: 'org_123',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+      },
+      org: { id: 'org_123', slug: 'my-org', type: 'user' },
+    });
+
+    // Default: store info, no connections
+    client.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        store: { name: 'my-store' },
+      })
+      .mockResolvedValueOnce({
+        connections: [],
+      });
+
+    // Default: initial list check returns blobs (not empty),
+    // then deletion loop: one page of blobs, then empty
+    mockedBlob.list
+      .mockResolvedValueOnce({
+        blobs: [{ url: 'https://example.com/a.txt' }],
+        cursor: '',
+        hasMore: false,
+      } as any)
+      .mockResolvedValueOnce({
+        blobs: [
+          { url: 'https://example.com/a.txt' },
+          { url: 'https://example.com/b.txt' },
+        ],
+        cursor: '',
+        hasMore: false,
+      } as any)
+      .mockResolvedValueOnce({
+        blobs: [],
+        cursor: '',
+        hasMore: false,
+      } as any);
+
+    mockedBlob.del.mockResolvedValue(undefined as any);
+  });
+
+  describe('successful empty', () => {
+    it('should confirm and empty store (single page)', async () => {
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+
+      // Should fetch store info and connections with accountId
+      expect(client.fetch).toHaveBeenCalledWith(
+        `/v1/storage/stores/${storeId}`,
+        { method: 'GET', accountId: 'org_123' }
+      );
+      expect(client.fetch).toHaveBeenCalledWith(
+        `/v1/storage/stores/${storeId}/connections`,
+        { method: 'GET', accountId: 'org_123' }
+      );
+
+      // Initial emptiness check via blob.list with limit 1
+      expect(mockedBlob.list).toHaveBeenNthCalledWith(1, {
+        token: testToken,
+        limit: 1,
+      });
+
+      // Should show confirmation prompt
+      expect(confirmInputMock).toHaveBeenCalledWith(
+        `Are you sure you want to delete all files in my-store (${storeId})? This action cannot be undone.`,
+        false
+      );
+
+      // Deletion loop lists with limit 1000
+      expect(mockedBlob.list).toHaveBeenNthCalledWith(2, {
+        token: testToken,
+        limit: 1000,
+      });
+      expect(mockedBlob.del).toHaveBeenCalledWith(
+        ['https://example.com/a.txt', 'https://example.com/b.txt'],
+        { token: testToken }
+      );
+
+      expect(mockedOutput.stopSpinner).toHaveBeenCalled();
+      expect(mockedOutput.success).toHaveBeenCalledWith(
+        'All blobs deleted (2 total)'
+      );
+    });
+
+    it('should confirm and empty store (multiple pages with pagination)', async () => {
+      mockedBlob.list.mockReset();
+      mockedBlob.list
+        // Initial emptiness check
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/1.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        // Deletion loop page 1
+        .mockResolvedValueOnce({
+          blobs: [
+            { url: 'https://example.com/1.txt' },
+            { url: 'https://example.com/2.txt' },
+          ],
+          cursor: 'cursor1',
+          hasMore: true,
+        } as any)
+        // Deletion loop page 2
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/3.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        // Deletion loop: no more blobs
+        .mockResolvedValueOnce({
+          blobs: [],
+          cursor: '',
+          hasMore: false,
+        } as any);
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+      // 1 initial check + 3 deletion loop calls
+      expect(mockedBlob.list).toHaveBeenCalledTimes(4);
+      expect(mockedBlob.del).toHaveBeenCalledTimes(2);
+      expect(mockedOutput.success).toHaveBeenCalledWith(
+        'All blobs deleted (3 total)'
+      );
+    });
+
+    it('should skip confirmation with --yes', async () => {
+      const exitCode = await emptyStore(
+        client,
+        ['--yes'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(confirmInputMock).not.toHaveBeenCalled();
+      expect(mockedBlob.del).toHaveBeenCalled();
+    });
+
+    it('should show connected projects in confirmation message', async () => {
+      client.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          store: { name: 'my-store' },
+        })
+        .mockResolvedValueOnce({
+          connections: [
+            { project: { name: 'project1' } },
+            { project: { name: 'project2' } },
+          ],
+        });
+
+      await emptyStore(client, [], testToken, fullToken);
+
+      expect(confirmInputMock).toHaveBeenCalledWith(
+        `Are you sure you want to delete all files in my-store (${storeId})? This store is connected to project1, project2. This action cannot be undone.`,
+        false
+      );
+    });
+
+    it('should show remaining project count when more than 2 connections', async () => {
+      client.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          store: { name: 'my-store' },
+        })
+        .mockResolvedValueOnce({
+          connections: [
+            { project: { name: 'project1' } },
+            { project: { name: 'project2' } },
+            { project: { name: 'project3' } },
+            { project: { name: 'project4' } },
+            { project: { name: 'project5' } },
+          ],
+        });
+
+      await emptyStore(client, [], testToken, fullToken);
+
+      expect(confirmInputMock).toHaveBeenCalledWith(
+        `Are you sure you want to delete all files in my-store (${storeId})? This store is connected to project1, project2 and 3 other projects. This action cannot be undone.`,
+        false
+      );
+    });
+
+    it('should work without accountId when project is not linked', async () => {
+      mockedGetLinkedProject.mockResolvedValue({
+        org: null,
+        project: null,
+        status: 'not_linked',
+      });
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+      expect(client.fetch).toHaveBeenCalledWith(
+        `/v1/storage/stores/${storeId}`,
+        { method: 'GET', accountId: undefined }
+      );
+    });
+  });
+
+  describe('empty store handling', () => {
+    it('should handle empty store gracefully', async () => {
+      mockedBlob.list.mockReset();
+      // Initial emptiness check returns no blobs
+      mockedBlob.list.mockResolvedValueOnce({
+        blobs: [],
+        cursor: '',
+        hasMore: false,
+      } as any);
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+      expect(confirmInputMock).not.toHaveBeenCalled();
+      // Only the initial check, no deletion loop
+      expect(mockedBlob.list).toHaveBeenCalledTimes(1);
+      expect(mockedBlob.list).toHaveBeenCalledWith({
+        token: testToken,
+        limit: 1,
+      });
+      expect(mockedBlob.del).not.toHaveBeenCalled();
+      expect(mockedOutput.log).toHaveBeenCalledWith('Store is already empty');
+    });
+  });
+
+  describe('cancellation', () => {
+    it('should cancel when user declines', async () => {
+      confirmInputMock.mockResolvedValueOnce(false);
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+      // Initial check happened but no deletion
+      expect(mockedBlob.list).toHaveBeenCalledTimes(1);
+      expect(mockedBlob.del).not.toHaveBeenCalled();
+      expect(mockedOutput.log).toHaveBeenCalledWith('Canceled');
+    });
+  });
+
+  describe('non-TTY behavior', () => {
+    it('should error in non-TTY without --yes', async () => {
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.error).toHaveBeenCalledWith(
+        'Missing --yes flag. This is a destructive operation, use --yes to confirm.'
+      );
+      // Initial check happened but no deletion
+      expect(mockedBlob.list).toHaveBeenCalledTimes(1);
+      expect(mockedBlob.del).not.toHaveBeenCalled();
+    });
+
+    it('should work in non-TTY with --yes', async () => {
+      (client.stdin as any).isTTY = false;
+
+      // Reset blob mocks for this test since beforeEach mocks may be consumed
+      mockedBlob.list.mockReset();
+      mockedBlob.list
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/a.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/a.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        .mockResolvedValueOnce({
+          blobs: [],
+          cursor: '',
+          hasMore: false,
+        } as any);
+
+      // Also reset fetch mocks
+      client.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({ store: { name: 'my-store' } })
+        .mockResolvedValueOnce({ connections: [] });
+
+      const exitCode = await emptyStore(
+        client,
+        ['--yes'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.del).toHaveBeenCalled();
+    });
+  });
+
+  describe('error cases', () => {
+    it('should return 1 when argument parsing fails', async () => {
+      const exitCode = await emptyStore(
+        client,
+        ['--invalid-flag'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should return 1 when token is not available', async () => {
+      const failedToken: BlobRWToken = {
+        success: false,
+        error: 'No token',
+      };
+
+      const exitCode = await emptyStore(client, [], testToken, failedToken);
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should handle API errors during store fetch', async () => {
+      client.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should handle API errors during blob list', async () => {
+      mockedBlob.list.mockReset();
+      mockedBlob.list.mockRejectedValue(new Error('List failed'));
+
+      const exitCode = await emptyStore(
+        client,
+        ['--yes'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should handle API errors during blob delete', async () => {
+      mockedBlob.list.mockReset();
+      // Initial check returns blobs
+      mockedBlob.list.mockResolvedValueOnce({
+        blobs: [{ url: 'https://example.com/a.txt' }],
+        cursor: '',
+        hasMore: false,
+      } as any);
+      // Deletion loop returns blobs
+      mockedBlob.list.mockResolvedValueOnce({
+        blobs: [{ url: 'https://example.com/a.txt' }],
+        cursor: '',
+        hasMore: false,
+      } as any);
+      mockedBlob.del.mockRejectedValue(new Error('Delete failed'));
+
+      const exitCode = await emptyStore(
+        client,
+        ['--yes'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  describe('telemetry', () => {
+    it('should track --yes flag', async () => {
+      await emptyStore(client, ['--yes'], testToken, fullToken);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:yes',
+          value: 'TRUE',
+        },
+      ]);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/blob/store-get.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-get.test.ts
@@ -36,6 +36,7 @@ describe('blob store get', () => {
         updatedAt: 1672531200000, // 2023-01-01 00:00:00
         billingState: 'active',
         size: 1048576, // 1MB
+        count: 42,
       },
     });
 
@@ -112,7 +113,7 @@ describe('blob store get', () => {
 
       expect(exitCode).toBe(0);
       expect(textInputMock).toHaveBeenCalledWith({
-        message: 'Enter the ID of the blob store you want to remove',
+        message: 'Enter the ID of the blob store you want to get info about',
         validate: expect.any(Function),
       });
       expect(client.fetch).toHaveBeenCalledWith(
@@ -170,6 +171,7 @@ describe('blob store get', () => {
           updatedAt: 1672531200000, // 2023-01-01 00:00:00 UTC
           billingState: 'active',
           size: 2097152, // 2MB
+          count: 150,
         },
       });
 
@@ -182,7 +184,7 @@ describe('blob store get', () => {
       expect(exitCode).toBe(0);
       expect(mockedOutput.print).toHaveBeenCalledWith(
         expect.stringContaining(
-          'Blob Store: Display Test Store (store_display_test_123)\nBilling State: Active\nSize: 2MB\nAccess: Public\nCreated At: 2022-01-01T00:00:00.000Z\nUpdated At: 2023-01-01T00:00:00.000Z'
+          'Blob Store: Display Test Store (store_display_test_123)\nBilling State: Active\nBlob Count: 150\nSize: 2MB\nAccess: Public\nBase URL: display_test_123.public.blob.vercel-storage.com\nDashboard: https://vercel.com/my-org/~/stores/blob/store_display_test_123\nCreated At: 2022-01-01T00:00:00.000Z\nUpdated At: 2023-01-01T00:00:00.000Z'
         )
       );
       expect(formatSpy).toHaveBeenCalledWith(
@@ -192,6 +194,62 @@ describe('blob store get', () => {
       expect(formatSpy).toHaveBeenCalledWith(
         new Date(1672531200000),
         'MM/DD/YYYY HH:mm:ss.SS'
+      );
+    });
+
+    it('should show base URL for public stores', async () => {
+      client.fetch = vi.fn().mockResolvedValue({
+        store: {
+          id: 'store_rem5xG5LTyEHV6Fu',
+          name: 'My Public Store',
+          createdAt: 1640995200000,
+          updatedAt: 1672531200000,
+          billingState: 'active',
+          size: 1024,
+          count: 10,
+          access: 'public',
+        },
+      });
+
+      const exitCode = await getStore(
+        client,
+        ['store_rem5xG5LTyEHV6Fu'],
+        noToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedOutput.print).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Base URL: rem5xg5ltyehv6fu.public.blob.vercel-storage.com'
+        )
+      );
+    });
+
+    it('should show private base URL for private stores', async () => {
+      client.fetch = vi.fn().mockResolvedValue({
+        store: {
+          id: 'store_rem5xG5LTyEHV6Fu',
+          name: 'My Private Store',
+          createdAt: 1640995200000,
+          updatedAt: 1672531200000,
+          billingState: 'active',
+          size: 1024,
+          count: 10,
+          access: 'private',
+        },
+      });
+
+      const exitCode = await getStore(
+        client,
+        ['store_rem5xG5LTyEHV6Fu'],
+        noToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedOutput.print).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Base URL: rem5xg5ltyehv6fu.private.blob.vercel-storage.com'
+        )
       );
     });
 
@@ -205,6 +263,7 @@ describe('blob store get', () => {
           updatedAt: Date.now(),
           billingState: 'active',
           size: 1024,
+          count: 5,
         },
       });
 
@@ -229,6 +288,7 @@ describe('blob store get', () => {
             updatedAt: Date.now(),
             billingState,
             size: 1024,
+            count: 5,
           },
         });
 
@@ -259,6 +319,7 @@ describe('blob store get', () => {
           updatedAt: Date.now(),
           billingState: 'active',
           size,
+          count: 100,
         },
       });
 
@@ -479,6 +540,7 @@ describe('blob store get', () => {
           updatedAt: 1672531200000,
           billingState: 'active',
           size: 1024,
+          count: 25,
         },
         {
           id: 'store_format_test_456',
@@ -487,6 +549,7 @@ describe('blob store get', () => {
           updatedAt: 1640995200000,
           billingState: 'suspended',
           size: 0,
+          count: 0,
         },
       ];
 
@@ -508,7 +571,7 @@ describe('blob store get', () => {
 
       expect(exitCode).toBe(0);
       expect(textInputMock).toHaveBeenCalledWith({
-        message: 'Enter the ID of the blob store you want to remove',
+        message: 'Enter the ID of the blob store you want to get info about',
         validate: expect.any(Function),
       });
     });

--- a/packages/cli/test/unit/commands/blob/store-list.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-list.test.ts
@@ -1,0 +1,329 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import listStores from '../../../../src/commands/blob/store-list';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+import getProjectByIdOrName from '../../../../src/util/projects/get-project-by-id-or-name';
+import output from '../../../../src/output-manager';
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+vi.mock('../../../../src/util/projects/get-project-by-id-or-name');
+vi.mock('../../../../src/output-manager');
+
+const mockedGetLinkFromDir = vi.mocked(linkModule.getLinkFromDir);
+const mockedGetVercelDirectory = vi.mocked(linkModule.getVercelDirectory);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+const mockedGetProjectByIdOrName = vi.mocked(getProjectByIdOrName);
+const mockedOutput = vi.mocked(output);
+
+describe('blob list-stores', () => {
+  const selectInputMock = vi.fn();
+
+  const mockStores = [
+    {
+      id: 'store_abc123def456ghij',
+      name: 'my-store',
+      projectsMetadata: [
+        {
+          projectId: 'proj_123',
+          name: 'my-project',
+          environments: ['production'],
+        },
+      ],
+    },
+    {
+      id: 'store_xyz789uvw012klmn',
+      name: 'other-store',
+      projectsMetadata: [
+        {
+          projectId: 'proj_456',
+          name: 'other-project',
+          environments: ['preview'],
+        },
+      ],
+    },
+    {
+      id: 'store_shared123456789',
+      name: 'shared-store',
+      projectsMetadata: [
+        {
+          projectId: 'proj_123',
+          name: 'my-project',
+          environments: ['production'],
+        },
+        {
+          projectId: 'proj_456',
+          name: 'other-project',
+          environments: ['preview'],
+        },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+
+    client.input.select = selectInputMock;
+
+    // Default: linked project via dirLink
+    mockedGetVercelDirectory.mockReturnValue('/test/.vercel');
+    mockedGetLinkFromDir.mockResolvedValue({
+      projectId: 'proj_123',
+      orgId: 'org_123',
+    });
+    mockedGetProjectByIdOrName.mockResolvedValue({
+      id: 'proj_123',
+      name: 'my-project',
+    } as any);
+
+    // Default: fetch returns all stores
+    client.fetch = vi.fn().mockResolvedValue({
+      stores: mockStores,
+    });
+
+    // Default: cancel on first select
+    selectInputMock.mockResolvedValue('');
+  });
+
+  describe('with linked project', () => {
+    it('should filter stores to those connected to the linked project', async () => {
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+      expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores', {
+        method: 'GET',
+        accountId: 'org_123',
+      });
+
+      // Should show select with only stores connected to proj_123
+      expect(selectInputMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Select a store to view details',
+          choices: expect.arrayContaining([
+            expect.objectContaining({ value: 'store_abc123def456ghij' }),
+            expect.objectContaining({ value: 'store_shared123456789' }),
+            expect.objectContaining({ name: 'Cancel', value: '' }),
+          ]),
+        })
+      );
+
+      // Should NOT include the store not connected to proj_123
+      const choices = selectInputMock.mock.calls[0][0].choices;
+      const storeValues = choices.map((c: { value: string }) => c.value);
+      expect(storeValues).not.toContain('store_xyz789uvw012klmn');
+    });
+
+    it('should show project-specific header', async () => {
+      await listStores(client, []);
+
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('Blob stores for project')
+      );
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('my-project')
+      );
+    });
+  });
+
+  describe('without linked project', () => {
+    beforeEach(() => {
+      mockedGetLinkFromDir.mockResolvedValue(null);
+      mockedGetScope.mockResolvedValue({
+        contextName: 'my-team',
+        team: { id: 'team_123', slug: 'my-team' } as any,
+        user: {} as any,
+      });
+    });
+
+    it('should show all team stores when no project is linked', async () => {
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+      expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores', {
+        method: 'GET',
+        accountId: 'team_123',
+      });
+
+      // Should show all stores
+      const choices = selectInputMock.mock.calls[0][0].choices;
+      const storeValues = choices.map((c: { value: string }) => c.value);
+      expect(storeValues).toContain('store_abc123def456ghij');
+      expect(storeValues).toContain('store_xyz789uvw012klmn');
+      expect(storeValues).toContain('store_shared123456789');
+    });
+
+    it('should show generic header', async () => {
+      await listStores(client, []);
+
+      expect(mockedOutput.log).toHaveBeenCalledWith('Blob stores:');
+    });
+
+    it('should return 1 when team is not found', async () => {
+      mockedGetScope.mockResolvedValue({
+        contextName: '',
+        team: null,
+        user: {} as any,
+      });
+
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.error).toHaveBeenCalledWith('Team not found.');
+    });
+  });
+
+  describe('store selection and details', () => {
+    it('should show store details on selection', async () => {
+      const storeDetails = {
+        store: {
+          id: 'store_abc123def456ghij',
+          name: 'my-store',
+          createdAt: 1640995200000,
+          updatedAt: 1672531200000,
+          billingState: 'active',
+          size: 1048576,
+          count: 42,
+        },
+      };
+
+      // First call: list stores, second call: store details
+      client.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({ stores: mockStores })
+        .mockResolvedValueOnce(storeDetails);
+
+      selectInputMock.mockResolvedValueOnce('store_abc123def456ghij');
+
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+
+      // Should have fetched store details
+      expect(client.fetch).toHaveBeenCalledWith(
+        '/v1/storage/stores/store_abc123def456ghij',
+        {
+          method: 'GET',
+          accountId: 'org_123',
+        }
+      );
+
+      // Should have printed store details
+      expect(mockedOutput.print).toHaveBeenCalledWith(
+        expect.stringContaining('my-store')
+      );
+
+      // Select should only be called once (no loop)
+      expect(selectInputMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('empty store list', () => {
+    it('should show message when no stores found', async () => {
+      client.fetch = vi.fn().mockResolvedValue({ stores: [] });
+
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOutput.log).toHaveBeenCalledWith('No blob stores found');
+      expect(selectInputMock).not.toHaveBeenCalled();
+    });
+
+    it('should show message when no stores match linked project', async () => {
+      client.fetch = vi.fn().mockResolvedValue({
+        stores: [
+          {
+            id: 'store_unrelated1234567',
+            name: 'unrelated-store',
+            projectsMetadata: [
+              { projectId: 'proj_other', name: 'other', environments: [] },
+            ],
+          },
+        ],
+      });
+
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOutput.log).toHaveBeenCalledWith('No blob stores found');
+    });
+  });
+
+  describe('non-TTY behavior', () => {
+    beforeEach(() => {
+      (client.stdin as any).isTTY = false;
+    });
+
+    it('should print table and exit for non-TTY', async () => {
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+      expect(selectInputMock).not.toHaveBeenCalled();
+      expect(mockedOutput.print).toHaveBeenCalledWith(
+        expect.stringContaining('my-store')
+      );
+      expect(mockedOutput.print).toHaveBeenCalledWith(
+        expect.stringContaining('store_abc123def456ghij')
+      );
+    });
+
+    it('should filter stores by project in non-TTY mode too', async () => {
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+      // Should only contain stores for proj_123
+      const printCall = mockedOutput.print.mock.calls[0][0];
+      expect(printCall).toContain('my-store');
+      expect(printCall).toContain('shared-store');
+      expect(printCall).not.toContain('other-store');
+    });
+  });
+
+  describe('cancel', () => {
+    it('should exit cleanly on cancel', async () => {
+      selectInputMock.mockResolvedValue('');
+
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe('error cases', () => {
+    it('should return 1 when argument parsing fails', async () => {
+      const exitCode = await listStores(client, ['--invalid-flag']);
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should return 1 when API call fails', async () => {
+      client.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should return 1 when store details fetch fails', async () => {
+      client.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({ stores: mockStores })
+        .mockRejectedValueOnce(new Error('Store not found'));
+
+      selectInputMock.mockResolvedValueOnce('store_abc123def456ghij');
+
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  describe('telemetry', () => {
+    it('should initialize telemetry client', async () => {
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI feature additions for blob store management commands with new subcommands, UX improvements, and extensive test coverage - no security-sensitive changes, database schema modifications, or auth logic.
> 
> - New CLI subcommands: `list-stores`, `empty-store` with confirmation prompts
> - UX improvements: interactive access type selection, auto-pull env vars after store operations
> - Extensive unit test coverage for new and modified commands
>
> <sup>Risk assessment for [commit 3568c2f](https://github.com/vercel/vercel/commit/3568c2f96560b8f7610f65d194351b4dda792de0).</sup>
<!-- VADE_RISK_END -->