### PR TITLE
[python/vercel-workers] refactor framework-specific logic into vercel-workers 

### DIFF
--- a/.changeset/thirty-hairs-speak.md
+++ b/.changeset/thirty-hairs-speak.md
@@ -1,0 +1,7 @@
+---
+"@vercel/python": patch
+"@vercel/python-runtime": patch
+"@vercel/python-workers": patch
+---
+
+[python/vercel-workers] refactor framework-specific logic into vercel-workers 

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -3248,8 +3248,9 @@ describe('worker services dependency installation', () => {
       }),
     } as Record<string, FileBlob>;
 
+    let result;
     try {
-      await buildWithMocks({
+      result = await buildWithMocks({
         workPath,
         files,
         entrypoint: 'handler.py',
@@ -3266,7 +3267,7 @@ describe('worker services dependency installation', () => {
       if (fs.existsSync(workPath)) fs.removeSync(workPath);
     }
 
-    return pipCalls;
+    return { pipCalls, result };
   }
 
   beforeEach(() => {
@@ -3285,13 +3286,13 @@ describe('worker services dependency installation', () => {
   });
 
   it('installs vercel-workers when worker services are enabled', async () => {
-    const pipCalls = await buildWithPipSpy({ hasWorkerServices: true });
+    const { pipCalls } = await buildWithPipSpy({ hasWorkerServices: true });
     const workersDep = `vercel-workers==${VERCEL_WORKERS_VERSION}`;
     expect(pipCalls.some(args => args.includes(workersDep))).toBe(true);
   });
 
   it('does not install vercel-workers when worker services are not enabled', async () => {
-    const pipCalls = await buildWithPipSpy();
+    const { pipCalls } = await buildWithPipSpy();
     expect(
       pipCalls.some(args =>
         args.some(arg => arg.startsWith('vercel-workers=='))
@@ -3302,12 +3303,24 @@ describe('worker services dependency installation', () => {
   it('uses VERCEL_WORKERS_PYTHON override when provided', async () => {
     process.env.VERCEL_WORKERS_PYTHON =
       'vercel-workers @ file:///tmp/vercel-workers.whl';
-    const pipCalls = await buildWithPipSpy({ hasWorkerServices: true });
+    const { pipCalls } = await buildWithPipSpy({ hasWorkerServices: true });
     expect(
       pipCalls.some(args =>
         args.includes('vercel-workers @ file:///tmp/vercel-workers.whl')
       )
     ).toBe(true);
+  });
+
+  it('marks python lambdas with internal worker services env when enabled', async () => {
+    const { result } = await buildWithPipSpy({ hasWorkerServices: true });
+    const lambda = getBuildOutputV3(result);
+    expect(lambda.environment?.VERCEL_HAS_WORKER_SERVICES).toBe('1');
+  });
+
+  it('does not mark python lambdas when worker services are not enabled', async () => {
+    const { result } = await buildWithPipSpy();
+    const lambda = getBuildOutputV3(result);
+    expect(lambda.environment?.VERCEL_HAS_WORKER_SERVICES).toBeUndefined();
   });
 });
 

--- a/python/vercel-runtime/src/vercel_runtime/dev.py
+++ b/python/vercel-runtime/src/vercel_runtime/dev.py
@@ -19,9 +19,9 @@ from vercel_runtime.routing import (
     strip_service_route_prefix,
 )
 from vercel_runtime.workers import (
-    bootstrap_worker_service_app,
     is_worker_service,
-    prepare_celery_environment,
+    maybe_bootstrap_worker_service_app,
+    prepare_worker_environment,
 )
 
 if TYPE_CHECKING:
@@ -397,7 +397,7 @@ def _setup_apps() -> None:
     variable_name = os.environ["VERCEL_DEV_VARIABLE_NAME"]
 
     _setup_server_log_routing()
-    prepare_celery_environment()
+    prepare_worker_environment()
 
     mod = import_module(module_name, entry_abs)
 
@@ -406,8 +406,10 @@ def _setup_apps() -> None:
         return
 
     if is_worker_service():
-        _asgi_user_app = cast("ASGI", bootstrap_worker_service_app(mod))
-        return
+        worker_app = maybe_bootstrap_worker_service_app(mod)
+        if worker_app is not None:
+            _asgi_user_app = cast("ASGI", worker_app)
+            return
 
     app_name, user_app = resolve_app(mod, module_name, variable_name)
     try:
@@ -432,7 +434,7 @@ def _wrap_django_static(app: WSGIApplication) -> WSGIApplication:
     # STATIC_URL are served from source directories via Django's staticfiles
     # finders, without needing collectstatic to have been run.
     try:
-        from django.conf import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        from django.conf import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports, reportMissingTypeStubs]
             settings as django_settings,  # pyright: ignore[reportUnknownVariableType, reportMissingTypeStubs]
         )
 
@@ -464,10 +466,10 @@ def _handle_manifest(app: WSGIApplication) -> WSGIApplication | None:
     """
     import os  # noqa: PLC0415
 
-    from django import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+    from django import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports, reportMissingTypeStubs]
         VERSION as DJANGO_VERSION,  # pyright: ignore[reportUnknownVariableType]
     )
-    from django.conf import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+    from django.conf import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports, reportMissingTypeStubs]
         settings as django_settings,  # pyright: ignore[reportUnknownVariableType, reportMissingTypeStubs]
     )
     from django.utils.module_loading import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports, reportMissingTypeStubs]
@@ -520,7 +522,8 @@ def _handle_manifest(app: WSGIApplication) -> WSGIApplication | None:
 
     # Override the storage backend so {% static %} produces unhashed URLs
     plain = "django.contrib.staticfiles.storage.StaticFilesStorage"
-    if DJANGO_VERSION >= (5, 0):
+    django_major_version = cast("int", DJANGO_VERSION[0])
+    if django_major_version >= 5:
         storages = {**storages, "staticfiles": {"BACKEND": plain}}
         django_settings.STORAGES = storages  # pyright: ignore[reportAttributeAccessIssue]
     else:

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -41,10 +41,9 @@ from vercel_runtime.routing import (
     split_request_target,
 )
 from vercel_runtime.workers import (
-    bootstrap_worker_service_app,
-    is_celery_app,
     is_worker_service,
-    prepare_celery_environment,
+    maybe_bootstrap_worker_service_app,
+    prepare_worker_environment,
 )
 
 if TYPE_CHECKING:
@@ -467,31 +466,22 @@ if _extra_path:
     os.environ["PATH"] = _extra_path + ":" + os.environ.get("PATH", "")
 
 try:
-    prepare_celery_environment()
+    prepare_worker_environment()
     __vc_module = import_module(_entrypoint_modname, _entrypoint_abs)
     __vc_variables = dir(__vc_module)
 except Exception:
     _fatal_exc(f'could not import "{_entrypoint_rel}"')
 
 if is_worker_service():
-    if "handler" not in __vc_variables and "Handler" not in __vc_variables:
-        should_bootstrap_worker_app = (
-            "app" not in __vc_variables
-            or is_celery_app(getattr(__vc_module, "app", None))
-        )
-    else:
-        should_bootstrap_worker_app = False
-
-    if should_bootstrap_worker_app:
-        try:
-            __vc_module.__dict__["app"] = bootstrap_worker_service_app(
-                __vc_module
-            )
+    try:
+        worker_app = maybe_bootstrap_worker_service_app(__vc_module)
+        if worker_app is not None:
+            __vc_module.__dict__["app"] = worker_app
             __vc_variables = dir(__vc_module)
-        except Exception:
-            _stderr("Error bootstrapping worker service app:")
-            _stderr(traceback.format_exc())
-            exit(1)
+    except Exception:
+        _stderr("Error bootstrapping worker service app:")
+        _stderr(traceback.format_exc())
+        exit(1)
 
 if is_cron_service():
     try:

--- a/python/vercel-runtime/src/vercel_runtime/workers.py
+++ b/python/vercel-runtime/src/vercel_runtime/workers.py
@@ -2,33 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
-from importlib import import_module
-from importlib.util import find_spec
-from typing import TYPE_CHECKING, cast
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
-
-
-def _has_module(module_name: str) -> bool:
-    try:
-        return find_spec(module_name) is not None
-    except ModuleNotFoundError:
-        return False
-
-
-def _import_optional_module(module_name: str) -> object | None:
-    with contextlib.suppress(Exception):
-        return import_module(module_name)
-    return None
-
-
-CELERY_AVAILABLE = _has_module("celery")
-DRAMATIQ_AVAILABLE = _has_module("dramatiq")
-DJANGO_TASKS_AVAILABLE = _has_module("django.tasks")
-VERCEL_WORKERS_AVAILABLE = _has_module("vercel.workers")
-
-VERCEL_CELERY_BROKER_URL = "vercel://"
+from typing import Any, cast
 
 
 def is_worker_service() -> bool:
@@ -47,271 +21,30 @@ def has_worker_services() -> bool:
     return value.strip().lower() in {"1", "true"}
 
 
-def _uses_vercel_celery_broker(broker_url: str | None) -> bool:
-    if broker_url is None:
-        return False
-    normalized = broker_url.strip().lower()
-    return normalized.startswith(VERCEL_CELERY_BROKER_URL)
+def _load_workers_runtime() -> Any | None:
+    with contextlib.suppress(ImportError):
+        import vercel.workers._runtime as workers_runtime  # type: ignore[import-not-found]  # noqa: PLC0415, PLC2701  # pyright: ignore[reportMissingImports]
+
+        return workers_runtime
+    return None
 
 
-def _install_vercel_celery_transport_alias() -> None:
-    with contextlib.suppress(Exception):
-        transport_module = _import_optional_module(
-            "vercel.workers.celery.transport"
-        )
-        if transport_module is None:
-            return
-
-        install_transport_alias = getattr(
-            transport_module,
-            "install_kombu_transport_alias",
-            None,
-        )
-        if not callable(install_transport_alias):
-            return
-
-        install_transport_alias_fn = cast(
-            "Callable[[str], None]",
-            install_transport_alias,
-        )
-        install_transport_alias_fn("vercel")
-
-
-def prepare_celery_environment() -> None:
-    has_worker_svcs = has_worker_services()
-    if has_worker_svcs and "CELERY_BROKER_URL" not in os.environ:
-        os.environ["CELERY_BROKER_URL"] = VERCEL_CELERY_BROKER_URL
-
-    broker_url = os.environ.get("CELERY_BROKER_URL")
-    if not has_worker_svcs and not _uses_vercel_celery_broker(broker_url):
+def prepare_worker_environment() -> None:
+    workers_runtime = _load_workers_runtime()
+    if workers_runtime is None:
         return
-
-    _install_vercel_celery_transport_alias()
-
-
-def is_celery_app(candidate: object) -> bool:
-    if candidate is None:
-        return False
-    module_name = getattr(candidate.__class__, "__module__", "")
-    if isinstance(module_name, str) and module_name.startswith("celery"):
-        return True
-    return (
-        hasattr(candidate, "conf")
-        and callable(getattr(candidate, "send_task", None))
-        and callable(getattr(candidate, "task", None))
-    )
+    workers_runtime.prepare_environment(os.environ)
 
 
-def _find_celery_app(module: object) -> object | None:
-    candidates = [
-        getattr(module, "app", None),
-        getattr(module, "celery_app", None),
-        getattr(module, "worker_app", None),
-        getattr(module, "worker", None),
-        getattr(module, "celery", None),
-    ]
-    for candidate in candidates:
-        if is_celery_app(candidate):
-            return candidate
-    return None
-
-
-def _bootstrap_dramatiq_worker_app(module: object) -> object | None:
-    if not DRAMATIQ_AVAILABLE:
-        return None
-
-    dramatiq_mod = _import_optional_module("dramatiq")
-    vercel_dramatiq = _import_optional_module("vercel.workers.dramatiq")
-    if dramatiq_mod is None or vercel_dramatiq is None:
-        if not VERCEL_WORKERS_AVAILABLE:
-            raise RuntimeError(
-                "Dramatiq worker service detected, but "
-                '"vercel-workers" is not installed. '
-                'Install "vercel-workers" and '
-                "configure "
-                '"from vercel.workers.dramatiq import '
-                'VercelQueuesBroker".'
-            )
-        raise RuntimeError(
-            "Failed to import Dramatiq worker adapter from vercel-workers."
-        )
-
-    broker_candidates: list[object] = []
-    module_broker = getattr(module, "broker", None)
-    if module_broker is not None:
-        broker_candidates.append(module_broker)
-    get_broker = getattr(dramatiq_mod, "get_broker", None)
-    if callable(get_broker):
-        with contextlib.suppress(Exception):
-            get_broker_fn = cast("Callable[[], object]", get_broker)
-            broker_candidates.append(get_broker_fn())
-
-    resolved_broker: object | None = None
-    broker_type = getattr(vercel_dramatiq, "VercelQueuesBroker", None)
-    if isinstance(broker_type, type):
-        for broker in broker_candidates:
-            if isinstance(broker, broker_type):
-                resolved_broker = broker
-                break
-
-    if resolved_broker is None:
-        return None
-
-    # Users must import task modules from the entrypoint.
-    actors = getattr(resolved_broker, "actors", None)
-    actors_mapping: Mapping[object, object] | None = None
-    if isinstance(actors, dict):
-        actors_mapping = cast("Mapping[object, object]", actors)
-    if actors_mapping is None or len(actors_mapping) == 0:
-        raise RuntimeError(
-            "Worker service did not register any Dramatiq "
-            "actors. Ensure your worker entrypoint imports "
-            "task modules before startup."
-        )
-
-    get_asgi_app = getattr(vercel_dramatiq, "get_asgi_app", None)
-    if not callable(get_asgi_app):
-        raise RuntimeError(
-            "Failed to resolve Dramatiq ASGI adapter from vercel-workers."
-        )
-    get_asgi_app_fn = cast(
-        "Callable[[object], object]",
-        get_asgi_app,
-    )
-    return get_asgi_app_fn(resolved_broker)
-
-
-def _bootstrap_celery_worker_app(module: object) -> object | None:
-    if not CELERY_AVAILABLE:
-        return None
-
-    celery_app = _find_celery_app(module)
-    if celery_app is None:
-        return None
-
-    vercel_celery = _import_optional_module("vercel.workers.celery")
-    if vercel_celery is None:
-        if not VERCEL_WORKERS_AVAILABLE:
-            raise RuntimeError(
-                'Celery worker service requires "vercel-workers". '
-                'Install "vercel-workers" and export a Celery app.'
-            )
-        raise RuntimeError(
-            "Failed to import Celery worker adapter from vercel-workers."
-        )
-
-    get_adapter_app = getattr(vercel_celery, "get_asgi_app", None)
-    if not callable(get_adapter_app):
-        raise RuntimeError(
-            "Failed to resolve Celery ASGI adapter from vercel-workers."
-        )
-    get_adapter_app_fn = cast(
-        "Callable[[object], object]",
-        get_adapter_app,
-    )
-    return get_adapter_app_fn(celery_app)
-
-
-def _bootstrap_django_worker_app(module: object) -> object | None:
-    if not DJANGO_TASKS_AVAILABLE:
-        return None
-
-    vercel_django = _import_optional_module("vercel.workers.django")
-    if vercel_django is None:
-        if not VERCEL_WORKERS_AVAILABLE:
-            raise RuntimeError(
-                "Django tasks worker service detected, but "
-                '"vercel-workers" is not installed. '
-                'Install "vercel-workers" and '
-                "configure "
-                '"vercel.workers.django.VercelQueuesBackend" '
-                "as your Django tasks backend."
-            )
-        raise RuntimeError(
-            "could not import Django tasks adapter from vercel-workers"
-        )
-
-    get_asgi_app = getattr(vercel_django, "get_asgi_app", None)
-    if not callable(get_asgi_app):
-        raise RuntimeError(
-            "could not resolve Django tasks ASGI adapter from vercel-workers"
-        )
-    get_asgi_app_fn = cast(
-        "Callable[[], object]",
-        get_asgi_app,
-    )
-    return get_asgi_app_fn()
-
-
-def _bootstrap_generic_worker_app() -> object | None:
-    if not VERCEL_WORKERS_AVAILABLE:
-        return None
-
-    vercel_workers = _import_optional_module("vercel.workers")
-    if vercel_workers is None:
-        return None
-
-    has_subscriptions = getattr(vercel_workers, "has_subscriptions", None)
-    get_asgi_app = getattr(vercel_workers, "get_asgi_app", None)
-    if not callable(has_subscriptions) or not callable(get_asgi_app):
-        return None
-
-    with contextlib.suppress(Exception):
-        has_subscriptions_fn = cast(
-            "Callable[[], bool]",
-            has_subscriptions,
-        )
-        if not has_subscriptions_fn():
-            return None
-
-        get_asgi_app_fn = cast(
-            "Callable[[], object]",
-            get_asgi_app,
-        )
-        return get_asgi_app_fn()
-
-    return None
-
-
-def bootstrap_worker_service_app(module: object) -> object:
-    if _find_celery_app(module) is not None:
-        try:
-            app = _bootstrap_celery_worker_app(module)
-            if app is not None:
-                return app
-        except Exception as exc:
-            raise RuntimeError("Celery worker bootstrap failed.") from exc
-
-    if DRAMATIQ_AVAILABLE:
-        try:
-            app = _bootstrap_dramatiq_worker_app(module)
-            if app is not None:
-                return app
-        except Exception as exc:
-            raise RuntimeError("Dramatiq worker bootstrap failed.") from exc
-
-    if DJANGO_TASKS_AVAILABLE:
-        try:
-            app = _bootstrap_django_worker_app(module)
-            if app is not None:
-                return app
-        except Exception as exc:
-            raise RuntimeError("Django tasks worker bootstrap failed.") from exc
-
-    app = _bootstrap_generic_worker_app()
-    if app is not None:
-        return app
-
-    if not VERCEL_WORKERS_AVAILABLE:
+def maybe_bootstrap_worker_service_app(module: object) -> object | None:
+    workers_runtime = _load_workers_runtime()
+    if workers_runtime is None:
         raise RuntimeError(
             "Unable to bootstrap worker service because "
             '"vercel-workers" is missing. Install '
-            '"vercel-workers" and configure an '
-            "explicit worker integration."
+            '"vercel-workers" and configure an explicit worker integration.'
         )
-
-    raise RuntimeError(
-        "Unable to bootstrap worker service. "
-        "Export an ASGI/WSGI app, or configure "
-        "Celery/Dramatiq/Django via vercel-workers."
+    return cast(
+        "object | None",
+        workers_runtime.maybe_bootstrap_worker_service_app(module),
     )

--- a/python/vercel-runtime/tests/test_workers.py
+++ b/python/vercel-runtime/tests/test_workers.py
@@ -1,76 +1,79 @@
 from __future__ import annotations
 
 import os
+import types
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import vercel_runtime.workers as vrw
 
 
-class TestPrepareCeleryEnvironment(unittest.TestCase):
-    def test_defaults_celery_broker_url_for_worker_services(self) -> None:
-        with (
-            patch.dict(
-                os.environ,
-                {"VERCEL_HAS_WORKER_SERVICES": "1"},
-                clear=True,
-            ),
-            patch.object(
-                vrw, "_install_vercel_celery_transport_alias"
-            ) as install_transport_alias,
+class TestIsWorkerService(unittest.TestCase):
+    def test_detects_legacy_worker_service_type(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"VERCEL_SERVICE_TYPE": "worker"},
+            clear=True,
         ):
-            vrw.prepare_celery_environment()
-            self.assertEqual(
-                os.environ.get("CELERY_BROKER_URL"),
-                vrw.VERCEL_CELERY_BROKER_URL,
-            )
+            self.assertTrue(vrw.is_worker_service())
 
-        install_transport_alias.assert_called_once_with()
-
-    def test_does_not_override_user_defined_celery_broker_url(self) -> None:
-        with (
-            patch.dict(
-                os.environ,
-                {
-                    "VERCEL_HAS_WORKER_SERVICES": "1",
-                    "CELERY_BROKER_URL": "redis://localhost:6379/0",
-                },
-                clear=True,
-            ),
-            patch.object(
-                vrw, "_install_vercel_celery_transport_alias"
-            ) as install_transport_alias,
+    def test_detects_queue_triggered_job_service(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "VERCEL_SERVICE_TYPE": "job",
+                "VERCEL_SERVICE_TRIGGER": "queue",
+            },
+            clear=True,
         ):
-            vrw.prepare_celery_environment()
-            self.assertEqual(
-                os.environ.get("CELERY_BROKER_URL"),
-                "redis://localhost:6379/0",
-            )
+            self.assertTrue(vrw.is_worker_service())
 
-        install_transport_alias.assert_called_once_with()
 
-    def test_registers_aliases_for_user_defined_vercel_broker(self) -> None:
-        with (
-            patch.dict(
-                os.environ,
-                {"CELERY_BROKER_URL": vrw.VERCEL_CELERY_BROKER_URL},
-                clear=True,
-            ),
-            patch.object(
-                vrw, "_install_vercel_celery_transport_alias"
-            ) as install_transport_alias,
-        ):
-            vrw.prepare_celery_environment()
+class TestPrepareWorkerEnvironment(unittest.TestCase):
+    def test_prepare_worker_environment_delegates_to_workers_runtime(
+        self,
+    ) -> None:
+        bridge = types.SimpleNamespace(prepare_environment=Mock())
 
-        install_transport_alias.assert_called_once_with()
-
-    def test_skips_setup_without_workers_or_vercel_broker(self) -> None:
         with (
             patch.dict(os.environ, {}, clear=True),
-            patch.object(
-                vrw, "_install_vercel_celery_transport_alias"
-            ) as install_transport_alias,
+            patch.object(vrw, "_load_workers_runtime", return_value=bridge),
         ):
-            vrw.prepare_celery_environment()
+            vrw.prepare_worker_environment()
 
-        install_transport_alias.assert_not_called()
+        bridge.prepare_environment.assert_called_once()
+        self.assertIs(bridge.prepare_environment.call_args.args[0], os.environ)
+
+    def test_prepare_worker_environment_skips_without_workers_runtime(
+        self,
+    ) -> None:
+        with patch.object(vrw, "_load_workers_runtime", return_value=None):
+            vrw.prepare_worker_environment()
+
+
+class TestMaybeBootstrapWorkerServiceApp(unittest.TestCase):
+    def test_delegates_to_workers_runtime(self) -> None:
+        module = types.SimpleNamespace()
+        expected_app = object()
+        bridge = types.SimpleNamespace(
+            maybe_bootstrap_worker_service_app=Mock(return_value=expected_app)
+        )
+
+        with patch.object(vrw, "_load_workers_runtime", return_value=bridge):
+            app = vrw.maybe_bootstrap_worker_service_app(module)
+
+        self.assertIs(app, expected_app)
+        bridge.maybe_bootstrap_worker_service_app.assert_called_once_with(
+            module
+        )
+
+    def test_raises_when_workers_runtime_is_missing(self) -> None:
+        with (
+            patch.object(vrw, "_load_workers_runtime", return_value=None),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "Unable to bootstrap worker service because "
+                '"vercel-workers" is missing',
+            ),
+        ):
+            vrw.maybe_bootstrap_worker_service_app(types.SimpleNamespace())

--- a/python/vercel-workers/src/vercel/workers/_runtime.py
+++ b/python/vercel-workers/src/vercel/workers/_runtime.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import MutableMapping
+from importlib.util import find_spec
+from typing import TYPE_CHECKING, TypeGuard
+
+from .client import (
+    get_asgi_app as get_generic_asgi_app,
+    has_subscriptions,
+)
+
+if TYPE_CHECKING:
+    from celery import Celery as CeleryAppType  # type: ignore[import-untyped]
+
+    from .dramatiq import VercelQueuesBroker as DramatiqBrokerType
+
+
+def _has_module(module_name: str) -> bool:
+    try:
+        return find_spec(module_name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+CELERY_AVAILABLE = _has_module("celery")
+DRAMATIQ_AVAILABLE = _has_module("dramatiq")
+DJANGO_TASKS_AVAILABLE = _has_module("django.tasks")
+
+
+def _truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _uses_vercel_celery_broker(broker_url: str | None) -> bool:
+    if broker_url is None:
+        return False
+    return broker_url.strip().lower().startswith("vercel://")
+
+
+def _install_celery_transport_alias() -> None:
+    if not CELERY_AVAILABLE:
+        return
+
+    from .celery.transport import install_kombu_transport_alias
+
+    install_kombu_transport_alias("vercel")
+
+
+def prepare_environment(environ: MutableMapping[str, str]) -> None:
+    has_worker_services = _truthy(environ.get("VERCEL_HAS_WORKER_SERVICES"))
+    if has_worker_services and "CELERY_BROKER_URL" not in environ:
+        environ["CELERY_BROKER_URL"] = "vercel://"
+
+    broker_url = environ.get("CELERY_BROKER_URL")
+    if not has_worker_services and not _uses_vercel_celery_broker(broker_url):
+        return
+
+    _install_celery_transport_alias()
+
+
+def is_celery_app(candidate: object) -> TypeGuard[CeleryAppType]:
+    if not CELERY_AVAILABLE:
+        return False
+
+    from celery import Celery as CeleryApp  # type: ignore[import-untyped]
+
+    return isinstance(candidate, CeleryApp)
+
+
+def is_vercel_dramatiq_broker(
+    candidate: object,
+) -> TypeGuard[DramatiqBrokerType]:
+    if not DRAMATIQ_AVAILABLE:
+        return False
+
+    from .dramatiq import VercelQueuesBroker
+
+    return isinstance(candidate, VercelQueuesBroker)
+
+
+def _find_celery_app(module: object) -> CeleryAppType | None:
+    candidates = [
+        getattr(module, "app", None),
+        getattr(module, "worker", None),
+        getattr(module, "celery", None),
+    ]
+    for candidate in candidates:
+        if is_celery_app(candidate):
+            return candidate
+    return None
+
+
+def _bootstrap_celery_worker_app(module: object) -> object | None:
+    if not CELERY_AVAILABLE:
+        return None
+
+    celery_app = _find_celery_app(module)
+    if celery_app is None:
+        return None
+
+    from .celery import get_asgi_app
+
+    return get_asgi_app(celery_app)
+
+
+def _bootstrap_dramatiq_worker_app(module: object) -> object | None:
+    if not DRAMATIQ_AVAILABLE:
+        return None
+
+    import dramatiq
+
+    from .dramatiq import get_asgi_app
+
+    broker_candidates: list[object] = []
+    module_broker = getattr(module, "broker", None)
+    if module_broker is not None:
+        broker_candidates.append(module_broker)
+
+    with contextlib.suppress(Exception):
+        broker_candidates.append(dramatiq.get_broker())
+
+    resolved_broker: DramatiqBrokerType | None = None
+    for broker in broker_candidates:
+        if is_vercel_dramatiq_broker(broker):
+            resolved_broker = broker
+            break
+
+    if resolved_broker is None:
+        return None
+
+    if not resolved_broker.get_declared_actors():
+        raise RuntimeError(
+            "Worker service did not register any Dramatiq actors. "
+            "Ensure your worker entrypoint imports task modules before startup."
+        )
+
+    return get_asgi_app(resolved_broker)
+
+
+def _bootstrap_django_worker_app() -> object | None:
+    if not DJANGO_TASKS_AVAILABLE:
+        return None
+
+    from .django import get_asgi_app
+
+    return get_asgi_app()
+
+
+def _bootstrap_generic_worker_app() -> object | None:
+    if not has_subscriptions():
+        return None
+    return get_generic_asgi_app()
+
+
+def _resolve_worker_service_app(module: object) -> object | None:
+    bootstrappers = (
+        ("Celery", lambda: _bootstrap_celery_worker_app(module)),
+        ("Dramatiq", lambda: _bootstrap_dramatiq_worker_app(module)),
+        ("Django tasks", _bootstrap_django_worker_app),
+    )
+
+    for label, bootstrap in bootstrappers:
+        try:
+            app = bootstrap()
+        except Exception as exc:
+            raise RuntimeError(f"{label} worker bootstrap failed.") from exc
+        if app is not None:
+            return app
+
+    return _bootstrap_generic_worker_app()
+
+
+def maybe_bootstrap_worker_service_app(module: object) -> object | None:
+    exported_names = dir(module)
+    app = _resolve_worker_service_app(module)
+    if app is not None:
+        return app
+
+    if "app" in exported_names:
+        return None
+
+    raise RuntimeError(
+        "Unable to bootstrap worker service. "
+        "Export an ASGI/WSGI app, or configure "
+        "Celery/Dramatiq/Django via vercel-workers."
+    )

--- a/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, cast
 
 from ..client import _DEPLOYMENT_ID_UNSET, WorkerJSONEncoder, _DeploymentIdOption, send
 
@@ -383,7 +383,8 @@ class VercelQueuesBroker(Broker):
 
     def get_declared_actors(self) -> set[str]:
         """Get the set of declared actor names."""
-        return set()
+        actors = cast("Mapping[str, object]", self.actors)
+        return set(actors)
 
     def get_declared_queues(self) -> set[str]:
         """Get the set of declared queue names."""

--- a/python/vercel-workers/tests/test_dramatiq_adapter.py
+++ b/python/vercel-workers/tests/test_dramatiq_adapter.py
@@ -83,6 +83,7 @@ class TestVercelQueuesBroker:
         broker = VercelQueuesBroker()
         assert isinstance(broker.options, VercelQueuesBrokerOptions)
         assert len(broker.get_declared_queues()) == 0
+        assert broker.get_declared_actors() == set()
 
     def test_broker_with_options(self):
         broker = VercelQueuesBroker(options={"timeout": 20.0})
@@ -103,6 +104,15 @@ class TestVercelQueuesBroker:
         broker = VercelQueuesBroker()
         broker.declare_queue("my-queue")
         assert broker.get_declared_delay_queues() == set()
+
+    def test_get_declared_actors(self):
+        broker = VercelQueuesBroker()
+
+        @dramatiq.actor(broker=broker, queue_name="actor-registration-test")
+        def registered_actor() -> None:
+            pass
+
+        assert "registered_actor" in broker.get_declared_actors()
 
     def test_consume_raises_not_implemented(self):
         broker = VercelQueuesBroker()

--- a/python/vercel-workers/tests/test_runtime_bridge.py
+++ b/python/vercel-workers/tests/test_runtime_bridge.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import types
+import unittest
+from unittest.mock import patch
+
+import vercel.workers._runtime as vwr
+
+
+class TestPrepareEnvironment(unittest.TestCase):
+    def test_defaults_celery_broker_url_for_worker_services(self) -> None:
+        environ = {"VERCEL_HAS_WORKER_SERVICES": "1"}
+
+        with patch.object(vwr, "_install_celery_transport_alias") as install_alias:
+            vwr.prepare_environment(environ)
+
+        self.assertEqual(
+            environ.get("CELERY_BROKER_URL"),
+            "vercel://",
+        )
+        install_alias.assert_called_once_with()
+
+    def test_does_not_override_user_defined_celery_broker_url(self) -> None:
+        environ = {
+            "VERCEL_HAS_WORKER_SERVICES": "1",
+            "CELERY_BROKER_URL": "redis://localhost:6379/0",
+        }
+
+        with patch.object(vwr, "_install_celery_transport_alias") as install_alias:
+            vwr.prepare_environment(environ)
+
+        self.assertEqual(
+            environ.get("CELERY_BROKER_URL"),
+            "redis://localhost:6379/0",
+        )
+        install_alias.assert_called_once_with()
+
+    def test_registers_aliases_for_user_defined_vercel_broker(self) -> None:
+        environ = {"CELERY_BROKER_URL": "vercel://"}
+
+        with patch.object(vwr, "_install_celery_transport_alias") as install_alias:
+            vwr.prepare_environment(environ)
+
+        install_alias.assert_called_once_with()
+
+    def test_skips_setup_without_workers_or_vercel_broker(self) -> None:
+        with patch.object(vwr, "_install_celery_transport_alias") as install_alias:
+            vwr.prepare_environment({})
+
+        install_alias.assert_not_called()
+
+
+class TestWorkerBootstrapBridge(unittest.TestCase):
+    def test_maybe_bootstrap_worker_service_app_returns_explicit_app(self) -> None:
+        module = types.SimpleNamespace(app=object())
+
+        with patch.object(vwr, "_resolve_worker_service_app", return_value=None):
+            app = vwr.maybe_bootstrap_worker_service_app(module)
+
+        self.assertIsNone(app)
+
+    def test_maybe_bootstrap_worker_service_app_prefers_worker_integration(self) -> None:
+        module = types.SimpleNamespace(app=object(), worker=object())
+        expected_app = object()
+
+        with patch.object(vwr, "_resolve_worker_service_app", return_value=expected_app):
+            app = vwr.maybe_bootstrap_worker_service_app(module)
+
+        self.assertIs(app, expected_app)
+
+    def test_resolve_worker_service_app_uses_generic_subscriptions(self) -> None:
+        expected_app = object()
+
+        with (
+            patch.object(vwr, "_bootstrap_celery_worker_app", return_value=None),
+            patch.object(vwr, "_bootstrap_dramatiq_worker_app", return_value=None),
+            patch.object(vwr, "_bootstrap_django_worker_app", return_value=None),
+            patch.object(vwr, "has_subscriptions", return_value=True),
+            patch.object(vwr, "get_generic_asgi_app", return_value=expected_app),
+        ):
+            app = vwr._resolve_worker_service_app(types.SimpleNamespace())
+
+        self.assertIs(app, expected_app)
+
+    def test_bootstrap_worker_service_app_wraps_framework_errors(self) -> None:
+        with (
+            patch.object(
+                vwr,
+                "_bootstrap_celery_worker_app",
+                side_effect=ValueError("boom"),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Celery worker bootstrap failed.",
+            ):
+                vwr.maybe_bootstrap_worker_service_app(types.SimpleNamespace())


### PR DESCRIPTION
Refactors specific framework-bootstrapping logic out of vercel-runtime `workers.py` into vercel-workers `_runtime.py` which exposes 2 functions that vercel-runtime calls into:
* `prepare_environment(...)`
* `maybe_bootstrap_worker_service_app(...)`

This is a cleaner separation of concerns since vercel-runtime shouldn't have to worry about whether Celery, Dramatiq, Django, etc. is installed