### PR TITLE
[config] Fix condition helpers to nest operators in value

### DIFF
--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -218,7 +218,7 @@ describe('Router', () => {
         expect(header('x-user-role', { inc: ['admin', 'moderator'] })).toEqual({
           type: 'header',
           key: 'x-user-role',
-          inc: ['admin', 'moderator'],
+          value: { inc: ['admin', 'moderator'] },
         });
       });
 
@@ -226,47 +226,47 @@ describe('Router', () => {
         expect(header('x-version', { eq: 2 })).toEqual({
           type: 'header',
           key: 'x-version',
-          eq: 2,
+          value: { eq: 2 },
         });
         expect(header('x-version', { neq: 'beta' })).toEqual({
           type: 'header',
           key: 'x-version',
-          neq: 'beta',
+          value: { neq: 'beta' },
         });
         expect(header('x-version', { gte: 2 })).toEqual({
           type: 'header',
           key: 'x-version',
-          gte: 2,
+          value: { gte: 2 },
         });
         expect(header('x-version', { gt: 1 })).toEqual({
           type: 'header',
           key: 'x-version',
-          gt: 1,
+          value: { gt: 1 },
         });
         expect(header('x-version', { lt: 5 })).toEqual({
           type: 'header',
           key: 'x-version',
-          lt: 5,
+          value: { lt: 5 },
         });
         expect(header('x-version', { lte: 5 })).toEqual({
           type: 'header',
           key: 'x-version',
-          lte: 5,
+          value: { lte: 5 },
         });
         expect(header('x-auth', { pre: 'Bearer ' })).toEqual({
           type: 'header',
           key: 'x-auth',
-          pre: 'Bearer ',
+          value: { pre: 'Bearer ' },
         });
         expect(header('x-auth', { suf: '-token' })).toEqual({
           type: 'header',
           key: 'x-auth',
-          suf: '-token',
+          value: { suf: '-token' },
         });
         expect(header('x-role', { ninc: ['guest'] })).toEqual({
           type: 'header',
           key: 'x-role',
-          ninc: ['guest'],
+          value: { ninc: ['guest'] },
         });
       });
     });
@@ -291,7 +291,7 @@ describe('Router', () => {
         expect(cookie('session', { pre: 'secure-' })).toEqual({
           type: 'cookie',
           key: 'session',
-          pre: 'secure-',
+          value: { pre: 'secure-' },
         });
       });
     });
@@ -316,7 +316,7 @@ describe('Router', () => {
         expect(query('page', { gte: 1 })).toEqual({
           type: 'query',
           key: 'page',
-          gte: 1,
+          value: { gte: 1 },
         });
       });
     });
@@ -332,7 +332,7 @@ describe('Router', () => {
       it('should create a host operator condition', () => {
         expect(host({ suf: '.example.com' })).toEqual({
           type: 'host',
-          suf: '.example.com',
+          value: { suf: '.example.com' },
         });
       });
     });
@@ -354,8 +354,12 @@ describe('Router', () => {
           source: '/admin/(.*)',
           destination: 'https://admin.backend.com/$1',
           has: [
-            { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] },
-            { type: 'cookie', key: 'session', pre: 'secure-' },
+            {
+              type: 'header',
+              key: 'x-user-role',
+              value: { inc: ['admin', 'moderator'] },
+            },
+            { type: 'cookie', key: 'session', value: { pre: 'secure-' } },
           ],
           missing: [{ type: 'header', key: 'x-legacy-auth' }],
         });
@@ -365,15 +369,15 @@ describe('Router', () => {
         const rewrite = router.rewrite('/api/(.*)', 'https://backend.com/$1', {
           has: [
             header('authorization', { pre: 'Bearer ' }),
-            { type: 'header', key: 'x-api-version', gte: 2 },
+            { type: 'header', key: 'x-api-version', value: { gte: 2 } },
           ],
         });
         expect(rewrite).toEqual({
           source: '/api/(.*)',
           destination: 'https://backend.com/$1',
           has: [
-            { type: 'header', key: 'authorization', pre: 'Bearer ' },
-            { type: 'header', key: 'x-api-version', gte: 2 },
+            { type: 'header', key: 'authorization', value: { pre: 'Bearer ' } },
+            { type: 'header', key: 'x-api-version', value: { gte: 2 } },
           ],
         });
       });

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -1,7 +1,12 @@
 import { cacheHeader } from 'pretty-cache-header';
 import { sourceToRegex } from '@vercel/routing-utils';
 import { validateRegexPattern, parseCronExpression } from './utils/validation';
-import type { Redirect, Rewrite } from './types';
+import type {
+  Condition,
+  MatchableValueObject,
+  Redirect,
+  Rewrite,
+} from './types';
 
 /**
  * Convert a destination string from path-to-regexp format to use capture group references.
@@ -171,104 +176,24 @@ export interface CacheOptions {
   staleIfError?: TimeString;
 }
 
-/**
- * Condition type for matching in redirects, headers, and rewrites.
- * - 'header': Match if a specific HTTP header key/value is present (or missing).
- * - 'cookie': Match if a specific cookie is present (or missing).
- * - 'host':   Match if the incoming host matches a given pattern.
- * - 'query':  Match if a query parameter is present (or missing).
- * - 'path':   Match if the path matches a given pattern.
- */
-export type ConditionType = 'header' | 'cookie' | 'host' | 'query' | 'path';
-
-/**
- * Conditional matching operators for has/missing conditions.
- * These can be used with the value field to perform advanced matching.
- */
-export interface ConditionOperators {
-  /** Check equality on a value (exact match) */
-  eq?: string | number;
-  /** Check inequality on a value (not equal) */
-  neq?: string;
-  /** Check inclusion in an array of values (value is one of) */
-  inc?: string[];
-  /** Check non-inclusion in an array of values (value is not one of) */
-  ninc?: string[];
-  /** Check if value starts with a prefix */
-  pre?: string;
-  /** Check if value ends with a suffix */
-  suf?: string;
-  /** Check if value is greater than (numeric comparison) */
-  gt?: number;
-  /** Check if value is greater than or equal to */
-  gte?: number;
-  /** Check if value is less than (numeric comparison) */
-  lt?: number;
-  /** Check if value is less than or equal to */
-  lte?: number;
-}
-
-/**
- * Used to define "has" or "missing" conditions with advanced matching operators.
- *
- * @example
- * // Simple header presence check
- * { type: 'header', key: 'x-api-key' }
- *
- * @example
- * // Header with exact value match
- * { type: 'header', key: 'x-api-version', value: 'v2' }
- *
- * @example
- * // Header with conditional operators
- * { type: 'header', key: 'x-user-role', inc: ['admin', 'moderator'] }
- *
- * @example
- * // Cookie with prefix matching
- * { type: 'cookie', key: 'session', pre: 'prod-' }
- *
- * @example
- * // Host matching
- * { type: 'host', value: 'api.example.com' }
- *
- * @example
- * // Query parameter with numeric comparison
- * { type: 'query', key: 'version', gte: 2 }
- *
- * @example
- * // Path pattern matching
- * { type: 'path', value: '^/api/v[0-9]+/.*' }
- */
-export interface Condition extends ConditionOperators {
-  type: ConditionType;
-  /** The key to match. Not used for 'host' or 'path' types. */
-  key?: string;
-  /**
-   * Simple string/regex pattern to match against.
-   * For 'host' and 'path' types, this is the only matching option.
-   * For other types, you can use value OR the conditional operators (eq, neq, etc).
-   */
-  value?: string;
-}
-
 function createKeyedConditionHelper(type: 'header' | 'cookie' | 'query') {
-  return (key: string, value?: string | ConditionOperators): Condition => {
+  return (key: string, value?: string | MatchableValueObject): Condition => {
     if (value === undefined) {
       return { type, key };
     }
     if (typeof value === 'string') {
       return { type, key, value };
     }
-    return { type, key, ...value };
+    return { type, key, value };
   };
 }
 
 function createKeylessConditionHelper(type: 'host') {
-  return (value: string | ConditionOperators): Condition => {
+  return (value: string | MatchableValueObject): Condition => {
     if (typeof value === 'string') {
       return { type, value };
     }
-    return { type, ...value };
+    return { type, value };
   };
 }
 


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR refactors condition helper functions to nest operator objects inside a 'value' property instead of spreading them at the top level, with corresponding test updates to verify the new structure.
> 
> - Refactor: condition helpers now wrap operators in `value` property instead of spreading
> - Test updates: expected output structures updated to match new nesting format
> - Type imports moved from local definitions to external types file
>
> <sup>Risk assessment for [commit 8440cb7](https://github.com/vercel/vercel/commit/8440cb7d61b29b57cd44817069a8b045a8f38dae).</sup>
<!-- VADE_RISK_END -->