### PR TITLE
Add role selection to vercel teams invite

### DIFF
--- a/.changeset/funny-squids-smile.md
+++ b/.changeset/funny-squids-smile.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add a `--role` option to `vercel teams invite` so team member invites can assign a role from the CLI.

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -1,5 +1,6 @@
 import { packageName } from '../../util/pkg-name';
 import { formatOption, nextOption } from '../../util/arg-common';
+import { TEAM_MEMBER_ROLE_LIST } from '../../util/teams/team-member-roles';
 
 export const addSubcommand = {
   name: 'add',
@@ -93,8 +94,7 @@ export const inviteSubcommand = {
       type: String,
       argument: 'ROLE',
       deprecated: false,
-      description:
-        'Role to assign to the invited team member (OWNER, MEMBER, DEVELOPER, SECURITY, BILLING, VIEWER, VIEWER_FOR_PLUS, CONTRIBUTOR)',
+      description: `Role to assign to the invited team member (${TEAM_MEMBER_ROLE_LIST})`,
     },
   ],
   examples: [

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -86,7 +86,17 @@ export const inviteSubcommand = {
       multiple: true,
     },
   ],
-  options: [],
+  options: [
+    {
+      name: 'role',
+      shorthand: null,
+      type: String,
+      argument: 'ROLE',
+      deprecated: false,
+      description:
+        'Role to assign to the invited team member (OWNER, MEMBER, DEVELOPER, SECURITY, BILLING, VIEWER, VIEWER_FOR_PLUS, CONTRIBUTOR)',
+    },
+  ],
   examples: [
     {
       name: 'Invite new members (interactively)',
@@ -95,6 +105,10 @@ export const inviteSubcommand = {
     {
       name: 'Invite multiple members (required in non-interactive mode)',
       value: `${packageName} teams invite abc@vercel.com xyz@vercel.com`,
+    },
+    {
+      name: 'Invite a member with a specific role',
+      value: `${packageName} teams invite abc@vercel.com --role DEVELOPER`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/teams/invite.ts
+++ b/packages/cli/src/commands/teams/invite.ts
@@ -26,6 +26,11 @@ import {
   getGlobalFlagsOnlyFromArgs,
   getSameSubcommandSuggestionFlags,
 } from '../../util/arg-common';
+import {
+  isTeamMemberRole,
+  TEAM_MEMBER_ROLE_LIST,
+  type TeamMemberRole,
+} from '../../util/teams/team-member-roles';
 
 /** Append global argv flags (--cwd, --non-interactive, etc.) so agents can re-run with same context. */
 function withGlobalFlags(client: Client, commandTemplate: string): string {
@@ -86,6 +91,35 @@ export default async function invite(
     return 1;
   }
   const { args: emails } = parsedArgs;
+  const roleFlag =
+    typeof parsedArgs.flags['--role'] === 'string'
+      ? parsedArgs.flags['--role'].trim()
+      : undefined;
+  let role: TeamMemberRole | undefined;
+
+  if (roleFlag !== undefined) {
+    const normalizedRole = roleFlag.toUpperCase();
+    if (!isTeamMemberRole(normalizedRole)) {
+      const message = `Invalid ${param(
+        '--role'
+      )}: must be one of ${TEAM_MEMBER_ROLE_LIST}`;
+      const messagePlain = `Invalid --role: must be one of ${TEAM_MEMBER_ROLE_LIST}`;
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          {
+            status: 'error',
+            reason: 'invalid_role',
+            message: messagePlain,
+          },
+          1
+        );
+      }
+      output.error(message);
+      return 1;
+    }
+    role = normalizedRole;
+  }
 
   if (client.nonInteractive && emails.length === 0) {
     const fullArgs = client.argv.slice(2);
@@ -167,7 +201,12 @@ export default async function invite(
         let userInfo = null;
 
         try {
-          const res = await inviteUserToTeam(client, currentTeam.id, email);
+          const res = await inviteUserToTeam(
+            client,
+            currentTeam.id,
+            email,
+            role
+          );
           userInfo = res.username;
         } catch (err: unknown) {
           if (isAPIError(err) && err.code === 'user_not_found') {
@@ -238,7 +277,8 @@ export default async function invite(
         const { username } = await inviteUserToTeam(
           client,
           currentTeam.id,
-          email
+          email,
+          role
         );
         email = `${email}${username ? ` (${username})` : ''} ${elapsed()}`;
         emails.push(email);

--- a/packages/cli/src/commands/teams/invite.ts
+++ b/packages/cli/src/commands/teams/invite.ts
@@ -192,6 +192,7 @@ export default async function invite(
   );
 
   telemetry.trackCliArgumentEmail(emails);
+  telemetry.trackCliOptionRole(role);
 
   if (emails.length > 0) {
     for (const email of emails) {

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -156,6 +156,7 @@ const SUBCOMMAND_FLAG_TAKES_VALUE = new Set([
   '--format',
   '--page',
   '--per-page',
+  '--role',
 ]);
 
 function suggestionFlagTakesSeparateValue(flagName: string): boolean {

--- a/packages/cli/src/util/teams/invite-user-to-team.ts
+++ b/packages/cli/src/util/teams/invite-user-to-team.ts
@@ -1,4 +1,5 @@
 import type Client from '../client';
+import type { TeamMemberRole } from './team-member-roles';
 
 interface InviteResponse {
   uid: string;
@@ -10,13 +11,14 @@ interface InviteResponse {
 export default async function inviteUserToTeam(
   client: Client,
   teamId: string,
-  email: string
+  email: string,
+  role?: TeamMemberRole
 ) {
   const body = await client.fetch<InviteResponse>(
     `/teams/${encodeURIComponent(teamId)}/members`,
     {
       method: 'POST',
-      body: { email },
+      body: role ? { email, role } : { email },
     }
   );
   return body;

--- a/packages/cli/src/util/teams/team-member-roles.ts
+++ b/packages/cli/src/util/teams/team-member-roles.ts
@@ -1,0 +1,18 @@
+export const TEAM_MEMBER_ROLES = [
+  'OWNER',
+  'MEMBER',
+  'DEVELOPER',
+  'SECURITY',
+  'BILLING',
+  'VIEWER',
+  'VIEWER_FOR_PLUS',
+  'CONTRIBUTOR',
+] as const;
+
+export type TeamMemberRole = (typeof TEAM_MEMBER_ROLES)[number];
+
+export const TEAM_MEMBER_ROLE_LIST = TEAM_MEMBER_ROLES.join(', ');
+
+export function isTeamMemberRole(role: string): role is TeamMemberRole {
+  return TEAM_MEMBER_ROLES.includes(role as TeamMemberRole);
+}

--- a/packages/cli/src/util/telemetry/commands/teams/invite.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/invite.ts
@@ -1,7 +1,7 @@
 import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { inviteSubcommand } from '../../../../commands/teams/command';
-import type { TeamMemberRole } from '../../../../teams/team-member-roles';
+import type { TeamMemberRole } from '../../../teams/team-member-roles';
 
 export class TeamsInviteTelemetryClient
   extends TelemetryClient

--- a/packages/cli/src/util/telemetry/commands/teams/invite.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/invite.ts
@@ -1,6 +1,7 @@
 import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { inviteSubcommand } from '../../../../commands/teams/command';
+import type { TeamMemberRole } from '../../../../teams/team-member-roles';
 
 export class TeamsInviteTelemetryClient
   extends TelemetryClient
@@ -11,6 +12,15 @@ export class TeamsInviteTelemetryClient
       this.trackCliArgument({
         arg: 'email',
         value: this.redactedArgumentsLength(values),
+      });
+    }
+  }
+
+  trackCliOptionRole(value: TeamMemberRole | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'role',
+        value,
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/teams/invite.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/invite.ts
@@ -1,7 +1,6 @@
 import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { inviteSubcommand } from '../../../../commands/teams/command';
-import type { TeamMemberRole } from '../../../teams/team-member-roles';
 
 export class TeamsInviteTelemetryClient
   extends TelemetryClient
@@ -16,7 +15,7 @@ export class TeamsInviteTelemetryClient
     }
   }
 
-  trackCliOptionRole(value: TeamMemberRole | undefined) {
+  trackCliOptionRole(value: string | undefined) {
     if (value) {
       this.trackCliOption({
         option: 'role',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5840,9 +5840,15 @@ exports[`help command > teams help output snapshots > teams help column width 12
 
 exports[`help command > teams help output snapshots > teams invite help output snapshots > teams invite help column width 120 1`] = `
 "
-  ▲ vercel teams invite email ...
+  ▲ vercel teams invite email ... [options]
 
   Invite a new member to a team                                                                                         
+
+  Options:
+
+   --role <ROLE>  Role to assign to the invited team member (OWNER, MEMBER, DEVELOPER, SECURITY, BILLING, VIEWER,        
+                  VIEWER_FOR_PLUS, CONTRIBUTOR)                                                                          
+
 
   Global Options:
 
@@ -5867,6 +5873,10 @@ exports[`help command > teams help output snapshots > teams invite help output s
   - Invite multiple members (required in non-interactive mode)
 
     $ vercel teams invite abc@vercel.com xyz@vercel.com
+
+  - Invite a member with a specific role
+
+    $ vercel teams invite abc@vercel.com --role DEVELOPER
 
 "
 `;

--- a/packages/cli/test/unit/commands/teams/invite.test.ts
+++ b/packages/cli/test/unit/commands/teams/invite.test.ts
@@ -67,6 +67,31 @@ describe('teams invite', () => {
       expect(exitCode).toBe(0);
     });
 
+    it('passes role in the invite request body when provided', async () => {
+      client.nonInteractive = true;
+      client.config = { currentTeam: currentTeamId };
+      let requestBody: { email: string; role?: string } | undefined;
+      client.scenario.post(`/teams/${currentTeamId}/members`, (req, res) => {
+        requestBody = req.body as { email: string; role?: string };
+        return res.json({ username: 'person1' });
+      });
+
+      client.setArgv(
+        'teams',
+        'invite',
+        'me@example.com',
+        '--role',
+        'developer'
+      );
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestBody).toEqual({
+        email: 'me@example.com',
+        role: 'DEVELOPER',
+      });
+    });
+
     it('outputs team_scope_required with global flags in next when no team scope', async () => {
       client.nonInteractive = true;
       // No currentTeam so invite cannot determine which team to invite to
@@ -134,6 +159,67 @@ describe('teams invite', () => {
       exitSpy.mockRestore();
       client.nonInteractive = false;
     });
+
+    it('preserves --role in retry suggestions when the invite fails', async () => {
+      client.nonInteractive = true;
+      client.config = { currentTeam: currentTeamId };
+      client.scenario.post(`/teams/${currentTeamId}/members`, (_req, res) => {
+        res.statusCode = 404;
+        return res.json({
+          error: {
+            code: 'user_not_found',
+            message: 'User not found',
+          },
+        });
+      });
+      const logSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined as unknown as void);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.setArgv(
+        'teams',
+        'invite',
+        'nobody@example.com',
+        '--role',
+        'DEVELOPER'
+      );
+      await expect(teams(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(payload.next[0].command).toContain('--role');
+      expect(payload.next[0].command).toContain('DEVELOPER');
+
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+      client.nonInteractive = false;
+    });
+
+    it('outputs error JSON when role is invalid', async () => {
+      client.nonInteractive = true;
+      client.config = { currentTeam: currentTeamId };
+      const logSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined as unknown as void);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.setArgv('teams', 'invite', 'me@example.com', '--role', 'invalid');
+      await expect(teams(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('invalid_role');
+      expect(payload.message).toContain('Invalid --role');
+      expect(payload.message).toContain('DEVELOPER');
+
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+      client.nonInteractive = false;
+    });
   });
 
   describe('[email]', () => {
@@ -162,6 +248,27 @@ describe('teams invite', () => {
           {
             key: 'argument:email',
             value: 'ONE',
+          },
+        ]);
+      });
+
+      it('tracks the role option telemetry event', async () => {
+        client.setArgv('teams', 'invite', 'me@example.com', '--role', 'viewer');
+        const exitCode = await teams(client);
+        expect(exitCode, 'exit code for "teams"').toEqual(0);
+
+        await expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: 'subcommand:invite',
+            value: 'invite',
+          },
+          {
+            key: 'argument:email',
+            value: 'ONE',
+          },
+          {
+            key: 'option:role',
+            value: 'VIEWER',
           },
         ]);
       });


### PR DESCRIPTION
## Summary
- add `--role <ROLE>` to `vercel teams invite`
- validate and normalize supported team member roles before calling the API
- pass `role` only when explicitly provided, add telemetry, and cover the flow with unit tests

## Testing
- pnpm vitest-run --run test/unit/commands/teams/invite.test.ts
- pnpm vitest-run --run test/unit/commands/help.test.ts -t "teams invite help column width 120"

## Follow-up
- Opened this as a draft first to confirm the direction.
- After getting confirmation on the [Vercel Community post](https://community.vercel.com/t/add-role-flag-to-vercel-teams-invite-for-automated-member-onboarding/36289), I marked this PR as ready for review.