### PR TITLE
[domains] show unavailable error instead of price check error on domain purchase

### DIFF
--- a/.changeset/five-parents-push.md
+++ b/.changeset/five-parents-push.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Show availability error instead of price check error when domain unavailable

--- a/packages/cli/src/commands/domains/buy.ts
+++ b/packages/cli/src/commands/domains/buy.ts
@@ -146,10 +146,18 @@ export default async function buy(client: Client, argv: string[]) {
   }
 
   const availableStamp = stamp();
-  const domainPrice = await getDomainPrice(client, domainName);
+  const [domainPrice, domainStatus] = await Promise.all([
+    getDomainPrice(client, domainName),
+    getDomainStatus(client, domainName),
+  ]);
 
   if (domainPrice instanceof Error) {
     output.prettyError(domainPrice);
+    return 1;
+  }
+
+  if (!domainStatus.available) {
+    output.error('This domain is unavailable');
     return 1;
   }
 

--- a/packages/cli/src/commands/domains/buy.ts
+++ b/packages/cli/src/commands/domains/buy.ts
@@ -157,7 +157,11 @@ export default async function buy(client: Client, argv: string[]) {
   }
 
   if (!domainStatus.available) {
-    output.error('This domain is unavailable');
+    output.error(
+      `The domain ${param(domainName)} is ${chalk.underline(
+        'unavailable'
+      )}! ${availableStamp()}`
+    );
     return 1;
   }
 
@@ -165,15 +169,6 @@ export default async function buy(client: Client, argv: string[]) {
 
   if (purchasePrice === null || renewalPrice === null) {
     output.error('Domain price not found');
-    return 1;
-  }
-
-  if (!(await getDomainStatus(client, domainName)).available) {
-    output.error(
-      `The domain ${param(domainName)} is ${chalk.underline(
-        'unavailable'
-      )}! ${availableStamp()}`
-    );
     return 1;
   }
 


### PR DESCRIPTION
Moves the availability error to before the null price error so that when a domain is unavailable during `vc domains buy example.com`, we show "The domain example.com is unavailable` instead of `Price not found`