### PR TITLE
[django] Produce a better diagnostic when Django settings discovery fails

### DIFF
--- a/.changeset/witty-cycles-tell.md
+++ b/.changeset/witty-cycles-tell.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Produce a better diagnostic when Django settings discovery fails

--- a/packages/python/src/django.ts
+++ b/packages/python/src/django.ts
@@ -24,27 +24,24 @@ export interface DjangoSettingsResult {
 export async function getDjangoSettings(
   projectDir: string,
   env: NodeJS.ProcessEnv
-): Promise<DjangoSettingsResult | null> {
-  try {
-    const { stdout } = await execa('python', ['-c', script], {
-      env,
-      cwd: projectDir,
-    });
-    const parsed = JSON.parse(stdout) as {
-      settings_module: string;
-      django_settings: Record<string, unknown>;
-      django_version?: DjangoVersion;
-    } | null;
-    if (!parsed) return null;
-    return {
-      settingsModule: parsed.settings_module,
-      djangoSettings: parsed.django_settings,
-      djangoVersion: parsed.django_version ?? null,
-    };
-  } catch (err) {
-    debug(`Django hook: failed to discover settings from manage.py: ${err}`);
-    return null;
+): Promise<DjangoSettingsResult> {
+  const { stdout } = await execa('python', ['-c', script], {
+    env,
+    cwd: projectDir,
+  });
+  const parsed = JSON.parse(stdout) as {
+    settings_module: string;
+    django_settings: Record<string, unknown>;
+    django_version?: DjangoVersion;
+  } | null;
+  if (!parsed) {
+    throw new Error('manage.py did not return any settings');
   }
+  return {
+    settingsModule: parsed.settings_module,
+    djangoSettings: parsed.django_settings,
+    djangoVersion: parsed.django_version ?? null,
+  };
 }
 
 export interface DjangoCollectStaticResult {

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -105,9 +105,22 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
       debug('Django hook: no manage.py detected, skipping');
       return;
     }
-    const settingsResult = await getDjangoSettings(projectDir, pythonEnv);
+    let settingsResult;
+    try {
+      settingsResult = await getDjangoSettings(projectDir, pythonEnv);
+    } catch (err: any) {
+      let detail: string;
+      if (err?.code === 'ENOENT') {
+        detail = `command not found: python\nHint: activate a venv or run with \`uv run vercel dev\``;
+      } else {
+        detail = err?.stderr || err?.message || String(err);
+      }
+      throw new NowBuildError({
+        code: 'DJANGO_SETTINGS_FAILED',
+        message: `Failed to read Django application settings from ${projectDir}/manage.py:\n${detail}`,
+      });
+    }
     debug(`Django settings: ${JSON.stringify(settingsResult)}`);
-    if (!settingsResult) return;
     const { djangoSettings, settingsModule, djangoVersion } = settingsResult;
     if (djangoVersion) {
       console.log(`Django ${djangoVersion.join('.')} detected`);


### PR DESCRIPTION
Currently we instead silently fail and produce the generic message
about not finding an entrypoint.

This is particularly bad in the situation where a user runs `vc dev`
without activating their venv, and currently we produce a completely
wrong error.
