### PR TITLE
[go] structured log level support

### DIFF
--- a/.changeset/neat-poems-share.md
+++ b/.changeset/neat-poems-share.md
@@ -2,4 +2,4 @@
 '@vercel/go': patch
 ---
 
-Add structured log level forwarding for standalone Go runtime bootstraps without pulling in the broader bootstrap refactor.
+[go] Add structured log level forwarding for standalone Go runtime

--- a/.changeset/neat-poems-share.md
+++ b/.changeset/neat-poems-share.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': patch
+---
+
+Add structured log level forwarding for standalone Go runtime bootstraps without pulling in the broader bootstrap refactor.

--- a/packages/go/src/standalone-server.ts
+++ b/packages/go/src/standalone-server.ts
@@ -104,8 +104,9 @@ export async function buildStandaloneServer({
     throw err;
   }
 
-  // Build the bootstrap wrapper that handles IPC protocol (vc-init.go + vc-utils.go)
+  // Build the bootstrap wrapper that handles IPC protocol and log forwarding.
   const bootstrapSrc = join(__dirname, '../vc-init.go');
+  const loggingSrc = join(__dirname, '../vc-logging.go');
   const utilsSrc = join(__dirname, '../vc-utils.go');
   debug(`Building bootstrap wrapper: ${bootstrapSrc} -> ${bootstrapPath}`);
 
@@ -114,8 +115,9 @@ export async function buildStandaloneServer({
     const bootstrapBuildDir = await getWriteableDirectory();
     const bootstrapGoFile = join(bootstrapBuildDir, 'main.go');
 
-    // Copy bootstrap source and shared utils to temp directory
+    // Copy bootstrap source and shared runtime helpers to temp directory
     await copy(bootstrapSrc, bootstrapGoFile);
+    await copy(loggingSrc, join(bootstrapBuildDir, 'vc-logging.go'));
     await copy(utilsSrc, join(bootstrapBuildDir, 'vc-utils.go'));
 
     // Initialize a minimal go.mod for the bootstrap

--- a/packages/go/vc-init.go
+++ b/packages/go/vc-init.go
@@ -1,13 +1,17 @@
+//go:build !vcdev
+// +build !vcdev
+
 // vc-init.go - Bootstrap wrapper for standalone Go servers on Vercel
 // This handles the IPC protocol required for executable runtime mode.
 //
 // The bootstrap:
 // 1. Connects to VERCEL_IPC_PATH Unix socket
 // 2. Starts the user's server on an internal port
-// 3. Sends "server-started" IPC message
-// 4. Reverse proxies requests to user's server
-// 5. Handles /_vercel/ping health check
-// 6. Sends "end" IPC message after each request
+// 3. Forwards user server logs over IPC with structured level detection
+// 4. Sends "server-started" IPC message
+// 5. Reverse proxies requests to user's server
+// 6. Handles /_vercel/ping health check
+// 7. Sends "end" IPC message after each request
 
 package main
 
@@ -56,7 +60,6 @@ type RequestContext struct {
 var (
 	ipcConn   net.Conn
 	ipcMutex  sync.Mutex
-	ipcReady  bool
 	startTime time.Time
 )
 
@@ -122,16 +125,34 @@ func main() {
 
 	cmd := exec.CommandContext(ctx, userBinary)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("PORT=%d", userPort))
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to capture user server stdout: %v\n", err)
+		os.Exit(1)
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to capture user server stderr: %v\n", err)
+		os.Exit(1)
+	}
 
 	if err := cmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to start user server: %v\n", err)
 		os.Exit(1)
 	}
 
+	go forwardProcessLogs(stdoutPipe, StreamStdout, func(err error) {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to read user server stdout: %v\n", err)
+	})
+	go forwardProcessLogs(stderrPipe, StreamStderr, func(err error) {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to read user server stderr: %v\n", err)
+	})
+
 	// Wait for user's server to be ready
 	if err := waitForServer(userPort, 30*time.Second); err != nil {
+		flushBufferedLogMessagesToLocalOutput()
 		fmt.Fprintf(os.Stderr, "User server failed to start: %v\n", err)
 		cmd.Process.Kill()
 		os.Exit(1)
@@ -217,8 +238,9 @@ func main() {
 
 	if err := sendIPCMessage(startMsg); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to send IPC start message: %v\n", err)
+		flushBufferedLogMessagesToLocalOutput()
 	} else {
-		ipcReady = true
+		flushBufferedLogMessages()
 	}
 
 	// If no IPC, print the port for local development

--- a/packages/go/vc-logging.go
+++ b/packages/go/vc-logging.go
@@ -54,10 +54,9 @@ func buildLogMessage(message string, sourceStream string) (LogMessage, bool) {
 	}
 
 	payload := LogPayload{
-		// TODO: Use the actual invocation ID and request ID from the request context
-		// Since the user code runs on a separate process, we can't reliably attribute it
-		// to a request since multiple requests can be handled concurrently and we are sourcing
-		// logs from the server's stdOut/stdErr
+		// Process logs come from the child server's shared stdout/stderr stream.
+		// They can include startup, background, and interleaved concurrent-request output,
+		// so attributing them to a specific invocation would be misleading.
 		Context: RequestContext{
 			InvocationID: "0",
 			RequestID:    0,

--- a/packages/go/vc-logging.go
+++ b/packages/go/vc-logging.go
@@ -54,6 +54,10 @@ func buildLogMessage(message string, sourceStream string) (LogMessage, bool) {
 	}
 
 	payload := LogPayload{
+		// TODO: Use the actual invocation ID and request ID from the request context
+		// Since the user code runs on a separate process, we can't reliably attribute it
+		// to a request since multiple requests can be handled concurrently and we are sourcing
+		// logs from the server's stdOut/stdErr
 		Context: RequestContext{
 			InvocationID: "0",
 			RequestID:    0,

--- a/packages/go/vc-logging.go
+++ b/packages/go/vc-logging.go
@@ -1,0 +1,374 @@
+//go:build !vcdev
+// +build !vcdev
+
+package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+const (
+	StreamStdout               = "stdout"
+	StreamStderr               = "stderr"
+	maxBufferedInitLogMessages = 1024
+)
+
+type LogMessage struct {
+	Type    string     `json:"type"`
+	Payload LogPayload `json:"payload"`
+}
+
+type LogPayload struct {
+	Context RequestContext `json:"context"`
+	Message string         `json:"message"`
+	Level   string         `json:"level,omitempty"`
+	Stream  string         `json:"stream,omitempty"`
+}
+
+type jsonSeverityFields struct {
+	Level        json.RawMessage `json:"level"`
+	Severity     json.RawMessage `json:"severity"`
+	Lvl          json.RawMessage `json:"lvl"`
+	LogLevel     json.RawMessage `json:"log.level"`
+	SeverityText json.RawMessage `json:"severity_text"`
+}
+
+var (
+	initLogMutex            sync.Mutex
+	initLogReady            bool
+	bufferedInitLogMessages []LogMessage
+)
+
+func buildLogMessage(message string, sourceStream string) (LogMessage, bool) {
+	trimmed := strings.TrimRight(message, "\r\n")
+	if strings.TrimSpace(trimmed) == "" {
+		return LogMessage{}, false
+	}
+
+	payload := LogPayload{
+		Context: RequestContext{
+			InvocationID: "0",
+			RequestID:    0,
+		},
+		Message: base64.StdEncoding.EncodeToString([]byte(trimmed)),
+	}
+
+	if level, ok := detectStructuredLevel(trimmed); ok {
+		payload.Level = level
+	} else {
+		payload.Stream = sourceStream
+	}
+
+	return LogMessage{
+		Type:    "log",
+		Payload: payload,
+	}, true
+}
+
+func forwardProcessLogs(
+	reader io.Reader,
+	sourceStream string,
+	handleReadError func(error),
+) {
+	bufferedReader := bufio.NewReader(reader)
+
+	for {
+		line, err := bufferedReader.ReadString('\n')
+		if line != "" {
+			if msg, ok := buildLogMessage(line, sourceStream); ok {
+				emitLogMessage(msg)
+			}
+		}
+
+		if err == nil {
+			continue
+		}
+
+		if errors.Is(err, io.EOF) {
+			return
+		}
+
+		if handleReadError != nil {
+			handleReadError(err)
+		}
+		return
+	}
+}
+
+func emitLogMessage(msg LogMessage) {
+	initLogMutex.Lock()
+	defer initLogMutex.Unlock()
+
+	if ipcConn == nil {
+		writeLogMessageToLocalOutput(msg)
+		return
+	}
+
+	if initLogReady {
+		forwardLogMessageToIPCOrLocalOutput(msg)
+		return
+	}
+
+	if len(bufferedInitLogMessages) < maxBufferedInitLogMessages {
+		bufferedInitLogMessages = append(bufferedInitLogMessages, msg)
+		return
+	}
+
+	writeLogMessageToLocalOutput(msg)
+}
+
+func flushBufferedLogMessages() {
+	initLogMutex.Lock()
+	defer initLogMutex.Unlock()
+
+	for _, msg := range bufferedInitLogMessages {
+		forwardLogMessageToIPCOrLocalOutput(msg)
+	}
+	bufferedInitLogMessages = nil
+	initLogReady = true
+}
+
+func flushBufferedLogMessagesToLocalOutput() {
+	initLogMutex.Lock()
+	defer initLogMutex.Unlock()
+
+	for _, msg := range bufferedInitLogMessages {
+		writeLogMessageToLocalOutput(msg)
+	}
+	bufferedInitLogMessages = nil
+	initLogReady = true
+}
+
+func forwardLogMessageToIPCOrLocalOutput(msg LogMessage) {
+	if err := sendIPCMessage(msg); err != nil {
+		writeLogMessageToLocalOutput(msg)
+	}
+}
+
+func writeLogMessageToLocalOutput(msg LogMessage) {
+	decoded, err := base64.StdEncoding.DecodeString(msg.Payload.Message)
+	if err != nil || len(decoded) == 0 {
+		return
+	}
+
+	writer := os.Stdout
+	switch {
+	case msg.Payload.Stream == StreamStderr:
+		writer = os.Stderr
+	case msg.Payload.Level == "warn" || msg.Payload.Level == "error" || msg.Payload.Level == "fatal":
+		writer = os.Stderr
+	}
+
+	fmt.Fprintln(writer, string(decoded))
+}
+
+func detectStructuredLevel(message string) (string, bool) {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return "", false
+	}
+
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "panic:") || strings.HasPrefix(lower, "fatal error:") {
+		return "fatal", true
+	}
+
+	if level, ok := detectJSONLevel(trimmed); ok {
+		return level, true
+	}
+
+	if level, ok := detectLogfmtLevel(trimmed); ok {
+		return level, true
+	}
+
+	if level, ok := detectBracketedLevel(trimmed); ok {
+		return level, true
+	}
+
+	return "", false
+}
+
+func detectJSONLevel(trimmed string) (string, bool) {
+	if len(trimmed) < 2 || trimmed[0] != '{' || trimmed[len(trimmed)-1] != '}' {
+		return "", false
+	}
+
+	var fields jsonSeverityFields
+	if err := json.Unmarshal([]byte(trimmed), &fields); err != nil {
+		return "", false
+	}
+
+	for _, raw := range []json.RawMessage{
+		fields.Level,
+		fields.Severity,
+		fields.Lvl,
+		fields.LogLevel,
+		fields.SeverityText,
+	} {
+		if level, ok := normalizeJSONLevel(raw); ok {
+			return level, true
+		}
+	}
+
+	return "", false
+}
+
+func normalizeJSONLevel(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", false
+	}
+
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+
+	return normalizeLevel(value)
+}
+
+func detectLogfmtLevel(line string) (string, bool) {
+	for idx := 0; idx < len(line); {
+		for idx < len(line) && isSpace(line[idx]) {
+			idx++
+		}
+
+		if idx >= len(line) {
+			break
+		}
+
+		keyStart := idx
+		for idx < len(line) && isLogfmtKeyChar(line[idx]) {
+			idx++
+		}
+
+		if keyStart == idx || idx >= len(line) || line[idx] != '=' {
+			for idx < len(line) && !isSpace(line[idx]) {
+				idx++
+			}
+			continue
+		}
+
+		key := line[keyStart:idx]
+		idx++
+
+		value, nextIdx, ok := parseLogfmtValue(line, idx)
+		if !ok {
+			for idx < len(line) && !isSpace(line[idx]) {
+				idx++
+			}
+			continue
+		}
+
+		idx = nextIdx
+		if !isSeverityKey(key) {
+			continue
+		}
+
+		if level, ok := normalizeLevel(value); ok {
+			return level, true
+		}
+	}
+
+	return "", false
+}
+
+func detectBracketedLevel(trimmed string) (string, bool) {
+	if !strings.HasPrefix(trimmed, "[") {
+		return "", false
+	}
+
+	endIdx := strings.IndexByte(trimmed, ']')
+	if endIdx <= 1 {
+		return "", false
+	}
+
+	if endIdx+1 < len(trimmed) {
+		next := trimmed[endIdx+1]
+		if next != ' ' && next != '\t' && next != ':' {
+			return "", false
+		}
+	}
+
+	return normalizeLevel(trimmed[1:endIdx])
+}
+
+func normalizeLevel(raw string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "trace", "trc":
+		return "debug", true
+	case "debug", "dbg":
+		return "debug", true
+	case "info", "inf":
+		return "info", true
+	case "warn", "warning", "wrn":
+		return "warn", true
+	case "error", "err":
+		return "error", true
+	case "fatal", "critical", "crit", "panic":
+		return "fatal", true
+	default:
+		return "", false
+	}
+}
+
+func isSeverityKey(key string) bool {
+	switch strings.ToLower(key) {
+	case "level", "severity", "lvl", "log.level", "severity_text":
+		return true
+	default:
+		return false
+	}
+}
+
+func isLogfmtKeyChar(char byte) bool {
+	return (char >= 'a' && char <= 'z') ||
+		(char >= 'A' && char <= 'Z') ||
+		(char >= '0' && char <= '9') ||
+		char == '_' ||
+		char == '-' ||
+		char == '.'
+}
+
+func isSpace(char byte) bool {
+	return char == ' ' || char == '\t' || char == '\n' || char == '\r'
+}
+
+func parseLogfmtValue(line string, startIdx int) (string, int, bool) {
+	if startIdx >= len(line) {
+		return "", startIdx, false
+	}
+
+	if line[startIdx] != '"' {
+		endIdx := startIdx
+		for endIdx < len(line) && !isSpace(line[endIdx]) {
+			endIdx++
+		}
+		return line[startIdx:endIdx], endIdx, true
+	}
+
+	var builder strings.Builder
+	for idx := startIdx + 1; idx < len(line); idx++ {
+		switch line[idx] {
+		case '\\':
+			if idx+1 >= len(line) {
+				return "", idx, false
+			}
+			builder.WriteByte(line[idx+1])
+			idx++
+		case '"':
+			return builder.String(), idx + 1, true
+		default:
+			builder.WriteByte(line[idx])
+		}
+	}
+
+	return "", len(line), false
+}

--- a/packages/go/vc-logging.go
+++ b/packages/go/vc-logging.go
@@ -173,6 +173,13 @@ func writeLogMessageToLocalOutput(msg LogMessage) {
 	fmt.Fprintln(writer, string(decoded))
 }
 
+// detectStructuredLevel recognizes explicit severity formats commonly emitted
+// by Go loggers, such as `slog` JSON/text output.
+
+// {"level":"error","msg":"boom"}                          // slog JSONHandler
+// time=2026-03-20T15:55:54Z level=WARN msg="slow path"    // slog TextHandler
+// [INFO] server started
+// panic: runtime error: index out of range                 // Go panic output
 func detectStructuredLevel(message string) (string, bool) {
 	trimmed := strings.TrimSpace(message)
 	if trimmed == "" {
@@ -180,6 +187,8 @@ func detectStructuredLevel(message string) (string, bool) {
 	}
 
 	lower := strings.ToLower(trimmed)
+	// Go panic output is plain text rather than JSON/logfmt, e.g.
+	// `panic: runtime error: index out of range`.
 	if strings.HasPrefix(lower, "panic:") || strings.HasPrefix(lower, "fatal error:") {
 		return "fatal", true
 	}
@@ -199,6 +208,9 @@ func detectStructuredLevel(message string) (string, bool) {
 	return "", false
 }
 
+// detectJSONLevel recognizes JSON logs with an explicit severity field, e.g.:
+//
+//	{"time":"2026-03-20T15:55:54Z","level":"ERROR","msg":"boom"} // slog JSONHandler
 func detectJSONLevel(trimmed string) (string, bool) {
 	if len(trimmed) < 2 || trimmed[0] != '{' || trimmed[len(trimmed)-1] != '}' {
 		return "", false
@@ -209,6 +221,8 @@ func detectJSONLevel(trimmed string) (string, bool) {
 		return "", false
 	}
 
+	// Check the common field names in priority order and return the first
+	// recognized severity value.
 	for _, raw := range []json.RawMessage{
 		fields.Level,
 		fields.Severity,
@@ -237,6 +251,10 @@ func normalizeJSONLevel(raw json.RawMessage) (string, bool) {
 	return normalizeLevel(value)
 }
 
+// detectLogfmtLevel recognizes key=value text logs like:
+//
+//	time=2026-03-20T15:55:54Z level=INFO msg="slow path"   // slog TextHandler
+//	time="2026-03-20T15:55:54Z" level=info msg="slow path" // logrus text formatter
 func detectLogfmtLevel(line string) (string, bool) {
 	for idx := 0; idx < len(line); {
 		for idx < len(line) && isSpace(line[idx]) {
@@ -252,6 +270,7 @@ func detectLogfmtLevel(line string) (string, bool) {
 			idx++
 		}
 
+		// Not a valid key=value token, so skip to the next space-delimited token.
 		if keyStart == idx || idx >= len(line) || line[idx] != '=' {
 			for idx < len(line) && !isSpace(line[idx]) {
 				idx++
@@ -264,6 +283,7 @@ func detectLogfmtLevel(line string) (string, bool) {
 
 		value, nextIdx, ok := parseLogfmtValue(line, idx)
 		if !ok {
+			// Malformed value; skip this token rather than failing the whole line.
 			for idx < len(line) && !isSpace(line[idx]) {
 				idx++
 			}
@@ -283,6 +303,7 @@ func detectLogfmtLevel(line string) (string, bool) {
 	return "", false
 }
 
+// detectBracketedLevel recognizes logger prefixes like "[WARN] message".
 func detectBracketedLevel(trimmed string) (string, bool) {
 	if !strings.HasPrefix(trimmed, "[") {
 		return "", false


### PR DESCRIPTION
Adds a new `vc-logging.go` which handles parsing structured logs to emit proper log levels in the dashboard

**Note:** This change is only for the _new_ Go standalone server path in `experimentalServices` or the new Go framework preset, not for the legacy serverless Go route handler path

Currently, all go logs sent to stderr are shown as errors in the dashboard, which is not a great experience since we do not support proper log levels:
**Prev:**
<img width="1052" height="449" alt="Screenshot 2026-03-20 at 11 00 09 AM" src="https://github.com/user-attachments/assets/f640cabb-a8aa-4258-a9a7-bafa4454ccbc" />

**Now:**
<img width="1315" height="231" alt="Screenshot 2026-03-20 at 11 25 45 AM" src="https://github.com/user-attachments/assets/dbe979a7-0e80-491b-b234-9f6b2cb62dc5" />