### PR TITLE
feat(cli): add `integration terms` command for agent-friendly terms acceptance

### DIFF
--- a/.changeset/integration-terms-command.md
+++ b/.changeset/integration-terms-command.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel integration terms` command for agent-friendly terms acceptance. Replaces browser-based terms flow for AI agents and non-TTY environments with a CLI-native two-step flow: view required terms URLs, then accept after user approval.

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -174,7 +174,7 @@ export async function addAutoProvision(
         reason: 'terms_not_accepted',
       });
       output.error(
-        `Terms have not been accepted for "${integration.name}".\n\nBefore accepting, the user must review the required terms:\n  vercel integration terms ${integrationSlug}\n\nAfter the user has reviewed and approved the terms, accept them with:\n  vercel integration terms ${integrationSlug} --accept`
+        `Terms have not been accepted for "${integration.name}".\n\nThese terms are legal agreements that require explicit user consent.\nTo view the required terms, run:\n  vercel integration terms ${integrationSlug}\n\nAfter the user has reviewed and approved, accept with:\n  vercel integration terms ${integrationSlug} --accept`
       );
       return 1;
     } else {

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -8,7 +8,6 @@ import indent from '../../util/output/indent';
 import { autoProvisionResource } from '../../util/integration/auto-provision-resource';
 import { fetchIntegrationWithTelemetry } from '../../util/integration/fetch-integration';
 import { fetchInstallations } from '../../util/integration/fetch-installations';
-import { acceptTermsViaBrowser } from '../../util/integration/accept-terms-via-browser';
 import { promptForTermAcceptance } from '../../util/integration/prompt-for-terms';
 import { selectProduct } from '../../util/integration/select-product';
 import type {
@@ -160,7 +159,6 @@ export async function addAutoProvision(
   );
 
   let acceptedPolicies: AcceptedPolicies = {};
-  let browserInstallationId: string | undefined;
   if (!teamInstallation) {
     if (
       // AI agent mode — cannot interact with terminal prompts
@@ -170,21 +168,15 @@ export async function addAutoProvision(
       // Server declares browser install required (e.g. needs device fingerprint)
       integration.capabilities?.requiresBrowserInstall
     ) {
-      // Browser flow: open browser for terms acceptance, poll for installation
-      const browserInstallation = await acceptTermsViaBrowser(
-        client,
-        integration,
-        team.id,
-        contextName
+      // Non-interactive: direct to `vercel integration terms` subcommand
+      telemetry.trackMarketplaceEvent('marketplace_install_flow_dropped', {
+        ...baseProps,
+        reason: 'terms_not_accepted',
+      });
+      output.error(
+        `Terms have not been accepted for "${integration.name}".\n\nTo view required terms, run:\n  vercel integration terms ${integrationSlug}\n\nTo accept terms after reviewing, run:\n  vercel integration terms ${integrationSlug} --accept`
       );
-      if (!browserInstallation) {
-        telemetry.trackMarketplaceEvent('marketplace_install_flow_dropped', {
-          ...baseProps,
-          reason: 'browser_terms_timeout',
-        });
-        return 1;
-      }
-      browserInstallationId = browserInstallation.id;
+      return 1;
     } else {
       // Interactive TTY: keep existing prompt behavior
       const policies = await promptForTermAcceptance(client, integration);
@@ -273,7 +265,7 @@ export async function addAutoProvision(
       metadata,
       acceptedPolicies,
       options.billingPlanId,
-      browserInstallationId ?? options.installationId
+      options.installationId
     );
   } catch (error) {
     output.stopSpinner();

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -174,7 +174,7 @@ export async function addAutoProvision(
         reason: 'terms_not_accepted',
       });
       output.error(
-        `Terms have not been accepted for "${integration.name}".\n\nTo view required terms, run:\n  vercel integration terms ${integrationSlug}\n\nTo accept terms after reviewing, run:\n  vercel integration terms ${integrationSlug} --accept`
+        `Terms have not been accepted for "${integration.name}".\n\nBefore accepting, the user must review the required terms:\n  vercel integration terms ${integrationSlug}\n\nAfter the user has reviewed and approved the terms, accept them with:\n  vercel integration terms ${integrationSlug} --accept`
       );
       return 1;
     } else {

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -13,7 +13,6 @@ import {
   type PostProvisionOptions,
 } from '../../util/integration/post-provision-setup';
 import type {
-  AcceptedPolicies,
   BillingPlan,
   Integration,
   IntegrationInstallation,
@@ -32,6 +31,7 @@ import {
 import { addAutoProvision } from './add-auto-provision';
 import { fetchBillingPlans } from '../../util/integration/fetch-billing-plans';
 import { fetchInstallations } from '../../util/integration/fetch-installations';
+import { installMarketplaceIntegration } from '../../util/integration/install-integration';
 import { fetchIntegrationWithTelemetry } from '../../util/integration/fetch-integration';
 import { selectProduct } from '../../util/integration/select-product';
 import output from '../../output-manager';
@@ -366,21 +366,6 @@ function provisionResourceViaWebUI(
   output.debug(`Opening URL: ${url.href}`);
   open(url.href).catch((err: unknown) =>
     output.debug(`Failed to open browser: ${err}`)
-  );
-}
-
-async function installMarketplaceIntegration(
-  client: Client,
-  integrationId: string,
-  acceptedPolicies: AcceptedPolicies
-): Promise<{ id: string }> {
-  return await client.fetch<{ id: string }>(
-    `/v2/integrations/integration/${encodeURIComponent(integrationId)}/marketplace/install`,
-    {
-      method: 'POST',
-      json: true,
-      body: { acceptedPolicies, source: 'cli' },
-    }
   );
 }
 

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -410,6 +410,29 @@ export const guideSubcommand = {
   ],
 } as const;
 
+export const termsSubcommand = {
+  name: 'terms',
+  aliases: [],
+  description: 'View or accept terms for a marketplace integration',
+  arguments: [
+    {
+      name: 'integration',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'accept',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Accept all terms for the integration',
+    },
+    formatOption,
+  ],
+  examples: [],
+} as const;
+
 export const integrationCommand = {
   name: 'integration',
   aliases: [],

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -19,12 +19,14 @@ import {
   listSubcommand,
   openSubcommand,
   removeSubcommand,
+  termsSubcommand,
 } from './command';
 import { list } from './list';
 import { openIntegration } from './open-integration';
 import { remove } from './remove-integration';
 import { discover } from './discover';
 import { guide } from './guide';
+import { terms } from './terms';
 import { printAddDynamicHelp } from './add-help';
 
 const COMMAND_CONFIG = {
@@ -35,6 +37,7 @@ const COMMAND_CONFIG = {
   guide: getCommandAliases(guideSubcommand),
   balance: getCommandAliases(balanceSubcommand),
   remove: getCommandAliases(removeSubcommand),
+  terms: getCommandAliases(termsSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -181,6 +184,15 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return remove(client);
+    }
+    case 'terms': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('integration', subcommandOriginal);
+        printHelp(termsSubcommand);
+        return 0;
+      }
+      telemetry.trackCliSubcommandTerms(subcommandOriginal);
+      return terms(client, subArgs);
     }
     default: {
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/integration/terms.ts
+++ b/packages/cli/src/commands/integration/terms.ts
@@ -172,6 +172,7 @@ export async function terms(client: Client, subArgs: string[]) {
         {
           integration: integrationSlug,
           terms: termsList,
+          userReviewRequired: true,
           acceptCommand: `${packageName} integration terms ${integrationSlug} --accept`,
         },
         null,
@@ -188,7 +189,7 @@ export async function terms(client: Client, subArgs: string[]) {
     }
 
     output.log(
-      `To accept all terms, run:\n  ${packageName} integration terms ${integrationSlug} --accept`
+      `Please ensure the user has reviewed the terms above before accepting.\nTo accept all terms, run:\n  ${packageName} integration terms ${integrationSlug} --accept`
     );
   }
 

--- a/packages/cli/src/commands/integration/terms.ts
+++ b/packages/cli/src/commands/integration/terms.ts
@@ -188,8 +188,14 @@ export async function terms(client: Client, subArgs: string[]) {
       output.log(`     ${term.url}\n`);
     }
 
+    if (client.isAgent || !client.stdin.isTTY) {
+      output.log(
+        `These terms are legal agreements. You must present the above terms to the user and obtain their explicit approval before running the --accept command.`
+      );
+    }
+
     output.log(
-      `These terms are legal agreements. You must present the above terms to the user and obtain their explicit approval before running the --accept command.\nTo accept all terms, run:\n  ${packageName} integration terms ${integrationSlug} --accept`
+      `To accept all terms, run:\n  ${packageName} integration terms ${integrationSlug} --accept`
     );
   }
 

--- a/packages/cli/src/commands/integration/terms.ts
+++ b/packages/cli/src/commands/integration/terms.ts
@@ -189,7 +189,7 @@ export async function terms(client: Client, subArgs: string[]) {
     }
 
     output.log(
-      `Please ensure the user has reviewed the terms above before accepting.\nTo accept all terms, run:\n  ${packageName} integration terms ${integrationSlug} --accept`
+      `These terms are legal agreements. You must present the above terms to the user and obtain their explicit approval before running the --accept command.\nTo accept all terms, run:\n  ${packageName} integration terms ${integrationSlug} --accept`
     );
   }
 

--- a/packages/cli/src/commands/integration/terms.ts
+++ b/packages/cli/src/commands/integration/terms.ts
@@ -1,0 +1,196 @@
+import type Client from '../../util/client';
+import { printError } from '../../util/error';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { fetchIntegration } from '../../util/integration/fetch-integration';
+import { installMarketplaceIntegration } from '../../util/integration/install-integration';
+import type { AcceptedPolicies } from '../../util/integration/types';
+import output from '../../output-manager';
+import getScope from '../../util/get-scope';
+import { termsSubcommand } from './command';
+import { IntegrationTermsTelemetryClient } from '../../util/telemetry/commands/integration/terms';
+import { validateJsonOutput } from '../../util/output-format';
+import { packageName } from '../../util/pkg-name';
+
+const MARKETPLACE_ADDENDUM_URL =
+  'https://vercel.com/legal/integration-marketplace-end-users-addendum';
+
+interface TermEntry {
+  type: string;
+  name: string;
+  url: string;
+}
+
+function buildTermsList(integration: {
+  privacyDocUri?: string;
+  eulaDocUri?: string;
+}): TermEntry[] {
+  const terms: TermEntry[] = [
+    {
+      type: 'toc',
+      name: 'Vercel Marketplace End User Addendum',
+      url: MARKETPLACE_ADDENDUM_URL,
+    },
+  ];
+
+  if (integration.privacyDocUri) {
+    terms.push({
+      type: 'privacy',
+      name: 'Privacy Policy',
+      url: integration.privacyDocUri,
+    });
+  }
+
+  if (integration.eulaDocUri) {
+    terms.push({
+      type: 'eula',
+      name: 'Terms of Service',
+      url: integration.eulaDocUri,
+    });
+  }
+
+  return terms;
+}
+
+function buildAcceptedPolicies(integration: {
+  privacyDocUri?: string;
+  eulaDocUri?: string;
+}): AcceptedPolicies {
+  const acceptedPolicies: AcceptedPolicies = {
+    toc: new Date().toISOString(),
+  };
+
+  if (integration.privacyDocUri) {
+    acceptedPolicies.privacy = new Date().toISOString();
+  }
+
+  if (integration.eulaDocUri) {
+    acceptedPolicies.eula = new Date().toISOString();
+  }
+
+  return acceptedPolicies;
+}
+
+export async function terms(client: Client, subArgs: string[]) {
+  const flagsSpecification = getFlagsSpecification(termsSubcommand.options);
+  let parsedArguments;
+
+  try {
+    parsedArguments = parseArguments(subArgs, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const telemetry = new IntegrationTermsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  const acceptFlag = parsedArguments.flags['--accept'] as boolean | undefined;
+  telemetry.trackCliFlagAccept(acceptFlag);
+
+  const formatResult = validateJsonOutput(parsedArguments.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const integrationSlug = parsedArguments.args[0];
+  if (!integrationSlug) {
+    output.error(
+      `You must specify an integration. Usage: ${packageName} integration terms <integration>`
+    );
+    return 1;
+  }
+
+  // Fetch integration details
+  let integration;
+  try {
+    integration = await fetchIntegration(client, integrationSlug);
+  } catch (error) {
+    telemetry.trackCliArgumentIntegration(integrationSlug);
+    output.error(
+      `Failed to fetch integration "${integrationSlug}": ${(error as Error).message}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentIntegration(integrationSlug, true);
+
+  const termsList = buildTermsList(integration);
+
+  if (acceptFlag) {
+    // Accept mode: accept all terms and call install API
+    const { team } = await getScope(client);
+    if (!team) {
+      output.error('Team not found');
+      return 1;
+    }
+    client.config.currentTeam = team.id;
+
+    const acceptedPolicies = buildAcceptedPolicies(integration);
+
+    try {
+      await installMarketplaceIntegration(
+        client,
+        integration.id,
+        acceptedPolicies
+      );
+    } catch (error) {
+      output.error(
+        `Failed to accept terms for "${integrationSlug}": ${(error as Error).message}`
+      );
+      return 1;
+    }
+
+    if (asJson) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            accepted: true,
+            integration: integrationSlug,
+            terms: termsList,
+          },
+          null,
+          2
+        )}\n`
+      );
+    } else {
+      output.success(
+        `Terms accepted for "${integration.name}". You can now run \`${packageName} integration add ${integrationSlug}\` to install.`
+      );
+    }
+
+    return 0;
+  }
+
+  // View mode: display terms
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          integration: integrationSlug,
+          terms: termsList,
+          acceptCommand: `${packageName} integration terms ${integrationSlug} --accept`,
+        },
+        null,
+        2
+      )}\n`
+    );
+  } else {
+    output.log(`Terms for "${integration.name}":\n`);
+
+    for (let i = 0; i < termsList.length; i++) {
+      const term = termsList[i];
+      output.log(`  ${i + 1}. ${term.name}`);
+      output.log(`     ${term.url}\n`);
+    }
+
+    output.log(
+      `To accept all terms, run:\n  ${packageName} integration terms ${integrationSlug} --accept`
+    );
+  }
+
+  return 0;
+}

--- a/packages/cli/src/util/integration/install-integration.ts
+++ b/packages/cli/src/util/integration/install-integration.ts
@@ -1,0 +1,17 @@
+import type Client from '../client';
+import type { AcceptedPolicies } from './types';
+
+export async function installMarketplaceIntegration(
+  client: Client,
+  integrationId: string,
+  acceptedPolicies: AcceptedPolicies
+): Promise<{ id: string }> {
+  return await client.fetch<{ id: string }>(
+    `/v2/integrations/integration/${encodeURIComponent(integrationId)}/marketplace/install`,
+    {
+      method: 'POST',
+      json: true,
+      body: { acceptedPolicies, source: 'cli' },
+    }
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/integration/index.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/index.ts
@@ -54,4 +54,11 @@ export class IntegrationTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandTerms(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'terms',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/integration/terms.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/terms.ts
@@ -1,0 +1,23 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { termsSubcommand } from '../../../../commands/integration/command';
+
+export class IntegrationTermsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof termsSubcommand>
+{
+  trackCliArgumentIntegration(v: string | undefined, known?: boolean) {
+    if (v) {
+      this.trackCliArgument({
+        arg: 'integration',
+        value: known ? v : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagAccept(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('accept');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -443,7 +443,7 @@ describe('integration add (auto-provision)', () => {
       expect(exitCode).toEqual(1);
     });
 
-    it('should open browser for terms acceptance in non-TTY mode', async () => {
+    it('should output terms error in non-TTY mode when not installed', async () => {
       client.reset();
       useUser();
       const teams = useTeams('team_dummy');
@@ -453,7 +453,6 @@ describe('integration add (auto-provision)', () => {
       useAutoProvision({
         responseKey: 'provisioned',
         withInstallation: false,
-        installationAppearsAfterPolls: 1,
       });
 
       client.stdin.isTTY = false;
@@ -461,21 +460,15 @@ describe('integration add (auto-provision)', () => {
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Waiting for terms acceptance in browser...'
-      );
-      await expect(client.stderr).toOutput('Terms accepted in browser.');
-      await expect(client.stderr).toOutput(
-        'Acme Product successfully provisioned: acme-gray-apple'
+        'Terms have not been accepted for "Acme Integration"'
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
-      expect(openMock).toHaveBeenCalledWith(
-        expect.stringContaining('/~/integrations/accept-terms/acme')
-      );
+      expect(exitCode).toEqual(1);
+      expect(openMock).not.toHaveBeenCalled();
     });
 
-    it('should open browser for terms acceptance when AI agent detected', async () => {
+    it('should output terms error when AI agent detected and not installed', async () => {
       client.reset();
       useUser();
       const teams = useTeams('team_dummy');
@@ -485,7 +478,6 @@ describe('integration add (auto-provision)', () => {
       useAutoProvision({
         responseKey: 'provisioned',
         withInstallation: false,
-        installationAppearsAfterPolls: 1,
       });
 
       client.isAgent = true;
@@ -493,21 +485,15 @@ describe('integration add (auto-provision)', () => {
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Waiting for terms acceptance in browser...'
-      );
-      await expect(client.stderr).toOutput('Terms accepted in browser.');
-      await expect(client.stderr).toOutput(
-        'Acme Product successfully provisioned: acme-gray-apple'
+        'Terms have not been accepted for "Acme Integration"'
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
-      expect(openMock).toHaveBeenCalledWith(
-        expect.stringContaining('/~/integrations/accept-terms/acme')
-      );
+      expect(exitCode).toEqual(1);
+      expect(openMock).not.toHaveBeenCalled();
     });
 
-    it('should open browser for terms when integration has requiresBrowserInstall capability', async () => {
+    it('should output terms error when integration has requiresBrowserInstall capability', async () => {
       client.reset();
       useUser();
       const teams = useTeams('team_dummy');
@@ -517,69 +503,23 @@ describe('integration add (auto-provision)', () => {
       useAutoProvision({
         responseKey: 'provisioned',
         withInstallation: false,
-        installationAppearsAfterPolls: 1,
       });
 
-      // TTY is true, isAgent is false — but requiresBrowserInstall should still trigger browser flow
       client.stdin.isTTY = true;
       client.isAgent = false;
       client.setArgv('integration', 'add', 'aws-apg');
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Waiting for terms acceptance in browser...'
-      );
-      await expect(client.stderr).toOutput('Terms accepted in browser.');
-      await expect(client.stderr).toOutput(
-        'Aurora Postgres successfully provisioned: aws-apg-gray-apple'
+        'Terms have not been accepted for "Aurora Postgres"'
       );
 
       const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
-      expect(openMock).toHaveBeenCalledWith(
-        expect.stringContaining('/~/integrations/accept-terms/aws-apg')
-      );
+      expect(exitCode).toEqual(1);
+      expect(openMock).not.toHaveBeenCalled();
     });
 
-    it('should exit with code 1 on browser terms timeout', async () => {
-      client.reset();
-      useUser();
-      const teams = useTeams('team_dummy');
-      const t = Array.isArray(teams) ? teams[0] : teams.teams[0];
-      client.config.currentTeam = t.id;
-
-      // Never return an installation — simulates user not accepting in browser
-      useAutoProvision({
-        responseKey: 'provisioned',
-        withInstallation: false,
-      });
-
-      // Mock sleep to be instant so the timeout loop completes quickly
-      vi.mock('../../../../src/util/sleep', () => ({
-        default: vi.fn().mockResolvedValue(undefined),
-      }));
-
-      // Import and call acceptTermsViaBrowser directly with a very short timeout
-      const { acceptTermsViaBrowser } = await import(
-        '../../../../src/util/integration/accept-terms-via-browser'
-      );
-
-      const result = await acceptTermsViaBrowser(
-        client,
-        { id: 'acme', slug: 'acme', name: 'Acme Integration' },
-        t.id,
-        t.slug,
-        100 // 100ms timeout — will expire almost immediately
-      );
-
-      expect(result).toBeNull();
-      expect(openMock).toHaveBeenCalledWith(
-        expect.stringContaining('/~/integrations/accept-terms/acme')
-      );
-    });
-
-    it('should skip browser when installation already exists (agent mode)', async () => {
-      // Need fresh mocks since beforeEach registered withInstallation: false
+    it('should skip terms check when installation already exists (agent mode)', async () => {
       client.reset();
       useUser();
       const teams = useTeams('team_dummy');
@@ -601,37 +541,7 @@ describe('integration add (auto-provision)', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
-      // Browser should NOT be opened since installation already exists
       expect(openMock).not.toHaveBeenCalled();
-    });
-
-    it('should include correct params in browser terms URL', async () => {
-      client.reset();
-      openMock.mockReset().mockResolvedValue(undefined as never);
-      useUser();
-      const teams = useTeams('team_dummy');
-      const t = Array.isArray(teams) ? teams[0] : teams.teams[0];
-      client.config.currentTeam = t.id;
-
-      useAutoProvision({
-        responseKey: 'provisioned',
-        withInstallation: false,
-        installationAppearsAfterPolls: 1,
-      });
-
-      client.isAgent = true;
-      client.setArgv('integration', 'add', 'acme');
-      const exitCodePromise = integrationCommand(client);
-
-      await expect(client.stderr).toOutput('Terms accepted in browser.');
-
-      const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(0);
-
-      const calledUrl = openMock.mock.calls[0]?.[0] as string;
-      const parsed = new URL(calledUrl);
-      expect(parsed.pathname).toContain('/~/integrations/accept-terms/acme');
-      expect(parsed.searchParams.get('source')).toEqual('cli');
     });
 
     it('should reject --yes flag to prevent automated term bypass (legal requirement)', async () => {

--- a/packages/cli/test/unit/commands/integration/terms.test.ts
+++ b/packages/cli/test/unit/commands/integration/terms.test.ts
@@ -65,6 +65,9 @@ describe('integration terms', () => {
       expect(stderr).toContain('Vercel Marketplace End User Addendum');
       expect(stderr).toContain('https://example.com/privacy');
       expect(stderr).toContain('https://example.com/eula');
+      expect(stderr).toContain(
+        'Please ensure the user has reviewed the terms above before accepting.'
+      );
       expect(stderr).toContain('vercel integration terms acme --accept');
       expect(exitCode).toEqual(0);
     });
@@ -91,6 +94,7 @@ describe('integration terms', () => {
       expect(jsonOutput.terms[0].type).toEqual('toc');
       expect(jsonOutput.terms[1].type).toEqual('privacy');
       expect(jsonOutput.terms[2].type).toEqual('eula');
+      expect(jsonOutput.userReviewRequired).toEqual(true);
       expect(jsonOutput.acceptCommand).toContain(
         'integration terms acme --accept'
       );

--- a/packages/cli/test/unit/commands/integration/terms.test.ts
+++ b/packages/cli/test/unit/commands/integration/terms.test.ts
@@ -65,8 +65,28 @@ describe('integration terms', () => {
       expect(stderr).toContain('Vercel Marketplace End User Addendum');
       expect(stderr).toContain('https://example.com/privacy');
       expect(stderr).toContain('https://example.com/eula');
-      expect(stderr).toContain('These terms are legal agreements.');
       expect(stderr).toContain('vercel integration terms acme --accept');
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should show legal framing when run by an agent', async () => {
+      client.isAgent = true;
+      client.setArgv('integration', 'terms', 'acme');
+      const exitCode = await integrationCommand(client);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('These terms are legal agreements.');
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should not show legal framing when run by a human in TTY', async () => {
+      client.isAgent = false;
+      client.stdin.isTTY = true;
+      client.setArgv('integration', 'terms', 'acme');
+      const exitCode = await integrationCommand(client);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).not.toContain('These terms are legal agreements.');
       expect(exitCode).toEqual(0);
     });
 

--- a/packages/cli/test/unit/commands/integration/terms.test.ts
+++ b/packages/cli/test/unit/commands/integration/terms.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import integrationCommand from '../../../../src/commands/integration';
+import { client } from '../../../mocks/client';
+import { useTeams, type Team } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+function useIntegrationFetch() {
+  client.scenario.get(
+    '/:version/integrations/integration/:slug',
+    (req, res) => {
+      const { slug } = req.params;
+      if (slug === 'acme') {
+        res.json({
+          id: 'acme',
+          name: 'Acme Integration',
+          slug: 'acme',
+          eulaDocUri: 'https://example.com/eula',
+          privacyDocUri: 'https://example.com/privacy',
+          products: [
+            {
+              id: 'acme-product',
+              name: 'Acme Product',
+              slug: 'acme',
+              type: 'storage',
+              shortDescription: 'The Acme product',
+              metadataSchema: { type: 'object', properties: {} },
+            },
+          ],
+        });
+      } else if (slug === 'minimal') {
+        res.json({
+          id: 'minimal',
+          name: 'Minimal Integration',
+          slug: 'minimal',
+          products: [],
+        });
+      } else {
+        res.status(404).json({ error: { message: 'Not found' } });
+      }
+    }
+  );
+}
+
+describe('integration terms', () => {
+  let team: Team;
+
+  beforeEach(() => {
+    useUser();
+    const teams = useTeams('team_dummy');
+    team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+    client.config.currentTeam = team.id;
+  });
+
+  describe('view mode (no --accept)', () => {
+    beforeEach(() => {
+      useIntegrationFetch();
+    });
+
+    it('should display terms for integration with all policy types', async () => {
+      client.setArgv('integration', 'terms', 'acme');
+      const exitCode = await integrationCommand(client);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Terms for "Acme Integration"');
+      expect(stderr).toContain('Vercel Marketplace End User Addendum');
+      expect(stderr).toContain('https://example.com/privacy');
+      expect(stderr).toContain('https://example.com/eula');
+      expect(stderr).toContain('vercel integration terms acme --accept');
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should display only Marketplace Addendum when no privacy/eula URIs', async () => {
+      client.setArgv('integration', 'terms', 'minimal');
+      const exitCode = await integrationCommand(client);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Terms for "Minimal Integration"');
+      expect(stderr).toContain('Vercel Marketplace End User Addendum');
+      expect(stderr).not.toContain('Privacy Policy');
+      expect(stderr).not.toContain('Terms of Service');
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should output JSON when --format=json is specified', async () => {
+      client.setArgv('integration', 'terms', 'acme', '--format=json');
+      const exitCode = await integrationCommand(client);
+
+      const jsonOutput = JSON.parse(client.stdout.getFullOutput());
+      expect(jsonOutput.integration).toEqual('acme');
+      expect(jsonOutput.terms).toHaveLength(3);
+      expect(jsonOutput.terms[0].type).toEqual('toc');
+      expect(jsonOutput.terms[1].type).toEqual('privacy');
+      expect(jsonOutput.terms[2].type).toEqual('eula');
+      expect(jsonOutput.acceptCommand).toContain(
+        'integration terms acme --accept'
+      );
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should error when no integration slug provided', async () => {
+      client.setArgv('integration', 'terms');
+      const exitCode = await integrationCommand(client);
+
+      await expect(client.stderr).toOutput('You must specify an integration');
+      expect(exitCode).toEqual(1);
+    });
+
+    it('should error when integration not found', async () => {
+      client.setArgv('integration', 'terms', 'nonexistent');
+      const exitCode = await integrationCommand(client);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Failed to fetch integration "nonexistent"');
+      expect(exitCode).toEqual(1);
+    });
+  });
+
+  describe('accept mode (--accept)', () => {
+    let installRequestBodies: unknown[];
+
+    beforeEach(() => {
+      installRequestBodies = [];
+      useIntegrationFetch();
+
+      client.scenario.post(
+        '/v2/integrations/integration/:integrationId/marketplace/install',
+        (req, res) => {
+          installRequestBodies.push(req.body);
+          res.json({ id: `${req.params.integrationId}-new-install` });
+        }
+      );
+    });
+
+    it('should accept terms and call install API', async () => {
+      client.setArgv('integration', 'terms', 'acme', '--accept');
+      const exitCode = await integrationCommand(client);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Terms accepted for "Acme Integration"');
+      expect(exitCode).toEqual(0);
+      expect(installRequestBodies).toHaveLength(1);
+
+      const body = installRequestBodies[0] as Record<string, unknown>;
+      const policies = body.acceptedPolicies as Record<string, string>;
+      expect(policies.toc).toBeDefined();
+      expect(policies.privacy).toBeDefined();
+      expect(policies.eula).toBeDefined();
+      expect(body.source).toEqual('cli');
+    });
+
+    it('should accept terms with only toc when no privacy/eula URIs', async () => {
+      client.setArgv('integration', 'terms', 'minimal', '--accept');
+      const exitCode = await integrationCommand(client);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Terms accepted for "Minimal Integration"');
+      expect(exitCode).toEqual(0);
+      expect(installRequestBodies).toHaveLength(1);
+
+      const body = installRequestBodies[0] as Record<string, unknown>;
+      const policies = body.acceptedPolicies as Record<string, string>;
+      expect(policies.toc).toBeDefined();
+      expect(policies.privacy).toBeUndefined();
+      expect(policies.eula).toBeUndefined();
+    });
+
+    it('should output JSON on accept with --format=json', async () => {
+      client.setArgv(
+        'integration',
+        'terms',
+        'acme',
+        '--accept',
+        '--format=json'
+      );
+      const exitCode = await integrationCommand(client);
+
+      const jsonOutput = JSON.parse(client.stdout.getFullOutput());
+      expect(jsonOutput.accepted).toEqual(true);
+      expect(jsonOutput.integration).toEqual('acme');
+      expect(jsonOutput.terms).toHaveLength(3);
+      expect(exitCode).toEqual(0);
+    });
+  });
+
+  describe('accept mode - API failure', () => {
+    beforeEach(() => {
+      useIntegrationFetch();
+
+      client.scenario.post(
+        '/v2/integrations/integration/:integrationId/marketplace/install',
+        (_req, res) => {
+          res.status(500).json({ error: { message: 'Internal Server Error' } });
+        }
+      );
+    });
+
+    it('should error on install API failure during accept', async () => {
+      client.setArgv('integration', 'terms', 'acme', '--accept');
+      const exitCode = await integrationCommand(client);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Failed to accept terms for "acme"');
+      expect(exitCode).toEqual(1);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/integration/terms.test.ts
+++ b/packages/cli/test/unit/commands/integration/terms.test.ts
@@ -65,9 +65,7 @@ describe('integration terms', () => {
       expect(stderr).toContain('Vercel Marketplace End User Addendum');
       expect(stderr).toContain('https://example.com/privacy');
       expect(stderr).toContain('https://example.com/eula');
-      expect(stderr).toContain(
-        'Please ensure the user has reviewed the terms above before accepting.'
-      );
+      expect(stderr).toContain('These terms are legal agreements.');
       expect(stderr).toContain('vercel integration terms acme --accept');
       expect(exitCode).toEqual(0);
     });


### PR DESCRIPTION
## Summary
- Adds a hidden \`vercel integration terms <integration>\` subcommand with two modes:
  - **View** (default): outputs required terms URLs (Marketplace Addendum, Privacy Policy, EULA)
  - **Accept** (\`--accept\`): calls the install API with acceptance timestamps
- Replaces the browser-based terms acceptance flow for AI agents/non-TTY with an error message directing to the new \`terms\` command
- Enables AI agents to view terms, show them to users in their own UI, get confirmation, and accept programmatically — without opening a browser

## Agent Flow
```
Agent: vercel integration add neon
CLI:   Error: Terms have not been accepted for "Neon".
       These terms are legal agreements that require explicit user consent.
       To view the required terms, run:
         vercel integration terms neon
       After the user has reviewed and approved, accept with:
         vercel integration terms neon --accept

Agent: vercel integration terms neon
CLI:   Terms for "Neon":
         1. Vercel Marketplace End User Addendum
            https://vercel.com/legal/...
         2. Privacy Policy  ...
       These terms are legal agreements. You must present the above terms
       to the user and obtain their explicit approval before running --accept.
       To accept all terms, run:
         vercel integration terms neon --accept

Agent: [shows links to user, gets explicit confirmation]

Agent: vercel integration terms neon --accept
CLI:   Terms accepted for "Neon". You can now run \`vercel integration add neon\`.

Agent: vercel integration add neon
CLI:   [proceeds with provisioning]
```

## Design decisions
- **Hidden command**: \`terms\` is not shown in \`vercel integration --help\` — it's only surfaced via the error message, so agents discover it naturally
- **Legal framing is agent-only**: The "legal agreements / explicit approval" language in \`terms\` view output is only shown to agents and non-TTY environments, not to humans in interactive terminals
- **Two-step by design**: Separating view and accept creates an audit trail and friction that nudges agents to involve the user before accepting
- **JSON support**: \`--format=json\` on the \`terms\` command returns structured output including \`userReviewRequired: true\` for agents that parse JSON

## Changes
- **New**: \`src/commands/integration/terms.ts\` — command implementation
- **New**: \`src/util/integration/install-integration.ts\` — extracted shared \`installMarketplaceIntegration\` utility
- **New**: \`src/util/telemetry/commands/integration/terms.ts\` — telemetry client
- **New**: \`test/unit/commands/integration/terms.test.ts\` — 11 tests
- **Modified**: \`add-auto-provision.ts\` — replaced browser flow with actionable error message
- **Modified**: \`add.ts\` — uses shared \`installMarketplaceIntegration\`
- **Modified**: \`command.ts\`, \`index.ts\`, telemetry \`index.ts\` — wiring

## Test plan
- [x] \`vercel integration terms <slug>\` shows terms URLs
- [x] \`vercel integration terms <slug> --accept\` calls install API with correct policies
- [x] \`vercel integration terms <slug> --format=json\` outputs structured JSON with \`userReviewRequired: true\`
- [x] Legal framing shown to agents/non-TTY, hidden from humans in TTY
- [x] \`vercel integration add <slug>\` as agent/non-TTY shows error with terms commands
- [x] \`vercel integration add <slug>\` as TTY human still uses interactive prompts (unchanged)
- [x] All auto-provision tests pass (103 tests)
- [x] Legacy add path tests pass (81 tests)
- [x] New terms tests pass (11 tests)

Fixes: [MKT-3153](https://linear.app/vercel/issue/MKT-3153/modify-the-cli-to-allow-for-accept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)