### PR TITLE
[python] leave more buffer space for src code when packing the lambda

### DIFF
--- a/.changeset/tidy-shoes-care.md
+++ b/.changeset/tidy-shoes-care.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Leave 10mb of space for src code before packing lambda.

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -22,8 +22,8 @@ const readFile = promisify(fs.readFile);
 
 // AWS Lambda uncompressed size limit is 250MB, but we use 249MB to leave a small buffer
 export const LAMBDA_SIZE_THRESHOLD_BYTES = 249 * 1024 * 1024;
-// Pack Lambda up to 245MB to leave a buffer
-export const LAMBDA_PACKING_TARGET_BYTES = 245 * 1024 * 1024;
+// Pack Lambda up to 240MB to leave a buffer
+export const LAMBDA_PACKING_TARGET_BYTES = 240 * 1024 * 1024;
 
 // AWS Lambda ephemeral storage (/tmp) is 512MB. Use 500MB to leave a buffer
 // for runtime overhead (.pyc generation, uv cache, metadata, etc.)

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -376,8 +376,8 @@ version = "2.31.0"
   });
 
   describe('LAMBDA_PACKING_TARGET_BYTES', () => {
-    it('defaults to 245 MB', () => {
-      expect(LAMBDA_PACKING_TARGET_BYTES).toBe(245 * 1024 * 1024);
+    it('defaults to 240 MB', () => {
+      expect(LAMBDA_PACKING_TARGET_BYTES).toBe(240 * 1024 * 1024);
     });
 
     it('is less than LAMBDA_SIZE_THRESHOLD_BYTES', () => {


### PR DESCRIPTION
Leave more buffer space for a user's code when packing the lambda.