### PR TITLE
[backends] Fix build crash for unresolvable workspace deps

### DIFF
--- a/.changeset/fix-workspace-dep-resolve.md
+++ b/.changeset/fix-workspace-dep-resolve.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Fix crash when a workspace dependency cannot be resolved by rolldown

--- a/packages/backends/src/rolldown/index.ts
+++ b/packages/backends/src/rolldown/index.ts
@@ -165,8 +165,9 @@ export const rolldown = async (
           // Track local files for NFT
           if (resolved?.id && isLocalImport(resolved.id)) {
             localBuildFiles.add(resolved.id);
-          } else if (!resolved) {
-            // Entry point or unresolved local file
+          } else if (!resolved && !(isBareImport(id) && importer)) {
+            // Entry point (no importer) or unresolved local file
+            // Skip bare imports from importers (e.g. @repo/pkg that failed to resolve)
             localBuildFiles.add(join(args.workPath, id));
           }
 

--- a/packages/backends/src/rolldown/nft.ts
+++ b/packages/backends/src/rolldown/nft.ts
@@ -93,6 +93,13 @@ export const nft = async (
   await nftSpan.trace(runNft);
 };
 const isTypeScriptFile = (fsPath: string) => {
+  if (
+    fsPath.endsWith('.d.ts') ||
+    fsPath.endsWith('.d.mts') ||
+    fsPath.endsWith('.d.cts')
+  ) {
+    return false;
+  }
   return (
     fsPath.endsWith('.ts') ||
     fsPath.endsWith('.tsx') ||

--- a/packages/backends/test/fixtures/17-turborepo-hono-monorepo/apps/api/package.json
+++ b/packages/backends/test/fixtures/17-turborepo-hono-monorepo/apps/api/package.json
@@ -6,6 +6,8 @@
   },
   "dependencies": {
     "@repo/echo-with-dep": "workspace:*",
+    "@repo/shared-types": "workspace:*",
+    "@repo/ts-utils": "workspace:*",
     "@vercel/nft": "^1.3.0",
     "hono": "^4.8.10",
     "jsonwebtoken": "9.0.2",

--- a/packages/backends/test/fixtures/17-turborepo-hono-monorepo/apps/api/server.ts
+++ b/packages/backends/test/fixtures/17-turborepo-hono-monorepo/apps/api/server.ts
@@ -7,6 +7,8 @@ import { info as esmFsRead } from "./lib/esm-fs-read";
 import { info as cjsRequiringCjs } from "./lib/cjs-requiring-cjs";
 import { info as esmImportingCjs } from "@/esm-importing-cjs";
 import { echo as echoWithDep } from '@repo/echo-with-dep/src'
+import { greet } from '@repo/ts-utils'
+import { type User, DEFAULT_PAGE_SIZE } from '@repo/shared-types'
 import { sign } from "jsonwebtoken";
 
 console.log('cjsRequiringCjs', cjsRequiringCjs())
@@ -14,6 +16,8 @@ console.log('esmImportingCjs', esmImportingCjs())
 console.log('esmFsRead', esmFsRead())
 console.log('cjsFsRead', cjsFsRead())
 console.log('echoWithDep', echoWithDep('hello from the server'))
+console.log('greet', greet('world'))
+console.log('pageSize', DEFAULT_PAGE_SIZE)
 console.log("sign", sign({ message: "hello from the server" }, "secret"));
 
 const app = new Hono();

--- a/packages/backends/test/fixtures/17-turborepo-hono-monorepo/files.json
+++ b/packages/backends/test/fixtures/17-turborepo-hono-monorepo/files.json
@@ -1,0 +1,9 @@
+[
+  "packages/echo-with-dep/src/index.mjs",
+  "packages/echo-with-dep/package.json",
+  "packages/ts-utils/src/index.mjs",
+  "packages/ts-utils/package.json",
+  "packages/shared-types/src/index.mjs",
+  "packages/shared-types/package.json",
+  "_virtual/_cjs-shim_packages_echo-with-dep_jsonwebtoken.mjs"
+]

--- a/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/echo-with-dep/package.json
+++ b/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/echo-with-dep/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@repo/echo-with-dep",
   "version": "0.0.0",
+  "exports": {
+    "./src": "./src/index.ts"
+  },
   "dependencies": {
     "jsonwebtoken": "9.0.3",
     "cowsay": "1.6.0"

--- a/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/shared-types/package.json
+++ b/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/shared-types/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repo/shared-types",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/shared-types/src/index.ts
+++ b/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/shared-types/src/index.ts
@@ -1,0 +1,12 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export type ApiResponse<T> = {
+  data: T;
+  status: number;
+};
+
+export const DEFAULT_PAGE_SIZE = 20;

--- a/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/ts-utils/package.json
+++ b/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/ts-utils/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repo/ts-utils",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/ts-utils/src/index.ts
+++ b/packages/backends/test/fixtures/17-turborepo-hono-monorepo/packages/ts-utils/src/index.ts
@@ -1,0 +1,1 @@
+export const greet = (name: string): string => `Hello, ${name}!`;

--- a/packages/backends/test/unit.test.ts
+++ b/packages/backends/test/unit.test.ts
@@ -206,6 +206,37 @@ describe('successful builds', async () => {
   }, 20000);
 });
 
+it.skipIf(process.platform === 'win32')(
+  'does not crash when a workspace dep cannot be resolved',
+  async () => {
+    const fixtureName = '17-turborepo-hono-monorepo';
+    const fixtureSource = join(__dirname, 'fixtures', fixtureName);
+    const { workDir } = await getWorkDir(fixtureName, fixtureSource);
+
+    // Add an unresolvable workspace dep import to server.ts
+    const serverPath = join(workDir, 'apps/api/server.ts');
+    const serverContent = await readFile(serverPath, 'utf-8');
+    await writeFile(
+      serverPath,
+      `// @ts-expect-error\nimport { MAGIC } from '@repo/unresolvable'\nconsole.log(MAGIC)\n${serverContent}`
+    );
+
+    // The workspace dep has no exports/main, so rolldown can't resolve it.
+    // Before the fix, this caused: "File .../apps/api/@repo/unresolvable does not exist."
+    await expect(
+      build({
+        files: {},
+        workPath: join(workDir, 'apps/api'),
+        config: getFixtureConfig(await loadVercelJson(fixtureSource)),
+        meta,
+        entrypoint: 'package.json',
+        repoRootPath: workDir,
+      })
+    ).resolves.toBeDefined();
+  },
+  30000
+);
+
 it('extractAndExecuteLambda throws with invalid code', async () => {
   const validLambda = new NodejsLambda({
     runtime: 'nodejs22.x',


### PR DESCRIPTION
## Summary
- Fix build crash when a workspace dep can't be resolved by rolldown (e.g. missing `exports`/`main`). The plugin was adding a bogus path like `join(workPath, '@repo/pkg')` to `localBuildFiles`, causing NFT to crash with `File .../@repo/pkg does not exist.`
- Fix `isTypeScriptFile` in NFT to exclude `.d.ts` files, aligning with the cervel implementation
- Expand monorepo workspace dep test coverage with new fixture packages (`@repo/ts-utils` with `exports` field, `@repo/shared-types` with types + values) and `files.json` assertions

## Test plan
- [x] Regression test: `does not crash when a workspace dep cannot be resolved` — injects an unresolvable bare import and asserts build completes
- [x] Fixture 17 now asserts workspace dep transpiled files are in the lambda (`files.json`)
- [x] Full test suite passes (27 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)