### PR TITLE
feat(cli): add --json flag to deploy init command

### DIFF
--- a/.changeset/deploy-init-json-flag.md
+++ b/.changeset/deploy-init-json-flag.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add --json flag to `vc deploy init` for machine-readable output

--- a/packages/cli/src/commands/deploy/command.ts
+++ b/packages/cli/src/commands/deploy/command.ts
@@ -105,6 +105,8 @@ export const initSubcommand = {
       deprecated: false,
       description: 'Specify the target deployment environment',
     },
+    formatOption,
+    jsonOption,
     confirmOption,
   ],
   examples: [

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -517,15 +517,9 @@ async function handleInitDeployment(
 
     if (asJson) {
       output.stopSpinner();
-      const jsonOutput = {
-        id: deployment.id,
-        url: `https://${deployment.url}`,
-        inspectorUrl: deployment.inspectorUrl ?? null,
-        readyState: deployment.readyState,
-        target: deployment.target ?? null,
-        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deployment.id}`,
-      };
-      client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+      client.stdout.write(
+        `${JSON.stringify(buildDeploymentJson(deployment, client.apiUrl), null, 2)}\n`
+      );
       return 0;
     }
 
@@ -1275,15 +1269,9 @@ async function handleDefaultDeploy(
 
   if (asJson) {
     output.stopSpinner();
-    const jsonOutput = {
-      id: deployment.id,
-      url: `https://${deployment.url}`,
-      inspectorUrl: deployment.inspectorUrl ?? null,
-      readyState: deployment.readyState,
-      target: deployment.target ?? null,
-      deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deployment.id}`,
-    };
-    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    client.stdout.write(
+      `${JSON.stringify(buildDeploymentJson(deployment, client.apiUrl), null, 2)}\n`
+    );
     return 0;
   }
 
@@ -1548,4 +1536,24 @@ async function handleContinueDeployment({
     }
     return 1;
   }
+}
+
+function buildDeploymentJson(
+  deployment: {
+    id: string;
+    url: string;
+    inspectorUrl?: string | null;
+    readyState: string;
+    target?: string | null;
+  },
+  apiUrl: string
+) {
+  return {
+    id: deployment.id,
+    url: `https://${deployment.url}`,
+    inspectorUrl: deployment.inspectorUrl ?? null,
+    readyState: deployment.readyState,
+    target: deployment.target ?? null,
+    deploymentApiUrl: `${apiUrl}/v13/deployments/${deployment.id}`,
+  };
 }

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -169,6 +169,16 @@ async function handleInitDeployment(
     return 1;
   }
 
+  telemetryClient.trackCliFlagJson(parsedArguments.flags['--json']);
+  telemetryClient.trackCliOptionFormat(parsedArguments.flags['--format']);
+
+  const formatResult = validateJsonOutput(parsedArguments.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
   // Strip 'deploy' and 'init' from args
   let args = parsedArguments.args;
   if (args[0] === 'deploy') args = args.slice(1);
@@ -436,6 +446,7 @@ async function handleInitDeployment(
       withFullLogs: false,
       autoAssignCustomDomains,
       manual: true,
+      jsonOutput: asJson,
     };
 
     if (!localConfig.builds || localConfig.builds.length === 0) {
@@ -502,6 +513,20 @@ async function handleInitDeployment(
     if (deployment === null) {
       error('Uploading failed. Please try again.');
       return 1;
+    }
+
+    if (asJson) {
+      output.stopSpinner();
+      const jsonOutput = {
+        id: deployment.id,
+        url: `https://${deployment.url}`,
+        inspectorUrl: deployment.inspectorUrl ?? null,
+        readyState: deployment.readyState,
+        target: deployment.target ?? null,
+        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deployment.id}`,
+      };
+      client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+      return 0;
     }
 
     return printDeploymentStatus(deployment, deployStamp, noWait, false, true);

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -518,7 +518,7 @@ async function handleInitDeployment(
     if (asJson) {
       output.stopSpinner();
       client.stdout.write(
-        `${JSON.stringify(buildDeploymentJson(deployment, client.apiUrl), null, 2)}\n`
+        `${JSON.stringify(getDeploymentOutputJson(deployment, client.apiUrl), null, 2)}\n`
       );
       return 0;
     }
@@ -1270,7 +1270,7 @@ async function handleDefaultDeploy(
   if (asJson) {
     output.stopSpinner();
     client.stdout.write(
-      `${JSON.stringify(buildDeploymentJson(deployment, client.apiUrl), null, 2)}\n`
+      `${JSON.stringify(getDeploymentOutputJson(deployment, client.apiUrl), null, 2)}\n`
     );
     return 0;
   }
@@ -1538,7 +1538,7 @@ async function handleContinueDeployment({
   }
 }
 
-function buildDeploymentJson(
+function getDeploymentOutputJson(
   deployment: {
     id: string;
     url: string;

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1804,4 +1804,137 @@ describe('deploy', () => {
       });
     });
   });
+
+  describe('deploy init --json', () => {
+    const deploymentUrl = 'my-app-init-abc123.vercel.app';
+    const deploymentId = 'dpl_init_json_test';
+    const inspectorUrl = 'https://vercel.com/team/project/dpl_init_json_test';
+
+    beforeEach(() => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.post(`/v13/deployments`, (req, res) => {
+        res.json({
+          creator: {
+            uid: user.id,
+            username: user.username,
+          },
+          id: deploymentId,
+          url: deploymentUrl,
+          inspectorUrl,
+          readyState: 'INITIALIZING',
+          target: 'production',
+        });
+      });
+      client.scenario.get(`/v13/deployments/${deploymentId}`, (req, res) => {
+        res.json({
+          creator: {
+            uid: user.id,
+            username: user.username,
+          },
+          id: deploymentId,
+          url: deploymentUrl,
+          inspectorUrl,
+          readyState: 'INITIALIZING',
+          target: 'production',
+          aliasAssigned: false,
+          alias: [],
+        });
+      });
+    });
+
+    it('should output deployment as JSON to stdout with --json', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', 'init', '--json');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const json = JSON.parse(stdoutOutput);
+
+      expect(json).toEqual({
+        id: deploymentId,
+        url: `https://${deploymentUrl}`,
+        inspectorUrl,
+        readyState: 'INITIALIZING',
+        target: 'production',
+        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
+      });
+    });
+
+    it('should output deployment as JSON to stdout with --format=json', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', 'init', '--format', 'json');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const json = JSON.parse(stdoutOutput);
+
+      expect(json).toEqual({
+        id: deploymentId,
+        url: `https://${deploymentUrl}`,
+        inspectorUrl,
+        readyState: 'INITIALIZING',
+        target: 'production',
+        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
+      });
+    });
+
+    it('should track --json flag telemetry', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', 'init', '--json');
+      await deploy(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:init', value: 'init' },
+        { key: 'flag:json', value: 'TRUE' },
+      ]);
+    });
+
+    it('should track --format telemetry', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', 'init', '--format', 'json');
+      await deploy(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:init', value: 'init' },
+        { key: 'option:format', value: 'json' },
+      ]);
+    });
+
+    it('should return error for invalid format', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', 'init', '--format', 'xml');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(1);
+    });
+
+    it('should output only valid JSON to stdout when piped (non-TTY)', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', 'init', '--json');
+      // Simulate piped stdout (non-TTY) like `vc deploy init --json | jq`
+      client.stdout.isTTY = false;
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      // Should be valid JSON parseable by jq
+      const json = JSON.parse(stdoutOutput);
+      expect(json).toEqual({
+        id: deploymentId,
+        url: `https://${deploymentUrl}`,
+        inspectorUrl,
+        readyState: 'INITIALIZING',
+        target: 'production',
+        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Context

PRs #15355 and #15363 added `--json` / `--format=json` support to `vc deploy`. This extends the same behavior to `vc deploy init` so that scripts automating manual deployments can consume machine-readable output.

## Changes

- Added `--json` and `--format=json` flags to the `deploy init` subcommand
- When used, outputs deployment details (`id`, `url`, `inspectorUrl`, `readyState`, `target`, `deploymentApiUrl`) as JSON to stdout instead of human-readable output
- Passes `jsonOutput` through `CreateOptions` to suppress the bare URL write to stdout (matching the fix from #15363)
- Added telemetry tracking for both flags
- Added unit tests for JSON output, telemetry, invalid format handling, and non-TTY piping

## References

- Related to #15355 (add --json flag to deploy command)
- Related to #15363 (suppress stdout URL when using --json in deploy)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a --json output flag to a CLI deploy init subcommand, containing only new feature code for output formatting, telemetry tracking, and comprehensive unit tests with no security, auth, or database changes.
> 
> - Adds --json/--format=json flags to deploy init subcommand for machine-readable output
> - Extracts shared getDeploymentOutputJson helper function for consistent JSON formatting
> - Adds unit tests covering JSON output, telemetry, error handling, and non-TTY piping
>
> <sup>Risk assessment for [commit 8d37983](https://github.com/vercel/vercel/commit/8d37983f6961090b514824a5de8d42bfe14cce74).</sup>
<!-- VADE_RISK_END -->