### PR TITLE
[cli] Read shouldCheckForUpdates env vars at startup

### DIFF
--- a/.changeset/fix-update-check-on-vercel.md
+++ b/.changeset/fix-update-check-on-vercel.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Fix update checker running after `vercel build` on Vercel by reading env vars before CLI internals can unset them

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -156,6 +156,10 @@ if (process.env.CLAUDECODE) {
   );
 }
 
+// Snapshot before any command has a chance to mutate process.env
+const SHOULD_CHECK_FOR_UPDATES =
+  !process.env.NO_UPDATE_NOTIFIER && !process.env.VERCEL;
+
 let { isTTY } = process.stdout;
 
 let apiUrl = 'https://api.vercel.com';
@@ -1120,10 +1124,7 @@ const main = async () => {
 
 main()
   .then(async exitCode => {
-    const shouldCheckForUpdates =
-      !process.env.NO_UPDATE_NOTIFIER && !process.env.VERCEL;
-
-    if (shouldCheckForUpdates) {
+    if (SHOULD_CHECK_FOR_UPDATES) {
       const latest = getLatestVersion({
         pkg,
       });


### PR DESCRIPTION
The `vercel build` command sets `process.env.VERCEL = '1'` during builds, then deletes it in a finally block (for unit test cleanup). The update checker runs after this cleanup, so `!process.env.VERCEL` evaluates to true and the update check runs (even on Vercel's infra where `VERCEL=1` was originally set!)

This makes builds on Vercel approx. 300ms faster by removing an endpoint call at the end of `vercel build`.

The original intent of this check is to skip checking for updates on Vercel infra:
- https://github.com/vercel/vercel/commit/41003fa7eda02f862aa1605db794305a99a852b4

So reading the pre-CLI `VERCEL` env var is correct.


<br>

### More notes

`VERCEL` added to `envToUnset` here: https://github.com/vercel/vercel/blob/7df9c4a18161cbcc15a170c38c44285e8a9815b6/packages/cli/src/commands/build/index.ts#L374
And then actually unset here: https://github.com/vercel/vercel/blob/7df9c4a18161cbcc15a170c38c44285e8a9815b6/packages/cli/src/commands/build/index.ts#L495