### PR TITLE
fix(cli): support installation-level metadata for integration add

### DIFF
--- a/.changeset/mkt-2913-cli-installation-metadata.md
+++ b/.changeset/mkt-2913-cli-installation-metadata.md
@@ -1,0 +1,10 @@
+---
+'vercel': patch
+---
+
+fix(cli): support installation-level metadata for `integration add`
+
+Integrations like Sentry have both product-level metadata (e.g. `platform`) and installation-level metadata (e.g. `name`, `region`). The CLI now:
+- Shows installation-level metadata fields in `--help` output
+- Accepts installation-level metadata keys via `-m` flags
+- Splits metadata into product and installation buckets, sending `installationMetadata` as a separate API field

--- a/.changeset/mkt-2913-cli-installation-metadata.md
+++ b/.changeset/mkt-2913-cli-installation-metadata.md
@@ -8,3 +8,6 @@ Integrations like Sentry have both product-level metadata (e.g. `platform`) and 
 - Shows installation-level metadata fields in `--help` output
 - Accepts installation-level metadata keys via `-m` flags
 - Splits metadata into product and installation buckets, sending `installationMetadata` as a separate API field
+- Shows actionable hint when required metadata is missing on browser fallback (lists missing fields with example `-m` flags)
+- Forwards `installationMetadata` to browser fallback URL so installation config isn't lost on redirect
+- Logs debug warning when product and installation schemas have overlapping key names

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -16,6 +16,7 @@ import type {
   AutoProvisionedResponse,
   AutoProvisionFallback,
   AutoProvisionResult,
+  MetadataSchema,
 } from '../../util/integration/types';
 import { buildSSOLink } from '../../util/integration/build-sso-link';
 import { resolveResourceName } from '../../util/integration/generate-resource-name';
@@ -199,16 +200,34 @@ export async function addAutoProvision(
     }
   }
 
-  // Validate metadata flags (if provided) BEFORE prompting for resource name
+  // Validate metadata flags (if provided) BEFORE prompting for resource name.
+  // For integrations with an installation-level metadataSchema (e.g. Sentry with
+  // name/region), we accept both product and installation keys via -m flags, then
+  // split them into separate fields for the API. This avoids key conflicts if a
+  // partner uses the same key name in both schemas.
+  const integrationSchemaProps = integration.metadataSchema?.properties ?? {};
+  const productSchemaProps = product.metadataSchema.properties;
+  const mergedParsingSchema: MetadataSchema = {
+    type: 'object',
+    properties: {
+      ...integrationSchemaProps,
+      ...productSchemaProps,
+    },
+    required: [
+      ...(integration.metadataSchema?.required ?? []),
+      ...(product.metadataSchema.required ?? []),
+    ],
+  };
   let metadata: Metadata;
+  let installationMetadata: Metadata = {};
   if (options.metadata?.length) {
-    // Parse metadata from CLI flags
+    // Parse metadata from CLI flags against merged schema (accepts all keys)
     output.debug(
       `Parsing metadata from flags: ${JSON.stringify(options.metadata)}`
     );
     const { metadata: parsed, errors } = parseMetadataFlags(
       options.metadata,
-      product.metadataSchema
+      mergedParsingSchema
     );
     if (errors.length) {
       for (const error of errors) {
@@ -220,14 +239,34 @@ export async function addAutoProvision(
       });
       return 1;
     }
-    if (!validateAndPrintRequiredMetadata(parsed, product.metadataSchema)) {
+    // Validate required fields against the merged schema (both product + installation required)
+    if (!validateAndPrintRequiredMetadata(parsed, mergedParsingSchema)) {
       telemetry.trackMarketplaceEvent('marketplace_install_flow_dropped', {
         ...baseProps,
         reason: 'metadata_validation_failed',
       });
       return 1;
     }
-    metadata = parsed;
+
+    // Split parsed metadata into product vs installation buckets.
+    // Keys in both schemas go to product metadata (the more common case).
+    const productMeta: Metadata = {};
+    const installMeta: Metadata = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (value === undefined) continue;
+      const inProduct = key in productSchemaProps;
+      const inInstallation = key in integrationSchemaProps;
+      if (inProduct) {
+        productMeta[key] = value;
+      } else if (inInstallation) {
+        installMeta[key] = value;
+      } else {
+        // Key was accepted by merged schema but somehow not in either — include in product
+        productMeta[key] = value;
+      }
+    }
+    metadata = productMeta;
+    installationMetadata = installMeta;
   } else {
     // No --metadata flags: pass {} and let server fill defaults (API PR #58905)
     metadata = {};
@@ -273,7 +312,8 @@ export async function addAutoProvision(
       metadata,
       acceptedPolicies,
       options.billingPlanId,
-      browserInstallationId ?? options.installationId
+      browserInstallationId ?? options.installationId,
+      installationMetadata
     );
   } catch (error) {
     output.stopSpinner();

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -218,8 +218,10 @@ export async function addAutoProvision(
       ...productSchemaProps,
     },
     required: [
-      ...(integration.metadataSchema?.required ?? []),
-      ...(product.metadataSchema.required ?? []),
+      ...new Set([
+        ...(integration.metadataSchema?.required ?? []),
+        ...(product.metadataSchema.required ?? []),
+      ]),
     ],
   };
   let metadata: Metadata;
@@ -426,6 +428,12 @@ export async function addAutoProvision(
     url.searchParams.set('source', 'cli');
     if (Object.keys(metadata).length > 0) {
       url.searchParams.set('metadata', JSON.stringify(metadata));
+    }
+    if (Object.keys(installationMetadata).length > 0) {
+      url.searchParams.set(
+        'installationMetadata',
+        JSON.stringify(installationMetadata)
+      );
     }
     if (projectLink.value) {
       url.searchParams.set('projectSlug', projectLink.value);

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -16,7 +16,6 @@ import type {
   AutoProvisionedResponse,
   AutoProvisionFallback,
   AutoProvisionResult,
-  MetadataSchema,
 } from '../../util/integration/types';
 import { buildSSOLink } from '../../util/integration/build-sso-link';
 import { resolveResourceName } from '../../util/integration/generate-resource-name';
@@ -34,6 +33,7 @@ import {
 import {
   isServerHandledRegion,
   getVisibleOptions,
+  mergeMetadataSchemas,
 } from '../../util/integration/format-schema-help';
 import type { Metadata } from '../../util/integration/types';
 
@@ -211,19 +211,17 @@ export async function addAutoProvision(
   // partner uses the same key name in both schemas.
   const integrationSchemaProps = integration.metadataSchema?.properties ?? {};
   const productSchemaProps = product.metadataSchema.properties;
-  const mergedParsingSchema: MetadataSchema = {
-    type: 'object',
-    properties: {
-      ...integrationSchemaProps,
-      ...productSchemaProps,
-    },
-    required: [
-      ...new Set([
-        ...(integration.metadataSchema?.required ?? []),
-        ...(product.metadataSchema.required ?? []),
-      ]),
-    ],
-  };
+  const mergedParsingSchema = mergeMetadataSchemas(
+    product.metadataSchema,
+    integration.metadataSchema
+  ) ?? product.metadataSchema;
+  for (const key of Object.keys(integrationSchemaProps)) {
+    if (key in productSchemaProps) {
+      output.debug(
+        `Metadata key "${key}" exists in both product and installation schemas — product definition wins`
+      );
+    }
+  }
   let metadata: Metadata;
   let installationMetadata: Metadata = {};
   if (options.metadata?.length) {

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -211,10 +211,9 @@ export async function addAutoProvision(
   // partner uses the same key name in both schemas.
   const integrationSchemaProps = integration.metadataSchema?.properties ?? {};
   const productSchemaProps = product.metadataSchema.properties;
-  const mergedParsingSchema = mergeMetadataSchemas(
-    product.metadataSchema,
-    integration.metadataSchema
-  ) ?? product.metadataSchema;
+  const mergedParsingSchema =
+    mergeMetadataSchemas(product.metadataSchema, integration.metadataSchema) ??
+    product.metadataSchema;
   for (const key of Object.keys(integrationSchemaProps)) {
     if (key in productSchemaProps) {
       output.debug(
@@ -409,18 +408,17 @@ export async function addAutoProvision(
         const exampleVal = options?.[0] ?? '<value>';
         return `-m ${key}=${exampleVal}`;
       });
+      output.error(`Missing required metadata: ${missingRequired.join(', ')}.`);
       output.log(
-        `Missing required metadata: ${missingRequired.join(', ')}. Opening browser to complete setup...`
-      );
-      output.log(
-        `  Tip: Provide ${examples.join(' ')} to provision directly from the CLI.`
+        `  Provide ${examples.join(' ')} to provision directly from the CLI.`
       );
       output.log(
         `  Run \`vercel ${commandName} ${integrationSlug} --help\` for all metadata options.`
       );
-    } else {
-      output.log('Additional setup required. Opening browser...');
+      return 1;
     }
+
+    output.log('Additional setup required. Opening browser...');
     const url = new URL(fallback.url);
     url.searchParams.set('defaultResourceName', resourceName);
     url.searchParams.set('source', 'cli');

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -31,6 +31,10 @@ import {
   parseMetadataFlags,
   validateAndPrintRequiredMetadata,
 } from '../../util/integration/parse-metadata';
+import {
+  isServerHandledRegion,
+  getVisibleOptions,
+} from '../../util/integration/format-schema-help';
 import type { Metadata } from '../../util/integration/types';
 
 export interface AddAutoProvisionOptions extends PostProvisionOptions {
@@ -391,7 +395,32 @@ export async function addAutoProvision(
       return projectLink.exitCode;
     }
 
-    output.log('Additional setup required. Opening browser...');
+    // Check for missing required metadata to give an actionable message
+    const missingRequired = (mergedParsingSchema.required ?? []).filter(key => {
+      if (key in metadata || key in installationMetadata) return false;
+      const prop = mergedParsingSchema.properties[key];
+      return prop && !isServerHandledRegion(prop);
+    });
+
+    if (missingRequired.length > 0) {
+      const examples = missingRequired.map(key => {
+        const prop = mergedParsingSchema.properties[key];
+        const options = prop ? getVisibleOptions(prop) : undefined;
+        const exampleVal = options?.[0] ?? '<value>';
+        return `-m ${key}=${exampleVal}`;
+      });
+      output.log(
+        `Missing required metadata: ${missingRequired.join(', ')}. Opening browser to complete setup...`
+      );
+      output.log(
+        `  Tip: Provide ${examples.join(' ')} to provision directly from the CLI.`
+      );
+      output.log(
+        `  Run \`vercel ${commandName} ${integrationSlug} --help\` for all metadata options.`
+      );
+    } else {
+      output.log('Additional setup required. Opening browser...');
+    }
     const url = new URL(fallback.url);
     url.searchParams.set('defaultResourceName', resourceName);
     url.searchParams.set('source', 'cli');

--- a/packages/cli/src/commands/integration/add-help.ts
+++ b/packages/cli/src/commands/integration/add-help.ts
@@ -1,5 +1,6 @@
 import type Client from '../../util/client';
 import type { Command } from '../help';
+import type { MetadataSchema } from '../../util/integration/types';
 import output from '../../output-manager';
 import { fetchIntegration } from '../../util/integration/fetch-integration';
 import { formatProductHelp } from '../../util/integration/format-product-help';
@@ -7,6 +8,31 @@ import { formatBillingPlansHelp } from '../../util/integration/format-billing-pl
 import { formatDynamicExamples } from '../../util/integration/format-dynamic-examples';
 import { formatMetadataSchemaHelp } from '../../util/integration/format-schema-help';
 import { fetchBillingPlans } from '../../util/integration/fetch-billing-plans';
+
+/**
+ * Merges integration-level metadata schema (e.g. org name, region) with
+ * product-level metadata schema (e.g. platform) into a single schema.
+ * Installation-level fields appear first, followed by product-level fields.
+ */
+function mergeMetadataSchemas(
+  productSchema?: MetadataSchema,
+  integrationSchema?: MetadataSchema
+): MetadataSchema | undefined {
+  if (!productSchema && !integrationSchema) return undefined;
+  if (!integrationSchema) return productSchema;
+  if (!productSchema) return integrationSchema;
+  return {
+    type: 'object',
+    properties: {
+      ...integrationSchema.properties,
+      ...productSchema.properties,
+    },
+    required: [
+      ...(integrationSchema.required ?? []),
+      ...(productSchema.required ?? []),
+    ],
+  };
+}
 
 /**
  * Prints dynamic, integration-specific help for the `integration add` / `install` command.
@@ -40,16 +66,22 @@ export async function printAddDynamicHelp(
       output.print(formatProductHelp(integrationSlug, products, commandName));
     }
 
-    // Show metadata schema for ALL products
+    // Show metadata schema for ALL products (and integration-level schema)
     for (const product of products) {
-      if (product.metadataSchema) {
+      // Merge integration-level metadata (e.g. org name, region) with
+      // product-level metadata (e.g. platform) so all fields appear in --help
+      const mergedSchema = mergeMetadataSchemas(
+        product.metadataSchema,
+        integration.metadataSchema
+      );
+      if (mergedSchema) {
         // For single-product integrations, don't show product slug
         // For multi-product integrations, show product slug for slash syntax
         const metadataProductSlug =
           products.length > 1 ? product.slug : undefined;
         output.print(
           formatMetadataSchemaHelp(
-            product.metadataSchema,
+            mergedSchema,
             integrationSlug,
             metadataProductSlug
           )

--- a/packages/cli/src/commands/integration/add-help.ts
+++ b/packages/cli/src/commands/integration/add-help.ts
@@ -28,8 +28,10 @@ function mergeMetadataSchemas(
       ...productSchema.properties,
     },
     required: [
-      ...(integrationSchema.required ?? []),
-      ...(productSchema.required ?? []),
+      ...new Set([
+        ...(integrationSchema.required ?? []),
+        ...(productSchema.required ?? []),
+      ]),
     ],
   };
 }

--- a/packages/cli/src/commands/integration/add-help.ts
+++ b/packages/cli/src/commands/integration/add-help.ts
@@ -1,40 +1,15 @@
 import type Client from '../../util/client';
 import type { Command } from '../help';
-import type { MetadataSchema } from '../../util/integration/types';
 import output from '../../output-manager';
 import { fetchIntegration } from '../../util/integration/fetch-integration';
 import { formatProductHelp } from '../../util/integration/format-product-help';
 import { formatBillingPlansHelp } from '../../util/integration/format-billing-plans-help';
 import { formatDynamicExamples } from '../../util/integration/format-dynamic-examples';
-import { formatMetadataSchemaHelp } from '../../util/integration/format-schema-help';
+import {
+  formatMetadataSchemaHelp,
+  mergeMetadataSchemas,
+} from '../../util/integration/format-schema-help';
 import { fetchBillingPlans } from '../../util/integration/fetch-billing-plans';
-
-/**
- * Merges integration-level metadata schema (e.g. org name, region) with
- * product-level metadata schema (e.g. platform) into a single schema.
- * Installation-level fields appear first, followed by product-level fields.
- */
-function mergeMetadataSchemas(
-  productSchema?: MetadataSchema,
-  integrationSchema?: MetadataSchema
-): MetadataSchema | undefined {
-  if (!productSchema && !integrationSchema) return undefined;
-  if (!integrationSchema) return productSchema;
-  if (!productSchema) return integrationSchema;
-  return {
-    type: 'object',
-    properties: {
-      ...integrationSchema.properties,
-      ...productSchema.properties,
-    },
-    required: [
-      ...new Set([
-        ...(integrationSchema.required ?? []),
-        ...(productSchema.required ?? []),
-      ]),
-    ],
-  };
-}
 
 /**
  * Prints dynamic, integration-specific help for the `integration add` / `install` command.

--- a/packages/cli/src/util/integration/auto-provision-resource.ts
+++ b/packages/cli/src/util/integration/auto-provision-resource.ts
@@ -30,7 +30,8 @@ export async function autoProvisionResource(
   metadata: Metadata,
   acceptedPolicies: AcceptedPolicies,
   billingPlanId?: string,
-  installationId?: string
+  installationId?: string,
+  installationMetadata?: Metadata
 ): Promise<AutoProvisionResult> {
   const endpoint = `/v1/integrations/integration/${encodeURIComponent(integrationSlug)}/marketplace/auto-provision/${encodeURIComponent(productSlug)}`;
   const body = {
@@ -40,6 +41,9 @@ export async function autoProvisionResource(
     source: 'cli',
     ...(billingPlanId ? { billingPlanId } : {}),
     ...(installationId ? { installationId } : {}),
+    ...(installationMetadata && Object.keys(installationMetadata).length > 0
+      ? { installationMetadata }
+      : {}),
   };
   output.debug(`Auto-provision request: POST ${endpoint}`);
   output.debug(`Auto-provision body: ${JSON.stringify(body, null, 2)}`);

--- a/packages/cli/src/util/integration/format-schema-help.ts
+++ b/packages/cli/src/util/integration/format-schema-help.ts
@@ -172,3 +172,31 @@ export function formatMetadataSchemaHelp(
 
   return lines.join('\n');
 }
+
+/**
+ * Merges integration-level metadata schema (e.g. org name, region) with
+ * product-level metadata schema (e.g. platform) into a single schema.
+ * Installation-level fields appear first, followed by product-level fields.
+ * Product properties win on key collision.
+ */
+export function mergeMetadataSchemas(
+  productSchema?: MetadataSchema,
+  integrationSchema?: MetadataSchema
+): MetadataSchema | undefined {
+  if (!productSchema && !integrationSchema) return undefined;
+  if (!integrationSchema) return productSchema;
+  if (!productSchema) return integrationSchema;
+  return {
+    type: 'object',
+    properties: {
+      ...integrationSchema.properties,
+      ...productSchema.properties,
+    },
+    required: [
+      ...new Set([
+        ...(integrationSchema.required ?? []),
+        ...(productSchema.required ?? []),
+      ]),
+    ],
+  };
+}

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -109,6 +109,8 @@ export interface Integration {
   slug: string;
   name: string;
   products?: IntegrationProduct[];
+  /** Integration-level metadata schema (e.g. org name, region for Sentry). */
+  metadataSchema?: MetadataSchema;
   eulaDocUri?: string;
   privacyDocUri?: string;
   capabilities?: {

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -371,6 +371,61 @@ const integrations: Record<string, Integration> = {
       },
     ],
   },
+  // Sentry-like integration with both installation-level and product-level metadata
+  'acme-install-meta': {
+    id: 'acme-install-meta',
+    name: 'Acme Install Meta',
+    slug: 'acme-install-meta',
+    eulaDocUri: 'https://example.com/eula',
+    privacyDocUri: 'https://example.com/privacy',
+    metadataSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          'ui:control': 'input',
+          'ui:label': 'Organization Name',
+          'ui:placeholder': 'e.g. my-org',
+        },
+        'install-region': {
+          type: 'string',
+          'ui:control': 'select',
+          'ui:label': 'Data Region',
+          'ui:placeholder': 'Choose region',
+          'ui:options': [
+            { value: 'us', label: 'US' },
+            { value: 'eu', label: 'EU' },
+          ],
+        },
+      },
+      required: ['name', 'install-region'],
+    },
+    products: [
+      {
+        id: 'acme-install-meta-product',
+        name: 'Acme Install Meta Product',
+        slug: 'acme-install-meta',
+        type: 'storage',
+        shortDescription: 'Product with installation-level metadata',
+        metadataSchema: {
+          type: 'object',
+          properties: {
+            platform: {
+              type: 'string',
+              'ui:control': 'select',
+              'ui:label': 'Platform',
+              'ui:placeholder': 'e.g. Next.js',
+              'ui:options': [
+                { value: 'nextjs', label: 'Next.js' },
+                { value: 'react', label: 'React' },
+              ],
+            },
+          },
+          required: ['platform'],
+        },
+      },
+    ],
+  },
 };
 
 const configurations: Record<string, Configuration[]> = {

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -2594,26 +2594,6 @@ describe('integration add (auto-provision)', () => {
       });
     });
 
-    it('should omit installationMetadata from request when no installation keys provided', async () => {
-      client.setArgv(
-        'integration',
-        'add',
-        'acme-install-meta',
-        '-m',
-        'platform=nextjs',
-        '-m',
-        'name=my-org',
-        '-m',
-        'install-region=us'
-      );
-      const exitCode = await integrationCommand(client);
-      expect(exitCode).toEqual(0);
-
-      // When installationMetadata is non-empty, it should be included
-      const body = requestBodies[0] as Record<string, unknown>;
-      expect(body).toHaveProperty('installationMetadata');
-    });
-
     it('should validate installation-level required fields', async () => {
       // Only provide product metadata, omit required installation fields (name, install-region)
       client.setArgv(
@@ -2643,6 +2623,39 @@ describe('integration add (auto-provision)', () => {
       const body = requestBodies[0] as Record<string, unknown>;
       expect(body.metadata).toEqual({ region: 'us-east-1' });
       expect(body).not.toHaveProperty('installationMetadata');
+    });
+  });
+
+  describe('installation metadata in browser fallback URL', () => {
+    it('should forward installationMetadata in browser fallback URL', async () => {
+      useAutoProvision({ responseKey: 'metadata' });
+
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-install-meta',
+        '-m',
+        'platform=nextjs',
+        '-m',
+        'name=my-org',
+        '-m',
+        'install-region=us'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('Opening browser');
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+
+      const calledUrl = new URL(openMock.mock.calls[0]?.[0] as string);
+      // Product metadata forwarded
+      expect(calledUrl.searchParams.get('metadata')).toEqual(
+        JSON.stringify({ platform: 'nextjs' })
+      );
+      // Installation metadata forwarded
+      expect(calledUrl.searchParams.get('installationMetadata')).toEqual(
+        JSON.stringify({ name: 'my-org', 'install-region': 'us' })
+      );
     });
   });
 });

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -671,7 +671,7 @@ describe('integration add (auto-provision)', () => {
   });
 
   describe('fallback to browser', () => {
-    it('should open browser for metadata fallback with source and defaultResourceName', async () => {
+    it('should show error for missing required metadata without opening browser', async () => {
       useAutoProvision({ responseKey: 'metadata' });
 
       client.setArgv('integration', 'add', 'acme');
@@ -679,26 +679,12 @@ describe('integration add (auto-provision)', () => {
 
       // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Error: Missing required metadata: region.'
       );
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(1);
-      expect(openMock).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'https://vercel.com/acme/~/integrations/checkout/acme'
-        )
-      );
-      expect(openMock).toHaveBeenCalledWith(
-        expect.stringMatching(/defaultResourceName=acme-gray-apple/)
-      );
-      expect(openMock).toHaveBeenCalledWith(
-        expect.stringMatching(/source=cli/)
-      );
-      // No --metadata flags, so metadata should NOT be in the URL
-      expect(openMock).toHaveBeenCalledWith(
-        expect.not.stringMatching(/metadata=/)
-      );
+      expect(openMock).not.toHaveBeenCalled();
 
       expect(client.telemetryEventStore.readonlyEvents).toEqual(
         expect.arrayContaining([
@@ -778,7 +764,7 @@ describe('integration add (auto-provision)', () => {
       expect(parsed.searchParams.get('source')).toEqual('cli');
     });
 
-    it('should open browser for unknown fallback without metadata in URL', async () => {
+    it('should show error for missing required metadata on unknown fallback', async () => {
       useAutoProvision({ responseKey: 'unknown' });
 
       client.setArgv('integration', 'add', 'acme');
@@ -786,31 +772,27 @@ describe('integration add (auto-provision)', () => {
 
       // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Error: Missing required metadata: region.'
       );
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(1);
-      expect(openMock).toHaveBeenCalled();
-      // No --metadata flags, so metadata should NOT be in the URL
-      expect(openMock).toHaveBeenCalledWith(
-        expect.not.stringMatching(/metadata=/)
-      );
+      expect(openMock).not.toHaveBeenCalled();
     });
 
-    it('should open browser for install fallback (policies not accepted server-side)', async () => {
+    it('should show error for missing required metadata on install fallback', async () => {
       useAutoProvision({ responseKey: 'install' });
 
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Error: Missing required metadata: region.'
       );
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(1);
-      expect(openMock).toHaveBeenCalled();
+      expect(openMock).not.toHaveBeenCalled();
     });
 
     it('should forward --metadata to browser URL on unknown fallback', async () => {
@@ -879,7 +861,7 @@ describe('integration add (auto-provision)', () => {
       expect(parsed.searchParams.get('source')).toEqual('cli');
     });
 
-    it('should not include metadata in URL after term acceptance falls back without --metadata', async () => {
+    it('should show missing metadata error after term acceptance without --metadata', async () => {
       useAutoProvision({
         responseKey: 'metadata',
         withInstallation: false,
@@ -899,14 +881,12 @@ describe('integration add (auto-provision)', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Error: Missing required metadata: region.'
       );
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(1);
-      expect(openMock).toHaveBeenCalledWith(
-        expect.not.stringMatching(/metadata=/)
-      );
+      expect(openMock).not.toHaveBeenCalled();
     });
 
     it('should include all three URL params (projectSlug, defaultResourceName, source) when project is linked', async () => {
@@ -919,12 +899,17 @@ describe('integration add (auto-provision)', () => {
       const cwd = setupUnitFixture('vercel-integration-add');
       client.cwd = cwd;
 
-      client.setArgv('integration', 'add', 'acme');
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=us-east-1'
+      );
       const exitCodePromise = integrationCommand(client);
 
-      // Auto-generated name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;
@@ -951,12 +936,18 @@ describe('integration add (auto-provision)', () => {
       const cwd = setupUnitFixture('vercel-integration-add');
       client.cwd = cwd;
 
-      client.setArgv('integration', 'add', 'acme', '--no-connect');
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--no-connect',
+        '--metadata',
+        'region=us-east-1'
+      );
       const exitCodePromise = integrationCommand(client);
 
-      // Auto-generated name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;
@@ -976,12 +967,19 @@ describe('integration add (auto-provision)', () => {
     it('should include custom --name in URL when fallback to browser without project', async () => {
       useAutoProvision({ responseKey: 'metadata' });
 
-      client.setArgv('integration', 'add', 'acme', '--name', 'my-custom-db');
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--name',
+        'my-custom-db',
+        '--metadata',
+        'region=us-east-1'
+      );
       const exitCodePromise = integrationCommand(client);
 
-      // --name flag provides the name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1004,12 +1002,19 @@ describe('integration add (auto-provision)', () => {
       const cwd = setupUnitFixture('vercel-integration-add');
       client.cwd = cwd;
 
-      client.setArgv('integration', 'add', 'acme', '--name', 'my-proj-db');
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--name',
+        'my-proj-db',
+        '--metadata',
+        'region=us-east-1'
+      );
       const exitCodePromise = integrationCommand(client);
 
-      // Server fills defaults, no wizard prompt
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1041,13 +1046,14 @@ describe('integration add (auto-provision)', () => {
         'acme',
         '--name',
         'my-nolink-db',
-        '--no-connect'
+        '--no-connect',
+        '--metadata',
+        'region=us-east-1'
       );
       const exitCodePromise = integrationCommand(client);
 
-      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1071,10 +1077,10 @@ describe('integration add (auto-provision)', () => {
 
       // Should show which metadata fields are missing
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Error: Missing required metadata: region.'
       );
       await expect(client.stderr).toOutput(
-        'Tip: Provide -m region=us-west-1 to provision directly from the CLI.'
+        'Provide -m region=us-west-1 to provision directly from the CLI.'
       );
       await expect(client.stderr).toOutput(
         'Run `vercel integration add acme --help` for all metadata options.'
@@ -1252,11 +1258,19 @@ describe('integration add (auto-provision)', () => {
     it('should include planId in fallback URL when --plan is provided', async () => {
       useAutoProvision({ responseKey: 'metadata' });
 
-      client.setArgv('integration', 'add', 'acme', '--plan', 'pro');
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--plan',
+        'pro',
+        '--metadata',
+        'region=us-east-1'
+      );
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1277,12 +1291,14 @@ describe('integration add (auto-provision)', () => {
         'add',
         'acme',
         '--environment',
-        'production'
+        'production',
+        '--metadata',
+        'region=us-east-1'
       );
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1302,12 +1318,14 @@ describe('integration add (auto-provision)', () => {
         '--environment',
         'production',
         '--environment',
-        'preview'
+        'preview',
+        '--metadata',
+        'region=us-east-1'
       );
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1322,11 +1340,17 @@ describe('integration add (auto-provision)', () => {
     it('should not include environment in fallback URL when --environment is not provided', async () => {
       useAutoProvision({ responseKey: 'metadata' });
 
-      client.setArgv('integration', 'add', 'acme');
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=us-east-1'
+      );
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1339,11 +1363,17 @@ describe('integration add (auto-provision)', () => {
     it('should not include planId in fallback URL when --plan is not provided', async () => {
       useAutoProvision({ responseKey: 'metadata' });
 
-      client.setArgv('integration', 'add', 'acme');
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=us-east-1'
+      );
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Missing required metadata: region. Opening browser to complete setup...'
+        'Additional setup required. Opening browser...'
       );
 
       const exitCode = await exitCodePromise;

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -2517,4 +2517,90 @@ describe('integration add (auto-provision)', () => {
       expect(client.stdout.getFullOutput()).toBe('');
     });
   });
+
+  describe('installation-level metadata (Sentry-like)', () => {
+    let requestBodies: ReturnType<typeof useAutoProvision>['requestBodies'];
+
+    beforeEach(() => {
+      ({ requestBodies } = useAutoProvision({ responseKey: 'provisioned' }));
+    });
+
+    it('should split -m flags into product and installation metadata', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-install-meta',
+        '-m',
+        'platform=nextjs',
+        '-m',
+        'name=my-org',
+        '-m',
+        'install-region=us'
+      );
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(0);
+
+      // Verify the API request separates metadata correctly
+      expect(requestBodies).toHaveLength(1);
+      const body = requestBodies[0] as Record<string, unknown>;
+      // Product metadata: only platform
+      expect(body.metadata).toEqual({ platform: 'nextjs' });
+      // Installation metadata: name + install-region
+      expect(body.installationMetadata).toEqual({
+        name: 'my-org',
+        'install-region': 'us',
+      });
+    });
+
+    it('should omit installationMetadata from request when no installation keys provided', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-install-meta',
+        '-m',
+        'platform=nextjs',
+        '-m',
+        'name=my-org',
+        '-m',
+        'install-region=us'
+      );
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(0);
+
+      // When installationMetadata is non-empty, it should be included
+      const body = requestBodies[0] as Record<string, unknown>;
+      expect(body).toHaveProperty('installationMetadata');
+    });
+
+    it('should validate installation-level required fields', async () => {
+      // Only provide product metadata, omit required installation fields (name, install-region)
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-install-meta',
+        '-m',
+        'platform=nextjs'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      // Should fail validation because name and install-region are required
+      await expect(client.stderr).toOutput('Required metadata missing');
+      expect(await exitCodePromise).toEqual(1);
+
+      // No API request should have been made
+      expect(requestBodies).toHaveLength(0);
+    });
+
+    it('should not send installationMetadata when integration has no metadataSchema', async () => {
+      // Use regular acme integration (no integration-level metadataSchema)
+      client.setArgv('integration', 'add', 'acme', '-m', 'region=us-east-1');
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(0);
+
+      // All metadata goes to product, no installationMetadata field
+      const body = requestBodies[0] as Record<string, unknown>;
+      expect(body.metadata).toEqual({ region: 'us-east-1' });
+      expect(body).not.toHaveProperty('installationMetadata');
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -679,7 +679,7 @@ describe('integration add (auto-provision)', () => {
 
       // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -786,7 +786,7 @@ describe('integration add (auto-provision)', () => {
 
       // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -805,7 +805,7 @@ describe('integration add (auto-provision)', () => {
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -899,7 +899,7 @@ describe('integration add (auto-provision)', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -924,7 +924,7 @@ describe('integration add (auto-provision)', () => {
 
       // Auto-generated name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -956,7 +956,7 @@ describe('integration add (auto-provision)', () => {
 
       // Auto-generated name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -981,7 +981,7 @@ describe('integration add (auto-provision)', () => {
 
       // --name flag provides the name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1009,7 +1009,7 @@ describe('integration add (auto-provision)', () => {
 
       // Server fills defaults, no wizard prompt
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1047,7 +1047,7 @@ describe('integration add (auto-provision)', () => {
 
       // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1061,6 +1061,48 @@ describe('integration add (auto-provision)', () => {
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/source=cli/)
       );
+    });
+
+    it('should show missing required metadata hint when fallback occurs without -m flags', async () => {
+      useAutoProvision({ responseKey: 'metadata' });
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      // Should show which metadata fields are missing
+      await expect(client.stderr).toOutput(
+        'Missing required metadata: region. Opening browser to complete setup...'
+      );
+      await expect(client.stderr).toOutput(
+        'Tip: Provide -m region=us-west-1 to provision directly from the CLI.'
+      );
+      await expect(client.stderr).toOutput(
+        'Run `vercel integration add acme --help` for all metadata options.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+    });
+
+    it('should show generic message when all required metadata is provided but fallback still occurs', async () => {
+      useAutoProvision({ responseKey: 'metadata' });
+
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=us-east-1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      // Required metadata is provided — show generic message (server has other reasons)
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
     });
   });
 
@@ -1214,7 +1256,7 @@ describe('integration add (auto-provision)', () => {
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1240,7 +1282,7 @@ describe('integration add (auto-provision)', () => {
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1265,7 +1307,7 @@ describe('integration add (auto-provision)', () => {
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1284,7 +1326,7 @@ describe('integration add (auto-provision)', () => {
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;
@@ -1301,7 +1343,7 @@ describe('integration add (auto-provision)', () => {
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Additional setup required. Opening browser...'
+        'Missing required metadata: region. Opening browser to complete setup...'
       );
 
       const exitCode = await exitCodePromise;


### PR DESCRIPTION
## Summary

- Integrations like Sentry have two metadata schemas: integration-level (`name`, `region`) for installation creation, and product-level (`platform`) for resource provisioning
- The CLI now merges both schemas so `--help` shows all fields and `-m` flags accept both installation-level and product-level keys
- Splits parsed metadata into product and installation buckets client-side, sending `installationMetadata` as a separate API field
- Enforces required fields from both schemas — installation-level required fields (e.g. `name`, `region`) are validated alongside product-level ones
- When required metadata is missing on fallback, shows an actionable error listing missing fields with example flags and exits without opening the browser
- When all required metadata is provided but the server still returns a fallback (e.g. payment required), opens the browser as before
- Forwards `installationMetadata` to browser fallback URL so installation config isn't lost on redirect

## Changes

- **`types.ts`**: Added optional `metadataSchema` to `Integration` type
- **`format-schema-help.ts`**: Shared `mergeMetadataSchemas()` utility — merges integration + product schemas with deduped required arrays (product wins on key collision)
- **`add-help.ts`**: Uses shared `mergeMetadataSchemas()` for `--help` display
- **`add-auto-provision.ts`**: Uses shared `mergeMetadataSchemas()` for `-m` flag parsing, validates both required arrays, splits parsed keys into product vs installation buckets, shows missing metadata error (no browser) on fallback, forwards `installationMetadata` to fallback URL, logs debug warning on key collision
- **`auto-provision-resource.ts`**: Sends `installationMetadata` as a separate body field (omitted when empty)
- **`test/mocks/integration.ts`**: Added `acme-install-meta` mock with integration-level metadataSchema
- **`add-auto-provision.test.ts`**: 6 new tests for metadata splitting, required field validation, backward compat, fallback messaging, and fallback URL forwarding

## Deploy order

**The API companion PR must deploy before this CLI version is published.** The old API's `BodySchema` has `additionalProperties: false` — sending `installationMetadata` to the old API causes a 400. The CLI omits the field when empty, but Sentry users providing `-m name=... -m install-region=...` would trigger it.

## Companion PR

- vercel/api#63622 — API-side fix that accepts `installationMetadata`, fetches free plans, creates installations with `skipAuthorizationCheck`

## Test Plan

### Unit Tests

```
$ cd packages/cli && pnpm vitest run test/unit/commands/integration/add-auto-provision.test.ts

 ✓ test/unit/commands/integration/add-auto-provision.test.ts  (114 tests) 4020ms

 Test Files  1 passed (1)
      Tests  114 passed (114)
```

### Manual Testing

**1. Sentry `--help` — merged schema display**

```
$ vc integration add sentry --help

  Metadata options for "sentry":

    name (required)
      Name for your Sentry organization
      Example: -m name=<value>

    region (required)
      Region where your Sentry organization's data is stored.
      Options: us, de
      Example: -m region=us

    platform (required)
      Options: javascript-nextjs, javascript-angular, javascript-astro, ...
      Example: -m platform=javascript-nextjs
```

✅ All three fields shown — `name` and `region` from integration-level schema, `platform` from product-level schema. All marked required.

**2. Upstash/Neon/Prisma `--help` — backward compat (no integration metadataSchema)**

```
$ vc integration add prisma --help

  Metadata options for "prisma":

    region
      Select the region closest to your application, for best performance
      Options: sfo1, cdg1, hnd1, iad1, sin1, fra1
      Default: iad1
      Example: -m region=sfo1
```

✅ Only product-level schema shown. No installation-level fields (integration has no `metadataSchema`).

**3. Sentry auto-provision — metadata splitting**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add sentry \
    -m platform=javascript-nextjs -m name=my-test-org -m region=us \
    --no-connect --debug --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV

> [debug] Auto-provision body: {
  "name": "sentry-cinnabar-horizon",
  "metadata": {
    "platform": "javascript-nextjs"
  },
  "acceptedPolicies": {},
  "source": "cli",
  "installationMetadata": {
    "name": "my-test-org",
    "region": "us"
  }
}
> [debug] #7 ← 201 Created [2.90s]
> Success! Sentry successfully provisioned: sentry-cinnabar-horizon
```

✅ `metadata` contains only product key (`platform`). `installationMetadata` contains only installation keys (`name`, `region`). API accepted and returned 201.

**4. Sentry auto-provision — missing required installation fields**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add sentry \
    -m platform=javascript-nextjs \
    --no-connect --debug --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV

Error: Required metadata missing: "name"
Error: Required metadata missing: "region"
```

✅ Validation catches missing installation-level required fields. No API request made.

**5. Prisma auto-provision — backward compat (no installationMetadata)**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add prisma \
    -m region=sfo1 \
    --no-connect --debug --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV

> [debug] Auto-provision body: {
  "name": "prisma-postgres-almond-coin",
  "metadata": {
    "region": "sfo1"
  },
  "acceptedPolicies": {},
  "source": "cli"
}
> [debug] #7 ← 201 Created [4.70s]
> Success! Prisma Postgres successfully provisioned: prisma-postgres-almond-coin
```

✅ No `installationMetadata` field in request body. All metadata goes to product. API accepted and returned 201.

**6. Sentry — missing metadata error on fallback (no browser)**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add sentry \
    --no-connect --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV

Error: Missing required metadata: name, region, platform.
>   Provide -m name=<value> -m region=us -m platform=javascript-nextjs to provision directly from the CLI.
>   Run `vercel integration add sentry --help` for all metadata options.
```

✅ Shows error listing missing fields with example flags. Does NOT open browser — exits with code 1. Agent/human can retry with the required `-m` flags.

**7. Prisma — no false hint for server-handled region**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add prisma \
    --no-connect --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV

> Success! Prisma Postgres successfully provisioned: prisma-postgres-byzantium-candle
```

✅ Prisma's `region` uses `vercel-region` control (server-handled) — no missing metadata hint, provisions directly.

**8. Braintrust — no metadata required, provisions directly**

```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add braintrust \
    --no-connect --scope team_ZrswwWlkgu3cRre7Tk7Rr0HV

> Success! Braintrust successfully provisioned: braintrust-...
```

✅ Integration has no required metadata fields. Provisions directly without any metadata-related messages.

### Code Paths Covered

| Path | Expected | Tested by |
|------|----------|-----------|
| `--help` with integration metadataSchema | Merged schema shows all fields | Manual (sentry) |
| `--help` without integration metadataSchema | Only product schema shown | Manual (prisma, neon, upstash) |
| Auto-provision with both product + installation `-m` flags | Split into `metadata` + `installationMetadata` | Unit + manual (sentry) |
| Auto-provision with missing installation required fields | Validation error, no API call | Unit + manual (sentry) |
| Auto-provision without integration metadataSchema | All keys go to `metadata`, no `installationMetadata` | Unit + manual (prisma) |
| `installationMetadata` empty → omitted from body | Field absent in request | Unit + manual (prisma) |
| `installationMetadata` non-empty → included in body | Field present in request | Unit + manual (sentry) |
| Browser fallback without `-m` flags, missing required metadata | Error with missing fields + example flags, no browser | Unit + manual (sentry) |
| Browser fallback with `-m` flags (server reason) | Generic "Additional setup required" message, opens browser | Unit |
| Browser fallback forwards installationMetadata in URL | `installationMetadata` param in fallback URL | Unit |
| Server-handled region without `-m` flags | No false hint, provisions directly | Manual (prisma) |

Linear: MKT-2913, MKT-3088