### PR TITLE
fs-detectors: fall back to `--scope` for Turborepo <= 1.1

### DIFF
--- a/.changeset/turbo-scope-fallback.md
+++ b/.changeset/turbo-scope-fallback.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Fall back to `--scope` flag for Turborepo versions 1.1 and below when generating default build commands.

--- a/packages/fs-detectors/src/monorepos/get-monorepo-default-settings.ts
+++ b/packages/fs-detectors/src/monorepos/get-monorepo-default-settings.ts
@@ -35,6 +35,18 @@ function supportsRootCommand(turboSemVer: string | undefined) {
   return !semver.intersects(turboSemVer, '<1.8.0');
 }
 
+function supportsFilter(turboSemVer: string | undefined) {
+  if (!turboSemVer) {
+    return true;
+  }
+
+  if (!semver.validRange(turboSemVer)) {
+    return true;
+  }
+
+  return !semver.intersects(turboSemVer, '<=1.1.0');
+}
+
 type MonorepoDefaultSettings = {
   buildCommand?: string | null;
   installCommand?: string | null;
@@ -113,9 +125,10 @@ export async function getMonorepoDefaultSettings(
     if (projectPath) {
       if (supportsRootCommand(turboSemVer)) {
         buildCommand = `turbo run build`;
-      } else {
-        // We don't know for sure if the local `turbo` supports inference.
+      } else if (supportsFilter(turboSemVer)) {
         buildCommand = `cd ${relativeToRoot} && turbo run build --filter={${projectPath}}...`;
+      } else {
+        buildCommand = `cd ${relativeToRoot} && turbo run build --scope=${projectName}`;
       }
     }
 

--- a/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-scope/package.json
+++ b/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-scope/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "devDependencies": {
+    "turbo": "1.1.0"
+  }
+}

--- a/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-scope/packages/app-1/package.json
+++ b/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-scope/packages/app-1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "app-14",
+  "version": "0.0.1",
+  "main": "index.js"
+}

--- a/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-scope/turbo.json
+++ b/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-scope/turbo.json
@@ -1,0 +1,1 @@
+{ "pipeline": { "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] } } }

--- a/packages/fs-detectors/test/unit.get-monorepo-default-settings.test.ts
+++ b/packages/fs-detectors/test/unit.get-monorepo-default-settings.test.ts
@@ -31,27 +31,46 @@ describe('getMonorepoDefaultSettings', () => {
   });
 
   test.each([
-    ['turbo', 'turbo', false, 'app-14', false, false],
-    ['turbo-has-filter', 'turbo', false, 'app-14', false, true],
-    ['turbo-package-config', 'turbo', false, 'app-13', false, false],
-    ['turbo-npm', 'turbo', true, 'app-15', false, false],
-    ['turbo-npm-root-proj', 'turbo', true, 'app-root-proj', true, false],
-    ['turbo-latest', 'turbo', false, 'app-14', false, false],
-    ['turbo-2', 'turbo', false, 'app-14', false, false],
-    ['turbo-jsonc', 'turbo', false, 'app-1', false, false],
-    ['nx', 'nx', false, 'app-12', false, false],
-    ['nx-package-config', 'nx', false, 'app-11', false, false],
-    ['nx-project-and-package-config-1', 'nx', false, 'app-10', false, false],
-    ['nx-project-and-package-config-2', 'nx', false, 'app-9', false, false],
-    ['nx-project-config', 'nx', false, 'app-8', false, false],
-  ])('fixture %s', async (fixture, expectedResultKey, isNpm, packageName, isRoot, supportsInference) => {
+    ['turbo', 'turbo', false, 'app-14', false, false, false],
+    ['turbo-has-filter', 'turbo', false, 'app-14', false, true, false],
+    ['turbo-scope', 'turbo', false, 'app-14', false, false, true],
+    ['turbo-package-config', 'turbo', false, 'app-13', false, false, false],
+    ['turbo-npm', 'turbo', true, 'app-15', false, false, false],
+    ['turbo-npm-root-proj', 'turbo', true, 'app-root-proj', true, false, false],
+    ['turbo-latest', 'turbo', false, 'app-14', false, false, false],
+    ['turbo-2', 'turbo', false, 'app-14', false, false, false],
+    ['turbo-jsonc', 'turbo', false, 'app-1', false, false, false],
+    ['nx', 'nx', false, 'app-12', false, false, false],
+    ['nx-package-config', 'nx', false, 'app-11', false, false, false],
+    [
+      'nx-project-and-package-config-1',
+      'nx',
+      false,
+      'app-10',
+      false,
+      false,
+      false,
+    ],
+    [
+      'nx-project-and-package-config-2',
+      'nx',
+      false,
+      'app-9',
+      false,
+      false,
+      false,
+    ],
+    ['nx-project-config', 'nx', false, 'app-8', false, false, false],
+  ])('fixture %s', async (fixture, expectedResultKey, isNpm, packageName, isRoot, supportsInference, usesScope) => {
     const expectedResultMap: Record<string, Record<string, string>> = {
       turbo: {
         monorepoManager: 'turbo',
         buildCommand:
           isRoot || supportsInference
             ? 'turbo run build'
-            : 'cd ../.. && turbo run build --filter={packages/app-1}...',
+            : usesScope
+              ? `cd ../.. && turbo run build --scope=${packageName}`
+              : 'cd ../.. && turbo run build --filter={packages/app-1}...',
         installCommand:
           isNpm && isRoot
             ? 'npm install'


### PR DESCRIPTION
## Summary

- Turborepo versions 1.1 and below don't support `--filter`. For those versions, the default build command now uses the legacy `--scope=<packageName>` flag instead.
- When the `turbo` version is unknown (no version pinned in `package.json`), we assume `--filter` support since the globally installed turbo on build containers is modern.
- For versions above 1.8 and above, we can leverage [Automatic Workspace Scoping](https://turborepo.dev/docs/crafting-your-repository/running-tasks#automatic-package-scoping) to keep the command tidy.

### Version tiers

| Turbo version | Generated build command |
|---|---|
| >= 1.8 | `turbo run build` |
| > 1.1, < 1.8 | `cd ../.. && turbo run build --filter={path}...` |
| <= 1.1 | `cd ../.. && turbo run build --scope=<name>` |

<sub>CLOSES TURBO-5405</sub>