### PR TITLE
[CLI] Adding User Id to Persist into auth.json

### DIFF
--- a/.changeset/tall-laws-check.md
+++ b/.changeset/tall-laws-check.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Cache the authenticated `userId` in the CLI auth config to reduce unnecessary `getUser()` requests.

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -32,6 +32,8 @@ export interface AuthConfig {
   skipWrite?: boolean;
   /** An `access_token` obtained using the OAuth Device Authorization flow.  */
   token?: string;
+  /** The ID of the currently authenticated user, cached from `/v2/user`. */
+  userId?: string;
   /** A `refresh_token` obtained using the OAuth Device Authorization flow. */
   refreshToken?: string;
   /**

--- a/packages/cli/src/commands/login/future.ts
+++ b/packages/cli/src/commands/login/future.ts
@@ -212,6 +212,7 @@ export async function login(
 
   client.updateAuthConfig({
     token: tokens.access_token,
+    userId: undefined,
     expiresAt: Math.floor(Date.now() / 1000) + tokens.expires_in,
     refreshToken: tokens.refresh_token,
   });

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -78,6 +78,7 @@ export default async function logout(client: Client): Promise<number> {
   delete config.currentTeam;
 
   delete authConfig.token;
+  delete authConfig.userId;
 
   try {
     writeToConfigFile(config);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -998,7 +998,7 @@ const main = async () => {
         func = func.default;
       }
 
-      if (!telemetryEventStore.hasUserId) {
+      if (!telemetryEventStore.hasUserId && !client.authConfig.userId) {
         earlyGetUserPromise = getUser(client).catch(() => undefined);
       }
 
@@ -1077,6 +1077,7 @@ const main = async () => {
   const postCommandSpan = rootSpan.child('vc.postCommand');
 
   telemetryEventStore.updateTeamId(client.config.currentTeam);
+  telemetryEventStore.updateUserId(client.authConfig.userId);
   if (!telemetryEventStore.hasUserId) {
     const getUserSpan = postCommandSpan.child('vc.postCommand.getUser');
     try {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -243,6 +243,8 @@ export default class Client extends EventEmitter implements Stdio {
       return;
     }
 
+    // Token refresh does not change the authenticated user, so the cached
+    // userId is intentionally preserved here.
     this.updateAuthConfig({
       token: tokens.access_token,
       expiresAt: Math.floor(Date.now() / 1000) + tokens.expires_in,

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -271,7 +271,7 @@ export default class Client extends EventEmitter implements Stdio {
   }
 
   emptyAuthConfig() {
-    this.authConfig = {};
+    this.authConfig = this.authConfig.skipWrite ? { skipWrite: true } : {};
   }
 
   writeToAuthConfigFile() {

--- a/packages/cli/src/util/get-user.ts
+++ b/packages/cli/src/util/get-user.ts
@@ -1,29 +1,7 @@
 import type Client from './client';
 import type { User } from '@vercel-internals/types';
 import { APIError, InvalidToken, MissingUser } from './errors-ts';
-import { isError } from '@vercel/error-utils';
-import writeJSON from 'write-json-file';
-import { getAuthConfigFilePath } from './config/files';
 import output from '../output-manager';
-
-function tryPersistCachedUserId(client: Client) {
-  if (client.authConfig.skipWrite) {
-    return;
-  }
-
-  try {
-    writeJSON.sync(getAuthConfigFilePath(), client.authConfig, {
-      indent: 2,
-      mode: 0o600,
-    });
-  } catch (err: unknown) {
-    output.debug(
-      `Failed to update cached userId in auth config: ${
-        isError(err) ? err.message : String(err)
-      }`
-    );
-  }
-}
 
 export default async function getUser(client: Client) {
   try {
@@ -37,7 +15,11 @@ export default async function getUser(client: Client) {
 
     if (client.authConfig.userId !== res.user.id) {
       client.updateAuthConfig({ userId: res.user.id });
-      tryPersistCachedUserId(client);
+      try {
+        client.writeToAuthConfigFile();
+      } catch {
+        output.debug('Failed to persist cached userId to auth config.');
+      }
     }
 
     client.telemetryEventStore.updateUserId(res.user.id);
@@ -47,7 +29,11 @@ export default async function getUser(client: Client) {
     if (error instanceof APIError && error.status === 403) {
       if (client.authConfig.userId) {
         client.updateAuthConfig({ userId: undefined });
-        tryPersistCachedUserId(client);
+        try {
+          client.writeToAuthConfigFile();
+        } catch {
+          output.debug('Failed to persist cached userId to auth config.');
+        }
       }
 
       throw new InvalidToken(client.authConfig.tokenSource);

--- a/packages/cli/src/util/get-user.ts
+++ b/packages/cli/src/util/get-user.ts
@@ -12,9 +12,21 @@ export default async function getUser(client: Client) {
       throw new MissingUser();
     }
 
+    if (client.authConfig.userId !== res.user.id) {
+      client.updateAuthConfig({ userId: res.user.id });
+      client.writeToAuthConfigFile();
+    }
+
+    client.telemetryEventStore.updateUserId(res.user.id);
+
     return res.user;
   } catch (error) {
     if (error instanceof APIError && error.status === 403) {
+      if (client.authConfig.userId) {
+        client.updateAuthConfig({ userId: undefined });
+        client.writeToAuthConfigFile();
+      }
+
       throw new InvalidToken(client.authConfig.tokenSource);
     }
 

--- a/packages/cli/src/util/get-user.ts
+++ b/packages/cli/src/util/get-user.ts
@@ -1,6 +1,29 @@
 import type Client from './client';
 import type { User } from '@vercel-internals/types';
 import { APIError, InvalidToken, MissingUser } from './errors-ts';
+import { isError } from '@vercel/error-utils';
+import writeJSON from 'write-json-file';
+import { getAuthConfigFilePath } from './config/files';
+import output from '../output-manager';
+
+function tryPersistCachedUserId(client: Client) {
+  if (client.authConfig.skipWrite) {
+    return;
+  }
+
+  try {
+    writeJSON.sync(getAuthConfigFilePath(), client.authConfig, {
+      indent: 2,
+      mode: 0o600,
+    });
+  } catch (err: unknown) {
+    output.debug(
+      `Failed to update cached userId in auth config: ${
+        isError(err) ? err.message : String(err)
+      }`
+    );
+  }
+}
 
 export default async function getUser(client: Client) {
   try {
@@ -14,7 +37,7 @@ export default async function getUser(client: Client) {
 
     if (client.authConfig.userId !== res.user.id) {
       client.updateAuthConfig({ userId: res.user.id });
-      client.writeToAuthConfigFile();
+      tryPersistCachedUserId(client);
     }
 
     client.telemetryEventStore.updateUserId(res.user.id);
@@ -24,7 +47,7 @@ export default async function getUser(client: Client) {
     if (error instanceof APIError && error.status === 403) {
       if (client.authConfig.userId) {
         client.updateAuthConfig({ userId: undefined });
-        client.writeToAuthConfigFile();
+        tryPersistCachedUserId(client);
       }
 
       throw new InvalidToken(client.authConfig.tokenSource);

--- a/packages/cli/src/util/login/reauthenticate.ts
+++ b/packages/cli/src/util/login/reauthenticate.ts
@@ -30,6 +30,7 @@ export default async function reauthenticate(
 
   client.updateAuthConfig({
     token: tokens.access_token,
+    userId: undefined,
     expiresAt: Math.floor(Date.now() / 1000) + tokens.expires_in,
     refreshToken: tokens.refresh_token,
   });

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -261,6 +261,7 @@ export class MockClient extends Client {
     this.argv = [];
     this.authConfig = {
       token: 'token_dummy',
+      skipWrite: true,
     };
     this.config = {};
     this.localConfig = {};

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -139,4 +139,53 @@ describe('login', () => {
 
   it.todo('Authorization request error');
   it.todo('Token request error');
+
+  it('clears stale cached userId on re-login', async () => {
+    vi.resetModules();
+    const freshOauth = await import('../../../../src/util/oauth');
+    const { default: freshLogin } = await import(
+      '../../../../src/commands/login'
+    );
+
+    fetch.mockResolvedValueOnce(
+      mockResponse({
+        issuer: 'https://vercel.com',
+        device_authorization_endpoint: 'https://vercel.com',
+        token_endpoint: 'https://vercel.com',
+        revocation_endpoint: 'https://vercel.com',
+        jwks_uri: 'https://vercel.com',
+        introspection_endpoint: 'https://vercel.com',
+      })
+    );
+    await freshOauth.as();
+
+    const authorizationResult = {
+      device_code: randomUUID(),
+      user_code: randomUUID(),
+      verification_uri: 'https://vercel.com/device',
+      verification_uri_complete: `https://vercel.com/device?code=${randomUUID()}`,
+      expires_in: 30,
+      interval: 0.005,
+    };
+
+    fetch.mockResolvedValueOnce(mockResponse(authorizationResult));
+
+    await simulateTokenPolling(
+      1,
+      mockResponse({
+        access_token: randomUUID(),
+        token_type: 'Bearer',
+        expires_in: 60,
+        scope: 'openid offline_access',
+      })
+    );
+
+    client.setArgv('login');
+    client.authConfig.userId = 'user_stale';
+
+    const exitCode = await freshLogin(client, { shouldParseArgs: true });
+
+    expect(exitCode).toBe(0);
+    expect(client.authConfig.userId).toBeUndefined();
+  });
 });

--- a/packages/cli/test/unit/commands/logout/future.test.ts
+++ b/packages/cli/test/unit/commands/logout/future.test.ts
@@ -48,6 +48,8 @@ describe('logout', () => {
     client.setArgv('logout');
     client.authConfig.token = randomUUID();
     const tokenBefore = client.authConfig.token;
+    client.authConfig.userId = randomUUID();
+    const userIdBefore = client.authConfig.userId;
     client.authConfig.refreshToken = randomUUID();
     const refreshTokenBefore = client.authConfig.refreshToken;
     client.config.currentTeam = randomUUID();
@@ -83,6 +85,9 @@ describe('logout', () => {
     const tokenAfter = client.authConfig.token;
     expect(tokenAfter).not.toBe(tokenBefore);
     expect(tokenAfter).toBeUndefined();
+    const userIdAfter = client.authConfig.userId;
+    expect(userIdAfter).not.toBe(userIdBefore);
+    expect(userIdAfter).toBeUndefined();
     const refreshTokenAfter = client.authConfig.refreshToken;
     expect(refreshTokenAfter).not.toBe(refreshTokenBefore);
     expect(refreshTokenAfter).toBeUndefined();
@@ -103,6 +108,8 @@ describe('logout', () => {
     client.setArgv('logout', '--debug');
     client.authConfig.token = randomUUID();
     const tokenBefore = client.authConfig.token;
+    client.authConfig.userId = randomUUID();
+    const userIdBefore = client.authConfig.userId;
     client.authConfig.refreshToken = randomUUID();
     const refreshTokenBefore = client.authConfig.refreshToken;
     client.config.currentTeam = randomUUID();
@@ -122,6 +129,9 @@ describe('logout', () => {
     const tokenAfter = client.authConfig.token;
     expect(tokenAfter).not.toBe(tokenBefore);
     expect(tokenAfter).toBeUndefined();
+    const userIdAfter = client.authConfig.userId;
+    expect(userIdAfter).not.toBe(userIdBefore);
+    expect(userIdAfter).toBeUndefined();
     const refreshTokenAfter = client.authConfig.refreshToken;
     expect(refreshTokenAfter).not.toBe(refreshTokenBefore);
     expect(refreshTokenAfter).toBeUndefined();

--- a/packages/cli/test/unit/util/get-user.test.ts
+++ b/packages/cli/test/unit/util/get-user.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import getUser from '../../../src/util/get-user';
+import { client } from '../../mocks/client';
+import { useUser } from '../../mocks/user';
+
+describe('getUser', () => {
+  beforeEach(() => {
+    client.telemetryEventStore.reset();
+  });
+
+  it('caches the userId after fetching the user', async () => {
+    const user = useUser();
+    const writeSpy = vi
+      .spyOn(client, 'writeToAuthConfigFile')
+      .mockImplementation(() => undefined);
+
+    const result = await getUser(client);
+
+    expect(result.id).toBe(user.id);
+    expect(client.authConfig.userId).toBe(user.id);
+    expect(client.telemetryEventStore.hasUserId).toBe(true);
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not rewrite auth config when the cached userId is already current', async () => {
+    const user = useUser();
+    client.authConfig.userId = user.id;
+    const writeSpy = vi
+      .spyOn(client, 'writeToAuthConfigFile')
+      .mockImplementation(() => undefined);
+
+    const result = await getUser(client);
+
+    expect(result.id).toBe(user.id);
+    expect(client.authConfig.userId).toBe(user.id);
+    expect(client.telemetryEventStore.hasUserId).toBe(true);
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/unit/util/get-user.test.ts
+++ b/packages/cli/test/unit/util/get-user.test.ts
@@ -1,33 +1,21 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import getUser from '../../../src/util/get-user';
 import { client } from '../../mocks/client';
 import { useUser } from '../../mocks/user';
-import writeJSON from 'write-json-file';
-
-vi.mock('write-json-file', () => ({
-  default: {
-    sync: vi.fn(),
-  },
-}));
-
-const writeJsonSync = vi.mocked(writeJSON.sync);
 
 describe('getUser', () => {
   beforeEach(() => {
     client.telemetryEventStore.reset();
-    writeJsonSync.mockReset();
   });
 
   it('caches the userId after fetching the user', async () => {
     const user = useUser();
-    client.authConfig.skipWrite = false;
 
     const result = await getUser(client);
 
     expect(result.id).toBe(user.id);
     expect(client.authConfig.userId).toBe(user.id);
     expect(client.telemetryEventStore.hasUserId).toBe(true);
-    expect(writeJsonSync).toHaveBeenCalledTimes(1);
   });
 
   it('does not rewrite auth config when the cached userId is already current', async () => {
@@ -39,12 +27,10 @@ describe('getUser', () => {
     expect(result.id).toBe(user.id);
     expect(client.authConfig.userId).toBe(user.id);
     expect(client.telemetryEventStore.hasUserId).toBe(true);
-    expect(writeJsonSync).not.toHaveBeenCalled();
   });
 
   it('clears cached userId in best-effort mode when the token is invalid', async () => {
     client.authConfig.userId = 'user_stale';
-    client.authConfig.skipWrite = false;
 
     client.scenario.get('/v2/user', (_req, res) => {
       res.status(403).json({ error: { message: 'forbidden' } });
@@ -55,6 +41,5 @@ describe('getUser', () => {
     });
 
     expect(client.authConfig.userId).toBeUndefined();
-    expect(writeJsonSync).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/test/unit/util/get-user.test.ts
+++ b/packages/cli/test/unit/util/get-user.test.ts
@@ -2,38 +2,59 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import getUser from '../../../src/util/get-user';
 import { client } from '../../mocks/client';
 import { useUser } from '../../mocks/user';
+import writeJSON from 'write-json-file';
+
+vi.mock('write-json-file', () => ({
+  default: {
+    sync: vi.fn(),
+  },
+}));
+
+const writeJsonSync = vi.mocked(writeJSON.sync);
 
 describe('getUser', () => {
   beforeEach(() => {
     client.telemetryEventStore.reset();
+    writeJsonSync.mockReset();
   });
 
   it('caches the userId after fetching the user', async () => {
     const user = useUser();
-    const writeSpy = vi
-      .spyOn(client, 'writeToAuthConfigFile')
-      .mockImplementation(() => undefined);
+    client.authConfig.skipWrite = false;
 
     const result = await getUser(client);
 
     expect(result.id).toBe(user.id);
     expect(client.authConfig.userId).toBe(user.id);
     expect(client.telemetryEventStore.hasUserId).toBe(true);
-    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeJsonSync).toHaveBeenCalledTimes(1);
   });
 
   it('does not rewrite auth config when the cached userId is already current', async () => {
     const user = useUser();
     client.authConfig.userId = user.id;
-    const writeSpy = vi
-      .spyOn(client, 'writeToAuthConfigFile')
-      .mockImplementation(() => undefined);
 
     const result = await getUser(client);
 
     expect(result.id).toBe(user.id);
     expect(client.authConfig.userId).toBe(user.id);
     expect(client.telemetryEventStore.hasUserId).toBe(true);
-    expect(writeSpy).not.toHaveBeenCalled();
+    expect(writeJsonSync).not.toHaveBeenCalled();
+  });
+
+  it('clears cached userId in best-effort mode when the token is invalid', async () => {
+    client.authConfig.userId = 'user_stale';
+    client.authConfig.skipWrite = false;
+
+    client.scenario.get('/v2/user', (_req, res) => {
+      res.status(403).json({ error: { message: 'forbidden' } });
+    });
+
+    await expect(getUser(client)).rejects.toMatchObject({
+      code: 'NOT_AUTHORIZED',
+    });
+
+    expect(client.authConfig.userId).toBeUndefined();
+    expect(writeJsonSync).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This adds a user_id to the auth.json file to persist when users run `getUser`