### PR TITLE
devin-detect

### DIFF
--- a/.changeset/shiny-lions-smile.md
+++ b/.changeset/shiny-lions-smile.md
@@ -1,6 +1,5 @@
 ---
 '@vercel/detect-agent': patch
-'vercel': patch
 ---
 
-Normalize Devin developer product `AI_AGENT` aliases so the Vercel CLI attributes them to the `devin` agent.
+Normalize supported Devin product `AI_AGENT` aliases so Vercel detects them as the `devin` agent.

--- a/.changeset/shiny-lions-smile.md
+++ b/.changeset/shiny-lions-smile.md
@@ -1,0 +1,6 @@
+---
+'@vercel/detect-agent': patch
+'vercel': patch
+---
+
+Normalize Devin developer product `AI_AGENT` aliases so the Vercel CLI attributes them to the `devin` agent.

--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -28,7 +28,7 @@ This package can detect the following AI agents and development environments:
 - **Custom agents** via `AI_AGENT` environment variable
 - **Cursor** (cursor editor and cursor-cli)
 - **Claude Code** (Anthropic's Claude)
-- **Devin** (Cognition Labs)
+- **Devin** (Cognition Labs, via `/opt/.devin` or `AI_AGENT` aliases like `ask-devin`, `deepwiki`, `dana`, `data-analyst-agent`, `devin-review`, and `devin-mcp`; all normalize to `devin`)
 - **Gemini CLI** (Google)
 - **Codex** (OpenAI)
 - **Antigravity** (Google DeepMind)

--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -28,7 +28,7 @@ This package can detect the following AI agents and development environments:
 - **Custom agents** via `AI_AGENT` environment variable
 - **Cursor** (cursor editor and cursor-cli)
 - **Claude Code** (Anthropic's Claude)
-- **Devin** (Cognition Labs, via `/opt/.devin` or `AI_AGENT` aliases like `ask-devin`, `deepwiki`, `dana`, `data-analyst-agent`, `devin-review`, and `devin-mcp`; all normalize to `devin`)
+- **Devin** (Cognition Labs, via `/opt/.devin` or supported `AI_AGENT` aliases for Devin developer products, all normalized to `devin`)
 - **Gemini CLI** (Google)
 - **Codex** (OpenAI)
 - **Antigravity** (Google DeepMind)

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -17,23 +17,15 @@ const OPENCODE = 'opencode' as const;
 const GITHUB_COPILOT = 'github-copilot' as const;
 const GITHUB_COPILOT_CLI = 'github-copilot-cli' as const;
 
-const AI_AGENT_ALIASES = {
-  [DEVIN]: DEVIN,
-  'ask-devin': DEVIN,
-  'data-analyst-agent': DEVIN,
-  dana: DEVIN,
-  deepwiki: DEVIN,
-  'devin-mcp': DEVIN,
-  'devin-review': DEVIN,
-  [GITHUB_COPILOT]: GITHUB_COPILOT,
-  [GITHUB_COPILOT_CLI]: GITHUB_COPILOT,
-} as const;
-
-function normalizeAIAgentName(name: string): string {
-  const [baseName] = name.split('@');
-
-  return AI_AGENT_ALIASES[baseName as keyof typeof AI_AGENT_ALIASES] ?? name;
-}
+const DEVIN_AI_AGENT_ALIASES = new Set([
+  DEVIN,
+  'ask-devin',
+  'data-analyst-agent',
+  'dana',
+  'deepwiki',
+  'devin-mcp',
+  'devin-review',
+]);
 
 export type KnownAgentNames =
   | typeof CURSOR
@@ -82,9 +74,22 @@ export async function determineAgent(): Promise<AgentResult> {
   if (process.env.AI_AGENT) {
     const name = process.env.AI_AGENT.trim();
     if (name) {
+      const [baseName] = name.split('@');
+
+      if (DEVIN_AI_AGENT_ALIASES.has(baseName)) {
+        return { isAgent: true, agent: { name: DEVIN } };
+      }
+
+      if (name === GITHUB_COPILOT || name === GITHUB_COPILOT_CLI) {
+        return {
+          isAgent: true,
+          agent: { name: GITHUB_COPILOT },
+        };
+      }
+
       return {
         isAgent: true,
-        agent: { name: normalizeAIAgentName(name) as KnownAgentNames },
+        agent: { name: name as KnownAgentNames },
       };
     }
   }

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -17,6 +17,24 @@ const OPENCODE = 'opencode' as const;
 const GITHUB_COPILOT = 'github-copilot' as const;
 const GITHUB_COPILOT_CLI = 'github-copilot-cli' as const;
 
+const AI_AGENT_ALIASES = {
+  [DEVIN]: DEVIN,
+  'ask-devin': DEVIN,
+  'data-analyst-agent': DEVIN,
+  dana: DEVIN,
+  deepwiki: DEVIN,
+  'devin-mcp': DEVIN,
+  'devin-review': DEVIN,
+  [GITHUB_COPILOT]: GITHUB_COPILOT,
+  [GITHUB_COPILOT_CLI]: GITHUB_COPILOT,
+} as const;
+
+function normalizeAIAgentName(name: string): string {
+  const [baseName] = name.split('@');
+
+  return AI_AGENT_ALIASES[baseName as keyof typeof AI_AGENT_ALIASES] ?? name;
+}
+
 export type KnownAgentNames =
   | typeof CURSOR
   | typeof CURSOR_CLI
@@ -64,16 +82,9 @@ export async function determineAgent(): Promise<AgentResult> {
   if (process.env.AI_AGENT) {
     const name = process.env.AI_AGENT.trim();
     if (name) {
-      if (name === GITHUB_COPILOT || name === GITHUB_COPILOT_CLI) {
-        return {
-          isAgent: true,
-          agent: { name: GITHUB_COPILOT },
-        };
-      }
-
       return {
         isAgent: true,
-        agent: { name: name as KnownAgentNames },
+        agent: { name: normalizeAIAgentName(name) as KnownAgentNames },
       };
     }
   }

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -54,6 +54,36 @@ describe('determineAgent', () => {
     });
   });
 
+  describe('devin detection from `AI_AGENT`', () => {
+    it.each([
+      'devin',
+      'ask-devin',
+      'data-analyst-agent',
+      'dana',
+      'deepwiki',
+      'devin-mcp',
+      'devin-review',
+    ])('detects devin from AI_AGENT=%s', async value => {
+      vi.stubEnv('AI_AGENT', value);
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: KNOWN_AGENTS.DEVIN },
+      });
+    });
+
+    it('detects devin from a versioned AI_AGENT alias', async () => {
+      vi.stubEnv('AI_AGENT', 'devin-review@2026.1');
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: KNOWN_AGENTS.DEVIN },
+      });
+    });
+  });
+
   describe('github copilot detection', () => {
     it('detects github copilot from AI_AGENT=github-copilot', async () => {
       vi.stubEnv('AI_AGENT', 'github-copilot');


### PR DESCRIPTION
## Summary
- normalize Devin developer product `AI_AGENT` aliases like `ask-devin`, `deepwiki`, `dana`, `data-analyst-agent`, `devin-review`, and `devin-mcp` back to the shared `devin` agent
- keep version-suffixed aliases working without changing how unrelated custom `AI_AGENT` values are reported
- document the new aliases and add regression coverage plus a changeset for the CLI-facing behavior change

## Testing
- pnpm --filter @vercel/detect-agent type-check
- pnpm --filter @vercel/detect-agent exec vitest run -c ../../vitest.config.mts test/unit/determine-agent.test.ts