### PR TITLE
[config] Fix type generation script

### DIFF
--- a/.changeset/modern-hounds-kneel.md
+++ b/.changeset/modern-hounds-kneel.md
@@ -1,0 +1,5 @@
+---
+'@vercel/config': patch
+---
+
+Fix type generation

--- a/packages/config/scripts/generate-types.ts
+++ b/packages/config/scripts/generate-types.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { resolve } from 'path';
 
 interface JSONSchema {
@@ -20,12 +20,18 @@ interface JSONSchema {
   additionalProperties?: boolean | any;
   patternProperties?: Record<string, any>;
   $ref?: string;
+  const?: string | number | boolean;
   private?: boolean;
 }
 
 const HEADER = `/**
- * Vercel configuration type that mirrors the vercel.json schema
- * https://openapi.vercel.sh/vercel.json
+ * AUTO-GENERATED — DO NOT EDIT
+ *
+ * This file is generated from the vercel.json OpenAPI schema.
+ * To modify, update scripts/generate-types.ts and re-run:
+ *   pnpm generate-types
+ *
+ * Schema: https://openapi.vercel.sh/vercel.json
  */
 `;
 
@@ -70,6 +76,11 @@ function generateJSDoc(schema: JSONSchema, indent = ''): string {
 function convertSchemaType(schema: JSONSchema, depth = 0): string {
   const indent = '  '.repeat(depth);
 
+  if (schema.const !== undefined) {
+    if (typeof schema.const === 'string') return `'${schema.const}'`;
+    return String(schema.const);
+  }
+
   if (schema.enum) {
     return schema.enum.map(v => (v === null ? 'null' : `'${v}'`)).join(' | ');
   }
@@ -85,6 +96,15 @@ function convertSchemaType(schema: JSONSchema, depth = 0): string {
   if (schema.type === 'array') {
     if (schema.items) {
       const itemType = convertSchemaType(schema.items, depth);
+      // Wrap in parens if items is a union (oneOf/anyOf/multi-value enum)
+      // to avoid precedence issues like 'a' | 'b'[] or {x} | {y}[]
+      const isUnion =
+        schema.items.oneOf ||
+        schema.items.anyOf ||
+        (schema.items.enum && schema.items.enum.length > 1);
+      if (isUnion) {
+        return `(${itemType})[]`;
+      }
       return `${itemType}[]`;
     }
     return 'any[]';
@@ -160,6 +180,127 @@ function convertSchemaType(schema: JSONSchema, depth = 0): string {
     default:
       return 'any';
   }
+}
+
+/**
+ * Generate routing types (MatchableValue, Condition, Header, Redirect, Rewrite, HeaderRule, RouteType)
+ * from the schema's has/redirects/rewrites/headers definitions.
+ *
+ * We can't just use convertSchemaType here because we need named types that reference
+ * each other (e.g. Condition references MatchableValue, Redirect references Condition[]).
+ */
+function generateRoutingTypes(schema: JSONSchema): string[] {
+  const output: string[] = [];
+
+  const redirectsItemSchema = schema.properties?.redirects?.items;
+  const rewritesItemSchema = schema.properties?.rewrites?.items;
+  const headersItemSchema = schema.properties?.headers?.items;
+  const hasVariants = redirectsItemSchema?.properties?.has?.items?.anyOf;
+
+  if (!hasVariants) return output;
+
+  // MatchableValue — extract from the host variant's value field schema
+  const hostVariant = hasVariants.find(
+    (v: any) => v.properties?.type?.enum?.[0] === 'host'
+  );
+  const valueSchema = hostVariant?.properties?.value;
+  if (valueSchema) {
+    output.push(
+      `/**\n * Value for condition matching - can be a string or an operator object\n */`
+    );
+    output.push(
+      `export type MatchableValue = ${convertSchemaType(valueSchema, 0)};`
+    );
+    output.push('');
+  }
+
+  // Condition — discriminated union from has variants, referencing MatchableValue
+  output.push(
+    `/**\n * Condition for matching in redirects, rewrites, and headers\n */`
+  );
+  output.push('export type Condition =');
+  for (const variant of hasVariants) {
+    const types = variant.properties?.type?.enum;
+    const required = variant.required || [];
+    const typeStr = types.map((t: string) => `'${t}'`).join(' | ');
+    const parts: string[] = [`type: ${typeStr}`];
+    for (const key of Object.keys(variant.properties || {})) {
+      if (key === 'type') continue;
+      const optional = !required.includes(key) ? '?' : '';
+      parts.push(
+        `${key}${optional}: ${key === 'value' ? 'MatchableValue' : 'string'}`
+      );
+    }
+    output.push(`  | { ${parts.join('; ')} }`);
+  }
+  output.push(';');
+  output.push('');
+
+  output.push(
+    `/**\n * The object form of MatchableValue (excludes the plain string shorthand)\n */`
+  );
+  output.push(
+    'export type MatchableValueObject = Exclude<MatchableValue, string>;'
+  );
+  output.push('');
+
+  // Header, Redirect, Rewrite, HeaderRule — generated from their schema definitions
+  // with special-cased fields to reference named types instead of inlining
+  const typeOverrides: Record<string, string> = {
+    has: 'Condition[]',
+    missing: 'Condition[]',
+    headers: 'Header[]',
+  };
+
+  function generateInterface(
+    name: string,
+    itemSchema: JSONSchema,
+    doc: string
+  ) {
+    if (!itemSchema?.properties) return;
+    output.push(`/**\n * ${doc}\n */`);
+    output.push(`export interface ${name} {`);
+    for (const [key, propSchema] of Object.entries(
+      itemSchema.properties as Record<string, JSONSchema>
+    )) {
+      const jsdoc = generateJSDoc(propSchema, '  ');
+      if (jsdoc) output.push(jsdoc);
+      const optional = !itemSchema.required?.includes(key) ? '?' : '';
+      const propType = typeOverrides[key] || convertSchemaType(propSchema, 1);
+      output.push(`  ${key}${optional}: ${propType};`);
+    }
+    output.push('}');
+    output.push('');
+  }
+
+  generateInterface(
+    'Header',
+    headersItemSchema?.properties?.headers?.items,
+    'HTTP header key/value pair'
+  );
+  generateInterface(
+    'Redirect',
+    redirectsItemSchema,
+    'Redirect definition matching vercel.json schema'
+  );
+  generateInterface(
+    'Rewrite',
+    rewritesItemSchema,
+    'Rewrite definition matching vercel.json schema'
+  );
+  generateInterface(
+    'HeaderRule',
+    headersItemSchema,
+    'Header rule definition matching vercel.json schema'
+  );
+
+  output.push(`/**\n * Union type for all routing helper outputs\n */`);
+  output.push(
+    'export type RouteType = Redirect | Rewrite | HeaderRule | any; // Route is internal to router'
+  );
+  output.push('');
+
+  return output;
 }
 
 function generateTypes(schema: JSONSchema): string {
@@ -295,78 +436,9 @@ function generateTypes(schema: JSONSchema): string {
     output.push('');
   }
 
-  // Keep existing routing types (Header, Condition, Redirect, Rewrite, HeaderRule)
-  output.push(`/**
- * HTTP header key/value pair
- */
-export interface Header {
-  key: string;
-  value: string;
-}
-
-/**
- * Condition for matching in redirects, rewrites, and headers
- */
-export interface Condition {
-  type: 'header' | 'cookie' | 'host' | 'query' | 'path';
-  key?: string;
-  value?: string | number;
-  eq?: string | number;
-  neq?: string;
-  inc?: string[];
-  ninc?: string[];
-  pre?: string;
-  suf?: string;
-  re?: string;
-  gt?: number;
-  gte?: number;
-  lt?: number;
-  lte?: number;
-}
-
-/**
- * Redirect matching vercel.json schema
- * Returned by routes.redirect()
- */
-export interface Redirect {
-  source: string;
-  destination: string;
-  permanent?: boolean;
-  statusCode?: number;
-  has?: Condition[];
-  missing?: Condition[];
-}
-
-/**
- * Rewrite matching vercel.json schema
- * Returned by routes.rewrite()
- */
-export interface Rewrite {
-  source: string;
-  destination: string;
-  has?: Condition[];
-  missing?: Condition[];
-  respectOriginCacheControl?: boolean;
-}
-
-/**
- * Header rule matching vercel.json schema
- * Returned by routes.header() and routes.cacheControl()
- */
-export interface HeaderRule {
-  source: string;
-  headers: Header[];
-  has?: Condition[];
-  missing?: Condition[];
-}
-
-/**
- * Union type for all routing helper outputs
- * Can be simple schema objects (Redirect, Rewrite, HeaderRule) or Routes with transforms
- * Note: Route type is defined in router.ts (uses src/dest instead of source/destination)
- */
-export type RouteType = Redirect | Rewrite | HeaderRule | any; // Route is internal to router
-`);
+  // Generate routing types (MatchableValue, Condition, Header, Redirect, Rewrite, HeaderRule)
+  // from the schema's has/redirects/rewrites/headers definitions
+  output.push(...generateRoutingTypes(schema));
 
   // Generate other helper types
   const wildcardProp = schema.properties?.wildcard;
@@ -460,8 +532,14 @@ export type RouteType = Redirect | Rewrite | HeaderRule | any; // Route is inter
           propType = 'BuildItem[]';
           break;
         case 'headers':
+          propType = 'HeaderRule[]';
+          break;
         case 'redirects':
+          propType = 'Redirect[]';
+          break;
         case 'rewrites':
+          propType = 'Rewrite[]';
+          break;
         case 'routes':
           propType = 'RouteType[]';
           break;
@@ -484,14 +562,16 @@ export const VercelConfig = {};`);
   return output.join('\n');
 }
 
-function main() {
+const SCHEMA_URL = 'https://openapi.vercel.sh/vercel.json';
+
+async function main() {
   try {
-    const schemaPath = process.argv[2] || '/tmp/vercel-schema.json';
     const outputPath = resolve(__dirname, '../src/types.ts');
 
-    console.log(`Reading schema from: ${schemaPath}`);
-    const schemaContent = readFileSync(schemaPath, 'utf-8');
-    const schema: JSONSchema = JSON.parse(schemaContent);
+    console.log(`Fetching schema from: ${SCHEMA_URL}`);
+    const res = await fetch(SCHEMA_URL);
+    if (!res.ok) throw new Error(`Failed to fetch schema: ${res.status}`);
+    const schema: JSONSchema = await res.json();
 
     console.log('Generating TypeScript types...');
     const types = generateTypes(schema);

--- a/packages/config/scripts/generate-types.ts
+++ b/packages/config/scripts/generate-types.ts
@@ -96,8 +96,6 @@ function convertSchemaType(schema: JSONSchema, depth = 0): string {
   if (schema.type === 'array') {
     if (schema.items) {
       const itemType = convertSchemaType(schema.items, depth);
-      // Wrap in parens if items is a union (oneOf/anyOf/multi-value enum)
-      // to avoid precedence issues like 'a' | 'b'[] or {x} | {y}[]
       const isUnion =
         schema.items.oneOf ||
         schema.items.anyOf ||
@@ -182,13 +180,6 @@ function convertSchemaType(schema: JSONSchema, depth = 0): string {
   }
 }
 
-/**
- * Generate routing types (MatchableValue, Condition, Header, Redirect, Rewrite, HeaderRule, RouteType)
- * from the schema's has/redirects/rewrites/headers definitions.
- *
- * We can't just use convertSchemaType here because we need named types that reference
- * each other (e.g. Condition references MatchableValue, Redirect references Condition[]).
- */
 function generateRoutingTypes(schema: JSONSchema): string[] {
   const output: string[] = [];
 
@@ -199,7 +190,6 @@ function generateRoutingTypes(schema: JSONSchema): string[] {
 
   if (!hasVariants) return output;
 
-  // MatchableValue — extract from the host variant's value field schema
   const hostVariant = hasVariants.find(
     (v: any) => v.properties?.type?.enum?.[0] === 'host'
   );
@@ -214,7 +204,6 @@ function generateRoutingTypes(schema: JSONSchema): string[] {
     output.push('');
   }
 
-  // Condition — discriminated union from has variants, referencing MatchableValue
   output.push(
     `/**\n * Condition for matching in redirects, rewrites, and headers\n */`
   );
@@ -244,8 +233,6 @@ function generateRoutingTypes(schema: JSONSchema): string[] {
   );
   output.push('');
 
-  // Header, Redirect, Rewrite, HeaderRule — generated from their schema definitions
-  // with special-cased fields to reference named types instead of inlining
   const typeOverrides: Record<string, string> = {
     has: 'Condition[]',
     missing: 'Condition[]',
@@ -436,8 +423,6 @@ function generateTypes(schema: JSONSchema): string {
     output.push('');
   }
 
-  // Generate routing types (MatchableValue, Condition, Header, Redirect, Rewrite, HeaderRule)
-  // from the schema's has/redirects/rewrites/headers definitions
   output.push(...generateRoutingTypes(schema));
 
   // Generate other helper types

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -218,7 +218,7 @@ describe('Router', () => {
         expect(header('x-user-role', { inc: ['admin', 'moderator'] })).toEqual({
           type: 'header',
           key: 'x-user-role',
-          value: { inc: ['admin', 'moderator'] },
+          inc: ['admin', 'moderator'],
         });
       });
 
@@ -226,47 +226,47 @@ describe('Router', () => {
         expect(header('x-version', { eq: 2 })).toEqual({
           type: 'header',
           key: 'x-version',
-          value: { eq: 2 },
+          eq: 2,
         });
         expect(header('x-version', { neq: 'beta' })).toEqual({
           type: 'header',
           key: 'x-version',
-          value: { neq: 'beta' },
+          neq: 'beta',
         });
         expect(header('x-version', { gte: 2 })).toEqual({
           type: 'header',
           key: 'x-version',
-          value: { gte: 2 },
+          gte: 2,
         });
         expect(header('x-version', { gt: 1 })).toEqual({
           type: 'header',
           key: 'x-version',
-          value: { gt: 1 },
+          gt: 1,
         });
         expect(header('x-version', { lt: 5 })).toEqual({
           type: 'header',
           key: 'x-version',
-          value: { lt: 5 },
+          lt: 5,
         });
         expect(header('x-version', { lte: 5 })).toEqual({
           type: 'header',
           key: 'x-version',
-          value: { lte: 5 },
+          lte: 5,
         });
         expect(header('x-auth', { pre: 'Bearer ' })).toEqual({
           type: 'header',
           key: 'x-auth',
-          value: { pre: 'Bearer ' },
+          pre: 'Bearer ',
         });
         expect(header('x-auth', { suf: '-token' })).toEqual({
           type: 'header',
           key: 'x-auth',
-          value: { suf: '-token' },
+          suf: '-token',
         });
         expect(header('x-role', { ninc: ['guest'] })).toEqual({
           type: 'header',
           key: 'x-role',
-          value: { ninc: ['guest'] },
+          ninc: ['guest'],
         });
       });
     });
@@ -291,7 +291,7 @@ describe('Router', () => {
         expect(cookie('session', { pre: 'secure-' })).toEqual({
           type: 'cookie',
           key: 'session',
-          value: { pre: 'secure-' },
+          pre: 'secure-',
         });
       });
     });
@@ -316,7 +316,7 @@ describe('Router', () => {
         expect(query('page', { gte: 1 })).toEqual({
           type: 'query',
           key: 'page',
-          value: { gte: 1 },
+          gte: 1,
         });
       });
     });
@@ -332,7 +332,7 @@ describe('Router', () => {
       it('should create a host operator condition', () => {
         expect(host({ suf: '.example.com' })).toEqual({
           type: 'host',
-          value: { suf: '.example.com' },
+          suf: '.example.com',
         });
       });
     });
@@ -354,12 +354,8 @@ describe('Router', () => {
           source: '/admin/(.*)',
           destination: 'https://admin.backend.com/$1',
           has: [
-            {
-              type: 'header',
-              key: 'x-user-role',
-              value: { inc: ['admin', 'moderator'] },
-            },
-            { type: 'cookie', key: 'session', value: { pre: 'secure-' } },
+            { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] },
+            { type: 'cookie', key: 'session', pre: 'secure-' },
           ],
           missing: [{ type: 'header', key: 'x-legacy-auth' }],
         });
@@ -369,15 +365,15 @@ describe('Router', () => {
         const rewrite = router.rewrite('/api/(.*)', 'https://backend.com/$1', {
           has: [
             header('authorization', { pre: 'Bearer ' }),
-            { type: 'header', key: 'x-api-version', value: { gte: 2 } },
+            { type: 'header', key: 'x-api-version', gte: 2 },
           ],
         });
         expect(rewrite).toEqual({
           source: '/api/(.*)',
           destination: 'https://backend.com/$1',
           has: [
-            { type: 'header', key: 'authorization', value: { pre: 'Bearer ' } },
-            { type: 'header', key: 'x-api-version', value: { gte: 2 } },
+            { type: 'header', key: 'authorization', pre: 'Bearer ' },
+            { type: 'header', key: 'x-api-version', gte: 2 },
           ],
         });
       });

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -218,7 +218,7 @@ describe('Router', () => {
         expect(header('x-user-role', { inc: ['admin', 'moderator'] })).toEqual({
           type: 'header',
           key: 'x-user-role',
-          inc: ['admin', 'moderator'],
+          value: { inc: ['admin', 'moderator'] },
         });
       });
 
@@ -226,47 +226,47 @@ describe('Router', () => {
         expect(header('x-version', { eq: 2 })).toEqual({
           type: 'header',
           key: 'x-version',
-          eq: 2,
+          value: { eq: 2 },
         });
         expect(header('x-version', { neq: 'beta' })).toEqual({
           type: 'header',
           key: 'x-version',
-          neq: 'beta',
+          value: { neq: 'beta' },
         });
         expect(header('x-version', { gte: 2 })).toEqual({
           type: 'header',
           key: 'x-version',
-          gte: 2,
+          value: { gte: 2 },
         });
         expect(header('x-version', { gt: 1 })).toEqual({
           type: 'header',
           key: 'x-version',
-          gt: 1,
+          value: { gt: 1 },
         });
         expect(header('x-version', { lt: 5 })).toEqual({
           type: 'header',
           key: 'x-version',
-          lt: 5,
+          value: { lt: 5 },
         });
         expect(header('x-version', { lte: 5 })).toEqual({
           type: 'header',
           key: 'x-version',
-          lte: 5,
+          value: { lte: 5 },
         });
         expect(header('x-auth', { pre: 'Bearer ' })).toEqual({
           type: 'header',
           key: 'x-auth',
-          pre: 'Bearer ',
+          value: { pre: 'Bearer ' },
         });
         expect(header('x-auth', { suf: '-token' })).toEqual({
           type: 'header',
           key: 'x-auth',
-          suf: '-token',
+          value: { suf: '-token' },
         });
         expect(header('x-role', { ninc: ['guest'] })).toEqual({
           type: 'header',
           key: 'x-role',
-          ninc: ['guest'],
+          value: { ninc: ['guest'] },
         });
       });
     });
@@ -291,7 +291,7 @@ describe('Router', () => {
         expect(cookie('session', { pre: 'secure-' })).toEqual({
           type: 'cookie',
           key: 'session',
-          pre: 'secure-',
+          value: { pre: 'secure-' },
         });
       });
     });
@@ -316,7 +316,7 @@ describe('Router', () => {
         expect(query('page', { gte: 1 })).toEqual({
           type: 'query',
           key: 'page',
-          gte: 1,
+          value: { gte: 1 },
         });
       });
     });
@@ -332,7 +332,7 @@ describe('Router', () => {
       it('should create a host operator condition', () => {
         expect(host({ suf: '.example.com' })).toEqual({
           type: 'host',
-          suf: '.example.com',
+          value: { suf: '.example.com' },
         });
       });
     });
@@ -354,8 +354,12 @@ describe('Router', () => {
           source: '/admin/(.*)',
           destination: 'https://admin.backend.com/$1',
           has: [
-            { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] },
-            { type: 'cookie', key: 'session', pre: 'secure-' },
+            {
+              type: 'header',
+              key: 'x-user-role',
+              value: { inc: ['admin', 'moderator'] },
+            },
+            { type: 'cookie', key: 'session', value: { pre: 'secure-' } },
           ],
           missing: [{ type: 'header', key: 'x-legacy-auth' }],
         });
@@ -365,15 +369,15 @@ describe('Router', () => {
         const rewrite = router.rewrite('/api/(.*)', 'https://backend.com/$1', {
           has: [
             header('authorization', { pre: 'Bearer ' }),
-            { type: 'header', key: 'x-api-version', gte: 2 },
+            { type: 'header', key: 'x-api-version', value: { gte: 2 } },
           ],
         });
         expect(rewrite).toEqual({
           source: '/api/(.*)',
           destination: 'https://backend.com/$1',
           has: [
-            { type: 'header', key: 'authorization', pre: 'Bearer ' },
-            { type: 'header', key: 'x-api-version', gte: 2 },
+            { type: 'header', key: 'authorization', value: { pre: 'Bearer ' } },
+            { type: 'header', key: 'x-api-version', value: { gte: 2 } },
           ],
         });
       });

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -1,12 +1,7 @@
 import { cacheHeader } from 'pretty-cache-header';
 import { sourceToRegex } from '@vercel/routing-utils';
 import { validateRegexPattern, parseCronExpression } from './utils/validation';
-import type {
-  Condition,
-  MatchableValueObject,
-  Redirect,
-  Rewrite,
-} from './types';
+import type { Redirect, Rewrite } from './types';
 
 /**
  * Convert a destination string from path-to-regexp format to use capture group references.
@@ -176,24 +171,104 @@ export interface CacheOptions {
   staleIfError?: TimeString;
 }
 
+/**
+ * Condition type for matching in redirects, headers, and rewrites.
+ * - 'header': Match if a specific HTTP header key/value is present (or missing).
+ * - 'cookie': Match if a specific cookie is present (or missing).
+ * - 'host':   Match if the incoming host matches a given pattern.
+ * - 'query':  Match if a query parameter is present (or missing).
+ * - 'path':   Match if the path matches a given pattern.
+ */
+export type ConditionType = 'header' | 'cookie' | 'host' | 'query' | 'path';
+
+/**
+ * Conditional matching operators for has/missing conditions.
+ * These can be used with the value field to perform advanced matching.
+ */
+export interface ConditionOperators {
+  /** Check equality on a value (exact match) */
+  eq?: string | number;
+  /** Check inequality on a value (not equal) */
+  neq?: string;
+  /** Check inclusion in an array of values (value is one of) */
+  inc?: string[];
+  /** Check non-inclusion in an array of values (value is not one of) */
+  ninc?: string[];
+  /** Check if value starts with a prefix */
+  pre?: string;
+  /** Check if value ends with a suffix */
+  suf?: string;
+  /** Check if value is greater than (numeric comparison) */
+  gt?: number;
+  /** Check if value is greater than or equal to */
+  gte?: number;
+  /** Check if value is less than (numeric comparison) */
+  lt?: number;
+  /** Check if value is less than or equal to */
+  lte?: number;
+}
+
+/**
+ * Used to define "has" or "missing" conditions with advanced matching operators.
+ *
+ * @example
+ * // Simple header presence check
+ * { type: 'header', key: 'x-api-key' }
+ *
+ * @example
+ * // Header with exact value match
+ * { type: 'header', key: 'x-api-version', value: 'v2' }
+ *
+ * @example
+ * // Header with conditional operators
+ * { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] }
+ *
+ * @example
+ * // Cookie with prefix matching
+ * { type: 'cookie', key: 'session', pre: 'prod-' }
+ *
+ * @example
+ * // Host matching
+ * { type: 'host', value: 'api.example.com' }
+ *
+ * @example
+ * // Query parameter with numeric comparison
+ * { type: 'query', key: 'version', gte: 2 }
+ *
+ * @example
+ * // Path pattern matching
+ * { type: 'path', value: '^/api/v[0-9]+/.*' }
+ */
+export interface Condition extends ConditionOperators {
+  type: ConditionType;
+  /** The key to match. Not used for 'host' or 'path' types. */
+  key?: string;
+  /**
+   * Simple string/regex pattern to match against.
+   * For 'host' and 'path' types, this is the only matching option.
+   * For other types, you can use value OR the conditional operators (eq, neq, etc).
+   */
+  value?: string;
+}
+
 function createKeyedConditionHelper(type: 'header' | 'cookie' | 'query') {
-  return (key: string, value?: string | MatchableValueObject): Condition => {
+  return (key: string, value?: string | ConditionOperators): Condition => {
     if (value === undefined) {
       return { type, key };
     }
     if (typeof value === 'string') {
       return { type, key, value };
     }
-    return { type, key, value };
+    return { type, key, ...value };
   };
 }
 
 function createKeylessConditionHelper(type: 'host') {
-  return (value: string | MatchableValueObject): Condition => {
+  return (value: string | ConditionOperators): Condition => {
     if (typeof value === 'string') {
       return { type, value };
     }
-    return { type, value };
+    return { type, ...value };
   };
 }
 

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -1,7 +1,12 @@
 import { cacheHeader } from 'pretty-cache-header';
 import { sourceToRegex } from '@vercel/routing-utils';
 import { validateRegexPattern, parseCronExpression } from './utils/validation';
-import type { Redirect, Rewrite } from './types';
+import type {
+  Condition,
+  MatchableValueObject,
+  Redirect,
+  Rewrite,
+} from './types';
 
 /**
  * Convert a destination string from path-to-regexp format to use capture group references.
@@ -171,104 +176,24 @@ export interface CacheOptions {
   staleIfError?: TimeString;
 }
 
-/**
- * Condition type for matching in redirects, headers, and rewrites.
- * - 'header': Match if a specific HTTP header key/value is present (or missing).
- * - 'cookie': Match if a specific cookie is present (or missing).
- * - 'host':   Match if the incoming host matches a given pattern.
- * - 'query':  Match if a query parameter is present (or missing).
- * - 'path':   Match if the path matches a given pattern.
- */
-export type ConditionType = 'header' | 'cookie' | 'host' | 'query' | 'path';
-
-/**
- * Conditional matching operators for has/missing conditions.
- * These can be used with the value field to perform advanced matching.
- */
-export interface ConditionOperators {
-  /** Check equality on a value (exact match) */
-  eq?: string | number;
-  /** Check inequality on a value (not equal) */
-  neq?: string;
-  /** Check inclusion in an array of values (value is one of) */
-  inc?: string[];
-  /** Check non-inclusion in an array of values (value is not one of) */
-  ninc?: string[];
-  /** Check if value starts with a prefix */
-  pre?: string;
-  /** Check if value ends with a suffix */
-  suf?: string;
-  /** Check if value is greater than (numeric comparison) */
-  gt?: number;
-  /** Check if value is greater than or equal to */
-  gte?: number;
-  /** Check if value is less than (numeric comparison) */
-  lt?: number;
-  /** Check if value is less than or equal to */
-  lte?: number;
-}
-
-/**
- * Used to define "has" or "missing" conditions with advanced matching operators.
- *
- * @example
- * // Simple header presence check
- * { type: 'header', key: 'x-api-key' }
- *
- * @example
- * // Header with exact value match
- * { type: 'header', key: 'x-api-version', value: 'v2' }
- *
- * @example
- * // Header with conditional operators
- * { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] }
- *
- * @example
- * // Cookie with prefix matching
- * { type: 'cookie', key: 'session', pre: 'prod-' }
- *
- * @example
- * // Host matching
- * { type: 'host', value: 'api.example.com' }
- *
- * @example
- * // Query parameter with numeric comparison
- * { type: 'query', key: 'version', gte: 2 }
- *
- * @example
- * // Path pattern matching
- * { type: 'path', value: '^/api/v[0-9]+/.*' }
- */
-export interface Condition extends ConditionOperators {
-  type: ConditionType;
-  /** The key to match. Not used for 'host' or 'path' types. */
-  key?: string;
-  /**
-   * Simple string/regex pattern to match against.
-   * For 'host' and 'path' types, this is the only matching option.
-   * For other types, you can use value OR the conditional operators (eq, neq, etc).
-   */
-  value?: string;
-}
-
 function createKeyedConditionHelper(type: 'header' | 'cookie' | 'query') {
-  return (key: string, value?: string | ConditionOperators): Condition => {
+  return (key: string, value?: string | MatchableValueObject): Condition => {
     if (value === undefined) {
       return { type, key };
     }
     if (typeof value === 'string') {
       return { type, key, value };
     }
-    return { type, key, ...value };
+    return { type, key, value };
   };
 }
 
 function createKeylessConditionHelper(type: 'host') {
-  return (value: string | ConditionOperators): Condition => {
+  return (value: string | MatchableValueObject): Condition => {
     if (typeof value === 'string') {
       return { type, value };
     }
-    return { type, ...value };
+    return { type, value };
   };
 }
 

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,6 +1,11 @@
 /**
- * Vercel configuration type that mirrors the vercel.json schema
- * https://openapi.vercel.sh/vercel.json
+ * AUTO-GENERATED — DO NOT EDIT
+ *
+ * This file is generated from the vercel.json OpenAPI schema.
+ * To modify, update scripts/generate-types.ts and re-run:
+ *   pnpm generate-types
+ *
+ * Schema: https://openapi.vercel.sh/vercel.json
  */
 
 export type Framework =
@@ -50,6 +55,7 @@ export type Framework =
   | 'fastapi'
   | 'flask'
   | 'fasthtml'
+  | 'django'
   | 'sanity-v3'
   | 'sanity'
   | 'storybook'
@@ -57,10 +63,17 @@ export type Framework =
   | 'hono'
   | 'express'
   | 'h3'
+  | 'koa'
   | 'nestjs'
   | 'elysia'
   | 'fastify'
   | 'xmcp'
+  | 'python'
+  | 'ruby'
+  | 'rust'
+  | 'node'
+  | 'go'
+  | 'services'
   | null;
 
 export interface FunctionConfig {
@@ -81,19 +94,17 @@ export interface FunctionConfig {
    */
   memory?: number;
   /**
-   * An array of regions where this Serverless Function will be deployed.
-   * This setting overrides the top-level `regions` setting for matching functions.
-   */
-  regions?: string[];
-  /**
-   * An array of passive regions where this Serverless Function can fail over during outages.
-   * This setting overrides top-level `functionFailoverRegions` for matching functions.
-   */
-  functionFailoverRegions?: string[];
-  /**
    * The npm package name of a Runtime, including its version
    */
   runtime?: string;
+  /**
+   * An array of regions this Serverless Function should be deployed to.
+   */
+  regions?: string[];
+  /**
+   * An array of passive regions this Serverless Function can fail over to during a lambda outage.
+   */
+  functionFailoverRegions?: string[];
   /**
    * A boolean that defines whether the Function supports cancellation (default: false)
    */
@@ -101,48 +112,64 @@ export interface FunctionConfig {
   /**
    * An array of experimental triggers for this Serverless Function. Currently only supports queue triggers.
    */
-  experimentalTriggers?: (TriggerEventConfigV1 | TriggerEventConfigV2)[];
-}
-
-interface TriggerEventConfigBase {
-  /**
-   * Name of the queue topic to consume from
-   */
-  topic: string;
-  /**
-   * Maximum number of delivery attempts
-   */
-  maxDeliveries?: number;
-  /**
-   * Delay in seconds before retrying failed executions
-   */
-  retryAfterSeconds?: number;
-  /**
-   * Initial delay in seconds before first execution attempt
-   */
-  initialDelaySeconds?: number;
-  /**
-   * Maximum number of concurrent executions for this consumer
-   */
-  maxConcurrency?: number;
-}
-
-/**
- * Queue trigger config for v1beta - requires explicit consumer name
- */
-export interface TriggerEventConfigV1 extends TriggerEventConfigBase {
-  type: 'queue/v1beta';
-  /**
-   * Name of the consumer group for this trigger (required for v1beta)
-   */
-  consumer: string;
-}
-
-/**
- * Queue trigger config for v2beta - consumer is derived from function path
- */
-export interface TriggerEventConfigV2 extends TriggerEventConfigBase {
-  type: 'queue/v2beta';
+  experimentalTriggers?: (
+    | {
+        /**
+         * Event type pattern this trigger handles
+         */
+        type: 'queue/v1beta';
+        /**
+         * Name of the queue topic to consume from
+         */
+        topic: string;
+        /**
+         * Name of the consumer group for this trigger
+         */
+        consumer: string;
+        /**
+         * Maximum number of delivery attempts
+         */
+        maxDeliveries?: number;
+        /**
+         * Delay in seconds before retrying failed executions
+         */
+        retryAfterSeconds?: number;
+        /**
+         * Initial delay in seconds before first execution attempt
+         */
+        initialDelaySeconds?: number;
+        /**
+         * Maximum number of concurrent executions for this consumer
+         */
+        maxConcurrency?: number;
+      }
+    | {
+        /**
+         * Event type pattern this trigger handles
+         */
+        type: 'queue/v2beta';
+        /**
+         * Name of the queue topic to consume from
+         */
+        topic: string;
+        /**
+         * Maximum number of delivery attempts
+         */
+        maxDeliveries?: number;
+        /**
+         * Delay in seconds before retrying failed executions
+         */
+        retryAfterSeconds?: number;
+        /**
+         * Initial delay in seconds before first execution attempt
+         */
+        initialDelaySeconds?: number;
+        /**
+         * Maximum number of concurrent executions for this consumer
+         */
+        maxConcurrency?: number;
+      }
+  )[];
 }
 
 export interface CronJob {
@@ -196,7 +223,7 @@ export interface ImageConfig {
   contentSecurityPolicy?: string;
   dangerouslyAllowSVG?: boolean;
   domains?: string[];
-  formats?: 'image/avif' | 'image/webp' | 'image/jpeg' | 'image/png'[];
+  formats?: ('image/avif' | 'image/webp' | 'image/jpeg' | 'image/png')[];
   localPatterns?: {
     pathname?: string;
     search?: string;
@@ -214,6 +241,74 @@ export interface ImageConfig {
 }
 
 /**
+ * Value for condition matching - can be a string or an operator object
+ */
+export type MatchableValue =
+  | string
+  | {
+      /**
+       * Equal to
+       */
+      eq?: string | number;
+      /**
+       * Not equal
+       */
+      neq?: string;
+      /**
+       * In array
+       */
+      inc?: string[];
+      /**
+       * Not in array
+       */
+      ninc?: string[];
+      /**
+       * Starts with
+       */
+      pre?: string;
+      /**
+       * Ends with
+       */
+      suf?: string;
+      /**
+       * Regex
+       */
+      re?: string;
+      /**
+       * Greater than
+       */
+      gt?: number;
+      /**
+       * Greater than or equal to
+       */
+      gte?: number;
+      /**
+       * Less than
+       */
+      lt?: number;
+      /**
+       * Less than or equal to
+       */
+      lte?: number;
+    };
+
+/**
+ * Condition for matching in redirects, rewrites, and headers
+ */
+export type Condition =
+  | { type: 'host'; value: MatchableValue }
+  | {
+      type: 'header' | 'cookie' | 'query';
+      key: string;
+      value?: MatchableValue;
+    };
+
+/**
+ * The object form of MatchableValue (excludes the plain string shorthand)
+ */
+export type MatchableValueObject = Exclude<MatchableValue, string>;
+
+/**
  * HTTP header key/value pair
  */
 export interface Header {
@@ -222,65 +317,98 @@ export interface Header {
 }
 
 /**
- * Condition for matching in redirects, rewrites, and headers
- */
-export interface Condition {
-  type: 'header' | 'cookie' | 'host' | 'query' | 'path';
-  key?: string;
-  value?: string | number;
-  eq?: string | number;
-  neq?: string;
-  inc?: string[];
-  ninc?: string[];
-  pre?: string;
-  suf?: string;
-  re?: string;
-  gt?: number;
-  gte?: number;
-  lt?: number;
-  lte?: number;
-}
-
-/**
- * Redirect matching vercel.json schema
- * Returned by routes.redirect()
+ * Redirect definition matching vercel.json schema
  */
 export interface Redirect {
+  /**
+   * A pattern that matches each incoming pathname (excluding querystring).
+   */
   source: string;
+  /**
+   * A location destination defined as an absolute pathname or external URL.
+   */
   destination: string;
+  /**
+   * A boolean to toggle between permanent and temporary redirect. When `true`, the status code is `308`. When `false` the status code is `307`.
+   */
   permanent?: boolean;
+  /**
+   * An optional integer to define the status code of the redirect.
+   * @private
+   */
   statusCode?: number;
+  /**
+   * An array of requirements that are needed to match
+   */
   has?: Condition[];
+  /**
+   * An array of requirements that are needed to match
+   */
   missing?: Condition[];
+  /**
+   * An array of environment variable names that should be replaced at runtime in the destination
+   */
+  env?: string[];
 }
 
 /**
- * Rewrite matching vercel.json schema
- * Returned by routes.rewrite()
+ * Rewrite definition matching vercel.json schema
  */
 export interface Rewrite {
+  /**
+   * A pattern that matches each incoming pathname (excluding querystring).
+   */
   source: string;
+  /**
+   * An absolute pathname to an existing resource or an external URL.
+   */
   destination: string;
+  /**
+   * An array of requirements that are needed to match
+   */
   has?: Condition[];
+  /**
+   * An array of requirements that are needed to match
+   */
   missing?: Condition[];
+  /**
+   * An optional integer to override the status code of the response.
+   */
+  statusCode?: number;
+  /**
+   * An array of environment variable names that should be replaced at runtime in the destination
+   */
+  env?: string[];
+  /**
+   * When set to true (default), external rewrites will respect the Cache-Control header from the origin. When false, caching is disabled for this rewrite.
+   */
   respectOriginCacheControl?: boolean;
 }
 
 /**
- * Header rule matching vercel.json schema
- * Returned by routes.header() and routes.cacheControl()
+ * Header rule definition matching vercel.json schema
  */
 export interface HeaderRule {
+  /**
+   * A pattern that matches each incoming pathname (excluding querystring)
+   */
   source: string;
+  /**
+   * An array of key/value pairs representing each response header.
+   */
   headers: Header[];
+  /**
+   * An array of requirements that are needed to match
+   */
   has?: Condition[];
+  /**
+   * An array of requirements that are needed to match
+   */
   missing?: Condition[];
 }
 
 /**
- * Union type for all router helper outputs
- * Can be simple schema objects (Redirect, Rewrite, HeaderRule) or Routes with transforms
- * Note: Route type is defined in router.ts (uses src/dest instead of source/destination)
+ * Union type for all routing helper outputs
  */
 export type RouteType = Redirect | Rewrite | HeaderRule | any; // Route is internal to router
 
@@ -343,7 +471,7 @@ export interface VercelConfig {
   /**
    * A list of header definitions.
    */
-  headers?: RouteType[];
+  headers?: HeaderRule[];
   images?: ImageConfig;
   /**
    * A name for the deployment
@@ -356,7 +484,7 @@ export interface VercelConfig {
   /**
    * A list of redirect definitions.
    */
-  redirects?: RouteType[];
+  redirects?: Redirect[];
   /**
    * The path to a file containing bulk redirects; supports JSON, JSONL, and CSV
    */
@@ -368,7 +496,7 @@ export interface VercelConfig {
   /**
    * A list of rewrite definitions.
    */
-  rewrites?: RouteType[];
+  rewrites?: Rewrite[];
   /**
    * A list of routes objects used to rewrite paths to point towards other internal or external paths
    */
@@ -427,6 +555,84 @@ export interface VercelConfig {
    * Enables Bun for the project and specifies the version to use.
    */
   bunVersion?: string;
+  /**
+   * Enables configuration of multiple services in a single deployment. Map of service name to service configuration.
+   * @private
+   */
+  experimentalServices?: Record<
+    string,
+    {
+      /**
+       * Service type: web, cron, or worker. Defaults to web.
+       */
+      type?: 'web' | 'cron' | 'worker';
+      /**
+       * Entry file for the service, relative to the workspace directory.
+       */
+      entrypoint?: string;
+      /**
+       * Path to the directory containing the service manifest file (package.json, pyproject.toml, etc.). Defaults to "." (project root).
+       */
+      workspace?: string;
+      /**
+       * URL prefix for routing (web services only).
+       */
+      routePrefix?: string;
+      /**
+       * Framework to use.
+       */
+      framework?: string;
+      /**
+       * Builder to use, e.g. @vercel/node, @vercel/python.
+       */
+      builder?: string;
+      /**
+       * Specific lambda runtime to use, e.g. nodejs24.x, python3.14.
+       */
+      runtime?: string;
+      /**
+       * Build command for the service.
+       */
+      buildCommand?: string;
+      /**
+       * Install command for the service.
+       */
+      installCommand?: string;
+      /**
+       * Memory allocation in MB (128-10240).
+       */
+      memory?: number;
+      /**
+       * Max duration in seconds (1-900).
+       */
+      maxDuration?: number;
+      /**
+       * Files to include in bundle.
+       */
+      includeFiles?: string | string[];
+      /**
+       * Files to exclude from bundle.
+       */
+      excludeFiles?: string | string[];
+      /**
+       * Cron schedule expression (e.g., "0 0 * * *"). Required for cron services.
+       */
+      schedule?: string;
+      /**
+       * Topic name for worker subscription.
+       */
+      topic?: string;
+      /**
+       * Consumer group name for worker subscription.
+       */
+      consumer?: string;
+    }
+  >;
+  /**
+   * Enables grouping of services. Map of service group name to an array of service names belonging to that group.
+   * @private
+   */
+  experimentalServiceGroups?: Record<string, string[]>;
 }
 
 /**

--- a/packages/config/src/v1/index.ts
+++ b/packages/config/src/v1/index.ts
@@ -6,6 +6,7 @@ export type {
   Rewrite,
   HeaderRule,
   Condition,
+  MatchableValue,
   RouteType,
 } from '../types';
 export {

--- a/packages/config/src/v1/types.ts
+++ b/packages/config/src/v1/types.ts
@@ -16,6 +16,7 @@ export type {
   ImageConfig,
   Header,
   Condition,
+  MatchableValue,
   Redirect,
   Rewrite,
   HeaderRule,


### PR DESCRIPTION
We discovered that the types for `@vercel/config`, which are supposed to be in sync with the vercel.json schema, contain a few inconsistencies 😓 including some hallucinated properties 😓😓😓😓

This has a few causes:
- The types generation script hardcoded routing types (Condition, Redirect, Rewrite, HeaderRule) instead of generating them from the schema
- The script didn't handle JSON Schema `const` values, producing `any` instead of literal types like `'queue/v1beta'`
- The script had an array-of-union precedence bug, generating `'a' | 'b'[]` instead of `('a' | 'b')[]`
- `router.ts` defined its own parallel `Condition` type that diverged from both the schema and the generated types

This PR fixes the following discrepancies:

1. `Condition` included a `'path'` type that doesn't exist in the schema or routing-utils (:chest-pain:)
2. `Condition` operators (`eq`, `inc`, `pre`, etc.) were flat on the object instead of nested inside `value`
3. `Condition` was a single interface instead of a discriminated union (`host` has no `key`, the others do)
4. `Redirect` was missing the `env` field
5. `Rewrite` was missing `statusCode` and `env` fields
6. `ImageConfig.formats` and `experimentalTriggers` had wrong array precedence

### What changed

- Routing types are now generated from the schema instead of hardcoded
- Added `const` support and array-of-union precedence fix
- Script now fetches the schema directly from `https://openapi.vercel.sh/vercel.json`
- Removed local `Condition` type definitions and used imported `MatchableValue` instead, which fixes nesting of operators inside `value`
- Updated assertions to match the correct nested `value` structure (the tests were enforcing the incorrect behavior)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR fixes a type generation script and updates generated TypeScript types to match the vercel.json schema, with no changes to security, auth, database schema, or critical business logic.
> 
> - Type generation script now fetches schema from URL instead of local file
> - Generated types updated to fix Condition nesting structure (operators inside `value`)
> - Test assertions updated to match corrected type structure
>
> <sup>Risk assessment for [commit 04cb352](https://github.com/vercel/vercel/commit/04cb352a0fdf61b024d8f73fd5eedebc12b7d2aa).</sup>
<!-- VADE_RISK_END -->