### PR TITLE
[CLI] fix: return exit code 0 for `logs --help`

### DIFF
--- a/.changeset/fix-logs-help-exit-code.md
+++ b/.changeset/fix-logs-help-exit-code.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix `vercel logs --help` returning non-zero exit code

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -219,7 +219,7 @@ export default async function logs(client: Client) {
   if (parsedArguments.flags['--help']) {
     telemetry.trackCliFlagHelp('logs');
     output.print(help(logsCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const subArgs = parsedArguments.args.slice(1);

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -73,7 +73,7 @@ describe('logs', () => {
       client.setArgv('logs', '--help');
       const exitCode = await logs(client);
 
-      expect(exitCode).toEqual(2);
+      expect(exitCode).toEqual(0);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',


### PR DESCRIPTION
Return exit code 0 instead of 2 when `--help` flag is used, aligning with standard CLI conventions (git, npm, docker) and the root `vercel --help` behavior. Return of `2` causes the `--help` run in agents to show an error even though there is no error here.

This follows the same fix applied in #13780 and #14834 for other commands.

There was a bigger PR in place for returning `0` for all the `--help` runs in #14953 though it didn't move through yet.

Here is a previous discussion for using `0` in `--help` output: https://vercel.slack.com/archives/C07PRDN82P8/p1755420565652369