### PR TITLE
[metrics] Fix metrics output formatting for aggregation-transforming measures

### DIFF
--- a/.changeset/fix-metrics-effective-display.md
+++ b/.changeset/fix-metrics-effective-display.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix metrics output formatting for aggregation-transforming measures (`percent`, `persecond`, `unique`). The displayed unit and stat columns now reflect the effective aggregation rather than the raw measure unit — e.g. `percent` shows `%` instead of `bytes`, `persecond` appends `/s`, and `unique` hides the unit entirely.

--- a/packages/cli/src/commands/metrics/text-output.ts
+++ b/packages/cli/src/commands/metrics/text-output.ts
@@ -208,12 +208,12 @@ function formatNumber(
   return formatDecimal(value);
 }
 
-/** Chooses summary statistic columns for a given measure type. */
-function getStatColumns(measureType: MeasureType): StatColumn[] {
-  if (measureType === 'duration' || measureType === 'ratio') {
-    return ['avg', 'min', 'max'];
+/** Chooses summary statistic columns based on aggregation. */
+function getStatColumns(aggregation: Aggregation): StatColumn[] {
+  if (aggregation === 'sum') {
+    return ['total', 'avg', 'min', 'max'];
   }
-  return ['total', 'avg', 'min', 'max'];
+  return ['avg', 'min', 'max'];
 }
 
 /** Parses API cell values into finite numbers or null for missing/invalid. */
@@ -684,7 +684,7 @@ export function formatMetadataHeader(opts: MetadataHeaderOptions): string {
 
 /** Renders the summary table section. */
 export function formatSummaryTable(opts: SummaryTableOptions): string {
-  const statColumns = getStatColumns(opts.measureType);
+  const statColumns = getStatColumns(opts.aggregation);
   const header = [...opts.groupByFields, ...statColumns];
   const rows: string[][] = [header.map(name => chalk.bold(chalk.cyan(name)))];
 
@@ -771,6 +771,38 @@ export function formatSparklineSection(
 }
 
 /**
+ * Computes the display unit and measure type based on the base unit and
+ * aggregation. Certain aggregations transform the output semantics:
+ * - `percent` → values are 0-100 percentages regardless of base unit
+ * - `persecond` → values are rates in base unit per second
+ * - `unique` → values are distinct counts, unit is hidden
+ * - all others → values stay in the original unit
+ */
+export function getEffectiveDisplay(
+  baseUnit: string | undefined,
+  aggregation: Aggregation
+): { displayUnit: string | undefined; measureType: MeasureType } {
+  switch (aggregation) {
+    case 'percent':
+      return { displayUnit: '%', measureType: 'ratio' };
+    case 'persecond': {
+      const label = baseUnit ? formatUnitLabel(baseUnit) : undefined;
+      return {
+        displayUnit: label ? `${label}/s` : undefined,
+        measureType: getMeasureType(baseUnit ?? 'ratio'),
+      };
+    }
+    case 'unique':
+      return { displayUnit: undefined, measureType: 'count' };
+    default:
+      return {
+        displayUnit: baseUnit,
+        measureType: getMeasureType(baseUnit ?? 'ratio'),
+      };
+  }
+}
+
+/**
  * Composes final text output:
  * metadata + summary table + sparklines.
  * If there is no data, returns metadata and a deterministic `No data` line.
@@ -780,8 +812,10 @@ export function formatText(
   opts: FormatTextOptions
 ): string {
   const rollupColumn = getRollupColumnName(opts.measure, opts.aggregation);
-  const measureUnit = opts.measureUnit;
-  const measureType = getMeasureType(measureUnit ?? 'ratio');
+  const { displayUnit, measureType } = getEffectiveDisplay(
+    opts.measureUnit,
+    opts.aggregation
+  );
   const granularityMs = toGranularityMsFromDuration(opts.granularity);
 
   const { groups, series, groupValues } = extractGroupedSeries(
@@ -804,7 +838,7 @@ export function formatText(
     scope: opts.scope,
     projectName: opts.projectName,
     teamName: opts.teamName,
-    unit: measureUnit,
+    unit: displayUnit,
     groupCount: opts.groupBy.length > 0 ? groups.length : undefined,
   });
 

--- a/packages/cli/test/unit/commands/metrics/text-output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/text-output.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import stripAnsi from 'strip-ansi';
 import {
   getMeasureType,
+  getEffectiveDisplay,
   formatCount,
   formatDecimal,
   formatMinMaxTimestamp,
@@ -53,6 +54,68 @@ describe('text-output', () => {
       expect(formatDecimal(0.87)).toBe('0.87');
       expect(formatDecimal(0.042)).toBe('0.042');
       expect(formatDecimal(0.003)).toBe('0.003');
+    });
+  });
+
+  describe('getEffectiveDisplay', () => {
+    it('should return percent display for percent aggregation', () => {
+      expect(getEffectiveDisplay('bytes', 'percent')).toEqual({
+        displayUnit: '%',
+        measureType: 'ratio',
+      });
+      expect(getEffectiveDisplay('count', 'percent')).toEqual({
+        displayUnit: '%',
+        measureType: 'ratio',
+      });
+      expect(getEffectiveDisplay('milliseconds', 'percent')).toEqual({
+        displayUnit: '%',
+        measureType: 'ratio',
+      });
+    });
+
+    it('should return rate display for persecond aggregation', () => {
+      expect(getEffectiveDisplay('bytes', 'persecond')).toEqual({
+        displayUnit: 'bytes/s',
+        measureType: 'bytes',
+      });
+      expect(getEffectiveDisplay('count', 'persecond')).toEqual({
+        displayUnit: 'count/s',
+        measureType: 'count',
+      });
+      expect(getEffectiveDisplay('milliseconds', 'persecond')).toEqual({
+        displayUnit: 'ms/s',
+        measureType: 'duration',
+      });
+    });
+
+    it('should return count display with hidden unit for unique aggregation', () => {
+      expect(getEffectiveDisplay('count', 'unique')).toEqual({
+        displayUnit: undefined,
+        measureType: 'count',
+      });
+      expect(getEffectiveDisplay('bytes', 'unique')).toEqual({
+        displayUnit: undefined,
+        measureType: 'count',
+      });
+    });
+
+    it('should pass through base unit for standard aggregations', () => {
+      expect(getEffectiveDisplay('bytes', 'sum')).toEqual({
+        displayUnit: 'bytes',
+        measureType: 'bytes',
+      });
+      expect(getEffectiveDisplay('milliseconds', 'avg')).toEqual({
+        displayUnit: 'milliseconds',
+        measureType: 'duration',
+      });
+      expect(getEffectiveDisplay('count', 'sum')).toEqual({
+        displayUnit: 'count',
+        measureType: 'count',
+      });
+      expect(getEffectiveDisplay(undefined, 'avg')).toEqual({
+        displayUnit: undefined,
+        measureType: 'ratio',
+      });
     });
   });
 
@@ -455,6 +518,152 @@ describe('text-output', () => {
       expect(output).toContain('Metric:');
       expect(output).toContain('No data found for this period.');
       expect(output).not.toContain('sparklines:');
+    });
+
+    it('should show Units: % and no total for percent aggregation with bytes measure', () => {
+      const response: MetricsQueryResponse = {
+        data: [
+          { timestamp: '2026-02-19T10:00:00.000Z', fdtInBytes_percent: 40 },
+          { timestamp: '2026-02-19T10:05:00.000Z', fdtInBytes_percent: 35 },
+          { timestamp: '2026-02-19T10:10:00.000Z', fdtInBytes_percent: 25 },
+        ],
+        summary: [],
+        statistics: {},
+      };
+
+      const output = formatText(response, {
+        event: 'edgeRequest',
+        measure: 'fdtInBytes',
+        measureUnit: 'bytes',
+        aggregation: 'percent',
+        groupBy: [],
+        scope: projectScope,
+        projectName: 'my-project',
+        teamName: 'my-team',
+        periodStart: '2026-02-19T10:00:00.000Z',
+        periodEnd: '2026-02-19T10:15:00.000Z',
+        granularity: { minutes: 5 },
+      });
+
+      const normalized = output
+        .split('\n')
+        .map(line => stripAnsi(line).trimEnd())
+        .join('\n');
+
+      expect(normalized).toContain('Units: %');
+      expect(normalized).not.toContain('Units: bytes');
+      expect(normalized).not.toContain('total');
+      expect(normalized).toContain('avg');
+      expect(normalized).toContain('min');
+      expect(normalized).toContain('max');
+    });
+
+    it('should show Units: bytes/s for persecond aggregation with bytes measure', () => {
+      const output = formatText(
+        {
+          data: [
+            {
+              timestamp: '2026-02-19T10:00:00.000Z',
+              fdtInBytes_persecond: 1024,
+            },
+            {
+              timestamp: '2026-02-19T10:05:00.000Z',
+              fdtInBytes_persecond: 2048,
+            },
+          ],
+          summary: [],
+          statistics: {},
+        },
+        {
+          event: 'edgeRequest',
+          measure: 'fdtInBytes',
+          measureUnit: 'bytes',
+          aggregation: 'persecond',
+          groupBy: [],
+          scope: projectScope,
+          periodStart: '2026-02-19T10:00:00.000Z',
+          periodEnd: '2026-02-19T10:10:00.000Z',
+          granularity: { minutes: 5 },
+        }
+      );
+
+      const normalized = output
+        .split('\n')
+        .map(line => stripAnsi(line).trimEnd())
+        .join('\n');
+
+      expect(normalized).toContain('Units: bytes/s');
+      expect(normalized).not.toContain('total');
+    });
+
+    it('should hide Units line for unique aggregation', () => {
+      const output = formatText(
+        {
+          data: [
+            { timestamp: '2026-02-19T10:00:00.000Z', count_unique: 5 },
+            { timestamp: '2026-02-19T10:05:00.000Z', count_unique: 8 },
+          ],
+          summary: [],
+          statistics: {},
+        },
+        {
+          event: 'edgeRequest',
+          measure: 'count',
+          measureUnit: 'count',
+          aggregation: 'unique',
+          groupBy: [],
+          scope: projectScope,
+          periodStart: '2026-02-19T10:00:00.000Z',
+          periodEnd: '2026-02-19T10:10:00.000Z',
+          granularity: { minutes: 5 },
+        }
+      );
+
+      const normalized = output
+        .split('\n')
+        .map(line => stripAnsi(line).trimEnd())
+        .join('\n');
+
+      expect(normalized).not.toContain('Units:');
+      expect(normalized).not.toContain('total');
+    });
+
+    it('should still show total for sum aggregation with duration measure', () => {
+      const output = formatText(
+        {
+          data: [
+            {
+              timestamp: '2026-02-19T10:00:00.000Z',
+              requestDurationMs_sum: 500,
+            },
+            {
+              timestamp: '2026-02-19T10:05:00.000Z',
+              requestDurationMs_sum: 300,
+            },
+          ],
+          summary: [],
+          statistics: {},
+        },
+        {
+          event: 'edgeRequest',
+          measure: 'requestDurationMs',
+          measureUnit: 'milliseconds',
+          aggregation: 'sum',
+          groupBy: [],
+          scope: projectScope,
+          periodStart: '2026-02-19T10:00:00.000Z',
+          periodEnd: '2026-02-19T10:10:00.000Z',
+          granularity: { minutes: 5 },
+        }
+      );
+
+      const normalized = output
+        .split('\n')
+        .map(line => stripAnsi(line).trimEnd())
+        .join('\n');
+
+      expect(normalized).toContain('Units: ms');
+      expect(normalized).toContain('total');
     });
   });
 });


### PR DESCRIPTION
The text output derived display units and stat columns solely from the measure's base unit, ignoring that certain aggregations (percent, persecond, unique) transform the output semantics. This caused incorrect "Units: bytes" for percent aggregations and a meaningless "total" column for non-sum aggregations.

- Add getEffectiveDisplay() to compute display unit and measure type from both base unit and aggregation
- Simplify getStatColumns() to show "total" only for sum aggregation
- Wire getEffectiveDisplay() into formatText()