### PR TITLE
feat(cli): improve webhooks command

### DIFF
--- a/.changeset/bright-waves-flow.md
+++ b/.changeset/bright-waves-flow.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add interactive mode to `webhooks create` and change warning prefix from `WARN!` to `WARNING!`

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -130,7 +130,7 @@ All output methods write to `stderr` (via the `output` singleton), except `outpu
 | ------------------------- | ------------------- | ----------------------------------------------------------- |
 | `output.log(msg)`         | `> msg`             | Success messages, status updates                            |
 | `output.error(msg)`       | `Error: msg`        | User-facing errors                                          |
-| `output.warn(msg)`        | `WARN! msg`         | Warnings that don't stop execution                          |
+| `output.warn(msg)`        | `WARNING! msg`      | Warnings that don't stop execution                          |
 | `output.debug(msg)`       | `> [debug] msg`     | Debug info (only shown with `--debug`)                      |
 | `output.print(msg)`       | raw to stdout       | Help text, JSON output, primary data                        |
 | `output.spinner(msg)`     | animated            | Long-running operations (>100ms)                            |

--- a/packages/cli/src/commands/webhooks/create.ts
+++ b/packages/cli/src/commands/webhooks/create.ts
@@ -34,8 +34,6 @@ export default async function create(client: Client, argv: string[]) {
   const { args, flags: opts } = parsedArgs;
   let [url] = args;
 
-  telemetry.trackCliArgumentUrl(url);
-
   // --- Collect URL ---
   if (!url) {
     if (client.nonInteractive) {
@@ -122,6 +120,7 @@ export default async function create(client: Client, argv: string[]) {
     events = eventFlags;
   }
 
+  telemetry.trackCliArgumentUrl(url);
   telemetry.trackCliOptionEvent(events);
   telemetry.trackCliOptionProject(projectIds);
 

--- a/packages/cli/src/commands/webhooks/create.ts
+++ b/packages/cli/src/commands/webhooks/create.ts
@@ -105,7 +105,7 @@ export default async function create(client: Client, argv: string[]) {
         name: event,
         value: event,
       })),
-      validate: (selected: string[]) => {
+      validate: (selected: readonly unknown[]) => {
         if (selected.length === 0) return 'At least one event is required';
         return true;
       },

--- a/packages/cli/src/commands/webhooks/create.ts
+++ b/packages/cli/src/commands/webhooks/create.ts
@@ -11,7 +11,10 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { isAPIError } from '../../util/errors-ts';
-import { validateWebhookEvents } from '../../util/webhooks/get-webhook-events';
+import {
+  getWebhookEvents,
+  validateWebhookEvents,
+} from '../../util/webhooks/get-webhook-events';
 
 export default async function create(client: Client, argv: string[]) {
   const telemetry = new WebhooksCreateTelemetryClient({
@@ -29,51 +32,94 @@ export default async function create(client: Client, argv: string[]) {
     return 1;
   }
   const { args, flags: opts } = parsedArgs;
-  const [url] = args;
+  let [url] = args;
 
   telemetry.trackCliArgumentUrl(url);
 
+  // --- Collect URL ---
   if (!url) {
-    output.error(
-      `${getCommandName(`webhooks create <url>`)} expects one argument`
-    );
-    return 1;
-  }
-
-  // Validate URL format
-  try {
-    const urlObj = new URL(url);
-    if (!['http:', 'https:'].includes(urlObj.protocol)) {
-      output.error('Webhook URL must use http or https protocol');
+    if (client.nonInteractive) {
+      output.error(
+        `${getCommandName(`webhooks create <url>`)} expects one argument`
+      );
       return 1;
     }
-  } catch {
-    output.error(`Invalid URL: ${url}`);
-    return 1;
+    url = await client.input.text({
+      message: 'Webhook URL:',
+      validate: (val: string) => {
+        if (!val) return 'URL is required';
+        try {
+          const urlObj = new URL(val);
+          if (!['http:', 'https:'].includes(urlObj.protocol)) {
+            return 'Webhook URL must use http or https protocol';
+          }
+        } catch {
+          return 'Invalid URL';
+        }
+        return true;
+      },
+    });
+  } else {
+    // Validate URL format when provided as argument
+    try {
+      const urlObj = new URL(url);
+      if (!['http:', 'https:'].includes(urlObj.protocol)) {
+        output.error('Webhook URL must use http or https protocol');
+        return 1;
+      }
+    } catch {
+      output.error(`Invalid URL: ${url}`);
+      return 1;
+    }
   }
 
-  const events = opts['--event'] as string[] | undefined;
+  // --- Collect events ---
   const projectIds = opts['--project'] as string[] | undefined;
+  const eventFlags = opts['--event'] as string[] | undefined;
+  let events: string[];
 
-  if (!events || events.length === 0) {
-    output.error(
-      `At least one event is required. Use ${chalk.cyan('--event <event>')} to specify events.`
-    );
-    output.log(
-      `Example: ${getCommandName(
-        'webhooks create https://example.com/webhook --event deployment.created'
-      )}`
-    );
-    return 1;
-  }
+  if (!eventFlags || eventFlags.length === 0) {
+    if (client.nonInteractive) {
+      output.error(
+        `At least one event is required. Use ${chalk.cyan('--event <event>')} to specify events.`
+      );
+      output.log(
+        `Example: ${getCommandName(
+          'webhooks create https://example.com/webhook --event deployment.created'
+        )}`
+      );
+      return 1;
+    }
 
-  // Validate events against the OpenAPI spec
-  const invalidEvents = await validateWebhookEvents(events);
-  if (invalidEvents.length > 0) {
-    output.error(
-      `Invalid event type${invalidEvents.length > 1 ? 's' : ''}: ${invalidEvents.join(', ')}`
-    );
-    return 1;
+    const availableEvents = await getWebhookEvents();
+    if (availableEvents.length === 0) {
+      output.error(
+        'Could not fetch available webhook events. Please specify events using --event flags.'
+      );
+      return 1;
+    }
+
+    events = await client.input.checkbox<string>({
+      message: 'Select events:',
+      choices: availableEvents.map(event => ({
+        name: event,
+        value: event,
+      })),
+      validate: (selected: string[]) => {
+        if (selected.length === 0) return 'At least one event is required';
+        return true;
+      },
+    });
+  } else {
+    // Validate events against the OpenAPI spec
+    const invalidEvents = await validateWebhookEvents(eventFlags);
+    if (invalidEvents.length > 0) {
+      output.error(
+        `Invalid event type${invalidEvents.length > 1 ? 's' : ''}: ${invalidEvents.join(', ')}`
+      );
+      return 1;
+    }
+    events = eventFlags;
   }
 
   telemetry.trackCliOptionEvent(events);
@@ -97,14 +143,14 @@ export default async function create(client: Client, argv: string[]) {
     );
     output.print('\n');
     output.print(chalk.bold('  Webhook Details\n\n'));
-    output.print(`    ${chalk.cyan('ID')}\t\t${webhook.id}\n`);
-    output.print(`    ${chalk.cyan('URL')}\t\t${webhook.url}\n`);
+    output.print(`    ${chalk.cyan('ID'.padEnd(10))}${webhook.id}\n`);
+    output.print(`    ${chalk.cyan('URL'.padEnd(10))}${webhook.url}\n`);
     output.print(
-      `    ${chalk.cyan('Events')}\t\t${webhook.events.join(', ')}\n`
+      `    ${chalk.cyan('Events'.padEnd(10))}${webhook.events.join(', ')}\n`
     );
     if (webhook.projectIds && webhook.projectIds.length > 0) {
       output.print(
-        `    ${chalk.cyan('Projects')}\t${webhook.projectIds.join(', ')}\n`
+        `    ${chalk.cyan('Projects'.padEnd(10))}${webhook.projectIds.join(', ')}\n`
       );
     }
     output.print('\n');

--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -111,7 +111,7 @@ export class Output {
 
     this.print(
       chalk.yellow(
-        chalk.bold('WARN! ') +
+        chalk.bold('WARNING! ') +
           str +
           (details ? `\n${action}: ${renderLink(details)}` : '')
       )

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -692,7 +692,7 @@ describe('deploy', () => {
     client.setArgv('deploy');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      'WARN! Node.js Version "10.x" is discontinued and must be upgraded. Please set "engines": { "node": "24.x" } in your `package.json` file to use Node.js 24.'
+      'WARNING! Node.js Version "10.x" is discontinued and must be upgraded. Please set "engines": { "node": "24.x" } in your `package.json` file to use Node.js 24.'
     );
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "deploy"').toEqual(0);

--- a/packages/cli/test/unit/commands/integration/discover.test.ts
+++ b/packages/cli/test/unit/commands/integration/discover.test.ts
@@ -80,7 +80,7 @@ describe('integration', () => {
 
       const stderr = client.stderr.getFullOutput();
       expect(stderr).toContain(
-        'WARN! Failed to fetch integration categories. Continuing without categories: Response Error (404)'
+        'WARNING! Failed to fetch integration categories. Continuing without categories: Response Error (404)'
       );
 
       const output = JSON.parse(client.stdout.getFullOutput());

--- a/packages/cli/test/unit/commands/webhooks/create.test.ts
+++ b/packages/cli/test/unit/commands/webhooks/create.test.ts
@@ -1,8 +1,24 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import webhooks from '../../../../src/commands/webhooks';
 import { useUser } from '../../../mocks/user';
 import { useCreateWebhook } from '../../../mocks/webhooks';
+
+vi.mock('../../../../src/util/webhooks/get-webhook-events', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../../src/util/webhooks/get-webhook-events')
+  >('../../../../src/util/webhooks/get-webhook-events');
+  return {
+    ...actual,
+    getWebhookEvents: vi
+      .fn()
+      .mockResolvedValue([
+        'deployment.created',
+        'deployment.ready',
+        'deployment.error',
+      ]),
+  };
+});
 
 describe('webhooks create', () => {
   describe('--help', () => {
@@ -23,15 +39,17 @@ describe('webhooks create', () => {
     });
   });
 
-  it('should show error when no url provided', async () => {
+  it('should show error when no url provided (non-interactive)', async () => {
     client.setArgv('webhooks', 'create');
+    client.nonInteractive = true;
     const exitCode = await webhooks(client);
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput('expects one argument');
   });
 
-  it('should show error when no events provided', async () => {
+  it('should show error when no events provided (non-interactive)', async () => {
     client.setArgv('webhooks', 'create', 'https://example.com/webhook');
+    client.nonInteractive = true;
     const exitCode = await webhooks(client);
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput('At least one event is required');
@@ -143,6 +161,71 @@ describe('webhooks create', () => {
         value: '3',
       },
     ]);
+  });
+
+  describe('interactive mode', () => {
+    it('should prompt for URL when not provided', async () => {
+      useUser();
+      useCreateWebhook();
+      client.setArgv('webhooks', 'create', '--event', 'deployment.created');
+      const exitCodePromise = webhooks(client);
+
+      // Wait for URL prompt and provide a valid URL
+      await expect(client.stderr).toOutput('Webhook URL:');
+      client.stdin.write('https://example.com/webhook\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Webhook created');
+    });
+
+    it('should validate URL in interactive prompt', async () => {
+      useUser();
+      useCreateWebhook();
+      client.setArgv('webhooks', 'create', '--event', 'deployment.created');
+      const exitCodePromise = webhooks(client);
+
+      // Wait for URL prompt, enter an invalid URL
+      await expect(client.stderr).toOutput('Webhook URL:');
+      client.stdin.write('not-a-url\n');
+
+      // Should show validation error and re-prompt
+      await expect(client.stderr).toOutput('Invalid URL');
+      client.stdin.write('https://example.com/webhook\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should prompt for events when not provided', async () => {
+      useUser();
+      useCreateWebhook();
+      client.setArgv('webhooks', 'create', 'https://example.com/webhook');
+      const exitCodePromise = webhooks(client);
+
+      // Wait for event selection prompt, select first item and submit
+      await expect(client.stderr).toOutput('Select events:');
+      client.stdin.write(' '); // toggle first item (deployment.created)
+      client.stdin.write('\n'); // submit
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Webhook created');
+    });
+
+    it('should error when getWebhookEvents returns empty', async () => {
+      const { getWebhookEvents } = await import(
+        '../../../../src/util/webhooks/get-webhook-events'
+      );
+      vi.mocked(getWebhookEvents).mockResolvedValueOnce([]);
+
+      client.setArgv('webhooks', 'create', 'https://example.com/webhook');
+      const exitCode = await webhooks(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Could not fetch available webhook events'
+      );
+    });
   });
 
   describe('add alias', () => {

--- a/packages/cli/test/unit/commands/webhooks/create.test.ts
+++ b/packages/cli/test/unit/commands/webhooks/create.test.ts
@@ -191,6 +191,7 @@ describe('webhooks create', () => {
 
       // Should show validation error and re-prompt
       await expect(client.stderr).toOutput('Invalid URL');
+      client.stdin.write('\x15'); // Ctrl+U to clear stale input
       client.stdin.write('https://example.com/webhook\n');
 
       const exitCode = await exitCodePromise;


### PR DESCRIPTION
## Summary

- Add interactive mode to `vercel webhooks create` — when run without arguments in a TTY, prompts for the webhook URL (with inline validation) and presents a multi-select checkbox of available events fetched from the OpenAPI spec
- Fix column alignment in webhook creation output by replacing tab characters with `padEnd(10)`
- Change warning prefix from `WARN!` to `WARNING!` across all CLI output

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI enhancement adding interactive mode to webhooks create command with URL/event prompts, cosmetic warning prefix change, and output formatting fixes - no security, auth, or data changes.
> 
> - Add interactive prompts for URL and event selection in webhooks create command
> - Change warning prefix from `WARN!` to `WARNING!` in CLI output
> - Fix column alignment using padEnd(10) instead of tabs
>
> <sup>Risk assessment for [commit 51946cb](https://github.com/vercel/vercel/commit/51946cbf790da3bb12068fc0661173bd06987aa8).</sup>
<!-- VADE_RISK_END -->