### PR TITLE
Update to latest Next.js adapter

### DIFF
--- a/.changeset/tame-feet-provide.md
+++ b/.changeset/tame-feet-provide.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Update to latest Next.js adapter

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@vercel/nft": "1.1.1"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.13",
+    "@next-community/adapter-vercel": "0.0.1-beta.14",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1701,8 +1701,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.13
-        version: 0.0.1-beta.13(next@16.1.6)
+        specifier: 0.0.1-beta.14
+        version: 0.0.1-beta.14(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6470,8 +6470,8 @@ packages:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  /@next-community/adapter-vercel@0.0.1-beta.13(next@16.1.6):
-    resolution: {integrity: sha512-klZhR/9LjXLvlt5n1wqJxM7xwd4c3VCflZzuBnFkd1fkMPUF49oXjHHyqsgG+Y1FQpwLuwqpymZLHRRiADsxfg==}
+  /@next-community/adapter-vercel@0.0.1-beta.14(next@16.1.6):
+    resolution: {integrity: sha512-K6KgP4cUztLGld0rIVdZFT8HpGNb1wfVsfWT2a6sVu37SVbC3NU0E45ghQBOvI6X3/ED5ly5tqtaplBe4qiiJg==}
     engines: {node: '>= 20.6.0'}
     peerDependencies:
       next: '>= 16.1.1-canary.18'


### PR DESCRIPTION
x-ref: https://github.com/nextjs/adapter-vercel/pull/42

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> Minor patch version bump of a dev dependency from beta.13 to beta.14 with no code changes.
> 
> - Dev dependency bump: @next-community/adapter-vercel 0.0.1-beta.13 → beta.14
> - Changeset file added for patch release
>
> <sup>Risk assessment for [commit 382a389](https://github.com/vercel/vercel/commit/382a3896035ee8beb05096548dfe4844951f33b8).</sup>
<!-- VADE_RISK_END -->