### PR TITLE
[detect-agent] Detect Amazon Q environments

### DIFF
--- a/.changeset/green-melons-think.md
+++ b/.changeset/green-melons-think.md
@@ -1,0 +1,5 @@
+---
+'@vercel/detect-agent': patch
+---
+
+Detect Amazon Q CLI and shell environments as the `amazon-q` agent so the Vercel CLI can apply its agent-specific behaviors consistently.

--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -32,6 +32,7 @@ This package can detect the following AI agents and development environments:
 - **Gemini CLI** (Google)
 - **Codex** (OpenAI)
 - **Antigravity** (Google DeepMind)
+- **Amazon Q** (via `PROCESS_LAUNCHED_BY_Q`, `QTERM_SESSION_ID`, `Q_TERM`, `Q_CLI_CLIENT_APPLICATION`, `AMAZON_Q_CHAT_SHELL`, or `AMAZON_Q_SIGV4`)
 - **GitHub Copilot** (via `AI_AGENT=github-copilot|github-copilot-cli`, `COPILOT_MODEL`, `COPILOT_ALLOW_ALL`, or `COPILOT_GITHUB_TOKEN`)
 - **Replit** (online IDE)
 

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -14,6 +14,7 @@ const CODEX = 'codex' as const;
 const ANTIGRAVITY = 'antigravity' as const;
 const AUGMENT_CLI = 'augment-cli' as const;
 const OPENCODE = 'opencode' as const;
+const AMAZON_Q = 'amazon-q' as const;
 const GITHUB_COPILOT = 'github-copilot' as const;
 const GITHUB_COPILOT_CLI = 'github-copilot-cli' as const;
 
@@ -29,6 +30,7 @@ export type KnownAgentNames =
   | typeof ANTIGRAVITY
   | typeof AUGMENT_CLI
   | typeof OPENCODE
+  | typeof AMAZON_Q
   | typeof GITHUB_COPILOT;
 
 export interface KnownAgentDetails {
@@ -57,6 +59,7 @@ export const KNOWN_AGENTS = {
   ANTIGRAVITY,
   AUGMENT_CLI,
   OPENCODE,
+  AMAZON_Q,
   GITHUB_COPILOT,
 } as const;
 
@@ -88,6 +91,17 @@ export async function determineAgent(): Promise<AgentResult> {
 
   if (process.env.GEMINI_CLI) {
     return { isAgent: true, agent: { name: GEMINI } };
+  }
+
+  if (
+    process.env.PROCESS_LAUNCHED_BY_Q ||
+    process.env.QTERM_SESSION_ID ||
+    process.env.Q_TERM ||
+    process.env.Q_CLI_CLIENT_APPLICATION ||
+    process.env.AMAZON_Q_CHAT_SHELL ||
+    process.env.AMAZON_Q_SIGV4
+  ) {
+    return { isAgent: true, agent: { name: AMAZON_Q } };
   }
 
   if (

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -11,6 +11,12 @@ describe('determineAgent', () => {
     vi.stubEnv('CURSOR_TRACE_ID', '');
     vi.stubEnv('CURSOR_AGENT', '');
     vi.stubEnv('GEMINI_CLI', '');
+    vi.stubEnv('PROCESS_LAUNCHED_BY_Q', '');
+    vi.stubEnv('QTERM_SESSION_ID', '');
+    vi.stubEnv('Q_TERM', '');
+    vi.stubEnv('Q_CLI_CLIENT_APPLICATION', '');
+    vi.stubEnv('AMAZON_Q_CHAT_SHELL', '');
+    vi.stubEnv('AMAZON_Q_SIGV4', '');
     vi.stubEnv('CODEX_SANDBOX', '');
     vi.stubEnv('CODEX_CI', '');
     vi.stubEnv('CODEX_THREAD_ID', '');
@@ -171,6 +177,25 @@ describe('determineAgent', () => {
           isAgent: true,
           agent: { name: KNOWN_AGENTS.GEMINI },
         });
+      });
+    });
+  });
+
+  describe('amazon q detection', () => {
+    it.each([
+      ['PROCESS_LAUNCHED_BY_Q', '1'],
+      ['QTERM_SESSION_ID', 'session-123'],
+      ['Q_TERM', '1.0.0'],
+      ['Q_CLI_CLIENT_APPLICATION', 'vscode'],
+      ['AMAZON_Q_CHAT_SHELL', 'bash'],
+      ['AMAZON_Q_SIGV4', '1'],
+    ])('detects Amazon Q from %s', async (envName, value) => {
+      vi.stubEnv(envName, value);
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: KNOWN_AGENTS.AMAZON_Q },
       });
     });
   });
@@ -468,6 +493,7 @@ describe('determineAgent', () => {
       vi.stubEnv('CURSOR_TRACE_ID', 'some-uuid');
       vi.stubEnv('CURSOR_AGENT', '1');
       vi.stubEnv('GEMINI_CLI', '1');
+      vi.stubEnv('PROCESS_LAUNCHED_BY_Q', '1');
       vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
       vi.stubEnv('ANTIGRAVITY_AGENT', '1');
       vi.stubEnv('AUGMENT_AGENT', '1');
@@ -538,6 +564,30 @@ describe('determineAgent', () => {
       expect(result).toEqual({
         isAgent: true,
         agent: { name: KNOWN_AGENTS.CURSOR_CLI },
+      });
+    });
+
+    it('Amazon Q markers take priority over later agent checks', async () => {
+      vi.stubEnv('QTERM_SESSION_ID', 'session-123');
+      vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
+      vi.stubEnv('ANTIGRAVITY_AGENT', '1');
+      vi.stubEnv('AUGMENT_AGENT', '1');
+      vi.stubEnv('OPENCODE_CLIENT', 'opencode');
+      vi.stubEnv('CLAUDE_CODE', '1');
+      vi.stubEnv('REPL_ID', '1');
+      vi.stubEnv('COPILOT_MODEL', 'gpt-5');
+      vi.stubEnv('COPILOT_ALLOW_ALL', 'true');
+      vi.stubEnv('COPILOT_GITHUB_TOKEN', 'ghp_xxx');
+      mockFs({
+        '/opt/.devin': mockFs.directory({
+          mode: 0o755,
+        }),
+      });
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: KNOWN_AGENTS.AMAZON_Q },
       });
     });
   });


### PR DESCRIPTION
## Summary
- add `amazon-q` as a normalized detected agent in `@vercel/detect-agent`
- detect Amazon Q CLI and shell launches via `PROCESS_LAUNCHED_BY_Q`, `QTERM_SESSION_ID`, `Q_TERM`, `Q_CLI_CLIENT_APPLICATION`, `AMAZON_Q_CHAT_SHELL`, and `AMAZON_Q_SIGV4`
- cover the new markers with unit tests and document the new detection inputs

## Testing
- `../../node_modules/.bin/vitest run test/unit/determine-agent.test.ts -c ../../vitest.config.mts`
- `../../node_modules/.bin/tsc --noEmit`