### PR TITLE
[cli] Fix SDK key detection to avoid false positives with third-party identifiers

### DIFF
--- a/packages/cli/src/commands/build/emit-flags-datafiles.ts
+++ b/packages/cli/src/commands/build/emit-flags-datafiles.ts
@@ -97,11 +97,22 @@ function generateDefinitionsModule(
 }
 
 /**
+ * Checks if a value is a valid Vercel Flags SDK key.
+ * SDK keys follow the format: vf_server_* or vf_client_*
+ * This is more specific than just checking for 'vf_' prefix to avoid
+ * false positives with third-party service identifiers (e.g., Stripe's
+ * identity flow IDs like 'vf_1PyHgVLpWuMxVFx...').
+ */
+function isVercelFlagsSdkKey(value: string): boolean {
+  return value.startsWith('vf_server_') || value.startsWith('vf_client_');
+}
+
+/**
  * Emits flag definitions into node_modules/@vercel/flags-definitions
  *
- * Reads SDK keys (vf_ prefix) from environment variables, fetches definitions
- * from flags.vercel.com, and writes them to a synthetic package that can be
- * imported at runtime.
+ * Reads SDK keys (vf_server_* or vf_client_* format) from environment
+ * variables, fetches definitions from flags.vercel.com, and writes them
+ * to a synthetic package that can be imported at runtime.
  */
 export async function emitFlagsDatafiles(
   cwd: string,
@@ -110,16 +121,16 @@ export async function emitFlagsDatafiles(
   output.debug('vercel-flags: checking env vars for SDK Keys');
 
   // Collect unique SDK keys from environment variables
-  // Supports both direct SDK keys (vf_ prefix) and flags: format
+  // Supports both direct SDK keys (vf_server_*/vf_client_*) and flags: format
   const sdkKeys = Array.from(
     Object.values(env).reduce<Set<string>>((acc, value) => {
       if (typeof value === 'string') {
-        if (value.startsWith('vf_')) {
+        if (isVercelFlagsSdkKey(value)) {
           acc.add(value);
         } else if (value.startsWith('flags:')) {
           const params = new URLSearchParams(value.slice('flags:'.length));
           const sdkKey = params.get('sdkKey');
-          if (sdkKey?.startsWith('vf_')) {
+          if (sdkKey && isVercelFlagsSdkKey(sdkKey)) {
             acc.add(sdkKey);
           }
         }

--- a/packages/cli/test/unit/commands/build/emit-flags-definitions.test.ts
+++ b/packages/cli/test/unit/commands/build/emit-flags-definitions.test.ts
@@ -57,8 +57,8 @@ describe('emitFlagsDatafiles', () => {
     expect(files[`${storageDir}/package.json`]).toBeDefined();
   });
 
-  it('should fetch definitions for a direct vf_ key and write files', async () => {
-    const sdkKey = 'vf_test_abc123def456';
+  it('should fetch definitions for a direct vf_server_ or vf_client_ key and write files', async () => {
+    const sdkKey = 'vf_server_abc123def456';
     const definitions = { flag1: { variants: ['on', 'off'] } };
 
     fetch.mockResolvedValueOnce(mockFetchResponse(definitions));
@@ -99,7 +99,7 @@ describe('emitFlagsDatafiles', () => {
   });
 
   it('should extract SDK key from flags: format', async () => {
-    const sdkKey = 'vf_flags_format_key';
+    const sdkKey = 'vf_server_flags_format_key';
     const definitions = { flag1: {} };
 
     fetch.mockResolvedValueOnce(mockFetchResponse(definitions));
@@ -120,7 +120,7 @@ describe('emitFlagsDatafiles', () => {
   });
 
   it('should deduplicate SDK keys across env vars', async () => {
-    const sdkKey = 'vf_duplicate_key';
+    const sdkKey = 'vf_server_duplicate_key';
     const definitions = { flag1: {} };
 
     fetch.mockResolvedValueOnce(mockFetchResponse(definitions));
@@ -135,8 +135,8 @@ describe('emitFlagsDatafiles', () => {
   });
 
   it('should handle multiple distinct SDK keys', async () => {
-    const key1 = 'vf_key_one_abcdef';
-    const key2 = 'vf_key_two_ghijkl';
+    const key1 = 'vf_server_key_one_abcdef';
+    const key2 = 'vf_client_key_two_ghijkl';
     const defs1 = { flagA: { enabled: true } };
     const defs2 = { flagB: { enabled: false } };
 
@@ -164,8 +164,8 @@ describe('emitFlagsDatafiles', () => {
   });
 
   it('should deduplicate identical definitions across keys', async () => {
-    const key1 = 'vf_key_one_abcdef';
-    const key2 = 'vf_key_two_ghijkl';
+    const key1 = 'vf_server_key_one_abcdef';
+    const key2 = 'vf_client_key_two_ghijkl';
     const sameDefs = { flagA: { enabled: true } };
 
     fetch
@@ -192,7 +192,7 @@ describe('emitFlagsDatafiles', () => {
   });
 
   it('should produce a valid module structure', async () => {
-    const sdkKey = 'vf_structure_test_key_123';
+    const sdkKey = 'vf_server_structure_test_key_123';
     const definitions = { myFlag: { variants: ['a', 'b'] } };
 
     fetch.mockResolvedValueOnce(mockFetchResponse(definitions));
@@ -229,7 +229,7 @@ describe('emitFlagsDatafiles', () => {
   });
 
   it('should include Vercel metadata headers when env vars are set', async () => {
-    const sdkKey = 'vf_meta_key_test';
+    const sdkKey = 'vf_server_meta_key_test';
 
     fetch.mockResolvedValueOnce(mockFetchResponse({}));
 
@@ -255,7 +255,7 @@ describe('emitFlagsDatafiles', () => {
   });
 
   it('should throw NowBuildError when fetch fails', async () => {
-    const sdkKey = 'vf_fail_key_abcdef123';
+    const sdkKey = 'vf_server_fail_key_abcdef123';
 
     fetch.mockResolvedValueOnce(mockFetchResponse(null, false));
 
@@ -276,11 +276,30 @@ describe('emitFlagsDatafiles', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it('should ignore third-party identifiers that start with vf_ but are not Vercel Flags SDK keys', async () => {
+    // Stripe identity flow IDs start with 'vf_' but should not be treated as SDK keys
+    // SDK keys must follow the format vf_server_* or vf_client_*
+    await emitFlagsDatafiles('/app', {
+      NEXT_PUBLIC_STRIPE_IDENTITY_FLOW_ID: 'vf_1PyHgVLpWuMxVFxAbCdEfGhIjKlMn',
+      STRIPE_FLOW_ID: 'vf_live_test_12345',
+      OTHER_SERVICE_ID: 'vf_something_else',
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+
+    const files = vol.toJSON();
+    const storageDir = '/app/node_modules/@vercel/flags-definitions';
+    const indexJs = files[`${storageDir}/index.js`] as string;
+    expect(indexJs).toBeDefined();
+    // Map should be empty since no valid SDK keys were found
+    expect(indexJs).toContain('const map = {\n};');
+  });
+
   it('should write version field in the generated module', async () => {
     fetch.mockResolvedValueOnce(mockFetchResponse({}));
 
     await emitFlagsDatafiles('/app', {
-      KEY: 'vf_version_test',
+      KEY: 'vf_server_version_test',
     });
 
     const files = vol.toJSON();


### PR DESCRIPTION
## Summary
- Fixes build failures caused by environment variables with values starting with `vf_` being incorrectly identified as Vercel Flags SDK keys
- Adds stricter validation: SDK keys must follow the format `vf_server_*` or `vf_client_*`

## Problem
The `emitFlagsDatafiles` function was scanning all environment variable values for the `vf_` prefix and treating them as Vercel Flags SDK keys. This caused build failures for users with third-party service identifiers that happen to start with `vf_` (e.g., Stripe's identity flow IDs like `vf_1PyHgVLpWuMxVFx...`).

Error message users were seeing:
```
Error: Failed to fetch flag definitions for vf_1PyHgVLpWuMxVFx*********: 401 Unauthorized
```

## Solution
Added an `isVercelFlagsSdkKey()` function that validates SDK keys against the proper format (`vf_server_*` or `vf_client_*`), preventing false positives from third-party identifiers.

## Test plan
- Added new test case for Stripe-like identifiers that should be ignored
- Updated existing tests to use valid SDK key formats
- All 12 tests pass