### PR TITLE
Restore env pull preview with backslash-safe parsing

### DIFF
--- a/.changeset/reapply-env-pull-local-preview.md
+++ b/.changeset/reapply-env-pull-local-preview.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Improve `vercel env pull` so local-only environment variables are preserved and planned changes are previewed before confirmation.
+Improve `vercel env pull` so local-only environment variables are preserved, planned changes are previewed before confirmation, and values ending in backslashes are handled safely.

--- a/.changeset/reapply-env-pull-local-preview.md
+++ b/.changeset/reapply-env-pull-local-preview.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve `vercel env pull` so local-only environment variables are preserved and planned changes are previewed before confirmation.

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -229,13 +229,14 @@ export async function envPullCommandLogic(
   let deltaString = '';
   let oldEnv;
   const downloadedEnv = getDownloadedEnv(records);
+  const comparableDownloadedEnv = getComparableDownloadedEnv(downloadedEnv);
 
   if (exists) {
     oldEnv = await createEnvObject(fullPath);
     if (oldEnv) {
       deltaString = buildDeltaString(oldEnv, {
         ...oldEnv,
-        ...downloadedEnv,
+        ...comparableDownloadedEnv,
       });
     }
   }
@@ -305,13 +306,24 @@ function escapeValue(value: string | undefined) {
 }
 
 function getDownloadedEnv(records: Record<string, string | undefined>) {
+  return Object.fromEntries(
+    Object.entries(records).filter(
+      ([key]) => !VARIABLES_TO_IGNORE.includes(key)
+    )
+  ) as Record<string, string | undefined>;
+}
+
+function getComparableDownloadedEnv(
+  downloadedEnv: Record<string, string | undefined>
+) {
   // Removes any double quotes from values, if they exist.
   // We need this because double quotes are stripped from the local .env file
   // (by createEnvObject), so we strip them here too to ensure consistent
   // comparison between local and remote values.
   return Object.fromEntries(
-    Object.entries(records)
-      .filter(([key]) => !VARIABLES_TO_IGNORE.includes(key))
-      .map(([key, value]) => [key, value?.replace(/"/g, '')])
+    Object.entries(downloadedEnv).map(([key, value]) => [
+      key,
+      value?.replace(/"/g, ''),
+    ])
   ) as Record<string, string | undefined>;
 }

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -176,36 +176,31 @@ export async function envPullCommandLogic(
   const fullPath = resolve(cwd, filename);
   const head = tryReadHeadSync(fullPath, Buffer.byteLength(CONTENTS_PREFIX));
   const exists = typeof head !== 'undefined';
+  const requiresConfirmation =
+    exists &&
+    head !== CONTENTS_PREFIX &&
+    !skipConfirmation &&
+    !client.nonInteractive;
 
   if (head === CONTENTS_PREFIX) {
     output.log(`Overwriting existing ${chalk.bold(filename)} file`);
-  } else if (exists && !skipConfirmation) {
-    if (client.nonInteractive) {
-      outputActionRequired(client, {
-        status: 'action_required',
-        reason: 'env_file_exists',
-        message: `File ${param(filename)} already exists and was not created by Vercel CLI. Use --yes to overwrite or specify a different filename.`,
-        next: [
-          {
-            command: getCommandNamePlain(`env pull ${filename} --yes`),
-            when: 'Overwrite this file',
-          },
-          {
-            command: getCommandNamePlain('env pull <filename>'),
-            when: 'Use a different filename',
-          },
-        ],
-      });
-    }
-    if (
-      !(await client.input.confirm(
-        `Found existing file ${param(filename)}. Do you want to overwrite?`,
-        false
-      ))
-    ) {
-      output.log('Canceled');
-      return;
-    }
+  } else if (exists && !skipConfirmation && client.nonInteractive) {
+    outputActionRequired(client, {
+      status: 'action_required',
+      reason: 'env_file_exists',
+      message: `File ${param(filename)} already exists and was not created by Vercel CLI. Use --yes to apply the downloaded changes or specify a different filename.`,
+      next: [
+        {
+          command: getCommandNamePlain(`env pull ${filename} --yes`),
+          when: 'Apply the downloaded changes to this file',
+        },
+        {
+          command: getCommandNamePlain('env pull <filename>'),
+          when: 'Use a different filename',
+        },
+      ],
+    });
+    return;
   }
 
   const projectSlugLink = formatProject(link.org.slug, link.project.name);
@@ -234,34 +229,52 @@ export async function envPullCommandLogic(
 
   let deltaString = '';
   let oldEnv;
+  const downloadedEnv = getDownloadedEnv(records);
+
   if (exists) {
     oldEnv = await createEnvObject(fullPath);
     if (oldEnv) {
-      // Removes any double quotes from `records`, if they exist
-      // We need this because double quotes are stripped from the local .env file,
-      // but `records` is already in the form of a JSON object that doesn't filter
-      // double quotes.
-      const newEnv = JSONparse(JSON.stringify(records).replace(/\\"/g, ''));
-      deltaString = buildDeltaString(oldEnv, newEnv);
+      deltaString = buildDeltaString(oldEnv, {
+        ...oldEnv,
+        ...downloadedEnv,
+      });
     }
   }
 
-  const contents =
-    CONTENTS_PREFIX +
-    Object.keys(records)
-      .sort()
-      .filter(key => !VARIABLES_TO_IGNORE.includes(key))
-      .map(key => `${key}="${escapeValue(records[key])}"`)
-      .join('\n') +
-    '\n';
-
-  await outputFile(fullPath, contents, 'utf8');
+  const envToWrite = oldEnv
+    ? {
+        ...oldEnv,
+        ...downloadedEnv,
+      }
+    : downloadedEnv;
 
   if (deltaString) {
     output.print('\n' + deltaString);
   } else if (oldEnv && exists) {
     output.log('No changes found.');
   }
+
+  if (
+    requiresConfirmation &&
+    deltaString !== '' &&
+    !(await client.input.confirm(
+      `Apply these changes to ${param(filename)}?`,
+      false
+    ))
+  ) {
+    output.log('Canceled');
+    return;
+  }
+
+  const contents =
+    CONTENTS_PREFIX +
+    Object.keys(envToWrite)
+      .sort()
+      .map(key => `${key}="${escapeValue(envToWrite[key])}"`)
+      .join('\n') +
+    '\n';
+
+  await outputFile(fullPath, contents, 'utf8');
 
   let isGitIgnoreUpdated = false;
   if (filename === '.env.local') {
@@ -290,4 +303,20 @@ function escapeValue(value: string | undefined) {
         .replace(new RegExp('\n', 'g'), '\\n') // combine newlines (unix) into one line
         .replace(new RegExp('\r', 'g'), '\\r') // combine newlines (windows) into one line
     : '';
+}
+
+function getDownloadedEnv(records: Record<string, string | undefined>) {
+  // Removes any double quotes from `records`, if they exist.
+  // We need this because double quotes are stripped from the local .env file,
+  // but `records` is already in the form of a JSON object that doesn't filter
+  // double quotes.
+  return JSONparse(
+    JSON.stringify(
+      Object.fromEntries(
+        Object.entries(records).filter(
+          ([key]) => !VARIABLES_TO_IGNORE.includes(key)
+        )
+      )
+    ).replace(/\\"/g, '')
+  ) as Record<string, string | undefined>;
 }

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -175,15 +175,18 @@ export async function envPullCommandLogic(
   const fullPath = resolve(cwd, filename);
   const head = tryReadHeadSync(fullPath, Buffer.byteLength(CONTENTS_PREFIX));
   const exists = typeof head !== 'undefined';
-  const requiresConfirmation =
-    exists &&
-    head !== CONTENTS_PREFIX &&
-    !skipConfirmation &&
-    !client.nonInteractive;
+  const isCliManagedFile = head === CONTENTS_PREFIX;
+  const isUserManagedExistingFile = exists && !isCliManagedFile;
+  const shouldConfirmChanges =
+    isUserManagedExistingFile && !skipConfirmation && !client.nonInteractive;
 
-  if (head === CONTENTS_PREFIX) {
+  if (isCliManagedFile) {
     output.log(`Overwriting existing ${chalk.bold(filename)} file`);
-  } else if (exists && !skipConfirmation && client.nonInteractive) {
+  } else if (
+    isUserManagedExistingFile &&
+    !skipConfirmation &&
+    client.nonInteractive
+  ) {
     outputActionRequired(client, {
       status: 'action_required',
       reason: 'env_file_exists',
@@ -226,38 +229,28 @@ export async function envPullCommandLogic(
     })
   ).env;
 
-  let deltaString = '';
   let oldEnv;
-  const downloadedEnv = getDownloadedEnv(records);
-
   if (exists) {
     oldEnv = await createEnvObject(fullPath);
   }
 
-  const envToWrite = oldEnv
-    ? {
-        ...oldEnv,
-        ...downloadedEnv,
-      }
-    : downloadedEnv;
-  const comparableEnvToWrite = getComparableEnv(envToWrite);
+  const { envToWrite, deltaString, hasChanges } = prepareEnvPullState(
+    oldEnv,
+    records
+  );
 
-  if (oldEnv) {
-    deltaString = buildDeltaString(oldEnv, comparableEnvToWrite);
-  }
-
-  if (deltaString) {
+  if (hasChanges) {
     output.print('\n' + deltaString);
   } else if (oldEnv && exists) {
     output.log('No changes found.');
-    if (head !== CONTENTS_PREFIX) {
+    if (isUserManagedExistingFile) {
       return;
     }
   }
 
   if (
-    requiresConfirmation &&
-    deltaString !== '' &&
+    shouldConfirmChanges &&
+    hasChanges &&
     !(await client.input.confirm(
       `Apply these changes to ${param(filename)}?`,
       false
@@ -314,7 +307,7 @@ function getDownloadedEnv(records: Record<string, string | undefined>) {
   ) as Record<string, string | undefined>;
 }
 
-function getComparableEnv(env: Record<string, string | undefined>) {
+function normalizeEnvForComparison(env: Record<string, string | undefined>) {
   // Removes any double quotes from values, if they exist.
   // We need this because double quotes are stripped from parsed local env
   // files (by createEnvObject), so we strip them here too to ensure
@@ -322,4 +315,28 @@ function getComparableEnv(env: Record<string, string | undefined>) {
   return Object.fromEntries(
     Object.entries(env).map(([key, value]) => [key, value?.replace(/"/g, '')])
   ) as Record<string, string | undefined>;
+}
+
+function prepareEnvPullState(
+  oldEnv: Record<string, string | undefined> | undefined,
+  records: Record<string, string | undefined>
+) {
+  const downloadedEnv = getDownloadedEnv(records);
+  const envToWrite = oldEnv
+    ? {
+        ...oldEnv,
+        ...downloadedEnv,
+      }
+    : downloadedEnv;
+  const normalizedEnvToWrite = normalizeEnvForComparison(envToWrite);
+  const deltaString = oldEnv
+    ? buildDeltaString(oldEnv, normalizedEnvToWrite)
+    : '';
+  const hasChanges = deltaString.length > 0;
+
+  return {
+    envToWrite,
+    deltaString,
+    hasChanges,
+  };
 }

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -229,16 +229,9 @@ export async function envPullCommandLogic(
   let deltaString = '';
   let oldEnv;
   const downloadedEnv = getDownloadedEnv(records);
-  const comparableDownloadedEnv = getComparableDownloadedEnv(downloadedEnv);
 
   if (exists) {
     oldEnv = await createEnvObject(fullPath);
-    if (oldEnv) {
-      deltaString = buildDeltaString(oldEnv, {
-        ...oldEnv,
-        ...comparableDownloadedEnv,
-      });
-    }
   }
 
   const envToWrite = oldEnv
@@ -247,11 +240,19 @@ export async function envPullCommandLogic(
         ...downloadedEnv,
       }
     : downloadedEnv;
+  const comparableEnvToWrite = getComparableEnv(envToWrite);
+
+  if (oldEnv) {
+    deltaString = buildDeltaString(oldEnv, comparableEnvToWrite);
+  }
 
   if (deltaString) {
     output.print('\n' + deltaString);
   } else if (oldEnv && exists) {
     output.log('No changes found.');
+    if (head !== CONTENTS_PREFIX) {
+      return;
+    }
   }
 
   if (
@@ -313,17 +314,12 @@ function getDownloadedEnv(records: Record<string, string | undefined>) {
   ) as Record<string, string | undefined>;
 }
 
-function getComparableDownloadedEnv(
-  downloadedEnv: Record<string, string | undefined>
-) {
+function getComparableEnv(env: Record<string, string | undefined>) {
   // Removes any double quotes from values, if they exist.
-  // We need this because double quotes are stripped from the local .env file
-  // (by createEnvObject), so we strip them here too to ensure consistent
-  // comparison between local and remote values.
+  // We need this because double quotes are stripped from parsed local env
+  // files (by createEnvObject), so we strip them here too to ensure
+  // comparisons reflect what the local parser sees.
   return Object.fromEntries(
-    Object.entries(downloadedEnv).map(([key, value]) => [
-      key,
-      value?.replace(/"/g, ''),
-    ])
+    Object.entries(env).map(([key, value]) => [key, value?.replace(/"/g, '')])
   ) as Record<string, string | undefined>;
 }

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -17,7 +17,6 @@ import {
 } from '../../util/env/diff-env-files';
 import { isErrnoException } from '@vercel/error-utils';
 import { addToGitIgnore } from '../../util/link/add-to-gitignore';
-import JSONparse from 'json-parse-better-errors';
 import { formatProject } from '../../util/projects/format-project';
 import type { ProjectLinked } from '@vercel-internals/types';
 import output from '../../output-manager';
@@ -306,17 +305,13 @@ function escapeValue(value: string | undefined) {
 }
 
 function getDownloadedEnv(records: Record<string, string | undefined>) {
-  // Removes any double quotes from `records`, if they exist.
-  // We need this because double quotes are stripped from the local .env file,
-  // but `records` is already in the form of a JSON object that doesn't filter
-  // double quotes.
-  return JSONparse(
-    JSON.stringify(
-      Object.fromEntries(
-        Object.entries(records).filter(
-          ([key]) => !VARIABLES_TO_IGNORE.includes(key)
-        )
-      )
-    ).replace(/\\"/g, '')
+  // Removes any double quotes from values, if they exist.
+  // We need this because double quotes are stripped from the local .env file
+  // (by createEnvObject), so we strip them here too to ensure consistent
+  // comparison between local and remote values.
+  return Object.fromEntries(
+    Object.entries(records)
+      .filter(([key]) => !VARIABLES_TO_IGNORE.includes(key))
+      .map(([key, value]) => [key, value?.replace(/"/g, '')])
   ) as Record<string, string | undefined>;
 }

--- a/packages/cli/src/util/env/diff-env-files.ts
+++ b/packages/cli/src/util/env/diff-env-files.ts
@@ -33,7 +33,6 @@ function findChanges(
 ): {
   added: string[];
   changed: string[];
-  removed: string[];
 } {
   const added = [];
   const changed = [];
@@ -44,14 +43,11 @@ function findChanges(
     } else if (oldEnv[key] !== newEnv[key]) {
       changed.push(key);
     }
-    delete oldEnv[key];
   }
-  const removed = Object.keys(oldEnv);
 
   return {
     added,
     changed,
-    removed,
   };
 }
 
@@ -59,28 +55,23 @@ export function buildDeltaString(
   oldEnv: Dictionary<string | undefined>,
   newEnv: Dictionary<string | undefined>
 ): string {
-  const { added, changed, removed } = findChanges(oldEnv, newEnv);
+  const { added, changed } = findChanges(oldEnv, newEnv);
 
   let deltaString = '';
-  deltaString += chalk.green(addDeltaSection('+', changed, true));
+  deltaString += chalk.yellow(addDeltaSection('M', changed));
   deltaString += chalk.green(addDeltaSection('+', added));
-  deltaString += chalk.red(addDeltaSection('-', removed));
 
   return deltaString
     ? chalk.gray('Changes:\n') + deltaString + '\n'
     : deltaString;
 }
 
-function addDeltaSection(
-  prefix: string,
-  arr: string[],
-  changed: boolean = false
-): string {
+function addDeltaSection(prefix: string, arr: string[]): string {
   if (arr.length === 0) return '';
   return (
     arr
       .sort()
-      .map(item => `${prefix} ${item}${changed ? ' (Updated)' : ''}`)
+      .map(item => `${prefix} ${item}`)
       .join('\n') + '\n'
   );
 }

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -5,7 +5,7 @@ import { getWriteableDirectory } from '@vercel/build-utils';
 import build from '../../../../src/commands/build';
 import cliPkg from '../../../../src/util/pkg';
 import { client } from '../../../mocks/client';
-import { defaultProject, useProject } from '../../../mocks/project';
+import { defaultProject, envs, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 import { execSync } from 'child_process';
@@ -402,6 +402,47 @@ describe.skipIf(flakey)('build', () => {
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'flag:yes', value: 'TRUE' },
     ]);
+  });
+
+  it('should build after auto-pulling preview env values ending with a backslash', async () => {
+    const cwd = fixture('static-pull');
+    useUser();
+    useTeams('team_dummy');
+    useProject(
+      {
+        ...defaultProject,
+        id: 'vercel-pull-next',
+        name: 'vercel-pull-next',
+      },
+      [
+        ...envs,
+        {
+          type: 'encrypted',
+          id: '781dt89g8r2h789g',
+          key: 'PATH_WITH_BACKSLASH',
+          value: 'C:\\Users\\foo\\',
+          target: ['preview'],
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    const envFilePath = join(cwd, '.vercel', '.env.preview.local');
+    const projectJsonPath = join(cwd, '.vercel', 'project.json');
+    const originalProjectJson = await fs.readJSON(projectJsonPath);
+    try {
+      client.cwd = cwd;
+      client.setArgv('build', '--yes');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      const previewEnv = await fs.readFile(envFilePath, 'utf8');
+      expect(previewEnv).toContain('PATH_WITH_BACKSLASH="C:\\Users\\foo\\"');
+    } finally {
+      await fs.remove(envFilePath);
+      await fs.writeJSON(projectJsonPath, originalProjectJson, { spaces: 2 });
+    }
   });
 
   it('should pull "production" env vars with `--prod`', async () => {

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -385,8 +385,7 @@ describe('env pull', () => {
     expect(client.stderr.getFullOutput()).not.toContain('- SPECIAL_FLAG');
 
     const pulledEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
-    expect(pulledEnv).toContain('LOCAL_ONLY="value"');
-    expect(pulledEnv).toContain('SPECIAL_FLAG="1"');
+    expect(pulledEnv).toEqual('LOCAL_ONLY=value\nSPECIAL_FLAG=1\n');
   });
 
   it('should show a delta string', async () => {
@@ -465,14 +464,22 @@ describe('env pull', () => {
       id: 'env-pull-delta-no-changes',
       name: 'env-pull-delta-no-changes',
     });
-    client.cwd = setupUnitFixture('vercel-env-pull-delta-no-changes');
+    const cwd = setupUnitFixture('vercel-env-pull-delta-no-changes');
+    const envFilePath = path.join(cwd, '.env.local');
+    const gitIgnorePath = path.join(cwd, '.gitignore');
+    const originalEnv = await fs.readFile(envFilePath, 'utf8');
+    const originalGitIgnore = await fs.readFile(gitIgnorePath, 'utf8');
+    client.cwd = cwd;
     client.setArgv('env', 'pull', '--yes');
     const pullPromise = env(client);
     await expect(client.stderr).toOutput('> No changes found.');
-    await expect(client.stderr).toOutput(
-      'Updated .env.local file and added it to .gitignore'
-    );
     await expect(pullPromise).resolves.toEqual(0);
+
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Updated .env.local file'
+    );
+    expect(await fs.readFile(envFilePath, 'utf8')).toEqual(originalEnv);
+    expect(await fs.readFile(gitIgnorePath, 'utf8')).toEqual(originalGitIgnore);
   });
 
   it('should not prompt for confirmation when no changes were found', async () => {
@@ -483,34 +490,29 @@ describe('env pull', () => {
       id: 'env-pull-delta-no-changes',
       name: 'env-pull-delta-no-changes',
     });
-    client.cwd = setupUnitFixture('vercel-env-pull-delta-no-changes');
+    const cwd = setupUnitFixture('vercel-env-pull-delta-no-changes');
+    const envFilePath = path.join(cwd, '.env.local');
+    const originalEnv = await fs.readFile(envFilePath, 'utf8');
+    client.cwd = cwd;
     client.input.confirm = vi.fn().mockResolvedValue(true);
 
     client.setArgv('env', 'pull');
     const pullPromise = env(client);
 
     await expect(client.stderr).toOutput('> No changes found.');
-    await expect(client.stderr).toOutput(
-      'Updated .env.local file and added it to .gitignore'
-    );
     await expect(pullPromise).resolves.toEqual(0);
 
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Updated .env.local file'
+    );
+    expect(await fs.readFile(envFilePath, 'utf8')).toEqual(originalEnv);
     expect(client.input.confirm).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      key: 'PATH_WITH_TRAILING_BACKSLASH',
-      value: 'C:\\Users\\foo\\',
-    },
-    {
-      key: 'UNC_PATH_WITH_TRAILING_BACKSLASH',
-      value: '\\\\server\\share\\folder\\',
-    },
-  ])('should handle env values ending with a backslash ($key)', async ({
-    key,
-    value,
-  }) => {
+  it('should handle env values ending with a backslash', async () => {
+    const key = 'PATH_WITH_TRAILING_BACKSLASH';
+    const value = 'C:\\Users\\foo\\';
+
     useUser();
     useTeams('team_dummy');
     useProject(
@@ -526,6 +528,16 @@ describe('env pull', () => {
           id: '781dt89g8r2h789g',
           key,
           value,
+          target: ['development'],
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+        {
+          type: 'encrypted',
+          id: '781dt89g8r2h789h',
+          key: 'QUOTED_VALUE',
+          value: '"testvalue"',
           target: ['development'],
           configurationId: null,
           updatedAt: 1557241361455,
@@ -547,6 +559,7 @@ describe('env pull', () => {
 
     const parsed = parse(pulledEnv);
     expect(parsed[key]).toEqual(value);
+    expect(parsed['QUOTED_VALUE']).toEqual('"testvalue"');
   });
 
   it('should correctly render delta string when env variable has quotes', async () => {
@@ -582,14 +595,11 @@ describe('env pull', () => {
         'Downloading `development` Environment Variables for'
       );
       await expect(client.stderr).toOutput('No changes found.\n');
-      await expect(client.stderr).toOutput(
-        'Updated .env.local file and added it to .gitignore'
-      );
 
       await expect(pullPromise).resolves.toEqual(0);
-
-      const pulledEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
-      expect(parse(pulledEnv)['NEW_VAR']).toEqual('"testvalue"');
+      expect(client.stderr.getFullOutput()).not.toContain(
+        'Updated .env.local file'
+      );
     } finally {
       client.setArgv('env', 'rm', 'NEW_VAR', '--yes');
       await env(client);
@@ -629,9 +639,11 @@ describe('env pull', () => {
         'Downloading `development` Environment Variables for'
       );
       await expect(client.stderr).toOutput('No changes found.\n');
-      await expect(client.stderr).toOutput('Updated .env.testquotes file');
 
       await expect(pullPromise).resolves.toEqual(0);
+      expect(client.stderr.getFullOutput()).not.toContain(
+        'Updated .env.testquotes file'
+      );
     } finally {
       client.setArgv('env', 'rm', 'NEW_VAR', '--yes');
       await env(client);

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -306,6 +306,89 @@ describe('env pull', () => {
     expect(devFileHasVercelEnv).toBeFalsy();
   });
 
+  it('should preview changes before confirmation and preserve local-only env vars', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+    });
+    const cwd = setupUnitFixture('vercel-env-pull');
+    client.cwd = cwd;
+    await fs.writeFile(
+      path.join(cwd, '.env.local'),
+      'LOCAL_ONLY=value\nSPECIAL_FLAG=2\n',
+      'utf8'
+    );
+
+    client.setArgv('env', 'pull');
+    const pullPromise = env(client);
+
+    await expect(client.stderr).toOutput(
+      'Downloading `development` Environment Variables for'
+    );
+    await expect(client.stderr).toOutput('Changes:\nM SPECIAL_FLAG\n');
+    await expect(client.stderr).toOutput(
+      'Apply these changes to ".env.local"?'
+    );
+
+    const fullOutput = client.stderr.getFullOutput();
+    expect(fullOutput.indexOf('Changes:\nM SPECIAL_FLAG\n')).toBeGreaterThan(
+      -1
+    );
+    expect(
+      fullOutput.indexOf('Apply these changes to ".env.local"?')
+    ).toBeGreaterThan(fullOutput.indexOf('Changes:\nM SPECIAL_FLAG\n'));
+
+    client.stdin.write('y\n');
+
+    await expect(pullPromise).resolves.toEqual(0);
+
+    const pulledEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(pulledEnv).toContain('LOCAL_ONLY="value"');
+    expect(pulledEnv).toContain('SPECIAL_FLAG="1"');
+  });
+
+  it('should preserve local env vars when a remote variable was deleted', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject(
+      {
+        ...defaultProject,
+        id: 'vercel-env-pull',
+        name: 'vercel-env-pull',
+      },
+      envs.filter(envVar => envVar.key !== 'SPECIAL_FLAG')
+    );
+    const cwd = setupUnitFixture('vercel-env-pull');
+    client.cwd = cwd;
+    await fs.writeFile(
+      path.join(cwd, '.env.local'),
+      'LOCAL_ONLY=value\nSPECIAL_FLAG=1\n',
+      'utf8'
+    );
+
+    client.setArgv('env', 'pull');
+    const pullPromise = env(client);
+
+    await expect(client.stderr).toOutput(
+      'Downloading `development` Environment Variables for'
+    );
+    await expect(client.stderr).toOutput('> No changes found.');
+
+    await expect(pullPromise).resolves.toEqual(0);
+
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Apply these changes to ".env.local"?'
+    );
+    expect(client.stderr.getFullOutput()).not.toContain('- SPECIAL_FLAG');
+
+    const pulledEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(pulledEnv).toContain('LOCAL_ONLY="value"');
+    expect(pulledEnv).toContain('SPECIAL_FLAG="1"');
+  });
+
   it('should show a delta string', async () => {
     const cwd = setupUnitFixture('vercel-env-pull-delta');
     client.cwd = cwd;
@@ -341,14 +424,15 @@ describe('env pull', () => {
       await expect(client.stderr).toOutput(
         'Downloading `development` Environment Variables for'
       );
-      await expect(client.stderr).toOutput(
-        '+ SPECIAL_FLAG (Updated)\n+ NEW_VAR\n- TEST\n'
-      );
+      await expect(client.stderr).toOutput('M SPECIAL_FLAG\n+ NEW_VAR\n');
       await expect(client.stderr).toOutput(
         'Updated .env.local file and added it to .gitignore'
       );
 
       await expect(pullPromise).resolves.toEqual(0);
+
+      const pulledEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+      expect(pulledEnv).toContain('TEST="hi"');
     } finally {
       client.setArgv('env', 'rm', 'NEW_VAR', '--yes');
       await env(client);
@@ -389,6 +473,29 @@ describe('env pull', () => {
       'Updated .env.local file and added it to .gitignore'
     );
     await expect(pullPromise).resolves.toEqual(0);
+  });
+
+  it('should not prompt for confirmation when no changes were found', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'env-pull-delta-no-changes',
+      name: 'env-pull-delta-no-changes',
+    });
+    client.cwd = setupUnitFixture('vercel-env-pull-delta-no-changes');
+    client.input.confirm = vi.fn().mockResolvedValue(true);
+
+    client.setArgv('env', 'pull');
+    const pullPromise = env(client);
+
+    await expect(client.stderr).toOutput('> No changes found.');
+    await expect(client.stderr).toOutput(
+      'Updated .env.local file and added it to .gitignore'
+    );
+    await expect(pullPromise).resolves.toEqual(0);
+
+    expect(client.input.confirm).not.toHaveBeenCalled();
   });
 
   it('should correctly render delta string when env variable has quotes', async () => {

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -587,6 +587,9 @@ describe('env pull', () => {
       );
 
       await expect(pullPromise).resolves.toEqual(0);
+
+      const pulledEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+      expect(parse(pulledEnv)['NEW_VAR']).toEqual('"testvalue"');
     } finally {
       client.setArgv('env', 'rm', 'NEW_VAR', '--yes');
       await env(client);

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -498,6 +498,57 @@ describe('env pull', () => {
     expect(client.input.confirm).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      key: 'PATH_WITH_TRAILING_BACKSLASH',
+      value: 'C:\\Users\\foo\\',
+    },
+    {
+      key: 'UNC_PATH_WITH_TRAILING_BACKSLASH',
+      value: '\\\\server\\share\\folder\\',
+    },
+  ])('should handle env values ending with a backslash ($key)', async ({
+    key,
+    value,
+  }) => {
+    useUser();
+    useTeams('team_dummy');
+    useProject(
+      {
+        ...defaultProject,
+        id: 'vercel-env-pull',
+        name: 'vercel-env-pull',
+      },
+      [
+        ...envs,
+        {
+          type: 'encrypted',
+          id: '781dt89g8r2h789g',
+          key,
+          value,
+          target: ['development'],
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    const cwd = setupUnitFixture('vercel-env-pull');
+    client.cwd = cwd;
+    client.setArgv('env', 'pull', '--yes');
+    const exitCodePromise = env(client);
+    await expect(client.stderr).toOutput(
+      'Downloading `development` Environment Variables for'
+    );
+    await expect(exitCodePromise).resolves.toEqual(0);
+
+    const pulledEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(pulledEnv).toContain(`${key}="${value}"`);
+
+    const parsed = parse(pulledEnv);
+    expect(parsed[key]).toEqual(value);
+  });
+
   it('should correctly render delta string when env variable has quotes', async () => {
     const cwd = setupUnitFixture('vercel-env-pull-delta-quotes');
     client.cwd = cwd;

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -2,10 +2,11 @@ import assert from 'assert';
 import { describe, expect, it, vi } from 'vitest';
 import fs from 'fs-extra';
 import path from 'path';
+import { parse } from 'dotenv';
 import pull from '../../../../src/commands/pull';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
-import { defaultProject, useProject } from '../../../mocks/project';
+import { defaultProject, envs, useProject } from '../../../mocks/project';
 import { useTeams, createTeam } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 
@@ -91,6 +92,46 @@ describe('pull', () => {
     );
     const devFileHasDevEnv = rawDevEnv.toString().includes('SPECIAL_FLAG');
     expect(devFileHasDevEnv).toBeTruthy();
+  });
+
+  it('should handle preview env values ending with a backslash', async () => {
+    const cwd = setupUnitFixture('vercel-pull-next');
+    useUser();
+    const teams = useTeams('team_dummy');
+    assert(Array.isArray(teams));
+    useProject(
+      {
+        ...defaultProject,
+        id: 'vercel-pull-next',
+        name: 'vercel-pull-next',
+      },
+      [
+        ...envs,
+        {
+          type: 'encrypted',
+          id: '781dt89g8r2h789g',
+          key: 'PATH_WITH_BACKSLASH',
+          value: 'C:\\Users\\foo\\',
+          target: ['preview'],
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    client.setArgv('pull', '--environment=preview', '--yes', cwd);
+    const exitCodePromise = pull(client);
+    await expect(client.stderr).toOutput(
+      `Downloading \`preview\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+    );
+    await expect(exitCodePromise).resolves.toEqual(0);
+
+    const rawPreviewEnv = await fs.readFile(
+      path.join(cwd, '.vercel', '.env.preview.local'),
+      'utf8'
+    );
+    const parsedPreviewEnv = parse(rawPreviewEnv);
+    expect(parsedPreviewEnv['PATH_WITH_BACKSLASH']).toEqual('C:\\Users\\foo\\');
   });
 
   it('should fail with message to pull without a link and without --env', async () => {

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -2,11 +2,10 @@ import assert from 'assert';
 import { describe, expect, it, vi } from 'vitest';
 import fs from 'fs-extra';
 import path from 'path';
-import { parse } from 'dotenv';
 import pull from '../../../../src/commands/pull';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
-import { defaultProject, envs, useProject } from '../../../mocks/project';
+import { defaultProject, useProject } from '../../../mocks/project';
 import { useTeams, createTeam } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 
@@ -92,86 +91,6 @@ describe('pull', () => {
     );
     const devFileHasDevEnv = rawDevEnv.toString().includes('SPECIAL_FLAG');
     expect(devFileHasDevEnv).toBeTruthy();
-  });
-
-  it('should handle preview env values ending with a backslash', async () => {
-    const cwd = setupUnitFixture('vercel-pull-next');
-    useUser();
-    const teams = useTeams('team_dummy');
-    assert(Array.isArray(teams));
-    useProject(
-      {
-        ...defaultProject,
-        id: 'vercel-pull-next',
-        name: 'vercel-pull-next',
-      },
-      [
-        ...envs,
-        {
-          type: 'encrypted',
-          id: '781dt89g8r2h789g',
-          key: 'PATH_WITH_BACKSLASH',
-          value: 'C:\\Users\\foo\\',
-          target: ['preview'],
-          configurationId: null,
-          updatedAt: 1557241361455,
-          createdAt: 1557241361455,
-        },
-      ]
-    );
-    client.setArgv('pull', '--environment=preview', '--yes', cwd);
-    const exitCodePromise = pull(client);
-    await expect(client.stderr).toOutput(
-      `Downloading \`preview\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
-    );
-    await expect(exitCodePromise).resolves.toEqual(0);
-
-    const rawPreviewEnv = await fs.readFile(
-      path.join(cwd, '.vercel', '.env.preview.local'),
-      'utf8'
-    );
-    const parsedPreviewEnv = parse(rawPreviewEnv);
-    expect(parsedPreviewEnv['PATH_WITH_BACKSLASH']).toEqual('C:\\Users\\foo\\');
-  });
-
-  it('should preserve quotes in preview env values', async () => {
-    const cwd = setupUnitFixture('vercel-pull-next');
-    useUser();
-    const teams = useTeams('team_dummy');
-    assert(Array.isArray(teams));
-    useProject(
-      {
-        ...defaultProject,
-        id: 'vercel-pull-next',
-        name: 'vercel-pull-next',
-      },
-      [
-        ...envs,
-        {
-          type: 'encrypted',
-          id: '781dt89g8r2h789g',
-          key: 'QUOTED_VALUE',
-          value: '"testvalue"',
-          target: ['preview'],
-          configurationId: null,
-          updatedAt: 1557241361455,
-          createdAt: 1557241361455,
-        },
-      ]
-    );
-    client.setArgv('pull', '--environment=preview', '--yes', cwd);
-    const exitCodePromise = pull(client);
-    await expect(client.stderr).toOutput(
-      `Downloading \`preview\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
-    );
-    await expect(exitCodePromise).resolves.toEqual(0);
-
-    const rawPreviewEnv = await fs.readFile(
-      path.join(cwd, '.vercel', '.env.preview.local'),
-      'utf8'
-    );
-    const parsedPreviewEnv = parse(rawPreviewEnv);
-    expect(parsedPreviewEnv['QUOTED_VALUE']).toEqual('"testvalue"');
   });
 
   it('should fail with message to pull without a link and without --env', async () => {

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -134,6 +134,46 @@ describe('pull', () => {
     expect(parsedPreviewEnv['PATH_WITH_BACKSLASH']).toEqual('C:\\Users\\foo\\');
   });
 
+  it('should preserve quotes in preview env values', async () => {
+    const cwd = setupUnitFixture('vercel-pull-next');
+    useUser();
+    const teams = useTeams('team_dummy');
+    assert(Array.isArray(teams));
+    useProject(
+      {
+        ...defaultProject,
+        id: 'vercel-pull-next',
+        name: 'vercel-pull-next',
+      },
+      [
+        ...envs,
+        {
+          type: 'encrypted',
+          id: '781dt89g8r2h789g',
+          key: 'QUOTED_VALUE',
+          value: '"testvalue"',
+          target: ['preview'],
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    client.setArgv('pull', '--environment=preview', '--yes', cwd);
+    const exitCodePromise = pull(client);
+    await expect(client.stderr).toOutput(
+      `Downloading \`preview\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+    );
+    await expect(exitCodePromise).resolves.toEqual(0);
+
+    const rawPreviewEnv = await fs.readFile(
+      path.join(cwd, '.vercel', '.env.preview.local'),
+      'utf8'
+    );
+    const parsedPreviewEnv = parse(rawPreviewEnv);
+    expect(parsedPreviewEnv['QUOTED_VALUE']).toEqual('"testvalue"');
+  });
+
   it('should fail with message to pull without a link and without --env', async () => {
     client.stdin.isTTY = false;
     (client as { nonInteractive: boolean }).nonInteractive = false;


### PR DESCRIPTION
## Summary
- restore the `vercel env pull` preview flow so existing files show planned changes and preserve local-only environment variables
- normalize downloaded env values without JSON round-tripping so values ending in backslashes no longer crash `env pull`, `vercel pull`, or `vercel build`
- add regression coverage for direct env pulls and the build auto-pull path, including Windows and UNC-style values that end in backslashes

## Testing
- `npx vitest run packages/cli/test/unit/commands/env/pull.test.ts packages/cli/test/unit/commands/pull/index.test.ts`
- `npx vitest run packages/cli/test/unit/commands/build/index.test.ts -t "should build after auto-pulling preview env values ending with a backslash"`
- `npx vitest run packages/cli/test/unit/commands/env/pull.test.ts packages/cli/test/unit/commands/pull/index.test.ts packages/cli/test/unit/commands/build/index.test.ts -t backslash`