### PR TITLE
Change promote -> Rollback, fix CertMissing error

### DIFF
--- a/.changeset/thin-peas-suffer.md
+++ b/.changeset/thin-peas-suffer.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix telemetry, add better error handling

--- a/packages/cli/src/commands/rollback/index.ts
+++ b/packages/cli/src/commands/rollback/index.ts
@@ -56,7 +56,7 @@ export default async (client: Client): Promise<number> => {
   try {
     if (actionOrDeployId === 'status') {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('promote', 'status');
+        telemetry.trackCliFlagHelp('rollback', 'status');
         output.print(
           help(statusSubcommand, {
             columns: client.stderr.columns,
@@ -69,7 +69,7 @@ export default async (client: Client): Promise<number> => {
       const project = await getProjectByCwdOrLink({
         autoConfirm: parsedArgs.flags['--yes'],
         client,
-        commandName: 'promote',
+        commandName: 'rollback',
         projectNameOrId: parsedArgs.args[2],
       });
 

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -701,12 +701,12 @@ export class AliasInUse extends NowError<'ALIAS_IN_USE', { alias: string }> {
  * a certificate for a domain but the domain is missing. An example would
  * be alias.
  */
-export class CertMissing extends NowError<'ALIAS_IN_USE', { domain: string }> {
+export class CertMissing extends NowError<'CERT_MISSING', { domain: string }> {
   constructor(domain: string) {
     super({
-      code: 'ALIAS_IN_USE',
+      code: 'CERT_MISSING',
       meta: { domain },
-      message: `The alias is already in use`,
+      message: `The certificate for domain ${domain} is missing`,
     });
   }
 }

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -701,12 +701,12 @@ export class AliasInUse extends NowError<'ALIAS_IN_USE', { alias: string }> {
  * a certificate for a domain but the domain is missing. An example would
  * be alias.
  */
-export class CertMissing extends NowError<'CERT_MISSING', { domain: string }> {
+export class CertMissing extends NowError<'ALIAS_IN_USE', { domain: string }> {
   constructor(domain: string) {
     super({
-      code: 'CERT_MISSING',
+      code: 'ALIAS_IN_USE',
       meta: { domain },
-      message: `The certificate for domain ${domain} is missing`,
+      message: `The alias is already in use`,
     });
   }
 }


### PR DESCRIPTION
**[Linear](https://linear.app/vercel/issue/CICD-2318/small-bugfixes-for-cli)**

# Description
quick bugfix: we track rollback telemetry as `promote` currently, we want to switch it to `rollback`


