### PR TITLE
fix: strip non-ASCII characters from hostname in User-Agent header

### DIFF
--- a/.changeset/sanitize-hostname-user-agent.md
+++ b/.changeset/sanitize-hostname-user-agent.md
@@ -1,0 +1,7 @@
+---
+'@vercel/cli-auth': patch
+'vercel': patch
+'@vercel/oidc': patch
+---
+
+Strip non-ASCII characters from hostname in User-Agent header

--- a/packages/cli-auth/user-agent.ts
+++ b/packages/cli-auth/user-agent.ts
@@ -10,7 +10,11 @@ import os from 'node:os';
  * ```
  */
 export function getUserAgent(pkg: { name: string; version: string }): string {
-  return `${os.hostname()} @ ${pkg.name} ${pkg.version} node-${
+  return `${os
+    .hostname()
+    // Strip non-ASCII characters (e.g. emoji) from hostname to avoid illegal HTTP header values
+    .replace(/[^\x20-\x7e]/g, '')
+    .trim()} @ ${pkg.name} ${pkg.version} node-${
     process.version
   } ${os.platform()} (${os.arch()})`;
 }

--- a/packages/cli/src/util/oauth.ts
+++ b/packages/cli/src/util/oauth.ts
@@ -4,7 +4,10 @@ import { hostname } from 'os';
 
 const VERCEL_ISSUER = new URL('https://vercel.com');
 export const VERCEL_CLI_CLIENT_ID = 'cl_HYyOPBNtFMfHhaUn9L4QPfTZz6TP47bp';
-export const userAgent = `${hostname()} @ ${ua}`;
+export const userAgent = `${hostname()
+  // Strip non-ASCII characters (e.g. emoji) from hostname to avoid illegal HTTP header values
+  .replace(/[^\x20-\x7e]/g, '')
+  .trim()} @ ${ua}`;
 
 interface AuthorizationServerMetadata {
   issuer: URL;

--- a/packages/cli/test/unit/util/oauth.test.ts
+++ b/packages/cli/test/unit/util/oauth.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('os', async importOriginal => {
+  const actual = (await importOriginal()) as typeof import('os');
+  return {
+    ...actual,
+    hostname: vi.fn(() => 'My Machine 💻'),
+  };
+});
+
+import { userAgent } from '../../../src/util/oauth';
+
+describe('oauth userAgent', () => {
+  it('should strip non-ASCII characters from hostname', () => {
+    expect(userAgent).toMatch(/^[\x20-\x7e]+$/);
+    expect(userAgent).not.toContain('💻');
+    expect(userAgent).toContain('My Machine');
+  });
+});

--- a/packages/oidc/src/oauth.ts
+++ b/packages/oidc/src/oauth.ts
@@ -4,7 +4,10 @@ const VERCEL_ISSUER = 'https://vercel.com';
 const VERCEL_CLI_CLIENT_ID = 'cl_HYyOPBNtFMfHhaUn9L4QPfTZz6TP47bp';
 
 // Simplified user agent for OIDC package
-const userAgent = `@vercel/oidc node-${process.version} ${platform()} (${arch()}) ${hostname()}`;
+const userAgent = `@vercel/oidc node-${process.version} ${platform()} (${arch()}) ${hostname()
+  // Strip non-ASCII characters (e.g. emoji) from hostname to avoid illegal HTTP header values
+  .replace(/[^\x20-\x7e]/g, '')
+  .trim()}`;
 
 export interface TokenSet {
   access_token: string;


### PR DESCRIPTION
Hostnames containing emoji (e.g. "🌮 tacobook") cause an "illegal HTTP header value" error when used in User-Agent headers