### PR TITLE
Unify all help returns to be 2 instead of 0 for some of them

### DIFF
--- a/.changeset/calm-schools-warn.md
+++ b/.changeset/calm-schools-warn.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Updating all help returns to be status 2 instead of 0

--- a/packages/cli/src/commands/activity/index.ts
+++ b/packages/cli/src/commands/activity/index.ts
@@ -41,7 +41,7 @@ export default async function activity(client: Client): Promise<number> {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('activity', subcommand);
     output.print(help(activityCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   function printSubcommandHelp(command: Command) {
@@ -55,7 +55,7 @@ export default async function activity(client: Client): Promise<number> {
       if (needHelp) {
         telemetry.trackCliFlagHelp('activity', subcommandOriginal);
         printSubcommandHelp(typesSubcommand);
-        return 0;
+        return 2;
       }
 
       telemetry.trackCliSubcommandTypes(subcommandOriginal);
@@ -66,7 +66,7 @@ export default async function activity(client: Client): Promise<number> {
       if (needHelp) {
         telemetry.trackCliFlagHelp('activity', subcommandOriginal);
         output.print(help(activityCommand, { columns: client.stderr.columns }));
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandLs(subcommandOriginal);
       const listFn = (await import('./list')).default;

--- a/packages/cli/src/commands/alerts/index.ts
+++ b/packages/cli/src/commands/alerts/index.ts
@@ -40,7 +40,7 @@ export default async function alerts(client: Client): Promise<number> {
   if (needHelp) {
     telemetry.trackCliFlagHelp('alerts', subcommandOriginal);
     output.print(help(alertsCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   telemetry.trackCliSubcommandLs(subcommandOriginal);

--- a/packages/cli/src/commands/cache/index.ts
+++ b/packages/cli/src/commands/cache/index.ts
@@ -53,7 +53,7 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp(cacheCommand.name);
     output.print(help(cacheCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   function printHelp(command: Command) {

--- a/packages/cli/src/commands/contract/index.ts
+++ b/packages/cli/src/commands/contract/index.ts
@@ -41,7 +41,7 @@ export default async function contract(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('contract');
     print(help(contractCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   const formatResult = validateJsonOutput(parsedArgs.flags);

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -51,7 +51,7 @@ export default async function install(client: Client) {
       output.print(help(cmd, { columns: client.stderr.columns }));
     }
 
-    return 0;
+    return 2;
   }
 
   if (!ffAutoProvision && flags['--installation-id']) {

--- a/packages/cli/src/commands/integration-resource/index.ts
+++ b/packages/cli/src/commands/integration-resource/index.ts
@@ -46,7 +46,7 @@ export default async function main(client: Client) {
     output.print(
       help(integrationResourceCommand, { columns: client.stderr.columns })
     );
-    return 0;
+    return 2;
   }
 
   function printHelp(command: Command) {
@@ -63,7 +63,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration-resource', subcommandOriginal);
         printHelp(createThresholdSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandCreateThreshold(subcommandOriginal);
       return createThreshold(client);
@@ -72,7 +72,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration-resource', subcommandOriginal);
         printHelp(removeSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return remove(client);
@@ -81,7 +81,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration-resource', subcommandOriginal);
         printHelp(disconnectSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandDisconnect(subcommandOriginal);
       return disconnect(client);

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -72,7 +72,7 @@ export default async function main(client: Client) {
         columns: client.stderr.columns,
       })
     );
-    return 0;
+    return 2;
   }
 
   switch (subcommand) {
@@ -102,7 +102,7 @@ export default async function main(client: Client) {
           printHelp(addCmd);
         }
 
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
 
@@ -132,7 +132,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(listSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return list(client);
@@ -141,7 +141,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(discoverSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandDiscover(subcommandOriginal);
       return discover(client, subArgs);
@@ -150,7 +150,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(guideSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandGuide(subcommandOriginal);
       return guide(client, subArgs);
@@ -159,7 +159,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(balanceSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandBalance(subcommandOriginal);
       return balance(client);
@@ -168,7 +168,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(openSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandOpen(subcommandOriginal);
       return openIntegration(client, subArgs);
@@ -177,7 +177,7 @@ export default async function main(client: Client) {
       if (needHelp) {
         telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(removeSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return remove(client);

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -69,7 +69,7 @@ export default async function list(client: Client) {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('list');
     print(help(listCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   const validationResult = validateLsArgs({

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -42,7 +42,7 @@ export default async function login(
   if (parsedArgs?.flags['--help']) {
     telemetry.trackCliFlagHelp('login');
     output.print(help(loginCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   if (parsedArgs?.flags['--token']) {

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -39,7 +39,7 @@ export default async function logout(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('logout');
     output.print(help(logoutCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   // Unless the authConfig has a refreshToken, fall back to legacy logout

--- a/packages/cli/src/commands/metrics/index.ts
+++ b/packages/cli/src/commands/metrics/index.ts
@@ -43,7 +43,7 @@ export default async function metrics(client: Client): Promise<number> {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('metrics', subcommand);
     output.print(help(metricsCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   function printSubHelp(command: Command) {
@@ -60,7 +60,7 @@ export default async function metrics(client: Client): Promise<number> {
       if (needHelp) {
         telemetry.trackCliFlagHelp('metrics', subcommandOriginal);
         printSubHelp(schemaSubcommand);
-        return 0;
+        return 2;
       }
       telemetry.trackCliSubcommandSchema(subcommandOriginal);
       const schemaFn = (await import('./schema')).default;
@@ -70,7 +70,7 @@ export default async function metrics(client: Client): Promise<number> {
       if (needHelp) {
         telemetry.trackCliFlagHelp('metrics', subcommandOriginal);
         output.print(help(metricsCommand, { columns: client.stderr.columns }));
-        return 0;
+        return 2;
       }
       // Show help if --event is not provided (required for query)
       if (!parsedArgs.flags['--event']) {

--- a/packages/cli/src/commands/open/index.ts
+++ b/packages/cli/src/commands/open/index.ts
@@ -33,7 +33,7 @@ export default async function openCommandHandler(
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('open');
     output.print(help(openCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   const autoConfirm = !!parsedArgs.flags['--yes'];

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -58,14 +58,14 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('project');
     output.print(help(projectCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   function printHelp(command: Command) {
     output.print(
       help(command, { parent: projectCommand, columns: client.stderr.columns })
     );
-    return 0;
+    return 2;
   }
 
   if (!parsedArgs.args[1]) {

--- a/packages/cli/src/commands/upgrade/index.ts
+++ b/packages/cli/src/commands/upgrade/index.ts
@@ -33,7 +33,7 @@ export default async function upgrade(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('upgrade');
     output.print(help(upgradeCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   const dryRun = parsedArgs.flags['--dry-run'];

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -55,7 +55,7 @@ export default async function usage(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('usage');
     print(help(usageCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   const formatResult = validateJsonOutput(parsedArgs.flags);

--- a/packages/cli/src/commands/whoami/index.ts
+++ b/packages/cli/src/commands/whoami/index.ts
@@ -32,7 +32,7 @@ export default async function whoami(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('whoami');
     output.print(help(whoamiCommand, { columns: client.stderr.columns }));
-    return 0;
+    return 2;
   }
 
   const formatResult = validateJsonOutput(parsedArgs.flags);

--- a/packages/cli/test/unit/commands/alerts/index.test.ts
+++ b/packages/cli/test/unit/commands/alerts/index.test.ts
@@ -49,7 +49,7 @@ describe('alerts', () => {
 
     const exitCode = await alerts(client);
 
-    expect(exitCode).toBe(0);
+    expect(exitCode).toBe(2);
     expect(client.stderr.getFullOutput()).toContain(
       'List alerts for a project or team'
     );

--- a/packages/cli/test/unit/commands/cache/index.test.ts
+++ b/packages/cli/test/unit/commands/cache/index.test.ts
@@ -8,7 +8,7 @@ describe('cache', () => {
   it('should track telemetry with --help', async () => {
     client.setArgv(command, '--help');
     const exitCodePromise = cache(client);
-    await expect(exitCodePromise).resolves.toEqual(0);
+    await expect(exitCodePromise).resolves.toEqual(2);
 
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       {

--- a/packages/cli/test/unit/commands/contract/index.test.ts
+++ b/packages/cli/test/unit/commands/contract/index.test.ts
@@ -45,7 +45,7 @@ describe('contract', () => {
       client.setArgv('contract', '--help');
       const exitCode = await contract(client);
 
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(2);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',

--- a/packages/cli/test/unit/commands/install/index.test.ts
+++ b/packages/cli/test/unit/commands/install/index.test.ts
@@ -47,7 +47,7 @@ describe('install', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = install(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
@@ -66,7 +66,7 @@ describe('install', () => {
 
       client.setArgv('install', 'acme', '--help');
       const exitCode = await install(client);
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(2);
 
       const output = client.getFullOutput();
       // Dynamic examples should use "install" not "integration add"
@@ -80,7 +80,7 @@ describe('install', () => {
     it('falls back to static help without a slug', async () => {
       client.setArgv('install', '--help');
       const exitCode = await install(client);
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(2);
 
       const output = client.getFullOutput();
       expect(output).toContain('vercel install');

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -1909,7 +1909,7 @@ describe('integration add (auto-provision)', () => {
       process.env.FF_AUTO_PROVISION_INSTALL = '0';
       client.setArgv('integration', 'add', '--help');
       const exitCode = await integrationCommand(client);
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(2);
       const stderr = client.stderr.getFullOutput();
       expect(stderr).not.toContain('--installation-id');
     });
@@ -1918,7 +1918,7 @@ describe('integration add (auto-provision)', () => {
       delete process.env.FF_AUTO_PROVISION_INSTALL;
       client.setArgv('integration', 'add', '--help');
       const exitCode = await integrationCommand(client);
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(2);
       const stderr = client.stderr.getFullOutput();
       expect(stderr).toContain('--installation-id');
     });
@@ -1945,7 +1945,7 @@ describe('integration add (auto-provision)', () => {
       process.env.FF_AUTO_PROVISION_INSTALL = '0';
       client.setArgv('install', '--help');
       const exitCode = await install(client);
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(2);
       const stderr = client.stderr.getFullOutput();
       expect(stderr).not.toContain('--installation-id');
     });
@@ -1954,7 +1954,7 @@ describe('integration add (auto-provision)', () => {
       delete process.env.FF_AUTO_PROVISION_INSTALL;
       client.setArgv('install', '--help');
       const exitCode = await install(client);
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(2);
       const stderr = client.stderr.getFullOutput();
       expect(stderr).toContain('--installation-id');
     });

--- a/packages/cli/test/unit/commands/integration/add.test.ts
+++ b/packages/cli/test/unit/commands/integration/add.test.ts
@@ -52,7 +52,7 @@ describe('integration', () => {
 
         client.setArgv(command, subcommand, '--help');
         const exitCodePromise = integrationCommand(client);
-        await expect(exitCodePromise).resolves.toEqual(0);
+        await expect(exitCodePromise).resolves.toEqual(2);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
           {

--- a/packages/cli/test/unit/commands/integration/add.test.ts
+++ b/packages/cli/test/unit/commands/integration/add.test.ts
@@ -70,7 +70,7 @@ describe('integration', () => {
         it('should show available products for multi-product integration', async () => {
           client.setArgv('integration', 'add', 'acme-two-products', '--help');
           const exitCode = await integrationCommand(client);
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(2);
           const output = client.getFullOutput();
           expect(output).toContain('Available products for');
           expect(output).toContain('acme-a');
@@ -83,7 +83,7 @@ describe('integration', () => {
         it('should not show product listing for single-product integration', async () => {
           client.setArgv('integration', 'add', 'acme', '--help');
           const exitCode = await integrationCommand(client);
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(2);
           // Single product — should NOT show product listing
           const output = client.getFullOutput();
           expect(output).not.toContain('Available products for');
@@ -97,7 +97,7 @@ describe('integration', () => {
             '--help'
           );
           const exitCode = await integrationCommand(client);
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(2);
           const output = client.getFullOutput();
           // Should strip product slug and still fetch the integration for dynamic help
           expect(output).toContain('Available products for');
@@ -108,7 +108,7 @@ describe('integration', () => {
         it('should show usage examples for metadata fields in dynamic help', async () => {
           client.setArgv('integration', 'add', 'acme-full-schema', '--help');
           const exitCode = await integrationCommand(client);
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(2);
           const output = client.getFullOutput();
           // String field with options should show first option
           expect(output).toContain('Example:');
@@ -122,7 +122,7 @@ describe('integration', () => {
         it('should fall back to standard help when integration not found', async () => {
           client.setArgv('integration', 'add', 'does-not-exist', '--help');
           const exitCode = await integrationCommand(client);
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(2);
           // Should still show standard help without errors
           const output = client.getFullOutput();
           expect(output).not.toContain('Available products for');

--- a/packages/cli/test/unit/commands/integration/balance.test.ts
+++ b/packages/cli/test/unit/commands/integration/balance.test.ts
@@ -20,7 +20,7 @@ describe('integration', () => {
 
         client.setArgv(command, subcommand, '--help');
         const exitCodePromise = integrationCommand(client);
-        await expect(exitCodePromise).resolves.toEqual(0);
+        await expect(exitCodePromise).resolves.toEqual(2);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
           {

--- a/packages/cli/test/unit/commands/integration/discover.test.ts
+++ b/packages/cli/test/unit/commands/integration/discover.test.ts
@@ -12,7 +12,7 @@ describe('integration', () => {
 
         client.setArgv(command, subcommand, '--help');
         const exitCode = await integrationCommand(client);
-        expect(exitCode).toEqual(0);
+        expect(exitCode).toEqual(2);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
           {

--- a/packages/cli/test/unit/commands/integration/guide.test.ts
+++ b/packages/cli/test/unit/commands/integration/guide.test.ts
@@ -157,7 +157,7 @@ describe('integration', () => {
       it('tracks telemetry', async () => {
         client.setArgv('integration', 'guide', '--help');
         const exitCode = await integrationCommand(client);
-        expect(exitCode).toEqual(0);
+        expect(exitCode).toEqual(2);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
           {

--- a/packages/cli/test/unit/commands/integration/index.test.ts
+++ b/packages/cli/test/unit/commands/integration/index.test.ts
@@ -9,7 +9,7 @@ describe('integration', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = integration(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/integration/list.test.ts
+++ b/packages/cli/test/unit/commands/integration/list.test.ts
@@ -22,7 +22,7 @@ describe('integration', () => {
 
         client.setArgv(command, subcommand, '--help');
         const exitCodePromise = integrationCommand(client);
-        await expect(exitCodePromise).resolves.toEqual(0);
+        await expect(exitCodePromise).resolves.toEqual(2);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
           {

--- a/packages/cli/test/unit/commands/integration/open-integration.test.ts
+++ b/packages/cli/test/unit/commands/integration/open-integration.test.ts
@@ -28,7 +28,7 @@ describe('integration', () => {
 
         client.setArgv(command, subcommand, '--help');
         const exitCodePromise = integrationCommand(client);
-        await expect(exitCodePromise).resolves.toEqual(0);
+        await expect(exitCodePromise).resolves.toEqual(2);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
           {

--- a/packages/cli/test/unit/commands/list/index.test.ts
+++ b/packages/cli/test/unit/commands/list/index.test.ts
@@ -56,7 +56,7 @@ describe('list', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = list(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/login/index.test.ts
+++ b/packages/cli/test/unit/commands/login/index.test.ts
@@ -12,7 +12,7 @@ describe('login', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = login(client, { shouldParseArgs: true });
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/metrics/index.test.ts
+++ b/packages/cli/test/unit/commands/metrics/index.test.ts
@@ -14,7 +14,7 @@ describe('metrics', () => {
 
       const exitCode = await metrics(client);
 
-      expect(exitCode).toBe(0);
+      expect(exitCode).toBe(2);
       const output = client.stderr.getFullOutput();
       // Shows schema subcommand
       expect(output).toContain('schema');

--- a/packages/cli/test/unit/commands/open/index.test.ts
+++ b/packages/cli/test/unit/commands/open/index.test.ts
@@ -28,7 +28,7 @@ describe('open', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = openCommand(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
@@ -41,7 +41,7 @@ describe('open', () => {
     it('prints help message', async () => {
       client.setArgv('open', '--help');
       const exitCode = await openCommand(client);
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(2);
       expect(client.getFullOutput()).toContain(
         'Opens the current project in the Vercel Dashboard'
       );

--- a/packages/cli/test/unit/commands/project/add.test.ts
+++ b/packages/cli/test/unit/commands/project/add.test.ts
@@ -12,7 +12,7 @@ describe('add', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = projects(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/project/index.test.ts
+++ b/packages/cli/test/unit/commands/project/index.test.ts
@@ -17,7 +17,7 @@ describe('project', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = project(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/project/inspect.test.ts
+++ b/packages/cli/test/unit/commands/project/inspect.test.ts
@@ -27,7 +27,7 @@ describe('inspect', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = projects(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/project/list.test.ts
+++ b/packages/cli/test/unit/commands/project/list.test.ts
@@ -28,7 +28,7 @@ describe('list', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = projects(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/project/rm.test.ts
+++ b/packages/cli/test/unit/commands/project/rm.test.ts
@@ -12,7 +12,7 @@ describe('rm', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = projects(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/upgrade/index.test.ts
+++ b/packages/cli/test/unit/commands/upgrade/index.test.ts
@@ -9,7 +9,7 @@ describe('upgrade', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = upgrade(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -46,7 +46,7 @@ describe('usage', () => {
       client.setArgv('usage', '--help');
       const exitCode = await usage(client);
 
-      expect(exitCode).toEqual(0);
+      expect(exitCode).toEqual(2);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',

--- a/packages/cli/test/unit/commands/whoami/index.test.ts
+++ b/packages/cli/test/unit/commands/whoami/index.test.ts
@@ -10,7 +10,7 @@ describe('whoami', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = whoami(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(exitCodePromise).resolves.toEqual(2);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {


### PR DESCRIPTION
# Description

The AGENTS.md says exit code `2` means "help displayed" [Link](https://github.com/vercel/vercel/blob/main/packages/cli/AGENTS.md#routing-and-flag-parsing-indexts) . But a fair few of them return 0. This PR unifies them to match AGENTS.md and convention

# Acceptance Criteria
- All commands return '2'  for help

