### PR TITLE
Add security check step types for deployment inspector

### DIFF
--- a/.changeset/security-check-step.md
+++ b/.changeset/security-check-step.md
@@ -1,0 +1,20 @@
+---
+'@vercel-internals/types': minor
+'@vercel/client': minor
+'vercel': minor
+---
+
+Add security check step types and events for the deployment inspector
+
+This adds support for displaying a "Performing security checks for dependencies" step in the deployment inspector UI:
+
+- Added `securityCheckState`, `securityCheckConclusion`, and `securityCheck` fields to the Deployment type
+- Added `SecurityCheckDetails`, `SecurityCheckSource`, and `SecurityCheckSkipReason` types
+- Added security check events: `security-check-pending`, `security-check-running`, `security-check-completed`, `security-check-skipped`, `security-check-succeeded`, `security-check-failed`, `security-check-warning`
+- Added CLI output for security check states during deployment
+
+The security check step is only rendered when the feature flag is enabled. It handles:
+- Prebuilt deployments (skipped with reason)
+- Missing lockfiles (falls back to package.json)
+- Monorepos (only audits the deployed subset via manifestPath)
+- Detailed results including malware count and vulnerability count

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -165,6 +165,79 @@ export interface CustomEnvironmentBranchMatcher {
 
 export type CustomEnvironmentType = 'production' | 'preview' | 'development';
 
+/**
+ * Source type used for security check scanning.
+ * - 'lockfile': Used pnpm-lock.yaml, package-lock.json, yarn.lock, or bun.lockb
+ * - 'package-json': Fell back to package.json (no lockfile available)
+ * - 'none': No dependency manifest found (security check skipped)
+ */
+export type SecurityCheckSource = 'lockfile' | 'package-json' | 'none';
+
+/**
+ * Reason why the security check was skipped.
+ * - 'prebuilt': Deployment is prebuilt, no source files to scan
+ * - 'no-manifest': No lockfile or package.json found
+ * - 'feature-disabled': Security check feature flag is disabled
+ * - 'unsupported-package-manager': Package manager not supported for scanning
+ */
+export type SecurityCheckSkipReason =
+  | 'prebuilt'
+  | 'no-manifest'
+  | 'feature-disabled'
+  | 'unsupported-package-manager';
+
+/**
+ * Details about the security check for dependencies.
+ */
+export interface SecurityCheckDetails {
+  /**
+   * The source used for the security check.
+   */
+  source: SecurityCheckSource;
+  /**
+   * Reason why the security check was skipped, if applicable.
+   */
+  skipReason?: SecurityCheckSkipReason;
+  /**
+   * Path to the lockfile or package.json that was scanned, relative to the deployment root.
+   * For monorepos, this is the path within the workspace being deployed.
+   */
+  manifestPath?: string;
+  /**
+   * Number of packages scanned.
+   */
+  packagesScanned?: number;
+  /**
+   * Number of security issues found.
+   */
+  issuesFound?: number;
+  /**
+   * Number of malware packages detected.
+   */
+  malwareCount?: number;
+  /**
+   * Number of known vulnerabilities detected.
+   */
+  vulnerabilityCount?: number;
+  /**
+   * Duration of the security check in milliseconds.
+   */
+  durationMs?: number;
+  /**
+   * Timestamp when the security check started.
+   */
+  startedAt?: number;
+  /**
+   * Timestamp when the security check completed.
+   */
+  completedAt?: number;
+  /**
+   * Error message if the security check failed due to an error (not security issues).
+   * This indicates an infrastructure problem, not a security finding.
+   */
+  errorMessage?: string;
+}
+
 export type Deployment = {
   alias?: string[];
   aliasAssigned?: boolean | null | number;
@@ -184,6 +257,28 @@ export type Deployment = {
   canceledAt?: number;
   checksState?: 'completed' | 'registered' | 'running';
   checksConclusion?: 'canceled' | 'failed' | 'skipped' | 'succeeded';
+  /**
+   * State of the security check for dependencies.
+   * Only present when the security check feature flag is enabled.
+   * - 'pending': Security check is queued but not yet started
+   * - 'running': Security check is in progress
+   * - 'completed': Security check finished (see securityCheckConclusion for result)
+   * - 'skipped': Security check was skipped (e.g., prebuilt deployment, no lockfile/package.json)
+   */
+  securityCheckState?: 'pending' | 'running' | 'completed' | 'skipped';
+  /**
+   * Conclusion of the security check for dependencies.
+   * Only present when securityCheckState is 'completed'.
+   * - 'succeeded': No security issues found
+   * - 'failed': Security issues (malware, vulnerabilities) were detected
+   * - 'warning': Non-blocking security issues were detected
+   */
+  securityCheckConclusion?: 'succeeded' | 'failed' | 'warning';
+  /**
+   * Details about the security check for dependencies.
+   * Provides context about what was checked and any issues found.
+   */
+  securityCheck?: SecurityCheckDetails;
   createdAt: number;
   createdIn?: string;
   creator: { uid: string; username?: string };

--- a/packages/cli/src/util/deploy/get-deployments-by-project-id.ts
+++ b/packages/cli/src/util/deploy/get-deployments-by-project-id.ts
@@ -11,6 +11,25 @@ type LegacyDeployment = {
   buildingAt: number;
   checksConclusion?: 'succeeded' | 'failed' | 'skipped' | 'canceled';
   checksState?: 'registered' | 'running' | 'completed';
+  /** Security check state (only present when feature flag is enabled) */
+  securityCheckState?: 'pending' | 'running' | 'completed' | 'skipped';
+  /** Security check conclusion (only present when securityCheckState is 'completed') */
+  securityCheckConclusion?: 'succeeded' | 'failed' | 'warning';
+  /** Security check details */
+  securityCheck?: {
+    source: 'lockfile' | 'package-json' | 'none';
+    skipReason?:
+      | 'prebuilt'
+      | 'no-manifest'
+      | 'feature-disabled'
+      | 'unsupported-package-manager';
+    manifestPath?: string;
+    packagesScanned?: number;
+    issuesFound?: number;
+    malwareCount?: number;
+    vulnerabilityCount?: number;
+    durationMs?: number;
+  };
   created: number;
   createdAt?: number;
   creator: {
@@ -78,6 +97,9 @@ export default async function getDeploymentsByProjectId(
       buildingAt: depl.buildingAt,
       checksConclusion: depl.checksConclusion,
       checksState: depl.checksState,
+      securityCheckState: depl.securityCheckState,
+      securityCheckConclusion: depl.securityCheckConclusion,
+      securityCheck: depl.securityCheck,
       createdAt: depl.created,
       creator: {
         uid: depl.creator.uid,

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -320,6 +320,55 @@ export default async function processDeployment({
         return event.payload;
       }
 
+      // Security check events
+      if (event.type === 'security-check-running' && !withFullLogs) {
+        output.spinner('Performing security checks for dependencies...', 0);
+      }
+
+      if (event.type === 'security-check-skipped' && !withFullLogs) {
+        const skipReason = event.payload.securityCheck?.skipReason;
+        const message =
+          skipReason === 'prebuilt'
+            ? 'Security check skipped (prebuilt deployment)'
+            : skipReason === 'no-manifest'
+              ? 'Security check skipped (no lockfile or package.json found)'
+              : 'Security check skipped';
+        output.debug(message);
+      }
+
+      if (event.type === 'security-check-succeeded' && !withFullLogs) {
+        const packagesScanned =
+          event.payload.securityCheck?.packagesScanned || 0;
+        output.debug(
+          `Security check passed (${packagesScanned} packages scanned)`
+        );
+      }
+
+      if (event.type === 'security-check-warning' && !withFullLogs) {
+        const issuesFound = event.payload.securityCheck?.issuesFound || 0;
+        output.warn(
+          `Security check found ${issuesFound} non-blocking issue(s)`
+        );
+      }
+
+      if (event.type === 'security-check-failed') {
+        stopSpinner();
+        const securityCheck = event.payload.securityCheck;
+        const malwareCount = securityCheck?.malwareCount || 0;
+        const vulnCount = securityCheck?.vulnerabilityCount || 0;
+        const totalIssues = securityCheck?.issuesFound || 0;
+
+        let message = `Security check failed: ${totalIssues} issue(s) found`;
+        if (malwareCount > 0) {
+          message += ` (${malwareCount} malware)`;
+        }
+        if (vulnCount > 0) {
+          message += ` (${vulnCount} vulnerabilities)`;
+        }
+        output.error(message);
+        return event.payload;
+      }
+
       // Handle error events
       if (event.type === 'error') {
         stopSpinner();

--- a/packages/client/src/check-deployment-status.ts
+++ b/packages/client/src/check-deployment-status.ts
@@ -198,6 +198,63 @@ export async function* checkDeploymentStatus(
       }
     }
 
+    // Security check events (only present when feature flag is enabled)
+    if (deploymentUpdate.securityCheckState !== undefined) {
+      if (
+        deploymentUpdate.securityCheckState === 'pending' &&
+        !finishedEvents.has('security-check-pending')
+      ) {
+        debug('Security check state changed to pending');
+        finishedEvents.add('security-check-pending');
+        yield { type: 'security-check-pending', payload: deploymentUpdate };
+      }
+
+      if (
+        deploymentUpdate.securityCheckState === 'running' &&
+        !finishedEvents.has('security-check-running')
+      ) {
+        debug('Security check state changed to running');
+        finishedEvents.add('security-check-running');
+        yield { type: 'security-check-running', payload: deploymentUpdate };
+      }
+
+      if (
+        deploymentUpdate.securityCheckState === 'skipped' &&
+        !finishedEvents.has('security-check-skipped')
+      ) {
+        debug(
+          `Security check skipped: ${deploymentUpdate.securityCheck?.skipReason || 'unknown reason'}`
+        );
+        finishedEvents.add('security-check-skipped');
+        yield { type: 'security-check-skipped', payload: deploymentUpdate };
+      }
+
+      if (
+        deploymentUpdate.securityCheckState === 'completed' &&
+        !finishedEvents.has('security-check-completed')
+      ) {
+        finishedEvents.add('security-check-completed');
+
+        if (deploymentUpdate.securityCheckConclusion === 'succeeded') {
+          debug('Security check succeeded');
+          yield {
+            type: 'security-check-succeeded',
+            payload: deploymentUpdate,
+          };
+        } else if (deploymentUpdate.securityCheckConclusion === 'failed') {
+          debug(
+            `Security check failed: ${deploymentUpdate.securityCheck?.issuesFound || 0} issues found`
+          );
+          yield { type: 'security-check-failed', payload: deploymentUpdate };
+        } else if (deploymentUpdate.securityCheckConclusion === 'warning') {
+          debug(
+            `Security check warning: ${deploymentUpdate.securityCheck?.issuesFound || 0} issues found`
+          );
+          yield { type: 'security-check-warning', payload: deploymentUpdate };
+        }
+      }
+    }
+
     if (isAliasAssigned(deploymentUpdate)) {
       debug('Deployment alias assigned');
       return yield { type: 'alias-assigned', payload: deploymentUpdate };

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -109,6 +109,43 @@ export interface Deployment {
   expiration?: number;
   proposedExpiration?: number;
   undeletedAt?: number;
+  /**
+   * State of the security check for dependencies.
+   * Only present when the security check feature flag is enabled.
+   */
+  securityCheckState?: 'pending' | 'running' | 'completed' | 'skipped';
+  /**
+   * Conclusion of the security check for dependencies.
+   * Only present when securityCheckState is 'completed'.
+   */
+  securityCheckConclusion?: 'succeeded' | 'failed' | 'warning';
+  /**
+   * Details about the security check for dependencies.
+   */
+  securityCheck?: {
+    /** The source used for the security check. */
+    source: 'lockfile' | 'package-json' | 'none';
+    /** Reason why the security check was skipped, if applicable. */
+    skipReason?:
+      | 'prebuilt'
+      | 'no-manifest'
+      | 'feature-disabled'
+      | 'unsupported-package-manager';
+    /** Path to the lockfile or package.json that was scanned. */
+    manifestPath?: string;
+    /** Number of packages scanned. */
+    packagesScanned?: number;
+    /** Number of security issues found. */
+    issuesFound?: number;
+    /** Number of malware packages detected. */
+    malwareCount?: number;
+    /** Number of known vulnerabilities detected. */
+    vulnerabilityCount?: number;
+    /** Duration of the security check in milliseconds. */
+    durationMs?: number;
+    /** Error message if the security check failed due to an error. */
+    errorMessage?: string;
+  };
 }
 
 export interface DeploymentBuild {

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -44,6 +44,14 @@ const EVENTS_ARRAY = [
   'checks-conclusion-failed',
   'checks-conclusion-skipped',
   'checks-conclusion-canceled',
+  // Security check events
+  'security-check-pending',
+  'security-check-running',
+  'security-check-completed',
+  'security-check-skipped',
+  'security-check-succeeded',
+  'security-check-failed',
+  'security-check-warning',
 ] as const;
 
 export type DeploymentEventType = (typeof EVENTS_ARRAY)[number];


### PR DESCRIPTION
Adds support for displaying a "Performing security checks for dependencies" step in the deployment inspector UI, as requested by [@rauchg](https://slack.com/team/U0CAL2338).

### What changed

- Added `securityCheckState`, `securityCheckConclusion`, and `securityCheck` fields to the `Deployment` type in `@vercel-internals/types`
- Added `SecurityCheckDetails`, `SecurityCheckSource`, and `SecurityCheckSkipReason` types for detailed security check metadata
- Added security check events to `@vercel/client`: `security-check-pending`, `security-check-running`, `security-check-completed`, `security-check-skipped`, `security-check-succeeded`, `security-check-failed`, `security-check-warning`
- Added CLI output for security check states during `vercel deploy`
- Updated `get-deployments-by-project-id.ts` to include security check fields in the legacy deployment transformation

### Design decisions

**Feature flag controlled**: The `securityCheckState` field is only present when the feature flag is enabled. When not present, no security check UI is rendered.

**Handles missing lockfiles**: Falls back to `package.json` if no lockfile is found. The `securityCheck.source` field indicates what was used (`lockfile`, `package-json`, or `none`).

**Handles prebuilt deployments**: These are skipped with `skipReason: 'prebuilt'` since there are no source files to scan.

**Monorepo support**: The `securityCheck.manifestPath` field indicates the path to the lockfile/package.json relative to the deployment root, so only the deployed workspace is audited.

**Detailed results**: Includes `malwareCount`, `vulnerabilityCount`, `packagesScanned`, and `durationMs` for observability.

### Note

This PR adds the types and client-side event handling. The actual security check implementation in the build container (calling Socket API) will be in a separate PR to `vercel/hive`.

<a href="https://vercel.slack.com/archives/CMMT0EZGC/p1774216494790449?thread_ts=1774216494.790449&cid=CMMT0EZGC"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>