### PR TITLE
fix(cli): allow `vercel env update <name> < file` without specifying a target

### DIFF
--- a/.changeset/fix-env-update-stdin-no-target.md
+++ b/.changeset/fix-env-update-stdin-no-target.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+fix(cli): allow `vercel env update <name> < file` without specifying a target environment

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -91,10 +91,10 @@ export default async function update(client: Client, argv: string[]) {
     return 1;
   }
 
-  if (stdInput && (!envName || !envTargetArg)) {
+  if (stdInput && !envName) {
     output.error(
       `Invalid number of arguments. Usage: ${getCommandName(
-        `env update <name> <target> <gitbranch> < <file>`
+        `env update <name> [target] [gitbranch] < <file>`
       )}`
     );
     return 1;


### PR DESCRIPTION
## Summary

Fixes #15764

When providing an env value via stdin redirect, the target environment argument should be optional — matching both the documented behavior of `vercel env update [name]` and the existing `--value` flag behavior.

## Root Cause

In `packages/cli/src/commands/env/update.ts`, the stdin validation guard incorrectly required `envTargetArg`:

```ts
// Before: required both name AND target when stdin is used
if (stdInput && (!envName || !envTargetArg)) {
```

This caused `vercel env update MY_VAR --yes < value.txt` to fail with:
```
Error: Invalid number of arguments. Usage: `vercel env update <name> <target> <gitbranch> < <file>`
```

## Fix

Remove `!envTargetArg` from the guard so only the variable name is required when providing value via stdin, matching `--value` behavior:

```ts
// After: only requires name (target is optional)
if (stdInput && !envName) {
```

## Testing

- All existing `env update` unit tests pass (`pnpm vitest-run test/unit/commands/env/update.test.ts`)