### PR TITLE
[cli/build] Namespace diagnostics keys by builder and service workspace

### DIFF
--- a/.changeset/strange-pets-turn.md
+++ b/.changeset/strange-pets-turn.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+'@vercel/build-utils': patch
+---
+
+Namespace diagnostics keys by builder and service workspace, and aggregate per-builder `package-manifest.json` files into a single `project-manifest.json`

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -153,3 +153,80 @@ export const buildsSchema = {
     },
   },
 };
+
+/**
+ * JSON Schema for builder-produced `package-manifest.json` files.
+ *
+ * Each builder (e.g. @vercel/python) may emit a `package-manifest.json`
+ * in its diagnostics output.
+ */
+export const packageManifestSchema = {
+  type: 'object',
+  required: ['runtime', 'dependencies'],
+  additionalProperties: false,
+  properties: {
+    version: {
+      type: 'string',
+      description: 'Manifest schema version, e.g. "20260304".',
+    },
+    runtime: {
+      type: 'string',
+      description: 'Runtime identifier, e.g. "python", "node".',
+    },
+    runtimeVersion: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['resolved'],
+      properties: {
+        requested: {
+          type: 'string',
+          description:
+            'Version constraint from the project manifest, e.g. ">=3.10".',
+        },
+        requestedSource: {
+          type: 'string',
+          description:
+            'File that declared the constraint, e.g. "pyproject.toml".',
+        },
+        resolved: {
+          type: 'string',
+          description: 'Actual resolved version, e.g. "3.12".',
+        },
+      },
+    },
+    dependencies: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['name', 'type', 'scopes', 'resolved'],
+        additionalProperties: false,
+        properties: {
+          name: { type: 'string' },
+          type: { type: 'string', enum: ['direct', 'transitive', 'peer'] },
+          scopes: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Dependency groups this package belongs to, e.g. ["main", "dev"].',
+          },
+          requested: {
+            type: 'string',
+            description: 'Version specifier as declared, e.g. "flask>=2.0".',
+          },
+          resolved: {
+            type: 'string',
+            description: 'Resolved version, e.g. "3.1.0".',
+          },
+          source: {
+            type: 'string',
+            description: 'Package source type, e.g. "registry", "git", "path".',
+          },
+          sourceUrl: {
+            type: 'string',
+            description: 'Source URL, e.g. "https://pypi.org".',
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -8,6 +8,7 @@ import { readdirSync, statSync } from 'fs';
 
 import {
   download,
+  FileBlob,
   FileFsRef,
   getDiscontinuedNodeVersions,
   getInstalledPackageVersion,
@@ -37,6 +38,7 @@ import {
   isBackendBuilder,
   type Lambda,
   type TriggerEvent,
+  downloadFile,
 } from '@vercel/build-utils';
 import type { VercelConfig } from '@vercel/client';
 import { fileNameSymbol } from '@vercel/client';
@@ -102,6 +104,7 @@ import {
 import { help } from '../help';
 import { pullCommandLogic } from '../pull';
 import { buildCommand } from './command';
+import { validatePackageManifest } from '../../util/validate-package-manifest';
 import { mkdir, writeFile } from 'fs/promises';
 
 type BuildResult = BuildResultV2 | BuildResultV3;
@@ -694,6 +697,13 @@ async function doBuild(
     corepackShimDir = await initCorepack({ repoRootPath });
   }
   const diagnostics: Files = {};
+  const packageManifests: Array<{
+    workspace: string;
+    key: string;
+    manifest: Record<string, unknown>;
+    service?: Service;
+    builderUse: string;
+  }> = [];
 
   const hasDetectedServices =
     detectedServices !== undefined && detectedServices.length > 0;
@@ -911,7 +921,51 @@ async function doBuild(
             .trace(async () => {
               return await builder.diagnostics?.(buildOptions);
             });
-          Object.assign(diagnostics, builderDiagnostics);
+          if (builderDiagnostics) {
+            const prefix =
+              service && service.workspace !== '.'
+                ? service.workspace + '/' + builderPkg.name + '/'
+                : '';
+            for (const [key, value] of Object.entries(builderDiagnostics)) {
+              const fullKey = prefix + key;
+              if (key.endsWith('package-manifest.json')) {
+                try {
+                  let data: string;
+                  if (value.type === 'FileBlob') {
+                    data = (value as unknown as FileBlob).data.toString();
+                  } else {
+                    data = await streamToString(value.toStream());
+                  }
+                  const packageManifest = JSON.parse(data);
+                  const validationError =
+                    validatePackageManifest(packageManifest);
+                  if (validationError) {
+                    output.warn(
+                      `Invalid package-manifest.json from ${fullKey}: ${validationError}`
+                    );
+                  } else {
+                    const workspace =
+                      service && service.workspace !== '.'
+                        ? service.workspace
+                        : '.';
+                    packageManifests.push({
+                      workspace,
+                      key: fullKey,
+                      manifest: packageManifest,
+                      service,
+                      builderUse: builderPkg.name,
+                    });
+                  }
+                } catch (e) {
+                  output.debug(
+                    `Failed to parse ${fullKey}: ${e instanceof Error ? e.message : String(e)}`
+                  );
+                }
+              } else {
+                diagnostics[fullKey] = value;
+              }
+            }
+          }
         } catch (error) {
           output.error('Collecting diagnostics failed');
           output.debug(error);
@@ -1102,6 +1156,43 @@ async function doBuild(
     } finally {
       ops.push(
         download(diagnostics, join(outputDir, 'diagnostics')).then(
+          () => undefined,
+          err => err
+        )
+      );
+    }
+  }
+
+  // Aggregate individual package-manifest.json files from builders into
+  // a single project-manifest.json keyed by service workspace.
+  if (packageManifests.length > 0) {
+    const projectManifest: Record<string, unknown> = {};
+    for (const {
+      workspace,
+      manifest,
+      service,
+      builderUse,
+    } of packageManifests) {
+      projectManifest[`${builderUse}:${workspace}`] = {
+        ...manifest,
+        workspace,
+        builder: builderUse,
+        framework: service?.framework,
+        serviceName: service?.name,
+        serviceType: service?.type,
+        routePrefix: service?.routePrefix,
+      };
+    }
+    if (Object.keys(projectManifest).length > 0) {
+      const projectManifestBlob = new FileBlob({
+        data: JSON.stringify(projectManifest),
+      });
+      diagnostics['project-manifest.json'] = projectManifestBlob;
+      ops.push(
+        downloadFile(
+          projectManifestBlob,
+          join(outputDir, 'diagnostics', 'project-manifest.json')
+        ).then(
           () => undefined,
           err => err
         )
@@ -1833,4 +1924,12 @@ function appendWorkerTrigger(lambda: Lambda, trigger: TriggerEvent): void {
   if (!alreadyConfigured) {
     lambda.experimentalTriggers = [...existingTriggers, trigger];
   }
+}
+
+async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
 }

--- a/packages/cli/src/util/validate-package-manifest.ts
+++ b/packages/cli/src/util/validate-package-manifest.ts
@@ -1,0 +1,17 @@
+import Ajv from 'ajv';
+import { packageManifestSchema } from '@vercel/build-utils';
+
+const ajv = new Ajv();
+const validate = ajv.compile(packageManifestSchema);
+
+/**
+ * Validate a parsed `package-manifest.json` object.
+ * Returns `null` on success or an error message string on failure.
+ */
+export function validatePackageManifest(data: unknown): string | null {
+  if (validate(data)) {
+    return null;
+  }
+  const errors = validate.errors ?? [];
+  return errors.map(e => `${e.dataPath || '(root)'} ${e.message}`).join('; ');
+}


### PR DESCRIPTION
Prefix diagnostics file keys with the builder name (e.g. `python/`) and
service workspace path for multi-service or multi-builder builds, so
that diagnostics from different builders or services do not collide.
Single-project, single-builder builds remain unprefixed.


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds JSON schema validation for package manifests and namespaces diagnostics keys by builder/workspace to prevent collisions in multi-service builds - purely additive build tooling changes with no auth, database, or billing impact.
> 
> - Adds `packageManifestSchema` JSON schema for validating builder diagnostics output
> - Namespaces diagnostics keys with builder name and workspace prefix for multi-service builds
> - Aggregates per-builder `package-manifest.json` files into single `project-manifest.json`
>
> <sup>Risk assessment for [commit 2d558e0](https://github.com/vercel/vercel/commit/2d558e04cef48b241424d782bb6daeaa60c7422d).</sup>
<!-- VADE_RISK_END -->