### PR TITLE
Block PR merge when Find Changes job fails

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -282,6 +282,7 @@ jobs:
     timeout-minutes: 5
     if: always()
     needs:
+      - setup
       - test
     steps:
       - name: Check All

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -405,6 +405,7 @@ jobs:
     timeout-minutes: 5
     if: always()
     needs:
+      - setup
       - test
     steps:
       - name: Check All


### PR DESCRIPTION
## Summary

Make PRs unmergeable when the Find Changes GitHub Actions job fails by adding the setup job to the summary job's dependencies.

## Changes

- Added `setup` (Find Changes) job to the dependencies of the `summary` job in both `test.yml` and `test-e2e.yml`
- Previously, when Find Changes failed, the test job would be skipped and summary would pass since it only checked test results
- Now the summary job will fail if Find Changes fails, making the PR unmergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)