### PR TITLE
feat(cli): add crons command

### DIFF
--- a/.changeset/add-crons-command.md
+++ b/.changeset/add-crons-command.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel crons` command with `ls`, `run`, and `add` subcommands for managing cron jobs

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -15,6 +15,7 @@ export { default as buy } from './commands/buy';
 export { default as cache } from './commands/cache';
 export { default as contract } from './commands/contract';
 export { default as certs } from './commands/certs';
+export { default as crons } from './commands/crons';
 export { default as curl } from './commands/curl';
 export { default as dns } from './commands/dns';
 export { default as domains } from './commands/domains';

--- a/packages/cli/src/commands/crons/add.ts
+++ b/packages/cli/src/commands/crons/add.ts
@@ -1,0 +1,245 @@
+import { resolve } from 'path';
+import { readFile, writeFile } from 'fs/promises';
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { getCommandName } from '../../util/pkg-name';
+import output from '../../output-manager';
+import { CronsAddTelemetryClient } from '../../util/telemetry/commands/crons/add';
+import { addSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+
+interface CronEntry {
+  path: string;
+  schedule: string;
+}
+
+const CRON_FIELD_RANGES: [string, number, number][] = [
+  ['minute', 0, 59],
+  ['hour', 0, 23],
+  ['day of month', 1, 31],
+  ['month', 1, 12],
+  ['day of week', 0, 7],
+];
+
+export function validateCronSchedule(expression: string): string | true {
+  if (expression.length > 256) {
+    return 'Schedule expression must be 256 characters or less';
+  }
+
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    return `Schedule must have exactly 5 fields (minute hour day-of-month month day-of-week), got ${fields.length}`;
+  }
+
+  for (let i = 0; i < fields.length; i++) {
+    const [name, min, max] = CRON_FIELD_RANGES[i];
+    const error = validateCronField(fields[i], name, min, max);
+    if (error) {
+      return error;
+    }
+  }
+
+  return true;
+}
+
+function validateCronField(
+  field: string,
+  name: string,
+  min: number,
+  max: number
+): string | null {
+  // Handle lists (e.g. "1,15,30")
+  const parts = field.split(',');
+  for (const part of parts) {
+    // Handle step values (e.g. "*/5" or "1-30/2")
+    const [range, stepStr] = part.split('/');
+
+    if (stepStr !== undefined) {
+      const step = Number(stepStr);
+      if (!Number.isInteger(step) || step < 1) {
+        return `Invalid step value "${stepStr}" in ${name} field`;
+      }
+    }
+
+    if (range === '*') {
+      continue;
+    }
+
+    // Handle ranges (e.g. "1-5")
+    if (range.includes('-')) {
+      const rangeParts = range.split('-');
+      if (
+        rangeParts.length !== 2 ||
+        rangeParts[0] === '' ||
+        rangeParts[1] === ''
+      ) {
+        return `Invalid range "${range}" in ${name} field`;
+      }
+      const [startStr, endStr] = rangeParts;
+      const start = Number(startStr);
+      const end = Number(endStr);
+      if (!Number.isInteger(start) || !Number.isInteger(end)) {
+        return `Invalid range "${range}" in ${name} field`;
+      }
+      if (start < min || start > max || end < min || end > max) {
+        return `Value out of range in ${name} field (${min}-${max})`;
+      }
+      if (start > end) {
+        return `Invalid range "${range}" in ${name} field: start is greater than end`;
+      }
+      continue;
+    }
+
+    // Single value
+    const value = Number(range);
+    if (!Number.isInteger(value)) {
+      return `Invalid value "${range}" in ${name} field`;
+    }
+    if (value < min || value > max) {
+      return `Value ${value} out of range in ${name} field (${min}-${max})`;
+    }
+  }
+
+  return null;
+}
+
+export default async function add(client: Client, argv: string[]) {
+  const telemetry = new CronsAddTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(addSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  let cronPath: string | undefined = flags['--path'];
+  let schedule: string | undefined = flags['--schedule'];
+
+  telemetry.trackCliOptionPath(cronPath);
+  telemetry.trackCliOptionSchedule(schedule);
+
+  // If flags not provided, prompt interactively
+  if (!cronPath || !schedule) {
+    if (!client.stdin.isTTY) {
+      output.error(
+        `Missing required flags. Use ${getCommandName('crons add --path /api/cron --schedule "0 10 * * *"')} in non-interactive mode.`
+      );
+      return 1;
+    }
+
+    if (!cronPath) {
+      cronPath = await client.input.text({
+        message: 'What is the API route path for the cron job?',
+        validate: (value: string) => {
+          if (!value.startsWith('/')) {
+            return 'Path must start with /';
+          }
+          if (value.length > 512) {
+            return 'Path must be 512 characters or less';
+          }
+          return true;
+        },
+      });
+    }
+
+    if (!schedule) {
+      schedule = await client.input.text({
+        message: 'What is the cron schedule expression?',
+        validate: validateCronSchedule,
+      });
+    }
+  }
+
+  // Validate inputs
+  if (!cronPath.startsWith('/')) {
+    output.error('Path must start with /');
+    return 1;
+  }
+  if (cronPath.length > 512) {
+    output.error('Path must be 512 characters or less');
+    return 1;
+  }
+  const scheduleValidation = validateCronSchedule(schedule);
+  if (scheduleValidation !== true) {
+    output.error(scheduleValidation);
+    return 1;
+  }
+
+  // Read existing vercel.json or create one
+  const configPath = resolve(process.cwd(), 'vercel.json');
+  let config: Record<string, unknown>;
+
+  try {
+    const content = await readFile(configPath, 'utf-8');
+    config = JSON.parse(content);
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError) {
+      output.error(
+        `Failed to parse ${chalk.cyan('vercel.json')}: ${err.message}`
+      );
+      return 1;
+    }
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      config = {};
+    } else {
+      output.error(
+        `Failed to read ${chalk.cyan('vercel.json')}: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return 1;
+    }
+  }
+
+  // Get existing crons or create empty array
+  const existingCrons: CronEntry[] = Array.isArray(config.crons)
+    ? config.crons
+    : [];
+
+  // Check for duplicate path
+  if (existingCrons.some(c => c.path === cronPath)) {
+    output.error(
+      `A cron job with path ${chalk.bold(cronPath)} already exists in vercel.json`
+    );
+    return 1;
+  }
+
+  // Add the new cron
+  existingCrons.push({ path: cronPath, schedule });
+  config.crons = existingCrons;
+
+  // Write back to vercel.json
+  try {
+    await writeFile(
+      configPath,
+      JSON.stringify(config, null, 2) + '\n',
+      'utf-8'
+    );
+  } catch (err: unknown) {
+    output.error(
+      `Failed to write ${chalk.cyan('vercel.json')}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return 1;
+  }
+
+  output.log(
+    `Added cron job ${chalk.bold(cronPath)} with schedule ${chalk.bold(schedule)} to ${chalk.cyan('vercel.json')}`
+  );
+  output.warn(
+    `This cron job won't be active until the project is deployed to production. Run ${getCommandName('deploy --prod')} to deploy.`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/crons/add.ts
+++ b/packages/cli/src/commands/crons/add.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path';
-import { readFile, writeFile } from 'fs/promises';
+import { access, readFile, writeFile } from 'fs/promises';
 import chalk from 'chalk';
 import type Client from '../../util/client';
 import { getCommandName } from '../../util/pkg-name';
@@ -9,6 +9,7 @@ import { addSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
+import { VERCEL_CONFIG_EXTENSIONS } from '../../util/compile-vercel-config';
 
 interface CronEntry {
   path: string;
@@ -175,8 +176,22 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
+  // Check for non-JSON config files (vercel.ts, vercel.mjs, etc.)
+  for (const ext of VERCEL_CONFIG_EXTENSIONS) {
+    const altPath = resolve(client.cwd, `vercel.${ext}`);
+    try {
+      await access(altPath);
+      output.error(
+        `Found ${chalk.cyan(`vercel.${ext}`)} — ${getCommandName('crons add')} only supports ${chalk.cyan('vercel.json')}. Add cron jobs directly to your ${chalk.cyan(`vercel.${ext}`)} file instead.`
+      );
+      return 1;
+    } catch {
+      // File doesn't exist, continue
+    }
+  }
+
   // Read existing vercel.json or create one
-  const configPath = resolve(process.cwd(), 'vercel.json');
+  const configPath = resolve(client.cwd, 'vercel.json');
   let config: Record<string, unknown>;
 
   try {

--- a/packages/cli/src/commands/crons/command.ts
+++ b/packages/cli/src/commands/crons/command.ts
@@ -1,0 +1,50 @@
+import { packageName } from '../../util/pkg-name';
+import { formatOption } from '../../util/arg-common';
+
+export const listSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List all cron jobs for a project',
+  default: true,
+  arguments: [],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'List all cron jobs',
+      value: `${packageName} crons ls`,
+    },
+    {
+      name: 'List all cron jobs as JSON',
+      value: `${packageName} crons ls --format json`,
+    },
+  ],
+} as const;
+
+export const runSubcommand = {
+  name: 'run',
+  aliases: [],
+  description: 'Trigger a cron job to run immediately',
+  arguments: [
+    {
+      name: 'path',
+      required: false,
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'Trigger a specific cron job',
+      value: `${packageName} crons run /api/cron`,
+    },
+  ],
+} as const;
+
+export const cronsCommand = {
+  name: 'crons',
+  aliases: ['cron'],
+  description: 'Manage cron jobs for a project',
+  arguments: [],
+  subcommands: [listSubcommand, runSubcommand],
+  options: [],
+  examples: [],
+} as const;

--- a/packages/cli/src/commands/crons/command.ts
+++ b/packages/cli/src/commands/crons/command.ts
@@ -1,6 +1,41 @@
 import { packageName } from '../../util/pkg-name';
 import { formatOption } from '../../util/arg-common';
 
+export const addSubcommand = {
+  name: 'add',
+  aliases: [],
+  description: 'Add a cron job to vercel.json',
+  arguments: [],
+  options: [
+    {
+      name: 'path',
+      shorthand: null,
+      type: String,
+      argument: 'PATH',
+      deprecated: false,
+      description: 'The API route path for the cron job (must start with /)',
+    },
+    {
+      name: 'schedule',
+      shorthand: null,
+      type: String,
+      argument: 'EXPRESSION',
+      deprecated: false,
+      description: 'The cron schedule expression (e.g. "0 10 * * *")',
+    },
+  ],
+  examples: [
+    {
+      name: 'Add a cron job interactively',
+      value: `${packageName} crons add`,
+    },
+    {
+      name: 'Add a cron job with flags',
+      value: `${packageName} crons add --path /api/cron --schedule "0 10 * * *"`,
+    },
+  ],
+} as const;
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -44,7 +79,7 @@ export const cronsCommand = {
   aliases: ['cron'],
   description: 'Manage cron jobs for a project',
   arguments: [],
-  subcommands: [listSubcommand, runSubcommand],
+  subcommands: [addSubcommand, listSubcommand, runSubcommand],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/commands/crons/index.ts
+++ b/packages/cli/src/commands/crons/index.ts
@@ -2,15 +2,22 @@ import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import { printError } from '../../util/error';
+import add from './add';
 import ls from './ls';
 import run from './run';
-import { cronsCommand, listSubcommand, runSubcommand } from './command';
+import {
+  cronsCommand,
+  addSubcommand,
+  listSubcommand,
+  runSubcommand,
+} from './command';
 import { type Command, help } from '../help';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { CronsTelemetryClient } from '../../util/telemetry/commands/crons';
 import output from '../../output-manager';
 
 const COMMAND_CONFIG = {
+  add: ['add'],
   ls: ['ls', 'list'],
   run: ['run'],
 };
@@ -54,6 +61,13 @@ export default async function main(client: Client) {
   }
 
   switch (subcommand) {
+    case 'add':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('crons', subcommandOriginal);
+        return printHelp(addSubcommand);
+      }
+      telemetry.trackCliSubcommandAdd(subcommandOriginal);
+      return add(client, args);
     case 'run':
       if (needHelp) {
         telemetry.trackCliFlagHelp('crons', subcommandOriginal);

--- a/packages/cli/src/commands/crons/index.ts
+++ b/packages/cli/src/commands/crons/index.ts
@@ -1,0 +1,72 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import getSubcommand from '../../util/get-subcommand';
+import { printError } from '../../util/error';
+import ls from './ls';
+import run from './run';
+import { cronsCommand, listSubcommand, runSubcommand } from './command';
+import { type Command, help } from '../help';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { CronsTelemetryClient } from '../../util/telemetry/commands/crons';
+import output from '../../output-manager';
+
+const COMMAND_CONFIG = {
+  ls: ['ls', 'list'],
+  run: ['run'],
+};
+
+export default async function main(client: Client) {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(cronsCommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const telemetry = new CronsTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    parsedArgs.args.slice(1),
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('crons');
+    output.print(help(cronsCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, { parent: cronsCommand, columns: client.stderr.columns })
+    );
+    return 2;
+  }
+
+  switch (subcommand) {
+    case 'run':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('crons', subcommandOriginal);
+        return printHelp(runSubcommand);
+      }
+      telemetry.trackCliSubcommandRun(subcommandOriginal);
+      return run(client, args);
+    default:
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('crons', subcommandOriginal);
+        return printHelp(listSubcommand);
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return ls(client, args);
+  }
+}

--- a/packages/cli/src/commands/crons/ls.ts
+++ b/packages/cli/src/commands/crons/ls.ts
@@ -12,7 +12,13 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { validateLsArgs } from '../../util/validate-ls-args';
+import { readLocalConfig } from '../../util/config/files';
 import type { CronJobDefinition } from './types';
+
+interface LocalCron {
+  path: string;
+  schedule: string;
+}
 
 export default async function ls(client: Client, argv: string[]) {
   const telemetry = new CronsLsTelemetryClient({
@@ -81,6 +87,23 @@ export default async function ls(client: Client, argv: string[]) {
   const definitions = projectData.crons?.definitions ?? [];
   const isDisabled = projectData.crons?.disabledAt != null;
 
+  // Read local vercel.json to find crons configured but not yet deployed
+  const localConfig = readLocalConfig();
+  const localCrons: LocalCron[] = Array.isArray(localConfig?.crons)
+    ? localConfig.crons
+    : [];
+  const deployedByPath = new Map(definitions.map(d => [d.path, d]));
+  const undeployedCrons: LocalCron[] = [];
+  const modifiedCrons: { local: LocalCron; deployed: CronJobDefinition }[] = [];
+  for (const local of localCrons) {
+    const deployed = deployedByPath.get(local.path);
+    if (!deployed) {
+      undeployedCrons.push(local);
+    } else if (deployed.schedule !== local.schedule) {
+      modifiedCrons.push({ local, deployed });
+    }
+  }
+
   if (asJson) {
     output.stopSpinner();
     const jsonOutput = {
@@ -89,21 +112,54 @@ export default async function ls(client: Client, argv: string[]) {
         schedule: cron.schedule,
         host: cron.host,
       })),
+      undeployed: undeployedCrons.map(cron => ({
+        path: cron.path,
+        schedule: cron.schedule,
+      })),
+      modified: modifiedCrons.map(({ local, deployed }) => ({
+        path: local.path,
+        localSchedule: local.schedule,
+        deployedSchedule: deployed.schedule,
+      })),
       enabled: !isDisabled,
     };
     client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
-  } else if (definitions.length === 0) {
+  } else if (
+    definitions.length === 0 &&
+    undeployedCrons.length === 0 &&
+    modifiedCrons.length === 0
+  ) {
     output.log(
       `No cron jobs found for ${chalk.bold(`${org.slug}/${project.name}`)} ${chalk.gray(lsStamp())}`
     );
   } else {
-    output.log(
-      `${definitions.length} cron ${definitions.length === 1 ? 'job' : 'jobs'} found for ${chalk.bold(`${org.slug}/${project.name}`)}${isDisabled ? chalk.yellow(' (disabled)') : ''} ${chalk.gray(lsStamp())}`
-    );
-    output.print(
-      formatCronsTable(definitions).replace(/^(.*)/gm, `${' '.repeat(1)}$1`)
-    );
-    output.print('\n\n');
+    const totalDeployed = definitions.length;
+    if (totalDeployed > 0) {
+      output.log(
+        `${totalDeployed} cron ${totalDeployed === 1 ? 'job' : 'jobs'} found for ${chalk.bold(`${org.slug}/${project.name}`)}${isDisabled ? chalk.yellow(' (disabled)') : ''} ${chalk.gray(lsStamp())}`
+      );
+      output.print(
+        formatCronsTable(definitions).replace(/^(.*)/gm, `${' '.repeat(1)}$1`)
+      );
+      output.print('\n\n');
+    }
+
+    if (undeployedCrons.length > 0 || modifiedCrons.length > 0) {
+      const pendingCount = undeployedCrons.length + modifiedCrons.length;
+      output.log(
+        `${pendingCount} local ${pendingCount === 1 ? 'change' : 'changes'} pending deploy`
+      );
+      output.print(
+        formatPendingCronsTable(undeployedCrons, modifiedCrons).replace(
+          /^(.*)/gm,
+          `${' '.repeat(1)}$1`
+        )
+      );
+      output.print('\n\n');
+      output.warn(
+        `Run ${getCommandName('deploy --prod')} to apply local changes.`
+      );
+    }
   }
 
   return 0;
@@ -116,4 +172,28 @@ function formatCronsTable(definitions: CronJobDefinition[]) {
   ]);
 
   return formatTable(['Path', 'Schedule'], ['l', 'l'], [{ rows }]);
+}
+
+function formatPendingCronsTable(
+  undeployed: LocalCron[],
+  modified: { local: LocalCron; deployed: CronJobDefinition }[]
+) {
+  const rows: string[][] = [
+    ...modified.map(({ local, deployed }) => [
+      chalk.bold(local.path),
+      `${chalk.dim(deployed.schedule)} → ${local.schedule}`,
+      chalk.yellow('modified'),
+    ]),
+    ...undeployed.map(cron => [
+      chalk.dim(cron.path),
+      chalk.dim(cron.schedule),
+      chalk.yellow('not deployed'),
+    ]),
+  ];
+
+  return formatTable(
+    ['Path', 'Schedule', 'Status'],
+    ['l', 'l', 'l'],
+    [{ rows }]
+  );
 }

--- a/packages/cli/src/commands/crons/ls.ts
+++ b/packages/cli/src/commands/crons/ls.ts
@@ -1,0 +1,119 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import formatTable from '../../util/format-table';
+import stamp from '../../util/output/stamp';
+import { getCommandName } from '../../util/pkg-name';
+import { getLinkedProject } from '../../util/projects/link';
+import { validateJsonOutput } from '../../util/output-format';
+import output from '../../output-manager';
+import { CronsLsTelemetryClient } from '../../util/telemetry/commands/crons/ls';
+import { listSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { validateLsArgs } from '../../util/validate-ls-args';
+import type { CronJobDefinition } from './types';
+
+export default async function ls(client: Client, argv: string[]) {
+  const telemetry = new CronsLsTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(listSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+
+  const validationResult = validateLsArgs({
+    commandName: 'crons ls',
+    args: args,
+    maxArgs: 0,
+    exitCode: 2,
+  });
+  if (validationResult !== 0) {
+    return validationResult;
+  }
+
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const link = await getLinkedProject(client);
+  if (link.status === 'error') {
+    return link.exitCode;
+  } else if (link.status === 'not_linked') {
+    output.error(
+      `Your codebase isn't linked to a project on Vercel. ${client.nonInteractive ? `Run ${getCommandName('link --yes --team <team-id> --project <project-id>')} to link non-interactively.` : `Run ${getCommandName('link')} to begin.`}`
+    );
+    return 1;
+  }
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+
+  const { project, org } = link;
+
+  const lsStamp = stamp();
+
+  output.spinner(
+    `Fetching cron jobs for ${chalk.bold(`${org.slug}/${project.name}`)}`
+  );
+
+  const projectData = await client.fetch<{
+    crons?: {
+      definitions: CronJobDefinition[];
+      disabledAt: number | null;
+      enabledAt: number;
+    };
+  }>(`/v9/projects/${encodeURIComponent(project.id)}`);
+
+  const definitions = projectData.crons?.definitions ?? [];
+  const isDisabled = projectData.crons?.disabledAt != null;
+
+  if (asJson) {
+    output.stopSpinner();
+    const jsonOutput = {
+      crons: definitions.map(cron => ({
+        path: cron.path,
+        schedule: cron.schedule,
+        host: cron.host,
+      })),
+      enabled: !isDisabled,
+    };
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+  } else if (definitions.length === 0) {
+    output.log(
+      `No cron jobs found for ${chalk.bold(`${org.slug}/${project.name}`)} ${chalk.gray(lsStamp())}`
+    );
+  } else {
+    output.log(
+      `${definitions.length} cron ${definitions.length === 1 ? 'job' : 'jobs'} found for ${chalk.bold(`${org.slug}/${project.name}`)}${isDisabled ? chalk.yellow(' (disabled)') : ''} ${chalk.gray(lsStamp())}`
+    );
+    output.print(
+      formatCronsTable(definitions).replace(/^(.*)/gm, `${' '.repeat(1)}$1`)
+    );
+    output.print('\n\n');
+  }
+
+  return 0;
+}
+
+function formatCronsTable(definitions: CronJobDefinition[]) {
+  const rows: string[][] = definitions.map(cron => [
+    chalk.bold(cron.path),
+    cron.schedule,
+  ]);
+
+  return formatTable(['Path', 'Schedule'], ['l', 'l'], [{ rows }]);
+}

--- a/packages/cli/src/commands/crons/ls.ts
+++ b/packages/cli/src/commands/crons/ls.ts
@@ -88,9 +88,9 @@ export default async function ls(client: Client, argv: string[]) {
   const isDisabled = projectData.crons?.disabledAt != null;
 
   // Read local vercel.json to find crons configured but not yet deployed
-  const localConfig = readLocalConfig();
+  const localConfig = readLocalConfig(client.cwd);
   const localCrons: LocalCron[] = Array.isArray(localConfig?.crons)
-    ? localConfig.crons
+    ? (localConfig!.crons as LocalCron[])
     : [];
   const deployedByPath = new Map(definitions.map(d => [d.path, d]));
   const undeployedCrons: LocalCron[] = [];

--- a/packages/cli/src/commands/crons/run.ts
+++ b/packages/cli/src/commands/crons/run.ts
@@ -1,0 +1,134 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import stamp from '../../util/output/stamp';
+import { getCommandName } from '../../util/pkg-name';
+import { getLinkedProject } from '../../util/projects/link';
+import output from '../../output-manager';
+import { CronsRunTelemetryClient } from '../../util/telemetry/commands/crons/run';
+import { runSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import type { CronJobDefinition } from './types';
+
+export default async function run(client: Client, argv: string[]) {
+  const telemetry = new CronsRunTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(runSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args } = parsedArgs;
+
+  let [cronPath] = args;
+
+  telemetry.trackCliArgumentPath(cronPath);
+
+  const link = await getLinkedProject(client);
+  if (link.status === 'error') {
+    return link.exitCode;
+  } else if (link.status === 'not_linked') {
+    output.error(
+      `Your codebase isn't linked to a project on Vercel. ${client.nonInteractive ? `Run ${getCommandName('link --yes --team <team-id> --project <project-id>')} to link non-interactively.` : `Run ${getCommandName('link')} to begin.`}`
+    );
+    return 1;
+  }
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+
+  const { project, org } = link;
+
+  const runStamp = stamp();
+
+  output.spinner(
+    `Fetching cron jobs for ${chalk.bold(`${org.slug}/${project.name}`)}`
+  );
+
+  const projectData = await client.fetch<{
+    crons?: {
+      definitions: CronJobDefinition[];
+      disabledAt: number | null;
+      enabledAt: number;
+    };
+  }>(`/v9/projects/${encodeURIComponent(project.id)}`);
+
+  const definitions = projectData.crons?.definitions ?? [];
+
+  if (definitions.length === 0) {
+    output.error(
+      `No cron jobs found for ${chalk.bold(`${org.slug}/${project.name}`)}. Define cron jobs in your vercel.json file.`
+    );
+    return 1;
+  }
+
+  if (projectData.crons?.disabledAt != null) {
+    output.error(
+      `Cron jobs are disabled for ${chalk.bold(`${org.slug}/${project.name}`)}. Enable them in the project settings.`
+    );
+    return 1;
+  }
+
+  // If no path provided, let user select interactively
+  if (!cronPath) {
+    if (client.nonInteractive) {
+      output.error(
+        `A cron path argument is required in non-interactive mode. Usage: ${getCommandName('crons run <path>')}`
+      );
+      return 1;
+    }
+
+    if (definitions.length === 1) {
+      cronPath = definitions[0].path;
+    } else {
+      cronPath = await client.input.select({
+        message: 'Which cron job would you like to run?',
+        choices: definitions.map(cron => ({
+          name: `${cron.path} (${cron.schedule})`,
+          value: cron.path,
+        })),
+      });
+    }
+  }
+
+  // Find the matching cron definition to get the schedule
+  const cronDef = definitions.find(d => d.path === cronPath);
+  if (!cronDef) {
+    output.error(
+      `Cron job with path ${chalk.bold(cronPath)} not found. Run ${getCommandName('crons ls')} to see available cron jobs.`
+    );
+    return 1;
+  }
+
+  output.spinner(`Triggering cron job ${chalk.bold(cronPath)}`);
+
+  const teamId = link.org.type === 'team' ? link.org.id : undefined;
+  const qs = teamId ? `?teamId=${encodeURIComponent(teamId)}` : '';
+
+  const result = await client.fetch<{ invocationAt: number }>(
+    `/v1/projects/${encodeURIComponent(project.id)}/crons/run${qs}`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        path: cronDef.path,
+        schedule: cronDef.schedule,
+      }),
+    }
+  );
+
+  output.log(
+    `Cron job ${chalk.bold(cronPath)} triggered ${chalk.gray(runStamp())}`
+  );
+  output.log(
+    `  Invocation time: ${chalk.cyan(new Date(result.invocationAt).toISOString())}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/crons/run.ts
+++ b/packages/cli/src/commands/crons/run.ts
@@ -9,6 +9,7 @@ import { runSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
 import type { CronJobDefinition } from './types';
 
 export default async function run(client: Client, argv: string[]) {
@@ -85,8 +86,11 @@ export default async function run(client: Client, argv: string[]) {
       return 1;
     }
 
+    output.stopSpinner();
+
     if (definitions.length === 1) {
       cronPath = definitions[0].path;
+      output.log(`Auto-selected ${chalk.bold(cronPath)} (only cron job)`);
     } else {
       cronPath = await client.input.select({
         message: 'Which cron job would you like to run?',
@@ -112,16 +116,28 @@ export default async function run(client: Client, argv: string[]) {
   const teamId = link.org.type === 'team' ? link.org.id : undefined;
   const qs = teamId ? `?teamId=${encodeURIComponent(teamId)}` : '';
 
-  const result = await client.fetch<{ invocationAt: number }>(
-    `/v1/projects/${encodeURIComponent(project.id)}/crons/run${qs}`,
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        path: cronDef.path,
-        schedule: cronDef.schedule,
-      }),
+  let result: { invocationAt: number };
+  try {
+    result = await client.fetch<{ invocationAt: number }>(
+      `/v1/projects/${encodeURIComponent(project.id)}/crons/run${qs}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          path: cronDef.path,
+          schedule: cronDef.schedule,
+        }),
+      }
+    );
+  } catch (err: unknown) {
+    if (isAPIError(err)) {
+      output.error(
+        `Failed to trigger cron job ${chalk.bold(cronPath)}: ${err.message}`
+      );
+      return 1;
     }
-  );
+    throw err;
+  }
 
   output.log(
     `Cron job ${chalk.bold(cronPath)} triggered ${chalk.gray(runStamp())}`

--- a/packages/cli/src/commands/crons/types.ts
+++ b/packages/cli/src/commands/crons/types.ts
@@ -1,0 +1,5 @@
+export interface CronJobDefinition {
+  host: string;
+  path: string;
+  schedule: string;
+}

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -250,7 +250,9 @@ export function buildSubcommandLines(
       nameCell,
       argsCell,
       {
-        content: command.description,
+        content: command.default
+          ? `${command.description} ${chalk.bold('(default)')}`
+          : command.description,
         wordWrap: true,
       },
     ]);

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -8,6 +8,7 @@ import { buyCommand } from './buy/command';
 import { cacheCommand } from './cache/command';
 import { certsCommand } from './certs/command';
 import { contractCommand } from './contract/command';
+import { cronsCommand } from './crons/command';
 import { curlCommand } from './curl/command';
 import { deployCommand } from './deploy/command';
 import { devCommand } from './dev/command';
@@ -64,6 +65,7 @@ const commandsStructs = [
   cacheCommand,
   certsCommand,
   contractCommand,
+  cronsCommand,
   curlCommand,
   deployCommand,
   devCommand,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -210,7 +210,7 @@ const main = async () => {
   const subSubCommand = parsedArgs.args[3];
 
   // If empty, leave this code here for easy adding of beta commands later
-  const betaCommands: string[] = ['api', 'curl', 'webhooks'];
+  const betaCommands: string[] = ['api', 'crons', 'curl', 'webhooks'];
   const msg = betaCommands.includes(targetOrSubcommand)
     ? `${getTitleName()} CLI ${pkg.version} | ${targetOrSubcommand} is in beta — https://vercel.com/feedback`
     : `${getTitleName()} CLI ${pkg.version}`;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -766,6 +766,11 @@ const main = async () => {
           telemetry.trackCliCommandCerts(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).certs;
           break;
+        case 'crons':
+        case 'cron':
+          telemetry.trackCliCommandCrons(userSuppliedSubCommand);
+          func = (await import('./commands-bulk.js')).crons;
+          break;
         case 'curl':
           telemetry.trackCliCommandCurl(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).curl;

--- a/packages/cli/src/util/telemetry/commands/crons/add.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/add.ts
@@ -1,0 +1,26 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { addSubcommand } from '../../../../commands/crons/command';
+
+export class CronsAddTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof addSubcommand>
+{
+  trackCliOptionPath(path: string | undefined) {
+    if (path) {
+      this.trackCliOption({
+        option: 'path',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSchedule(schedule: string | undefined) {
+    if (schedule) {
+      this.trackCliOption({
+        option: 'schedule',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/crons/index.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/index.ts
@@ -6,6 +6,13 @@ export class CronsTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof cronsCommand>
 {
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandList(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'list',

--- a/packages/cli/src/util/telemetry/commands/crons/index.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/index.ts
@@ -1,0 +1,22 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { cronsCommand } from '../../../../commands/crons/command';
+
+export class CronsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof cronsCommand>
+{
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRun(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'run',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/crons/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/ls.ts
@@ -1,0 +1,17 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { listSubcommand } from '../../../../commands/crons/command';
+
+export class CronsLsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof listSubcommand>
+{
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/crons/run.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/run.ts
@@ -1,0 +1,17 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { runSubcommand } from '../../../../commands/crons/command';
+
+export class CronsRunTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof runSubcommand>
+{
+  trackCliArgumentPath(path: string | undefined) {
+    if (path) {
+      this.trackCliArgument({
+        arg: 'path',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -89,6 +89,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandCrons(actual: string) {
+    this.trackCliCommand({
+      command: 'crons',
+      value: actual,
+    });
+  }
+
   trackCliCommandCurl(actual: string) {
     this.trackCliCommand({
       command: 'curl',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -20,6 +20,7 @@ exports[`help command > alias help output snapshots > alias help column width 40
   set     deployment alias  Create 
                             a new  
                             alias  
+                            (defau…
 
 
   Global Options:
@@ -97,7 +98,7 @@ exports[`help command > alias help output snapshots > alias help column width 80
 
   list                      Show all aliases                               
   remove  alias             Remove an alias using its hostname             
-  set     deployment alias  Create a new alias                             
+  set     deployment alias  Create a new alias (default)                   
 
 
   Global Options:
@@ -143,7 +144,7 @@ exports[`help command > alias help output snapshots > alias help column width 12
 
   list                      Show all aliases                                                                       
   remove  alias             Remove an alias using its hostname                                                     
-  set     deployment alias  Create a new alias                                                                     
+  set     deployment alias  Create a new alias (default)                                                           
 
 
   Global Options:
@@ -1219,6 +1220,7 @@ exports[`help command > dns help output snapshots > dns help column width 40 1`]
                            entr…
                            for a
                            doma…
+                           (def…
   remove  id               Remo…
                            a DNS
                            entry
@@ -1321,7 +1323,7 @@ exports[`help command > dns help output snapshots > dns help column width 80 1`]
   add     domain details   Add a new DNS entry (see below for examples) 
   import  domain zonefile  Import a DNS zone file (see below for        
                            examples)                                    
-  list    domain           List all DNS entries for a domain            
+  list    domain           List all DNS entries for a domain (default)  
   remove  id               Remove a DNS entry using its ID              
 
 
@@ -1386,7 +1388,7 @@ exports[`help command > dns help output snapshots > dns help column width 120 1`
 
   add     domain details   Add a new DNS entry (see below for examples)                                         
   import  domain zonefile  Import a DNS zone file (see below for examples)                                      
-  list    domain           List all DNS entries for a domain                                                    
+  list    domain           List all DNS entries for a domain (default)                                          
   remove  id               Remove a DNS entry using its ID                                                      
 
 
@@ -1591,6 +1593,7 @@ exports[`help command > domains help output snapshots > domains help column widt
                                    dom…
                                    in a
                                    list
+                                   (de…
   inspect      domain              Dis…
                                    inf…
                                    rel…
@@ -1697,7 +1700,7 @@ exports[`help command > domains help output snapshots > domains help column widt
 
   Commands:
 
-  list                             Show all domains in a list                  
+  list                             Show all domains in a list (default)        
   inspect      domain              Displays information related to a domain    
   add          domain project      Add a domain name that you already own to a 
                                    Vercel Team                                 
@@ -1736,7 +1739,7 @@ exports[`help command > domains help output snapshots > domains help column widt
 
   Commands:
 
-  list                             Show all domains in a list                                                          
+  list                             Show all domains in a list (default)                                                
   inspect      domain              Displays information related to a domain                                            
   add          domain project      Add a domain name that you already own to a Vercel Team                             
   buy          domain              Purchase a new domain name                                                          
@@ -4283,6 +4286,7 @@ exports[`help command > project help output snapshots > project help column widt
                    projects in  
                    the selected 
                    scope        
+                   (default)    
   remove   name    Delete a     
                    project      
   token    [name]  Get a        
@@ -4352,7 +4356,7 @@ exports[`help command > project help output snapshots > project help column widt
 
   add      name    Add a new project                                    
   inspect  [name]  Displays information related to a project            
-  list             Show all projects in the selected scope              
+  list             Show all projects in the selected scope (default)    
   remove   name    Delete a project                                     
   token    [name]  Get a development OIDC token for a project           
 
@@ -4386,7 +4390,7 @@ exports[`help command > project help output snapshots > project help column widt
 
   add      name    Add a new project                                                                            
   inspect  [name]  Displays information related to a project                                                    
-  list             Show all projects in the selected scope                                                      
+  list             Show all projects in the selected scope (default)                                            
   remove   name    Delete a project                                                                             
   token    [name]  Get a development OIDC token for a project                                                   
 

--- a/packages/cli/test/unit/commands/crons/add.test.ts
+++ b/packages/cli/test/unit/commands/crons/add.test.ts
@@ -1,0 +1,254 @@
+import { resolve } from 'path';
+import { readFile, writeFile } from 'fs/promises';
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import crons from '../../../../src/commands/crons';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+
+describe('crons add', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    cwd = setupTmpDir('crons-add');
+    client.cwd = cwd;
+  });
+
+  describe('--help', () => {
+    it('prints help and tracks telemetry', async () => {
+      client.setArgv('crons', 'add', '--help');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(2);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'crons:add' },
+      ]);
+    });
+  });
+
+  describe('with flags', () => {
+    it('adds cron to new vercel.json', async () => {
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        '/api/cron',
+        '--schedule',
+        '0 10 * * *'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      const content = JSON.parse(
+        await readFile(resolve(cwd, 'vercel.json'), 'utf-8')
+      );
+      expect(content.crons).toEqual([
+        { path: '/api/cron', schedule: '0 10 * * *' },
+      ]);
+      await expect(client.stderr).toOutput('Added cron job');
+    });
+
+    it('appends cron to existing vercel.json', async () => {
+      await writeFile(
+        resolve(cwd, 'vercel.json'),
+        JSON.stringify(
+          { crons: [{ path: '/api/existing', schedule: '0 0 * * *' }] },
+          null,
+          2
+        ) + '\n',
+        'utf-8'
+      );
+
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        '/api/new',
+        '--schedule',
+        '*/5 * * * *'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      const content = JSON.parse(
+        await readFile(resolve(cwd, 'vercel.json'), 'utf-8')
+      );
+      expect(content.crons).toEqual([
+        { path: '/api/existing', schedule: '0 0 * * *' },
+        { path: '/api/new', schedule: '*/5 * * * *' },
+      ]);
+    });
+
+    it('preserves other config in vercel.json', async () => {
+      await writeFile(
+        resolve(cwd, 'vercel.json'),
+        JSON.stringify(
+          { rewrites: [{ source: '/', destination: '/index' }] },
+          null,
+          2
+        ) + '\n',
+        'utf-8'
+      );
+
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        '/api/cron',
+        '--schedule',
+        '0 0 * * *'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      const content = JSON.parse(
+        await readFile(resolve(cwd, 'vercel.json'), 'utf-8')
+      );
+      expect(content.rewrites).toEqual([
+        { source: '/', destination: '/index' },
+      ]);
+      expect(content.crons).toEqual([
+        { path: '/api/cron', schedule: '0 0 * * *' },
+      ]);
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects path not starting with /', async () => {
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        'api/cron',
+        '--schedule',
+        '0 0 * * *'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Path must start with /');
+    });
+
+    it('rejects invalid cron schedule', async () => {
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        '/api/cron',
+        '--schedule',
+        'not-a-schedule'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('must have exactly 5 fields');
+    });
+
+    it('rejects duplicate cron path', async () => {
+      await writeFile(
+        resolve(cwd, 'vercel.json'),
+        JSON.stringify(
+          { crons: [{ path: '/api/cron', schedule: '0 0 * * *' }] },
+          null,
+          2
+        ) + '\n',
+        'utf-8'
+      );
+
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        '/api/cron',
+        '--schedule',
+        '*/5 * * * *'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('already exists');
+    });
+
+    it('rejects path longer than 512 characters', async () => {
+      const longPath = '/' + 'a'.repeat(512);
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        longPath,
+        '--schedule',
+        '0 0 * * *'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('512 characters or less');
+    });
+  });
+
+  describe('error handling', () => {
+    it('fails on malformed vercel.json', async () => {
+      await writeFile(resolve(cwd, 'vercel.json'), '{invalid json', 'utf-8');
+
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        '/api/cron',
+        '--schedule',
+        '0 0 * * *'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Failed to parse');
+    });
+  });
+
+  describe('interactive mode', () => {
+    it('prompts for path and schedule', async () => {
+      client.setArgv('crons', 'add');
+      const exitCodePromise = crons(client);
+
+      await expect(client.stderr).toOutput('API route path');
+      client.stdin.write('/api/cron\n');
+
+      await expect(client.stderr).toOutput('cron schedule expression');
+      client.stdin.write('0 0 * * *\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      const content = JSON.parse(
+        await readFile(resolve(cwd, 'vercel.json'), 'utf-8')
+      );
+      expect(content.crons).toEqual([
+        { path: '/api/cron', schedule: '0 0 * * *' },
+      ]);
+    });
+
+    it('errors in non-interactive mode without flags', async () => {
+      client.setArgv('crons', 'add');
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Missing required flags');
+    });
+  });
+
+  describe('telemetry', () => {
+    it('tracks subcommand and options', async () => {
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        '/api/cron',
+        '--schedule',
+        '0 0 * * *'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:add', value: 'add' },
+        { key: 'option:path', value: '[REDACTED]' },
+        { key: 'option:schedule', value: '[REDACTED]' },
+      ]);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/crons/add.test.ts
+++ b/packages/cli/test/unit/commands/crons/add.test.ts
@@ -183,6 +183,32 @@ describe('crons add', () => {
   });
 
   describe('error handling', () => {
+    it.each([
+      'ts',
+      'mts',
+      'js',
+      'mjs',
+      'cjs',
+    ])('fails when vercel.%s exists', async ext => {
+      await writeFile(
+        resolve(cwd, `vercel.${ext}`),
+        'export default {}',
+        'utf-8'
+      );
+
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        '/api/cron',
+        '--schedule',
+        '0 0 * * *'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('only supports');
+    });
+
     it('fails on malformed vercel.json', async () => {
       await writeFile(resolve(cwd, 'vercel.json'), '{invalid json', 'utf-8');
 

--- a/packages/cli/test/unit/commands/crons/ls.test.ts
+++ b/packages/cli/test/unit/commands/crons/ls.test.ts
@@ -1,0 +1,291 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import crons from '../../../../src/commands/crons';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as configFiles from '../../../../src/util/config/files';
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/config/files', async importOriginal => {
+  const actual = await importOriginal<typeof configFiles>();
+  return {
+    ...actual,
+    readLocalConfig: vi.fn(),
+  };
+});
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedReadLocalConfig = vi.mocked(configFiles.readLocalConfig);
+
+const projectId = 'proj_crons_test';
+const projectName = 'crons-project';
+const orgSlug = 'my-team';
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: projectId,
+      name: projectName,
+      accountId: 'org_123',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: { id: 'org_123', slug: orgSlug, type: 'team' },
+  });
+}
+
+function mockProjectWithCrons(
+  definitions: { host: string; path: string; schedule: string }[],
+  opts?: { disabledAt?: number | null }
+) {
+  client.scenario.get(`/v9/projects/${projectId}`, (_req, res) => {
+    res.json({
+      id: projectId,
+      name: projectName,
+      crons: {
+        definitions,
+        disabledAt: opts?.disabledAt ?? null,
+        enabledAt: 1700000000000,
+      },
+    });
+  });
+}
+
+describe('crons ls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockedReadLocalConfig.mockReturnValue(undefined);
+  });
+
+  describe('--help', () => {
+    it('prints help and tracks telemetry', async () => {
+      client.setArgv('crons', 'ls', '--help');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(2);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'crons:ls' },
+      ]);
+    });
+  });
+
+  describe('not linked', () => {
+    it('errors when project is not linked', async () => {
+      mockedGetLinkedProject.mockResolvedValue({
+        status: 'not_linked',
+      } as any);
+      client.setArgv('crons', 'ls');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput("isn't linked");
+    });
+  });
+
+  describe('with deployed crons', () => {
+    it('lists cron jobs in table format', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+        {
+          host: 'example.vercel.app',
+          path: '/api/daily',
+          schedule: '0 0 * * *',
+        },
+      ]);
+      client.setArgv('crons', 'ls');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('2 cron jobs found');
+    });
+
+    it('shows disabled indicator', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons(
+        [
+          {
+            host: 'example.vercel.app',
+            path: '/api/cron',
+            schedule: '0 * * * *',
+          },
+        ],
+        { disabledAt: 1700000000000 }
+      );
+      client.setArgv('crons', 'ls');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('(disabled)');
+    });
+
+    it('shows no crons message when empty', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([]);
+      client.setArgv('crons', 'ls');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('No cron jobs found');
+    });
+  });
+
+  describe('JSON output', () => {
+    it('outputs JSON with --format json', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      client.setArgv('crons', 'ls', '--format', 'json');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      const stdout = client.stdout.getFullOutput();
+      const parsed = JSON.parse(stdout);
+      expect(parsed.crons).toEqual([
+        {
+          path: '/api/cron',
+          schedule: '0 * * * *',
+          host: 'example.vercel.app',
+        },
+      ]);
+      expect(parsed.enabled).toBe(true);
+    });
+
+    it('includes undeployed and modified in JSON', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      mockedReadLocalConfig.mockReturnValue({
+        crons: [
+          { path: '/api/cron', schedule: '0 0 * * *' }, // modified
+          { path: '/api/new', schedule: '*/5 * * * *' }, // undeployed
+        ],
+      } as any);
+      client.setArgv('crons', 'ls', '--format', 'json');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      const stdout = client.stdout.getFullOutput();
+      const parsed = JSON.parse(stdout);
+      expect(parsed.undeployed).toEqual([
+        { path: '/api/new', schedule: '*/5 * * * *' },
+      ]);
+      expect(parsed.modified).toEqual([
+        {
+          path: '/api/cron',
+          localSchedule: '0 0 * * *',
+          deployedSchedule: '0 * * * *',
+        },
+      ]);
+    });
+  });
+
+  describe('local config comparison', () => {
+    it('shows undeployed crons from vercel.json', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([]);
+      mockedReadLocalConfig.mockReturnValue({
+        crons: [{ path: '/api/new-cron', schedule: '0 0 * * *' }],
+      } as any);
+      client.setArgv('crons', 'ls');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('1 local change pending deploy');
+    });
+
+    it('shows modified crons with schedule changes', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      mockedReadLocalConfig.mockReturnValue({
+        crons: [{ path: '/api/cron', schedule: '0 0 * * *' }],
+      } as any);
+      client.setArgv('crons', 'ls');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('1 local change pending deploy');
+    });
+
+    it('does not show pending section when local matches deployed', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      mockedReadLocalConfig.mockReturnValue({
+        crons: [{ path: '/api/cron', schedule: '0 * * * *' }],
+      } as any);
+      client.setArgv('crons', 'ls');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('1 cron job found');
+    });
+
+    it('handles missing local config gracefully', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      mockedReadLocalConfig.mockReturnValue(undefined);
+      client.setArgv('crons', 'ls');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('1 cron job found');
+    });
+  });
+
+  describe('telemetry', () => {
+    it('tracks subcommand invocation', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([]);
+      client.setArgv('crons', 'ls');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:list', value: 'ls' },
+      ]);
+    });
+
+    it('tracks format option', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([]);
+      client.setArgv('crons', 'ls', '--format', 'json');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:list', value: 'ls' },
+        { key: 'option:format', value: 'json' },
+      ]);
+    });
+  });
+
+  describe('extra arguments', () => {
+    it('rejects extra arguments', async () => {
+      client.setArgv('crons', 'ls', 'extra-arg');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(2);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/crons/run.test.ts
+++ b/packages/cli/test/unit/commands/crons/run.test.ts
@@ -1,0 +1,263 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import crons from '../../../../src/commands/crons';
+import * as linkModule from '../../../../src/util/projects/link';
+
+vi.mock('../../../../src/util/projects/link');
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+
+const projectId = 'proj_crons_test';
+const projectName = 'crons-project';
+const orgSlug = 'my-team';
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: projectId,
+      name: projectName,
+      accountId: 'org_123',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: { id: 'org_123', slug: orgSlug, type: 'team' },
+  });
+}
+
+function mockProjectWithCrons(
+  definitions: { host: string; path: string; schedule: string }[]
+) {
+  client.scenario.get(`/v9/projects/${projectId}`, (_req, res) => {
+    res.json({
+      id: projectId,
+      name: projectName,
+      crons: {
+        definitions,
+        disabledAt: null,
+        enabledAt: 1700000000000,
+      },
+    });
+  });
+}
+
+function mockRunEndpoint(opts?: { fail?: boolean; statusCode?: number }) {
+  let requestBody: any;
+  client.scenario.post(`/v1/projects/${projectId}/crons/run`, (req, res) => {
+    requestBody = req.body;
+    if (opts?.fail) {
+      res.status(opts.statusCode ?? 500).json({
+        error: { message: 'Internal Server Error', code: 'internal_error' },
+      });
+      return;
+    }
+    res.json({ invocationAt: Date.now() });
+  });
+  return { getRequestBody: () => requestBody };
+}
+
+describe('crons run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+  });
+
+  describe('--help', () => {
+    it('prints help and tracks telemetry', async () => {
+      client.setArgv('crons', 'run', '--help');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(2);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'crons:run' },
+      ]);
+    });
+  });
+
+  describe('not linked', () => {
+    it('errors when project is not linked', async () => {
+      mockedGetLinkedProject.mockResolvedValue({
+        status: 'not_linked',
+      } as any);
+      client.setArgv('crons', 'run', '/api/cron');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput("isn't linked");
+    });
+  });
+
+  describe('with path argument', () => {
+    it('triggers cron job successfully', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      const { getRequestBody } = mockRunEndpoint();
+
+      client.setArgv('crons', 'run', '/api/cron');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('triggered');
+      expect(getRequestBody()).toEqual({
+        path: '/api/cron',
+        schedule: '0 * * * *',
+      });
+    });
+
+    it('errors when cron path not found', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      client.setArgv('crons', 'run', '/api/nonexistent');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('not found');
+    });
+
+    it('errors when no cron jobs exist', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([]);
+      client.setArgv('crons', 'run', '/api/cron');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('No cron jobs found');
+    });
+
+    it('errors when crons are disabled', async () => {
+      mockLinkedProject();
+      client.scenario.get(`/v9/projects/${projectId}`, (_req, res) => {
+        res.json({
+          id: projectId,
+          name: projectName,
+          crons: {
+            definitions: [
+              {
+                host: 'example.vercel.app',
+                path: '/api/cron',
+                schedule: '0 * * * *',
+              },
+            ],
+            disabledAt: 1700000000000,
+            enabledAt: 1700000000000,
+          },
+        });
+      });
+      client.setArgv('crons', 'run', '/api/cron');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('disabled');
+    });
+  });
+
+  describe('API error handling', () => {
+    it('handles API errors from run endpoint', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      mockRunEndpoint({ fail: true, statusCode: 403 });
+
+      client.setArgv('crons', 'run', '/api/cron');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Failed to trigger');
+    });
+  });
+
+  describe('interactive selection', () => {
+    it('auto-selects when only one cron job exists', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      mockRunEndpoint();
+
+      client.setArgv('crons', 'run');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Auto-selected');
+    });
+
+    it('prompts for selection with multiple crons', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron1',
+          schedule: '0 * * * *',
+        },
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron2',
+          schedule: '0 0 * * *',
+        },
+      ]);
+      mockRunEndpoint();
+
+      client.setArgv('crons', 'run');
+      const exitCodePromise = crons(client);
+
+      await expect(client.stderr).toOutput('Which cron job');
+      client.stdin.write('\n'); // select first option
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('errors in non-interactive mode without path', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+
+      client.setArgv('crons', 'run');
+      client.nonInteractive = true;
+
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('required in non-interactive');
+    });
+  });
+
+  describe('telemetry', () => {
+    it('tracks subcommand and path argument', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+        },
+      ]);
+      mockRunEndpoint();
+
+      client.setArgv('crons', 'run', '/api/cron');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:run', value: 'run' },
+        { key: 'argument:path', value: '[REDACTED]' },
+      ]);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/crons/validate-cron-schedule.test.ts
+++ b/packages/cli/test/unit/commands/crons/validate-cron-schedule.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { validateCronSchedule } from '../../../../src/commands/crons/add';
+
+describe('validateCronSchedule', () => {
+  it.each([
+    ['* * * * *', 'all wildcards'],
+    ['0 0 * * *', 'midnight daily'],
+    ['0 10 * * *', 'every day at 10am'],
+    ['*/5 * * * *', 'every 5 minutes'],
+    ['0 */2 * * *', 'every 2 hours'],
+    ['30 8 1 * *', 'first of month at 8:30'],
+    ['0 0 * * 0', 'every Sunday (0)'],
+    ['0 0 * * 7', 'every Sunday (7)'],
+    ['0 9 1-15 * *', 'first half of month at 9am'],
+    ['0 9 * 1,6 *', 'Jan and Jun at 9am'],
+    ['0,30 * * * *', 'every half hour'],
+    ['0 0 1,15 * *', '1st and 15th of month'],
+    ['1-30/2 * * * *', 'odd minutes in first half'],
+    ['0 0-5 * * *', 'midnight to 5am'],
+    ['0 0 * * 1-5', 'weekdays at midnight'],
+    ['59 23 31 12 *', 'last minute of the year'],
+    ['0 0 1 1 0', 'Jan 1 if Sunday'],
+    ['0  10  *  *  *', 'extra whitespace between fields'],
+    ['  0 10 * * *  ', 'leading/trailing whitespace'],
+  ])('accepts valid: "%s" (%s)', expression => {
+    expect(validateCronSchedule(expression)).toBe(true);
+  });
+
+  it.each([
+    ['* * *', 'too few fields', 'exactly 5 fields'],
+    ['* * * * * *', 'too many fields', 'exactly 5 fields'],
+    ['*', 'single field', 'exactly 5 fields'],
+    ['', 'empty string', 'exactly 5 fields'],
+  ])('rejects wrong field count: "%s" (%s)', (expression, _desc, expected) => {
+    expect(validateCronSchedule(expression)).toContain(expected);
+  });
+
+  it.each([
+    ['60 * * * *', 'minute > 59', 'minute'],
+    ['-1 * * * *', 'negative minute', 'minute'],
+    ['0 24 * * *', 'hour > 23', 'hour'],
+    ['0 0 32 * *', 'day of month > 31', 'day of month'],
+    ['0 0 0 * *', 'day of month 0', 'day of month'],
+    ['0 0 * 13 *', 'month > 12', 'month'],
+    ['0 0 * 0 *', 'month 0', 'month'],
+    ['0 0 * * 8', 'day of week > 7', 'day of week'],
+  ])('rejects out of range: "%s" (%s)', (expression, _desc, field) => {
+    const result = validateCronSchedule(expression);
+    expect(result).not.toBe(true);
+    expect(result).toContain(field);
+  });
+
+  it.each([
+    ['30-10 * * * *', 'start > end', 'start is greater than end'],
+    ['0 0-25 * * *', 'out-of-bounds range', 'out of range'],
+    ['a-b * * * *', 'non-numeric range', 'Invalid range'],
+  ])('rejects invalid range: "%s" (%s)', (expression, _desc, expected) => {
+    expect(validateCronSchedule(expression)).toContain(expected);
+  });
+
+  it.each([
+    ['*/0 * * * *', 'step of 0', 'Invalid step value'],
+    ['*/-1 * * * *', 'negative step', 'Invalid step value'],
+    ['*/abc * * * *', 'non-numeric step', 'Invalid step value'],
+  ])('rejects invalid step: "%s" (%s)', (expression, _desc, expected) => {
+    expect(validateCronSchedule(expression)).toContain(expected);
+  });
+
+  it.each([
+    ['abc * * * *', 'non-numeric value', 'Invalid value'],
+    ['1.5 * * * *', 'float value', 'Invalid value'],
+  ])('rejects invalid value: "%s" (%s)', (expression, _desc, expected) => {
+    expect(validateCronSchedule(expression)).toContain(expected);
+  });
+
+  it('rejects expressions longer than 256 characters', () => {
+    const long = `${'0,1,2,3,4,5,6,7,8,9,'.repeat(15)}0 * * * *`;
+    expect(long.length).toBeGreaterThan(256);
+    expect(validateCronSchedule(long)).toContain('256 characters or less');
+  });
+});

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -17,6 +17,8 @@ describe('index', () => {
         ['cert', 'certs'],
         ['certs', 'certs'],
         ['contract', 'contract'],
+        ['cron', 'crons'],
+        ['crons', 'crons'],
         ['curl', 'curl'],
         ['deploy', 'deploy'],
         ['dev', 'dev'],


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new CLI command for managing cron jobs with ls, run, and add subcommands - entirely new feature code with comprehensive tests and no changes to auth, billing, database schemas, or shared infrastructure.
> 
> - New CLI command `crons` with `ls`, `run`, `add` subcommands
> - Adds cron schedule validation and vercel.json modification logic
> - Comprehensive unit tests for all subcommands
>
> <sup>Risk assessment for [commit 19f8957](https://github.com/vercel/vercel/commit/19f895720056b976841dcd2fce595078d724c5e4).</sup>
<!-- VADE_RISK_END -->