### PR TITLE
[flags] Fixed flag-cli example

### DIFF
--- a/.changeset/mean-knives-try.md
+++ b/.changeset/mean-knives-try.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fixed example in flags disable command with --variant

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -350,7 +350,7 @@ export const disableSubcommand = {
     },
     {
       name: 'Disable a flag with a specific variant',
-      value: `${packageName} flags disable my-feature -e production --variant off`,
+      value: `${packageName} flags disable my-feature -e production --variant false`,
     },
     {
       name: 'Disable a flag with a revision message',


### PR DESCRIPTION
The example for passing a boolean variant was wrong. The `--variant` flag excepts id's or values, not labels.