### PR TITLE
[cli] Add missing help snapshot test for integration remove

### DIFF
--- a/.changeset/add-help-snapshot-integration-remove.md
+++ b/.changeset/add-help-snapshot-integration-remove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] Add missing help snapshot test for `integration remove` subcommand

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3283,6 +3283,50 @@ exports[`help command > integration help output snapshots > integration list sub
 "
 `;
 
+exports[`help command > integration help output snapshots > integration remove subcommand > integration remove subcommand help column width 120 1`] = `
+"
+  ▲ vercel integration remove integration [options]
+
+  Uninstalls a marketplace integration. Resources must be removed first using \`integration-resource remove\`.            
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+  -y,  --yes              Skip the confirmation prompt when uninstalling an integration                                 
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Uninstall an integration
+
+    $ vercel integration remove <integration>
+    $ vercel integration remove acme
+
+  - Remove a resource before uninstalling
+
+    $ vercel integration-resource remove <resource-name> --disconnect-all --yes
+
+  - Output as JSON
+
+    $ vercel integration remove acme --format=json --yes
+
+"
+`;
+
 exports[`help command > integration-resource help output snapshots > integration-resource create-threshold subcommand > integration-resource create-threshold subcommand help column width 120 1`] = `
 "
   ▲ vercel integration-resource create-threshold resource minimum spend limit [options]

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -471,6 +471,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('integration remove subcommand', () => {
+      it('integration remove subcommand help column width 120', () => {
+        expect(
+          help(integration.removeSubcommand, {
+            columns: 120,
+            parent: integration.integrationCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('integration-resource help output snapshots', () => {


### PR DESCRIPTION
## Summary
- Adds the missing help snapshot test for the `integration remove` subcommand in `help.test.ts`
- Other subcommands (`integration list`, `integration balance`, `integration guide`, `integration discover`) all had corresponding snapshots, but `integration remove` did not

## Test plan
- [x] `vitest run test/unit/commands/help.test.ts` passes (127 tests, 1 new snapshot written)

Fixes: [MKT-2822](https://linear.app/vercel/issue/MKT-2822/add-missing-help-snapshot-test-for-integration-remove-subcommand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VADE_RISK_START -->
> [!NOTE]
> **Low Risk** — Test-only change adding missing snapshot test.
>
>
> - help.test.ts: added snapshot test for `integration remove` subcommand help output
> - .changeset/add-help-snapshot-integration-remove.md: added changeset for patch release
> <sup>Assessed at [177653b](https://github.com/vercel/vercel/commit/177653b82785567365dec745bad5c33a8d72cb04).</sup>
<!-- VADE_RISK_END -->