### PR TITLE
[config] Fix rewrite() and redirect() return types for VercelConfig compatibility

### DIFF
--- a/.changeset/strange-brooms-listen.md
+++ b/.changeset/strange-brooms-listen.md
@@ -1,5 +1,0 @@
----
-'@vercel/config': patch
----
-
-Fix rewrite() and redirect() return types

--- a/.changeset/strange-brooms-listen.md
+++ b/.changeset/strange-brooms-listen.md
@@ -1,0 +1,5 @@
+---
+'@vercel/config': patch
+---
+
+Fix rewrite() and redirect() return types

--- a/.changeset/unlucky-plums-peel.md
+++ b/.changeset/unlucky-plums-peel.md
@@ -1,0 +1,5 @@
+---
+"@vercel/config": patch
+---
+
+[config] Fix rewrite() and redirect() return types for VercelConfig compatibility

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -86,6 +86,18 @@ describe('Router', () => {
       expect(rewrite).toHaveProperty('source');
       expect(rewrite).toHaveProperty('destination');
     });
+
+    it('should return Rewrite type when destination has env vars', () => {
+      const rewrite = router.rewrite(
+        '/api/:path*',
+        `https://${deploymentEnv('API_HOST')}/$path*`
+      );
+      expect(rewrite).toEqual({
+        source: '/api/:path*',
+        destination: 'https://$API_HOST/$path*',
+        env: ['API_HOST'],
+      });
+    });
   });
 
   describe('redirect', () => {
@@ -116,6 +128,18 @@ describe('Router', () => {
         source: '/old-path',
         destination: '/new-path',
         statusCode: 301,
+      });
+    });
+
+    it('should return Redirect type when destination has env vars', () => {
+      const redirect = router.redirect(
+        '/old/:path*',
+        `https://${deploymentEnv('NEW_HOST')}/$path*`
+      );
+      expect(redirect).toEqual({
+        source: '/old/:path*',
+        destination: 'https://$NEW_HOST/$path*',
+        env: ['NEW_HOST'],
       });
     });
   });

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -642,7 +642,7 @@ export class Router {
    *    })
    * @internal Can return Route with transforms internally
    */
-  rewrite<T extends string>(source: T, destination: string): Rewrite | Route;
+  rewrite<T extends string>(source: T, destination: string): Rewrite;
   rewrite<T extends string>(
     source: T,
     destination: string,
@@ -866,10 +866,7 @@ export class Router {
    *    })
    * @internal Can return Route with transforms internally
    */
-  public redirect<T extends string>(
-    source: T,
-    destination: string
-  ): Redirect | Route;
+  public redirect<T extends string>(source: T, destination: string): Redirect;
   public redirect<T extends string>(
     source: T,
     destination: string,

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -800,34 +800,16 @@ export class Router {
       return route;
     }
 
-    // Simple rewrite without transforms - check if destination has env vars
+    // Simple rewrite without transforms
     const pathParams = this.extractPathParams(source);
     const destEnvVars = extractEnvVars(destination, pathParams);
 
-    if (destEnvVars.length > 0) {
-      // Need Route format to include env field
-      // Convert path-to-regexp patterns to regex for routes format
-      const { src: regexSrc, segments } = sourceToRegex(source);
-      const convertedDest = convertDestination(destination, segments);
-
-      const route: Route = {
-        src: regexSrc,
-        dest: convertedDest,
-        env: destEnvVars,
-      };
-      if (has) route.has = has;
-      if (missing) route.missing = missing;
-      if (respectOriginCacheControl !== undefined)
-        route.respectOriginCacheControl = respectOriginCacheControl;
-      return route;
-    }
-
-    // Simple rewrite without transforms or env vars
     const rewrite: Rewrite = {
       source,
       destination,
     };
 
+    if (destEnvVars.length > 0) rewrite.env = destEnvVars;
     if (has) rewrite.has = has;
     if (missing) rewrite.missing = missing;
     if (respectOriginCacheControl !== undefined)
@@ -976,33 +958,16 @@ export class Router {
       return route;
     }
 
-    // Simple redirect without transforms - check if destination has env vars
+    // Simple redirect without transforms
     const pathParams = this.extractPathParams(source);
     const destEnvVars = extractEnvVars(destination, pathParams);
 
-    if (destEnvVars.length > 0) {
-      // Need Route format to include env field
-      // Convert path-to-regexp patterns to regex for routes format
-      const { src: regexSrc, segments } = sourceToRegex(source);
-      const convertedDest = convertDestination(destination, segments);
-
-      const route: Route = {
-        src: regexSrc,
-        dest: convertedDest,
-        status: statusCode || (permanent ? 308 : 307),
-        env: destEnvVars,
-      };
-      if (has) route.has = has;
-      if (missing) route.missing = missing;
-      return route;
-    }
-
-    // Simple redirect without transforms or env vars
     const redirect: Redirect = {
       source,
       destination,
     };
 
+    if (destEnvVars.length > 0) redirect.env = destEnvVars;
     if (permanent !== undefined) redirect.permanent = permanent;
     if (statusCode !== undefined) redirect.statusCode = statusCode;
     if (has) redirect.has = has;


### PR DESCRIPTION
## Summary

- Narrow the return type of the 2-arg `rewrite(source, destination)` overload from `Rewrite | Route` to `Rewrite`
- Narrow the return type of the 2-arg `redirect(source, destination)` overload from `Redirect | Route` to `Redirect`
- Fix the no-transforms code path that incorrectly returned a `Route` (with `src`/`dest`) instead of `Rewrite`/`Redirect` (with `source`/`destination`) when the destination contained env vars from `deploymentEnv()`

### Bug

Since #15016 made `Route.source` optional (`string | undefined`), the union `Rewrite | Route` is no longer assignable to `Rewrite[]` in `VercelConfig.rewrites`, causing a type error on the documented usage pattern:

```ts
import { routes, type VercelConfig } from '@vercel/config/v1';

export const config: VercelConfig = {
  rewrites: [
    routes.rewrite('/about', '/about-our-company.html'), // TS2322
  ],
};
```

<img width="867" height="402" alt="image" src="https://github.com/user-attachments/assets/92216a53-8107-4db6-818f-128ae4cfda58" />

### Type fix

The 2-arg overloads always produce `Rewrite` / `Redirect` at runtime, so the return type is narrowed to match. The callback and options overloads retain `Rewrite | Route` / `Redirect | Route`.

### Runtime fix

When the destination contained env var references (e.g. `deploymentEnv('API_HOST')`), the no-transforms code path eagerly converted to `Route` format (regex `src`/`dest`). This meant the returned object had `src`/`dest` properties instead of the declared `source`/`destination`, which would break if passed to `convertRewrites()` downstream. Since both `Rewrite` and `Redirect` already have an `env` field, we now return the high-level type directly and let `convertRewrites`/`convertRedirects` handle regex conversion.