### PR TITLE
[build-utils] Add process-serverless utils

### DIFF
--- a/.changeset/add-process-serverless-utils.md
+++ b/.changeset/add-process-serverless-utils.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Add `process-serverless` utilities: `getLambdaEnvironment`, `getLambdaPreloadScripts`, `getLambdaSupportsStreaming`, and `getEncryptedEnv`.

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -19,7 +19,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/python-analysis": "workspace:*"
+    "@vercel/python-analysis": "workspace:*",
+    "cjs-module-lexer": "1.2.3",
+    "es-module-lexer": "1.5.0"
   },
   "devDependencies": {
     "@iarna/toml": "2.2.3",

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -172,4 +172,7 @@ export {
   getLambdaPreloadScripts,
   type BytecodeCachingOptions,
 } from './process-serverless/get-lambda-preload-scripts';
-export { getLambdaSupportsStreaming } from './process-serverless/get-lambda-supports-streaming';
+export {
+  getLambdaSupportsStreaming,
+  type SupportsStreamingResult,
+} from './process-serverless/get-lambda-supports-streaming';

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -162,3 +162,14 @@ export {
 } from './framework-helpers';
 
 export * from './python';
+
+export {
+  getEncryptedEnv,
+  type EncryptedEnvFile,
+} from './process-serverless/get-encrypted-env-file';
+export { getLambdaEnvironment } from './process-serverless/get-lambda-environment';
+export {
+  getLambdaPreloadScripts,
+  type BytecodeCachingOptions,
+} from './process-serverless/get-lambda-preload-scripts';
+export { getLambdaSupportsStreaming } from './process-serverless/get-lambda-supports-streaming';

--- a/packages/build-utils/src/process-serverless/get-encrypted-env-file.ts
+++ b/packages/build-utils/src/process-serverless/get-encrypted-env-file.ts
@@ -1,0 +1,25 @@
+import FileBlob from '../file-blob';
+
+/**
+ * A type to represent the encrypted environment file that needs to be
+ * attached to Lambdas with ENV > 4kb
+ */
+export type EncryptedEnvFile = [string, FileBlob];
+
+/**
+ * Get the encrypted environment file from the environment variables if it
+ * exists and it is supported by the runtime.
+ */
+export function getEncryptedEnv(
+  envFilename: string | undefined,
+  envContent: string | undefined
+): EncryptedEnvFile | undefined {
+  if (!envFilename || !envContent) {
+    return;
+  }
+
+  return [
+    envFilename,
+    new FileBlob({ data: Buffer.from(envContent, 'base64') }),
+  ];
+}

--- a/packages/build-utils/src/process-serverless/get-lambda-environment.ts
+++ b/packages/build-utils/src/process-serverless/get-lambda-environment.ts
@@ -1,0 +1,87 @@
+import {
+  getLambdaPreloadScripts,
+  type BytecodeCachingOptions,
+} from './get-lambda-preload-scripts';
+
+interface LambdaLike {
+  awsLambdaHandler?: string;
+  launcherType?: string;
+  runtime: string;
+  shouldAddHelpers?: boolean;
+  shouldAddSourcemapSupport?: boolean;
+  useWebApi?: boolean;
+  shouldDisableAutomaticFetchInstrumentation?: boolean;
+}
+
+/**
+ * Extract system environment variables that need to be injected in the Lambda.
+ * Buffer is required just to determine if Bytecode Caching should be enabled
+ * but it doesn't need to be super precise.
+ */
+export function getLambdaEnvironment(
+  lambda: LambdaLike,
+  buffer: Buffer,
+  options: BytecodeCachingOptions
+) {
+  const environment: Record<string, string> = {};
+
+  if ('launcherType' in lambda && lambda.launcherType === 'Nodejs') {
+    /**
+     * For rusty-runtime, we can't use these lambda options at build time because
+     * we no longer inject any launcher. Instead, we can forward these options
+     * as environment variables to make them available at runtime.
+     *
+     * **DON'T FORGET TO UPDATE** `packages/util-env-variable/src/validate-env-length.ts
+     * when adding or updating environment variables here.
+     */
+    if (lambda.awsLambdaHandler) {
+      environment.AWS_LAMBDA_HANDLER = lambda.awsLambdaHandler;
+    }
+
+    /**
+     * Instruct the runtime to add helpers to the user's code so that i.e.
+     * the request has a `query` property that is a parsed URL query string.
+     */
+    if (lambda.shouldAddHelpers) {
+      environment.VERCEL_SHOULD_ADD_HELPERS = '1';
+    }
+
+    /**
+     * When `useWebApi` is true, the runtime should assume that the default
+     * export of the entrypoint is a function that accepts a `Request` and
+     * returns a `Response`.
+     *
+     * https://github.com/vercel/vercel/pull/12873
+     */
+    if (lambda.useWebApi === true) {
+      environment.VERCEL_USE_WEB_API = '1';
+    }
+
+    /**
+     * When `shouldAddSourcemapSupport` is true, we should map into an env
+     * variable to be used at runtime.
+     */
+    if (lambda.shouldAddSourcemapSupport) {
+      environment.VERCEL_SOURCE_MAP = '1';
+    }
+
+    /**
+     * Instruct rusty-runtime to disable the automatic fetch instrumentation
+     * in order to avoid duplicate instrumentation of the HTTP requests.
+     */
+    if (lambda.shouldDisableAutomaticFetchInstrumentation) {
+      environment.VERCEL_TRACING_DISABLE_AUTOMATIC_FETCH_INSTRUMENTATION = '1';
+    }
+
+    /**
+     * Generate an environment variable that contains a comma-separated list
+     * of scripts to preload before the user's code.
+     */
+    const scripts = getLambdaPreloadScripts(lambda, buffer, options);
+    if (scripts.length > 0) {
+      environment.VERCEL_NODE_PRELOAD_SCRIPTS = scripts.join(',');
+    }
+  }
+
+  return environment;
+}

--- a/packages/build-utils/src/process-serverless/get-lambda-preload-scripts.ts
+++ b/packages/build-utils/src/process-serverless/get-lambda-preload-scripts.ts
@@ -1,0 +1,71 @@
+export interface BytecodeCachingOptions {
+  vercelEnv: string | undefined;
+  useBytecodeCaching: string | undefined;
+  useNativeBytecodeCaching: string | undefined;
+  bytecodeCachingThreshold: string | undefined;
+}
+
+interface LambdaLike {
+  framework?: { slug: string };
+  runtime: string;
+  shouldAddSourcemapSupport?: boolean;
+}
+
+/**
+ * Returns an array of scripts that should be preloaded in Node.js Lambdas.
+ * The `buffer` parameter is needed to decide wether or not to enable Bytecode
+ * Caching so it doesn't **need** to be exact (we can leave out the env layer)
+ */
+export function getLambdaPreloadScripts(
+  lambda: LambdaLike,
+  buffer: Buffer,
+  options: BytecodeCachingOptions
+) {
+  const scripts: string[] = [];
+
+  /**
+   * TODO: remove from the nodePreloadScripts array once rusty is fully
+   * released with support VERCEL_SOURCE_MAP
+   */
+  if (lambda.shouldAddSourcemapSupport) {
+    scripts.push('/opt/rust/source-map-support.js');
+  }
+
+  /**
+   * Defines the minimum size of the lambda zip to enable bytecode
+   * caching. The default value is 400KB.
+   */
+  const BYTECODE_MIN_SIZE_BYTES =
+    (Number.parseInt(options.bytecodeCachingThreshold || '', 10) || 400) * 1024;
+
+  /**
+   * Only enable Bytecode Caching when:
+   *   - The feature flag is enabled.
+   *   - The deployment is targeting production.
+   *   - The lambda is using Node.js 20, 22 or 24
+   *   - The lambda zip is larger than the minimum size.
+   */
+  if (
+    options.vercelEnv === 'production' &&
+    options.useBytecodeCaching === '1' &&
+    ['nodejs20.x', 'nodejs22.x', 'nodejs24.x'].includes(lambda.runtime) &&
+    buffer.byteLength >= BYTECODE_MIN_SIZE_BYTES
+  ) {
+    scripts.push(
+      ['nodejs22.x', 'nodejs24.x'].includes(lambda.runtime) &&
+        options.useNativeBytecodeCaching === '1'
+        ? '/opt/rust/bytecode-native.js'
+        : '/opt/rust/bytecode.js'
+    );
+  }
+
+  /**
+   * Inject a fetch cache handler in the runtime in Next.js lambdas.
+   * x-ref: https://github.com/vercel/edge-functions/pull/1879
+   */
+  if (lambda.framework?.slug === 'nextjs') {
+    scripts.push('/opt/rust/next-data.js');
+  }
+
+  return scripts;
+}

--- a/packages/build-utils/src/process-serverless/get-lambda-supports-streaming.ts
+++ b/packages/build-utils/src/process-serverless/get-lambda-supports-streaming.ts
@@ -1,0 +1,113 @@
+import type { Files } from '../types';
+import { init as initCjs, parse as parseCjs } from 'cjs-module-lexer';
+import { init as initEsm, parse as parseEsm } from 'es-module-lexer';
+
+interface LambdaLike {
+  files?: Files;
+  handler: string;
+  launcherType?: string;
+  runtime: string;
+  supportsResponseStreaming?: boolean;
+}
+
+/**
+ * Determines if a Lambda should have streaming enabled. If
+ * `forceStreamingRuntime` is true, streaming is always enabled. If the
+ * setting is defined it will be honored. For Node.js it checks the handler
+ * exports which is why it needs to be asynchronous.
+ */
+export async function getLambdaSupportsStreaming(
+  lambda: LambdaLike,
+  forceStreamingRuntime: boolean
+) {
+  if (forceStreamingRuntime) {
+    return true;
+  }
+
+  if (typeof lambda.supportsResponseStreaming === 'boolean') {
+    return lambda.supportsResponseStreaming;
+  }
+
+  if ('launcherType' in lambda && lambda.launcherType === 'Nodejs') {
+    return (await lambdaShouldStream(lambda)) || undefined;
+  }
+
+  return undefined;
+}
+
+/* https://nextjs.org/docs/app/building-your-application/routing/router-handlers#supported-http-methods */
+const HTTP_METHODS = [
+  'GET',
+  'HEAD',
+  'OPTIONS',
+  'POST',
+  'PUT',
+  'DELETE',
+  'PATCH',
+];
+
+/**
+ * Determines if a Lambda should have streaming enabled by default by checking
+ * its handler exports. When using Web Handlers (contains named exports after
+ * HTTP methods), it should be enabled.
+ *
+ * It works for both ESM and CJS modules. In case of a parsing error it will
+ * simply not opt-in so that we keep the same behavior as before where we
+ * fail on runtime.
+ */
+async function lambdaShouldStream(lambda: LambdaLike): Promise<boolean> {
+  const stream = lambda.files?.[lambda.handler]?.toStream();
+  if (!stream) {
+    return false;
+  }
+
+  try {
+    const buffer = await streamToBuffer(stream);
+    const names = await getFileExports(lambda.handler, buffer.toString('utf8'));
+    for (const name of names) {
+      if (HTTP_METHODS.includes(name)) {
+        return true;
+      }
+    }
+  } catch (err) {
+    console.warn(`[vc] failed to parse exports for ${lambda.handler}:`);
+    console.warn(`[vc] ${String(err)}`);
+  }
+
+  return false;
+}
+
+async function getFileExports(
+  filename: string,
+  content: string
+): Promise<string[]> {
+  if (filename.endsWith('.mjs')) {
+    await initEsm;
+    return parseEsm(content)[1].map(specifier => specifier.n);
+  }
+
+  // Assume CJS by default, but fallback to ESM as the file might end with `.js`
+  // but still be ESM (e.g. `package.json` specifying `"type": "module"`).
+  try {
+    await initCjs();
+    return parseCjs(content).exports;
+  } catch {
+    await initEsm;
+    return parseEsm(content)[1].map(specifier => specifier.n);
+  }
+}
+
+function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    const buffers: Buffer[] = [];
+    stream.on('error', (err: Error) => {
+      reject(err);
+    });
+    stream.on('data', (buffer: Buffer) => {
+      buffers.push(buffer);
+    });
+    stream.on('end', () => {
+      resolve(Buffer.concat(buffers));
+    });
+  });
+}

--- a/packages/build-utils/src/process-serverless/get-lambda-supports-streaming.ts
+++ b/packages/build-utils/src/process-serverless/get-lambda-supports-streaming.ts
@@ -10,6 +10,11 @@ interface LambdaLike {
   supportsResponseStreaming?: boolean;
 }
 
+export interface SupportsStreamingResult {
+  supportsStreaming: boolean | undefined;
+  error?: { handler: string; message: string };
+}
+
 /**
  * Determines if a Lambda should have streaming enabled. If
  * `forceStreamingRuntime` is true, streaming is always enabled. If the
@@ -19,20 +24,20 @@ interface LambdaLike {
 export async function getLambdaSupportsStreaming(
   lambda: LambdaLike,
   forceStreamingRuntime: boolean
-) {
+): Promise<SupportsStreamingResult> {
   if (forceStreamingRuntime) {
-    return true;
+    return { supportsStreaming: true };
   }
 
   if (typeof lambda.supportsResponseStreaming === 'boolean') {
-    return lambda.supportsResponseStreaming;
+    return { supportsStreaming: lambda.supportsResponseStreaming };
   }
 
   if ('launcherType' in lambda && lambda.launcherType === 'Nodejs') {
-    return (await lambdaShouldStream(lambda)) || undefined;
+    return lambdaShouldStream(lambda);
   }
 
-  return undefined;
+  return { supportsStreaming: undefined };
 }
 
 /* https://nextjs.org/docs/app/building-your-application/routing/router-handlers#supported-http-methods */
@@ -55,10 +60,12 @@ const HTTP_METHODS = [
  * simply not opt-in so that we keep the same behavior as before where we
  * fail on runtime.
  */
-async function lambdaShouldStream(lambda: LambdaLike): Promise<boolean> {
+async function lambdaShouldStream(
+  lambda: LambdaLike
+): Promise<SupportsStreamingResult> {
   const stream = lambda.files?.[lambda.handler]?.toStream();
   if (!stream) {
-    return false;
+    return { supportsStreaming: undefined };
   }
 
   try {
@@ -66,15 +73,17 @@ async function lambdaShouldStream(lambda: LambdaLike): Promise<boolean> {
     const names = await getFileExports(lambda.handler, buffer.toString('utf8'));
     for (const name of names) {
       if (HTTP_METHODS.includes(name)) {
-        return true;
+        return { supportsStreaming: true };
       }
     }
   } catch (err) {
-    console.warn(`[vc] failed to parse exports for ${lambda.handler}:`);
-    console.warn(`[vc] ${String(err)}`);
+    return {
+      supportsStreaming: undefined,
+      error: { handler: lambda.handler, message: String(err) },
+    };
   }
 
-  return false;
+  return { supportsStreaming: undefined };
 }
 
 async function getFileExports(

--- a/packages/build-utils/test/unit.get-lambda-environment.test.ts
+++ b/packages/build-utils/test/unit.get-lambda-environment.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest';
+import { NodejsLambda } from '../src/nodejs-lambda';
+import { getLambdaEnvironment } from '../src/process-serverless/get-lambda-environment';
+import type { BytecodeCachingOptions } from '../src/process-serverless/get-lambda-preload-scripts';
+
+const NO_BYTECODE: BytecodeCachingOptions = {
+  vercelEnv: undefined,
+  useBytecodeCaching: undefined,
+  useNativeBytecodeCaching: undefined,
+  bytecodeCachingThreshold: undefined,
+};
+
+describe('getLambdaEnvironment()', () => {
+  it('adds AWS_LAMBDA_HANDLER if needed', () => {
+    const lambda = new NodejsLambda({
+      shouldAddHelpers: false,
+      shouldAddSourcemapSupport: false,
+      files: {},
+      handler: 'index.js',
+      runtime: 'nodejs20.x',
+      awsLambdaHandler: 'handler.handler',
+    });
+
+    const environment = getLambdaEnvironment(
+      lambda,
+      Buffer.from(''),
+      NO_BYTECODE
+    );
+    expect(environment.AWS_LAMBDA_HANDLER).toEqual('handler.handler');
+    expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+    expect(environment.VERCEL_SOURCE_MAP).toBeUndefined();
+    expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toBeUndefined();
+  });
+
+  it('adds VERCEL_SHOULD_ADD_HELPERS if needed', () => {
+    const lambda = new NodejsLambda({
+      shouldAddHelpers: true,
+      shouldAddSourcemapSupport: false,
+      files: {},
+      handler: 'index.js',
+      runtime: 'nodejs20.x',
+    });
+
+    const environment = getLambdaEnvironment(
+      lambda,
+      Buffer.from(''),
+      NO_BYTECODE
+    );
+    expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+    expect(environment.VERCEL_SHOULD_ADD_HELPERS).toEqual('1');
+    expect(environment.VERCEL_SOURCE_MAP).toBeUndefined();
+    expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toBeUndefined();
+  });
+
+  it('adds VERCEL_SOURCE_MAP if needed', () => {
+    const lambda = new NodejsLambda({
+      shouldAddHelpers: false,
+      shouldAddSourcemapSupport: true,
+      files: {},
+      handler: 'index.js',
+      runtime: 'nodejs20.x',
+    });
+
+    const environment = getLambdaEnvironment(
+      lambda,
+      Buffer.from(''),
+      NO_BYTECODE
+    );
+    expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+    expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+    expect(environment.VERCEL_SOURCE_MAP).toEqual('1');
+    expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toEqual(
+      '/opt/rust/source-map-support.js'
+    );
+  });
+
+  it('adds VERCEL_TRACING_DISABLE_AUTOMATIC_FETCH_INSTRUMENTATION if needed', () => {
+    const lambda = new NodejsLambda({
+      shouldAddHelpers: false,
+      shouldAddSourcemapSupport: true,
+      shouldDisableAutomaticFetchInstrumentation: true,
+      files: {},
+      handler: 'index.js',
+      runtime: 'nodejs20.x',
+    });
+
+    const environment = getLambdaEnvironment(
+      lambda,
+      Buffer.from(''),
+      NO_BYTECODE
+    );
+    expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+    expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+    expect(environment.VERCEL_SOURCE_MAP).toEqual('1');
+    expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toEqual(
+      '/opt/rust/source-map-support.js'
+    );
+    expect(
+      environment.VERCEL_TRACING_DISABLE_AUTOMATIC_FETCH_INSTRUMENTATION
+    ).toEqual('1');
+  });
+
+  describe('bytecode caching', () => {
+    it.each([
+      'nodejs20.x',
+      'nodejs22.x',
+      'nodejs24.x',
+    ])('adds bytecode caching to VERCEL_NODE_PRELOAD_SCRIPTS using %s', runtime => {
+      const zipBuffer = Buffer.alloc(401 * 1024);
+      const lambda = new NodejsLambda({
+        shouldAddHelpers: false,
+        shouldAddSourcemapSupport: false,
+        files: {},
+        handler: 'index.js',
+        runtime,
+      });
+
+      const environment = getLambdaEnvironment(lambda, zipBuffer, {
+        vercelEnv: 'production',
+        useBytecodeCaching: '1',
+        useNativeBytecodeCaching: undefined,
+        bytecodeCachingThreshold: undefined,
+      });
+      expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+      expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+      expect(environment.VERCEL_SOURCE_MAP).toBeUndefined();
+      expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toEqual(
+        '/opt/rust/bytecode.js'
+      );
+    });
+
+    it("doesn't add bytecode caching to VERCEL_NODE_PRELOAD_SCRIPTS if using Node.js 18", () => {
+      const zipBuffer = Buffer.alloc(401 * 1024);
+      const lambda = new NodejsLambda({
+        shouldAddHelpers: false,
+        shouldAddSourcemapSupport: false,
+        files: {},
+        handler: 'index.js',
+        runtime: 'nodejs18.x',
+      });
+
+      const environment = getLambdaEnvironment(lambda, zipBuffer, {
+        vercelEnv: 'production',
+        useBytecodeCaching: '1',
+        useNativeBytecodeCaching: undefined,
+        bytecodeCachingThreshold: undefined,
+      });
+      expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+      expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+      expect(environment.VERCEL_SOURCE_MAP).toBeUndefined();
+      expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toBeUndefined();
+    });
+
+    it("doesn't add bytecode caching to VERCEL_NODE_PRELOAD_SCRIPTS if VERCEL_ENV isn't production", () => {
+      const zipBuffer = Buffer.alloc(401 * 1024);
+      const lambda = new NodejsLambda({
+        shouldAddHelpers: false,
+        shouldAddSourcemapSupport: false,
+        files: {},
+        handler: 'index.js',
+        runtime: 'nodejs20.x',
+      });
+
+      const environment = getLambdaEnvironment(lambda, zipBuffer, {
+        vercelEnv: 'preview',
+        useBytecodeCaching: '1',
+        useNativeBytecodeCaching: undefined,
+        bytecodeCachingThreshold: undefined,
+      });
+      expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+      expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+      expect(environment.VERCEL_SOURCE_MAP).toBeUndefined();
+      expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toBeUndefined();
+    });
+
+    it("doesn't add bytecode caching to VERCEL_NODE_PRELOAD_SCRIPTS if FF is disabled", () => {
+      const zipBuffer = Buffer.alloc(401 * 1024);
+      const lambda = new NodejsLambda({
+        shouldAddHelpers: false,
+        shouldAddSourcemapSupport: false,
+        files: {},
+        handler: 'index.js',
+        runtime: 'nodejs20.x',
+      });
+
+      const environment = getLambdaEnvironment(lambda, zipBuffer, {
+        vercelEnv: 'production',
+        useBytecodeCaching: '0',
+        useNativeBytecodeCaching: undefined,
+        bytecodeCachingThreshold: undefined,
+      });
+      expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+      expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+      expect(environment.VERCEL_SOURCE_MAP).toBeUndefined();
+      expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toBeUndefined();
+    });
+
+    it("doesn't add bytecode caching to VERCEL_NODE_PRELOAD_SCRIPTS if lambda size below threshold", () => {
+      const zipBuffer = Buffer.alloc(100 * 1024);
+      const lambda = new NodejsLambda({
+        shouldAddHelpers: false,
+        shouldAddSourcemapSupport: false,
+        files: {},
+        handler: 'index.js',
+        runtime: 'nodejs20.x',
+      });
+
+      const environment = getLambdaEnvironment(lambda, zipBuffer, {
+        vercelEnv: 'production',
+        useBytecodeCaching: '1',
+        useNativeBytecodeCaching: undefined,
+        bytecodeCachingThreshold: undefined,
+      });
+      expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+      expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+      expect(environment.VERCEL_SOURCE_MAP).toBeUndefined();
+      expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toBeUndefined();
+    });
+  });
+
+  it('adds next-data file to VERCEL_NODE_PRELOAD_SCRIPTS if framework is nextjs', () => {
+    const lambda = new NodejsLambda({
+      shouldAddHelpers: false,
+      shouldAddSourcemapSupport: false,
+      files: {},
+      handler: 'index.js',
+      runtime: 'nodejs20.x',
+      framework: { slug: 'nextjs' },
+    });
+
+    const environment = getLambdaEnvironment(
+      lambda,
+      Buffer.alloc(0),
+      NO_BYTECODE
+    );
+    expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+    expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+    expect(environment.VERCEL_SOURCE_MAP).toBeUndefined();
+    expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toEqual(
+      '/opt/rust/next-data.js'
+    );
+  });
+
+  it('combines multiple scripts to VERCEL_NODE_PRELOAD_SCRIPTS', () => {
+    const lambda = new NodejsLambda({
+      shouldAddHelpers: false,
+      shouldAddSourcemapSupport: true,
+      files: {},
+      handler: 'index.js',
+      runtime: 'nodejs20.x',
+      framework: { slug: 'nextjs' },
+    });
+
+    const environment = getLambdaEnvironment(
+      lambda,
+      Buffer.alloc(0),
+      NO_BYTECODE
+    );
+    expect(environment.AWS_LAMBDA_HANDLER).toBeUndefined();
+    expect(environment.VERCEL_SHOULD_ADD_HELPERS).toBeUndefined();
+    expect(environment.VERCEL_SOURCE_MAP).toEqual('1');
+    expect(environment.VERCEL_NODE_PRELOAD_SCRIPTS).toEqual(
+      '/opt/rust/source-map-support.js,/opt/rust/next-data.js'
+    );
+  });
+});

--- a/packages/build-utils/test/unit.get-lambda-supports-streaming.test.ts
+++ b/packages/build-utils/test/unit.get-lambda-supports-streaming.test.ts
@@ -4,40 +4,40 @@ import FileBlob from '../src/file-blob';
 
 describe('getLambdaSupportsStreaming()', () => {
   it('returns undefined when streaming is not supported', async () => {
-    expect(
-      await getLambdaSupportsStreaming(
-        {
-          launcherType: 'Nodejs',
-          handler: 'handler.js',
-          runtime: 'nodejs20.x',
-          files: {
-            'handler.js': new FileBlob({
-              data: `module.exports.handler = () => {};`,
-            }),
-          },
+    const result = await getLambdaSupportsStreaming(
+      {
+        launcherType: 'Nodejs',
+        handler: 'handler.js',
+        runtime: 'nodejs20.x',
+        files: {
+          'handler.js': new FileBlob({
+            data: `module.exports.handler = () => {};`,
+          }),
         },
-        false
-      )
-    ).toEqual(undefined);
+      },
+      false
+    );
+    expect(result.supportsStreaming).toEqual(undefined);
+    expect(result.error).toBeUndefined();
   });
 
   it('honors `supportsResponseStreaming` from the lambda', async () => {
-    expect(
-      await getLambdaSupportsStreaming(
-        {
-          supportsResponseStreaming: false,
-          launcherType: 'Nodejs',
-          handler: 'handler.js',
-          runtime: 'nodejs20.x',
-          files: {
-            'handler.js': new FileBlob({
-              data: `module.exports.handler = () => {};`,
-            }),
-          },
+    const result = await getLambdaSupportsStreaming(
+      {
+        supportsResponseStreaming: false,
+        launcherType: 'Nodejs',
+        handler: 'handler.js',
+        runtime: 'nodejs20.x',
+        files: {
+          'handler.js': new FileBlob({
+            data: `module.exports.handler = () => {};`,
+          }),
         },
-        false
-      )
-    ).toEqual(false);
+      },
+      false
+    );
+    expect(result.supportsStreaming).toEqual(false);
+    expect(result.error).toBeUndefined();
   });
 
   it.each([
@@ -51,21 +51,21 @@ describe('getLambdaSupportsStreaming()', () => {
   ])('should return `true` when lambda exports %s in CJS', async ({
     method,
   }) => {
-    expect(
-      await getLambdaSupportsStreaming(
-        {
-          launcherType: 'Nodejs',
-          handler: 'handler.js',
-          runtime: 'nodejs20.x',
-          files: {
-            'handler.js': new FileBlob({
-              data: `module.exports.${method} = () => {};`,
-            }),
-          },
+    const result = await getLambdaSupportsStreaming(
+      {
+        launcherType: 'Nodejs',
+        handler: 'handler.js',
+        runtime: 'nodejs20.x',
+        files: {
+          'handler.js': new FileBlob({
+            data: `module.exports.${method} = () => {};`,
+          }),
         },
-        false
-      )
-    ).toEqual(true);
+      },
+      false
+    );
+    expect(result.supportsStreaming).toEqual(true);
+    expect(result.error).toBeUndefined();
   });
 
   it.each([
@@ -79,21 +79,21 @@ describe('getLambdaSupportsStreaming()', () => {
   ])('should return `true` when lambda exports %s handler method in ESM', async ({
     method,
   }) => {
-    expect(
-      await getLambdaSupportsStreaming(
-        {
-          launcherType: 'Nodejs',
-          handler: 'handler.mjs',
-          runtime: 'nodejs20.x',
-          files: {
-            'handler.mjs': new FileBlob({
-              data: `export const ${method} = () => {};`,
-            }),
-          },
+    const result = await getLambdaSupportsStreaming(
+      {
+        launcherType: 'Nodejs',
+        handler: 'handler.mjs',
+        runtime: 'nodejs20.x',
+        files: {
+          'handler.mjs': new FileBlob({
+            data: `export const ${method} = () => {};`,
+          }),
         },
-        false
-      )
-    ).toEqual(true);
+      },
+      false
+    );
+    expect(result.supportsStreaming).toEqual(true);
+    expect(result.error).toBeUndefined();
   });
 
   it.each([
@@ -107,63 +107,83 @@ describe('getLambdaSupportsStreaming()', () => {
   ])('should return `true` when lambda exports %s handler in ESM but with a .js extension', async ({
     method,
   }) => {
-    expect(
-      await getLambdaSupportsStreaming(
-        {
-          launcherType: 'Nodejs',
-          handler: 'handler.js',
-          runtime: 'nodejs20.x',
-          files: {
-            'handler.js': new FileBlob({
-              data: `export const ${method} = () => {};`,
-            }),
-          },
+    const result = await getLambdaSupportsStreaming(
+      {
+        launcherType: 'Nodejs',
+        handler: 'handler.js',
+        runtime: 'nodejs20.x',
+        files: {
+          'handler.js': new FileBlob({
+            data: `export const ${method} = () => {};`,
+          }),
         },
-        false
-      )
-    ).toEqual(true);
+      },
+      false
+    );
+    expect(result.supportsStreaming).toEqual(true);
+    expect(result.error).toBeUndefined();
   });
 
   it("should return `undefined` when lambda doesn't export an HTTP method", async () => {
-    expect(
-      await getLambdaSupportsStreaming(
-        {
-          launcherType: 'Nodejs',
-          handler: 'handler.js',
-          runtime: 'nodejs20.x',
-          files: {
-            'handler.js': new FileBlob({
-              data: `module.exports.handler = () => {};`,
-            }),
-          },
+    const result = await getLambdaSupportsStreaming(
+      {
+        launcherType: 'Nodejs',
+        handler: 'handler.js',
+        runtime: 'nodejs20.x',
+        files: {
+          'handler.js': new FileBlob({
+            data: `module.exports.handler = () => {};`,
+          }),
         },
-        false
-      )
-    ).toEqual(undefined);
+      },
+      false
+    );
+    expect(result.supportsStreaming).toEqual(undefined);
+    expect(result.error).toBeUndefined();
   });
 
   it('honors the default setting for Python runtimes', async () => {
-    expect(
-      await getLambdaSupportsStreaming(
-        {
-          handler: 'handler.py',
-          runtime: 'python3.8',
-          supportsResponseStreaming: true,
-        },
-        false
-      )
-    ).toEqual(true);
+    const result = await getLambdaSupportsStreaming(
+      {
+        handler: 'handler.py',
+        runtime: 'python3.8',
+        supportsResponseStreaming: true,
+      },
+      false
+    );
+    expect(result.supportsStreaming).toEqual(true);
+    expect(result.error).toBeUndefined();
   });
 
   it('returns true when forceStreamingRuntime is true', async () => {
-    expect(
-      await getLambdaSupportsStreaming(
-        {
-          handler: 'handler.py',
-          runtime: 'python3.8',
+    const result = await getLambdaSupportsStreaming(
+      {
+        handler: 'handler.py',
+        runtime: 'python3.8',
+      },
+      true
+    );
+    expect(result.supportsStreaming).toEqual(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns error when handler cannot be parsed', async () => {
+    const result = await getLambdaSupportsStreaming(
+      {
+        launcherType: 'Nodejs',
+        handler: 'handler.mjs',
+        runtime: 'nodejs20.x',
+        files: {
+          'handler.mjs': new FileBlob({
+            data: `this is not valid javascript {{{`,
+          }),
         },
-        true
-      )
-    ).toEqual(true);
+      },
+      false
+    );
+    expect(result.supportsStreaming).toEqual(undefined);
+    expect(result.error).toBeDefined();
+    expect(result.error?.handler).toEqual('handler.mjs');
+    expect(result.error?.message).toBeTruthy();
   });
 });

--- a/packages/build-utils/test/unit.get-lambda-supports-streaming.test.ts
+++ b/packages/build-utils/test/unit.get-lambda-supports-streaming.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { getLambdaSupportsStreaming } from '../src/process-serverless/get-lambda-supports-streaming';
+import FileBlob from '../src/file-blob';
+
+describe('getLambdaSupportsStreaming()', () => {
+  it('returns undefined when streaming is not supported', async () => {
+    expect(
+      await getLambdaSupportsStreaming(
+        {
+          launcherType: 'Nodejs',
+          handler: 'handler.js',
+          runtime: 'nodejs20.x',
+          files: {
+            'handler.js': new FileBlob({
+              data: `module.exports.handler = () => {};`,
+            }),
+          },
+        },
+        false
+      )
+    ).toEqual(undefined);
+  });
+
+  it('honors `supportsResponseStreaming` from the lambda', async () => {
+    expect(
+      await getLambdaSupportsStreaming(
+        {
+          supportsResponseStreaming: false,
+          launcherType: 'Nodejs',
+          handler: 'handler.js',
+          runtime: 'nodejs20.x',
+          files: {
+            'handler.js': new FileBlob({
+              data: `module.exports.handler = () => {};`,
+            }),
+          },
+        },
+        false
+      )
+    ).toEqual(false);
+  });
+
+  it.each([
+    { method: 'GET' },
+    { method: 'HEAD' },
+    { method: 'OPTIONS' },
+    { method: 'POST' },
+    { method: 'PUT' },
+    { method: 'DELETE' },
+    { method: 'PATCH' },
+  ])('should return `true` when lambda exports %s in CJS', async ({
+    method,
+  }) => {
+    expect(
+      await getLambdaSupportsStreaming(
+        {
+          launcherType: 'Nodejs',
+          handler: 'handler.js',
+          runtime: 'nodejs20.x',
+          files: {
+            'handler.js': new FileBlob({
+              data: `module.exports.${method} = () => {};`,
+            }),
+          },
+        },
+        false
+      )
+    ).toEqual(true);
+  });
+
+  it.each([
+    { method: 'GET' },
+    { method: 'HEAD' },
+    { method: 'OPTIONS' },
+    { method: 'POST' },
+    { method: 'PUT' },
+    { method: 'DELETE' },
+    { method: 'PATCH' },
+  ])('should return `true` when lambda exports %s handler method in ESM', async ({
+    method,
+  }) => {
+    expect(
+      await getLambdaSupportsStreaming(
+        {
+          launcherType: 'Nodejs',
+          handler: 'handler.mjs',
+          runtime: 'nodejs20.x',
+          files: {
+            'handler.mjs': new FileBlob({
+              data: `export const ${method} = () => {};`,
+            }),
+          },
+        },
+        false
+      )
+    ).toEqual(true);
+  });
+
+  it.each([
+    { method: 'GET' },
+    { method: 'HEAD' },
+    { method: 'OPTIONS' },
+    { method: 'POST' },
+    { method: 'PUT' },
+    { method: 'DELETE' },
+    { method: 'PATCH' },
+  ])('should return `true` when lambda exports %s handler in ESM but with a .js extension', async ({
+    method,
+  }) => {
+    expect(
+      await getLambdaSupportsStreaming(
+        {
+          launcherType: 'Nodejs',
+          handler: 'handler.js',
+          runtime: 'nodejs20.x',
+          files: {
+            'handler.js': new FileBlob({
+              data: `export const ${method} = () => {};`,
+            }),
+          },
+        },
+        false
+      )
+    ).toEqual(true);
+  });
+
+  it("should return `undefined` when lambda doesn't export an HTTP method", async () => {
+    expect(
+      await getLambdaSupportsStreaming(
+        {
+          launcherType: 'Nodejs',
+          handler: 'handler.js',
+          runtime: 'nodejs20.x',
+          files: {
+            'handler.js': new FileBlob({
+              data: `module.exports.handler = () => {};`,
+            }),
+          },
+        },
+        false
+      )
+    ).toEqual(undefined);
+  });
+
+  it('honors the default setting for Python runtimes', async () => {
+    expect(
+      await getLambdaSupportsStreaming(
+        {
+          handler: 'handler.py',
+          runtime: 'python3.8',
+          supportsResponseStreaming: true,
+        },
+        false
+      )
+    ).toEqual(true);
+  });
+
+  it('returns true when forceStreamingRuntime is true', async () => {
+    expect(
+      await getLambdaSupportsStreaming(
+        {
+          handler: 'handler.py',
+          runtime: 'python3.8',
+        },
+        true
+      )
+    ).toEqual(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,12 @@ importers:
       '@vercel/python-analysis':
         specifier: workspace:*
         version: link:../python-analysis
+      cjs-module-lexer:
+        specifier: 1.2.3
+        version: 1.2.3
+      es-module-lexer:
+        specifier: 1.5.0
+        version: 1.5.0
     devDependencies:
       '@iarna/toml':
         specifier: 2.2.3
@@ -6953,7 +6959,7 @@ packages:
       babel-dead-code-elimination: 1.0.10
       chokidar: 4.0.0
       dedent: 1.6.0
-      es-module-lexer: 1.4.1
+      es-module-lexer: 1.5.0
       exit-hook: 2.2.1
       fs-extra: 10.0.0
       gunzip-maybe: 1.4.2
@@ -12709,6 +12715,10 @@ packages:
 
   /es-module-lexer@1.4.1:
     resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
+    dev: false
+
+  /es-module-lexer@1.5.0:
+    resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
 
   /es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -13019,7 +13029,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
       debug: 3.2.7
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
@@ -13050,7 +13060,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
@@ -13154,7 +13164,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.35.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
     dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.35.0):


### PR DESCRIPTION
Extract process-serverless utils to `build-utils` so we can use it here in `vercel/vercel` as well as `vercel/api` without duplicating code.

The only meaningful change is avoiding direct `process.env` reads and instead accepting arguments for these functions. I'll refactor the existing call sites to pass in `process.env` values after this ships.