### PR TITLE
fix: updated js-yaml to 3.14.2

### DIFF
--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@iarna/toml": "2.2.3",
-    "js-yaml": "3.13.1",
+    "js-yaml": "3.14.2",
     "@vercel/error-utils": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1265,8 +1265,8 @@ importers:
         specifier: workspace:*
         version: link:../error-utils
       js-yaml:
-        specifier: 3.13.1
-        version: 3.13.1
+        specifier: 3.14.2
+        version: 3.14.2
     devDependencies:
       '@types/jest':
         specifier: 27.4.1
@@ -4360,7 +4360,7 @@ packages:
     resolution: {integrity: sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q==}
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 3.13.1
+      js-yaml: 3.14.2
     dev: true
 
   /@changesets/pre@2.0.2:
@@ -6036,7 +6036,7 @@ packages:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.13.1
+      js-yaml: 3.14.2
       resolve-from: 5.0.0
     dev: true
 
@@ -11968,7 +11968,7 @@ packages:
     dependencies:
       import-fresh: 2.0.0
       is-directory: 0.3.1
-      js-yaml: 3.13.1
+      js-yaml: 3.14.2
       parse-json: 4.0.0
     dev: true
 
@@ -15810,6 +15810,7 @@ packages:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+    dev: true
 
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -15818,6 +15819,13 @@ packages:
       argparse: 1.0.10
       esprima: 4.0.1
     dev: true
+
+  /js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -18045,7 +18053,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.13.1
+      js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
     dev: true


### PR DESCRIPTION
Bumps `js-yaml` from `3.13.1` to `3.14.2` to patch a prototype pollution vulnerability in the YAML merge (`<<`) operator.