### PR TITLE
[go] improve error message on failed go build

### DIFF
--- a/.changeset/ten-lamps-help.md
+++ b/.changeset/ten-lamps-help.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': patch
+---
+
+Improve Go build failures by including the compiler output in surfaced errors.

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -90,6 +90,38 @@ interface Analyzed {
   watch?: boolean;
 }
 
+type GoCommandError = Error & {
+  all?: string;
+  stderr?: string;
+  stdout?: string;
+};
+
+function getGoCommandOutput(error: GoCommandError) {
+  const stderr = error.stderr?.trim();
+  const stdout = error.stdout?.trim();
+  const all = error.all?.trim();
+
+  if (stderr && stdout && stdout !== stderr) {
+    return `stderr:\n${stderr}\n\nstdout:\n${stdout}`;
+  }
+
+  return stderr || stdout || all;
+}
+
+function enrichGoCommandError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return error;
+  }
+
+  const output = getGoCommandOutput(error as GoCommandError);
+  if (!output || error.message.includes(output)) {
+    return error;
+  }
+
+  error.message = `${error.message}\n\n${output}`;
+  return error;
+}
+
 /**
  * Parses the AST of the specified entrypoint Go file.
  * @param workPath The work path (e.g. `/path/to/project`)
@@ -180,7 +212,7 @@ export class GoWrapper {
     this.opts = opts;
   }
 
-  private execute(...args: string[]) {
+  private async execute(...args: string[]) {
     const { opts, env } = this;
     debug(
       `Exec: go ${args.map(a => (a.includes(' ') ? `"${a}"` : a)).join(' ')}`
@@ -188,7 +220,25 @@ export class GoWrapper {
     debug(`  CWD=${opts.cwd}`);
     debug(`  GOROOT=${(env || opts.env).GOROOT}`);
     debug(`  GO_BUILD_FLAGS=${(env || opts.env).GO_BUILD_FLAGS}`);
-    return execa('go', args, { stdio: 'inherit', ...opts, env });
+
+    const captureAndForwardOutput =
+      opts.stdio === undefined || opts.stdio === 'inherit';
+    const subprocess = execa('go', args, {
+      ...opts,
+      env,
+      stdio: captureAndForwardOutput ? 'pipe' : opts.stdio,
+    });
+
+    if (captureAndForwardOutput) {
+      subprocess.stdout?.pipe(process.stdout);
+      subprocess.stderr?.pipe(process.stderr);
+    }
+
+    try {
+      return await subprocess;
+    } catch (error) {
+      throw enrichGoCommandError(error);
+    }
   }
 
   mod() {

--- a/packages/go/test/go-helpers.test.ts
+++ b/packages/go/test/go-helpers.test.ts
@@ -1,0 +1,62 @@
+jest.mock('execa', () => {
+  const execa = Object.assign(jest.fn(), {
+    stdout: jest.fn(),
+  });
+  return { __esModule: true, default: execa };
+});
+
+import execa from 'execa';
+import { GoWrapper } from '../src/go-helpers';
+
+const mockedExeca = execa as unknown as jest.MockedFunction<typeof execa> & {
+  stdout: jest.Mock;
+};
+
+function createRejectedSubprocess(error: Error) {
+  return Object.assign(Promise.reject(error), {
+    stdout: undefined,
+    stderr: undefined,
+  });
+}
+
+describe('GoWrapper', () => {
+  beforeEach(() => {
+    mockedExeca.mockReset();
+    mockedExeca.stdout.mockReset();
+  });
+
+  it('includes compiler output when go build fails', async () => {
+    const compilerOutput =
+      '# example.com/project\n./main.go:14:9: undefined: handler';
+    const execaError = Object.assign(
+      new Error(
+        'Command failed: go build -ldflags -s -w -o /tmp/3db69a0d/user-server .'
+      ),
+      {
+        stderr: compilerOutput,
+        stdout: '',
+      }
+    );
+    mockedExeca.mockReturnValue(createRejectedSubprocess(execaError) as any);
+
+    const go = new GoWrapper(process.env as any);
+
+    let error: Error | undefined;
+    try {
+      await go.build('.', '/tmp/3db69a0d/user-server');
+    } catch (err: unknown) {
+      error = err as Error;
+    }
+
+    expect(error).toBeDefined();
+    expect(error?.message).toContain(
+      'Command failed: go build -ldflags -s -w -o /tmp/3db69a0d/user-server .'
+    );
+    expect(error?.message).toContain(compilerOutput);
+    expect(mockedExeca).toHaveBeenCalledWith(
+      'go',
+      ['build', '-ldflags', '-s -w', '-o', '/tmp/3db69a0d/user-server', '.'],
+      expect.objectContaining({ stdio: 'pipe' })
+    );
+  });
+});


### PR DESCRIPTION
Currently, the error message on failed go build looks like:
```
Command failed: go build -ldflags -s -w -o /tmp/418328cb/user-server .
```
Which is not very helpful
Show stderr and/or stdout on failed go build

Now it shows, e.g.:
```
Command failed: go build -ldflags -s -w -o /tmp/1a0b9a5f/user-server .
# test-failure
./main.go:11:6: undefined: thisSymbolDoesNotExist
```
