### PR TITLE
Make the generic "python" framework not experimental

### DIFF
--- a/.changeset/yellow-crews-relate.md
+++ b/.changeset/yellow-crews-relate.md
@@ -2,4 +2,4 @@
 '@vercel/frameworks': minor
 ---
 
-Make the generic "python" framework not experimental
+Make the generic "python" framework and the Django framework not experimental

--- a/.changeset/yellow-crews-relate.md
+++ b/.changeset/yellow-crews-relate.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': minor
+---
+
+Make the generic "python" framework not experimental

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2217,7 +2217,6 @@ export const frameworks = [
   {
     name: 'Django',
     slug: 'django',
-    experimental: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/django.svg',
     tagline:
       'Django is a high-level Python web framework that encourages rapid development and clean, pragmatic design. ',

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4133,7 +4133,6 @@ export const frameworks = [
   {
     name: 'Python',
     slug: 'python',
-    experimental: true,
     runtimeFramework: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/python.svg',
     tagline:


### PR DESCRIPTION
Is there any reason why it should be experimental? Honestly it is
identical to fastapi and flake, except that it has less strict
detectors.


<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR removes the experimental flag from Django and Python framework configurations, which is a minor metadata change with no security, auth, or business logic implications.
> 
> - Removes `experimental: true` from Django framework config
> - Removes `experimental: true` from Python framework config
> - Changeset added for minor version bump
>
> <sup>Risk assessment for [commit 6abe1b9](https://github.com/vercel/vercel/commit/6abe1b96bc5251f63c2cb8e791d041edff638434).</sup>
<!-- VADE_RISK_END -->