### PR TITLE
[build-utils] Start extracting collect-build-result

### DIFF
--- a/.changeset/add-build-result-utils.md
+++ b/.changeset/add-build-result-utils.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Add hash utilities (`streamToDigestAsync`, `sha256`, `md5`) and build result helpers (`getBuildResultMetadata`, `getLambdaByOutputPath`, `isRouteMiddleware`, `getPrerenderChain`, `streamWithExtendedPayload`) for shared use.

--- a/packages/build-utils/src/collect-build-result/get-build-result-metadata.ts
+++ b/packages/build-utils/src/collect-build-result/get-build-result-metadata.ts
@@ -1,0 +1,127 @@
+import type { Route } from '@vercel/routing-utils';
+import type { EdgeFunction } from '../edge-function';
+import type { File } from '../types';
+import type { Lambda } from '../lambda';
+import type { Prerender } from '../prerender';
+import { NowBuildError } from '../errors';
+import { getLambdaByOutputPath } from './get-lambda-by-output-path';
+import { getPrerenderChain } from './get-prerender-chain';
+import { isRouteMiddleware } from './is-route-middleware';
+
+export interface BuildResultMetadata {
+  middleware: Map<string, MiddlewareMeta>;
+  ppr: Map<string, boolean>;
+}
+
+/**
+ * Extract metadata about the build result that depend on the relationship
+ * between components in the build output. This data is later used to map to
+ * the infrastructure that we need to create.
+ */
+export function getBuildResultMetadata(params: {
+  buildOutputMap: Record<string, EdgeFunction | Lambda | Prerender | File>;
+  routes: Route[];
+}): BuildResultMetadata {
+  return {
+    middleware: getMiddlewareMetadata(params),
+    ppr: new Map(
+      Object.entries(params.buildOutputMap).flatMap(([_outputPath, output]) => {
+        if (output.type === 'Prerender') {
+          const chain = getPrerenderChain(output);
+          if (chain) {
+            const maybeLambda = getLambdaByOutputPath({
+              buildOutputMap: params.buildOutputMap,
+              outputPath: chain.outputPath,
+            });
+
+            if (maybeLambda) {
+              return [[chain.outputPath, true]];
+            }
+          }
+        }
+
+        return [];
+      })
+    ),
+  };
+}
+
+type MiddlewareMeta =
+  | {
+      type: 'middleware';
+      middlewarePath: string;
+      outputPath: string;
+      match: Set<string>;
+      edgeFunction: EdgeFunction;
+      index: number;
+    }
+  | {
+      type: 'middleware-lambda';
+      middlewarePath: string;
+      outputPath: string;
+      match: Set<string>;
+      index: number;
+    };
+
+function getMiddlewareMetadata(params: {
+  buildOutputMap: Record<string, EdgeFunction | Lambda | Prerender | File>;
+  routes: Route[];
+}): Map<string, MiddlewareMeta> {
+  const deduped = new Map(
+    params.routes.filter(isRouteMiddleware).map(route =>
+      toMiddlewareTuple({
+        buildOutputMap: params.buildOutputMap,
+        middlewarePath: route.middlewarePath,
+      })
+    )
+  );
+
+  return new Map(
+    Array.from(deduped, ([outputPath, metadata], index) => [
+      outputPath,
+      { ...metadata, index },
+    ])
+  );
+}
+
+function toMiddlewareTuple(params: {
+  middlewarePath: string;
+  buildOutputMap: Record<string, EdgeFunction | Lambda | Prerender | File>;
+}) {
+  const keys = [
+    params.middlewarePath,
+    params.middlewarePath.replace(/^\//, ''),
+  ];
+
+  const [outputPath, output] =
+    Object.entries(params.buildOutputMap).find(
+      (entry): entry is [string, EdgeFunction | Lambda] =>
+        keys.includes(entry[0]) &&
+        (entry[1].type === 'EdgeFunction' || entry[1].type === 'Lambda')
+    ) ?? [];
+
+  if (!outputPath || !output) {
+    throw new NowBuildError({
+      message: `Mapping ${params.middlewarePath} not found. Maybe you provided a wrong middlewarePath?`,
+      code: 'middleware_path_not_found',
+    });
+  }
+
+  return [
+    outputPath,
+    output.type === 'EdgeFunction'
+      ? {
+          edgeFunction: output,
+          match: new Set<string>(keys),
+          middlewarePath: params.middlewarePath,
+          outputPath,
+          type: 'middleware' as const,
+        }
+      : {
+          match: new Set<string>(keys),
+          middlewarePath: params.middlewarePath,
+          outputPath,
+          type: 'middleware-lambda' as const,
+        },
+  ] as const;
+}

--- a/packages/build-utils/src/collect-build-result/get-lambda-by-output-path.ts
+++ b/packages/build-utils/src/collect-build-result/get-lambda-by-output-path.ts
@@ -1,0 +1,21 @@
+import type { EdgeFunction } from '../edge-function';
+import type { File } from '../types';
+import type { Lambda } from '../lambda';
+import type { Prerender } from '../prerender';
+
+/**
+ * A Prerender can hold references to a Lambda or another Prerender when
+ * using PPR. This function retrieves the Lambda or Prerender from the
+ * build output map ensuring its type.
+ */
+export function getLambdaByOutputPath(params: {
+  buildOutputMap: Record<string, EdgeFunction | Lambda | Prerender | File>;
+  outputPath: string;
+}): Lambda | undefined {
+  const output = params.buildOutputMap[params.outputPath];
+  return output?.type === 'Lambda'
+    ? output
+    : output?.type === 'Prerender'
+      ? output.lambda
+      : undefined;
+}

--- a/packages/build-utils/src/collect-build-result/get-prerender-chain.ts
+++ b/packages/build-utils/src/collect-build-result/get-prerender-chain.ts
@@ -1,0 +1,27 @@
+import type { Chain } from '../types';
+import type { Prerender } from '../prerender';
+
+/**
+ * The Prerender chain can be defined as a `chain` property or as a flag
+ * `experimentalStreamingLambdaPath`. This function normalizes the chain
+ * to a single structure.
+ */
+export function getPrerenderChain(prerender: Prerender): Chain | undefined {
+  if (prerender.chain) {
+    return {
+      outputPath: prerender.chain.outputPath,
+      headers: prerender.chain.headers,
+    };
+  }
+
+  if (prerender.experimentalStreamingLambdaPath) {
+    return {
+      outputPath: prerender.experimentalStreamingLambdaPath,
+      headers: {
+        'x-matched-path': prerender.experimentalStreamingLambdaPath,
+      },
+    };
+  }
+
+  return undefined;
+}

--- a/packages/build-utils/src/collect-build-result/is-route-middleware.ts
+++ b/packages/build-utils/src/collect-build-result/is-route-middleware.ts
@@ -1,0 +1,7 @@
+import type { Route } from '@vercel/routing-utils';
+
+export function isRouteMiddleware(
+  route: Route
+): route is Route & { middlewarePath: string } {
+  return 'middlewarePath' in route && typeof route.middlewarePath === 'string';
+}

--- a/packages/build-utils/src/collect-build-result/stream-with-extended-payload.ts
+++ b/packages/build-utils/src/collect-build-result/stream-with-extended-payload.ts
@@ -1,0 +1,38 @@
+import { Readable } from 'stream';
+
+export interface ExtendedBodyData {
+  prefix: string;
+  suffix: string;
+}
+
+export function streamWithExtendedPayload(
+  stream: NodeJS.ReadableStream,
+  data?: ExtendedBodyData
+): NodeJS.ReadableStream {
+  return data ? new MultipartContentStream(stream, data) : stream;
+}
+
+class MultipartContentStream extends Readable {
+  constructor(stream: NodeJS.ReadableStream, data: ExtendedBodyData) {
+    super();
+
+    stream.on('error', err => {
+      this.emit('error', err);
+    });
+
+    stream.on('end', () => {
+      this.push(data.suffix);
+      this.push(null);
+    });
+
+    this.push(data.prefix);
+
+    stream.on('data', chunk => {
+      this.push(chunk);
+    });
+  }
+
+  _read(): void {
+    // noop
+  }
+}

--- a/packages/build-utils/src/fs/stream-to-digest-async.ts
+++ b/packages/build-utils/src/fs/stream-to-digest-async.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'crypto';
+
+export interface FileDigest {
+  md5: string;
+  sha256: string;
+  size: number;
+}
+
+export async function streamToDigestAsync(
+  stream: NodeJS.ReadableStream
+): Promise<FileDigest> {
+  return await new Promise((resolve, reject) => {
+    stream.once('error', reject);
+
+    let count = 0;
+    const sha256 = createHash('sha256');
+    const md5 = createHash('md5');
+
+    stream.on('end', () => {
+      const res = {
+        sha256: sha256.digest('hex'),
+        md5: md5.digest('hex'),
+        size: count,
+      };
+      resolve(res);
+    });
+
+    // listening the `readable` event and calling stream.read()
+    // is slightly faster than using a callback on the `data` event
+    // for large files
+    stream.on('readable', () => {
+      let chunk: any;
+      while (null !== (chunk = stream.read())) {
+        md5.update(chunk);
+        sha256.update(chunk);
+        count += chunk.length;
+      }
+    });
+  });
+}
+
+export function sha256(value: any) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function md5(value: Buffer) {
+  return createHash('md5').update(value).digest('hex');
+}

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -176,3 +176,22 @@ export {
   getLambdaSupportsStreaming,
   type SupportsStreamingResult,
 } from './process-serverless/get-lambda-supports-streaming';
+
+export {
+  streamToDigestAsync,
+  sha256,
+  md5,
+  type FileDigest,
+} from './fs/stream-to-digest-async';
+
+export {
+  getBuildResultMetadata,
+  type BuildResultMetadata,
+} from './collect-build-result/get-build-result-metadata';
+export { getLambdaByOutputPath } from './collect-build-result/get-lambda-by-output-path';
+export { isRouteMiddleware } from './collect-build-result/is-route-middleware';
+export { getPrerenderChain } from './collect-build-result/get-prerender-chain';
+export {
+  streamWithExtendedPayload,
+  type ExtendedBodyData,
+} from './collect-build-result/stream-with-extended-payload';

--- a/packages/build-utils/test/unit.collect-build-result.test.ts
+++ b/packages/build-utils/test/unit.collect-build-result.test.ts
@@ -1,0 +1,209 @@
+import { it, describe, expect } from 'vitest';
+import { getBuildResultMetadata } from '../src/collect-build-result/get-build-result-metadata';
+import { getLambdaByOutputPath } from '../src/collect-build-result/get-lambda-by-output-path';
+import { isRouteMiddleware } from '../src/collect-build-result/is-route-middleware';
+import { getPrerenderChain } from '../src/collect-build-result/get-prerender-chain';
+import {
+  streamWithExtendedPayload,
+  type ExtendedBodyData,
+} from '../src/collect-build-result/stream-with-extended-payload';
+import { Readable } from 'stream';
+import streamToBuffer from '../src/fs/stream-to-buffer';
+import { Lambda } from '../src/lambda';
+import { Prerender } from '../src/prerender';
+import { EdgeFunction } from '../src/edge-function';
+
+function createLambda(overrides: Partial<Lambda> = {}): Lambda {
+  return Object.assign(Object.create(Lambda.prototype), {
+    type: 'Lambda' as const,
+    zipBuffer: Buffer.from('zip'),
+    handler: 'index.handler',
+    runtime: 'nodejs20.x',
+    ...overrides,
+  });
+}
+
+function createPrerender(overrides: Partial<Prerender> = {}): Prerender {
+  return Object.assign(Object.create(Prerender.prototype), {
+    type: 'Prerender' as const,
+    expiration: 60,
+    ...overrides,
+  });
+}
+
+function createEdgeFunction(
+  overrides: Partial<EdgeFunction> = {}
+): EdgeFunction {
+  return Object.assign(Object.create(EdgeFunction.prototype), {
+    type: 'EdgeFunction' as const,
+    deploymentTarget: 'v8-worker' as const,
+    entrypoint: 'index.js',
+    files: {},
+    ...overrides,
+  });
+}
+
+describe('getLambdaByOutputPath', () => {
+  it('returns a Lambda when the output is a Lambda', () => {
+    const lambda = createLambda();
+    const result = getLambdaByOutputPath({
+      buildOutputMap: { 'api/hello': lambda },
+      outputPath: 'api/hello',
+    });
+    expect(result).toBe(lambda);
+  });
+
+  it('returns the lambda from a Prerender', () => {
+    const lambda = createLambda();
+    const prerender = createPrerender({ lambda });
+    const result = getLambdaByOutputPath({
+      buildOutputMap: { page: prerender },
+      outputPath: 'page',
+    });
+    expect(result).toBe(lambda);
+  });
+
+  it('returns undefined for missing paths', () => {
+    const result = getLambdaByOutputPath({
+      buildOutputMap: {},
+      outputPath: 'missing',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for EdgeFunction outputs', () => {
+    const edge = createEdgeFunction();
+    const result = getLambdaByOutputPath({
+      buildOutputMap: { middleware: edge },
+      outputPath: 'middleware',
+    });
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('isRouteMiddleware', () => {
+  it('returns true for routes with middlewarePath', () => {
+    const route = { src: '/.*', middlewarePath: 'middleware' };
+    expect(isRouteMiddleware(route)).toBe(true);
+  });
+
+  it('returns false for routes without middlewarePath', () => {
+    const route = { src: '/.*', dest: '/index' };
+    expect(isRouteMiddleware(route)).toBe(false);
+  });
+
+  it('returns false when middlewarePath is not a string', () => {
+    const route = { src: '/.*', middlewarePath: 123 } as any;
+    expect(isRouteMiddleware(route)).toBe(false);
+  });
+});
+
+describe('getPrerenderChain', () => {
+  it('returns chain when chain property exists', () => {
+    const prerender = createPrerender({
+      chain: { outputPath: 'page.rsc', headers: { 'x-test': 'value' } },
+    });
+    const result = getPrerenderChain(prerender);
+    expect(result).toEqual({
+      outputPath: 'page.rsc',
+      headers: { 'x-test': 'value' },
+    });
+  });
+
+  it('returns chain from experimentalStreamingLambdaPath', () => {
+    const prerender = createPrerender({
+      experimentalStreamingLambdaPath: 'page.stream',
+    });
+    const result = getPrerenderChain(prerender);
+    expect(result).toEqual({
+      outputPath: 'page.stream',
+      headers: { 'x-matched-path': 'page.stream' },
+    });
+  });
+
+  it('returns undefined when no chain info', () => {
+    const prerender = createPrerender();
+    const result = getPrerenderChain(prerender);
+    expect(result).toBeUndefined();
+  });
+
+  it('prefers chain over experimentalStreamingLambdaPath', () => {
+    const prerender = createPrerender({
+      chain: { outputPath: 'page.rsc', headers: {} },
+      experimentalStreamingLambdaPath: 'page.stream',
+    });
+    const result = getPrerenderChain(prerender);
+    expect(result?.outputPath).toBe('page.rsc');
+  });
+});
+
+describe('getBuildResultMetadata', () => {
+  it('detects EdgeFunction middleware from routes', () => {
+    const edge = createEdgeFunction();
+    const result = getBuildResultMetadata({
+      buildOutputMap: { middleware: edge },
+      routes: [{ src: '/.*', middlewarePath: 'middleware' }],
+    });
+    expect(result.middleware.size).toBe(1);
+    const meta = result.middleware.get('middleware');
+    expect(meta?.type).toBe('middleware');
+    if (meta?.type === 'middleware') {
+      expect(meta.edgeFunction).toBe(edge);
+    }
+  });
+
+  it('detects Lambda middleware from routes', () => {
+    const lambda = createLambda();
+    const result = getBuildResultMetadata({
+      buildOutputMap: { middleware: lambda },
+      routes: [{ src: '/.*', middlewarePath: 'middleware' }],
+    });
+    expect(result.middleware.size).toBe(1);
+    const meta = result.middleware.get('middleware');
+    expect(meta?.type).toBe('middleware-lambda');
+  });
+
+  it('detects PPR chains', () => {
+    const lambda = createLambda();
+    const prerender = createPrerender({
+      chain: { outputPath: 'page.rsc', headers: {} },
+    });
+    const result = getBuildResultMetadata({
+      buildOutputMap: {
+        page: prerender,
+        'page.rsc': lambda,
+      },
+      routes: [],
+    });
+    expect(result.ppr.get('page.rsc')).toBe(true);
+  });
+
+  it('returns empty maps for empty inputs', () => {
+    const result = getBuildResultMetadata({
+      buildOutputMap: {},
+      routes: [],
+    });
+    expect(result.middleware.size).toBe(0);
+    expect(result.ppr.size).toBe(0);
+  });
+});
+
+describe('streamWithExtendedPayload', () => {
+  it('returns original stream when no data provided', async () => {
+    const stream = Readable.from([Buffer.from('content')]);
+    const result = streamWithExtendedPayload(stream);
+    const buf = await streamToBuffer(result);
+    expect(buf.toString()).toBe('content');
+  });
+
+  it('wraps stream with prefix and suffix', async () => {
+    const stream = Readable.from([Buffer.from('body')]);
+    const data: ExtendedBodyData = {
+      prefix: 'PRE:',
+      suffix: ':POST',
+    };
+    const result = streamWithExtendedPayload(stream, data);
+    const buf = await streamToBuffer(result);
+    expect(buf.toString()).toBe('PRE:body:POST');
+  });
+});

--- a/packages/build-utils/test/unit.stream-to-digest-async.test.ts
+++ b/packages/build-utils/test/unit.stream-to-digest-async.test.ts
@@ -1,0 +1,79 @@
+import { it, describe, expect } from 'vitest';
+import { Readable } from 'stream';
+import {
+  streamToDigestAsync,
+  sha256,
+  md5,
+} from '../src/fs/stream-to-digest-async';
+import { createHash } from 'crypto';
+
+describe('streamToDigestAsync', () => {
+  it('computes sha256, md5, and size for a stream', async () => {
+    const content = Buffer.from('hello world');
+    const stream = Readable.from([content]);
+
+    const result = await streamToDigestAsync(stream);
+
+    expect(result.sha256).toBe(
+      createHash('sha256').update(content).digest('hex')
+    );
+    expect(result.md5).toBe(createHash('md5').update(content).digest('hex'));
+    expect(result.size).toBe(content.length);
+  });
+
+  it('handles multi-chunk streams', async () => {
+    const chunk1 = Buffer.from('hello ');
+    const chunk2 = Buffer.from('world');
+    const combined = Buffer.concat([chunk1, chunk2]);
+    const stream = Readable.from([chunk1, chunk2]);
+
+    const result = await streamToDigestAsync(stream);
+
+    expect(result.sha256).toBe(
+      createHash('sha256').update(combined).digest('hex')
+    );
+    expect(result.md5).toBe(createHash('md5').update(combined).digest('hex'));
+    expect(result.size).toBe(combined.length);
+  });
+
+  it('handles empty streams', async () => {
+    const stream = Readable.from([]);
+
+    const result = await streamToDigestAsync(stream);
+
+    expect(result.sha256).toBe(
+      createHash('sha256').update(Buffer.alloc(0)).digest('hex')
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it('rejects on stream error', async () => {
+    const stream = new Readable({
+      read() {
+        this.destroy(new Error('stream failed'));
+      },
+    });
+
+    await expect(streamToDigestAsync(stream)).rejects.toThrow('stream failed');
+  });
+});
+
+describe('sha256', () => {
+  it('returns hex sha256 of a buffer', () => {
+    const buf = Buffer.from('test');
+    expect(sha256(buf)).toBe(createHash('sha256').update(buf).digest('hex'));
+  });
+
+  it('returns hex sha256 of a string', () => {
+    expect(sha256('test')).toBe(
+      createHash('sha256').update('test').digest('hex')
+    );
+  });
+});
+
+describe('md5', () => {
+  it('returns hex md5 of a buffer', () => {
+    const buf = Buffer.from('test');
+    expect(md5(buf)).toBe(createHash('md5').update(buf).digest('hex'));
+  });
+});


### PR DESCRIPTION
Similar to https://github.com/vercel/vercel/pull/15712, we're starting to extract `collect-build-result` here in `build-utils` so it can be used in `vercel/vercel` and `vercel/api`.

This code has been moved without changes.