### PR TITLE
Pin lodash.template to 4.5.0 in preact example

### DIFF
--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -31,6 +31,9 @@
     "preact-render-to-string": "6.0.3",
     "preact-router": "^4.1.1"
   },
+  "overrides": {
+    "lodash.template": "4.5.0"
+  },
   "jest": {
     "preset": "jest-preset-preact",
     "setupFiles": [


### PR DESCRIPTION
## Summary
- `lodash.template@4.18.0` was published today (2026-03-31) after 7 years of inactivity and breaks `assignWith`, causing `npm run build` failures in the preact example
- Pins `lodash.template` to `4.5.0` (last known good version) via npm overrides

## Test plan
- [ ] Preact e2e example test passes (`npm run build` no longer fails with `assignWith is not defined`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)