### PR TITLE
[cli] narrow SDK key detection for Vercel Flags

### DIFF
--- a/.changeset/tasty-pianos-tease.md
+++ b/.changeset/tasty-pianos-tease.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix SDK key detection for Vercel Flags to avoid false positives with third-party identifiers. Previously any `vf_` prefix matched, now only `vf_server_` and `vf_client_` prefixes match.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,7 +60,7 @@
     "@vercel/nestjs": "workspace:*",
     "@vercel/next": "workspace:*",
     "@vercel/node": "workspace:*",
-    "@vercel/prepare-flags-definitions": "0.2.0",
+    "@vercel/prepare-flags-definitions": "0.2.1",
     "@vercel/python": "workspace:*",
     "@vercel/redwood": "workspace:*",
     "@vercel/remix-builder": "workspace:*",

--- a/packages/cli/test/unit/commands/build/emit-flags-definitions.test.ts
+++ b/packages/cli/test/unit/commands/build/emit-flags-definitions.test.ts
@@ -63,8 +63,8 @@ describe('prepareFlagsDefinitions', () => {
     expect(await outputExists('index.js')).toBe(false);
   });
 
-  it('should fetch definitions for a direct vf_ key and write files', async () => {
-    const sdkKey = 'vf_test_abc123def456';
+  it('should fetch definitions for a direct vf_server_ key and write files', async () => {
+    const sdkKey = 'vf_server_test_abc123def456';
     const definitions = { flag1: { variants: ['on', 'off'] } };
 
     const fetch = mockFetch([{ data: definitions }]);
@@ -101,7 +101,7 @@ describe('prepareFlagsDefinitions', () => {
   });
 
   it('should extract SDK key from flags: format', async () => {
-    const sdkKey = 'vf_flags_format_key';
+    const sdkKey = 'vf_server_flags_format_key';
     const definitions = { flag1: {} };
 
     const fetch = mockFetch([{ data: definitions }]);
@@ -124,7 +124,7 @@ describe('prepareFlagsDefinitions', () => {
   });
 
   it('should deduplicate SDK keys across env vars', async () => {
-    const sdkKey = 'vf_duplicate_key';
+    const sdkKey = 'vf_server_duplicate_key';
     const definitions = { flag1: {} };
 
     const fetch = mockFetch([{ data: definitions }]);
@@ -143,8 +143,8 @@ describe('prepareFlagsDefinitions', () => {
   });
 
   it('should handle multiple distinct SDK keys', async () => {
-    const key1 = 'vf_key_one_abcdef';
-    const key2 = 'vf_key_two_ghijkl';
+    const key1 = 'vf_server_key_one_abcdef';
+    const key2 = 'vf_server_key_two_ghijkl';
     const defs1 = { flagA: { enabled: true } };
     const defs2 = { flagB: { enabled: false } };
 
@@ -168,8 +168,8 @@ describe('prepareFlagsDefinitions', () => {
   });
 
   it('should deduplicate identical definitions across keys', async () => {
-    const key1 = 'vf_key_one_abcdef';
-    const key2 = 'vf_key_two_ghijkl';
+    const key1 = 'vf_server_key_one_abcdef';
+    const key2 = 'vf_server_key_two_ghijkl';
     const sameDefs = { flagA: { enabled: true } };
 
     const fetch = mockFetch([{ data: sameDefs }, { data: sameDefs }]);
@@ -192,7 +192,7 @@ describe('prepareFlagsDefinitions', () => {
   });
 
   it('should produce a valid module structure', async () => {
-    const sdkKey = 'vf_structure_test_key_123';
+    const sdkKey = 'vf_server_structure_test_key_123';
     const definitions = { myFlag: { variants: ['a', 'b'] } };
 
     const fetch = mockFetch([{ data: definitions }]);
@@ -227,7 +227,7 @@ describe('prepareFlagsDefinitions', () => {
   });
 
   it('should include Vercel metadata headers when env vars are set', async () => {
-    const sdkKey = 'vf_meta_key_test';
+    const sdkKey = 'vf_server_meta_key_test';
 
     const fetch = mockFetch([{ data: {} }]);
 
@@ -257,7 +257,7 @@ describe('prepareFlagsDefinitions', () => {
   });
 
   it('should throw when fetch fails', async () => {
-    const sdkKey = 'vf_fail_key_abcdef123';
+    const sdkKey = 'vf_server_fail_key_abcdef123';
 
     const fetch = mockFetch([{ data: null, ok: false }]);
 
@@ -280,7 +280,7 @@ describe('prepareFlagsDefinitions', () => {
         PATH: '/usr/bin',
         NODE_ENV: 'production',
         FLAGS_VAR: 'flags:other=value',
-        PARTIAL: 'flags:sdkKey=not_vf_prefix',
+        PARTIAL: 'flags:sdkKey=no_vf_server_prefix',
       },
       fetch,
     });
@@ -293,7 +293,7 @@ describe('prepareFlagsDefinitions', () => {
 
     await prepareFlagsDefinitions({
       cwd,
-      env: { KEY: 'vf_version_test' },
+      env: { KEY: 'vf_server_version_test' },
       fetch,
     });
 

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1623,7 +1623,7 @@ describe.skipIf(flakey)('build', () => {
     );
 
     beforeEach(() => {
-      vi.stubEnv('FLAGS', 'vf_test_fake_sdk_key_for_testing');
+      vi.stubEnv('FLAGS', 'vf_server_test_fake_sdk_key_for_testing');
 
       vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
         const url = typeof input === 'string' ? input : input.toString();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,8 +466,8 @@ importers:
         specifier: workspace:*
         version: link:../node
       '@vercel/prepare-flags-definitions':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.2.1
+        version: 0.2.1
       '@vercel/python':
         specifier: workspace:*
         version: link:../python
@@ -10096,8 +10096,8 @@ packages:
     engines: {node: '>= 20'}
     dev: true
 
-  /@vercel/prepare-flags-definitions@0.2.0:
-    resolution: {integrity: sha512-2yvulNR7yyv/gbWLPPRvLYBq70X6sBuG5kMQWQMQrIJQZrcrTagy/OCj9gTnhNGod5JmYKXjVBV6GW6DZcNWlQ==}
+  /@vercel/prepare-flags-definitions@0.2.1:
+    resolution: {integrity: sha512-ouXTsqn7I9xZ1KKezgvn/w3tZeQHL/tc52j9GHiOYi6kT8xgdbT8s2x8C9BQr44iceX0hfhtZwk9q7NuI2Tqbw==}
     dev: false
 
   /@vercel/sandbox@1.6.0:


### PR DESCRIPTION
Fix SDK key detection for Vercel Flags to avoid false positives with third-party identifiers. Previously any `vf_` prefix matched, now only `vf_server_` and `vf_client_` prefixes match.

The actual fix is made in the `@vercel/prepare-flags-definitions` package, which is being upgraded in this PR.