### PR TITLE
[python] Fix serving static files for a django WSGI app in vercel dev.

### DIFF
--- a/.changeset/dull-tips-grow.md
+++ b/.changeset/dull-tips-grow.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python-runtime': minor
+'@vercel/python': minor
+---
+
+Fix serving static files for a django WSGI app in vercel dev.

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -60,7 +60,7 @@ interface FrameworkHookContext {
   pythonEnv: NodeJS.ProcessEnv;
   projectDir: string;
   workPath: string;
-  venvPath: string;
+  venvPath?: string;
   entrypoint: string;
   detected: DetectedPythonEntrypoint | undefined;
 }
@@ -120,15 +120,18 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
       }
     }
 
-    const outputStaticDir = join(workPath, '.vercel', 'output', 'static');
-    const djangoStatic = await runDjangoCollectStatic(
-      venvPath,
-      workPath,
-      pythonEnv,
-      outputStaticDir,
-      settingsModule,
-      djangoSettings
-    );
+    let djangoStatic: DjangoCollectStaticResult | null = null;
+    if (venvPath) {
+      const outputStaticDir = join(workPath, '.vercel', 'output', 'static');
+      djangoStatic = await runDjangoCollectStatic(
+        venvPath,
+        workPath,
+        pythonEnv,
+        outputStaticDir,
+        settingsModule,
+        djangoSettings
+      );
+    }
     return { entrypoint, djangoStatic };
   },
 };

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -470,7 +470,8 @@ interface DevShimResult {
 function createDevShim(
   workPath: string,
   entry: string,
-  modulePath: string
+  modulePath: string,
+  framework: string
 ): DevShimResult | null {
   try {
     const vercelPythonDir = join(workPath, '.vercel', 'python');
@@ -499,7 +500,8 @@ function createDevShim(
     const template = readFileSync(templatePath, 'utf8');
     const shimSource = template
       .replace(/__VC_DEV_MODULE_NAME__/g, qualifiedModule)
-      .replace(/__VC_DEV_ENTRY_ABS__/g, entryAbs);
+      .replace(/__VC_DEV_ENTRY_ABS__/g, entryAbs)
+      .replace(/__VC_DEV_FRAMEWORK__/g, framework);
     writeFileSync(shimPath, shimSource, 'utf8');
     debug(`Prepared Python dev shim at ${shimPath}`);
     return { module: DEV_SHIM_MODULE, extraPythonPath };
@@ -736,7 +738,7 @@ export const startDevServer: StartDevServer = async opts => {
     env.PORT = `${port}`;
 
     // Spawn the actual server process
-    const devShim = createDevShim(workPath, entry, modulePath);
+    const devShim = createDevShim(workPath, entry, modulePath, framework);
 
     // Add .vercel/python to PYTHONPATH so the shim can be imported
     if (devShim) {

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -600,6 +600,7 @@ export const startDevServer: StartDevServer = async opts => {
     const hookResult = await runFrameworkHook(framework, {
       pythonEnv: env,
       projectDir: join(workPath, detected?.baseDir ?? ''),
+      workPath,
       entrypoint: rawEntrypoint,
       detected: detected ?? undefined,
     });

--- a/packages/python/templates/vc_init_dev.py
+++ b/packages/python/templates/vc_init_dev.py
@@ -6,6 +6,7 @@ os.environ.update(
     {
         "VERCEL_DEV_MODULE_NAME": "__VC_DEV_MODULE_NAME__",
         "VERCEL_DEV_ENTRY_ABS": "__VC_DEV_ENTRY_ABS__",
+        "VERCEL_DEV_FRAMEWORK": "__VC_DEV_FRAMEWORK__",
     }
 )
 

--- a/python/vercel-runtime/src/vercel_runtime/dev.py
+++ b/python/vercel-runtime/src/vercel_runtime/dev.py
@@ -383,6 +383,7 @@ def _setup_apps() -> None:
 
     module_name = os.environ["VERCEL_DEV_MODULE_NAME"]
     entry_abs = os.environ["VERCEL_DEV_ENTRY_ABS"]
+    framework = os.environ["VERCEL_DEV_FRAMEWORK"]
 
     _setup_server_log_routing()
 
@@ -397,12 +398,40 @@ def _setup_apps() -> None:
     if result[0] == "asgi":
         _asgi_user_app = result[1]
     else:
-        _wsgi_user_app = result[1]
+        wsgi_app = result[1]
+
+        if framework == "django":
+            wsgi_app = _wrap_django_static(wsgi_app)
+
+        _wsgi_user_app = wsgi_app
+
+
+def _wrap_django_static(app: WSGIApplication) -> WSGIApplication:
+    # If this is a django app, wrap it with StaticFilesHandler to serve static
+    # files. This is necessary because the dev server will not run the full
+    # build process (including collectstatic), so static files may not
+    # be available depending on the user's configuration.
+    #
+    # Special cases:
+    # - If whitenoise is used, this will override it but that's ok because we
+    #   don't need it in the dev server.
+    # - If django-storages is used, this will override it but that's ok because
+    #   django-storages handles its own upload to some other CDN.
+    try:
+        from django.contrib.staticfiles.handlers import (  # type: ignore[import-not-found]  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            StaticFilesHandler,  # pyright: ignore[reportUnknownVariableType]
+        )
+
+        return cast("WSGIApplication", StaticFilesHandler(app))
+    except ImportError:
+        return app
 
 
 # Setup apps at import time so that servers reloader can pick them up.
-if os.environ.get("VERCEL_DEV_MODULE_NAME") and os.environ.get(
-    "VERCEL_DEV_ENTRY_ABS"
+if (
+    os.environ.get("VERCEL_DEV_MODULE_NAME")
+    and os.environ.get("VERCEL_DEV_ENTRY_ABS")
+    and os.environ.get("VERCEL_DEV_FRAMEWORK")
 ):
     _setup_apps()
 


### PR DESCRIPTION
When running `vercel dev` on a django project, requests for static files would return 404. This could be fixed by users adding `staticfiles_urlpatterns()` to `urls.py` but this is cumbersome and also breaks "zero config".

This PR fixes serving static files by detecting a django WSGI app and wrapping it with django's built in `StaticFilesHandler` automatically.

