### PR TITLE
Add routing rules reference to Vercel CLI skill

### DIFF
--- a/.changeset/nine-tomatoes-add.md
+++ b/.changeset/nine-tomatoes-add.md
@@ -1,4 +1,5 @@
 ---
+'vercel': patch
 ---
 
 Add routing rules reference to the Vercel CLI skill for AI agents

--- a/.changeset/nine-tomatoes-add.md
+++ b/.changeset/nine-tomatoes-add.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Add routing rules reference to the Vercel CLI skill for AI agents
+Add routing rules reference to the Vercel CLI skill

--- a/.changeset/routes-skill-file.md
+++ b/.changeset/routes-skill-file.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add routing rules reference to the Vercel CLI skill for AI agents

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -45,12 +45,12 @@ Use this to route to the correct reference file:
 - **Logs, debugging, or accessing preview deploys** → `references/monitoring-and-debugging.md`
 - **Blob storage** → `references/storage.md`
 - **Integrations (databases, storage, etc.)** → `references/integrations.md`
+- **Routing rules** → `references/routing.md`
 - **Access a preview deployment** → use `vercel curl` (see `references/monitoring-and-debugging.md`)
 - **CLI doesn't have a command for it** → use `vercel api` as a fallback (see `references/advanced.md`)
 - **Node.js backends (Express, Hono, etc.)** → `references/node-backends.md`
 - **Monorepos (Turborepo, Nx, workspaces)** → `references/monorepos.md`
 - **Bun runtime** → `references/bun.md`
-- **Routing rules** → `references/routing.md`
 - **Feature flags** → `references/flags.md`
 - **Advanced (API, webhooks)** → `references/advanced.md`
 - **Global flags** → `references/global-options.md`

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -50,6 +50,7 @@ Use this to route to the correct reference file:
 - **Node.js backends (Express, Hono, etc.)** → `references/node-backends.md`
 - **Monorepos (Turborepo, Nx, workspaces)** → `references/monorepos.md`
 - **Bun runtime** → `references/bun.md`
+- **Routing rules** → `references/routing.md`
 - **Feature flags** → `references/flags.md`
 - **Advanced (API, webhooks)** → `references/advanced.md`
 - **Global flags** → `references/global-options.md`

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -2,11 +2,23 @@
 
 ## Overview
 
-`vercel routes` manages project-level CDN routing rules. These take effect immediately without a deployment and take precedence over routes defined in your deployment configuration (`vercel.json`, `next.config.js`, etc.).
+`vercel routes` manages project-level routing rules. Each rule matches requests by path pattern and optional conditions (headers, cookies, query params), then applies an action (rewrite, redirect, set status) or modifies headers and query params.
 
-All changes are staged as drafts before going live. After making changes, run `vercel routes publish` to push them to production, or `vercel routes discard-staging` to undo.
+Routing rules take effect immediately without a deployment and take precedence over routes defined in your deployment configuration (`vercel.json`, `next.config.js`, etc.).
+
+All changes are staged as drafts. After a single change with no existing draft, the CLI offers to publish immediately. Otherwise, run `vercel routes publish` to push staged changes to production, or `vercel routes discard-staging` to undo.
+
+When in doubt about flags or subcommands, use `--help`:
+
+```bash
+vercel routes -h             # list subcommands
+vercel routes add -h         # flags for add
+vercel routes edit -h        # flags for edit
+```
 
 ## Viewing Routing Rules
+
+Use `list` to see all routing rules and `inspect` for full details on a specific rule.
 
 ```bash
 vercel routes list                       # all routing rules
@@ -21,15 +33,17 @@ vercel routes inspect "My Route" --diff  # compare staged vs production
 
 ## Creating Routing Rules
 
-### Source path syntax (`--src-syntax`)
+### Source path (`--src` and `--src-syntax`)
 
-| Syntax | Default | Example | When to use |
-|--------|---------|---------|-------------|
-| `regex` | Yes | `^/api/(.*)$` | Full regex control. Default if not specified. |
-| `path-to-regexp` | No | `/api/:path*` | Express-style named params. More readable. |
-| `equals` | No | `/about` | Exact string match. Simplest option. |
+Use `--src` to specify the path pattern and `--src-syntax` to control how it's interpreted:
 
-`path-to-regexp` and `equals` paths must start with `/`. Only `regex` allows patterns without a leading `/`.
+| Syntax | Example | When to use |
+|--------|---------|-------------|
+| `regex` | `^/api/(.*)$` | Full regex control. |
+| `path-to-regexp` | `/api/:path*` | Express-style named params. More readable. |
+| `equals` | `/about` | Exact string match. Simplest option. |
+
+Defaults to `regex` if `--src-syntax` is not specified. `path-to-regexp` and `equals` paths must start with `/`.
 
 ### Actions
 
@@ -67,11 +81,12 @@ vercel routes add "CORS" \
   --src "^/api/.*$" \
   --set-response-header "Access-Control-Allow-Origin=*" --yes
 
-# Routing rule with conditions — redirect if auth cookie missing
+# Routing rule with conditions and a description
 vercel routes add "Auth Required" \
   --src "/dashboard/:path*" --src-syntax path-to-regexp \
   --action redirect --dest "/login" --status 307 \
-  --missing "cookie:session" --yes
+  --missing "cookie:session" \
+  --description "Redirect unauthenticated users to login" --yes
 
 # Control position in priority order
 vercel routes add "Priority Route" \
@@ -82,11 +97,11 @@ vercel routes add "Priority Route" \
 
 ## Conditions
 
-Control when a routing rule matches using `--has` (must match) and `--missing` (must not match). Repeatable, max 16 total.
+Used with `--has` and `--missing` flags on both `add` and `edit` commands. Repeatable.
 
 **Types:** `header`, `cookie`, `query`, `host`
 
-**Formats:**
+Max 16 conditions per routing rule (has + missing combined).
 
 ```bash
 # Existence check
@@ -106,7 +121,7 @@ Control when a routing rule matches using `--has` (must match) and `--missing` (
 
 ## Response Headers & Request Transforms
 
-Modify headers and query params on the request or response. All flags are repeatable.
+Used on both `add` and `edit` commands. Applied at the CDN level — response headers are set before the response reaches the client, request transforms are applied before the request reaches the origin. All flags are repeatable.
 
 ```bash
 # Response headers
@@ -132,7 +147,7 @@ vercel routes edit "My Route" --ai "Add CORS headers and change to 308 redirect"
 # Interactive — pick fields to edit
 vercel routes edit "My Route"
 
-# Change specific fields (other fields preserved)
+# Only the specified fields are changed; everything else is preserved
 vercel routes edit "My Route" --dest "https://new-api.example.com/:path*" --yes
 vercel routes edit "My Route" --action redirect --dest "/new" --status 301 --yes
 vercel routes edit "My Route" --name "New Name" --yes
@@ -146,6 +161,8 @@ vercel routes edit "My Route" --clear-transforms --yes
 ```
 
 ## Managing Routing Rules
+
+Use `vercel routes list` or `inspect` to find routing rule names and IDs.
 
 ```bash
 vercel routes enable "My Route"           # enable a disabled routing rule
@@ -163,8 +180,8 @@ vercel routes reorder "My Route" --position before:<id>     # move before anothe
 vercel routes publish                    # promote staged changes to production
 vercel routes discard-staging            # discard all staged changes
 vercel routes list-versions              # view version history
-vercel routes restore <version-id>       # restore a previous version
-vercel routes export                     # export as vercel.json/vercel.ts format
+vercel routes restore <version-id>       # roll back to a previous version
+vercel routes export                     # export routing rules in vercel.json or vercel.ts format
 ```
 
 ## Anti-patterns

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -105,8 +105,6 @@ vercel routes add "Auth Required" \
 
 ## Editing Routing Rules
 
-Use `--ai` to describe changes in natural language, or use flags to change specific fields.
-
 ```bash
 # AI — describe the changes
 vercel routes edit "My Route" --ai "Add CORS headers and change to 308 redirect"

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -6,9 +6,21 @@
 
 All changes are staged as drafts before going live. After making changes, run `vercel routes publish` to push them to production, or `vercel routes discard-staging` to undo.
 
-## Actions
+## Creating Routing Rules
 
-A route can have at most one primary action:
+### Source path syntax (`--src-syntax`)
+
+| Syntax | Default | Example | When to use |
+|--------|---------|---------|-------------|
+| `regex` | Yes | `^/api/(.*)$` | Full regex control. Default if not specified. |
+| `path-to-regexp` | No | `/api/:path*` | Express-style named params. More readable. |
+| `equals` | No | `/about` | Exact string match. Simplest option. |
+
+`path-to-regexp` and `equals` paths must start with `/`. Only `regex` allows patterns without a leading `/`.
+
+### Actions
+
+Each routing rule can have at most one primary action:
 
 | Action | Required flags | Description |
 |--------|---------------|-------------|
@@ -16,22 +28,59 @@ A route can have at most one primary action:
 | `redirect` | `--dest` + `--status` (301/302/307/308) | Redirect the client to a new URL |
 | `set-status` | `--status` (100-599) | Return a status code (no destination) |
 
-A route can also have no primary action — only response headers or request transforms.
+Routing rules can also be used without a primary action to only set response headers or apply request transforms.
+
+### Examples
+
+```bash
+# AI — describe what you want
+vercel routes add --ai "Rewrite /api/* to https://backend.example.com/*"
+
+# Interactive — step by step
+vercel routes add
+
+# Rewrite with path-to-regexp syntax
+vercel routes add "API Proxy" \
+  --src "/api/:path*" --src-syntax path-to-regexp \
+  --action rewrite --dest "https://api.example.com/:path*" --yes
+
+# Redirect with status
+vercel routes add "Legacy Redirect" \
+  --src "/old-blog" --src-syntax equals \
+  --action redirect --dest "/blog" --status 301 --yes
+
+# Response headers only (no primary action)
+vercel routes add "CORS" \
+  --src "^/api/.*$" \
+  --set-response-header "Access-Control-Allow-Origin=*" --yes
+
+# Routing rule with conditions — redirect if auth cookie missing
+vercel routes add "Auth Required" \
+  --src "/dashboard/:path*" --src-syntax path-to-regexp \
+  --action redirect --dest "/login" --status 307 \
+  --missing "cookie:session" --yes
+
+# Control position in priority order
+vercel routes add "Priority Route" \
+  --src "/critical" --src-syntax equals \
+  --action rewrite --dest "/handler" \
+  --position start --yes
+```
 
 ## Conditions
 
-Control when a route matches using `--has` (must match) and `--missing` (must not match). Repeatable, max 16 total.
+Control when a routing rule matches using `--has` (must match) and `--missing` (must not match). Repeatable, max 16 total.
 
 **Types:** `header`, `cookie`, `query`, `host`
 
 **Formats:**
 
 ```bash
-# Existence check — does the header/cookie/query exist?
+# Existence check
 --has "cookie:session"
 --missing "header:Authorization"
 
-# Value matching — check the actual value
+# Value matching
 --has "header:X-API-Key:eq=my-secret"          # exact match
 --has "cookie:theme:contains=dark"              # value contains substring
 --has "header:Accept:re=application/json.*"     # regex match
@@ -61,56 +110,7 @@ Modify headers and query params on the request or response. All flags are repeat
 --delete-request-query "debug"
 ```
 
-## Creating Routes
-
-### Source path syntax (`--src-syntax`)
-
-| Syntax | Default | Example | When to use |
-|--------|---------|---------|-------------|
-| `regex` | Yes | `^/api/(.*)$` | Full regex control. Default if not specified. |
-| `path-to-regexp` | No | `/api/:path*` | Express-style named params. More readable. |
-| `equals` | No | `/about` | Exact string match. Simplest option. |
-
-`path-to-regexp` and `equals` paths must start with `/`. Only `regex` allows patterns without a leading `/`.
-
-### Examples
-
-```bash
-# AI — describe what you want
-vercel routes add --ai "Rewrite /api/* to https://backend.example.com/*"
-
-# Interactive — step by step
-vercel routes add
-
-# Flags — full control
-vercel routes add "API Proxy" \
-  --src "/api/:path*" --src-syntax path-to-regexp \
-  --action rewrite --dest "https://api.example.com/:path*" --yes
-
-# Redirect with status
-vercel routes add "Legacy Redirect" \
-  --src "/old-blog" --src-syntax equals \
-  --action redirect --dest "/blog" --status 301 --yes
-
-# CORS headers (no primary action, just headers)
-vercel routes add "CORS" \
-  --src "^/api/.*$" \
-  --set-response-header "Access-Control-Allow-Origin=*" --yes
-
-# Route with conditions — redirect if auth cookie missing
-vercel routes add "Auth Required" \
-  --src "/dashboard/:path*" --src-syntax path-to-regexp \
-  --action redirect --dest "/login" --status 307 \
-  --missing "cookie:session" --yes
-
-# Control position in priority order
-vercel routes add "Priority Route" \
-  --src "/critical" --src-syntax equals \
-  --action rewrite --dest "/handler" \
-  --position start --yes
-```
-
-## Editing Routes
+## Editing Routing Rules
 
 ```bash
 # AI — describe the changes
@@ -132,28 +132,28 @@ vercel routes edit "My Route" --clear-headers --yes
 vercel routes edit "My Route" --clear-transforms --yes
 ```
 
-## Managing Routes
+## Managing Routing Rules
 
 ```bash
-vercel routes enable "My Route"           # enable a disabled route
+vercel routes enable "My Route"           # enable a disabled routing rule
 vercel routes disable "My Route"          # disable without removing
-vercel routes delete "My Route"           # delete a route
+vercel routes delete "My Route"           # delete a routing rule
 vercel routes reorder "My Route" --position start           # move to top
 vercel routes reorder "My Route" --position end             # move to bottom
 vercel routes reorder "My Route" --position after:<id>      # move after another
 vercel routes reorder "My Route" --position before:<id>     # move before another
 ```
 
-## Viewing Routes
+## Viewing Routing Rules
 
 ```bash
-vercel routes list                       # all routes
+vercel routes list                       # all routing rules
 vercel routes list --diff                # staged changes vs production
 vercel routes list --production          # production only
 vercel routes list --search "api"        # search by name, src, dest
 vercel routes list --filter rewrite      # filter: rewrite, redirect, set_status, transform
 vercel routes list --expand              # show expanded details
-vercel routes inspect "My Route"         # full details of a specific route
+vercel routes inspect "My Route"         # full details of a specific routing rule
 vercel routes inspect "My Route" --diff  # compare staged vs production
 ```
 

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -2,64 +2,134 @@
 
 ## Overview
 
-The `vercel routes` command manages project-level routing rules. These rules take effect immediately without requiring a deployment and take precedence over routes defined in your deployment configuration (`vercel.json`, `next.config.js`, etc.).
+`vercel routes` manages project-level CDN routing rules. These take effect immediately without a deployment and take precedence over routes defined in your deployment configuration (`vercel.json`, `next.config.js`, etc.).
 
-All changes go through a **draft workflow** — stage changes, review, then publish to production.
+All changes are staged as drafts before going live. After making changes, run `vercel routes publish` to push them to production, or `vercel routes discard-staging` to undo.
 
-## Draft Workflow
+## Source Path Syntax
+
+Three pattern types via `--src-syntax`:
+
+| Syntax | Default | Example | When to use |
+|--------|---------|---------|-------------|
+| `regex` | Yes | `^/api/(.*)$` | Full regex control. Default if `--src-syntax` is not specified. |
+| `path-to-regexp` | No | `/api/:path*` | Express-style named params. More readable for dynamic routes. |
+| `equals` | No | `/about` | Exact string match. Simplest option for static paths. |
+
+`path-to-regexp` and `equals` paths must start with `/`. Only `regex` allows patterns without a leading `/`.
+
+## Actions
+
+Every route needs an action. Specify with `--action`:
+
+| Action | Required flags | Description |
+|--------|---------------|-------------|
+| `rewrite` | `--dest` | Proxy to destination URL (transparent to the client) |
+| `redirect` | `--dest` + `--status` (301/302/307/308) | Redirect the client to a new URL |
+| `set-status` | `--status` (100-599) | Return a status code (no destination) |
+
+A route can also have only response headers or request transforms (no `--action` needed).
+
+## Conditions
+
+Control when a route matches using `--has` (must match) and `--missing` (must not match). Repeatable, max 16 total.
+
+**Types:** `header`, `cookie`, `query`, `host`
+
+**Formats:**
 
 ```bash
-vercel routes list --diff      # see staged vs production changes
-vercel routes publish           # promote staged changes to production
-vercel routes discard-staging   # discard all staged changes
+# Existence check — does the header/cookie/query exist?
+--has "cookie:session"
+--missing "header:Authorization"
+
+# Value matching — check the actual value
+--has "header:X-API-Key:eq=my-secret"          # exact match
+--has "cookie:theme:contains=dark"              # value contains substring
+--has "header:Accept:re=application/json.*"     # regex match
+--missing "query:debug:eq=true"                 # must NOT have debug=true
+
+# Host matching (no key, just value)
+--has "host:eq=example.com"
+--has "host:contains=staging"
 ```
 
-## Viewing Routes
+## Response Headers & Request Transforms
+
+Modify headers and query params on the request or response. All flags are repeatable.
 
 ```bash
-vercel routes list                          # list all routes (shows draft state)
-vercel routes list --diff                   # show staged changes vs production
-vercel routes list --production             # show only production routes
-vercel routes inspect "My Route"            # full details of a specific route
-vercel routes inspect "My Route" --diff     # compare staged vs production
+# Response headers
+--set-response-header "Cache-Control=public, max-age=3600"
+--append-response-header "X-Custom=value"
+--delete-response-header "X-Powered-By"
+
+# Request headers (before forwarding to destination)
+--set-request-header "X-Forwarded-Host=myapp.com"
+--delete-request-header "Cookie"
+
+# Request query params
+--set-request-query "version=2"
+--delete-request-query "debug"
 ```
 
 ## Creating Routes
 
-Four creation modes — AI, interactive, flags, or JSON:
-
 ```bash
-# AI (natural language)
-vercel routes add --ai "Redirect /old to /new with 301"
+# AI — describe what you want
+vercel routes add --ai "Rewrite /api/* to https://backend.example.com/*"
 
-# Interactive (step by step)
+# Interactive — step by step
 vercel routes add
 
-# Flags
+# Flags — full control
 vercel routes add "API Proxy" \
-  --src "/api/:path*" \
-  --dest "https://api.example.com/:path*" \
-  --action rewrite
+  --src "/api/:path*" --src-syntax path-to-regexp \
+  --action rewrite --dest "https://api.example.com/:path*" --yes
 
 # Redirect with status
 vercel routes add "Legacy Redirect" \
-  --src "/old-path" \
-  --dest "/new-path" \
-  --action redirect --status 301
+  --src "/old-blog" --src-syntax equals \
+  --action redirect --dest "/blog" --status 301 --yes
+
+# CORS headers (no action, just headers)
+vercel routes add "CORS" \
+  --src "^/api/.*$" \
+  --set-response-header "Access-Control-Allow-Origin=*" --yes
+
+# Route with conditions — require auth cookie with specific value
+vercel routes add "Auth Required" \
+  --src "/dashboard/:path*" --src-syntax path-to-regexp \
+  --action redirect --dest "/login" --status 307 \
+  --missing "cookie:session" --yes
+
+# Control position in priority order
+vercel routes add "Priority Route" \
+  --src "/critical" --src-syntax equals \
+  --action rewrite --dest "/handler" \
+  --position start --yes
 ```
 
 ## Editing Routes
 
 ```bash
-# AI
-vercel routes edit "My Route" --ai "Add CORS headers"
+# AI — describe the changes
+vercel routes edit "My Route" --ai "Add CORS headers and change to 308 redirect"
 
-# Interactive (field by field)
+# Interactive — pick fields to edit
 vercel routes edit "My Route"
 
-# Flags (partial overrides — only specified fields change)
-vercel routes edit "My Route" --dest "https://new-api.example.com/:path*"
-vercel routes edit "My Route" --action redirect --dest "/new" --status 301
+# Change specific fields (other fields preserved)
+vercel routes edit "My Route" --dest "https://new-api.example.com/:path*" --yes
+vercel routes edit "My Route" --action redirect --dest "/new" --status 301 --yes
+vercel routes edit "My Route" --name "New Name" --yes
+
+# Clear and replace conditions
+vercel routes edit "My Route" --clear-conditions --has "header:Authorization" --yes
+
+# Clear all response headers or transforms
+vercel routes edit "My Route" --clear-headers --yes
+vercel routes edit "My Route" --clear-transforms --yes
 ```
 
 ## Managing Routes
@@ -67,47 +137,39 @@ vercel routes edit "My Route" --action redirect --dest "/new" --status 301
 ```bash
 vercel routes enable "My Route"           # enable a disabled route
 vercel routes disable "My Route"          # disable without removing
-vercel routes remove "My Route"           # delete a route
-vercel routes reorder "My Route" --position start   # move to top
-vercel routes reorder "My Route" --position after:<id>  # move after another
+vercel routes delete "My Route"           # delete a route
+vercel routes reorder "My Route" --position start           # move to top
+vercel routes reorder "My Route" --position end             # move to bottom
+vercel routes reorder "My Route" --position after:<id>      # move after another
+vercel routes reorder "My Route" --position before:<id>     # move before another
 ```
 
-## Key Concepts
-
-- **Priority order**: Routes are evaluated top to bottom. Use `reorder` to change priority.
-- **Source pattern**: The URL path to match. Supports `path-to-regexp` syntax (`:param`, `*`, `(.*)`).
-- **Actions**: `rewrite` (proxy to destination), `redirect` (301/302/307/308), `set-status` (return status code).
-- **Conditions**: `--has` and `--missing` check for headers, cookies, query params, or host.
-- **Response headers**: Set, append, or delete headers on the response.
-- **Request transforms**: Modify request headers and query params before forwarding.
-
-## Conditions
+## Viewing Routes
 
 ```bash
-# Route only matches if Authorization header exists
-vercel routes add "Auth API" \
-  --src "/api/:path*" \
-  --dest "https://api.example.com/:path*" \
-  --action rewrite \
-  --has "header:Authorization"
-
-# Route only matches if session cookie is missing
-vercel routes add "Login Redirect" \
-  --src "/dashboard" \
-  --dest "/login" \
-  --action redirect --status 302 \
-  --missing "cookie:session"
+vercel routes list                       # all routes
+vercel routes list --diff                # staged changes vs production
+vercel routes list --production          # production only
+vercel routes list --search "api"        # search by name, src, dest
+vercel routes list --filter rewrite      # filter: rewrite, redirect, set_status, transform
+vercel routes list --expand              # show expanded details
+vercel routes inspect "My Route"         # full details of a specific route
+vercel routes inspect "My Route" --diff  # compare staged vs production
 ```
 
-## JSON Output
+## Publishing & Versioning
 
 ```bash
-vercel routes list --json          # machine-readable route list
-vercel routes inspect "My Route" --json   # single route as JSON
+vercel routes publish                    # promote staged changes to production
+vercel routes discard-staging            # discard all staged changes
+vercel routes list-versions              # view version history
+vercel routes restore <version-id>       # restore a previous version
+vercel routes export                     # export as vercel.json/vercel.ts format
 ```
 
-## Anti-Patterns
+## Anti-patterns
 
 - Don't forget to `vercel routes publish` after making changes — they stay staged until published.
-- Don't use `--production` flag when you want to see draft state — it only shows live routes.
-- Use `--yes` in CI to skip confirmation prompts.
+- Don't use `--production` when you want to see draft changes — it only shows live routes.
+- Use `--yes` in CI/automation to skip confirmation prompts.
+- `--action redirect` requires both `--dest` AND `--status` — omitting either will error.

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`vercel routes` manages project-level routing rules. Each rule matches requests by path pattern and optional conditions (headers, cookies, query params), then applies an action (rewrite, redirect, set status) or modifies headers and query params.
+`vercel routes` manages project-level routing rules. Each rule matches requests by path pattern and optional conditions (headers, cookies, query parameters), then applies an action (rewrite, redirect, set status) or modifies headers and query parameters. Use `--ai` with a natural language description to generate or edit rules with AI.
 
 Routing rules take effect immediately without a deployment and take precedence over routes defined in your deployment configuration (`vercel.json`, `next.config.js`, etc.).
 
@@ -10,27 +10,12 @@ Each routing rule has a unique name within the project, used to identify it in `
 
 All changes are staged as drafts. Run `vercel routes publish` to push staged changes to production.
 
-When in doubt about flags or subcommands, use `--help`:
-
-```bash
-vercel routes -h             # list subcommands
-vercel routes add -h         # flags for add
-vercel routes edit -h        # flags for edit
-```
-
 ## Viewing Routing Rules
-
-Use `list` to see all routing rules and `inspect` for full details on a specific rule.
 
 ```bash
 vercel routes list                       # all routing rules
 vercel routes list --diff                # staged changes vs production
-vercel routes list --production          # production only
-vercel routes list --search "api"        # search by name, src, dest
-vercel routes list --filter rewrite      # filter: rewrite, redirect, set_status, transform
-vercel routes list --expand              # show expanded details
-vercel routes inspect "My Route"         # full details of a specific routing rule
-vercel routes inspect "My Route" --diff  # compare staged vs production
+vercel routes inspect "My Route"         # full details of a specific rule
 ```
 
 ## Creating Routing Rules
@@ -78,32 +63,17 @@ vercel routes add "Legacy Redirect" \
   --src "/old-blog" --src-syntax equals \
   --action redirect --dest "/blog" --status 301 --yes
 
-# Response headers only (no primary action)
-vercel routes add "CORS" \
-  --src "^/api/.*$" \
-  --set-response-header "Access-Control-Allow-Origin=*" --yes
-
 # Routing rule with conditions and a description
 vercel routes add "Auth Required" \
   --src "/dashboard/:path*" --src-syntax path-to-regexp \
   --action redirect --dest "/login" --status 307 \
   --missing "cookie:session" \
   --description "Redirect unauthenticated users to login" --yes
-
-# Control position in priority order
-vercel routes add "Priority Route" \
-  --src "/critical" --src-syntax equals \
-  --action rewrite --dest "/handler" \
-  --position start --yes
 ```
 
 ## Conditions
 
-Used with `--has` and `--missing` flags on both `add` and `edit` commands. Repeatable.
-
-**Types:** `header`, `cookie`, `query`, `host`
-
-Max 16 conditions per routing rule (has + missing combined).
+Conditions control when a routing rule matches. Use `--has` to require something is present, and `--missing` to require it is absent. Supported types are `header`, `cookie`, `query`, and `host`. Conditions are repeatable, up to 16 per rule.
 
 ```bash
 # Existence check
@@ -118,25 +88,15 @@ Max 16 conditions per routing rule (has + missing combined).
 
 # Host matching (no key, just value)
 --has "host:eq=example.com"
---has "host:contains=staging"
 ```
 
 ## Response Headers & Request Transforms
 
-Used on both `add` and `edit` commands. Applied at the CDN level — response headers are set before the response reaches the client, request transforms are applied before the request reaches the origin. All flags are repeatable.
+Modify headers and query parameters on the request or response. All flags support `set`, `append`, and `delete` variants for each type (`response-header`, `request-header`, `request-query`). All are repeatable.
 
 ```bash
-# Response headers
 --set-response-header "Cache-Control=public, max-age=3600"
---append-response-header "X-Custom=value"
---delete-response-header "X-Powered-By"
-
-# Request headers (before forwarding to destination)
---set-request-header "X-Forwarded-Host=myapp.com"
---delete-request-header "Cookie"
-
-# Request query params
---set-request-query "version=2"
+--append-request-header "X-Forwarded-Host=myapp.com"
 --delete-request-query "debug"
 ```
 
@@ -153,13 +113,6 @@ vercel routes edit "My Route"
 vercel routes edit "My Route" --dest "https://new-api.example.com/:path*" --yes
 vercel routes edit "My Route" --action redirect --dest "/new" --status 301 --yes
 vercel routes edit "My Route" --name "New Name" --yes
-
-# Clear and replace conditions
-vercel routes edit "My Route" --clear-conditions --has "header:Authorization" --yes
-
-# Clear all response headers or transforms
-vercel routes edit "My Route" --clear-headers --yes
-vercel routes edit "My Route" --clear-transforms --yes
 ```
 
 ## Managing Routing Rules
@@ -185,8 +138,3 @@ vercel routes list-versions              # view version history
 vercel routes restore <version-id>       # roll back to a previous version
 vercel routes export                     # export routing rules in vercel.json or vercel.ts format
 ```
-
-## Anti-patterns
-
-- Don't forget to `vercel routes publish` after making changes — they stay staged until published.
-- `--action redirect` requires both `--dest` AND `--status` — omitting either will error.

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -81,7 +81,7 @@ Response headers, request headers, and request query parameters can each be set,
 # AI — describe what you want
 vercel routes add --ai "Rewrite /api/* to https://backend.example.com/*"
 
-# Interactive — step by step
+# Interactive — guided builder with prompts
 vercel routes add
 
 # Rewrite with path-to-regexp syntax and a request header
@@ -111,7 +111,7 @@ Use `--ai` to describe changes in natural language, or use flags to change speci
 # AI — describe the changes
 vercel routes edit "My Route" --ai "Add CORS headers and change to 308 redirect"
 
-# Interactive — pick fields to edit
+# Interactive — choose which fields to modify
 vercel routes edit "My Route"
 
 # Change specific fields

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -95,7 +95,7 @@ Conditions control when a routing rule matches. Use `--has` to require something
 
 ## Response Headers & Request Transforms
 
-Modify headers and query parameters on the request or response. All flags support `set`, `append`, and `delete` variants for each type (`response-header`, `request-header`, `request-query`). All are repeatable.
+Response headers, request headers, and request query parameters can each be set, appended to, or deleted. All flags are repeatable.
 
 ```bash
 --set-response-header "Cache-Control=public, max-age=3600"

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`vercel routes` manages project-level routing rules. Each rule matches requests by path pattern and optional conditions (headers, cookies, query parameters), then applies an action (rewrite, redirect, set status) or modifies headers and query parameters. Use `--ai` with a natural language description to generate or edit rules with AI.
+`vercel routes` manages project-level routing rules. Each rule matches requests by path pattern and optional conditions (headers, cookies, query parameters), then applies an action (rewrite, redirect, set status) or modifies headers and query parameters.
 
 Routing rules take effect immediately without a deployment and take precedence over routes defined in your deployment configuration (`vercel.json`, `next.config.js`, etc.).
 
@@ -19,6 +19,8 @@ vercel routes inspect "My Route"         # full details of a specific rule
 ```
 
 ## Creating Routing Rules
+
+Use `--ai` with a natural language description to generate routing rules with AI. For full control, use flags or interactive mode.
 
 ### Source path (`--src` and `--src-syntax`)
 
@@ -53,10 +55,11 @@ vercel routes add --ai "Rewrite /api/* to https://backend.example.com/*"
 # Interactive — step by step
 vercel routes add
 
-# Rewrite with path-to-regexp syntax
+# Rewrite with path-to-regexp syntax and a request header
 vercel routes add "API Proxy" \
   --src "/api/:path*" --src-syntax path-to-regexp \
-  --action rewrite --dest "https://api.example.com/:path*" --yes
+  --action rewrite --dest "https://api.example.com/:path*" \
+  --set-request-header "X-Forwarded-Host=myapp.com" --yes
 
 # Redirect with status
 vercel routes add "Legacy Redirect" \
@@ -136,5 +139,4 @@ vercel routes publish                    # promote staged changes to production
 vercel routes discard-staging            # discard all staged changes
 vercel routes list-versions              # view version history
 vercel routes restore <version-id>       # roll back to a previous version
-vercel routes export                     # export routing rules in vercel.json or vercel.ts format
 ```

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -46,6 +46,35 @@ Each routing rule can have at most one primary action:
 
 A routing rule without a primary action can still set response headers or apply request transforms.
 
+### Conditions
+
+Conditions control when a routing rule matches. Use `--has` to require something is present, and `--missing` to require it is absent. Supported types are `header`, `cookie`, `query`, and `host`. Conditions are repeatable, up to 16 per rule.
+
+```bash
+# Existence check
+--has "cookie:session"
+--missing "header:Authorization"
+
+# Value matching
+--has "header:X-API-Key:eq=my-secret"          # exact match
+--has "cookie:theme:contains=dark"              # value contains substring
+--has "header:Accept:re=application/json.*"     # regex match
+--missing "query:debug:eq=true"                 # must NOT have debug=true
+
+# Host matching (no key, just value)
+--has "host:eq=example.com"
+```
+
+### Response headers & request transforms
+
+Response headers, request headers, and request query parameters can each be set, appended to, or deleted. All flags are repeatable.
+
+```bash
+--set-response-header "Cache-Control=public, max-age=3600"
+--append-request-header "X-Forwarded-Host=myapp.com"
+--delete-request-query "debug"
+```
+
 ### Examples
 
 ```bash
@@ -74,36 +103,9 @@ vercel routes add "Auth Required" \
   --description "Redirect unauthenticated users to login" --yes
 ```
 
-## Conditions
-
-Conditions control when a routing rule matches. Use `--has` to require something is present, and `--missing` to require it is absent. Supported types are `header`, `cookie`, `query`, and `host`. Conditions are repeatable, up to 16 per rule.
-
-```bash
-# Existence check
---has "cookie:session"
---missing "header:Authorization"
-
-# Value matching
---has "header:X-API-Key:eq=my-secret"          # exact match
---has "cookie:theme:contains=dark"              # value contains substring
---has "header:Accept:re=application/json.*"     # regex match
---missing "query:debug:eq=true"                 # must NOT have debug=true
-
-# Host matching (no key, just value)
---has "host:eq=example.com"
-```
-
-## Response Headers & Request Transforms
-
-Response headers, request headers, and request query parameters can each be set, appended to, or deleted. All flags are repeatable.
-
-```bash
---set-response-header "Cache-Control=public, max-age=3600"
---append-request-header "X-Forwarded-Host=myapp.com"
---delete-request-query "debug"
-```
-
 ## Editing Routing Rules
+
+Use `--ai` to describe changes in natural language, or use flags to change specific fields.
 
 ```bash
 # AI — describe the changes

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -6,6 +6,19 @@
 
 All changes are staged as drafts before going live. After making changes, run `vercel routes publish` to push them to production, or `vercel routes discard-staging` to undo.
 
+## Viewing Routing Rules
+
+```bash
+vercel routes list                       # all routing rules
+vercel routes list --diff                # staged changes vs production
+vercel routes list --production          # production only
+vercel routes list --search "api"        # search by name, src, dest
+vercel routes list --filter rewrite      # filter: rewrite, redirect, set_status, transform
+vercel routes list --expand              # show expanded details
+vercel routes inspect "My Route"         # full details of a specific routing rule
+vercel routes inspect "My Route" --diff  # compare staged vs production
+```
+
 ## Creating Routing Rules
 
 ### Source path syntax (`--src-syntax`)
@@ -142,19 +155,6 @@ vercel routes reorder "My Route" --position start           # move to top
 vercel routes reorder "My Route" --position end             # move to bottom
 vercel routes reorder "My Route" --position after:<id>      # move after another
 vercel routes reorder "My Route" --position before:<id>     # move before another
-```
-
-## Viewing Routing Rules
-
-```bash
-vercel routes list                       # all routing rules
-vercel routes list --diff                # staged changes vs production
-vercel routes list --production          # production only
-vercel routes list --search "api"        # search by name, src, dest
-vercel routes list --filter rewrite      # filter: rewrite, redirect, set_status, transform
-vercel routes list --expand              # show expanded details
-vercel routes inspect "My Route"         # full details of a specific routing rule
-vercel routes inspect "My Route" --diff  # compare staged vs production
 ```
 
 ## Publishing & Versioning

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -6,21 +6,9 @@
 
 All changes are staged as drafts before going live. After making changes, run `vercel routes publish` to push them to production, or `vercel routes discard-staging` to undo.
 
-## Source Path Syntax
-
-Three pattern types via `--src-syntax`:
-
-| Syntax | Default | Example | When to use |
-|--------|---------|---------|-------------|
-| `regex` | Yes | `^/api/(.*)$` | Full regex control. Default if `--src-syntax` is not specified. |
-| `path-to-regexp` | No | `/api/:path*` | Express-style named params. More readable for dynamic routes. |
-| `equals` | No | `/about` | Exact string match. Simplest option for static paths. |
-
-`path-to-regexp` and `equals` paths must start with `/`. Only `regex` allows patterns without a leading `/`.
-
 ## Actions
 
-Every route needs an action. Specify with `--action`:
+A route can have at most one primary action:
 
 | Action | Required flags | Description |
 |--------|---------------|-------------|
@@ -28,7 +16,7 @@ Every route needs an action. Specify with `--action`:
 | `redirect` | `--dest` + `--status` (301/302/307/308) | Redirect the client to a new URL |
 | `set-status` | `--status` (100-599) | Return a status code (no destination) |
 
-A route can also have only response headers or request transforms (no `--action` needed).
+A route can also have no primary action — only response headers or request transforms.
 
 ## Conditions
 
@@ -75,6 +63,18 @@ Modify headers and query params on the request or response. All flags are repeat
 
 ## Creating Routes
 
+### Source path syntax (`--src-syntax`)
+
+| Syntax | Default | Example | When to use |
+|--------|---------|---------|-------------|
+| `regex` | Yes | `^/api/(.*)$` | Full regex control. Default if not specified. |
+| `path-to-regexp` | No | `/api/:path*` | Express-style named params. More readable. |
+| `equals` | No | `/about` | Exact string match. Simplest option. |
+
+`path-to-regexp` and `equals` paths must start with `/`. Only `regex` allows patterns without a leading `/`.
+
+### Examples
+
 ```bash
 # AI — describe what you want
 vercel routes add --ai "Rewrite /api/* to https://backend.example.com/*"
@@ -92,12 +92,12 @@ vercel routes add "Legacy Redirect" \
   --src "/old-blog" --src-syntax equals \
   --action redirect --dest "/blog" --status 301 --yes
 
-# CORS headers (no action, just headers)
+# CORS headers (no primary action, just headers)
 vercel routes add "CORS" \
   --src "^/api/.*$" \
   --set-response-header "Access-Control-Allow-Origin=*" --yes
 
-# Route with conditions — require auth cookie with specific value
+# Route with conditions — redirect if auth cookie missing
 vercel routes add "Auth Required" \
   --src "/dashboard/:path*" --src-syntax path-to-regexp \
   --action redirect --dest "/login" --status 307 \
@@ -170,6 +170,4 @@ vercel routes export                     # export as vercel.json/vercel.ts forma
 ## Anti-patterns
 
 - Don't forget to `vercel routes publish` after making changes — they stay staged until published.
-- Don't use `--production` when you want to see draft changes — it only shows live routes.
-- Use `--yes` in CI/automation to skip confirmation prompts.
 - `--action redirect` requires both `--dest` AND `--status` — omitting either will error.

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -1,0 +1,113 @@
+# Routing Rules
+
+## Overview
+
+The `vercel routes` command manages project-level routing rules. These rules take effect immediately without requiring a deployment and take precedence over routes defined in your deployment configuration (`vercel.json`, `next.config.js`, etc.).
+
+All changes go through a **draft workflow** — stage changes, review, then publish to production.
+
+## Draft Workflow
+
+```bash
+vercel routes list --diff      # see staged vs production changes
+vercel routes publish           # promote staged changes to production
+vercel routes discard-staging   # discard all staged changes
+```
+
+## Viewing Routes
+
+```bash
+vercel routes list                          # list all routes (shows draft state)
+vercel routes list --diff                   # show staged changes vs production
+vercel routes list --production             # show only production routes
+vercel routes inspect "My Route"            # full details of a specific route
+vercel routes inspect "My Route" --diff     # compare staged vs production
+```
+
+## Creating Routes
+
+Four creation modes — AI, interactive, flags, or JSON:
+
+```bash
+# AI (natural language)
+vercel routes add --ai "Redirect /old to /new with 301"
+
+# Interactive (step by step)
+vercel routes add
+
+# Flags
+vercel routes add "API Proxy" \
+  --src "/api/:path*" \
+  --dest "https://api.example.com/:path*" \
+  --action rewrite
+
+# Redirect with status
+vercel routes add "Legacy Redirect" \
+  --src "/old-path" \
+  --dest "/new-path" \
+  --action redirect --status 301
+```
+
+## Editing Routes
+
+```bash
+# AI
+vercel routes edit "My Route" --ai "Add CORS headers"
+
+# Interactive (field by field)
+vercel routes edit "My Route"
+
+# Flags (partial overrides — only specified fields change)
+vercel routes edit "My Route" --dest "https://new-api.example.com/:path*"
+vercel routes edit "My Route" --action redirect --dest "/new" --status 301
+```
+
+## Managing Routes
+
+```bash
+vercel routes enable "My Route"           # enable a disabled route
+vercel routes disable "My Route"          # disable without removing
+vercel routes remove "My Route"           # delete a route
+vercel routes reorder "My Route" --position start   # move to top
+vercel routes reorder "My Route" --position after:<id>  # move after another
+```
+
+## Key Concepts
+
+- **Priority order**: Routes are evaluated top to bottom. Use `reorder` to change priority.
+- **Source pattern**: The URL path to match. Supports `path-to-regexp` syntax (`:param`, `*`, `(.*)`).
+- **Actions**: `rewrite` (proxy to destination), `redirect` (301/302/307/308), `set-status` (return status code).
+- **Conditions**: `--has` and `--missing` check for headers, cookies, query params, or host.
+- **Response headers**: Set, append, or delete headers on the response.
+- **Request transforms**: Modify request headers and query params before forwarding.
+
+## Conditions
+
+```bash
+# Route only matches if Authorization header exists
+vercel routes add "Auth API" \
+  --src "/api/:path*" \
+  --dest "https://api.example.com/:path*" \
+  --action rewrite \
+  --has "header:Authorization"
+
+# Route only matches if session cookie is missing
+vercel routes add "Login Redirect" \
+  --src "/dashboard" \
+  --dest "/login" \
+  --action redirect --status 302 \
+  --missing "cookie:session"
+```
+
+## JSON Output
+
+```bash
+vercel routes list --json          # machine-readable route list
+vercel routes inspect "My Route" --json   # single route as JSON
+```
+
+## Anti-Patterns
+
+- Don't forget to `vercel routes publish` after making changes — they stay staged until published.
+- Don't use `--production` flag when you want to see draft state — it only shows live routes.
+- Use `--yes` in CI to skip confirmation prompts.

--- a/skills/vercel-cli/references/routing.md
+++ b/skills/vercel-cli/references/routing.md
@@ -6,7 +6,9 @@
 
 Routing rules take effect immediately without a deployment and take precedence over routes defined in your deployment configuration (`vercel.json`, `next.config.js`, etc.).
 
-All changes are staged as drafts. After a single change with no existing draft, the CLI offers to publish immediately. Otherwise, run `vercel routes publish` to push staged changes to production, or `vercel routes discard-staging` to undo.
+Each routing rule has a unique name within the project, used to identify it in `edit`, `delete`, `enable`, `disable`, and `reorder` commands. Rules are evaluated in priority order (top to bottom). Use `reorder` to control placement.
+
+All changes are staged as drafts. Run `vercel routes publish` to push staged changes to production.
 
 When in doubt about flags or subcommands, use `--help`:
 
@@ -55,7 +57,7 @@ Each routing rule can have at most one primary action:
 | `redirect` | `--dest` + `--status` (301/302/307/308) | Redirect the client to a new URL |
 | `set-status` | `--status` (100-599) | Return a status code (no destination) |
 
-Routing rules can also be used without a primary action to only set response headers or apply request transforms.
+A routing rule without a primary action can still set response headers or apply request transforms.
 
 ### Examples
 
@@ -147,7 +149,7 @@ vercel routes edit "My Route" --ai "Add CORS headers and change to 308 redirect"
 # Interactive — pick fields to edit
 vercel routes edit "My Route"
 
-# Only the specified fields are changed; everything else is preserved
+# Change specific fields
 vercel routes edit "My Route" --dest "https://new-api.example.com/:path*" --yes
 vercel routes edit "My Route" --action redirect --dest "/new" --status 301 --yes
 vercel routes edit "My Route" --name "New Name" --yes


### PR DESCRIPTION
## Summary

Adds a comprehensive routing rules reference to the Vercel CLI skill, covering the full `vercel routes` command surface.

**New file:** `skills/vercel-cli/references/routing.md`

Covers:
- **Overview**: what routing rules are, immediate effect without deployment, precedence over deployment routes, unique names, priority order, draft workflow
- **Viewing**: list, diff, inspect
- **Creating**: source path syntax (regex/path-to-regexp/equals), actions (rewrite/redirect/set-status), conditions (has/missing with value matching: eq=, contains=, re=), response headers & request transforms, AI and interactive modes
- **Editing**: AI, interactive, flag-based partial overrides
- **Managing**: enable/disable/delete/reorder
- **Publishing**: publish, discard, versioning, restore

**Updated:** `skills/vercel-cli/SKILL.md` — added routing rules reference