### PR TITLE
fix(go): respect vendor directory and skip go mod tidy

### DIFF
--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -243,10 +243,16 @@ export class GoWrapper {
   }
 
   mod() {
-    if (this.useVendor) {
+    const envVars = this.env || this.opts.env || {};
+    const envGoBuildFlags = envVars.GO_BUILD_FLAGS;
+
+    const safeVendor = this.useVendor && !envGoBuildFlags;
+
+    if (safeVendor) {
       debug('Skipping `go mod tidy` because vendor mode is enabled');
       return Promise.resolve() as any;
     }
+
     return this.execute('mod', 'tidy');
   }
 
@@ -265,13 +271,13 @@ export class GoWrapper {
     debug(`Building optimized 'go' binary ${src} -> ${dest}`);
     const sources = Array.isArray(src) ? src : [src];
 
-    const envGoBuildFlags = (this.env || this.opts.env).GO_BUILD_FLAGS;
+    const envVars = this.env || this.opts.env || {};
+    const envGoBuildFlags = envVars.GO_BUILD_FLAGS;
+
     const flags = envGoBuildFlags ? stringArgv(envGoBuildFlags) : [...GO_FLAGS];
 
-    // Only apply -mod=vendor when vendor mode is enabled AND the user
-    // has not supplied custom GO_BUILD_FLAGS. Custom flags may modify
-    // go.mod behavior, making vendor/modules.txt stale.
     const safeVendor = this.useVendor && !envGoBuildFlags;
+
     if (safeVendor) {
       flags.push('-mod=vendor');
     }

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -268,7 +268,11 @@ export class GoWrapper {
     const envGoBuildFlags = (this.env || this.opts.env).GO_BUILD_FLAGS;
     const flags = envGoBuildFlags ? stringArgv(envGoBuildFlags) : [...GO_FLAGS];
 
-    if (this.useVendor) {
+    // Only apply -mod=vendor when vendor mode is enabled AND the user
+    // has not supplied custom GO_BUILD_FLAGS. Custom flags may modify
+    // go.mod behavior, making vendor/modules.txt stale.
+    const safeVendor = this.useVendor && !envGoBuildFlags;
+    if (safeVendor) {
       flags.push('-mod=vendor');
     }
 

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -203,6 +203,7 @@ Learn more: https://vercel.com/docs/functions/serverless-functions/runtimes/go
 export class GoWrapper {
   private env: Env;
   private opts: execa.Options;
+  public useVendor = false;
 
   constructor(env: Env, opts: execa.Options = {}) {
     if (!opts.cwd) {
@@ -242,6 +243,10 @@ export class GoWrapper {
   }
 
   mod() {
+    if (this.useVendor) {
+      debug('Skipping `go mod tidy` because vendor mode is enabled');
+      return Promise.resolve() as any;
+    }
     return this.execute('mod', 'tidy');
   }
 
@@ -261,7 +266,11 @@ export class GoWrapper {
     const sources = Array.isArray(src) ? src : [src];
 
     const envGoBuildFlags = (this.env || this.opts.env).GO_BUILD_FLAGS;
-    const flags = envGoBuildFlags ? stringArgv(envGoBuildFlags) : GO_FLAGS;
+    const flags = envGoBuildFlags ? stringArgv(envGoBuildFlags) : [...GO_FLAGS];
+
+    if (this.useVendor) {
+      flags.push('-mod=vendor');
+    }
 
     return this.execute('build', ...flags, '-o', dest, ...sources);
   }

--- a/packages/go/src/index.ts
+++ b/packages/go/src/index.ts
@@ -360,6 +360,18 @@ async function buildHandlerWithGoMod({
     }
   }
 
+  // Detect vendored dependencies by checking for vendor/modules.txt
+  // which is the canonical marker created by `go mod vendor`
+  const vendorModulesPath = join(
+    goModDirname || entrypointDirname,
+    'vendor',
+    'modules.txt'
+  );
+  if (await pathExists(vendorModulesPath)) {
+    console.log('Detected vendor directory, using vendor mode');
+    go.useVendor = true;
+  }
+
   const entrypointArr = entrypoint.split(posix.sep);
   let goPackageName = `${packageName}/${packageName}`;
   const goFuncName = `${packageName}.${handlerFunctionName}`;


### PR DESCRIPTION
Closes #12350

Fix: Respect vendor directory in Go builds
Problem

As described in #12350, Vercel ignores vendored dependencies and always runs go mod tidy, causing failures for projects using private modules.

Solution
Detect vendor/modules.txt
Skip go mod tidy when vendor exists
Use -mod=vendor flag
Result

Vendored Go projects now build successfully without requiring external dependency downloads.

Testing
Verified vendor detection locally
Ensured normal behavior when vendor is absent