### PR TITLE
cli: make non-interactive login passcode-first and non-blocking

### DIFF
--- a/packages/cli/src/commands/login/command.ts
+++ b/packages/cli/src/commands/login/command.ts
@@ -12,6 +12,13 @@ export const loginCommand = {
   ],
   options: [
     {
+      name: 'passcode',
+      description: 'Use a generated login passcode',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+    },
+    {
       name: 'github',
       description: 'Log in with GitHub',
       shorthand: null,

--- a/packages/cli/src/commands/login/future.ts
+++ b/packages/cli/src/commands/login/future.ts
@@ -200,7 +200,10 @@ export async function login(
   client: Client,
   telemetry: LoginTelemetryClient
 ): Promise<number> {
-  const tokens = await performDeviceCodeFlow(client);
+  const passcode = getPasscodeFromArgv(client.argv);
+  const tokens = passcode
+    ? await exchangePasscodeForTokens(passcode)
+    : await performDeviceCodeFlow(client);
 
   if (!tokens) {
     telemetry.trackState('error');
@@ -246,4 +249,42 @@ export async function login(
 
 async function wait(intervalMs: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, intervalMs));
+}
+
+function getPasscodeFromArgv(argv: string[]): string | undefined {
+  const args = argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--passcode' && i + 1 < args.length) {
+      return args[i + 1];
+    }
+    if (args[i].startsWith('--passcode=')) {
+      return args[i].slice('--passcode='.length);
+    }
+  }
+  return undefined;
+}
+
+async function exchangePasscodeForTokens(
+  passcode: string
+): Promise<DeviceCodeTokens | null> {
+  const [tokenResponseError, tokenResponse] = await deviceAccessTokenRequest({
+    passcode,
+  });
+
+  if (tokenResponseError) {
+    printError(tokenResponseError);
+    return null;
+  }
+
+  const [tokensError, tokens] = await processTokenResponse(tokenResponse);
+  if (tokensError) {
+    printError(tokensError);
+    return null;
+  }
+
+  return {
+    access_token: tokens.access_token,
+    expires_in: tokens.expires_in,
+    refresh_token: tokens.refresh_token,
+  };
 }

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -10,6 +10,10 @@ import { LoginTelemetryClient } from '../../util/telemetry/commands/login';
 import { login as future } from './future';
 import { outputActionRequired } from '../../util/agent-output';
 import { AGENT_ACTION, AGENT_STATUS } from '../../util/agent-output-constants';
+import {
+  deviceAuthorizationRequest,
+  processDeviceAuthorizationResponse,
+} from '../../util/oauth';
 
 export default async function login(
   client: Client,
@@ -56,14 +60,20 @@ export default async function login(
   const passcode = typeof passcodeFlag === 'string' ? passcodeFlag : undefined;
 
   if (client.nonInteractive && !passcode) {
-    const message =
-      "Visit https://vercel.com/login/generate to generate a login passcode, then run 'vc login --passcode <passcode>'";
+    const deviceAuthorizationResponse = await deviceAuthorizationRequest();
+    const [deviceAuthorizationError, deviceAuthorization] =
+      await processDeviceAuthorizationResponse(deviceAuthorizationResponse);
+    if (deviceAuthorizationError) {
+      printError(deviceAuthorizationError);
+      return 1;
+    }
+    const message = `Visit ${deviceAuthorization.verification_uri} to generate a login passcode, then run 'vc login --passcode <passcode>'`;
     client.stdout.write(`${message}\n`);
     outputActionRequired(client, {
       status: AGENT_STATUS.ACTION_REQUIRED,
       action: AGENT_ACTION.LOGIN_PASSCODE_REQUIRED,
       message,
-      verification_uri: 'https://vercel.com/login/generate',
+      verification_uri: deviceAuthorization.verification_uri_complete,
       next: [{ command: 'vc login --passcode <passcode>' }],
     });
     return 1;

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -8,6 +8,8 @@ import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { LoginTelemetryClient } from '../../util/telemetry/commands/login';
 import { login as future } from './future';
+import { outputActionRequired } from '../../util/agent-output';
+import { AGENT_ACTION, AGENT_STATUS } from '../../util/agent-output-constants';
 
 export default async function login(
   client: Client,
@@ -48,6 +50,23 @@ export default async function login(
   if (parsedArgs?.flags['--token']) {
     output.error('`--token` may not be used with the "login" command');
     return 2;
+  }
+
+  const passcodeFlag = parsedArgs?.flags['--passcode'];
+  const passcode = typeof passcodeFlag === 'string' ? passcodeFlag : undefined;
+
+  if (client.nonInteractive && !passcode) {
+    const message =
+      "Visit https://vercel.com/login/generate to generate a login passcode, then run 'vc login --passcode <passcode>'";
+    client.stdout.write(`${message}\n`);
+    outputActionRequired(client, {
+      status: AGENT_STATUS.ACTION_REQUIRED,
+      action: AGENT_ACTION.LOGIN_PASSCODE_REQUIRED,
+      message,
+      verification_uri: 'https://vercel.com/login/generate',
+      next: [{ command: 'vc login --passcode <passcode>' }],
+    });
+    return 1;
   }
 
   if (options.shouldParseArgs && parsedArgs) {

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -10,10 +10,6 @@ import { LoginTelemetryClient } from '../../util/telemetry/commands/login';
 import { login as future } from './future';
 import { outputActionRequired } from '../../util/agent-output';
 import { AGENT_ACTION, AGENT_STATUS } from '../../util/agent-output-constants';
-import {
-  deviceAuthorizationRequest,
-  processDeviceAuthorizationResponse,
-} from '../../util/oauth';
 
 export default async function login(
   client: Client,
@@ -60,20 +56,14 @@ export default async function login(
   const passcode = typeof passcodeFlag === 'string' ? passcodeFlag : undefined;
 
   if (client.nonInteractive && !passcode) {
-    const deviceAuthorizationResponse = await deviceAuthorizationRequest();
-    const [deviceAuthorizationError, deviceAuthorization] =
-      await processDeviceAuthorizationResponse(deviceAuthorizationResponse);
-    if (deviceAuthorizationError) {
-      printError(deviceAuthorizationError);
-      return 1;
-    }
-    const message = `Visit ${deviceAuthorization.verification_uri} to generate a login passcode, then run 'vc login --passcode <passcode>'`;
+    const message =
+      "Visit https://vercel.com/login/generate to generate a login passcode, then run 'vc login --passcode <passcode>'";
     client.stdout.write(`${message}\n`);
     outputActionRequired(client, {
       status: AGENT_STATUS.ACTION_REQUIRED,
       action: AGENT_ACTION.LOGIN_PASSCODE_REQUIRED,
       message,
-      verification_uri: deviceAuthorization.verification_uri_complete,
+      verification_uri: 'https://vercel.com/login/generate',
       next: [{ command: 'vc login --passcode <passcode>' }],
     });
     return 1;

--- a/packages/cli/src/util/agent-output-constants.ts
+++ b/packages/cli/src/util/agent-output-constants.ts
@@ -75,4 +75,5 @@ export const AGENT_ACTION = {
   MISSING_ARGUMENTS: 'missing_arguments',
   CONFIRMATION_REQUIRED: 'confirmation_required',
   LOGIN_REQUIRED: 'login_required',
+  LOGIN_PASSCODE_REQUIRED: 'login_passcode_required',
 } as const;

--- a/packages/cli/src/util/oauth.ts
+++ b/packages/cli/src/util/oauth.ts
@@ -199,7 +199,8 @@ export async function processDeviceAuthorizationResponse(
  * @see https://datatracker.ietf.org/doc/html/rfc8628#section-3.4
  */
 export async function deviceAccessTokenRequest(options: {
-  device_code: string;
+  device_code?: string;
+  passcode?: string;
 }): Promise<[Error] | [null, Response]> {
   try {
     return [

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -188,4 +188,46 @@ describe('login', () => {
     expect(exitCode).toBe(0);
     expect(client.authConfig.userId).toBeUndefined();
   });
+
+  it('exchanges passcode without polling', async () => {
+    const tokenResponse = mockResponse({
+      access_token: randomUUID(),
+      token_type: 'Bearer',
+      expires_in: 60,
+      scope: 'openid offline_access',
+    });
+    fetch.mockImplementation((_url, options) => {
+      if (options?.method === 'POST') {
+        return Promise.resolve(tokenResponse);
+      }
+      return Promise.resolve(
+        mockResponse({
+          issuer: 'https://vercel.com',
+          device_authorization_endpoint:
+            'https://vercel.com/login/oauth/device-authorization',
+          token_endpoint: 'https://vercel.com/login/oauth/token',
+          revocation_endpoint: 'https://vercel.com/login/oauth/revoke',
+          jwks_uri: 'https://vercel.com/login/oauth/jwks',
+          introspection_endpoint: 'https://vercel.com/login/oauth/introspect',
+        })
+      );
+    });
+
+    client.setArgv('login', '--passcode', 'BCDF-GHJK');
+    client.authConfig.token = 'existing-token';
+    const tokenBefore = client.authConfig.token;
+
+    const exitCodePromise = login(client, { shouldParseArgs: true });
+    expect(await exitCodePromise, 'exit code for "login --passcode"').toBe(0);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][1]?.body?.toString()).toBe(
+      new URLSearchParams({
+        client_id: oauth.VERCEL_CLI_CLIENT_ID,
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        passcode: 'BCDF-GHJK',
+      }).toString()
+    );
+    expect(client.authConfig.token).not.toBe(tokenBefore);
+  });
 });

--- a/packages/cli/test/unit/commands/login/index.test.ts
+++ b/packages/cli/test/unit/commands/login/index.test.ts
@@ -38,9 +38,28 @@ describe('login', () => {
     (client as { nonInteractive: boolean }).nonInteractive = true;
 
     const futureSpy = vi.spyOn(loginFuture, 'login').mockResolvedValue(0);
+    const exitCodePromise = login(client, { shouldParseArgs: true });
+    await expect(exitCodePromise).rejects.toThrowError(
+      'process.exit unexpectedly called with "1"'
+    );
+    expect(futureSpy).toHaveBeenCalledTimes(0);
+    await expect(client.stdout).toOutput(
+      'Visit https://vercel.com/login/generate to generate a login passcode, then run \'vc login --passcode <passcode>\'\n{\n  "status": "action_required",\n  "action": "login_passcode_required",\n  "message": "Visit https://vercel.com/login/generate to generate a login passcode, then run \'vc login --passcode <passcode>\'",\n  "verification_uri": "https://vercel.com/login/generate",\n  "next": [\n    {\n      "command": "vc login --passcode <passcode>"\n    }\n  ],\n  "hint": "Run one of the commands in next[] to complete without prompting."\n}\n'
+    );
+
+    futureSpy.mockRestore();
+    (client as { nonInteractive: boolean }).nonInteractive = false;
+  });
+
+  it('passes --passcode through to login flow', async () => {
+    client.setArgv('login', '--passcode', 'ABCD-1234');
+    (client as { nonInteractive: boolean }).nonInteractive = true;
+
+    const futureSpy = vi.spyOn(loginFuture, 'login').mockResolvedValue(0);
     const exitCode = await login(client, { shouldParseArgs: true });
     expect(exitCode).toBe(0);
     expect(futureSpy).toHaveBeenCalledTimes(1);
+    expect(futureSpy).toHaveBeenCalledWith(client, expect.anything());
 
     futureSpy.mockRestore();
     (client as { nonInteractive: boolean }).nonInteractive = false;

--- a/packages/cli/test/unit/commands/login/index.test.ts
+++ b/packages/cli/test/unit/commands/login/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import login from '../../../../src/commands/login';
 import { client } from '../../../mocks/client';
 import * as loginFuture from '../../../../src/commands/login/future';
+import * as oauth from '../../../../src/util/oauth';
 
 vi.setConfig({ testTimeout: 10000 });
 
@@ -36,6 +37,19 @@ describe('login', () => {
   it('continues to login flow in non-interactive mode with no args', async () => {
     client.setArgv('login');
     (client as { nonInteractive: boolean }).nonInteractive = true;
+    vi.spyOn(oauth, 'deviceAuthorizationRequest').mockResolvedValue({} as any);
+    vi.spyOn(oauth, 'processDeviceAuthorizationResponse').mockResolvedValue([
+      null,
+      {
+        device_code: 'device-code',
+        user_code: 'BCDF-GHJK',
+        verification_uri: 'https://vercel.com/device',
+        verification_uri_complete:
+          'https://vercel.com/oauth/device?user_code=BCDF-GHJK',
+        expiresAt: Date.now() + 60_000,
+        interval: 5,
+      },
+    ]);
 
     const futureSpy = vi.spyOn(loginFuture, 'login').mockResolvedValue(0);
     const exitCodePromise = login(client, { shouldParseArgs: true });
@@ -44,7 +58,7 @@ describe('login', () => {
     );
     expect(futureSpy).toHaveBeenCalledTimes(0);
     await expect(client.stdout).toOutput(
-      'Visit https://vercel.com/login/generate to generate a login passcode, then run \'vc login --passcode <passcode>\'\n{\n  "status": "action_required",\n  "action": "login_passcode_required",\n  "message": "Visit https://vercel.com/login/generate to generate a login passcode, then run \'vc login --passcode <passcode>\'",\n  "verification_uri": "https://vercel.com/login/generate",\n  "next": [\n    {\n      "command": "vc login --passcode <passcode>"\n    }\n  ],\n  "hint": "Run one of the commands in next[] to complete without prompting."\n}\n'
+      'Visit https://vercel.com/device to generate a login passcode, then run \'vc login --passcode <passcode>\'\n{\n  "status": "action_required",\n  "action": "login_passcode_required",\n  "message": "Visit https://vercel.com/device to generate a login passcode, then run \'vc login --passcode <passcode>\'",\n  "verification_uri": "https://vercel.com/oauth/device?user_code=BCDF-GHJK",\n  "next": [\n    {\n      "command": "vc login --passcode <passcode>"\n    }\n  ],\n  "hint": "Run one of the commands in next[] to complete without prompting."\n}\n'
     );
 
     futureSpy.mockRestore();

--- a/packages/cli/test/unit/commands/login/index.test.ts
+++ b/packages/cli/test/unit/commands/login/index.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import login from '../../../../src/commands/login';
 import { client } from '../../../mocks/client';
 import * as loginFuture from '../../../../src/commands/login/future';
-import * as oauth from '../../../../src/util/oauth';
 
 vi.setConfig({ testTimeout: 10000 });
 
@@ -37,19 +36,6 @@ describe('login', () => {
   it('continues to login flow in non-interactive mode with no args', async () => {
     client.setArgv('login');
     (client as { nonInteractive: boolean }).nonInteractive = true;
-    vi.spyOn(oauth, 'deviceAuthorizationRequest').mockResolvedValue({} as any);
-    vi.spyOn(oauth, 'processDeviceAuthorizationResponse').mockResolvedValue([
-      null,
-      {
-        device_code: 'device-code',
-        user_code: 'BCDF-GHJK',
-        verification_uri: 'https://vercel.com/device',
-        verification_uri_complete:
-          'https://vercel.com/oauth/device?user_code=BCDF-GHJK',
-        expiresAt: Date.now() + 60_000,
-        interval: 5,
-      },
-    ]);
 
     const futureSpy = vi.spyOn(loginFuture, 'login').mockResolvedValue(0);
     const exitCodePromise = login(client, { shouldParseArgs: true });
@@ -58,7 +44,7 @@ describe('login', () => {
     );
     expect(futureSpy).toHaveBeenCalledTimes(0);
     await expect(client.stdout).toOutput(
-      'Visit https://vercel.com/device to generate a login passcode, then run \'vc login --passcode <passcode>\'\n{\n  "status": "action_required",\n  "action": "login_passcode_required",\n  "message": "Visit https://vercel.com/device to generate a login passcode, then run \'vc login --passcode <passcode>\'",\n  "verification_uri": "https://vercel.com/oauth/device?user_code=BCDF-GHJK",\n  "next": [\n    {\n      "command": "vc login --passcode <passcode>"\n    }\n  ],\n  "hint": "Run one of the commands in next[] to complete without prompting."\n}\n'
+      'Visit https://vercel.com/login/generate to generate a login passcode, then run \'vc login --passcode <passcode>\'\n{\n  "status": "action_required",\n  "action": "login_passcode_required",\n  "message": "Visit https://vercel.com/login/generate to generate a login passcode, then run \'vc login --passcode <passcode>\'",\n  "verification_uri": "https://vercel.com/login/generate",\n  "next": [\n    {\n      "command": "vc login --passcode <passcode>"\n    }\n  ],\n  "hint": "Run one of the commands in next[] to complete without prompting."\n}\n'
     );
 
     futureSpy.mockRestore();


### PR DESCRIPTION
## Summary
- make `vc login` in non-interactive mode return immediately with a machine-readable `action_required` payload instead of entering browser + polling flow
- add `--passcode` support so `vc login --passcode <passcode>` performs a single token exchange and stores credentials without polling
- keep OAuth device-code grant semantics in the exchange request while exposing a passcode-oriented CLI UX for agent workflows

## Notes
- `/login/generate` is **not created by this PR**; it is an existing Vercel web login UX endpoint used as the verification step for humans.
- RFC alignment: this still uses Device Authorization Grant semantics (`urn:ietf:params:oauth:grant-type:device_code`), with `passcode` as a CLI UX alias for the user-entered code step.

## Existing flow vs new flow
- **Today (existing):** `vc login` kicks off device auth, may open browser, then polls token endpoint until completion.
- **With this PR (non-interactive):**
  1) `vc login` returns immediately with action-required output and next step
  2) user generates passcode in browser
  3) caller runs `vc login --passcode <passcode>` for one-shot exchange
- Interactive behavior remains device-auth based; this changes the non-interactive execution model to be non-blocking.

## Test plan
- [x] `pnpm vitest-run test/unit/commands/login/index.test.ts test/unit/commands/login/future.test.ts`
- [ ] full CLI typecheck (currently blocked by unrelated main-branch type issues in `packages/cli`)