### PR TITLE
[python-runtime] Use hardlinks instead of copy.

### DIFF
--- a/.changeset/large-tips-try.md
+++ b/.changeset/large-tips-try.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-runtime': patch
+---
+
+Use hardlink link mode instead of copy.

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -393,6 +393,9 @@ if os.path.exists(_runtime_config_path):
             # Use uv sync --inexact --frozen to install only the
             # missing public packages. --inexact avoids removing
             # packages already present in _vendor (bundled deps).
+            # --link-mode hardlink lets the temporary download cache
+            # and the target venv share inode blocks on /tmp, reducing
+            # peak disk usage on Lambda's limited ephemeral storage.
             _sync_cmd = [
                 _uv_path,
                 "sync",
@@ -406,7 +409,7 @@ if os.path.exists(_runtime_config_path):
                 "--no-cache",
                 "--no-progress",
                 "--link-mode",
-                "copy",
+                "hardlink",
             ]
             for _pkg in _config.get("bundledPackages", []):
                 _sync_cmd.extend(["--no-install-package", _pkg])


### PR DESCRIPTION
Go back to using `--link-mode hardlink` (which is the default) to reduce the overall space required in `/tmp` when doing runtime dependency installs.