### PR TITLE
cli: Hide `--search` flag from `vc logs` help and update `--query` description

### DIFF
--- a/.changeset/vc-logs-help-text.md
+++ b/.changeset/vc-logs-help-text.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Hide `--search` flag from `vc logs --help` output while continuing to accept it, and update the `--query` flag description to indicate advanced querying with filter syntax support.

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -18,6 +18,7 @@ export interface CommandOption {
   readonly type: PrimitiveConstructor | ReadonlyArray<PrimitiveConstructor>;
   readonly argument?: string;
   readonly deprecated: boolean;
+  readonly hidden?: boolean;
   readonly description?: string;
 }
 export interface CommandArgument {
@@ -146,9 +147,9 @@ export function buildCommandOptionLines(
   options: BuildHelpOutputOptions,
   sectionTitle: string
 ) {
-  // Filter out deprecated and intentionally undocumented options
+  // Filter out deprecated, hidden, and intentionally undocumented options
   const filteredCommandOptions = commandOptions.filter(
-    option => !option.deprecated && option.description !== undefined
+    option => !option.deprecated && !option.hidden && option.description !== undefined
   );
 
   if (filteredCommandOptions.length === 0) {

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -18,7 +18,6 @@ export interface CommandOption {
   readonly type: PrimitiveConstructor | ReadonlyArray<PrimitiveConstructor>;
   readonly argument?: string;
   readonly deprecated: boolean;
-  readonly hidden?: boolean;
   readonly description?: string;
 }
 export interface CommandArgument {
@@ -147,9 +146,9 @@ export function buildCommandOptionLines(
   options: BuildHelpOutputOptions,
   sectionTitle: string
 ) {
-  // Filter out deprecated, hidden, and intentionally undocumented options
+  // Filter out deprecated and intentionally undocumented options
   const filteredCommandOptions = commandOptions.filter(
-    option => !option.deprecated && !option.hidden && option.description !== undefined
+    option => !option.deprecated && option.description !== undefined
   );
 
   if (filteredCommandOptions.length === 0) {

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -109,13 +109,15 @@ export const logsCommand = {
       shorthand: 'q',
       type: String,
       deprecated: false,
-      description: 'Full-text search query',
+      description:
+        'Advanced search query (supports filter syntax, e.g. "status:500 error")',
     },
     {
       name: 'search',
       shorthand: null,
       type: String,
       deprecated: false,
+      hidden: true,
       description:
         'Advanced search query (supports filter syntax, e.g. "status:500 error")',
     },
@@ -180,7 +182,7 @@ export const logsCommand = {
     },
     {
       name: 'Use advanced search query with filters',
-      value: `${packageName} logs --search 'status:500 error' --json | jq '.message'`,
+      value: `${packageName} logs --query 'status:500 error' --json | jq '.message'`,
     },
     {
       name: 'Display production logs only',

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -116,8 +116,7 @@ export const logsCommand = {
       name: 'search',
       shorthand: null,
       type: String,
-      deprecated: false,
-      hidden: true,
+      deprecated: true,
       description:
         'Advanced search query (supports filter syntax, e.g. "status:500 error")',
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Based on usage analytics showing `--query` is the dominant flag (~8x more sessions than `--search` in the last 7 days), this PR consolidates the `vc logs` help output by:

1. **Deprecating `--search`** — The flag is marked `deprecated: true`, which hides it from `--help` output while keeping it fully accepted and functional. No changes needed to `help.ts` since it already filters deprecated options.

2. **Updating `--query` description** — Changed from "Full-text search query" to "Advanced search query (supports filter syntax, e.g. "status:500 error")" to match what `--search` previously described, making it clear that `--query` supports the advanced filter syntax.

3. **Updating examples** — The example that previously used `--search` now uses `--query` instead.

## Changes

### `packages/cli/src/commands/logs/command.ts`
- Marked `--search` option with `deprecated: true` (hides from help, still works)
- Updated `--query` description to indicate advanced querying with filter syntax
- Changed the "advanced search" example to use `--query` instead of `--search`

## Testing

- All 47 `vc logs` unit tests pass (including `--search` functional tests — flag still works)
- All 127 help unit tests pass
- Biome format check passes
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0ALU2FH67L/p1774566159775759?thread_ts=1774566159.775759&cid=C0ALU2FH67L)

<div><a href="https://cursor.com/agents/bc-e361050e-93c7-5631-9961-abfe92d8d9e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e361050e-93c7-5631-9961-abfe92d8d9e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

