### PR TITLE
Update Next.js adapter version

### DIFF
--- a/.changeset/big-buckets-attend.md
+++ b/.changeset/big-buckets-attend.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Update Next.js adapter version

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.12",
+    "@next-community/adapter-vercel": "0.0.1-beta.13",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1716,8 +1716,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.12
-        version: 0.0.1-beta.12(next@16.1.6)
+        specifier: 0.0.1-beta.13
+        version: 0.0.1-beta.13(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6547,8 +6547,8 @@ packages:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  /@next-community/adapter-vercel@0.0.1-beta.12(next@16.1.6):
-    resolution: {integrity: sha512-pvINuPgfGWKA8YquGl3xwRp6aDnKvZDrlu3ZtbsnUiTt/CKPTgBmWJ1jpE4OCLSCM+frQUOl2FEZzUSdSUcs1A==}
+  /@next-community/adapter-vercel@0.0.1-beta.13(next@16.1.6):
+    resolution: {integrity: sha512-klZhR/9LjXLvlt5n1wqJxM7xwd4c3VCflZzuBnFkd1fkMPUF49oXjHHyqsgG+Y1FQpwLuwqpymZLHRRiADsxfg==}
     engines: {node: '>= 20.6.0'}
     peerDependencies:
       next: '>= 16.1.1-canary.18'


### PR DESCRIPTION
x-ref: https://github.com/nextjs/adapter-vercel/pull/40

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR is a minor patch version bump of a dev dependency from beta.12 to beta.13 with no code changes.
> 
> - Dev dependency bump: @next-community/adapter-vercel 0.0.1-beta.12 → 0.0.1-beta.13
> - Changeset file added for patch release
>
> <sup>Risk assessment for [commit 440d226](https://github.com/vercel/vercel/commit/440d226a6e465b54332df5a96c88974a0bbc074d).</sup>
<!-- VADE_RISK_END -->