### PR TITLE
[vercel-workers] fix release from minor to patch

### DIFF
--- a/.changeset/tough-chefs-brake.md
+++ b/.changeset/tough-chefs-brake.md
@@ -1,5 +1,5 @@
 ---
-'@vercel/python-workers': minor
+'@vercel/python-workers': patch
 ---
 
 [vercel-workers] support encoding of common non-stdlib types as args


### PR DESCRIPTION
`vercel-workers` is still under development, it wasn't supposed to be released this time