### PR TITLE
[vercel dev] Don't set changeOrigin on dev server proxy

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -204,7 +204,7 @@ export default class DevServer {
     this.apiExtensions = new Set();
 
     this.proxy = httpProxy.createProxyServer({
-      changeOrigin: true,
+      changeOrigin: false,
       ws: true,
       xfwd: true,
     });


### PR DESCRIPTION
When running django under `vc dev`, POSTs will fail with CSRF
validation issues, because the proxy rewrites Host but doesn't rewrite
Origin, and django's CSRF protection checks those against each other.

This does appear to be stricter than what other frameworks do, so
maybe it would be better to inject some extra configuration when
running django under `vc dev`?

I'm a little uncertain about this one and would love feedback from
somebody better versed in this area.
