### PR TITLE
Revert "[next] vary fallback allowQuery for partial fallback shells"

### DIFF
--- a/.changeset/cuddly-colts-shave.md
+++ b/.changeset/cuddly-colts-shave.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Revert "[next] vary fallback allowQuery for partial fallback shells"

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3037,12 +3037,6 @@ export const onPrerenderRoute =
         };
       }
 
-      const partialFallback =
-        isAppPathRoute &&
-        renderingMode === RenderingMode.PARTIALLY_STATIC &&
-        isFallback &&
-        Boolean(postponedState);
-
       // If this is a fallback page with PPR enabled, we should not have the
       // cache key vary based on the route parameters to ensure that we always
       // have a HIT for the fallback page.
@@ -3068,15 +3062,20 @@ export const onPrerenderRoute =
         }
         // We additionally vary based on if there's a postponed prerender
         // because if there isn't, then that means that we generated an
-        // empty shell. For partial fallbacks when cache components are enabled,
-        // we still want to vary the HTML by params so the route shell can be
-        // cached per-param. Otherwise, keep the fallback shell shared across
-        // params.
+        // empty shell, and producing an empty RSC shell would be a waste.
+        // If there is a postponed prerender, then the RSC shell would be
+        // non-empty, and it would be valuable to also generate an empty
+        // RSC shell.
         else if (postponedPrerender) {
-          htmlAllowQuery =
-            partialFallback && isAppClientParamParsingEnabled ? allowQuery : [];
+          htmlAllowQuery = [];
         }
       }
+
+      const partialFallback =
+        isAppPathRoute &&
+        renderingMode === RenderingMode.PARTIALLY_STATIC &&
+        isFallback &&
+        Boolean(postponedState);
 
       // If this is a static metadata file that should output FileRef instead of Prerender
       const staticMetadataFile = getSourceFileRefOfStaticMetadata(


### PR DESCRIPTION
Reverts vercel/vercel#15338

This can result in degraded perf because it introduces cache fragmentation - we need a way to disambiguate between "allowQuery" (these params can be part of the CDN cache key) and "upgradeQuery" (the intent behind this PR: the params can be part of the cache key once the partial fallback is revalidated with the params)

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This revert changes caching behavior for Next.js fallback pages by simplifying htmlAllowQuery logic, removing conditional param-based cache variation - a build/rendering optimization change with no auth, billing, or schema impact.
> 
> - Reverts conditional htmlAllowQuery logic to always use empty array for postponed prerenders
> - Moves partialFallback variable declaration after its previous usage point
> - Changes Next.js build-time caching strategy for fallback shells
>
> <sup>Risk assessment for [commit c167b99](https://github.com/vercel/vercel/commit/c167b99a681c75e4f7eee17676ca523da5b32f2c).</sup>
<!-- VADE_RISK_END -->