### PR TITLE
[python] Centralize and simplify python entrypoint finding logic more

### DIFF
--- a/.changeset/curvy-lies-try.md
+++ b/.changeset/curvy-lies-try.md
@@ -1,0 +1,8 @@
+---
+'@vercel/fs-detectors': minor
+'@vercel/frameworks': minor
+'@vercel/python': minor
+'vercel': minor
+---
+
+Simplify and streamline python builder logic

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -408,7 +408,7 @@ async function writeBuildResultV3(args: {
       });
     }
   }
-  const src = build.src === '<detect>' ? 'index' : build.src;
+  const src = build.src;
   if (typeof src !== 'string') {
     throw new Error(`Expected "build.src" to be a string`);
   }

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -408,7 +408,7 @@ async function writeBuildResultV3(args: {
       });
     }
   }
-  const src = build.src;
+  const src = build.src === '<detect>' ? 'index' : build.src;
   if (typeof src !== 'string') {
     throw new Error(`Expected "build.src" to be a string`);
   }

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -561,12 +561,18 @@ export async function getBuildMatches(
       src = 'package.json';
     }
 
-    // The Python builder will handle the actual entrypoint discovery, we just need to
-    // point it to a manifest file that exists.
+    // lambda function files are trimmed of their file extension
+    const mapToEntrypoint = new Map<string, string>();
+
+    // The Python builder handles entrypoint discovery itself via <detect>.
+    // We still need to match a real file so the dev server creates a BuildMatch,
+    // but we preserve the original src (e.g. "<detect>") as the entrypoint
+    // passed to startDevServer/build.
     if (
       buildConfig.config?.framework &&
       isPythonFramework(buildConfig.config?.framework)
     ) {
+      const originalSrc = src;
       const pythonManifestFiles = [
         'pyproject.toml',
         'requirements.txt',
@@ -575,11 +581,9 @@ export async function getBuildMatches(
       const existing = pythonManifestFiles.filter(p => fileList.includes(p));
       if (existing.length > 0) {
         src = existing[0];
+        mapToEntrypoint.set(src, originalSrc);
       }
     }
-
-    // lambda function files are trimmed of their file extension
-    const mapToEntrypoint = new Map<string, string>();
     const extensionless = devServer.getExtensionlessFile(src);
     if (extensionless) {
       mapToEntrypoint.set(extensionless, src);

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -448,6 +448,13 @@ export class ServicesOrchestrator {
           syncDependencies: true,
           serviceName: service.name,
         },
+        service: {
+          name: service.name,
+          type: service.type,
+          routePrefix: service.routePrefix,
+          subdomain: service.subdomain,
+          workspace: service.workspace,
+        },
         files: {},
         onStdout: (data: Buffer) => logger.stdout.write(data),
         onStderr: (data: Buffer) => logger.stderr.write(data),

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2069,7 +2069,7 @@ export const frameworks = [
       'FastAPI framework, high performance, easy to learn, fast to code, ready for production',
     website: 'https://fastapi.tiangolo.com',
     supersedes: ['python'],
-    useRuntime: { src: 'index.py', use: '@vercel/python' },
+    useRuntime: { src: '<detect>', use: '@vercel/python' },
     ignoreRuntimes: ['@vercel/python'],
     detectors: {
       some: [
@@ -2122,7 +2122,7 @@ export const frameworks = [
     description: 'A Flask app, ready for production',
     website: 'https://flask.palletsprojects.com',
     supersedes: ['python'],
-    useRuntime: { src: 'index.py', use: '@vercel/python' },
+    useRuntime: { src: '<detect>', use: '@vercel/python' },
     ignoreRuntimes: ['@vercel/python'],
     detectors: {
       some: [
@@ -2223,7 +2223,7 @@ export const frameworks = [
     description: 'A Django project served via the Python Runtime.',
     website: 'https://www.djangoproject.com',
     supersedes: ['python'],
-    useRuntime: { src: 'index.py', use: '@vercel/python' },
+    useRuntime: { src: '<detect>', use: '@vercel/python' },
     ignoreRuntimes: ['@vercel/python'],
     detectors: {
       some: [
@@ -4139,7 +4139,7 @@ export const frameworks = [
     description:
       'A generic Python application deployed as a serverless function.',
     website: 'https://python.org',
-    useRuntime: { src: 'index.py', use: '@vercel/python' },
+    useRuntime: { src: '<detect>', use: '@vercel/python' },
     ignoreRuntimes: ['@vercel/python'],
     detectors: {
       some: [

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -526,7 +526,7 @@ describe('detectServices', () => {
         workspace: 'apps/api',
         entrypoint: undefined,
       });
-      expect(result.services[0].builder.src).toBe('apps/api/index.py');
+      expect(result.services[0].builder.src).toBe('apps/api/<detect>');
     });
 
     it('should auto-detect framework for directory entrypoint when omitted', async () => {
@@ -552,7 +552,7 @@ describe('detectServices', () => {
         entrypoint: undefined,
       });
       expect(result.services[0].builder.use).toBe('@vercel/python');
-      expect(result.services[0].builder.src).toBe('apps/api/index.py');
+      expect(result.services[0].builder.src).toBe('apps/api/<detect>');
     });
 
     it('should treat existing dotted directory entrypoint as a directory', async () => {
@@ -701,7 +701,7 @@ describe('detectServices', () => {
         entrypoint: undefined,
       });
       expect(result.services[0].builder.use).toBe('@vercel/python');
-      expect(result.services[0].builder.src).toBe('apps/api/index.py');
+      expect(result.services[0].builder.src).toBe('apps/api/<detect>');
     });
 
     it('should auto-detect framework for file entrypoint and keep node backend builder', async () => {

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -216,7 +216,6 @@ export async function detectPythonEntrypoint(
   configuredEntrypoint?: string,
   service?: { type?: string }
 ): Promise<DetectedPythonEntrypoint | null> {
-  // TODO: factor out?
   // If a configured entrypoint was provided, check it first
   if (configuredEntrypoint) {
     const entrypoint = configuredEntrypoint.endsWith('.py')

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { join, posix as pathPosix } from 'path';
-import type { PythonFramework } from '@vercel/build-utils';
+import { PythonFramework, NowBuildError } from '@vercel/build-utils';
 import { debug } from '@vercel/build-utils';
 import { readConfigFile } from '@vercel/build-utils';
 import { findAppOrHandler } from '@vercel/python-analysis';
@@ -17,6 +17,8 @@ export interface DetectedPythonEntrypoint {
   entrypoint?: PythonEntrypoint;
   /** Directory containing manage.py, if detected via Django path. */
   baseDir?: string;
+  /** Exception to raise, if we can't fix it with per-framework hooks */
+  error?: NowBuildError;
 }
 
 export const PYTHON_ENTRYPOINT_FILENAMES = [
@@ -144,26 +146,23 @@ async function getSubdirectories(workPath: string): Promise<string[]> {
   }
 }
 
+function makeDetectError(framework: string): NowBuildError {
+  const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
+  return new NowBuildError({
+    code: `${framework!.toUpperCase()}_ENTRYPOINT_NOT_FOUND`,
+    message: `No ${framework} entrypoint found. Add an 'app' script in pyproject.toml or define an entrypoint in one of: ${searchedList}.`,
+    link: `https://vercel.com/docs/frameworks/backend/${framework}#exporting-the-${framework}-application`,
+    action: 'Learn More',
+  });
+}
+
 /**
  * Detect a Python entrypoint for any Python framework using AST-based detection.
  */
 export async function detectGenericPythonEntrypoint(
-  workPath: string,
-  configuredEntrypoint?: string
+  workPath: string
 ): Promise<DetectedPythonEntrypoint | null> {
   try {
-    // If a configured entrypoint was provided, check it first
-    if (configuredEntrypoint) {
-      const entry = configuredEntrypoint.endsWith('.py')
-        ? configuredEntrypoint
-        : `${configuredEntrypoint}.py`;
-      const varName = await checkEntrypoint(workPath, entry);
-      if (varName) {
-        debug(`Using configured Python entrypoint: ${entry}`);
-        return { entrypoint: { entrypoint: entry, variableName: varName } };
-      }
-    }
-
     // Search candidate locations using AST-based detection
     const found = await findValidEntrypoint(
       workPath,
@@ -181,22 +180,9 @@ export async function detectGenericPythonEntrypoint(
  * DJANGO_SETTINGS_MODULE, then fall back to AST-based detection if needed.
  */
 export async function detectDjangoPythonEntrypoint(
-  workPath: string,
-  configuredEntrypoint?: string
+  workPath: string
 ): Promise<DetectedPythonEntrypoint | null> {
   try {
-    // If a configured entrypoint was provided, check it first
-    if (configuredEntrypoint) {
-      const entry = configuredEntrypoint.endsWith('.py')
-        ? configuredEntrypoint
-        : `${configuredEntrypoint}.py`;
-      const varName = await checkEntrypoint(workPath, entry);
-      if (varName) {
-        debug(`Using configured Python entrypoint: ${entry}`);
-        return { entrypoint: { entrypoint: entry, variableName: varName } };
-      }
-    }
-
     // Get root directories (workPath root + immediate subdirs)
     const subdirs = await getSubdirectories(workPath);
     const rootDirs = ['', ...subdirs];
@@ -206,7 +192,7 @@ export async function detectDjangoPythonEntrypoint(
       const currPath = join(workPath, rootDir);
       const isDjango = await checkDjangoManage(currPath);
       if (isDjango) {
-        return { baseDir: rootDir };
+        return { baseDir: rootDir, error: makeDetectError('django') };
       }
     }
 
@@ -225,15 +211,55 @@ export async function detectDjangoPythonEntrypoint(
  * Detect a Python entrypoint path for a given framework relative to workPath, or return null if not found.
  */
 export async function detectPythonEntrypoint(
-  framework: PythonFramework,
+  framework: PythonFramework | undefined,
   workPath: string,
-  configuredEntrypoint?: string
+  configuredEntrypoint?: string,
+  service?: { type?: string }
 ): Promise<DetectedPythonEntrypoint | null> {
+  // TODO: factor out?
+  // If a configured entrypoint was provided, check it first
+  if (configuredEntrypoint) {
+    const entrypoint = configuredEntrypoint.endsWith('.py')
+      ? configuredEntrypoint
+      : `${configuredEntrypoint}.py`;
+    let varName = await checkEntrypoint(workPath, entrypoint);
+
+    if (!varName) {
+      const isSpecialService =
+        service?.type === 'cron' || service?.type === 'worker';
+      if (isSpecialService) {
+        // Crons and worker have their own special entry point logic
+        // that involves creating an `app` dynamically.
+        varName = 'app';
+      }
+    }
+
+    if (varName) {
+      debug(`Using configured Python entrypoint: ${entrypoint}`);
+      return { entrypoint: { entrypoint, variableName: varName } };
+    } else {
+      return {
+        error: new NowBuildError({
+          code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
+          message: `Could not find a top-level "app", "application", or "handler" in "${entrypoint}".`,
+          link: 'https://vercel.com/docs/functions/serverless-functions/runtimes/python',
+          action: 'Learn More',
+        }),
+      };
+    }
+  }
+  if (!framework) {
+    return null;
+  }
+
+  // Otherwise do a search
   const result =
     framework === 'django'
-      ? await detectDjangoPythonEntrypoint(workPath, configuredEntrypoint)
-      : await detectGenericPythonEntrypoint(workPath, configuredEntrypoint);
+      ? await detectDjangoPythonEntrypoint(workPath)
+      : await detectGenericPythonEntrypoint(workPath);
   if (result) return result;
   const pyprojectEntry = await getPyprojectEntrypoint(workPath);
-  return pyprojectEntry ? { entrypoint: pyprojectEntry } : null;
+  return pyprojectEntry
+    ? { entrypoint: pyprojectEntry }
+    : { error: makeDetectError(framework) };
 }

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -149,18 +149,19 @@ async function getSubdirectories(workPath: string): Promise<string[]> {
  */
 export async function detectGenericPythonEntrypoint(
   workPath: string,
-  configuredEntrypoint: string
+  configuredEntrypoint?: string
 ): Promise<DetectedPythonEntrypoint | null> {
-  const entry = configuredEntrypoint.endsWith('.py')
-    ? configuredEntrypoint
-    : `${configuredEntrypoint}.py`;
-
   try {
-    // If the configured entrypoint exists and is valid, use it
-    const varName = await checkEntrypoint(workPath, entry);
-    if (varName) {
-      debug(`Using configured Python entrypoint: ${entry}`);
-      return { entrypoint: { entrypoint: entry, variableName: varName } };
+    // If a configured entrypoint was provided, check it first
+    if (configuredEntrypoint) {
+      const entry = configuredEntrypoint.endsWith('.py')
+        ? configuredEntrypoint
+        : `${configuredEntrypoint}.py`;
+      const varName = await checkEntrypoint(workPath, entry);
+      if (varName) {
+        debug(`Using configured Python entrypoint: ${entry}`);
+        return { entrypoint: { entrypoint: entry, variableName: varName } };
+      }
     }
 
     // Search candidate locations using AST-based detection
@@ -181,18 +182,19 @@ export async function detectGenericPythonEntrypoint(
  */
 export async function detectDjangoPythonEntrypoint(
   workPath: string,
-  configuredEntrypoint: string
+  configuredEntrypoint?: string
 ): Promise<DetectedPythonEntrypoint | null> {
-  const entry = configuredEntrypoint.endsWith('.py')
-    ? configuredEntrypoint
-    : `${configuredEntrypoint}.py`;
-
   try {
-    // If the configured entrypoint exists and is valid, use it
-    const varName = await checkEntrypoint(workPath, entry);
-    if (varName) {
-      debug(`Using configured Python entrypoint: ${entry}`);
-      return { entrypoint: { entrypoint: entry, variableName: varName } };
+    // If a configured entrypoint was provided, check it first
+    if (configuredEntrypoint) {
+      const entry = configuredEntrypoint.endsWith('.py')
+        ? configuredEntrypoint
+        : `${configuredEntrypoint}.py`;
+      const varName = await checkEntrypoint(workPath, entry);
+      if (varName) {
+        debug(`Using configured Python entrypoint: ${entry}`);
+        return { entrypoint: { entrypoint: entry, variableName: varName } };
+      }
     }
 
     // Get root directories (workPath root + immediate subdirs)
@@ -225,7 +227,7 @@ export async function detectDjangoPythonEntrypoint(
 export async function detectPythonEntrypoint(
   framework: PythonFramework,
   workPath: string,
-  configuredEntrypoint: string
+  configuredEntrypoint?: string
 ): Promise<DetectedPythonEntrypoint | null> {
   const result =
     framework === 'django'

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -199,8 +199,6 @@ export const build: BuildVX = async ({
   let hasCustomCommand = false;
 
   debug(`workPath: ${workPath}`);
-  debug(`entrypoint!!!: ${entrypoint}`);
-  debug(`framework!!!: ${framework}`);
 
   workPath = await downloadFilesInWorkPath({
     workPath,

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -720,7 +720,12 @@ from vercel_runtime.vc_init import vc_handler
     return { resultVersion: 3, result: { output } };
   }
 
-  const lambdaPath = entrypoint.replace(/\.py$/, '');
+  // If there is a service name, we need to mount this under the
+  // service properly, for a V2 build.
+  // TODO: Ideally this should be handled by writeBuildResultV2.
+  const lambdaPath = service?.name
+    ? `_svc/${service.name}/index`
+    : entrypoint.replace(/\.py$/, '');
   const staticFiles = djangoStatic?.cdnOutputDir
     ? await glob('**', { cwd: djangoStatic.cdnOutputDir })
     : {};

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -67,7 +67,7 @@ interface FrameworkHookContext {
   projectDir: string;
   workPath?: string;
   venvPath?: string;
-  entrypoint: string;
+  entrypoint: string | undefined;
   detected: DetectedPythonEntrypoint | undefined;
 }
 
@@ -159,10 +159,12 @@ export async function downloadFilesInWorkPath({
   workPath,
   files,
   meta = {},
-}: Pick<BuildOptions, 'entrypoint' | 'workPath' | 'files' | 'meta'>) {
+}: Pick<BuildOptions, 'workPath' | 'files' | 'meta'> & {
+  entrypoint: string | undefined;
+}) {
   debug('Downloading user files...');
   let downloadedFiles = await download(files, workPath, meta);
-  if (meta.isDev) {
+  if (meta.isDev && entrypoint) {
     // Old versions of the CLI don't assign this property
     const { devCacheDir = join(workPath, '.now', 'cache') } = meta;
     // Replace dots in the entrypoint basename with underscores so the cache
@@ -180,12 +182,15 @@ export const build: BuildVX = async ({
   workPath,
   repoRootPath,
   files: originalFiles,
-  entrypoint,
+  entrypoint: rawEntrypoint,
   meta = {},
   config,
   span: parentSpan,
   service,
 }) => {
+  let entrypoint: string | undefined =
+    rawEntrypoint === '<detect>' ? undefined : rawEntrypoint;
+
   const builderSpan = parentSpan ?? new Span({ name: 'vc.builder' });
   const framework = config?.framework;
   const shouldInstallVercelWorkers = config?.hasWorkerServices === true;
@@ -198,6 +203,8 @@ export const build: BuildVX = async ({
   let hasCustomCommand = false;
 
   debug(`workPath: ${workPath}`);
+  debug(`entrypoint!!!: ${entrypoint}`);
+  debug(`framework!!!: ${framework}`);
 
   workPath = await downloadFilesInWorkPath({
     workPath,
@@ -225,14 +232,37 @@ export const build: BuildVX = async ({
 
   let fsFiles = await glob('**', workPath);
 
-  // Zero config entrypoint discovery
+  // Entrypoint discovery
   let detected: DetectedPythonEntrypoint | undefined;
   let entrypointNotFound: NowBuildError | undefined;
-  if (
+
+  if (!entrypoint && isPythonFramework(framework)) {
+    // Autodetect: no entrypoint configured (src was "<detect>")
+    detected =
+      (await detectPythonEntrypoint(
+        config.framework as PythonFramework,
+        workPath
+      )) ?? undefined;
+    if (detected?.entrypoint) {
+      debug(
+        `Autodetected Python entrypoint: "${detected.entrypoint.entrypoint}"`
+      );
+      entrypoint = detected.entrypoint.entrypoint;
+    } else {
+      const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
+      entrypointNotFound = new NowBuildError({
+        code: `${framework!.toUpperCase()}_ENTRYPOINT_NOT_FOUND`,
+        message: `No ${framework} entrypoint found. Add an 'app' script in pyproject.toml or define an entrypoint in one of: ${searchedList}.`,
+        link: `https://vercel.com/docs/frameworks/backend/${framework}#exporting-the-${framework}-application`,
+        action: 'Learn More',
+      });
+    }
+  } else if (
+    entrypoint &&
     isPythonFramework(framework) &&
-    // XXX: we might want to detect anyway for django!
     (!fsFiles[entrypoint] || !entrypoint.endsWith('.py'))
   ) {
+    // Configured entrypoint doesn't exist or isn't a .py file — try detection
     detected =
       (await detectPythonEntrypoint(
         config.framework as PythonFramework,
@@ -247,7 +277,7 @@ export const build: BuildVX = async ({
     } else {
       const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
       entrypointNotFound = new NowBuildError({
-        code: `${framework.toUpperCase()}_ENTRYPOINT_NOT_FOUND`,
+        code: `${framework!.toUpperCase()}_ENTRYPOINT_NOT_FOUND`,
         message: `No ${framework} entrypoint found. Add an 'app' script in pyproject.toml or define an entrypoint in one of: ${searchedList}.`,
         link: `https://vercel.com/docs/frameworks/backend/${framework}#exporting-the-${framework}-application`,
         action: 'Learn More',
@@ -255,11 +285,11 @@ export const build: BuildVX = async ({
     }
   }
 
-  // When the entrypoint file already exists, detection is skipped above.
+  // When the entrypoint file already exists, detection may have been skipped.
   // Still read the file to find the variable name.
   if (
     !detected?.entrypoint &&
-    entrypoint.endsWith('.py') &&
+    entrypoint?.endsWith('.py') &&
     fsFiles[entrypoint]
   ) {
     const content = await fs.promises.readFile(
@@ -274,7 +304,7 @@ export const build: BuildVX = async ({
         // Crons and worker have their own special entry point logic
         // that involves creating an `app` dynamically.
         varName = 'app';
-      } else if (!varName) {
+      } else {
         throw new NowBuildError({
           code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
           message: `Could not find a top-level "app", "application", or "handler" in "${entrypoint}".`,
@@ -290,7 +320,8 @@ export const build: BuildVX = async ({
     throw entrypointNotFound;
   }
 
-  const entryDirectory = detected?.baseDir ?? dirname(entrypoint);
+  const entryDirectory =
+    detected?.baseDir ?? (entrypoint ? dirname(entrypoint) : '.');
 
   const entrypointAbsDir = join(workPath, entryDirectory);
   const rootDir = repoRootPath ?? workPath;
@@ -518,6 +549,14 @@ export const build: BuildVX = async ({
 
   if (entrypointNotFound) {
     throw entrypointNotFound;
+  }
+
+  if (!entrypoint) {
+    throw new NowBuildError({
+      code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
+      message:
+        'No Python entrypoint could be detected. Please specify an entrypoint file.',
+    });
   }
 
   const djangoStatic: DjangoCollectStaticResult | null =

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -46,15 +46,11 @@ import {
   runDjangoCollectStatic,
   type DjangoCollectStaticResult,
 } from './django';
-import {
-  findAppOrHandler,
-  containsTopLevelCallable,
-} from '@vercel/python-analysis';
+import { containsTopLevelCallable } from '@vercel/python-analysis';
 
 const writeFile = fs.promises.writeFile;
 
 import {
-  PYTHON_CANDIDATE_ENTRYPOINTS,
   detectPythonEntrypoint,
   type DetectedPythonEntrypoint,
   type PythonEntrypoint,
@@ -230,68 +226,19 @@ export const build: BuildVX = async ({
     throw err;
   }
 
-  let fsFiles = await glob('**', workPath);
-
   // Entrypoint discovery
   let detected: DetectedPythonEntrypoint | undefined;
-  let entrypointNotFound: NowBuildError | undefined;
 
-  if (isPythonFramework(framework) && !entrypoint) {
-    // Autodetect entrypoint: no entrypoint configured (src was "<detect>")
-    detected =
-      (await detectPythonEntrypoint(
-        config.framework as PythonFramework,
-        workPath
-      )) ?? undefined;
-    if (detected?.entrypoint) {
-      debug(
-        `Autodetected Python entrypoint: "${detected.entrypoint.entrypoint}"`
-      );
-      entrypoint = detected.entrypoint.entrypoint;
-    } else {
-      const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
-      entrypointNotFound = new NowBuildError({
-        code: `${framework!.toUpperCase()}_ENTRYPOINT_NOT_FOUND`,
-        message: `No ${framework} entrypoint found. Add an 'app' script in pyproject.toml or define an entrypoint in one of: ${searchedList}.`,
-        link: `https://vercel.com/docs/frameworks/backend/${framework}#exporting-the-${framework}-application`,
-        action: 'Learn More',
-      });
-    }
-  }
+  detected =
+    (await detectPythonEntrypoint(
+      config.framework as PythonFramework,
+      workPath,
+      entrypoint,
+      service
+    )) ?? undefined;
 
-  // When the entrypoint file already exists, detection may have been skipped.
-  // Still read the file to find the variable name.
-  if (
-    !detected?.entrypoint &&
-    entrypoint?.endsWith('.py') &&
-    fsFiles[entrypoint]
-  ) {
-    const content = await fs.promises.readFile(
-      join(workPath, entrypoint),
-      'utf-8'
-    );
-    let varName = await findAppOrHandler(content);
-    if (!varName) {
-      const isSpecialService =
-        service?.type === 'cron' || service?.type === 'worker';
-      if (isSpecialService) {
-        // Crons and worker have their own special entry point logic
-        // that involves creating an `app` dynamically.
-        varName = 'app';
-      } else {
-        throw new NowBuildError({
-          code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
-          message: `Could not find a top-level "app", "application", or "handler" in "${entrypoint}".`,
-          link: 'https://vercel.com/docs/functions/serverless-functions/runtimes/python',
-          action: 'Learn More',
-        });
-      }
-    }
-    detected = { entrypoint: { entrypoint, variableName: varName } };
-  }
-
-  if (entrypointNotFound && detected?.baseDir === undefined) {
-    throw entrypointNotFound;
+  if (detected?.error && detected?.baseDir === undefined) {
+    throw detected?.error;
   }
 
   const entryDirectory =
@@ -333,8 +280,6 @@ export const build: BuildVX = async ({
       `${pythonVersionString(pythonVersion)}\n`
     );
   }
-
-  fsFiles = await glob('**', workPath);
 
   // Create a virtual environment so dependencies can be installed via
   // `uv sync` and then vendored into the Lambda bundle.  When building as
@@ -516,15 +461,11 @@ export const build: BuildVX = async ({
 
   // Collect the resolved entrypoint from detection or hook, preferring the hook.
   const resolved = hookResult?.entrypoint ?? detected?.entrypoint;
-  if (entrypointNotFound && resolved) {
-    entrypoint = resolved.entrypoint;
-    entrypointNotFound = undefined;
+  if (!resolved && detected?.error) {
+    throw detected?.error;
   }
 
-  if (entrypointNotFound) {
-    throw entrypointNotFound;
-  }
-
+  entrypoint = resolved?.entrypoint;
   if (!entrypoint) {
     throw new NowBuildError({
       code: 'PYTHON_ENTRYPOINT_NOT_FOUND',

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -716,25 +716,28 @@ from vercel_runtime.vc_init import vc_handler
     }
   }
 
-  if (djangoStatic?.cdnOutputDir) {
-    const lambdaPath = entrypoint.replace(/\.py$/, '');
-    const staticFiles = await glob('**', { cwd: djangoStatic.cdnOutputDir });
-    return {
-      resultVersion: 2,
-      result: {
-        output: {
-          [lambdaPath]: output,
-          ...staticFiles,
-        },
-        routes: [
-          { handle: 'filesystem' },
-          { src: '/(.*)', dest: `/${lambdaPath}` },
-        ],
-      },
-    };
+  if (!isPythonFramework(framework)) {
+    return { resultVersion: 3, result: { output } };
   }
 
-  return { resultVersion: 3, result: { output } };
+  const lambdaPath = entrypoint.replace(/\.py$/, '');
+  const staticFiles = djangoStatic?.cdnOutputDir
+    ? await glob('**', { cwd: djangoStatic.cdnOutputDir })
+    : {};
+
+  return {
+    resultVersion: 2,
+    result: {
+      output: {
+        [lambdaPath]: output,
+        ...staticFiles,
+      },
+      routes: [
+        { handle: 'filesystem' },
+        { src: '/(.*)', dest: `/${lambdaPath}` },
+      ],
+    },
+  };
 };
 
 export { startDevServer };

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -236,8 +236,8 @@ export const build: BuildVX = async ({
   let detected: DetectedPythonEntrypoint | undefined;
   let entrypointNotFound: NowBuildError | undefined;
 
-  if (!entrypoint && isPythonFramework(framework)) {
-    // Autodetect: no entrypoint configured (src was "<detect>")
+  if (isPythonFramework(framework) && !entrypoint) {
+    // Autodetect entrypoint: no entrypoint configured (src was "<detect>")
     detected =
       (await detectPythonEntrypoint(
         config.framework as PythonFramework,
@@ -246,32 +246,6 @@ export const build: BuildVX = async ({
     if (detected?.entrypoint) {
       debug(
         `Autodetected Python entrypoint: "${detected.entrypoint.entrypoint}"`
-      );
-      entrypoint = detected.entrypoint.entrypoint;
-    } else {
-      const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
-      entrypointNotFound = new NowBuildError({
-        code: `${framework!.toUpperCase()}_ENTRYPOINT_NOT_FOUND`,
-        message: `No ${framework} entrypoint found. Add an 'app' script in pyproject.toml or define an entrypoint in one of: ${searchedList}.`,
-        link: `https://vercel.com/docs/frameworks/backend/${framework}#exporting-the-${framework}-application`,
-        action: 'Learn More',
-      });
-    }
-  } else if (
-    entrypoint &&
-    isPythonFramework(framework) &&
-    (!fsFiles[entrypoint] || !entrypoint.endsWith('.py'))
-  ) {
-    // Configured entrypoint doesn't exist or isn't a .py file — try detection
-    detected =
-      (await detectPythonEntrypoint(
-        config.framework as PythonFramework,
-        workPath,
-        entrypoint
-      )) ?? undefined;
-    if (detected?.entrypoint) {
-      debug(
-        `Resolved Python entrypoint to "${detected.entrypoint.entrypoint}" (configured "${entrypoint}" not found).`
       );
       entrypoint = detected.entrypoint.entrypoint;
     } else {

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -6,11 +6,7 @@ import type { PythonFramework, StartDevServer } from '@vercel/build-utils';
 import { debug, NowBuildError } from '@vercel/build-utils';
 import getPort from 'get-port';
 import isPortReachable from 'is-port-reachable';
-import {
-  PYTHON_CANDIDATE_ENTRYPOINTS,
-  detectPythonEntrypoint,
-  type PythonEntrypoint,
-} from './entrypoint';
+import { detectPythonEntrypoint, type PythonEntrypoint } from './entrypoint';
 import { runFrameworkHook } from './index';
 import { getDefaultPythonVersion } from './version';
 import {
@@ -715,6 +711,7 @@ export const startDevServer: StartDevServer = async opts => {
     workPath,
     meta = {},
     config,
+    service,
     onStdout,
     onStderr,
   } = opts;
@@ -724,7 +721,8 @@ export const startDevServer: StartDevServer = async opts => {
   // Check for an existing persistent server.
   // Include serviceName so that services sharing a workspace get separate servers.
   const serviceName =
-    typeof meta.serviceName === 'string' ? meta.serviceName : undefined;
+    service?.name ??
+    (typeof meta.serviceName === 'string' ? meta.serviceName : undefined);
   const serverKey = serviceName
     ? `${workPath}::${framework}::${serviceName}`
     : `${workPath}::${framework}`;
@@ -764,43 +762,38 @@ export const startDevServer: StartDevServer = async opts => {
   if (!restoreWarnings) restoreWarnings = silenceNodeWarnings();
   installGlobalCleanupHandlers();
   const env = { ...process.env, ...(meta.env || {}) } as NodeJS.ProcessEnv;
-  const serviceType = env.VERCEL_SERVICE_TYPE;
+  const entrypoint = rawEntrypoint === '<detect>' ? undefined : rawEntrypoint;
 
   // For cron/worker services, use the raw entrypoint directly, because
   // they don't export app/application so standard detection would skip them.
   let resolved: PythonEntrypoint | undefined;
-  if (
-    (serviceType === 'cron' || serviceType === 'worker') &&
-    rawEntrypoint?.endsWith('.py')
-  ) {
-    resolved = { entrypoint: rawEntrypoint, variableName: 'app' };
+  const detected = await detectPythonEntrypoint(
+    framework as PythonFramework,
+    workPath,
+    entrypoint,
+    service
+  );
+  if (detected?.entrypoint) {
+    resolved = detected.entrypoint;
   } else {
-    const detected = await detectPythonEntrypoint(
-      framework as PythonFramework,
+    const hookResult = await runFrameworkHook(framework, {
+      pythonEnv: env,
+      projectDir: join(workPath, detected?.baseDir ?? ''),
       workPath,
-      rawEntrypoint
-    );
-    if (detected?.entrypoint) {
-      resolved = detected.entrypoint;
-    } else {
-      const hookResult = await runFrameworkHook(framework, {
-        pythonEnv: env,
-        projectDir: join(workPath, detected?.baseDir ?? ''),
-        workPath,
-        entrypoint: rawEntrypoint,
-        detected: detected ?? undefined,
-      });
-      resolved = hookResult?.entrypoint;
+      entrypoint,
+      detected: detected ?? undefined,
+    });
+    resolved = hookResult?.entrypoint;
+  }
+  if (!resolved) {
+    if (detected?.error) {
+      throw detected.error;
     }
-    if (!resolved) {
-      const searched = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
-      throw new NowBuildError({
-        code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
-        message: `No ${framework} entrypoint found. Add an 'app' script in pyproject.toml or define an entrypoint in one of: ${searched}.`,
-        link: `https://vercel.com/docs/frameworks/backend/${framework?.toLowerCase()}#exporting-the-${framework?.toLowerCase()}-application`,
-        action: 'Learn More',
-      });
-    }
+    throw new NowBuildError({
+      code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
+      message:
+        'No Python entrypoint could be detected. Please specify an entrypoint file.',
+    });
   }
   const { entrypoint: entry, variableName } = resolved;
 

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -63,6 +63,13 @@ function getBuildOutputV2(result: Awaited<ReturnType<typeof build>>) {
   return (result as any).result as BuildResultV2;
 }
 
+function getBuildOutputV2Lambda(result: Awaited<ReturnType<typeof build>>) {
+  const v2 = getBuildOutputV2(result) as any;
+  const lambdas = Object.values(v2.output).filter((o: any) => 'handler' in o);
+  expect(lambdas).toHaveLength(1);
+  return lambdas[0] as BuildResultV3['output'];
+}
+
 function getBuildOutputV3(result: Awaited<ReturnType<typeof build>>) {
   expect(result.resultVersion).toBe(3);
   return (result as any).result.output as BuildResultV3['output'];
@@ -998,7 +1005,8 @@ describe('uv workspace lockfile resolution (workspace root above workPath)', () 
       repoRootPath: repoRoot,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     expect(handler).toBeDefined();
 
     fs.removeSync(repoRoot);
@@ -1063,7 +1071,8 @@ describe('fastapi entrypoint discovery - positive cases', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1098,7 +1107,8 @@ describe('fastapi entrypoint discovery - positive cases', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1134,7 +1144,8 @@ describe('fastapi entrypoint discovery - positive cases', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1179,7 +1190,8 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1215,7 +1227,8 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1259,7 +1272,8 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1307,7 +1321,8 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1351,7 +1366,8 @@ describe('Django entrypoint discovery', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1473,7 +1489,8 @@ describe('pyproject.toml entrypoint detection', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1519,7 +1536,8 @@ describe('pyproject.toml entrypoint detection', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }
@@ -1562,7 +1580,8 @@ describe('pyproject.toml entrypoint detection', () => {
       repoRootPath: workPath,
     });
 
-    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
     if (!handler || !('data' in handler)) {
       throw new Error('handler bootstrap not found');
     }

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -55,7 +55,6 @@ import { createVenvEnv, getVenvBinDir } from '../src/utils';
 import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
 import { VERCEL_WORKERS_VERSION } from '../src/package-versions';
 import { createPyprojectToml } from '../src/install';
-import { detectDjangoPythonEntrypoint } from '../src/entrypoint';
 import { getDjangoSettings, runDjangoCollectStatic } from '../src/django';
 import { FileBlob, download } from '@vercel/build-utils';
 
@@ -1147,39 +1146,6 @@ describe('fastapi entrypoint discovery - positive cases', () => {
 });
 
 describe('Django entrypoint discovery', () => {
-  async function writeFiles(
-    workPath: string,
-    files: Record<string, string>
-  ): Promise<void> {
-    for (const [rel, content] of Object.entries(files)) {
-      const full = path.join(workPath, rel);
-      fs.mkdirSync(path.dirname(full), { recursive: true });
-      fs.writeFileSync(full, content);
-    }
-  }
-
-  it('uses configured entrypoint when it exists and is valid', async () => {
-    const workPath = path.join(
-      tmpdir(),
-      `python-django-configured-${Date.now()}`
-    );
-    fs.mkdirSync(workPath, { recursive: true });
-
-    await writeFiles(workPath, {
-      'hello/world.py': `application = lambda env, start: None`,
-    });
-
-    const result = await detectDjangoPythonEntrypoint(
-      workPath,
-      'hello/world.py'
-    );
-    expect(result).toEqual({
-      entrypoint: { entrypoint: 'hello/world.py', variableName: 'application' },
-    });
-
-    if (fs.existsSync(workPath)) fs.removeSync(workPath);
-  });
-
   it('build() resolves Django entrypoint from WSGI_APPLICATION (hello.wsgi.application -> hello/wsgi.py)', async () => {
     vi.mocked(getDjangoSettings).mockResolvedValueOnce({
       settingsModule: 'hello.settings',

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -57,7 +57,7 @@ import { VERCEL_WORKERS_VERSION } from '../src/package-versions';
 import { createPyprojectToml } from '../src/install';
 import { detectDjangoPythonEntrypoint } from '../src/entrypoint';
 import { getDjangoSettings, runDjangoCollectStatic } from '../src/django';
-import { FileBlob } from '@vercel/build-utils';
+import { FileBlob, download } from '@vercel/build-utils';
 
 function getBuildOutputV2(result: Awaited<ReturnType<typeof build>>) {
   expect(result.resultVersion).toBe(2);
@@ -1025,7 +1025,7 @@ describe('fastapi entrypoint discovery', () => {
       build({
         workPath: mockWorkPath,
         files,
-        entrypoint: 'main.py',
+        entrypoint: '<detect>',
         meta: { isDev: true },
         config: { framework: 'fastapi' },
         repoRootPath: mockWorkPath,
@@ -1052,11 +1052,13 @@ describe('fastapi entrypoint discovery - positive cases', () => {
         data: 'from fastapi import FastAPI\napp = FastAPI()\n',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await build({
       workPath,
       files,
-      entrypoint: 'server.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'fastapi' },
       repoRootPath: workPath,
@@ -1085,11 +1087,13 @@ describe('fastapi entrypoint discovery - positive cases', () => {
         data: 'import fastapi\n\napp = fastapi.FastAPI()',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await build({
       workPath,
       files,
-      entrypoint: 'server.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'fastapi' },
       repoRootPath: workPath,
@@ -1119,11 +1123,13 @@ describe('fastapi entrypoint discovery - positive cases', () => {
         data: 'import fastapi\nfrom fastapi import FastAPI\napp = FastAPI()\n',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await build({
       workPath,
       files,
-      entrypoint: 'server.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'fastapi' },
       repoRootPath: workPath,
@@ -1195,11 +1201,13 @@ describe('Django entrypoint discovery', () => {
         data: 'application = lambda env, start: None\n',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await build({
       workPath,
       files,
-      entrypoint: 'index.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'django' },
       repoRootPath: workPath,
@@ -1229,11 +1237,13 @@ describe('Django entrypoint discovery', () => {
         data: 'application = lambda env, start: None\n',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await build({
       workPath,
       files,
-      entrypoint: 'index.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'django' },
       repoRootPath: workPath,
@@ -1271,11 +1281,13 @@ describe('Django entrypoint discovery', () => {
         data: "WSGI_APPLICATION = 'hello.wsgi.application'\n",
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await build({
       workPath,
       files,
-      entrypoint: 'index.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'django' },
       repoRootPath: workPath,
@@ -1317,11 +1329,13 @@ describe('Django entrypoint discovery', () => {
         data: 'application = lambda env, start: None\n',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await build({
       workPath,
       files,
-      entrypoint: 'index.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'django' },
       repoRootPath: workPath,
@@ -1359,11 +1373,13 @@ describe('Django entrypoint discovery', () => {
         data: 'application = lambda env, start: None\n',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await build({
       workPath,
       files,
-      entrypoint: 'index.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'django' },
       repoRootPath: workPath,
@@ -1410,8 +1426,6 @@ describe('Django entrypoint discovery', () => {
     fs.mkdirSync(workPath, { recursive: true });
     makeMockPython('3.9');
 
-    // Omit the configured entrypoint from files so that framework detection
-    // runs and sets detected.baseDir, which the Django hook requires.
     const files = {
       'manage.py': new FileBlob({
         data: "os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'myapp.settings')\n",
@@ -1421,11 +1435,13 @@ describe('Django entrypoint discovery', () => {
       }),
       'static/app.css': new FileBlob({ data: 'body {}' }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await build({
       workPath: workPath,
       files,
-      entrypoint: 'index.py',
+      entrypoint: '<detect>',
       meta: { isDev: false },
       config: { framework: 'django', zeroConfig: true },
       repoRootPath: workPath,
@@ -1479,11 +1495,13 @@ describe('pyproject.toml entrypoint detection', () => {
         data: 'from fastapi import FastAPI\napp = FastAPI()\n',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await buildWithMocks({
       workPath,
       files,
-      entrypoint: 'missing.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'fastapi' },
       repoRootPath: workPath,
@@ -1523,11 +1541,13 @@ describe('pyproject.toml entrypoint detection', () => {
         data: 'from flask import Flask\napp = Flask(__name__)\n',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await buildWithMocks({
       workPath,
       files,
-      entrypoint: 'missing.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'flask' },
       repoRootPath: workPath,
@@ -1564,11 +1584,13 @@ describe('pyproject.toml entrypoint detection', () => {
         data: 'from flask import Flask\napp = Flask(__name__)\n',
       }),
     } as Record<string, FileBlob>;
+    // isDev mode assumes files are already present
+    await download(files, workPath);
 
     const result = await buildWithMocks({
       workPath,
       files,
-      entrypoint: 'missing.py',
+      entrypoint: '<detect>',
       meta: { isDev: true },
       config: { framework: 'flask' },
       repoRootPath: workPath,


### PR DESCRIPTION
Main components here:

 * Get rid of the behavior where, if the entrypoint file isn't found,
   we search elsewhere. Instead, if the entrypoint is `<detect>`, we
   search, otherwise we expect the entrypoint to be in the actual
   file.
 * Move all the detection logic to `detectPythonEntrypoint`, more or
   less. Some complication remains because we support doing dynamic
   searches as part of framework-specific hooks, so
   `detectPythonEntrypoint` will actually return an error to be raised
   if the hooks can't resolve it.
 * Always use BuildResultV2 for framework builds
