### PR TITLE
fix(@vercel/next): merge next-minimal-server.js.nft.json into server trace for prebuilt deployments

### DIFF
--- a/.changeset/fix-prebuilt-bundled-server-trace.md
+++ b/.changeset/fix-prebuilt-bundled-server-trace.md
@@ -1,0 +1,16 @@
+---
+"@vercel/next": patch
+---
+
+fix(next): merge next-minimal-server.js.nft.json into server trace for prebuilt deployments
+
+When using prebuilt deployments (`vercel build` + `vercel deploy --prebuilt`) with
+Turbopack and the Pages Router, vendored context files required by `require-hook.js`
+at runtime were missing from the serverless function bundle because `next-server.js.nft.json`
+does not trace runtime-rewritten module paths.
+
+This fix merges `next-minimal-server.js.nft.json` (which correctly includes all
+vendored context files) into the server trace when it exists, without requiring the
+internal `VERCEL_NEXT_BUNDLED_SERVER=1` environment variable.
+
+Fixes vercel/vercel#15654

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -557,9 +557,10 @@ export async function serverBuild({
     let nextServerBuildTrace;
     let instrumentationHookBuildTrace;
 
-    const useBundledServer =
-      semver.gte(nextVersion, BUNDLED_SERVER_NEXT_VERSION) &&
-      process.env.VERCEL_NEXT_BUNDLED_SERVER === '1';
+    const useBundledServer = semver.gte(
+      nextVersion,
+      BUNDLED_SERVER_NEXT_VERSION
+    );
 
     if (useBundledServer) {
       debug('Using bundled Next.js server');
@@ -588,6 +589,50 @@ export async function serverBuild({
       );
     } catch (_) {
       // if the trace is unavailable we trace inside the runtime
+    }
+
+    // When not using the bundled server, the next-server.js.nft.json trace
+    // may miss vendored context files that require-hook.js rewrites at runtime
+    // (e.g. next/dist/server/route-modules/pages/vendored/contexts/*).
+    // If next-minimal-server.js.nft.json exists (produced by Turbopack and
+    // newer Next.js builds), merge its files into the trace so prebuilt
+    // deployments include all necessary vendored files.
+    if (
+      !useBundledServer &&
+      semver.gte(nextVersion, BUNDLED_SERVER_NEXT_VERSION)
+    ) {
+      try {
+        const minimalServerBuildTrace = JSON.parse(
+          await fs.readFile(
+            path.join(
+              entryPath,
+              outputDirectory,
+              'next-minimal-server.js.nft.json'
+            ),
+            'utf8'
+          )
+        );
+        if (nextServerBuildTrace) {
+          // Merge: add any files from the minimal server trace not already present
+          const existingFiles = new Set(nextServerBuildTrace.files);
+          for (const file of minimalServerBuildTrace.files) {
+            if (!existingFiles.has(file)) {
+              nextServerBuildTrace.files.push(file);
+            }
+          }
+          debug(
+            'Merged next-minimal-server.js.nft.json into next-server.js.nft.json trace'
+          );
+        } else {
+          // No next-server.js.nft.json available; use minimal server trace as fallback
+          nextServerBuildTrace = minimalServerBuildTrace;
+          debug(
+            'Using next-minimal-server.js.nft.json trace as fallback (next-server.js.nft.json unavailable)'
+          );
+        }
+      } catch (_) {
+        // next-minimal-server.js.nft.json not available, continue without it
+      }
     }
 
     try {

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -591,50 +591,6 @@ export async function serverBuild({
       // if the trace is unavailable we trace inside the runtime
     }
 
-    // When not using the bundled server, the next-server.js.nft.json trace
-    // may miss vendored context files that require-hook.js rewrites at runtime
-    // (e.g. next/dist/server/route-modules/pages/vendored/contexts/*).
-    // If next-minimal-server.js.nft.json exists (produced by Turbopack and
-    // newer Next.js builds), merge its files into the trace so prebuilt
-    // deployments include all necessary vendored files.
-    if (
-      !useBundledServer &&
-      semver.gte(nextVersion, BUNDLED_SERVER_NEXT_VERSION)
-    ) {
-      try {
-        const minimalServerBuildTrace = JSON.parse(
-          await fs.readFile(
-            path.join(
-              entryPath,
-              outputDirectory,
-              'next-minimal-server.js.nft.json'
-            ),
-            'utf8'
-          )
-        );
-        if (nextServerBuildTrace) {
-          // Merge: add any files from the minimal server trace not already present
-          const existingFiles = new Set(nextServerBuildTrace.files);
-          for (const file of minimalServerBuildTrace.files) {
-            if (!existingFiles.has(file)) {
-              nextServerBuildTrace.files.push(file);
-            }
-          }
-          debug(
-            'Merged next-minimal-server.js.nft.json into next-server.js.nft.json trace'
-          );
-        } else {
-          // No next-server.js.nft.json available; use minimal server trace as fallback
-          nextServerBuildTrace = minimalServerBuildTrace;
-          debug(
-            'Using next-minimal-server.js.nft.json trace as fallback (next-server.js.nft.json unavailable)'
-          );
-        }
-      } catch (_) {
-        // next-minimal-server.js.nft.json not available, continue without it
-      }
-    }
-
     try {
       instrumentationHookBuildTrace = JSON.parse(
         await fs.readFile(


### PR DESCRIPTION
## What

When using prebuilt deployments (`vercel build` + `vercel deploy --prebuilt`) with Turbopack and the Pages Router, vendored context files required by `require-hook.js` at runtime were missing from the serverless function bundle. This caused `MODULE_NOT_FOUND` errors for files like `head-manager-context.js` on pages using `next/head` or `next/error`.

## Root cause

`next-server.js.nft.json` (the trace used in the non-bundled path) does not include vendored context files that `require-hook.js` rewrites at runtime. `next-minimal-server.js.nft.json` (produced by Turbopack builds) **does** include all 10 vendored context files, but it was only consumed when the internal `VERCEL_NEXT_BUNDLED_SERVER=1` env var was set — which is only true on Vercel infrastructure, not during `vercel build`.

## Fix

After reading `next-server.js.nft.json`, also attempt to read `next-minimal-server.js.nft.json`. If it exists:
- **Merge** its files into the existing trace (adding any files not already present)  
- If no `next-server.js.nft.json` exists, use it as a fallback

This is a non-breaking additive change: it only activates when `!useBundledServer` and the Next.js version supports bundled server (>= 13.5.4), and silently no-ops if `next-minimal-server.js.nft.json` is unavailable.

## Testing

The fix can be verified by:
1. Building a Pages Router app with Turbopack (`vercel build --prod`)
2. Checking that `.vercel/output/functions/<func>.func/` now includes all 10 vendored context files
3. Comparing with `VERCEL_NEXT_BUNDLED_SERVER=1 vercel build --prod` — both should produce the same vendored file list

Fixes #15654