### PR TITLE
[python] Rewrite patch-level version pins in build container

### DIFF
--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -204,3 +204,12 @@ export {
   PythonVersionRequest,
   UnknownPythonImplementation,
 } from './manifest/python-specifiers';
+
+// =============================================================================
+// .python-version file serialization
+// =============================================================================
+
+export {
+  serializePythonRequest,
+  writePythonVersionFile,
+} from './manifest/uv-python-version-parser';

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -210,6 +210,9 @@ export {
 // =============================================================================
 
 export {
+  parseUvPythonRequest,
   serializePythonRequest,
   writePythonVersionFile,
 } from './manifest/uv-python-version-parser';
+
+export type { Pep440Constraint } from './manifest/pep440';

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -103,6 +103,7 @@ export { selectPython, selectPythonVersion } from './manifest/python-selector';
 // =============================================================================
 
 export { PythonAnalysisError } from './util/error';
+export { parseConfig } from './util/config';
 
 // =============================================================================
 // Schemas (runtime validation)
@@ -210,6 +211,7 @@ export {
 // =============================================================================
 
 export {
+  parsePythonVersionFile,
   parseUvPythonRequest,
   serializePythonRequest,
   writePythonVersionFile,

--- a/packages/python-analysis/src/manifest/uv-python-version-parser.ts
+++ b/packages/python-analysis/src/manifest/uv-python-version-parser.ts
@@ -39,6 +39,10 @@ export function pythonRequestFromConstraint(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
 /**
  * Parse the contents of a `.python-version` file.
  */
@@ -329,4 +333,62 @@ function tryParsePlatformRequest(raw: string): PythonRequest | null {
   }
 
   return { implementation, version, platform };
+}
+
+// ---------------------------------------------------------------------------
+// Serialization (inverse of parsing)
+// ---------------------------------------------------------------------------
+
+function serializeConstraint(constraint: Pep440Constraint[]): string {
+  return constraint.map(c => `${c.operator}${c.version}`).join(',');
+}
+
+function serializeVersionRequest(vr: PythonVersionRequest): string {
+  const base = serializeConstraint(vr.constraint);
+  if (!vr.variant || vr.variant === 'default') return base;
+  return `${base}+${PythonVariant.toString(vr.variant)}`;
+}
+
+/**
+ * Serialize a single Python version request to a string suitable for a
+ * `.python-version` line.  This is the inverse of `parseUvPythonRequest`.
+ * Comments are not preserved.
+ */
+export function serializePythonRequest(request: PythonRequest): string {
+  const { implementation, version, platform } = request;
+
+  if (!implementation && !version && !platform) return 'any';
+
+  if (platform) {
+    const implStr = implementation
+      ? PythonImplementation.toString(implementation)
+      : 'any';
+    const verStr = version ? serializeVersionRequest(version) : 'any';
+    return [
+      implStr,
+      verStr,
+      platform.os ?? 'any',
+      platform.arch ?? 'any',
+      platform.libc ?? 'any',
+    ].join('-');
+  }
+
+  if (implementation && !version) {
+    return PythonImplementation.toString(implementation);
+  }
+
+  const verStr = version ? serializeVersionRequest(version) : '';
+  if (implementation) {
+    return `${PythonImplementation.toString(implementation)}@${verStr}`;
+  }
+  return verStr;
+}
+
+/**
+ * Serialize an array of Python version requests to `.python-version` file
+ * content.  This is the inverse of `parsePythonVersionFile`.
+ * Comments are not preserved.
+ */
+export function writePythonVersionFile(requests: PythonRequest[]): string {
+  return requests.map(serializePythonRequest).join('\n') + '\n';
 }

--- a/packages/python-analysis/test/uv-python-version-parser.test.ts
+++ b/packages/python-analysis/test/uv-python-version-parser.test.ts
@@ -3,6 +3,8 @@ import {
   parseUvPythonRequest,
   parsePythonVersionFile,
   pythonRequestFromConstraint,
+  serializePythonRequest,
+  writePythonVersionFile,
 } from '../src/manifest/uv-python-version-parser';
 
 describe('parseUvPythonRequest', () => {
@@ -849,4 +851,207 @@ describe('pythonRequestFromConstraint', () => {
     const result = pythonRequestFromConstraint(constraint);
     expect(result.version?.variant).toBe('default');
   });
+});
+
+describe('serializePythonRequest', () => {
+  it('serializes empty request as "any"', () => {
+    expect(serializePythonRequest({})).toBe('any');
+  });
+
+  it('serializes implementation-only request', () => {
+    expect(serializePythonRequest({ implementation: 'cpython' })).toBe(
+      'cpython'
+    );
+    expect(serializePythonRequest({ implementation: 'pypy' })).toBe('pypy');
+    expect(serializePythonRequest({ implementation: 'graalpy' })).toBe(
+      'graalpy'
+    );
+  });
+
+  it('serializes version-only request', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [{ operator: '==', version: '3.12', prefix: '' }],
+          variant: 'default',
+        },
+      })
+    ).toBe('cpython@==3.12');
+  });
+
+  it('serializes patch-level version', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [{ operator: '==', version: '3.12.8', prefix: '' }],
+          variant: 'default',
+        },
+      })
+    ).toBe('cpython@==3.12.8');
+  });
+
+  it('serializes compound specifier', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [
+            { operator: '>=', version: '3.12', prefix: '' },
+            { operator: '<', version: '3.13', prefix: '' },
+          ],
+          variant: 'default',
+        },
+      })
+    ).toBe('cpython@>=3.12,<3.13');
+  });
+
+  it('serializes freethreaded variant', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [{ operator: '==', version: '3.13', prefix: '' }],
+          variant: 'freethreaded',
+        },
+      })
+    ).toBe('cpython@==3.13+freethreaded');
+  });
+
+  it('serializes debug variant', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [{ operator: '==', version: '3.12.0', prefix: '' }],
+          variant: 'debug',
+        },
+      })
+    ).toBe('cpython@==3.12.0+debug');
+  });
+
+  it('serializes freethreaded+debug variant', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [{ operator: '==', version: '3.13', prefix: '' }],
+          variant: 'freethreaded+debug',
+        },
+      })
+    ).toBe('cpython@==3.13+freethreaded+debug');
+  });
+
+  it('serializes gil variant', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [{ operator: '==', version: '3.14', prefix: '' }],
+          variant: 'gil',
+        },
+      })
+    ).toBe('cpython@==3.14+gil');
+  });
+
+  it('serializes gil+debug variant', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [{ operator: '==', version: '3.14', prefix: '' }],
+          variant: 'gil+debug',
+        },
+      })
+    ).toBe('cpython@==3.14+gil+debug');
+  });
+
+  it('serializes platform request', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [{ operator: '==', version: '3.12.3', prefix: '' }],
+          variant: 'default',
+        },
+        platform: { os: 'macos', arch: 'aarch64', libc: 'none' },
+      })
+    ).toBe('cpython-==3.12.3-macos-aarch64-none');
+  });
+
+  it('serializes platform request with missing fields as "any"', () => {
+    expect(
+      serializePythonRequest({
+        implementation: 'cpython',
+        version: {
+          constraint: [{ operator: '==', version: '3.12', prefix: '' }],
+          variant: 'default',
+        },
+        platform: { os: 'linux' },
+      })
+    ).toBe('cpython-==3.12-linux-any-any');
+  });
+});
+
+describe('writePythonVersionFile', () => {
+  it('writes a single request', () => {
+    const requests = [
+      {
+        implementation: 'cpython' as const,
+        version: {
+          constraint: [{ operator: '==', version: '3.12', prefix: '' }],
+          variant: 'default' as const,
+        },
+      },
+    ];
+    expect(writePythonVersionFile(requests)).toBe('cpython@==3.12\n');
+  });
+
+  it('writes multiple requests one per line', () => {
+    const requests = [
+      {
+        implementation: 'cpython' as const,
+        version: {
+          constraint: [{ operator: '==', version: '3.12', prefix: '' }],
+          variant: 'default' as const,
+        },
+      },
+      {
+        implementation: 'pypy' as const,
+        version: {
+          constraint: [{ operator: '==', version: '3.10', prefix: '' }],
+          variant: 'default' as const,
+        },
+      },
+    ];
+    expect(writePythonVersionFile(requests)).toBe(
+      'cpython@==3.12\npypy@==3.10\n'
+    );
+  });
+});
+
+describe('round-trip: parsePythonVersionFile → writePythonVersionFile', () => {
+  // Serialize the input, then verify that serializing again produces the same
+  // string — i.e. the canonical form is stable.  Both parses go through the
+  // same pep440 code path so no normalization is needed.
+  function roundTrip(input: string): string | null {
+    const parsed = parsePythonVersionFile(input);
+    if (parsed === null) return null;
+    return writePythonVersionFile(parsed);
+  }
+
+  function isStable(input: string) {
+    const serialized = roundTrip(input);
+    expect(roundTrip(serialized!)).toBe(serialized);
+  }
+
+  it('round-trips a bare patch version', () => isStable('3.12.8'));
+  it('round-trips a minor version', () => isStable('3.12'));
+  it('round-trips a compound specifier', () => isStable('>=3.12,<3.13'));
+  it('round-trips a freethreaded variant (short form normalizes to long)', () =>
+    isStable('3.13t'));
+  it('round-trips a platform request', () =>
+    isStable('cpython-3.12.3-macos-aarch64-none'));
+  it('round-trips multiple requests', () => isStable('3.12\npypy@3.10\n'));
 });

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -30,6 +30,7 @@ import {
   discoverPackage,
   ensureUvProject,
   resolveVendorDir,
+  rewritePatchVersionPins,
   installRequirementsFile,
   installRequirement,
 } from './install';
@@ -287,6 +288,13 @@ export const build: BuildV3 = async ({
       `${pythonVersionString(pythonVersion)}\n`
     );
   }
+
+  // In the build container, rewrite any patch-level Python version pins in
+  // .python-version and pyproject.toml to minor-version ranges.
+  await rewritePatchVersionPins({
+    pythonPackage,
+    rootDir,
+  });
 
   fsFiles = await glob('**', workPath);
 

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -414,7 +414,7 @@ function trimPatchLevel(
           { ...constraint, version: `${majorStr}.${minorNum + 1}` },
         ];
       }
-      // <X.Y.0: strip patch, keep operator (semantically equivalent)
+      // <X.Y.0 → <X.Y (semantically equivalent)
       return [true, { ...constraint, version: `${majorStr}.${minorStr}` }];
     case '>':
       // >X.Y.Z → >=X.Y to include all patches of X.Y
@@ -422,9 +422,20 @@ function trimPatchLevel(
         true,
         { ...constraint, operator: '>=', version: `${majorStr}.${minorStr}` },
       ];
-    default:
-      // >=, ==, !=, ~=, ===: strip patch to X.Y
+    case '~=':
+      // ~=X.Y.Z → >=X.Y (~=X.Y would be >=X.Y, ==X.*, allowing X.(Y+1)+)
+      return [
+        true,
+        { ...constraint, operator: '>=', version: `${majorStr}.${minorStr}` },
+      ];
+    case '>=':
+    case '==':
+      // >=X.Y.Z → >=X.Y (slightly more permissive, includes X.Y.0 to X.Y.Z-1)
+      // ==X.Y.Z → ==X.Y (callers may further adjust, e.g. ==X.Y.* for pyproject.toml)
       return [true, { ...constraint, version: `${majorStr}.${minorStr}` }];
+    default:
+      // Unknown or unsafe to strip (!=, ===, etc.): leave unchanged
+      return [false, constraint];
   }
 }
 

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -7,8 +7,10 @@ import {
   stringifyManifest,
   createMinimalManifest,
   PythonAnalysisError,
+  PythonConfigKind,
   PythonLockFileKind,
   PythonManifestConvertedKind,
+  writePythonVersionFile,
   type PythonPackage,
 } from '@vercel/python-analysis';
 import { getVenvPythonBin } from './utils';
@@ -364,6 +366,82 @@ export async function ensureUvProject({
     lockPath: resolvedLockPath,
     lockFileProvidedByUser,
   };
+}
+
+/**
+ * In the Vercel build container, rewrite patch-level Python version pins to
+ * minor-version ranges so that uv (running with UV_PYTHON_DOWNLOADS=never)
+ * can resolve against the pre-installed patch version.
+ *
+ * Examples:
+ *   .python-version:  "3.12.8"   → "3.12"
+ *   pyproject.toml:   "==3.12.8" → ">=3.12,<3.13"
+ *
+ * This is a no-op outside the Vercel build container.
+ */
+async function rewritePythonVersionFiles({
+  pythonPackage,
+  rootDir,
+}: {
+  pythonPackage: PythonPackage;
+  rootDir: string;
+}): Promise<void> {
+  for (const configSet of pythonPackage.configs ?? []) {
+    const pvConfig = configSet[PythonConfigKind.PythonVersion];
+    if (!pvConfig) continue;
+
+    let changed = false;
+    const rewritten = pvConfig.data.map(req => {
+      if (!req.version) return req;
+      const newConstraint = req.version.constraint.map(c => {
+        const parts = c.version.split('.');
+        if (parts.length < 3) return c;
+        changed = true;
+        const [majorStr, minorStr] = parts;
+        const minorNum = parseInt(minorStr, 10);
+        const patchNum = parseInt(parts[2], 10);
+        switch (c.operator) {
+          case '<=':
+            // <=X.Y.Z → <X.(Y+1) to include all patches of X.Y
+            return {
+              ...c,
+              operator: '<',
+              version: `${majorStr}.${minorNum + 1}`,
+            };
+          case '<':
+            if (patchNum > 0) {
+              // <X.Y.Z (Z>0) → <X.(Y+1) to avoid excluding patches of X.Y
+              return { ...c, version: `${majorStr}.${minorNum + 1}` };
+            }
+            // <X.Y.0: strip patch, keep operator (semantically equivalent)
+            return { ...c, version: `${majorStr}.${minorStr}` };
+          case '>':
+            // >X.Y.Z → >=X.Y to include all patches of X.Y
+            return { ...c, operator: '>=', version: `${majorStr}.${minorStr}` };
+          default:
+            // >=, ==, !=, ~=, ===: strip patch to X.Y
+            return { ...c, version: `${majorStr}.${minorStr}` };
+        }
+      });
+      return { ...req, version: { ...req.version, constraint: newConstraint } };
+    });
+    if (!changed) continue;
+
+    const absPath = join(rootDir, pvConfig.path);
+    await fs.promises.writeFile(absPath, writePythonVersionFile(rewritten));
+  }
+}
+
+export async function rewritePatchVersionPins({
+  pythonPackage,
+  rootDir,
+}: {
+  pythonPackage: PythonPackage;
+  rootDir: string;
+}): Promise<void> {
+  if (!process.env.VERCEL_BUILD_IMAGE) return;
+
+  await rewritePythonVersionFiles({ pythonPackage, rootDir });
 }
 
 async function pipInstall(

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -6,12 +6,15 @@ import {
   discoverPythonPackage,
   stringifyManifest,
   createMinimalManifest,
+  parseUvPythonRequest,
   PythonAnalysisError,
   PythonConfigKind,
   PythonLockFileKind,
   PythonManifestConvertedKind,
   writePythonVersionFile,
   type PythonPackage,
+  type Pep440Constraint,
+  serializePythonRequest,
 } from '@vercel/python-analysis';
 import { getVenvPythonBin } from './utils';
 import { UvRunner, filterUnsafeUvPipArgs, getProtectedUvEnv } from './uv';
@@ -379,6 +382,52 @@ export async function ensureUvProject({
  *
  * This is a no-op outside the Vercel build container.
  */
+function hasPatchLevelPin(specifier: string): boolean {
+  // matches 3.12.8 but not 3.12
+  return /\d+\.\d+\.\d+/.test(specifier);
+}
+
+function trimPatchLevel(
+  constraint: Pep440Constraint
+): [boolean, Pep440Constraint] {
+  const parts = constraint.version.split('.');
+  if (parts.length < 3) return [false, constraint];
+  const [majorStr, minorStr] = parts;
+  const minorNum = parseInt(minorStr, 10);
+  const patchNum = parseInt(parts[2], 10);
+  switch (constraint.operator) {
+    case '<=':
+      // <=X.Y.Z → <X.(Y+1) to include all patches of X.Y
+      return [
+        true,
+        {
+          ...constraint,
+          operator: '<',
+          version: `${majorStr}.${minorNum + 1}`,
+        },
+      ];
+    case '<':
+      if (patchNum > 0) {
+        // <X.Y.Z (Z>0) → <X.(Y+1) to avoid excluding patches of X.Y
+        return [
+          true,
+          { ...constraint, version: `${majorStr}.${minorNum + 1}` },
+        ];
+      }
+      // <X.Y.0: strip patch, keep operator (semantically equivalent)
+      return [true, { ...constraint, version: `${majorStr}.${minorStr}` }];
+    case '>':
+      // >X.Y.Z → >=X.Y to include all patches of X.Y
+      return [
+        true,
+        { ...constraint, operator: '>=', version: `${majorStr}.${minorStr}` },
+      ];
+    default:
+      // >=, ==, !=, ~=, ===: strip patch to X.Y
+      return [true, { ...constraint, version: `${majorStr}.${minorStr}` }];
+  }
+}
+
 async function rewritePythonVersionFiles({
   pythonPackage,
   rootDir,
@@ -394,34 +443,11 @@ async function rewritePythonVersionFiles({
     const rewritten = pvConfig.data.map(req => {
       if (!req.version) return req;
       const newConstraint = req.version.constraint.map(c => {
-        const parts = c.version.split('.');
-        if (parts.length < 3) return c;
-        changed = true;
-        const [majorStr, minorStr] = parts;
-        const minorNum = parseInt(minorStr, 10);
-        const patchNum = parseInt(parts[2], 10);
-        switch (c.operator) {
-          case '<=':
-            // <=X.Y.Z → <X.(Y+1) to include all patches of X.Y
-            return {
-              ...c,
-              operator: '<',
-              version: `${majorStr}.${minorNum + 1}`,
-            };
-          case '<':
-            if (patchNum > 0) {
-              // <X.Y.Z (Z>0) → <X.(Y+1) to avoid excluding patches of X.Y
-              return { ...c, version: `${majorStr}.${minorNum + 1}` };
-            }
-            // <X.Y.0: strip patch, keep operator (semantically equivalent)
-            return { ...c, version: `${majorStr}.${minorStr}` };
-          case '>':
-            // >X.Y.Z → >=X.Y to include all patches of X.Y
-            return { ...c, operator: '>=', version: `${majorStr}.${minorStr}` };
-          default:
-            // >=, ==, !=, ~=, ===: strip patch to X.Y
-            return { ...c, version: `${majorStr}.${minorStr}` };
+        const [currentChanged, trimmed] = trimPatchLevel(c);
+        if (currentChanged) {
+          changed = true;
         }
+        return trimmed;
       });
       return { ...req, version: { ...req.version, constraint: newConstraint } };
     });
@@ -429,6 +455,52 @@ async function rewritePythonVersionFiles({
 
     const absPath = join(rootDir, pvConfig.path);
     await fs.promises.writeFile(absPath, writePythonVersionFile(rewritten));
+  }
+}
+
+async function rewritePyprojectRequiresPython({
+  pythonPackage,
+  rootDir,
+}: {
+  pythonPackage: PythonPackage;
+  rootDir: string;
+}): Promise<void> {
+  // Converted manifests (Pipfile, requirements.txt) are already handled
+  // in ensureUvProject so we skip them here.
+  const manifest = pythonPackage.manifest;
+  if (!manifest || manifest.origin) return;
+
+  const requiresPython = manifest.data.project?.['requires-python'];
+  if (!requiresPython || !hasPatchLevelPin(requiresPython)) return;
+
+  const request = parseUvPythonRequest(requiresPython);
+  if (!request || !request.version) return;
+
+  let changed = false;
+  const newConstraint = request.version.constraint.map(c => {
+    const [currentChanged, trimmed] = trimPatchLevel(c);
+    if (currentChanged) changed = true;
+    // In pyproject.toml, ==X.Y means exactly X.Y.0; use the wildcard form instead
+    if (trimmed.operator === '==' && !trimmed.version.endsWith('.*')) {
+      return { ...trimmed, version: `${trimmed.version}.*` };
+    }
+    return trimmed;
+  });
+  if (!changed) return;
+
+  // Drop implementation — only the version constraint is relevant for pyproject.toml
+  const updatedRequiresPython = serializePythonRequest({
+    version: { ...request.version, constraint: newConstraint },
+  });
+
+  const absPath = join(rootDir, manifest.path);
+  const content = await fs.promises.readFile(absPath, 'utf8');
+  const rewritten = content.replace(
+    /(requires-python\s*=\s*["'])([^"']*)(['"])/,
+    `$1${updatedRequiresPython}$3`
+  );
+  if (rewritten !== content) {
+    await fs.promises.writeFile(absPath, rewritten);
   }
 }
 
@@ -442,6 +514,7 @@ export async function rewritePatchVersionPins({
   if (!process.env.VERCEL_BUILD_IMAGE) return;
 
   await rewritePythonVersionFiles({ pythonPackage, rootDir });
+  await rewritePyprojectRequiresPython({ pythonPackage, rootDir });
 }
 
 async function pipInstall(

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -351,9 +351,14 @@ export function filterUnsafeUvPipArgs(args: string[]): string[] {
 export function getProtectedUvEnv(
   baseEnv: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv {
+  // In the Vercel build container we ship pre-installed Python versions, so
+  // uv should not download Python.
+  const uvPythonDownloads = baseEnv.VERCEL_BUILD_IMAGE
+    ? 'never'
+    : UV_PYTHON_DOWNLOADS_MODE;
   return {
     ...baseEnv,
-    UV_PYTHON_DOWNLOADS: UV_PYTHON_DOWNLOADS_MODE,
+    UV_PYTHON_DOWNLOADS: uvPythonDownloads,
   };
 }
 

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -2700,4 +2700,123 @@ describe('rewritePatchVersionPins', () => {
 
     expect(fs.readFileSync(pvPath, 'utf8')).toBe('3.12\n');
   });
+
+  it('rewrites requires-python in native pyproject.toml with a patch-level pin', async () => {
+    process.env.VERCEL_BUILD_IMAGE = '1';
+    const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
+    fs.writeFileSync(
+      pyprojectPath,
+      '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = "==3.12.8"\n'
+    );
+
+    await rewritePatchVersionPins({
+      pythonPackage: {
+        manifest: {
+          path: 'pyproject.toml',
+          data: {
+            project: {
+              name: 'myapp',
+              version: '0.1.0',
+              'requires-python': '==3.12.8',
+              dependencies: [],
+            },
+          },
+        },
+      },
+      rootDir: tmpDir,
+    });
+
+    const updated = fs.readFileSync(pyprojectPath, 'utf8');
+    expect(updated).toContain('requires-python = "==3.12.*"'); // ==3.12 would mean exactly 3.12.0
+    expect(updated).not.toContain('==3.12.8');
+  });
+
+  it('rewrites requires-python with >=X.Y.Z style patch constraint', async () => {
+    process.env.VERCEL_BUILD_IMAGE = '1';
+    const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
+    fs.writeFileSync(
+      pyprojectPath,
+      '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = ">=3.12.8,<3.13"\n'
+    );
+
+    await rewritePatchVersionPins({
+      pythonPackage: {
+        manifest: {
+          path: 'pyproject.toml',
+          data: {
+            project: {
+              name: 'myapp',
+              version: '0.1.0',
+              'requires-python': '>=3.12.8,<3.13',
+              dependencies: [],
+            },
+          },
+        },
+      },
+      rootDir: tmpDir,
+    });
+
+    const updated = fs.readFileSync(pyprojectPath, 'utf8');
+    expect(updated).toContain('requires-python = ">=3.12,<3.13"');
+  });
+
+  it('does not rewrite requires-python that has no patch-level version', async () => {
+    process.env.VERCEL_BUILD_IMAGE = '1';
+    const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
+    const original =
+      '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = ">=3.12"\n';
+    fs.writeFileSync(pyprojectPath, original);
+
+    await rewritePatchVersionPins({
+      pythonPackage: {
+        manifest: {
+          path: 'pyproject.toml',
+          data: {
+            project: {
+              name: 'myapp',
+              version: '0.1.0',
+              'requires-python': '>=3.12',
+              dependencies: [],
+            },
+          },
+        },
+      },
+      rootDir: tmpDir,
+    });
+
+    expect(fs.readFileSync(pyprojectPath, 'utf8')).toBe(original);
+  });
+
+  it('skips requires-python rewrite for converted manifests (origin set)', async () => {
+    process.env.VERCEL_BUILD_IMAGE = '1';
+    const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
+    const original =
+      '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = "==3.12.8"\n';
+    fs.writeFileSync(pyprojectPath, original);
+
+    await rewritePatchVersionPins({
+      pythonPackage: {
+        manifest: {
+          path: 'pyproject.toml',
+          data: {
+            project: {
+              name: 'myapp',
+              version: '0.1.0',
+              'requires-python': '==3.12.8',
+              dependencies: [],
+            },
+          },
+          // origin marks this as a converted (e.g. requirements.txt) manifest
+          origin: {
+            kind: 'requirements.txt' as any,
+            path: 'requirements.txt' as any,
+          },
+        },
+      },
+      rootDir: tmpDir,
+    });
+
+    // Converted manifests are handled elsewhere; file should be untouched
+    expect(fs.readFileSync(pyprojectPath, 'utf8')).toBe(original);
+  });
 });

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -2471,6 +2471,11 @@ describe('UV_PYTHON_DOWNLOADS environment variable protection', () => {
       expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
 
+    it('sets UV_PYTHON_DOWNLOADS to "never" inside the build container', () => {
+      const env = getProtectedUvEnv({ VERCEL_BUILD_IMAGE: '1' });
+      expect(env.UV_PYTHON_DOWNLOADS).toBe('never');
+    });
+
     it('overrides UV_PYTHON_DOWNLOADS when user tries to set it to "auto"', () => {
       const userEnv = { UV_PYTHON_DOWNLOADS: 'auto' };
       const env = getProtectedUvEnv(userEnv);

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -49,11 +49,12 @@ import {
   resetInstalledPythonsCache,
 } from '../src/version';
 import type { PythonConstraint, PythonPackage } from '@vercel/python-analysis';
+import { PythonConfigKind } from '@vercel/python-analysis';
 import { build } from '../src/index';
 import { createVenvEnv, getVenvBinDir } from '../src/utils';
 import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
 import { VERCEL_WORKERS_VERSION } from '../src/package-versions';
-import { createPyprojectToml } from '../src/install';
+import { createPyprojectToml, rewritePatchVersionPins } from '../src/install';
 import { detectDjangoPythonEntrypoint } from '../src/entrypoint';
 import { getDjangoSettings } from '../src/django';
 import { FileBlob } from '@vercel/build-utils';
@@ -2513,5 +2514,190 @@ describe('UV_PYTHON_DOWNLOADS environment variable protection', () => {
       expect(env.PATH).toContain('/usr/bin');
       expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
+  });
+});
+
+describe('rewritePatchVersionPins', () => {
+  let tmpDir: string;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    tmpDir = path.join(tmpdir(), `rewrite-patch-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    if (fs.existsSync(tmpDir)) fs.removeSync(tmpDir);
+  });
+
+  it('is a no-op outside the build container', async () => {
+    delete process.env.VERCEL_BUILD_IMAGE;
+    const pvPath = path.join(tmpDir, '.python-version');
+    fs.writeFileSync(pvPath, '3.12.8\n');
+
+    await rewritePatchVersionPins({
+      pythonPackage: {
+        configs: [
+          {
+            [PythonConfigKind.PythonVersion]: {
+              kind: PythonConfigKind.PythonVersion,
+              path: '.python-version',
+              data: [
+                {
+                  implementation: 'cpython',
+                  version: {
+                    constraint: [
+                      { operator: '==', version: '3.12.8', prefix: '' },
+                    ],
+                    variant: 'default',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      rootDir: tmpDir,
+    });
+
+    expect(fs.readFileSync(pvPath, 'utf8')).toBe('3.12.8\n');
+  });
+
+  it('rewrites .python-version with a patch-level version to major.minor', async () => {
+    process.env.VERCEL_BUILD_IMAGE = '1';
+    const pvPath = path.join(tmpDir, '.python-version');
+    fs.writeFileSync(pvPath, '3.12.8\n');
+
+    await rewritePatchVersionPins({
+      pythonPackage: {
+        configs: [
+          {
+            [PythonConfigKind.PythonVersion]: {
+              kind: PythonConfigKind.PythonVersion,
+              path: '.python-version',
+              data: [
+                {
+                  implementation: 'cpython',
+                  version: {
+                    constraint: [
+                      { operator: '==', version: '3.12.8', prefix: '' },
+                    ],
+                    variant: 'default',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      rootDir: tmpDir,
+    });
+
+    expect(fs.readFileSync(pvPath, 'utf8')).toBe('cpython@==3.12\n');
+  });
+
+  it('rewrites .python-version with compound patch constraints using correct operators', async () => {
+    process.env.VERCEL_BUILD_IMAGE = '1';
+    const pvPath = path.join(tmpDir, '.python-version');
+    fs.writeFileSync(pvPath, '>=3.12.4,<=3.12.9\n');
+
+    await rewritePatchVersionPins({
+      pythonPackage: {
+        configs: [
+          {
+            [PythonConfigKind.PythonVersion]: {
+              kind: PythonConfigKind.PythonVersion,
+              path: '.python-version',
+              data: [
+                {
+                  implementation: 'cpython',
+                  version: {
+                    constraint: [
+                      { operator: '>=', version: '3.12.4', prefix: '' },
+                      { operator: '<=', version: '3.12.9', prefix: '' },
+                    ],
+                    variant: 'default',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      rootDir: tmpDir,
+    });
+
+    // >=3.12.4 → >=3.12 (strip patch)
+    // <=3.12.9 → <3.13 (convert to exclusive upper bound)
+    expect(fs.readFileSync(pvPath, 'utf8')).toBe('cpython@>=3.12,<3.13\n');
+  });
+
+  it('rewrites .python-version with strict greater-than patch constraint', async () => {
+    process.env.VERCEL_BUILD_IMAGE = '1';
+    const pvPath = path.join(tmpDir, '.python-version');
+    fs.writeFileSync(pvPath, '>3.12.4\n');
+
+    await rewritePatchVersionPins({
+      pythonPackage: {
+        configs: [
+          {
+            [PythonConfigKind.PythonVersion]: {
+              kind: PythonConfigKind.PythonVersion,
+              path: '.python-version',
+              data: [
+                {
+                  implementation: 'cpython',
+                  version: {
+                    constraint: [
+                      { operator: '>', version: '3.12.4', prefix: '' },
+                    ],
+                    variant: 'default',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      rootDir: tmpDir,
+    });
+
+    // >3.12.4 → >=3.12 (include all patches of 3.12)
+    expect(fs.readFileSync(pvPath, 'utf8')).toBe('cpython@>=3.12\n');
+  });
+
+  it('does not rewrite .python-version that already has only major.minor', async () => {
+    process.env.VERCEL_BUILD_IMAGE = '1';
+    const pvPath = path.join(tmpDir, '.python-version');
+    fs.writeFileSync(pvPath, '3.12\n');
+
+    await rewritePatchVersionPins({
+      pythonPackage: {
+        configs: [
+          {
+            [PythonConfigKind.PythonVersion]: {
+              kind: PythonConfigKind.PythonVersion,
+              path: '.python-version',
+              data: [
+                {
+                  implementation: 'cpython',
+                  version: {
+                    constraint: [
+                      { operator: '==', version: '3.12', prefix: '' },
+                    ],
+                    variant: 'default',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      rootDir: tmpDir,
+    });
+
+    expect(fs.readFileSync(pvPath, 'utf8')).toBe('3.12\n');
   });
 });

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -49,7 +49,12 @@ import {
   resetInstalledPythonsCache,
 } from '../src/version';
 import type { PythonConstraint, PythonPackage } from '@vercel/python-analysis';
-import { PythonConfigKind } from '@vercel/python-analysis';
+import {
+  PythonConfigKind,
+  parsePythonVersionFile,
+  parseConfig,
+  PyProjectTomlSchema,
+} from '@vercel/python-analysis';
 import { build } from '../src/index';
 import { createVenvEnv, getVenvBinDir } from '../src/utils';
 import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
@@ -2532,33 +2537,28 @@ describe('rewritePatchVersionPins', () => {
     if (fs.existsSync(tmpDir)) fs.removeSync(tmpDir);
   });
 
+  function makePvConfig(content: string) {
+    return {
+      configs: [
+        {
+          [PythonConfigKind.PythonVersion]: {
+            kind: PythonConfigKind.PythonVersion,
+            path: '.python-version',
+            data: parsePythonVersionFile(content)!,
+          },
+        },
+      ],
+    };
+  }
+
   it('is a no-op outside the build container', async () => {
     delete process.env.VERCEL_BUILD_IMAGE;
+    const content = '3.12.8\n';
     const pvPath = path.join(tmpDir, '.python-version');
-    fs.writeFileSync(pvPath, '3.12.8\n');
+    fs.writeFileSync(pvPath, content);
 
     await rewritePatchVersionPins({
-      pythonPackage: {
-        configs: [
-          {
-            [PythonConfigKind.PythonVersion]: {
-              kind: PythonConfigKind.PythonVersion,
-              path: '.python-version',
-              data: [
-                {
-                  implementation: 'cpython',
-                  version: {
-                    constraint: [
-                      { operator: '==', version: '3.12.8', prefix: '' },
-                    ],
-                    variant: 'default',
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
+      pythonPackage: makePvConfig(content),
       rootDir: tmpDir,
     });
 
@@ -2567,31 +2567,12 @@ describe('rewritePatchVersionPins', () => {
 
   it('rewrites .python-version with a patch-level version to major.minor', async () => {
     process.env.VERCEL_BUILD_IMAGE = '1';
+    const content = '3.12.8\n';
     const pvPath = path.join(tmpDir, '.python-version');
-    fs.writeFileSync(pvPath, '3.12.8\n');
+    fs.writeFileSync(pvPath, content);
 
     await rewritePatchVersionPins({
-      pythonPackage: {
-        configs: [
-          {
-            [PythonConfigKind.PythonVersion]: {
-              kind: PythonConfigKind.PythonVersion,
-              path: '.python-version',
-              data: [
-                {
-                  implementation: 'cpython',
-                  version: {
-                    constraint: [
-                      { operator: '==', version: '3.12.8', prefix: '' },
-                    ],
-                    variant: 'default',
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
+      pythonPackage: makePvConfig(content),
       rootDir: tmpDir,
     });
 
@@ -2600,32 +2581,12 @@ describe('rewritePatchVersionPins', () => {
 
   it('rewrites .python-version with compound patch constraints using correct operators', async () => {
     process.env.VERCEL_BUILD_IMAGE = '1';
+    const content = '>=3.12.4,<=3.12.9\n';
     const pvPath = path.join(tmpDir, '.python-version');
-    fs.writeFileSync(pvPath, '>=3.12.4,<=3.12.9\n');
+    fs.writeFileSync(pvPath, content);
 
     await rewritePatchVersionPins({
-      pythonPackage: {
-        configs: [
-          {
-            [PythonConfigKind.PythonVersion]: {
-              kind: PythonConfigKind.PythonVersion,
-              path: '.python-version',
-              data: [
-                {
-                  implementation: 'cpython',
-                  version: {
-                    constraint: [
-                      { operator: '>=', version: '3.12.4', prefix: '' },
-                      { operator: '<=', version: '3.12.9', prefix: '' },
-                    ],
-                    variant: 'default',
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
+      pythonPackage: makePvConfig(content),
       rootDir: tmpDir,
     });
 
@@ -2636,31 +2597,12 @@ describe('rewritePatchVersionPins', () => {
 
   it('rewrites .python-version with strict greater-than patch constraint', async () => {
     process.env.VERCEL_BUILD_IMAGE = '1';
+    const content = '>3.12.4\n';
     const pvPath = path.join(tmpDir, '.python-version');
-    fs.writeFileSync(pvPath, '>3.12.4\n');
+    fs.writeFileSync(pvPath, content);
 
     await rewritePatchVersionPins({
-      pythonPackage: {
-        configs: [
-          {
-            [PythonConfigKind.PythonVersion]: {
-              kind: PythonConfigKind.PythonVersion,
-              path: '.python-version',
-              data: [
-                {
-                  implementation: 'cpython',
-                  version: {
-                    constraint: [
-                      { operator: '>', version: '3.12.4', prefix: '' },
-                    ],
-                    variant: 'default',
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
+      pythonPackage: makePvConfig(content),
       rootDir: tmpDir,
     });
 
@@ -2670,59 +2612,40 @@ describe('rewritePatchVersionPins', () => {
 
   it('does not rewrite .python-version that already has only major.minor', async () => {
     process.env.VERCEL_BUILD_IMAGE = '1';
+    const content = '3.12\n';
     const pvPath = path.join(tmpDir, '.python-version');
-    fs.writeFileSync(pvPath, '3.12\n');
+    fs.writeFileSync(pvPath, content);
 
     await rewritePatchVersionPins({
-      pythonPackage: {
-        configs: [
-          {
-            [PythonConfigKind.PythonVersion]: {
-              kind: PythonConfigKind.PythonVersion,
-              path: '.python-version',
-              data: [
-                {
-                  implementation: 'cpython',
-                  version: {
-                    constraint: [
-                      { operator: '==', version: '3.12', prefix: '' },
-                    ],
-                    variant: 'default',
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
+      pythonPackage: makePvConfig(content),
       rootDir: tmpDir,
     });
 
     expect(fs.readFileSync(pvPath, 'utf8')).toBe('3.12\n');
   });
 
+  function makePyprojectConfig(
+    content: string,
+    origin?: { kind: any; path: any }
+  ) {
+    return {
+      manifest: {
+        path: 'pyproject.toml',
+        data: parseConfig(content, 'pyproject.toml', PyProjectTomlSchema),
+        ...(origin ? { origin } : {}),
+      },
+    };
+  }
+
   it('rewrites requires-python in native pyproject.toml with a patch-level pin', async () => {
     process.env.VERCEL_BUILD_IMAGE = '1';
+    const content =
+      '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = "==3.12.8"\n';
     const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
-    fs.writeFileSync(
-      pyprojectPath,
-      '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = "==3.12.8"\n'
-    );
+    fs.writeFileSync(pyprojectPath, content);
 
     await rewritePatchVersionPins({
-      pythonPackage: {
-        manifest: {
-          path: 'pyproject.toml',
-          data: {
-            project: {
-              name: 'myapp',
-              version: '0.1.0',
-              'requires-python': '==3.12.8',
-              dependencies: [],
-            },
-          },
-        },
-      },
+      pythonPackage: makePyprojectConfig(content),
       rootDir: tmpDir,
     });
 
@@ -2733,90 +2656,52 @@ describe('rewritePatchVersionPins', () => {
 
   it('rewrites requires-python with >=X.Y.Z style patch constraint', async () => {
     process.env.VERCEL_BUILD_IMAGE = '1';
+    const content =
+      '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = ">=3.12.8,<3.13"\n';
     const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
-    fs.writeFileSync(
-      pyprojectPath,
-      '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = ">=3.12.8,<3.13"\n'
-    );
+    fs.writeFileSync(pyprojectPath, content);
 
     await rewritePatchVersionPins({
-      pythonPackage: {
-        manifest: {
-          path: 'pyproject.toml',
-          data: {
-            project: {
-              name: 'myapp',
-              version: '0.1.0',
-              'requires-python': '>=3.12.8,<3.13',
-              dependencies: [],
-            },
-          },
-        },
-      },
+      pythonPackage: makePyprojectConfig(content),
       rootDir: tmpDir,
     });
 
-    const updated = fs.readFileSync(pyprojectPath, 'utf8');
-    expect(updated).toContain('requires-python = ">=3.12,<3.13"');
+    expect(fs.readFileSync(pyprojectPath, 'utf8')).toContain(
+      'requires-python = ">=3.12,<3.13"'
+    );
   });
 
   it('does not rewrite requires-python that has no patch-level version', async () => {
     process.env.VERCEL_BUILD_IMAGE = '1';
-    const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
-    const original =
+    const content =
       '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = ">=3.12"\n';
-    fs.writeFileSync(pyprojectPath, original);
+    const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
+    fs.writeFileSync(pyprojectPath, content);
 
     await rewritePatchVersionPins({
-      pythonPackage: {
-        manifest: {
-          path: 'pyproject.toml',
-          data: {
-            project: {
-              name: 'myapp',
-              version: '0.1.0',
-              'requires-python': '>=3.12',
-              dependencies: [],
-            },
-          },
-        },
-      },
+      pythonPackage: makePyprojectConfig(content),
       rootDir: tmpDir,
     });
 
-    expect(fs.readFileSync(pyprojectPath, 'utf8')).toBe(original);
+    expect(fs.readFileSync(pyprojectPath, 'utf8')).toBe(content);
   });
 
   it('skips requires-python rewrite for converted manifests (origin set)', async () => {
     process.env.VERCEL_BUILD_IMAGE = '1';
-    const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
-    const original =
+    const content =
       '[project]\nname = "myapp"\nversion = "0.1.0"\nrequires-python = "==3.12.8"\n';
-    fs.writeFileSync(pyprojectPath, original);
+    const pyprojectPath = path.join(tmpDir, 'pyproject.toml');
+    fs.writeFileSync(pyprojectPath, content);
 
     await rewritePatchVersionPins({
-      pythonPackage: {
-        manifest: {
-          path: 'pyproject.toml',
-          data: {
-            project: {
-              name: 'myapp',
-              version: '0.1.0',
-              'requires-python': '==3.12.8',
-              dependencies: [],
-            },
-          },
-          // origin marks this as a converted (e.g. requirements.txt) manifest
-          origin: {
-            kind: 'requirements.txt' as any,
-            path: 'requirements.txt' as any,
-          },
-        },
-      },
+      pythonPackage: makePyprojectConfig(content, {
+        kind: 'requirements.txt',
+        path: 'requirements.txt',
+      }),
       rootDir: tmpDir,
     });
 
     // Converted manifests are handled elsewhere; file should be untouched
-    expect(fs.readFileSync(pyprojectPath, 'utf8')).toBe(original);
+    expect(fs.readFileSync(pyprojectPath, 'utf8')).toBe(content);
   });
 });


### PR DESCRIPTION
The build container ships the latest patch of each supported python minor version.

If a project has an exact pinned version, `UV_PYTHON_DOWNLOADS_MODE ` cannot be set to `'never'` because uv cannot download the pinned patch and the installed patch does not match exactly, breaking the project.

The fix is to rewrite patch level pins to accept all patch versions and set the python download mode to never in build containers.

| Input        | Output       |
|--------------|--------------|
| `==X.Y.Z`    | `==X.Y.*`    |
| `~=X.Y.Z`    | `==X.Y.*`    |
| `>=X.Y.Z`    | `>=X.Y`      |
| `>X.Y.Z`     | `>=X.Y`      |
| `<X.Y.Z` (Z>0) | `<X.(Y+1)` |
| `<X.Y.0`     | `<X.Y`       |
| `<=X.Y.Z`    | `<X.(Y+1)`   |