### PR TITLE
[python] Always pass in wsgi/asgi app variable name to python runtime

### DIFF
--- a/.changeset/thin-ears-teach.md
+++ b/.changeset/thin-ears-teach.md
@@ -1,0 +1,8 @@
+---
+'@vercel/python-analysis': minor
+'@vercel/python-runtime': minor
+'@vercel/build-utils': minor
+'@vercel/python': minor
+---
+
+Simplify python runtime by always passing in app variable

--- a/packages/build-utils/src/python.ts
+++ b/packages/build-utils/src/python.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { containsAppOrHandler } from '@vercel/python-analysis';
+import { findAppOrHandler } from '@vercel/python-analysis';
 import debug from './debug';
 import FileFsRef from './file-fs-ref';
 
@@ -16,7 +16,7 @@ export async function isPythonEntrypoint(
     const fsPath = (file as FileFsRef).fsPath;
     if (!fsPath) return false;
     const content = await fs.promises.readFile(fsPath, 'utf-8');
-    return (await containsAppOrHandler(content)) !== null;
+    return (await findAppOrHandler(content)) !== null;
   } catch (err) {
     debug(`Failed to check Python entrypoint: ${err}`);
     return false;

--- a/packages/build-utils/src/python.ts
+++ b/packages/build-utils/src/python.ts
@@ -16,7 +16,7 @@ export async function isPythonEntrypoint(
     const fsPath = (file as FileFsRef).fsPath;
     if (!fsPath) return false;
     const content = await fs.promises.readFile(fsPath, 'utf-8');
-    return await containsAppOrHandler(content);
+    return (await containsAppOrHandler(content)) !== null;
   } catch (err) {
     debug(`Failed to check Python entrypoint: ${err}`);
     return false;

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -121,6 +121,8 @@ export interface BuildOptions {
   service?: {
     /** The service name as declared in the project configuration. */
     name?: string;
+    /** The service type (e.g., "web", "cron", "worker"). */
+    type?: ServiceType;
     /** URL path prefix where the service is mounted (e.g., "/api"). */
     routePrefix?: string;
     /** Optional subdomain this service is mounted on (e.g., "api"). */

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -977,6 +977,7 @@ async function doBuild(
           ? {
               service: {
                 name: service.name,
+                type: service.type,
                 routePrefix:
                   typeof serviceRoutePrefix === 'string'
                     ? serviceRoutePrefix

--- a/packages/fs-detectors/src/index.ts
+++ b/packages/fs-detectors/src/index.ts
@@ -1,4 +1,3 @@
-// cache bust
 export {
   detectBuilders,
   detectOutputDirectory,

--- a/packages/fs-detectors/src/index.ts
+++ b/packages/fs-detectors/src/index.ts
@@ -1,3 +1,4 @@
+// cache bust
 export {
   detectBuilders,
   detectOutputDirectory,

--- a/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
@@ -8,10 +8,11 @@
 use ruff_python_ast::{Expr, Stmt};
 use ruff_python_parser::parse_module;
 
-pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
+/// Returns the name of the matched app/handler variable, or `None` if not found.
+pub(crate) fn contains_app_or_handler_impl(source: &str) -> Option<String> {
     let parsed = match parse_module(source) {
         Ok(parsed) => parsed,
-        Err(_) => return false, // Couldn't parse
+        Err(_) => return None, // Couldn't parse
     };
 
     // Iterate over top-level statements
@@ -21,8 +22,8 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
             // e.g., app = Sanic() or app = Flask(__name__) or app = create_app()
             Stmt::Assign(assign) => {
                 for target in &assign.targets {
-                    if is_name_expr(target, "app") || is_name_expr(target, "application") {
-                        return true;
+                    if let Some(name) = get_name_if_matches(target, &["app", "application"]) {
+                        return Some(name.to_string());
                     }
                 }
             }
@@ -30,10 +31,10 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
             // Check for annotated assignment to 'app' or 'application'
             // e.g., app: Sanic = Sanic()
             Stmt::AnnAssign(ann_assign) => {
-                if is_name_expr(&ann_assign.target, "app")
-                    || is_name_expr(&ann_assign.target, "application")
+                if let Some(name) =
+                    get_name_if_matches(&ann_assign.target, &["app", "application"])
                 {
-                    return true;
+                    return Some(name.to_string());
                 }
             }
 
@@ -41,8 +42,9 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
             // e.g., def app(environ, start_response): ...
             // e.g., async def app(scope, receive, send): ...
             Stmt::FunctionDef(func_def) => {
-                if func_def.name.as_str() == "app" || func_def.name.as_str() == "application" {
-                    return true;
+                let name = func_def.name.as_str();
+                if name == "app" || name == "application" {
+                    return Some(name.to_string());
                 }
             }
 
@@ -59,7 +61,7 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
                         .map(|id| id.as_str())
                         .unwrap_or_else(|| alias.name.as_str());
                     if imported_as == "app" || imported_as == "application" {
-                        return true;
+                        return Some(imported_as.to_string());
                     }
                 }
             }
@@ -68,7 +70,7 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
             // e.g., class handler(BaseHTTPRequestHandler):
             Stmt::ClassDef(class_def) => {
                 if class_def.name.as_str().eq_ignore_ascii_case("handler") {
-                    return true;
+                    return Some(class_def.name.as_str().to_string());
                 }
             }
 
@@ -77,7 +79,21 @@ pub(crate) fn contains_app_or_handler_impl(source: &str) -> bool {
         }
     }
 
-    false
+    None
+}
+
+fn get_name_if_matches<'a>(expr: &'a Expr, candidates: &[&str]) -> Option<&'a str> {
+    match expr {
+        Expr::Name(name_expr) => {
+            let name = name_expr.id.as_str();
+            if candidates.contains(&name) {
+                Some(name)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
 }
 
 /// Check if a top-level callable with the given name exists in Python source.
@@ -185,7 +201,7 @@ mod tests {
 from flask import Flask
 app = Flask(__name__)
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -194,7 +210,7 @@ app = Flask(__name__)
 from fastapi import FastAPI
 app = FastAPI()
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -203,7 +219,18 @@ app = FastAPI()
 from sanic import Sanic
 app: Sanic = Sanic()
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+    }
+
+    #[test]
+    fn test_application_variable() {
+        let source = r#"
+application = get_wsgi_application()
+"#;
+        assert_eq!(
+            contains_app_or_handler_impl(source),
+            Some("application".to_string())
+        );
     }
 
     #[test]
@@ -212,7 +239,7 @@ app: Sanic = Sanic()
 def app(environ, start_response):
     pass
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -221,7 +248,7 @@ def app(environ, start_response):
 async def app(scope, receive, send):
     pass
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -229,7 +256,7 @@ async def app(scope, receive, send):
         let source = r#"
 from server import app
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -237,7 +264,7 @@ from server import app
         let source = r#"
 from server import application as app
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -247,7 +274,10 @@ from http.server import BaseHTTPRequestHandler
 class handler(BaseHTTPRequestHandler):
     pass
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(
+            contains_app_or_handler_impl(source),
+            Some("handler".to_string())
+        );
     }
 
     #[test]
@@ -257,7 +287,10 @@ from http.server import BaseHTTPRequestHandler
 class Handler(BaseHTTPRequestHandler):
     pass
 "#;
-        assert!(contains_app_or_handler_impl(source));
+        assert_eq!(
+            contains_app_or_handler_impl(source),
+            Some("Handler".to_string())
+        );
     }
 
     #[test]
@@ -266,7 +299,7 @@ class Handler(BaseHTTPRequestHandler):
 def main():
     print("Hello")
 "#;
-        assert!(!contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), None);
     }
 
     #[test]
@@ -274,7 +307,7 @@ def main():
         let source = r#"
 def invalid(
 "#;
-        assert!(!contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), None);
     }
 
     #[test]
@@ -285,7 +318,7 @@ def create():
     app = Flask(__name__)
     return app
 "#;
-        assert!(!contains_app_or_handler_impl(source));
+        assert_eq!(contains_app_or_handler_impl(source), None);
     }
 
     // -------------------------------------------------------------------------

--- a/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/entrypoint.rs
@@ -9,7 +9,7 @@ use ruff_python_ast::{Expr, Stmt};
 use ruff_python_parser::parse_module;
 
 /// Returns the name of the matched app/handler variable, or `None` if not found.
-pub(crate) fn contains_app_or_handler_impl(source: &str) -> Option<String> {
+pub(crate) fn find_app_or_handler_impl(source: &str) -> Option<String> {
     let parsed = match parse_module(source) {
         Ok(parsed) => parsed,
         Err(_) => return None, // Couldn't parse
@@ -201,7 +201,7 @@ mod tests {
 from flask import Flask
 app = Flask(__name__)
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(find_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -210,7 +210,7 @@ app = Flask(__name__)
 from fastapi import FastAPI
 app = FastAPI()
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(find_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -219,7 +219,7 @@ app = FastAPI()
 from sanic import Sanic
 app: Sanic = Sanic()
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(find_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -228,7 +228,7 @@ app: Sanic = Sanic()
 application = get_wsgi_application()
 "#;
         assert_eq!(
-            contains_app_or_handler_impl(source),
+            find_app_or_handler_impl(source),
             Some("application".to_string())
         );
     }
@@ -239,7 +239,7 @@ application = get_wsgi_application()
 def app(environ, start_response):
     pass
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(find_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -248,7 +248,7 @@ def app(environ, start_response):
 async def app(scope, receive, send):
     pass
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(find_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -256,7 +256,7 @@ async def app(scope, receive, send):
         let source = r#"
 from server import app
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(find_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -264,7 +264,7 @@ from server import app
         let source = r#"
 from server import application as app
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), Some("app".to_string()));
+        assert_eq!(find_app_or_handler_impl(source), Some("app".to_string()));
     }
 
     #[test]
@@ -275,7 +275,7 @@ class handler(BaseHTTPRequestHandler):
     pass
 "#;
         assert_eq!(
-            contains_app_or_handler_impl(source),
+            find_app_or_handler_impl(source),
             Some("handler".to_string())
         );
     }
@@ -288,7 +288,7 @@ class Handler(BaseHTTPRequestHandler):
     pass
 "#;
         assert_eq!(
-            contains_app_or_handler_impl(source),
+            find_app_or_handler_impl(source),
             Some("Handler".to_string())
         );
     }
@@ -299,7 +299,7 @@ class Handler(BaseHTTPRequestHandler):
 def main():
     print("Hello")
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), None);
+        assert_eq!(find_app_or_handler_impl(source), None);
     }
 
     #[test]
@@ -307,7 +307,7 @@ def main():
         let source = r#"
 def invalid(
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), None);
+        assert_eq!(find_app_or_handler_impl(source), None);
     }
 
     #[test]
@@ -318,7 +318,7 @@ def create():
     app = Flask(__name__)
     return app
 "#;
-        assert_eq!(contains_app_or_handler_impl(source), None);
+        assert_eq!(find_app_or_handler_impl(source), None);
     }
 
     // -------------------------------------------------------------------------

--- a/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
@@ -44,9 +44,9 @@ impl crate::bindings::Guest for PythonAnalyzer {
     /// - A top-level 'application' callable (e.g., Django)
     /// - A top-level 'handler' class (e.g., BaseHTTPRequestHandler subclass)
     ///
-    /// Returns true if found, false otherwise.
-    /// Returns false for invalid Python syntax.
-    fn contains_app_or_handler(source: String) -> bool {
+    /// Returns the matched variable name if found, or None otherwise.
+    /// Returns None for invalid Python syntax.
+    fn contains_app_or_handler(source: String) -> Option<String> {
         contains_app_or_handler_impl(&source)
     }
 

--- a/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
@@ -23,7 +23,7 @@ use uv_platform_tags::{Arch, Os, Platform, Tags};
 
 use crate::bindings::{DirectUrlInfo, DistMetadata, ParsedReqEntry, ParsedRequirementsTxt, RecordEntry};
 use crate::entrypoint::{
-    contains_app_or_handler_impl, contains_top_level_callable_impl, get_string_constant_impl,
+    find_app_or_handler_impl, contains_top_level_callable_impl, get_string_constant_impl,
 };
 
 /// Single-poll executor for WASM: all stub I/O resolves synchronously via host-bridge,
@@ -46,8 +46,8 @@ impl crate::bindings::Guest for PythonAnalyzer {
     ///
     /// Returns the matched variable name if found, or None otherwise.
     /// Returns None for invalid Python syntax.
-    fn contains_app_or_handler(source: String) -> Option<String> {
-        contains_app_or_handler_impl(&source)
+    fn find_app_or_handler(source: String) -> Option<String> {
+        find_app_or_handler_impl(&source)
     }
 
     /// Check if a top-level callable with the given name exists in Python source.

--- a/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
+++ b/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
@@ -41,9 +41,9 @@ world python-analysis {
     /// - A top-level 'application' callable (e.g., Django)
     /// - A top-level 'handler' class (e.g., BaseHTTPRequestHandler subclass)
     ///
-    /// Returns true if found, false otherwise.
-    /// Returns false for invalid Python syntax.
-    export contains-app-or-handler: func(source: string) -> bool;
+    /// Returns the matched variable name if found, or none otherwise.
+    /// Returns none for invalid Python syntax.
+    export contains-app-or-handler: func(source: string) -> option<string>;
 
     /// Extract the string value of a top-level constant with the given name.
     /// Only considers simple or annotated assignments at module level whose value is a string literal.

--- a/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
+++ b/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
@@ -43,7 +43,7 @@ world python-analysis {
     ///
     /// Returns the matched variable name if found, or none otherwise.
     /// Returns none for invalid Python syntax.
-    export contains-app-or-handler: func(source: string) -> option<string>;
+    export find-app-or-handler: func(source: string) -> option<string>;
 
     /// Extract the string value of a top-level constant with the given name.
     /// Only considers simple or annotated assignments at module level whose value is a string literal.

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -12,7 +12,7 @@
 // =============================================================================
 
 export {
-  containsAppOrHandler,
+  findAppOrHandler,
   containsTopLevelCallable,
   getStringConstant,
 } from './semantic/entrypoints';

--- a/packages/python-analysis/src/semantic/entrypoints.ts
+++ b/packages/python-analysis/src/semantic/entrypoints.ts
@@ -15,21 +15,24 @@ import { importWasmModule } from '../wasm/load';
  * accurate AST analysis without requiring a Python runtime.
  *
  * @param source - The Python source code to analyze
- * @returns Promise that resolves to true if an app or handler is found, false otherwise.
- *          Returns false for invalid Python syntax.
+ * @returns Promise that resolves to the matched variable name (e.g. "app",
+ *          "application", "handler"), or null if not found.
+ *          Returns null for invalid Python syntax.
  *
  * @example
  * ```typescript
  * import { containsAppOrHandler } from '@vercel/python-analysis';
  *
- * const hasApp = await containsAppOrHandler(`
+ * const name = await containsAppOrHandler(`
  * from flask import Flask
  * app = Flask(__name__)
  * `);
- * console.log(hasApp); // true
+ * console.log(name); // "app"
  * ```
  */
-export async function containsAppOrHandler(source: string): Promise<boolean> {
+export async function containsAppOrHandler(
+  source: string
+): Promise<string | null> {
   // Skip parsing if file doesn't contain {app|application|[Hh]andler}
   if (
     !source.includes('app') &&
@@ -37,10 +40,10 @@ export async function containsAppOrHandler(source: string): Promise<boolean> {
     !source.includes('handler') &&
     !source.includes('Handler')
   ) {
-    return false;
+    return null;
   }
   const mod = await importWasmModule();
-  return mod.containsAppOrHandler(source);
+  return mod.containsAppOrHandler(source) ?? null;
 }
 
 /**

--- a/packages/python-analysis/src/semantic/entrypoints.ts
+++ b/packages/python-analysis/src/semantic/entrypoints.ts
@@ -21,18 +21,16 @@ import { importWasmModule } from '../wasm/load';
  *
  * @example
  * ```typescript
- * import { containsAppOrHandler } from '@vercel/python-analysis';
+ * import { findAppOrHandler } from '@vercel/python-analysis';
  *
- * const name = await containsAppOrHandler(`
+ * const name = await findAppOrHandler(`
  * from flask import Flask
  * app = Flask(__name__)
  * `);
  * console.log(name); // "app"
  * ```
  */
-export async function containsAppOrHandler(
-  source: string
-): Promise<string | null> {
+export async function findAppOrHandler(source: string): Promise<string | null> {
   // Skip parsing if file doesn't contain {app|application|[Hh]andler}
   if (
     !source.includes('app') &&
@@ -43,7 +41,7 @@ export async function containsAppOrHandler(
     return null;
   }
   const mod = await importWasmModule();
-  return mod.containsAppOrHandler(source) ?? null;
+  return mod.findAppOrHandler(source) ?? null;
 }
 
 /**

--- a/packages/python-analysis/test/semantic.test.ts
+++ b/packages/python-analysis/test/semantic.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { containsAppOrHandler } from '../src';
+import { findAppOrHandler } from '../src';
 
-describe('containsAppOrHandler', () => {
+describe('findAppOrHandler', () => {
   describe('app detection', () => {
     it('detects Flask app assignment', async () => {
       const source = `
 from flask import Flask
 app = Flask(__name__)
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await findAppOrHandler(source)).toBe('app');
     });
 
     it('detects FastAPI app assignment', async () => {
@@ -16,7 +16,7 @@ app = Flask(__name__)
 from fastapi import FastAPI
 app = FastAPI()
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await findAppOrHandler(source)).toBe('app');
     });
 
     it('detects Sanic app with type annotation', async () => {
@@ -24,14 +24,14 @@ app = FastAPI()
 from sanic import Sanic
 app: Sanic = Sanic()
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await findAppOrHandler(source)).toBe('app');
     });
 
     it('detects app created via factory function', async () => {
       const source = `
 app = create_app()
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await findAppOrHandler(source)).toBe('app');
     });
 
     it('detects WSGI function named app', async () => {
@@ -39,7 +39,7 @@ app = create_app()
 def app(environ, start_response):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await findAppOrHandler(source)).toBe('app');
     });
 
     it('detects ASGI async function named app', async () => {
@@ -47,7 +47,7 @@ def app(environ, start_response):
 async def app(scope, receive, send):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await findAppOrHandler(source)).toBe('app');
     });
 
     it('detects Django WSGI application', async () => {
@@ -55,7 +55,7 @@ async def app(scope, receive, send):
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
 `;
-      expect(await containsAppOrHandler(source)).toBe('application');
+      expect(await findAppOrHandler(source)).toBe('application');
     });
 
     it('detects Django ASGI application', async () => {
@@ -63,35 +63,35 @@ application = get_wsgi_application()
 from django.core.asgi import get_asgi_application
 application = get_asgi_application()
 `;
-      expect(await containsAppOrHandler(source)).toBe('application');
+      expect(await findAppOrHandler(source)).toBe('application');
     });
 
     it('detects imported app', async () => {
       const source = `
 from server import app
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await findAppOrHandler(source)).toBe('app');
     });
 
     it('detects aliased import as app', async () => {
       const source = `
 from server import application as app
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await findAppOrHandler(source)).toBe('app');
     });
 
     it('detects imported application', async () => {
       const source = `
 from server import application as app
 `;
-      expect(await containsAppOrHandler(source)).toBe('app');
+      expect(await findAppOrHandler(source)).toBe('app');
     });
 
     it('detects aliased import as application', async () => {
       const source = `
 from server import callable as application
 `;
-      expect(await containsAppOrHandler(source)).toBe('application');
+      expect(await findAppOrHandler(source)).toBe('application');
     });
 
     it('does not detect nested app assignment', async () => {
@@ -100,7 +100,7 @@ def create():
     app = Flask(__name__)
     return app
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app in class method', async () => {
@@ -110,7 +110,7 @@ class Factory:
         app = FastAPI()
         return app
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
   });
 
@@ -121,7 +121,7 @@ from http.server import BaseHTTPRequestHandler
 class handler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('handler');
+      expect(await findAppOrHandler(source)).toBe('handler');
     });
 
     it('detects Handler class (capitalized)', async () => {
@@ -130,7 +130,7 @@ from http.server import BaseHTTPRequestHandler
 class Handler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('Handler');
+      expect(await findAppOrHandler(source)).toBe('Handler');
     });
 
     it('detects HANDLER class (uppercase)', async () => {
@@ -139,7 +139,7 @@ from http.server import BaseHTTPRequestHandler
 class HANDLER(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe('HANDLER');
+      expect(await findAppOrHandler(source)).toBe('HANDLER');
     });
 
     it('does not detect nested handler class', async () => {
@@ -149,13 +149,13 @@ def create_handler():
         pass
     return handler
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
   });
 
   describe('negative cases', () => {
     it('returns null for empty file', async () => {
-      expect(await containsAppOrHandler('')).toBeNull();
+      expect(await findAppOrHandler('')).toBeNull();
     });
 
     it('returns null for file without app or handler', async () => {
@@ -166,14 +166,14 @@ def main():
 if __name__ == "__main__":
     main()
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('returns null for invalid Python syntax', async () => {
       const source = `
 def invalid(
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect other class names', async () => {
@@ -181,21 +181,21 @@ def invalid(
 class MyHandler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('does not match app in comments', async () => {
       const source = `
 # app = Flask(__name__)
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('does not match app in strings', async () => {
       const source = `
 code = "app = Flask(__name__)"
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('returns null for file with only comments', async () => {
@@ -203,7 +203,7 @@ code = "app = Flask(__name__)"
 # just a comment
 # another comment
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app as function parameter', async () => {
@@ -211,7 +211,7 @@ code = "app = Flask(__name__)"
 def process(app):
     return app.run()
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect handler function (only class)', async () => {
@@ -219,7 +219,7 @@ def process(app):
 def handler(request):
     return response
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app in decorator', async () => {
@@ -228,14 +228,14 @@ def handler(request):
 def index():
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app as attribute access', async () => {
       const source = `
 result = server.app.run()
 `;
-      expect(await containsAppOrHandler(source)).toBeNull();
+      expect(await findAppOrHandler(source)).toBeNull();
     });
   });
 });

--- a/packages/python-analysis/test/semantic.test.ts
+++ b/packages/python-analysis/test/semantic.test.ts
@@ -8,7 +8,7 @@ describe('containsAppOrHandler', () => {
 from flask import Flask
 app = Flask(__name__)
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects FastAPI app assignment', async () => {
@@ -16,7 +16,7 @@ app = Flask(__name__)
 from fastapi import FastAPI
 app = FastAPI()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects Sanic app with type annotation', async () => {
@@ -24,14 +24,14 @@ app = FastAPI()
 from sanic import Sanic
 app: Sanic = Sanic()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects app created via factory function', async () => {
       const source = `
 app = create_app()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects WSGI function named app', async () => {
@@ -39,7 +39,7 @@ app = create_app()
 def app(environ, start_response):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects ASGI async function named app', async () => {
@@ -47,7 +47,7 @@ def app(environ, start_response):
 async def app(scope, receive, send):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects Django WSGI application', async () => {
@@ -55,7 +55,7 @@ async def app(scope, receive, send):
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('application');
     });
 
     it('detects Django ASGI application', async () => {
@@ -63,35 +63,35 @@ application = get_wsgi_application()
 from django.core.asgi import get_asgi_application
 application = get_asgi_application()
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('application');
     });
 
     it('detects imported app', async () => {
       const source = `
 from server import app
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects aliased import as app', async () => {
       const source = `
 from server import application as app
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects imported application', async () => {
       const source = `
 from server import application as app
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('app');
     });
 
     it('detects aliased import as application', async () => {
       const source = `
 from server import callable as application
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('application');
     });
 
     it('does not detect nested app assignment', async () => {
@@ -100,7 +100,7 @@ def create():
     app = Flask(__name__)
     return app
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app in class method', async () => {
@@ -110,7 +110,7 @@ class Factory:
         app = FastAPI()
         return app
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
   });
 
@@ -121,7 +121,7 @@ from http.server import BaseHTTPRequestHandler
 class handler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('handler');
     });
 
     it('detects Handler class (capitalized)', async () => {
@@ -130,7 +130,7 @@ from http.server import BaseHTTPRequestHandler
 class Handler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('Handler');
     });
 
     it('detects HANDLER class (uppercase)', async () => {
@@ -139,7 +139,7 @@ from http.server import BaseHTTPRequestHandler
 class HANDLER(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(true);
+      expect(await containsAppOrHandler(source)).toBe('HANDLER');
     });
 
     it('does not detect nested handler class', async () => {
@@ -149,16 +149,16 @@ def create_handler():
         pass
     return handler
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
   });
 
   describe('negative cases', () => {
-    it('returns false for empty file', async () => {
-      expect(await containsAppOrHandler('')).toBe(false);
+    it('returns null for empty file', async () => {
+      expect(await containsAppOrHandler('')).toBeNull();
     });
 
-    it('returns false for file without app or handler', async () => {
+    it('returns null for file without app or handler', async () => {
       const source = `
 def main():
     print("Hello, world!")
@@ -166,14 +166,14 @@ def main():
 if __name__ == "__main__":
     main()
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
-    it('returns false for invalid Python syntax', async () => {
+    it('returns null for invalid Python syntax', async () => {
       const source = `
 def invalid(
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect other class names', async () => {
@@ -181,29 +181,29 @@ def invalid(
 class MyHandler(BaseHTTPRequestHandler):
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not match app in comments', async () => {
       const source = `
 # app = Flask(__name__)
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not match app in strings', async () => {
       const source = `
 code = "app = Flask(__name__)"
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
-    it('returns false for file with only comments', async () => {
+    it('returns null for file with only comments', async () => {
       const source = `
 # just a comment
 # another comment
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app as function parameter', async () => {
@@ -211,7 +211,7 @@ code = "app = Flask(__name__)"
 def process(app):
     return app.run()
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect handler function (only class)', async () => {
@@ -219,7 +219,7 @@ def process(app):
 def handler(request):
     return response
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app in decorator', async () => {
@@ -228,14 +228,14 @@ def handler(request):
 def index():
     pass
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
 
     it('does not detect app as attribute access', async () => {
       const source = `
 result = server.app.run()
 `;
-      expect(await containsAppOrHandler(source)).toBe(false);
+      expect(await containsAppOrHandler(source)).toBeNull();
     });
   });
 });

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "type-check": "tsc --noEmit",
-    "test": "cross-env VERCEL_FORCE_PYTHON_STREAMING=1 jest --reporters=default --reporters=jest-junit --env node --verbose --runInBand --bail",
+    "test": "cross-env VERCEL_FORCE_PYTHON_STREAMING=1 NODE_OPTIONS=--experimental-vm-modules jest --reporters=default --reporters=jest-junit --env node --verbose --runInBand --bail",
     "test-unit": "vitest run --config ../../vitest.config.mts test/unit.test.ts",
     "test-e2e": "pnpm test test/integration-*",
     "vitest-run": "vitest -c ../../vitest.config.mts",

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -1,8 +1,9 @@
 import fs from 'fs';
 import { join, posix as pathPosix } from 'path';
 import type { PythonFramework } from '@vercel/build-utils';
-import { debug, isPythonEntrypoint } from '@vercel/build-utils';
+import { debug } from '@vercel/build-utils';
 import { readConfigFile } from '@vercel/build-utils';
+import { containsAppOrHandler } from '@vercel/python-analysis';
 
 export interface DetectedPythonEntrypoint {
   entrypoint?: string; // path to the entrypoint file (e.g. "src/app.py")
@@ -43,13 +44,18 @@ async function fileExists(filePath: string): Promise<boolean> {
   }
 }
 
+/**
+ * Check if a Python file contains a top-level app/handler.
+ * Returns the matched variable name (e.g. "app"), or null if not found.
+ */
 async function checkEntrypoint(
   workPath: string,
   relPath: string
-): Promise<boolean> {
+): Promise<string | null> {
   const absPath = join(workPath, relPath);
-  if (!(await fileExists(absPath))) return false;
-  return isPythonEntrypoint({ fsPath: absPath });
+  if (!(await fileExists(absPath))) return null;
+  const content = await fs.promises.readFile(absPath, 'utf-8');
+  return containsAppOrHandler(content);
 }
 
 interface PyprojectEntrypoint {
@@ -94,11 +100,12 @@ export async function getPyprojectEntrypoint(
 async function findValidEntrypoint(
   workPath: string,
   candidates: string[]
-): Promise<string | null> {
+): Promise<{ entrypoint: string; variableName: string } | null> {
   for (const candidate of candidates) {
-    if (await checkEntrypoint(workPath, candidate)) {
-      debug(`Detected Python entrypoint: ${candidate}`);
-      return candidate;
+    const varName = await checkEntrypoint(workPath, candidate);
+    if (varName) {
+      debug(`Detected Python entrypoint: ${candidate} (variable: ${varName})`);
+      return { entrypoint: candidate, variableName: varName };
     }
   }
   return null;
@@ -149,9 +156,10 @@ export async function detectGenericPythonEntrypoint(
 
   try {
     // If the configured entrypoint exists and is valid, use it
-    if (await checkEntrypoint(workPath, entry)) {
+    const varName = await checkEntrypoint(workPath, entry);
+    if (varName) {
       debug(`Using configured Python entrypoint: ${entry}`);
-      return { entrypoint: entry };
+      return { entrypoint: entry, variableName: varName };
     }
 
     // Search candidate locations using AST-based detection
@@ -159,7 +167,9 @@ export async function detectGenericPythonEntrypoint(
       workPath,
       PYTHON_CANDIDATE_ENTRYPOINTS
     );
-    return found ? { entrypoint: found } : null;
+    return found
+      ? { entrypoint: found.entrypoint, variableName: found.variableName }
+      : null;
   } catch {
     debug('Failed to discover Python entrypoint');
     return null;
@@ -180,9 +190,10 @@ export async function detectDjangoPythonEntrypoint(
 
   try {
     // If the configured entrypoint exists and is valid, use it
-    if (await checkEntrypoint(workPath, entry)) {
+    const varName = await checkEntrypoint(workPath, entry);
+    if (varName) {
       debug(`Using configured Python entrypoint: ${entry}`);
-      return { entrypoint: entry };
+      return { entrypoint: entry, variableName: varName };
     }
 
     // Get root directories (workPath root + immediate subdirs)
@@ -202,7 +213,9 @@ export async function detectDjangoPythonEntrypoint(
     // Look in all immediate subdirectories, not just those specified in PYTHON_ENTRYPOINT_DIRS.
     const candidates = getCandidateEntrypointsInDirs(rootDirs);
     const found = await findValidEntrypoint(workPath, candidates);
-    return found ? { entrypoint: found } : null;
+    return found
+      ? { entrypoint: found.entrypoint, variableName: found.variableName }
+      : null;
   } catch {
     debug('Failed to discover Django Python entrypoint');
     return null;

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -5,12 +5,18 @@ import { debug } from '@vercel/build-utils';
 import { readConfigFile } from '@vercel/build-utils';
 import { containsAppOrHandler } from '@vercel/python-analysis';
 
+export interface PythonEntrypoint {
+  /** Path to the entrypoint file (e.g. "src/app.py"). */
+  entrypoint: string;
+  /** The callable name within the module (e.g. "app"). */
+  variableName: string;
+}
+
 export interface DetectedPythonEntrypoint {
-  entrypoint?: string; // path to the entrypoint file (e.g. "src/app.py")
-  // the callable name within the module (e.g. "app" from "module:app")
-  // *currently* only populated by 'app' script in pyproject.toml
-  variableName?: string;
-  baseDir?: string; // directory containing manage.py, if detected via Django path
+  /** Resolved entrypoint, if found. */
+  entrypoint?: PythonEntrypoint;
+  /** Directory containing manage.py, if detected via Django path. */
+  baseDir?: string;
 }
 
 export const PYTHON_ENTRYPOINT_FILENAMES = [
@@ -58,14 +64,9 @@ async function checkEntrypoint(
   return containsAppOrHandler(content);
 }
 
-interface PyprojectEntrypoint {
-  entrypoint: string;
-  variableName: string;
-}
-
 export async function getPyprojectEntrypoint(
   workPath: string
-): Promise<PyprojectEntrypoint | null> {
+): Promise<PythonEntrypoint | null> {
   const pyprojectData = await readConfigFile<{
     project?: { scripts?: Record<string, unknown> };
   }>(join(workPath, 'pyproject.toml'));
@@ -100,7 +101,7 @@ export async function getPyprojectEntrypoint(
 async function findValidEntrypoint(
   workPath: string,
   candidates: string[]
-): Promise<{ entrypoint: string; variableName: string } | null> {
+): Promise<PythonEntrypoint | null> {
   for (const candidate of candidates) {
     const varName = await checkEntrypoint(workPath, candidate);
     if (varName) {
@@ -159,7 +160,7 @@ export async function detectGenericPythonEntrypoint(
     const varName = await checkEntrypoint(workPath, entry);
     if (varName) {
       debug(`Using configured Python entrypoint: ${entry}`);
-      return { entrypoint: entry, variableName: varName };
+      return { entrypoint: { entrypoint: entry, variableName: varName } };
     }
 
     // Search candidate locations using AST-based detection
@@ -167,9 +168,7 @@ export async function detectGenericPythonEntrypoint(
       workPath,
       PYTHON_CANDIDATE_ENTRYPOINTS
     );
-    return found
-      ? { entrypoint: found.entrypoint, variableName: found.variableName }
-      : null;
+    return found ? { entrypoint: found } : null;
   } catch {
     debug('Failed to discover Python entrypoint');
     return null;
@@ -193,7 +192,7 @@ export async function detectDjangoPythonEntrypoint(
     const varName = await checkEntrypoint(workPath, entry);
     if (varName) {
       debug(`Using configured Python entrypoint: ${entry}`);
-      return { entrypoint: entry, variableName: varName };
+      return { entrypoint: { entrypoint: entry, variableName: varName } };
     }
 
     // Get root directories (workPath root + immediate subdirs)
@@ -213,9 +212,7 @@ export async function detectDjangoPythonEntrypoint(
     // Look in all immediate subdirectories, not just those specified in PYTHON_ENTRYPOINT_DIRS.
     const candidates = getCandidateEntrypointsInDirs(rootDirs);
     const found = await findValidEntrypoint(workPath, candidates);
-    return found
-      ? { entrypoint: found.entrypoint, variableName: found.variableName }
-      : null;
+    return found ? { entrypoint: found } : null;
   } catch {
     debug('Failed to discover Django Python entrypoint');
     return null;
@@ -236,9 +233,5 @@ export async function detectPythonEntrypoint(
       : await detectGenericPythonEntrypoint(workPath, configuredEntrypoint);
   if (result) return result;
   const pyprojectEntry = await getPyprojectEntrypoint(workPath);
-  if (!pyprojectEntry) return null;
-  return {
-    entrypoint: pyprojectEntry.entrypoint,
-    variableName: pyprojectEntry.variableName,
-  };
+  return pyprojectEntry ? { entrypoint: pyprojectEntry } : null;
 }

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -3,7 +3,7 @@ import { join, posix as pathPosix } from 'path';
 import type { PythonFramework } from '@vercel/build-utils';
 import { debug } from '@vercel/build-utils';
 import { readConfigFile } from '@vercel/build-utils';
-import { containsAppOrHandler } from '@vercel/python-analysis';
+import { findAppOrHandler } from '@vercel/python-analysis';
 
 export interface PythonEntrypoint {
   /** Path to the entrypoint file (e.g. "src/app.py"). */
@@ -61,7 +61,7 @@ async function checkEntrypoint(
   const absPath = join(workPath, relPath);
   if (!(await fileExists(absPath))) return null;
   const content = await fs.promises.readFile(absPath, 'utf-8');
-  return containsAppOrHandler(content);
+  return findAppOrHandler(content);
 }
 
 export async function getPyprojectEntrypoint(

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -262,20 +262,26 @@ export const build: BuildVX = async ({
       join(workPath, entrypoint),
       'utf-8'
     );
-    const isSpecialService =
-      service?.type === 'cron' || service?.type === 'worker';
     let varName = await containsAppOrHandler(content);
-    if (!varName && isSpecialService) {
-      // Crons and worker have their own special entry point logic
-      // that involves creating an `app` dynamically.
-      varName = 'app';
-    } else if (!varName) {
-      throw new NowBuildError({
-        code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
-        message: `Could not find a top-level "app", "application", or "handler" in "${entrypoint}".`,
-        link: 'https://vercel.com/docs/functions/serverless-functions/runtimes/python',
-        action: 'Learn More',
-      });
+    if (!varName) {
+      const isSpecialService =
+        service?.type === 'cron' || service?.type === 'worker';
+      if (isSpecialService) {
+        // Crons and worker have their own special entry point logic
+        // that involves creating an `app` dynamically.
+        varName = 'app';
+      } else if (!isPythonFramework(framework)) {
+        // Don't throw here for framework: "null", etc
+        // TODO: Can we change this and throw here?
+        varName = 'app';
+      } else if (!varName) {
+        throw new NowBuildError({
+          code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
+          message: `Could not find a top-level "app", "application", or "handler" in "${entrypoint}".`,
+          link: 'https://vercel.com/docs/functions/serverless-functions/runtimes/python',
+          action: 'Learn More',
+        });
+      }
     }
     detected = { entrypoint: { entrypoint, variableName: varName } };
   }

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -262,11 +262,15 @@ export const build: BuildVX = async ({
       join(workPath, entrypoint),
       'utf-8'
     );
-    // If we couldn't find the variable, fall back to trying app.
-    // TODO: The main case where this is actually useful is with
-    // workers/crons, which currently work by injecting an `app` at
-    // runtime.
-    const varName = (await containsAppOrHandler(content)) ?? 'app';
+    // NOTE: this will fail!
+    const varName = await containsAppOrHandler(content);
+    if (!varName) {
+      throw new NowBuildError({
+        code: `PYTHON_ENTRYPOINT_NOT_FOUND`,
+        message: `Couldn't find python entrypoint in entrypoint file`,
+        action: 'Learn More',
+      });
+    }
     detected = { entrypoint: { entrypoint, variableName: varName } };
   }
 

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -46,7 +46,10 @@ import {
   runDjangoCollectStatic,
   type DjangoCollectStaticResult,
 } from './django';
-import { containsTopLevelCallable } from '@vercel/python-analysis';
+import {
+  containsAppOrHandler,
+  containsTopLevelCallable,
+} from '@vercel/python-analysis';
 
 const writeFile = fs.promises.writeFile;
 
@@ -246,6 +249,25 @@ export const build: BuildVX = async ({
         action: 'Learn More',
       });
     }
+  }
+
+  // When the entrypoint file already exists, detection is skipped above.
+  // Still read the file to find the variable name.
+  if (
+    !detected?.entrypoint &&
+    entrypoint.endsWith('.py') &&
+    fsFiles[entrypoint]
+  ) {
+    const content = await fs.promises.readFile(
+      join(workPath, entrypoint),
+      'utf-8'
+    );
+    // If we couldn't find the variable, fall back to trying app.
+    // TODO: The main case where this is actually useful is with
+    // workers/crons, which currently work by injecting an `app` at
+    // runtime.
+    const varName = (await containsAppOrHandler(content)) ?? 'app';
+    detected = { entrypoint: { entrypoint, variableName: varName } };
   }
 
   if (entrypointNotFound && detected?.baseDir === undefined) {

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -270,10 +270,6 @@ export const build: BuildVX = async ({
         // Crons and worker have their own special entry point logic
         // that involves creating an `app` dynamically.
         varName = 'app';
-      } else if (!isPythonFramework(framework)) {
-        // Don't throw here for framework: "null", etc
-        // TODO: Can we change this and throw here?
-        varName = 'app';
       } else if (!varName) {
         throw new NowBuildError({
           code: 'PYTHON_ENTRYPOINT_NOT_FOUND',

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -54,6 +54,7 @@ import {
   PYTHON_CANDIDATE_ENTRYPOINTS,
   detectPythonEntrypoint,
   type DetectedPythonEntrypoint,
+  type PythonEntrypoint,
 } from './entrypoint';
 
 export const version = -1;
@@ -68,8 +69,7 @@ interface FrameworkHookContext {
 }
 
 interface FrameworkHookResult {
-  entrypoint?: string;
-  variableName?: string;
+  entrypoint?: PythonEntrypoint;
 }
 
 interface DjangoFrameworkHookResult extends FrameworkHookResult {
@@ -107,28 +107,27 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
     if (!settingsResult) return;
     const { djangoSettings, settingsModule } = settingsResult;
 
-    let entrypoint: string | undefined;
-    let variableName: string | undefined;
+    let resolvedEntrypoint: PythonEntrypoint | undefined;
     const baseDir = detected?.baseDir ?? '';
     const asgiApp = djangoSettings['ASGI_APPLICATION'];
     if (typeof asgiApp === 'string') {
       const parts = asgiApp.split('.');
-      variableName = parts.at(-1);
+      const variableName = parts.at(-1)!;
       const rel = `${parts.slice(0, -1).join('/')}.py`;
-      entrypoint = baseDir ? `${baseDir}/${rel}` : rel;
-      debug(
-        `Django hook: ASGI entrypoint: ${entrypoint} (variable: ${variableName})`
-      );
+      const ep = baseDir ? `${baseDir}/${rel}` : rel;
+      debug(`Django hook: ASGI entrypoint: ${ep} (variable: ${variableName})`);
+      resolvedEntrypoint = { entrypoint: ep, variableName };
     } else {
       const wsgiApp = djangoSettings['WSGI_APPLICATION'];
       if (typeof wsgiApp === 'string') {
         const parts = wsgiApp.split('.');
-        variableName = parts.at(-1);
+        const variableName = parts.at(-1)!;
         const rel = `${parts.slice(0, -1).join('/')}.py`;
-        entrypoint = baseDir ? `${baseDir}/${rel}` : rel;
+        const ep = baseDir ? `${baseDir}/${rel}` : rel;
         debug(
-          `Django hook: WSGI entrypoint: ${entrypoint} (variable: ${variableName})`
+          `Django hook: WSGI entrypoint: ${ep} (variable: ${variableName})`
         );
+        resolvedEntrypoint = { entrypoint: ep, variableName };
       }
     }
 
@@ -144,7 +143,7 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
         djangoSettings
       );
     }
-    return { entrypoint, variableName, djangoStatic };
+    return { entrypoint: resolvedEntrypoint, djangoStatic };
   },
 };
 
@@ -235,9 +234,9 @@ export const build: BuildVX = async ({
       )) ?? undefined;
     if (detected?.entrypoint) {
       debug(
-        `Resolved Python entrypoint to "${detected.entrypoint}" (configured "${entrypoint}" not found).`
+        `Resolved Python entrypoint to "${detected.entrypoint.entrypoint}" (configured "${entrypoint}" not found).`
       );
-      entrypoint = detected.entrypoint;
+      entrypoint = detected.entrypoint.entrypoint;
     } else {
       const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
       entrypointNotFound = new NowBuildError({
@@ -471,8 +470,11 @@ export const build: BuildVX = async ({
     entrypoint,
     detected,
   });
-  if (entrypointNotFound && hookResult?.entrypoint) {
-    entrypoint = hookResult.entrypoint;
+
+  // Collect the resolved entrypoint from detection or hook, preferring the hook.
+  const resolved = hookResult?.entrypoint ?? detected?.entrypoint;
+  if (entrypointNotFound && resolved) {
+    entrypoint = resolved.entrypoint;
     entrypointNotFound = undefined;
   }
 
@@ -556,7 +558,7 @@ export const build: BuildVX = async ({
     ? `\n  "__VC_HANDLER_FUNC_NAME": "${handlerFunction}",`
     : '';
 
-  const variableName = hookResult?.variableName ?? detected?.variableName ?? '';
+  const variableName = resolved?.variableName ?? '';
 
   const runtimeTrampoline = `
 import importlib

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -262,12 +262,18 @@ export const build: BuildVX = async ({
       join(workPath, entrypoint),
       'utf-8'
     );
-    // NOTE: this will fail!
-    const varName = await containsAppOrHandler(content);
-    if (!varName) {
+    const isSpecialService =
+      service?.type === 'cron' || service?.type === 'worker';
+    let varName = await containsAppOrHandler(content);
+    if (!varName && isSpecialService) {
+      // Crons and worker have their own special entry point logic
+      // that involves creating an `app` dynamically.
+      varName = 'app';
+    } else if (!varName) {
       throw new NowBuildError({
-        code: `PYTHON_ENTRYPOINT_NOT_FOUND`,
-        message: `Couldn't find python entrypoint in entrypoint file`,
+        code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
+        message: `Could not find a top-level "app", "application", or "handler" in "${entrypoint}".`,
+        link: 'https://vercel.com/docs/functions/serverless-functions/runtimes/python',
         action: 'Learn More',
       });
     }

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -47,7 +47,7 @@ import {
   type DjangoCollectStaticResult,
 } from './django';
 import {
-  containsAppOrHandler,
+  findAppOrHandler,
   containsTopLevelCallable,
 } from '@vercel/python-analysis';
 
@@ -262,7 +262,7 @@ export const build: BuildVX = async ({
       join(workPath, entrypoint),
       'utf-8'
     );
-    let varName = await containsAppOrHandler(content);
+    let varName = await findAppOrHandler(content);
     if (!varName) {
       const isSpecialService =
         service?.type === 'cron' || service?.type === 'worker';

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -773,7 +773,7 @@ export const startDevServer: StartDevServer = async opts => {
     (serviceType === 'cron' || serviceType === 'worker') &&
     rawEntrypoint?.endsWith('.py')
   ) {
-    resolved = { entrypoint: rawEntrypoint, variableName: '' };
+    resolved = { entrypoint: rawEntrypoint, variableName: 'app' };
   } else {
     const detected = await detectPythonEntrypoint(
       framework as PythonFramework,

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -9,6 +9,7 @@ import isPortReachable from 'is-port-reachable';
 import {
   PYTHON_CANDIDATE_ENTRYPOINTS,
   detectPythonEntrypoint,
+  type PythonEntrypoint,
 } from './entrypoint';
 import { runFrameworkHook } from './index';
 import { getDefaultPythonVersion } from './version';
@@ -767,22 +768,21 @@ export const startDevServer: StartDevServer = async opts => {
 
   // For cron/worker services, use the raw entrypoint directly, because
   // they don't export app/application so standard detection would skip them.
-  let entry: string | undefined;
-  let variableName: string | undefined;
+  let resolved: PythonEntrypoint | undefined;
   if (
     (serviceType === 'cron' || serviceType === 'worker') &&
     rawEntrypoint?.endsWith('.py')
   ) {
-    entry = rawEntrypoint;
+    resolved = { entrypoint: rawEntrypoint, variableName: '' };
   } else {
     const detected = await detectPythonEntrypoint(
       framework as PythonFramework,
       workPath,
       rawEntrypoint
     );
-    entry = detected?.entrypoint;
-    variableName = detected?.variableName;
-    if (!entry) {
+    if (detected?.entrypoint) {
+      resolved = detected.entrypoint;
+    } else {
       const hookResult = await runFrameworkHook(framework, {
         pythonEnv: env,
         projectDir: join(workPath, detected?.baseDir ?? ''),
@@ -790,10 +790,9 @@ export const startDevServer: StartDevServer = async opts => {
         entrypoint: rawEntrypoint,
         detected: detected ?? undefined,
       });
-      entry = hookResult?.entrypoint;
-      variableName = hookResult?.variableName;
+      resolved = hookResult?.entrypoint;
     }
-    if (!entry) {
+    if (!resolved) {
       const searched = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
       throw new NowBuildError({
         code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
@@ -803,6 +802,7 @@ export const startDevServer: StartDevServer = async opts => {
       });
     }
   }
+  const { entrypoint: entry, variableName } = resolved;
 
   // Convert to module path, e.g. "src/app.py" -> "src.app"
   const modulePath = entry.replace(/\.py$/i, '').replace(/[\\/]/g, '.');

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -731,7 +731,9 @@ describe('file exclusions', () => {
     // Test with one excluded directory
     const excludedDir = '.pnpm-store';
     const testFiles = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'package.json': new FileBlob({ data: 'package.json' }),
       'pnpm-lock.yaml': new FileBlob({ data: 'pnpm-lock.yaml' }),
       'yarn.lock': new FileBlob({ data: 'yarn.lock' }),
@@ -788,16 +790,13 @@ describe('file exclusions', () => {
 
   it('should add config.excludeFiles to predefined exclusions', async () => {
     const testFiles = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'secret.txt': new FileBlob({ data: 'secret data' }),
       'config.ini': new FileBlob({ data: '[settings]' }),
       'public.txt': new FileBlob({ data: 'public data' }),
     };
-
-    // Create the files in workPath
-    fs.writeFileSync(path.join(mockWorkPath, 'secret.txt'), 'secret data');
-    fs.writeFileSync(path.join(mockWorkPath, 'config.ini'), '[settings]');
-    fs.writeFileSync(path.join(mockWorkPath, 'public.txt'), 'public data');
 
     // Should still exclude predefined files (test with .git if it exists)
     const gitDir = path.join(mockWorkPath, '.git');
@@ -844,7 +843,9 @@ describe('python version selection from uv.lock and pyproject.toml', () => {
 
   it('uses python version from uv.lock when present (build succeeds)', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'uv.lock': new FileBlob({ data: '[project]\npython = "3.11"\n' }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\n',
@@ -866,7 +867,9 @@ describe('python version selection from uv.lock and pyproject.toml', () => {
 
   it('falls back to pyproject.toml requires-python when no uv.lock (build succeeds)', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\nrequires-python = ">=3.10,<3.12"\n',
       }),
@@ -887,7 +890,9 @@ describe('python version selection from uv.lock and pyproject.toml', () => {
 
   it('throws when pyproject.toml requires discontinued python version', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\nrequires-python = ">=3.6,<3.7"\n',
       }),
@@ -1162,7 +1167,9 @@ describe('Django entrypoint discovery', () => {
       workPath,
       'hello/world.py'
     );
-    expect(result).toEqual({ entrypoint: 'hello/world.py' });
+    expect(result).toEqual({
+      entrypoint: { entrypoint: 'hello/world.py', variableName: 'application' },
+    });
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
@@ -1605,6 +1612,7 @@ describe('handlerFunction validation', () => {
       meta: { isDev: false },
       config: { handlerFunction: 'sync_handler' },
       repoRootPath: mockWorkPath,
+      service: { type: 'cron' },
     });
 
     const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
@@ -1633,6 +1641,7 @@ describe('handlerFunction validation', () => {
       meta: { isDev: false },
       config: { handlerFunction: 'async_handler' },
       repoRootPath: mockWorkPath,
+      service: { type: 'cron' },
     });
 
     const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
@@ -1662,6 +1671,7 @@ describe('handlerFunction validation', () => {
         meta: { isDev: false },
         config: { handlerFunction: 'nonexistent_handler' },
         repoRootPath: mockWorkPath,
+        service: { type: 'cron' },
       })
     ).rejects.toThrow(/Handler function "nonexistent_handler" not found/);
   });
@@ -1684,13 +1694,16 @@ describe('handlerFunction validation', () => {
         meta: { isDev: false },
         config: { handlerFunction: 'cleanup' },
         repoRootPath: mockWorkPath,
+        service: { type: 'cron' },
       })
     ).rejects.toThrow(/Handler function "cleanup" not found/);
   });
 
   it('does not set __VC_HANDLER_FUNC_NAME when handlerFunction is not configured', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\n',
       }),
@@ -1734,7 +1747,9 @@ describe('python version fallback logging', () => {
 
   it('logs when no Python version is specified in pyproject.toml', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "myproject"\nversion = "0.1.0"\n',
       }),
@@ -1762,7 +1777,9 @@ describe('python version fallback logging', () => {
 
   it('logs when Python version is found in pyproject.toml', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\nrequires-python = ">=3.11,<3.13"\n',
       }),
@@ -1784,7 +1801,9 @@ describe('python version fallback logging', () => {
 
   it('logs when Python version is found in .python-version', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       '.python-version': new FileBlob({ data: '3.11\n' }),
     } as Record<string, FileBlob>;
 
@@ -1831,7 +1850,9 @@ describe('.python-version file priority', () => {
 
   it('.python-version takes priority over pyproject.toml', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       '.python-version': new FileBlob({ data: '3.10\n' }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\nrequires-python = ">=3.12"\n',
@@ -1858,7 +1879,9 @@ describe('.python-version file priority', () => {
     // which requires pipfile2req. The important part is that .python-version
     // takes priority over the python_version in Pipfile.lock.
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       '.python-version': new FileBlob({ data: '3.10\n' }),
       'Pipfile.lock': new FileBlob({
         data: JSON.stringify({
@@ -1889,7 +1912,9 @@ describe('.python-version file priority', () => {
 
   it('parses .python-version with patch version (3.11.4 -> 3.11)', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       '.python-version': new FileBlob({ data: '3.11.4\n' }),
     } as Record<string, FileBlob>;
 
@@ -1910,7 +1935,9 @@ describe('.python-version file priority', () => {
 
   it('parses .python-version with comments', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       '.python-version': new FileBlob({
         data: '# This is a comment\n3.11\n',
       }),
@@ -1933,7 +1960,9 @@ describe('.python-version file priority', () => {
 
   it('throws error when .python-version has invalid content', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       '.python-version': new FileBlob({ data: 'invalid-version\n' }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\nrequires-python = ">=3.12"\n',
@@ -1980,7 +2009,9 @@ describe('.python-version file auto-creation', () => {
 
   it('writes .python-version file when pyproject.toml selects version <= 3.12', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\nrequires-python = ">=3.9"\n',
       }),
@@ -2009,7 +2040,9 @@ describe('.python-version file auto-creation', () => {
 
   it('does NOT write .python-version file when one already exists', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       '.python-version': new FileBlob({ data: '3.11\n' }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\nrequires-python = ">=3.9"\n',
@@ -2038,7 +2071,9 @@ describe('.python-version file auto-creation', () => {
 
   it('does NOT write .python-version file when selecting 3.13+', async () => {
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'pyproject.toml': new FileBlob({
         data: '[project]\nname = "x"\nversion = "0.0.1"\nrequires-python = ">=3.13"\n',
       }),
@@ -2067,7 +2102,9 @@ describe('.python-version file auto-creation', () => {
   it('does NOT write .python-version file for Pipfile.lock projects', async () => {
     // Include pyproject.toml to avoid triggering pipfile2req
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'Pipfile.lock': new FileBlob({
         data: JSON.stringify({
           _meta: { requires: { python_version: '3.11' } },
@@ -2206,7 +2243,9 @@ describe('custom install hooks', () => {
     fs.mkdirSync(workPath, { recursive: true });
 
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
     } as Record<string, FileBlob>;
 
     try {
@@ -2279,7 +2318,9 @@ describe('custom install hooks', () => {
     fs.mkdirSync(workPath, { recursive: true });
 
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
       'pyproject.toml': new FileBlob({
         data: [
           '[project]',
@@ -2369,7 +2410,9 @@ describe('custom install hooks', () => {
     fs.mkdirSync(workPath, { recursive: true });
 
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
     } as Record<string, FileBlob>;
 
     try {
@@ -2457,7 +2500,9 @@ describe('worker services dependency installation', () => {
     fs.mkdirSync(workPath, { recursive: true });
 
     const files = {
-      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'handler.py': new FileBlob({
+        data: 'def app(environ, start_response): pass',
+      }),
     } as Record<string, FileBlob>;
 
     try {

--- a/python/vercel-runtime/src/vercel_runtime/dev.py
+++ b/python/vercel-runtime/src/vercel_runtime/dev.py
@@ -394,7 +394,7 @@ def _setup_apps() -> None:
     module_name = os.environ["VERCEL_DEV_MODULE_NAME"]
     entry_abs = os.environ["VERCEL_DEV_ENTRY_ABS"]
     framework = os.environ["VERCEL_DEV_FRAMEWORK"]
-    variable_name = os.environ.get("VERCEL_DEV_VARIABLE_NAME") or None
+    variable_name = os.environ["VERCEL_DEV_VARIABLE_NAME"]
 
     _setup_server_log_routing()
     prepare_celery_environment()

--- a/python/vercel-runtime/src/vercel_runtime/resolver.py
+++ b/python/vercel-runtime/src/vercel_runtime/resolver.py
@@ -32,7 +32,8 @@ def resolve_app(
         return var, getattr(mod, var)
 
     raise RuntimeError(
-        f"Configured application '{var}' missing in module '{module_name}'"
+        f'missing variable "{var}" in file "{module_name}".\n'
+        "See the docs: https://vercel.com/docs/functions/serverless-functions/runtimes/python"
     )
 
 

--- a/python/vercel-runtime/src/vercel_runtime/resolver.py
+++ b/python/vercel-runtime/src/vercel_runtime/resolver.py
@@ -25,9 +25,7 @@ def import_module(name: str, path: str) -> ModuleType:
     return mod
 
 
-def resolve_app(
-    mod: ModuleType, module_name: str, var: str
-) -> tuple[str, Any]:
+def resolve_app(mod: ModuleType, module_name: str, var: str) -> tuple[str, Any]:
     if hasattr(mod, var):
         return var, getattr(mod, var)
 

--- a/python/vercel-runtime/src/vercel_runtime/resolver.py
+++ b/python/vercel-runtime/src/vercel_runtime/resolver.py
@@ -26,23 +26,13 @@ def import_module(name: str, path: str) -> ModuleType:
 
 
 def resolve_app(
-    mod: ModuleType, module_name: str, var: str | None
+    mod: ModuleType, module_name: str, var: str
 ) -> tuple[str, Any]:
-    if var:
-        if hasattr(mod, var):
-            return var, getattr(mod, var)
-
-        raise RuntimeError(
-            f"Configured application '{var}' missing in module '{module_name}'"
-        )
-
-    for app_var in ("app", "application"):
-        if hasattr(mod, app_var):
-            return app_var, getattr(mod, app_var)
+    if hasattr(mod, var):
+        return var, getattr(mod, var)
 
     raise RuntimeError(
-        f"Missing 'app' or 'application' in module '{module_name}': "
-        "define `app = ...` or `application = ...` in your entrypoint"
+        f"Configured application '{var}' missing in module '{module_name}'"
     )
 
 

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -805,12 +805,11 @@ if "VERCEL_IPC_PATH" in os.environ:
     except RuntimeError as exc:
         _fatal(str(exc))
 
-    if app_name.lower() == "handler" and isinstance(app_obj, type):
-        if not issubclass(app_obj, BaseHTTPRequestHandler):
-            _fatal(
-                f'"handler" must inherit from BaseHTTPRequestHandler '
-                f'in "{_entrypoint_modname}"'
-            )
+    if (
+        app_name.lower() == "handler"
+        and isinstance(app_obj, type)
+        and issubclass(app_obj, BaseHTTPRequestHandler)
+    ):
 
         class Handler(BaseHandler, app_obj):  # type: ignore[valid-type,misc]
             def handle_request(self) -> None:
@@ -826,11 +825,14 @@ if "VERCEL_IPC_PATH" in os.environ:
                 self.wfile.flush()
 
     else:
-        detection_result = detect_app_type(
-            app_obj,
-            _entrypoint_modname,
-            app_name,
-        )
+        try:
+            detection_result = detect_app_type(
+                app_obj,  # pyright: ignore[reportUnknownArgumentType]
+                _entrypoint_modname,
+                app_name,
+            )
+        except RuntimeError as exc:
+            _fatal(str(exc))
         if detection_result[0] == "wsgi":
             from io import BytesIO
 
@@ -1024,11 +1026,14 @@ if (
         return return_dict
 
 else:
-    detection_result = detect_app_type(
-        app_obj,  # pyright: ignore[reportUnknownArgumentType]
-        _entrypoint_modname,
-        app_name,
-    )
+    try:
+        detection_result = detect_app_type(
+            app_obj,  # pyright: ignore[reportUnknownArgumentType]
+            _entrypoint_modname,
+            app_name,
+        )
+    except RuntimeError as exc:
+        _fatal(str(exc))
     if detection_result[0] == "wsgi":
         _stderr("using Web Server Gateway Interface (WSGI)")
         from io import BytesIO

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -58,6 +58,22 @@ type _ASGIApp = Callable[[_ASGIScope, _ASGIReceive, _ASGISend], Awaitable[None]]
 
 _original_stderr = sys.stderr
 
+# --- IPC socket & send_message (must be available before _fatal) ----------
+_ipc_sock: socket.socket | None = None
+if "VERCEL_IPC_PATH" in os.environ:
+    _ipc_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    with contextlib.suppress(Exception):
+        _ipc_sock.connect(os.environ["VERCEL_IPC_PATH"])
+
+
+def send_message(message: _IpcMessage) -> None:
+    if _ipc_sock is not None:
+        with contextlib.suppress(Exception):
+            _ipc_sock.sendall((json.dumps(message) + "\0").encode())
+
+
+# -------------------------------------------------------------------------
+
 
 def _stderr(message: str) -> None:
     with contextlib.suppress(Exception):
@@ -260,17 +276,12 @@ def setup_logging(
 # If running in the platform (IPC present), logging must be
 # setup before importing user code so that logs happening
 # outside the request context are emitted correctly.
-ipc_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 storage: contextvars.ContextVar[dict[str, str | int] | None] = (
     contextvars.ContextVar(
         "storage",
         default=None,
     )
 )
-
-
-def send_message(message: _IpcMessage) -> None:
-    return None
 
 
 # Buffer for pre-handshake logs (to avoid blocking IPC on startup)
@@ -339,15 +350,8 @@ def flush_init_log_buf_to_stderr() -> None:
 atexit.register(flush_init_log_buf_to_stderr)
 
 
-if "VERCEL_IPC_PATH" in os.environ:
-    with contextlib.suppress(Exception):
-        ipc_sock.connect(os.getenv("VERCEL_IPC_PATH", ""))
-
-        def send_message(message: _IpcMessage) -> None:
-            with contextlib.suppress(Exception):
-                ipc_sock.sendall((json.dumps(message) + "\0").encode())
-
-        setup_logging(send_message, storage)
+if _ipc_sock is not None:
+    setup_logging(send_message, storage)
 
 
 # Runtime dependency installation for large Lambda functions

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -805,11 +805,12 @@ if "VERCEL_IPC_PATH" in os.environ:
     except RuntimeError as exc:
         _fatal(str(exc))
 
-    if (
-        app_name.lower() == "handler"
-        and isinstance(app_obj, type)
-        and issubclass(app_obj, BaseHTTPRequestHandler)
-    ):
+    if app_name.lower() == "handler" and isinstance(app_obj, type):
+        if not issubclass(app_obj, BaseHTTPRequestHandler):
+            _fatal(
+                f'"handler" must inherit from BaseHTTPRequestHandler '
+                f'in "{_entrypoint_modname}"'
+            )
 
         class Handler(BaseHandler, app_obj):  # type: ignore[valid-type,misc]
             def handle_request(self) -> None:

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -794,19 +794,20 @@ if "VERCEL_IPC_PATH" in os.environ:
                     }
                 )
 
-    if "handler" in __vc_variables or "Handler" in __vc_variables:
-        base = (
-            __vc_module.handler
-            if "handler" in __vc_variables
-            else __vc_module.Handler
+    try:
+        app_name, app_obj = resolve_app(
+            __vc_module, _entrypoint_modname, _entrypoint_varname
         )
-        if not issubclass(base, BaseHTTPRequestHandler):
-            _fatal(
-                "Handler must inherit from BaseHTTPRequestHandler\n"
-                "See the docs: https://vercel.com/docs/functions/serverless-functions/runtimes/python"
-            )
+    except RuntimeError as exc:
+        _fatal(str(exc))
 
-        class Handler(BaseHandler, base):  # type: ignore[valid-type,misc]
+    if (
+        app_name.lower() == "handler"
+        and isinstance(app_obj, type)
+        and issubclass(app_obj, BaseHTTPRequestHandler)
+    ):
+
+        class Handler(BaseHandler, app_obj):  # type: ignore[valid-type,misc]
             def handle_request(self) -> None:
                 mname = "do_" + self.command
                 if not hasattr(self, mname):
@@ -819,14 +820,7 @@ if "VERCEL_IPC_PATH" in os.environ:
                 method()
                 self.wfile.flush()
 
-    elif (
-        "app" in __vc_variables
-        or "application" in __vc_variables
-        or _entrypoint_varname in __vc_variables
-    ):
-        app_name, app_obj = resolve_app(
-            __vc_module, _entrypoint_modname, _entrypoint_varname
-        )
+    else:
         detection_result = detect_app_type(
             app_obj,
             _entrypoint_modname,
@@ -966,29 +960,24 @@ if "VERCEL_IPC_PATH" in os.environ:
         _flush_init_log_buf()
         server.serve_forever()  # type: ignore[attr-defined]
 
-    _fatal(
-        f'Missing variable `handler` or `app` in file "{_entrypoint_rel}".\n'
-        "See the docs: https://vercel.com/docs/functions/serverless-functions/runtimes/python"
+try:
+    app_name, app_obj = resolve_app(
+        __vc_module, _entrypoint_modname, _entrypoint_varname
     )
+except RuntimeError as exc:
+    _fatal(str(exc))
 
-if "handler" in __vc_variables or "Handler" in __vc_variables:
-    base = (
-        __vc_module.handler
-        if "handler" in __vc_variables
-        else __vc_module.Handler
-    )
-    if not issubclass(base, BaseHTTPRequestHandler):
-        _fatal(
-            "Handler must inherit from BaseHTTPRequestHandler\n"
-            "See the docs: https://vercel.com/docs/functions/serverless-functions/runtimes/python"
-        )
-
+if (
+    app_name.lower() == "handler"
+    and isinstance(app_obj, type)
+    and issubclass(app_obj, BaseHTTPRequestHandler)
+):
     _stderr("using HTTP Handler")
     import _thread  # noqa: PLC2701
     import http.client
     from http.server import HTTPServer
 
-    server = HTTPServer(("127.0.0.1", 0), base)  # type: ignore[assignment]
+    server = HTTPServer(("127.0.0.1", 0), app_obj)  # type: ignore[assignment]
     port = server.server_address[1]  # type: ignore[attr-defined]
 
     def vc_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
@@ -1029,14 +1018,7 @@ if "handler" in __vc_variables or "Handler" in __vc_variables:
 
         return return_dict
 
-elif (
-    "app" in __vc_variables
-    or "application" in __vc_variables
-    or _entrypoint_varname in __vc_variables
-):
-    app_name, app_obj = resolve_app(
-        __vc_module, _entrypoint_modname, _entrypoint_varname
-    )
+else:
     detection_result = detect_app_type(
         app_obj,
         _entrypoint_modname,
@@ -1413,9 +1395,3 @@ elif (
             finally:
                 clear_vercel_headers_context()
 
-else:
-    _fatal(
-        f"Missing variable `handler`, `app`, or `application` "
-        f'in file "{_entrypoint_rel}".\n'
-        "See the docs: https://vercel.com/docs/functions/serverless-functions/runtimes/python"
-    )

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -105,7 +105,7 @@ _here = os.path.dirname(__file__)
 _entrypoint_rel = _must_getenv("__VC_HANDLER_ENTRYPOINT")
 _entrypoint_abs = _must_getenv("__VC_HANDLER_ENTRYPOINT_ABS")
 _entrypoint_modname = _must_getenv("__VC_HANDLER_MODULE_NAME")
-_entrypoint_varname = os.environ.get("__VC_HANDLER_VARIABLE_NAME", "")
+_entrypoint_varname = _must_getenv("__VC_HANDLER_VARIABLE_NAME")
 
 
 def setup_logging(

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -1025,7 +1025,7 @@ if (
 
 else:
     detection_result = detect_app_type(
-        app_obj,
+        app_obj,  # pyright: ignore[reportUnknownArgumentType]
         _entrypoint_modname,
         app_name,
     )
@@ -1399,4 +1399,3 @@ else:
                 return response
             finally:
                 clear_vercel_headers_context()
-

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -728,7 +728,7 @@ class TestErrorPaths(_RuntimeTestCase):
             )
             self.assertEqual(msg.payload.exit_code, 1)
             self.assertIn(
-                "must inherit from BaseHTTPRequestHandler",
+                "Could not determine the application interface",
                 msg.payload.message,
             )
             async with asyncio.timeout(10.0):
@@ -736,7 +736,7 @@ class TestErrorPaths(_RuntimeTestCase):
             self.assertEqual(returncode, 1)
             stderr = await _read_stderr(proc)
             self.assertIn(
-                "must inherit from BaseHTTPRequestHandler",
+                "Could not determine the application interface",
                 stderr,
             )
 

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -73,6 +73,7 @@ async def _run_runtime(
     entrypoint_rel: str,
     module_name: str,
     ipc_socket_path: str,
+    variable_name: str = "app",
     extra_env: dict[str, str] | None = None,
 ) -> AsyncIterator[asyncio.subprocess.Process]:
     env = {
@@ -80,6 +81,7 @@ async def _run_runtime(
         "__VC_HANDLER_ENTRYPOINT": entrypoint_rel,
         "__VC_HANDLER_ENTRYPOINT_ABS": str(entrypoint_abs),
         "__VC_HANDLER_MODULE_NAME": module_name,
+        "__VC_HANDLER_VARIABLE_NAME": variable_name,
         "VERCEL_IPC_PATH": ipc_socket_path,
     }
     if extra_env:
@@ -133,6 +135,7 @@ async def _invoke_lambda(
     entrypoint_rel: str,
     module_name: str,
     event: dict[str, Any],
+    variable_name: str = "app",
 ) -> dict[str, Any]:
     """Run vc_init.py in legacy mode and call vc_handler.
 
@@ -144,6 +147,7 @@ async def _invoke_lambda(
         "__VC_HANDLER_ENTRYPOINT": entrypoint_rel,
         "__VC_HANDLER_ENTRYPOINT_ABS": str(entrypoint_abs),
         "__VC_HANDLER_MODULE_NAME": module_name,
+        "__VC_HANDLER_VARIABLE_NAME": variable_name,
     }
     env.pop("VERCEL_IPC_PATH", None)
 
@@ -278,6 +282,7 @@ class TestHTTPHandler(_RuntimeTestCase):
             entrypoint_rel=ep_rel,
             module_name=mod,
             ipc_socket_path=self.n1.socket_path,
+            variable_name="handler",
         ):
             ss = await self.n1.wait_for_message(
                 ServerStartedMessage, timeout=10.0
@@ -320,6 +325,7 @@ class TestHTTPHandler(_RuntimeTestCase):
             entrypoint_rel=ep_rel,
             module_name=mod,
             ipc_socket_path=self.n1.socket_path,
+            variable_name="handler",
         ):
             ss = await self.n1.wait_for_message(
                 ServerStartedMessage, timeout=10.0
@@ -338,6 +344,7 @@ class TestHTTPHandler(_RuntimeTestCase):
             entrypoint_rel=ep_rel,
             module_name=mod,
             ipc_socket_path=self.n1.socket_path,
+            variable_name="handler",
         ):
             ss = await self.n1.wait_for_message(
                 ServerStartedMessage, timeout=10.0
@@ -683,7 +690,7 @@ class TestErrorPaths(_RuntimeTestCase):
                 UnrecoverableErrorMessage, timeout=10.0
             )
             self.assertEqual(msg.payload.exit_code, 1)
-            self.assertIn("Missing variable", msg.payload.message)
+            self.assertIn("missing variable", msg.payload.message)
             async with asyncio.timeout(10.0):
                 returncode = await proc.wait()
             self.assertEqual(returncode, 1)
@@ -714,13 +721,14 @@ class TestErrorPaths(_RuntimeTestCase):
             entrypoint_rel=ep_rel,
             module_name=mod,
             ipc_socket_path=self.n1.socket_path,
+            variable_name="handler",
         ) as proc:
             msg = await self.n1.wait_for_message(
                 UnrecoverableErrorMessage, timeout=10.0
             )
             self.assertEqual(msg.payload.exit_code, 1)
             self.assertIn(
-                "Handler must inherit from BaseHTTPRequestHandler",
+                "must inherit from BaseHTTPRequestHandler",
                 msg.payload.message,
             )
             async with asyncio.timeout(10.0):
@@ -728,7 +736,7 @@ class TestErrorPaths(_RuntimeTestCase):
             self.assertEqual(returncode, 1)
             stderr = await _read_stderr(proc)
             self.assertIn(
-                "Handler must inherit from BaseHTTPRequestHandler",
+                "must inherit from BaseHTTPRequestHandler",
                 stderr,
             )
 
@@ -794,6 +802,7 @@ class TestLambdaHTTPHandler(_LambdaTestCase):
             entrypoint_rel=ep_rel,
             module_name=mod,
             event=_lambda_event("GET", "/hello"),
+            variable_name="handler",
         )
         self.assertEqual(result["statusCode"], 200)
         self.assertIn("GET /hello", result["body"])
@@ -810,6 +819,7 @@ class TestLambdaHTTPHandler(_LambdaTestCase):
                 body=base64.b64encode(b"encoded").decode(),
                 encoding="base64",
             ),
+            variable_name="handler",
         )
         self.assertEqual(result["statusCode"], 200)
         self.assertIn("encoded", result["body"])
@@ -823,6 +833,7 @@ class TestLambdaHTTPHandler(_LambdaTestCase):
             entrypoint_rel=ep_rel,
             module_name=mod,
             event=_lambda_event("GET", "/"),
+            variable_name="handler",
         )
         self.assertEqual(result["statusCode"], 200)
         self.assertEqual(result["encoding"], "base64")
@@ -967,6 +978,7 @@ class TestLambdaErrorPaths(_LambdaTestCase):
                 entrypoint_rel=ep_rel,
                 module_name=mod,
                 event=_lambda_event("GET", "/"),
+                variable_name="handler",
             )
 
     async def test_asgi_bad_start_message(self) -> None:


### PR DESCRIPTION
Currently we do detection both in the python builder and in the runtime. Adjust that so that we always actually extract the wsgi/asgi entry point name in the builder and pass it to the runtime.

(We still do some runtime detection for workers/crons, though, and may want to revisit that later)