### PR TITLE
feat(cli): add plan field to `vercel teams list` output

### DIFF
--- a/.changeset/teams-list-plan.md
+++ b/.changeset/teams-list-plan.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add plan field to `vercel teams list` output in both table and JSON formats

--- a/packages/cli/src/commands/teams/list.ts
+++ b/packages/cli/src/commands/teams/list.ts
@@ -93,10 +93,11 @@ export default async function list(
     currentTeam = user.id;
   }
 
-  const teamList = teams.map(({ id, slug, name }) => ({
+  const teamList = teams.map(({ id, slug, name, billing }) => ({
     id,
     name,
     value: slug,
+    plan: billing?.plan ?? '',
     isCurrent: id === currentTeam,
   }));
 
@@ -105,6 +106,7 @@ export default async function list(
       id: user.id,
       name: user.email,
       value: user.username || user.email,
+      plan: user.billing?.plan ?? '',
       isCurrent: accountIsCurrent,
     });
   }
@@ -124,6 +126,7 @@ export default async function list(
         id: team.id,
         slug: team.value,
         name: team.name,
+        plan: team.plan,
         current: team.isCurrent,
       })),
       pagination,
@@ -134,8 +137,8 @@ export default async function list(
 
     const teamTable = table(
       [
-        ['id', 'Team name'].map(str => gray(str)),
-        ...teamList.map(team => [team.value, team.name]),
+        ['id', 'Team name', 'Plan'].map(str => gray(str)),
+        ...teamList.map(team => [team.value, team.name, team.plan]),
       ],
       { hsep: 5 }
     );

--- a/packages/cli/test/mocks/team.ts
+++ b/packages/cli/test/mocks/team.ts
@@ -11,6 +11,14 @@ export type Team = {
   creatorId: string;
   created: string;
   avatar: null;
+  billing: {
+    addons: string[];
+    period: { start: number; end: number };
+    plan: string;
+    platform: string;
+    status: string;
+    trial: { start: number; end: number };
+  };
 };
 
 let teams: Team[] = [];
@@ -98,13 +106,21 @@ export function createTeam(teamId?: string, slug?: string, name?: string) {
   const id = teamId || chance().guid();
   const teamSlug = slug || chance().string({ length: 5, casing: 'lower' });
   const teamName = name || chance().company();
-  const newTeam = {
+  const newTeam: Team = {
     id,
     slug: teamSlug,
     name: teamName,
     creatorId: chance().guid(),
     created: '2017-04-29T17:21:54.514Z',
     avatar: null,
+    billing: {
+      addons: [],
+      period: { start: 0, end: 0 },
+      plan: 'pro',
+      platform: 'stripe',
+      status: 'active',
+      trial: { start: 0, end: 0 },
+    },
   };
   teams.push(newTeam);
   return newTeam;

--- a/packages/cli/test/unit/commands/teams/ls.test.ts
+++ b/packages/cli/test/unit/commands/teams/ls.test.ts
@@ -148,7 +148,20 @@ describe('teams ls', () => {
         expect(firstTeam).toHaveProperty('id');
         expect(firstTeam).toHaveProperty('slug');
         expect(firstTeam).toHaveProperty('name');
+        expect(firstTeam).toHaveProperty('plan');
         expect(firstTeam).toHaveProperty('current');
+      });
+
+      it('includes plan field from billing data', async () => {
+        client.setArgv('teams', 'ls', '--format', 'json');
+        const exitCode = await teams(client);
+        expect(exitCode).toEqual(0);
+
+        const output = client.stdout.getFullOutput();
+        const jsonOutput = JSON.parse(output);
+
+        const firstTeam = jsonOutput.teams[0];
+        expect(firstTeam.plan).toBe('pro');
       });
     });
   });


### PR DESCRIPTION
## Summary
- The `/v2/teams` API already returns `billing.plan` on team objects, but `vercel teams list` was discarding it during destructuring
- Surfaces the plan (hobby, pro, enterprise) in both the table output (new "Plan" column) and JSON output (new `plan` field)
- Enables CLI users and agents to determine what plan a team is on without additional API calls

## Manual test results

### Table output (`vercel teams list`)

```
id                                           Team name                                    Plan
vercel                                       Vercel                                       enterprise
vercel-cli-evals                             vercel-cli-evals-vtest314                    pro
templates-test-vtest314                      Templates Test vtest314                      pro
shipai-marketplace-demo-vtest314             ShipAI Marketplace Demo vtest314             pro
vtest314-dima2                               vtest314-dima2                               pro
claims-deployment-with-resource-vtest314     Claims Deployment with Resource vtest314     enterprise
tonypan-test-team-vtest314                   Tony Pan Test Team vtest314                  enterprise
tony-s-team-0f8da06b                         My Hobby Team                                hobby
tony-pans-projects                           My Projects                                  pro
vercel-admin                                 Vercel Admin                                 enterprise
```

### JSON output (`vercel teams list --format json`)

```json
{
  "teams": [
    {
      "id": "team_nLlpyC6REAqxydlFKbrMDlud",
      "slug": "vercel",
      "name": "Vercel",
      "plan": "enterprise",
      "current": false
    },
    {
      "id": "team_3XMnUKL2XpDri6KnzH3TSTEy",
      "slug": "vercel-cli-evals",
      "name": "vercel-cli-evals-vtest314",
      "plan": "pro",
      "current": false
    },
    {
      "id": "team_XgYksaCJwUbPD01UWu2Tw6G1",
      "slug": "templates-test-vtest314",
      "name": "Templates Test vtest314",
      "plan": "pro",
      "current": false
    },
    {
      "id": "team_ZqOQxHNAJda0SaYedNKz1hNs",
      "slug": "shipai-marketplace-demo-vtest314",
      "name": "ShipAI Marketplace Demo vtest314",
      "plan": "pro",
      "current": false
    },
    {
      "id": "team_h2pqNxnJHiqu7gr1nVum5Lug",
      "slug": "vtest314-dima2",
      "name": "vtest314-dima2",
      "plan": "pro",
      "current": false
    },
    {
      "id": "team_ZnmHvIkJh92n5BadmZq24e1Y",
      "slug": "claims-deployment-with-resource-vtest314",
      "name": "Claims Deployment with Resource vtest314",
      "plan": "enterprise",
      "current": false
    },
    {
      "id": "team_Lm7240vRCjhKFv8D4CBDzNhS",
      "slug": "marketplace-team-ownership-transfer-b",
      "name": "TeamB vtest314",
      "plan": "pro",
      "current": false
    },
    {
      "id": "team_2sYfPtGmLBPbSijBuO16XDmN",
      "slug": "marketplace-team-ownership-transfer-a",
      "name": "TeamA vtest314",
      "plan": "pro",
      "current": false
    },
    {
      "id": "team_15vPyMr7tqqmtcwqVgk270bY",
      "slug": "tonypan-test-team-vtest314",
      "name": "Tony Pan Test Team vtest314",
      "plan": "enterprise",
      "current": false
    },
    {
      "id": "team_sUAlxuancLUgNO07KHKJ00uW",
      "slug": "tony-s-team-0f8da06b",
      "name": "My Hobby Team",
      "plan": "hobby",
      "current": false
    },
    {
      "id": "team_13qx8aXIm3ymy5gSwuyTrRiM",
      "slug": "vtest314-jake-pro-test",
      "name": "vtest314-jake-pro-test",
      "plan": "pro",
      "current": false
    },
    {
      "id": "team_ov5OA2knzmq1RWO70NtrGMF6",
      "slug": "tony-pans-projects",
      "name": "My Projects",
      "plan": "pro",
      "current": false
    },
    {
      "id": "team_ZrswwWlkgu3cRre7Tk7Rr0HV",
      "slug": "acme-marketplace-team-vtest314",
      "name": "ACME Marketplace Team",
      "plan": "pro",
      "current": false
    },
    {
      "id": "team_tLSLQpFZF0PDpZGC7eWcQbyJ",
      "slug": "vercel-admin",
      "name": "Vercel Admin",
      "plan": "enterprise",
      "current": false
    }
  ],
  "pagination": {
    "count": 14,
    "next": null,
    "prev": 1769822552340
  }
}
```

## Test plan
- [x] Existing tests pass (11/11)
- [x] New test verifies `plan` field appears in JSON output with correct value
- [x] Type-check clean (only pre-existing failures on main)
- [x] Manual test: table output shows Plan column with correct values (hobby/pro/enterprise)
- [x] Manual test: JSON output includes `plan` field on every team object