### PR TITLE
Fix env pull JSON parse error on values with backslashes

### DIFF
--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -17,7 +17,6 @@ import {
 } from '../../util/env/diff-env-files';
 import { isErrnoException } from '@vercel/error-utils';
 import { addToGitIgnore } from '../../util/link/add-to-gitignore';
-import JSONparse from 'json-parse-better-errors';
 import { formatProject } from '../../util/projects/format-project';
 import type { ProjectLinked } from '@vercel-internals/types';
 import output from '../../output-manager';
@@ -306,17 +305,13 @@ function escapeValue(value: string | undefined) {
 }
 
 function getDownloadedEnv(records: Record<string, string | undefined>) {
-  // Removes any double quotes from `records`, if they exist.
-  // We need this because double quotes are stripped from the local .env file,
-  // but `records` is already in the form of a JSON object that doesn't filter
-  // double quotes.
-  return JSONparse(
-    JSON.stringify(
-      Object.fromEntries(
-        Object.entries(records).filter(
-          ([key]) => !VARIABLES_TO_IGNORE.includes(key)
-        )
-      )
-    ).replace(/\\"/g, '')
+  // Removes any double quotes from values, if they exist.
+  // We need this because double quotes are stripped from the local .env file
+  // (by createEnvObject), so we strip them here too to ensure consistent
+  // comparison between local and remote values.
+  return Object.fromEntries(
+    Object.entries(records)
+      .filter(([key]) => !VARIABLES_TO_IGNORE.includes(key))
+      .map(([key, value]) => [key, value?.replace(/"/g, '')])
   ) as Record<string, string | undefined>;
 }

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -498,6 +498,46 @@ describe('env pull', () => {
     expect(client.input.confirm).not.toHaveBeenCalled();
   });
 
+  it('should handle env values containing backslashes', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject(
+      {
+        ...defaultProject,
+        id: 'vercel-env-pull',
+        name: 'vercel-env-pull',
+      },
+      [
+        ...envs,
+        {
+          type: 'encrypted',
+          id: '781dt89g8r2h789g',
+          key: 'PATH_WITH_BACKSLASH',
+          value: 'C:\\Users\\foo\\',
+          target: ['development'],
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    const cwd = setupUnitFixture('vercel-env-pull');
+    client.cwd = cwd;
+    client.setArgv('env', 'pull', '--yes');
+    const exitCodePromise = env(client);
+    await expect(client.stderr).toOutput(
+      'Downloading `development` Environment Variables for'
+    );
+    await expect(client.stderr).toOutput(
+      'Created .env.local file and added it to .gitignore'
+    );
+    const exitCode = await exitCodePromise;
+    expect(exitCode).toEqual(0);
+
+    const pulledEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(pulledEnv).toContain('PATH_WITH_BACKSLASH="C:\\Users\\foo\\"');
+  });
+
   it('should correctly render delta string when env variable has quotes', async () => {
     const cwd = setupUnitFixture('vercel-env-pull-delta-quotes');
     client.cwd = cwd;


### PR DESCRIPTION
## Summary

- Fixes `SyntaxError: Expected property name or '}' in JSON` when running `vc env pull` with env values containing backslashes
- The `getDownloadedEnv` function (introduced in #15420) used `JSON.stringify(...).replace(/\\"/g, '')` then `JSONparse()` to strip double quotes from values. If any value contained a trailing backslash (e.g. a Windows path like `C:\Users\foo\`), the regex would also remove the JSON string delimiter, producing invalid JSON.
- Strips quotes directly from values instead of manipulating serialized JSON

## Test plan

- [x] All 23 existing `env pull` unit tests pass
- [ ] Manually test `vc env pull` with env values containing backslashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)