### PR TITLE
Suppress warning message about implicit `public/**/*` builders not matching

### DIFF
--- a/.changeset/real-lamps-fly.md
+++ b/.changeset/real-lamps-fly.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Suppress warning message about implicit `public/**/*` builders not matching

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -591,7 +591,11 @@ export async function getBuildMatches(
       .map(name => join(cwd, name));
 
     if (files.length === 0) {
-      noMatches.push(buildConfig);
+      // Don't warn about zero-config static builders (e.g. public/**)
+      // when the directory simply doesn't exist.
+      if (!(config.zeroConfig && use === '@vercel/static')) {
+        noMatches.push(buildConfig);
+      }
     }
 
     for (const file of files) {


### PR DESCRIPTION
For a bunch of frameworks, and in some other cases, we create implicit
static builders for things like `public/**/*`, which may not match
anything.

That generates a warning which produces a lot of spam when running
`vc dev`.
