### PR TITLE
[cli] Remove FF_ALERTS feature flag and clean up list output formatting

### DIFF
--- a/.changeset/remove-ff-alerts-flag.md
+++ b/.changeset/remove-ff-alerts-flag.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove `FF_ALERTS` feature flag and make the `vc alerts` command available by default.

--- a/.changeset/remove-ff-alerts-flag.md
+++ b/.changeset/remove-ff-alerts-flag.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Remove `FF_ALERTS` feature flag and make the `vc alerts` command available by default.
+Remove `FF_ALERTS` feature flag and make the `vc alerts` command available by default. Remove numbered list output from `vc activity` and `vc alerts` commands and normalize padding between them.

--- a/.changeset/remove-numbered-list-output.md
+++ b/.changeset/remove-numbered-list-output.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove numbered list output from `vc activity` and `vc alerts` commands and normalize padding between them.

--- a/.changeset/remove-numbered-list-output.md
+++ b/.changeset/remove-numbered-list-output.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Remove numbered list output from `vc activity` and `vc alerts` commands and normalize padding between them.

--- a/packages/cli/src/commands/activity/list.ts
+++ b/packages/cli/src/commands/activity/list.ts
@@ -171,14 +171,12 @@ function formatEventText(text: string): string {
 function printExpandedEvents(events: UserEventDTO[]) {
   const lines = [''];
 
-  events.forEach((event, index) => {
-    lines.push(
-      `  ${chalk.bold(`${index + 1}. ${formatEventText(event.text)}`)}`
-    );
-    lines.push(`     ${chalk.cyan('Type:')} ${event.type ?? '-'}`);
-    lines.push(`     ${chalk.cyan('Actor:')} ${formatActor(event)}`);
-    lines.push(`     ${chalk.cyan('Age:')} ${formatAge(event.createdAt)}`);
-    lines.push(`     ${chalk.cyan('ID:')} ${event.id}`);
+  events.forEach(event => {
+    lines.push(chalk.bold(formatEventText(event.text)));
+    lines.push(`   ${chalk.cyan('Type:')} ${event.type ?? '-'}`);
+    lines.push(`   ${chalk.cyan('Actor:')} ${formatActor(event)}`);
+    lines.push(`   ${chalk.cyan('Age:')} ${formatAge(event.createdAt)}`);
+    lines.push(`   ${chalk.cyan('ID:')} ${event.id}`);
     lines.push('');
   });
 

--- a/packages/cli/src/commands/alerts/list.ts
+++ b/packages/cli/src/commands/alerts/list.ts
@@ -316,7 +316,7 @@ function printAiSections(groups: AlertGroup[]) {
   }
 
   const rendered = groups
-    .map((group, index) => {
+    .map(group => {
       const title = getGroupTitle(group);
       const summary = group.ai?.currentSummary || 'N/A';
       const findings = group.ai?.keyFindings?.filter(Boolean) ?? [];
@@ -326,7 +326,7 @@ function printAiSections(groups: AlertGroup[]) {
           : '  - N/A';
 
       return [
-        chalk.bold(`${index + 1}. ${title}`),
+        chalk.bold(title),
         `   ${chalk.cyan('Resolved At:')} ${getResolvedAt(group)}`,
         `   ${chalk.cyan('Summary:')} ${summary}`,
         `   ${chalk.cyan('Key Findings:')}`,

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -57,6 +57,7 @@ import output from '../output-manager';
 
 const commandsStructs = [
   agentCommand,
+  alertsCommand,
   aliasCommand,
   activityCommand,
   apiCommand,
@@ -117,10 +118,6 @@ if (process.env.FF_GUIDANCE_MODE) {
 
 if (process.env.FF_METRICS) {
   commandsStructs.push(metricsCommand);
-}
-
-if (process.env.FF_ALERTS) {
-  commandsStructs.push(alertsCommand);
 }
 
 export function getCommandAliases(command: Pick<Command, 'name' | 'aliases'>) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -736,14 +736,9 @@ const main = async () => {
           func = (await import('./commands-bulk.js')).activity;
           break;
         case 'alerts':
-          if (process.env.FF_ALERTS) {
-            telemetry.trackCliCommandAlerts(userSuppliedSubCommand);
-            func = (await import('./commands-bulk.js')).alerts;
-            break;
-          } else {
-            func = null;
-            break;
-          }
+          telemetry.trackCliCommandAlerts(userSuppliedSubCommand);
+          func = (await import('./commands-bulk.js')).alerts;
+          break;
         case 'api':
           telemetry.trackCliCommandApi(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).api;

--- a/packages/cli/test/unit/commands/activity/list.test.ts
+++ b/packages/cli/test/unit/commands/activity/list.test.ts
@@ -153,7 +153,7 @@ describe('activity ls', () => {
 
     expect(exitCode).toBe(0);
     const output = client.stderr.getFullOutput();
-    expect(output).toContain(`1. ${longText}`);
+    expect(output).toContain(longText);
     expect(output).toContain('Type: firewall-bypass-created');
     expect(output).toContain('Actor: jane');
   });

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -5,6 +5,7 @@ describe('index', () => {
     expect(commands).toEqual(
       new Map([
         ['agent', 'agent'],
+        ['alerts', 'alerts'],
         ['alias', 'alias'],
         ['aliases', 'alias'],
         ['activity', 'activity'],


### PR DESCRIPTION
### Summary

  - Remove the `FF_ALERTS` feature flag and make the `vc alerts` command available by default
  - Remove numbered list items from `vc activity` and `vc alerts` expanded output, aligning with the standard CLI pattern of unnumbered lists
  - Normalize padding between activity and alerts expanded views for consistency

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR removes a feature flag to enable the `vc alerts` command by default and makes cosmetic formatting changes to CLI output (removing numbered list items and adjusting padding).
> 
> - Remove FF_ALERTS feature flag check, making alerts command always available
> - Remove numbered list formatting from activity and alerts expanded output
> - Test updates to match new output format
>
> <sup>Risk assessment for [commit 5d0ab8f](https://github.com/vercel/vercel/commit/5d0ab8fc9dce7c7b02373ec1e9752567631fef3f).</sup>
<!-- VADE_RISK_END -->