### PR TITLE
[python] Use `LAMBDA_SIZE_THRESHOLD_BYTES` to determine remaining capacity.

### DIFF
--- a/.changeset/rich-falcons-pull.md
+++ b/.changeset/rich-falcons-pull.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Use LAMBDA_SIZE_THRESHOLD_BYTES to determine remaining capacity.

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -20,10 +20,8 @@ import { getUvBinaryForBundling, UV_BUNDLE_DIR } from './uv';
 
 const readFile = promisify(fs.readFile);
 
-// AWS Lambda uncompressed size limit is 250MB, but we use 249MB to leave a small buffer
-export const LAMBDA_SIZE_THRESHOLD_BYTES = 249 * 1024 * 1024;
-// Pack Lambda up to 240MB to leave a buffer
-export const LAMBDA_PACKING_TARGET_BYTES = 240 * 1024 * 1024;
+// AWS Lambda uncompressed size limit is 250MB, but we use 245MB to leave room for Lambda layers
+export const LAMBDA_SIZE_THRESHOLD_BYTES = 245 * 1024 * 1024;
 
 // AWS Lambda ephemeral storage (/tmp) is 512MB. Use 500MB to leave a buffer
 // for runtime overhead (.pyc generation, uv cache, metadata, etc.)
@@ -316,8 +314,13 @@ export class PythonDependencyExternalizer {
       }
     }
 
+    // Dynamically derive the packing target: start from the hard Lambda size
+    // threshold and subtract everything that is already committed to the bundle
+    // (user source code, private packages, always-bundled packages, and the uv
+    // binary). The remainder is the budget the knapsack can fill with public
+    // packages.
     const remainingCapacity =
-      LAMBDA_PACKING_TARGET_BYTES - fixedOverhead - runtimeToolingOverhead;
+      LAMBDA_SIZE_THRESHOLD_BYTES - fixedOverhead - runtimeToolingOverhead;
 
     debug(
       `Fixed overhead: ${(fixedOverhead / (1024 * 1024)).toFixed(2)} MB, ` +

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -7,7 +7,6 @@ import {
   calculateBundleSize,
   lambdaKnapsack,
   LAMBDA_SIZE_THRESHOLD_BYTES,
-  LAMBDA_PACKING_TARGET_BYTES,
   LAMBDA_EPHEMERAL_STORAGE_BYTES,
 } from '../src/dependency-externalizer';
 import { classifyPackages, parseUvLock } from '@vercel/python-analysis';
@@ -148,8 +147,8 @@ describe('dependency externalizer support', () => {
   });
 
   describe('Lambda size constants', () => {
-    it('LAMBDA_SIZE_THRESHOLD_BYTES is 249 MB', () => {
-      expect(LAMBDA_SIZE_THRESHOLD_BYTES).toBe(249 * 1024 * 1024);
+    it('LAMBDA_SIZE_THRESHOLD_BYTES is 245 MB', () => {
+      expect(LAMBDA_SIZE_THRESHOLD_BYTES).toBe(245 * 1024 * 1024);
     });
 
     it('LAMBDA_EPHEMERAL_STORAGE_BYTES is 500 MB', () => {
@@ -372,18 +371,6 @@ version = "2.31.0"
       );
       const result = lambdaKnapsack(packages, 95);
       expect(result).toHaveLength(9);
-    });
-  });
-
-  describe('LAMBDA_PACKING_TARGET_BYTES', () => {
-    it('defaults to 240 MB', () => {
-      expect(LAMBDA_PACKING_TARGET_BYTES).toBe(240 * 1024 * 1024);
-    });
-
-    it('is less than LAMBDA_SIZE_THRESHOLD_BYTES', () => {
-      expect(LAMBDA_PACKING_TARGET_BYTES).toBeLessThan(
-        LAMBDA_SIZE_THRESHOLD_BYTES
-      );
     });
   });
 });


### PR DESCRIPTION
`LAMBDA_SIZE_THRESHOLD_BYTES` did not account for the size of lambda layers which we cannot easily know at build time. That means a user's function at `248MB` could still fail the uncompressed size check later in the build because:

- The runtime dependency install would not be triggered
- The lambda layers could cause the function to exceed `250MB`

This PR reduces that to `245MB` - leaving a 5MB buffer for all lambda layers.

Also the `remainingCapacity` variable is now computed by  `LAMBDA_SIZE_THRESHOLD_BYTES` instead, making the total size `250MB - 5MB buffer - fixedOverhead - runtimeToolingOverhead`