### PR TITLE
[django] Don't exclude the /static directory when using staticfiles

### DIFF
--- a/.changeset/loud-coats-appear.md
+++ b/.changeset/loud-coats-appear.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+[django] Don't exclude the /static directory when using staticfiles

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
-import { join, dirname, basename, parse, relative } from 'path';
+import { join, dirname, basename, parse } from 'path';
 import {
   VERCEL_RUNTIME_VERSION,
   VERCEL_WORKERS_VERSION,
@@ -652,20 +652,6 @@ from vercel_runtime.vc_init import vc_handler
     '**/yarn.lock',
     '**/package-lock.json',
   ];
-
-  // Exclude source static dirs and STATIC_ROOT from the Lambda bundle.
-  if (djangoStatic) {
-    const dirsToExclude = [
-      ...djangoStatic.staticSourceDirs,
-      ...(djangoStatic.staticRoot ? [djangoStatic.staticRoot] : []),
-    ];
-    for (const absDir of dirsToExclude) {
-      const rel = relative(workPath, absDir);
-      if (!rel.startsWith('..')) {
-        predefinedExcludes.push(`${rel}/**`);
-      }
-    }
-  }
 
   const lambdaEnv = {} as Record<string, string>;
   lambdaEnv.PYTHONPATH = vendorDir;

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1433,7 +1433,7 @@ describe('Django entrypoint discovery', () => {
     );
     const lambda = v2result.output['myapp/wsgi'];
     expect(lambda).toBeDefined(); // Lambda keyed by entrypoint sans extension
-    expect((lambda as any).files?.['static/app.css']).toBeUndefined(); // Excluded from Lambda bundle
+    expect((lambda as any).files?.['static/app.css']).toBeDefined(); // Included in Lambda bundle
     expect(v2result.output['static/app.css']).toBeDefined(); // Static file from collectstatic
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);


### PR DESCRIPTION
One of the test applications I was using read a file out of static and
served it directly on a different endpoint.

I don't feel super strongly about doing this, though. Another option
would be adding a documented way to workaround this sort of behavior.
