### PR TITLE
Standarize toml parsing on smol-toml

### DIFF
--- a/.changeset/warm-geckos-happen.md
+++ b/.changeset/warm-geckos-happen.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': patch
+'@vercel/frameworks': patch
+'@vercel/rust': patch
+---
+
+Switch to using smol-toml for toml parsing

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -24,7 +24,7 @@
     "es-module-lexer": "1.5.0"
   },
   "devDependencies": {
-    "@iarna/toml": "2.2.3",
+    "smol-toml": "1.5.2",
     "@types/async-retry": "^1.2.1",
     "@types/cross-spawn": "6.0.0",
     "@types/end-of-stream": "^1.4.0",

--- a/packages/build-utils/src/fs/read-config-file.ts
+++ b/packages/build-utils/src/fs/read-config-file.ts
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import toml from '@iarna/toml';
+import { parse as tomlParse } from 'smol-toml';
 import { readFile } from 'fs-extra';
 import { isErrnoException } from '@vercel/error-utils';
 import { join } from 'path';
@@ -35,7 +35,7 @@ export async function readConfigFile<T>(
         if (name.endsWith('.json')) {
           return JSON.parse(str) as T;
         } else if (name.endsWith('.toml')) {
-          return toml.parse(str) as unknown as T;
+          return tomlParse(str) as unknown as T;
         } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
           return yaml.safeLoad(str, { filename: name }) as T;
         }

--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -19,7 +19,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@iarna/toml": "2.2.3",
+    "smol-toml": "1.5.2",
     "js-yaml": "3.13.1",
     "@vercel/error-utils": "workspace:*"
   },

--- a/packages/frameworks/src/read-config-file.ts
+++ b/packages/frameworks/src/read-config-file.ts
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import toml from '@iarna/toml';
+import { parse as tomlParse } from 'smol-toml';
 import { promises } from 'fs';
 import { isErrnoException } from '@vercel/error-utils';
 
@@ -34,7 +34,7 @@ export async function readConfigFile<T>(
       if (name.endsWith('.json')) {
         return JSON.parse(str) as T;
       } else if (name.endsWith('.toml')) {
-        return toml.parse(str) as unknown as T;
+        return tomlParse(str) as unknown as T;
       } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
         return yaml.safeLoad(str, { filename: name }) as T;
       }

--- a/packages/rust/package.json
+++ b/packages/rust/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "dependencies": {
-    "@iarna/toml": "^2.2.5",
+    "smol-toml": "1.5.2",
     "execa": "5"
   },
   "devDependencies": {

--- a/packages/rust/src/lib/cargo.ts
+++ b/packages/rust/src/lib/cargo.ts
@@ -1,6 +1,7 @@
-import fs from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
-import toml from '@iarna/toml';
+import { parse as tomlParse } from 'smol-toml';
 import execa from 'execa';
 
 export interface CargoMetadataRoot {
@@ -163,7 +164,7 @@ export async function findCargoWorkspace(
     root: string;
   };
   return {
-    toml: await toml.parse.stream(fs.createReadStream(projectDescription.root)),
+    toml: tomlParse(await readFile(projectDescription.root, 'utf8')),
     root: projectDescription.root,
   };
 }
@@ -189,11 +190,11 @@ export async function findCargoBuildConfiguration(
     '.cargo/config.toml'
   );
 
-  if (!fs.existsSync(configPath)) {
+  if (!existsSync(configPath)) {
     return null;
   }
 
-  const config = await toml.parse.stream(fs.createReadStream(configPath));
+  const config = tomlParse(await readFile(configPath, 'utf8'));
   return config as unknown as CargoBuildConfiguration;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,9 +287,6 @@ importers:
         specifier: 1.5.0
         version: 1.5.0
     devDependencies:
-      '@iarna/toml':
-        specifier: 2.2.3
-        version: 2.2.3
       '@types/async-retry':
         specifier: ^1.2.1
         version: 1.2.1
@@ -392,6 +389,9 @@ importers:
       semver:
         specifier: 6.3.1
         version: 6.3.1
+      smol-toml:
+        specifier: 1.5.2
+        version: 1.5.2
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -1267,15 +1267,15 @@ importers:
 
   packages/frameworks:
     dependencies:
-      '@iarna/toml':
-        specifier: 2.2.3
-        version: 2.2.3
       '@vercel/error-utils':
         specifier: workspace:*
         version: link:../error-utils
       js-yaml:
         specifier: 3.13.1
         version: 3.13.1
+      smol-toml:
+        specifier: 1.5.2
+        version: 1.5.2
     devDependencies:
       '@types/jest':
         specifier: 27.4.1
@@ -2334,12 +2334,12 @@ importers:
 
   packages/rust:
     dependencies:
-      '@iarna/toml':
-        specifier: ^2.2.5
-        version: 2.2.5
       execa:
         specifier: '5'
         version: 5.1.1
+      smol-toml:
+        specifier: 1.5.2
+        version: 1.5.2
     devDependencies:
       '@types/jest':
         specifier: ^29.4.0
@@ -5624,13 +5624,6 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
     dev: true
-
-  /@iarna/toml@2.2.3:
-    resolution: {integrity: sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==}
-
-  /@iarna/toml@2.2.5:
-    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
-    dev: false
 
   /@img/colour@1.0.0:
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -13029,7 +13022,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       debug: 3.2.7
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
@@ -13060,7 +13053,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
@@ -13164,7 +13157,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.35.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
     dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.35.0):


### PR DESCRIPTION
Currently we are using two different libraries. Our smol-toml version
supports 1.0, and the version of @iarna/toml we were using doesn't.
