### PR TITLE
chore(cli): update @vercel/prepare-flags-definitions to 0.2.1

### DIFF
--- a/.changeset/update-prepare-flags-definitions.md
+++ b/.changeset/update-prepare-flags-definitions.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Updated `@vercel/prepare-flags-definitions` from 0.2.0 to 0.2.1.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,7 +60,7 @@
     "@vercel/nestjs": "workspace:*",
     "@vercel/next": "workspace:*",
     "@vercel/node": "workspace:*",
-    "@vercel/prepare-flags-definitions": "0.2.0",
+    "@vercel/prepare-flags-definitions": "0.2.1",
     "@vercel/python": "workspace:*",
     "@vercel/redwood": "workspace:*",
     "@vercel/remix-builder": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,8 +466,8 @@ importers:
         specifier: workspace:*
         version: link:../node
       '@vercel/prepare-flags-definitions':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.2.1
+        version: 0.2.1
       '@vercel/python':
         specifier: workspace:*
         version: link:../python
@@ -10096,8 +10096,8 @@ packages:
     engines: {node: '>= 20'}
     dev: true
 
-  /@vercel/prepare-flags-definitions@0.2.0:
-    resolution: {integrity: sha512-2yvulNR7yyv/gbWLPPRvLYBq70X6sBuG5kMQWQMQrIJQZrcrTagy/OCj9gTnhNGod5JmYKXjVBV6GW6DZcNWlQ==}
+  /@vercel/prepare-flags-definitions@0.2.1:
+    resolution: {integrity: sha512-ouXTsqn7I9xZ1KKezgvn/w3tZeQHL/tc52j9GHiOYi6kT8xgdbT8s2x8C9BQr44iceX0hfhtZwk9q7NuI2Tqbw==}
     dev: false
 
   /@vercel/sandbox@1.6.0:


### PR DESCRIPTION


- Updates `@vercel/prepare-flags-definitions` from 0.2.0 to 0.2.1

This brings in the latest version which is compatible with `@vercel/flags-core` 1.3.1.

