### PR TITLE
chore(cli): make agents readonly by default

### DIFF
--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -237,13 +237,16 @@ async function executeSingleRequest(
   flags: ParsedFlags
 ): Promise<number> {
   try {
-    // Check for confirmation before proceeding with DELETE operations
-    const confirmed = await client.confirmMutatingOperation(
-      config.url,
-      config.method
-    );
-    if (!confirmed) {
-      return 1;
+    // For non-agent users: prompt for confirmation on DELETE operations.
+    // For agents: the agent confirmation check in fetch() covers all non-GET.
+    if (!client.isAgent) {
+      const confirmed = await client.confirmMutatingOperation(
+        config.url,
+        config.method
+      );
+      if (!confirmed) {
+        return 1;
+      }
     }
 
     const response: Response = await client.fetch(config.url, {
@@ -268,13 +271,16 @@ async function executePaginatedRequest(
   const results: unknown[] = [];
 
   try {
-    // Check for confirmation before proceeding with DELETE operations
-    const confirmed = await client.confirmMutatingOperation(
-      config.url,
-      config.method
-    );
-    if (!confirmed) {
-      return 1;
+    // For non-agent users: prompt for confirmation on DELETE operations.
+    // For agents: the agent confirmation check in fetch() covers all non-GET.
+    if (!client.isAgent) {
+      const confirmed = await client.confirmMutatingOperation(
+        config.url,
+        config.method
+      );
+      if (!confirmed) {
+        return 1;
+      }
     }
 
     for await (const page of client.fetchPaginated<Record<string, unknown>>(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -387,6 +387,8 @@ const main = async () => {
     isAgent,
     agentName: detectedAgent?.name,
     nonInteractive,
+    withAgentConfirmation:
+      parsedArgs.flags['--with-agent-confirmation'] === true,
   });
 
   // The `--cwd` flag is respected for all sub-commands
@@ -950,6 +952,12 @@ const main = async () => {
       if (func.default) {
         func = func.default;
       }
+
+      // Set the command name for agent confirmation messages
+      const fullCommandName = subSubCommand
+        ? `${targetCommand} ${subSubCommand}`
+        : targetCommand;
+      client.commandName = fullCommandName;
 
       exitCode = await func(client);
     }

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -79,6 +79,13 @@ export const globalCommandOptions = [
   },
   { name: 'team', shorthand: 'T', type: String, deprecated: false },
   { name: 'api', shorthand: null, type: String, deprecated: false },
+  // Hidden flag: used by agents to confirm mutating operations after user approval
+  {
+    name: 'with-agent-confirmation',
+    shorthand: null,
+    type: Boolean,
+    deprecated: false,
+  },
 ] as const;
 
 const GLOBAL_OPTIONS = getFlagsSpecification(globalCommandOptions);

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -440,7 +440,7 @@ export default class Client extends EventEmitter implements Stdio {
         ? { teamId, ...(teamName ? { teamSlug: teamName } : {}) }
         : {}),
       message: `Confirmation required: "vercel ${command}" requires write permissions${scopeInfo}.`,
-      description: `The command "vercel ${command}" makes non-GET API requests and requires explicit user approval when running as an agent.`,
+      description: `The command "vercel ${command}" requires write privileges which require user approval.`,
       prompt:
         'Use a yes/no confirmation prompt to ask the user if they want to proceed with this operation. Do not proceed without explicit user approval.',
       resolution:

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -72,6 +72,8 @@ export interface ClientOptions extends Stdio {
   nonInteractive?: boolean;
   /** Dangerously skip all permission prompts (--dangerously-skip-permissions flag) */
   dangerouslySkipPermissions?: boolean;
+  /** Agent has received user confirmation for mutating operations (--with-agent-confirmation flag) */
+  withAgentConfirmation?: boolean;
 }
 
 export const isJSONObject = (v: any): v is JSONObject => {
@@ -117,6 +119,10 @@ export default class Client extends EventEmitter implements Stdio {
   nonInteractive: boolean;
   /** Dangerously skip all permission prompts (--dangerously-skip-permissions flag) */
   dangerouslySkipPermissions: boolean;
+  /** Agent has received user confirmation for mutating operations (--with-agent-confirmation flag) */
+  withAgentConfirmation: boolean;
+  /** The current CLI command name, set during dispatch for agent confirmation messages */
+  commandName?: string;
   /** Track if we've already logged the token source debug message */
   private _loggedTokenSource: boolean = false;
 
@@ -138,6 +144,7 @@ export default class Client extends EventEmitter implements Stdio {
     this.agentName = opts.agentName;
     this.nonInteractive = opts.nonInteractive ?? this.isAgent;
     this.dangerouslySkipPermissions = opts.dangerouslySkipPermissions ?? false;
+    this.withAgentConfirmation = opts.withAgentConfirmation ?? false;
 
     const theme = {
       prefix: gray('?'),
@@ -340,6 +347,115 @@ export default class Client extends EventEmitter implements Stdio {
     return confirmed;
   }
 
+  /**
+   * Confirms non-GET operations when running under an AI agent.
+   * Called automatically from fetch() — all commands get this protection.
+   *
+   * When in non-TTY mode (typical for agents), outputs a structured JSON
+   * confirmation request to stdout and exits with code 0. The agent can
+   * then ask the user for confirmation and re-run with --with-agent-confirmation.
+   *
+   * - GET operations are always allowed
+   * - Non-GET operations require confirmation (unless --dangerously-skip-permissions is used)
+   * - TTY mode uses interactive prompts
+   * - Non-TTY mode outputs JSON and exits (no blocking)
+   *
+   * @returns true if the operation should proceed, false if canceled
+   */
+  async confirmAgentMutatingOperation(
+    url: string,
+    method: string | undefined
+  ): Promise<boolean> {
+    const normalizedMethod = (method || 'GET').toUpperCase();
+
+    // GET operations are always allowed for agents
+    if (normalizedMethod === 'GET') {
+      return true;
+    }
+
+    // --with-agent-confirmation: the agent has already obtained user approval
+    if (this.withAgentConfirmation) {
+      return true;
+    }
+
+    // Show agent mode warning when --dangerously-skip-permissions is used
+    if (this.dangerouslySkipPermissions) {
+      const agentInfo = this.agentName ? ` (${this.agentName})` : '';
+      output.print('\n');
+      output.print(
+        bgRed(white(bold(' ⚠ WARNING '))) +
+          red(bold(` AGENT MODE - ${normalizedMethod} CONFIRMATION BYPASSED\n`))
+      );
+      output.print(
+        yellow(
+          `  An AI agent${agentInfo} is executing a ${bold(normalizedMethod)} request with --dangerously-skip-permissions flag.\n`
+        )
+      );
+      output.print(yellow(`  Target: ${bold(url)}\n`));
+      output.print(
+        yellow(
+          `  The --dangerously-skip-permissions flag has bypassed the confirmation prompt.\n\n`
+        )
+      );
+      return true;
+    }
+
+    // If TTY is available, use interactive prompt
+    if (this.stdin.isTTY) {
+      const message = `You are about to perform a ${yellow(bold(normalizedMethod))} operation on:\n  ${bold(url)}\n\nAre you sure you want to proceed?`;
+      output.print('\n');
+      const confirmed = await this.input.confirm(message, false);
+      output.print('\n');
+      if (!confirmed) {
+        output.log('Operation canceled by user.');
+      }
+      return confirmed;
+    }
+
+    // Non-TTY agent mode: output structured confirmation request and exit.
+    // The agent should present the operation to the user and re-run with
+    // --with-agent-confirmation. This is a one-time check per command — the
+    // first non-GET fetch triggers it and the command fails. The re-run with
+    // the flag bypasses all subsequent checks.
+    const teamId = this.config.currentTeam;
+    let teamName: string | undefined;
+    if (teamId) {
+      try {
+        const res = await this._fetch(`/teams/${teamId}`, { method: 'GET' });
+        if (res.ok) {
+          const team = await res.json();
+          teamName = team.slug || team.name;
+        }
+      } catch {
+        // Fall back to teamId if we can't resolve the name
+      }
+    }
+    const scopeLabel = teamName || teamId;
+    const scopeInfo = scopeLabel ? ` on team "${scopeLabel}"` : '';
+    const command = this.commandName ?? `${normalizedMethod} ${url}`;
+    const confirmationRequest = {
+      type: 'agent_confirmation_required',
+      command,
+      ...(teamId
+        ? { teamId, ...(teamName ? { teamSlug: teamName } : {}) }
+        : {}),
+      message: `Confirmation required: "vercel ${command}" requires write permissions${scopeInfo}.`,
+      description: `The command "vercel ${command}" makes non-GET API requests and requires explicit user approval when running as an agent.`,
+      prompt:
+        'Use a yes/no confirmation prompt to ask the user if they want to proceed with this operation. Do not proceed without explicit user approval.',
+      resolution:
+        'If the user confirms, re-run the same command with the --with-agent-confirmation flag.',
+    };
+
+    // Write JSON and exit immediately with code 0.
+    // Using exit code 0 signals this is not an error — it's a confirmation
+    // request. The agent reads the JSON from stdout and acts on it.
+    // We must exit here to prevent the command's error handler from printing
+    // additional noise to stderr.
+    this.stdout.write(`${JSON.stringify(confirmationRequest)}\n`);
+    process.exit(0);
+  }
+
   private async _fetch(_url: string, opts: FetchOptions = {}) {
     const url = new URL(_url, this.apiUrl);
 
@@ -394,6 +510,20 @@ export default class Client extends EventEmitter implements Stdio {
   fetch<T>(url: string, opts?: FetchOptions): Promise<T>;
   fetch(url: string, opts: FetchOptions = {}) {
     return this.retry(async bail => {
+      // In agent mode, confirm non-GET operations before proceeding
+      if (this.isAgent) {
+        const confirmed = await this.confirmAgentMutatingOperation(
+          url,
+          opts.method
+        );
+        if (!confirmed) {
+          const err = new Error(
+            'Operation canceled: non-GET operations require confirmation when running as an agent.'
+          );
+          return bail(err);
+        }
+      }
+
       const res = await this._fetch(url, opts);
 
       printIndications(res);

--- a/packages/cli/test/unit/util/client-confirmation.test.ts
+++ b/packages/cli/test/unit/util/client-confirmation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { client } from '../../mocks/client';
 
 describe('Client confirmation prompts', () => {
@@ -7,11 +7,9 @@ describe('Client confirmation prompts', () => {
     client.reset();
   });
 
-  describe('DELETE operations', () => {
+  describe('confirmMutatingOperation (DELETE only)', () => {
     it('should prompt for confirmation on DELETE', async () => {
-      // Disable skip to test confirmation prompt
       client.dangerouslySkipPermissions = false;
-      // Mock confirm to return true
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
       const result = await client.confirmMutatingOperation(
@@ -28,9 +26,7 @@ describe('Client confirmation prompts', () => {
     });
 
     it('should cancel DELETE when user says no', async () => {
-      // Disable skip to test confirmation prompt
       client.dangerouslySkipPermissions = false;
-      // Mock confirm to return false
       client.input.confirm = vi.fn().mockResolvedValue(false);
 
       const result = await client.confirmMutatingOperation(
@@ -51,13 +47,11 @@ describe('Client confirmation prompts', () => {
         'DELETE'
       );
 
-      // Confirm should NOT be called when dangerouslySkipPermissions is true
       expect(client.input.confirm).not.toHaveBeenCalled();
       expect(result).toBe(true);
     });
 
     it('should show error in non-TTY mode without --dangerously-skip-permissions', async () => {
-      // Disable skip to test non-TTY error behavior
       client.dangerouslySkipPermissions = false;
       client.stdin.isTTY = false;
       client.input.confirm = vi.fn().mockResolvedValue(true);
@@ -67,11 +61,9 @@ describe('Client confirmation prompts', () => {
         'DELETE'
       );
 
-      // Confirm should NOT be called in non-TTY mode
       expect(client.input.confirm).not.toHaveBeenCalled();
       expect(result).toBe(false);
 
-      // Should show error message
       const output = client.stderr.getFullOutput();
       expect(output).toContain('DELETE operations require confirmation');
       expect(output).toContain('--dangerously-skip-permissions');
@@ -88,13 +80,10 @@ describe('Client confirmation prompts', () => {
       );
 
       expect(result).toBe(true);
-      // Confirm should NOT be called when dangerouslySkipPermissions is true
       expect(client.input.confirm).not.toHaveBeenCalled();
     });
-  });
 
-  describe('Agent mode', () => {
-    it('should show warning when agent bypasses DELETE confirmation', async () => {
+    it('should show agent warning when agent bypasses DELETE confirmation', async () => {
       client.isAgent = true;
       client.agentName = 'test-agent';
       client.dangerouslySkipPermissions = true;
@@ -131,12 +120,9 @@ describe('Client confirmation prompts', () => {
       const output = client.stderr.getFullOutput();
       expect(output).toContain('WARNING');
       expect(output).toContain('AGENT MODE');
-      // Should NOT contain the agent name info when not provided
       expect(output).not.toContain('(undefined)');
     });
-  });
 
-  describe('Non-DELETE operations', () => {
     it('should not prompt for GET requests', async () => {
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
@@ -184,9 +170,7 @@ describe('Client confirmation prompts', () => {
       expect(client.input.confirm).not.toHaveBeenCalled();
       expect(result).toBe(true);
     });
-  });
 
-  describe('Edge cases', () => {
     it('should handle lowercase delete method', async () => {
       client.dangerouslySkipPermissions = true;
       client.input.confirm = vi.fn().mockResolvedValue(true);
@@ -212,7 +196,6 @@ describe('Client confirmation prompts', () => {
     });
 
     it('should include URL in confirmation message', async () => {
-      // Disable skip to test confirmation message content
       client.dangerouslySkipPermissions = false;
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
@@ -222,6 +205,219 @@ describe('Client confirmation prompts', () => {
         expect.stringContaining('/v9/test'),
         false
       );
+    });
+  });
+
+  describe('confirmAgentMutatingOperation', () => {
+    it('should allow GET requests without confirmation', async () => {
+      client.input.confirm = vi.fn().mockResolvedValue(true);
+
+      const result = await client.confirmAgentMutatingOperation(
+        '/v9/test',
+        'GET'
+      );
+
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('should allow requests with no method (defaults to GET)', async () => {
+      client.input.confirm = vi.fn().mockResolvedValue(true);
+
+      const result = await client.confirmAgentMutatingOperation(
+        '/v9/test',
+        undefined
+      );
+
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('should skip confirmation with --dangerously-skip-permissions and show warning', async () => {
+      client.agentName = 'test-agent';
+      client.dangerouslySkipPermissions = true;
+      client.input.confirm = vi.fn().mockResolvedValue(true);
+
+      const result = await client.confirmAgentMutatingOperation(
+        '/v9/test',
+        'POST'
+      );
+
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+
+      const output = client.stderr.getFullOutput();
+      expect(output).toContain('WARNING');
+      expect(output).toContain('AGENT MODE');
+      expect(output).toContain('POST');
+      expect(output).toContain('test-agent');
+    });
+
+    it('should bypass confirmation with --with-agent-confirmation flag', async () => {
+      client.withAgentConfirmation = true;
+      client.dangerouslySkipPermissions = false;
+      client.input.confirm = vi.fn().mockResolvedValue(true);
+
+      const result = await client.confirmAgentMutatingOperation(
+        '/v9/test',
+        'POST'
+      );
+
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('should bypass confirmation with --with-agent-confirmation for DELETE', async () => {
+      client.withAgentConfirmation = true;
+      client.dangerouslySkipPermissions = false;
+      client.input.confirm = vi.fn().mockResolvedValue(true);
+
+      const result = await client.confirmAgentMutatingOperation(
+        '/v9/test',
+        'DELETE'
+      );
+
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('should still allow GET without --with-agent-confirmation', async () => {
+      client.withAgentConfirmation = false;
+      client.input.confirm = vi.fn().mockResolvedValue(true);
+
+      const result = await client.confirmAgentMutatingOperation(
+        '/v9/test',
+        'GET'
+      );
+
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    describe('TTY mode (interactive prompt)', () => {
+      it('should use interactive confirm for POST requests', async () => {
+        client.dangerouslySkipPermissions = false;
+        client.input.confirm = vi.fn().mockResolvedValue(true);
+
+        const result = await client.confirmAgentMutatingOperation(
+          '/v9/test',
+          'POST'
+        );
+
+        expect(client.input.confirm).toHaveBeenCalledTimes(1);
+        expect(client.input.confirm).toHaveBeenCalledWith(
+          expect.stringContaining('POST'),
+          false
+        );
+        expect(result).toBe(true);
+      });
+
+      it('should cancel when user says no', async () => {
+        client.dangerouslySkipPermissions = false;
+        client.input.confirm = vi.fn().mockResolvedValue(false);
+
+        const result = await client.confirmAgentMutatingOperation(
+          '/v9/test',
+          'POST'
+        );
+
+        expect(client.input.confirm).toHaveBeenCalledTimes(1);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('non-TTY mode (structured JSON output)', () => {
+      let mockExit: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        mockExit = vi
+          .spyOn(process, 'exit')
+          .mockImplementation(() => undefined as never);
+      });
+
+      afterEach(() => {
+        mockExit.mockRestore();
+      });
+
+      it('should output command-level confirmation JSON and exit with code 0', async () => {
+        client.dangerouslySkipPermissions = false;
+        client.stdin.isTTY = false;
+        client.commandName = 'project add';
+        client.input.confirm = vi.fn().mockResolvedValue(true);
+
+        await client.confirmAgentMutatingOperation('/v9/projects', 'POST');
+
+        // Should NOT have used interactive confirm
+        expect(client.input.confirm).not.toHaveBeenCalled();
+        // Should exit cleanly with code 0
+        expect(mockExit).toHaveBeenCalledWith(0);
+
+        // Should have output structured JSON to stdout
+        const stdoutOutput = client.stdout.getFullOutput();
+        const confirmation = JSON.parse(stdoutOutput.trim());
+        expect(confirmation.type).toBe('agent_confirmation_required');
+        expect(confirmation.command).toBe('project add');
+        expect(confirmation.message).toContain('vercel project add');
+        expect(confirmation.message).toContain('write permissions');
+        expect(confirmation.resolution).toContain('--with-agent-confirmation');
+      });
+
+      it('should fall back to method/url when commandName is not set', async () => {
+        client.dangerouslySkipPermissions = false;
+        client.stdin.isTTY = false;
+        client.commandName = undefined;
+
+        await client.confirmAgentMutatingOperation(
+          '/v9/projects/my-proj',
+          'DELETE'
+        );
+
+        expect(mockExit).toHaveBeenCalledWith(0);
+
+        const stdoutOutput = client.stdout.getFullOutput();
+        const confirmation = JSON.parse(stdoutOutput.trim());
+        expect(confirmation.command).toBe('DELETE /v9/projects/my-proj');
+      });
+
+      it('should include teamId and resolved team slug when team is scoped', async () => {
+        client.dangerouslySkipPermissions = false;
+        client.stdin.isTTY = false;
+        client.commandName = 'env add';
+        client.config.currentTeam = 'team_abc123';
+        client.scenario.get('/teams/team_abc123', (_req, res) => {
+          res.json({ id: 'team_abc123', slug: 'my-team', name: 'My Team' });
+        });
+
+        await client.confirmAgentMutatingOperation('/v9/test', 'POST');
+
+        expect(mockExit).toHaveBeenCalledWith(0);
+
+        const stdoutOutput = client.stdout.getFullOutput();
+        const confirmation = JSON.parse(stdoutOutput.trim());
+        expect(confirmation.teamId).toBe('team_abc123');
+        expect(confirmation.teamSlug).toBe('my-team');
+        expect(confirmation.message).toContain('my-team');
+      });
+
+      it('should fall back to teamId when team name resolution fails', async () => {
+        client.dangerouslySkipPermissions = false;
+        client.stdin.isTTY = false;
+        client.commandName = 'env add';
+        client.config.currentTeam = 'team_abc123';
+        client.scenario.get('/teams/team_abc123', (_req, res) => {
+          res.status(404).json({ error: 'not found' });
+        });
+
+        await client.confirmAgentMutatingOperation('/v9/test', 'POST');
+
+        expect(mockExit).toHaveBeenCalledWith(0);
+
+        const stdoutOutput = client.stdout.getFullOutput();
+        const confirmation = JSON.parse(stdoutOutput.trim());
+        expect(confirmation.teamId).toBe('team_abc123');
+        expect(confirmation.teamSlug).toBeUndefined();
+        expect(confirmation.message).toContain('team_abc123');
+      });
     });
   });
 });


### PR DESCRIPTION
Require that agents ask for permission when using commands that use non GET operations. 