### PR TITLE
[python-analysis] Stub unicode/IDNA crates to reduce WASM size

### DIFF
--- a/.changeset/quiet-wolves-hunt.md
+++ b/.changeset/quiet-wolves-hunt.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-analysis': patch
+---
+
+Stub unicode/IDNA crates to reduce WASM binary size

--- a/packages/python-analysis/Cargo.lock
+++ b/packages/python-analysis/Cargo.lock
@@ -370,26 +370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,8 +500,16 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 [[package]]
 name = "idna"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "host-bridge",
+ "idna 1.1.0 (git+https://github.com/servo/rust-url?tag=v2.5.8)",
+ "wasm-test-support",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "git+https://github.com/servo/rust-url?tag=v2.5.8#d6ea13c5f8e7e6e627f6390161b3e185bda5e5ce"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -647,12 +635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "libc"
-version = "0.2.183"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
-
-[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,44 +752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,15 +779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -940,36 +875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
 dependencies = [
  "ptr_meta",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -1095,7 +1000,7 @@ dependencies = [
  "rustc-hash",
  "static_assertions",
  "unicode-ident",
- "unicode-normalization",
+ "unicode-normalization 0.1.25",
  "unicode_names2",
 ]
 
@@ -1226,12 +1131,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -1426,8 +1325,16 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 [[package]]
 name = "unicode-normalization"
 version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "host-bridge",
+ "unicode-normalization 0.1.25 (git+https://github.com/unicode-rs/unicode-normalization?rev=576ae0b)",
+ "wasm-test-support",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "git+https://github.com/unicode-rs/unicode-normalization?rev=576ae0b#576ae0b1407dd14854876c93f1a348df0c19dffe"
 dependencies = [
  "tinyvec",
 ]
@@ -1447,24 +1354,6 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unicode_names2"
 version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
-dependencies = [
- "phf",
- "unicode_names2_generator",
-]
-
-[[package]]
-name = "unicode_names2_generator"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
-dependencies = [
- "getopts",
- "log",
- "phf_codegen",
- "rand",
-]
 
 [[package]]
 name = "unscanny"
@@ -1479,7 +1368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.1.0",
  "percent-encoding",
  "serde",
  "serde_derive",
@@ -1771,12 +1660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,26 +1882,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/packages/python-analysis/Cargo.toml
+++ b/packages/python-analysis/Cargo.toml
@@ -43,6 +43,9 @@ uv-fs = { path = "crates/uv-fs-stub" }
 
 [patch.crates-io]
 fs-err = { path = "crates/fs-err-stub" }
+idna = { path = "crates/idna-stub" }
+unicode-normalization = { path = "crates/unicode-normalization-stub" }
+unicode_names2 = { path = "crates/unicode-names2-stub" }
 
 [profile.release]
 opt-level = "z"

--- a/packages/python-analysis/crates/idna-stub/Cargo.toml
+++ b/packages/python-analysis/crates/idna-stub/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "idna"
+version = "1.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+host-bridge = { path = "../host-bridge" }
+idna-upstream = { package = "idna", git = "https://github.com/servo/rust-url", tag = "v2.5.8", optional = true }
+
+[[test]]
+name = "unit"
+harness = false
+
+[dev-dependencies]
+wasm-test-support = { path = "../wasm-test-support" }
+
+[features]
+default = []
+alloc = []           # no-op, required by url crate
+compiled_data = []   # no-op, required by url crate
+std = []
+upstream = ["dep:idna-upstream"]

--- a/packages/python-analysis/crates/idna-stub/README.md
+++ b/packages/python-analysis/crates/idna-stub/README.md
@@ -1,0 +1,29 @@
+# idna-stub
+
+Local stub for the [`idna`](https://github.com/servo/rust-url/tree/main/idna)
+crate (v1.1.0) that replaces ICU-based IDNA processing with a WIT host import,
+eliminating ~275 KB of ICU/Unicode lookup tables from the WASM binary.
+
+Domain-to-ASCII conversion is delegated to the JS host via the
+`vercel:python-analysis/host-utils` WIT interface, which uses the Node.js `URL`
+API internally. This means the runtime behavior follows IDNA2008 (via
+Node.js/ICU) rather than UTS #46 (as in the upstream crate).
+
+## API surface
+
+Only the subset of `idna` used by the [`url`](https://crates.io/crates/url)
+crate is implemented:
+
+- `domain_to_ascii_from_cow(domain, deny_list) -> Result<Cow<str>, Errors>`
+- `domain_to_unicode(domain) -> (String, Result<(), Errors>)` -- passthrough, no
+  round-trip decoding
+- `AsciiDenyList` -- `URL`, `STD3`, `EMPTY` variants
+
+Fast paths avoid host calls for all-ASCII lowercase domains.
+
+## Upstream
+
+Based on [`idna` v1.1.0](https://crates.io/crates/idna/1.1.0) from
+[servo/rust-url](https://github.com/servo/rust-url/).
+
+Copyright (c) The Servo Project Developers. Licensed under MIT OR Apache-2.0.

--- a/packages/python-analysis/crates/idna-stub/src/lib.rs
+++ b/packages/python-analysis/crates/idna-stub/src/lib.rs
@@ -1,0 +1,122 @@
+// Derived from the idna crate (https://github.com/servo/rust-url).
+// Copyright (c) The Servo Project Developers.
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+
+//! Stubbed `idna` crate that delegates IDNA processing to the JS host
+//! via WIT imports, eliminating overhead of ICU lookup tables.
+
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
+use alloc::borrow::Cow;
+use alloc::string::String;
+
+pub mod uts46;
+
+pub use uts46::AsciiDenyList;
+
+/// Type indicating errors during IDNA processing.
+#[derive(Default, Debug)]
+#[non_exhaustive]
+pub struct Errors {}
+
+impl From<Errors> for Result<(), Errors> {
+    fn from(e: Errors) -> Self {
+        Err(e)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Errors {}
+
+#[cfg(not(feature = "std"))]
+impl core::error::Error for Errors {}
+
+impl core::fmt::Display for Errors {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self, f)
+    }
+}
+
+/// Check if a byte sequence is all ASCII lowercase (or non-alpha).
+fn is_ascii_lowercase_domain(domain: &[u8]) -> bool {
+    domain.iter().all(|&b| b != 0 && !b.is_ascii_uppercase())
+}
+
+/// Check if a byte sequence is all ASCII.
+fn is_all_ascii(domain: &[u8]) -> bool {
+    domain.iter().all(|&b| b < 0x80)
+}
+
+/// Check if any label starts with `xn--` (punycode prefix).
+fn has_punycode_label(domain: &[u8]) -> bool {
+    domain
+        .split(|&b| b == b'.')
+        .any(|label| label.starts_with(b"xn--"))
+}
+
+/// Check if the domain contains any characters forbidden by the given deny list.
+fn check_deny_list(domain: &str, ascii_deny_list: AsciiDenyList) -> bool {
+    domain.bytes().any(|b| ascii_deny_list.denies(b))
+}
+
+/// The [domain to ASCII](https://url.spec.whatwg.org/#concept-domain-to-ascii) algorithm;
+/// version accepting and returning a `Cow`.
+pub fn domain_to_ascii_from_cow(
+    domain: Cow<'_, [u8]>,
+    ascii_deny_list: AsciiDenyList,
+) -> Result<Cow<'_, str>, Errors> {
+    // Fast path: all-ASCII lowercase domain with no denied chars.
+    // Domains with xn-- labels need punycode validation via the host.
+    if is_all_ascii(&domain)
+        && is_ascii_lowercase_domain(&domain)
+        && !has_punycode_label(&domain)
+    {
+        match domain {
+            Cow::Borrowed(b) => {
+                let s = core::str::from_utf8(b).map_err(|_| Errors {})?;
+                if !check_deny_list(s, ascii_deny_list) {
+                    return Ok(Cow::Borrowed(s));
+                }
+                return Err(Errors {});
+            }
+            Cow::Owned(b) => {
+                let s = String::from_utf8(b).map_err(|_| Errors {})?;
+                if !check_deny_list(&s, ascii_deny_list) {
+                    return Ok(Cow::Owned(s));
+                }
+                return Err(Errors {});
+            }
+        }
+    }
+
+    // Delegate to host for normalization
+    let domain_str = match &domain {
+        Cow::Borrowed(b) => core::str::from_utf8(b).map_err(|_| Errors {})?,
+        Cow::Owned(b) => core::str::from_utf8(b).map_err(|_| Errors {})?,
+    };
+    let result = host_bridge::domain_to_ascii(domain_str).map_err(|_| Errors {})?;
+
+    if check_deny_list(&result, ascii_deny_list) {
+        return Err(Errors {});
+    }
+
+    Ok(Cow::Owned(result))
+}
+
+/// The [domain to Unicode](https://url.spec.whatwg.org/#concept-domain-to-unicode) algorithm.
+///
+/// Delegates to the JS host for full UTS #46 processing: punycode decoding,
+/// case folding, and NFC normalization.
+pub fn domain_to_unicode(domain: &str) -> (String, Result<(), Errors>) {
+    let (result, ok) = host_bridge::domain_to_unicode(domain);
+    if ok {
+        (result, Ok(()))
+    } else {
+        (result, Err(Errors {}))
+    }
+}

--- a/packages/python-analysis/crates/idna-stub/src/uts46.rs
+++ b/packages/python-analysis/crates/idna-stub/src/uts46.rs
@@ -1,0 +1,91 @@
+// Derived from the idna crate (https://github.com/servo/rust-url).
+// Copyright (c) The Servo Project Developers.
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+
+//! Stub for `idna::uts46` module -- provides `AsciiDenyList` and other types
+//! needed by the `url` crate.
+
+/// A deny list of ASCII code points that are rejected during domain-to-ASCII
+/// processing.
+pub struct AsciiDenyList {
+    bits: u128,
+}
+
+// Mask for uppercase ASCII letters (A-Z at positions 0x41-0x5A)
+const UPPER_CASE_MASK: u128 = {
+    let mut mask = 0u128;
+    let mut b = b'A';
+    while b <= b'Z' {
+        mask |= 1u128 << b;
+        b += 1;
+    }
+    mask
+};
+
+// Mask for glyphless characters (0x00-0x20 space and below, plus 0x7F DEL)
+const GLYPHLESS_MASK: u128 = {
+    let mut mask = 0u128;
+    let mut b: u8 = 0;
+    while b <= 0x20 {
+        mask |= 1u128 << b;
+        b += 1;
+    }
+    mask |= 1u128 << 0x7F;
+    mask
+};
+
+impl AsciiDenyList {
+    pub const fn new(deny_glyphless: bool, deny_list: &str) -> Self {
+        let mut bits = UPPER_CASE_MASK;
+        if deny_glyphless {
+            bits |= GLYPHLESS_MASK;
+        }
+        let bytes = deny_list.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            bits |= 1u128 << bytes[i];
+            i += 1;
+        }
+        Self { bits }
+    }
+
+    /// No deny list (_UseSTD3ASCIIRules=false_).
+    pub const EMPTY: Self = Self::new(false, "");
+
+    /// The STD3 deny list (_UseSTD3ASCIIRules=true_).
+    pub const STD3: Self = Self { bits: ldh_mask() };
+
+    /// Forbidden domain code points from the WHATWG URL Standard.
+    pub const URL: Self = Self::new(true, "%#/:<>?@[\\]^|");
+
+    /// Returns true if the given byte is denied.
+    pub const fn denies(&self, b: u8) -> bool {
+        if b >= 0x80 {
+            return false;
+        }
+        (self.bits >> b) & 1 != 0
+    }
+}
+
+/// Compute the LDH (letter-digit-hyphen) complement mask for STD3.
+/// Denies everything except letters, digits, hyphen, and dot.
+const fn ldh_mask() -> u128 {
+    let mut mask = 0u128;
+    let mut b: u8 = 0;
+    loop {
+        let is_allowed = (b >= b'a' && b <= b'z')
+            || (b >= b'A' && b <= b'Z')
+            || (b >= b'0' && b <= b'9')
+            || b == b'-'
+            || b == b'.';
+        if !is_allowed {
+            mask |= 1u128 << b;
+        }
+        if b == 127 {
+            break;
+        }
+        b += 1;
+    }
+    mask
+}
+

--- a/packages/python-analysis/crates/idna-stub/tests/unit.rs
+++ b/packages/python-analysis/crates/idna-stub/tests/unit.rs
@@ -1,0 +1,308 @@
+#[cfg(feature = "upstream")]
+extern crate idna_upstream as idna;
+
+use std::borrow::Cow;
+
+use idna::{domain_to_ascii_from_cow, domain_to_unicode};
+use idna::AsciiDenyList;
+
+use wasm_test_support::wasm_tests;
+
+/// Helper: run domain_to_ascii_from_cow with borrowed input and EMPTY deny list.
+fn domain_to_ascii(domain: &str) -> Result<String, idna::Errors> {
+    domain_to_ascii_from_cow(Cow::Borrowed(domain.as_bytes()), AsciiDenyList::EMPTY)
+        .map(|cow| cow.into_owned())
+}
+
+wasm_tests! {
+    // ---------------------------------------------------------------------------
+    // domain_to_ascii_from_cow -- basic
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn ascii_passthrough() {
+        assert_eq!(domain_to_ascii("example.com").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn lowercase_normalization() {
+        assert_eq!(domain_to_ascii("EXAMPLE.COM").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn mixed_case_normalization() {
+        assert_eq!(domain_to_ascii("Example.Org").unwrap(), "example.org");
+    }
+
+    #[test]
+    fn unicode_domain() {
+        // Node.js URL API uses IDNA2008: 日本語.jp -> xn--wgv71a119e.jp
+        assert_eq!(domain_to_ascii("日本語.jp").unwrap(), "xn--wgv71a119e.jp");
+    }
+
+    #[test]
+    fn emoji_domain() {
+        assert_eq!(domain_to_ascii("☕.com").unwrap(), "xn--53h.com");
+    }
+
+    #[test]
+    fn german_eszett() {
+        // Node.js URL API uses IDNA2008: ß is preserved (not mapped to "ss")
+        assert_eq!(domain_to_ascii("Bloß.de").unwrap(), "xn--blo-7ka.de");
+    }
+
+    #[test]
+    fn empty_domain() {
+        assert_eq!(domain_to_ascii("").unwrap(), "");
+    }
+
+    // ---------------------------------------------------------------------------
+    // domain_to_unicode
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn unicode_passthrough() {
+        let (result, errors) = domain_to_unicode("example.com");
+        assert_eq!(result, "example.com");
+        assert!(errors.is_ok());
+    }
+
+    // ---------------------------------------------------------------------------
+    // domain_to_ascii_from_cow -- borrowing behavior
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn from_cow_borrows_ascii_lowercase() {
+        let input: Cow<[u8]> = Cow::Borrowed(b"example.com");
+        let result = domain_to_ascii_from_cow(input, AsciiDenyList::EMPTY).unwrap();
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(&*result, "example.com");
+    }
+
+    #[test]
+    fn from_cow_owned_for_uppercase() {
+        let input: Cow<[u8]> = Cow::Borrowed(b"EXAMPLE.COM");
+        let result = domain_to_ascii_from_cow(input, AsciiDenyList::EMPTY).unwrap();
+        assert!(matches!(result, Cow::Owned(_)));
+        assert_eq!(&*result, "example.com");
+    }
+
+    #[test]
+    fn from_cow_owned_input() {
+        let input: Cow<[u8]> = Cow::Owned(b"example.com".to_vec());
+        let result = domain_to_ascii_from_cow(input, AsciiDenyList::EMPTY).unwrap();
+        assert!(matches!(result, Cow::Owned(_)));
+        assert_eq!(&*result, "example.com");
+    }
+
+    // ---------------------------------------------------------------------------
+    // AsciiDenyList
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn deny_list_url_rejects_space() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"exam ple.com"), AsciiDenyList::URL);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deny_list_url_rejects_hash() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"example.com#fragment"), AsciiDenyList::URL);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deny_list_std3_rejects_underscore() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"ex_ample.com"), AsciiDenyList::STD3);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deny_list_empty_allows_all_ascii() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"ex_ample.com"), AsciiDenyList::EMPTY);
+        assert!(result.is_ok());
+        assert_eq!(&*result.unwrap(), "ex_ample.com");
+    }
+
+    #[test]
+    fn deny_list_empty_allows_space() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"exam ple.com"), AsciiDenyList::EMPTY);
+        assert!(result.is_ok());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Multiple labels
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn multiple_labels() {
+        assert_eq!(domain_to_ascii("a.b.c.d").unwrap(), "a.b.c.d");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Trailing dot
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn trailing_dot() {
+        assert_eq!(domain_to_ascii("example.com.").unwrap(), "example.com.");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Mixed Unicode/ASCII labels
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn mixed_unicode_ascii_labels() {
+        let result = domain_to_ascii("api.\u{65E5}\u{672C}\u{8A9E}.jp").unwrap();
+        assert_eq!(result, "api.xn--wgv71a119e.jp");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Already-punycode passthrough
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn already_punycode_passthrough() {
+        assert_eq!(
+            domain_to_ascii("xn--nxasmq6b.com").unwrap(),
+            "xn--nxasmq6b.com"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // AsciiDenyList -- URL-specific deny characters
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn deny_list_url_rejects_percent() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"exam%ple.com"), AsciiDenyList::URL);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deny_list_url_rejects_backslash() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"exam\\ple.com"), AsciiDenyList::URL);
+        assert!(result.is_err());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Single-label domains
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn single_label() {
+        assert_eq!(domain_to_ascii("localhost").unwrap(), "localhost");
+    }
+
+    #[test]
+    fn single_label_uppercase() {
+        assert_eq!(domain_to_ascii("LOCALHOST").unwrap(), "localhost");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Long domain
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn multi_level_subdomain() {
+        let domain = "a.b.c.d.e.f.example.com";
+        assert_eq!(domain_to_ascii(domain).unwrap(), domain);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Numeric domains
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn numeric_labels() {
+        assert_eq!(domain_to_ascii("123.456.789").unwrap(), "123.456.789");
+    }
+
+    // ---------------------------------------------------------------------------
+    // domain_to_unicode -- more cases
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn domain_to_unicode_unicode_input() {
+        let (result, errors) = domain_to_unicode("\u{00E9}xample.com");
+        assert_eq!(result, "\u{00E9}xample.com");
+        assert!(errors.is_ok());
+    }
+
+    // ---------------------------------------------------------------------------
+    // AsciiDenyList::URL -- more forbidden characters
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn deny_list_url_rejects_question_mark() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"exam?ple.com"), AsciiDenyList::URL);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deny_list_url_rejects_at_sign() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"exam@ple.com"), AsciiDenyList::URL);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deny_list_url_rejects_slash() {
+        let result = domain_to_ascii_from_cow(Cow::Borrowed(b"exam/ple.com"), AsciiDenyList::URL);
+        assert!(result.is_err());
+    }
+
+    // ---------------------------------------------------------------------------
+    // domain_to_unicode -- additional cases
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn domain_to_unicode_already_punycode() {
+        let (result, _errors) = domain_to_unicode("xn--nxasmq6b.com");
+        // Should return the decoded Unicode form
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn domain_to_unicode_ascii_uppercase() {
+        let (result, errors) = domain_to_unicode("EXAMPLE.COM");
+        assert_eq!(result, "example.com");
+        assert!(errors.is_ok());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Invalid punycode error cases
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn invalid_punycode_bare_prefix() {
+        assert!(domain_to_ascii("xn--").is_err());
+    }
+
+    #[test]
+    fn invalid_punycode_bad_encoding() {
+        assert!(domain_to_ascii("xn--55555577").is_err());
+    }
+
+    #[test]
+    fn invalid_punycode_in_multi_label() {
+        assert!(domain_to_ascii("xn--.example.org").is_err());
+    }
+
+    // ---------------------------------------------------------------------------
+    // @ in domain -- must not be silently consumed as userinfo
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn deny_list_url_rejects_at_sign_via_host() {
+        // This domain has uppercase, so the fast path is skipped and
+        // the host is called.  The host must reject '@' to avoid
+        // URL-parsing it as userinfo (user@host).
+        let result = domain_to_ascii_from_cow(
+            Cow::Borrowed(b"User@Example.com"),
+            AsciiDenyList::URL,
+        );
+        assert!(result.is_err());
+    }
+
+}

--- a/packages/python-analysis/crates/unicode-names2-stub/Cargo.toml
+++ b/packages/python-analysis/crates/unicode-names2-stub/Cargo.toml
@@ -1,0 +1,8 @@
+# Stub unicode_names2: eliminates ~820 KB of Unicode name lookup tables from .rodata.
+# Only ruff_python_parser uses this (for Python's \N{...} escape), which is
+# irrelevant for dependency/entrypoint analysis.
+[package]
+name = "unicode_names2"
+version = "1.3.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"

--- a/packages/python-analysis/crates/unicode-names2-stub/README.md
+++ b/packages/python-analysis/crates/unicode-names2-stub/README.md
@@ -1,0 +1,19 @@
+# unicode-names2-stub
+
+Stub replacement for the [`unicode_names2`](https://github.com/progval/unicode_names2) 
+crate that eliminates ~820 KB of Unicode name lookup tables from the WASM binary.
+
+This crate is pulled in by `ruff_python_parser` for Python's `\N{UNICODE NAME}` string
+escape syntax, which is irrelevant for the analyses that we perform.
+
+## API surface
+
+- `name(char) -> Option<Name>` -- always returns `None`
+- `character(name) -> Option<char>` -- always returns `U+FFFD` (replacement character)
+
+## Upstream
+
+Based on [`unicode_names2` v1.3.0](https://crates.io/crates/unicode_names2/1.3.0)
+from [progval/unicode_names2](https://github.com/progval/unicode_names2).
+
+Copyright (c) Valentin Lorentz. Licensed under MIT OR Apache-2.0.

--- a/packages/python-analysis/crates/unicode-names2-stub/src/lib.rs
+++ b/packages/python-analysis/crates/unicode-names2-stub/src/lib.rs
@@ -1,0 +1,33 @@
+// Derived from the unicode_names2 crate (https://github.com/progval/unicode_names2).
+// Copyright (c) Valentin Lorentz.
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+
+use core::fmt;
+
+/// A stub name type that is never constructed.
+pub struct Name;
+
+impl Name {
+    pub fn as_str(&self) -> &str {
+        ""
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
+/// Stub: always returns `None`.
+pub fn name(_c: char) -> Option<Name> {
+    None
+}
+
+/// Stub: always returns the Unicode replacement character.
+/// Returning `None` would cause the ruff parser to emit an error and
+/// potentially abort, so we return a placeholder instead.  The actual
+/// character value is irrelevant for dependency/entrypoint analysis.
+pub fn character(_name: &str) -> Option<char> {
+    Some('\u{FFFD}')
+}

--- a/packages/python-analysis/crates/unicode-normalization-stub/Cargo.toml
+++ b/packages/python-analysis/crates/unicode-normalization-stub/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "unicode-normalization"
+version = "0.1.25"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+host-bridge = { path = "../host-bridge" }
+unicode-normalization-upstream = { package = "unicode-normalization", git = "https://github.com/unicode-rs/unicode-normalization", rev = "576ae0b", optional = true }
+
+[[test]]
+name = "norm"
+harness = false
+
+[dev-dependencies]
+wasm-test-support = { path = "../wasm-test-support" }
+
+[features]
+default = ["std"]
+std = []
+upstream = ["dep:unicode-normalization-upstream"]

--- a/packages/python-analysis/crates/unicode-normalization-stub/README.md
+++ b/packages/python-analysis/crates/unicode-normalization-stub/README.md
@@ -1,0 +1,19 @@
+# unicode-normalization-stub
+
+Local stub for the [`unicode-normalization`](https://github.com/unicode-rs/unicode-normalization)
+crate that replaces ~180 KB of NFC/NFD/NFKC/NFKD decomposition/composition
+tables with WIT host imports delegating to JavaScript's `String.prototype.normalize()`.
+
+## API surface
+
+Implements the `UnicodeNormalization` trait with all four normalization forms:
+
+- `.nfc()`, `.nfd()`, `.nfkc()`, `.nfkd()` -- return iterators over normalized characters
+- `.cjk_compat_variants()`, `.stream_safe()` -- passthrough (required by trait)
+
+## Upstream
+
+Based on [`unicode-normalization` v0.1.25](https://crates.io/crates/unicode-normalization/0.1.25)
+from [unicode-rs/unicode-normalization](https://github.com/unicode-rs/unicode-normalization).
+
+Copyright (c) The Rust Project Developers. Licensed under MIT OR Apache-2.0.

--- a/packages/python-analysis/crates/unicode-normalization-stub/src/lib.rs
+++ b/packages/python-analysis/crates/unicode-normalization-stub/src/lib.rs
@@ -1,0 +1,336 @@
+// Derived from the unicode-normalization crate (https://github.com/unicode-rs/unicode-normalization).
+// Copyright (c) The Rust Project Developers.
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+
+//! Stubbed `unicode-normalization` crate that delegates normalization
+//! to the JS host via WIT imports, eliminating ~180 KB of lookup tables.
+//!
+//! All four Unicode normalization forms (NFC, NFD, NFKC, NFKD) are provided
+//! via host calls to `String.prototype.normalize()`.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+#[cfg(feature = "std")]
+use std::string::String;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+use core::str::Chars;
+use core::{fmt, option};
+
+/// Unicode version stub.
+pub const UNICODE_VERSION: (u8, u8, u8) = (16, 0, 0);
+
+// ---------------------------------------------------------------------------
+// Shared eager-normalization iterator
+// ---------------------------------------------------------------------------
+
+/// Collects an iterator into a String, applies a normalization function,
+/// and returns the result as a Vec<char>.
+fn eager_normalize(iter: impl Iterator<Item = char>, host_fn: fn(&str) -> String) -> Vec<char> {
+    let input: String = iter.collect();
+    if input.is_ascii() {
+        return input.chars().collect();
+    }
+    host_fn(&input).chars().collect()
+}
+
+// ---------------------------------------------------------------------------
+// Iterator types -- replicate the public API of unicode-normalization
+// ---------------------------------------------------------------------------
+
+/// Iterator adaptor for NFC / NFKC recomposition.
+///
+/// In this patched version, the host call is made eagerly when the iterator
+/// is constructed, and `next()` simply yields characters from the result.
+pub struct Recompositions<I> {
+    chars: Vec<char>,
+    pos: usize,
+    _marker: core::marker::PhantomData<I>,
+}
+
+impl<I: Iterator<Item = char>> Recompositions<I> {
+    #[inline]
+    pub fn new_canonical(iter: I) -> Self {
+        let chars = eager_normalize(iter, host_bridge::nfc_normalize);
+        Recompositions {
+            chars,
+            pos: 0,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn new_compatible(iter: I) -> Self {
+        let chars = eager_normalize(iter, host_bridge::nfkc_normalize);
+        Recompositions {
+            chars,
+            pos: 0,
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<I: Iterator<Item = char>> Iterator for Recompositions<I> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<char> {
+        if self.pos < self.chars.len() {
+            let c = self.chars[self.pos];
+            self.pos += 1;
+            Some(c)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.chars.len() - self.pos;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<I: Iterator<Item = char>> core::iter::FusedIterator for Recompositions<I> {}
+
+impl<I: Iterator<Item = char> + Clone> fmt::Display for Recompositions<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for &c in &self.chars[self.pos..] {
+            f.write_str(c.encode_utf8(&mut [0u8; 4]))?;
+        }
+        Ok(())
+    }
+}
+
+/// Iterator adaptor for NFD / NFKD decomposition.
+///
+/// In this patched version, the host call is made eagerly when the iterator
+/// is constructed, and `next()` simply yields characters from the result.
+pub struct Decompositions<I> {
+    chars: Vec<char>,
+    pos: usize,
+    _marker: core::marker::PhantomData<I>,
+}
+
+impl<I: Iterator<Item = char>> Decompositions<I> {
+    #[inline]
+    pub fn new_canonical(iter: I) -> Self {
+        let chars = eager_normalize(iter, host_bridge::nfd_normalize);
+        Decompositions {
+            chars,
+            pos: 0,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn new_compatible(iter: I) -> Self {
+        let chars = eager_normalize(iter, host_bridge::nfkd_normalize);
+        Decompositions {
+            chars,
+            pos: 0,
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<I: Iterator<Item = char>> Iterator for Decompositions<I> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<char> {
+        if self.pos < self.chars.len() {
+            let c = self.chars[self.pos];
+            self.pos += 1;
+            Some(c)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.chars.len() - self.pos;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<I: Iterator<Item = char>> core::iter::FusedIterator for Decompositions<I> {}
+
+impl<I: Iterator<Item = char> + Clone> fmt::Display for Decompositions<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for &c in &self.chars[self.pos..] {
+            f.write_str(c.encode_utf8(&mut [0u8; 4]))?;
+        }
+        Ok(())
+    }
+}
+
+/// CJK compatibility variant replacement iterator.
+///
+/// This is intentionally a passthrough: the only caller is the `url` crate's
+/// IDNA processing path, which delegates the actual domain-to-ASCII conversion
+/// to the JS host (via `host_bridge::domain_to_ascii`).  The host's
+/// `URL` / `domainToUnicode` implementation already applies CJK compat variant
+/// mapping, so performing it here would be redundant.
+pub struct Replacements<I> {
+    inner: I,
+}
+
+impl<I: Iterator<Item = char>> Replacements<I> {
+    #[inline]
+    pub fn new_cjk_compat_variants(iter: I) -> Self {
+        Replacements { inner: iter }
+    }
+}
+
+impl<I: Iterator<Item = char>> Iterator for Replacements<I> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<char> {
+        self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+/// Stream-safe text process iterator (stub -- passthrough).
+pub struct StreamSafe<I> {
+    inner: I,
+}
+
+impl<I: Iterator<Item = char>> StreamSafe<I> {
+    #[inline]
+    pub fn new(iter: I) -> Self {
+        StreamSafe { inner: iter }
+    }
+}
+
+impl<I: Iterator<Item = char>> Iterator for StreamSafe<I> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<char> {
+        self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// UnicodeNormalization trait
+// ---------------------------------------------------------------------------
+
+/// Methods for iterating over strings while applying Unicode normalizations.
+pub trait UnicodeNormalization<I: Iterator<Item = char>> {
+    /// Returns an iterator over the string in Unicode Normalization Form D.
+    fn nfd(self) -> Decompositions<I>;
+    /// Returns an iterator over the string in Unicode Normalization Form KD.
+    fn nfkd(self) -> Decompositions<I>;
+    /// An Iterator over the string in Unicode Normalization Form C.
+    fn nfc(self) -> Recompositions<I>;
+    /// An Iterator over the string in Unicode Normalization Form KC.
+    fn nfkc(self) -> Recompositions<I>;
+    /// CJK Compatibility Ideograph replacement.
+    fn cjk_compat_variants(self) -> Replacements<I>;
+    /// Stream-Safe Text Process.
+    fn stream_safe(self) -> StreamSafe<I>;
+}
+
+impl<'a> UnicodeNormalization<Chars<'a>> for &'a str {
+    #[inline]
+    fn nfd(self) -> Decompositions<Chars<'a>> {
+        Decompositions::new_canonical(self.chars())
+    }
+    #[inline]
+    fn nfkd(self) -> Decompositions<Chars<'a>> {
+        Decompositions::new_compatible(self.chars())
+    }
+    #[inline]
+    fn nfc(self) -> Recompositions<Chars<'a>> {
+        Recompositions::new_canonical(self.chars())
+    }
+    #[inline]
+    fn nfkc(self) -> Recompositions<Chars<'a>> {
+        Recompositions::new_compatible(self.chars())
+    }
+    #[inline]
+    fn cjk_compat_variants(self) -> Replacements<Chars<'a>> {
+        Replacements::new_cjk_compat_variants(self.chars())
+    }
+    #[inline]
+    fn stream_safe(self) -> StreamSafe<Chars<'a>> {
+        StreamSafe::new(self.chars())
+    }
+}
+
+impl UnicodeNormalization<option::IntoIter<char>> for char {
+    #[inline]
+    fn nfd(self) -> Decompositions<option::IntoIter<char>> {
+        Decompositions::new_canonical(Some(self).into_iter())
+    }
+    #[inline]
+    fn nfkd(self) -> Decompositions<option::IntoIter<char>> {
+        Decompositions::new_compatible(Some(self).into_iter())
+    }
+    #[inline]
+    fn nfc(self) -> Recompositions<option::IntoIter<char>> {
+        Recompositions::new_canonical(Some(self).into_iter())
+    }
+    #[inline]
+    fn nfkc(self) -> Recompositions<option::IntoIter<char>> {
+        Recompositions::new_compatible(Some(self).into_iter())
+    }
+    #[inline]
+    fn cjk_compat_variants(self) -> Replacements<option::IntoIter<char>> {
+        Replacements::new_cjk_compat_variants(Some(self).into_iter())
+    }
+    #[inline]
+    fn stream_safe(self) -> StreamSafe<option::IntoIter<char>> {
+        StreamSafe::new(Some(self).into_iter())
+    }
+}
+
+impl<I: Iterator<Item = char>> UnicodeNormalization<I> for I {
+    #[inline]
+    fn nfd(self) -> Decompositions<I> {
+        Decompositions::new_canonical(self)
+    }
+    #[inline]
+    fn nfkd(self) -> Decompositions<I> {
+        Decompositions::new_compatible(self)
+    }
+    #[inline]
+    fn nfc(self) -> Recompositions<I> {
+        Recompositions::new_canonical(self)
+    }
+    #[inline]
+    fn nfkc(self) -> Recompositions<I> {
+        Recompositions::new_compatible(self)
+    }
+    #[inline]
+    fn cjk_compat_variants(self) -> Replacements<I> {
+        Replacements::new_cjk_compat_variants(self)
+    }
+    #[inline]
+    fn stream_safe(self) -> StreamSafe<I> {
+        StreamSafe::new(self)
+    }
+}
+

--- a/packages/python-analysis/crates/unicode-normalization-stub/tests/norm.rs
+++ b/packages/python-analysis/crates/unicode-normalization-stub/tests/norm.rs
@@ -1,0 +1,405 @@
+#[cfg(feature = "upstream")]
+extern crate unicode_normalization_upstream as unicode_normalization;
+
+use unicode_normalization::UnicodeNormalization;
+
+use wasm_test_support::wasm_tests;
+
+wasm_tests! {
+    // ---------------------------------------------------------------------------
+    // NFC composition
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_combines_e_acute() {
+        // U+0065 (e) + U+0301 (combining acute) -> U+00E9 (é)
+        let input = "e\u{0301}";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{00E9}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // NFD decomposition
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfd_decomposes_e_acute() {
+        // U+00E9 (é) -> U+0065 (e) + U+0301 (combining acute)
+        let input = "\u{00E9}";
+        let result: String = input.nfd().collect();
+        assert_eq!(result, "e\u{0301}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // NFKC -- compatibility composition
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfkc_decomposes_ligature() {
+        // U+FB01 (ﬁ ligature) -> "fi"
+        let input = "\u{FB01}";
+        let result: String = input.nfkc().collect();
+        assert_eq!(result, "fi");
+    }
+
+    // ---------------------------------------------------------------------------
+    // NFKD -- compatibility decomposition
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfkd_decomposes_ligature() {
+        // U+FB01 (ﬁ ligature) -> "fi"
+        let input = "\u{FB01}";
+        let result: String = input.nfkd().collect();
+        assert_eq!(result, "fi");
+    }
+
+    // ---------------------------------------------------------------------------
+    // ASCII passthrough (all four forms)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_ascii_passthrough() {
+        let input = "hello world 123";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn nfd_ascii_passthrough() {
+        let input = "hello world 123";
+        let result: String = input.nfd().collect();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn nfkc_ascii_passthrough() {
+        let input = "hello world 123";
+        let result: String = input.nfkc().collect();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn nfkd_ascii_passthrough() {
+        let input = "hello world 123";
+        let result: String = input.nfkd().collect();
+        assert_eq!(result, input);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Already-normalized text unchanged
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_already_normalized() {
+        let input = "\u{00E9}"; // é is already NFC
+        let result: String = input.nfc().collect();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn nfd_already_decomposed() {
+        let input = "e\u{0301}"; // already NFD
+        let result: String = input.nfd().collect();
+        assert_eq!(result, input);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Hangul syllable composition/decomposition
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_hangul_composition() {
+        // U+1100 (ᄀ) + U+1161 (ᅡ) -> U+AC00 (가)
+        let input = "\u{1100}\u{1161}";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{AC00}");
+    }
+
+    #[test]
+    fn nfd_hangul_decomposition() {
+        // U+AC00 (가) -> U+1100 (ᄀ) + U+1161 (ᅡ)
+        let input = "\u{AC00}";
+        let result: String = input.nfd().collect();
+        assert_eq!(result, "\u{1100}\u{1161}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Multiple combining marks ordering
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_multiple_combining_marks() {
+        // o + combining diaeresis (U+0308) + combining acute (U+0301)
+        let input = "o\u{0308}\u{0301}";
+        let result: String = input.nfc().collect();
+        // Should compose o+diaeresis to ö (U+00F6), then keep combining acute
+        assert_eq!(result, "\u{00F6}\u{0301}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Iterator collect correctness
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_iterator_collect() {
+        let input = "e\u{0301}e\u{0301}";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{00E9}\u{00E9}");
+    }
+
+    #[test]
+    fn nfd_iterator_collect() {
+        let input = "\u{00E9}\u{00E9}";
+        let result: String = input.nfd().collect();
+        assert_eq!(result, "e\u{0301}e\u{0301}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Combining mark reordering
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_combining_mark_reorder() {
+        // U+1E0B (ḋ, d with dot above) + U+0323 (combining dot below)
+        // NFC should reorder: -> U+1E0D (ḍ, d with dot below) + U+0307 (combining dot above)
+        let input = "\u{1E0B}\u{0323}";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{1E0D}\u{0307}");
+    }
+
+    #[test]
+    fn nfd_combining_mark_reorder() {
+        // Same input decomposed: d + dot above + dot below -> d + dot below + dot above
+        let input = "\u{1E0B}\u{0323}";
+        let result: String = input.nfd().collect();
+        // NFD: d (U+0064) + dot below (U+0323) + dot above (U+0307)
+        assert_eq!(result, "d\u{0323}\u{0307}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Compatibility vs canonical difference
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_preserves_ellipsis() {
+        // U+2026 (…) is canonically stable -- NFC should not decompose it
+        let input = "\u{2026}";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{2026}");
+    }
+
+    #[test]
+    fn nfkc_decomposes_ellipsis() {
+        // U+2026 (…) -> "..." under compatibility decomposition
+        let input = "\u{2026}";
+        let result: String = input.nfkc().collect();
+        assert_eq!(result, "...");
+    }
+
+    #[test]
+    fn nfkd_decomposes_ellipsis() {
+        let input = "\u{2026}";
+        let result: String = input.nfkd().collect();
+        assert_eq!(result, "...");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Idempotency
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_idempotent() {
+        let input = "e\u{0301}\u{00E9}\u{FB01}café";
+        let once: String = input.nfc().collect();
+        let twice: String = once.nfc().collect();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn nfd_idempotent() {
+        let input = "\u{00E9}\u{00F6}\u{00FC}";
+        let once: String = input.nfd().collect();
+        let twice: String = once.nfd().collect();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn nfkc_idempotent() {
+        let input = "\u{FB01}\u{2026}\u{00E9}";
+        let once: String = input.nfkc().collect();
+        let twice: String = once.nfkc().collect();
+        assert_eq!(once, twice);
+    }
+
+    // ---------------------------------------------------------------------------
+    // NFKD-specific decomposition
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfkd_decomposes_superscript() {
+        // U+00B2 (²) -> "2" under NFKD
+        let input = "\u{00B2}";
+        let result: String = input.nfkd().collect();
+        assert_eq!(result, "2");
+    }
+
+    #[test]
+    fn nfkc_decomposes_superscript() {
+        // U+00B2 (²) -> "2" under NFKC as well
+        let input = "\u{00B2}";
+        let result: String = input.nfkc().collect();
+        assert_eq!(result, "2");
+    }
+
+    #[test]
+    fn nfc_preserves_superscript() {
+        // Canonical normalization does NOT decompose compatibility chars
+        let input = "\u{00B2}";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{00B2}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Hangul with trailing consonant
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_hangul_lvt() {
+        // U+1100 (ᄀ) + U+1161 (ᅡ) + U+11A8 (ᆨ) -> U+AC01 (각)
+        let input = "\u{1100}\u{1161}\u{11A8}";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{AC01}");
+    }
+
+    #[test]
+    fn nfd_hangul_lvt() {
+        // U+AC01 (각) -> U+1100 (ᄀ) + U+1161 (ᅡ) + U+11A8 (ᆨ)
+        let input = "\u{AC01}";
+        let result: String = input.nfd().collect();
+        assert_eq!(result, "\u{1100}\u{1161}\u{11A8}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Empty string
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn empty_string_all_forms() {
+        let empty = "";
+        assert_eq!(empty.nfc().collect::<String>(), "");
+        assert_eq!(empty.nfd().collect::<String>(), "");
+        assert_eq!(empty.nfkc().collect::<String>(), "");
+        assert_eq!(empty.nfkd().collect::<String>(), "");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Compatibility-only decompositions (NFC preserves, NFKC decomposes)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfkc_decomposes_interrobang() {
+        // U+2049 (⁉) -> "!?" under NFKC
+        let input = "\u{2049}";
+        let result: String = input.nfkc().collect();
+        assert_eq!(result, "!?");
+    }
+
+    #[test]
+    fn nfc_preserves_interrobang() {
+        let input = "\u{2049}";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{2049}");
+    }
+
+    #[test]
+    fn nfkc_decomposes_circled_latin() {
+        // U+24B6 (Ⓐ) -> "A" under NFKC
+        let input = "\u{24B6}";
+        let result: String = input.nfkc().collect();
+        assert_eq!(result, "A");
+    }
+
+    #[test]
+    fn nfkd_decomposes_fraction() {
+        // U+00BD (½) -> "1⁄2" under NFKD (1 + fraction slash + 2)
+        let input = "\u{00BD}";
+        let result: String = input.nfkd().collect();
+        assert_eq!(result, "1\u{2044}2");
+    }
+
+    #[test]
+    fn nfc_preserves_fraction() {
+        let input = "\u{00BD}";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{00BD}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Complex combining mark ordering (3+ marks)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_three_combining_marks() {
+        // D + dot above (class 230) + dot below (class 220) + cedilla (class 202)
+        // Should reorder by class: cedilla (202) < dot below (220) < dot above (230)
+        let input = "D\u{0307}\u{0323}\u{0327}";
+        let result: String = input.nfc().collect();
+        let nfd_result: String = result.nfd().collect();
+        // After NFC->NFD round-trip, marks should be in canonical order
+        let expected_nfd: String = input.nfd().collect();
+        assert_eq!(nfd_result, expected_nfd);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Leading combining marks
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_leading_combining_mark() {
+        // A combining mark at the start of a string stays put
+        let input = "\u{0301}a";
+        let result: String = input.nfc().collect();
+        assert_eq!(result, "\u{0301}a");
+    }
+
+    #[test]
+    fn nfd_leading_combining_mark() {
+        let input = "\u{0301}a";
+        let result: String = input.nfd().collect();
+        assert_eq!(result, "\u{0301}a");
+    }
+
+    // ---------------------------------------------------------------------------
+    // NFC/NFD round-trip stability
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn nfc_nfd_roundtrip() {
+        let input = "\u{00E9}\u{00F6}\u{00FC}café";
+        let nfd: String = input.nfd().collect();
+        let back: String = nfd.nfc().collect();
+        let expected: String = input.nfc().collect();
+        assert_eq!(back, expected);
+    }
+
+    // ---------------------------------------------------------------------------
+    // CJK compatibility variants
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn cjk_compat_variants_passthrough() {
+        // For plain ASCII, cjk_compat_variants is a no-op
+        let input = "hello";
+        let result: String = input.cjk_compat_variants().collect();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn stream_safe_passthrough() {
+        // stream_safe should pass through normal text
+        let input = "hello world";
+        let result: String = input.stream_safe().collect();
+        assert_eq!(result, "hello world");
+    }
+}

--- a/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
+++ b/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
@@ -1,6 +1,28 @@
 package vercel:python-analysis;
 
 interface host-utils {
+    /// IDNA domain-to-ASCII conversion (WHATWG URL Standard).
+    /// Normalizes a domain name to ASCII using UTS #46 rules.
+    domain-to-ascii: func(domain: string) -> result<string, string>;
+
+    /// IDNA domain-to-Unicode conversion (WHATWG URL Standard).
+    /// Converts a domain name to its Unicode display form with full UTS #46
+    /// case folding and normalization.
+    /// Returns the best-effort result (even on error) and a separate error flag.
+    domain-to-unicode: func(domain: string) -> tuple<string, bool>;
+
+    /// Unicode NFC normalization (canonical decomposition + canonical composition).
+    nfc-normalize: func(s: string) -> string;
+
+    /// Unicode NFD normalization (canonical decomposition).
+    nfd-normalize: func(s: string) -> string;
+
+    /// Unicode NFKC normalization (compatibility decomposition + canonical composition).
+    nfkc-normalize: func(s: string) -> string;
+
+    /// Unicode NFKD normalization (compatibility decomposition).
+    nfkd-normalize: func(s: string) -> string;
+
     /// Read a file to a UTF-8 string (for requirements.txt `-r`/`-c` recursion).
     read-file: func(path: string) -> result<string, string>;
 }

--- a/packages/python-analysis/src/wasm/host-utils.ts
+++ b/packages/python-analysis/src/wasm/host-utils.ts
@@ -3,6 +3,7 @@
  */
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { normalize } from 'node:path';
+import { domainToUnicode as nodeDomainToUnicode } from 'url';
 
 /**
  * Function type for reading referenced requirement files.
@@ -46,6 +47,56 @@ export function createHostUtils() {
       // readFileSync because the WASM module could request arbitrary host
       // paths (e.g. via `-r /etc/passwd` in requirements.txt).
       throw new WitResultError(`File not found: ${path}`);
+    },
+    domainToAscii(domain: string): string {
+      try {
+        // Use the WHATWG URL parser for IDNA2008 conversion.
+        // We must validate the input to avoid URL-level parsing artifacts:
+        // colons would be interpreted as port separators, brackets as IPv6,
+        // @ as userinfo separator, # as fragment, ? as query, / as path,
+        // \ as path separator (equivalent to / in special schemes),
+        // % as percent-encoding, tab/LF/CR are silently stripped by the URL parser.
+        if (/[:#?/@[\]%\\\t\n\r]/.test(domain)) {
+          throw new Error('domain contains invalid characters');
+        }
+        const url = new URL(`http://${domain}/`);
+        // Verify the hostname wasn't mangled by URL parsing (e.g. empty after normalization)
+        if (url.hostname === '' && domain !== '') {
+          throw new Error('domain resolved to empty hostname');
+        }
+        return url.hostname;
+      } catch {
+        // jco expects { payload: string } for WIT result<_, string> errors
+        throw { payload: `Invalid domain: ${domain}` };
+      }
+    },
+
+    domainToUnicode(domain: string): [string, boolean] {
+      // Node.js url.domainToUnicode provides full UTS #46 domain-to-unicode:
+      // punycode decoding, case folding, and NFC normalization.
+      // Node returns '' on failure; we return the input as best-effort in that
+      // case (matching upstream idna which returns a string even on error).
+      const result = nodeDomainToUnicode(domain);
+      if (result !== '' || domain === '') {
+        return [result, true];
+      }
+      return [domain, false];
+    },
+
+    nfcNormalize(s: string): string {
+      return s.normalize('NFC');
+    },
+
+    nfdNormalize(s: string): string {
+      return s.normalize('NFD');
+    },
+
+    nfkcNormalize(s: string): string {
+      return s.normalize('NFKC');
+    },
+
+    nfkdNormalize(s: string): string {
+      return s.normalize('NFKD');
     },
   };
 }


### PR DESCRIPTION
Move IDNA and Unicode normalization operations out of the WASM binary
and into the Node.js host via the new `host-utils` WIT interface.
This eliminates ICU/Unicode lookup tables from the compiled component,
using the host's native `URL` and `String.prototype.normalize` instead.

Specifically:

- `idna-stub`: delegates domain-to-ASCII/Unicode to host
- `unicode-normalization-stub`: delegates NFC/NFD/NFKC/NFKD to host
- `unicode-names2-stub`: returns Unicode replacement char (U+FFFD) as
  this is only used by the ruff parser to normalize Unicode name
  escapes in Python string literals (`\N{CAPITAL LETTER L}`) which is
  irrelevant to the analyses.
- `host-bridge`: codegen crate for WASM host import bindings
- `wasm-test-support`: test harness for running WASM tests with host fns

Because the stub crates delegate to the JS host at runtime, their tests
must run inside a WASM component with the real `host-utils` wired in.
A custom `wasm-test-runner.mjs` is added and registered via
`.cargo/config.toml` as the `cargo test --target wasm32-wasip2` runner.
The runner transpiles each test binary with jco, instantiates it with
the same `host-utils` implementation used in production, so `cargo test`
works seamlessly for WASM targets.

Before:

    Binary Overview
    ───────────────
    Total (code+data):   2,865,491 bytes (2.73 MB)

    Code:                   1.24 MB  █████████████▌                   45.4%
    Data:                   1.49 MB  ████████████████▍                54.6%
      .rodata:              1.39 MB
      .data+.bss:          106.5 KB

    Top 10 Crates by Size
    ─────────────────────
                                     total        code        data                             %
    ────────────────────────────────────────────────────────────────────────────────────────────
      1. unicode_names2           823.9 KB      4.8 KB    819.1 KB  ████████████████████   29.4%
      2. regex_syntax             420.5 KB    113.0 KB    307.5 KB  ██████████             15.0%
      3. core                     255.8 KB    220.4 KB     35.5 KB  ██████                  9.1%
      4. regex_automata           246.7 KB    228.9 KB     17.9 KB  █████                   8.8%
      5. unicode_normalization    111.0 KB      2.2 KB    108.8 KB  ██                      4.0%
      6. ruff_python_parser       106.7 KB     96.2 KB     10.5 KB  ██                      3.8%
      7. alloc                     96.3 KB     95.8 KB       502 B  ██                      3.4%
      8. aho_corasick              92.1 KB     84.4 KB      7.7 KB  ██                      3.3%
      9. icu_normalizer            75.1 KB      6.4 KB     68.7 KB  █                       2.7%
     10. uv_pep508                 73.3 KB     66.4 KB      6.9 KB  █                       2.6%

After:

    Binary Overview
    ───────────────
    Total (code+data):   1,716,626 bytes (1.64 MB)

    Code:                   1.18 MB  █████████████████████▋           72.1%
    Data:                  467.7 KB  ████████▎                        27.9%
      .rodata:             369.0 KB
      .data+.bss:           98.7 KB

    Top 10 Crates by Size
    ─────────────────────
                                      total        code        data                             %
    ─────────────────────────────────────────────────────────────────────────────────────────────
      1. regex_syntax              420.5 KB    113.0 KB    307.5 KB  ████████████████████   25.1%
      2. regex_automata            246.7 KB    228.9 KB     17.9 KB  ███████████            14.7%
      3. core                      239.0 KB    203.6 KB     35.5 KB  ███████████            14.3%
      4. ruff_python_parser        106.3 KB     95.9 KB     10.4 KB  █████                   6.3%
      5. alloc                      94.3 KB     93.8 KB       502 B  ████                    5.6%
      6. aho_corasick               92.1 KB     84.4 KB      7.7 KB  ████                    5.5%
      7. uv_pep508                  73.3 KB     66.4 KB      6.9 KB  ███                     4.4%
      8. uv_pep440                  33.3 KB     28.6 KB      4.7 KB  █                       2.0%
      9. url                        31.8 KB     29.6 KB      2.3 KB  █                       1.9%
     10. vercel_python_analysis     31.2 KB     28.7 KB      2.5 KB  █                       1.9%
