### PR TITLE
[python] Fix env marker-excluded deps erroneously flagged as lacking wheels

### DIFF
--- a/.changeset/silly-falcons-march.md
+++ b/.changeset/silly-falcons-march.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python-analysis': patch
+'@vercel/python': patch
+---
+
+Fix env marker-excluded deps erroneously flagged as lacking wheels

--- a/packages/python-analysis/Cargo.lock
+++ b/packages/python-analysis/Cargo.lock
@@ -1652,6 +1652,7 @@ dependencies = [
  "uv-distribution-types",
  "uv-git-types",
  "uv-normalize",
+ "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",

--- a/packages/python-analysis/Cargo.toml
+++ b/packages/python-analysis/Cargo.toml
@@ -30,6 +30,7 @@ uv-platform-tags = { git = "https://github.com/astral-sh/uv", rev = "35d1e90961c
 uv-distribution-types = { git = "https://github.com/astral-sh/uv", rev = "35d1e90961c1c2bd238ee6b015f970c0cf97f5d5" }
 uv-git-types = { git = "https://github.com/astral-sh/uv", rev = "35d1e90961c1c2bd238ee6b015f970c0cf97f5d5" }
 uv-normalize = { git = "https://github.com/astral-sh/uv", rev = "35d1e90961c1c2bd238ee6b015f970c0cf97f5d5" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", rev = "35d1e90961c1c2bd238ee6b015f970c0cf97f5d5" }
 uv-pep508 = { git = "https://github.com/astral-sh/uv", rev = "35d1e90961c1c2bd238ee6b015f970c0cf97f5d5", features = ["non-pep508-extensions"] }
 uv-pypi-types = { git = "https://github.com/astral-sh/uv", rev = "35d1e90961c1c2bd238ee6b015f970c0cf97f5d5" }
 uv-redacted = { git = "https://github.com/astral-sh/uv", rev = "35d1e90961c1c2bd238ee6b015f970c0cf97f5d5" }

--- a/packages/python-analysis/crates/vercel_python_analysis/Cargo.toml
+++ b/packages/python-analysis/crates/vercel_python_analysis/Cargo.toml
@@ -19,6 +19,7 @@ uv-platform-tags.workspace = true
 uv-distribution-types.workspace = true
 uv-git-types.workspace = true
 uv-normalize.workspace = true
+uv-pep440.workspace = true
 uv-pep508.workspace = true
 uv-pypi-types.workspace = true
 uv-requirements-txt.workspace = true

--- a/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
+++ b/packages/python-analysis/crates/vercel_python_analysis/src/lib.rs
@@ -14,7 +14,12 @@ struct PythonAnalyzer;
 
 use std::future::Future;
 use std::pin::pin;
+use std::str::FromStr;
 use std::task::{Context, Poll, Waker};
+
+use uv_distribution_filename::WheelFilename;
+use uv_pep508::{MarkerEnvironmentBuilder, MarkerTree};
+use uv_platform_tags::{Arch, Os, Platform, Tags};
 
 use crate::bindings::{DirectUrlInfo, DistMetadata, ParsedReqEntry, ParsedRequirementsTxt, RecordEntry};
 use crate::entrypoint::{
@@ -98,10 +103,6 @@ impl crate::bindings::Guest for PythonAnalyzer {
         os_major: u16,
         os_minor: u16,
     ) -> Result<bool, String> {
-        use std::str::FromStr;
-        use uv_distribution_filename::WheelFilename;
-        use uv_platform_tags::{Arch, Os, Platform, Tags};
-
         let wheel = WheelFilename::from_str(&wheel_filename)
             .map_err(|e| format!("invalid wheel filename: {e}"))?;
 
@@ -140,5 +141,48 @@ impl crate::bindings::Guest for PythonAnalyzer {
         .map_err(|e| format!("failed to build platform tags: {e}"))?;
 
         Ok(wheel.is_compatible(&tags))
+    }
+
+    fn evaluate_marker(
+        marker: String,
+        python_major: u8,
+        python_minor: u8,
+        sys_platform: String,
+        platform_machine: String,
+    ) -> Result<bool, String> {
+        let marker_tree = MarkerTree::from_str(&marker)
+            .map_err(|e| format!("invalid marker expression: {e}"))?;
+
+        let python_version = format!("{python_major}.{python_minor}");
+        let python_full_version = format!("{python_major}.{python_minor}.0");
+
+        // Derive os_name and platform_system from sys_platform
+        let (os_name, platform_system) = match sys_platform.as_str() {
+            "linux" => ("posix", "Linux"),
+            "win32" => ("nt", "Windows"),
+            "darwin" => ("posix", "Darwin"),
+            _ => ("posix", "Linux"), // conservative default
+        };
+
+        let env = MarkerEnvironmentBuilder {
+            implementation_name: "cpython",
+            implementation_version: &python_full_version,
+            os_name,
+            platform_machine: &platform_machine,
+            platform_python_implementation: "CPython",
+            platform_release: "",
+            platform_system,
+            platform_version: "",
+            python_full_version: &python_full_version,
+            python_version: &python_version,
+            sys_platform: &sys_platform,
+        }
+        .try_into()
+        .map_err(|e: uv_pep440::VersionParseError| {
+            format!("failed to build marker environment: {e}")
+        })?;
+
+        let extras: &[uv_normalize::ExtraName] = &[];
+        Ok(marker_tree.evaluate(&env, extras))
     }
 }

--- a/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
+++ b/packages/python-analysis/crates/vercel_python_analysis/wit/world.wit
@@ -199,4 +199,25 @@ world python-analysis {
         os-major: u16,
         os-minor: u16,
     ) -> result<bool, string>;
+
+    // =========================================================================
+    // PEP 508 environment marker evaluation
+    // =========================================================================
+
+    /// Evaluate a PEP 508 environment marker against a target environment.
+    ///
+    /// `marker` is a PEP 508 marker expression (e.g. "sys_platform == 'win32'").
+    /// `sys-platform` is e.g. "linux", "win32", "darwin".
+    /// `platform-machine` is e.g. "x86_64", "aarch64".
+    /// The remaining environment variables (`os_name`, `platform_system`, etc.)
+    /// are derived from `sys-platform`.
+    ///
+    /// Returns true if the marker is satisfied for the target environment.
+    export evaluate-marker: func(
+        marker: string,
+        python-major: u8,
+        python-minor: u8,
+        sys-platform: string,
+        platform-machine: string,
+    ) -> result<bool, string>;
 }

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -86,7 +86,10 @@ export {
 // Wheel compatibility checking
 // =============================================================================
 
-export { isWheelCompatible } from './manifest/wheel-compat';
+export {
+  evaluateMarker,
+  isWheelCompatible,
+} from './manifest/wheel-compat';
 
 // =============================================================================
 // Python selection (runtime + types)

--- a/packages/python-analysis/src/manifest/uv-lock-parser.ts
+++ b/packages/python-analysis/src/manifest/uv-lock-parser.ts
@@ -29,7 +29,7 @@ export interface UvLockPackage {
   version: string;
   source?: UvLockPackageSource;
   wheels: UvLockWheel[];
-  dependencies?: Array<{ name: string }>;
+  dependencies?: Array<{ name: string; marker?: string }>;
 }
 
 /**
@@ -50,7 +50,7 @@ interface UvLockToml {
     version: string;
     source?: UvLockPackageSource;
     wheels?: Array<{ url: string }>;
-    dependencies?: Array<{ name: string }>;
+    dependencies?: Array<{ name: string; marker?: string }>;
   }>;
 }
 

--- a/packages/python-analysis/src/manifest/wheel-compat.ts
+++ b/packages/python-analysis/src/manifest/wheel-compat.ts
@@ -4,7 +4,7 @@ import { importWasmModule } from '../wasm/load';
  * Check if a wheel filename is compatible with a given platform.
  *
  * Uses uv's `WheelFilename::is_compatible()` and `Tags::from_env()` via WASM
- * — the same logic uv uses for resolution.
+ * -- the same logic uv uses for resolution.
  *
  * @param wheelFilename - The wheel filename (e.g. "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.whl")
  * @param pythonMajor - Python major version (e.g. 3)
@@ -33,5 +33,35 @@ export async function isWheelCompatible(
     archName,
     osMajor,
     osMinor
+  );
+}
+
+/**
+ * Evaluate a PEP 508 environment marker against a target environment.
+ *
+ * Uses uv's `MarkerTree::evaluate()` via WASM -- the same logic uv uses
+ * for dependency resolution.
+ *
+ * @param marker - PEP 508 marker expression (e.g. "sys_platform == 'win32'")
+ * @param pythonMajor - Python major version (e.g. 3)
+ * @param pythonMinor - Python minor version (e.g. 12)
+ * @param sysPlatform - sys_platform value: "linux", "win32", "darwin"
+ * @param platformMachine - platform_machine value: "x86_64", "aarch64", etc.
+ * @returns true if the marker is satisfied for the target environment
+ */
+export async function evaluateMarker(
+  marker: string,
+  pythonMajor: number,
+  pythonMinor: number,
+  sysPlatform: string,
+  platformMachine: string
+): Promise<boolean> {
+  const mod = await importWasmModule();
+  return mod.evaluateMarker(
+    marker,
+    pythonMajor,
+    pythonMinor,
+    sysPlatform,
+    platformMachine
   );
 }

--- a/packages/python-analysis/test/uv-lock-parser.test.ts
+++ b/packages/python-analysis/test/uv-lock-parser.test.ts
@@ -1,7 +1,39 @@
 import { describe, it, expect } from 'vitest';
 import { parseUvLock } from '../src/manifest/uv-lock-parser';
+import { evaluateMarker } from '../src/manifest/wheel-compat';
 
 describe('uv-lock-parser', () => {
+  describe('parseUvLock dependency marker parsing', () => {
+    it('extracts marker field from dependencies', () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "myapp"
+version = "1.0.0"
+dependencies = [
+    { name = "requests" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "os_name == 'nt'" },
+]
+`;
+      const lockFile = parseUvLock(lockContent);
+      expect(lockFile.packages).toHaveLength(1);
+      const deps = lockFile.packages[0].dependencies!;
+      expect(deps).toHaveLength(3);
+      expect(deps[0]).toEqual({ name: 'requests' });
+      expect(deps[1]).toEqual({
+        name: 'pywin32',
+        marker: "sys_platform == 'win32'",
+      });
+      expect(deps[2]).toEqual({
+        name: 'colorama',
+        marker: "os_name == 'nt'",
+      });
+    });
+  });
+
   describe('parseUvLock wheel parsing', () => {
     it('extracts wheel entries from packages', () => {
       const lockContent = `
@@ -83,6 +115,154 @@ version = "0.1.0"
 
       const customPkg = lockFile.packages.find(p => p.name === 'custom-pkg');
       expect(customPkg?.wheels).toEqual([]);
+    });
+  });
+
+  describe('evaluateMarker', () => {
+    it('rejects win32-only markers on Linux', async () => {
+      expect(
+        await evaluateMarker(
+          "sys_platform == 'win32'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(false);
+    });
+
+    it('accepts linux markers on Linux', async () => {
+      expect(
+        await evaluateMarker(
+          "sys_platform == 'linux'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(true);
+    });
+
+    it('rejects os_name == nt on Linux', async () => {
+      expect(
+        await evaluateMarker("os_name == 'nt'", 3, 12, 'linux', 'x86_64')
+      ).toBe(false);
+    });
+
+    it('accepts os_name == posix on Linux', async () => {
+      expect(
+        await evaluateMarker("os_name == 'posix'", 3, 12, 'linux', 'x86_64')
+      ).toBe(true);
+    });
+
+    it('rejects platform_system == Windows on Linux', async () => {
+      expect(
+        await evaluateMarker(
+          "platform_system == 'Windows'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(false);
+    });
+
+    it('accepts platform_system == Linux on Linux', async () => {
+      expect(
+        await evaluateMarker(
+          "platform_system == 'Linux'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(true);
+    });
+
+    it('handles compound markers with and', async () => {
+      // Both conditions must be true; sys_platform == 'win32' is false on Linux
+      expect(
+        await evaluateMarker(
+          "python_version >= '3.12' and sys_platform == 'win32'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(false);
+    });
+
+    it('handles compound markers with or', async () => {
+      // At least one condition must be true; sys_platform == 'linux' is true
+      expect(
+        await evaluateMarker(
+          "sys_platform == 'win32' or sys_platform == 'linux'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(true);
+    });
+
+    it('accepts python version markers for matching version', async () => {
+      expect(
+        await evaluateMarker(
+          "python_version >= '3.12'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(true);
+    });
+
+    it('rejects python version markers for non-matching version', async () => {
+      expect(
+        await evaluateMarker(
+          "python_full_version < '3.12'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(false);
+    });
+
+    it('handles platform_machine markers', async () => {
+      expect(
+        await evaluateMarker(
+          "platform_machine == 'x86_64'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(true);
+      expect(
+        await evaluateMarker(
+          "platform_machine == 'aarch64'",
+          3,
+          12,
+          'linux',
+          'x86_64'
+        )
+      ).toBe(false);
+    });
+
+    it('evaluates markers for win32 target', async () => {
+      expect(
+        await evaluateMarker(
+          "sys_platform == 'win32'",
+          3,
+          12,
+          'win32',
+          'x86_64'
+        )
+      ).toBe(true);
+      expect(
+        await evaluateMarker("os_name == 'nt'", 3, 12, 'win32', 'x86_64')
+      ).toBe(true);
     });
   });
 });

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -10,13 +10,14 @@ import {
 } from '@vercel/build-utils';
 import {
   classifyPackages,
+  evaluateMarker,
   isWheelCompatible,
   normalizePackageName,
   parseUvLock,
   PythonAnalysisError,
   scanDistributions,
 } from '@vercel/python-analysis';
-import type { UvLockFile } from '@vercel/python-analysis';
+import type { UvLockFile, UvLockPackage } from '@vercel/python-analysis';
 import { getVenvSitePackagesDirs } from './install';
 import { getUvBinaryForBundling, UV_BUNDLE_DIR } from './uv';
 import { detectPlatform } from './utils';
@@ -490,13 +491,44 @@ export class PythonDependencyExternalizer {
    * Identify public packages that have no compatible wheel for the Lambda platform.
    * These packages must be force-bundled because `uv sync --no-build` at cold start
    * will refuse to build from source.
+   *
+   * Packages that are not reachable on the target platform (e.g. pywin32 which is
+   * only a dependency when `sys_platform == 'win32'`) are excluded -- they will
+   * never be installed by `uv sync` on Lambda, so their wheel compatibility is
+   * irrelevant.
    */
   private async findPackagesWithoutCompatibleWheels(
     lockFile: UvLockFile,
     publicPackageNames: string[]
   ): Promise<string[]> {
     const platform = detectPlatform();
-    const publicSet = new Set(publicPackageNames.map(normalizePackageName));
+
+    // Determine which packages are actually reachable on the target platform
+    // by traversing the dependency graph and evaluating environment markers.
+    const reachable = await getPackagesReachableOnPlatform(
+      lockFile,
+      this.projectName,
+      this.pythonMajor,
+      this.pythonMinor,
+      platform.sysPlatform,
+      platform.archName
+    );
+
+    // Only check wheel compatibility for packages reachable on the target platform.
+    const relevantPackages = reachable
+      ? publicPackageNames.filter(name =>
+          reachable.has(normalizePackageName(name))
+        )
+      : publicPackageNames;
+
+    if (relevantPackages.length < publicPackageNames.length) {
+      debug(
+        `Skipping wheel check for ${publicPackageNames.length - relevantPackages.length} ` +
+          `package(s) not reachable on the target platform`
+      );
+    }
+
+    const publicSet = new Set(relevantPackages.map(normalizePackageName));
 
     // Build a map of normalized package name -> wheels from the lock file
     const packageWheels = new Map<string, Array<{ url: string }>>();
@@ -509,12 +541,12 @@ export class PythonDependencyExternalizer {
 
     const incompatible: string[] = [];
 
-    for (const name of publicPackageNames) {
+    for (const name of relevantPackages) {
       const normalized = normalizePackageName(name);
       const wheels = packageWheels.get(normalized);
 
       if (!wheels || wheels.length === 0) {
-        // No wheels listed in the lock file — must be source-only
+        // No wheels listed in the lock file -- must be source-only
         incompatible.push(name);
         continue;
       }
@@ -555,6 +587,92 @@ export class PythonDependencyExternalizer {
 
     return incompatible;
   }
+}
+
+/**
+ * Compute the set of packages reachable from the project root on the target
+ * platform by traversing the dependency graph and evaluating environment
+ * markers using uv's PEP 508 marker evaluator.
+ *
+ * Packages guarded by markers that exclude the target platform (e.g.
+ * `sys_platform == 'win32'` when targeting Linux) are not traversed.
+ *
+ * Returns `null` if the project name is not provided (cannot determine root),
+ * in which case callers should fall back to considering all packages.
+ */
+export async function getPackagesReachableOnPlatform(
+  lockFile: UvLockFile,
+  projectName: string | undefined,
+  pythonMajor: number,
+  pythonMinor: number,
+  sysPlatform: string,
+  platformMachine: string
+): Promise<Set<string> | null> {
+  if (!projectName) return null;
+
+  const rootNormalized = normalizePackageName(projectName);
+
+  // Build a map from normalized name to package entry
+  const packageMap = new Map<string, UvLockPackage>();
+  for (const pkg of lockFile.packages) {
+    packageMap.set(normalizePackageName(pkg.name), pkg);
+  }
+
+  const rootPkg = packageMap.get(rootNormalized);
+  if (!rootPkg) return null;
+
+  const visited = new Set<string>();
+  const queue: string[] = [];
+  let queueHead = 0;
+
+  // Seed the BFS with the root package's compatible dependencies
+  async function enqueueDeps(pkg: UvLockPackage): Promise<void> {
+    if (!pkg.dependencies) return;
+    for (const dep of pkg.dependencies) {
+      const normalized = normalizePackageName(dep.name);
+      if (visited.has(normalized)) continue;
+      if (dep.marker) {
+        try {
+          const compatible = await evaluateMarker(
+            dep.marker,
+            pythonMajor,
+            pythonMinor,
+            sysPlatform,
+            platformMachine
+          );
+          if (!compatible) {
+            debug(
+              `Skipping dependency ${dep.name}: marker "${dep.marker}" not satisfied on ${sysPlatform}`
+            );
+            continue;
+          }
+        } catch (err) {
+          // If we can't evaluate the marker, conservatively include the dependency
+          debug(
+            `Failed to evaluate marker "${dep.marker}" for ${dep.name}, including conservatively: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      }
+      queue.push(normalized);
+    }
+  }
+
+  await enqueueDeps(rootPkg);
+
+  while (queueHead < queue.length) {
+    const current = queue[queueHead++];
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    const pkg = packageMap.get(current);
+    if (pkg) {
+      await enqueueDeps(pkg);
+    }
+  }
+
+  return visited;
 }
 
 // Utility functions

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -152,8 +152,10 @@ export interface PlatformInfo {
   osMajor: number;
   /** Libc minor version */
   osMinor: number;
-  /** High-level OS for PythonBuild: always "linux" for Lambda */
+  /** High-level OS for PythonBuild: "linux", "macos", or "windows" */
   os: string;
+  /** PEP 508 sys_platform value: "linux", "win32", or "darwin" */
+  sysPlatform: string;
   /** High-level libc for PythonBuild: "gnu" or "musl" */
   libc: string;
 }
@@ -169,19 +171,20 @@ const ARCH_MAP: Record<string, string> = {
 };
 
 /**
- * Detect the Lambda target platform for wheel compatibility checking.
+ * Detect the host platform for wheel compatibility checking and build selection.
  *
- * The Lambda runtime is always Linux. On the Vercel build image (which shares
- * the Lambda base), we use `detect-libc` to get the exact glibc/musl version.
- * For local `vercel build` on non-Linux hosts we fall back to conservative
- * defaults (manylinux, glibc 2.17, x86_64).
+ * On the Vercel build image (Linux), we use `detect-libc` to get the exact
+ * glibc/musl version. For local `vercel build` on non-Linux hosts we fall
+ * back to conservative manylinux defaults for wheel tags (since the host
+ * doesn't have a Linux libc).
  */
 export function detectPlatform(): PlatformInfo {
   const arch = os.arch();
   const archName = ARCH_MAP[arch] || arch;
 
-  // Lambda is always Linux — detect libc family and version from the
-  // build image (which runs the same base as the Lambda runtime).
+  // Detect libc family and version from the host. On the Vercel build
+  // image this matches the Lambda runtime; on non-Linux hosts it will
+  // be null and we fall back to conservative defaults.
   const libcFamily = detectLibc.familySync();
   const libcVersion = detectLibc.versionSync();
 
@@ -200,7 +203,7 @@ export function detectPlatform(): PlatformInfo {
     osMajor = parseInt(parts[0], 10);
     osMinor = parseInt(parts[1], 10) || 0;
   } else if (libcFamily === detectLibc.GLIBC) {
-    // glibc detected but version unknown — use conservative default
+    // glibc detected but version unknown -- use conservative default
     osMajor = 2;
     osMinor = 17;
   } else {
@@ -212,5 +215,29 @@ export function detectPlatform(): PlatformInfo {
 
   const libc = libcFamily === detectLibc.MUSL ? 'musl' : 'gnu';
 
-  return { osName, archName, osMajor, osMinor, os: 'linux', libc };
+  // PEP 508 sys_platform value derived from the Node.js process platform.
+  const SYS_PLATFORM_MAP: Record<string, string> = {
+    linux: 'linux',
+    win32: 'win32',
+    darwin: 'darwin',
+  };
+  const sysPlatform = SYS_PLATFORM_MAP[process.platform] || 'linux';
+
+  // High-level OS for PythonBuild selection, derived from the host platform.
+  const OS_MAP: Record<string, string> = {
+    linux: 'linux',
+    win32: 'windows',
+    darwin: 'macos',
+  };
+  const detectedOs = OS_MAP[process.platform] || 'linux';
+
+  return {
+    osName,
+    archName,
+    osMajor,
+    osMinor,
+    os: detectedOs,
+    sysPlatform,
+    libc,
+  };
 }

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'os';
 import {
   PythonDependencyExternalizer,
   calculateBundleSize,
+  getPackagesReachableOnPlatform,
   lambdaKnapsack,
   LAMBDA_SIZE_THRESHOLD_BYTES,
   LAMBDA_EPHEMERAL_STORAGE_BYTES,
@@ -265,6 +266,454 @@ version = "2.31.0"
       expect(result.packageVersions['my-app']).toBeUndefined();
       // requests should still be classified
       expect(result.publicPackages).toContain('requests');
+    });
+  });
+
+  describe('getPackagesReachableOnPlatform', () => {
+    it('returns null when projectName is undefined', async () => {
+      const lockFile = { packages: [] };
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        undefined,
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null when root package is not found in lock file', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).toBeNull();
+    });
+
+    it('includes all unmarked dependencies', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "requests" },
+    { name = "flask" },
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[[package]]
+name = "flask"
+version = "3.0.0"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('requests')).toBe(true);
+      expect(result!.has('flask')).toBe(true);
+    });
+
+    it('excludes packages guarded by win32 marker on linux', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "requests" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[[package]]
+name = "pywin32"
+version = "306"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('requests')).toBe(true);
+      expect(result!.has('pywin32')).toBe(false);
+    });
+
+    it('prunes entire subtree behind an excluded marker', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "requests" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[[package]]
+name = "pywin32"
+version = "306"
+dependencies = [
+    { name = "pywin32-ctypes" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.2"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('requests')).toBe(true);
+      expect(result!.has('pywin32')).toBe(false);
+      expect(result!.has('pywin32-ctypes')).toBe(false);
+    });
+
+    it('includes packages with linux-satisfied markers', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "uvloop", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.19.0"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('uvloop')).toBe(true);
+    });
+
+    it('includes win32 packages when target is win32', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+
+[[package]]
+name = "pywin32"
+version = "306"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'win32',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('pywin32')).toBe(true);
+    });
+
+    it('traverses transitive dependencies', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+dependencies = [
+    { name = "urllib3" },
+    { name = "certifi" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.1.0"
+
+[[package]]
+name = "certifi"
+version = "2024.2.2"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('requests')).toBe(true);
+      expect(result!.has('urllib3')).toBe(true);
+      expect(result!.has('certifi')).toBe(true);
+    });
+
+    it('does not include the root project itself in the reachable set', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('my-app')).toBe(false);
+      expect(result!.has('requests')).toBe(true);
+    });
+
+    it('handles diamond dependencies without duplication', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "pkg-a" },
+    { name = "pkg-b" },
+]
+
+[[package]]
+name = "pkg-a"
+version = "1.0.0"
+dependencies = [
+    { name = "shared" },
+]
+
+[[package]]
+name = "pkg-b"
+version = "1.0.0"
+dependencies = [
+    { name = "shared" },
+]
+
+[[package]]
+name = "shared"
+version = "1.0.0"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('pkg-a')).toBe(true);
+      expect(result!.has('pkg-b')).toBe(true);
+      expect(result!.has('shared')).toBe(true);
+      expect(result!.size).toBe(3);
+    });
+
+    it('handles compound markers with mixed platform conditions', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "linux-only", marker = "sys_platform == 'linux' and python_version >= '3.12'" },
+    { name = "win-and-py", marker = "sys_platform == 'win32' and python_version >= '3.12'" },
+]
+
+[[package]]
+name = "linux-only"
+version = "1.0.0"
+
+[[package]]
+name = "win-and-py"
+version = "1.0.0"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('linux-only')).toBe(true);
+      expect(result!.has('win-and-py')).toBe(false);
+    });
+
+    it('normalizes package names for matching', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "My-App"
+version = "0.1.0"
+dependencies = [
+    { name = "My-Package" },
+]
+
+[[package]]
+name = "My-Package"
+version = "1.0.0"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('my-package')).toBe(true);
+    });
+
+    it('returns empty set when root has no dependencies', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.size).toBe(0);
+    });
+
+    it('excludes os_name == nt dependencies on linux', async () => {
+      const lockContent = `
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "click" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+
+[[package]]
+name = "click"
+version = "8.1.7"
+`;
+      const lockFile = parseUvLock(lockContent);
+      const result = await getPackagesReachableOnPlatform(
+        lockFile,
+        'my-app',
+        3,
+        12,
+        'linux',
+        'x86_64'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.has('click')).toBe(true);
+      expect(result!.has('colorama')).toBe(false);
     });
   });
 


### PR DESCRIPTION
Dependencies guarded by PEP 508 environment markers that exclude the
target platform (e.g. pywin32 with `sys_platform == 'win32'`) are
being checked for Linux wheel compatibility and incorrectly marked
for force-bundling.

Fix by traversing the `uv.lock` dependency graph from the project root,
evaluating markers via uv's `MarkerTree::evaluate()` (exposed through
the WASM module), to determine which packages are actually reachable
on the target platform before checking wheel compatibility.
