### PR TITLE
[config] Fix types

### DIFF
--- a/packages/config/scripts/generate-types.ts
+++ b/packages/config/scripts/generate-types.ts
@@ -270,7 +270,12 @@ function generateTypes(schema: JSONSchema): string {
         output.push(jsdoc);
       }
       const optional = !imagesProp.required?.includes(key) ? '?' : '';
-      const propType = convertSchemaType(propSchema as JSONSchema, 1);
+      let propType = convertSchemaType(propSchema as JSONSchema, 1);
+      // Fix array-of-union types: wrap union in parentheses for array items
+      if (key === 'formats' && propType.includes('|') && propType.endsWith('[]')) {
+        const inner = propType.slice(0, -2);
+        propType = `(${inner})[]`;
+      }
       output.push(`  ${key}${optional}: ${propType};`);
     }
     output.push('}');
@@ -305,12 +310,10 @@ export interface Header {
 }
 
 /**
- * Condition for matching in redirects, rewrites, and headers
+ * Object form of a matchable value with comparison operators.
+ * Matches the MatchableValue type from routing-utils.
  */
-export interface Condition {
-  type: 'header' | 'cookie' | 'host' | 'query' | 'path';
-  key?: string;
-  value?: string | number;
+export interface MatchableValueObject {
   eq?: string | number;
   neq?: string;
   inc?: string[];
@@ -323,6 +326,26 @@ export interface Condition {
   lt?: number;
   lte?: number;
 }
+
+/**
+ * A value that can be matched against: either a simple string or an object with operators.
+ */
+export type MatchableValue = string | MatchableValueObject;
+
+/**
+ * Condition for matching in redirects, rewrites, and headers.
+ * Matches the HasField type from routing-utils.
+ */
+export type Condition =
+  | {
+      type: 'host';
+      value: MatchableValue;
+    }
+  | {
+      type: 'header' | 'cookie' | 'query';
+      key: string;
+      value?: MatchableValue;
+    };
 
 /**
  * Redirect matching vercel.json schema
@@ -344,6 +367,7 @@ export interface Redirect {
 export interface Rewrite {
   source: string;
   destination: string;
+  statusCode?: number;
   has?: Condition[];
   missing?: Condition[];
   respectOriginCacheControl?: boolean;

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -218,7 +218,7 @@ describe('Router', () => {
         expect(header('x-user-role', { inc: ['admin', 'moderator'] })).toEqual({
           type: 'header',
           key: 'x-user-role',
-          inc: ['admin', 'moderator'],
+          value: { inc: ['admin', 'moderator'] },
         });
       });
 
@@ -226,47 +226,47 @@ describe('Router', () => {
         expect(header('x-version', { eq: 2 })).toEqual({
           type: 'header',
           key: 'x-version',
-          eq: 2,
+          value: { eq: 2 },
         });
         expect(header('x-version', { neq: 'beta' })).toEqual({
           type: 'header',
           key: 'x-version',
-          neq: 'beta',
+          value: { neq: 'beta' },
         });
         expect(header('x-version', { gte: 2 })).toEqual({
           type: 'header',
           key: 'x-version',
-          gte: 2,
+          value: { gte: 2 },
         });
         expect(header('x-version', { gt: 1 })).toEqual({
           type: 'header',
           key: 'x-version',
-          gt: 1,
+          value: { gt: 1 },
         });
         expect(header('x-version', { lt: 5 })).toEqual({
           type: 'header',
           key: 'x-version',
-          lt: 5,
+          value: { lt: 5 },
         });
         expect(header('x-version', { lte: 5 })).toEqual({
           type: 'header',
           key: 'x-version',
-          lte: 5,
+          value: { lte: 5 },
         });
         expect(header('x-auth', { pre: 'Bearer ' })).toEqual({
           type: 'header',
           key: 'x-auth',
-          pre: 'Bearer ',
+          value: { pre: 'Bearer ' },
         });
         expect(header('x-auth', { suf: '-token' })).toEqual({
           type: 'header',
           key: 'x-auth',
-          suf: '-token',
+          value: { suf: '-token' },
         });
         expect(header('x-role', { ninc: ['guest'] })).toEqual({
           type: 'header',
           key: 'x-role',
-          ninc: ['guest'],
+          value: { ninc: ['guest'] },
         });
       });
     });
@@ -291,7 +291,7 @@ describe('Router', () => {
         expect(cookie('session', { pre: 'secure-' })).toEqual({
           type: 'cookie',
           key: 'session',
-          pre: 'secure-',
+          value: { pre: 'secure-' },
         });
       });
     });
@@ -316,7 +316,7 @@ describe('Router', () => {
         expect(query('page', { gte: 1 })).toEqual({
           type: 'query',
           key: 'page',
-          gte: 1,
+          value: { gte: 1 },
         });
       });
     });
@@ -332,7 +332,7 @@ describe('Router', () => {
       it('should create a host operator condition', () => {
         expect(host({ suf: '.example.com' })).toEqual({
           type: 'host',
-          suf: '.example.com',
+          value: { suf: '.example.com' },
         });
       });
     });
@@ -354,8 +354,8 @@ describe('Router', () => {
           source: '/admin/(.*)',
           destination: 'https://admin.backend.com/$1',
           has: [
-            { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] },
-            { type: 'cookie', key: 'session', pre: 'secure-' },
+            { type: 'header', key: 'x-user-role', value: { inc: ['admin', 'moderator'] } },
+            { type: 'cookie', key: 'session', value: { pre: 'secure-' } },
           ],
           missing: [{ type: 'header', key: 'x-legacy-auth' }],
         });
@@ -365,15 +365,15 @@ describe('Router', () => {
         const rewrite = router.rewrite('/api/(.*)', 'https://backend.com/$1', {
           has: [
             header('authorization', { pre: 'Bearer ' }),
-            { type: 'header', key: 'x-api-version', gte: 2 },
+            { type: 'header', key: 'x-api-version', value: { gte: 2 } },
           ],
         });
         expect(rewrite).toEqual({
           source: '/api/(.*)',
           destination: 'https://backend.com/$1',
           has: [
-            { type: 'header', key: 'authorization', pre: 'Bearer ' },
-            { type: 'header', key: 'x-api-version', gte: 2 },
+            { type: 'header', key: 'authorization', value: { pre: 'Bearer ' } },
+            { type: 'header', key: 'x-api-version', value: { gte: 2 } },
           ],
         });
       });

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -177,15 +177,14 @@ export interface CacheOptions {
  * - 'cookie': Match if a specific cookie is present (or missing).
  * - 'host':   Match if the incoming host matches a given pattern.
  * - 'query':  Match if a query parameter is present (or missing).
- * - 'path':   Match if the path matches a given pattern.
  */
-export type ConditionType = 'header' | 'cookie' | 'host' | 'query' | 'path';
+export type ConditionType = 'header' | 'cookie' | 'host' | 'query';
 
 /**
- * Conditional matching operators for has/missing conditions.
- * These can be used with the value field to perform advanced matching.
+ * Object form of a matchable value with comparison operators.
+ * Matches the MatchableValue type from routing-utils.
  */
-export interface ConditionOperators {
+export interface MatchableValueObject {
   /** Check equality on a value (exact match) */
   eq?: string | number;
   /** Check inequality on a value (not equal) */
@@ -198,6 +197,8 @@ export interface ConditionOperators {
   pre?: string;
   /** Check if value ends with a suffix */
   suf?: string;
+  /** Check if value matches a regular expression */
+  re?: string;
   /** Check if value is greater than (numeric comparison) */
   gt?: number;
   /** Check if value is greater than or equal to */
@@ -207,6 +208,11 @@ export interface ConditionOperators {
   /** Check if value is less than or equal to */
   lte?: number;
 }
+
+/**
+ * A value that can be matched against: either a simple string or an object with operators.
+ */
+export type MatchableValue = string | MatchableValueObject;
 
 /**
  * Used to define "has" or "missing" conditions with advanced matching operators.
@@ -221,11 +227,11 @@ export interface ConditionOperators {
  *
  * @example
  * // Header with conditional operators
- * { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] }
+ * { type: 'header', key: 'x-user-role', value: { inc: ['admin', 'moderator'] } }
  *
  * @example
  * // Cookie with prefix matching
- * { type: 'cookie', key: 'session', pre: 'prod-' }
+ * { type: 'cookie', key: 'session', value: { pre: 'prod-' } }
  *
  * @example
  * // Host matching
@@ -233,42 +239,41 @@ export interface ConditionOperators {
  *
  * @example
  * // Query parameter with numeric comparison
- * { type: 'query', key: 'version', gte: 2 }
- *
- * @example
- * // Path pattern matching
- * { type: 'path', value: '^/api/v[0-9]+/.*' }
+ * { type: 'query', key: 'version', value: { gte: 2 } }
  */
-export interface Condition extends ConditionOperators {
-  type: ConditionType;
-  /** The key to match. Not used for 'host' or 'path' types. */
-  key?: string;
-  /**
-   * Simple string/regex pattern to match against.
-   * For 'host' and 'path' types, this is the only matching option.
-   * For other types, you can use value OR the conditional operators (eq, neq, etc).
-   */
-  value?: string;
-}
+/**
+ * Condition for matching in redirects, rewrites, and headers.
+ * Matches the HasField type from routing-utils.
+ */
+export type Condition =
+  | {
+      type: 'host';
+      value: MatchableValue;
+    }
+  | {
+      type: 'header' | 'cookie' | 'query';
+      key: string;
+      value?: MatchableValue;
+    };
 
 function createKeyedConditionHelper(type: 'header' | 'cookie' | 'query') {
-  return (key: string, value?: string | ConditionOperators): Condition => {
+  return (key: string, value?: string | MatchableValueObject): Condition => {
     if (value === undefined) {
       return { type, key };
     }
     if (typeof value === 'string') {
       return { type, key, value };
     }
-    return { type, key, ...value };
+    return { type, key, value };
   };
 }
 
 function createKeylessConditionHelper(type: 'host') {
-  return (value: string | ConditionOperators): Condition => {
+  return (value: string | MatchableValueObject): Condition => {
     if (typeof value === 'string') {
       return { type, value };
     }
-    return { type, ...value };
+    return { type, value };
   };
 }
 

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -196,7 +196,7 @@ export interface ImageConfig {
   contentSecurityPolicy?: string;
   dangerouslyAllowSVG?: boolean;
   domains?: string[];
-  formats?: 'image/avif' | 'image/webp' | 'image/jpeg' | 'image/png'[];
+  formats?: ('image/avif' | 'image/webp' | 'image/jpeg' | 'image/png')[];
   localPatterns?: {
     pathname?: string;
     search?: string;
@@ -222,12 +222,10 @@ export interface Header {
 }
 
 /**
- * Condition for matching in redirects, rewrites, and headers
+ * Object form of a matchable value with comparison operators.
+ * Matches the MatchableValue type from routing-utils.
  */
-export interface Condition {
-  type: 'header' | 'cookie' | 'host' | 'query' | 'path';
-  key?: string;
-  value?: string | number;
+export interface MatchableValueObject {
   eq?: string | number;
   neq?: string;
   inc?: string[];
@@ -240,6 +238,26 @@ export interface Condition {
   lt?: number;
   lte?: number;
 }
+
+/**
+ * A value that can be matched against: either a simple string or an object with operators.
+ */
+export type MatchableValue = string | MatchableValueObject;
+
+/**
+ * Condition for matching in redirects, rewrites, and headers.
+ * Matches the HasField type from routing-utils.
+ */
+export type Condition =
+  | {
+      type: 'host';
+      value: MatchableValue;
+    }
+  | {
+      type: 'header' | 'cookie' | 'query';
+      key: string;
+      value?: MatchableValue;
+    };
 
 /**
  * Redirect matching vercel.json schema
@@ -261,6 +279,7 @@ export interface Redirect {
 export interface Rewrite {
   source: string;
   destination: string;
+  statusCode?: number;
   has?: Condition[];
   missing?: Condition[];
   respectOriginCacheControl?: boolean;


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!WARNING]
> High Risk Change
>
> This PR refactors TypeScript type definitions for routing conditions, changing from interface to discriminated union and removing 'path' type - these are breaking API changes to exported types that consumers depend on.
> 
> - Breaking type change: `Condition` interface replaced with discriminated union type
> - Removed 'path' from `ConditionType` enum
> - Restructured condition operators into nested `value` property
>
> <sup>Risk assessment for [commit 09a8a73](https://github.com/vercel/vercel/commit/09a8a734569f8938b0c67d2455feccbd4c80b5b2).</sup>
<!-- VADE_RISK_END -->