### PR TITLE
[python-analysis] Fix parsing of  environment markers that combine  and  expressions with parentheses

### DIFF
--- a/.changeset/bright-mangos-talk.md
+++ b/.changeset/bright-mangos-talk.md
@@ -2,4 +2,4 @@
 '@vercel/python-analysis': patch
 ---
 
-Fix parsing of `requirements.txt` environment markers that combine `and` and `or` expressions with parentheses.
+Update `pip-requirements-js` to include fixes for grouped `requirements.txt` environment markers and add regression coverage for Poetry-style marker expressions.

--- a/.changeset/bright-mangos-talk.md
+++ b/.changeset/bright-mangos-talk.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-analysis': patch
+---
+
+Fix parsing of `requirements.txt` environment markers that combine `and` and `or` expressions with parentheses.

--- a/packages/python-analysis/package.json
+++ b/packages/python-analysis/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "11.1.1",
     "js-yaml": "4.1.1",
     "minimatch": "10.1.1",
-    "pip-requirements-js": "github:Twixes/pip-requirements-js#e0b1ce18bcea0749805701644f2134f8fabf0e3f",
+    "pip-requirements-js": "1.0.3",
     "smol-toml": "1.5.2",
     "zod": "3.22.4"
   },

--- a/packages/python-analysis/package.json
+++ b/packages/python-analysis/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "11.1.1",
     "js-yaml": "4.1.1",
     "minimatch": "10.1.1",
-    "pip-requirements-js": "1.0.2",
+    "pip-requirements-js": "github:Twixes/pip-requirements-js#e0b1ce18bcea0749805701644f2134f8fabf0e3f",
     "smol-toml": "1.5.2",
     "zod": "3.22.4"
   },

--- a/packages/python-analysis/src/manifest/requirements-txt-parser.ts
+++ b/packages/python-analysis/src/manifest/requirements-txt-parser.ts
@@ -362,17 +362,6 @@ function stripInlineHashes(line: string): string {
 }
 
 /**
- * Strip an inline comment introduced by " #" while leaving URL fragments intact.
- */
-function stripInlineComment(line: string): string {
-  const commentIdx = line.indexOf(' #');
-  if (commentIdx === -1) {
-    return line.trim();
-  }
-  return line.slice(0, commentIdx).trim();
-}
-
-/**
  * Extract all --hash values from a requirement line.
  * Returns an array of hash strings in the format "algorithm:value".
  */
@@ -411,204 +400,6 @@ function extractArgValue(line: string, option: string): string | null {
   }
 
   return value || null;
-}
-
-/**
- * Split a requirement line into the requirement spec and optional environment marker.
- */
-function splitRequirementMarker(line: string): {
-  requirement: string;
-  markers?: string;
-} {
-  let inSingleQuote = false;
-  let inDoubleQuote = false;
-
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-    if (char === "'" && !inDoubleQuote) {
-      inSingleQuote = !inSingleQuote;
-      continue;
-    }
-    if (char === '"' && !inSingleQuote) {
-      inDoubleQuote = !inDoubleQuote;
-      continue;
-    }
-    if (char === ';' && !inSingleQuote && !inDoubleQuote) {
-      const requirement = line.slice(0, i).trim();
-      const markers = line.slice(i + 1).trim();
-      return {
-        requirement,
-        markers: markers || undefined,
-      };
-    }
-  }
-
-  return {
-    requirement: line.trim(),
-  };
-}
-
-function hasBalancedParentheses(input: string): boolean {
-  let depth = 0;
-  let inSingleQuote = false;
-  let inDoubleQuote = false;
-
-  for (const char of input) {
-    if (char === "'" && !inDoubleQuote) {
-      inSingleQuote = !inSingleQuote;
-      continue;
-    }
-    if (char === '"' && !inSingleQuote) {
-      inDoubleQuote = !inDoubleQuote;
-      continue;
-    }
-    if (inSingleQuote || inDoubleQuote) {
-      continue;
-    }
-    if (char === '(') {
-      depth++;
-    } else if (char === ')') {
-      depth--;
-      if (depth < 0) {
-        return false;
-      }
-    }
-  }
-
-  return depth === 0;
-}
-
-function shouldFallbackToManualRequirementParsing(line: string): boolean {
-  const { markers } = splitRequirementMarker(stripInlineComment(line));
-  return (
-    markers != null && /[()]/.test(markers) && hasBalancedParentheses(markers)
-  );
-}
-
-/**
- * Normalize a standard named requirement line without relying on pip-requirements-js.
- *
- * Supports:
- * - name
- * - name[extras]
- * - name>=1.0,<2.0
- * - name[extras] @ url
- * - any of the above with environment markers
- */
-function normalizeNamedRequirement(
-  rawLine: string
-): NormalizedRequirement | null {
-  const line = stripInlineComment(rawLine);
-  const { requirement, markers } = splitRequirementMarker(line);
-
-  const match = requirement.match(
-    /^([a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\[([^\]]+)\])?\s*(.*)$/
-  );
-  if (!match) {
-    return null;
-  }
-
-  const [, name, extrasRaw, remainderRaw] = match;
-  const remainder = remainderRaw.trim();
-  const normalized: NormalizedRequirement = { name };
-
-  if (extrasRaw) {
-    const extras = extrasRaw
-      .split(',')
-      .map(extra => extra.trim())
-      .filter(Boolean);
-    if (extras.length > 0) {
-      normalized.extras = extras;
-    }
-  }
-
-  if (markers) {
-    normalized.markers = markers;
-  }
-
-  if (remainder.startsWith('@')) {
-    const url = remainder.slice(1).trim();
-    if (!url) {
-      return null;
-    }
-    normalized.url = url;
-
-    if (isGitUrl(url)) {
-      const parsed = parseGitUrl(url);
-      if (parsed) {
-        const source: DependencySource = {
-          git: parsed.url,
-        };
-        if (parsed.ref) {
-          source.rev = parsed.ref;
-        }
-        if (parsed.editable) {
-          source.editable = true;
-        }
-        normalized.source = source;
-      }
-    }
-  } else if (remainder) {
-    normalized.version = remainder;
-  }
-
-  return normalized;
-}
-
-function getLogicalRequirementsLines(fileContent: string): string[] {
-  const lines = fileContent.split(/\r?\n/);
-  const logicalLines: string[] = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
-    if (trimmed === '' || trimmed.startsWith('#')) {
-      continue;
-    }
-
-    let fullLine = trimmed;
-    while (fullLine.endsWith('\\') && i + 1 < lines.length) {
-      i++;
-      fullLine = fullLine.slice(0, -1) + lines[i].trim();
-    }
-
-    logicalLines.push(fullLine);
-  }
-
-  return logicalLines;
-}
-
-function parseRequirementsWithFallback(cleanedContent: string): {
-  requirements: Requirement[];
-  manualRequirements: NormalizedRequirement[];
-} {
-  try {
-    return {
-      requirements: parsePipRequirementsFile(cleanedContent),
-      manualRequirements: [],
-    };
-  } catch {
-    const requirements: Requirement[] = [];
-    const manualRequirements: NormalizedRequirement[] = [];
-
-    for (const line of getLogicalRequirementsLines(cleanedContent)) {
-      try {
-        requirements.push(...parsePipRequirementsFile(line));
-      } catch (lineError) {
-        if (!shouldFallbackToManualRequirementParsing(line)) {
-          throw lineError;
-        }
-
-        const normalized = normalizeNamedRequirement(line);
-        if (!normalized) {
-          throw lineError;
-        }
-
-        manualRequirements.push(normalized);
-      }
-    }
-
-    return { requirements, manualRequirements };
-  }
 }
 
 /**
@@ -974,8 +765,7 @@ function parseRequirementsFileInternal(
   // Build a map from requirement name to hashes from the original content
   const hashMap = buildHashMap(fileContent);
 
-  const { requirements, manualRequirements } =
-    parseRequirementsWithFallback(cleanedContent);
+  const requirements = parsePipRequirementsFile(cleanedContent);
   const normalized: NormalizedRequirement[] = [];
 
   // Collect all pip options (will be merged with referenced files)
@@ -1008,14 +798,6 @@ function parseRequirementsFileInternal(
       }
       normalized.push(norm);
     }
-  }
-
-  for (const req of manualRequirements) {
-    const hashes = hashMap.get(req.name.toLowerCase());
-    if (hashes && hashes.length > 0) {
-      req.hashes = hashes;
-    }
-    normalized.push(req);
   }
 
   // Process bare file path and URL requirements that pip-requirements-js can't parse

--- a/packages/python-analysis/src/manifest/requirements-txt-parser.ts
+++ b/packages/python-analysis/src/manifest/requirements-txt-parser.ts
@@ -362,6 +362,17 @@ function stripInlineHashes(line: string): string {
 }
 
 /**
+ * Strip an inline comment introduced by " #" while leaving URL fragments intact.
+ */
+function stripInlineComment(line: string): string {
+  const commentIdx = line.indexOf(' #');
+  if (commentIdx === -1) {
+    return line.trim();
+  }
+  return line.slice(0, commentIdx).trim();
+}
+
+/**
  * Extract all --hash values from a requirement line.
  * Returns an array of hash strings in the format "algorithm:value".
  */
@@ -400,6 +411,204 @@ function extractArgValue(line: string, option: string): string | null {
   }
 
   return value || null;
+}
+
+/**
+ * Split a requirement line into the requirement spec and optional environment marker.
+ */
+function splitRequirementMarker(line: string): {
+  requirement: string;
+  markers?: string;
+} {
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+    if (char === ';' && !inSingleQuote && !inDoubleQuote) {
+      const requirement = line.slice(0, i).trim();
+      const markers = line.slice(i + 1).trim();
+      return {
+        requirement,
+        markers: markers || undefined,
+      };
+    }
+  }
+
+  return {
+    requirement: line.trim(),
+  };
+}
+
+function hasBalancedParentheses(input: string): boolean {
+  let depth = 0;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+
+  for (const char of input) {
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+    if (inSingleQuote || inDoubleQuote) {
+      continue;
+    }
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+      if (depth < 0) {
+        return false;
+      }
+    }
+  }
+
+  return depth === 0;
+}
+
+function shouldFallbackToManualRequirementParsing(line: string): boolean {
+  const { markers } = splitRequirementMarker(stripInlineComment(line));
+  return (
+    markers != null && /[()]/.test(markers) && hasBalancedParentheses(markers)
+  );
+}
+
+/**
+ * Normalize a standard named requirement line without relying on pip-requirements-js.
+ *
+ * Supports:
+ * - name
+ * - name[extras]
+ * - name>=1.0,<2.0
+ * - name[extras] @ url
+ * - any of the above with environment markers
+ */
+function normalizeNamedRequirement(
+  rawLine: string
+): NormalizedRequirement | null {
+  const line = stripInlineComment(rawLine);
+  const { requirement, markers } = splitRequirementMarker(line);
+
+  const match = requirement.match(
+    /^([a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\[([^\]]+)\])?\s*(.*)$/
+  );
+  if (!match) {
+    return null;
+  }
+
+  const [, name, extrasRaw, remainderRaw] = match;
+  const remainder = remainderRaw.trim();
+  const normalized: NormalizedRequirement = { name };
+
+  if (extrasRaw) {
+    const extras = extrasRaw
+      .split(',')
+      .map(extra => extra.trim())
+      .filter(Boolean);
+    if (extras.length > 0) {
+      normalized.extras = extras;
+    }
+  }
+
+  if (markers) {
+    normalized.markers = markers;
+  }
+
+  if (remainder.startsWith('@')) {
+    const url = remainder.slice(1).trim();
+    if (!url) {
+      return null;
+    }
+    normalized.url = url;
+
+    if (isGitUrl(url)) {
+      const parsed = parseGitUrl(url);
+      if (parsed) {
+        const source: DependencySource = {
+          git: parsed.url,
+        };
+        if (parsed.ref) {
+          source.rev = parsed.ref;
+        }
+        if (parsed.editable) {
+          source.editable = true;
+        }
+        normalized.source = source;
+      }
+    }
+  } else if (remainder) {
+    normalized.version = remainder;
+  }
+
+  return normalized;
+}
+
+function getLogicalRequirementsLines(fileContent: string): string[] {
+  const lines = fileContent.split(/\r?\n/);
+  const logicalLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed === '' || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    let fullLine = trimmed;
+    while (fullLine.endsWith('\\') && i + 1 < lines.length) {
+      i++;
+      fullLine = fullLine.slice(0, -1) + lines[i].trim();
+    }
+
+    logicalLines.push(fullLine);
+  }
+
+  return logicalLines;
+}
+
+function parseRequirementsWithFallback(cleanedContent: string): {
+  requirements: Requirement[];
+  manualRequirements: NormalizedRequirement[];
+} {
+  try {
+    return {
+      requirements: parsePipRequirementsFile(cleanedContent),
+      manualRequirements: [],
+    };
+  } catch {
+    const requirements: Requirement[] = [];
+    const manualRequirements: NormalizedRequirement[] = [];
+
+    for (const line of getLogicalRequirementsLines(cleanedContent)) {
+      try {
+        requirements.push(...parsePipRequirementsFile(line));
+      } catch (lineError) {
+        if (!shouldFallbackToManualRequirementParsing(line)) {
+          throw lineError;
+        }
+
+        const normalized = normalizeNamedRequirement(line);
+        if (!normalized) {
+          throw lineError;
+        }
+
+        manualRequirements.push(normalized);
+      }
+    }
+
+    return { requirements, manualRequirements };
+  }
 }
 
 /**
@@ -765,7 +974,8 @@ function parseRequirementsFileInternal(
   // Build a map from requirement name to hashes from the original content
   const hashMap = buildHashMap(fileContent);
 
-  const requirements = parsePipRequirementsFile(cleanedContent);
+  const { requirements, manualRequirements } =
+    parseRequirementsWithFallback(cleanedContent);
   const normalized: NormalizedRequirement[] = [];
 
   // Collect all pip options (will be merged with referenced files)
@@ -798,6 +1008,14 @@ function parseRequirementsFileInternal(
       }
       normalized.push(norm);
     }
+  }
+
+  for (const req of manualRequirements) {
+    const hashes = hashMap.get(req.name.toLowerCase());
+    if (hashes && hashes.length > 0) {
+      req.hashes = hashes;
+    }
+    normalized.push(req);
   }
 
   // Process bare file path and URL requirements that pip-requirements-js can't parse

--- a/packages/python-analysis/test/requirements-txt-parser.test.ts
+++ b/packages/python-analysis/test/requirements-txt-parser.test.ts
@@ -58,6 +58,44 @@ pywin32>=300 ; sys_platform == "win32"
     expect(result.requirements[0].markers).toBeDefined();
   });
 
+  it('parses packages with nested and/or environment markers', () => {
+    const content = `
+greenlet==3.3.0 ; python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'greenlet',
+        version: '==3.3.0',
+        markers:
+          'python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")',
+      },
+    ]);
+  });
+
+  it('preserves hashes for packages with nested and/or environment markers', () => {
+    const content = `
+greenlet==3.3.0 ; python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32") --hash=sha256:abc123
+`;
+    const result = parseRequirementsFile(content);
+    expect(result.requirements).toEqual([
+      {
+        name: 'greenlet',
+        version: '==3.3.0',
+        markers:
+          'python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")',
+        hashes: ['sha256:abc123'],
+      },
+    ]);
+  });
+
+  it('still rejects invalid grouped environment markers', () => {
+    const content = `
+greenlet==3.3.0 ; python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le"
+`;
+    expect(() => parseRequirementsFile(content)).toThrow();
+  });
+
   it('parses URL-based requirements', () => {
     const content = `
 mypackage @ https://github.com/user/repo/archive/v1.0.0.zip
@@ -646,6 +684,16 @@ pywin32>=300 ; sys_platform == "win32"
     expect(result.project?.dependencies?.[0]).toContain('pywin32');
     expect(result.project?.dependencies?.[0]).toContain('>=300');
     expect(result.project?.dependencies?.[0]).toContain(';');
+  });
+
+  it('converts nested and/or environment markers without parse errors', () => {
+    const content = `
+greenlet==3.3.0 ; python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")
+`;
+    const result = convertRequirementsToPyprojectToml(content);
+    expect(result.project?.dependencies).toEqual([
+      'greenlet==3.3.0 ; python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")',
+    ]);
   });
 
   it('strips --hash when converting to pyproject.toml', () => {

--- a/packages/python-analysis/test/requirements-txt-parser.test.ts
+++ b/packages/python-analysis/test/requirements-txt-parser.test.ts
@@ -68,7 +68,7 @@ greenlet==3.3.0 ; python_version == "3.12" and (platform_machine == "aarch64" or
         name: 'greenlet',
         version: '==3.3.0',
         markers:
-          'python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")',
+          '(python_version == "3.12") and ((platform_machine == "aarch64") or ((platform_machine == "ppc64le") or ((platform_machine == "x86_64") or ((platform_machine == "amd64") or ((platform_machine == "AMD64") or ((platform_machine == "win32") or (platform_machine == "WIN32")))))))',
       },
     ]);
   });
@@ -83,7 +83,7 @@ greenlet==3.3.0 ; python_version == "3.12" and (platform_machine == "aarch64" or
         name: 'greenlet',
         version: '==3.3.0',
         markers:
-          'python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")',
+          '(python_version == "3.12") and ((platform_machine == "aarch64") or ((platform_machine == "ppc64le") or ((platform_machine == "x86_64") or ((platform_machine == "amd64") or ((platform_machine == "AMD64") or ((platform_machine == "win32") or (platform_machine == "WIN32")))))))',
         hashes: ['sha256:abc123'],
       },
     ]);
@@ -692,7 +692,7 @@ greenlet==3.3.0 ; python_version == "3.12" and (platform_machine == "aarch64" or
 `;
     const result = convertRequirementsToPyprojectToml(content);
     expect(result.project?.dependencies).toEqual([
-      'greenlet==3.3.0 ; python_version == "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")',
+      'greenlet==3.3.0 ; (python_version == "3.12") and ((platform_machine == "aarch64") or ((platform_machine == "ppc64le") or ((platform_machine == "x86_64") or ((platform_machine == "amd64") or ((platform_machine == "AMD64") or ((platform_machine == "win32") or (platform_machine == "WIN32")))))))',
     ]);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2094,8 +2094,8 @@ importers:
         specifier: 10.1.1
         version: 10.1.1
       pip-requirements-js:
-        specifier: github:Twixes/pip-requirements-js#e0b1ce18bcea0749805701644f2134f8fabf0e3f
-        version: github.com/Twixes/pip-requirements-js/e0b1ce18bcea0749805701644f2134f8fabf0e3f
+        specifier: 1.0.3
+        version: 1.0.3
       smol-toml:
         specifier: 1.5.2
         version: 1.5.2
@@ -17540,6 +17540,12 @@ packages:
       ohm-js: 17.2.1
     dev: true
 
+  /pip-requirements-js@1.0.3:
+    resolution: {integrity: sha512-1O9Bx0mPOZht3tW4LuxOA46qkD8A1AGymWXz3UwIMqGQgiTiOaFptsCf+9IE67qcbBrg8KHG6l8ePF7CoFRW/A==}
+    dependencies:
+      ohm-js: 17.2.1
+    dev: false
+
   /pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -21272,14 +21278,4 @@ packages:
 
   /zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
-    dev: false
-
-  github.com/Twixes/pip-requirements-js/e0b1ce18bcea0749805701644f2134f8fabf0e3f:
-    resolution: {tarball: https://codeload.github.com/Twixes/pip-requirements-js/tar.gz/e0b1ce18bcea0749805701644f2134f8fabf0e3f}
-    name: pip-requirements-js
-    version: 1.0.2
-    prepare: true
-    requiresBuild: true
-    dependencies:
-      ohm-js: 17.2.1
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: link:packages/build-utils
       '@vercel/style-guide':
         specifier: 4.0.2
-        version: 4.0.2(eslint@8.24.0)(jest@29.5.0)(prettier@3.3.3)(typescript@4.9.5)
+        version: 4.0.2(eslint@8.35.0)(jest@29.5.0)(prettier@3.3.3)(typescript@4.9.5)
       async-retry:
         specifier: 1.2.3
         version: 1.2.3
@@ -2094,8 +2094,8 @@ importers:
         specifier: 10.1.1
         version: 10.1.1
       pip-requirements-js:
-        specifier: 1.0.2
-        version: 1.0.2
+        specifier: github:Twixes/pip-requirements-js#e0b1ce18bcea0749805701644f2134f8fabf0e3f
+        version: github.com/Twixes/pip-requirements-js/e0b1ce18bcea0749805701644f2134f8fabf0e3f
       smol-toml:
         specifier: 1.5.2
         version: 1.5.2
@@ -3647,20 +3647,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/eslint-parser@7.27.1(@babel/core@7.24.4)(eslint@8.24.0):
-    resolution: {integrity: sha512-q8rjOuadH0V6Zo4XLMkJ3RMQ9MSBqwaDByyYB0izsYdaIWGNLmEblbCOf1vyFHICcg16CD7Fsi51vcQnYxmt6Q==}
-    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
-    peerDependencies:
-      '@babel/core': ^7.11.0
-      eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
-    dependencies:
-      '@babel/core': 7.24.4
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.24.0
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
     dev: true
 
   /@babel/eslint-parser@7.27.1(@babel/core@7.24.4)(eslint@8.35.0):
@@ -5527,16 +5513,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.7.0(eslint@8.24.0):
-    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.24.0
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
   /@eslint-community/eslint-utils@4.7.0(eslint@8.35.0):
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5550,23 +5526,6 @@ packages:
   /@eslint-community/regexpp@4.12.1:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
-
-  /@eslint/eslintrc@1.4.1:
-    resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
-      espree: 9.6.1
-      globals: 13.24.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@eslint/eslintrc@2.1.4:
@@ -5635,18 +5594,6 @@ packages:
       hono: 4.12.0
     dev: true
 
-  /@humanwhocodes/config-array@0.10.7:
-    resolution: {integrity: sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==}
-    engines: {node: '>=10.10.0'}
-    deprecated: Use @eslint/config-array instead
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -5659,18 +5606,9 @@ packages:
       - supports-color
     dev: true
 
-  /@humanwhocodes/gitignore-to-minimatch@1.0.2:
-    resolution: {integrity: sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==}
-    dev: true
-
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
-    dev: true
-
-  /@humanwhocodes/object-schema@1.2.1:
-    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
-    deprecated: Use @eslint/object-schema instead
     dev: true
 
   /@humanwhocodes/object-schema@2.0.3:
@@ -9631,34 +9569,6 @@ packages:
       '@types/node': 20.11.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.24.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare-lite: 1.4.0
-      semver: 7.5.2
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.35.0)(typescript@4.9.4):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9715,26 +9625,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.24.0
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser@5.62.0(eslint@8.35.0)(typescript@4.9.4):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9781,26 +9671,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-    dev: true
-
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.24.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/type-utils@5.62.0(eslint@8.35.0)(typescript@4.9.4):
@@ -9888,26 +9758,6 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/utils@5.62.0(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.24.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      eslint: 8.24.0
-      eslint-scope: 5.1.1
-      semver: 7.5.2
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /@typescript-eslint/utils@5.62.0(eslint@8.35.0)(typescript@4.9.4):
@@ -10294,53 +10144,6 @@ packages:
       - supports-color
     dev: true
 
-  /@vercel/style-guide@4.0.2(eslint@8.24.0)(jest@29.5.0)(prettier@3.3.3)(typescript@4.9.5):
-    resolution: {integrity: sha512-FroL+oOePzhw7n/I+f7zr4WNroGHT/+2TlW6WH9+CVSjMNsEyu7Qstj2mI5gWIBjT1Y2ZImKPppCzI2cIYmNZw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@next/eslint-plugin-next': ^12.3.0
-      eslint: ^8.24.0
-      prettier: ^2.7.0
-      typescript: ^4.8.0
-    peerDependenciesMeta:
-      '@next/eslint-plugin-next':
-        optional: true
-      eslint:
-        optional: true
-      prettier:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.24.4
-      '@babel/eslint-parser': 7.27.1(@babel/core@7.24.4)(eslint@8.24.0)
-      '@rushstack/eslint-patch': 1.11.0
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.24.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      eslint: 8.24.0
-      eslint-config-prettier: 8.5.0(eslint@8.24.0)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
-      eslint-plugin-eslint-comments: 3.2.0(eslint@8.24.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.24.0)
-      eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.24.0)
-      eslint-plugin-react: 7.37.5(eslint@8.24.0)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.24.0)
-      eslint-plugin-testing-library: 5.11.1(eslint@8.24.0)(typescript@4.9.5)
-      eslint-plugin-tsdoc: 0.2.17
-      eslint-plugin-unicorn: 43.0.2(eslint@8.24.0)
-      prettier: 3.3.3
-      prettier-plugin-packagejson: 2.5.11(prettier@3.3.3)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - jest
-      - supports-color
-    dev: true
-
   /@vercel/style-guide@4.0.2(eslint@8.35.0)(jest@29.5.0)(prettier@2.8.8)(typescript@4.9.4):
     resolution: {integrity: sha512-FroL+oOePzhw7n/I+f7zr4WNroGHT/+2TlW6WH9+CVSjMNsEyu7Qstj2mI5gWIBjT1Y2ZImKPppCzI2cIYmNZw==}
     engines: {node: '>=16'}
@@ -10369,7 +10172,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -10416,7 +10219,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -10463,7 +10266,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -13157,15 +12960,6 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /eslint-config-prettier@8.5.0(eslint@8.24.0):
-    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      eslint: 8.24.0
-    dev: true
-
   /eslint-config-prettier@8.5.0(eslint@8.35.0):
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
     hasBin: true
@@ -13181,7 +12975,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -13190,32 +12984,6 @@ packages:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.10
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0):
-    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      eslint-plugin-import: '*'
-      eslint-plugin-import-x: '*'
-    peerDependenciesMeta:
-      eslint-plugin-import:
-        optional: true
-      eslint-plugin-import-x:
-        optional: true
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.24.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.7.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13236,7 +13004,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.35.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -13246,7 +13014,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13267,24 +13035,13 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       debug: 3.2.7
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /eslint-plugin-eslint-comments@3.2.0(eslint@8.24.0):
-    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
-    engines: {node: '>=6.5.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
-    dependencies:
-      escape-string-regexp: 1.0.5
-      eslint: 8.24.0
-      ignore: 5.3.2
     dev: true
 
   /eslint-plugin-eslint-comments@3.2.0(eslint@8.35.0):
@@ -13298,7 +13055,7 @@ packages:
       ignore: 5.3.2
     dev: true
 
-  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13309,16 +13066,16 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13333,28 +13090,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: true
-
-  /eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.0.0 || ^6.0.0 || ^7.0.0
-      eslint: ^7.0.0 || ^8.0.0
-      jest: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.24.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      eslint: 8.24.0
-      jest: 29.5.0(@types/node@20.11.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4):
@@ -13401,30 +13136,6 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jsx-a11y@6.10.2(eslint@8.24.0):
-    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
-    dependencies:
-      aria-query: 5.3.2
-      array-includes: 3.1.8
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.10.3
-      axobject-query: 4.1.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 8.24.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
-    dev: true
-
   /eslint-plugin-jsx-a11y@6.10.2(eslint@8.35.0):
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
@@ -13449,19 +13160,6 @@ packages:
       string.prototype.includes: 2.0.1
     dev: true
 
-  /eslint-plugin-playwright@0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.24.0):
-    resolution: {integrity: sha512-uRLRLk7uTzc8NE6t4wBU8dijQwHvC66R/h7xwdM779jsJjMUtSmeaB8ayRkkpfwi+UU5BEfwvDANwmE+ccMVDw==}
-    peerDependencies:
-      eslint: '>=7'
-      eslint-plugin-jest: '>=24'
-    peerDependenciesMeta:
-      eslint-plugin-jest:
-        optional: true
-    dependencies:
-      eslint: 8.24.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
-    dev: true
-
   /eslint-plugin-playwright@0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0):
     resolution: {integrity: sha512-uRLRLk7uTzc8NE6t4wBU8dijQwHvC66R/h7xwdM779jsJjMUtSmeaB8ayRkkpfwi+UU5BEfwvDANwmE+ccMVDw==}
     peerDependencies:
@@ -13475,15 +13173,6 @@ packages:
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
     dev: true
 
-  /eslint-plugin-react-hooks@4.6.2(eslint@8.24.0):
-    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 8.24.0
-    dev: true
-
   /eslint-plugin-react-hooks@4.6.2(eslint@8.35.0):
     resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
     engines: {node: '>=10'}
@@ -13491,33 +13180,6 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.35.0
-    dev: true
-
-  /eslint-plugin-react@7.37.5(eslint@8.24.0):
-    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
-    dependencies:
-      array-includes: 3.1.8
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.2.1
-      eslint: 8.24.0
-      estraverse: 5.3.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.9
-      object.fromentries: 2.0.8
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-      string.prototype.repeat: 1.0.0
     dev: true
 
   /eslint-plugin-react@7.37.5(eslint@8.35.0):
@@ -13545,19 +13207,6 @@ packages:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
-    dev: true
-
-  /eslint-plugin-testing-library@5.11.1(eslint@8.24.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
-    peerDependencies:
-      eslint: ^7.5.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
-      eslint: 8.24.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /eslint-plugin-testing-library@5.11.1(eslint@8.35.0)(typescript@4.9.4):
@@ -13591,29 +13240,6 @@ packages:
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-    dev: true
-
-  /eslint-plugin-unicorn@43.0.2(eslint@8.24.0):
-    resolution: {integrity: sha512-DtqZ5mf/GMlfWoz1abIjq5jZfaFuHzGBZYIeuJfEoKKGWRHr2JiJR+ea+BF7Wx2N1PPRoT/2fwgiK1NnmNE3Hg==}
-    engines: {node: '>=14.18'}
-    peerDependencies:
-      eslint: '>=8.18.0'
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      ci-info: 3.9.0
-      clean-regexp: 1.0.0
-      eslint: 8.24.0
-      eslint-utils: 3.0.0(eslint@8.24.0)
-      esquery: 1.6.0
-      indent-string: 4.0.0
-      is-builtin-module: 3.2.1
-      lodash: 4.17.21
-      pluralize: 8.0.0
-      read-pkg-up: 7.0.1
-      regexp-tree: 0.1.27
-      safe-regex: 2.1.1
-      semver: 7.5.2
-      strip-indent: 3.0.0
     dev: true
 
   /eslint-plugin-unicorn@43.0.2(eslint@8.35.0):
@@ -13655,16 +13281,6 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /eslint-utils@3.0.0(eslint@8.24.0):
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 8.24.0
-      eslint-visitor-keys: 2.1.0
-    dev: true
-
   /eslint-utils@3.0.0(eslint@8.35.0):
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
@@ -13683,55 +13299,6 @@ packages:
   /eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /eslint@8.24.0:
-    resolution: {integrity: sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
-    dependencies:
-      '@eslint/eslintrc': 1.4.1
-      '@humanwhocodes/config-array': 0.10.7
-      '@humanwhocodes/gitignore-to-minimatch': 1.0.2
-      '@humanwhocodes/module-importer': 1.0.1
-      ajv: 6.12.3
-      chalk: 4.1.0
-      cross-spawn: 7.0.6
-      debug: 4.4.0
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-utils: 3.0.0(eslint@8.24.0)
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.24.0
-      globby: 11.1.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      js-sdsl: 4.4.2
-      js-yaml: 4.1.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-      regexpp: 3.2.0
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint@8.35.0:
@@ -17971,6 +17538,7 @@ packages:
     resolution: {integrity: sha512-awqoNOSOl4Blu4E4Hzp7jL0g8WKEhCwO+s7C2ibtIW3CAJMwspgoTXd4vnHd21UmhdrsI44Pn8FFSuA8QKrzvg==}
     dependencies:
       ohm-js: 17.2.1
+    dev: true
 
   /pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -21704,4 +21272,14 @@ packages:
 
   /zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+    dev: false
+
+  github.com/Twixes/pip-requirements-js/e0b1ce18bcea0749805701644f2134f8fabf0e3f:
+    resolution: {tarball: https://codeload.github.com/Twixes/pip-requirements-js/tar.gz/e0b1ce18bcea0749805701644f2134f8fabf0e3f}
+    name: pip-requirements-js
+    version: 1.0.2
+    prepare: true
+    requiresBuild: true
+    dependencies:
+      ohm-js: 17.2.1
     dev: false


### PR DESCRIPTION
<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Minor patch version bump of pip-requirements-js dependency with added test coverage for parsing environment markers.
> 
> - Dependency bump: pip-requirements-js 1.0.2 → 1.0.3
> - Test additions: 4 new test cases for nested and/or environment marker parsing
> - Changeset: documents patch for grouped requirements.txt markers
>
> <sup>Risk assessment for [commit 5909c95](https://github.com/vercel/vercel/commit/5909c954e7ed1343616e58a3af3a325633aa6e20).</sup>
<!-- VADE_RISK_END -->