### PR TITLE
[go] remove experimental flag on "go" frameworks preset

### DIFF
--- a/.changeset/tiny-terms-boil.md
+++ b/.changeset/tiny-terms-boil.md
@@ -1,0 +1,5 @@
+---
+"@vercel/frameworks": patch
+---
+
+[go] remove experimental flag on "go" frameworks preset

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4337,7 +4337,6 @@ export const frameworks = [
   {
     name: 'Go',
     slug: 'go',
-    experimental: true,
     runtimeFramework: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/go.svg',
     tagline: 'An open-source programming language supported by Google.',


### PR DESCRIPTION
Remove experimental flag on "go" frameworks preset

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR removes the experimental flag from the Go framework preset configuration, which is a simple feature flag change with no security, auth, or data implications.
> 
> - Removes `experimental: true` from Go framework preset definition
> - Changeset added for patch version bump
>
> <sup>Risk assessment for [commit 4abb46f](https://github.com/vercel/vercel/commit/4abb46f5916dc257b898e6b55ac7ba6350ad503a).</sup>
<!-- VADE_RISK_END -->