### PR TITLE
[test] Remove storybook detect-projects test for deleted example

### DIFF
--- a/.changeset/remove-storybook-test.md
+++ b/.changeset/remove-storybook-test.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove storybook detect-projects test referencing deleted example

--- a/packages/cli/test/unit/util/projects/detect-projects.test.ts
+++ b/packages/cli/test/unit/util/projects/detect-projects.test.ts
@@ -25,12 +25,6 @@ describe('detectProjects()', () => {
     expect(mapDetected(detected)).toEqual([['', ['nextjs']]]);
   });
 
-  it('should match 2 Projects in "storybook" example', async () => {
-    const dir = join(EXAMPLES_DIR, 'storybook');
-    const detected = await detectProjects(dir);
-    expect(mapDetected(detected)).toEqual([['', ['nextjs', 'storybook']]]);
-  });
-
   it('should match "30-double-nested-workspaces"', async () => {
     const dir = join(FS_DETECTORS_FIXTURES, '30-double-nested-workspaces');
     const detected = await detectProjects(dir);


### PR DESCRIPTION
Remove the `"should match 2 Projects in 'storybook' example"` test from `detect-projects.test.ts` since the `examples/storybook/` directory was removed in 27d6065.