### PR TITLE
fix(cli): `--help` flag exits with code 0 instead of 2

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1089,6 +1089,8 @@ Run ${chalk.cyan(cmd(await getUpdateCommand()))} to update.${errorMsg}`
       }
     }
 
-    process.exitCode = exitCode;
+    // Exit code 2 is used internally to signal that --help was printed
+    // and is not an error, so map it to 0 for the process exit code.
+    process.exitCode = exitCode === 2 ? 0 : exitCode;
   })
   .catch(handleUnexpected);


### PR DESCRIPTION
## Bug

`vercel logs --help` (and all other `vercel <cmd> --help` invocations) exit with code 2.

Exit code 2 signals an error to shells, CI pipelines, and tools that check `$?`. For example, `set -e` scripts abort after running `vercel logs --help`, and CI steps report a failure.

## Root Cause

All command handlers use `return 2` as an internal convention to signal "help was printed". This value is already special-cased in the update-check logic (`exitCode && exitCode !== 2`), but at the very end of `main()` it's passed through as-is to `process.exitCode`.

## Fix

Map exit code 2 → 0 at the process boundary in `packages/cli/src/index.ts`, so `--help` correctly exits with success. The internal convention (`return 2`) is preserved — only the final process exit code changes.

```diff
-    process.exitCode = exitCode;
+    // Exit code 2 is used internally to signal that --help was printed
+    // and is not an error, so map it to 0 for the process exit code.
+    process.exitCode = exitCode === 2 ? 0 : exitCode;
```

No test changes needed — existing tests verify the internal return value (2), which is unchanged. The fix only affects the process-level exit code.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Simple CLI fix that maps internal exit code 2 (help printed) to 0 at process boundary, affecting only command-line exit status behavior.
> 
> - Maps exit code 2 → 0 for `--help` flag at process boundary
> - No auth, data, or business logic changes
>
> <sup>Risk assessment for [commit 5b09bb3](https://github.com/vercel/vercel/commit/5b09bb3ee4319f74273dfaf44cbae2471b64db1b).</sup>
<!-- VADE_RISK_END -->