### PR TITLE
[CLI] Adding getScope enrichment to modify scope design

### DIFF
--- a/.changeset/few-points-switch.md
+++ b/.changeset/few-points-switch.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve CLI scope resolution groundwork and fix `vercel switch` current-team detection.

--- a/packages/cli/src/commands/domains/ls.ts
+++ b/packages/cli/src/commands/domains/ls.ts
@@ -69,7 +69,9 @@ export default async function ls(client: Client, argv: string[]) {
     return 1;
   }
 
-  const { contextName } = await getScope(client);
+  const { contextName } = await getScope(client, {
+    resolveLocalScope: true,
+  });
 
   const lsStamp = stamp();
 

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -63,7 +63,9 @@ export default async function list(
 
   const start = Date.now();
 
-  const { contextName } = await getScope(client);
+  const { contextName } = await getScope(client, {
+    resolveLocalScope: true,
+  });
   output.spinner(`Fetching projects in ${chalk.bold(contextName)}`);
 
   // Process flags and build URL

--- a/packages/cli/src/commands/teams/switch.ts
+++ b/packages/cli/src/commands/teams/switch.ts
@@ -21,6 +21,7 @@ import {
   getGlobalFlagsOnlyFromArgs,
   getSameSubcommandSuggestionFlags,
 } from '../../util/arg-common';
+import { getLinkFromDir, getVercelDirectory } from '../../util/projects/link';
 
 /** Append global argv flags (--cwd, --non-interactive, etc.) so agents can re-run with same context. */
 function withGlobalFlags(client: Client, commandTemplate: string): string {
@@ -37,6 +38,30 @@ const updateCurrentTeam = (config: GlobalConfig, team?: Team) => {
 
   writeToConfigFile(config);
 };
+
+async function warnIfStaleLinkExists(
+  client: Client,
+  newOrgId: string
+): Promise<void> {
+  let link: { orgId: string } | null = null;
+  try {
+    link = await getLinkFromDir<{ orgId: string }>(
+      getVercelDirectory(client.cwd)
+    );
+  } catch (_error) {
+    link = null;
+  }
+
+  if (!link || link.orgId === newOrgId) {
+    return;
+  }
+
+  output.warn(
+    `This directory is linked to a project under a different team/scope. ` +
+      `Commands like \`deploy\` will still use the linked project's team. ` +
+      `Run \`vc link\` to re-link.`
+  );
+}
 
 export default async function change(client: Client, argv: string[]) {
   let parsedArgs;
@@ -108,14 +133,18 @@ export default async function change(client: Client, argv: string[]) {
     },
   });
   telemetry.trackCliArgumentName(desiredSlug);
-  const personalScopeSelected = !config.currentTeam;
 
   output.spinner('Fetching teams information');
   const [user, teams] = await Promise.all([getUser(client), getTeams(client)]);
 
-  const currentTeam = personalScopeSelected
-    ? undefined
-    : teams.find(team => team.id === config.currentTeam);
+  const defaultTeamId =
+    user.version === 'northstar' ? user.defaultTeamId : undefined;
+  const currentTeamId = config.currentTeam || defaultTeamId;
+  const personalScopeSelected = !currentTeamId;
+
+  const currentTeam = currentTeamId
+    ? teams.find(team => team.id === currentTeamId)
+    : undefined;
 
   if (!personalScopeSelected && !currentTeam) {
     if (client.nonInteractive) {
@@ -287,6 +316,7 @@ export default async function change(client: Client, argv: string[]) {
     output.success(
       `Your account (${chalk.bold(user.username)}) is now active!`
     );
+    await warnIfStaleLinkExists(client, user.id);
     return 0;
   }
 
@@ -335,5 +365,6 @@ export default async function change(client: Client, argv: string[]) {
   output.success(
     `The team ${chalk.bold(newTeam.name)} (${newTeam.slug}) is now active!`
   );
+  await warnIfStaleLinkExists(client, newTeam.id);
   return 0;
 }

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -1,17 +1,59 @@
+import { relative } from 'path';
 import type Client from './client';
+import type { Org, Team, User } from '@vercel-internals/types';
 import getUser from './get-user';
 import getTeamById from './teams/get-team-by-id';
 import { TeamDeleted } from './errors-ts';
-import type { Team } from '@vercel-internals/types';
+import { getLinkFromDir, getVercelDirectory } from './projects/link';
+import { getRepoLink, findProjectsFromPath } from './link/repo';
+import type { RepoProjectsConfig } from './link/repo';
+import output from '../output-manager';
+
+export interface ScopeContext {
+  org: Org;
+  contextName: string;
+  user: User;
+  team: Team | null;
+  linkedRepo: {
+    repoConfig: RepoProjectsConfig;
+    rootPath: string;
+  } | null;
+  isCrossTeamRepo: boolean;
+  scopeMismatch: boolean;
+  explicitScopeProvided: boolean;
+}
+
+interface BasicScopeContext {
+  contextName: string;
+  user: User;
+  team: Team | null;
+}
 
 interface GetScopeOptions {
   getTeam?: boolean;
+  resolveLocalScope?: boolean;
 }
 
+interface GetScopeWithLocalScopeOptions extends GetScopeOptions {
+  resolveLocalScope: true;
+}
+
+interface GetScopeWithoutLocalScopeOptions extends GetScopeOptions {
+  resolveLocalScope?: false;
+}
+
+export default function getScope(
+  client: Client,
+  opts: GetScopeWithLocalScopeOptions
+): Promise<ScopeContext>;
+export default function getScope(
+  client: Client,
+  opts?: GetScopeWithoutLocalScopeOptions
+): Promise<BasicScopeContext>;
 export default async function getScope(
   client: Client,
   opts: GetScopeOptions = {}
-) {
+): Promise<BasicScopeContext | ScopeContext> {
   const user = await getUser(client);
   let contextName = user.username || user.email;
   let team: Team | null = null;
@@ -29,5 +71,173 @@ export default async function getScope(
     contextName = team.slug;
   }
 
-  return { contextName, team, user };
+  if (!opts.resolveLocalScope) {
+    return { contextName, team, user };
+  }
+
+  const explicitScopeProvided = detectExplicitScope(client);
+  const globalTeamId = client.config.currentTeam;
+
+  const cwd = client.cwd;
+  let projectLink: { orgId: string; projectId: string } | null = null;
+  try {
+    projectLink = await getLinkFromDir<{
+      orgId: string;
+      projectId: string;
+    }>(getVercelDirectory(cwd));
+  } catch (_error) {
+    projectLink = null;
+  }
+
+  let repoLink: Awaited<ReturnType<typeof getRepoLink>> | null = null;
+  try {
+    repoLink = await getRepoLink(client, cwd);
+  } catch (_error) {
+    repoLink = null;
+  }
+
+  let localOrgId: string | undefined;
+  if (projectLink) {
+    localOrgId = projectLink.orgId;
+  } else if (repoLink?.repoConfig) {
+    const repoConfig = repoLink.repoConfig;
+    const projects = findProjectsFromPath(
+      repoConfig.projects,
+      relative(repoLink.rootPath, cwd)
+    );
+    if (projects.length === 1) {
+      localOrgId = projects[0].orgId ?? repoLink.repoConfig.orgId ?? undefined;
+    } else if (projects.length > 1) {
+      const orgIds = new Set(
+        projects.map(p => p.orgId ?? repoConfig.orgId ?? '')
+      );
+      if (orgIds.size === 1) {
+        const [singleOrgId] = orgIds;
+        if (singleOrgId) {
+          localOrgId = singleOrgId;
+        }
+      }
+    }
+  }
+
+  const isCrossTeamRepo = detectCrossTeamRepo(repoLink?.repoConfig);
+
+  const scopeMismatch = Boolean(
+    localOrgId && globalTeamId && globalTeamId !== localOrgId
+  );
+
+  let resolvedOrg: Org;
+  let resolvedContextName = contextName;
+  let resolvedTeam = team;
+  let linkedRepoResult: ScopeContext['linkedRepo'] = null;
+
+  if (repoLink?.repoConfig) {
+    linkedRepoResult = {
+      repoConfig: repoLink.repoConfig,
+      rootPath: repoLink.rootPath,
+    };
+  }
+
+  if (explicitScopeProvided) {
+    resolvedOrg = team
+      ? { type: 'team', id: team.id, slug: team.slug }
+      : { type: 'user', id: user.id, slug: user.username };
+  } else if (localOrgId) {
+    client.config.currentTeam = localOrgId.startsWith('team_')
+      ? localOrgId
+      : undefined;
+
+    const correctedTeam = client.config.currentTeam
+      ? await getTeamById(client, client.config.currentTeam)
+      : null;
+    const correctedUser = await getUser(client);
+    resolvedOrg = correctedTeam
+      ? { type: 'team', id: correctedTeam.id, slug: correctedTeam.slug }
+      : {
+          type: 'user',
+          id: correctedUser.id,
+          slug: correctedUser.username,
+        };
+    resolvedContextName = correctedTeam
+      ? correctedTeam.slug
+      : correctedUser.username || correctedUser.email;
+    resolvedTeam = correctedTeam;
+  } else {
+    if (isCrossTeamRepo) {
+      output.warn(
+        `This repository has projects across multiple teams. ` +
+          `Use \`--scope\` to specify which team, or \`cd\` into a project directory.`
+      );
+    }
+    resolvedOrg = team
+      ? { type: 'team', id: team.id, slug: team.slug }
+      : { type: 'user', id: user.id, slug: user.username };
+  }
+
+  return {
+    org: resolvedOrg,
+    contextName: resolvedContextName,
+    user,
+    team: resolvedTeam,
+    linkedRepo: linkedRepoResult,
+    isCrossTeamRepo,
+    scopeMismatch,
+    explicitScopeProvided,
+  } satisfies ScopeContext;
+}
+
+export function applyScopeFromLink(client: Client, link: { org: Org }): void {
+  const localOrgId = link.org.id;
+  const globalTeamId = client.config.currentTeam;
+
+  const scopeMismatch = Boolean(globalTeamId && globalTeamId !== localOrgId);
+
+  if (scopeMismatch) {
+    output.warn(
+      `This directory is linked to a project under a different team than your current scope. ` +
+        `Using the linked project's team. To change, run \`vc link\`.`
+    );
+  }
+
+  client.config.currentTeam = localOrgId.startsWith('team_')
+    ? localOrgId
+    : undefined;
+}
+
+function detectExplicitScope(client: Client): boolean {
+  const argv = client.argv;
+  for (const arg of argv) {
+    if (
+      arg === '--scope' ||
+      arg === '--team' ||
+      arg.startsWith('--scope=') ||
+      arg.startsWith('--team=') ||
+      arg === '-T'
+    ) {
+      return true;
+    }
+  }
+
+  if (client.localConfig?.scope) {
+    return true;
+  }
+
+  return false;
+}
+
+function detectCrossTeamRepo(
+  repoConfig: RepoProjectsConfig | undefined
+): boolean {
+  if (!repoConfig?.projects || repoConfig.projects.length < 2) {
+    return false;
+  }
+
+  const orgIds = new Set<string>();
+  for (const project of repoConfig.projects) {
+    const orgId = project.orgId ?? repoConfig.orgId;
+    if (orgId) {
+      orgIds.add(orgId);
+    }
+  }
+  return orgIds.size > 1;
 }

--- a/packages/cli/test/unit/commands/teams/switch.test.ts
+++ b/packages/cli/test/unit/commands/teams/switch.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
+import { join } from 'path';
+import { outputFile } from 'fs-extra';
 import { client } from '../../../mocks/client';
 import teams from '../../../../src/commands/teams';
 import { useUser } from '../../../mocks/user';
-import { useTeam } from '../../../mocks/team';
+import { useTeam, createTeam } from '../../../mocks/team';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
 
 describe('teams switch', () => {
   describe('non-northstar', () => {
@@ -120,6 +123,29 @@ describe('teams switch', () => {
         'You cannot set your Personal Account as the scope.'
       );
       await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should preselect the default team when currentTeam is unset', async () => {
+      const defaultTeam = useTeam('team_zulu');
+      defaultTeam.slug = 'zulu-team';
+      defaultTeam.name = 'Zulu Team';
+      createTeam('team_alpha', 'alpha-team', 'Alpha Team');
+      useUser({
+        version: 'northstar',
+        defaultTeamId: defaultTeam.id,
+      });
+
+      client.config.currentTeam = undefined;
+      client.setArgv('teams', 'switch');
+      const exitCodePromise = teams(client);
+
+      await expect(client.stderr).toOutput(
+        `${defaultTeam.name} (${defaultTeam.slug}) (current)`
+      );
+
+      client.stdin.write('\r');
+      await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(client.stderr).toOutput('No changes made');
     });
   });
 
@@ -255,6 +281,53 @@ describe('teams switch', () => {
       logSpy.mockRestore();
       exitSpy.mockRestore();
       client.nonInteractive = false;
+    });
+  });
+
+  describe('stale-link detection', () => {
+    it('should warn when switching to a team that differs from the linked project', async () => {
+      useUser();
+      const teamA = useTeam('team_aaa');
+      const teamB = createTeam('team_bbb', 'team-b', 'Team B');
+
+      const cwd = setupTmpDir();
+      client.cwd = cwd;
+      await outputFile(
+        join(cwd, '.vercel', 'project.json'),
+        JSON.stringify({ projectId: 'prj_xxx', orgId: 'team_aaa' })
+      );
+
+      client.config.currentTeam = teamA.id;
+      client.setArgv('teams', 'switch', teamB.slug);
+      const exitCode = await teams(client);
+      expect(exitCode).toBe(0);
+      await expect(client.stderr).toOutput(
+        'This directory is linked to a project under a different team/scope'
+      );
+    });
+
+    it('should not warn when switching to the same team as the linked project', async () => {
+      useUser();
+      const teamA = useTeam('team_aaa');
+      const teamB = createTeam('team_bbb', 'team-b', 'Team B');
+
+      const cwd = setupTmpDir();
+      client.cwd = cwd;
+      await outputFile(
+        join(cwd, '.vercel', 'project.json'),
+        JSON.stringify({ projectId: 'prj_xxx', orgId: 'team_bbb' })
+      );
+
+      client.config.currentTeam = teamA.id;
+      client.setArgv('teams', 'switch', teamB.slug);
+      const exitCode = await teams(client);
+      expect(exitCode).toBe(0);
+      await expect(client.stderr).toOutput(
+        `The team ${teamB.name} (${teamB.slug}) is now active!`
+      );
+      await expect(client.stderr).not.toOutput(
+        'This directory is linked to a project under a different team/scope'
+      );
     });
   });
 });

--- a/packages/cli/test/unit/util/scope-context.test.ts
+++ b/packages/cli/test/unit/util/scope-context.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { join } from 'path';
+import { outputFile } from 'fs-extra';
+import { client } from '../../mocks/client';
+import { useUser } from '../../mocks/user';
+import { useTeam } from '../../mocks/team';
+import { setupTmpDir } from '../../helpers/setup-unit-fixture';
+import getScope, { applyScopeFromLink } from '../../../src/util/get-scope';
+
+describe('resolveScopeContext', () => {
+  describe('with no local links', () => {
+    let mockTeam: ReturnType<typeof useTeam>;
+    let mockUser: ReturnType<typeof useUser>;
+
+    beforeEach(() => {
+      mockTeam = useTeam();
+      mockUser = useUser();
+    });
+
+    it('should use global scope when no local link and no --scope', async () => {
+      client.config.currentTeam = mockTeam.id;
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.org.id).toEqual(mockTeam.id);
+      expect(ctx.contextName).toEqual(mockTeam.slug);
+      expect(ctx.user.id).toEqual(mockUser.id);
+      expect(ctx.team?.id).toEqual(mockTeam.id);
+      expect(ctx.linkedRepo).toBeNull();
+      expect(ctx.isCrossTeamRepo).toBe(false);
+      expect(ctx.scopeMismatch).toBe(false);
+      expect(ctx.explicitScopeProvided).toBe(false);
+    });
+
+    it('should use personal account when no team set', async () => {
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.org.type).toEqual('user');
+      expect(ctx.org.id).toEqual(mockUser.id);
+      expect(ctx.contextName).toEqual(mockUser.username);
+      expect(ctx.team).toBeNull();
+    });
+
+    it('should detect --scope flag as explicit scope', async () => {
+      client.config.currentTeam = mockTeam.id;
+      client.argv = ['projects', 'ls', '--scope', mockTeam.slug];
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.explicitScopeProvided).toBe(true);
+    });
+
+    it('should detect --scope=value flag as explicit scope', async () => {
+      client.config.currentTeam = mockTeam.id;
+      client.argv = ['projects', 'ls', `--scope=${mockTeam.slug}`];
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.explicitScopeProvided).toBe(true);
+    });
+
+    it('should detect --team flag as explicit scope', async () => {
+      client.config.currentTeam = mockTeam.id;
+      client.argv = ['projects', 'ls', '--team', mockTeam.slug];
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.explicitScopeProvided).toBe(true);
+    });
+
+    it('should detect -T flag as explicit scope', async () => {
+      client.config.currentTeam = mockTeam.id;
+      client.argv = ['projects', 'ls', '-T', mockTeam.slug];
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.explicitScopeProvided).toBe(true);
+    });
+
+    it('should detect localConfig scope as explicit scope', async () => {
+      client.config.currentTeam = mockTeam.id;
+      client.localConfig = { scope: mockTeam.slug };
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.explicitScopeProvided).toBe(true);
+    });
+  });
+
+  describe('detectCrossTeamRepo (via isCrossTeamRepo)', () => {
+    beforeEach(() => {
+      useTeam();
+      useUser();
+    });
+
+    it('should not flag cross-team when there is no repo link', async () => {
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.isCrossTeamRepo).toBe(false);
+    });
+  });
+
+  describe('cross-team repo awareness', () => {
+    let mockTeam: ReturnType<typeof useTeam>;
+
+    beforeEach(() => {
+      mockTeam = useTeam('team_dummy');
+      useUser();
+    });
+
+    it('should warn about cross-team repo without prompting for a project', async () => {
+      const cwd = setupTmpDir();
+      client.cwd = cwd;
+      client.config.currentTeam = mockTeam.id;
+      const selectSpy = vi.spyOn(client.input, 'select');
+
+      await outputFile(
+        join(cwd, '.vercel', 'repo.json'),
+        JSON.stringify({
+          remoteName: 'origin',
+          projects: [
+            {
+              id: 'prj_aaa',
+              name: 'proj-a',
+              directory: 'apps/a',
+              orgId: 'team_aaa',
+            },
+            {
+              id: 'prj_bbb',
+              name: 'proj-b',
+              directory: 'apps/b',
+              orgId: 'team_bbb',
+            },
+          ],
+        })
+      );
+
+      const exitCodePromise = getScope(client, {
+        resolveLocalScope: true,
+      });
+      await expect(client.stderr).toOutput(
+        'This repository has projects across multiple teams'
+      );
+      const ctx = await exitCodePromise;
+
+      expect(selectSpy).not.toHaveBeenCalled();
+      expect(ctx.isCrossTeamRepo).toBe(true);
+      expect(ctx.org.id).toEqual(mockTeam.id);
+    });
+
+    it('should not warn about cross-team repo when explicit --scope is provided', async () => {
+      const cwd = setupTmpDir();
+      client.cwd = cwd;
+      client.config.currentTeam = mockTeam.id;
+      client.argv = ['projects', 'ls', '--scope', mockTeam.slug];
+
+      await outputFile(
+        join(cwd, '.vercel', 'repo.json'),
+        JSON.stringify({
+          remoteName: 'origin',
+          projects: [
+            {
+              id: 'prj_aaa',
+              name: 'proj-a',
+              directory: 'apps/a',
+              orgId: 'team_aaa',
+            },
+            {
+              id: 'prj_bbb',
+              name: 'proj-b',
+              directory: 'apps/b',
+              orgId: 'team_bbb',
+            },
+          ],
+        })
+      );
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.isCrossTeamRepo).toBe(true);
+      expect(ctx.explicitScopeProvided).toBe(true);
+      expect(ctx.org.id).toEqual(mockTeam.id);
+    });
+
+    it('should resolve localOrgId when multiple matched projects share the same orgId', async () => {
+      const cwd = setupTmpDir();
+      client.cwd = cwd;
+      client.config.currentTeam = mockTeam.id;
+
+      await outputFile(
+        join(cwd, '.vercel', 'repo.json'),
+        JSON.stringify({
+          remoteName: 'origin',
+          projects: [
+            {
+              id: 'prj_aaa',
+              name: 'proj-a',
+              directory: '.',
+              orgId: mockTeam.id,
+            },
+            {
+              id: 'prj_bbb',
+              name: 'proj-b',
+              directory: '.',
+              orgId: mockTeam.id,
+            },
+            {
+              id: 'prj_ccc',
+              name: 'proj-c',
+              directory: 'apps/c',
+              orgId: 'team_other',
+            },
+          ],
+        })
+      );
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.isCrossTeamRepo).toBe(true);
+      expect(ctx.org.id).toEqual(mockTeam.id);
+    });
+  });
+
+  describe('detectExplicitScope edge cases', () => {
+    beforeEach(() => {
+      useTeam();
+      useUser();
+    });
+
+    it('should return false when no scope indicators present', async () => {
+      client.argv = ['deploy'];
+      client.localConfig = {};
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.explicitScopeProvided).toBe(false);
+    });
+
+    it('should not false-positive on unrelated flags', async () => {
+      client.argv = ['deploy', '--force', '--yes'];
+      client.localConfig = {};
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.explicitScopeProvided).toBe(false);
+    });
+  });
+
+  describe('northstar user', () => {
+    let mockTeam: ReturnType<typeof useTeam>;
+    let mockUser: ReturnType<typeof useUser>;
+
+    beforeEach(() => {
+      mockTeam = useTeam();
+      mockUser = useUser({
+        version: 'northstar',
+        defaultTeamId: mockTeam.id,
+      });
+    });
+
+    it('should use default team for northstar user', async () => {
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.org.id).toEqual(mockTeam.id);
+      expect(ctx.user.id).toEqual(mockUser.id);
+      expect(ctx.team?.id).toEqual(mockTeam.id);
+    });
+  });
+});
+
+describe('applyScopeFromLink', () => {
+  it('should set currentTeam from team org', () => {
+    client.config.currentTeam = undefined;
+    applyScopeFromLink(client, {
+      org: { type: 'team', id: 'team_abc', slug: 'my-team' },
+    });
+    expect(client.config.currentTeam).toEqual('team_abc');
+  });
+
+  it('should clear currentTeam for personal account org', () => {
+    client.config.currentTeam = 'team_old';
+    applyScopeFromLink(client, {
+      org: { type: 'user', id: 'user_abc', slug: 'johndoe' },
+    });
+    expect(client.config.currentTeam).toBeUndefined();
+  });
+
+  it('should override currentTeam when switching teams', () => {
+    client.config.currentTeam = 'team_old';
+    applyScopeFromLink(client, {
+      org: { type: 'team', id: 'team_new', slug: 'new-team' },
+    });
+    expect(client.config.currentTeam).toEqual('team_new');
+  });
+
+  it('should warn on scope mismatch', async () => {
+    client.config.currentTeam = 'team_global';
+    applyScopeFromLink(client, {
+      org: { type: 'team', id: 'team_local', slug: 'local-team' },
+    });
+    await expect(client.stderr).toOutput(
+      'This directory is linked to a project under a different team'
+    );
+    expect(client.config.currentTeam).toEqual('team_local');
+  });
+
+  it('should not warn when scopes match', () => {
+    client.config.currentTeam = 'team_abc';
+    applyScopeFromLink(client, {
+      org: { type: 'team', id: 'team_abc', slug: 'my-team' },
+    });
+    expect(client.config.currentTeam).toEqual('team_abc');
+  });
+});


### PR DESCRIPTION
This Pr does a few things:
- updates the `vc switch` command to be more explicit
- enriches the `getScope` function to be opt-in for `localScope` flag. This flag choose the local scope for a project over any global scope
- Passing explicit `--scope` flag trumps all scope logic
(additional information supplied with videos in Slack)