### PR TITLE
fix(cli): fix `vc build` failing on subsequent runs for repo-linked monorepo projects

### DIFF
--- a/.changeset/fix-repo-link-build-regression.md
+++ b/.changeset/fix-repo-link-build-regression.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vc build` failing on subsequent runs for repo-linked monorepo projects with "Project Settings are invalid" error.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -250,6 +250,15 @@ export default async function main(client: Client): Promise<number> {
   // Read project settings, and pull them from Vercel if necessary
   const vercelDir = join(cwd, projectRootDirectory, VERCEL_DIR);
   let project = await readProjectSettings(vercelDir);
+
+  // If the project is not linked (no repo link or directory link found) but a
+  // settings-only `project.json` exists (written for repo-linked projects
+  // without `projectId`/`orgId`), ignore it. The project needs to be
+  // re-linked before building.
+  if (!link && project?.settings && !project?.projectId) {
+    project = null;
+  }
+
   const isTTY = process.stdin.isTTY;
   while (!project?.settings) {
     let confirmed = yes;

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -80,15 +80,10 @@ export async function getProjectLink(
   client: Client,
   path: string
 ): Promise<ProjectLink | null> {
-  // Prefer an explicit per-directory link (`.vercel/project.json`) over a
-  // repository-level link (`.vercel/repo.json`). This prevents scenarios where
-  // a freshly-created local link (e.g. after `vc link`) is ignored and the
-  // user is re-prompted to select a repo-linked project again.
-  const dirLink = await getLinkFromDir(getVercelDirectory(path));
-  if (dirLink) {
-    return dirLink;
-  }
-  return await getProjectLinkFromRepoLink(client, path);
+  return (
+    (await getProjectLinkFromRepoLink(client, path)) ||
+    (await getLinkFromDir(getVercelDirectory(path)))
+  );
 }
 
 async function getProjectLinkFromRepoLink(
@@ -152,9 +147,11 @@ export async function getLinkFromDir<T = ProjectLink>(
     const link: T = JSON.parse(json);
 
     if (!ajv.validate(linkSchema, link)) {
-      throw new Error(
-        `Project Settings are invalid. To link your project again, remove the ${dir} directory.`
-      );
+      // The file exists but doesn't contain valid project link data
+      // (e.g. a settings-only file written for repo-linked projects).
+      // Return `null` so that callers can fall through to other link
+      // resolution strategies such as `repo.json`.
+      return null;
     }
 
     return link;

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { join } from 'path';
 import { mkdirp, writeJSON } from 'fs-extra';
 import { getLinkedProject } from '../../../../src/util/projects/link';
@@ -204,58 +204,60 @@ describe('getLinkedProject', () => {
     expect(link.repoRoot).toEqual(cwd);
   });
 
-  it('should prefer `project.json` over `repo.json` when both exist', async () => {
-    const repoRoot = setupTmpDir('project-link-precedence');
-    const cwd = join(repoRoot, 'apps', 'docs');
+  it('should fall through to `repo.json` when `project.json` has settings but no projectId/orgId', async () => {
+    // Simulates the scenario after `vc build` writes a settings-only
+    // `project.json` for a repo-linked project. On subsequent runs,
+    // `getProjectLink()` should skip the invalid per-directory file and
+    // resolve the link via `repo.json` instead.
+    const repoRoot = setupTmpDir('repo-link-settings-only');
+    const cwd = join(repoRoot, 'apps', 'my-app');
 
-    // Repo-level link that would normally require disambiguation.
+    // Repo-level link at the repo root.
     await mkdirp(join(repoRoot, '.vercel'));
     await writeJSON(join(repoRoot, '.vercel', 'repo.json'), {
       remoteName: 'origin',
       projects: [
         {
-          id: 'repo-proj-1',
-          name: 'repo-proj-1',
-          directory: '.',
-          orgId: 'team_dummy',
-        },
-        {
-          id: 'repo-proj-2',
-          name: 'repo-proj-2',
-          directory: '.',
+          id: 'repo-proj-abc',
+          name: 'my-app',
+          directory: 'apps/my-app',
           orgId: 'team_dummy',
         },
       ],
     });
 
-    // Explicit directory-level link should win.
+    // Settings-only project.json (no projectId/orgId) as written by
+    // `writeProjectSettings()` when `isRepoLinked` is true.
     await mkdirp(join(cwd, '.vercel'));
     await writeJSON(join(cwd, '.vercel', 'project.json'), {
-      orgId: 'team_dummy',
-      projectId: 'project-json-project',
-      projectName: 'project-json-project',
+      settings: {
+        createdAt: 1770822175969,
+        framework: 'nextjs',
+        devCommand: null,
+        installCommand: '',
+        buildCommand: null,
+        outputDirectory: null,
+        rootDirectory: 'apps/my-app',
+        directoryListing: false,
+        nodeVersion: '20.x',
+      },
     });
 
     useUser();
     useTeams('team_dummy');
     useProject({
       ...defaultProject,
-      id: 'project-json-project',
-      name: 'project-json-project',
+      id: 'repo-proj-abc',
+      name: 'my-app',
     });
 
-    const selectSpy = vi.spyOn(client.input, 'select');
     const link = await getLinkedProject(client, cwd);
-
-    // If repo.json was consulted, we'd have prompted to disambiguate.
-    expect(selectSpy).not.toHaveBeenCalled();
-    selectSpy.mockRestore();
 
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
-    expect(link.project.id).toEqual('project-json-project');
-    expect(link.repoRoot).toBeUndefined();
+    expect(link.project.id).toEqual('repo-proj-abc');
+    expect(link.repoRoot).toEqual(repoRoot);
   });
 
   it('should return link with legacy `repo.json` (top-level orgId)', async () => {


### PR DESCRIPTION
## Summary

Fixes `vc build` failing with "Project Settings are invalid" on the second run when using `vc link --repo` in a monorepo.

## Root Cause

PR #15017 swapped the precedence in `getProjectLink()` to check `project.json` before `repo.json`. For repo-linked monorepos, `writeProjectSettings()` writes a settings-only `project.json` (without `projectId`/`orgId`) during `vc build`. On subsequent runs, `getLinkFromDir()` found this file, failed AJV schema validation (which requires `projectId`/`orgId`), and threw the error instead of falling through to `repo.json`.

The duplicate-prompt bug that #15017 intended to fix was already properly handled in `ensureLink` via the `forceDelete` guard — the precedence swap was unnecessary.

## Changes

- **`packages/cli/src/util/projects/link.ts`**: Restore original `repo.json`-first precedence in `getProjectLink()`. Change `getLinkFromDir()` to return `null` on validation failure instead of throwing, since a settings-only file is not corrupted.
- **`packages/cli/src/commands/build/index.ts`**: Ignore orphaned settings-only `project.json` in `vc build` when no link is found (has `settings` but no `projectId`), so the user is properly prompted to re-link.
- **`packages/cli/test/unit/util/projects/link.test.ts`**: Replace incorrect precedence test with a test for the actual bug scenario (settings-only `project.json` with `repo.json` present).