### PR TITLE
[static-build] Pin lodash.template to 4.5.0 in preact-v2 example

### DIFF
--- a/.changeset/pin-lodash-template-preact-v2.md
+++ b/.changeset/pin-lodash-template-preact-v2.md
@@ -1,0 +1,4 @@
+---
+---
+
+Pin lodash.template to 4.5.0 in preact-v2 test fixture

--- a/packages/static-build/test/fixtures/preact-v2/package.json
+++ b/packages/static-build/test/fixtures/preact-v2/package.json
@@ -22,5 +22,8 @@
     "preact-compat": "^3.17.0",
     "preact-render-to-string": "^4.1.0",
     "preact-router": "^2.5.7"
+  },
+  "overrides": {
+    "lodash.template": "4.5.0"
   }
 }


### PR DESCRIPTION
See CI failure here: https://github.com/vercel/vercel/actions/runs/23840529711/job/69494976800?pr=15800

Similar to https://github.com/vercel/vercel/pull/15793, we need to pin lodash.template to 4.5.0 for the other preact (v2) example.