### PR TITLE
[cli] feat:support inspect-group in the microfrontends commands

### DIFF
--- a/.changeset/short-camels-march.md
+++ b/.changeset/short-camels-march.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add a new `vercel microfrontends inspect-group` subcommand to provide structured group/project metadata for automation, including JSON output and improved non-interactive agent behavior when `--group` is missing.

--- a/packages/cli/src/commands/microfrontends/command.ts
+++ b/packages/cli/src/commands/microfrontends/command.ts
@@ -180,6 +180,14 @@ export const inspectGroupSubcommand = {
       deprecated: false,
       description: 'Name or ID of the microfrontends group to inspect',
     },
+    {
+      name: 'config-file-name',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Custom microfrontends config file path/name relative to the default app root (must end with .json or .jsonc)',
+    },
     formatOption,
   ],
   examples: [

--- a/packages/cli/src/commands/microfrontends/command.ts
+++ b/packages/cli/src/commands/microfrontends/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { formatOption, yesOption } from '../../util/arg-common';
 
 export const createGroupSubcommand = {
   name: 'create-group',
@@ -166,6 +166,34 @@ export const pullSubcommand = {
   ],
 } as const;
 
+export const inspectGroupSubcommand = {
+  name: 'inspect-group',
+  aliases: [],
+  description:
+    'Inspect a microfrontends group and return project metadata used for setup automation',
+  arguments: [],
+  options: [
+    {
+      name: 'group',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Name or ID of the microfrontends group to inspect',
+    },
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Inspect a microfrontends group interactively',
+      value: `${packageName} microfrontends inspect-group`,
+    },
+    {
+      name: 'Inspect a microfrontends group as JSON',
+      value: `${packageName} mf inspect-group --group="My Group" --format=json`,
+    },
+  ],
+} as const;
+
 export const microfrontendsCommand = {
   name: 'microfrontends',
   aliases: ['mf'],
@@ -177,6 +205,7 @@ export const microfrontendsCommand = {
     addToGroupSubcommand,
     removeFromGroupSubcommand,
     deleteGroupSubcommand,
+    inspectGroupSubcommand,
     pullSubcommand,
   ],
   options: [],

--- a/packages/cli/src/commands/microfrontends/index.ts
+++ b/packages/cli/src/commands/microfrontends/index.ts
@@ -8,6 +8,7 @@ import createGroup from './create-group';
 import addToGroup from './add-to-group';
 import removeFromGroup from './remove-from-group';
 import deleteGroup from './delete-group';
+import inspectGroup from './inspect-group';
 import {
   microfrontendsCommand,
   pullSubcommand,
@@ -15,6 +16,7 @@ import {
   addToGroupSubcommand,
   removeFromGroupSubcommand,
   deleteGroupSubcommand,
+  inspectGroupSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
@@ -27,6 +29,7 @@ const COMMAND_CONFIG = {
   'add-to-group': getCommandAliases(addToGroupSubcommand),
   'remove-from-group': getCommandAliases(removeFromGroupSubcommand),
   'delete-group': getCommandAliases(deleteGroupSubcommand),
+  'inspect-group': getCommandAliases(inspectGroupSubcommand),
   pull: getCommandAliases(pullSubcommand),
 };
 
@@ -104,6 +107,13 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandDeleteGroup(subcommandOriginal);
       return deleteGroup(client);
+    case 'inspect-group':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('microfrontends', subcommandOriginal);
+        return printHelp(inspectGroupSubcommand);
+      }
+      telemetry.trackCliSubcommandInspectGroup(subcommandOriginal);
+      return inspectGroup(client);
     case 'pull':
       if (needHelp) {
         telemetry.trackCliFlagHelp('microfrontends', subcommandOriginal);

--- a/packages/cli/src/commands/microfrontends/inspect-group.ts
+++ b/packages/cli/src/commands/microfrontends/inspect-group.ts
@@ -89,6 +89,9 @@ export default async function inspectGroup(client: Client): Promise<number> {
   const asJson = formatResult.jsonOutput;
 
   const groupFlag = parsedArgs.flags['--group'] as string | undefined;
+  const configFileNameFlag = parsedArgs.flags['--config-file-name'] as
+    | string
+    | undefined;
   const { team } = await getScope(client);
 
   if (!team) {
@@ -171,7 +174,19 @@ export default async function inspectGroup(client: Client): Promise<number> {
   output.stopSpinner();
 
   const defaultProject = projects.find(p => p.isDefaultApp);
-  const configFile = resolveLocalConfigFilePath(projects, localRepoContext);
+  const configuredConfigFileName =
+    resolveConfiguredMicrofrontendsConfigFileName(configFileNameFlag);
+  if (configFileNameFlag && !configuredConfigFileName) {
+    output.error(
+      'Invalid --config-file-name. Value must end with .json or .jsonc.'
+    );
+    return 1;
+  }
+  const configFile = resolveLocalConfigFilePath(
+    projects,
+    localRepoContext,
+    configuredConfigFileName
+  );
   const json: InspectGroupJson = {
     group: {
       id: selectedGroup.group.id,
@@ -361,7 +376,8 @@ async function resolvePackageNameFromLocalRepo(
 
 function resolveLocalConfigFilePath(
   projects: InspectGroupProject[],
-  localRepoContext: LocalRepoContext
+  localRepoContext: LocalRepoContext,
+  configuredConfigFileName?: string | null
 ): string | null {
   const defaultProject = projects.find(project => project.isDefaultApp);
   if (!defaultProject) {
@@ -381,6 +397,13 @@ function resolveLocalConfigFilePath(
     localRepoContext.repoRoot!,
     defaultProject.git.rootDirectory || ''
   );
+  const configuredName = configuredConfigFileName ?? null;
+  if (configuredName) {
+    const configuredPath = join(projectDir, configuredName);
+    if (existsSync(configuredPath)) {
+      return configuredPath;
+    }
+  }
   const jsonPath = join(projectDir, 'microfrontends.json');
   const jsoncPath = join(projectDir, 'microfrontends.jsonc');
   if (existsSync(jsonPath)) {
@@ -390,4 +413,20 @@ function resolveLocalConfigFilePath(
     return jsoncPath;
   }
   return null;
+}
+
+function resolveConfiguredMicrofrontendsConfigFileName(
+  configured?: string | null
+): string | null {
+  if (!configured) {
+    return null;
+  }
+
+  const normalized = configured.trim();
+  if (!normalized.endsWith('.json') && !normalized.endsWith('.jsonc')) {
+    return null;
+  }
+
+  // Treat leading slash as app-root relative.
+  return normalized.replace(/^\/+/, '');
 }

--- a/packages/cli/src/commands/microfrontends/inspect-group.ts
+++ b/packages/cli/src/commands/microfrontends/inspect-group.ts
@@ -1,0 +1,396 @@
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { inspectGroupSubcommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import getScope from '../../util/get-scope';
+import { fetchMicrofrontendsGroups } from './utils';
+import getProjectByIdOrName from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
+import { validateJsonOutput } from '../../util/output-format';
+import type { Project } from '@vercel-internals/types';
+import type {
+  MicrofrontendsGroupResponse,
+  MicrofrontendsProject,
+} from './types';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { getLinkedProject } from '../../util/projects/link';
+import readJSONFile from '../../util/read-json-file';
+import { outputActionRequired } from '../../util/agent-output';
+import {
+  AGENT_ACTION,
+  AGENT_REASON,
+  AGENT_STATUS,
+} from '../../util/agent-output-constants';
+
+interface InspectGroupProject {
+  id: string;
+  name: string;
+  isDefaultApp: boolean;
+  enabled: boolean;
+  defaultRoute: string | null;
+  productionDomain: string | null;
+  framework: string | null;
+  git: {
+    org: string | null;
+    repo: string | null;
+    rootDirectory: string | null;
+  };
+  packageName: string | null;
+  inGroupConfig: boolean;
+  gitRepo: string | null;
+  gitOrg: string | null;
+  projectFetchStatus: 'ok' | 'not_found' | 'error';
+}
+
+interface InspectGroupJson {
+  group: {
+    id: string;
+    slug: string;
+    name: string;
+    fallbackEnvironment: string | null;
+  };
+  projectCount: number;
+  defaultApp: string | null;
+  fallbackEnvironment: string | null;
+  configFile: string | null;
+  config: {
+    exists: boolean;
+    applications: string[];
+  };
+  projects: InspectGroupProject[];
+}
+
+interface LocalRepoContext {
+  repoRoot: string | null;
+  linkedProjectId: string | null;
+  linkedRepoOrg: string | null;
+  linkedRepoName: string | null;
+}
+
+export default async function inspectGroup(client: Client): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    inspectGroupSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    output.error(
+      'error' in formatResult ? formatResult.error : 'Invalid output format'
+    );
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const groupFlag = parsedArgs.flags['--group'] as string | undefined;
+  const { team } = await getScope(client);
+
+  if (!team) {
+    output.error('Microfrontends are only available for teams.');
+    return 1;
+  }
+
+  const groupsResponse = await fetchMicrofrontendsGroups(client, team.id);
+  const { groups } = groupsResponse;
+
+  if (groups.length === 0) {
+    output.error('No microfrontends groups exist.');
+    return 1;
+  }
+
+  if (!groupFlag && client.nonInteractive) {
+    outputActionRequired(
+      client,
+      {
+        status: AGENT_STATUS.ACTION_REQUIRED,
+        reason: AGENT_REASON.MISSING_ARGUMENTS,
+        action: AGENT_ACTION.MISSING_ARGUMENTS,
+        message:
+          'Missing required flag --group. Use --group and --format=json in non-interactive mode.',
+        next: [
+          {
+            command:
+              'vercel microfrontends inspect-group --group="<group-name-or-id>" --format=json',
+            when: 'to inspect a specific microfrontends group non-interactively',
+          },
+        ],
+      },
+      1
+    );
+    return 1;
+  }
+
+  if (!client.stdin.isTTY && !groupFlag) {
+    output.error(
+      'Missing required flag --group. Use --group to specify the microfrontends group, or run interactively.'
+    );
+    return 1;
+  }
+
+  let selectedGroup: MicrofrontendsGroupResponse;
+  if (groupFlag) {
+    const found = groups.find(
+      g => g.group.name === groupFlag || g.group.id === groupFlag
+    );
+    if (!found) {
+      output.error(`Microfrontends group "${groupFlag}" not found.`);
+      return 1;
+    }
+    selectedGroup = found;
+  } else {
+    const groupId = await client.input.select({
+      message: 'Select a microfrontends group to inspect:',
+      choices: groups.map(g => ({ name: g.group.name, value: g.group.id })),
+    });
+    selectedGroup = groups.find(g => g.group.id === groupId)!;
+  }
+
+  const localRepoContext = await getLocalRepoContext(client);
+
+  output.spinner('Fetching project metadata…');
+  const projects = await Promise.all(
+    selectedGroup.projects.map(project =>
+      enrichGroupProject(
+        client,
+        team.id,
+        selectedGroup,
+        project,
+        localRepoContext
+      )
+    )
+  );
+  output.stopSpinner();
+
+  const configFile = resolveLocalConfigFilePath(projects, localRepoContext);
+  const json: InspectGroupJson = {
+    group: {
+      id: selectedGroup.group.id,
+      slug: selectedGroup.group.slug,
+      name: selectedGroup.group.name,
+      fallbackEnvironment: selectedGroup.group.fallbackEnvironment ?? null,
+    },
+    projectCount: projects.length,
+    defaultApp:
+      projects.find(project => project.isDefaultApp)?.name ??
+      projects.find(project => project.isDefaultApp)?.id ??
+      null,
+    fallbackEnvironment: selectedGroup.group.fallbackEnvironment ?? null,
+    configFile,
+    config: {
+      exists: !!selectedGroup.config,
+      applications: Object.keys(selectedGroup.config?.applications ?? {}),
+    },
+    projects,
+  };
+
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify(json, null, 2)}\n`);
+    return 0;
+  }
+
+  output.log(`Group: ${selectedGroup.group.name}`);
+  output.log(`  ID: ${selectedGroup.group.id}`);
+  output.log(`  Slug: ${selectedGroup.group.slug}`);
+  output.log(`  Projects: ${projects.length}`);
+  output.log(`  Fallback environment: ${json.fallbackEnvironment ?? '(none)'}`);
+  output.log(`  Local config file: ${json.configFile ?? '(not found)'}`);
+  output.log(
+    `  Config applications: ${json.config.applications.length > 0 ? json.config.applications.join(', ') : '(none)'}`
+  );
+  output.log('');
+  output.log('Projects:');
+  for (const project of projects) {
+    output.log(
+      `  - ${project.name} (${project.id})${project.isDefaultApp ? ' [default app]' : ''}`
+    );
+    output.log(
+      `    enabled=${project.enabled} defaultRoute=${project.defaultRoute ?? '(none)'} inConfig=${project.inGroupConfig}`
+    );
+    output.log(
+      `    productionDomain=${project.productionDomain ?? '(none)'} framework=${project.framework ?? '(unknown)'}`
+    );
+    output.log(
+      `    rootDirectory=${project.git.rootDirectory ?? '(unknown)'} git=${project.git.org ?? '(unknown)'}/${project.git.repo ?? '(unknown)'} packageName=${project.packageName ?? '(unknown)'}`
+    );
+    if (project.projectFetchStatus !== 'ok') {
+      output.warn(
+        `Project metadata for "${project.id}" is incomplete (status: ${project.projectFetchStatus}).`
+      );
+    }
+  }
+
+  return 0;
+}
+
+async function enrichGroupProject(
+  client: Client,
+  teamId: string,
+  group: MicrofrontendsGroupResponse,
+  groupProject: MicrofrontendsProject,
+  localRepoContext: LocalRepoContext
+): Promise<InspectGroupProject> {
+  let fullProject: Project | undefined;
+  let projectFetchStatus: InspectGroupProject['projectFetchStatus'] = 'ok';
+
+  try {
+    const maybeProject = await getProjectByIdOrName(
+      client,
+      groupProject.id,
+      teamId
+    );
+    if (maybeProject instanceof ProjectNotFound) {
+      projectFetchStatus = 'not_found';
+    } else {
+      fullProject = maybeProject;
+    }
+  } catch {
+    projectFetchStatus = 'error';
+  }
+
+  const name = groupProject.name ?? fullProject?.name ?? groupProject.id;
+  const inGroupConfig = Object.prototype.hasOwnProperty.call(
+    group.config?.applications ?? {},
+    name
+  );
+  const rootDirectory = fullProject?.rootDirectory ?? null;
+  const gitRepo = fullProject?.link?.repo ?? null;
+  const gitOrg = fullProject?.link?.org ?? null;
+  const productionDomain =
+    fullProject?.targets?.production?.alias?.[0] ??
+    fullProject?.targets?.production?.url ??
+    null;
+  const framework = fullProject?.framework ?? null;
+  const packageName = await resolvePackageNameFromLocalRepo(
+    localRepoContext,
+    gitOrg,
+    gitRepo,
+    rootDirectory
+  );
+
+  return {
+    id: groupProject.id,
+    name,
+    isDefaultApp: !!groupProject.microfrontends?.isDefaultApp,
+    enabled: !!groupProject.microfrontends?.enabled,
+    defaultRoute: groupProject.microfrontends?.defaultRoute ?? null,
+    productionDomain,
+    framework,
+    git: {
+      org: gitOrg,
+      repo: gitRepo,
+      rootDirectory,
+    },
+    packageName,
+    inGroupConfig,
+    gitRepo,
+    gitOrg,
+    projectFetchStatus,
+  };
+}
+
+async function getLocalRepoContext(client: Client): Promise<LocalRepoContext> {
+  try {
+    const link = await getLinkedProject(client, client.cwd);
+    // link is discriminated union, need to make TS happy
+    if (link.status !== 'linked') {
+      return {
+        repoRoot: null,
+        linkedProjectId: null,
+        linkedRepoOrg: null,
+        linkedRepoName: null,
+      };
+    }
+
+    return {
+      repoRoot: link.repoRoot ?? null,
+      linkedProjectId: link.project.id,
+      linkedRepoOrg: link.project.link?.org ?? null,
+      linkedRepoName: link.project.link?.repo ?? null,
+    };
+  } catch {
+    return {
+      repoRoot: null,
+      linkedProjectId: null,
+      linkedRepoOrg: null,
+      linkedRepoName: null,
+    };
+  }
+}
+
+function isProjectInLocalRepo(
+  localRepoContext: LocalRepoContext,
+  gitOrg: string | null,
+  gitRepo: string | null
+): boolean {
+  if (!localRepoContext.repoRoot) {
+    return false;
+  }
+  if (!localRepoContext.linkedRepoOrg || !localRepoContext.linkedRepoName) {
+    return false;
+  }
+  return (
+    localRepoContext.linkedRepoOrg === gitOrg &&
+    localRepoContext.linkedRepoName === gitRepo
+  );
+}
+
+async function resolvePackageNameFromLocalRepo(
+  localRepoContext: LocalRepoContext,
+  gitOrg: string | null,
+  gitRepo: string | null,
+  rootDirectory: string | null
+): Promise<string | null> {
+  if (!isProjectInLocalRepo(localRepoContext, gitOrg, gitRepo)) {
+    return null;
+  }
+
+  const projectDir = join(localRepoContext.repoRoot!, rootDirectory || '');
+  const packageJsonPath = join(projectDir, 'package.json');
+  const pkg = await readJSONFile<{ name?: unknown }>(packageJsonPath);
+  if (!pkg || pkg instanceof Error) {
+    return null;
+  }
+  return typeof pkg.name === 'string' ? pkg.name : null;
+}
+
+function resolveLocalConfigFilePath(
+  projects: InspectGroupProject[],
+  localRepoContext: LocalRepoContext
+): string | null {
+  const defaultProject = projects.find(project => project.isDefaultApp);
+  if (!defaultProject) {
+    return null;
+  }
+  if (
+    !isProjectInLocalRepo(
+      localRepoContext,
+      defaultProject.git.org,
+      defaultProject.git.repo
+    )
+  ) {
+    return null;
+  }
+
+  const projectDir = join(
+    localRepoContext.repoRoot!,
+    defaultProject.git.rootDirectory || ''
+  );
+  const jsonPath = join(projectDir, 'microfrontends.json');
+  const jsoncPath = join(projectDir, 'microfrontends.jsonc');
+  if (existsSync(jsonPath)) {
+    return jsonPath;
+  }
+  if (existsSync(jsoncPath)) {
+    return jsoncPath;
+  }
+  return null;
+}

--- a/packages/cli/src/commands/microfrontends/inspect-group.ts
+++ b/packages/cli/src/commands/microfrontends/inspect-group.ts
@@ -40,8 +40,6 @@ interface InspectGroupProject {
   };
   packageName: string | null;
   inGroupConfig: boolean;
-  gitRepo: string | null;
-  gitOrg: string | null;
   projectFetchStatus: 'ok' | 'not_found' | 'error';
 }
 
@@ -54,7 +52,6 @@ interface InspectGroupJson {
   };
   projectCount: number;
   defaultApp: string | null;
-  fallbackEnvironment: string | null;
   configFile: string | null;
   config: {
     exists: boolean;
@@ -139,7 +136,10 @@ export default async function inspectGroup(client: Client): Promise<number> {
   let selectedGroup: MicrofrontendsGroupResponse;
   if (groupFlag) {
     const found = groups.find(
-      g => g.group.name === groupFlag || g.group.id === groupFlag
+      g =>
+        g.group.name === groupFlag ||
+        g.group.id === groupFlag ||
+        g.group.slug === groupFlag
     );
     if (!found) {
       output.error(`Microfrontends group "${groupFlag}" not found.`);
@@ -170,6 +170,7 @@ export default async function inspectGroup(client: Client): Promise<number> {
   );
   output.stopSpinner();
 
+  const defaultProject = projects.find(p => p.isDefaultApp);
   const configFile = resolveLocalConfigFilePath(projects, localRepoContext);
   const json: InspectGroupJson = {
     group: {
@@ -179,11 +180,7 @@ export default async function inspectGroup(client: Client): Promise<number> {
       fallbackEnvironment: selectedGroup.group.fallbackEnvironment ?? null,
     },
     projectCount: projects.length,
-    defaultApp:
-      projects.find(project => project.isDefaultApp)?.name ??
-      projects.find(project => project.isDefaultApp)?.id ??
-      null,
-    fallbackEnvironment: selectedGroup.group.fallbackEnvironment ?? null,
+    defaultApp: defaultProject?.name ?? defaultProject?.id ?? null,
     configFile,
     config: {
       exists: !!selectedGroup.config,
@@ -201,7 +198,9 @@ export default async function inspectGroup(client: Client): Promise<number> {
   output.log(`  ID: ${selectedGroup.group.id}`);
   output.log(`  Slug: ${selectedGroup.group.slug}`);
   output.log(`  Projects: ${projects.length}`);
-  output.log(`  Fallback environment: ${json.fallbackEnvironment ?? '(none)'}`);
+  output.log(
+    `  Fallback environment: ${json.group.fallbackEnvironment ?? '(none)'}`
+  );
   output.log(`  Local config file: ${json.configFile ?? '(not found)'}`);
   output.log(
     `  Config applications: ${json.config.applications.length > 0 ? json.config.applications.join(', ') : '(none)'}`
@@ -291,8 +290,6 @@ async function enrichGroupProject(
     },
     packageName,
     inGroupConfig,
-    gitRepo,
-    gitOrg,
     projectFetchStatus,
   };
 }

--- a/packages/cli/src/commands/microfrontends/inspect-group.ts
+++ b/packages/cli/src/commands/microfrontends/inspect-group.ts
@@ -25,6 +25,7 @@ import {
   AGENT_STATUS,
 } from '../../util/agent-output-constants';
 import table from '../../util/output/table';
+import { red } from 'chalk';
 
 interface InspectGroupProject {
   id: string;
@@ -233,11 +234,11 @@ export default async function inspectGroup(client: Client): Promise<number> {
   output.log('');
 
   for (const project of projects) {
-    const projectTable = table([
-      ['Project', project.name],
-      ['ID', project.id],
-      ['Default app', project.isDefaultApp ? 'yes' : 'no'],
-      ['Enabled', project.enabled ? 'yes' : 'no'],
+    const rows: string[][] = [
+      [
+        'Project',
+        project.isDefaultApp ? `${project.name} (default app)` : project.name,
+      ],
       ['Default route', project.defaultRoute ?? '(none)'],
       ['Production domain', project.productionDomain ?? '(none)'],
       ['Framework', project.framework ?? '(unknown)'],
@@ -246,10 +247,17 @@ export default async function inspectGroup(client: Client): Promise<number> {
         `${project.git.org ?? '(unknown)'}/${project.git.repo ?? '(unknown)'}`,
       ],
       ['Root directory', project.git.rootDirectory ?? '(unknown)'],
-      ['Package name', project.packageName ?? '(unknown)'],
-      ['In config', project.inGroupConfig ? 'yes' : 'no'],
-      ['Fetch status', project.projectFetchStatus],
-    ]);
+    ];
+
+    if (project.packageName) {
+      rows.push(['Package name', project.packageName]);
+    }
+
+    if (!project.inGroupConfig) {
+      rows.push(['In config', red('no')]);
+    }
+
+    const projectTable = table(rows);
     output.log(projectTable);
     output.log('');
   }

--- a/packages/cli/src/commands/microfrontends/inspect-group.ts
+++ b/packages/cli/src/commands/microfrontends/inspect-group.ts
@@ -24,6 +24,7 @@ import {
   AGENT_REASON,
   AGENT_STATUS,
 } from '../../util/agent-output-constants';
+import table from '../../util/output/table';
 
 interface InspectGroupProject {
   id: string;
@@ -209,32 +210,51 @@ export default async function inspectGroup(client: Client): Promise<number> {
     return 0;
   }
 
-  output.log(`Group: ${selectedGroup.group.name}`);
-  output.log(`  ID: ${selectedGroup.group.id}`);
-  output.log(`  Slug: ${selectedGroup.group.slug}`);
-  output.log(`  Projects: ${projects.length}`);
-  output.log(
-    `  Fallback environment: ${json.group.fallbackEnvironment ?? '(none)'}`
-  );
-  output.log(`  Local config file: ${json.configFile ?? '(not found)'}`);
-  output.log(
-    `  Config applications: ${json.config.applications.length > 0 ? json.config.applications.join(', ') : '(none)'}`
-  );
+  const groupTable = table([
+    ['Group', json.group.name],
+    ['ID', json.group.id],
+    ['Slug', json.group.slug],
+    ['Projects', String(json.projectCount)],
+    ['Default app', json.defaultApp ?? '(none)'],
+    ['Fallback environment', json.group.fallbackEnvironment ?? '(none)'],
+    ['Local config file', json.configFile ?? '(not found)'],
+    [
+      'Config applications',
+      json.config.applications.length > 0
+        ? json.config.applications.join(', ')
+        : '(none)',
+    ],
+  ]);
   output.log('');
-  output.log('Projects:');
+  output.log(groupTable);
+  output.log('');
+
+  output.log('Projects');
+  output.log('');
+
   for (const project of projects) {
-    output.log(
-      `  - ${project.name} (${project.id})${project.isDefaultApp ? ' [default app]' : ''}`
-    );
-    output.log(
-      `    enabled=${project.enabled} defaultRoute=${project.defaultRoute ?? '(none)'} inConfig=${project.inGroupConfig}`
-    );
-    output.log(
-      `    productionDomain=${project.productionDomain ?? '(none)'} framework=${project.framework ?? '(unknown)'}`
-    );
-    output.log(
-      `    rootDirectory=${project.git.rootDirectory ?? '(unknown)'} git=${project.git.org ?? '(unknown)'}/${project.git.repo ?? '(unknown)'} packageName=${project.packageName ?? '(unknown)'}`
-    );
+    const projectTable = table([
+      ['Project', project.name],
+      ['ID', project.id],
+      ['Default app', project.isDefaultApp ? 'yes' : 'no'],
+      ['Enabled', project.enabled ? 'yes' : 'no'],
+      ['Default route', project.defaultRoute ?? '(none)'],
+      ['Production domain', project.productionDomain ?? '(none)'],
+      ['Framework', project.framework ?? '(unknown)'],
+      [
+        'Git org/repo',
+        `${project.git.org ?? '(unknown)'}/${project.git.repo ?? '(unknown)'}`,
+      ],
+      ['Root directory', project.git.rootDirectory ?? '(unknown)'],
+      ['Package name', project.packageName ?? '(unknown)'],
+      ['In config', project.inGroupConfig ? 'yes' : 'no'],
+      ['Fetch status', project.projectFetchStatus],
+    ]);
+    output.log(projectTable);
+    output.log('');
+  }
+
+  for (const project of projects) {
     if (project.projectFetchStatus !== 'ok') {
       output.warn(
         `Project metadata for "${project.id}" is incomplete (status: ${project.projectFetchStatus}).`

--- a/packages/cli/src/util/telemetry/commands/microfrontends/index.ts
+++ b/packages/cli/src/util/telemetry/commands/microfrontends/index.ts
@@ -40,4 +40,11 @@ export class MicrofrontendsTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandInspectGroup(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect-group',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
@@ -260,6 +260,23 @@ describe('microfrontends inspect-group', () => {
     });
   });
 
+  it('errors when --config-file-name has an invalid extension', async () => {
+    client.setArgv(
+      'microfrontends',
+      'inspect-group',
+      '--group=My Group',
+      '--config-file-name=microfrontends.txt',
+      '--format=json'
+    );
+
+    const exitCodePromise = microfrontends(client);
+
+    await expect(client.stderr).toOutput(
+      'Error: Invalid --config-file-name. Value must end with .json or .jsonc.'
+    );
+    expect(await exitCodePromise).toBe(1);
+  });
+
   it('errors in non-TTY mode without --group', async () => {
     client.setArgv('microfrontends', 'inspect-group');
     (client.stdin as any).isTTY = false;

--- a/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
@@ -50,7 +50,12 @@ const groupsResponse: MicrofrontendsGroupsResponse = {
   maxMicrofrontendsPerGroup: 20,
 };
 
-function setupMocks() {
+interface SetupMocksOptions {
+  projectIdsNotFound?: string[];
+}
+
+function setupMocks(options: SetupMocksOptions = {}) {
+  const { projectIdsNotFound = [] } = options;
   client.config.currentTeam = 'team_123';
 
   client.scenario.get('/v2/user', (_req, res) => {
@@ -72,6 +77,10 @@ function setupMocks() {
 
   client.scenario.get('/v9/projects/:projectId', (req, res) => {
     const projectId = req.params.projectId;
+    if (projectIdsNotFound.includes(projectId)) {
+      res.status(404).json({ error: { code: 'not_found' } });
+      return;
+    }
     if (projectId === 'proj_web') {
       res.json({
         id: 'proj_web',
@@ -156,12 +165,40 @@ describe('microfrontends inspect-group', () => {
     const stdout = client.stdout.getFullOutput().trim();
     const parsed = JSON.parse(stdout);
 
+    expect(Object.keys(parsed).sort()).toEqual(
+      [
+        'config',
+        'configFile',
+        'defaultApp',
+        'group',
+        'projectCount',
+        'projects',
+      ].sort()
+    );
+    expect(Object.keys(parsed.group).sort()).toEqual(
+      ['fallbackEnvironment', 'id', 'name', 'slug'].sort()
+    );
+
     expect(parsed.group.name).toBe('My Group');
     expect(parsed.group.id).toBe('group_1');
     expect(parsed.defaultApp).toBe('web');
-    expect(parsed.fallbackEnvironment).toBe(null);
     expect(parsed.configFile).toBe(null);
     expect(parsed.projects).toHaveLength(2);
+    expect(Object.keys(parsed.projects[0]).sort()).toEqual(
+      [
+        'defaultRoute',
+        'enabled',
+        'framework',
+        'git',
+        'id',
+        'inGroupConfig',
+        'isDefaultApp',
+        'name',
+        'packageName',
+        'productionDomain',
+        'projectFetchStatus',
+      ].sort()
+    );
     expect(parsed.projects[0]).toMatchObject({
       id: 'proj_web',
       name: 'web',
@@ -173,11 +210,53 @@ describe('microfrontends inspect-group', () => {
         repo: 'vercel/front',
         rootDirectory: 'apps/web',
       },
-      gitRepo: 'vercel/front',
-      gitOrg: 'vercel',
       packageName: null,
       inGroupConfig: true,
       projectFetchStatus: 'ok',
+    });
+  });
+
+  it('resolves group by slug', async () => {
+    client.setArgv(
+      'microfrontends',
+      'inspect-group',
+      '--group=my-group',
+      '--format=json'
+    );
+
+    const exitCode = await microfrontends(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(parsed.group).toMatchObject({
+      id: 'group_1',
+      slug: 'my-group',
+      name: 'My Group',
+    });
+  });
+
+  it('marks project as not_found when project metadata 404s', async () => {
+    client.reset();
+    teamCache.clear();
+    setupMocks({ projectIdsNotFound: ['proj_docs'] });
+    client.setArgv(
+      'microfrontends',
+      'inspect-group',
+      '--group=My Group',
+      '--format=json'
+    );
+
+    const exitCode = await microfrontends(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+    const docs = parsed.projects.find((p: any) => p.id === 'proj_docs');
+    expect(docs).toMatchObject({
+      id: 'proj_docs',
+      projectFetchStatus: 'not_found',
+      framework: null,
+      productionDomain: null,
+      packageName: null,
     });
   });
 

--- a/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
@@ -267,10 +267,11 @@ describe('microfrontends inspect-group', () => {
     expect(exitCode).toBe(0);
     const stderrOutput = client.stderr.getFullOutput();
     expect(stderrOutput).toContain('Projects');
-    expect(stderrOutput).toContain('Project            web');
-    expect(stderrOutput).toContain('ID                 proj_web');
+    expect(stderrOutput).toContain('Project            web (default app)');
     expect(stderrOutput).toContain('Project            docs');
-    expect(stderrOutput).toContain('ID                 proj_docs');
+    expect(stderrOutput).not.toContain('Enabled');
+    expect(stderrOutput).not.toContain('Fetch status');
+    expect(stderrOutput).not.toContain('ID                 proj_');
   });
 
   it('errors when --config-file-name has an invalid extension', async () => {

--- a/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
@@ -260,6 +260,19 @@ describe('microfrontends inspect-group', () => {
     });
   });
 
+  it('prints one project table per project in text output', async () => {
+    client.setArgv('microfrontends', 'inspect-group', '--group=My Group');
+    const exitCode = await microfrontends(client);
+
+    expect(exitCode).toBe(0);
+    const stderrOutput = client.stderr.getFullOutput();
+    expect(stderrOutput).toContain('Projects');
+    expect(stderrOutput).toContain('Project            web');
+    expect(stderrOutput).toContain('ID                 proj_web');
+    expect(stderrOutput).toContain('Project            docs');
+    expect(stderrOutput).toContain('ID                 proj_docs');
+  });
+
   it('errors when --config-file-name has an invalid extension', async () => {
     client.setArgv(
       'microfrontends',

--- a/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
@@ -1,0 +1,196 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import microfrontends from '../../../../src/commands/microfrontends';
+import { teamCache } from '../../../../src/util/teams/get-team-by-id';
+import type { MicrofrontendsGroupsResponse } from '../../../../src/commands/microfrontends/types';
+
+const groupsResponse: MicrofrontendsGroupsResponse = {
+  groups: [
+    {
+      group: {
+        id: 'group_1',
+        slug: 'my-group',
+        name: 'My Group',
+      },
+      projects: [
+        {
+          id: 'proj_web',
+          name: 'web',
+          microfrontends: {
+            isDefaultApp: true,
+            enabled: true,
+            defaultRoute: '/',
+          },
+        },
+        {
+          id: 'proj_docs',
+          name: 'docs',
+          microfrontends: {
+            isDefaultApp: false,
+            enabled: true,
+            defaultRoute: '/docs',
+          },
+        },
+      ],
+      config: {
+        applications: {
+          web: {
+            development: {
+              fallback: 'my-group.vercel.app',
+            },
+          },
+          docs: {
+            routing: [{ paths: ['/docs', '/docs/*'] }],
+          },
+        },
+      },
+    },
+  ],
+  maxMicrofrontendsGroupsPerTeam: 10,
+  maxMicrofrontendsPerGroup: 20,
+};
+
+function setupMocks() {
+  client.config.currentTeam = 'team_123';
+
+  client.scenario.get('/v2/user', (_req, res) => {
+    res.json({ user: { id: 'user_123', username: 'testuser' } });
+  });
+
+  client.scenario.get('/teams/team_123', (_req, res) => {
+    res.json({
+      id: 'team_123',
+      slug: 'my-team',
+      name: 'My Team',
+      billing: { plan: 'pro', period: { start: 0, end: 0 }, addons: [] },
+    });
+  });
+
+  client.scenario.get('/v1/microfrontends/groups', (_req, res) => {
+    res.json(groupsResponse);
+  });
+
+  client.scenario.get('/v9/projects/:projectId', (req, res) => {
+    const projectId = req.params.projectId;
+    if (projectId === 'proj_web') {
+      res.json({
+        id: 'proj_web',
+        name: 'web',
+        accountId: 'team_123',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+        framework: 'nextjs',
+        targets: {
+          production: {
+            alias: ['web-production.vercel.app'],
+            url: 'web-production.vercel.app',
+          },
+        },
+        rootDirectory: 'apps/web',
+        link: {
+          type: 'github',
+          repo: 'vercel/front',
+          org: 'vercel',
+          repoId: 1,
+          gitCredentialId: 'cred_1',
+          sourceless: false,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      });
+      return;
+    }
+
+    res.json({
+      id: 'proj_docs',
+      name: 'docs',
+      accountId: 'team_123',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+      framework: 'nextjs',
+      targets: {
+        production: {
+          alias: ['docs-production.vercel.app'],
+          url: 'docs-production.vercel.app',
+        },
+      },
+      rootDirectory: 'apps/docs',
+      link: {
+        type: 'github',
+        repo: 'vercel/docs',
+        org: 'vercel',
+        repoId: 2,
+        gitCredentialId: 'cred_2',
+        sourceless: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    });
+  });
+}
+
+describe('microfrontends inspect-group', () => {
+  beforeEach(() => {
+    client.reset();
+    teamCache.clear();
+    setupMocks();
+  });
+
+  it('prints usage with --help', async () => {
+    client.setArgv('microfrontends', 'inspect-group', '--help');
+    const exitCode = await microfrontends(client);
+    expect(exitCode).toBe(2);
+  });
+
+  it('outputs JSON when --format=json is provided', async () => {
+    client.setArgv(
+      'microfrontends',
+      'inspect-group',
+      '--group=My Group',
+      '--format=json'
+    );
+
+    const exitCode = await microfrontends(client);
+
+    expect(exitCode).toBe(0);
+    const stdout = client.stdout.getFullOutput().trim();
+    const parsed = JSON.parse(stdout);
+
+    expect(parsed.group.name).toBe('My Group');
+    expect(parsed.group.id).toBe('group_1');
+    expect(parsed.defaultApp).toBe('web');
+    expect(parsed.fallbackEnvironment).toBe(null);
+    expect(parsed.configFile).toBe(null);
+    expect(parsed.projects).toHaveLength(2);
+    expect(parsed.projects[0]).toMatchObject({
+      id: 'proj_web',
+      name: 'web',
+      isDefaultApp: true,
+      productionDomain: 'web-production.vercel.app',
+      framework: 'nextjs',
+      git: {
+        org: 'vercel',
+        repo: 'vercel/front',
+        rootDirectory: 'apps/web',
+      },
+      gitRepo: 'vercel/front',
+      gitOrg: 'vercel',
+      packageName: null,
+      inGroupConfig: true,
+      projectFetchStatus: 'ok',
+    });
+  });
+
+  it('errors in non-TTY mode without --group', async () => {
+    client.setArgv('microfrontends', 'inspect-group');
+    (client.stdin as any).isTTY = false;
+
+    const exitCodePromise = microfrontends(client);
+
+    await expect(client.stderr).toOutput(
+      'Error: Missing required flag --group.'
+    );
+    expect(await exitCodePromise).toBe(1);
+    (client.stdin as any).isTTY = true;
+  });
+});


### PR DESCRIPTION
**Summary**
Added a new vercel microfrontends inspect-group subcommand (alias available through vercel mf) to provide structured, read-only metadata for a microfrontends group.

**Motivation**
After creating a microfrontends group, agents/scripts still lacked a single command to fetch enough context to automate follow-up setup tasks across projects. This command closes that gap by exposing group/project metadata in one place.

<img width="1025" height="274" alt="Screenshot 2026-03-23 at 12 41 02" src="https://github.com/user-attachments/assets/190828ba-7bed-43be-a3c3-9b1c0bb64c14" />
