### PR TITLE
[cli] Improve activity command output with scope headers and better formatting

### DIFF
--- a/.changeset/better-activity-output.md
+++ b/.changeset/better-activity-output.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improved `vercel activity` command output formatting: added scope headers showing the team/project being queried, aligned event detail fields in expanded view, and included scope information in JSON output.

--- a/packages/cli/src/commands/activity/list.ts
+++ b/packages/cli/src/commands/activity/list.ts
@@ -405,6 +405,16 @@ function paginateEvents(
   return { events, next };
 }
 
+function printScopeHeader(scope: ActivityScope, flags: ListFlags) {
+  if (flags['--all'] && scope.teamSlug) {
+    output.log(`Showing all activity for team ${chalk.bold(scope.teamSlug)}`);
+  } else if (flags['--project'] && scope.teamSlug) {
+    output.log(
+      `Showing activity for project ${chalk.bold(flags['--project'])} in team ${chalk.bold(scope.teamSlug)}`
+    );
+  }
+}
+
 function printNextPageHint(flags: ListFlags, next: number) {
   const commandFlags = getCommandFlags(flags, ['--next']);
   output.log(
@@ -474,11 +484,21 @@ export default async function list(
     const { events, next } = paginateEvents(allEvents, validatedInputs.limit);
 
     if (jsonOutput) {
-      client.stdout.write(
-        `${JSON.stringify({ events, pagination: { next } }, null, 2)}\n`
-      );
+      const jsonResponse = {
+        ...(scope.teamSlug && {
+          scope: {
+            teamSlug: scope.teamSlug,
+            ...(scope.projectIds && { projectIds: scope.projectIds }),
+          },
+        }),
+        events,
+        pagination: { next },
+      };
+      client.stdout.write(`${JSON.stringify(jsonResponse, null, 2)}\n`);
       return 0;
     }
+
+    printScopeHeader(scope, flags);
 
     if (events.length === 0) {
       output.log('No activity events found.');

--- a/packages/cli/src/commands/activity/list.ts
+++ b/packages/cli/src/commands/activity/list.ts
@@ -48,6 +48,7 @@ interface UserEventsResponse {
 
 interface ActivityScope {
   projectIds?: string[];
+  projectName?: string;
   teamId?: string;
   teamSlug?: string;
 }
@@ -328,6 +329,7 @@ async function resolveScope(
       teamId: team.id,
       teamSlug: team.slug,
       projectIds: [projectResult.id],
+      projectName: projectResult.name,
     };
   }
 
@@ -348,6 +350,7 @@ async function resolveScope(
   const isTeamProject = linkedProject.org.type === 'team';
   return {
     projectIds: [linkedProject.project.id],
+    projectName: linkedProject.project.name,
     teamId: isTeamProject ? linkedProject.org.id : undefined,
     teamSlug: isTeamProject ? linkedProject.org.slug : undefined,
   };
@@ -405,13 +408,15 @@ function paginateEvents(
   return { events, next };
 }
 
-function printScopeHeader(scope: ActivityScope, flags: ListFlags) {
-  if (flags['--all'] && scope.teamSlug) {
+function printScopeHeader(scope: ActivityScope) {
+  if (!scope.projectName && scope.teamSlug) {
     output.log(`Showing all activity for team ${chalk.bold(scope.teamSlug)}`);
-  } else if (flags['--project'] && scope.teamSlug) {
+  } else if (scope.projectName && scope.teamSlug) {
     output.log(
-      `Showing activity for project ${chalk.bold(flags['--project'])} in team ${chalk.bold(scope.teamSlug)}`
+      `Showing activity for project ${chalk.bold(scope.projectName)} in team ${chalk.bold(scope.teamSlug)}`
     );
+  } else if (scope.projectName) {
+    output.log(`Showing activity for project ${chalk.bold(scope.projectName)}`);
   }
 }
 
@@ -484,10 +489,12 @@ export default async function list(
     const { events, next } = paginateEvents(allEvents, validatedInputs.limit);
 
     if (jsonOutput) {
+      const hasScope = scope.teamSlug || scope.projectName;
       const jsonResponse = {
-        ...(scope.teamSlug && {
+        ...(hasScope && {
           scope: {
-            teamSlug: scope.teamSlug,
+            ...(scope.teamSlug && { teamSlug: scope.teamSlug }),
+            ...(scope.projectName && { projectName: scope.projectName }),
             ...(scope.projectIds && { projectIds: scope.projectIds }),
           },
         }),
@@ -498,7 +505,7 @@ export default async function list(
       return 0;
     }
 
-    printScopeHeader(scope, flags);
+    printScopeHeader(scope);
 
     if (events.length === 0) {
       output.log('No activity events found.');

--- a/packages/cli/src/commands/activity/list.ts
+++ b/packages/cli/src/commands/activity/list.ts
@@ -175,13 +175,13 @@ function printExpandedEvents(events: UserEventDTO[]) {
   const lines = [''];
 
   events.forEach(event => {
-    lines.push(chalk.bold(formatEventText(event.text)));
-    lines.push(`   ${chalk.cyan('Type:')} ${event.type ?? '-'}`);
-    lines.push(`   ${chalk.cyan('Actor:')} ${formatActor(event)}`);
+    lines.push(`${chalk.gray('-')} ${formatEventText(event.text)}`);
+    lines.push(`    ${chalk.cyan('Type'.padEnd(14))}${event.type ?? '-'}`);
+    lines.push(`    ${chalk.cyan('Actor'.padEnd(14))}${formatActor(event)}`);
     lines.push(
-      `   ${chalk.cyan('Timestamp:')} ${formatTimestamp(event.createdAt)}`
+      `    ${chalk.cyan('Timestamp'.padEnd(14))}${formatTimestamp(event.createdAt)}`
     );
-    lines.push(`   ${chalk.cyan('ID:')} ${event.id}`);
+    lines.push(`    ${chalk.cyan('ID'.padEnd(14))}${event.id}`);
     lines.push('');
   });
 

--- a/packages/cli/test/unit/commands/activity/list.test.ts
+++ b/packages/cli/test/unit/commands/activity/list.test.ts
@@ -154,9 +154,12 @@ describe('activity ls', () => {
     expect(exitCode).toBe(0);
     const output = client.stderr.getFullOutput();
     expect(output).toContain(longText);
-    expect(output).toContain('Type: firewall-bypass-created');
-    expect(output).toContain('Actor: jane');
-    expect(output).toContain('Timestamp: 2023-11-14T22:13:20.000Z');
+    expect(output).toContain('Type');
+    expect(output).toContain('firewall-bypass-created');
+    expect(output).toContain('Actor');
+    expect(output).toContain('jane');
+    expect(output).toContain('Timestamp');
+    expect(output).toContain('2023-11-14T22:13:20.000Z');
   });
 
   it('supports repeatable and comma-separated --type filters', async () => {

--- a/packages/cli/test/unit/commands/activity/list.test.ts
+++ b/packages/cli/test/unit/commands/activity/list.test.ts
@@ -381,6 +381,7 @@ describe('activity ls', () => {
     expect(parsed).toEqual({
       scope: {
         teamSlug: 'my-team',
+        projectName: 'activity-project',
         projectIds: ['prj_activity'],
       },
       events: [
@@ -492,7 +493,7 @@ describe('activity ls', () => {
     expect(output).toContain('my-team');
   });
 
-  it('does not show scope header for default linked project', async () => {
+  it('shows scope header with project and team for default linked project', async () => {
     client.scenario.get('/v3/events', (_req, res) => {
       res.json({
         events: [
@@ -513,8 +514,51 @@ describe('activity ls', () => {
 
     expect(exitCode).toBe(0);
     const output = client.stderr.getFullOutput();
-    expect(output).not.toContain('Showing all activity for team');
-    expect(output).not.toContain('Showing activity for project');
+    expect(output).toContain('Showing activity for project');
+    expect(output).toContain('activity-project');
+    expect(output).toContain('my-team');
+  });
+
+  it('shows scope header without team for personal linked project', async () => {
+    mockedGetLinkedProject.mockResolvedValue({
+      status: 'linked',
+      project: {
+        id: 'prj_personal',
+        name: 'personal-project',
+        accountId: 'user_dummy',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+      },
+      org: {
+        id: 'user_dummy',
+        slug: 'my-user',
+        type: 'user',
+      },
+    });
+
+    client.scenario.get('/v3/events', (_req, res) => {
+      res.json({
+        events: [
+          {
+            id: 'uev_1',
+            createdAt: 1700000000000,
+            text: 'Deployed to production',
+            type: 'deployment',
+            principalId: 'user_1',
+          },
+        ],
+      });
+    });
+
+    client.setArgv('activity', 'ls');
+
+    const exitCode = await activity(client);
+
+    expect(exitCode).toBe(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('Showing activity for project');
+    expect(output).toContain('personal-project');
+    expect(output).not.toContain('in team');
   });
 
   it('includes scope in JSON output when using --all', async () => {
@@ -556,7 +600,26 @@ describe('activity ls', () => {
     const parsed = JSON.parse(client.stdout.getFullOutput());
     expect(parsed.scope).toEqual({
       teamSlug: 'my-team',
+      projectName: 'my-app',
       projectIds: ['prj_overridden'],
+    });
+  });
+
+  it('includes scope in JSON output for default linked project', async () => {
+    client.scenario.get('/v3/events', (_req, res) => {
+      res.json({ events: [] });
+    });
+
+    client.setArgv('activity', 'ls', '--format=json');
+
+    const exitCode = await activity(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.scope).toEqual({
+      teamSlug: 'my-team',
+      projectName: 'activity-project',
+      projectIds: ['prj_activity'],
     });
   });
 

--- a/packages/cli/test/unit/commands/activity/list.test.ts
+++ b/packages/cli/test/unit/commands/activity/list.test.ts
@@ -379,6 +379,10 @@ describe('activity ls', () => {
 
     const parsed = JSON.parse(client.stdout.getFullOutput());
     expect(parsed).toEqual({
+      scope: {
+        teamSlug: 'my-team',
+        projectIds: ['prj_activity'],
+      },
       events: [
         {
           id: 'uev_1',
@@ -426,6 +430,134 @@ describe('activity ls', () => {
     expect(client.stderr.getFullOutput()).toContain(
       'You do not have permission to list activity events'
     );
+  });
+
+  it('shows scope header with team name when using --all', async () => {
+    client.scenario.get('/v3/events', (_req, res) => {
+      res.json({
+        events: [
+          {
+            id: 'uev_1',
+            createdAt: 1700000000000,
+            text: 'Deployed to production',
+            type: 'deployment',
+            principalId: 'user_1',
+          },
+        ],
+      });
+    });
+
+    client.setArgv('activity', 'ls', '--all');
+
+    const exitCode = await activity(client);
+
+    expect(exitCode).toBe(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('Showing all activity for team');
+    expect(output).toContain('my-team');
+  });
+
+  it('shows scope header with project and team name when using --project', async () => {
+    client.scenario.get('/v9/projects/:projectNameOrId', (_req, res) => {
+      res.json({
+        id: 'prj_overridden',
+        name: 'my-app',
+        accountId: 'team_dummy',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+      });
+    });
+    client.scenario.get('/v3/events', (_req, res) => {
+      res.json({
+        events: [
+          {
+            id: 'uev_1',
+            createdAt: 1700000000000,
+            text: 'Deployed to production',
+            type: 'deployment',
+            principalId: 'user_1',
+          },
+        ],
+      });
+    });
+
+    client.setArgv('activity', 'ls', '--project', 'my-app');
+
+    const exitCode = await activity(client);
+
+    expect(exitCode).toBe(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('Showing activity for project');
+    expect(output).toContain('my-app');
+    expect(output).toContain('my-team');
+  });
+
+  it('does not show scope header for default linked project', async () => {
+    client.scenario.get('/v3/events', (_req, res) => {
+      res.json({
+        events: [
+          {
+            id: 'uev_1',
+            createdAt: 1700000000000,
+            text: 'Deployed to production',
+            type: 'deployment',
+            principalId: 'user_1',
+          },
+        ],
+      });
+    });
+
+    client.setArgv('activity', 'ls');
+
+    const exitCode = await activity(client);
+
+    expect(exitCode).toBe(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).not.toContain('Showing all activity for team');
+    expect(output).not.toContain('Showing activity for project');
+  });
+
+  it('includes scope in JSON output when using --all', async () => {
+    client.scenario.get('/v3/events', (_req, res) => {
+      res.json({ events: [] });
+    });
+
+    client.setArgv('activity', 'ls', '--all', '--format=json');
+
+    const exitCode = await activity(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.scope).toEqual({
+      teamSlug: 'my-team',
+    });
+    expect(parsed.scope.projectIds).toBeUndefined();
+  });
+
+  it('includes scope with projectIds in JSON output when using --project', async () => {
+    client.scenario.get('/v9/projects/:projectNameOrId', (_req, res) => {
+      res.json({
+        id: 'prj_overridden',
+        name: 'my-app',
+        accountId: 'team_dummy',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+      });
+    });
+    client.scenario.get('/v3/events', (_req, res) => {
+      res.json({ events: [] });
+    });
+
+    client.setArgv('activity', 'ls', '--project', 'my-app', '--format=json');
+
+    const exitCode = await activity(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.scope).toEqual({
+      teamSlug: 'my-team',
+      projectIds: ['prj_overridden'],
+    });
   });
 
   it('works in non-TTY mode', async () => {


### PR DESCRIPTION
  ## Summary
  - Add scope headers to `activity ls` output so users know what scope they're viewing (team-wide via `--all` or project-specific via `--project`)
  - Include `scope` object in JSON output (`--format=json`) with `teamSlug` and `projectIds` when applicable
  - Clean up expanded event formatting: use consistent column alignment with padded labels and a `-` bullet prefix instead of bold text. This is aligned with the `vc domains inspect` output.