### PR TITLE
feat: Detect opencode running environment

### DIFF
--- a/.changeset/stale-peaches-double.md
+++ b/.changeset/stale-peaches-double.md
@@ -1,0 +1,5 @@
+---
+'@vercel/detect-agent': patch
+---
+
+Detect opencode

--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -32,6 +32,7 @@ This package can detect the following AI agents and development environments:
 - **Gemini CLI** (Google)
 - **Codex** (OpenAI)
 - **Antigravity** (Google DeepMind)
+- **OpenCode** (via `OPENCODE`)
 - **GitHub Copilot** (via `AI_AGENT=github-copilot|github-copilot-cli`, `COPILOT_MODEL`, `COPILOT_ALLOW_ALL`, or `COPILOT_GITHUB_TOKEN`)
 - **Replit** (online IDE)
 

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -106,7 +106,7 @@ export async function determineAgent(): Promise<AgentResult> {
     return { isAgent: true, agent: { name: AUGMENT_CLI } };
   }
 
-  if (process.env.OPENCODE_CLIENT) {
+  if (process.env.OPENCODE) {
     return { isAgent: true, agent: { name: OPENCODE } };
   }
 

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -106,7 +106,7 @@ export async function determineAgent(): Promise<AgentResult> {
     return { isAgent: true, agent: { name: AUGMENT_CLI } };
   }
 
-  if (process.env.OPENCODE) {
+  if (process.env.OPENCODE || process.env.OPENCODE_CLIENT) {
     return { isAgent: true, agent: { name: OPENCODE } };
   }
 

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -17,6 +17,7 @@ describe('determineAgent', () => {
     vi.stubEnv('ANTIGRAVITY_AGENT', '');
     vi.stubEnv('AUGMENT_AGENT', '');
     vi.stubEnv('OPENCODE', '');
+    vi.stubEnv('OPENCODE_CLIENT', '');
     vi.stubEnv('CLAUDECODE', '');
     vi.stubEnv('CLAUDE_CODE', '');
     vi.stubEnv('CLAUDE_CODE_IS_COWORK', '');
@@ -296,7 +297,7 @@ describe('determineAgent', () => {
   });
 
   describe('opencode detection', () => {
-    describe('OPENCODE not set', () => {
+    describe('neither OPENCODE nor OPENCODE_CLIENT set', () => {
       it('returns no agent', async () => {
         const result = await determineAgent();
         expect(result).toEqual({ isAgent: false });
@@ -306,6 +307,20 @@ describe('determineAgent', () => {
     describe('OPENCODE set', () => {
       beforeEach(() => {
         vi.stubEnv('OPENCODE', '1');
+      });
+
+      it('detects opencode', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({
+          isAgent: true,
+          agent: { name: KNOWN_AGENTS.OPENCODE },
+        });
+      });
+    });
+
+    describe('OPENCODE_CLIENT set', () => {
+      beforeEach(() => {
+        vi.stubEnv('OPENCODE_CLIENT', 'opencode');
       });
 
       it('detects opencode', async () => {

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -16,7 +16,7 @@ describe('determineAgent', () => {
     vi.stubEnv('CODEX_THREAD_ID', '');
     vi.stubEnv('ANTIGRAVITY_AGENT', '');
     vi.stubEnv('AUGMENT_AGENT', '');
-    vi.stubEnv('OPENCODE_CLIENT', '');
+    vi.stubEnv('OPENCODE', '');
     vi.stubEnv('CLAUDECODE', '');
     vi.stubEnv('CLAUDE_CODE', '');
     vi.stubEnv('CLAUDE_CODE_IS_COWORK', '');
@@ -296,16 +296,16 @@ describe('determineAgent', () => {
   });
 
   describe('opencode detection', () => {
-    describe('OPENCODE_CLIENT not set', () => {
+    describe('OPENCODE not set', () => {
       it('returns no agent', async () => {
         const result = await determineAgent();
         expect(result).toEqual({ isAgent: false });
       });
     });
 
-    describe('OPENCODE_CLIENT set', () => {
+    describe('OPENCODE set', () => {
       beforeEach(() => {
-        vi.stubEnv('OPENCODE_CLIENT', 'opencode');
+        vi.stubEnv('OPENCODE', '1');
       });
 
       it('detects opencode', async () => {
@@ -471,7 +471,7 @@ describe('determineAgent', () => {
       vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
       vi.stubEnv('ANTIGRAVITY_AGENT', '1');
       vi.stubEnv('AUGMENT_AGENT', '1');
-      vi.stubEnv('OPENCODE_CLIENT', 'opencode');
+      vi.stubEnv('OPENCODE', '1');
       vi.stubEnv('CLAUDE_CODE', '1');
       vi.stubEnv('REPL_ID', '1');
       vi.stubEnv('COPILOT_MODEL', 'gpt-5');
@@ -497,7 +497,7 @@ describe('determineAgent', () => {
       vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
       vi.stubEnv('ANTIGRAVITY_AGENT', '1');
       vi.stubEnv('AUGMENT_AGENT', '1');
-      vi.stubEnv('OPENCODE_CLIENT', 'opencode');
+      vi.stubEnv('OPENCODE', '1');
       vi.stubEnv('CLAUDE_CODE', '1');
       vi.stubEnv('REPL_ID', '1');
       vi.stubEnv('COPILOT_MODEL', 'gpt-5');
@@ -522,7 +522,7 @@ describe('determineAgent', () => {
       vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
       vi.stubEnv('ANTIGRAVITY_AGENT', '1');
       vi.stubEnv('AUGMENT_AGENT', '1');
-      vi.stubEnv('OPENCODE_CLIENT', 'opencode');
+      vi.stubEnv('OPENCODE', '1');
       vi.stubEnv('CLAUDE_CODE', '1');
       vi.stubEnv('REPL_ID', '1');
       vi.stubEnv('COPILOT_MODEL', 'gpt-5');


### PR DESCRIPTION
opencode

```
A few other related env vars are also set at the same time:
Variable	Value
OPENCODE	"1"
OPENCODE_PID	String(process.pid)
AGENT	"1"
There are also context-specific ones like OPENCODE_TERMINAL=1 (set in PTY child processes) and OPENCODE_PURE=1 (set when --pure flag is used), but OPENCODE=1 is the general-purpose indicator.
```