### PR TITLE
[services] exclude service route prefixes on subdomain rewrites

### DIFF
--- a/.changeset/curly-days-invent.md
+++ b/.changeset/curly-days-invent.md
@@ -1,0 +1,5 @@
+---
+"@vercel/fs-detectors": patch
+---
+
+[services] exclude service route prefixes on subdomain rewrites

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -186,6 +186,8 @@ export function generateServicesRoutes(services: Service[]): ServicesRoutes {
     .sort((a, b) => b.routePrefix.length - a.routePrefix.length);
 
   const allWebPrefixes = getWebRoutePrefixes(sortedWebServices);
+  const explicitHostPrefixGuard =
+    getExplicitHostPrefixNegativeLookahead(allWebPrefixes);
 
   for (const service of sortedWebServices) {
     const { routePrefix } = service;
@@ -195,7 +197,6 @@ export function generateServicesRoutes(services: Service[]): ServicesRoutes {
 
     if (hostCondition && routePrefix !== '/') {
       const normalizedRoutePrefix = normalizeRoutePrefix(routePrefix);
-      const escapedPrefix = escapeRegex(normalizedRoutePrefix.slice(1));
       hostRewrites.push({
         src: '^/$',
         dest: normalizedRoutePrefix,
@@ -204,7 +205,9 @@ export function generateServicesRoutes(services: Service[]): ServicesRoutes {
         check: true,
       });
       hostRewrites.push({
-        src: `^/(?!${escapedPrefix}(?:/|$))(.*)$`,
+        // Preserve explicit service prefixes so canonical paths like /_/api
+        // keep routing to their target service even on another service's host.
+        src: `^/${explicitHostPrefixGuard}(.*)$`,
         dest: `${normalizedRoutePrefix}/$1`,
         has: hostCondition,
         missing: PREVIEW_DOMAIN_MISSING,
@@ -307,6 +310,22 @@ function getWebRoutePrefixes(services: Service[]): string[] {
     unique.add(normalizeRoutePrefix(service.routePrefix));
   }
   return Array.from(unique);
+}
+
+function getExplicitHostPrefixNegativeLookahead(
+  routePrefixes: string[]
+): string {
+  const explicitPrefixes = routePrefixes
+    .map(normalizeRoutePrefix)
+    .filter(prefix => prefix !== '/')
+    .sort((a, b) => b.length - a.length)
+    .map(prefix => escapeRegex(prefix.slice(1)));
+
+  if (explicitPrefixes.length === 0) {
+    return '';
+  }
+
+  return `(?!${explicitPrefixes.map(prefix => `${prefix}(?:/|$)`).join('|')})`;
 }
 
 function getHostCondition(service: Service): HasField | undefined {

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -325,7 +325,11 @@ function getExplicitHostPrefixNegativeLookahead(
     return '';
   }
 
-  return `(?!${explicitPrefixes.map(prefix => `${prefix}(?:/|$)`).join('|')})`;
+  if (explicitPrefixes.length === 1) {
+    return `(?!${explicitPrefixes[0]}(?:/|$))`;
+  }
+
+  return `(?!(?:${explicitPrefixes.join('|')})(?:/|$))`;
 }
 
 function getHostCondition(service: Service): HasField | undefined {

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -1463,6 +1463,59 @@ describe('detectServices', () => {
       });
     });
 
+    it('should preserve explicit service prefixes on another service subdomain', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            web: {
+              framework: 'nextjs',
+              entrypoint: 'apps/web',
+              routePrefix: '/',
+            },
+            docs: {
+              framework: 'vite',
+              entrypoint: 'apps/docs',
+              routePrefix: '/__docs__',
+              subdomain: 'docs',
+            },
+            dashboard: {
+              framework: 'nextjs',
+              entrypoint: 'apps/dashboard',
+              routePrefix: '/__app__',
+              subdomain: 'app',
+            },
+            api: {
+              entrypoint: 'services/api/index.go',
+              subdomain: 'api',
+            },
+          },
+        }),
+        'apps/web/package.json': JSON.stringify({
+          dependencies: { next: '15.0.0' },
+        }),
+        'apps/docs/package.json': JSON.stringify({
+          dependencies: { vite: '6.0.0' },
+        }),
+        'apps/dashboard/package.json': JSON.stringify({
+          dependencies: { next: '15.0.0' },
+        }),
+        'services/api/index.go': 'package main',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.routes.hostRewrites).toContainEqual({
+        src: '^/(?!(?:__docs__|__app__|_/api)(?:/|$))(.*)$',
+        dest: '/__app__/$1',
+        has: [{ type: 'host', value: { pre: 'app.' } }],
+        missing: [
+          { type: 'host', value: { suf: '.vercel.app' } },
+          { type: 'host', value: { suf: '.vercel.dev' } },
+        ],
+        check: true,
+      });
+    });
+
     it('should generate host-based rewrites for route-owning builders', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({


### PR DESCRIPTION
Exclude known service route prefixes from the subdomain rewrites so that `app.myapp.com/_/api` actually reaches the api service
This effectively makes services accessible at their route prefix globally across all hosts

Without this change, if you mount:
* next.js landing page at /
* next.js dashboard at app.domain.com
* api service at /svc/api

the dashboard service will receive `API_URL = /svc/api` and will try to make requests to `app.domain.com/svc/api` which will not reach the api service