### PR TITLE
fix(.claude): add session-start-profiler hook with Windows-aware CLI detection

### DIFF
--- a/.changeset/fix-claude-hooks-windows-binary.md
+++ b/.changeset/fix-claude-hooks-windows-binary.md
@@ -1,0 +1,16 @@
+---
+---
+
+fix(.claude): add session-start-profiler hook with Windows-aware CLI detection
+
+Adds `.claude/hooks/session-start-profiler.mjs` — a Claude Code `SessionStart`
+hook that warns when the Vercel CLI is not installed.
+
+The key fix is Windows compatibility: on Windows, npm installs an extensionless
+wrapper script (e.g. `vercel`) alongside `vercel.CMD` and `vercel.EXE`. The
+extensionless file passes `fs.accessSync(X_OK)` but cannot be spawned directly
+via `execFileSync`, causing a false "CLI not installed" warning. The hook now
+probes `.CMD` and `.EXE` candidates **before** the extensionless name on
+Windows to find an actually-executable binary first.
+
+Closes #15697

--- a/.claude/hooks/session-start-profiler.mjs
+++ b/.claude/hooks/session-start-profiler.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Claude Code SessionStart hook: vercel-version-check
+ *
+ * Checks whether the Vercel CLI is available on the current PATH and prints a
+ * warning if it is not found or cannot be executed.
+ *
+ * Windows note: npm installs an extensionless wrapper script (e.g.
+ * `C:\...\npm\vercel`) alongside the actual launchers `vercel.CMD` and
+ * `vercel.EXE`.  The extensionless file passes an `fs.accessSync(X_OK)`
+ * check on Windows, but `child_process.execFileSync` cannot run it directly
+ * and throws ENOENT.  To work around this we probe the extension-bearing
+ * candidates BEFORE the extensionless name on Windows.
+ */
+
+import { accessSync, constants } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const IS_WINDOWS = process.platform === 'win32';
+
+/**
+ * Return the ordered list of binary name candidates for `name`.
+ *
+ * On Windows: `.CMD` and `.EXE` variants come first so that the executableone
+ * is found before the extensionless npm wrapper script that cannot be spawned
+ * directly.
+ *
+ * @param {string} name
+ * @returns {string[]}
+ */
+function candidates(name) {
+  if (IS_WINDOWS) {
+    return [`${name}.CMD`, `${name}.EXE`, `${name}.BAT`, `${name}.COM`, name];
+  }
+  return [name];
+}
+
+/**
+ * Resolve the first candidate that (a) exists on PATH and is executable and
+ * (b) can actually be spawned to produce output.
+ *
+ * Returns `null` when no candidate succeeds.
+ *
+ * @param {string} name
+ * @returns {{ path: string; version: string } | null}
+ */
+function resolveBinaryFromPath(name) {
+  const pathDirs = (process.env.PATH ?? '').split(IS_WINDOWS ? ';' : ':');
+
+  for (const candidate of candidates(name)) {
+    for (const dir of pathDirs) {
+      if (!dir) continue;
+      const full = `${dir}${IS_WINDOWS ? '\\' : '/'}${candidate}`;
+
+      // Step 1: does the file exist and is it executable?
+      try {
+        accessSync(full, constants.X_OK);
+      } catch {
+        continue;
+      }
+
+      // Step 2: can we actually spawn it?  This is the check that fails for
+      // the extensionless npm wrapper on Windows.
+      try {
+        const output = execFileSync(full, ['--version'], {
+          encoding: 'utf8',
+          timeout: 5000,
+        }).trim();
+        return { path: full, version: output };
+      } catch {
+        // ENOENT or non-zero exit — try next candidate
+        continue;
+      }
+    }
+  }
+
+  return null;
+}
+
+const result = resolveBinaryFromPath('vercel');
+
+if (!result) {
+  process.stderr.write(
+    [
+      '',
+      'IMPORTANT: The Vercel CLI is not installed.',
+      'Install it with:  npm i -g vercel',
+      "Then verify with: vercel --version",
+      '',
+    ].join('\n')
+  );
+
+  if (process.env.VERCEL_PLUGIN_HOOK_DEBUG === '1') {
+    process.stderr.write('session-start-profiler:vercel-version-check-failed\n');
+  }
+} else {
+  if (process.env.VERCEL_PLUGIN_HOOK_DEBUG === '1') {
+    process.stderr.write(
+      `session-start-profiler:vercel-version-check-ok command=${result.path} version=${result.version}\n`
+    );
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/session-start-profiler.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.claude/hooks/session-start-profiler.mjs` — a Claude Code `SessionStart` hook that checks whether the Vercel CLI is installed and prints a helpful message if not.

Fixes the Windows false-negative reported in #15697.

## Root Cause

On Windows, npm installs an extensionless wrapper script (e.g. `C:\Users\<user>\AppData\Roaming\npm\vercel`) alongside the actual launchers `vercel.CMD` and `vercel.EXE`. The extensionless file passes `fs.accessSync(constants.X_OK)`, so it was returned first as the resolved binary — but `child_process.execFileSync` cannot spawn it directly and throws `ENOENT`. The hook catches that error and (incorrectly) concludes the CLI is not installed.

## Fix

`resolveBinaryFromPath` now probes `.CMD` and `.EXE` candidates **before** the extensionless name on Windows. The first candidate that both exists+is-executable AND can be successfully spawned is returned.

## Changes

- `.claude/hooks/session-start-profiler.mjs` — new SessionStart hook
- `.claude/settings.json` — registers the hook for Claude Code
- `.changeset/fix-claude-hooks-windows-binary.md` — empty-frontmatter changeset (non-package file change)

Closes #15697