### PR TITLE
fix(cli): respect `--scope` flag in `vercel link` when agent formatter forces non-interactive mode

### DIFF
--- a/.changeset/purple-falcons-refuse.md
+++ b/.changeset/purple-falcons-refuse.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+fix(cli): respect `--scope` flag in `vercel link` when agent formatter forces non-interactive mode

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -124,7 +124,7 @@ export default async function link(client: Client) {
     // (e.g. no scope passed), currentTeam may be undefined or from saved config. If the user passed
     // --team to link but currentTeam is still unset, resolve to a team ID and set it so selectOrg
     // has a default; never set a raw slug (always use team ID).
-    const teamFlag = parsedArgs.flags['--team'];
+    const teamFlag = parsedArgs.flags['--team'] || parsedArgs.flags['--scope'];
     if (typeof teamFlag === 'string' && !client.config.currentTeam) {
       try {
         const teams = await getTeams(client);

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -814,6 +814,42 @@ describe('link', () => {
       logSpy.mockRestore();
       (client as { nonInteractive: boolean }).nonInteractive = false;
     });
+
+    it('uses --scope flag when agent detects non-interactive mode', async () => {
+      const cwd = setupTmpDir();
+      useUser({ version: 'northstar' });
+      useTeams('team_dummy');
+      const secondTeam = createTeam();
+      client.cwd = cwd;
+      client.setArgv('link', '--non-interactive', '--scope', secondTeam.id);
+      (client as { nonInteractive: boolean }).nonInteractive = true;
+
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: number) => {
+          throw new Error(`process.exit(${code})`);
+        });
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // It should NOT fail with missing_scope. It might fail with missing_project or succeed.
+      try {
+        await link(client);
+      } catch (err: any) {
+        if (err.message.includes('process.exit')) {
+          const payloadString = logSpy.mock.calls[0]?.[0];
+          if (payloadString) {
+            const payload = JSON.parse(payloadString);
+            expect(payload.reason).not.toBe('missing_scope');
+          }
+        } else {
+          throw err;
+        }
+      }
+
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
+      (client as { nonInteractive: boolean }).nonInteractive = false;
+    });
   });
 
   describe('--confirm', () => {


### PR DESCRIPTION
Fixes #15068.

In Vercel CLI, when an agent is detected, it forces non-interactive mode and requires `--scope`. However, when `--scope` was provided, it was dropped/ignored during the `link` command because it only checked `--team` from its parsed flags. This PR ensures `--scope` is properly respected alongside `--team`. Added a test to verify this behavior.