### PR TITLE
Refactor flags prepare to use @vercel/prepare-flags-definitions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "jose": "5.9.6",
     "luxon": "^3.4.0",
     "proxy-agent": "6.4.0",
+    "@vercel/prepare-flags-definitions": "^0.1.0",
     "@vercel/backends": "workspace:*",
     "@vercel/elysia": "workspace:*",
     "@vercel/express": "workspace:*",

--- a/packages/cli/src/commands/build/emit-flags-datafiles.ts
+++ b/packages/cli/src/commands/build/emit-flags-datafiles.ts
@@ -1,216 +1,36 @@
-import { createHash } from 'node:crypto';
 import { NowBuildError } from '@vercel/build-utils';
-import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { prepareFlagsDefinitions } from '@vercel/prepare-flags-definitions';
 import nodeFetch from 'node-fetch';
 import output from '../../output-manager';
 import pkg from '../../util/pkg';
 
-const FLAGS_HOST = 'https://flags.vercel.com';
-const FLAGS_DEFINITIONS_VERSION = '1.0.1';
-
-type BundledDefinitions = Record<string, unknown>;
-
-/**
- * Obfuscates SDK key for logging (shows first 18 chars)
- */
-function obfuscate(sdkKey: string, prefixLength = 18): string {
-  if (prefixLength >= sdkKey.length) return sdkKey;
-  return (
-    sdkKey.slice(0, prefixLength) + '*'.repeat(sdkKey.length - prefixLength)
-  );
-}
-
-/**
- * Computes a SHA-256 hex digest of the given SDK key.
- */
-function hashSdkKey(sdkKey: string): string {
-  return createHash('sha256').update(sdkKey).digest('hex');
-}
-
-/**
- * Generates a JS module with deduplicated, lazily-parsed definitions.
- *
- * The map keys are SHA-256 hashes of the SDK keys so that raw keys
- * are not embedded in the output.
- *
- * Output format:
- * ```js
- * const memo = (fn) => { let cached; return () => (cached ??= fn()); };
- * const _d0 = memo(() => JSON.parse('...'));
- * const map = { "<sha256_hash>": _d0 };
- * export function get(hashedSdkKey) { return map[hashedSdkKey]?.() ?? null; }
- * ```
- */
-function generateDefinitionsModule(
-  sdkKeys: string[],
-  values: BundledDefinitions[]
-): string {
-  // Stringify each definition
-  const stringified = sdkKeys.map((_, i) => JSON.stringify(values[i]));
-
-  // Deduplicate: map unique strings to indices
-  const uniqueStrings: string[] = [];
-  const stringToIndex = new Map<string, number>();
-  for (const s of stringified) {
-    if (!stringToIndex.has(s)) {
-      stringToIndex.set(s, uniqueStrings.length);
-      uniqueStrings.push(s);
-    }
-  }
-
-  // Map SDK keys to their definition index
-  const keyToIndex = sdkKeys.map((_, i) => stringToIndex.get(stringified[i]));
-
-  // Hash each SDK key
-  const hashedKeys = sdkKeys.map(hashSdkKey);
-
-  // Generate JS
-  const lines: string[] = [
-    'const memo = (fn) => { let cached; return () => (cached ??= fn()); };',
-    '',
-  ];
-
-  // Add definition constants
-  for (let i = 0; i < uniqueStrings.length; i++) {
-    lines.push(
-      `const _d${i} = memo(() => JSON.parse(${JSON.stringify(uniqueStrings[i])}));`
-    );
-  }
-
-  lines.push('');
-  lines.push('const map = {');
-  for (let i = 0; i < sdkKeys.length; i++) {
-    lines.push(`  ${JSON.stringify(hashedKeys[i])}: _d${keyToIndex[i]},`);
-  }
-  lines.push('};');
-  lines.push('');
-  lines.push('export function get(hashedSdkKey) {');
-  lines.push('  return map[hashedSdkKey]?.() ?? null;');
-  lines.push('}');
-  lines.push('');
-  lines.push(
-    `export const version = ${JSON.stringify(FLAGS_DEFINITIONS_VERSION)};`
-  );
-
-  return lines.join('\n');
-}
-
 /**
  * Emits flag definitions into node_modules/@vercel/flags-definitions
  *
- * Reads SDK keys (vf_ prefix) from environment variables, fetches definitions
- * from flags.vercel.com, and writes them to a synthetic package that can be
- * imported at runtime.
+ * Thin wrapper around @vercel/prepare-flags-definitions that adapts
+ * the CLI's output, fetch, and error conventions.
  */
 export async function emitFlagsDatafiles(
   cwd: string,
   env: NodeJS.ProcessEnv
 ): Promise<void> {
-  output.debug('vercel-flags: checking env vars for SDK Keys');
-
-  // Collect unique SDK keys from environment variables
-  // Supports both direct SDK keys (vf_ prefix) and flags: format
-  const sdkKeys = Array.from(
-    Object.values(env).reduce<Set<string>>((acc, value) => {
-      if (typeof value === 'string') {
-        if (value.startsWith('vf_')) {
-          acc.add(value);
-        } else if (value.startsWith('flags:')) {
-          const params = new URLSearchParams(value.slice('flags:'.length));
-          const sdkKey = params.get('sdkKey');
-          if (sdkKey?.startsWith('vf_')) {
-            acc.add(sdkKey);
-          }
-        }
-      }
-      return acc;
-    }, new Set<string>())
-  );
-
-  output.debug(`vercel-flags: found ${sdkKeys.length} SDK keys`);
-
-  // Fetch definitions for each SDK key
-  const fetchPromise = Promise.all(
-    sdkKeys.map(async sdkKey => {
-      const headers: Record<string, string> = {
-        authorization: `Bearer ${sdkKey}`,
-        'user-agent': `VercelCLI/${pkg.version}`,
-      };
-
-      // Add Vercel metadata headers if available
-      if (env.VERCEL_PROJECT_ID) {
-        headers['x-vercel-project-id'] = env.VERCEL_PROJECT_ID;
-      }
-      if (env.VERCEL_ENV) {
-        headers['x-vercel-env'] = env.VERCEL_ENV;
-      }
-      if (env.VERCEL_DEPLOYMENT_ID) {
-        headers['x-vercel-deployment-id'] = env.VERCEL_DEPLOYMENT_ID;
-      }
-      if (env.VERCEL_REGION) {
-        headers['x-vercel-region'] = env.VERCEL_REGION;
-      }
-
-      const res = await nodeFetch(`${FLAGS_HOST}/v1/datafile`, { headers });
-
-      if (!res.ok) {
-        throw new NowBuildError({
-          code: 'VERCEL_FLAGS_DEFINITIONS_FETCH_FAILED',
-          message: `Failed to fetch flag definitions for ${obfuscate(sdkKey)}: ${res.status} ${res.statusText}`,
-          link: 'https://vercel.com/docs/flags', // TODO replace with better link once we have a docs page
-        });
-      }
-
-      return res.json() as Promise<BundledDefinitions>;
-    })
-  );
-
-  const values = await output.time(
-    'vercel-flags: load datafiles',
-    fetchPromise
-  );
-
-  // Generate the JS module
-  const definitionsJs = generateDefinitionsModule(sdkKeys, values);
-
-  // Write to node_modules/@vercel/flags-definitions/
-  const storageDir = join(cwd, 'node_modules', '@vercel', 'flags-definitions');
-  const indexPath = join(storageDir, 'index.js');
-  const dtsPath = join(storageDir, 'index.d.ts');
-  const packageJsonPath = join(storageDir, 'package.json');
-  const dts = [
-    'export function get(hashedSdkKey: string): Record<string, unknown> | null;',
-    'export const version: string;',
-    '',
-  ].join('\n');
-
-  const packageJson = {
-    name: '@vercel/flags-definitions',
-    version: FLAGS_DEFINITIONS_VERSION,
-    type: 'module',
-    main: './index.js',
-    types: './index.d.ts',
-    exports: {
-      '.': {
-        types: './index.d.ts',
-        import: './index.js',
+  try {
+    await prepareFlagsDefinitions({
+      cwd,
+      env,
+      version: pkg.version,
+      fetch: nodeFetch as unknown as typeof globalThis.fetch,
+      output: {
+        debug: (msg: string) => output.debug(msg),
+        time: <T>(label: string, promise: Promise<T>) =>
+          output.time(label, promise),
       },
-    },
-  };
-
-  await mkdir(storageDir, { recursive: true });
-  await Promise.all([
-    writeFile(indexPath, definitionsJs),
-    writeFile(dtsPath, dts),
-    writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2)),
-  ]);
-
-  output.debug('vercel-flags: created module');
-  output.debug(`  → ${indexPath}`);
-  output.debug(`  → ${dtsPath}`);
-  output.debug(`  → ${packageJsonPath}`);
-  output.debug(
-    `  → included definitions for keys "${sdkKeys.map(key => obfuscate(key)).join(', ')}"`
-  );
+    });
+  } catch (err) {
+    throw new NowBuildError({
+      code: 'VERCEL_FLAGS_DEFINITIONS_FETCH_FAILED',
+      message: err instanceof Error ? err.message : String(err),
+      link: 'https://vercel.com/docs/flags',
+    });
+  }
 }

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -962,16 +962,14 @@ test('`flags prepare` should not require login', async () => {
   // Command actually completes (progresses past auth), not just absence of error
   expect(output.exitCode, formatOutput(output)).toBe(0);
   expect(output.stderr).not.toContain('No existing credentials found');
-  // Module is emitted to the filesystem
+  // No SDK keys in env, so no files are written (early return)
   const definitionsDir = path.join(
     cwd,
     'node_modules',
     '@vercel',
     'flags-definitions'
   );
-  expect(fs.existsSync(path.join(definitionsDir, 'index.js'))).toBe(true);
-  expect(fs.existsSync(path.join(definitionsDir, 'index.d.ts'))).toBe(true);
-  expect(fs.existsSync(path.join(definitionsDir, 'package.json'))).toBe(true);
+  expect(fs.existsSync(definitionsDir)).toBe(false);
 });
 
 test('`flags prepare` happy path emits flags-definitions module', async () => {
@@ -981,15 +979,12 @@ test('`flags prepare` happy path emits flags-definitions module', async () => {
     reject: false,
   });
   expect(output.exitCode, formatOutput(output)).toBe(0);
+  // No SDK keys in env, so no files are written (early return)
   const definitionsDir = path.join(
     cwd,
     'node_modules',
     '@vercel',
     'flags-definitions'
   );
-  expect(fs.existsSync(path.join(definitionsDir, 'index.js'))).toBe(true);
-  expect(fs.existsSync(path.join(definitionsDir, 'index.d.ts'))).toBe(true);
-  const pkg = await fs.readJSON(path.join(definitionsDir, 'package.json'));
-  expect(pkg.name).toBe('@vercel/flags-definitions');
-  expect(pkg.version).toBeDefined();
+  expect(fs.existsSync(definitionsDir)).toBe(false);
 });

--- a/packages/cli/test/unit/commands/build/emit-flags-definitions.test.ts
+++ b/packages/cli/test/unit/commands/build/emit-flags-definitions.test.ts
@@ -1,292 +1,117 @@
-import { createHash } from 'node:crypto';
-import { type fs, vol } from 'memfs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('node:fs/promises', async () => {
-  const memfs: { fs: typeof fs } = await vi.importActual('memfs');
-  return memfs.fs.promises;
-});
+const { prepareFlagsDefinitions } = vi.hoisted(() => ({
+  prepareFlagsDefinitions: vi.fn(),
+}));
 
-import _fetch, { type Response } from 'node-fetch';
+vi.mock('@vercel/build-utils', () => ({
+  NowBuildError: class NowBuildError extends Error {
+    code: string;
+    link: string;
+    constructor(opts: { code: string; message: string; link: string }) {
+      super(opts.message);
+      this.code = opts.code;
+      this.link = opts.link;
+    }
+  },
+}));
 
-const fetch = vi.mocked(_fetch);
-vi.mock('node-fetch', async () => ({
-  ...(await vi.importActual('node-fetch')),
-  default: vi.fn(),
+vi.mock('@vercel/prepare-flags-definitions', () => ({
+  prepareFlagsDefinitions,
+}));
+
+vi.mock('../../../../src/output-manager', () => ({
+  default: {
+    debug: vi.fn(),
+    time: vi.fn((_label: string, promise: Promise<unknown>) => promise),
+  },
+}));
+
+vi.mock('../../../../src/util/pkg', () => ({
+  default: { version: '1.0.0-test' },
 }));
 
 import { emitFlagsDatafiles } from '../../../../src/commands/build/emit-flags-datafiles';
 
-function sha256(input: string): string {
-  return createHash('sha256').update(input).digest('hex');
-}
-
-function mockFetchResponse(data: unknown, ok = true): Response {
-  return {
-    ok,
-    status: ok ? 200 : 500,
-    statusText: ok ? 'OK' : 'Internal Server Error',
-    json: async () => data,
-  } as unknown as Response;
-}
-
 beforeEach(() => {
   vi.resetAllMocks();
-  vol.reset();
 });
 
 describe('emitFlagsDatafiles', () => {
-  it('should emit an empty package when no SDK keys are present', async () => {
-    await emitFlagsDatafiles('/app', {
-      SOME_VAR: 'hello',
-    });
+  it('should call prepareFlagsDefinitions with cwd and env', async () => {
+    prepareFlagsDefinitions.mockResolvedValueOnce(undefined);
 
-    expect(fetch).not.toHaveBeenCalled();
+    await emitFlagsDatafiles('/app', { SOME_VAR: 'hello' });
 
-    const files = vol.toJSON();
-    const storageDir = '/app/node_modules/@vercel/flags-definitions';
-
-    // index.js should exist with an empty map
-    const indexJs = files[`${storageDir}/index.js`] as string;
-    expect(indexJs).toBeDefined();
-    expect(indexJs).toContain('export function get(hashedSdkKey)');
-    expect(indexJs).toContain('const map = {\n};');
-
-    // index.d.ts and package.json should exist
-    expect(files[`${storageDir}/index.d.ts`]).toBeDefined();
-    expect(files[`${storageDir}/package.json`]).toBeDefined();
-  });
-
-  it('should fetch definitions for a direct vf_ key and write files', async () => {
-    const sdkKey = 'vf_test_abc123def456';
-    const definitions = { flag1: { variants: ['on', 'off'] } };
-
-    fetch.mockResolvedValueOnce(mockFetchResponse(definitions));
-
-    await emitFlagsDatafiles('/app', {
-      FLAGS_SECRET: sdkKey,
-    });
-
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(
-      'https://flags.vercel.com/v1/datafile',
+    expect(prepareFlagsDefinitions).toHaveBeenCalledTimes(1);
+    expect(prepareFlagsDefinitions).toHaveBeenCalledWith(
       expect.objectContaining({
-        headers: expect.objectContaining({
-          authorization: `Bearer ${sdkKey}`,
-        }),
-      })
-    );
-
-    const files = vol.toJSON();
-    const storageDir = '/app/node_modules/@vercel/flags-definitions';
-
-    // index.js should exist and use hashed key
-    const indexJs = files[`${storageDir}/index.js`] as string;
-    expect(indexJs).toBeDefined();
-    expect(indexJs).toContain(sha256(sdkKey));
-    expect(indexJs).not.toContain(sdkKey);
-    expect(indexJs).toContain('export function get(hashedSdkKey)');
-
-    // index.d.ts should exist
-    const dts = files[`${storageDir}/index.d.ts`] as string;
-    expect(dts).toContain('export function get(hashedSdkKey: string)');
-
-    // package.json should exist
-    const packageJson = JSON.parse(
-      files[`${storageDir}/package.json`] as string
-    );
-    expect(packageJson.name).toBe('@vercel/flags-definitions');
-  });
-
-  it('should extract SDK key from flags: format', async () => {
-    const sdkKey = 'vf_flags_format_key';
-    const definitions = { flag1: {} };
-
-    fetch.mockResolvedValueOnce(mockFetchResponse(definitions));
-
-    await emitFlagsDatafiles('/app', {
-      MY_FLAG_VAR: `flags:sdkKey=${sdkKey}&other=value`,
-    });
-
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(
-      'https://flags.vercel.com/v1/datafile',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          authorization: `Bearer ${sdkKey}`,
-        }),
+        cwd: '/app',
+        env: { SOME_VAR: 'hello' },
       })
     );
   });
 
-  it('should deduplicate SDK keys across env vars', async () => {
-    const sdkKey = 'vf_duplicate_key';
-    const definitions = { flag1: {} };
+  it('should pass version from package.json', async () => {
+    prepareFlagsDefinitions.mockResolvedValueOnce(undefined);
 
-    fetch.mockResolvedValueOnce(mockFetchResponse(definitions));
+    await emitFlagsDatafiles('/app', {});
 
-    await emitFlagsDatafiles('/app', {
-      VAR1: sdkKey,
-      VAR2: sdkKey,
-      VAR3: `flags:sdkKey=${sdkKey}`,
-    });
-
-    expect(fetch).toHaveBeenCalledTimes(1);
+    const opts = prepareFlagsDefinitions.mock.calls[0][0];
+    expect(opts.version).toBe('1.0.0-test');
   });
 
-  it('should handle multiple distinct SDK keys', async () => {
-    const key1 = 'vf_key_one_abcdef';
-    const key2 = 'vf_key_two_ghijkl';
-    const defs1 = { flagA: { enabled: true } };
-    const defs2 = { flagB: { enabled: false } };
+  it('should pass a fetch function', async () => {
+    prepareFlagsDefinitions.mockResolvedValueOnce(undefined);
 
-    fetch
-      .mockResolvedValueOnce(mockFetchResponse(defs1))
-      .mockResolvedValueOnce(mockFetchResponse(defs2));
+    await emitFlagsDatafiles('/app', {});
 
-    await emitFlagsDatafiles('/app', {
-      VAR1: key1,
-      VAR2: key2,
-    });
-
-    expect(fetch).toHaveBeenCalledTimes(2);
-
-    const files = vol.toJSON();
-    const indexJs = files[
-      '/app/node_modules/@vercel/flags-definitions/index.js'
-    ] as string;
-
-    // Both hashed keys should be present, raw keys should not
-    expect(indexJs).toContain(sha256(key1));
-    expect(indexJs).toContain(sha256(key2));
-    expect(indexJs).not.toContain(key1);
-    expect(indexJs).not.toContain(key2);
+    const opts = prepareFlagsDefinitions.mock.calls[0][0];
+    expect(typeof opts.fetch).toBe('function');
   });
 
-  it('should deduplicate identical definitions across keys', async () => {
-    const key1 = 'vf_key_one_abcdef';
-    const key2 = 'vf_key_two_ghijkl';
-    const sameDefs = { flagA: { enabled: true } };
+  it('should pass an output adapter with debug and time', async () => {
+    prepareFlagsDefinitions.mockResolvedValueOnce(undefined);
 
-    fetch
-      .mockResolvedValueOnce(mockFetchResponse(sameDefs))
-      .mockResolvedValueOnce(mockFetchResponse(sameDefs));
+    await emitFlagsDatafiles('/app', {});
 
-    await emitFlagsDatafiles('/app', {
-      VAR1: key1,
-      VAR2: key2,
-    });
-
-    const files = vol.toJSON();
-    const indexJs = files[
-      '/app/node_modules/@vercel/flags-definitions/index.js'
-    ] as string;
-
-    // Only one _d0 constant should exist (deduplicated)
-    expect(indexJs).toContain('const _d0');
-    expect(indexJs).not.toContain('const _d1');
-
-    // Both hashed keys map to _d0
-    expect(indexJs).toContain(`${JSON.stringify(sha256(key1))}: _d0`);
-    expect(indexJs).toContain(`${JSON.stringify(sha256(key2))}: _d0`);
+    const opts = prepareFlagsDefinitions.mock.calls[0][0];
+    expect(typeof opts.output.debug).toBe('function');
+    expect(typeof opts.output.time).toBe('function');
   });
 
-  it('should produce a valid module structure', async () => {
-    const sdkKey = 'vf_structure_test_key_123';
-    const definitions = { myFlag: { variants: ['a', 'b'] } };
-
-    fetch.mockResolvedValueOnce(mockFetchResponse(definitions));
-
-    await emitFlagsDatafiles('/app', {
-      SDK_KEY: sdkKey,
-    });
-
-    const files = vol.toJSON();
-    const indexJs = files[
-      '/app/node_modules/@vercel/flags-definitions/index.js'
-    ] as string;
-
-    const hashedKey = sha256(sdkKey);
-
-    // Map entry uses hashed key pointing to _d0
-    expect(indexJs).toContain(`"${hashedKey}": _d0`);
-
-    // _d0 contains the JSON-serialized definitions
-    expect(indexJs).toContain(
-      `const _d0 = memo(() => JSON.parse(${JSON.stringify(JSON.stringify(definitions))}));`
+  it('should wrap errors from the package in NowBuildError', async () => {
+    prepareFlagsDefinitions.mockRejectedValueOnce(
+      new Error(
+        'Failed to fetch flag definitions for vf_test_abc123de******: 500 Internal Server Error'
+      )
     );
 
-    // Lookup function uses the hashed key parameter
-    expect(indexJs).toContain(
-      'export function get(hashedSdkKey) {\n  return map[hashedSdkKey]?.() ?? null;\n}'
-    );
-
-    // Raw key must not appear
-    expect(indexJs).not.toContain(sdkKey);
-
-    // Version is included
-    expect(indexJs).toContain('export const version = "1.0.1"');
-  });
-
-  it('should include Vercel metadata headers when env vars are set', async () => {
-    const sdkKey = 'vf_meta_key_test';
-
-    fetch.mockResolvedValueOnce(mockFetchResponse({}));
-
-    await emitFlagsDatafiles('/app', {
-      MY_KEY: sdkKey,
-      VERCEL_PROJECT_ID: 'prj_123',
-      VERCEL_ENV: 'production',
-      VERCEL_DEPLOYMENT_ID: 'dpl_456',
-      VERCEL_REGION: 'iad1',
+    await expect(
+      emitFlagsDatafiles('/app', { KEY: 'vf_test' })
+    ).rejects.toMatchObject({
+      code: 'VERCEL_FLAGS_DEFINITIONS_FETCH_FAILED',
+      message: expect.stringContaining('Failed to fetch flag definitions'),
+      link: 'https://vercel.com/docs/flags',
     });
-
-    expect(fetch).toHaveBeenCalledWith(
-      'https://flags.vercel.com/v1/datafile',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          'x-vercel-project-id': 'prj_123',
-          'x-vercel-env': 'production',
-          'x-vercel-deployment-id': 'dpl_456',
-          'x-vercel-region': 'iad1',
-        }),
-      })
-    );
   });
 
-  it('should throw NowBuildError when fetch fails', async () => {
-    const sdkKey = 'vf_fail_key_abcdef123';
+  it('should wrap non-Error exceptions in NowBuildError', async () => {
+    prepareFlagsDefinitions.mockRejectedValueOnce('string error');
 
-    fetch.mockResolvedValueOnce(mockFetchResponse(null, false));
-
-    await expect(emitFlagsDatafiles('/app', { KEY: sdkKey })).rejects.toThrow(
-      'Failed to fetch flag definitions'
-    );
-  });
-
-  it('should ignore env vars that do not contain SDK keys', async () => {
-    await emitFlagsDatafiles('/app', {
-      HOME: '/home/user',
-      PATH: '/usr/bin',
-      NODE_ENV: 'production',
-      FLAGS_VAR: 'flags:other=value',
-      PARTIAL: 'flags:sdkKey=not_vf_prefix',
+    await expect(
+      emitFlagsDatafiles('/app', { KEY: 'vf_test' })
+    ).rejects.toMatchObject({
+      code: 'VERCEL_FLAGS_DEFINITIONS_FETCH_FAILED',
+      message: 'string error',
     });
-
-    expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('should write version field in the generated module', async () => {
-    fetch.mockResolvedValueOnce(mockFetchResponse({}));
+  it('should succeed when prepareFlagsDefinitions resolves', async () => {
+    prepareFlagsDefinitions.mockResolvedValueOnce(undefined);
 
-    await emitFlagsDatafiles('/app', {
-      KEY: 'vf_version_test',
-    });
-
-    const files = vol.toJSON();
-    const indexJs = files[
-      '/app/node_modules/@vercel/flags-definitions/index.js'
-    ] as string;
-    expect(indexJs).toContain('export const version = "1.0.1"');
+    await expect(
+      emitFlagsDatafiles('/app', { SDK_KEY: 'vf_abc123' })
+    ).resolves.toBeUndefined();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: link:packages/build-utils
       '@vercel/style-guide':
         specifier: 4.0.2
-        version: 4.0.2(eslint@8.24.0)(jest@29.5.0)(prettier@3.3.3)(typescript@4.9.5)
+        version: 4.0.2(eslint@8.35.0)(jest@29.5.0)(prettier@3.3.3)(typescript@4.9.5)
       async-retry:
         specifier: 1.2.3
         version: 1.2.3
@@ -465,6 +465,9 @@ importers:
       '@vercel/node':
         specifier: workspace:*
         version: link:../node
+      '@vercel/prepare-flags-definitions':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@vercel/python':
         specifier: workspace:*
         version: link:../python
@@ -3649,20 +3652,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser@7.27.1(@babel/core@7.24.4)(eslint@8.24.0):
-    resolution: {integrity: sha512-q8rjOuadH0V6Zo4XLMkJ3RMQ9MSBqwaDByyYB0izsYdaIWGNLmEblbCOf1vyFHICcg16CD7Fsi51vcQnYxmt6Q==}
-    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
-    peerDependencies:
-      '@babel/core': ^7.11.0
-      eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
-    dependencies:
-      '@babel/core': 7.24.4
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.24.0
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
-    dev: true
-
   /@babel/eslint-parser@7.27.1(@babel/core@7.24.4)(eslint@8.35.0):
     resolution: {integrity: sha512-q8rjOuadH0V6Zo4XLMkJ3RMQ9MSBqwaDByyYB0izsYdaIWGNLmEblbCOf1vyFHICcg16CD7Fsi51vcQnYxmt6Q==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
@@ -5527,16 +5516,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.7.0(eslint@8.24.0):
-    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.24.0
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
   /@eslint-community/eslint-utils@4.7.0(eslint@8.35.0):
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5550,23 +5529,6 @@ packages:
   /@eslint-community/regexpp@4.12.1:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
-
-  /@eslint/eslintrc@1.4.1:
-    resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
-      espree: 9.6.1
-      globals: 13.24.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@eslint/eslintrc@2.1.4:
@@ -5635,18 +5597,6 @@ packages:
       hono: 4.12.0
     dev: true
 
-  /@humanwhocodes/config-array@0.10.7:
-    resolution: {integrity: sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==}
-    engines: {node: '>=10.10.0'}
-    deprecated: Use @eslint/config-array instead
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -5659,18 +5609,9 @@ packages:
       - supports-color
     dev: true
 
-  /@humanwhocodes/gitignore-to-minimatch@1.0.2:
-    resolution: {integrity: sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==}
-    dev: true
-
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
-    dev: true
-
-  /@humanwhocodes/object-schema@1.2.1:
-    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
-    deprecated: Use @eslint/object-schema instead
     dev: true
 
   /@humanwhocodes/object-schema@2.0.3:
@@ -9631,34 +9572,6 @@ packages:
       '@types/node': 20.11.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.24.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare-lite: 1.4.0
-      semver: 7.5.2
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.35.0)(typescript@4.9.4):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9715,26 +9628,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.24.0
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser@5.62.0(eslint@8.35.0)(typescript@4.9.4):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9781,26 +9674,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-    dev: true
-
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.24.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/type-utils@5.62.0(eslint@8.35.0)(typescript@4.9.4):
@@ -9888,26 +9761,6 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/utils@5.62.0(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.24.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      eslint: 8.24.0
-      eslint-scope: 5.1.1
-      semver: 7.5.2
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /@typescript-eslint/utils@5.62.0(eslint@8.35.0)(typescript@4.9.4):
@@ -10266,6 +10119,10 @@ packages:
     engines: {node: '>= 20'}
     dev: true
 
+  /@vercel/prepare-flags-definitions@0.1.0:
+    resolution: {integrity: sha512-d5OvW/6ZlzX2d96xMFAlex8+uCfEswhnE7DilxiYdtC3vZq6ILQGmIpEoAQwjENfFhssRdujQBEhkjsGVCdwWA==}
+    dev: false
+
   /@vercel/sandbox@1.6.0:
     resolution: {integrity: sha512-T204S3RZIdo+BCR5gpErTQBYz+ruXjTMRiZyf+HV/UQeKjPKAVKWu27T65kahDvVvJrbadHhxR2Cds28rXXF/Q==}
     dependencies:
@@ -10291,53 +10148,6 @@ packages:
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
-      - supports-color
-    dev: true
-
-  /@vercel/style-guide@4.0.2(eslint@8.24.0)(jest@29.5.0)(prettier@3.3.3)(typescript@4.9.5):
-    resolution: {integrity: sha512-FroL+oOePzhw7n/I+f7zr4WNroGHT/+2TlW6WH9+CVSjMNsEyu7Qstj2mI5gWIBjT1Y2ZImKPppCzI2cIYmNZw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@next/eslint-plugin-next': ^12.3.0
-      eslint: ^8.24.0
-      prettier: ^2.7.0
-      typescript: ^4.8.0
-    peerDependenciesMeta:
-      '@next/eslint-plugin-next':
-        optional: true
-      eslint:
-        optional: true
-      prettier:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.24.4
-      '@babel/eslint-parser': 7.27.1(@babel/core@7.24.4)(eslint@8.24.0)
-      '@rushstack/eslint-patch': 1.11.0
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.24.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      eslint: 8.24.0
-      eslint-config-prettier: 8.5.0(eslint@8.24.0)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
-      eslint-plugin-eslint-comments: 3.2.0(eslint@8.24.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.24.0)
-      eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.24.0)
-      eslint-plugin-react: 7.37.5(eslint@8.24.0)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.24.0)
-      eslint-plugin-testing-library: 5.11.1(eslint@8.24.0)(typescript@4.9.5)
-      eslint-plugin-tsdoc: 0.2.17
-      eslint-plugin-unicorn: 43.0.2(eslint@8.24.0)
-      prettier: 3.3.3
-      prettier-plugin-packagejson: 2.5.11(prettier@3.3.3)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - jest
       - supports-color
     dev: true
 
@@ -10369,7 +10179,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -10416,7 +10226,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -10463,7 +10273,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -13157,15 +12967,6 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /eslint-config-prettier@8.5.0(eslint@8.24.0):
-    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      eslint: 8.24.0
-    dev: true
-
   /eslint-config-prettier@8.5.0(eslint@8.35.0):
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
     hasBin: true
@@ -13181,7 +12982,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -13190,32 +12991,6 @@ packages:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.10
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0):
-    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      eslint-plugin-import: '*'
-      eslint-plugin-import-x: '*'
-    peerDependenciesMeta:
-      eslint-plugin-import:
-        optional: true
-      eslint-plugin-import-x:
-        optional: true
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.24.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.7.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13236,7 +13011,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.35.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -13246,7 +13021,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13267,24 +13042,13 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
       debug: 3.2.7
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /eslint-plugin-eslint-comments@3.2.0(eslint@8.24.0):
-    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
-    engines: {node: '>=6.5.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
-    dependencies:
-      escape-string-regexp: 1.0.5
-      eslint: 8.24.0
-      ignore: 5.3.2
     dev: true
 
   /eslint-plugin-eslint-comments@3.2.0(eslint@8.35.0):
@@ -13298,7 +13062,7 @@ packages:
       ignore: 5.3.2
     dev: true
 
-  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13309,16 +13073,16 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13333,28 +13097,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: true
-
-  /eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.0.0 || ^6.0.0 || ^7.0.0
-      eslint: ^7.0.0 || ^8.0.0
-      jest: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.24.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      eslint: 8.24.0
-      jest: 29.5.0(@types/node@20.11.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4):
@@ -13401,30 +13143,6 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jsx-a11y@6.10.2(eslint@8.24.0):
-    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
-    dependencies:
-      aria-query: 5.3.2
-      array-includes: 3.1.8
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.10.3
-      axobject-query: 4.1.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 8.24.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
-    dev: true
-
   /eslint-plugin-jsx-a11y@6.10.2(eslint@8.35.0):
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
@@ -13449,19 +13167,6 @@ packages:
       string.prototype.includes: 2.0.1
     dev: true
 
-  /eslint-plugin-playwright@0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.24.0):
-    resolution: {integrity: sha512-uRLRLk7uTzc8NE6t4wBU8dijQwHvC66R/h7xwdM779jsJjMUtSmeaB8ayRkkpfwi+UU5BEfwvDANwmE+ccMVDw==}
-    peerDependencies:
-      eslint: '>=7'
-      eslint-plugin-jest: '>=24'
-    peerDependenciesMeta:
-      eslint-plugin-jest:
-        optional: true
-    dependencies:
-      eslint: 8.24.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
-    dev: true
-
   /eslint-plugin-playwright@0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0):
     resolution: {integrity: sha512-uRLRLk7uTzc8NE6t4wBU8dijQwHvC66R/h7xwdM779jsJjMUtSmeaB8ayRkkpfwi+UU5BEfwvDANwmE+ccMVDw==}
     peerDependencies:
@@ -13472,16 +13177,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.35.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
-    dev: true
-
-  /eslint-plugin-react-hooks@4.6.2(eslint@8.24.0):
-    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 8.24.0
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
     dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.35.0):
@@ -13491,33 +13187,6 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.35.0
-    dev: true
-
-  /eslint-plugin-react@7.37.5(eslint@8.24.0):
-    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
-    dependencies:
-      array-includes: 3.1.8
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.2.1
-      eslint: 8.24.0
-      estraverse: 5.3.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.9
-      object.fromentries: 2.0.8
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-      string.prototype.repeat: 1.0.0
     dev: true
 
   /eslint-plugin-react@7.37.5(eslint@8.35.0):
@@ -13545,19 +13214,6 @@ packages:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
-    dev: true
-
-  /eslint-plugin-testing-library@5.11.1(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
-    peerDependencies:
-      eslint: ^7.5.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      eslint: 8.24.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /eslint-plugin-testing-library@5.11.1(eslint@8.35.0)(typescript@4.9.4):
@@ -13591,29 +13247,6 @@ packages:
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-    dev: true
-
-  /eslint-plugin-unicorn@43.0.2(eslint@8.24.0):
-    resolution: {integrity: sha512-DtqZ5mf/GMlfWoz1abIjq5jZfaFuHzGBZYIeuJfEoKKGWRHr2JiJR+ea+BF7Wx2N1PPRoT/2fwgiK1NnmNE3Hg==}
-    engines: {node: '>=14.18'}
-    peerDependencies:
-      eslint: '>=8.18.0'
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      ci-info: 3.9.0
-      clean-regexp: 1.0.0
-      eslint: 8.24.0
-      eslint-utils: 3.0.0(eslint@8.24.0)
-      esquery: 1.6.0
-      indent-string: 4.0.0
-      is-builtin-module: 3.2.1
-      lodash: 4.17.21
-      pluralize: 8.0.0
-      read-pkg-up: 7.0.1
-      regexp-tree: 0.1.27
-      safe-regex: 2.1.1
-      semver: 7.5.2
-      strip-indent: 3.0.0
     dev: true
 
   /eslint-plugin-unicorn@43.0.2(eslint@8.35.0):
@@ -13655,16 +13288,6 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /eslint-utils@3.0.0(eslint@8.24.0):
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 8.24.0
-      eslint-visitor-keys: 2.1.0
-    dev: true
-
   /eslint-utils@3.0.0(eslint@8.35.0):
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
@@ -13683,55 +13306,6 @@ packages:
   /eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /eslint@8.24.0:
-    resolution: {integrity: sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
-    dependencies:
-      '@eslint/eslintrc': 1.4.1
-      '@humanwhocodes/config-array': 0.10.7
-      '@humanwhocodes/gitignore-to-minimatch': 1.0.2
-      '@humanwhocodes/module-importer': 1.0.1
-      ajv: 6.12.3
-      chalk: 4.1.0
-      cross-spawn: 7.0.6
-      debug: 4.4.0
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-utils: 3.0.0(eslint@8.24.0)
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.24.0
-      globby: 11.1.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      js-sdsl: 4.4.2
-      js-yaml: 4.1.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-      regexpp: 3.2.0
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint@8.35.0:


### PR DESCRIPTION
## Summary

Refactor the flag definitions preparation logic to use the new @vercel/prepare-flags-definitions package. This extracts the ~216 lines of inline logic (SDK key scanning, definition fetching, and module generation) into a standalone, reusable package.

## Changes

- Add @vercel/prepare-flags-definitions dependency
- Reduce emit-flags-datafiles.ts from 216 lines to 35 lines with a thin wrapper
- Adapt CLI output singleton and error handling to package interface
- Update unit tests to mock the package instead of low-level I/O
- Update integration tests to match new behavior (no files written when no SDK keys present)

## Notes

The new package returns early when no SDK keys are found, so the integration tests no longer expect files to be created in those scenarios. All unit tests pass with the wrapper implementation.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR refactors flag definitions preparation logic by extracting inline code into a new package dependency, reducing the file from 216 to 35 lines with updated tests to match the new behavior.
> 
> - Replaces inline SDK key scanning and module generation with @vercel/prepare-flags-definitions package
> - Simplifies emit-flags-datafiles.ts to thin wrapper with error handling
> - Updates unit and integration tests to mock package instead of low-level I/O
>
> <sup>Risk assessment for [commit 0798036](https://github.com/vercel/vercel/commit/0798036cfa41449e18fca18af335208288602885).</sup>
<!-- VADE_RISK_END -->