### PR TITLE
[python] Always make the path name for a python service be `/index`

### DIFF
--- a/.changeset/shiny-pianos-sleep.md
+++ b/.changeset/shiny-pianos-sleep.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Always make the path name for a python service be `/index`

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -723,9 +723,7 @@ from vercel_runtime.vc_init import vc_handler
   // If there is a service name, we need to mount this under the
   // service properly, for a V2 build.
   // TODO: Ideally this should be handled by writeBuildResultV2.
-  const lambdaPath = service?.name
-    ? `_svc/${service.name}/index`
-    : entrypoint.replace(/\.py$/, '');
+  const lambdaPath = service?.name ? `_svc/${service.name}/index` : 'index';
   const staticFiles = djangoStatic?.cdnOutputDir
     ? await glob('**', { cwd: djangoStatic.cdnOutputDir })
     : {};

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1432,9 +1432,9 @@ describe('Django entrypoint discovery', () => {
     const v2result = getBuildOutputV2(result);
     expect(v2result.routes).toContainEqual({ handle: 'filesystem' });
     expect(v2result.routes).toContainEqual(
-      expect.objectContaining({ src: '/(.*)', dest: '/myapp/wsgi' })
+      expect.objectContaining({ src: '/(.*)', dest: '/index' })
     );
-    const lambda = v2result.output['myapp/wsgi'];
+    const lambda = v2result.output['index'];
     expect(lambda).toBeDefined(); // Lambda keyed by entrypoint sans extension
     expect((lambda as any).files?.['static/app.css']).toBeDefined(); // Included in Lambda bundle
     expect(v2result.output['static/app.css']).toBeDefined(); // Static file from collectstatic


### PR DESCRIPTION
Follow up for https://github.com/vercel/vercel/pull/15696#issuecomment-4159064245
