### PR TITLE
Copy static files when writing build results.

### DIFF
--- a/.changeset/funny-rules-worry.md
+++ b/.changeset/funny-rules-worry.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': minor
+'@vercel/python': minor
+'vercel': minor
+---
+
+Ensure django static files are copied in build output.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -447,6 +447,18 @@ export interface ProjectSettings {
   commandForIgnoringBuildStep?: string | null;
 }
 
+/*
+ * This is a builder whose build output version may dynamically change.
+ */
+export interface BuilderVX {
+  version: -1;
+  build: BuildVX;
+  diagnostics?: Diagnostics;
+  prepareCache?: PrepareCache;
+  shouldServe?: ShouldServe;
+  startDevServer?: StartDevServer;
+}
+
 export interface BuilderV2 {
   version: 2;
   build: BuildV2;
@@ -611,15 +623,20 @@ export interface BuildResultV2Typical {
   deploymentId?: string;
 }
 
+export interface BuildResultVX {
+  resultVersion: 2 | 3;
+  result: BuildResultV2 | BuildResultV3;
+}
+
 export type BuildResultV2 = BuildResultV2Typical | BuildResultBuildOutput;
 
 export interface BuildResultV3 {
   // TODO: use proper `Route` type from `routing-utils` (perhaps move types to a common package)
   routes?: any[];
   output: Lambda | EdgeFunction;
-  staticFilesPath?: string;
 }
 
+export type BuildVX = (options: BuildOptions) => Promise<BuildResultVX>;
 export type BuildV2 = (options: BuildOptions) => Promise<BuildResultV2>;
 export type BuildV3 = (options: BuildOptions) => Promise<BuildResultV3>;
 export type PrepareCache = (options: PrepareCacheOptions) => Promise<Files>;

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -617,6 +617,7 @@ export interface BuildResultV3 {
   // TODO: use proper `Route` type from `routing-utils` (perhaps move types to a common package)
   routes?: any[];
   output: Lambda | EdgeFunction;
+  staticFilesPath?: string;
 }
 
 export type BuildV2 = (options: BuildOptions) => Promise<BuildResultV2>;

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -623,10 +623,9 @@ export interface BuildResultV2Typical {
   deploymentId?: string;
 }
 
-export interface BuildResultVX {
-  resultVersion: 2 | 3;
-  result: BuildResultV2 | BuildResultV3;
-}
+export type BuildResultVX =
+  | { resultVersion: 2; result: BuildResultV2 }
+  | { resultVersion: 3; result: BuildResultV3 };
 
 export type BuildResultV2 = BuildResultV2Typical | BuildResultBuildOutput;
 

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -26,6 +26,7 @@ import {
   type BuildResultV2,
   type BuildResultV2Typical,
   type BuildResultV3,
+  type BuildResultVX,
   type Config,
   type Cron,
   type Files,
@@ -886,10 +887,15 @@ async function doBuild(
         `Building entrypoint "${build.src}" with "${builderPkg.name}"`
       );
       let buildResult: BuildResultV2 | BuildResultV3;
+      let rawBuildResult: BuildResultV2 | BuildResultV3 | BuildResultVX;
       try {
-        buildResult = await builderSpan.trace<BuildResultV2 | BuildResultV3>(
-          async () => builder.build(buildOptions)
-        );
+        rawBuildResult = await builderSpan.trace<
+          BuildResultV2 | BuildResultV3 | BuildResultVX
+        >(async () => builder.build(buildOptions));
+        buildResult =
+          builder.version === -1
+            ? (rawBuildResult as BuildResultVX).result
+            : (rawBuildResult as BuildResultV2 | BuildResultV3);
 
         // If the build result has no routes and the framework has default routes,
         // then add the default routes to the build result
@@ -1083,7 +1089,7 @@ async function doBuild(
             writeBuildResult({
               repoRootPath,
               outputDir,
-              buildResult,
+              buildResult: rawBuildResult,
               build,
               builder,
               builderPkg,

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -892,10 +892,12 @@ async function doBuild(
         rawBuildResult = await builderSpan.trace<
           BuildResultV2 | BuildResultV3 | BuildResultVX
         >(async () => builder.build(buildOptions));
-        buildResult =
-          builder.version === -1
-            ? (rawBuildResult as BuildResultVX).result
-            : (rawBuildResult as BuildResultV2 | BuildResultV3);
+        if (builder.version === -1) {
+          const vx = rawBuildResult as BuildResultVX;
+          buildResult = vx.result;
+        } else {
+          buildResult = rawBuildResult as BuildResultV2 | BuildResultV3;
+        }
 
         // If the build result has no routes and the framework has default routes,
         // then add the default routes to the build result

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -7,6 +7,7 @@ import { isStaticRuntime } from '@vercel/fs-detectors';
 import type {
   BuilderV2,
   BuilderV3,
+  BuilderVX,
   PackageJson,
   Span,
 } from '@vercel/build-utils';
@@ -25,7 +26,7 @@ export interface BuilderWithPkg {
    * absolute path to the package.json of the builder
    */
   pkgPath: string;
-  builder: BuilderV2 | BuilderV3;
+  builder: BuilderV2 | BuilderV3 | BuilderVX;
   pkg: PackageJson & { name: string };
   /**
    * true if the builder was installed into `.vercel/builders` (e.g. via npm);

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -11,11 +11,13 @@ import {
 } from 'path';
 import {
   type Builder,
+  type BuildResultVX,
   type BuildResultV2,
   type BuildResultV3,
   type File,
   type Files,
   FileFsRef,
+  type BuilderVX,
   type BuilderV2,
   type BuilderV3,
   type Lambda,
@@ -63,9 +65,9 @@ interface FunctionConfiguration {
 export async function writeBuildResult(args: {
   repoRootPath: string;
   outputDir: string;
-  buildResult: BuildResultV2 | BuildResultV3;
+  buildResult: BuildResultVX | BuildResultV2 | BuildResultV3;
   build: Builder;
-  builder: BuilderV2 | BuilderV3;
+  builder: BuilderVX | BuilderV2 | BuilderV3;
   builderPkg: PackageJson;
   vercelConfig: VercelConfig | null;
   standalone: boolean;
@@ -86,12 +88,20 @@ export async function writeBuildResult(args: {
     service,
     stripServiceRoutePrefix = false,
   } = args;
-  const version = builder.version;
+  const version =
+    builder.version === -1
+      ? (buildResult as BuildResultVX).resultVersion
+      : builder.version;
+  const actualResult =
+    builder.version === -1
+      ? (buildResult as BuildResultVX).result
+      : (buildResult as BuildResultV2 | BuildResultV3);
+
   if (typeof version !== 'number' || version === 2) {
     return writeBuildResultV2({
       repoRootPath,
       outputDir,
-      buildResult: buildResult as BuildResultV2,
+      buildResult: actualResult as BuildResultV2,
       build,
       vercelConfig,
       standalone,
@@ -103,7 +113,7 @@ export async function writeBuildResult(args: {
     return writeBuildResultV3({
       repoRootPath,
       outputDir,
-      buildResult: buildResult as BuildResultV3,
+      buildResult: actualResult as BuildResultV3,
       build,
       vercelConfig,
       standalone,
@@ -442,10 +452,6 @@ async function writeBuildResultV3(args: {
       `Unsupported output type: "${(output as any).type}" for ${build.src}`
     );
   }
-
-  if (buildResult.staticFilesPath) {
-    await mergeStaticFiles(outputDir, buildResult.staticFilesPath, workPath);
-  }
 }
 
 /**
@@ -746,31 +752,6 @@ async function mergeBuilderOutput(
   };
 
   await merge(buildResult.buildOutputPath, outputDir, ignoreFilter);
-}
-
-async function mergeStaticFiles(
-  outputDir: string,
-  staticFilesPath: string,
-  workPath: string
-) {
-  const outputStaticDir = join(outputDir, 'static');
-  const { ig } = await getVercelIgnore(workPath);
-  const filter = ig.createFilter();
-
-  if (resolve(staticFilesPath) === resolve(outputStaticDir)) {
-    try {
-      await cleanIgnoredFiles(outputStaticDir, outputStaticDir, filter);
-    } catch (err: any) {
-      if (err.code !== 'ENOENT') throw err;
-    }
-    return;
-  }
-
-  // Unlike mergeBuilderOutput (which sources from buildOutputPath root and sees
-  // paths like "static/app/style.css"), staticFilesPath is already the static
-  // dir, so merge sees paths like "app/style.css" directly — no prefix
-  // stripping needed before applying the filter.
-  await merge(staticFilesPath, outputStaticDir, filter);
 }
 
 async function cleanIgnoredFiles(

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -442,6 +442,17 @@ async function writeBuildResultV3(args: {
       `Unsupported output type: "${(output as any).type}" for ${build.src}`
     );
   }
+
+  // If the builder declared a staticFilesPath, copy CDN static files to the
+  // correct output location
+  if (buildResult.staticFilesPath) {
+    const outputStaticDir = join(outputDir, 'static');
+    if (resolve(buildResult.staticFilesPath) !== resolve(outputStaticDir)) {
+      await fs.copy(buildResult.staticFilesPath, outputStaticDir, {
+        overwrite: false,
+      });
+    }
+  }
 }
 
 /**

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -88,14 +88,16 @@ export async function writeBuildResult(args: {
     service,
     stripServiceRoutePrefix = false,
   } = args;
-  const version =
-    builder.version === -1
-      ? (buildResult as BuildResultVX).resultVersion
-      : builder.version;
-  const actualResult =
-    builder.version === -1
-      ? (buildResult as BuildResultVX).result
-      : (buildResult as BuildResultV2 | BuildResultV3);
+  let version: number;
+  let actualResult: BuildResultV2 | BuildResultV3;
+  if (builder.version === -1) {
+    const vx = buildResult as BuildResultVX;
+    version = vx.resultVersion;
+    actualResult = vx.result;
+  } else {
+    version = builder.version;
+    actualResult = buildResult as BuildResultV2 | BuildResultV3;
+  }
 
   if (typeof version !== 'number' || version === 2) {
     return writeBuildResultV2({

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -443,15 +443,8 @@ async function writeBuildResultV3(args: {
     );
   }
 
-  // If the builder declared a staticFilesPath, copy CDN static files to the
-  // correct output location
   if (buildResult.staticFilesPath) {
-    const outputStaticDir = join(outputDir, 'static');
-    if (resolve(buildResult.staticFilesPath) !== resolve(outputStaticDir)) {
-      await fs.copy(buildResult.staticFilesPath, outputStaticDir, {
-        overwrite: false,
-      });
-    }
+    await mergeStaticFiles(outputDir, buildResult.staticFilesPath, workPath);
   }
 }
 
@@ -753,6 +746,31 @@ async function mergeBuilderOutput(
   };
 
   await merge(buildResult.buildOutputPath, outputDir, ignoreFilter);
+}
+
+async function mergeStaticFiles(
+  outputDir: string,
+  staticFilesPath: string,
+  workPath: string
+) {
+  const outputStaticDir = join(outputDir, 'static');
+  const { ig } = await getVercelIgnore(workPath);
+  const filter = ig.createFilter();
+
+  if (resolve(staticFilesPath) === resolve(outputStaticDir)) {
+    try {
+      await cleanIgnoredFiles(outputStaticDir, outputStaticDir, filter);
+    } catch (err: any) {
+      if (err.code !== 'ENOENT') throw err;
+    }
+    return;
+  }
+
+  // Unlike mergeBuilderOutput (which sources from buildOutputPath root and sees
+  // paths like "static/app/style.css"), staticFilesPath is already the static
+  // dir, so merge sees paths like "app/style.css" directly — no prefix
+  // stripping needed before applying the filter.
+  await merge(staticFilesPath, outputStaticDir, filter);
 }
 
 async function cleanIgnoredFiles(

--- a/packages/cli/src/util/dev/builder-worker.cjs
+++ b/packages/cli/src/util/dev/builder-worker.cjs
@@ -47,11 +47,19 @@ async function processMessage(message) {
     buildOptions.files[name] = ref;
   }
 
-  const result = await builder.build(buildOptions);
+  let result = await builder.build(buildOptions);
 
   // `@vercel/next` sets this, but it causes "Converting circular
   // structure to JSON" errors, so delete the property...
   delete result.childProcesses;
+
+  // Unwrap BuildResultVX (builder.version === -1) to the actual V2 or V3 result.
+  // effectiveVersion reflects the actual result version for downstream checks.
+  let effectiveVersion = builder.version;
+  if (builder.version === -1) {
+    effectiveVersion = result.resultVersion;
+    result = result.result;
+  }
 
   // Helper to handle zipBuffer - writes to temp file if too large for IPC
   async function processLambdaOutput(output) {
@@ -77,7 +85,7 @@ async function processMessage(message) {
     }
   }
 
-  if (builder.version === 3) {
+  if (effectiveVersion === 3) {
     if (result.output.type === 'Lambda') {
       await processLambdaOutput(result.output);
     }

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -15,6 +15,7 @@ import {
   normalizePath,
   isBackendFramework,
   isPythonFramework,
+  type BuildResultVX,
 } from '@vercel/build-utils';
 import { isStaticRuntime } from '@vercel/fs-detectors';
 import plural from 'pluralize';
@@ -327,17 +328,36 @@ export async function executeBuild(
     buildResultOrOutputs = await builder.build(buildOptions);
   }
 
+  // Unwrap BuildResultVX (version === -1) to the actual V2 or V3 result.
+  // When using a build process, builder-worker.cjs sends back the already-
+  // unwrapped result, so we detect V2 vs V3 by output shape.
+  // If builder.build() was called directly (no build process), the raw VX
+  // wrapper is returned and we use resultVersion to unwrap it.
+  let effectiveVersion: number = builder.version;
+  if (effectiveVersion === -1) {
+    if ('resultVersion' in (buildResultOrOutputs as object)) {
+      const vx = buildResultOrOutputs as BuildResultVX;
+      effectiveVersion = vx.resultVersion;
+      buildResultOrOutputs = vx.result;
+    } else {
+      effectiveVersion =
+        (buildResultOrOutputs as BuildResultV3).output?.type === 'Lambda'
+          ? 3
+          : 2;
+    }
+  }
+
   // Sort out build result to builder v2 shape
-  if (!builder.version || (builder as any).version === 1) {
+  if (!effectiveVersion || effectiveVersion === 1) {
     // `BuilderOutputs` map was returned (Now Builder v1 behavior)
     result = {
       output: buildResultOrOutputs as BuilderOutputs,
       routes: [],
       watch: [],
     };
-  } else if (builder.version === 2) {
+  } else if (effectiveVersion === 2) {
     result = buildResultOrOutputs as BuildResult;
-  } else if (builder.version === 3) {
+  } else if (effectiveVersion === 3) {
     const { output, ...rest } = buildResultOrOutputs as BuildResultV3;
 
     if (!output || (output as BuilderOutput).type !== 'Lambda') {

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -2110,7 +2110,10 @@ export default class DevServer {
     // to. Once the proxied request is finished, vercel dev shuts down the dev
     // server child process.
     const { builder, pkg: builderPkg } = match.builderWithPkg;
-    if (builder.version === 3 && typeof builder.startDevServer === 'function') {
+    if (
+      (builder.version === 3 || builder.version === -1) &&
+      typeof builder.startDevServer === 'function'
+    ) {
       let devServerResult: StartDevServerResult = null;
       try {
         const { envConfigs, files, devCacheDir, cwd: workPath } = this;

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1678,7 +1678,7 @@ export default class DevServer {
       const { envConfigs, files, devCacheDir, cwd: workPath } = this;
       try {
         const { builder } = middleware.builderWithPkg;
-        if (builder.version === 3) {
+        if (builder.version === 3 || builder.version === -1) {
           startMiddlewareResult = await builder.startDevServer?.({
             files,
             entrypoint: middleware.entrypoint,

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -19,6 +19,7 @@ import {
   runNpmInstall,
   getServiceUrlEnvVars,
   type BuilderV3,
+  type BuilderVX,
   type Config,
 } from '@vercel/build-utils';
 import { checkForPort } from './port-utils';
@@ -397,9 +398,15 @@ export class ServicesOrchestrator {
     try {
       const builders = await importBuilders(new Set([builderSpec]), this.cwd);
       const builderWithPkg = builders.get(builderSpec);
-      const builder = builderWithPkg?.builder as BuilderV3 | undefined;
+      const builder = builderWithPkg?.builder as
+        | BuilderV3
+        | BuilderVX
+        | undefined;
 
-      if (builder?.version !== 3 || !builder.startDevServer) {
+      if (
+        (builder?.version !== 3 && builder?.version !== -1) ||
+        !builder?.startDevServer
+      ) {
         return null;
       }
 
@@ -578,7 +585,7 @@ export class ServicesOrchestrator {
     return Promise.race([checkForPort(port, STARTUP_TIMEOUT), processError]);
   }
 
-  // This is needed, because only BuilderV3 exposes a dev server,
+  // This is needed, because only BuilderV3 and BuilderVX expose a dev server,
   // but we still want to keep dependencies in sync for BuilderV2 (e.g. Next/Vite/etc).
   // We'll try with the provided installCommand (if any) and then fallback
   // to just trying to install dependencnies for Node.

--- a/packages/python/src/django.ts
+++ b/packages/python/src/django.ts
@@ -48,6 +48,11 @@ export interface DjangoCollectStaticResult {
   /** Absolute path of STATIC_ROOT to exclude from the Lambda bundle. */
   staticRoot: string | null;
   /**
+   * Absolute path to the directory where CDN static files were written,
+   * or null if not applicable (e.g. django-storages handles upload itself).
+   */
+  cdnOutputDir: string | null;
+  /**
    * workPath-relative path to `staticfiles.json` to inject into the Lambda
    * bundle, or null if the storage backend doesn't use a manifest.
    */
@@ -128,6 +133,7 @@ export async function runDjangoCollectStatic(
     return {
       staticSourceDirs,
       staticRoot: staticRoot ? resolve(workPath, staticRoot) : null,
+      cdnOutputDir: null,
       manifestRelPath: null,
     };
   }
@@ -193,6 +199,7 @@ export async function runDjangoCollectStatic(
   return {
     staticSourceDirs,
     staticRoot: staticRoot ? resolve(workPath, staticRoot) : null,
+    cdnOutputDir: outputStaticDir,
     manifestRelPath,
   };
 }

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -20,7 +20,7 @@ import {
   BUILDER_COMPILE_STEP,
   type BuildOptions,
   type GlobOptions,
-  type BuildV3,
+  type BuildVX,
   type Files,
   type ShouldServe,
   FileFsRef,
@@ -55,7 +55,7 @@ import {
   type DetectedPythonEntrypoint,
 } from './entrypoint';
 
-export const version = 3;
+export const version = -1;
 
 interface FrameworkHookContext {
   pythonEnv: NodeJS.ProcessEnv;
@@ -166,7 +166,7 @@ export async function downloadFilesInWorkPath({
   return workPath;
 }
 
-export const build: BuildV3 = async ({
+export const build: BuildVX = async ({
   workPath,
   repoRootPath,
   files: originalFiles,
@@ -730,12 +730,25 @@ from vercel_runtime.vc_init import vc_handler
     }
   }
 
-  return {
-    output,
-    ...(djangoStatic?.cdnOutputDir
-      ? { staticFilesPath: djangoStatic.cdnOutputDir }
-      : {}),
-  };
+  if (djangoStatic?.cdnOutputDir) {
+    const lambdaPath = entrypoint.replace(/\.py$/, '');
+    const staticFiles = await glob('**', { cwd: djangoStatic.cdnOutputDir });
+    return {
+      resultVersion: 2,
+      result: {
+        output: {
+          [lambdaPath]: output,
+          ...staticFiles,
+        },
+        routes: [
+          { handle: 'filesystem' },
+          { src: '/(.*)', dest: `/${lambdaPath}` },
+        ],
+      },
+    };
+  }
+
+  return { resultVersion: 3, result: { output } };
 };
 
 export { startDevServer };

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -730,7 +730,12 @@ from vercel_runtime.vc_init import vc_handler
     }
   }
 
-  return { output };
+  return {
+    output,
+    ...(djangoStatic?.cdnOutputDir
+      ? { staticFilesPath: djangoStatic.cdnOutputDir }
+      : {}),
+  };
 };
 
 export { startDevServer };

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -158,7 +158,10 @@ export async function downloadFilesInWorkPath({
   if (meta.isDev) {
     // Old versions of the CLI don't assign this property
     const { devCacheDir = join(workPath, '.now', 'cache') } = meta;
-    const destCache = join(devCacheDir, basename(entrypoint, '.py'));
+    // Replace dots in the entrypoint basename with underscores so the cache
+    // directory name doesn't collide with the entrypoint file itself.
+    const cacheKey = basename(entrypoint).replace(/\./g, '_');
+    const destCache = join(devCacheDir, cacheKey);
     await download(downloadedFiles, destCache);
     downloadedFiles = await glob('**', destCache);
     workPath = destCache;

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -50,6 +50,7 @@ import {
 } from '../src/version';
 import type { PythonConstraint, PythonPackage } from '@vercel/python-analysis';
 import { build } from '../src/index';
+import type { BuildResultV3 } from '@vercel/build-utils';
 import { createVenvEnv, getVenvBinDir } from '../src/utils';
 import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
 import { VERCEL_WORKERS_VERSION } from '../src/package-versions';
@@ -57,6 +58,11 @@ import { createPyprojectToml } from '../src/install';
 import { detectDjangoPythonEntrypoint } from '../src/entrypoint';
 import { getDjangoSettings } from '../src/django';
 import { FileBlob } from '@vercel/build-utils';
+
+function getBuildOutputV3(result: Awaited<ReturnType<typeof build>>) {
+  expect(result.resultVersion).toBe(3);
+  return (result as any).result.output as BuildResultV3['output'];
+}
 
 /**
  * Build a PythonConstraint from a PEP 440 version specifier string.
@@ -758,7 +764,7 @@ describe('file exclusions', () => {
       repoRootPath: mockWorkPath,
     });
 
-    const outputFiles = Object.keys(result.output.files || {});
+    const outputFiles = Object.keys(getBuildOutputV3(result).files || {});
     const excludedLockFiles = [
       'pnpm-lock.yaml',
       'yarn.lock',
@@ -802,7 +808,7 @@ describe('file exclusions', () => {
       repoRootPath: mockWorkPath,
     });
 
-    const outputFiles = Object.keys(result.output.files || {});
+    const outputFiles = Object.keys(getBuildOutputV3(result).files || {});
 
     // Should not include the user-excluded file
     expect(outputFiles.some(f => f.includes('secret.txt'))).toBe(false);
@@ -849,7 +855,7 @@ describe('python version selection from uv.lock and pyproject.toml', () => {
       repoRootPath: mockWorkPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     expect(handler).toBeDefined();
   });
 
@@ -870,7 +876,7 @@ describe('python version selection from uv.lock and pyproject.toml', () => {
       repoRootPath: mockWorkPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     expect(handler).toBeDefined();
   });
 
@@ -983,7 +989,7 @@ describe('uv workspace lockfile resolution (workspace root above workPath)', () 
       repoRootPath: repoRoot,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     expect(handler).toBeDefined();
 
     fs.removeSync(repoRoot);
@@ -1046,7 +1052,7 @@ describe('fastapi entrypoint discovery - positive cases', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1079,7 +1085,7 @@ describe('fastapi entrypoint discovery - positive cases', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1113,7 +1119,7 @@ describe('fastapi entrypoint discovery - positive cases', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1186,7 +1192,7 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1220,7 +1226,7 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1261,7 +1267,7 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1306,7 +1312,7 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1347,7 +1353,7 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1402,7 +1408,7 @@ describe('pyproject.toml entrypoint detection', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1446,7 +1452,7 @@ describe('pyproject.toml entrypoint detection', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1487,7 +1493,7 @@ describe('pyproject.toml entrypoint detection', () => {
       repoRootPath: workPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1532,7 +1538,7 @@ describe('handlerFunction validation', () => {
       repoRootPath: mockWorkPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1560,7 +1566,7 @@ describe('handlerFunction validation', () => {
       repoRootPath: mockWorkPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1630,7 +1636,7 @@ describe('handlerFunction validation', () => {
       repoRootPath: mockWorkPath,
     });
 
-    const handler = result.output.files?.['vc__handler__python.py'];
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -50,14 +50,19 @@ import {
 } from '../src/version';
 import type { PythonConstraint, PythonPackage } from '@vercel/python-analysis';
 import { build } from '../src/index';
-import type { BuildResultV3 } from '@vercel/build-utils';
+import type { BuildResultV3, BuildResultV2 } from '@vercel/build-utils';
 import { createVenvEnv, getVenvBinDir } from '../src/utils';
 import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
 import { VERCEL_WORKERS_VERSION } from '../src/package-versions';
 import { createPyprojectToml } from '../src/install';
 import { detectDjangoPythonEntrypoint } from '../src/entrypoint';
-import { getDjangoSettings } from '../src/django';
+import { getDjangoSettings, runDjangoCollectStatic } from '../src/django';
 import { FileBlob } from '@vercel/build-utils';
+
+function getBuildOutputV2(result: Awaited<ReturnType<typeof build>>) {
+  expect(result.resultVersion).toBe(2);
+  return (result as any).result as BuildResultV2;
+}
 
 function getBuildOutputV3(result: Awaited<ReturnType<typeof build>>) {
   expect(result.resultVersion).toBe(3);
@@ -1359,6 +1364,70 @@ describe('Django entrypoint discovery', () => {
     }
     const content = handler.data.toString();
     expect(content).toContain('os.path.join(_here, "hello/world.py")');
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('returns a v2 result with static files in output and filesystem route', async () => {
+    vi.mocked(getDjangoSettings).mockResolvedValueOnce({
+      settingsModule: 'myapp.settings',
+      djangoSettings: {
+        WSGI_APPLICATION: 'myapp.wsgi.application',
+        STATIC_URL: '/static/',
+        STATIC_ROOT: 'staticfiles',
+      },
+    });
+    // Simulate collectstatic succeeding
+    vi.mocked(runDjangoCollectStatic).mockImplementationOnce(
+      async (_venvPath, _workPath, _env, outputStaticDir) => {
+        fs.mkdirSync(path.join(outputStaticDir, 'static'), { recursive: true });
+        fs.writeFileSync(
+          path.join(outputStaticDir, 'static', 'app.css'),
+          'body {}'
+        );
+        return {
+          staticSourceDirs: [path.join(_workPath, 'static')],
+          staticRoot: null,
+          cdnOutputDir: outputStaticDir,
+          manifestRelPath: null,
+        };
+      }
+    );
+
+    const workPath = path.join(tmpdir(), `python-django-build-${Date.now()}`);
+    fs.mkdirSync(workPath, { recursive: true });
+    makeMockPython('3.9');
+
+    // Omit the configured entrypoint from files so that framework detection
+    // runs and sets detected.baseDir, which the Django hook requires.
+    const files = {
+      'manage.py': new FileBlob({
+        data: "os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'myapp.settings')\n",
+      }),
+      'myapp/wsgi.py': new FileBlob({
+        data: 'application = lambda env, start: None\n',
+      }),
+      'static/app.css': new FileBlob({ data: 'body {}' }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath: workPath,
+      files,
+      entrypoint: 'index.py',
+      meta: { isDev: false },
+      config: { framework: 'django', zeroConfig: true },
+      repoRootPath: workPath,
+    });
+
+    const v2result = getBuildOutputV2(result);
+    expect(v2result.routes).toContainEqual({ handle: 'filesystem' });
+    expect(v2result.routes).toContainEqual(
+      expect.objectContaining({ src: '/(.*)', dest: '/myapp/wsgi' })
+    );
+    const lambda = v2result.output['myapp/wsgi'];
+    expect(lambda).toBeDefined(); // Lambda keyed by entrypoint sans extension
+    expect((lambda as any).files?.['static/app.css']).toBeUndefined(); // Excluded from Lambda bundle
+    expect(v2result.output['static/app.css']).toBeDefined(); // Static file from collectstatic
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });


### PR DESCRIPTION
Build V3 has no mechanism to copy static files from build results.

This PR:
- Adds Build VX which can dynamically switch between build v2 and v3 outputs
- Switches python to use this new build mechanism.
