### PR TITLE
[next] Copy post-build public files into V3 build output

### DIFF
--- a/.changeset/post-build-public-files.md
+++ b/.changeset/post-build-public-files.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Copy post-build public files into V3 build output so they are included in Git-driven deploys

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -608,7 +608,6 @@ export const build: BuildV2 = async buildOptions => {
         if (!(await pathExists(destPath))) {
           const srcPath = publicFiles[fileName].fsPath;
           await copy(srcPath, destPath);
-          debug(`Copied post-build public file: ${fileName}`);
         }
       }
     }

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -44,6 +44,7 @@ import { Sema } from 'async-sema';
 import escapeStringRegexp from 'escape-string-regexp';
 import findUp from 'find-up';
 import {
+  copy,
   lstat,
   pathExists,
   readdir,
@@ -589,6 +590,29 @@ export const build: BuildV2 = async buildOptions => {
   }
 
   if (buildOutputVersion) {
+    // Files generated into public/ after `next build` (e.g. service workers
+    // from Serwist) won't be in .vercel/output/static/ yet because Next.js
+    // only copies public/ at build-start.  Sync any missing files now so
+    // they are included in the deploy.
+    const publicDir = path.join(entryPath, 'public');
+    const staticOutputDir = path.join(
+      entryPath,
+      outputDirectory,
+      'output/static'
+    );
+
+    if (await pathExists(publicDir)) {
+      const publicFiles = await glob('**/*', publicDir);
+      for (const fileName of Object.keys(publicFiles)) {
+        const destPath = path.join(staticOutputDir, fileName);
+        if (!(await pathExists(destPath))) {
+          const srcPath = publicFiles[fileName].fsPath;
+          await copy(srcPath, destPath);
+          debug(`Copied post-build public file: ${fileName}`);
+        }
+      }
+    }
+
     return {
       buildOutputPath: path.join(entryPath, outputDirectory, 'output'),
       buildOutputVersion,


### PR DESCRIPTION
## Summary

- Files generated into `public/` after `next build` completes (e.g. service workers from Serwist) were not included in Git-driven production deploys, returning 404.
- The V3 build output path in `@vercel/next` returns early without calling `getStaticFiles()`, so post-build public files never made it into `.vercel/output/static/`.
- This fix globs `public/` before the early return and copies any files not already present in the static output directory.

Fixes PIPE-6173

## Test plan

- [ ] Deploy a Next.js app with a build script like `next build && node generate-public-file.js` that writes a file to `public/` after `next build`
- [ ] Verify the generated file is served on a Git-driven production deploy (previously 404)
- [ ] Verify files that existed in `public/` before `next build` are still served and not duplicated
- [ ] Verify `vercel build --prod` + `vercel deploy --prebuilt` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)