### PR TITLE
Revert "[python] Cache venv and uv cache using prepareCache."

### DIFF
--- a/.changeset/cool-planets-turn.md
+++ b/.changeset/cool-planets-turn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Revert the prepareCache python implementation.

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -25,7 +25,6 @@ import {
   type ShouldServe,
   FileFsRef,
   PythonFramework,
-  type PrepareCache,
 } from '@vercel/build-utils';
 import {
   discoverPackage,
@@ -35,7 +34,7 @@ import {
   installRequirement,
 } from './install';
 import { PythonDependencyExternalizer } from './dependency-externalizer';
-import { UvRunner, getUvBinaryOrInstall, getUvCacheDir } from './uv';
+import { UvRunner, getUvBinaryOrInstall } from './uv';
 import { resolvePythonVersion, pythonVersionString } from './version';
 import { startDevServer } from './start-dev-server';
 import { runPyprojectScript, ensureVenv, createVenvEnv } from './utils';
@@ -251,12 +250,10 @@ export const build: BuildV3 = async ({
   // Create a virtual environment under ".vercel/python/.venv" so dependencies
   // can be installed via `uv sync` and then vendored into the Lambda bundle.
   const venvPath = join(workPath, '.vercel', 'python', '.venv');
-  const uvCacheDir = getUvCacheDir(workPath);
   await builderSpan.child('vc.builder.python.venv').trace(async () => {
     await ensureVenv({
       pythonPath: pythonVersion.pythonPath,
       venvPath,
-      uvCacheDir,
     });
   });
 
@@ -289,7 +286,7 @@ export const build: BuildV3 = async ({
   }
 
   const baseEnv = spawnEnv || process.env;
-  const pythonEnv = createVenvEnv(venvPath, baseEnv, uvCacheDir);
+  const pythonEnv = createVenvEnv(venvPath, baseEnv);
 
   pythonEnv.VERCEL_PYTHON_VENV_PATH = venvPath;
 
@@ -302,7 +299,7 @@ export const build: BuildV3 = async ({
   try {
     const uvPath = await getUvBinaryOrInstall(pythonVersion.pythonPath);
     console.log(`Using uv at "${uvPath}"`);
-    uv = new UvRunner(uvPath, uvCacheDir);
+    uv = new UvRunner(uvPath);
   } catch (err) {
     console.log('Failed to install or locate uv');
     throw new Error(
@@ -661,48 +658,6 @@ from vercel_runtime.vc_init import vc_handler
 };
 
 export { startDevServer };
-
-async function readBuildOutputV3Config(
-  workPath: string
-): Promise<{ cache?: string[] } | undefined> {
-  try {
-    const configPath = join(workPath, '.vercel', 'output', 'config.json');
-    return JSON.parse(await fs.promises.readFile(configPath, 'utf8'));
-  } catch (err: any) {
-    if (err.code !== 'ENOENT') {
-      throw err;
-    }
-  }
-  return undefined;
-}
-
-export const prepareCache: PrepareCache = async ({
-  repoRootPath,
-  workPath,
-}) => {
-  const cacheFiles: Files = {};
-  const root = repoRootPath || workPath;
-  const ignore = ['**/*.pyc', '**/__pycache__/**'];
-
-  const configV3 = await readBuildOutputV3Config(workPath);
-  if (configV3?.cache && Array.isArray(configV3.cache)) {
-    for (const cacheGlob of configV3.cache) {
-      Object.assign(cacheFiles, await glob(cacheGlob, workPath));
-    }
-    return cacheFiles;
-  }
-
-  Object.assign(
-    cacheFiles,
-    await glob('**/.vercel/python/.venv/**', { cwd: root, ignore })
-  );
-  Object.assign(
-    cacheFiles,
-    await glob('**/.vercel/python/cache/uv/**', { cwd: root, ignore })
-  );
-
-  return cacheFiles;
-};
 
 export const shouldServe: ShouldServe = opts => {
   const framework = opts.config.framework;

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -12,12 +12,7 @@ import {
   type PythonPackage,
 } from '@vercel/python-analysis';
 import { getVenvPythonBin } from './utils';
-import {
-  UvRunner,
-  filterUnsafeUvPipArgs,
-  getProtectedUvEnv,
-  getUvCacheDir,
-} from './uv';
+import { UvRunner, filterUnsafeUvPipArgs, getProtectedUvEnv } from './uv';
 import { DEFAULT_PYTHON_VERSION_STRING } from './version';
 
 const makeDependencyCheckCode = (dependency: string) => `
@@ -405,7 +400,7 @@ async function pipInstall(
     try {
       await execa(uvPath!, uvArgs, {
         cwd: workPath,
-        env: getProtectedUvEnv(process.env, getUvCacheDir(workPath)),
+        env: getProtectedUvEnv(),
       });
       return;
     } catch (err) {

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -529,12 +529,7 @@ async function getMultiServicePythonRunner(
 
   // Create a per-service .venv, so deps are managed separately.
   const venvPath = join(workPath, '.venv');
-  await ensureVenv({
-    pythonPath: systemPython,
-    venvPath,
-    uvPath,
-    quiet: true,
-  });
+  await ensureVenv({ pythonPath: systemPython, venvPath, uvPath, quiet: true });
   debug(`Created virtualenv at ${venvPath} for multi-service dev`);
 
   const pythonBin = getVenvPythonBin(venvPath);

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -44,11 +44,10 @@ export function useVirtualEnv(
 
 export function createVenvEnv(
   venvPath: string,
-  baseEnv: NodeJS.ProcessEnv = process.env,
-  uvCacheDir?: string
+  baseEnv: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
-    ...getProtectedUvEnv(baseEnv, uvCacheDir),
+    ...getProtectedUvEnv(baseEnv),
     VIRTUAL_ENV: venvPath,
   };
   const binDir = getVenvBinDir(venvPath);
@@ -61,13 +60,11 @@ export async function ensureVenv({
   pythonPath,
   venvPath,
   uvPath,
-  uvCacheDir,
   quiet,
 }: {
   pythonPath: string;
   venvPath: string;
   uvPath?: string | null;
-  uvCacheDir?: string;
   quiet?: boolean;
 }) {
   const marker = join(venvPath, 'pyvenv.cfg');
@@ -82,9 +79,7 @@ export async function ensureVenv({
     console.log(`Creating virtual environment at "${venvPath}"...`);
   }
   if (uvPath) {
-    await execa(uvPath, ['venv', venvPath], {
-      env: getProtectedUvEnv(process.env, uvCacheDir),
-    });
+    await execa(uvPath, ['venv', venvPath]);
   } else {
     await execa(pythonPath, ['-m', 'venv', venvPath]);
   }

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -10,7 +10,6 @@ import { debug } from '@vercel/build-utils';
 export const UV_VERSION = '0.9.22';
 export const UV_PYTHON_PATH_PREFIX = '/uv/python/';
 export const UV_PYTHON_DOWNLOADS_MODE = 'automatic';
-export const UV_CACHE_DIR_SUBPATH = ['.vercel', 'python', 'cache', 'uv'];
 
 const isWin = process.platform === 'win32';
 const uvExec = isWin ? 'uv.exe' : 'uv';
@@ -28,17 +27,11 @@ export function findUvInPath(): string | null {
   return which.sync('uv', { nothrow: true });
 }
 
-export function getUvCacheDir(workPath: string): string {
-  return join(workPath, ...UV_CACHE_DIR_SUBPATH);
-}
-
 export class UvRunner {
   private uvPath: string;
-  private uvCacheDir?: string;
 
-  constructor(uvPath: string, uvCacheDir?: string) {
+  constructor(uvPath: string) {
     this.uvPath = uvPath;
-    this.uvCacheDir = uvCacheDir;
   }
 
   getPath(): string {
@@ -139,7 +132,7 @@ export class UvRunner {
     try {
       await execa(this.uvPath, args, {
         cwd: projectDir,
-        env: getProtectedUvEnv(process.env, this.uvCacheDir),
+        env: getProtectedUvEnv(process.env),
       });
     } catch (err) {
       const error: Error & { code?: unknown } = new Error(
@@ -232,7 +225,7 @@ export class UvRunner {
     const existingPath = process.env.PATH || '';
 
     return {
-      ...getProtectedUvEnv(process.env, this.uvCacheDir),
+      ...getProtectedUvEnv(process.env),
       VIRTUAL_ENV: venvPath,
       PATH: existingPath ? `${binDir}${pathDelimiter}${existingPath}` : binDir,
     };
@@ -356,17 +349,12 @@ export function filterUnsafeUvPipArgs(args: string[]): string[] {
 }
 
 export function getProtectedUvEnv(
-  baseEnv: NodeJS.ProcessEnv = process.env,
-  uvCacheDir?: string
+  baseEnv: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {
+  return {
     ...baseEnv,
     UV_PYTHON_DOWNLOADS: UV_PYTHON_DOWNLOADS_MODE,
   };
-  if (uvCacheDir) {
-    env.UV_CACHE_DIR = uvCacheDir;
-  }
-  return env;
 }
 
 /**

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -48,13 +48,9 @@ import {
   resetInstalledPythonsCache,
 } from '../src/version';
 import type { PythonConstraint, PythonPackage } from '@vercel/python-analysis';
-import { build, prepareCache } from '../src/index';
+import { build } from '../src/index';
 import { createVenvEnv, getVenvBinDir } from '../src/utils';
-import {
-  UV_PYTHON_DOWNLOADS_MODE,
-  getProtectedUvEnv,
-  getUvCacheDir,
-} from '../src/uv';
+import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
 import { VERCEL_WORKERS_VERSION } from '../src/package-versions';
 import { createPyprojectToml } from '../src/install';
 import { detectDjangoPythonEntrypoint } from '../src/entrypoint';
@@ -161,98 +157,6 @@ afterEach(() => {
   if (fs.existsSync(tmpPythonDir)) {
     fs.removeSync(tmpPythonDir);
   }
-});
-
-describe('prepareCache()', () => {
-  it('caches the builder virtualenv and uv cache under .vercel/python, excluding bytecode caches', async () => {
-    const workPath = path.join(
-      tmpdir(),
-      `vc-python-cache-${Math.floor(Math.random() * 1e6)}`
-    );
-
-    await fs.outputFile(
-      path.join(workPath, '.vercel/python/.venv/pyvenv.cfg'),
-      'home = /usr/bin\n'
-    );
-    await fs.outputFile(
-      path.join(workPath, '.vercel/python/.venv/bin/python'),
-      ''
-    );
-    await fs.outputFile(
-      path.join(workPath, '.vercel/python/.venv/lib/site.pyc'),
-      ''
-    );
-    await fs.outputFile(
-      path.join(
-        workPath,
-        '.vercel/python/.venv/lib/__pycache__/site.cpython-312.pyc'
-      ),
-      ''
-    );
-    await fs.outputFile(
-      path.join(workPath, '.vercel/python/cache/uv/wheels/example.whl'),
-      ''
-    );
-    await fs.outputFile(
-      path.join(workPath, '.vercel/python/cache/uv/archive/foo.pyc'),
-      ''
-    );
-    await fs.outputFile(path.join(workPath, 'app.py'), 'print("hello")\n');
-
-    try {
-      const files = await prepareCache({
-        files: {},
-        entrypoint: 'app.py',
-        config: {},
-        workPath,
-        repoRootPath: workPath,
-      });
-
-      expect(files['.vercel/python/.venv/pyvenv.cfg']).toBeDefined();
-      expect(files['.vercel/python/.venv/bin/python']).toBeDefined();
-      expect(files['.vercel/python/cache/uv/wheels/example.whl']).toBeDefined();
-      expect(files['.vercel/python/.venv/lib/site.pyc']).toBeUndefined();
-      expect(
-        files['.vercel/python/.venv/lib/__pycache__/site.cpython-312.pyc']
-      ).toBeUndefined();
-      expect(files['.vercel/python/cache/uv/archive/foo.pyc']).toBeUndefined();
-      expect(files['app.py']).toBeUndefined();
-    } finally {
-      await fs.remove(workPath);
-    }
-  });
-
-  it('uses Build Output API v3 cache globs when config.json is present', async () => {
-    const workPath = path.join(
-      tmpdir(),
-      `vc-python-build-output-cache-${Math.floor(Math.random() * 1e6)}`
-    );
-
-    await fs.outputJson(path.join(workPath, '.vercel/output/config.json'), {
-      cache: ['custom-cache/**'],
-    });
-    await fs.outputFile(path.join(workPath, 'custom-cache/result.txt'), '1\n');
-    await fs.outputFile(
-      path.join(workPath, '.vercel/python/.venv/pyvenv.cfg'),
-      'home = /usr/bin\n'
-    );
-
-    try {
-      const files = await prepareCache({
-        files: {},
-        entrypoint: 'app.py',
-        config: {},
-        workPath,
-        repoRootPath: workPath,
-      });
-
-      expect(Object.keys(files).sort()).toStrictEqual([
-        'custom-cache/result.txt',
-      ]);
-    } finally {
-      await fs.remove(workPath);
-    }
-  });
 });
 
 it('should only match supported versions, otherwise throw an error', () => {
@@ -2590,27 +2494,19 @@ describe('UV_PYTHON_DOWNLOADS environment variable protection', () => {
       expect(env.HOME).toBe('/home/user');
       expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
-
-    it('sets UV_CACHE_DIR when provided', () => {
-      const cacheDir = '/tmp/project/.vercel/python/cache/uv';
-      const env = getProtectedUvEnv({}, cacheDir);
-      expect(env.UV_CACHE_DIR).toBe(cacheDir);
-    });
   });
 
   describe('createVenvEnv', () => {
-    it('sets VIRTUAL_ENV and PATH correctly while protecting uv env', () => {
+    it('sets VIRTUAL_ENV and PATH correctly while protecting UV_PYTHON_DOWNLOADS', () => {
       process.env.UV_PYTHON_DOWNLOADS = 'manual';
       process.env.PATH = '/usr/bin';
       const venvPath = '/path/to/venv';
-      const cacheDir = getUvCacheDir('/repo');
-      const env = createVenvEnv(venvPath, process.env, cacheDir);
+      const env = createVenvEnv(venvPath);
 
       expect(env.VIRTUAL_ENV).toBe(venvPath);
       expect(env.PATH).toContain(getVenvBinDir(venvPath));
       expect(env.PATH).toContain('/usr/bin');
       expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
-      expect(env.UV_CACHE_DIR).toBe(cacheDir);
     });
   });
 });


### PR DESCRIPTION
Reverts vercel/vercel#15407
Caching the `.venv` causes `.venv` to grow over time as stale packages are not pruned. This causes the cache to grow larger and the runtime dependency externalizer counts everything in the `.venv`. That leads to a functions runtime uncompressed size to be improperly calculated.