### PR TITLE
Fix a flaky python-runtime test

### DIFF
--- a/.changeset/slow-lions-poke.md
+++ b/.changeset/slow-lions-poke.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-runtime': patch
+---
+
+Fix a flakey unit test

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -285,7 +285,7 @@ class TestHTTPHandler(_RuntimeTestCase):
             port = ss.payload.http_port
             self.assertIsInstance(port, int)
             self.assertGreater(port, 0)
-            self.assertGreater(ss.payload.init_duration, 0)
+            self.assertIsNotNone(ss.payload.init_duration)
 
             resp = await _http_get(port, "/hello")
             self.assertEqual(resp.status, 200)
@@ -422,7 +422,7 @@ class TestASGIApp(_RuntimeTestCase):
                 ServerStartedMessage, timeout=10.0
             )
             port = ss.payload.http_port
-            self.assertGreater(ss.payload.init_duration, 0)
+            self.assertIsNotNone(ss.payload.init_duration)
 
             resp = await _http_get(port, "/hello")
             self.assertEqual(resp.status, 200)


### PR DESCRIPTION
We were asserting init_duration was greater than 0 but its an integer
number of milliseconds.  Sometimes computers can do things in less
than a millisecond!  (Maybe not in the cloud, but on my laptop.)
