### PR TITLE
fix(detect-agent): add antigravity environment detection

### DIFF
--- a/.changeset/smart-snakes-wave.md
+++ b/.changeset/smart-snakes-wave.md
@@ -1,0 +1,5 @@
+---
+'@vercel/detect-agent': patch
+---
+
+Add Antigravity agent detection via `ANTIGRAVITY_AGENT` environment variable

--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -31,6 +31,7 @@ This package can detect the following AI agents and development environments:
 - **Devin** (Cognition Labs)
 - **Gemini CLI** (Google)
 - **Codex** (OpenAI)
+- **Antigravity** (Google DeepMind)
 - **Replit** (online IDE)
 
 ## The AI_AGENT Standard

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -10,6 +10,7 @@ const DEVIN = 'devin' as const;
 const REPLIT = 'replit' as const;
 const GEMINI = 'gemini' as const;
 const CODEX = 'codex' as const;
+const ANTIGRAVITY = 'antigravity' as const;
 const AUGMENT_CLI = 'augment-cli' as const;
 const OPENCODE = 'opencode' as const;
 
@@ -21,6 +22,7 @@ export type KnownAgentNames =
   | typeof REPLIT
   | typeof GEMINI
   | typeof CODEX
+  | typeof ANTIGRAVITY
   | typeof AUGMENT_CLI
   | typeof OPENCODE;
 
@@ -46,6 +48,7 @@ export const KNOWN_AGENTS = {
   REPLIT,
   GEMINI,
   CODEX,
+  ANTIGRAVITY,
   AUGMENT_CLI,
   OPENCODE,
 } as const;
@@ -79,6 +82,10 @@ export async function determineAgent(): Promise<AgentResult> {
     process.env.CODEX_THREAD_ID
   ) {
     return { isAgent: true, agent: { name: CODEX } };
+  }
+
+  if (process.env.ANTIGRAVITY_AGENT) {
+    return { isAgent: true, agent: { name: ANTIGRAVITY } };
   }
 
   if (process.env.AUGMENT_AGENT) {

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -14,6 +14,7 @@ describe('determineAgent', () => {
     vi.stubEnv('CODEX_SANDBOX', '');
     vi.stubEnv('CODEX_CI', '');
     vi.stubEnv('CODEX_THREAD_ID', '');
+    vi.stubEnv('ANTIGRAVITY_AGENT', '');
     vi.stubEnv('AUGMENT_AGENT', '');
     vi.stubEnv('OPENCODE_CLIENT', '');
     vi.stubEnv('CLAUDECODE', '');
@@ -169,6 +170,29 @@ describe('determineAgent', () => {
     });
   });
 
+  describe('antigravity detection', () => {
+    describe('ANTIGRAVITY_AGENT not set', () => {
+      it('returns no agent', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({ isAgent: false });
+      });
+    });
+
+    describe('ANTIGRAVITY_AGENT set', () => {
+      beforeEach(() => {
+        vi.stubEnv('ANTIGRAVITY_AGENT', '1');
+      });
+
+      it('detects antigravity', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({
+          isAgent: true,
+          agent: { name: KNOWN_AGENTS.ANTIGRAVITY },
+        });
+      });
+    });
+  });
+
   describe('augment cli detection', () => {
     describe('AUGMENT_AGENT not set', () => {
       it('returns no agent', async () => {
@@ -309,6 +333,7 @@ describe('determineAgent', () => {
       vi.stubEnv('CURSOR_AGENT', '1');
       vi.stubEnv('GEMINI_CLI', '1');
       vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
+      vi.stubEnv('ANTIGRAVITY_AGENT', '1');
       vi.stubEnv('AUGMENT_AGENT', '1');
       vi.stubEnv('OPENCODE_CLIENT', 'opencode');
       vi.stubEnv('CLAUDE_CODE', '1');
@@ -331,6 +356,7 @@ describe('determineAgent', () => {
       vi.stubEnv('CURSOR_AGENT', '1');
       vi.stubEnv('GEMINI_CLI', '1');
       vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
+      vi.stubEnv('ANTIGRAVITY_AGENT', '1');
       vi.stubEnv('AUGMENT_AGENT', '1');
       vi.stubEnv('OPENCODE_CLIENT', 'opencode');
       vi.stubEnv('CLAUDE_CODE', '1');
@@ -352,6 +378,7 @@ describe('determineAgent', () => {
       vi.stubEnv('CURSOR_AGENT', '1');
       vi.stubEnv('GEMINI_CLI', '1');
       vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
+      vi.stubEnv('ANTIGRAVITY_AGENT', '1');
       vi.stubEnv('AUGMENT_AGENT', '1');
       vi.stubEnv('OPENCODE_CLIENT', 'opencode');
       vi.stubEnv('CLAUDE_CODE', '1');


### PR DESCRIPTION
## Summary
- Add first-class `ANTIGRAVITY_AGENT` detection in `@vercel/detect-agent` using the same env-based pattern as existing agent checks.
- Extend known agent typings/constants and add unit coverage for antigravity detection and priority-order behavior.
- Document Antigravity support in the package README and include a patch changeset for `@vercel/detect-agent`.

## Testing
- `CI=1 pnpm test` (in `packages/detect-agent`)
- `pnpm lint`
- `pnpm type-check` *(fails due existing repo issues unrelated to this change: missing `#wasm/vercel_python_analysis.js` in `packages/python-analysis` and missing `./templates/*` modules in `packages/cli`)*

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR adds a new agent detection constant and environment variable check for Antigravity, following the existing pattern for other agents, with corresponding tests and documentation updates.
> 
> - Adds `ANTIGRAVITY` constant and `ANTIGRAVITY_AGENT` env var check in detect-agent package
> - Extends type definitions and exports for new agent
> - Adds unit tests for antigravity detection and priority-order behavior
>
> <sup>Risk assessment for [commit ce50f08](https://github.com/vercel/vercel/commit/ce50f08948468d124956b14aee1233d199cef52f).</sup>
<!-- VADE_RISK_END -->