### PR TITLE
feat(cli): add share command

### DIFF
--- a/.changeset/cuddly-walls-wonder.md
+++ b/.changeset/cuddly-walls-wonder.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix branch-based deployment lookup in the CLI when deployment list responses expose `id` and `readyState`.

--- a/.changeset/cuddly-walls-wonder.md
+++ b/.changeset/cuddly-walls-wonder.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Fix branch-based deployment lookup in the CLI when deployment list responses expose `id` and `readyState`.

--- a/.changeset/flat-geese-admire.md
+++ b/.changeset/flat-geese-admire.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add a `vercel share` command for generating shareable links to protected deployments.

--- a/.changeset/flat-geese-admire.md
+++ b/.changeset/flat-geese-admire.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Add a `vercel share` command for generating shareable links to protected deployments.
+Add a `vercel share` command for generating shareable links to protected deployments, including current-branch deployment discovery.

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -52,6 +52,7 @@ export { default as rollback } from './commands/rollback';
 export { default as rollingRelease } from './commands/rolling-release';
 export { default as routes } from './commands/routes';
 export { default as sandbox } from './commands/sandbox';
+export { default as share } from './commands/share';
 export { default as skills } from './commands/skills';
 export { default as target } from './commands/target';
 export { default as teams } from './commands/teams';

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -50,6 +50,7 @@ import { routesCommand } from './routes/command';
 import { rollbackCommand } from './rollback/command';
 import { rollingReleaseCommand } from './rolling-release/command';
 import { sandboxCommand } from './sandbox/command';
+import { shareCommand } from './share/command';
 import { skillsCommand } from './skills/command';
 import { targetCommand } from './target/command';
 import { teamsCommand } from './teams/command';
@@ -115,6 +116,7 @@ const commandsStructs = [
   rollbackCommand,
   rollingReleaseCommand,
   sandboxCommand,
+  shareCommand,
   skillsCommand,
   targetCommand,
   teamsCommand,

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import format from 'date-fns/format';
 import type Client from '../../util/client';
 import { createGitMeta } from '../../util/create-git-meta';
+import { getLatestDeploymentByBranch } from '../../util/deploy/get-latest-deployment-by-branch';
 import { printError } from '../../util/error';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -29,11 +30,6 @@ import { help } from '../help';
 import { logsCommand } from './command';
 import output from '../../output-manager';
 
-interface BranchDeployment {
-  id: string;
-  url: string;
-}
-
 interface LogsTarget {
   projectId: string;
   projectSlug: string;
@@ -49,45 +45,6 @@ interface ResolveLogsTargetOptions {
 }
 
 type ResolveLogsTargetResult = LogsTarget | { exitCode: number };
-
-async function getLatestDeploymentByBranch(
-  client: Client,
-  projectId: string,
-  branch: string
-): Promise<BranchDeployment | null> {
-  interface DeploymentResponse {
-    deployments: Array<{ uid: string; url: string }>;
-  }
-
-  // Different git providers use different metadata keys for the branch
-  const branchMetaKeys = [
-    'githubCommitRef',
-    'gitlabCommitRef',
-    'bitbucketCommitRef',
-  ];
-
-  for (const metaKey of branchMetaKeys) {
-    const query = new URLSearchParams();
-    query.set('projectId', projectId);
-    query.set('limit', '1');
-    query.set('state', 'READY');
-    query.set(`meta-${metaKey}`, branch);
-
-    const { deployments } = await client.fetch<DeploymentResponse>(
-      `/v6/deployments?${query}`
-    );
-
-    if (deployments.length > 0) {
-      return {
-        id: deployments[0].uid,
-        url: deployments[0].url,
-      };
-    }
-  }
-
-  return null;
-}
-
 const TIME_ONLY_FORMAT = 'HH:mm:ss.SS';
 const DATE_TIME_FORMAT = 'MMM DD HH:mm:ss.SS';
 

--- a/packages/cli/src/commands/share/command.ts
+++ b/packages/cli/src/commands/share/command.ts
@@ -1,0 +1,42 @@
+import { packageName } from '../../util/pkg-name';
+
+export const shareCommand = {
+  name: 'share',
+  aliases: [],
+  description: 'Create a shareable link for a protected deployment.',
+  arguments: [
+    {
+      name: 'url|deploymentId',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      name: 'ttl',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Optional expiry for the share link (for example: 30m, 1h, 82800)',
+      argument: 'DURATION',
+    },
+  ],
+  examples: [
+    {
+      name: 'Create a shareable link for a deployment URL',
+      value: `${packageName} share my-deployment-abc123.vercel.app`,
+    },
+    {
+      name: 'Create a shareable link for a deployment ID',
+      value: `${packageName} share dpl_1234567890abcdef`,
+    },
+    {
+      name: 'Create a shareable link for the current branch deployment',
+      value: `${packageName} share`,
+    },
+    {
+      name: 'Create a shareable link with a one hour TTL',
+      value: `${packageName} share my-deployment-abc123.vercel.app --ttl 1h`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/share/command.ts
+++ b/packages/cli/src/commands/share/command.ts
@@ -1,4 +1,5 @@
 import { packageName } from '../../util/pkg-name';
+import { yesOption } from '../../util/arg-common';
 
 export const shareCommand = {
   name: 'share',
@@ -11,6 +12,10 @@ export const shareCommand = {
     },
   ],
   options: [
+    {
+      ...yesOption,
+      description: 'Skip the approval prompt before creating the share link',
+    },
     {
       name: 'ttl',
       shorthand: null,

--- a/packages/cli/src/commands/share/command.ts
+++ b/packages/cli/src/commands/share/command.ts
@@ -22,7 +22,7 @@ export const shareCommand = {
       type: String,
       deprecated: false,
       description:
-        'Optional expiry for the share link (for example: 30m, 1h, 82800)',
+        'Optional expiry for the share link, up to 730d (for example: 30m, 1h, 82800)',
       argument: 'DURATION',
     },
   ],

--- a/packages/cli/src/commands/share/index.ts
+++ b/packages/cli/src/commands/share/index.ts
@@ -1,0 +1,319 @@
+import { isErrnoException } from '@vercel/error-utils';
+import ms from 'ms';
+import type { Deployment } from '@vercel-internals/types';
+import type Client from '../../util/client';
+import { createGitMeta } from '../../util/create-git-meta';
+import { printError } from '../../util/error';
+import {
+  DeploymentNotFound,
+  DeploymentPermissionDenied,
+  InvalidDeploymentId,
+  isAPIError,
+} from '../../util/errors-ts';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import getScope from '../../util/get-scope';
+import { getCommandName } from '../../util/pkg-name';
+import { getLinkedProject } from '../../util/projects/link';
+import { ShareTelemetryClient } from '../../util/telemetry/commands/share';
+import { getLatestDeploymentByBranch } from '../../util/deploy/get-latest-deployment-by-branch';
+import toHost from '../../util/to-host';
+import output from '../../output-manager';
+import { help } from '../help';
+import { shareCommand } from './command';
+
+interface ProtectionBypassResponse {
+  protectionBypass?: Record<string, unknown>;
+}
+
+export default async function share(client: Client): Promise<number> {
+  const telemetry = new ShareTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(shareCommand.options);
+
+  let parsedArguments;
+  try {
+    parsedArguments = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  if (parsedArguments.flags['--help']) {
+    telemetry.trackCliFlagHelp('share');
+    output.print(help(shareCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  if (parsedArguments.args[0] === shareCommand.name) {
+    parsedArguments.args.shift();
+  }
+
+  const [target] = parsedArguments.args;
+
+  if (parsedArguments.args.length > 1) {
+    output.error(
+      `${getCommandName('share <url|deploymentId>')} accepts at most one argument`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentUrlOrDeploymentId(target);
+  telemetry.trackCliOptionTtl(parsedArguments.flags['--ttl']);
+
+  const ttl = parseTTL(parsedArguments.flags['--ttl']);
+  if (ttl instanceof Error) {
+    output.error(ttl.message);
+    return 1;
+  }
+
+  let contextName: string;
+  let scopeTeamId: string | undefined;
+  let userId: string;
+
+  try {
+    const scope = await getScope(client);
+    contextName = scope.contextName;
+    scopeTeamId = scope.team?.id;
+    userId = scope.user.id;
+  } catch (err: unknown) {
+    if (
+      isErrnoException(err) &&
+      (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED')
+    ) {
+      output.error(err.message);
+      return 1;
+    }
+
+    throw err;
+  }
+
+  let deploymentId: string;
+  let baseUrl: string;
+  let accountId: string;
+
+  if (target) {
+    try {
+      accountId = await inferAccountId(client, scopeTeamId, userId);
+      const deployment = await getDeploymentForShare(
+        client,
+        contextName,
+        target,
+        accountId
+      );
+      deploymentId = deployment.id;
+      baseUrl = target.includes('.')
+        ? `https://${toHost(target)}`
+        : `https://${deployment.url}`;
+    } catch (err) {
+      if (err instanceof DeploymentNotFound) {
+        output.error(`Deployment not found: ${target}`);
+        return 1;
+      }
+      if (err instanceof InvalidDeploymentId) {
+        output.error(`Invalid deployment ID: ${target}`);
+        return 1;
+      }
+      if (err instanceof DeploymentPermissionDenied) {
+        output.error(err.message);
+        return 1;
+      }
+      throw err;
+    }
+  } else {
+    const linkedProject = await getLinkedProject(client, client.cwd);
+    if (linkedProject.status === 'error') {
+      return linkedProject.exitCode;
+    }
+
+    if (
+      linkedProject.status !== 'linked' ||
+      !linkedProject.project ||
+      !linkedProject.org
+    ) {
+      output.error(
+        `No linked project found. Run ${getCommandName(
+          'link'
+        )} or pass a deployment URL or ID.`
+      );
+      return 1;
+    }
+
+    const gitMeta = await createGitMeta(
+      linkedProject.repoRoot ?? client.cwd,
+      linkedProject.project
+    );
+    const branch = gitMeta?.commitRef;
+
+    if (!branch) {
+      output.error(
+        'Could not detect the current git branch. Pass a deployment URL or ID, or run this command from a git repository.'
+      );
+      return 1;
+    }
+
+    const branchDeployment = await getLatestDeploymentByBranch(
+      client,
+      linkedProject.project.id,
+      branch,
+      linkedProject.org.id
+    );
+
+    if (!branchDeployment) {
+      const latestBranchDeployment = await getLatestDeploymentByBranch(
+        client,
+        linkedProject.project.id,
+        branch,
+        linkedProject.org.id,
+        { readyOnly: false }
+      );
+
+      if (latestBranchDeployment) {
+        output.error(
+          `Latest deployment for branch "${branch}" is not ready: https://${latestBranchDeployment.url} (${latestBranchDeployment.readyState ?? 'UNKNOWN'}). Fix the deployment first or pass a deployment URL or ID.`
+        );
+        return 1;
+      }
+
+      output.error(
+        `No deployments found for branch "${branch}". Deploy this branch first or pass a deployment URL or ID.`
+      );
+      return 1;
+    }
+
+    accountId = linkedProject.org.id;
+    deploymentId = branchDeployment.id;
+    baseUrl = `https://${branchDeployment.url}`;
+  }
+
+  return await createShareUrl(client, deploymentId, baseUrl, ttl, accountId);
+}
+
+async function inferAccountId(
+  client: Client,
+  scopeTeamId: string | undefined,
+  userId: string
+): Promise<string> {
+  if (scopeTeamId) {
+    return scopeTeamId;
+  }
+
+  try {
+    const linkedProject = await getLinkedProject(client, client.cwd);
+    if (linkedProject.status === 'linked' && linkedProject.org) {
+      return linkedProject.org.id;
+    }
+  } catch {
+    // Ignore link lookup failures and fall back to the user account.
+  }
+
+  return userId;
+}
+
+async function createShareUrl(
+  client: Client,
+  deploymentId: string,
+  baseUrl: string,
+  ttl: number | undefined,
+  accountId: string
+): Promise<number> {
+  try {
+    const response = await client.fetch<ProtectionBypassResponse>(
+      `/v1/aliases/${encodeURIComponent(deploymentId)}/protection-bypass`,
+      {
+        method: 'PATCH',
+        body: ttl === undefined ? '{}' : JSON.stringify({ ttl }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        accountId,
+      }
+    );
+
+    const token = extractShareToken(response);
+    const shareUrl = new URL(baseUrl);
+    shareUrl.pathname = '/';
+    shareUrl.search = '';
+    shareUrl.searchParams.set('_vercel_share', token);
+
+    client.stdout.write(`${shareUrl.toString()}\n`);
+    return 0;
+  } catch (err: unknown) {
+    if (isAPIError(err)) {
+      output.error(err.message);
+      return 1;
+    }
+
+    output.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}
+
+async function getDeploymentForShare(
+  client: Client,
+  contextName: string,
+  target: string,
+  accountId: string
+): Promise<Deployment> {
+  const hostOrId = target.includes('.') ? toHost(target) : target;
+
+  try {
+    return await client.fetch<Deployment>(
+      `/v13/deployments/${encodeURIComponent(hostOrId)}`,
+      { accountId }
+    );
+  } catch (err: unknown) {
+    if (isAPIError(err)) {
+      if (err.status === 404) {
+        throw new DeploymentNotFound({ id: hostOrId, context: contextName });
+      }
+      if (err.status === 403) {
+        throw new DeploymentPermissionDenied(hostOrId, contextName);
+      }
+      if (err.status === 400 && err.message.includes('`id`')) {
+        throw new InvalidDeploymentId(hostOrId);
+      }
+    }
+
+    throw err;
+  }
+}
+
+function parseTTL(value: string | undefined): number | Error | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (/^\d+$/.test(value)) {
+    const seconds = Number(value);
+    if (!Number.isSafeInteger(seconds) || seconds <= 0) {
+      return new Error('Invalid TTL. Provide a positive number of seconds.');
+    }
+    return seconds;
+  }
+
+  const duration = ms(value);
+  if (duration === undefined || duration < 1000) {
+    return new Error(
+      'Invalid TTL. Provide a positive duration like "30m", "1h", or seconds such as "3600".'
+    );
+  }
+
+  return Math.ceil(duration / 1000);
+}
+
+function extractShareToken(response: ProtectionBypassResponse): string {
+  const token = response.protectionBypass
+    ? Object.keys(response.protectionBypass)[0]
+    : undefined;
+
+  if (!token) {
+    throw new Error('Failed to create a share token for this deployment.');
+  }
+
+  return token;
+}

--- a/packages/cli/src/commands/share/index.ts
+++ b/packages/cli/src/commands/share/index.ts
@@ -13,10 +13,14 @@ import {
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import getScope from '../../util/get-scope';
-import { getCommandName } from '../../util/pkg-name';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import { getLinkedProject } from '../../util/projects/link';
 import { ShareTelemetryClient } from '../../util/telemetry/commands/share';
 import { getLatestDeploymentByBranch } from '../../util/deploy/get-latest-deployment-by-branch';
+import {
+  buildCommandWithYes,
+  outputActionRequired,
+} from '../../util/agent-output';
 import toHost from '../../util/to-host';
 import output from '../../output-manager';
 import { help } from '../help';
@@ -63,6 +67,7 @@ export default async function share(client: Client): Promise<number> {
   }
 
   telemetry.trackCliArgumentUrlOrDeploymentId(target);
+  telemetry.trackCliFlagYes(parsedArguments.flags['--yes']);
   telemetry.trackCliOptionTtl(parsedArguments.flags['--ttl']);
 
   const ttl = parseTTL(parsedArguments.flags['--ttl']);
@@ -190,7 +195,66 @@ export default async function share(client: Client): Promise<number> {
     baseUrl = `https://${branchDeployment.url}`;
   }
 
+  const approved = await confirmShareCreation(
+    client,
+    baseUrl,
+    Boolean(parsedArguments.flags['--yes'])
+  );
+  if (!approved) {
+    return 0;
+  }
+
   return await createShareUrl(client, deploymentId, baseUrl, ttl, accountId);
+}
+
+async function confirmShareCreation(
+  client: Client,
+  baseUrl: string,
+  autoConfirm: boolean
+): Promise<boolean> {
+  if (autoConfirm) {
+    return true;
+  }
+
+  if (!client.stdin.isTTY) {
+    if (client.nonInteractive) {
+      outputActionRequired(
+        client,
+        {
+          status: 'action_required',
+          reason: 'confirmation_required',
+          message: `Command ${getCommandNamePlain('share')} requires confirmation. Use option --yes to confirm.`,
+          next: [
+            {
+              command: buildCommandWithYes(client.argv),
+              when: 'Confirm and run',
+            },
+          ],
+        },
+        1
+      );
+    } else {
+      output.error(
+        'Confirmation required. Use `--yes` to skip the confirmation prompt in non-interactive mode.'
+      );
+    }
+    return false;
+  }
+
+  output.log(
+    `This will create a shareable link that bypasses deployment protection for ${baseUrl}.`
+  );
+
+  const confirmed = await client.input.confirm(
+    'Are you sure you want to continue?',
+    false
+  );
+
+  if (!confirmed) {
+    output.log('Canceled');
+  }
+
+  return confirmed;
 }
 
 async function inferAccountId(

--- a/packages/cli/src/commands/share/index.ts
+++ b/packages/cli/src/commands/share/index.ts
@@ -27,8 +27,10 @@ import { help } from '../help';
 import { shareCommand } from './command';
 
 interface ProtectionBypassResponse {
-  protectionBypass?: Record<string, unknown>;
+  protectionBypass?: Record<string, { scope?: string }>;
 }
+
+const MAX_TTL_SECONDS = 63_072_000;
 
 export default async function share(client: Client): Promise<number> {
   const telemetry = new ShareTelemetryClient({
@@ -103,17 +105,16 @@ export default async function share(client: Client): Promise<number> {
 
   if (target) {
     try {
-      accountId = await inferAccountId(client, scopeTeamId, userId);
+      const selectedAccountId = scopeTeamId ?? userId;
       const deployment = await getDeploymentForShare(
         client,
         contextName,
         target,
-        accountId
+        selectedAccountId
       );
       deploymentId = deployment.id;
-      baseUrl = target.includes('.')
-        ? `https://${toHost(target)}`
-        : `https://${deployment.url}`;
+      accountId = deployment.ownerId ?? selectedAccountId;
+      baseUrl = getShareBaseUrl(target, deployment.url);
     } catch (err) {
       if (err instanceof DeploymentNotFound) {
         output.error(`Deployment not found: ${target}`);
@@ -257,27 +258,6 @@ async function confirmShareCreation(
   return confirmed;
 }
 
-async function inferAccountId(
-  client: Client,
-  scopeTeamId: string | undefined,
-  userId: string
-): Promise<string> {
-  if (scopeTeamId) {
-    return scopeTeamId;
-  }
-
-  try {
-    const linkedProject = await getLinkedProject(client, client.cwd);
-    if (linkedProject.status === 'linked' && linkedProject.org) {
-      return linkedProject.org.id;
-    }
-  } catch {
-    // Ignore link lookup failures and fall back to the user account.
-  }
-
-  return userId;
-}
-
 async function createShareUrl(
   client: Client,
   deploymentId: string,
@@ -290,18 +270,13 @@ async function createShareUrl(
       `/v1/aliases/${encodeURIComponent(deploymentId)}/protection-bypass`,
       {
         method: 'PATCH',
-        body: ttl === undefined ? '{}' : JSON.stringify({ ttl }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        body: ttl === undefined ? {} : { ttl },
         accountId,
       }
     );
 
     const token = extractShareToken(response);
     const shareUrl = new URL(baseUrl);
-    shareUrl.pathname = '/';
-    shareUrl.search = '';
     shareUrl.searchParams.set('_vercel_share', token);
 
     client.stdout.write(`${shareUrl.toString()}\n`);
@@ -321,30 +296,60 @@ async function getDeploymentForShare(
   client: Client,
   contextName: string,
   target: string,
-  accountId: string
+  selectedAccountId: string
 ): Promise<Deployment> {
   const hostOrId = target.includes('.') ? toHost(target) : target;
+  let lookupError: unknown;
 
-  try {
-    return await client.fetch<Deployment>(
-      `/v13/deployments/${encodeURIComponent(hostOrId)}`,
-      { accountId }
-    );
-  } catch (err: unknown) {
-    if (isAPIError(err)) {
-      if (err.status === 404) {
-        throw new DeploymentNotFound({ id: hostOrId, context: contextName });
+  for (const options of [
+    { accountId: selectedAccountId },
+    { useCurrentTeam: false },
+  ] as const) {
+    try {
+      return await client.fetch<Deployment>(
+        `/v13/deployments/${encodeURIComponent(hostOrId)}`,
+        options
+      );
+    } catch (err: unknown) {
+      if (!isAPIError(err) || (err.status !== 403 && err.status !== 404)) {
+        lookupError = err;
+        break;
       }
-      if (err.status === 403) {
-        throw new DeploymentPermissionDenied(hostOrId, contextName);
-      }
-      if (err.status === 400 && err.message.includes('`id`')) {
-        throw new InvalidDeploymentId(hostOrId);
+
+      if (!lookupError || err.status === 403) {
+        lookupError = err;
       }
     }
-
-    throw err;
   }
+
+  if (isAPIError(lookupError)) {
+    if (lookupError.status === 404) {
+      throw new DeploymentNotFound({ id: hostOrId, context: contextName });
+    }
+    if (lookupError.status === 403) {
+      throw new DeploymentPermissionDenied(hostOrId, contextName);
+    }
+    if (lookupError.status === 400 && lookupError.message.includes('`id`')) {
+      throw new InvalidDeploymentId(hostOrId);
+    }
+  }
+
+  throw lookupError;
+}
+
+function getShareBaseUrl(target: string, deploymentUrl: string): string {
+  if (!target.includes('.')) {
+    return `https://${deploymentUrl}`;
+  }
+
+  const url = new URL(
+    /^[a-z][a-z\d+.-]*:\/\//i.test(target) ? target : `https://${target}`
+  );
+  url.protocol = 'https:';
+
+  return url.pathname === '/' && !url.search && !url.hash
+    ? url.origin
+    : url.toString();
 }
 
 function parseTTL(value: string | undefined): number | Error | undefined {
@@ -357,7 +362,7 @@ function parseTTL(value: string | undefined): number | Error | undefined {
     if (!Number.isSafeInteger(seconds) || seconds <= 0) {
       return new Error('Invalid TTL. Provide a positive number of seconds.');
     }
-    return seconds;
+    return validateTTLMaximum(seconds);
   }
 
   const duration = ms(value);
@@ -367,13 +372,24 @@ function parseTTL(value: string | undefined): number | Error | undefined {
     );
   }
 
-  return Math.ceil(duration / 1000);
+  return validateTTLMaximum(Math.ceil(duration / 1000));
+}
+
+function validateTTLMaximum(seconds: number): number | Error {
+  if (seconds > MAX_TTL_SECONDS) {
+    return new Error(
+      `Invalid TTL. The maximum duration is ${MAX_TTL_SECONDS} seconds (730d).`
+    );
+  }
+
+  return seconds;
 }
 
 function extractShareToken(response: ProtectionBypassResponse): string {
-  const token = response.protectionBypass
-    ? Object.keys(response.protectionBypass)[0]
-    : undefined;
+  const entries = Object.entries(response.protectionBypass ?? {});
+  const token =
+    entries.find(([, bypass]) => bypass.scope === 'shareable-link')?.[0] ??
+    (entries.length === 1 ? entries[0][0] : undefined);
 
   if (!token) {
     throw new Error('Failed to create a share token for this deployment.');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1129,6 +1129,10 @@ const main = async () => {
           telemetry.trackCliCommandSandbox(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).sandbox;
           break;
+        case 'share':
+          telemetry.trackCliCommandShare(userSuppliedSubCommand);
+          func = (await import('./commands-bulk.js')).share;
+          break;
         case 'skills':
           telemetry.trackCliCommandSkills(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).skills;

--- a/packages/cli/src/util/deploy/get-latest-deployment-by-branch.ts
+++ b/packages/cli/src/util/deploy/get-latest-deployment-by-branch.ts
@@ -8,7 +8,13 @@ export interface BranchDeployment {
 }
 
 interface DeploymentResponse {
-  deployments: Array<{ uid: string; url: string; state?: string }>;
+  deployments: Array<{
+    id?: string;
+    uid?: string;
+    readyState?: string;
+    state?: string;
+    url: string;
+  }>;
 }
 
 export async function getLatestDeploymentByBranch(
@@ -42,10 +48,16 @@ export async function getLatestDeploymentByBranch(
     );
 
     if (deployments.length > 0) {
+      const deployment = deployments[0];
+      const id = deployment.uid ?? deployment.id;
+      if (!id) {
+        continue;
+      }
+
       return {
-        id: deployments[0].uid,
-        readyState: deployments[0].state,
-        url: deployments[0].url,
+        id,
+        readyState: deployment.state ?? deployment.readyState,
+        url: deployment.url,
       };
     }
   }

--- a/packages/cli/src/util/deploy/get-latest-deployment-by-branch.ts
+++ b/packages/cli/src/util/deploy/get-latest-deployment-by-branch.ts
@@ -1,0 +1,54 @@
+import { URLSearchParams } from 'url';
+import type Client from '../client';
+
+export interface BranchDeployment {
+  id: string;
+  url: string;
+  readyState?: string;
+}
+
+interface DeploymentResponse {
+  deployments: Array<{ uid: string; url: string; state?: string }>;
+}
+
+export async function getLatestDeploymentByBranch(
+  client: Client,
+  projectId: string,
+  branch: string,
+  accountId?: string,
+  options: {
+    readyOnly?: boolean;
+  } = {}
+): Promise<BranchDeployment | null> {
+  const branchMetaKeys = [
+    'githubCommitRef',
+    'gitlabCommitRef',
+    'bitbucketCommitRef',
+  ];
+  const { readyOnly = true } = options;
+
+  for (const metaKey of branchMetaKeys) {
+    const query = new URLSearchParams();
+    query.set('projectId', projectId);
+    query.set('limit', '1');
+    if (readyOnly) {
+      query.set('state', 'READY');
+    }
+    query.set(`meta-${metaKey}`, branch);
+
+    const { deployments } = await client.fetch<DeploymentResponse>(
+      `/v6/deployments?${query}`,
+      { accountId }
+    );
+
+    if (deployments.length > 0) {
+      return {
+        id: deployments[0].uid,
+        readyState: deployments[0].state,
+        url: deployments[0].url,
+      };
+    }
+  }
+
+  return null;
+}

--- a/packages/cli/src/util/telemetry/commands/share/index.ts
+++ b/packages/cli/src/util/telemetry/commands/share/index.ts
@@ -6,6 +6,12 @@ export class ShareTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof shareCommand>
 {
+  trackCliFlagYes(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('yes');
+    }
+  }
+
   trackCliArgumentUrlOrDeploymentId(value: string | undefined) {
     if (value) {
       this.trackCliArgument({

--- a/packages/cli/src/util/telemetry/commands/share/index.ts
+++ b/packages/cli/src/util/telemetry/commands/share/index.ts
@@ -1,0 +1,26 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { shareCommand } from '../../../../commands/share/command';
+
+export class ShareTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof shareCommand>
+{
+  trackCliArgumentUrlOrDeploymentId(value: string | undefined) {
+    if (value) {
+      this.trackCliArgument({
+        arg: 'deploymentIdOrHost',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionTtl(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'ttl',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -348,6 +348,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandShare(actual: string) {
+    this.trackCliCommand({
+      command: 'share',
+      value: actual,
+    });
+  }
+
   trackCliCommandRedeploy(actual: string) {
     this.trackCliCommand({
       command: 'redeploy',

--- a/packages/cli/test/mocks/deployment.ts
+++ b/packages/cli/test/mocks/deployment.ts
@@ -20,6 +20,7 @@ export function useDeployment({
   createdAt,
   project = defaultProject,
   target = 'production',
+  meta = {},
 }: {
   creator: Pick<User, 'id' | 'email' | 'name' | 'username'>;
   state?:
@@ -32,6 +33,7 @@ export function useDeployment({
   createdAt?: number;
   project?: any; // FIX ME: Use `Project` once PR #9956 is merged
   target?: Deployment['target'];
+  meta?: Deployment['meta'];
 }) {
   setupDeploymentEndpoints();
 
@@ -55,7 +57,7 @@ export function useDeployment({
     env: [],
     id,
     inspectorUrl: `https://vercel.com/${creator.name}/${id}`,
-    meta: {},
+    meta,
     name,
     ownerId: creator.id,
     plan: 'hobby',
@@ -190,12 +192,29 @@ function setupDeploymentEndpoints(): void {
       }
     );
 
+    const projectIdFilter = req.query.projectId;
+    if (typeof projectIdFilter === 'string') {
+      currentDeployments = currentDeployments.filter(
+        deployment => deployment.projectId === projectIdFilter
+      );
+    }
+
     // Filter by state if provided
     const stateFilter = req.query.state;
     if (stateFilter && typeof stateFilter === 'string') {
       const allowedStates = stateFilter.split(',').map(s => s.trim());
       currentDeployments = currentDeployments.filter(deployment =>
         allowedStates.includes(deployment.readyState || '')
+      );
+    }
+
+    for (const [key, value] of Object.entries(req.query)) {
+      if (!key.startsWith('meta-') || typeof value !== 'string') {
+        continue;
+      }
+      const metaKey = key.slice(5);
+      currentDeployments = currentDeployments.filter(
+        deployment => deployment.meta?.[metaKey] === value
       );
     }
 

--- a/packages/cli/test/mocks/deployment.ts
+++ b/packages/cli/test/mocks/deployment.ts
@@ -21,6 +21,7 @@ export function useDeployment({
   project = defaultProject,
   target = 'production',
   meta = {},
+  ownerId = creator.id,
 }: {
   creator: Pick<User, 'id' | 'email' | 'name' | 'username'>;
   state?:
@@ -34,6 +35,7 @@ export function useDeployment({
   project?: any; // FIX ME: Use `Project` once PR #9956 is merged
   target?: Deployment['target'];
   meta?: Deployment['meta'];
+  ownerId?: string;
 }) {
   setupDeploymentEndpoints();
 
@@ -59,7 +61,7 @@ export function useDeployment({
     inspectorUrl: `https://vercel.com/${creator.name}/${id}`,
     meta,
     name,
-    ownerId: creator.id,
+    ownerId,
     plan: 'hobby',
     projectId: project.id,
     public: false,

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -73,6 +73,7 @@ describe('index', () => {
         ['routes', 'routes'],
         ['rr', 'rolling-release'],
         ['sandbox', 'sandbox'],
+        ['share', 'share'],
         ['skills', 'skills'],
         ['switch', 'teams'],
         ['target', 'target'],

--- a/packages/cli/test/unit/commands/share/index.test.ts
+++ b/packages/cli/test/unit/commands/share/index.test.ts
@@ -158,7 +158,7 @@ describe('share', () => {
 
     expect(exitCode).toBe(1);
     await expect(client.stderr).toOutput(
-      'No linked project found. Run vercel link or pass a deployment URL or ID.'
+      'No linked project found. Run `vercel link` or pass a deployment URL or ID.'
     );
   });
 

--- a/packages/cli/test/unit/commands/share/index.test.ts
+++ b/packages/cli/test/unit/commands/share/index.test.ts
@@ -57,7 +57,7 @@ describe('share', () => {
       });
     });
 
-    client.setArgv('share', `https://${deployment.url}`);
+    client.setArgv('share', `https://${deployment.url}`, '--yes');
     const exitCode = await share(client);
 
     expect(exitCode).toBe(0);
@@ -68,6 +68,10 @@ describe('share', () => {
       {
         key: 'argument:deploymentIdOrHost',
         value: '[REDACTED]',
+      },
+      {
+        key: 'flag:yes',
+        value: 'TRUE',
       },
     ]);
   });
@@ -90,7 +94,7 @@ describe('share', () => {
       });
     });
 
-    client.setArgv('share', deployment.id, '--ttl', '1h');
+    client.setArgv('share', deployment.id, '--ttl', '1h', '--yes');
     const exitCode = await share(client);
 
     expect(exitCode).toBe(0);
@@ -103,10 +107,47 @@ describe('share', () => {
         value: '[REDACTED]',
       },
       {
+        key: 'flag:yes',
+        value: 'TRUE',
+      },
+      {
         key: 'option:ttl',
         value: '[REDACTED]',
       },
     ]);
+  });
+
+  it('asks for approval before creating a share URL', async () => {
+    client.cwd = setupTmpDir();
+    const user = useUser();
+    const deployment = useDeployment({ creator: user });
+    const confirmMock = vi
+      .spyOn(client.input, 'confirm')
+      .mockResolvedValue(true as never);
+
+    client.scenario.patch('/v1/aliases/:id/protection-bypass', (req, res) => {
+      expect(req.params.id).toBe(deployment.id);
+      res.json({
+        protectionBypass: {
+          prompted_token: {},
+        },
+      });
+    });
+
+    client.setArgv('share', `https://${deployment.url}`);
+    const exitCode = await share(client);
+
+    expect(exitCode).toBe(0);
+    expect(confirmMock).toHaveBeenCalledWith(
+      'Are you sure you want to continue?',
+      false
+    );
+    await expect(client.stderr).toOutput(
+      `This will create a shareable link that bypasses deployment protection for https://${deployment.url}.`
+    );
+    expect(client.stdout.getFullOutput()).toBe(
+      `https://${deployment.url}/?_vercel_share=prompted_token\n`
+    );
   });
 
   it('uses the current branch deployment when no argument is provided', async () => {
@@ -140,13 +181,45 @@ describe('share', () => {
       });
     });
 
-    client.setArgv('share');
+    client.setArgv('share', '--yes');
     const exitCode = await share(client);
 
     expect(exitCode).toBe(0);
     expect(client.stdout.getFullOutput()).toBe(
       `https://${deployment.url}/?_vercel_share=branch_token\n`
     );
+  });
+
+  describe('--non-interactive', () => {
+    it('outputs action_required JSON and exits when approval is required', async () => {
+      client.cwd = setupTmpDir();
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+      client.setArgv('share', `https://${deployment.url}`);
+      (client as { nonInteractive: boolean }).nonInteractive = true;
+      client.stdin.isTTY = false;
+
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: number) => {
+          throw new Error(`process.exit(${code})`);
+        });
+
+      await expect(share(client)).rejects.toThrow('process.exit(1)');
+      expect(client.stdout.getFullOutput()).toContain(
+        '"status": "action_required"'
+      );
+      expect(client.stdout.getFullOutput()).toContain(
+        '"reason": "confirmation_required"'
+      );
+      expect(client.stdout.getFullOutput()).toContain(
+        `vercel share https://${deployment.url} --yes`
+      );
+
+      exitSpy.mockRestore();
+      (client as { nonInteractive: boolean }).nonInteractive = false;
+      client.stdin.isTTY = true;
+    });
   });
 
   it('errors when no linked project exists for the branch-based default', async () => {

--- a/packages/cli/test/unit/commands/share/index.test.ts
+++ b/packages/cli/test/unit/commands/share/index.test.ts
@@ -1,13 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock(
-  '@inquirer/search',
-  () => ({
-    default: vi.fn(),
-  }),
-  { virtual: true }
-);
-
 import share from '../../../../src/commands/share';
 import { client } from '../../../mocks/client';
 import { useDeployment } from '../../../mocks/deployment';

--- a/packages/cli/test/unit/commands/share/index.test.ts
+++ b/packages/cli/test/unit/commands/share/index.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock(
+  '@inquirer/search',
+  () => ({
+    default: vi.fn(),
+  }),
+  { virtual: true }
+);
+
+import share from '../../../../src/commands/share';
+import { client } from '../../../mocks/client';
+import { useDeployment } from '../../../mocks/deployment';
+import { useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
+import * as createGitMetaModule from '../../../../src/util/create-git-meta';
+
+describe('share', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    client.reset();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('share', '--help');
+      const exitCode = await share(client);
+
+      expect(exitCode).toBe(2);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'share',
+        },
+      ]);
+    });
+
+    it('prints help output', async () => {
+      client.setArgv('share', '--help');
+      const exitCode = await share(client);
+
+      expect(exitCode).toBe(2);
+      expect(client.getFullOutput()).toContain(
+        'Create a shareable link for a protected deployment'
+      );
+    });
+  });
+
+  it('creates a share URL from an explicit deployment URL', async () => {
+    client.cwd = setupTmpDir();
+    const user = useUser();
+    const deployment = useDeployment({ creator: user });
+
+    client.scenario.patch('/v1/aliases/:id/protection-bypass', (req, res) => {
+      expect(req.params.id).toBe(deployment.id);
+      res.json({
+        protectionBypass: {
+          share_token: {},
+        },
+      });
+    });
+
+    client.setArgv('share', `https://${deployment.url}`);
+    const exitCode = await share(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe(
+      `https://${deployment.url}/?_vercel_share=share_token\n`
+    );
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'argument:deploymentIdOrHost',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('creates a share URL from a deployment ID and normalizes --ttl', async () => {
+    client.cwd = setupTmpDir();
+    const user = useUser();
+    useTeams('team_dummy');
+    client.config.currentTeam = 'team_dummy';
+    const deployment = useDeployment({ creator: user });
+
+    client.scenario.patch('/v1/aliases/:id/protection-bypass', (req, res) => {
+      expect(req.params.id).toBe(deployment.id);
+      expect(req.query.teamId).toBe('team_dummy');
+      expect(req.body).toEqual({ ttl: 3600 });
+      res.json({
+        protectionBypass: {
+          ttl_token: {},
+        },
+      });
+    });
+
+    client.setArgv('share', deployment.id, '--ttl', '1h');
+    const exitCode = await share(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe(
+      `https://${deployment.url}/?_vercel_share=ttl_token\n`
+    );
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'argument:deploymentIdOrHost',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:ttl',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('uses the current branch deployment when no argument is provided', async () => {
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    const user = useUser();
+    useTeams('team_dummy');
+    const project = {
+      id: 'static',
+      name: 'static-project',
+    };
+    useProject(project);
+    const deployment = useDeployment({
+      creator: user,
+      project,
+      meta: {
+        githubCommitRef: 'feature-share',
+      },
+    });
+
+    vi.spyOn(createGitMetaModule, 'createGitMeta').mockResolvedValue({
+      commitRef: 'feature-share',
+    });
+
+    client.scenario.patch('/v1/aliases/:id/protection-bypass', (req, res) => {
+      expect(req.params.id).toBe(deployment.id);
+      expect(req.query.teamId).toBe('team_dummy');
+      res.json({
+        protectionBypass: {
+          branch_token: {},
+        },
+      });
+    });
+
+    client.setArgv('share');
+    const exitCode = await share(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe(
+      `https://${deployment.url}/?_vercel_share=branch_token\n`
+    );
+  });
+
+  it('errors when no linked project exists for the branch-based default', async () => {
+    client.cwd = setupTmpDir();
+    useUser();
+
+    client.setArgv('share');
+    const exitCode = await share(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput(
+      'No linked project found. Run vercel link or pass a deployment URL or ID.'
+    );
+  });
+
+  it('returns failed deployment context when the branch has no ready deployment', async () => {
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    const user = useUser();
+    useTeams('team_dummy');
+    const project = {
+      id: 'static',
+      name: 'static-project',
+    };
+    useProject(project);
+    const deployment = useDeployment({
+      creator: user,
+      project,
+      state: 'ERROR',
+      meta: {
+        githubCommitRef: 'feature-broken',
+      },
+    });
+
+    vi.spyOn(createGitMetaModule, 'createGitMeta').mockResolvedValue({
+      commitRef: 'feature-broken',
+    });
+
+    client.setArgv('share');
+    const exitCode = await share(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput(
+      `Latest deployment for branch "feature-broken" is not ready: https://${deployment.url} (ERROR).`
+    );
+  });
+
+  it('errors when --ttl is invalid', async () => {
+    client.setArgv('share', 'dpl_123', '--ttl', '500ms');
+    const exitCode = await share(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput('Invalid TTL');
+  });
+});

--- a/packages/cli/test/unit/commands/share/index.test.ts
+++ b/packages/cli/test/unit/commands/share/index.test.ts
@@ -52,17 +52,26 @@ describe('share', () => {
       expect(req.params.id).toBe(deployment.id);
       res.json({
         protectionBypass: {
-          share_token: {},
+          user_token: {
+            scope: 'user',
+          },
+          share_token: {
+            scope: 'shareable-link',
+          },
         },
       });
     });
 
-    client.setArgv('share', `https://${deployment.url}`, '--yes');
+    client.setArgv(
+      'share',
+      `http://${deployment.url}/docs?mode=preview`,
+      '--yes'
+    );
     const exitCode = await share(client);
 
     expect(exitCode).toBe(0);
     expect(client.stdout.getFullOutput()).toBe(
-      `https://${deployment.url}/?_vercel_share=share_token\n`
+      `https://${deployment.url}/docs?mode=preview&_vercel_share=share_token\n`
     );
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       {
@@ -81,7 +90,10 @@ describe('share', () => {
     const user = useUser();
     useTeams('team_dummy');
     client.config.currentTeam = 'team_dummy';
-    const deployment = useDeployment({ creator: user });
+    const deployment = useDeployment({
+      creator: user,
+      ownerId: 'team_dummy',
+    });
 
     client.scenario.patch('/v1/aliases/:id/protection-bypass', (req, res) => {
       expect(req.params.id).toBe(deployment.id);
@@ -272,5 +284,15 @@ describe('share', () => {
 
     expect(exitCode).toBe(1);
     await expect(client.stderr).toOutput('Invalid TTL');
+  });
+
+  it('errors when --ttl exceeds the API maximum', async () => {
+    client.setArgv('share', 'dpl_123', '--ttl', '731d');
+    const exitCode = await share(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput(
+      'The maximum duration is 63072000 seconds (730d).'
+    );
   });
 });


### PR DESCRIPTION
Share command to create a shareable link with protection bypass for a deployment.

This is especially nice for agents to programmatically get access to a protected deployment without having to share a bypass token in your context.