### PR TITLE
Vc logs URL filtering conflict

### DIFF
--- a/.changeset/vc-logs-url-filtering-conflict.md
+++ b/.changeset/vc-logs-url-filtering-conflict.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vc logs` error when passing a deployment URL with filtering flags like `--since` or `--until`. Previously, a positional deployment URL would implicitly enable `--follow`, which conflicts with filtering flags and produced a confusing error. Now, when filtering flags are present, the implicit `--follow` is suppressed and the deployment URL is used as a deployment filter instead.

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -251,11 +251,24 @@ export default async function logs(client: Client) {
   const branchFlagValue = parsedArguments.flags['--branch'];
 
   // Implicit --follow when deployment is specified (for backwards compatibility)
-  // unless --no-follow is explicitly set
+  // unless --no-follow is explicitly set or filtering flags are used
   const followFlagValue = parsedArguments.flags['--follow'];
   const noFollowFlagValue = parsedArguments.flags['--no-follow'];
+  const hasFilteringFlags =
+    environmentOption !== undefined ||
+    levelOption !== undefined ||
+    statusCodeOption !== undefined ||
+    sourceOption !== undefined ||
+    sinceOption !== undefined ||
+    untilOption !== undefined ||
+    limitOption !== undefined ||
+    queryOption !== undefined ||
+    searchOption !== undefined ||
+    requestIdOption !== undefined;
   const followOption =
-    deploymentOption && !noFollowFlagValue ? true : followFlagValue;
+    deploymentOption && !noFollowFlagValue && !hasFilteringFlags
+      ? true
+      : followFlagValue;
 
   telemetry.trackCliArgumentUrlOrDeploymentId(deploymentArgument);
   telemetry.trackCliOptionProject(projectOption);

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -187,6 +187,21 @@ function logsSpanMultipleDays(logs: RequestLogEntry[]): boolean {
   return logs.some(log => new Date(log.timestamp).toDateString() !== firstDay);
 }
 
+function isAnyFilterOptionEnabled(flags: {
+  environment?: string;
+  level?: string | string[];
+  statusCode?: string;
+  source?: string | string[];
+  since?: string;
+  until?: string;
+  limit?: number;
+  query?: string;
+  search?: string;
+  requestId?: string;
+}): boolean {
+  return Object.values(flags).some(v => v !== undefined);
+}
+
 function parseLevels(levels?: string | string[]): string[] {
   if (!levels) return [];
   if (typeof levels === 'string') return [levels];
@@ -254,19 +269,21 @@ export default async function logs(client: Client) {
   // unless --no-follow is explicitly set or filtering flags are used
   const followFlagValue = parsedArguments.flags['--follow'];
   const noFollowFlagValue = parsedArguments.flags['--no-follow'];
-  const hasFilteringFlags =
-    environmentOption !== undefined ||
-    levelOption !== undefined ||
-    statusCodeOption !== undefined ||
-    sourceOption !== undefined ||
-    sinceOption !== undefined ||
-    untilOption !== undefined ||
-    limitOption !== undefined ||
-    queryOption !== undefined ||
-    searchOption !== undefined ||
-    requestIdOption !== undefined;
   const followOption =
-    deploymentOption && !noFollowFlagValue && !hasFilteringFlags
+    deploymentOption &&
+    !noFollowFlagValue &&
+    !isAnyFilterOptionEnabled({
+      environment: environmentOption,
+      level: levelOption,
+      statusCode: statusCodeOption,
+      source: sourceOption,
+      since: sinceOption,
+      until: untilOption,
+      limit: limitOption,
+      query: queryOption,
+      search: searchOption,
+      requestId: requestIdOption,
+    })
       ? true
       : followFlagValue;
 

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -664,6 +664,27 @@ describe('logs', () => {
       expect(receivedDeploymentId).toEqual(deployment.id);
     });
 
+    it('should disable implicit --follow when --since is used with --deployment', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string;
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--deployment', deployment.id, '--since', '1h');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedDeploymentId).toEqual(deployment.id);
+    });
+
     it('should track telemetry for --deployment option', async () => {
       const user = useUser();
       const deployment = useDeployment({ creator: user });
@@ -766,6 +787,112 @@ describe('logs', () => {
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);
+    });
+
+    it('should disable implicit --follow when --since is used with positional deployment', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string;
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', deployment.id, '--since', '1h');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedDeploymentId).toEqual(deployment.id);
+    });
+
+    it('should disable implicit --follow when --until is used with positional deployment', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string;
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', deployment.id, '--until', '30m');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedDeploymentId).toEqual(deployment.id);
+    });
+
+    it('should disable implicit --follow when --since and --until are used with URL positional argument', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      client.scenario.get(`/v13/deployments/${deployment.url}`, (_req, res) => {
+        res.json(deployment);
+      });
+
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string;
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv(
+        'logs',
+        `https://${deployment.url}`,
+        '--since',
+        '2026-03-09T10:13:50Z',
+        '--until',
+        '2026-03-09T10:15:00Z'
+      );
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedDeploymentId).toEqual(deployment.id);
+    });
+
+    it('should disable implicit --follow when --level is used with positional deployment', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        res.json({
+          rows: [
+            createMockLog({ deploymentId: deployment.id, level: 'error' }),
+          ],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', deployment.id, '--level', 'error');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should still error when explicit --follow is used with filtering flags', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', deployment.id, '--follow', '--since', '1h');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Remove: --since');
     });
 
     it('should prioritize positional argument over --deployment flag', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prevents `vc logs` from implicitly enabling `--follow` when a deployment URL is used with filtering flags, resolving a confusing error.

Previously, providing a deployment URL as a positional argument would automatically enable `--follow` for backwards compatibility. This conflicted with filtering options like `--since` or `--until`, resulting in an "Error: The --follow flag does not support filtering" message, even though the user never explicitly requested `--follow`. This change improves developer experience by treating the deployment URL as a deployment filter in such cases, rather than forcing follow mode.

---
Linear Issue: [O11Y-4020](https://linear.app/vercel/issue/O11Y-4020/make-vc-logs-error-clearer-with-deployment-urls)

<p><a href="https://cursor.com/agents/bc-db62a195-688f-4afb-b598-ffd841fe6a84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db62a195-688f-4afb-b598-ffd841fe6a84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> CLI behavior change that adds a helper function to check filter options and conditionally suppresses implicit --follow mode, with comprehensive test coverage.
> 
> - Adds `isAnyFilterOptionEnabled` helper to detect filtering flags
> - Modifies `followOption` logic to suppress implicit --follow when filters present
> - Adds 6 unit tests covering various filter flag combinations
>
> <sup>Risk assessment for [commit 124be71](https://github.com/vercel/vercel/commit/124be719ebf13c3dc2d8ed5440a1ddbc9e8a3df2).</sup>
<!-- VADE_RISK_END -->