### PR TITLE
fix(cli): output JSON for failed deployments with `--json` flag

### DIFF
--- a/.changeset/fix-deploy-json-build-error.md
+++ b/.changeset/fix-deploy-json-build-error.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Output JSON to stdout when `--json` flag is used with `vercel deploy` and the deployment fails (build error, canceled, or checks failed).

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -1298,7 +1298,22 @@ async function handleDefaultDeploy(
             );
           }
         } catch (_) {
-          if (!asJson) {
+          if (asJson) {
+            output.stopSpinner();
+            client.stdout.write(
+              `${JSON.stringify(
+                {
+                  error: {
+                    name: 'BUILD_ERROR',
+                    message: err.message,
+                  },
+                  url: `https://${now.url}`,
+                },
+                null,
+                2
+              )}\n`
+            );
+          } else {
             output.log(
               `To check build logs run: ${getCommandName(
                 `inspect ${now.url} --logs`

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -506,7 +506,21 @@ async function handleInitDeployment(
     }
 
     if (deployment.readyState === 'CANCELED') {
-      output.print('The deployment has been canceled.\n');
+      if (asJson) {
+        output.stopSpinner();
+        client.stdout.write(
+          `${JSON.stringify(
+            getDeploymentOutputJson(deployment, client.apiUrl, {
+              name: 'DEPLOYMENT_CANCELED',
+              message: 'The deployment has been canceled.',
+            }),
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        output.print('The deployment has been canceled.\n');
+      }
       return 1;
     }
 
@@ -1139,7 +1153,21 @@ async function handleDefaultDeploy(
     }
 
     if (deployment.readyState === 'CANCELED') {
-      output.print('The deployment has been canceled.\n');
+      if (asJson) {
+        output.stopSpinner();
+        client.stdout.write(
+          `${JSON.stringify(
+            getDeploymentOutputJson(deployment, client.apiUrl, {
+              name: 'DEPLOYMENT_CANCELED',
+              message: 'The deployment has been canceled.',
+            }),
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        output.print('The deployment has been canceled.\n');
+      }
       return 1;
     }
 
@@ -1153,7 +1181,22 @@ async function handleDefaultDeploy(
       const counterList = Array.from(counters)
         .map(([name, no]) => `${no} ${name}`)
         .join(', ');
-      output.error(`Running Checks: ${counterList}`);
+
+      if (asJson) {
+        output.stopSpinner();
+        client.stdout.write(
+          `${JSON.stringify(
+            getDeploymentOutputJson(deployment, client.apiUrl, {
+              name: 'CHECKS_FAILED',
+              message: `Running Checks: ${counterList}`,
+            }),
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        output.error(`Running Checks: ${counterList}`);
+      }
       return 1;
     }
 
@@ -1227,14 +1270,27 @@ async function handleDefaultDeploy(
     }
 
     if (err instanceof BuildError) {
-      if (withFullLogs === false) {
+      if (now.url) {
         try {
-          if (now.url) {
-            const failedDeployment = await getDeployment(
-              client,
-              contextName,
-              now.url
+          const failedDeployment = await getDeployment(
+            client,
+            contextName,
+            now.url
+          );
+
+          if (asJson) {
+            output.stopSpinner();
+            client.stdout.write(
+              `${JSON.stringify(
+                getDeploymentOutputJson(failedDeployment, client.apiUrl, {
+                  name: 'BUILD_ERROR',
+                  message: err.message,
+                }),
+                null,
+                2
+              )}\n`
             );
+          } else if (withFullLogs === false) {
             await displayBuildLogsUntilFinalError(
               client,
               failedDeployment,
@@ -1242,14 +1298,16 @@ async function handleDefaultDeploy(
             );
           }
         } catch (_) {
-          output.log(
-            `To check build logs run: ${getCommandName(
-              `inspect ${now.url} --logs`
-            )}`
-          );
-          output.log(
-            `Or inspect them in your browser at https://${now.url}/_logs`
-          );
+          if (!asJson) {
+            output.log(
+              `To check build logs run: ${getCommandName(
+                `inspect ${now.url} --logs`
+              )}`
+            );
+            output.log(
+              `Or inspect them in your browser at https://${now.url}/_logs`
+            );
+          }
         }
       }
 
@@ -1546,7 +1604,8 @@ function getDeploymentOutputJson(
     readyState: string;
     target?: string | null;
   },
-  apiUrl: string
+  apiUrl: string,
+  error?: { name: string; message: string }
 ) {
   return {
     id: deployment.id,
@@ -1555,5 +1614,6 @@ function getDeploymentOutputJson(
     readyState: deployment.readyState,
     target: deployment.target ?? null,
     deploymentApiUrl: `${apiUrl}/v13/deployments/${deployment.id}`,
+    ...(error ? { error } : {}),
   };
 }

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -18,6 +18,8 @@ import { useUser } from '../../../mocks/user';
 import humanizePath from '../../../../src/util/humanize-path';
 import sleep from '../../../../src/util/sleep';
 import * as createDeployModule from '../../../../src/util/deploy/create-deploy';
+import { BuildError } from '../../../../src/util/errors-ts';
+import type Now from '../../../../src/util';
 
 describe('deploy', () => {
   describe('--non-interactive', () => {
@@ -1801,6 +1803,171 @@ describe('deploy', () => {
         readyState: 'READY',
         target: 'production',
         deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
+      });
+    });
+  });
+
+  describe('--json with failed deployment', () => {
+    const deploymentUrl = 'my-app-failed-abc123.vercel.app';
+    const deploymentId = 'dpl_json_failed_test';
+    const inspectorUrl = 'https://vercel.com/team/project/dpl_json_failed_test';
+
+    it('should output JSON with error field when build fails', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      // Mock getDeployment endpoint to return a failed deployment
+      client.scenario.get(`/v13/deployments/${deploymentUrl}`, (_req, res) => {
+        res.json({
+          id: deploymentId,
+          url: deploymentUrl,
+          inspectorUrl,
+          readyState: 'ERROR',
+          target: null,
+          aliasAssigned: false,
+          alias: [],
+        });
+      });
+
+      // Mock createDeploy to simulate a build error
+      const mock = vi
+        .spyOn(createDeployModule, 'default')
+        .mockImplementation(async (_client, now: Now) => {
+          // Simulate what processDeployment does: set now.url before throwing
+          now.url = deploymentUrl;
+          throw new BuildError({
+            message: 'Command "npm run build" exited with 1',
+            meta: {},
+          });
+        });
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--json');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(1);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const json = JSON.parse(stdoutOutput);
+
+      expect(json).toEqual({
+        id: deploymentId,
+        url: `https://${deploymentUrl}`,
+        inspectorUrl,
+        readyState: 'ERROR',
+        target: null,
+        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
+        error: {
+          name: 'BUILD_ERROR',
+          message: 'Command "npm run build" exited with 1',
+        },
+      });
+
+      mock.mockRestore();
+    });
+
+    it('should output valid JSON to stdout when piped (non-TTY) and build fails', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.get(`/v13/deployments/${deploymentUrl}`, (_req, res) => {
+        res.json({
+          id: deploymentId,
+          url: deploymentUrl,
+          inspectorUrl,
+          readyState: 'ERROR',
+          target: null,
+          aliasAssigned: false,
+          alias: [],
+        });
+      });
+
+      const mock = vi
+        .spyOn(createDeployModule, 'default')
+        .mockImplementation(async (_client, now: Now) => {
+          now.url = deploymentUrl;
+          throw new BuildError({
+            message: 'Command "npm run build" exited with 1',
+            meta: {},
+          });
+        });
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--json');
+      client.stdout.isTTY = false;
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(1);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      // Should be valid JSON parseable by jq
+      const json = JSON.parse(stdoutOutput);
+      expect(json.error).toEqual({
+        name: 'BUILD_ERROR',
+        message: 'Command "npm run build" exited with 1',
+      });
+      expect(json.readyState).toEqual('ERROR');
+
+      mock.mockRestore();
+    });
+
+    it('should output JSON with error field when deployment is canceled', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.post(`/v13/deployments`, (_req, res) => {
+        res.json({
+          id: deploymentId,
+          url: deploymentUrl,
+          inspectorUrl,
+          readyState: 'CANCELED',
+          target: null,
+        });
+      });
+      client.scenario.get(`/v13/deployments/${deploymentId}`, (_req, res) => {
+        res.json({
+          id: deploymentId,
+          url: deploymentUrl,
+          inspectorUrl,
+          readyState: 'CANCELED',
+          target: null,
+          aliasAssigned: false,
+          alias: [],
+        });
+      });
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--json');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(1);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const json = JSON.parse(stdoutOutput);
+
+      expect(json).toEqual({
+        id: deploymentId,
+        url: `https://${deploymentUrl}`,
+        inspectorUrl,
+        readyState: 'CANCELED',
+        target: null,
+        deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
+        error: {
+          name: 'DEPLOYMENT_CANCELED',
+          message: 'The deployment has been canceled.',
+        },
       });
     });
   });


### PR DESCRIPTION
## Context

When using `vercel deploy --json`, failed deployments (build errors, canceled deployments, failed checks) produced no JSON output on stdout, while successful deployments correctly output JSON. This made it impossible for scripts and automation tools to parse the result of failed deployments.

## Changes

- When `--json` is used and a deployment fails due to a build error, canceled state, or failed checks, the CLI now outputs JSON to stdout with the deployment info and an `error` field describing the failure
- Extended `getDeploymentOutputJson` to accept an optional `error` parameter
- Refactored the `BuildError` catch block to fetch the deployment once and reuse it for both JSON output and build log display

## References

- Related to #15355 (add --json flag to deploy command)
- Related to #15363 (suppress stdout URL when using --json in deploy)
- Related to #15390 (add --json flag to deploy init command)