### PR TITLE
[CLI] feat: deployment protection

### DIFF
--- a/.changeset/cli-project-protection.md
+++ b/.changeset/cli-project-protection.md
@@ -1,0 +1,5 @@
+---
+vercel: minor
+---
+
+Add `vercel project protection` to display deployment protection-related project settings (read-only).

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -19,6 +19,10 @@ export interface CommandOption {
   readonly argument?: string;
   readonly deprecated: boolean;
   readonly description?: string;
+  /**
+   * When false, omit from agent `next` hints (CLI parsing and `--help` unchanged).
+   */
+  readonly agentSuggest?: boolean;
 }
 export interface CommandArgument {
   readonly name: string;

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -310,6 +310,44 @@ export const protectionSubcommand = {
         'Apply action to password protection (requires eligible plan/permissions).',
       deprecated: false,
     },
+    {
+      name: 'skew',
+      shorthand: null,
+      type: Boolean,
+      description: 'Apply action to skew protection.',
+      deprecated: false,
+    },
+    {
+      name: 'customer-support-code-visibility',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Apply action to customer support code visibility protection.',
+      deprecated: false,
+    },
+    {
+      name: 'git-fork-protection',
+      shorthand: null,
+      type: Boolean,
+      description: 'Apply action to Git fork protection.',
+      deprecated: false,
+    },
+    {
+      name: 'protection-bypass',
+      shorthand: null,
+      type: Boolean,
+      description: 'Apply action to automation protection bypass secrets.',
+      deprecated: false,
+    },
+    {
+      name: 'protection-bypass-secret',
+      shorthand: null,
+      type: String,
+      argument: 'SECRET',
+      description:
+        'Optional secret value for protection bypass. Required when disabling bypass.',
+      deprecated: false,
+    },
   ],
   examples: [
     {
@@ -331,6 +369,18 @@ export const protectionSubcommand = {
     {
       name: 'Enable only password protection',
       value: `${packageName} project protection enable my-app --password`,
+    },
+    {
+      name: 'Enable skew protection',
+      value: `${packageName} project protection enable my-app --skew`,
+    },
+    {
+      name: 'Disable git fork protection',
+      value: `${packageName} project protection disable my-app --git-fork-protection`,
+    },
+    {
+      name: 'Enable automation protection bypass',
+      value: `${packageName} project protection enable my-app --protection-bypass`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -309,6 +309,7 @@ export const protectionSubcommand = {
       description:
         'Apply action to password protection (requires eligible plan/permissions).',
       deprecated: false,
+      agentSuggest: false,
     },
     {
       name: 'skew',

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -279,6 +279,30 @@ export const membersSubcommand = {
   ],
 } as const;
 
+export const protectionSubcommand = {
+  name: 'protection',
+  aliases: [],
+  description:
+    'Show deployment protection-related settings for a project (read-only)',
+  arguments: [
+    {
+      name: 'name',
+      required: false,
+    },
+  ],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'Protection settings for the linked project',
+      value: `${packageName} project protection`,
+    },
+    {
+      name: 'Named project as JSON',
+      value: `${packageName} project protection my-app --format json`,
+    },
+  ],
+} as const;
+
 export const accessGroupsSubcommand = {
   name: 'access-groups',
   aliases: ['accessgroups'],
@@ -386,6 +410,7 @@ export const projectCommand = {
     listSubcommand,
     membersSubcommand,
     accessGroupsSubcommand,
+    protectionSubcommand,
     webAnalyticsSubcommand,
     speedInsightsSubcommand,
     removeSubcommand,

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -299,8 +299,7 @@ export const protectionSubcommand = {
       name: 'sso',
       shorthand: null,
       type: Boolean,
-      description:
-        'Apply action to SSO protection. Defaults to enabled when no target flags are provided.',
+      description: 'Apply action to SSO protection.',
       deprecated: false,
     },
     {
@@ -323,7 +322,7 @@ export const protectionSubcommand = {
     },
     {
       name: 'Enable deployment protection for the linked project',
-      value: `${packageName} project protection enable`,
+      value: `${packageName} project protection enable --sso`,
     },
     {
       name: 'Disable deployment protection for a named project',

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -282,15 +282,36 @@ export const membersSubcommand = {
 export const protectionSubcommand = {
   name: 'protection',
   aliases: [],
-  description:
-    'Show deployment protection-related settings for a project (read-only)',
+  description: 'Show or toggle deployment protection settings for a project',
   arguments: [
+    {
+      name: 'action',
+      required: false,
+    },
     {
       name: 'name',
       required: false,
     },
   ],
-  options: [formatOption],
+  options: [
+    formatOption,
+    {
+      name: 'sso',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Apply action to SSO protection. Defaults to enabled when no target flags are provided.',
+      deprecated: false,
+    },
+    {
+      name: 'password',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Apply action to password protection (requires eligible plan/permissions).',
+      deprecated: false,
+    },
+  ],
   examples: [
     {
       name: 'Protection settings for the linked project',
@@ -299,6 +320,18 @@ export const protectionSubcommand = {
     {
       name: 'Named project as JSON',
       value: `${packageName} project protection my-app --format json`,
+    },
+    {
+      name: 'Enable deployment protection for the linked project',
+      value: `${packageName} project protection enable`,
+    },
+    {
+      name: 'Disable deployment protection for a named project',
+      value: `${packageName} project protection disable my-app`,
+    },
+    {
+      name: 'Enable only password protection',
+      value: `${packageName} project protection enable my-app --password`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -14,6 +14,7 @@ import rm from './rm';
 import getOidcToken from './token';
 import speedInsights from './speed-insights';
 import webAnalytics from './web-analytics';
+import protection from './protection';
 import {
   accessGroupsSubcommand,
   addSubcommand,
@@ -23,6 +24,7 @@ import {
   listSubcommand,
   membersSubcommand,
   projectCommand,
+  protectionSubcommand,
   removeSubcommand,
   speedInsightsSubcommand,
   tokenSubcommand,
@@ -42,6 +44,7 @@ const COMMAND_CONFIG = {
   add: getCommandAliases(addSubcommand),
   'access-summary': getCommandAliases(accessSummarySubcommand),
   checks: getCommandAliases(checksSubcommand),
+  protection: getCommandAliases(protectionSubcommand),
   remove: getCommandAliases(removeSubcommand),
   token: getCommandAliases(tokenSubcommand),
   speedInsights: getCommandAliases(speedInsightsSubcommand),
@@ -146,6 +149,13 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandAccessGroups(subcommandOriginal);
       return accessGroups(client, args);
+    case 'protection':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('project', subcommandOriginal);
+        return printHelp(protectionSubcommand);
+      }
+      telemetry.trackCliSubcommandProtection(subcommandOriginal);
+      return protection(client, args);
     case 'webAnalytics':
       if (needHelp) {
         telemetry.trackCliFlagHelp('project', subcommandOriginal);

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -154,7 +154,13 @@ export default async function main(client: Client) {
         telemetry.trackCliFlagHelp('project', subcommandOriginal);
         return printHelp(protectionSubcommand);
       }
-      telemetry.trackCliSubcommandProtection(subcommandOriginal);
+      telemetry.trackCliSubcommandProtection(
+        args[0] === 'enable'
+          ? 'protection enable'
+          : args[0] === 'disable'
+            ? 'protection disable'
+            : subcommandOriginal
+      );
       return protection(client, args);
     case 'webAnalytics':
       if (needHelp) {

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -11,7 +11,11 @@ import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
 import chalk from 'chalk';
-import type { Project } from '@vercel-internals/types';
+import type { JSONObject, Project } from '@vercel-internals/types';
+
+const PROTECTION_ACTIONS = ['enable', 'disable'] as const;
+type ProtectionAction = (typeof PROTECTION_ACTIONS)[number];
+const ENABLED_DEPLOYMENT_TYPE = 'prod_deployment_urls_and_all_previews';
 
 const PROTECTION_KEYS = [
   'passwordProtection',
@@ -21,6 +25,10 @@ const PROTECTION_KEYS = [
   'gitForkProtection',
   'protectionBypass',
 ] as const;
+
+function isProtectionAction(v: string | undefined): v is ProtectionAction {
+  return !!v && (PROTECTION_ACTIONS as readonly string[]).includes(v);
+}
 
 export default async function protection(
   client: Client,
@@ -48,9 +56,18 @@ export default async function protection(
     return 1;
   }
 
-  if (parsedArgs.args.length > 1) {
+  const actionArg = parsedArgs.args[0];
+  const action = isProtectionAction(actionArg) ? actionArg : undefined;
+
+  if (!action && parsedArgs.args.length > 1) {
     output.error(
       'Invalid arguments. Usage: `vercel project protection [name]`'
+    );
+    return 2;
+  }
+  if (action && parsedArgs.args.length > 2) {
+    output.error(
+      `Invalid arguments. Usage: \`vercel project protection ${action} [name]\``
     );
     return 2;
   }
@@ -61,13 +78,18 @@ export default async function protection(
     return 1;
   }
 
+  const withSso = Boolean(parsedArgs.flags['--sso']);
+  const withPassword = Boolean(parsedArgs.flags['--password']);
+  const selectedSso = withSso || (!withSso && !withPassword);
+  const selectedPassword = withPassword;
+
   let project: Project;
   try {
     project = await getProjectByCwdOrLink({
       client,
       commandName: 'project protection',
-      projectNameOrId: parsedArgs.args[0],
-      forReadOnlyCommand: true,
+      projectNameOrId: action ? parsedArgs.args[1] : parsedArgs.args[0],
+      forReadOnlyCommand: !action,
     });
   } catch (err: unknown) {
     exitWithNonInteractiveError(client, err, 1, {
@@ -75,6 +97,57 @@ export default async function protection(
     });
     printError(err);
     return 1;
+  }
+
+  if (action) {
+    const patchBody: JSONObject = {};
+    if (selectedSso) {
+      patchBody.ssoProtection =
+        action === 'enable'
+          ? { deploymentType: ENABLED_DEPLOYMENT_TYPE }
+          : null;
+    }
+    if (selectedPassword) {
+      patchBody.passwordProtection =
+        action === 'enable'
+          ? { deploymentType: ENABLED_DEPLOYMENT_TYPE }
+          : null;
+    }
+
+    try {
+      await client.fetch(`/v9/projects/${encodeURIComponent(project.id)}`, {
+        method: 'PATCH',
+        body: patchBody,
+      });
+    } catch (err: unknown) {
+      exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
+      printError(err);
+      return 1;
+    }
+
+    if (formatResult.jsonOutput) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            action,
+            projectId: project.id,
+            projectName: project.name,
+            ssoProtection: selectedSso ? action === 'enable' : undefined,
+            passwordProtection: selectedPassword
+              ? action === 'enable'
+              : undefined,
+          },
+          null,
+          2
+        )}\n`
+      );
+      return 0;
+    }
+
+    output.log(
+      `${chalk.bold('Deployment protection')} ${action === 'enable' ? 'enabled' : 'disabled'} for ${chalk.cyan(project.name)}`
+    );
+    return 0;
   }
 
   const raw = project as Project & Record<string, unknown>;

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -1,0 +1,106 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import {
+  exitWithNonInteractiveError,
+  outputAgentError,
+} from '../../util/agent-output';
+import { protectionSubcommand } from './command';
+import { validateJsonOutput } from '../../util/output-format';
+import output from '../../output-manager';
+import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
+import chalk from 'chalk';
+import type { Project } from '@vercel-internals/types';
+
+const PROTECTION_KEYS = [
+  'passwordProtection',
+  'ssoProtection',
+  'skewProtection',
+  'customerSupportCodeVisibility',
+  'gitForkProtection',
+  'protectionBypass',
+] as const;
+
+export default async function protection(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    protectionSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'invalid_arguments',
+          message: error instanceof Error ? error.message : String(error),
+        },
+        1
+      );
+    }
+    printError(error);
+    return 1;
+  }
+
+  if (parsedArgs.args.length > 1) {
+    output.error(
+      'Invalid arguments. Usage: `vercel project protection [name]`'
+    );
+    return 2;
+  }
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+
+  let project: Project;
+  try {
+    project = await getProjectByCwdOrLink({
+      client,
+      commandName: 'project protection',
+      projectNameOrId: parsedArgs.args[0],
+      forReadOnlyCommand: true,
+    });
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, {
+      variant: 'protection',
+    });
+    printError(err);
+    return 1;
+  }
+
+  const raw = project as Project & Record<string, unknown>;
+  const slice: Record<string, unknown> = {};
+  for (const key of PROTECTION_KEYS) {
+    if (key in raw) {
+      slice[key] = raw[key];
+    }
+  }
+
+  if (formatResult.jsonOutput) {
+    client.stdout.write(
+      `${JSON.stringify({ projectId: project.id, name: project.name, ...slice }, null, 2)}\n`
+    );
+    return 0;
+  }
+
+  output.log(
+    `${chalk.bold('Protection settings')} for ${chalk.cyan(project.name)} (${project.id})`
+  );
+  if (Object.keys(slice).length === 0) {
+    output.log('No deployment protection fields returned for this project.');
+    return 0;
+  }
+  for (const [k, v] of Object.entries(slice)) {
+    output.log(`${chalk.cyan(`${k}:`)} ${JSON.stringify(v)}`);
+  }
+  return 0;
+}

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -3,9 +3,11 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import {
+  buildCommandWithGlobalFlags,
   exitWithNonInteractiveError,
   outputAgentError,
 } from '../../util/agent-output';
+import { AGENT_REASON } from '../../util/agent-output-constants';
 import { protectionSubcommand } from './command';
 import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
@@ -42,17 +44,15 @@ export default async function protection(
   try {
     parsedArgs = parseArguments(argv, flagsSpecification);
   } catch (error) {
-    if (client.nonInteractive) {
-      outputAgentError(
-        client,
-        {
-          status: 'error',
-          reason: 'invalid_arguments',
-          message: error instanceof Error ? error.message : String(error),
-        },
-        1
-      );
-    }
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: error instanceof Error ? error.message : String(error),
+      },
+      1
+    );
     printError(error);
     return 1;
   }
@@ -61,12 +61,48 @@ export default async function protection(
   const action = isProtectionAction(actionArg) ? actionArg : undefined;
 
   if (!action && parsedArgs.args.length > 1) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: 'Invalid arguments. Usage: `vercel project protection [name]`',
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'project protection'
+            ),
+            when: 'Show deployment protection for the linked project',
+          },
+        ],
+      },
+      2
+    );
     output.error(
       'Invalid arguments. Usage: `vercel project protection [name]`'
     );
     return 2;
   }
   if (action && parsedArgs.args.length > 2) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: `Invalid arguments. Usage: \`vercel project protection ${action} [name]\``,
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              `project protection ${action}`
+            ),
+            when: 'Retry with at most one project name',
+          },
+        ],
+      },
+      2
+    );
     output.error(
       `Invalid arguments. Usage: \`vercel project protection ${action} [name]\``
     );
@@ -75,9 +111,20 @@ export default async function protection(
 
   const formatResult = validateJsonOutput(parsedArgs.flags);
   if (!formatResult.valid) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: formatResult.error,
+      },
+      1
+    );
     output.error(formatResult.error);
     return 1;
   }
+
+  const preferJson = formatResult.jsonOutput || Boolean(client.nonInteractive);
 
   const selectedSso = Boolean(parsedArgs.flags['--sso']);
   const selectedPassword = Boolean(parsedArgs.flags['--password']);
@@ -102,9 +149,28 @@ export default async function protection(
     selectedProtectionBypass;
 
   if (action && !hasAnySelection) {
-    output.error(
-      `No protection selected. Pass one or more selectors (for example --sso, --password, --skew, --customer-support-code-visibility, --git-fork-protection, --protection-bypass).`
+    const msg =
+      'No protection selected. Pass one or more selectors (for example --sso, --password, --skew, --customer-support-code-visibility, --git-fork-protection, --protection-bypass).';
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.MISSING_ARGUMENTS,
+        message: msg,
+        hint: 'Use `project protection enable|disable` with at least one protection flag.',
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'project protection disable --sso'
+            ),
+            when: 'Example: disable with SSO protection selected',
+          },
+        ],
+      },
+      2
     );
+    output.error(msg);
     return 2;
   }
 
@@ -151,9 +217,28 @@ export default async function protection(
 
     if (selectedProtectionBypass) {
       if (action === 'disable' && !protectionBypassSecret) {
-        output.error(
-          'Disabling protection bypass requires --protection-bypass-secret <secret>.'
+        const secretMsg =
+          'Disabling protection bypass requires --protection-bypass-secret <secret>.';
+        outputAgentError(
+          client,
+          {
+            status: 'error',
+            reason: AGENT_REASON.MISSING_ARGUMENTS,
+            message: secretMsg,
+            hint: 'Pass the existing automation bypass secret to revoke it.',
+            next: [
+              {
+                command: buildCommandWithGlobalFlags(
+                  client.argv,
+                  'project protection disable --protection-bypass --protection-bypass-secret <secret>'
+                ),
+                when: 'Replace <secret> with the bypass secret to revoke',
+              },
+            ],
+          },
+          2
         );
+        output.error(secretMsg);
         return 2;
       }
       try {
@@ -197,7 +282,7 @@ export default async function protection(
       }
     }
 
-    if (formatResult.jsonOutput) {
+    if (preferJson) {
       client.stdout.write(
         `${JSON.stringify(
           {
@@ -240,7 +325,7 @@ export default async function protection(
     }
   }
 
-  if (formatResult.jsonOutput) {
+  if (preferJson) {
     client.stdout.write(
       `${JSON.stringify({ projectId: project.id, name: project.name, ...slice }, null, 2)}\n`
     );

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -1,7 +1,9 @@
+import type arg from 'arg';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
+import type { CommandOption } from '../help';
 import {
   buildCommandWithGlobalFlags,
   exitWithNonInteractiveError,
@@ -33,14 +35,72 @@ function isProtectionAction(v: string | undefined): v is ProtectionAction {
   return !!v && (PROTECTION_ACTIONS as readonly string[]).includes(v);
 }
 
+/** Same visibility rules as `buildCommandOptionLines` (non-deprecated, documented). */
+function isCommandOptionDocumented(o: CommandOption): boolean {
+  return !o.deprecated && o.description !== undefined;
+}
+
+/** All boolean toggles the parser accepts (used to detect “at least one selector”). */
+function getProtectionParserToggleFlagNames(spec: arg.Spec): string[] {
+  return protectionSubcommand.options
+    .filter(
+      o =>
+        o.type === Boolean &&
+        spec[`--${o.name}` as keyof typeof spec] === Boolean
+    )
+    .map(o => `--${o.name}`);
+}
+
+/** Documented toggles for the error text (may include flags omitted from `next`). */
+function getProtectionToggleFlagsForMessage(): string[] {
+  return protectionSubcommand.options
+    .filter(o => o.type === Boolean && isCommandOptionDocumented(o))
+    .map(o => `--${o.name}`);
+}
+
+/** Toggles to suggest in `next`: documented, parser-backed, and not opted out via `agentSuggest`. */
+function getProtectionToggleFlagsForNext(spec: arg.Spec): string[] {
+  return protectionSubcommand.options
+    .filter(o => {
+      const opt = o as CommandOption;
+      return (
+        opt.type === Boolean &&
+        isCommandOptionDocumented(opt) &&
+        opt.agentSuggest !== false &&
+        spec[`--${opt.name}` as keyof typeof spec] === Boolean
+      );
+    })
+    .map(o => `--${(o as CommandOption).name}`);
+}
+
+function buildMissingSelectorMessage(): string {
+  const flags = getProtectionToggleFlagsForMessage();
+  const joined = flags.join(', ');
+  return `No protection selected. Pass one or more selectors (for example ${joined}).`;
+}
+
+function buildMissingSelectorNext(
+  client: Client,
+  action: ProtectionAction,
+  spec: arg.Spec
+): Array<{ command: string; when: string }> {
+  return getProtectionToggleFlagsForNext(spec).map(flag => ({
+    command: buildCommandWithGlobalFlags(
+      client.argv,
+      `project protection ${action} ${flag}`
+    ),
+    when: `Run with ${flag} (same action)`,
+  }));
+}
+
 export default async function protection(
   client: Client,
   argv: string[]
 ): Promise<number> {
-  let parsedArgs;
   const flagsSpecification = getFlagsSpecification(
     protectionSubcommand.options
   );
+  let parsedArgs: { args: string[]; flags: Record<string, unknown> };
   try {
     parsedArgs = parseArguments(argv, flagsSpecification);
   } catch (error) {
@@ -140,17 +200,14 @@ export default async function protection(
     '--protection-bypass-secret'
   ] as string | undefined;
 
-  const hasAnySelection =
-    selectedSso ||
-    selectedPassword ||
-    selectedSkew ||
-    selectedSupportCode ||
-    selectedGitFork ||
-    selectedProtectionBypass;
+  const parserToggleFlagNames =
+    getProtectionParserToggleFlagNames(flagsSpecification);
+  const hasAnySelection = parserToggleFlagNames.some(flag =>
+    Boolean(parsedArgs.flags[flag])
+  );
 
   if (action && !hasAnySelection) {
-    const msg =
-      'No protection selected. Pass one or more selectors (for example --sso, --password, --skew, --customer-support-code-visibility, --git-fork-protection, --protection-bypass).';
+    const msg = buildMissingSelectorMessage();
     outputAgentError(
       client,
       {
@@ -158,15 +215,7 @@ export default async function protection(
         reason: AGENT_REASON.MISSING_ARGUMENTS,
         message: msg,
         hint: 'Use `project protection enable|disable` with at least one protection flag.',
-        next: [
-          {
-            command: buildCommandWithGlobalFlags(
-              client.argv,
-              `project protection ${action} --sso`
-            ),
-            when: 'Example: same action with SSO protection selected',
-          },
-        ],
+        next: buildMissingSelectorNext(client, action, flagsSpecification),
       },
       2
     );

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -16,6 +16,7 @@ import type { JSONObject, Project } from '@vercel-internals/types';
 const PROTECTION_ACTIONS = ['enable', 'disable'] as const;
 type ProtectionAction = (typeof PROTECTION_ACTIONS)[number];
 const ENABLED_DEPLOYMENT_TYPE = 'prod_deployment_urls_and_all_previews';
+const DEFAULT_SKEW_PROTECTION_MAX_AGE = 2592000;
 
 const PROTECTION_KEYS = [
   'passwordProtection',
@@ -80,10 +81,29 @@ export default async function protection(
 
   const selectedSso = Boolean(parsedArgs.flags['--sso']);
   const selectedPassword = Boolean(parsedArgs.flags['--password']);
+  const selectedSkew = Boolean(parsedArgs.flags['--skew']);
+  const selectedSupportCode = Boolean(
+    parsedArgs.flags['--customer-support-code-visibility']
+  );
+  const selectedGitFork = Boolean(parsedArgs.flags['--git-fork-protection']);
+  const selectedProtectionBypass = Boolean(
+    parsedArgs.flags['--protection-bypass']
+  );
+  const protectionBypassSecret = parsedArgs.flags[
+    '--protection-bypass-secret'
+  ] as string | undefined;
 
-  if (action && !selectedSso && !selectedPassword) {
+  const hasAnySelection =
+    selectedSso ||
+    selectedPassword ||
+    selectedSkew ||
+    selectedSupportCode ||
+    selectedGitFork ||
+    selectedProtectionBypass;
+
+  if (action && !hasAnySelection) {
     output.error(
-      `No protection selected. Pass at least one of --sso or --password. Usage: \`vercel project protection ${action} [name] --sso|--password\``
+      `No protection selected. Pass one or more selectors (for example --sso, --password, --skew, --customer-support-code-visibility, --git-fork-protection, --protection-bypass).`
     );
     return 2;
   }
@@ -118,16 +138,63 @@ export default async function protection(
           ? { deploymentType: ENABLED_DEPLOYMENT_TYPE }
           : null;
     }
+    if (selectedSkew) {
+      patchBody.skewProtectionMaxAge =
+        action === 'enable' ? DEFAULT_SKEW_PROTECTION_MAX_AGE : 0;
+    }
+    if (selectedSupportCode) {
+      patchBody.customerSupportCodeVisibility = action === 'enable';
+    }
+    if (selectedGitFork) {
+      patchBody.gitForkProtection = action === 'enable';
+    }
 
-    try {
-      await client.fetch(`/v9/projects/${encodeURIComponent(project.id)}`, {
-        method: 'PATCH',
-        body: patchBody,
-      });
-    } catch (err: unknown) {
-      exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
-      printError(err);
-      return 1;
+    if (selectedProtectionBypass) {
+      if (action === 'disable' && !protectionBypassSecret) {
+        output.error(
+          'Disabling protection bypass requires --protection-bypass-secret <secret>.'
+        );
+        return 2;
+      }
+      try {
+        const bypassBody =
+          action === 'enable'
+            ? {
+                generate: protectionBypassSecret
+                  ? { secret: protectionBypassSecret }
+                  : {},
+              }
+            : {
+                revoke: {
+                  secret: protectionBypassSecret,
+                  regenerate: false,
+                },
+              };
+        await client.fetch(
+          `/v1/projects/${encodeURIComponent(project.id)}/protection-bypass`,
+          {
+            method: 'PATCH',
+            body: bypassBody,
+          }
+        );
+      } catch (err: unknown) {
+        exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
+        printError(err);
+        return 1;
+      }
+    }
+
+    if (Object.keys(patchBody).length > 0) {
+      try {
+        await client.fetch(`/v9/projects/${encodeURIComponent(project.id)}`, {
+          method: 'PATCH',
+          body: patchBody,
+        });
+      } catch (err: unknown) {
+        exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
+        printError(err);
+        return 1;
+      }
     }
 
     if (formatResult.jsonOutput) {
@@ -139,6 +206,16 @@ export default async function protection(
             projectName: project.name,
             ssoProtection: selectedSso ? action === 'enable' : undefined,
             passwordProtection: selectedPassword
+              ? action === 'enable'
+              : undefined,
+            skewProtection: selectedSkew ? action === 'enable' : undefined,
+            customerSupportCodeVisibility: selectedSupportCode
+              ? action === 'enable'
+              : undefined,
+            gitForkProtection: selectedGitFork
+              ? action === 'enable'
+              : undefined,
+            protectionBypass: selectedProtectionBypass
               ? action === 'enable'
               : undefined,
           },

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -162,9 +162,9 @@ export default async function protection(
           {
             command: buildCommandWithGlobalFlags(
               client.argv,
-              'project protection disable --sso'
+              `project protection ${action} --sso`
             ),
-            when: 'Example: disable with SSO protection selected',
+            when: 'Example: same action with SSO protection selected',
           },
         ],
       },

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -78,10 +78,15 @@ export default async function protection(
     return 1;
   }
 
-  const withSso = Boolean(parsedArgs.flags['--sso']);
-  const withPassword = Boolean(parsedArgs.flags['--password']);
-  const selectedSso = withSso || (!withSso && !withPassword);
-  const selectedPassword = withPassword;
+  const selectedSso = Boolean(parsedArgs.flags['--sso']);
+  const selectedPassword = Boolean(parsedArgs.flags['--password']);
+
+  if (action && !selectedSso && !selectedPassword) {
+    output.error(
+      `No protection selected. Pass at least one of --sso or --password. Usage: \`vercel project protection ${action} [name] --sso|--password\``
+    );
+    return 2;
+  }
 
   let project: Project;
   try {

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -452,6 +452,7 @@ export type ExitWithNonInteractiveErrorVariant =
   | 'members'
   | 'access-groups'
   | 'access-summary'
+  | 'protection'
   | 'speed-insights'
   | 'web-analytics'
   | 'checks'
@@ -478,25 +479,30 @@ function buildNextStepsForProjectSubcommands(
             template: 'project access-summary <name>' as const,
             when: 'Show role counts by project name (replace <name>)',
           }
-        : variant === 'speed-insights'
+        : variant === 'protection'
           ? {
-              template: 'project speed-insights <name>' as const,
-              when: 'Enable Speed Insights by project name (replace <name>)',
+              template: 'project protection <name>' as const,
+              when: 'Show deployment protection by project name (replace <name>)',
             }
-          : variant === 'web-analytics'
+          : variant === 'speed-insights'
             ? {
-                template: 'project web-analytics <name>' as const,
-                when: 'Enable Web Analytics by project name (replace <name>)',
+                template: 'project speed-insights <name>' as const,
+                when: 'Enable Speed Insights by project name (replace <name>)',
               }
-            : variant === 'checks'
+            : variant === 'web-analytics'
               ? {
-                  template: 'project checks add <name>' as const,
-                  when: 'Create a deployment check by project name (replace <name>)',
+                  template: 'project web-analytics <name>' as const,
+                  when: 'Enable Web Analytics by project name (replace <name>)',
                 }
-              : {
-                  template: 'project members <name>' as const,
-                  when: 'List members by project name (replace <name>)',
-                };
+              : variant === 'checks'
+                ? {
+                    template: 'project checks add <name>' as const,
+                    when: 'Create a deployment check by project name (replace <name>)',
+                  }
+                : {
+                    template: 'project members <name>' as const,
+                    when: 'List members by project name (replace <name>)',
+                  };
   return [
     {
       command: buildCommandWithGlobalFlags(client.argv, 'link'),

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -69,6 +69,13 @@ export class ProjectTelemetryClient
     });
   }
 
+  trackCliSubcommandProtection(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'protection',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandWebAnalytics(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'web-analytics',

--- a/packages/cli/test/unit/commands/project/protection.test.ts
+++ b/packages/cli/test/unit/commands/project/protection.test.ts
@@ -18,27 +18,18 @@ describe('project protection', () => {
     await expect(client.stderr).toOutput('Protection settings');
   });
 
-  it('enables SSO protection by default', async () => {
+  it('requires explicit protection selector for action mode', async () => {
     useProject({
       ...defaultProject,
       id: 'prj_123',
       name: 'my-project',
     });
 
-    client.scenario.patch('/v9/projects/prj_123', (req, res) => {
-      expect(req.body).toEqual({
-        ssoProtection: {
-          deploymentType: 'prod_deployment_urls_and_all_previews',
-        },
-      });
-      res.json({ id: 'prj_123' });
-    });
-
     client.setArgv('project', 'protection', 'enable', 'my-project');
     const exitCode = await project(client);
 
-    expect(exitCode).toBe(0);
-    await expect(client.stderr).toOutput('Deployment protection enabled');
+    expect(exitCode).toBe(2);
+    await expect(client.stderr).toOutput('No protection selected');
   });
 
   it('disables only password protection when --password is set', async () => {
@@ -84,6 +75,7 @@ describe('project protection', () => {
       'protection',
       'enable',
       'my-project',
+      '--sso',
       '--format',
       'json'
     );

--- a/packages/cli/test/unit/commands/project/protection.test.ts
+++ b/packages/cli/test/unit/commands/project/protection.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import project from '../../../../src/commands/project';
+import type { CommandOption } from '../../../../src/commands/help';
+import { protectionSubcommand } from '../../../../src/commands/project/command';
 import { client } from '../../../mocks/client';
 import { defaultProject, useProject } from '../../../mocks/project';
 
@@ -202,6 +204,29 @@ describe('project protection', () => {
         reason: 'missing_arguments',
       });
       expect(payload.message).toMatch(/No protection selected/);
+      expect(payload.message).toContain('--password');
+      const toggleFlagsForNext = protectionSubcommand.options
+        .filter(o => {
+          const opt = o as CommandOption;
+          return (
+            opt.type === Boolean &&
+            !opt.deprecated &&
+            opt.description !== undefined &&
+            opt.agentSuggest !== false
+          );
+        })
+        .map(o => `--${(o as CommandOption).name}`);
+      expect(payload.next).toHaveLength(toggleFlagsForNext.length);
+      expect(
+        payload.next.some((n: { command: string }) =>
+          n.command.includes('--password')
+        )
+      ).toBe(false);
+      for (let i = 0; i < toggleFlagsForNext.length; i++) {
+        expect(payload.next[i].command).toContain(
+          `project protection enable ${toggleFlagsForNext[i]}`
+        );
+      }
     });
 
     it('outputs JSON when listing protection settings without --format', async () => {

--- a/packages/cli/test/unit/commands/project/protection.test.ts
+++ b/packages/cli/test/unit/commands/project/protection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import project from '../../../../src/commands/project';
 import { client } from '../../../mocks/client';
 import { defaultProject, useProject } from '../../../mocks/project';
@@ -165,6 +165,64 @@ describe('project protection', () => {
       projectId: 'prj_123',
       projectName: 'my-project',
       ssoProtection: true,
+    });
+  });
+
+  describe('--non-interactive', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+      client.nonInteractive = false;
+    });
+
+    it('outputs missing_arguments JSON when enable has no protection flag', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+
+      vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code ?? 0}`);
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv(
+        'project',
+        'protection',
+        'enable',
+        'my-project',
+        '--non-interactive'
+      );
+
+      await expect(project(client)).rejects.toThrow('exit:2');
+
+      const payload = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_arguments',
+      });
+      expect(payload.message).toMatch(/No protection selected/);
+    });
+
+    it('outputs JSON when listing protection settings without --format', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+
+      client.nonInteractive = true;
+      client.setArgv(
+        'project',
+        'protection',
+        'my-project',
+        '--non-interactive'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      const payload = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(payload.projectId).toBe('prj_123');
+      expect(payload.name).toBe('my-project');
     });
   });
 });

--- a/packages/cli/test/unit/commands/project/protection.test.ts
+++ b/packages/cli/test/unit/commands/project/protection.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import project from '../../../../src/commands/project';
+import { client } from '../../../mocks/client';
+import { defaultProject, useProject } from '../../../mocks/project';
+
+describe('project protection', () => {
+  it('shows protection settings by default', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.setArgv('project', 'protection', 'my-project');
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('Protection settings');
+  });
+
+  it('enables SSO protection by default', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.patch('/v9/projects/prj_123', (req, res) => {
+      expect(req.body).toEqual({
+        ssoProtection: {
+          deploymentType: 'prod_deployment_urls_and_all_previews',
+        },
+      });
+      res.json({ id: 'prj_123' });
+    });
+
+    client.setArgv('project', 'protection', 'enable', 'my-project');
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('Deployment protection enabled');
+  });
+
+  it('disables only password protection when --password is set', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.patch('/v9/projects/prj_123', (req, res) => {
+      expect(req.body).toEqual({
+        passwordProtection: null,
+      });
+      res.json({ id: 'prj_123' });
+    });
+
+    client.setArgv(
+      'project',
+      'protection',
+      'disable',
+      'my-project',
+      '--password'
+    );
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('Deployment protection disabled');
+  });
+
+  it('returns JSON for action mode with --format json', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.patch('/v9/projects/prj_123', (_req, res) => {
+      res.json({ id: 'prj_123' });
+    });
+
+    client.setArgv(
+      'project',
+      'protection',
+      'enable',
+      'my-project',
+      '--format',
+      'json'
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out).toMatchObject({
+      action: 'enable',
+      projectId: 'prj_123',
+      projectName: 'my-project',
+      ssoProtection: true,
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/project/protection.test.ts
+++ b/packages/cli/test/unit/commands/project/protection.test.ts
@@ -59,6 +59,83 @@ describe('project protection', () => {
     await expect(client.stderr).toOutput('Deployment protection disabled');
   });
 
+  it('updates skew, support-code visibility and git-fork protection in one call', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.patch('/v9/projects/prj_123', (req, res) => {
+      expect(req.body).toEqual({
+        skewProtectionMaxAge: 2592000,
+        customerSupportCodeVisibility: true,
+        gitForkProtection: true,
+      });
+      res.json({ id: 'prj_123' });
+    });
+
+    client.setArgv(
+      'project',
+      'protection',
+      'enable',
+      'my-project',
+      '--skew',
+      '--customer-support-code-visibility',
+      '--git-fork-protection'
+    );
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('enables protection bypass via project bypass endpoint', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.patch(
+      '/v1/projects/prj_123/protection-bypass',
+      (req, res) => {
+        expect(req.body).toEqual({
+          generate: {},
+        });
+        res.json({ protectionBypass: {} });
+      }
+    );
+
+    client.setArgv(
+      'project',
+      'protection',
+      'enable',
+      'my-project',
+      '--protection-bypass'
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+  });
+
+  it('requires bypass secret when disabling protection bypass', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.setArgv(
+      'project',
+      'protection',
+      'disable',
+      'my-project',
+      '--protection-bypass'
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(2);
+    await expect(client.stderr).toOutput('requires --protection-bypass-secret');
+  });
+
   it('returns JSON for action mode with --format json', async () => {
     useProject({
       ...defaultProject,


### PR DESCRIPTION
## Summary
Scope note for [CLI-236](https://linear.app/vercel/issue/CLI-236/parity-deployment-protection-and-skew-stale-deployment-settings-cli): project protection / skew settings, dedup vs CLI-229 (checks) and CLI-226 (DNS).

## Path
`packages/cli/docs/parity/cli-236-deployment-protection-skew.md`

Made with [Cursor](https://cursor.com)

<!-- commands-to-test:start -->
### Supported CRUD Operations To Test
- **Read:** `vercel project protection`, `vercel project protection <project-name>`, `vercel project protection --format json`
- **Update:** `vercel project protection enable|disable` for `--sso`, `--password`, `--skew`, `--customer-support-code-visibility`, `--git-fork-protection`, and `--protection-bypass`

### Commands To Test
- `vercel project protection`
- `vercel project protection <project-name>`
- `vercel project protection --format json`
- `vercel project protection enable <project-name> --sso`
- `vercel project protection disable <project-name> --sso`
- `vercel project protection enable <project-name> --password`
- `vercel project protection disable <project-name> --password`
- `vercel project protection enable <project-name> --skew`
- `vercel project protection disable <project-name> --skew`
- `vercel project protection enable <project-name> --customer-support-code-visibility`
- `vercel project protection disable <project-name> --customer-support-code-visibility`
- `vercel project protection enable <project-name> --git-fork-protection`
- `vercel project protection disable <project-name> --git-fork-protection`
- `vercel project protection enable <project-name> --protection-bypass`
- `vercel project protection disable <project-name> --protection-bypass --protection-bypass-secret <secret>`
- `vercel project protection enable <project-name> --sso --format json`

<!-- commands-to-test:end -->
