### PR TITLE
Update Python framework install command placeholders

### DIFF
--- a/.changeset/nine-steaks-sparkle.md
+++ b/.changeset/nine-steaks-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Improve Python framework install command placeholders

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2089,7 +2089,8 @@ export const frameworks = [
     },
     settings: {
       installCommand: {
-        placeholder: '`pip install -r requirements.txt`',
+        placeholder:
+          '`uv sync` from `pyproject.toml`, `requirements.txt`, `Pipfile`, or lock files',
       },
       buildCommand: {
         placeholder: 'None',
@@ -2142,7 +2143,8 @@ export const frameworks = [
     },
     settings: {
       installCommand: {
-        placeholder: '`pip install -r requirements.txt`',
+        placeholder:
+          '`uv sync` from `pyproject.toml`, `requirements.txt`, `Pipfile`, or lock files',
       },
       buildCommand: {
         placeholder: 'None',
@@ -2190,7 +2192,8 @@ export const frameworks = [
     },
     settings: {
       installCommand: {
-        placeholder: '`pip install`',
+        placeholder:
+          '`uv sync` from `pyproject.toml`, `requirements.txt`, `Pipfile`, or lock files',
       },
       buildCommand: {
         placeholder: 'None',
@@ -2249,7 +2252,8 @@ export const frameworks = [
     },
     settings: {
       installCommand: {
-        placeholder: '`pip install -r requirements.txt`',
+        placeholder:
+          '`uv sync` from `pyproject.toml`, `requirements.txt`, `Pipfile`, or lock files',
       },
       buildCommand: {
         placeholder: 'None',
@@ -4158,7 +4162,8 @@ export const frameworks = [
     },
     settings: {
       installCommand: {
-        placeholder: '`pip install -r requirements.txt`',
+        placeholder:
+          '`uv sync` from `pyproject.toml`, `requirements.txt`, `Pipfile`, or lock files',
       },
       buildCommand: {
         placeholder: 'None',


### PR DESCRIPTION
Replace outdated `pip install` placeholders with accurate `uv sync`
description reflecting the actual install path used by @vercel/python.

It is kind of clunky though, so does anybody have any better wording
suggestions?
(The JS packages also have a clunky list of options.)


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR only updates placeholder text strings for Python framework install commands, changing documentation/help text from pip to uv sync with no logic or behavior changes.
> 
> - Updates placeholder strings in 5 framework settings from `pip install` to `uv sync`
> - Changeset file added for patch version bump
>
> <sup>Risk assessment for [commit f3026e1](https://github.com/vercel/vercel/commit/f3026e1389c38dc5eb8d80df29bbbdb931ad05ba).</sup>
<!-- VADE_RISK_END -->