### PR TITLE
fix(node): honour skipLibCheck tsconfig option in TypeScript Language Service per-file analysis

### DIFF
--- a/.changeset/wfvivxxhjkar.md
+++ b/.changeset/wfvivxxhjkar.md
@@ -1,0 +1,7 @@
+---
+"@vercel/node": patch
+---
+
+fix(node): honour skipLibCheck tsconfig option in TypeScript Language Service per-file analysis
+
+When EXPERIMENTAL_NODE_TYPESCRIPT_ERRORS is enabled (used by @vercel/hono and other framework presets), the TypeScript Language Service per-file getSemanticDiagnostics() call did not respect skipLibCheck: true from tsconfig. This caused build failures from type errors in node_modules .d.ts files that tsc would normally suppress. The fix manually filters diagnostics originating from .d.ts files when skipLibCheck is enabled, matching tsc behaviour.

--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -324,7 +324,11 @@ export function register(opts: Options = {}): Register {
         .getSemanticDiagnostics(fileName)
         .concat(service.getSyntacticDiagnostics(fileName));
 
-      const diagnosticList = filterDiagnostics(diagnostics, ignoreDiagnostics);
+      const diagnosticList = filterDiagnostics(
+        diagnostics,
+        ignoreDiagnostics,
+        config.options.skipLibCheck
+      );
 
       if (process.env.EXPERIMENTAL_NODE_TYPESCRIPT_ERRORS) {
         reportTSError(diagnosticList, true);
@@ -523,6 +527,21 @@ type SourceOutput = { code: string; map: string };
 /**
  * Filter diagnostics.
  */
-function filterDiagnostics(diagnostics: _ts.Diagnostic[], ignore: number[]) {
-  return diagnostics.filter(x => ignore.indexOf(x.code) === -1);
+function filterDiagnostics(
+  diagnostics: _ts.Diagnostic[],
+  ignore: number[],
+  skipLibCheck?: boolean
+) {
+  return diagnostics.filter(x => {
+    if (ignore.indexOf(x.code) !== -1) return false;
+    // When skipLibCheck is enabled, suppress diagnostics that originate from
+    // declaration files (.d.ts) — this mirrors what tsc does with skipLibCheck.
+    // The TypeScript Language Service used in per-file mode does not always
+    // honour skipLibCheck when calling getSemanticDiagnostics(), so we filter
+    // manually here to match the expected tsc behaviour.
+    if (skipLibCheck && x.file && x.file.fileName.endsWith('.d.ts')) {
+      return false;
+    }
+    return true;
+  });
 }


### PR DESCRIPTION
## Summary

When `@vercel/hono` (or other framework presets) set `EXPERIMENTAL_NODE_TYPESCRIPT_ERRORS=1`, the TypeScript Language Service's per-file `getSemanticDiagnostics()` call does not respect `skipLibCheck: true` from the project's `tsconfig.json`.

This causes build failures from type errors inside `node_modules` `.d.ts` files — for example, `@badrap/valita`'s declaration file — that a standard `tsc --noEmit` would suppress via `skipLibCheck`.

## Root Cause

The TypeScript Language Service used in per-file compilation mode does not always honour `skipLibCheck` when calling `getSemanticDiagnostics(fileName)` on a source file. The resulting diagnostic list may include errors whose `file` property points to a `.d.ts` file in `node_modules`, even when `skipLibCheck: true` is set in the tsconfig.

## Fix

In `filterDiagnostics()`, when `skipLibCheck` is `true`, filter out diagnostics that originate from `.d.ts` files. This mirrors the behaviour of a whole-project `tsc` run and ensures the Language Service respects the user's tsconfig setting.

## Testing

No new tests added (the TypeScript Language Service internals make this difficult to unit-test), but the fix is minimal and targeted:
- Only filters diagnostics from `.d.ts` files
- Only when `config.options.skipLibCheck` is `true`
- Does not affect the transpile-only path or config-level diagnostic filtering

Fixes #15701