### PR TITLE
Substantially speed up entry point detection for python

### DIFF
--- a/.changeset/loud-wombats-buy.md
+++ b/.changeset/loud-wombats-buy.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+speed up python entrypoint detection

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -1,12 +1,7 @@
 import fs from 'fs';
 import { join, posix as pathPosix } from 'path';
-import type { FileFsRef, PythonFramework } from '@vercel/build-utils';
-import {
-  glob,
-  debug,
-  isDirectory,
-  isPythonEntrypoint,
-} from '@vercel/build-utils';
+import type { PythonFramework } from '@vercel/build-utils';
+import { debug, isPythonEntrypoint } from '@vercel/build-utils';
 import { readConfigFile } from '@vercel/build-utils';
 
 export interface DetectedPythonEntrypoint {
@@ -36,6 +31,24 @@ function getCandidateEntrypointsInDirs(dirs: string[]) {
   );
 }
 
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function checkEntrypoint(
+  workPath: string,
+  relPath: string
+): Promise<boolean> {
+  const absPath = join(workPath, relPath);
+  if (!(await fileExists(absPath))) return false;
+  return isPythonEntrypoint({ fsPath: absPath });
+}
+
 export async function getPyprojectEntrypoint(
   workPath: string
 ): Promise<string | null> {
@@ -60,30 +73,21 @@ export async function getPyprojectEntrypoint(
   const relPath = modulePath.replace(/\./g, '/');
 
   // Prefer an existing file match if present; otherwise fall back to "<module>.py".
-  try {
-    const fsFiles = await glob('**', workPath);
-    const candidates = [`${relPath}.py`, `${relPath}/__init__.py`];
-    for (const candidate of candidates) {
-      if (fsFiles[candidate]) return candidate;
-    }
-    return null;
-  } catch {
-    debug('Failed to discover Python entrypoint from pyproject.toml');
-    return null;
+  const candidates = [`${relPath}.py`, `${relPath}/__init__.py`];
+  for (const candidate of candidates) {
+    if (await fileExists(join(workPath, candidate))) return candidate;
   }
+  return null;
 }
 
 async function findValidEntrypoint(
-  fsFiles: Record<string, FileFsRef>,
+  workPath: string,
   candidates: string[]
 ): Promise<string | null> {
   for (const candidate of candidates) {
-    if (fsFiles[candidate]) {
-      const isValid = await isPythonEntrypoint(fsFiles[candidate] as FileFsRef);
-      if (isValid) {
-        debug(`Detected Python entrypoint: ${candidate}`);
-        return candidate;
-      }
+    if (await checkEntrypoint(workPath, candidate)) {
+      debug(`Detected Python entrypoint: ${candidate}`);
+      return candidate;
     }
   }
   return null;
@@ -105,6 +109,23 @@ async function checkDjangoManage(workPath: string): Promise<boolean> {
 }
 
 /**
+ * List immediate subdirectories of workPath (non-hidden).
+ */
+async function getSubdirectories(workPath: string): Promise<string[]> {
+  try {
+    const entries = await fs.promises.readdir(workPath, {
+      withFileTypes: true,
+    });
+    return entries
+      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+      .map(e => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Detect a Python entrypoint for any Python framework using AST-based detection.
  */
 export async function detectGenericPythonEntrypoint(
@@ -116,22 +137,17 @@ export async function detectGenericPythonEntrypoint(
     : `${configuredEntrypoint}.py`;
 
   try {
-    const fsFiles = await glob('**', workPath);
-
     // If the configured entrypoint exists and is valid, use it
-    if (fsFiles[entry]) {
-      const isValid = await isPythonEntrypoint(fsFiles[entry] as FileFsRef);
-      if (isValid) {
-        debug(`Using configured Python entrypoint: ${entry}`);
-        return { entrypoint: entry };
-      }
+    if (await checkEntrypoint(workPath, entry)) {
+      debug(`Using configured Python entrypoint: ${entry}`);
+      return { entrypoint: entry };
     }
 
     // Search candidate locations using AST-based detection
-    const candidates = PYTHON_CANDIDATE_ENTRYPOINTS.filter(
-      (c: string) => !!fsFiles[c]
+    const found = await findValidEntrypoint(
+      workPath,
+      PYTHON_CANDIDATE_ENTRYPOINTS
     );
-    const found = await findValidEntrypoint(fsFiles, candidates);
     return found ? { entrypoint: found } : null;
   } catch {
     debug('Failed to discover Python entrypoint');
@@ -140,9 +156,8 @@ export async function detectGenericPythonEntrypoint(
 }
 
 /**
- * Detect a Django Python entrypoint: resolve WSGI_APPLICATION from settings
- * to get the wsgi module file (e.g. hello/wsgi.py), then fall back to
- * AST-based detection if needed.
+ * Detect a Django Python entrypoint: look for manage.py with
+ * DJANGO_SETTINGS_MODULE, then fall back to AST-based detection if needed.
  */
 export async function detectDjangoPythonEntrypoint(
   workPath: string,
@@ -153,31 +168,15 @@ export async function detectDjangoPythonEntrypoint(
     : `${configuredEntrypoint}.py`;
 
   try {
-    const fsFiles = await glob('**', workPath);
-
     // If the configured entrypoint exists and is valid, use it
-    if (fsFiles[entry]) {
-      const isValid = await isPythonEntrypoint(fsFiles[entry] as FileFsRef);
-      if (isValid) {
-        debug(`Using configured Python entrypoint: ${entry}`);
-        return { entrypoint: entry };
-      }
+    if (await checkEntrypoint(workPath, entry)) {
+      debug(`Using configured Python entrypoint: ${entry}`);
+      return { entrypoint: entry };
     }
 
-    // Get root directories
-    const rootGlobs = await glob('*', {
-      cwd: workPath,
-      includeDirectories: true,
-    });
-    const rootDirs = [
-      '',
-      ...Object.keys(rootGlobs).filter(
-        name =>
-          !name.startsWith('.') &&
-          rootGlobs[name].mode != null &&
-          isDirectory(rootGlobs[name].mode)
-      ),
-    ];
+    // Get root directories (workPath root + immediate subdirs)
+    const subdirs = await getSubdirectories(workPath);
+    const rootDirs = ['', ...subdirs];
 
     // Look for a Django manage.py in workPath and immediate subdirectories.
     for (const rootDir of rootDirs) {
@@ -190,9 +189,8 @@ export async function detectDjangoPythonEntrypoint(
 
     // Fall back to AST-based detection,
     // Look in all immediate subdirectories, not just those specified in PYTHON_ENTRYPOINT_DIRS.
-    const baseCandidates = getCandidateEntrypointsInDirs(rootDirs);
-    const candidates = baseCandidates.filter((c: string) => !!fsFiles[c]);
-    const found = await findValidEntrypoint(fsFiles, candidates);
+    const candidates = getCandidateEntrypointsInDirs(rootDirs);
+    const found = await findValidEntrypoint(workPath, candidates);
     return found ? { entrypoint: found } : null;
   } catch {
     debug('Failed to discover Django Python entrypoint');


### PR DESCRIPTION
We were doing a glob('**') to discover the entire file system tree,
which can be slow if there are a lot of files. (Which there probably
will be in the .venv at least in dev mode!)

Do targeted file system operations instead.


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR refactors Python entrypoint detection to use targeted filesystem operations instead of glob('**'), a pure performance optimization with no security, auth, or data implications.
> 
> - Replaces glob('**') with direct fs.promises.stat and fs.promises.readdir calls
> - Adds helper functions fileExists, checkEntrypoint, getSubdirectories
> - Updates findValidEntrypoint signature to take workPath instead of fsFiles record
>
> <sup>Risk assessment for [commit 9774126](https://github.com/vercel/vercel/commit/9774126858d401975194dfa99fdb104a67bc9a03).</sup>
<!-- VADE_RISK_END -->