### PR TITLE
[cli] standardize non-interactive context propagation via env var

### DIFF
--- a/.changeset/non-interactive-env-var-standardization.md
+++ b/.changeset/non-interactive-env-var-standardization.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Standardize non-interactive context propagation via VERCEL_NON_INTERACTIVE env var

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -84,6 +84,7 @@ import {
   type TraceEvent,
 } from '@vercel/build-utils';
 import { mkdir, writeFile } from 'fs/promises';
+import { resolveNonInteractive } from './util/resolve-non-interactive';
 
 const VERCEL_DIR = getGlobalPathConfig();
 const VERCEL_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -502,7 +503,8 @@ const main = async () => {
   }
 
   // Shared API `Client` instance for all sub-commands to utilize.
-  // Non-interactive when: --non-interactive is set, or agent is detected (and no TTY). Explicit --non-interactive=false overrides agent detection.
+  // Non-interactive when VERCEL_NON_INTERACTIVE is set to a supported boolean-like value.
+  // Otherwise, fallback to legacy --non-interactive + agent/non-TTY behavior.
   const stdinIsTTY = process.stdin?.isTTY === true;
   const nonInteractiveFlag = parsedArgs.flags['--non-interactive'] === true;
   const argv = process.argv;
@@ -510,12 +512,17 @@ const main = async () => {
     argv.includes('--non-interactive=false') ||
     (argv.includes('--non-interactive') &&
       argv[argv.indexOf('--non-interactive') + 1] === 'false');
-  const nonInteractive = explicitNonInteractiveFalse
-    ? false
-    : nonInteractiveFlag || (isAgent && !stdinIsTTY);
+  const nonInteractiveResolved = resolveNonInteractive({
+    envValue: process.env.VERCEL_NON_INTERACTIVE,
+    cliFlag: nonInteractiveFlag,
+    explicitCliFalse: explicitNonInteractiveFalse,
+    isAgent,
+    stdinIsTTY,
+  });
+  const nonInteractive = nonInteractiveResolved.nonInteractive;
 
   output.debug(
-    `Agent/TTY/nonInteractive: isAgent=${isAgent} agentName=${detectedAgent?.name ?? 'none'} stdin.isTTY=${String(process.stdin?.isTTY)} --non-interactive=${nonInteractiveFlag} explicitFalse=${explicitNonInteractiveFalse} => nonInteractive=${nonInteractive}`
+    `Agent/TTY/nonInteractive: isAgent=${isAgent} agentName=${detectedAgent?.name ?? 'none'} stdin.isTTY=${String(process.stdin?.isTTY)} --non-interactive=${nonInteractiveFlag} explicitFalse=${explicitNonInteractiveFalse} VERCEL_NON_INTERACTIVE=${process.env.VERCEL_NON_INTERACTIVE ?? 'unset'} parsedEnv=${String(nonInteractiveResolved.parsedEnv)} => nonInteractive=${nonInteractive}`
   );
 
   // Only load proxy-agent if proxy env vars are configured (saves ~60ms startup)

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -88,13 +88,12 @@ export function buildCommandWithYes(
   return `${pkgName} ${out.join(' ')}`;
 }
 
-/** Global flags that should be preserved in suggested "next" commands (e.g. --cwd, --non-interactive). */
+/** Global flags that should be preserved in suggested "next" commands (e.g. --cwd). */
 const GLOBAL_FLAG_NAMES = new Set([
   '--cwd',
   '--config',
   '--yes',
   '-y',
-  '--non-interactive',
   '--scope',
   '--team',
   '-S',
@@ -106,7 +105,7 @@ const GLOBAL_FLAG_NAMES = new Set([
 const GLOBAL_FLAGS_BOOLEAN = new Set(['--yes', '-y', '--non-interactive']);
 
 /**
- * Returns global flag args from argv so suggested commands can include them (e.g. --cwd, --non-interactive).
+ * Returns global flag args from argv so suggested commands can include them (e.g. --cwd).
  */
 export function getGlobalFlagsFromArgv(argv: string[]): string[] {
   const args = argv.slice(2);
@@ -128,6 +127,24 @@ export function getGlobalFlagsFromArgv(argv: string[]): string[] {
     }
   }
   return out;
+}
+
+function getNonInteractiveEnvFromArgv(argv: string[]): '1' | '0' | undefined {
+  const args = argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--non-interactive') {
+      const next = args[i + 1];
+      if (next === 'false' || next === '0') return '0';
+      return '1';
+    }
+    if (arg.startsWith('--non-interactive=')) {
+      const value = arg.slice('--non-interactive='.length).toLowerCase();
+      if (value === 'false' || value === '0') return '0';
+      if (value === 'true' || value === '1') return '1';
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -179,8 +196,8 @@ export interface BuildCommandWithGlobalFlagsOptions {
 
 /**
  * Builds a suggested command string from a template and appends global flags from argv
- * (e.g. --cwd, --non-interactive) so the next command can be run with the same context.
- * Use excludeFlags to omit flags that must not appear (e.g. --non-interactive for login).
+ * (e.g. --cwd) so the next command can be run with the same context.
+ * Use excludeFlags to omit flags that must not appear.
  */
 export function buildCommandWithGlobalFlags(
   argv: string[],
@@ -210,13 +227,17 @@ export function buildCommandWithGlobalFlags(
     preserved = out;
   }
   const base = `${pkgName} ${commandTemplate}`;
+  let command: string;
   if (preserved.length === 0) {
-    return base;
+    command = base;
+  } else if (options?.prependGlobalFlags) {
+    command = `${pkgName} ${preserved.join(' ')} ${commandTemplate}`;
+  } else {
+    command = `${base} ${preserved.join(' ')}`;
   }
-  if (options?.prependGlobalFlags) {
-    return `${pkgName} ${preserved.join(' ')} ${commandTemplate}`;
-  }
-  return `${base} ${preserved.join(' ')}`;
+  const nonInteractiveEnv = getNonInteractiveEnvFromArgv(argv);
+  if (!nonInteractiveEnv) return command;
+  return `VERCEL_NON_INTERACTIVE=${nonInteractiveEnv} ${command}`;
 }
 
 /**

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -267,11 +267,15 @@ export function getGlobalFlagsOnlyFromArgs(args: string[]): string[] {
     if (a.startsWith('--') && a.includes('=')) {
       const name = a.slice(2).split('=')[0];
       opt = GLOBAL_LONG_TO_OPT.get(`--${name}`);
-      if (opt) out.push(a);
+      if (opt && opt.name !== 'non-interactive') out.push(a);
       continue;
     }
     opt = GLOBAL_LONG_TO_OPT.get(a) || GLOBAL_SHORT_TO_OPT.get(a);
     if (!opt) continue;
+    // Non-interactive is now propagated as env var in suggested commands.
+    if (opt.name === 'non-interactive') {
+      continue;
+    }
     out.push(a);
     if (opt.type === String && !a.includes('=')) {
       const next = args[i + 1];
@@ -284,6 +288,23 @@ export function getGlobalFlagsOnlyFromArgs(args: string[]): string[] {
   return out;
 }
 
+function getNonInteractiveEnvFromArgs(args: string[]): '1' | '0' | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--non-interactive') {
+      const next = args[i + 1];
+      if (next === 'false' || next === '0') return '0';
+      return '1';
+    }
+    if (arg.startsWith('--non-interactive=')) {
+      const value = arg.slice('--non-interactive='.length).toLowerCase();
+      if (value === 'false' || value === '0') return '0';
+      if (value === 'true' || value === '1') return '1';
+    }
+  }
+  return undefined;
+}
+
 /**
  * Builds a suggested command with only global CLI flags preserved from argv.
  * Useful for agent next[] hints that should keep context flags like --cwd.
@@ -292,6 +313,10 @@ export function getCommandNameWithGlobalFlags(
   commandTemplate: string,
   argv: string[]
 ): string {
-  const flags = getGlobalFlagsOnlyFromArgs(argv.slice(2));
-  return getCommandNamePlain(`${commandTemplate} ${flags.join(' ')}`.trim());
+  const args = argv.slice(2);
+  const flags = getGlobalFlagsOnlyFromArgs(args);
+  const command = `${commandTemplate} ${flags.join(' ')}`.trim();
+  const nonInteractiveEnv = getNonInteractiveEnvFromArgs(args);
+  if (!nonInteractiveEnv) return getCommandNamePlain(command);
+  return `VERCEL_NON_INTERACTIVE=${nonInteractiveEnv} ${getCommandNamePlain(command)}`;
 }

--- a/packages/cli/src/util/resolve-non-interactive.ts
+++ b/packages/cli/src/util/resolve-non-interactive.ts
@@ -1,0 +1,40 @@
+export function parseBooleanEnv(
+  value: string | undefined
+): boolean | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return undefined;
+}
+
+/**
+ * Resolve non-interactive mode globally.
+ *
+ * Priority:
+ * 1) VERCEL_NON_INTERACTIVE env var when set to a supported boolean-like value.
+ * 2) Agent fallback for non-TTY sessions.
+ */
+export function resolveNonInteractive(opts: {
+  envValue: string | undefined;
+  cliFlag: boolean;
+  explicitCliFalse: boolean;
+  isAgent: boolean;
+  stdinIsTTY: boolean;
+}): { nonInteractive: boolean; fromEnv: boolean; parsedEnv?: boolean } {
+  const parsedEnv = parseBooleanEnv(opts.envValue);
+  if (parsedEnv !== undefined) {
+    return { nonInteractive: parsedEnv, fromEnv: true, parsedEnv };
+  }
+
+  const fallback = opts.isAgent && !opts.stdinIsTTY;
+  const nonInteractive = opts.explicitCliFalse
+    ? false
+    : opts.cliFlag || fallback;
+
+  return {
+    nonInteractive,
+    fromEnv: false,
+    parsedEnv: undefined,
+  };
+}

--- a/packages/cli/test/unit/util/agent-output.test.ts
+++ b/packages/cli/test/unit/util/agent-output.test.ts
@@ -284,6 +284,18 @@ describe('buildCommandWithScope', () => {
   });
 });
 
+describe('buildCommandWithGlobalFlags', () => {
+  it('uses VERCEL_NON_INTERACTIVE env prefix instead of preserving the flag', () => {
+    const command = buildCommandWithGlobalFlags(
+      ['/node', '/vc.js', 'env', 'add', '--cwd', '/tmp', '--non-interactive'],
+      'env add SOME_KEY'
+    );
+    expect(command).toBe(
+      'VERCEL_NON_INTERACTIVE=1 vercel env add SOME_KEY --cwd /tmp'
+    );
+  });
+});
+
 describe('enrichActionRequiredWithInvokingCommand', () => {
   it('adds link and invoking command with scope for each choice', () => {
     const payload: ActionRequiredPayload = {

--- a/packages/cli/test/unit/util/agent-output.test.ts
+++ b/packages/cli/test/unit/util/agent-output.test.ts
@@ -445,12 +445,7 @@ describe('getGlobalFlagsFromArgv', () => {
       'neon',
       '--yes',
     ];
-    expect(getGlobalFlagsFromArgv(argv)).toEqual([
-      '--cwd',
-      '/tmp/p',
-      '--non-interactive',
-      '--yes',
-    ]);
+    expect(getGlobalFlagsFromArgv(argv)).toEqual(['--cwd', '/tmp/p', '--yes']);
   });
 });
 
@@ -475,7 +470,7 @@ describe('buildCommandWithGlobalFlags', () => {
         { prependGlobalFlags: true, excludeFlags: ['--yes', '-y'] }
       )
     ).toBe(
-      'vercel --cwd /tmp/p --non-interactive integration-resource remove r1 --disconnect-all --yes'
+      'VERCEL_NON_INTERACTIVE=1 vercel --cwd /tmp/p integration-resource remove r1 --disconnect-all --yes'
     );
   });
 });

--- a/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
+++ b/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getCommandNameWithGlobalFlags,
   getGlobalFlagsOnlyFromArgs,
   getSameSubcommandSuggestionFlags,
 } from '../../../src/util/arg-common';
@@ -40,5 +41,38 @@ describe('getGlobalFlagsOnlyFromArgs', () => {
     expect(out).not.toContain('acme');
     expect(out).not.toContain('--status');
     expect(out).not.toContain('301');
+  });
+
+  it('does not preserve --non-interactive as a global flag', () => {
+    const out = getGlobalFlagsOnlyFromArgs([
+      '--cwd',
+      '/tmp',
+      '--non-interactive',
+    ]);
+    expect(out).toEqual(['--cwd', '/tmp']);
+  });
+});
+
+describe('getCommandNameWithGlobalFlags', () => {
+  it('converts --non-interactive to VERCEL_NON_INTERACTIVE=1 prefix', () => {
+    const out = getCommandNameWithGlobalFlags('deploy', [
+      'node',
+      'vc',
+      'deploy',
+      '--cwd',
+      '/tmp',
+      '--non-interactive',
+    ]);
+    expect(out).toBe('VERCEL_NON_INTERACTIVE=1 vercel deploy --cwd /tmp');
+  });
+
+  it('converts --non-interactive=false to VERCEL_NON_INTERACTIVE=0 prefix', () => {
+    const out = getCommandNameWithGlobalFlags('deploy', [
+      'node',
+      'vc',
+      'deploy',
+      '--non-interactive=false',
+    ]);
+    expect(out).toBe('VERCEL_NON_INTERACTIVE=0 vercel deploy');
   });
 });

--- a/packages/cli/test/unit/util/resolve-non-interactive.test.ts
+++ b/packages/cli/test/unit/util/resolve-non-interactive.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseBooleanEnv,
+  resolveNonInteractive,
+} from '../../../src/util/resolve-non-interactive';
+
+describe('parseBooleanEnv', () => {
+  it('parses truthy env values', () => {
+    expect(parseBooleanEnv('1')).toBe(true);
+    expect(parseBooleanEnv('true')).toBe(true);
+    expect(parseBooleanEnv('YES')).toBe(true);
+    expect(parseBooleanEnv('on')).toBe(true);
+  });
+
+  it('parses falsy env values', () => {
+    expect(parseBooleanEnv('0')).toBe(false);
+    expect(parseBooleanEnv('false')).toBe(false);
+    expect(parseBooleanEnv('No')).toBe(false);
+    expect(parseBooleanEnv('off')).toBe(false);
+  });
+
+  it('returns undefined for invalid values', () => {
+    expect(parseBooleanEnv(undefined)).toBeUndefined();
+    expect(parseBooleanEnv('')).toBeUndefined();
+    expect(parseBooleanEnv('maybe')).toBeUndefined();
+  });
+});
+
+describe('resolveNonInteractive', () => {
+  it('uses VERCEL_NON_INTERACTIVE when valid', () => {
+    expect(
+      resolveNonInteractive({
+        envValue: 'true',
+        cliFlag: false,
+        explicitCliFalse: false,
+        isAgent: false,
+        stdinIsTTY: true,
+      })
+    ).toEqual({
+      nonInteractive: true,
+      fromEnv: true,
+      parsedEnv: true,
+    });
+
+    expect(
+      resolveNonInteractive({
+        envValue: '0',
+        cliFlag: true,
+        explicitCliFalse: false,
+        isAgent: true,
+        stdinIsTTY: false,
+      })
+    ).toEqual({
+      nonInteractive: false,
+      fromEnv: true,
+      parsedEnv: false,
+    });
+  });
+
+  it('falls back to agent and non-tty when env is missing/invalid', () => {
+    expect(
+      resolveNonInteractive({
+        envValue: undefined,
+        cliFlag: false,
+        explicitCliFalse: false,
+        isAgent: true,
+        stdinIsTTY: false,
+      })
+    ).toEqual({
+      nonInteractive: true,
+      fromEnv: false,
+      parsedEnv: undefined,
+    });
+
+    expect(
+      resolveNonInteractive({
+        envValue: 'invalid',
+        cliFlag: false,
+        explicitCliFalse: false,
+        isAgent: false,
+        stdinIsTTY: false,
+      })
+    ).toEqual({
+      nonInteractive: false,
+      fromEnv: false,
+      parsedEnv: undefined,
+    });
+  });
+
+  it('falls back to legacy --non-interactive flag semantics when env unset', () => {
+    expect(
+      resolveNonInteractive({
+        envValue: undefined,
+        cliFlag: true,
+        explicitCliFalse: false,
+        isAgent: false,
+        stdinIsTTY: true,
+      })
+    ).toEqual({
+      nonInteractive: true,
+      fromEnv: false,
+      parsedEnv: undefined,
+    });
+
+    expect(
+      resolveNonInteractive({
+        envValue: undefined,
+        cliFlag: true,
+        explicitCliFalse: true,
+        isAgent: true,
+        stdinIsTTY: false,
+      })
+    ).toEqual({
+      nonInteractive: false,
+      fromEnv: false,
+      parsedEnv: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- keep existing non-interactive behavior resolution (CLI flag + agent/non-TTY fallback) while adding explicit env-var resolution in a shared utility
- standardize suggested `next[]` command generation to convert `--non-interactive` usage into `VERCEL_NON_INTERACTIVE=1|0` prefixes instead of forwarding `--non-interactive` as a global flag
- add focused unit coverage for env parsing/resolution and command suggestion behavior in `arg-common` and `agent-output`

## Test plan
- [x] `pnpm exec vitest run --config ./vitest.config.mts test/unit/util/resolve-non-interactive.test.ts test/unit/util/arg-common-suggestion-flags.test.ts test/unit/util/agent-output.test.ts`
- [x] `ReadLints` for touched files (no lints)
- [ ] `pnpm run type-check` (currently fails due to pre-existing unrelated type issues in this checkout)

Made with [Cursor](https://cursor.com)