### PR TITLE
[flags] Fix percentage based rollout output

### DIFF
--- a/.changeset/fresh-drinks-peel.md
+++ b/.changeset/fresh-drinks-peel.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vercel flags` environment details output to show weighted split variants as normalized percentages in rule and default summaries.

--- a/packages/cli/src/util/flags/print-flag-details.ts
+++ b/packages/cli/src/util/flags/print-flag-details.ts
@@ -152,13 +152,10 @@ export function printFlagEnvironmentDetails(
           );
           output.print(`      ${chalk.dim('Default:')} ${defaultSummary}\n`);
         } else if (fallthrough.type === 'split') {
-          const weights = Object.entries(fallthrough.weights)
-            .map(([id, weight]) => {
-              const variant = flag.variants.find(v => v.id === id);
-              const summary = formatEnvironmentVariantSummary(variant, id);
-              return `${summary}: ${weight}%`;
-            })
-            .join(', ');
+          const weights = formatSplitWeights(
+            fallthrough.weights,
+            flag.variants
+          );
           output.print(`      ${chalk.dim('Default split:')} ${weights}\n`);
         }
       }
@@ -248,17 +245,31 @@ function formatEnvironmentOutcome(
   }
 
   if (outcome.type === 'split') {
-    const weights = Object.entries(outcome.weights)
-      .map(([id, weight]) => {
-        const variant = variants.find(v => v.id === id);
-        const summary = formatEnvironmentVariantSummary(variant, id);
-        return `${summary}: ${weight}%`;
-      })
-      .join(', ');
+    const weights = formatSplitWeights(outcome.weights, variants);
     return `split (${weights})`;
   }
 
   return 'unknown';
+}
+
+function formatSplitWeights(
+  weights: Record<string, number>,
+  variants: FlagVariant[]
+): string {
+  const total = Object.values(weights).reduce((sum, weight) => sum + weight, 0);
+
+  return Object.entries(weights)
+    .map(([id, weight]) => {
+      const variant = variants.find(v => v.id === id);
+      const summary = formatEnvironmentVariantSummary(variant, id);
+      const percentage = total > 0 ? (weight / total) * 100 : 0;
+      const formattedPercentage = Number.isInteger(percentage)
+        ? String(percentage)
+        : String(Number(percentage.toFixed(2)));
+
+      return `${summary}: ${formattedPercentage}%`;
+    })
+    .join(', ');
 }
 
 function formatEnvironmentVariantSummary(

--- a/packages/cli/test/unit/util/flags/print-flag-details.test.ts
+++ b/packages/cli/test/unit/util/flags/print-flag-details.test.ts
@@ -1,0 +1,98 @@
+import stripAnsi from 'strip-ansi';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { printFlagEnvironmentDetails } from '../../../../src/util/flags/print-flag-details';
+import type { Flag } from '../../../../src/util/flags/types';
+
+vi.mock('../../../../src/output-manager', () => ({
+  default: {
+    log: vi.fn(),
+    print: vi.fn(),
+  },
+}));
+
+import output from '../../../../src/output-manager';
+
+const testFlag: Flag = {
+  id: 'flag_123',
+  slug: 'my-feature',
+  kind: 'string',
+  state: 'active',
+  variants: [
+    { id: 'control', value: 'control', label: 'Control' },
+    { id: 'variant-a', value: 'variant-a', label: 'Variant A' },
+  ],
+  environments: {
+    production: {
+      active: true,
+      pausedOutcome: { type: 'variant', variantId: 'control' },
+      fallthrough: {
+        type: 'split',
+        base: {
+          type: 'entity',
+          kind: 'user',
+          attribute: 'userId',
+        },
+        weights: {
+          control: 1,
+          'variant-a': 3,
+        },
+        defaultVariantId: 'control',
+      },
+      rules: [
+        {
+          id: 'rule_1',
+          conditions: [
+            {
+              lhs: { type: 'entity', kind: 'user', attribute: 'plan' },
+              cmp: 'eq',
+              rhs: 'pro',
+            },
+          ],
+          outcome: {
+            type: 'split',
+            base: {
+              type: 'entity',
+              kind: 'user',
+              attribute: 'userId',
+            },
+            weights: {
+              control: 1,
+              'variant-a': 3,
+            },
+            defaultVariantId: 'control',
+          },
+        },
+      ],
+    },
+  },
+  createdAt: 0,
+  updatedAt: 0,
+  createdBy: 'user_123',
+  projectId: 'project_123',
+  ownerId: 'team_123',
+  revision: 1,
+  seed: 1,
+  typeName: 'flag',
+};
+
+describe('printFlagEnvironmentDetails', () => {
+  beforeEach(() => {
+    vi.mocked(output.print).mockClear();
+    vi.mocked(output.log).mockClear();
+  });
+
+  it('shows split weights as normalized percentages', () => {
+    printFlagEnvironmentDetails(testFlag);
+
+    const printed = stripAnsi(
+      vi
+        .mocked(output.print)
+        .mock.calls.map(([message]) => message)
+        .join('')
+    );
+
+    expect(printed).toContain('production: custom');
+    expect(printed).toContain('split (Control: 25%, Variant A: 75%)');
+    expect(printed).toContain('Default split: Control: 25%, Variant A: 75%');
+  });
+});


### PR DESCRIPTION
This PR fixes an issue where we did not render the percentages for a weighted split for a flag