### PR TITLE
aider-detect

### DIFF
--- a/.changeset/aider-detect.md
+++ b/.changeset/aider-detect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/detect-agent': patch
+---
+
+Add first-class Aider detection and normalize aider-prefixed `AI_AGENT` values to the canonical `aider` actor.

--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -26,6 +26,7 @@ if (isAgent) {
 This package can detect the following AI agents and development environments:
 
 - **Custom agents** via `AI_AGENT` environment variable
+- **Aider** (via `AI_AGENT=aider` and aider-prefixed product names like `aider-chat`, `aider-browser`, and `aider-watch`, canonicalized to `aider`)
 - **Cursor** (cursor editor and cursor-cli)
 - **Claude Code** (Anthropic's Claude)
 - **Devin** (Cognition Labs)

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -3,6 +3,7 @@ import { constants } from 'node:fs';
 
 const DEVIN_LOCAL_PATH = '/opt/.devin';
 
+const AIDER = 'aider' as const;
 const CURSOR = 'cursor' as const;
 const CURSOR_CLI = 'cursor-cli' as const;
 const CLAUDE = 'claude' as const;
@@ -18,6 +19,7 @@ const GITHUB_COPILOT = 'github-copilot' as const;
 const GITHUB_COPILOT_CLI = 'github-copilot-cli' as const;
 
 export type KnownAgentNames =
+  | typeof AIDER
   | typeof CURSOR
   | typeof CURSOR_CLI
   | typeof CLAUDE
@@ -46,6 +48,7 @@ export type AgentResult =
     };
 
 export const KNOWN_AGENTS = {
+  AIDER,
   CURSOR,
   CURSOR_CLI,
   CLAUDE,
@@ -60,20 +63,29 @@ export const KNOWN_AGENTS = {
   GITHUB_COPILOT,
 } as const;
 
+function normalizeAgentName(name: string): string {
+  if (name === GITHUB_COPILOT || name === GITHUB_COPILOT_CLI) {
+    return GITHUB_COPILOT;
+  }
+
+  const [nameWithoutVersion] = name.split('@', 1);
+  if (
+    nameWithoutVersion === AIDER ||
+    nameWithoutVersion.startsWith(`${AIDER}-`)
+  ) {
+    return AIDER;
+  }
+
+  return name;
+}
+
 export async function determineAgent(): Promise<AgentResult> {
   if (process.env.AI_AGENT) {
     const name = process.env.AI_AGENT.trim();
     if (name) {
-      if (name === GITHUB_COPILOT || name === GITHUB_COPILOT_CLI) {
-        return {
-          isAgent: true,
-          agent: { name: GITHUB_COPILOT },
-        };
-      }
-
       return {
         isAgent: true,
-        agent: { name: name as KnownAgentNames },
+        agent: { name: normalizeAgentName(name) as KnownAgentNames },
       };
     }
   }

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -54,6 +54,48 @@ describe('determineAgent', () => {
     });
   });
 
+  describe('aider detection', () => {
+    it('detects aider from AI_AGENT=aider', async () => {
+      vi.stubEnv('AI_AGENT', 'aider');
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: KNOWN_AGENTS.AIDER },
+      });
+    });
+
+    it('normalizes aider product names from AI_AGENT', async () => {
+      vi.stubEnv('AI_AGENT', 'aider-browser');
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: KNOWN_AGENTS.AIDER },
+      });
+    });
+
+    it('normalizes versioned aider product names from AI_AGENT', async () => {
+      vi.stubEnv('AI_AGENT', 'aider-watch@0.82.0');
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: KNOWN_AGENTS.AIDER },
+      });
+    });
+
+    it('leaves unrelated custom agents unchanged', async () => {
+      vi.stubEnv('AI_AGENT', 'aiderish');
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: 'aiderish' },
+      });
+    });
+  });
+
   describe('github copilot detection', () => {
     it('detects github copilot from AI_AGENT=github-copilot', async () => {
       vi.stubEnv('AI_AGENT', 'github-copilot');


### PR DESCRIPTION
## Summary
- add first-class `aider` detection to `@vercel/detect-agent`
- normalize aider-prefixed `AI_AGENT` values, including product variants and versioned names, to the canonical `aider` actor
- document the new detection behavior and cover it with unit tests plus a changeset

## Testing
- `pnpm --filter @vercel/detect-agent exec vitest run -c ../../vitest.config.mts test/unit/determine-agent.test.ts`
- `pnpm --filter @vercel/detect-agent type-check`
- `pnpm biome format --write "packages/detect-agent/src/index.ts" "packages/detect-agent/test/unit/determine-agent.test.ts" && pnpm biome lint "packages/detect-agent/src/index.ts" "packages/detect-agent/test/unit/determine-agent.test.ts"`