### PR TITLE
fix(client): support directories for bulkRedirectsPath with --prebuilt

### DIFF
--- a/.changeset/bulk-redirects-directory-fix.md
+++ b/.changeset/bulk-redirects-directory-fix.md
@@ -1,0 +1,7 @@
+---
+'@vercel/client': patch
+---
+
+Fix bulkRedirectsPath with --prebuilt to support directories
+
+When using `bulkRedirectsPath` with `--prebuilt` deployments, the path can now point to either a file or a directory containing redirect files. Previously, only single files were supported, causing deployments to fail with "No files found at path" when using a directory.

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -7,7 +7,7 @@ import { pkgVersion } from '../pkg';
 import { NowBuildError } from '@vercel/build-utils';
 import { VercelClientOptions, VercelConfig } from '../types';
 import { Sema } from 'async-sema';
-import { readFile } from 'fs-extra';
+import { readFile, stat } from 'fs-extra';
 import readdir from './readdir-recursive';
 import {
   findConfig as findMicrofrontendsConfig,
@@ -170,7 +170,7 @@ export async function buildFileTree(
       debug(`Error checking for .vercel/routes.json: ${e}`);
     }
 
-    // Include bulkRedirectsPath file if specified (for prebuilt deployments)
+    // Include bulkRedirectsPath file or directory if specified (for prebuilt deployments)
     if (prebuilt && bulkRedirectsPath) {
       try {
         const projectRoot = path;
@@ -184,24 +184,33 @@ export async function buildFileTree(
         const relativeFromRoot = relative(projectRoot, bulkRedirectsFullPath);
         if (relativeFromRoot.startsWith('..')) {
           debug(
-            `Skipping bulk redirects file "${bulkRedirectsPath}" - path traversal detected (resolves outside project root)`
+            `Skipping bulk redirects path "${bulkRedirectsPath}" - path traversal detected (resolves outside project root)`
           );
         } else {
-          const bulkRedirectsContent = await maybeRead(
-            bulkRedirectsFullPath,
-            null
-          );
-          if (bulkRedirectsContent !== null) {
-            refs.add(bulkRedirectsFullPath);
-            debug(
-              `Including bulk redirects file "${bulkRedirectsPath}" in deployment`
-            );
-          } else {
-            debug(`Bulk redirects file "${bulkRedirectsPath}" not found`);
+          try {
+            const stats = await stat(bulkRedirectsFullPath);
+            if (stats.isDirectory()) {
+              // If it's a directory, recursively include all files
+              const dirFiles = await readdir(bulkRedirectsFullPath, []);
+              for (const file of dirFiles) {
+                refs.add(file);
+              }
+              debug(
+                `Including ${dirFiles.length} files from bulk redirects directory "${bulkRedirectsPath}" in deployment`
+              );
+            } else if (stats.isFile()) {
+              // If it's a file, include it directly
+              refs.add(bulkRedirectsFullPath);
+              debug(
+                `Including bulk redirects file "${bulkRedirectsPath}" in deployment`
+              );
+            }
+          } catch (_e) {
+            debug(`Bulk redirects path "${bulkRedirectsPath}" not found`);
           }
         }
       } catch (e) {
-        debug(`Error checking for bulk redirects file: ${e}`);
+        debug(`Error checking for bulk redirects path: ${e}`);
       }
     }
 

--- a/packages/client/tests/fixtures/bulk-redirects-dir/redirects/redirects1.json
+++ b/packages/client/tests/fixtures/bulk-redirects-dir/redirects/redirects1.json
@@ -1,0 +1,7 @@
+[
+  {
+    "source": "/old-path-1",
+    "destination": "/new-path-1",
+    "permanent": true
+  }
+]

--- a/packages/client/tests/fixtures/bulk-redirects-dir/redirects/redirects2.json
+++ b/packages/client/tests/fixtures/bulk-redirects-dir/redirects/redirects2.json
@@ -1,0 +1,7 @@
+[
+  {
+    "source": "/old-path-2",
+    "destination": "/new-path-2",
+    "permanent": false
+  }
+]

--- a/packages/client/tests/fixtures/bulk-redirects-dir/vercel.json
+++ b/packages/client/tests/fixtures/bulk-redirects-dir/vercel.json
@@ -1,0 +1,3 @@
+{
+  "bulkRedirectsPath": "redirects"
+}

--- a/packages/client/tests/unit.utils.test.ts
+++ b/packages/client/tests/unit.utils.test.ts
@@ -268,4 +268,27 @@ describe('buildFileTree()', () => {
       normalizeWindowsPaths(bulkRedirectsFile)[0]
     );
   });
+
+  it('should include all files from bulkRedirectsPath directory when prebuilt=true', async () => {
+    const cwd = fixture('bulk-redirects-dir');
+    const { fileList } = await buildFileTree(
+      cwd,
+      {
+        isDirectory: true,
+        prebuilt: true,
+        vercelOutputDir: join(cwd, '.vercel/output'),
+        bulkRedirectsPath: 'redirects',
+      },
+      noop
+    );
+
+    const expectedFiles = toAbsolutePaths(cwd, [
+      'redirects/redirects1.json',
+      'redirects/redirects2.json',
+    ]);
+    const normalizedFileList = normalizeWindowsPaths(fileList);
+    for (const expectedFile of normalizeWindowsPaths(expectedFiles)) {
+      expect(normalizedFileList).toContain(expectedFile);
+    }
+  });
 });


### PR DESCRIPTION
When using bulkRedirectsPath with --prebuilt deployments, the path can now point to either a file or a directory containing redirect files. Previously, only single files were supported, causing deployments to fail with "No files found at path" when using a directory.