### PR TITLE
feat(cli): add blob empty-store command

### DIFF
--- a/.changeset/blob-breaking-changes.md
+++ b/.changeset/blob-breaking-changes.md
@@ -1,0 +1,17 @@
+---
+'vercel': major
+---
+
+feat(cli): blob command improvements and breaking changes
+
+**Breaking Changes:**
+- `--access` flag is now required for `put`, `copy`, `get`, and `create-store` (no longer defaults to `public`)
+- `--force` flag removed from `blob put` (use `--allow-overwrite` instead)
+- `blob store add|remove|get` subcommands removed (use `blob create-store`, `blob delete-store`, `blob get-store`)
+
+**New Features:**
+- `blob list-stores` (`ls-stores`): browse blob stores interactively or pipe as a table
+- `blob empty-store`: delete all blobs in a store with confirmation
+- `blob get-store` and `blob list-stores` now show a dashboard link
+- `blob create-store` interactive prompt now shows Private first with doc links
+- `blob delete-store` now shows connected projects in confirmation and auto-pulls `.env.local` after deletion

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -28,6 +28,8 @@ const accessOption = {
   choices: ['public', 'private'],
 } as const;
 
+import { yesOption } from '../../util/arg-common';
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -345,6 +347,15 @@ export const deleteStoreSubcommand = {
   examples: [],
 } as const;
 
+export const emptyStoreSubcommand = {
+  name: 'empty-store',
+  aliases: [],
+  description: 'Delete all blobs in a Blob store',
+  arguments: [],
+  options: [yesOption],
+  examples: [],
+} as const;
+
 export const getStoreInfoSubcommand = {
   name: 'get-store',
   aliases: [],
@@ -383,6 +394,7 @@ export const blobCommand = {
     deleteStoreSubcommand,
     getStoreInfoSubcommand,
     listStoresSubcommand,
+    emptyStoreSubcommand,
   ],
   options: [
     {

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -15,6 +15,7 @@ import {
   deleteStoreSubcommand,
   getStoreInfoSubcommand,
   listStoresSubcommand,
+  emptyStoreSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
@@ -28,6 +29,7 @@ import addStore from './store-add';
 import removeStore from './store-remove';
 import getStore from './store-get';
 import listStores from './store-list';
+import emptyStore from './store-empty';
 import { printError } from '../../util/error';
 import { getBlobRWToken } from '../../util/blob/token';
 
@@ -41,6 +43,7 @@ const COMMAND_CONFIG = {
   'delete-store': getCommandAliases(deleteStoreSubcommand),
   'get-store': getCommandAliases(getStoreInfoSubcommand),
   'list-stores': getCommandAliases(listStoresSubcommand),
+  'empty-store': getCommandAliases(emptyStoreSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -200,6 +203,21 @@ export default async function main(client: Client) {
       telemetry.trackCliSubcommandListStores(subcommandOriginal);
 
       return listStores(client, args);
+    case 'empty-store':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(emptyStoreSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandEmptyStore(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
+      return emptyStore(client, args, token.token, token);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(blobCommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/blob/store-empty.ts
+++ b/packages/cli/src/commands/blob/store-empty.ts
@@ -1,0 +1,130 @@
+import type Client from '../../util/client';
+import { printError } from '../../util/error';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { emptyStoreSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import * as blob from '@vercel/blob';
+import type { BlobRWToken } from '../../util/blob/token';
+import { BlobEmptyStoreTelemetryClient } from '../../util/telemetry/commands/blob/store-empty';
+import { getLinkedProject } from '../../util/projects/link';
+import {
+  formatStoreLabel,
+  formatConnectedProjects,
+} from '../../util/blob/confirm';
+
+export default async function emptyStore(
+  client: Client,
+  argv: string[],
+  rwToken: string,
+  fullToken: BlobRWToken
+): Promise<number> {
+  const telemetryClient = new BlobEmptyStoreTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(
+    emptyStoreSubcommand.options
+  );
+
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const {
+    flags: { '--yes': yes },
+  } = parsedArgs;
+
+  telemetryClient.trackCliFlagYes(yes);
+
+  if (!fullToken.success) {
+    printError(fullToken.error);
+    return 1;
+  }
+
+  const [, , , id] = fullToken.token.split('_');
+  const storeId = `store_${id}`;
+
+  try {
+    const link = await getLinkedProject(client);
+    const accountId = link.status === 'linked' ? link.org.id : undefined;
+
+    const [storeResponse, connectionsResponse, initialList] = await Promise.all(
+      [
+        client.fetch<{ store: { name: string } }>(
+          `/v1/storage/stores/${storeId}`,
+          { method: 'GET', accountId }
+        ),
+        client.fetch<{
+          connections: { project: { name: string } }[];
+        }>(`/v1/storage/stores/${storeId}/connections`, {
+          method: 'GET',
+          accountId,
+        }),
+        blob.list({ token: rwToken, limit: 1 }),
+      ]
+    );
+
+    const { name } = storeResponse.store;
+    const { connections } = connectionsResponse;
+
+    if (initialList.blobs.length === 0) {
+      output.log('Store is already empty');
+      return 0;
+    }
+
+    const label = formatStoreLabel(name, storeId);
+    const projectsInfo = formatConnectedProjects(connections);
+    const message = `Are you sure you want to delete all files in ${label}?${projectsInfo} This action cannot be undone.`;
+
+    if (!yes) {
+      if (!client.stdin.isTTY) {
+        output.error(
+          'Missing --yes flag. This is a destructive operation, use --yes to confirm.'
+        );
+        return 1;
+      }
+
+      const confirmed = await client.input.confirm(message, false);
+      if (!confirmed) {
+        output.log('Canceled');
+        return 0;
+      }
+    }
+
+    let totalDeleted = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+      output.spinner(`Deleting blobs... (${totalDeleted} deleted)`);
+
+      const listResult = await blob.list({
+        token: rwToken,
+        limit: 1000,
+      });
+
+      if (listResult.blobs.length === 0) {
+        hasMore = false;
+        break;
+      }
+
+      const urls = listResult.blobs.map(b => b.url);
+      await blob.del(urls, { token: rwToken });
+      totalDeleted += urls.length;
+    }
+
+    output.stopSpinner();
+    output.success(`All blobs deleted (${totalDeleted} total)`);
+
+    return 0;
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/blob/index.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/index.ts
@@ -69,6 +69,13 @@ export class BlobTelemetryClient
     });
   }
 
+  trackCliSubcommandEmptyStore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'empty-store',
+      value: actual,
+    });
+  }
+
   trackCliOptionRwToken() {
     this.trackCliOption({
       option: '--rw-token',

--- a/packages/cli/src/util/telemetry/commands/blob/store-empty.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-empty.ts
@@ -1,0 +1,14 @@
+import { TelemetryClient } from '../..';
+import type { emptyStoreSubcommand } from '../../../../commands/blob/command';
+import type { TelemetryMethods } from '../../types';
+
+export class BlobEmptyStoreTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof emptyStoreSubcommand>
+{
+  trackCliFlagYes(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/blob/store-empty.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-empty.test.ts
@@ -1,0 +1,417 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import emptyStore from '../../../../src/commands/blob/store-empty';
+import * as blobModule from '@vercel/blob';
+import * as linkModule from '../../../../src/util/projects/link';
+import output from '../../../../src/output-manager';
+import type { BlobRWToken } from '../../../../src/util/blob/token';
+
+vi.mock('@vercel/blob');
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/output-manager');
+
+const mockedBlob = vi.mocked(blobModule);
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedOutput = vi.mocked(output);
+
+describe('blob empty-store', () => {
+  const testToken = 'vercel_blob_rw_abc123_additional_data';
+  const fullToken: BlobRWToken = { success: true, token: testToken };
+  const storeId = 'store_abc123';
+
+  const confirmInputMock = vi.fn().mockResolvedValue(true);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+
+    client.input.confirm = confirmInputMock;
+    (client.stdin as any).isTTY = true;
+
+    mockedGetLinkedProject.mockResolvedValue({
+      status: 'linked',
+      project: {
+        id: 'proj_123',
+        name: 'my-project',
+        accountId: 'org_123',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+      },
+      org: { id: 'org_123', slug: 'my-org', type: 'user' },
+    });
+
+    // Default: store info, no connections
+    client.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        store: { name: 'my-store' },
+      })
+      .mockResolvedValueOnce({
+        connections: [],
+      });
+
+    // Default: initial list check returns blobs (not empty),
+    // then deletion loop: one page of blobs, then empty
+    mockedBlob.list
+      .mockResolvedValueOnce({
+        blobs: [{ url: 'https://example.com/a.txt' }],
+        cursor: '',
+        hasMore: false,
+      } as any)
+      .mockResolvedValueOnce({
+        blobs: [
+          { url: 'https://example.com/a.txt' },
+          { url: 'https://example.com/b.txt' },
+        ],
+        cursor: '',
+        hasMore: false,
+      } as any)
+      .mockResolvedValueOnce({
+        blobs: [],
+        cursor: '',
+        hasMore: false,
+      } as any);
+
+    mockedBlob.del.mockResolvedValue(undefined as any);
+  });
+
+  describe('successful empty', () => {
+    it('should confirm and empty store (single page)', async () => {
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+
+      // Should fetch store info and connections with accountId
+      expect(client.fetch).toHaveBeenCalledWith(
+        `/v1/storage/stores/${storeId}`,
+        { method: 'GET', accountId: 'org_123' }
+      );
+      expect(client.fetch).toHaveBeenCalledWith(
+        `/v1/storage/stores/${storeId}/connections`,
+        { method: 'GET', accountId: 'org_123' }
+      );
+
+      // Initial emptiness check via blob.list with limit 1
+      expect(mockedBlob.list).toHaveBeenNthCalledWith(1, {
+        token: testToken,
+        limit: 1,
+      });
+
+      // Should show confirmation prompt
+      expect(confirmInputMock).toHaveBeenCalledWith(
+        `Are you sure you want to delete all files in my-store (${storeId})? This action cannot be undone.`,
+        false
+      );
+
+      // Deletion loop lists with limit 1000
+      expect(mockedBlob.list).toHaveBeenNthCalledWith(2, {
+        token: testToken,
+        limit: 1000,
+      });
+      expect(mockedBlob.del).toHaveBeenCalledWith(
+        ['https://example.com/a.txt', 'https://example.com/b.txt'],
+        { token: testToken }
+      );
+
+      expect(mockedOutput.stopSpinner).toHaveBeenCalled();
+      expect(mockedOutput.success).toHaveBeenCalledWith(
+        'All blobs deleted (2 total)'
+      );
+    });
+
+    it('should confirm and empty store (multiple pages with pagination)', async () => {
+      mockedBlob.list.mockReset();
+      mockedBlob.list
+        // Initial emptiness check
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/1.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        // Deletion loop page 1
+        .mockResolvedValueOnce({
+          blobs: [
+            { url: 'https://example.com/1.txt' },
+            { url: 'https://example.com/2.txt' },
+          ],
+          cursor: 'cursor1',
+          hasMore: true,
+        } as any)
+        // Deletion loop page 2
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/3.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        // Deletion loop: no more blobs
+        .mockResolvedValueOnce({
+          blobs: [],
+          cursor: '',
+          hasMore: false,
+        } as any);
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+      // 1 initial check + 3 deletion loop calls
+      expect(mockedBlob.list).toHaveBeenCalledTimes(4);
+      expect(mockedBlob.del).toHaveBeenCalledTimes(2);
+      expect(mockedOutput.success).toHaveBeenCalledWith(
+        'All blobs deleted (3 total)'
+      );
+    });
+
+    it('should skip confirmation with --yes', async () => {
+      const exitCode = await emptyStore(
+        client,
+        ['--yes'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(confirmInputMock).not.toHaveBeenCalled();
+      expect(mockedBlob.del).toHaveBeenCalled();
+    });
+
+    it('should show connected projects in confirmation message', async () => {
+      client.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          store: { name: 'my-store' },
+        })
+        .mockResolvedValueOnce({
+          connections: [
+            { project: { name: 'project1' } },
+            { project: { name: 'project2' } },
+          ],
+        });
+
+      await emptyStore(client, [], testToken, fullToken);
+
+      expect(confirmInputMock).toHaveBeenCalledWith(
+        `Are you sure you want to delete all files in my-store (${storeId})? This store is connected to project1, project2. This action cannot be undone.`,
+        false
+      );
+    });
+
+    it('should show remaining project count when more than 2 connections', async () => {
+      client.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          store: { name: 'my-store' },
+        })
+        .mockResolvedValueOnce({
+          connections: [
+            { project: { name: 'project1' } },
+            { project: { name: 'project2' } },
+            { project: { name: 'project3' } },
+            { project: { name: 'project4' } },
+            { project: { name: 'project5' } },
+          ],
+        });
+
+      await emptyStore(client, [], testToken, fullToken);
+
+      expect(confirmInputMock).toHaveBeenCalledWith(
+        `Are you sure you want to delete all files in my-store (${storeId})? This store is connected to project1, project2 and 3 other projects. This action cannot be undone.`,
+        false
+      );
+    });
+
+    it('should work without accountId when project is not linked', async () => {
+      mockedGetLinkedProject.mockResolvedValue({
+        org: null,
+        project: null,
+        status: 'not_linked',
+      });
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+      expect(client.fetch).toHaveBeenCalledWith(
+        `/v1/storage/stores/${storeId}`,
+        { method: 'GET', accountId: undefined }
+      );
+    });
+  });
+
+  describe('empty store handling', () => {
+    it('should handle empty store gracefully', async () => {
+      mockedBlob.list.mockReset();
+      // Initial emptiness check returns no blobs
+      mockedBlob.list.mockResolvedValueOnce({
+        blobs: [],
+        cursor: '',
+        hasMore: false,
+      } as any);
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+      expect(confirmInputMock).not.toHaveBeenCalled();
+      // Only the initial check, no deletion loop
+      expect(mockedBlob.list).toHaveBeenCalledTimes(1);
+      expect(mockedBlob.list).toHaveBeenCalledWith({
+        token: testToken,
+        limit: 1,
+      });
+      expect(mockedBlob.del).not.toHaveBeenCalled();
+      expect(mockedOutput.log).toHaveBeenCalledWith('Store is already empty');
+    });
+  });
+
+  describe('cancellation', () => {
+    it('should cancel when user declines', async () => {
+      confirmInputMock.mockResolvedValueOnce(false);
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(0);
+      // Initial check happened but no deletion
+      expect(mockedBlob.list).toHaveBeenCalledTimes(1);
+      expect(mockedBlob.del).not.toHaveBeenCalled();
+      expect(mockedOutput.log).toHaveBeenCalledWith('Canceled');
+    });
+  });
+
+  describe('non-TTY behavior', () => {
+    it('should error in non-TTY without --yes', async () => {
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.error).toHaveBeenCalledWith(
+        'Missing --yes flag. This is a destructive operation, use --yes to confirm.'
+      );
+      // Initial check happened but no deletion
+      expect(mockedBlob.list).toHaveBeenCalledTimes(1);
+      expect(mockedBlob.del).not.toHaveBeenCalled();
+    });
+
+    it('should work in non-TTY with --yes', async () => {
+      (client.stdin as any).isTTY = false;
+
+      // Reset blob mocks for this test since beforeEach mocks may be consumed
+      mockedBlob.list.mockReset();
+      mockedBlob.list
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/a.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/a.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        .mockResolvedValueOnce({
+          blobs: [],
+          cursor: '',
+          hasMore: false,
+        } as any);
+
+      // Also reset fetch mocks
+      client.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({ store: { name: 'my-store' } })
+        .mockResolvedValueOnce({ connections: [] });
+
+      const exitCode = await emptyStore(
+        client,
+        ['--yes'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.del).toHaveBeenCalled();
+    });
+  });
+
+  describe('error cases', () => {
+    it('should return 1 when argument parsing fails', async () => {
+      const exitCode = await emptyStore(
+        client,
+        ['--invalid-flag'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should return 1 when token is not available', async () => {
+      const failedToken: BlobRWToken = {
+        success: false,
+        error: 'No token',
+      };
+
+      const exitCode = await emptyStore(client, [], testToken, failedToken);
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should handle API errors during store fetch', async () => {
+      client.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      const exitCode = await emptyStore(client, [], testToken, fullToken);
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should handle API errors during blob list', async () => {
+      mockedBlob.list.mockReset();
+      mockedBlob.list.mockRejectedValue(new Error('List failed'));
+
+      const exitCode = await emptyStore(
+        client,
+        ['--yes'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('should handle API errors during blob delete', async () => {
+      mockedBlob.list.mockReset();
+      // Initial check returns blobs
+      mockedBlob.list.mockResolvedValueOnce({
+        blobs: [{ url: 'https://example.com/a.txt' }],
+        cursor: '',
+        hasMore: false,
+      } as any);
+      // Deletion loop returns blobs
+      mockedBlob.list.mockResolvedValueOnce({
+        blobs: [{ url: 'https://example.com/a.txt' }],
+        cursor: '',
+        hasMore: false,
+      } as any);
+      mockedBlob.del.mockRejectedValue(new Error('Delete failed'));
+
+      const exitCode = await emptyStore(
+        client,
+        ['--yes'],
+        testToken,
+        fullToken
+      );
+
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  describe('telemetry', () => {
+    it('should track --yes flag', async () => {
+      await emptyStore(client, ['--yes'], testToken, fullToken);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:yes',
+          value: 'TRUE',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Delete all blobs in a store with confirmation prompt.
Includes changeset covering all breaking changes and new features.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> New CLI command `blob empty-store` adds destructive operation to delete all blobs with proper confirmation prompts, --yes flag requirement for non-TTY, and comprehensive test coverage - standard feature addition with no security weakening.
> 
> - New `empty-store` subcommand with confirmation prompt and --yes flag for non-interactive use
> - Requires explicit confirmation or --yes flag before deleting blobs
> - Comprehensive unit tests covering success, cancellation, error handling, and non-TTY behavior
>
> <sup>Risk assessment for [commit 080ea71](https://github.com/vercel/vercel/commit/080ea7101209df7d27a0bf0591f54622baca43ca).</sup>
<!-- VADE_RISK_END -->