### PR TITLE
[cli] Fix buy command payment error handling

### DIFF
--- a/.changeset/silver-kids-exercise.md
+++ b/.changeset/silver-kids-exercise.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve buy command error handling: handle new API error codes (invalid_plan, already_on_plan, invalid_status, forbidden, purchase_create_hosted_failed), distinguish 402 payment failures from server errors, and auto-open billing page in TTY mode for payment-related errors.

--- a/packages/cli/src/commands/buy/addon.ts
+++ b/packages/cli/src/commands/buy/addon.ts
@@ -143,6 +143,8 @@ export default async function addon(client: Client, argv: string[]) {
     return 0;
   } catch (err: unknown) {
     output.stopSpinner();
-    return handlePurchaseError(err, contextName);
+    return handlePurchaseError(err, contextName, {
+      openBrowser: !!client.stdout.isTTY,
+    });
   }
 }

--- a/packages/cli/src/commands/buy/credits.ts
+++ b/packages/cli/src/commands/buy/credits.ts
@@ -152,6 +152,8 @@ export default async function credits(client: Client, argv: string[]) {
     return 0;
   } catch (err: unknown) {
     output.stopSpinner();
-    return handlePurchaseError(err, contextName);
+    return handlePurchaseError(err, contextName, {
+      openBrowser: !!client.stdout.isTTY,
+    });
   }
 }

--- a/packages/cli/src/commands/buy/pro.ts
+++ b/packages/cli/src/commands/buy/pro.ts
@@ -92,6 +92,8 @@ export default async function pro(client: Client, argv: string[]) {
     return 0;
   } catch (err: unknown) {
     output.stopSpinner();
-    return handlePurchaseError(err, contextName);
+    return handlePurchaseError(err, contextName, {
+      openBrowser: !!client.stdout.isTTY,
+    });
   }
 }

--- a/packages/cli/src/util/buy/handle-purchase-error.ts
+++ b/packages/cli/src/util/buy/handle-purchase-error.ts
@@ -1,3 +1,4 @@
+import open from 'open';
 import { errorToString } from '@vercel/error-utils';
 import output from '../../output-manager';
 import { isAPIError } from '../errors-ts';
@@ -5,13 +6,38 @@ import { isAPIError } from '../errors-ts';
 const getBillingUrl = (teamSlug: string) =>
   `https://vercel.com/${teamSlug}/~/settings/billing`;
 
+interface HandlePurchaseErrorOptions {
+  /** When true (TTY), automatically opens the billing page in the browser for payment-related errors. */
+  openBrowser?: boolean;
+}
+
+function tryOpenBillingPage(
+  teamSlug: string | undefined,
+  openBrowser: boolean
+): void {
+  if (!openBrowser) return;
+  const billingUrl = teamSlug
+    ? getBillingUrl(teamSlug)
+    : 'https://vercel.com/dashboard';
+  void open(billingUrl).catch((err: unknown) => {
+    output.debug(`Failed to open browser: ${err}`);
+  });
+}
+
 /**
  * Handle errors from the billing buy API. All purchase flows (credits, addon, pro,
  * v0, etc.) can use this to show consistent messages and return the CLI exit code.
  *
- * @param teamSlug - When provided, the missing_stripe_customer message includes a link to that team's billing settings.
+ * @param teamSlug - When provided, error messages include a link to that team's billing settings.
+ * @param opts.openBrowser - When true, payment-related errors automatically open the billing page.
  */
-export function handlePurchaseError(err: unknown, teamSlug?: string): number {
+export function handlePurchaseError(
+  err: unknown,
+  teamSlug?: string,
+  opts?: HandlePurchaseErrorOptions
+): number {
+  const openBrowser = opts?.openBrowser ?? false;
+
   if (isAPIError(err)) {
     if (err.code === 'invalid_plan_iteration') {
       output.error('Your team must be on the Flex plan to purchase add-ons.');
@@ -24,29 +50,67 @@ export function handlePurchaseError(err: unknown, teamSlug?: string): number {
       return 1;
     }
     if (err.code === 'missing_stripe_customer') {
+      const billingUrl = teamSlug
+        ? getBillingUrl(teamSlug)
+        : 'https://vercel.com/dashboard';
       const dashboardHint = teamSlug
-        ? ` Please add one: ${output.link(getBillingUrl(teamSlug), getBillingUrl(teamSlug))}`
-        : ` Please add one in the ${output.link('Vercel dashboard', 'https://vercel.com/dashboard')}.`;
+        ? ` Please add one: ${output.link(billingUrl, billingUrl)}`
+        : ` Please add one in the ${output.link('Vercel dashboard', billingUrl)}.`;
       output.error(
         `Your team does not have a payment method on file.${dashboardHint}`
       );
+      tryOpenBillingPage(teamSlug, openBrowser);
       return 1;
     }
-    if (err.status === 402 || err.code === 'payment_failed') {
+    if (err.code === 'invalid_plan') {
+      output.error("Your team's current plan does not support this purchase.");
+      return 1;
+    }
+    if (err.code === 'already_on_plan') {
       output.error(
-        'Payment failed. Please check the payment method on file for your team.'
+        'Your team already has an active subscription for this plan.'
+      );
+      return 1;
+    }
+    if (err.code === 'invalid_status') {
+      output.error(
+        'Your team is not in a state that allows plan changes. Please contact support.'
+      );
+      return 1;
+    }
+    if (err.code === 'forbidden') {
+      output.error(
+        'You do not have permission to make purchases for this team. Please contact your account administrator.'
       );
       return 1;
     }
     if (
       err.code === 'purchase_create_failed' ||
       err.code === 'purchase_confirm_failed' ||
-      err.code === 'purchase_complete_failed'
+      err.code === 'purchase_complete_failed' ||
+      err.code === 'purchase_create_hosted_failed'
     ) {
+      // A 402 inside a purchase_*_failed response likely indicates a
+      // payment-method issue (e.g. missing or declined card), but the exact
+      // cause isn't guaranteed — nudge the user to check billing settings.
+      if (err.status === 402) {
+        output.error(
+          'Payment failed. Please check that your team has a valid payment method on file.'
+        );
+        tryOpenBillingPage(teamSlug, openBrowser);
+        return 1;
+      }
       output.error(
         'An error occurred while processing your purchase. Please try again later.'
       );
       output.debug(`Error code: ${err.code}`);
+      return 1;
+    }
+    if (err.status === 402 || err.code === 'payment_failed') {
+      output.error(
+        'Payment failed. Please check the payment method on file for your team.'
+      );
+      tryOpenBillingPage(teamSlug, openBrowser);
       return 1;
     }
   }

--- a/packages/cli/test/unit/commands/buy/addon.test.ts
+++ b/packages/cli/test/unit/commands/buy/addon.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import open from 'open';
+import { describe, it, expect, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import buy from '../../../../src/commands/buy';
 import { useUser } from '../../../mocks/user';
 import { useTeam } from '../../../mocks/team';
+
+vi.mock('open', () => {
+  return {
+    default: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const openMock = vi.mocked(open);
 
 function useBuyEndpoint(handler?: (req: any, res: any) => void) {
   client.scenario.post('/v1/billing/buy', (req, res) => {
@@ -127,7 +136,7 @@ describe('buy addon', () => {
 
   describe('API errors', () => {
     it('handles missing_stripe_customer error', async () => {
-      setupTeam();
+      const team = setupTeam();
       client.scenario.post('/v1/billing/buy', (_req, res) => {
         res.status(400).json({
           error: {
@@ -140,10 +149,13 @@ describe('buy addon', () => {
       const exitCode = await buy(client);
       expect(exitCode).toBe(1);
       await expect(client.stderr).toOutput('payment method');
+      expect(openMock).toHaveBeenCalledWith(
+        `https://vercel.com/${team.slug}/~/settings/billing`
+      );
     });
 
     it('handles payment_failed error', async () => {
-      setupTeam();
+      const team = setupTeam();
       client.scenario.post('/v1/billing/buy', (_req, res) => {
         res.status(402).json({
           error: {
@@ -156,6 +168,9 @@ describe('buy addon', () => {
       const exitCode = await buy(client);
       expect(exitCode).toBe(1);
       await expect(client.stderr).toOutput('Payment failed');
+      expect(openMock).toHaveBeenCalledWith(
+        `https://vercel.com/${team.slug}/~/settings/billing`
+      );
     });
 
     it('handles invalid_plan_iteration error', async () => {

--- a/packages/cli/test/unit/commands/buy/addon.test.ts
+++ b/packages/cli/test/unit/commands/buy/addon.test.ts
@@ -1,5 +1,5 @@
 import open from 'open';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { client } from '../../../mocks/client';
 import buy from '../../../../src/commands/buy';
 import { useUser } from '../../../mocks/user';
@@ -36,6 +36,10 @@ function setupTeam() {
 }
 
 describe('buy addon', () => {
+  beforeEach(() => {
+    openMock.mockClear();
+  });
+
   describe('validation', () => {
     it('errors when addon name is missing', async () => {
       client.setArgv('buy', 'addon');

--- a/packages/cli/test/unit/commands/buy/credits.test.ts
+++ b/packages/cli/test/unit/commands/buy/credits.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import open from 'open';
+import { describe, it, expect, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import buy from '../../../../src/commands/buy';
 import { useUser } from '../../../mocks/user';
 import { useTeam } from '../../../mocks/team';
+
+vi.mock('open', () => {
+  return {
+    default: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const openMock = vi.mocked(open);
 
 function useBuyEndpoint(handler?: (req: any, res: any) => void) {
   client.scenario.post('/v1/billing/buy', (req, res) => {
@@ -144,7 +153,7 @@ describe('buy credits', () => {
 
   describe('API errors', () => {
     it('handles missing_stripe_customer error', async () => {
-      setupTeam();
+      const team = setupTeam();
       client.scenario.post('/v1/billing/buy', (_req, res) => {
         res.status(400).json({
           error: {
@@ -157,10 +166,13 @@ describe('buy credits', () => {
       const exitCode = await buy(client);
       expect(exitCode).toBe(1);
       await expect(client.stderr).toOutput('payment method');
+      expect(openMock).toHaveBeenCalledWith(
+        `https://vercel.com/${team.slug}/~/settings/billing`
+      );
     });
 
     it('handles payment_failed error', async () => {
-      setupTeam();
+      const team = setupTeam();
       client.scenario.post('/v1/billing/buy', (_req, res) => {
         res.status(402).json({
           error: {
@@ -173,6 +185,9 @@ describe('buy credits', () => {
       const exitCode = await buy(client);
       expect(exitCode).toBe(1);
       await expect(client.stderr).toOutput('Payment failed');
+      expect(openMock).toHaveBeenCalledWith(
+        `https://vercel.com/${team.slug}/~/settings/billing`
+      );
     });
   });
 

--- a/packages/cli/test/unit/commands/buy/credits.test.ts
+++ b/packages/cli/test/unit/commands/buy/credits.test.ts
@@ -1,5 +1,5 @@
 import open from 'open';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { client } from '../../../mocks/client';
 import buy from '../../../../src/commands/buy';
 import { useUser } from '../../../mocks/user';
@@ -36,6 +36,10 @@ function setupTeam() {
 }
 
 describe('buy credits', () => {
+  beforeEach(() => {
+    openMock.mockClear();
+  });
+
   describe('validation', () => {
     it('errors when credit type is missing', async () => {
       client.setArgv('buy', 'credits');

--- a/packages/cli/test/unit/commands/buy/pro.test.ts
+++ b/packages/cli/test/unit/commands/buy/pro.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import open from 'open';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { client } from '../../../mocks/client';
 import buy from '../../../../src/commands/buy';
 import { useUser } from '../../../mocks/user';
 import { useTeam } from '../../../mocks/team';
+
+vi.mock('open', () => {
+  return {
+    default: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const openMock = vi.mocked(open);
 
 function useBuyEndpoint(handler?: (req: any, res: any) => void) {
   client.scenario.post('/v1/billing/buy', (req, res) => {
@@ -27,6 +36,10 @@ function setupTeam() {
 }
 
 describe('buy pro', () => {
+  beforeEach(() => {
+    openMock.mockClear();
+  });
+
   describe('--yes', () => {
     it('skips confirmation and purchases successfully', async () => {
       setupTeam();
@@ -76,7 +89,7 @@ describe('buy pro', () => {
 
   describe('API errors', () => {
     it('handles missing_stripe_customer error', async () => {
-      setupTeam();
+      const team = setupTeam();
       client.scenario.post('/v1/billing/buy', (_req, res) => {
         res.status(400).json({
           error: {
@@ -89,10 +102,155 @@ describe('buy pro', () => {
       const exitCode = await buy(client);
       expect(exitCode).toBe(1);
       await expect(client.stderr).toOutput('payment method');
+      expect(openMock).toHaveBeenCalledWith(
+        `https://vercel.com/${team.slug}/~/settings/billing`
+      );
+    });
+
+    it('handles purchase_confirm_failed with 402 as payment error', async () => {
+      const team = setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(402).json({
+          error: {
+            code: 'purchase_confirm_failed',
+            message: 'No default payment method set on this Customer',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput(
+        'check that your team has a valid payment method'
+      );
+      expect(openMock).toHaveBeenCalledWith(
+        `https://vercel.com/${team.slug}/~/settings/billing`
+      );
+    });
+
+    it('handles purchase_create_failed with 402 as payment error', async () => {
+      const team = setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(402).json({
+          error: {
+            code: 'purchase_create_failed',
+            message: 'No default payment method set on this Customer',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput(
+        'check that your team has a valid payment method'
+      );
+      expect(openMock).toHaveBeenCalledWith(
+        `https://vercel.com/${team.slug}/~/settings/billing`
+      );
+    });
+
+    it('handles purchase_confirm_failed with non-402 as generic error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(500).json({
+          error: {
+            code: 'purchase_confirm_failed',
+            message: 'Internal error',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('try again later');
+      expect(openMock).not.toHaveBeenCalled();
+    });
+
+    it('handles invalid_plan error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'invalid_plan',
+            message: 'Team must be on Hobby plan',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('does not support this purchase');
+    });
+
+    it('handles already_on_plan error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'already_on_plan',
+            message: 'Already on Pro',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput(
+        'already has an active subscription'
+      );
+    });
+
+    it('handles invalid_status error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'invalid_status',
+            message: 'Team not upgradeable',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('not in a state');
+    });
+
+    it('handles forbidden error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(403).json({
+          error: {
+            code: 'forbidden',
+            message: 'Cannot create subscription for this team',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('do not have permission');
+    });
+
+    it('handles purchase_create_hosted_failed as generic purchase error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(500).json({
+          error: {
+            code: 'purchase_create_hosted_failed',
+            message: 'Failed to create hosted checkout',
+          },
+        });
+      });
+      client.setArgv('buy', 'pro', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('try again later');
+      expect(openMock).not.toHaveBeenCalled();
     });
 
     it('handles payment_failed error', async () => {
-      setupTeam();
+      const team = setupTeam();
       client.scenario.post('/v1/billing/buy', (_req, res) => {
         res.status(402).json({
           error: {
@@ -105,6 +263,9 @@ describe('buy pro', () => {
       const exitCode = await buy(client);
       expect(exitCode).toBe(1);
       await expect(client.stderr).toOutput('Payment failed');
+      expect(openMock).toHaveBeenCalledWith(
+        `https://vercel.com/${team.slug}/~/settings/billing`
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Handle new API error codes from the billing buy endpoint: `invalid_plan`, `already_on_plan`, `invalid_status`, `forbidden`, `purchase_create_hosted_failed`
- Distinguish `purchase_*_failed` with HTTP 402 as a payment-method issue vs. generic server error
- Auto-open the billing settings page in the browser for payment-related errors when running in a TTY
- Add test coverage for all new error paths across `pro`, `addon`, and `credits` commands

## Test plan

- [x] All 56 buy command tests pass (`npx vitest run packages/cli/test/unit/commands/buy/`)
- [ ] Manual test: `vc buy pro --yes` with a team missing a payment method opens the billing page
- [ ] Manual test: piped output (`vc buy pro --yes | cat`) does **not** open the browser


🤖 Generated with [Claude Code](https://claude.com/claude-code)