### PR TITLE
[cli] Add --group-by project/region to vc usage

### DIFF
--- a/.changeset/usage-group-by-project-region.md
+++ b/.changeset/usage-group-by-project-region.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add `--group-by project` and `--group-by region` flags to `vc usage` for grouping billing charges by project or region

--- a/packages/cli/src/commands/usage/command.ts
+++ b/packages/cli/src/commands/usage/command.ts
@@ -33,6 +33,15 @@ export const usageCommand = {
         'Show usage breakdown by time period instead of aggregated totals (daily, weekly, monthly)',
       deprecated: false,
     },
+    {
+      name: 'group-by',
+      shorthand: null,
+      type: String,
+      argument: 'DIMENSION',
+      description:
+        'Group usage by a dimension instead of aggregated totals (project, region)',
+      deprecated: false,
+    },
     formatOption,
     jsonOption,
   ],
@@ -52,6 +61,14 @@ export const usageCommand = {
     {
       name: 'Show weekly usage breakdown',
       value: `${packageName} usage --breakdown weekly`,
+    },
+    {
+      name: 'Show usage grouped by project',
+      value: `${packageName} usage --group-by project`,
+    },
+    {
+      name: 'Show usage grouped by region',
+      value: `${packageName} usage --group-by region`,
     },
     {
       name: 'Output usage data as JSON',

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -124,6 +124,13 @@ export default async function usage(client: Client): Promise<number> {
     groupByDimension = groupByFlag;
   }
 
+  if (breakdownPeriod && groupByDimension) {
+    error(
+      '--breakdown and --group-by cannot be used together. Use one or the other.'
+    );
+    return 1;
+  }
+
   telemetry.trackCliOptionFrom(fromFlag);
   telemetry.trackCliOptionTo(toFlag);
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -15,8 +15,10 @@ import { isErrnoException } from '@vercel/error-utils';
 import type { FocusCharge } from '../../util/billing/focus-charge';
 import type {
   BreakdownPeriod,
+  GroupByDimension,
   ServiceAggregation,
   PeriodAggregation,
+  GroupAggregation,
   UsageData,
 } from './types';
 import {
@@ -29,8 +31,13 @@ import {
   isValidBreakdownPeriod,
   VALID_BREAKDOWN_PERIODS,
 } from '../../util/billing/period-utils';
+import {
+  isValidGroupByDimension,
+  VALID_GROUP_BY_DIMENSIONS,
+} from '../../util/billing/group-by-utils';
 import { outputAggregated } from './output-aggregated';
 import { outputBreakdown } from './output-breakdown';
+import { outputGroupBy } from './output-group-by';
 import { outputJson } from './output-json';
 
 export default async function usage(client: Client): Promise<number> {
@@ -104,10 +111,24 @@ export default async function usage(client: Client): Promise<number> {
     breakdownPeriod = breakdownFlag;
   }
 
+  const groupByFlag = parsedArgs.flags['--group-by'];
+  let groupByDimension: GroupByDimension | undefined;
+
+  if (groupByFlag) {
+    if (!isValidGroupByDimension(groupByFlag)) {
+      error(
+        `Invalid group-by dimension: "${groupByFlag}". Valid options are: ${VALID_GROUP_BY_DIMENSIONS.join(', ')}`
+      );
+      return 1;
+    }
+    groupByDimension = groupByFlag;
+  }
+
   telemetry.trackCliOptionFrom(fromFlag);
   telemetry.trackCliOptionTo(toFlag);
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
   telemetry.trackCliOptionBreakdown(breakdownFlag);
+  telemetry.trackCliOptionGroupBy(groupByFlag);
 
   if (fromFlag) {
     debug(`Date conversion: ${fromFlag} -> ${fromDate}`);
@@ -164,6 +185,7 @@ export default async function usage(client: Client): Promise<number> {
     const usageData = await processCharges(
       response,
       breakdownPeriod,
+      groupByDimension,
       contextName,
       fromDisplay,
       toDisplay,
@@ -176,11 +198,18 @@ export default async function usage(client: Client): Promise<number> {
         fromDate,
         toDate,
         breakdownPeriod,
+        groupByDimension,
       });
       return 0;
     }
 
-    if (breakdownPeriod) {
+    if (groupByDimension) {
+      outputGroupBy({
+        data: usageData,
+        groupByDimension,
+        startTime: start,
+      });
+    } else if (breakdownPeriod) {
       outputBreakdown({
         data: usageData,
         breakdownPeriod,
@@ -200,9 +229,19 @@ export default async function usage(client: Client): Promise<number> {
   }
 }
 
+function getGroupKey(charge: FocusCharge, dimension: GroupByDimension): string {
+  if (dimension === 'project') {
+    return (
+      charge.Tags?.ProjectName || charge.Tags?.ProjectId || '(unattributed)'
+    );
+  }
+  return charge.RegionName || charge.RegionId || '(global)';
+}
+
 async function processCharges(
   response: Response,
   breakdownPeriod: BreakdownPeriod | undefined,
+  groupByDimension: GroupByDimension | undefined,
   contextName: string,
   fromDisplay: string,
   toDisplay: string,
@@ -210,6 +249,7 @@ async function processCharges(
 ): Promise<UsageData> {
   const services = new Map<string, ServiceAggregation>();
   const periodUsage = new Map<string, PeriodAggregation>();
+  const groupByUsage = new Map<string, GroupAggregation>();
   let grandPricingQuantity = 0;
   let grandEffective = 0;
   let grandBilled = 0;
@@ -285,6 +325,37 @@ async function processCharges(
           pricingUnit: periodService.pricingUnit,
         });
       }
+
+      // Accumulate per group-by dimension
+      if (groupByDimension) {
+        const groupKey = getGroupKey(charge, groupByDimension);
+
+        if (!groupByUsage.has(groupKey)) {
+          groupByUsage.set(groupKey, {
+            services: new Map(),
+            totalPricingQuantity: 0,
+            totalEffectiveCost: 0,
+            totalBilledCost: 0,
+          });
+        }
+        const groupData = groupByUsage.get(groupKey)!;
+        groupData.totalPricingQuantity += quantity;
+        groupData.totalEffectiveCost += effective;
+        groupData.totalBilledCost += billed;
+
+        const groupService = groupData.services.get(serviceName) || {
+          pricingQuantity: 0,
+          effectiveCost: 0,
+          billedCost: 0,
+          pricingUnit: charge.PricingUnit || pricingUnit,
+        };
+        groupData.services.set(serviceName, {
+          pricingQuantity: groupService.pricingQuantity + quantity,
+          effectiveCost: groupService.effectiveCost + effective,
+          billedCost: groupService.billedCost + billed,
+          pricingUnit: groupService.pricingUnit,
+        });
+      }
     });
 
     stream.on('end', resolve);
@@ -301,6 +372,7 @@ async function processCharges(
     chargeCount,
     services,
     periodUsage,
+    groupByUsage,
     grandTotals: {
       pricingQuantity: grandPricingQuantity,
       effectiveCost: grandEffective,

--- a/packages/cli/src/commands/usage/output-group-by.ts
+++ b/packages/cli/src/commands/usage/output-group-by.ts
@@ -1,0 +1,79 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import output from '../../output-manager';
+import elapsed from '../../util/output/elapsed';
+import { formatCurrency, formatQuantity } from '../../util/billing/format';
+import type { OutputOptions, GroupByDimension } from './types';
+
+function getDimensionLabel(dimension: GroupByDimension): string {
+  switch (dimension) {
+    case 'project':
+      return 'Project';
+    case 'region':
+      return 'Region';
+    default:
+      return 'Group';
+  }
+}
+
+export function outputGroupBy({
+  data,
+  groupByDimension,
+  startTime,
+}: OutputOptions): void {
+  const { print, log } = output;
+  const dimensionLabel = getDimensionLabel(groupByDimension!);
+
+  log(
+    `Usage by ${dimensionLabel} for ${chalk.bold(data.contextName)} ${elapsed(Date.now() - startTime)}`
+  );
+  log('');
+  const periodSuffix = data.usingDefaults ? ' (current month)' : '';
+  log(
+    `${chalk.gray('Period:')} ${data.fromDisplay} to ${data.toDisplay}${periodSuffix}`
+  );
+  log(`${chalk.gray('Charges processed:')} ${data.chargeCount}`);
+  log(`${chalk.gray('Pricing unit:')} ${data.pricingUnit}`);
+  log('');
+
+  const sortedGroups = [...data.groupByUsage.entries()].sort(
+    (a, b) => b[1].totalBilledCost - a[1].totalBilledCost
+  );
+
+  if (sortedGroups.length === 0) {
+    log('No usage data found for this period.');
+    return;
+  }
+
+  const quantityHeader =
+    data.pricingUnit === 'USD' ? 'Usage (USD)' : data.pricingUnit;
+
+  for (const [groupName, groupData] of sortedGroups) {
+    log(
+      `${chalk.bold(chalk.cyan(groupName))} (Total: ${formatQuantity(groupData.totalPricingQuantity, data.pricingUnit)}, ${formatCurrency(groupData.totalBilledCost)})`
+    );
+
+    const sortedServices = [...groupData.services.entries()].sort(
+      (a, b) => b[1].billedCost - a[1].billedCost
+    );
+
+    const headers = ['Service', quantityHeader, 'Billed Cost'];
+    const rows = sortedServices.map(([name, svc]) => [
+      name,
+      formatQuantity(svc.pricingQuantity, svc.pricingUnit),
+      formatCurrency(svc.billedCost),
+    ]);
+
+    const tablePrint = table(
+      [headers.map(h => chalk.bold(chalk.gray(h))), ...rows],
+      { hsep: 4, align: ['l', 'r', 'r'] }
+    ).replace(/^/gm, '  ');
+
+    print(`${tablePrint}\n`);
+  }
+
+  log('');
+  log(
+    `${chalk.gray('Amount due:')} ${chalk.bold(formatCurrency(data.grandTotals.billedCost))}`
+  );
+}

--- a/packages/cli/src/commands/usage/output-json.ts
+++ b/packages/cli/src/commands/usage/output-json.ts
@@ -3,7 +3,13 @@ import type { JsonOutputOptions } from './types';
 
 export function outputJson(
   client: Client,
-  { data, fromDate, toDate, breakdownPeriod }: JsonOutputOptions
+  {
+    data,
+    fromDate,
+    toDate,
+    breakdownPeriod,
+    groupByDimension,
+  }: JsonOutputOptions
 ): void {
   const sortedServices = [...data.services.entries()].sort(
     (a, b) => b[1].billedCost - a[1].billedCost
@@ -42,6 +48,37 @@ export function outputJson(
             pricingQuantity: periodData.totalPricingQuantity,
             effectiveCost: periodData.totalEffectiveCost,
             billedCost: periodData.totalBilledCost,
+          },
+        };
+      }),
+    };
+  }
+
+  // Include group-by data if a dimension is specified
+  if (groupByDimension) {
+    const sortedGroups = [...data.groupByUsage.entries()].sort(
+      (a, b) => b[1].totalBilledCost - a[1].totalBilledCost
+    );
+
+    jsonOutput.groupBy = {
+      dimension: groupByDimension,
+      data: sortedGroups.map(([groupName, groupData]) => {
+        const sortedGroupServices = [...groupData.services.entries()].sort(
+          (a, b) => b[1].billedCost - a[1].billedCost
+        );
+        return {
+          name: groupName,
+          services: sortedGroupServices.map(([name, svc]) => ({
+            name,
+            pricingQuantity: svc.pricingQuantity,
+            pricingUnit: svc.pricingUnit,
+            effectiveCost: svc.effectiveCost,
+            billedCost: svc.billedCost,
+          })),
+          totals: {
+            pricingQuantity: groupData.totalPricingQuantity,
+            effectiveCost: groupData.totalEffectiveCost,
+            billedCost: groupData.totalBilledCost,
           },
         };
       }),

--- a/packages/cli/src/commands/usage/types.ts
+++ b/packages/cli/src/commands/usage/types.ts
@@ -1,5 +1,7 @@
 export type BreakdownPeriod = 'daily' | 'weekly' | 'monthly';
 
+export type GroupByDimension = 'project' | 'region';
+
 export interface ServiceAggregation {
   pricingQuantity: number;
   effectiveCost: number;
@@ -8,6 +10,13 @@ export interface ServiceAggregation {
 }
 
 export interface PeriodAggregation {
+  services: Map<string, ServiceAggregation>;
+  totalPricingQuantity: number;
+  totalEffectiveCost: number;
+  totalBilledCost: number;
+}
+
+export interface GroupAggregation {
   services: Map<string, ServiceAggregation>;
   totalPricingQuantity: number;
   totalEffectiveCost: number;
@@ -23,6 +32,7 @@ export interface UsageData {
   chargeCount: number;
   services: Map<string, ServiceAggregation>;
   periodUsage: Map<string, PeriodAggregation>;
+  groupByUsage: Map<string, GroupAggregation>;
   grandTotals: {
     pricingQuantity: number;
     effectiveCost: number;
@@ -33,6 +43,7 @@ export interface UsageData {
 export interface OutputOptions {
   data: UsageData;
   breakdownPeriod?: BreakdownPeriod;
+  groupByDimension?: GroupByDimension;
   startTime: number;
 }
 
@@ -41,4 +52,5 @@ export interface JsonOutputOptions {
   fromDate: string;
   toDate: string;
   breakdownPeriod?: BreakdownPeriod;
+  groupByDimension?: GroupByDimension;
 }

--- a/packages/cli/src/util/billing/group-by-utils.ts
+++ b/packages/cli/src/util/billing/group-by-utils.ts
@@ -1,0 +1,15 @@
+import type { GroupByDimension } from '../../commands/usage/types';
+
+export const VALID_GROUP_BY_DIMENSIONS: GroupByDimension[] = [
+  'project',
+  'region',
+];
+
+export function isValidGroupByDimension(
+  value: string | undefined
+): value is GroupByDimension {
+  return (
+    value !== undefined &&
+    VALID_GROUP_BY_DIMENSIONS.includes(value as GroupByDimension)
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/usage/index.ts
+++ b/packages/cli/src/util/telemetry/commands/usage/index.ts
@@ -38,4 +38,13 @@ export class UsageTelemetryClient
       });
     }
   }
+
+  trackCliOptionGroupBy(groupBy: string | undefined) {
+    if (groupBy) {
+      this.trackCliOption({
+        option: 'group-by',
+        value: groupBy,
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -360,5 +360,250 @@ describe('usage', () => {
       expect(output).toContain('Invalid breakdown period');
       expect(output).toContain('daily, weekly, monthly');
     });
+
+    it('should display usage grouped by project with --group-by project', async () => {
+      const mockCharges = [
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 100,
+          BilledCost: 10,
+          EffectiveCost: 8,
+          Tags: { ProjectId: 'prj_abc', ProjectName: 'my-web-app' },
+        }),
+        createMockCharge({
+          ServiceName: 'Edge Middleware Invocations',
+          PricingQuantity: 50,
+          BilledCost: 5,
+          EffectiveCost: 4,
+          Tags: { ProjectId: 'prj_abc', ProjectName: 'my-web-app' },
+        }),
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 200,
+          BilledCost: 20,
+          EffectiveCost: 16,
+          Tags: { ProjectId: 'prj_def', ProjectName: 'my-api' },
+        }),
+      ];
+      useBillingCharges(mockCharges);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--group-by',
+        'project'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('my-web-app');
+      expect(output).toContain('my-api');
+      expect(output).toContain('Usage by Project');
+    });
+
+    it('should display usage grouped by region with --group-by region', async () => {
+      const mockCharges = [
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 100,
+          BilledCost: 10,
+          EffectiveCost: 8,
+          RegionId: 'iad1',
+          RegionName: 'Washington, D.C., USA',
+        }),
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 200,
+          BilledCost: 20,
+          EffectiveCost: 16,
+          RegionId: 'sfo1',
+          RegionName: 'San Francisco, CA, USA',
+        }),
+      ];
+      useBillingCharges(mockCharges);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--group-by',
+        'region'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('Washington, D.C., USA');
+      expect(output).toContain('San Francisco, CA, USA');
+      expect(output).toContain('Usage by Region');
+    });
+
+    it('should show (unattributed) for charges without project data', async () => {
+      const mockCharges = [
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 100,
+          BilledCost: 10,
+          EffectiveCost: 8,
+          Tags: { ProjectId: 'prj_abc', ProjectName: 'my-web-app' },
+        }),
+        createMockCharge({
+          ServiceName: 'Edge Middleware Invocations',
+          PricingQuantity: 50,
+          BilledCost: 5,
+          EffectiveCost: 4,
+          Tags: {},
+        }),
+      ];
+      useBillingCharges(mockCharges);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--group-by',
+        'project'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('my-web-app');
+      expect(output).toContain('(unattributed)');
+    });
+
+    it('should show (global) for charges without region data', async () => {
+      const mockCharges = [
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 100,
+          BilledCost: 10,
+          EffectiveCost: 8,
+          RegionId: 'iad1',
+          RegionName: 'Washington, D.C., USA',
+        }),
+        createMockCharge({
+          ServiceName: 'Edge Middleware Invocations',
+          PricingQuantity: 50,
+          BilledCost: 5,
+          EffectiveCost: 4,
+          RegionId: undefined,
+          RegionName: undefined,
+        }),
+      ];
+      useBillingCharges(mockCharges);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--group-by',
+        'region'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('Washington, D.C., USA');
+      expect(output).toContain('(global)');
+    });
+
+    it('should output JSON with group-by data when --group-by project and --format json', async () => {
+      const mockCharges = [
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 100,
+          BilledCost: 10,
+          EffectiveCost: 8,
+          Tags: { ProjectId: 'prj_abc', ProjectName: 'my-web-app' },
+        }),
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 200,
+          BilledCost: 20,
+          EffectiveCost: 16,
+          Tags: { ProjectId: 'prj_def', ProjectName: 'my-api' },
+        }),
+      ];
+      useBillingCharges(mockCharges);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--group-by',
+        'project',
+        '--format',
+        'json'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.stdout.getFullOutput();
+      const json = JSON.parse(output);
+      expect(json.groupBy).toBeDefined();
+      expect(json.groupBy.dimension).toEqual('project');
+      expect(json.groupBy.data).toHaveLength(2);
+      // Sorted by billedCost descending
+      expect(json.groupBy.data[0].name).toEqual('my-api');
+      expect(json.groupBy.data[0].totals.billedCost).toEqual(20);
+      expect(json.groupBy.data[1].name).toEqual('my-web-app');
+      expect(json.groupBy.data[1].totals.billedCost).toEqual(10);
+      // Grand totals should still be present
+      expect(json.totals.billedCost).toEqual(30);
+    });
+
+    it('should error on invalid group-by dimension', async () => {
+      useBillingCharges([]);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--group-by',
+        'user'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(1);
+      const output = client.getFullOutput();
+      expect(output).toContain('Invalid group-by dimension');
+      expect(output).toContain('project, region');
+    });
+
+    it('should track telemetry for --group-by option', async () => {
+      useBillingCharges([]);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--group-by',
+        'project'
+      );
+      await usage(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'option:from', value: '[REDACTED]' },
+        { key: 'option:to', value: '[REDACTED]' },
+        { key: 'option:group-by', value: 'project' },
+      ]);
+    });
   });
 });

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -565,6 +565,29 @@ describe('usage', () => {
       expect(json.totals.billedCost).toEqual(30);
     });
 
+    it('should error when --breakdown and --group-by are used together', async () => {
+      useBillingCharges([]);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--breakdown',
+        'daily',
+        '--group-by',
+        'project'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(1);
+      const output = client.getFullOutput();
+      expect(output).toContain(
+        '--breakdown and --group-by cannot be used together'
+      );
+    });
+
     it('should error on invalid group-by dimension', async () => {
       useBillingCharges([]);
 


### PR DESCRIPTION
## Summary
- Adds a new `--group-by` flag to the `vc usage` command that groups billing charges by `project` or `region`
- The `/v1/billing/charges` API already returns per-project data (`Tags.ProjectId`/`ProjectName`) and per-region data (`RegionId`/`RegionName`) in every charge record — this PR adds client-side aggregation to surface these dimensions
- Charges without project attribution show as `(unattributed)`, charges without region show as `(global)`
- Supports both table output and `--format json`

## Usage
```bash
# Group by project
vc usage --group-by project

# Group by region
vc usage --group-by region

# JSON output
vc usage --group-by project --format json
```

## Context
Request from #ask-vercel (MONEY-32596) — per-project and per-region usage breakdowns for cost attribution. Per-user breakdowns were also requested but are not feasible with the current billing pipeline (`GroupingDimensions` only supports `product`, `region`, `project` — no user dimension in ClickHouse or Orb).

## Test plan
- [x] All 19 usage tests pass (12 existing + 7 new)
- [ ] Manual test with `--group-by project` on a real team
- [ ] Manual test with `--group-by region` on a real team
- [ ] Verify graceful handling when `api-billing-costs-no-projects` LD flag strips project/region data (charges show as `(unattributed)` / `(global)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)