### PR TITLE
[cli] Add --id flag to build and env pull for deployment-scoped env vars

### DIFF
--- a/.changeset/build-env-pull-deployment-id.md
+++ b/.changeset/build-env-pull-deployment-id.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `--id` flag to `vercel build` and `vercel env pull` to fetch deployment-scoped environment variables

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -43,6 +43,15 @@ export const buildCommand = {
       type: Boolean,
       deprecated: false,
     },
+    {
+      name: 'id',
+      description:
+        'Deployment ID to pull environment variables from (e.g. dpl_xxx)',
+      shorthand: null,
+      type: String,
+      argument: 'ID',
+      deprecated: false,
+    },
   ],
   examples: [
     {
@@ -52,6 +61,10 @@ export const buildCommand = {
     {
       name: 'Build the project in a specific directory',
       value: `${packageName} build --cwd ./path-to-project`,
+    },
+    {
+      name: 'Build with deployment-scoped environment variables',
+      value: `${packageName} build --id dpl_xxx`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -380,6 +380,12 @@ export default async function main(client: Client): Promise<number> {
     const loadEnvSpan = rootSpan.child('vc.loadEnv');
     try {
       if (deploymentId) {
+        // Set the team context so API calls include the teamId query param.
+        // Without this, the API can't find the deployment.
+        if (link?.orgId?.startsWith('team_')) {
+          client.config.currentTeam = link.orgId;
+        }
+
         // When --id is provided, fetch env vars from the deployment
         // instead of loading from local .env files.
         output.debug(

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -367,13 +367,19 @@ export default async function main(client: Client): Promise<number> {
     cliVersion: cliPkg.version,
   };
 
-  if (!process.env.VERCEL_BUILD_IMAGE && !client.nonInteractive) {
+  const deploymentId = parsedArgs.flags['--id'];
+
+  // When --id is provided, system env vars are fetched from the deployment,
+  // so the warning about missing system env vars does not apply.
+  if (
+    !process.env.VERCEL_BUILD_IMAGE &&
+    !deploymentId &&
+    !client.nonInteractive
+  ) {
     output.warn(
       'Build not running on Vercel. System environment variables will not be available.'
     );
   }
-
-  const deploymentId = parsedArgs.flags['--id'];
   const envToUnset = new Set<string>(['VERCEL', 'NOW_BUILDER']);
 
   try {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -107,6 +107,7 @@ import {
 } from '../../util/compile-vercel-config';
 import { help } from '../help';
 import { pullCommandLogic } from '../pull';
+import { pullEnvRecords } from '../../util/env/get-env-records';
 import { buildCommand } from './command';
 import { validatePackageManifest } from '../../util/validate-package-manifest';
 
@@ -206,6 +207,7 @@ export default async function main(client: Client): Promise<number> {
     telemetryClient.trackCliFlagProd(parsedArgs.flags['--prod']);
     telemetryClient.trackCliFlagYes(parsedArgs.flags['--yes']);
     telemetryClient.trackCliFlagStandalone(parsedArgs.flags['--standalone']);
+    telemetryClient.trackCliOptionId(parsedArgs.flags['--id']);
   } catch (error) {
     printError(error);
     return 1;
@@ -371,31 +373,51 @@ export default async function main(client: Client): Promise<number> {
     );
   }
 
+  const deploymentId = parsedArgs.flags['--id'];
   const envToUnset = new Set<string>(['VERCEL', 'NOW_BUILDER']);
 
   try {
     const loadEnvSpan = rootSpan.child('vc.loadEnv');
     try {
-      const envPath = join(
-        cwd,
-        projectRootDirectory,
-        VERCEL_DIR,
-        `.env.${target}.local`
-      );
-      // TODO (maybe?): load env vars from the API, fall back to the local file if that fails
-      const dotenvResult = dotenv.config({
-        path: envPath,
-        debug: output.isDebugEnabled(),
-      });
-      if (dotenvResult.error) {
+      if (deploymentId) {
+        // When --id is provided, fetch env vars from the deployment
+        // instead of loading from local .env files.
         output.debug(
-          `Failed loading environment variables: ${dotenvResult.error}`
+          `Fetching environment variables for deployment ${deploymentId}`
         );
-      } else if (dotenvResult.parsed) {
-        for (const key of Object.keys(dotenvResult.parsed)) {
+        const { buildEnv } = await fetchDeploymentBuildEnv(
+          client,
+          deploymentId
+        );
+        for (const [key, value] of Object.entries(buildEnv)) {
           envToUnset.add(key);
+          process.env[key] = value;
         }
-        output.debug(`Loaded environment variables from "${envPath}"`);
+        output.debug(
+          `Loaded ${Object.keys(buildEnv).length} environment variables from deployment ${deploymentId}`
+        );
+      } else {
+        const envPath = join(
+          cwd,
+          projectRootDirectory,
+          VERCEL_DIR,
+          `.env.${target}.local`
+        );
+        // TODO (maybe?): load env vars from the API, fall back to the local file if that fails
+        const dotenvResult = dotenv.config({
+          path: envPath,
+          debug: output.isDebugEnabled(),
+        });
+        if (dotenvResult.error) {
+          output.debug(
+            `Failed loading environment variables: ${dotenvResult.error}`
+          );
+        } else if (dotenvResult.parsed) {
+          for (const key of Object.keys(dotenvResult.parsed)) {
+            envToUnset.add(key);
+          }
+          output.debug(`Loaded environment variables from "${envPath}"`);
+        }
       }
     } finally {
       loadEnvSpan.stop();
@@ -2055,4 +2077,47 @@ async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
   return Buffer.concat(chunks).toString('utf-8');
+}
+
+const INTEGRATIONS_POLL_INTERVAL_MS = 5000;
+const INTEGRATIONS_POLL_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes, matches API timeout
+
+/**
+ * Fetches build environment variables for a deployment from the API.
+ * If integrations are still provisioning, polls until they complete.
+ */
+async function fetchDeploymentBuildEnv(
+  client: Client,
+  deploymentId: string
+): Promise<{ env: Record<string, string>; buildEnv: Record<string, string> }> {
+  const startTime = Date.now();
+
+  while (true) {
+    try {
+      return await pullEnvRecords(client, deploymentId, 'vercel-cli:pull');
+    } catch (err: unknown) {
+      // If the API returns integrationsStatus: 'pending', poll until ready
+      if (
+        err &&
+        typeof err === 'object' &&
+        'integrationsStatus' in err &&
+        (err as { integrationsStatus?: string }).integrationsStatus ===
+          'pending'
+      ) {
+        if (Date.now() - startTime > INTEGRATIONS_POLL_TIMEOUT_MS) {
+          throw new Error(
+            'Timed out waiting for deployment integrations to complete provisioning.'
+          );
+        }
+        output.spinner(
+          'Waiting for deployment integrations to finish provisioning...'
+        );
+        await new Promise(resolve =>
+          setTimeout(resolve, INTEGRATIONS_POLL_INTERVAL_MS)
+        );
+        continue;
+      }
+      throw err;
+    }
+  }
 }

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -2090,9 +2090,10 @@ async function fetchDeploymentBuildEnv(
   client: Client,
   deploymentId: string
 ): Promise<{ env: Record<string, string>; buildEnv: Record<string, string> }> {
-  const startTime = Date.now();
+  const deadline = Date.now() + INTEGRATIONS_POLL_TIMEOUT_MS;
+  let isPolling = false;
 
-  while (true) {
+  while (Date.now() < deadline) {
     try {
       return await pullEnvRecords(client, deploymentId, 'vercel-cli:pull');
     } catch (err: unknown) {
@@ -2104,14 +2105,12 @@ async function fetchDeploymentBuildEnv(
         (err as { integrationsStatus?: string }).integrationsStatus ===
           'pending'
       ) {
-        if (Date.now() - startTime > INTEGRATIONS_POLL_TIMEOUT_MS) {
-          throw new Error(
-            'Timed out waiting for deployment integrations to complete provisioning.'
+        if (!isPolling) {
+          output.spinner(
+            'Waiting for deployment integrations to finish provisioning...'
           );
+          isPolling = true;
         }
-        output.spinner(
-          'Waiting for deployment integrations to finish provisioning...'
-        );
         await new Promise(resolve =>
           setTimeout(resolve, INTEGRATIONS_POLL_INTERVAL_MS)
         );
@@ -2120,4 +2119,8 @@ async function fetchDeploymentBuildEnv(
       throw err;
     }
   }
+
+  throw new Error(
+    'Timed out waiting for deployment integrations to complete provisioning.'
+  );
 }

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -205,6 +205,15 @@ export const pullSubcommand = {
       deprecated: false,
     },
     {
+      name: 'id',
+      description:
+        'Pull environment variables for a specific deployment (e.g. dpl_xxx)',
+      shorthand: null,
+      type: String,
+      argument: 'ID',
+      deprecated: false,
+    },
+    {
       ...yesOption,
       description:
         'Skip the confirmation prompt when removing an environment variable',
@@ -217,6 +226,10 @@ export const pullSubcommand = {
         `${packageName} env pull <file>`,
         `${packageName} env pull .env.development.local`,
       ],
+    },
+    {
+      name: 'Pull environment variables for a specific deployment',
+      value: `${packageName} env pull --id dpl_xxx`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -103,6 +103,7 @@ export default async function pull(
   telemetryClient.trackCliFlagYes(skipConfirmation);
   telemetryClient.trackCliOptionGitBranch(gitBranch);
   telemetryClient.trackCliOptionEnvironment(opts['--environment']);
+  telemetryClient.trackCliOptionId(opts['--id']);
 
   const link = await getLinkedProject(client);
   if (link.status === 'error') {
@@ -143,6 +144,8 @@ export default async function pull(
   client.config.currentTeam =
     link.org.type === 'team' ? link.org.id : undefined;
 
+  const deploymentId = opts['--id'];
+
   const environment =
     parseTarget({
       flagName: 'environment',
@@ -157,7 +160,8 @@ export default async function pull(
     link,
     gitBranch,
     client.cwd,
-    source
+    source,
+    deploymentId
   );
 
   return 0;
@@ -171,7 +175,8 @@ export async function envPullCommandLogic(
   link: ProjectLinked,
   gitBranch: string | undefined,
   cwd: string,
-  source: EnvRecordsSource
+  source: EnvRecordsSource,
+  deploymentId?: string
 ) {
   const fullPath = resolve(cwd, filename);
   const head = tryReadHeadSync(fullPath, Buffer.byteLength(CONTENTS_PREFIX));
@@ -225,8 +230,9 @@ export async function envPullCommandLogic(
   const pullStamp = stamp();
   output.spinner('Downloading');
 
+  const pullId = deploymentId || link.project.id;
   const records = (
-    await pullEnvRecords(client, link.project.id, source, {
+    await pullEnvRecords(client, pullId, source, {
       target: environment || 'development',
       gitBranch,
     })

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -231,12 +231,15 @@ export async function envPullCommandLogic(
   output.spinner('Downloading');
 
   const pullId = deploymentId || link.project.id;
-  const records = (
-    await pullEnvRecords(client, pullId, source, {
-      target: environment || 'development',
-      gitBranch,
-    })
-  ).env;
+  const pullResult = await pullEnvRecords(client, pullId, source, {
+    target: environment || 'development',
+    gitBranch,
+  });
+  // When pulling by deployment ID, use buildEnv which always contains the full
+  // set of env vars. The `env` dict may only contain decryption keys when large
+  // env encryption is active (the actual values are in an encrypted blob for
+  // Lambda runtime use).
+  const records = deploymentId ? pullResult.buildEnv : pullResult.env;
 
   let deltaString = '';
   let oldEnv;

--- a/packages/cli/src/util/env/get-env-records.ts
+++ b/packages/cli/src/util/env/get-env-records.ts
@@ -68,21 +68,25 @@ interface PullEnvOptions {
 
 export async function pullEnvRecords(
   client: Client,
-  projectId: string,
+  projectIdOrDeploymentId: string,
   source: EnvRecordsSource,
   { target, gitBranch }: PullEnvOptions = {}
 ) {
   output.debug(
-    `Fetching Environment Variables of project ${projectId} and target ${target}`
+    `Fetching Environment Variables of ${projectIdOrDeploymentId} and target ${target}`
   );
   const query = new URLSearchParams();
 
-  let url = `/v3/env/pull/${projectId}`;
+  let url = `/v3/env/pull/${projectIdOrDeploymentId}`;
 
-  if (target) {
-    url += `/${encodeURIComponent(target)}`;
-    if (gitBranch) {
-      url += `/${encodeURIComponent(gitBranch)}`;
+  // When pulling by deployment ID, target and gitBranch are irrelevant
+  // since the deployment already has its env fully resolved.
+  if (!projectIdOrDeploymentId.startsWith('dpl_')) {
+    if (target) {
+      url += `/${encodeURIComponent(target)}`;
+      if (gitBranch) {
+        url += `/${encodeURIComponent(gitBranch)}`;
+      }
     }
   }
 

--- a/packages/cli/src/util/telemetry/commands/build/index.ts
+++ b/packages/cli/src/util/telemetry/commands/build/index.ts
@@ -41,4 +41,13 @@ export class BuildTelemetryClient
       this.trackCliFlag('standalone');
     }
   }
+
+  trackCliOptionId(id: string | undefined) {
+    if (id) {
+      this.trackCliOption({
+        option: 'id',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/env/pull.ts
+++ b/packages/cli/src/util/telemetry/commands/env/pull.ts
@@ -44,4 +44,13 @@ export class EnvPullTelemetryClient
       this.trackCliFlag('yes');
     }
   }
+
+  trackCliOptionId(id: string | undefined) {
+    if (id) {
+      this.trackCliOption({
+        option: 'id',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2207,6 +2207,7 @@ exports[`help command > env help output snapshots > env pull help output snapsho
 
        --environment <TARGET>  Set the Environment when pulling Environment Variables                                        
        --git-branch <NAME>     Specify the Git branch to pull specific Environment Variables for                             
+       --id <ID>               Pull environment variables for a specific deployment (e.g. dpl_xxx)                           
   -y,  --yes                   Skip the confirmation prompt when removing an environment variable                            
 
 
@@ -2230,6 +2231,10 @@ exports[`help command > env help output snapshots > env pull help output snapsho
 
     $ vercel env pull <file>
     $ vercel env pull .env.development.local
+
+  - Pull environment variables for a specific deployment
+
+    $ vercel env pull --id dpl_xxx
 
 "
 `;


### PR DESCRIPTION
## Context

For the BYOC workflow, `vercel build` needs access to the same environment variables that the build-container receives. Currently it loads env vars from local `.env` files created by `vercel pull`, which miss deployment-specific vars (integration overrides, system vars like `VERCEL_URL`/`VERCEL_DEPLOYMENT_ID`, LaunchDarkly flags, etc.).

This adds `--id` support to both `vercel build` and `vercel env pull` so they can fetch the fully resolved env vars stored on a specific deployment.

## Changes

- Added `--id` flag to `vercel build` — when provided, fetches `buildEnv` from the deployment via the env pull API instead of loading from local `.env` files. Polls if integrations are still provisioning (checks `integrationsStatus` in the error response, 5s interval, 3min timeout matching the API).
- Added `--id` flag to `vercel env pull` — when provided, fetches env from the deployment in one shot (no polling). Writes to file same as before.
- Updated `pullEnvRecords()` to accept deployment IDs — skips target/gitBranch path segments when the ID starts with `dpl_`.
- Added telemetry tracking for the new `--id` option in both commands.

## References

- Depends on vercel/api#66324 (API-side: extends `pull-env-vars` endpoint to accept deployment IDs)