### PR TITLE
Bump @vercel/nft to 1.5.0

### DIFF
--- a/.changeset/bump-nft-150.md
+++ b/.changeset/bump-nft-150.md
@@ -1,0 +1,11 @@
+---
+'@vercel/backends': patch
+'@vercel/express': patch
+'@vercel/hono': patch
+'@vercel/next': patch
+'@vercel/node': patch
+'@vercel/redwood': patch
+'@vercel/remix-builder': patch
+---
+
+Bump @vercel/nft to 1.5.0

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "@vercel/build-utils": "workspace:*",
-    "@vercel/nft": "1.4.0",
+    "@vercel/nft": "1.5.0",
     "execa": "3.2.0",
     "fs-extra": "11.1.0",
     "oxc-transform": "0.111.0",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -23,7 +23,7 @@
     "edge-entry.js"
   ],
   "dependencies": {
-    "@vercel/nft": "1.4.0",
+    "@vercel/nft": "1.5.0",
     "@vercel/static-config": "workspace:*",
     "fs-extra": "11.1.0",
     "path-to-regexp": "8.3.0",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -23,7 +23,7 @@
     "edge-entry.js"
   ],
   "dependencies": {
-    "@vercel/nft": "1.4.0",
+    "@vercel/nft": "1.5.0",
     "@vercel/static-config": "workspace:*",
     "@vercel/node": "workspace:*",
     "fs-extra": "11.1.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "dependencies": {
-    "@vercel/nft": "1.4.0"
+    "@vercel/nft": "1.5.0"
   },
   "devDependencies": {
     "@next-community/adapter-vercel": "0.0.1-beta.14",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,7 +27,7 @@
     "@types/node": "20.11.0",
     "@vercel/build-utils": "workspace:*",
     "@vercel/error-utils": "workspace:*",
-    "@vercel/nft": "1.4.0",
+    "@vercel/nft": "1.5.0",
     "@vercel/static-config": "workspace:*",
     "async-listen": "3.0.0",
     "cjs-module-lexer": "1.2.3",

--- a/packages/redwood/package.json
+++ b/packages/redwood/package.json
@@ -17,7 +17,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/nft": "1.4.0",
+    "@vercel/nft": "1.5.0",
     "@vercel/static-config": "workspace:*",
     "semver": "6.3.1",
     "ts-morph": "12.0.0"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@vercel/error-utils": "workspace:*",
-    "@vercel/nft": "1.4.0",
+    "@vercel/nft": "1.5.0",
     "@vercel/static-config": "workspace:*",
     "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
     "path-to-regexp": "6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,8 +214,8 @@ importers:
         specifier: workspace:*
         version: link:../build-utils
       '@vercel/nft':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.5.0
+        version: 1.5.0
       execa:
         specifier: 3.2.0
         version: 3.2.0
@@ -1152,8 +1152,8 @@ importers:
         specifier: workspace:*
         version: link:../cervel
       '@vercel/nft':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.5.0
+        version: 1.5.0
       '@vercel/node':
         specifier: workspace:*
         version: link:../node
@@ -1553,8 +1553,8 @@ importers:
   packages/hono:
     dependencies:
       '@vercel/nft':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.5.0
+        version: 1.5.0
       '@vercel/node':
         specifier: workspace:*
         version: link:../node
@@ -1700,8 +1700,8 @@ importers:
   packages/next:
     dependencies:
       '@vercel/nft':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.5.0
+        version: 1.5.0
     devDependencies:
       '@next-community/adapter-vercel':
         specifier: 0.0.1-beta.14
@@ -1842,8 +1842,8 @@ importers:
         specifier: workspace:*
         version: link:../error-utils
       '@vercel/nft':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.5.0
+        version: 1.5.0
       '@vercel/static-config':
         specifier: workspace:*
         version: link:../static-config
@@ -2168,8 +2168,8 @@ importers:
   packages/redwood:
     dependencies:
       '@vercel/nft':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.5.0
+        version: 1.5.0
       '@vercel/static-config':
         specifier: workspace:*
         version: link:../static-config
@@ -2230,8 +2230,8 @@ importers:
         specifier: workspace:*
         version: link:../error-utils
       '@vercel/nft':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.5.0
+        version: 1.5.0
       '@vercel/static-config':
         specifier: workspace:*
         version: link:../static-config
@@ -10063,8 +10063,8 @@ packages:
       - debug
     dev: false
 
-  /@vercel/nft@1.4.0:
-    resolution: {integrity: sha512-rr7JVnI7YGjA4lngucrWjZ7eCOJZZQaDHB+5NRGOuNc+k4PU2Lb9PmYm8uBmW8qichF7WkR2RmwmhXHBhx6wzw==}
+  /@vercel/nft@1.5.0:
+    resolution: {integrity: sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==}
     engines: {node: '>=20'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
## Summary

Bump @vercel/nft from 1.4.0 to 1.5.0 across all packages that depend on it. This update is applied to backends, express, hono, next, node, redwood, and remix packages.

## Test plan

- Verify lockfile updates correctly
- Run existing tests to ensure no regressions