### PR TITLE
[ci] Add GH action for syncing vercel.json schema with @vercel/config types

### DIFF
--- a/.github/workflows/sync-config-types.yml
+++ b/.github/workflows/sync-config-types.yml
@@ -1,0 +1,37 @@
+name: Sync @vercel/config types
+
+on:
+  pull_request:
+    paths:
+      - 'packages/config/scripts/generate-types.ts'
+      - 'packages/config/src/types.ts'
+
+jobs:
+  sync-types:
+    name: Regenerate types from schema
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: corepack enable pnpm
+      - run: pnpm install --filter @vercel/config...
+
+      - name: Regenerate types
+        run: pnpm --filter @vercel/config generate-types
+
+      - name: Commit if changed
+        run: |
+          git diff --quiet packages/config/src/types.ts && exit 0
+          git config user.email 'infra+release@vercel.com'
+          git config user.name 'vercel-release-bot'
+          git add packages/config/src/types.ts
+          git commit -m 'Regenerate @vercel/config types from schema'
+          git push


### PR DESCRIPTION
Follow-up to https://github.com/vercel/vercel/pull/15386. Adds a new GitHub Action which updates `@vercel/config` types automatically if it detects that the vercel.json schema was changed.

I'm not 100% sure about the auto-committing, but I did it because I want to make sure these are always in sync and usually when someone is adding a new property to the schema they are updating many places at once including `@vercel/config` so they are modifying multiple packages anyway.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> New GitHub Actions workflow for CI automation that syncs config types; uses secrets for push access but is scoped to internal PRs only via repository check.
> 
> - New CI workflow triggered on PR changes to config type files
> - Uses GH_TOKEN_PULL_REQUESTS secret for push access
> - Guarded by repository ownership check to prevent fork execution
>
> <sup>Risk assessment for [commit ff8cf5b](https://github.com/vercel/vercel/commit/ff8cf5bac15462c5b52ff101b9a31d4623ab904a).</sup>
<!-- VADE_RISK_END -->