### PR TITLE
Update @vercel/nft to 1.4.0 across packages

### DIFF
--- a/.changeset/yellow-maps-applaud.md
+++ b/.changeset/yellow-maps-applaud.md
@@ -1,0 +1,11 @@
+---
+"@vercel/backends": patch
+"@vercel/express": patch
+"@vercel/hono": patch
+"@vercel/next": patch
+"@vercel/node": patch
+"@vercel/redwood": patch
+"@vercel/remix-builder": patch
+---
+
+Update @vercel/nft to 1.4.0 across packages

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "@vercel/build-utils": "workspace:*",
-    "@vercel/nft": "1.3.0",
+    "@vercel/nft": "1.4.0",
     "execa": "3.2.0",
     "fs-extra": "11.1.0",
     "oxc-transform": "0.111.0",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -23,7 +23,7 @@
     "edge-entry.js"
   ],
   "dependencies": {
-    "@vercel/nft": "1.1.1",
+    "@vercel/nft": "1.4.0",
     "@vercel/static-config": "workspace:*",
     "fs-extra": "11.1.0",
     "path-to-regexp": "8.3.0",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -23,7 +23,7 @@
     "edge-entry.js"
   ],
   "dependencies": {
-    "@vercel/nft": "1.1.1",
+    "@vercel/nft": "1.4.0",
     "@vercel/static-config": "workspace:*",
     "@vercel/node": "workspace:*",
     "fs-extra": "11.1.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "dependencies": {
-    "@vercel/nft": "1.1.1"
+    "@vercel/nft": "1.4.0"
   },
   "devDependencies": {
     "@next-community/adapter-vercel": "0.0.1-beta.14",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,7 +27,7 @@
     "@types/node": "20.11.0",
     "@vercel/build-utils": "workspace:*",
     "@vercel/error-utils": "workspace:*",
-    "@vercel/nft": "1.1.1",
+    "@vercel/nft": "1.4.0",
     "@vercel/static-config": "workspace:*",
     "async-listen": "3.0.0",
     "cjs-module-lexer": "1.2.3",

--- a/packages/redwood/package.json
+++ b/packages/redwood/package.json
@@ -17,7 +17,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/nft": "1.1.1",
+    "@vercel/nft": "1.4.0",
     "@vercel/static-config": "workspace:*",
     "semver": "6.3.1",
     "ts-morph": "12.0.0"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@vercel/error-utils": "workspace:*",
-    "@vercel/nft": "1.1.1",
+    "@vercel/nft": "1.4.0",
     "@vercel/static-config": "workspace:*",
     "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
     "path-to-regexp": "6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,8 +214,8 @@ importers:
         specifier: workspace:*
         version: link:../build-utils
       '@vercel/nft':
-        specifier: 1.3.0
-        version: 1.3.0
+        specifier: 1.4.0
+        version: 1.4.0
       execa:
         specifier: 3.2.0
         version: 3.2.0
@@ -1149,8 +1149,8 @@ importers:
         specifier: workspace:*
         version: link:../cervel
       '@vercel/nft':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.4.0
+        version: 1.4.0
       '@vercel/node':
         specifier: workspace:*
         version: link:../node
@@ -1550,8 +1550,8 @@ importers:
   packages/hono:
     dependencies:
       '@vercel/nft':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.4.0
+        version: 1.4.0
       '@vercel/node':
         specifier: workspace:*
         version: link:../node
@@ -1697,8 +1697,8 @@ importers:
   packages/next:
     dependencies:
       '@vercel/nft':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.4.0
+        version: 1.4.0
     devDependencies:
       '@next-community/adapter-vercel':
         specifier: 0.0.1-beta.14
@@ -1839,8 +1839,8 @@ importers:
         specifier: workspace:*
         version: link:../error-utils
       '@vercel/nft':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.4.0
+        version: 1.4.0
       '@vercel/static-config':
         specifier: workspace:*
         version: link:../static-config
@@ -2165,8 +2165,8 @@ importers:
   packages/redwood:
     dependencies:
       '@vercel/nft':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.4.0
+        version: 1.4.0
       '@vercel/static-config':
         specifier: workspace:*
         version: link:../static-config
@@ -2227,8 +2227,8 @@ importers:
         specifier: workspace:*
         version: link:../error-utils
       '@vercel/nft':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.4.0
+        version: 1.4.0
       '@vercel/static-config':
         specifier: workspace:*
         version: link:../static-config
@@ -10060,38 +10060,15 @@ packages:
       - debug
     dev: false
 
-  /@vercel/nft@1.1.1:
-    resolution: {integrity: sha512-mKMGa7CEUcXU75474kOeqHbtvK1kAcu4wiahhmlUenB5JbTQB8wVlDI8CyHR3rpGo0qlzoRWqcDzI41FUoBJCA==}
+  /@vercel/nft@1.4.0:
+    resolution: {integrity: sha512-rr7JVnI7YGjA4lngucrWjZ7eCOJZZQaDHB+5NRGOuNc+k4PU2Lb9PmYm8uBmW8qichF7WkR2RmwmhXHBhx6wzw==}
     engines: {node: '>=20'}
     hasBin: true
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.0
       '@rollup/pluginutils': 5.1.4
-      acorn: 8.14.1
-      acorn-import-attributes: 1.9.5(acorn@8.14.1)
-      async-sema: 3.1.1
-      bindings: 1.5.0
-      estree-walker: 2.0.2
-      glob: 13.0.0
-      graceful-fs: 4.2.11
-      node-gyp-build: 4.8.4
-      picomatch: 4.0.3
-      resolve-from: 5.0.0
-    transitivePeerDependencies:
-      - encoding
-      - rollup
-      - supports-color
-    dev: false
-
-  /@vercel/nft@1.3.0:
-    resolution: {integrity: sha512-i4EYGkCsIjzu4vorDUbqglZc5eFtQI2syHb++9ZUDm6TU4edVywGpVnYDein35x9sevONOn9/UabfQXuNXtuzQ==}
-    engines: {node: '>=20'}
-    hasBin: true
-    dependencies:
-      '@mapbox/node-pre-gyp': 2.0.0
-      '@rollup/pluginutils': 5.1.4
-      acorn: 8.14.1
-      acorn-import-attributes: 1.9.5(acorn@8.14.1)
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -10508,12 +10485,12 @@ packages:
       negotiator: 1.0.0
     dev: true
 
-  /acorn-import-attributes@1.9.5(acorn@8.14.1):
+  /acorn-import-attributes@1.9.5(acorn@8.15.0):
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
       acorn: ^8
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.15.0
     dev: false
 
   /acorn-jsx@5.3.2(acorn@8.15.0):
@@ -10535,12 +10512,12 @@ packages:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
 
   /acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /adm-zip@0.5.16:
     resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
@@ -14192,7 +14169,7 @@ packages:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.1
+      minimatch: 10.1.1
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1


### PR DESCRIPTION
## Summary

Upgrade @vercel/nft from 1.1.1 to 1.4.0 in express, hono, node, next, redwood, and remix packages, and from 1.3.0 to 1.4.0 in backends.

All packages use stable public APIs (`nodeFileTrace()`) that remain compatible across these versions. The internal import used by packages/node (`@vercel/nft/out/resolve-dependency`) is still available in 1.4.0.

## Changes

- Updated 7 package.json files with new @vercel/nft version
- Regenerated pnpm-lock.yaml with dependency resolution

## Test plan

- [x] Dependency installation successful (pnpm install)
- Code review for API compatibility (all use standard `nodeFileTrace()` API)