### PR TITLE
[CLI] feat: migrate crons to API with update and rm

### DIFF
--- a/.changeset/cron-api-commands.md
+++ b/.changeset/cron-api-commands.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Migrate `crons add` from vercel.json to API, add `crons update` and `crons rm` subcommands

--- a/packages/cli/src/commands/crons/add.ts
+++ b/packages/cli/src/commands/crons/add.ts
@@ -1,20 +1,15 @@
-import { resolve } from 'path';
-import { access, readFile, writeFile } from 'fs/promises';
 import chalk from 'chalk';
 import type Client from '../../util/client';
 import { getCommandName } from '../../util/pkg-name';
+import { getLinkedProject } from '../../util/projects/link';
 import output from '../../output-manager';
 import { CronsAddTelemetryClient } from '../../util/telemetry/commands/crons/add';
 import { addSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { VERCEL_CONFIG_EXTENSIONS } from '../../util/compile-vercel-config';
-
-interface CronEntry {
-  path: string;
-  schedule: string;
-}
+import { isAPIError } from '../../util/errors-ts';
+import type { CronDefinitionsResponse } from './types';
 
 const CRON_FIELD_RANGES: [string, number, number][] = [
   ['minute', 0, 59],
@@ -125,6 +120,7 @@ export default async function add(client: Client, argv: string[]) {
 
   let cronPath: string | undefined = flags['--path'];
   let schedule: string | undefined = flags['--schedule'];
+  const host: string | undefined = flags['--host'];
 
   telemetry.trackCliOptionPath(cronPath);
   telemetry.trackCliOptionSchedule(schedule);
@@ -176,84 +172,51 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
-  // Check for non-JSON config files (vercel.ts, vercel.mjs, etc.)
-  for (const ext of VERCEL_CONFIG_EXTENSIONS) {
-    const altPath = resolve(client.cwd, `vercel.${ext}`);
-    try {
-      await access(altPath);
-      output.error(
-        `Found ${chalk.cyan(`vercel.${ext}`)} — ${getCommandName('crons add')} only supports ${chalk.cyan('vercel.json')}. Add cron jobs directly to your ${chalk.cyan(`vercel.${ext}`)} file instead.`
-      );
-      return 1;
-    } catch {
-      // File doesn't exist, continue
-    }
-  }
-
-  // Read existing vercel.json or create one
-  const configPath = resolve(client.cwd, 'vercel.json');
-  let config: Record<string, unknown>;
-
-  try {
-    const content = await readFile(configPath, 'utf-8');
-    config = JSON.parse(content);
-  } catch (err: unknown) {
-    if (err instanceof SyntaxError) {
-      output.error(
-        `Failed to parse ${chalk.cyan('vercel.json')}: ${err.message}`
-      );
-      return 1;
-    }
-    if (
-      err instanceof Error &&
-      'code' in err &&
-      (err as NodeJS.ErrnoException).code === 'ENOENT'
-    ) {
-      config = {};
-    } else {
-      output.error(
-        `Failed to read ${chalk.cyan('vercel.json')}: ${err instanceof Error ? err.message : String(err)}`
-      );
-      return 1;
-    }
-  }
-
-  // Get existing crons or create empty array
-  const existingCrons: CronEntry[] = Array.isArray(config.crons)
-    ? config.crons
-    : [];
-
-  // Check for duplicate path
-  if (existingCrons.some(c => c.path === cronPath)) {
+  const link = await getLinkedProject(client);
+  if (link.status === 'error') {
+    return link.exitCode;
+  } else if (link.status === 'not_linked') {
     output.error(
-      `A cron job with path ${chalk.bold(cronPath)} already exists in vercel.json`
+      `Your codebase isn't linked to a project on Vercel. ${client.nonInteractive ? `Run ${getCommandName('link --yes --team <team-id> --project <project-id>')} to link non-interactively.` : `Run ${getCommandName('link')} to begin.`}`
     );
     return 1;
   }
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
 
-  // Add the new cron
-  existingCrons.push({ path: cronPath, schedule });
-  config.crons = existingCrons;
+  const { project } = link;
 
-  // Write back to vercel.json
+  output.spinner(`Adding cron job ${chalk.bold(cronPath)}`);
+
+  const body: { path: string; schedule: string; host?: string } = {
+    path: cronPath,
+    schedule,
+  };
+  if (host) {
+    body.host = host;
+  }
+
   try {
-    await writeFile(
-      configPath,
-      JSON.stringify(config, null, 2) + '\n',
-      'utf-8'
+    await client.fetch<CronDefinitionsResponse>(
+      `/v1/projects/${encodeURIComponent(project.id)}/crons/definitions`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }
     );
   } catch (err: unknown) {
-    output.error(
-      `Failed to write ${chalk.cyan('vercel.json')}: ${err instanceof Error ? err.message : String(err)}`
-    );
-    return 1;
+    if (isAPIError(err)) {
+      output.error(
+        `Failed to add cron job ${chalk.bold(cronPath)}: ${err.message}`
+      );
+      return 1;
+    }
+    throw err;
   }
 
   output.log(
-    `Added cron job ${chalk.bold(cronPath)} with schedule ${chalk.bold(schedule)} to ${chalk.cyan('vercel.json')}`
-  );
-  output.warn(
-    `This cron job won't be active until the project is deployed to production. Run ${getCommandName('deploy --prod')} to deploy.`
+    `Added cron job ${chalk.bold(cronPath)} with schedule ${chalk.bold(schedule)}`
   );
 
   return 0;

--- a/packages/cli/src/commands/crons/add.ts
+++ b/packages/cli/src/commands/crons/add.ts
@@ -121,9 +121,11 @@ export default async function add(client: Client, argv: string[]) {
   let cronPath: string | undefined = flags['--path'];
   let schedule: string | undefined = flags['--schedule'];
   const host: string | undefined = flags['--host'];
+  const description: string | undefined = flags['--description'];
 
   telemetry.trackCliOptionPath(cronPath);
   telemetry.trackCliOptionSchedule(schedule);
+  telemetry.trackCliOptionDescription(description);
 
   // If flags not provided, prompt interactively
   if (!cronPath || !schedule) {
@@ -188,12 +190,20 @@ export default async function add(client: Client, argv: string[]) {
 
   output.spinner(`Adding cron job ${chalk.bold(cronPath)}`);
 
-  const body: { path: string; schedule: string; host?: string } = {
+  const body: {
+    path: string;
+    schedule: string;
+    host?: string;
+    description?: string;
+  } = {
     path: cronPath,
     schedule,
   };
   if (host) {
     body.host = host;
+  }
+  if (description) {
+    body.description = description;
   }
 
   try {

--- a/packages/cli/src/commands/crons/command.ts
+++ b/packages/cli/src/commands/crons/command.ts
@@ -32,6 +32,14 @@ export const addSubcommand = {
       description:
         'The hostname for invocation (defaults to production deployment URL)',
     },
+    {
+      name: 'description',
+      shorthand: null,
+      type: String,
+      argument: 'TEXT',
+      deprecated: false,
+      description: 'A description for the cron job',
+    },
   ],
   examples: [
     {
@@ -74,6 +82,14 @@ export const updateSubcommand = {
       argument: 'HOSTNAME',
       deprecated: false,
       description: 'The new hostname for invocation',
+    },
+    {
+      name: 'description',
+      shorthand: null,
+      type: String,
+      argument: 'TEXT',
+      deprecated: false,
+      description: 'The new description for the cron job',
     },
   ],
   examples: [

--- a/packages/cli/src/commands/crons/command.ts
+++ b/packages/cli/src/commands/crons/command.ts
@@ -1,10 +1,10 @@
 import { packageName } from '../../util/pkg-name';
-import { formatOption } from '../../util/arg-common';
+import { formatOption, yesOption } from '../../util/arg-common';
 
 export const addSubcommand = {
   name: 'add',
   aliases: [],
-  description: 'Add a cron job to vercel.json',
+  description: 'Add a cron job to the project',
   arguments: [],
   options: [
     {
@@ -23,6 +23,15 @@ export const addSubcommand = {
       deprecated: false,
       description: 'The cron schedule expression (e.g. "0 10 * * *")',
     },
+    {
+      name: 'host',
+      shorthand: null,
+      type: String,
+      argument: 'HOSTNAME',
+      deprecated: false,
+      description:
+        'The hostname for invocation (defaults to production deployment URL)',
+    },
   ],
   examples: [
     {
@@ -32,6 +41,68 @@ export const addSubcommand = {
     {
       name: 'Add a cron job with flags',
       value: `${packageName} crons add --path /api/cron --schedule "0 10 * * *"`,
+    },
+  ],
+} as const;
+
+export const updateSubcommand = {
+  name: 'update',
+  aliases: [],
+  description: 'Update an existing cron job',
+  arguments: [],
+  options: [
+    {
+      name: 'path',
+      shorthand: null,
+      type: String,
+      argument: 'PATH',
+      deprecated: false,
+      description: 'The path of the cron job to update',
+    },
+    {
+      name: 'schedule',
+      shorthand: null,
+      type: String,
+      argument: 'EXPRESSION',
+      deprecated: false,
+      description: 'The new cron schedule expression',
+    },
+    {
+      name: 'host',
+      shorthand: null,
+      type: String,
+      argument: 'HOSTNAME',
+      deprecated: false,
+      description: 'The new hostname for invocation',
+    },
+  ],
+  examples: [
+    {
+      name: 'Update a cron schedule',
+      value: `${packageName} crons update --path /api/cron --schedule "0 0 * * *"`,
+    },
+  ],
+} as const;
+
+export const rmSubcommand = {
+  name: 'rm',
+  aliases: ['remove'],
+  description: 'Remove a cron job from the project',
+  arguments: [
+    {
+      name: 'path',
+      required: false,
+    },
+  ],
+  options: [yesOption],
+  examples: [
+    {
+      name: 'Remove a cron job',
+      value: `${packageName} crons rm /api/cron`,
+    },
+    {
+      name: 'Remove without confirmation',
+      value: `${packageName} crons rm /api/cron --yes`,
     },
   ],
 } as const;
@@ -79,7 +150,13 @@ export const cronsCommand = {
   aliases: ['cron'],
   description: 'Manage cron jobs for a project',
   arguments: [],
-  subcommands: [addSubcommand, listSubcommand, runSubcommand],
+  subcommands: [
+    addSubcommand,
+    updateSubcommand,
+    rmSubcommand,
+    listSubcommand,
+    runSubcommand,
+  ],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/commands/crons/index.ts
+++ b/packages/cli/src/commands/crons/index.ts
@@ -3,11 +3,15 @@ import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import { printError } from '../../util/error';
 import add from './add';
+import update from './update';
+import rm from './rm';
 import ls from './ls';
 import run from './run';
 import {
   cronsCommand,
   addSubcommand,
+  updateSubcommand,
+  rmSubcommand,
   listSubcommand,
   runSubcommand,
 } from './command';
@@ -18,6 +22,8 @@ import output from '../../output-manager';
 
 const COMMAND_CONFIG = {
   add: ['add'],
+  update: ['update'],
+  rm: ['rm', 'remove'],
   ls: ['ls', 'list'],
   run: ['run'],
 };
@@ -68,6 +74,20 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
+    case 'update':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('crons', subcommandOriginal);
+        return printHelp(updateSubcommand);
+      }
+      telemetry.trackCliSubcommandUpdate(subcommandOriginal);
+      return update(client, args);
+    case 'rm':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('crons', subcommandOriginal);
+        return printHelp(rmSubcommand);
+      }
+      telemetry.trackCliSubcommandRm(subcommandOriginal);
+      return rm(client, args);
     case 'run':
       if (needHelp) {
         telemetry.trackCliFlagHelp('crons', subcommandOriginal);

--- a/packages/cli/src/commands/crons/ls.ts
+++ b/packages/cli/src/commands/crons/ls.ts
@@ -111,6 +111,7 @@ export default async function ls(client: Client, argv: string[]) {
         path: cron.path,
         schedule: cron.schedule,
         host: cron.host,
+        description: cron.description ?? null,
       })),
       undeployed: undeployedCrons.map(cron => ({
         path: cron.path,
@@ -166,12 +167,20 @@ export default async function ls(client: Client, argv: string[]) {
 }
 
 function formatCronsTable(definitions: CronJobDefinition[]) {
-  const rows: string[][] = definitions.map(cron => [
-    chalk.bold(cron.path),
-    cron.schedule,
-  ]);
+  const hasDescriptions = definitions.some(cron => cron.description);
+  const rows: string[][] = definitions.map(cron =>
+    hasDescriptions
+      ? [chalk.bold(cron.path), cron.schedule, cron.description ?? '']
+      : [chalk.bold(cron.path), cron.schedule]
+  );
 
-  return formatTable(['Path', 'Schedule'], ['l', 'l'], [{ rows }]);
+  return hasDescriptions
+    ? formatTable(
+        ['Path', 'Schedule', 'Description'],
+        ['l', 'l', 'l'],
+        [{ rows }]
+      )
+    : formatTable(['Path', 'Schedule'], ['l', 'l'], [{ rows }]);
 }
 
 function formatPendingCronsTable(

--- a/packages/cli/src/commands/crons/rm.ts
+++ b/packages/cli/src/commands/crons/rm.ts
@@ -1,0 +1,139 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { getCommandName } from '../../util/pkg-name';
+import { getLinkedProject } from '../../util/projects/link';
+import output from '../../output-manager';
+import { CronsRmTelemetryClient } from '../../util/telemetry/commands/crons/rm';
+import { rmSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
+import type { CronDefinitionsResponse, CronJobDefinition } from './types';
+
+export default async function rm(client: Client, argv: string[]) {
+  const telemetry = new CronsRmTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(rmSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+
+  let [cronPath] = args;
+  const yes = flags['--yes'];
+
+  telemetry.trackCliArgumentPath(cronPath);
+
+  const link = await getLinkedProject(client);
+  if (link.status === 'error') {
+    return link.exitCode;
+  } else if (link.status === 'not_linked') {
+    output.error(
+      `Your codebase isn't linked to a project on Vercel. ${client.nonInteractive ? `Run ${getCommandName('link --yes --team <team-id> --project <project-id>')} to link non-interactively.` : `Run ${getCommandName('link')} to begin.`}`
+    );
+    return 1;
+  }
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+
+  const { project, org } = link;
+
+  if (!cronPath) {
+    if (!client.stdin.isTTY) {
+      output.error(
+        `A cron path argument is required in non-interactive mode. Usage: ${getCommandName('crons rm <path>')}`
+      );
+      return 1;
+    }
+
+    // Fetch crons to let user select
+    output.spinner(
+      `Fetching cron jobs for ${chalk.bold(`${org.slug}/${project.name}`)}`
+    );
+
+    const projectData = await client.fetch<{
+      crons?: {
+        definitions: CronJobDefinition[];
+      };
+    }>(`/v9/projects/${encodeURIComponent(project.id)}`);
+
+    const definitions = (projectData.crons?.definitions ?? []).filter(
+      d => d.source === 'api'
+    );
+
+    if (definitions.length === 0) {
+      output.error(
+        `No API-managed cron jobs found for ${chalk.bold(`${org.slug}/${project.name}`)}.`
+      );
+      return 1;
+    }
+
+    output.stopSpinner();
+
+    if (definitions.length === 1) {
+      cronPath = definitions[0].path;
+      output.log(`Auto-selected ${chalk.bold(cronPath)} (only cron job)`);
+    } else {
+      cronPath = await client.input.select({
+        message: 'Which cron job would you like to remove?',
+        choices: definitions.map(cron => ({
+          name: `${cron.path} (${cron.schedule})`,
+          value: cron.path,
+        })),
+      });
+    }
+  }
+
+  // Confirm deletion
+  if (!yes) {
+    if (!client.stdin.isTTY) {
+      output.error(
+        `Confirmation required. Use --yes to skip confirmation in non-interactive mode.`
+      );
+      return 1;
+    }
+
+    const confirmed = await client.input.confirm(
+      `Remove cron job ${chalk.bold(cronPath)}?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Aborted.');
+      return 0;
+    }
+  }
+
+  output.spinner(`Removing cron job ${chalk.bold(cronPath)}`);
+
+  try {
+    await client.fetch<CronDefinitionsResponse>(
+      `/v1/projects/${encodeURIComponent(project.id)}/crons/definitions`,
+      {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: cronPath }),
+      }
+    );
+  } catch (err: unknown) {
+    if (isAPIError(err)) {
+      output.error(
+        `Failed to remove cron job ${chalk.bold(cronPath)}: ${err.message}`
+      );
+      return 1;
+    }
+    throw err;
+  }
+
+  output.log(`Removed cron job ${chalk.bold(cronPath)}`);
+
+  return 0;
+}

--- a/packages/cli/src/commands/crons/types.ts
+++ b/packages/cli/src/commands/crons/types.ts
@@ -2,4 +2,9 @@ export interface CronJobDefinition {
   host: string;
   path: string;
   schedule: string;
+  source?: 'api';
+}
+
+export interface CronDefinitionsResponse {
+  definitions: CronJobDefinition[];
 }

--- a/packages/cli/src/commands/crons/types.ts
+++ b/packages/cli/src/commands/crons/types.ts
@@ -2,6 +2,7 @@ export interface CronJobDefinition {
   host: string;
   path: string;
   schedule: string;
+  description?: string;
   source?: 'api';
 }
 

--- a/packages/cli/src/commands/crons/update.ts
+++ b/packages/cli/src/commands/crons/update.ts
@@ -32,9 +32,11 @@ export default async function update(client: Client, argv: string[]) {
   let cronPath: string | undefined = flags['--path'];
   let schedule: string | undefined = flags['--schedule'];
   const host: string | undefined = flags['--host'];
+  const description: string | undefined = flags['--description'];
 
   telemetry.trackCliOptionPath(cronPath);
   telemetry.trackCliOptionSchedule(schedule);
+  telemetry.trackCliOptionDescription(description);
 
   if (!cronPath) {
     if (!client.stdin.isTTY) {
@@ -55,9 +57,11 @@ export default async function update(client: Client, argv: string[]) {
     });
   }
 
-  if (!schedule && !host) {
+  if (!schedule && !host && !description) {
     if (!client.stdin.isTTY) {
-      output.error(`At least one of --schedule or --host must be provided.`);
+      output.error(
+        `At least one of --schedule, --host, or --description must be provided.`
+      );
       return 1;
     }
 
@@ -97,7 +101,12 @@ export default async function update(client: Client, argv: string[]) {
 
   output.spinner(`Updating cron job ${chalk.bold(cronPath)}`);
 
-  const body: { path: string; schedule?: string; host?: string } = {
+  const body: {
+    path: string;
+    schedule?: string;
+    host?: string;
+    description?: string;
+  } = {
     path: cronPath,
   };
   if (schedule) {
@@ -105,6 +114,9 @@ export default async function update(client: Client, argv: string[]) {
   }
   if (host) {
     body.host = host;
+  }
+  if (description) {
+    body.description = description;
   }
 
   try {
@@ -132,6 +144,9 @@ export default async function update(client: Client, argv: string[]) {
   }
   if (host) {
     parts.push(`host ${chalk.bold(host)}`);
+  }
+  if (description) {
+    parts.push(`description ${chalk.bold(description)}`);
   }
 
   output.log(

--- a/packages/cli/src/commands/crons/update.ts
+++ b/packages/cli/src/commands/crons/update.ts
@@ -1,0 +1,142 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { getCommandName } from '../../util/pkg-name';
+import { getLinkedProject } from '../../util/projects/link';
+import output from '../../output-manager';
+import { CronsUpdateTelemetryClient } from '../../util/telemetry/commands/crons/update';
+import { updateSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
+import { validateCronSchedule } from './add';
+import type { CronDefinitionsResponse } from './types';
+
+export default async function update(client: Client, argv: string[]) {
+  const telemetry = new CronsUpdateTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(updateSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  let cronPath: string | undefined = flags['--path'];
+  let schedule: string | undefined = flags['--schedule'];
+  const host: string | undefined = flags['--host'];
+
+  telemetry.trackCliOptionPath(cronPath);
+  telemetry.trackCliOptionSchedule(schedule);
+
+  if (!cronPath) {
+    if (!client.stdin.isTTY) {
+      output.error(
+        `Missing required flag --path. Use ${getCommandName('crons update --path /api/cron --schedule "0 10 * * *"')} in non-interactive mode.`
+      );
+      return 1;
+    }
+
+    cronPath = await client.input.text({
+      message: 'What is the path of the cron job to update?',
+      validate: (value: string) => {
+        if (!value.startsWith('/')) {
+          return 'Path must start with /';
+        }
+        return true;
+      },
+    });
+  }
+
+  if (!schedule && !host) {
+    if (!client.stdin.isTTY) {
+      output.error(`At least one of --schedule or --host must be provided.`);
+      return 1;
+    }
+
+    schedule = await client.input.text({
+      message: 'What is the new cron schedule expression?',
+      validate: validateCronSchedule,
+    });
+  }
+
+  // Validate inputs
+  if (!cronPath.startsWith('/')) {
+    output.error('Path must start with /');
+    return 1;
+  }
+
+  if (schedule) {
+    const scheduleValidation = validateCronSchedule(schedule);
+    if (scheduleValidation !== true) {
+      output.error(scheduleValidation);
+      return 1;
+    }
+  }
+
+  const link = await getLinkedProject(client);
+  if (link.status === 'error') {
+    return link.exitCode;
+  } else if (link.status === 'not_linked') {
+    output.error(
+      `Your codebase isn't linked to a project on Vercel. ${client.nonInteractive ? `Run ${getCommandName('link --yes --team <team-id> --project <project-id>')} to link non-interactively.` : `Run ${getCommandName('link')} to begin.`}`
+    );
+    return 1;
+  }
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+
+  const { project } = link;
+
+  output.spinner(`Updating cron job ${chalk.bold(cronPath)}`);
+
+  const body: { path: string; schedule?: string; host?: string } = {
+    path: cronPath,
+  };
+  if (schedule) {
+    body.schedule = schedule;
+  }
+  if (host) {
+    body.host = host;
+  }
+
+  try {
+    await client.fetch<CronDefinitionsResponse>(
+      `/v1/projects/${encodeURIComponent(project.id)}/crons/definitions`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }
+    );
+  } catch (err: unknown) {
+    if (isAPIError(err)) {
+      output.error(
+        `Failed to update cron job ${chalk.bold(cronPath)}: ${err.message}`
+      );
+      return 1;
+    }
+    throw err;
+  }
+
+  const parts: string[] = [];
+  if (schedule) {
+    parts.push(`schedule ${chalk.bold(schedule)}`);
+  }
+  if (host) {
+    parts.push(`host ${chalk.bold(host)}`);
+  }
+
+  output.log(
+    `Updated cron job ${chalk.bold(cronPath)} with ${parts.join(' and ')}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/crons/add.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/add.ts
@@ -32,4 +32,13 @@ export class CronsAddTelemetryClient
       });
     }
   }
+
+  trackCliOptionDescription(description: string | undefined) {
+    if (description) {
+      this.trackCliOption({
+        option: 'description',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/crons/index.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/index.ts
@@ -13,6 +13,20 @@ export class CronsTelemetryClient
     });
   }
 
+  trackCliSubcommandUpdate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'update',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRm(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'rm',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandList(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'list',

--- a/packages/cli/src/util/telemetry/commands/crons/rm.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/rm.ts
@@ -1,0 +1,26 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { rmSubcommand } from '../../../../commands/crons/command';
+
+export class CronsRmTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof rmSubcommand>
+{
+  trackCliArgumentPath(path: string | undefined) {
+    if (path) {
+      this.trackCliArgument({
+        arg: 'path',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag({
+        flag: 'yes',
+        value: yes,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/crons/rm.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/rm.ts
@@ -17,10 +17,7 @@ export class CronsRmTelemetryClient
 
   trackCliFlagYes(yes: boolean | undefined) {
     if (yes) {
-      this.trackCliFlag({
-        flag: 'yes',
-        value: yes,
-      });
+      this.trackCliFlag('yes');
     }
   }
 }

--- a/packages/cli/src/util/telemetry/commands/crons/update.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/update.ts
@@ -1,10 +1,10 @@
 import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
-import type { addSubcommand } from '../../../../commands/crons/command';
+import type { updateSubcommand } from '../../../../commands/crons/command';
 
-export class CronsAddTelemetryClient
+export class CronsUpdateTelemetryClient
   extends TelemetryClient
-  implements TelemetryMethods<typeof addSubcommand>
+  implements TelemetryMethods<typeof updateSubcommand>
 {
   trackCliOptionPath(path: string | undefined) {
     if (path) {

--- a/packages/cli/src/util/telemetry/commands/crons/update.ts
+++ b/packages/cli/src/util/telemetry/commands/crons/update.ts
@@ -32,4 +32,13 @@ export class CronsUpdateTelemetryClient
       });
     }
   }
+
+  trackCliOptionDescription(description: string | undefined) {
+    if (description) {
+      this.trackCliOption({
+        option: 'description',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -151,6 +151,10 @@ const cronsSchema = {
         minLength: 9,
         maxLength: 256,
       },
+      description: {
+        type: 'string',
+        maxLength: 256,
+      },
     },
   },
 };

--- a/packages/cli/test/unit/commands/crons/add.test.ts
+++ b/packages/cli/test/unit/commands/crons/add.test.ts
@@ -128,6 +128,30 @@ describe('crons add', () => {
         host: 'custom.vercel.app',
       });
     });
+
+    it('includes description when provided', async () => {
+      mockLinkedProject();
+      const { getRequestBody } = mockAddEndpoint();
+
+      client.setArgv(
+        'crons',
+        'add',
+        '--path',
+        '/api/cron',
+        '--schedule',
+        '0 10 * * *',
+        '--description',
+        'Daily cleanup job'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      expect(getRequestBody()).toEqual({
+        path: '/api/cron',
+        schedule: '0 10 * * *',
+        description: 'Daily cleanup job',
+      });
+    });
   });
 
   describe('validation', () => {

--- a/packages/cli/test/unit/commands/crons/ls.test.ts
+++ b/packages/cli/test/unit/commands/crons/ls.test.ts
@@ -151,6 +151,7 @@ describe('crons ls', () => {
           path: '/api/cron',
           schedule: '0 * * * *',
           host: 'example.vercel.app',
+          description: null,
         },
       ]);
       expect(parsed.enabled).toBe(true);

--- a/packages/cli/test/unit/commands/crons/rm.test.ts
+++ b/packages/cli/test/unit/commands/crons/rm.test.ts
@@ -1,0 +1,285 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import crons from '../../../../src/commands/crons';
+import * as linkModule from '../../../../src/util/projects/link';
+
+vi.mock('../../../../src/util/projects/link');
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+
+const projectId = 'proj_crons_test';
+const projectName = 'crons-project';
+const orgSlug = 'my-team';
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: projectId,
+      name: projectName,
+      accountId: 'org_123',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: { id: 'org_123', slug: orgSlug, type: 'team' },
+  });
+}
+
+function mockProjectWithCrons(
+  definitions: {
+    host: string;
+    path: string;
+    schedule: string;
+    source?: 'api';
+  }[]
+) {
+  client.scenario.get(`/v9/projects/${projectId}`, (_req, res) => {
+    res.json({
+      id: projectId,
+      name: projectName,
+      crons: {
+        definitions,
+        disabledAt: null,
+        enabledAt: 1700000000000,
+      },
+    });
+  });
+}
+
+function mockDeleteEndpoint(opts?: { fail?: boolean; statusCode?: number }) {
+  let requestBody: any;
+  client.scenario.delete(
+    `/v1/projects/${projectId}/crons/definitions`,
+    (req, res) => {
+      requestBody = req.body;
+      if (opts?.fail) {
+        const code = opts.statusCode ?? 500;
+        if (code === 404) {
+          res.status(404).json({
+            error: {
+              message: 'Cron definition not found',
+              code: 'not_found',
+            },
+          });
+        } else {
+          res.status(code).json({
+            error: {
+              message: 'Internal Server Error',
+              code: 'internal_error',
+            },
+          });
+        }
+        return;
+      }
+      res.json({ definitions: [] });
+    }
+  );
+  return { getRequestBody: () => requestBody };
+}
+
+describe('crons rm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+  });
+
+  describe('--help', () => {
+    it('prints help and tracks telemetry', async () => {
+      client.setArgv('crons', 'rm', '--help');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(2);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'crons:rm' },
+      ]);
+    });
+  });
+
+  describe('with path argument and --yes', () => {
+    it('removes cron via API call', async () => {
+      mockLinkedProject();
+      const { getRequestBody } = mockDeleteEndpoint();
+
+      client.setArgv('crons', 'rm', '/api/cron', '--yes');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      expect(getRequestBody()).toEqual({ path: '/api/cron' });
+      await expect(client.stderr).toOutput('Removed cron job');
+    });
+  });
+
+  describe('confirmation prompt', () => {
+    it('prompts for confirmation and proceeds on yes', async () => {
+      mockLinkedProject();
+      mockDeleteEndpoint();
+
+      client.setArgv('crons', 'rm', '/api/cron');
+      const exitCodePromise = crons(client);
+
+      await expect(client.stderr).toOutput('Remove cron job');
+      client.stdin.write('y\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Removed cron job');
+    });
+
+    it('aborts when user declines confirmation', async () => {
+      mockLinkedProject();
+
+      client.setArgv('crons', 'rm', '/api/cron');
+      const exitCodePromise = crons(client);
+
+      await expect(client.stderr).toOutput('Remove cron job');
+      client.stdin.write('n\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Aborted');
+    });
+
+    it('errors in non-interactive mode without --yes', async () => {
+      mockedGetLinkedProject.mockResolvedValue({
+        status: 'linked',
+        project: {
+          id: projectId,
+          name: projectName,
+          accountId: 'org_123',
+          updatedAt: Date.now(),
+          createdAt: Date.now(),
+        },
+        org: { id: 'org_123', slug: orgSlug, type: 'team' },
+      });
+      client.setArgv('crons', 'rm', '/api/cron');
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Confirmation required');
+    });
+  });
+
+  describe('interactive selection', () => {
+    it('auto-selects when only one API-managed cron exists', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+          source: 'api',
+        },
+      ]);
+      mockDeleteEndpoint();
+
+      client.setArgv('crons', 'rm', '--yes');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Auto-selected');
+    });
+
+    it('prompts for selection with multiple API-managed crons', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron1',
+          schedule: '0 * * * *',
+          source: 'api',
+        },
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron2',
+          schedule: '0 0 * * *',
+          source: 'api',
+        },
+      ]);
+      mockDeleteEndpoint();
+
+      client.setArgv('crons', 'rm', '--yes');
+      const exitCodePromise = crons(client);
+
+      await expect(client.stderr).toOutput('Which cron job');
+      client.stdin.write('\n'); // select first option
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('errors when no API-managed crons exist', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: '0 * * * *',
+          // no source: 'api' — this is deployment-sourced
+        },
+      ]);
+
+      client.setArgv('crons', 'rm', '--yes');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('No API-managed cron jobs found');
+    });
+
+    it('errors in non-interactive mode without path', async () => {
+      mockedGetLinkedProject.mockResolvedValue({
+        status: 'linked',
+        project: {
+          id: projectId,
+          name: projectName,
+          accountId: 'org_123',
+          updatedAt: Date.now(),
+          createdAt: Date.now(),
+        },
+        org: { id: 'org_123', slug: orgSlug, type: 'team' },
+      });
+      client.setArgv('crons', 'rm', '--yes');
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('required in non-interactive');
+    });
+  });
+
+  describe('API error handling', () => {
+    it('handles not found error', async () => {
+      mockLinkedProject();
+      mockDeleteEndpoint({ fail: true, statusCode: 404 });
+
+      client.setArgv('crons', 'rm', '/api/nonexistent', '--yes');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Failed to remove cron job');
+    });
+  });
+
+  describe('not linked', () => {
+    it('errors when project is not linked', async () => {
+      mockedGetLinkedProject.mockResolvedValue({
+        status: 'not_linked',
+      } as any);
+      client.setArgv('crons', 'rm', '/api/cron', '--yes');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput("isn't linked");
+    });
+  });
+
+  describe('telemetry', () => {
+    it('tracks subcommand and path argument', async () => {
+      mockLinkedProject();
+      mockDeleteEndpoint();
+
+      client.setArgv('crons', 'rm', '/api/cron', '--yes');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:rm', value: 'rm' },
+        { key: 'argument:path', value: '[REDACTED]' },
+      ]);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/crons/update.test.ts
+++ b/packages/cli/test/unit/commands/crons/update.test.ts
@@ -150,6 +150,28 @@ describe('crons update', () => {
         host: 'custom.vercel.app',
       });
     });
+
+    it('updates description via API', async () => {
+      mockLinkedProject();
+      const { getRequestBody } = mockUpdateEndpoint();
+
+      client.setArgv(
+        'crons',
+        'update',
+        '--path',
+        '/api/cron',
+        '--description',
+        'Updated cleanup job'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      expect(getRequestBody()).toEqual({
+        path: '/api/cron',
+        description: 'Updated cleanup job',
+      });
+      await expect(client.stderr).toOutput('Updated cron job');
+    });
   });
 
   describe('validation', () => {
@@ -247,14 +269,14 @@ describe('crons update', () => {
       await expect(client.stderr).toOutput('Missing required flag --path');
     });
 
-    it('errors in non-interactive mode with path but no schedule or host', async () => {
+    it('errors in non-interactive mode with path but no schedule, host, or description', async () => {
       client.setArgv('crons', 'update', '--path', '/api/cron');
       (client.stdin as any).isTTY = false;
 
       const exitCode = await crons(client);
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput(
-        'At least one of --schedule or --host'
+        'At least one of --schedule, --host, or --description'
       );
     });
   });

--- a/packages/cli/test/unit/commands/crons/update.test.ts
+++ b/packages/cli/test/unit/commands/crons/update.test.ts
@@ -25,19 +25,19 @@ function mockLinkedProject() {
   });
 }
 
-function mockAddEndpoint(opts?: { fail?: boolean; statusCode?: number }) {
+function mockUpdateEndpoint(opts?: { fail?: boolean; statusCode?: number }) {
   let requestBody: any;
-  client.scenario.post(
+  client.scenario.patch(
     `/v1/projects/${projectId}/crons/definitions`,
     (req, res) => {
       requestBody = req.body;
       if (opts?.fail) {
         const code = opts.statusCode ?? 500;
-        if (code === 409) {
-          res.status(409).json({
+        if (code === 404) {
+          res.status(404).json({
             error: {
-              message: 'A cron definition with this path already exists',
-              code: 'conflict',
+              message: 'Cron definition not found',
+              code: 'not_found',
             },
           });
         } else {
@@ -50,12 +50,12 @@ function mockAddEndpoint(opts?: { fail?: boolean; statusCode?: number }) {
         }
         return;
       }
-      res.status(201).json({
+      res.json({
         definitions: [
           {
-            host: 'example.vercel.app',
+            host: req.body.host ?? 'example.vercel.app',
             path: req.body.path,
-            schedule: req.body.schedule,
+            schedule: req.body.schedule ?? '0 0 * * *',
             source: 'api',
           },
         ],
@@ -65,7 +65,7 @@ function mockAddEndpoint(opts?: { fail?: boolean; statusCode?: number }) {
   return { getRequestBody: () => requestBody };
 }
 
-describe('crons add', () => {
+describe('crons update', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     client.reset();
@@ -73,49 +73,47 @@ describe('crons add', () => {
 
   describe('--help', () => {
     it('prints help and tracks telemetry', async () => {
-      client.setArgv('crons', 'add', '--help');
+      client.setArgv('crons', 'update', '--help');
       const exitCode = await crons(client);
       expect(exitCode).toEqual(2);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'flag:help', value: 'crons:add' },
+        { key: 'flag:help', value: 'crons:update' },
       ]);
     });
   });
 
   describe('with flags', () => {
-    it('adds cron via API call', async () => {
+    it('updates cron schedule via API', async () => {
       mockLinkedProject();
-      const { getRequestBody } = mockAddEndpoint();
+      const { getRequestBody } = mockUpdateEndpoint();
 
       client.setArgv(
         'crons',
-        'add',
+        'update',
         '--path',
         '/api/cron',
         '--schedule',
-        '0 10 * * *'
+        '0 0 * * *'
       );
       const exitCode = await crons(client);
       expect(exitCode).toEqual(0);
 
       expect(getRequestBody()).toEqual({
         path: '/api/cron',
-        schedule: '0 10 * * *',
+        schedule: '0 0 * * *',
       });
-      await expect(client.stderr).toOutput('Added cron job');
+      await expect(client.stderr).toOutput('Updated cron job');
     });
 
-    it('includes host when provided', async () => {
+    it('updates cron host via API', async () => {
       mockLinkedProject();
-      const { getRequestBody } = mockAddEndpoint();
+      const { getRequestBody } = mockUpdateEndpoint();
 
       client.setArgv(
         'crons',
-        'add',
+        'update',
         '--path',
         '/api/cron',
-        '--schedule',
-        '0 10 * * *',
         '--host',
         'custom.vercel.app'
       );
@@ -124,7 +122,31 @@ describe('crons add', () => {
 
       expect(getRequestBody()).toEqual({
         path: '/api/cron',
-        schedule: '0 10 * * *',
+        host: 'custom.vercel.app',
+      });
+      await expect(client.stderr).toOutput('Updated cron job');
+    });
+
+    it('updates both schedule and host', async () => {
+      mockLinkedProject();
+      const { getRequestBody } = mockUpdateEndpoint();
+
+      client.setArgv(
+        'crons',
+        'update',
+        '--path',
+        '/api/cron',
+        '--schedule',
+        '*/5 * * * *',
+        '--host',
+        'custom.vercel.app'
+      );
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      expect(getRequestBody()).toEqual({
+        path: '/api/cron',
+        schedule: '*/5 * * * *',
         host: 'custom.vercel.app',
       });
     });
@@ -134,7 +156,7 @@ describe('crons add', () => {
     it('rejects path not starting with /', async () => {
       client.setArgv(
         'crons',
-        'add',
+        'update',
         '--path',
         'api/cron',
         '--schedule',
@@ -148,66 +170,34 @@ describe('crons add', () => {
     it('rejects invalid cron schedule', async () => {
       client.setArgv(
         'crons',
-        'add',
+        'update',
         '--path',
         '/api/cron',
         '--schedule',
-        'not-a-schedule'
+        'invalid'
       );
       const exitCode = await crons(client);
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput('must have exactly 5 fields');
     });
-
-    it('rejects path longer than 512 characters', async () => {
-      const longPath = '/' + 'a'.repeat(512);
-      client.setArgv(
-        'crons',
-        'add',
-        '--path',
-        longPath,
-        '--schedule',
-        '0 0 * * *'
-      );
-      const exitCode = await crons(client);
-      expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('512 characters or less');
-    });
   });
 
   describe('API error handling', () => {
-    it('handles duplicate path conflict', async () => {
+    it('handles not found error', async () => {
       mockLinkedProject();
-      mockAddEndpoint({ fail: true, statusCode: 409 });
+      mockUpdateEndpoint({ fail: true, statusCode: 404 });
 
       client.setArgv(
         'crons',
-        'add',
+        'update',
         '--path',
-        '/api/cron',
+        '/api/nonexistent',
         '--schedule',
         '0 0 * * *'
       );
       const exitCode = await crons(client);
       expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('Failed to add cron job');
-    });
-
-    it('handles server errors', async () => {
-      mockLinkedProject();
-      mockAddEndpoint({ fail: true, statusCode: 500 });
-
-      client.setArgv(
-        'crons',
-        'add',
-        '--path',
-        '/api/cron',
-        '--schedule',
-        '0 0 * * *'
-      );
-      const exitCode = await crons(client);
-      expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('Failed to add cron job');
+      await expect(client.stderr).toOutput('Failed to update cron job');
     });
   });
 
@@ -218,7 +208,7 @@ describe('crons add', () => {
       } as any);
       client.setArgv(
         'crons',
-        'add',
+        'update',
         '--path',
         '/api/cron',
         '--schedule',
@@ -231,42 +221,52 @@ describe('crons add', () => {
   });
 
   describe('interactive mode', () => {
-    it('prompts for path and schedule', async () => {
+    it('prompts for path and schedule when not provided', async () => {
       mockLinkedProject();
-      mockAddEndpoint();
+      mockUpdateEndpoint();
 
-      client.setArgv('crons', 'add');
+      client.setArgv('crons', 'update');
       const exitCodePromise = crons(client);
 
-      await expect(client.stderr).toOutput('API route path');
+      await expect(client.stderr).toOutput('path of the cron job to update');
       client.stdin.write('/api/cron\n');
 
-      await expect(client.stderr).toOutput('cron schedule expression');
+      await expect(client.stderr).toOutput('new cron schedule expression');
       client.stdin.write('0 0 * * *\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Added cron job');
     });
 
-    it('errors in non-interactive mode without flags', async () => {
-      client.setArgv('crons', 'add');
+    it('errors in non-interactive mode without path', async () => {
+      client.setArgv('crons', 'update');
       (client.stdin as any).isTTY = false;
 
       const exitCode = await crons(client);
       expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('Missing required flags');
+      await expect(client.stderr).toOutput('Missing required flag --path');
+    });
+
+    it('errors in non-interactive mode with path but no schedule or host', async () => {
+      client.setArgv('crons', 'update', '--path', '/api/cron');
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'At least one of --schedule or --host'
+      );
     });
   });
 
   describe('telemetry', () => {
     it('tracks subcommand and options', async () => {
       mockLinkedProject();
-      mockAddEndpoint();
+      mockUpdateEndpoint();
 
       client.setArgv(
         'crons',
-        'add',
+        'update',
         '--path',
         '/api/cron',
         '--schedule',
@@ -275,7 +275,7 @@ describe('crons add', () => {
       const exitCode = await crons(client);
       expect(exitCode).toEqual(0);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'subcommand:add', value: 'add' },
+        { key: 'subcommand:update', value: 'update' },
         { key: 'option:path', value: '[REDACTED]' },
         { key: 'option:schedule', value: '[REDACTED]' },
       ]);

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -175,6 +175,7 @@ export interface FunctionConfig {
 export interface CronJob {
   schedule: string;
   path: string;
+  description?: string;
 }
 
 export interface GitDeploymentConfig {


### PR DESCRIPTION
## Summary
- Replace `crons add` vercel.json file I/O with `POST /v1/projects/:id/crons/definitions` API call
- Add `crons update` subcommand (`PATCH`) for modifying schedule and host of existing cron definitions
- Add `crons rm` subcommand (`DELETE`) with confirmation prompt and interactive selection
- All subcommands support interactive and non-interactive (CI) modes with full telemetry

## Test plan
- [x] All 101 cron unit tests pass (`npx vitest run packages/cli/test/unit/commands/crons/`)
- [ ] Manual test `vercel crons add --path /api/cron --schedule "0 0 * * *"` against linked project
- [ ] Manual test `vercel crons update --path /api/cron --schedule "*/5 * * * *"`
- [ ] Manual test `vercel crons rm /api/cron --yes`
- [ ] Verify interactive prompts work for all three subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)