### PR TITLE
fix(cli): detect codex in codex ci environments

### DIFF
--- a/.changeset/thin-codex-detect.md
+++ b/.changeset/thin-codex-detect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/detect-agent': patch
+---
+
+Detect Codex when `CODEX_CI` or `CODEX_THREAD_ID` is present.

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -73,7 +73,11 @@ export async function determineAgent(): Promise<AgentResult> {
     return { isAgent: true, agent: { name: GEMINI } };
   }
 
-  if (process.env.CODEX_SANDBOX) {
+  if (
+    process.env.CODEX_SANDBOX ||
+    process.env.CODEX_CI ||
+    process.env.CODEX_THREAD_ID
+  ) {
     return { isAgent: true, agent: { name: CODEX } };
   }
 

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -12,6 +12,8 @@ describe('determineAgent', () => {
     vi.stubEnv('CURSOR_AGENT', '');
     vi.stubEnv('GEMINI_CLI', '');
     vi.stubEnv('CODEX_SANDBOX', '');
+    vi.stubEnv('CODEX_CI', '');
+    vi.stubEnv('CODEX_THREAD_ID', '');
     vi.stubEnv('AUGMENT_AGENT', '');
     vi.stubEnv('OPENCODE_CLIENT', '');
     vi.stubEnv('CLAUDECODE', '');
@@ -127,6 +129,34 @@ describe('determineAgent', () => {
     describe('CODEX_SANDBOX set', () => {
       beforeEach(() => {
         vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
+      });
+
+      it('detects codex', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({
+          isAgent: true,
+          agent: { name: KNOWN_AGENTS.CODEX },
+        });
+      });
+    });
+
+    describe('CODEX_CI set', () => {
+      beforeEach(() => {
+        vi.stubEnv('CODEX_CI', '1');
+      });
+
+      it('detects codex', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({
+          isAgent: true,
+          agent: { name: KNOWN_AGENTS.CODEX },
+        });
+      });
+    });
+
+    describe('CODEX_THREAD_ID set', () => {
+      beforeEach(() => {
+        vi.stubEnv('CODEX_THREAD_ID', 'thread-123');
       });
 
       it('detects codex', async () => {


### PR DESCRIPTION
## Summary
- detect Codex when `CODEX_CI` or `CODEX_THREAD_ID` is present, in addition to `CODEX_SANDBOX`
- add unit coverage for both Codex env variants

## Why
Codex-driven Vercel CLI invocations in this environment expose `CODEX_CI` / `CODEX_THREAD_ID`, but not `CODEX_SANDBOX`, so they currently fall through to human/unknown attribution.

## Testing
- `pnpm --filter @vercel/detect-agent exec vitest run -c ../../vitest.config.mts`
- `pnpm dlx @biomejs/biome@2.4.4 format --write packages/detect-agent/src/index.ts packages/detect-agent/test/unit/determine-agent.test.ts`
- `pnpm dlx @biomejs/biome@2.4.4 lint packages/detect-agent/src/index.ts packages/detect-agent/test/unit/determine-agent.test.ts`

## Note
The local Husky pre-commit hook failed to execute `biome` from its hook environment, so I ran the equivalent formatting/linting manually before committing.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds additional environment variable checks for Codex agent detection and corresponding unit tests, with no security, auth, or database changes.
> 
> - Adds CODEX_CI and CODEX_THREAD_ID env checks to existing agent detection logic
> - Adds unit tests covering new Codex environment variants
> - Includes changeset for patch version bump
>
> <sup>Risk assessment for [commit 8e0bb2a](https://github.com/vercel/vercel/commit/8e0bb2af71a3633b04f7ef1f8e168369c2754e19).</sup>
<!-- VADE_RISK_END -->