### PR TITLE
Revert "Update Next.js adapter version"

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.13",
+    "@next-community/adapter-vercel": "0.0.1-beta.12",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1701,8 +1701,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.13
-        version: 0.0.1-beta.13(next@16.1.6)
+        specifier: 0.0.1-beta.12
+        version: 0.0.1-beta.12(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6532,8 +6532,8 @@ packages:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  /@next-community/adapter-vercel@0.0.1-beta.13(next@16.1.6):
-    resolution: {integrity: sha512-klZhR/9LjXLvlt5n1wqJxM7xwd4c3VCflZzuBnFkd1fkMPUF49oXjHHyqsgG+Y1FQpwLuwqpymZLHRRiADsxfg==}
+  /@next-community/adapter-vercel@0.0.1-beta.12(next@16.1.6):
+    resolution: {integrity: sha512-pvINuPgfGWKA8YquGl3xwRp6aDnKvZDrlu3ZtbsnUiTt/CKPTgBmWJ1jpE4OCLSCM+frQUOl2FEZzUSdSUcs1A==}
     engines: {node: '>= 20.6.0'}
     peerDependencies:
       next: '>= 16.1.1-canary.18'


### PR DESCRIPTION
Reverts vercel/vercel#15382

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR reverts a dev dependency version bump from beta.13 to beta.12, which is a minor dependency change with no code logic changes.
> 
> - Reverts devDependency version: adapter-vercel beta.13 → beta.12
> - Lockfile updated accordingly
>
> <sup>Risk assessment for [commit d482b14](https://github.com/vercel/vercel/commit/d482b14834c98debeb4c01baf92d7dc1cf5b45ff).</sup>
<!-- VADE_RISK_END -->