### PR TITLE
[cli] surface metadata validation errors in integration add

### DIFF
--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -328,6 +328,29 @@ export async function addAutoProvision(
     return 1;
   }
 
+  // Handle metadata validation errors — show the error instead of opening the browser
+  if (result.kind === 'metadata') {
+    const fallback = result as AutoProvisionFallback;
+    telemetry.trackMarketplaceEvent('marketplace_install_flow_metadata_error', {
+      ...baseProps,
+      reason: fallback.reason ?? fallback.kind,
+      auto_provision_result_kind: fallback.kind,
+      auto_provision_result_reason: fallback.reason,
+      auto_provision_error_message:
+        fallback.validationError ?? fallback.error_message,
+    });
+
+    const errorMessage =
+      fallback.validationError ??
+      fallback.error_message ??
+      'Metadata validation failed';
+    output.error(errorMessage);
+    output.log(
+      `Use ${chalk.cyan('--metadata KEY=VALUE')} to provide the required metadata fields.`
+    );
+    return 1;
+  }
+
   // Handle non-provisioned responses — pass through kind/reason from server
   if (result.kind !== 'provisioned') {
     const fallback = result as AutoProvisionFallback;

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -236,10 +236,17 @@ export interface AutoProvisionInstallationInfo {
   status?: string;
 }
 
+export interface AutoProvisionValidationField {
+  message: string;
+  key: string;
+}
+
 export interface AutoProvisionFallback {
   kind: string;
   reason?: string;
   error_message?: string;
+  validationError?: string;
+  validationFields?: AutoProvisionValidationField[];
   url: string;
   integration: AutoProvisionIntegration;
   product: AutoProvisionProduct;

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -1014,6 +1014,19 @@ const autoProvisionResponses: Record<
     kind: 'metadata',
     reason: 'invalid_metadata_schema',
     error_message: 'Metadata field "region" is required',
+    validationError:
+      "Failed to validate metadata: metadata should have required property 'region'",
+    validationFields: [
+      { message: "should have required property 'region'", key: 'required' },
+    ],
+    url: 'https://vercel.com/acme/~/integrations/checkout/acme?productSlug=acme',
+    integration: autoProvisionIntegration,
+    product: autoProvisionProduct,
+  },
+  metadata_no_validation: {
+    kind: 'metadata',
+    reason: 'invalid_metadata_schema',
+    error_message: 'Metadata field "region" is required',
     url: 'https://vercel.com/acme/~/integrations/checkout/acme?productSlug=acme',
     integration: autoProvisionIntegration,
     product: autoProvisionProduct,

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -671,8 +671,8 @@ describe('integration add (auto-provision)', () => {
   });
 
   describe('fallback to browser', () => {
-    it('should open browser for metadata fallback with source and defaultResourceName', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+    it('should open browser for install fallback with source and defaultResourceName', async () => {
+      useAutoProvision({ responseKey: 'install' });
 
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
@@ -723,7 +723,7 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should forward --metadata to browser fallback URL', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+      useAutoProvision({ responseKey: 'install' });
 
       client.setArgv(
         'integration',
@@ -748,7 +748,7 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should forward --metadata to browser URL with slash syntax, --name, and --metadata together', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+      useAutoProvision({ responseKey: 'install' });
 
       client.setArgv(
         'integration',
@@ -839,9 +839,9 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should forward --metadata to browser URL after term acceptance falls back', async () => {
-      // No installation, auto-provision returns metadata fallback
+      // No installation, auto-provision returns install fallback
       useAutoProvision({
-        responseKey: 'metadata',
+        responseKey: 'install',
         withInstallation: false,
       });
 
@@ -881,7 +881,7 @@ describe('integration add (auto-provision)', () => {
 
     it('should not include metadata in URL after term acceptance falls back without --metadata', async () => {
       useAutoProvision({
-        responseKey: 'metadata',
+        responseKey: 'install',
         withInstallation: false,
       });
 
@@ -910,7 +910,7 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should include all three URL params (projectSlug, defaultResourceName, source) when project is linked', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+      useAutoProvision({ responseKey: 'install' });
       useProject({
         ...defaultProject,
         id: 'vercel-integration-add',
@@ -942,7 +942,7 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should not include projectSlug in URL with --no-connect', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+      useAutoProvision({ responseKey: 'install' });
       useProject({
         ...defaultProject,
         id: 'vercel-integration-add',
@@ -974,7 +974,7 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should include custom --name in URL when fallback to browser without project', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+      useAutoProvision({ responseKey: 'install' });
 
       client.setArgv('integration', 'add', 'acme', '--name', 'my-custom-db');
       const exitCodePromise = integrationCommand(client);
@@ -995,7 +995,7 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should include custom --name and projectSlug in URL when project is linked', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+      useAutoProvision({ responseKey: 'install' });
       useProject({
         ...defaultProject,
         id: 'vercel-integration-add',
@@ -1026,7 +1026,7 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should not include projectSlug with --no-connect and custom --name', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+      useAutoProvision({ responseKey: 'install' });
       useProject({
         ...defaultProject,
         id: 'vercel-integration-add',
@@ -1061,6 +1061,54 @@ describe('integration add (auto-provision)', () => {
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/source=cli/)
       );
+    });
+  });
+
+  describe('metadata validation errors', () => {
+    it('should surface validation error instead of opening browser when kind is metadata', async () => {
+      useAutoProvision({ responseKey: 'metadata' });
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        "Failed to validate metadata: metadata should have required property 'region'"
+      );
+      await expect(client.stderr).toOutput(
+        'Use --metadata KEY=VALUE to provide the required metadata fields.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+      // Should NOT open the browser
+      expect(openMock).not.toHaveBeenCalled();
+
+      expect(client.telemetryEventStore.readonlyEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: 'output:marketplace_install_flow_metadata_error',
+            value: expect.stringContaining('"reason"'),
+          }),
+        ])
+      );
+    });
+
+    it('should show error_message when validationError is absent', async () => {
+      useAutoProvision({ responseKey: 'metadata_no_validation' });
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Metadata field "region" is required'
+      );
+      await expect(client.stderr).toOutput(
+        'Use --metadata KEY=VALUE to provide the required metadata fields.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+      expect(openMock).not.toHaveBeenCalled();
     });
   });
 
@@ -1208,7 +1256,7 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should include planId in fallback URL when --plan is provided', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+      useAutoProvision({ responseKey: 'install' });
 
       client.setArgv('integration', 'add', 'acme', '--plan', 'pro');
       const exitCodePromise = integrationCommand(client);
@@ -1228,7 +1276,7 @@ describe('integration add (auto-provision)', () => {
     });
 
     it('should not include planId in fallback URL when --plan is not provided', async () => {
-      useAutoProvision({ responseKey: 'metadata' });
+      useAutoProvision({ responseKey: 'install' });
 
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);


### PR DESCRIPTION
## Summary

- When the auto-provision API returns a 422 with `kind: 'metadata'` (metadata validation failure), the CLI now surfaces the validation error message directly to the user instead of silently falling back to the browser.
- Displays a hint to use `--metadata KEY=VALUE` to provide the required fields.
- Other non-provisioned fallback kinds (e.g., `install`, `unknown`) continue to open the browser as before.

Fixes: MKT-2822

## Validation

- New tests verify the metadata error is displayed and browser is NOT opened for `kind: 'metadata'` responses.
- Tests cover both `validationError` (preferred) and `error_message` (fallback) fields.
- All 107 existing tests in `add-auto-provision.test.ts` pass.
- Existing browser-fallback tests updated to use `responseKey: 'install'` since they test generic fallback behavior, not metadata-specific behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI error handling improvement that surfaces metadata validation errors to users instead of silently falling back to browser, with comprehensive test coverage.
> 
> - Adds new error handling branch for `kind: 'metadata'` responses to display validation errors
> - Adds TypeScript interface fields for validation error data
> - Updates existing tests to use `responseKey: 'install'` and adds new metadata error tests
>
> <sup>Risk assessment for [commit 95f82d7](https://github.com/vercel/vercel/commit/95f82d7b8552d453d60e6aa0e26d86d4fd55fb25).</sup>
<!-- VADE_RISK_END -->