### PR TITLE
feat(cli): add --skip-env flag to `vercel link` to skip env pull

### DIFF
--- a/.changeset/link-skip-env.md
+++ b/.changeset/link-skip-env.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(cli): add `--skip-env` flag to `vercel link` to skip pulling environment variables

--- a/packages/cli/src/commands/link/command.ts
+++ b/packages/cli/src/commands/link/command.ts
@@ -57,6 +57,13 @@ export const linkCommand = {
         'Skip questions when setting up new project using default scope and settings',
     },
     confirmOption,
+    {
+      name: 'skip-env',
+      description: 'Skip pulling environment variables after linking',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
   ],
   examples: [
     {
@@ -70,6 +77,10 @@ export const linkCommand = {
     {
       name: 'Non-interactive: link to an existing project (CI/agents)',
       value: `${packageName} link --yes --team <team-id> --project <project-name-or-id>`,
+    },
+    {
+      name: 'Link a project without pulling environment variables',
+      value: `${packageName} link --yes --skip-env`,
     },
     {
       name: 'Link a specific directory to a Vercel Project',

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -94,6 +94,7 @@ export default async function link(client: Client) {
 
   telemetry.trackCliFlagRepo(parsedArgs.flags['--repo']);
   telemetry.trackCliFlagYes(parsedArgs.flags['--yes']);
+  telemetry.trackCliFlagSkipEnv(parsedArgs.flags['--skip-env']);
   telemetry.trackCliOptionProject(parsedArgs.flags['--project']);
 
   if ('--confirm' in parsedArgs.flags) {
@@ -103,6 +104,7 @@ export default async function link(client: Client) {
   }
 
   const yes = !!parsedArgs.flags['--yes'];
+  const skipEnv = !!parsedArgs.flags['--skip-env'];
 
   let cwd = parsedArgs.args[1];
   if (cwd) {
@@ -141,6 +143,7 @@ export default async function link(client: Client) {
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
       searchAcrossTeams: !explicitScopeProvided,
+      pullEnv: !skipEnv,
     });
 
     if (typeof link === 'number') {

--- a/packages/cli/src/util/telemetry/commands/link/index.ts
+++ b/packages/cli/src/util/telemetry/commands/link/index.ts
@@ -31,6 +31,21 @@ export class LinkTelemetryClient
     }
   }
 
+  trackCliFlagSkipEnv(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('skip-env');
+    }
+  }
+
+  trackCliOptionProject(project: string | undefined) {
+    if (project) {
+      this.trackCliOption({
+        option: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliOptionTeam(value: string | undefined) {
     if (value) {
       this.trackCliOption({


### PR DESCRIPTION
## Summary

Adds a `--skip-env` flag to `vercel link` that prevents automatically pulling environment variables to `.env.local` after linking.

## Context

When running `vercel link --yes`, the CLI automatically pulls environment variables to `.env.local`. Users in monorepo setups who manage their own `.env.local` get their files overwritten. The only workaround is piping `< /dev/null` to trick the CLI into thinking it's non-TTY.

This PR exposes the existing `pullEnv` option in `SetupAndLinkOptions` as a CLI flag.

## Usage

```bash
# Link without pulling env vars
vercel link --yes --skip-env

# Then pull env vars to .vercel/ instead
vercel pull --environment=production --yes
```

Fixes #15713