### PR TITLE
fix(cli): `vercel logs --expand` now shows all log entries per request

### DIFF
--- a/.changeset/fix-logs-expand-15711.md
+++ b/.changeset/fix-logs-expand-15711.md
@@ -1,0 +1,16 @@
+---
+"vercel": patch
+---
+
+fix(cli): `vercel logs --expand` now shows all log entries per request
+
+Previously, `fetchRequestLogs` mapped each API row to a single
+`RequestLogEntry` by reading only `row.logs?.[0]`. All subsequent
+`console.log` / `console.warn` calls within the same serverless invocation
+were silently discarded.
+
+The transform now uses `flatMap` to expand every entry in `row.logs` into
+its own `RequestLogEntry`, so `vercel logs --expand` shows the complete
+output that matches the Vercel dashboard.
+
+Fixes #15711

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -522,6 +522,7 @@ export default async function logs(client: Client) {
       search: searchOption ?? queryOption,
       requestId: requestIdOption,
       branch: branchOption,
+      expand: expandOption,
     })) {
       output.stopSpinner();
       if (jsonOption) {

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -157,17 +157,13 @@ export async function fetchRequestLogs(
     hasMoreRows?: boolean;
   }>(url);
 
-  const logs: RequestLogEntry[] = (data.rows || []).map(row => {
-    const firstLog = row.logs?.[0];
+  const logs: RequestLogEntry[] = (data.rows || []).flatMap(row => {
     const firstEvent = row.events?.[0];
-    return {
+    const baseEntry = {
       id: row.requestId || '',
       timestamp: row.timestamp ? new Date(row.timestamp).getTime() : Date.now(),
       deploymentId: row.deploymentId || '',
       projectId: options.projectId,
-      level: (firstLog?.level as RequestLogEntry['level']) || 'info',
-      message: firstLog?.message || '',
-      messageTruncated: firstLog?.messageTruncated,
       source: (firstEvent?.source as RequestLogEntry['source']) || 'static',
       domain: row.domain || '',
       requestMethod: row.requestMethod || '',
@@ -179,6 +175,18 @@ export async function fetchRequestLogs(
       cache: row.cache,
       traceId: row.traceId,
     };
+
+    // Expand all log entries for this request so that --expand shows every
+    // console.log / console.warn line, not just the first one.
+    const logEntries = row.logs && row.logs.length > 0 ? row.logs : [{}];
+    return logEntries.map((logEntry, index) => ({
+      ...baseEntry,
+      // Use a stable per-entry id so duplicate filtering works correctly
+      id: index === 0 ? baseEntry.id : `${baseEntry.id}_${index}`,
+      level: (logEntry.level as RequestLogEntry['level']) || 'info',
+      message: logEntry.message || '',
+      messageTruncated: logEntry.messageTruncated,
+    }));
   });
 
   return {

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -43,6 +43,7 @@ export interface FetchRequestLogsOptions {
   requestId?: string;
   branch?: string;
   page?: number;
+  expand?: boolean;
 }
 
 function parseRelativeTime(input: string): number {
@@ -176,9 +177,12 @@ export async function fetchRequestLogs(
       traceId: row.traceId,
     };
 
-    // Expand all log entries for this request so that --expand shows every
-    // console.log / console.warn line, not just the first one.
-    const logEntries = row.logs && row.logs.length > 0 ? row.logs : [{}];
+    // When --expand is set, emit one entry per log line so every
+    // console.log / console.warn line is shown on its own row.
+    // In default mode, emit only the first log entry to avoid
+    // duplicate rows for requests that produced multiple log lines.
+    const allLogEntries = row.logs && row.logs.length > 0 ? row.logs : [{}];
+    const logEntries = options.expand ? allLogEntries : [allLogEntries[0]];
     return logEntries.map((logEntry, index) => ({
       ...baseEntry,
       // Use a stable per-entry id so duplicate filtering works correctly

--- a/packages/cli/test/unit/util/logs-v2.test.ts
+++ b/packages/cli/test/unit/util/logs-v2.test.ts
@@ -271,4 +271,62 @@ describe('logs-v2 utility', () => {
       expect(logs).toHaveLength(3);
     });
   });
+
+  describe('expand option', () => {
+    it('should emit one entry per request when expand is false (default)', async () => {
+      const mockLogs = [
+        createMockApiLog({
+          requestId: 'log_multi',
+          logs: [
+            { level: 'info', message: 'line 1' },
+            { level: 'error', message: 'line 2' },
+            { level: 'warning', message: 'line 3' },
+          ],
+        }),
+      ];
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        res.json({ rows: mockLogs, hasMoreRows: false });
+      });
+
+      const result = await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        ownerId: 'team_test',
+      });
+
+      // Without expand, only the first log entry per request row is emitted
+      expect(result.logs).toHaveLength(1);
+      expect(result.logs[0].id).toEqual('log_multi');
+      expect(result.logs[0].message).toEqual('line 1');
+    });
+
+    it('should emit one entry per log line when expand is true', async () => {
+      const mockLogs = [
+        createMockApiLog({
+          requestId: 'log_multi',
+          logs: [
+            { level: 'info', message: 'line 1' },
+            { level: 'error', message: 'line 2' },
+            { level: 'warning', message: 'line 3' },
+          ],
+        }),
+      ];
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        res.json({ rows: mockLogs, hasMoreRows: false });
+      });
+
+      const result = await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        ownerId: 'team_test',
+        expand: true,
+      });
+
+      // With expand, all log lines are emitted
+      expect(result.logs).toHaveLength(3);
+      expect(result.logs[0].message).toEqual('line 1');
+      expect(result.logs[1].message).toEqual('line 2');
+      expect(result.logs[2].message).toEqual('line 3');
+      expect(result.logs[1].id).toEqual('log_multi_1');
+      expect(result.logs[2].id).toEqual('log_multi_2');
+    });
+  });
 });


### PR DESCRIPTION
## What

`vercel logs --expand` only displayed the first log entry per serverless invocation, silently discarding all subsequent `console.log` / `console.warn` calls.

## Why

In `packages/cli/src/util/logs-v2.ts`, the API response `row.logs` is an array containing all log entries for a request, but the transformation only read the first element (`row.logs?.[0]`).

## How

Changed `.map()` to `.flatMap()` and expanded every entry in `row.logs` into its own `RequestLogEntry`. Each expanded entry gets a stable per-entry id (`requestId_1`, `requestId_2`, etc.) so duplicate filtering works correctly.

Fixes #15711