### PR TITLE
[services] add preDeployCommand for experimentalServices

### DIFF
--- a/.changeset/silent-chairs-run.md
+++ b/.changeset/silent-chairs-run.md
@@ -1,0 +1,8 @@
+---
+'@vercel/fs-detectors': minor
+'@vercel/build-utils': minor
+'@vercel/config': minor
+'vercel': minor
+---
+
+[services] add preDeployCommand for experimentalServices

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,9 +1,11 @@
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
 import {
   defaultCachePathGlob,
+  execCommand,
+  getNodeBinPaths,
   getReportedServiceType,
   glob,
   NodejsLambda,
@@ -114,6 +116,28 @@ export const build: BuildV2 = async args => {
     const isCronService = cronEntries !== undefined;
 
     const userBuildResult = await maybeDoBuildCommand(args, downloadResult);
+
+    const preDeployCommand = args.config.preDeployCommand;
+    if (args.registerPreDeploy && typeof preDeployCommand === 'string') {
+      const repoRoot = args.repoRootPath || args.workPath;
+      const nodeBinPaths = getNodeBinPaths({
+        base: repoRoot,
+        start: args.workPath,
+      });
+      const nodeBinPath = nodeBinPaths.join(delimiter);
+      const capturedEnv = {
+        ...downloadResult.spawnEnv,
+        PATH: `${nodeBinPath}${delimiter}${downloadResult.spawnEnv?.PATH || process.env.PATH}`,
+      };
+      const capturedCwd = args.workPath;
+      args.registerPreDeploy(async () => {
+        debug(`Running pre-deploy command: \`${preDeployCommand}\``);
+        await execCommand(preDeployCommand, {
+          env: capturedEnv,
+          cwd: capturedCwd,
+        });
+      });
+    }
 
     const functionConfig = args.config.functions?.[entrypoint];
     if (functionConfig) {

--- a/packages/build-utils/src/trace/constants.ts
+++ b/packages/build-utils/src/trace/constants.ts
@@ -1,3 +1,5 @@
 export const BUILDER_INSTALLER_STEP = 'vc.builder.install';
 
 export const BUILDER_COMPILE_STEP = 'vc.builder.build';
+
+export const BUILDER_PRE_DEPLOY_STEP = 'vc.builder.preDeploy';

--- a/packages/build-utils/src/trace/index.ts
+++ b/packages/build-utils/src/trace/index.ts
@@ -1,3 +1,7 @@
 export { Span } from './trace';
-export { BUILDER_COMPILE_STEP, BUILDER_INSTALLER_STEP } from './constants';
+export {
+  BUILDER_COMPILE_STEP,
+  BUILDER_INSTALLER_STEP,
+  BUILDER_PRE_DEPLOY_STEP,
+} from './constants';
 export type { SpanId, TraceEvent, Reporter } from './trace';

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -110,6 +110,13 @@ export interface BuildOptions {
   buildCallback?: (opts: Omit<BuildOptions, 'buildCallback'>) => Promise<void>;
 
   /**
+   * Called by the builder to register a callback that will execute the
+   * service's pre-deploy command. The CLI collects these and invokes
+   * them only after every builder has succeeded.
+   */
+  registerPreDeploy?: (callback: () => Promise<void>) => void;
+
+  /**
    * The current trace state from the internal vc tracing
    */
   span?: Span;
@@ -608,6 +615,7 @@ export interface Service {
   runtime?: string;
   buildCommand?: string;
   installCommand?: string;
+  preDeployCommand?: string;
   /* web service config */
   routePrefix?: string;
   routePrefixSource?: 'configured' | 'generated';

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -863,6 +863,11 @@ async function doBuild(
     }
   }
 
+  const preDeployEntries: {
+    service: string;
+    callback?: () => Promise<void>;
+  }[] = [];
+
   for (const build of sortedBuilders) {
     if (typeof build.src !== 'string') continue;
 
@@ -973,6 +978,7 @@ async function doBuild(
             },
             installCommand: service.installCommand ?? undefined,
             buildCommand: service.buildCommand ?? undefined,
+            preDeployCommand: service.preDeployCommand ?? undefined,
             framework: builderFramework,
             nodeVersion: projectSettings.nodeVersion,
             bunVersion: localConfig.bunVersion ?? undefined,
@@ -1007,6 +1013,16 @@ async function doBuild(
 
       const serviceRoutePrefix = build.config?.routePrefix;
       const serviceWorkspace = build.config?.workspace;
+      const preDeployCmd = service?.preDeployCommand?.trim();
+
+      const preDeployEntry =
+        preDeployCmd && service
+          ? ({ service: service.name } as (typeof preDeployEntries)[number])
+          : undefined;
+      if (preDeployEntry) {
+        preDeployEntries.push(preDeployEntry);
+      }
+
       const buildOptions: BuildOptions = {
         files: buildFiles,
         entrypoint: buildEntrypoint,
@@ -1015,6 +1031,13 @@ async function doBuild(
         config: buildConfig,
         meta,
         span: builderSpan,
+        ...(preDeployCmd
+          ? {
+              registerPreDeploy: (callback: () => Promise<void>) => {
+                preDeployEntry!.callback = callback;
+              },
+            }
+          : undefined),
         ...(service
           ? {
               service: {
@@ -1379,6 +1402,21 @@ async function doBuild(
           () => undefined,
           err => err
         )
+      );
+    }
+  }
+
+  // Run pre-deploy commands after all builders succeeded.
+  // A builder is responsible for handling preDeployCommand, so
+  // it will actually own its env, tracing, etc.
+  // We do not fire them during the build itself, because not all builds
+  // might succeed and be actually deployed.
+  for (const entry of preDeployEntries) {
+    if (entry.callback) {
+      await entry.callback();
+    } else {
+      output.warn(
+        `Service "${entry.service}" has a preDeployCommand but its builder does not support it. The command was not executed.`
       );
     }
   }

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/.vercel/project.json
@@ -1,0 +1,1 @@
+{"orgId":".","projectId":".","settings":{"framework":null,"installCommand":""}}

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/index.js
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/index.js
@@ -1,0 +1,6 @@
+const { createServer } = require('node:http');
+
+createServer((_req, res) => {
+  res.statusCode = 200;
+  res.end('ok');
+}).listen(3000);

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/package.json
@@ -1,0 +1,1 @@
+{ "name": "pre-deploy-test", "private": true }

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/pre-deploy.js
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/pre-deploy.js
@@ -1,0 +1,1 @@
+require('fs').writeFileSync('pre-deploy-ran.txt', 'ok');

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-pre-deploy-command/vercel.json
@@ -1,0 +1,9 @@
+{
+  "experimentalServices": {
+    "api": {
+      "entrypoint": "index.js",
+      "routePrefix": "/",
+      "preDeployCommand": "node pre-deploy.js"
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -2534,6 +2534,22 @@ fs.writeFileSync(
     }
   });
 
+  it('should run preDeployCommand after build succeeds', async () => {
+    const cwd = fixture('with-services-pre-deploy-command');
+    const sideEffectFile = join(cwd, 'pre-deploy-ran.txt');
+
+    await fs.remove(sideEffectFile);
+
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toBe(0);
+
+    expect(await fs.pathExists(sideEffectFile)).toBe(true);
+    expect(await fs.readFile(sideEffectFile, 'utf8')).toBe('ok');
+
+    await fs.remove(sideEffectFile);
+  });
+
   it('should not write trace spans for non-build commands', async () => {
     const cwd = fixture('static');
     const tracePath = join(cwd, '.vercel/output/diagnostics/cli_traces.json');

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -637,6 +637,12 @@ export interface VercelConfig {
        */
       installCommand?: string;
       /**
+       * Command to run after build process succeed but before the deployment's
+       * output is uploaded. Runs during `vercel build` including local builds
+       * and builds on Vercel.
+       */
+      preDeployCommand?: string;
+      /**
        * Memory allocation in MB (128-10240).
        */
       memory?: number;

--- a/packages/fs-detectors/src/services/detect-railway.ts
+++ b/packages/fs-detectors/src/services/detect-railway.ts
@@ -176,12 +176,14 @@ export async function detectRailwayServices(options: {
       serviceConfig.entrypoint = cf.dirPath;
     }
 
-    const buildCommand = combineBuildCommand(
-      cf.config.build?.buildCommand,
-      cf.config.deploy?.preDeployCommand
-    );
-    if (buildCommand) {
-      serviceConfig.buildCommand = buildCommand;
+    if (cf.config.build?.buildCommand) {
+      serviceConfig.buildCommand = cf.config.build.buildCommand;
+    }
+    const railwayPreDeploy = cf.config.deploy?.preDeployCommand;
+    if (railwayPreDeploy) {
+      serviceConfig.preDeployCommand = Array.isArray(railwayPreDeploy)
+        ? railwayPreDeploy.join(' && ')
+        : railwayPreDeploy;
     }
 
     services[serviceName] = serviceConfig;
@@ -311,23 +313,6 @@ function deriveServiceName(dirPath: string): string {
   }
   const segments = dirPath.split('/');
   return segments[segments.length - 1];
-}
-
-function combineBuildCommand(
-  buildCommand: string | undefined,
-  preDeployCommand: string | string[] | undefined
-): string | undefined {
-  const preDeploy = Array.isArray(preDeployCommand)
-    ? preDeployCommand.join(' && ')
-    : preDeployCommand;
-
-  if (preDeploy && buildCommand) {
-    return `${buildCommand} && ${preDeploy}`;
-  } else if (preDeploy) {
-    return preDeploy;
-  } else {
-    return buildCommand;
-  }
 }
 
 /**

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -948,6 +948,7 @@ export async function resolveConfiguredService(
     runtime,
     buildCommand: config.buildCommand,
     installCommand: config.installCommand,
+    preDeployCommand: config.preDeployCommand,
     schedule: config.schedule,
     handlerFunction: moduleAttrParsed?.attrName,
     topics,

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/probes.json
@@ -1,0 +1,9 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "version:v0.0.0"
+    }
+  ]
+}

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/pyproject.toml
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "api-pre-deploy"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+  "fastapi",
+]

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/src/app.py
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/src/app.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from src.version import VERSION
+
+app = FastAPI()
+
+
+@app.get("/")
+def root():
+    return PlainTextResponse(f"version:{VERSION}")

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/src/version.py
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/src/version.py
@@ -1,0 +1,1 @@
+VERSION = 'to-be-modified'

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-pre-deploy-command/vercel.json
@@ -1,0 +1,11 @@
+{
+  "uploadNowJson": true,
+  "projectSettings": { "framework": "services" },
+  "experimentalServices": {
+    "api": {
+      "entrypoint": "src/app.py",
+      "routePrefix": "/",
+      "preDeployCommand": "python -c \"import pathlib; pathlib.Path('src/version.py').write_text(\\\"VERSION = 'v0.0.0'\\\\n\\\")\""
+    }
+  }
+}

--- a/packages/fs-detectors/test/unit.detect-railway-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-railway-services.test.ts
@@ -260,7 +260,7 @@ describe('detectRailwayServices', () => {
   });
 
   describe('preDeployCommand', () => {
-    it('should append preDeployCommand string to buildCommand', async () => {
+    it('should map preDeployCommand string to preDeployCommand field', async () => {
       const fs = new VirtualFilesystem({
         'railway.json': JSON.stringify({
           build: { buildCommand: 'npm run build' },
@@ -273,30 +273,11 @@ describe('detectRailwayServices', () => {
 
       const result = await detectRailwayServices({ fs });
 
-      expect(result.services!.web.buildCommand).toBe(
-        'npm run build && npm run db:migrate'
-      );
+      expect(result.services!.web.buildCommand).toBe('npm run build');
+      expect(result.services!.web.preDeployCommand).toBe('npm run db:migrate');
     });
 
-    it('should append preDeployCommand array to buildCommand', async () => {
-      const fs = new VirtualFilesystem({
-        'railway.json': JSON.stringify({
-          build: { buildCommand: 'npm run build' },
-          deploy: { preDeployCommand: ['npm run db:migrate'] },
-        }),
-        'package.json': JSON.stringify({
-          dependencies: { next: '14.0.0' },
-        }),
-      });
-
-      const result = await detectRailwayServices({ fs });
-
-      expect(result.services!.web.buildCommand).toBe(
-        'npm run build && npm run db:migrate'
-      );
-    });
-
-    it('should use preDeployCommand alone when no buildCommand', async () => {
+    it('should set preDeployCommand alone when no buildCommand', async () => {
       const fs = new VirtualFilesystem({
         'api/railway.json': JSON.stringify({
           deploy: { preDeployCommand: 'python manage.py migrate' },
@@ -307,7 +288,8 @@ describe('detectRailwayServices', () => {
 
       const result = await detectRailwayServices({ fs });
 
-      expect(result.services!.api.buildCommand).toBe(
+      expect(result.services!.api.buildCommand).toBeUndefined();
+      expect(result.services!.api.preDeployCommand).toBe(
         'python manage.py migrate'
       );
     });
@@ -325,6 +307,7 @@ describe('detectRailwayServices', () => {
       const result = await detectRailwayServices({ fs });
 
       expect(result.services!.web.buildCommand).toBe('npm run build');
+      expect(result.services!.web.preDeployCommand).toBeUndefined();
     });
   });
 

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -22,6 +22,7 @@ import {
   Span,
   BUILDER_INSTALLER_STEP,
   BUILDER_COMPILE_STEP,
+  BUILDER_PRE_DEPLOY_STEP,
   type BuildOptions,
   type GlobOptions,
   type BuildVX,
@@ -229,6 +230,7 @@ export const build: BuildVX = async ({
   config,
   span: parentSpan,
   service,
+  registerPreDeploy,
 }) => {
   let entrypoint: string | undefined =
     rawEntrypoint === '<detect>' ? undefined : rawEntrypoint;
@@ -622,6 +624,28 @@ export const build: BuildVX = async ({
   if (quirksResult.buildEnv) {
     Object.assign(pythonEnv, quirksResult.buildEnv);
   }
+
+  // Register a pre-deploy command that will be fired in the end of the
+  // build process (if all builders including this one succeed)
+  const preDeployCommand = config?.preDeployCommand;
+  if (registerPreDeploy && typeof preDeployCommand === 'string') {
+    const capturedEnv = { ...pythonEnv };
+    const capturedCwd = workPath;
+    registerPreDeploy(async () => {
+      await builderSpan
+        .child(BUILDER_PRE_DEPLOY_STEP, {
+          preDeployCommand,
+        })
+        .trace(async () => {
+          console.log(`Running pre-deploy command: \`${preDeployCommand}\``);
+          await execCommand(preDeployCommand, {
+            env: capturedEnv,
+            cwd: capturedCwd,
+          });
+        });
+    });
+  }
+
   debug('Entrypoint is', entrypoint);
   const moduleName = entrypointToModule(entrypoint);
 


### PR DESCRIPTION
This will allow users to run additional commands (e.g. database migrations) after the build process is complete:
```json
{
  "experimentalServices": {
    "api": {
      "entrypoint": "services/api",
      "framework": "fastapi",
      "routePrefix": "/api",
      "preDeployCommand": "uv run alembic upgrade head"
    },
    "web": {
      "entrypoint": "ui/web",
      "framework": "nextjs",
      "routePrefix": "/"
    }
  }
}
``` 

This can be done right now by including these commands in `buildCommand`, but from a semantic and practical point, these are two different things. We don't want to run the database migration if our `api` service has finished building, but the sibling `worker` service has, for some reason, failed. We want to do this only after all our services for a project together are ready to be deployed