### PR TITLE
[Logs] Preserve all request log messages in vc logs

### DIFF
--- a/.changeset/swift-oranges-end.md
+++ b/.changeset/swift-oranges-end.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Show `vc logs --help` output when invalid flags are provided, and exit successfully for explicit `--help`.
+Improve `vc logs` ergonomics by showing `vc logs --help` when invalid flags are provided, exiting successfully for explicit `--help`, and preserving the full nested `logs[]` array in JSON output so all request log messages remain available.

--- a/.changeset/swift-oranges-end.md
+++ b/.changeset/swift-oranges-end.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Show `vc logs --help` output when invalid flags are provided, and exit successfully for explicit `--help`.

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -16,7 +16,11 @@ import {
   ProjectNotFound,
 } from '../../util/errors-ts';
 import { displayRuntimeLogs } from '../../util/logs';
-import { fetchAllRequestLogs, type RequestLogEntry } from '../../util/logs-v2';
+import {
+  fetchAllRequestLogs,
+  type RequestLogEntry,
+  type RequestLogMessage,
+} from '../../util/logs-v2';
 import getDeployment from '../../util/get-deployment';
 import { getCommandName } from '../../util/pkg-name';
 import { LogsTelemetryClient } from '../../util/telemetry/commands/logs';
@@ -207,6 +211,7 @@ export default async function logs(client: Client) {
     parsedArguments = parseArguments(client.argv.slice(2), flagsSpecification);
   } catch (err) {
     printError(err);
+    output.print(help(logsCommand, { columns: client.stderr.columns }));
     return 1;
   }
 
@@ -219,7 +224,7 @@ export default async function logs(client: Client) {
   if (parsedArguments.flags['--help']) {
     telemetry.trackCliFlagHelp('logs');
     output.print(help(logsCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const subArgs = parsedArguments.args.slice(1);
@@ -562,6 +567,7 @@ export default async function logs(client: Client) {
         statusCode: number;
         message: string;
         messageTruncated?: boolean;
+        logs: RequestLogMessage[];
       };
 
       const rowData: RowData[] = logs.map(log => {
@@ -575,6 +581,7 @@ export default async function logs(client: Client) {
           statusCode,
           message: log.message?.replace(/\n/g, ' ').trim() || '',
           messageTruncated: log.messageTruncated,
+          logs: log.logs,
         };
       });
 
@@ -632,12 +639,18 @@ export default async function logs(client: Client) {
         formatHeader: header => chalk.dim(header),
         formatRow: expandOption
           ? (rowStr, row) => {
-              if (row.message) {
-                const coloredMessage = colorizeMessage(row.message, row.level);
-                const truncatedIndicator = row.messageTruncated
-                  ? chalk.gray('…')
-                  : '';
-                return `${rowStr}\n${coloredMessage}${truncatedIndicator}\n`;
+              if (row.logs.length > 0) {
+                const renderedLogs = row.logs
+                  .map(log => {
+                    const message = log.message.replace(/\n/g, ' ').trim();
+                    const safeMessage = message || '(no message)';
+                    const truncatedIndicator = log.messageTruncated
+                      ? chalk.gray('…')
+                      : '';
+                    return `${colorizeMessage(safeMessage, log.level)}${truncatedIndicator}`;
+                  })
+                  .join('\n');
+                return `${rowStr}\n${renderedLogs}\n`;
               }
               return rowStr + '\n';
             }

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -52,6 +52,8 @@ export interface FetchRequestLogsOptions {
   page?: number;
 }
 
+type DisplayLogLevel = RequestLogEntry['level'];
+
 const LOG_LEVEL_SEVERITY: Record<
   'info' | 'warning' | 'error' | 'fatal',
   number
@@ -213,7 +215,7 @@ export async function fetchRequestLogs(
       timestamp: row.timestamp ? new Date(row.timestamp).getTime() : Date.now(),
       deploymentId: row.deploymentId || '',
       projectId: options.projectId,
-      level: displayLog?.level || 'info',
+      level: (displayLog?.level as DisplayLogLevel) || 'info',
       message: displayLog?.message || '',
       messageTruncated: displayLog?.messageTruncated,
       source: (firstEvent?.source as RequestLogEntry['source']) || 'static',

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -2,7 +2,7 @@ import ms from 'ms';
 import type Client from './client';
 
 export interface RequestLogMessage {
-  level: 'error' | 'warning' | 'info' | 'fatal';
+  level: string;
   message: string;
   messageTruncated?: boolean;
 }
@@ -52,23 +52,18 @@ export interface FetchRequestLogsOptions {
   page?: number;
 }
 
-const LOG_LEVEL_SEVERITY: Record<RequestLogMessage['level'], number> = {
+const LOG_LEVEL_SEVERITY: Record<
+  'info' | 'warning' | 'error' | 'fatal',
+  number
+> = {
   info: 0,
   warning: 1,
   error: 2,
   fatal: 3,
 };
 
-function normalizeLogLevel(level?: string): RequestLogMessage['level'] {
-  switch (level) {
-    case 'fatal':
-    case 'error':
-    case 'warning':
-    case 'info':
-      return level;
-    default:
-      return 'info';
-  }
+function getLogLevelSeverity(level: string): number {
+  return LOG_LEVEL_SEVERITY[level as keyof typeof LOG_LEVEL_SEVERITY] ?? -1;
 }
 
 function getDisplayLog(
@@ -87,7 +82,7 @@ function getDisplayLog(
   const candidates = matchingLogs.length > 0 ? matchingLogs : logs;
 
   return candidates.reduce((selected, current) =>
-    LOG_LEVEL_SEVERITY[current.level] > LOG_LEVEL_SEVERITY[selected.level]
+    getLogLevelSeverity(current.level) > getLogLevelSeverity(selected.level)
       ? current
       : selected
   );
@@ -207,7 +202,7 @@ export async function fetchRequestLogs(
 
   const logs: RequestLogEntry[] = (data.rows || []).map(row => {
     const requestLogs: RequestLogMessage[] = (row.logs || []).map(log => ({
-      level: normalizeLogLevel(log.level),
+      level: log.level || 'info',
       message: log.message || '',
       messageTruncated: log.messageTruncated,
     }));

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -1,6 +1,12 @@
 import ms from 'ms';
 import type Client from './client';
 
+export interface RequestLogMessage {
+  level: 'error' | 'warning' | 'info' | 'fatal';
+  message: string;
+  messageTruncated?: boolean;
+}
+
 export interface RequestLogEntry {
   id: string;
   timestamp: number;
@@ -18,6 +24,7 @@ export interface RequestLogEntry {
   cache?: string;
   traceId?: string;
   messageTruncated?: boolean;
+  logs: RequestLogMessage[];
 }
 
 export interface RequestLogsResponse {
@@ -43,6 +50,47 @@ export interface FetchRequestLogsOptions {
   requestId?: string;
   branch?: string;
   page?: number;
+}
+
+const LOG_LEVEL_SEVERITY: Record<RequestLogMessage['level'], number> = {
+  info: 0,
+  warning: 1,
+  error: 2,
+  fatal: 3,
+};
+
+function normalizeLogLevel(level?: string): RequestLogMessage['level'] {
+  switch (level) {
+    case 'fatal':
+    case 'error':
+    case 'warning':
+    case 'info':
+      return level;
+    default:
+      return 'info';
+  }
+}
+
+function getDisplayLog(
+  logs: RequestLogMessage[],
+  requestedLevels?: string[]
+): RequestLogMessage | undefined {
+  if (logs.length === 0) {
+    return undefined;
+  }
+
+  const matchingLogs =
+    requestedLevels && requestedLevels.length > 0
+      ? logs.filter(log => requestedLevels.includes(log.level))
+      : logs;
+
+  const candidates = matchingLogs.length > 0 ? matchingLogs : logs;
+
+  return candidates.reduce((selected, current) =>
+    LOG_LEVEL_SEVERITY[current.level] > LOG_LEVEL_SEVERITY[selected.level]
+      ? current
+      : selected
+  );
 }
 
 function parseRelativeTime(input: string): number {
@@ -158,16 +206,21 @@ export async function fetchRequestLogs(
   }>(url);
 
   const logs: RequestLogEntry[] = (data.rows || []).map(row => {
-    const firstLog = row.logs?.[0];
+    const requestLogs: RequestLogMessage[] = (row.logs || []).map(log => ({
+      level: normalizeLogLevel(log.level),
+      message: log.message || '',
+      messageTruncated: log.messageTruncated,
+    }));
+    const displayLog = getDisplayLog(requestLogs, options.level);
     const firstEvent = row.events?.[0];
     return {
       id: row.requestId || '',
       timestamp: row.timestamp ? new Date(row.timestamp).getTime() : Date.now(),
       deploymentId: row.deploymentId || '',
       projectId: options.projectId,
-      level: (firstLog?.level as RequestLogEntry['level']) || 'info',
-      message: firstLog?.message || '',
-      messageTruncated: firstLog?.messageTruncated,
+      level: displayLog?.level || 'info',
+      message: displayLog?.message || '',
+      messageTruncated: displayLog?.messageTruncated,
       source: (firstEvent?.source as RequestLogEntry['source']) || 'static',
       domain: row.domain || '',
       requestMethod: row.requestMethod || '',
@@ -178,6 +231,7 @@ export async function fetchRequestLogs(
       branch: row.branch,
       cache: row.cache,
       traceId: row.traceId,
+      logs: requestLogs,
     };
   });
 

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -73,7 +73,7 @@ describe('logs', () => {
       client.setArgv('logs', '--help');
       const exitCode = await logs(client);
 
-      expect(exitCode).toEqual(2);
+      expect(exitCode).toEqual(0);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
@@ -131,6 +131,35 @@ describe('logs', () => {
       await expect(client.stdout).toOutput('"message":"JSON log test"');
     });
 
+    it('should output all request logs as a logs array in JSON mode', async () => {
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        res.json({
+          rows: [
+            {
+              ...createMockLog(),
+              logs: [
+                { level: 'info', message: 'first message' },
+                { level: 'error', message: 'actual error' },
+              ],
+            },
+          ],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--json', '--level', 'error');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.stdout.getFullOutput();
+      expect(output).toContain(
+        '"logs":[{"level":"info","message":"first message"},{"level":"error","message":"actual error"}]'
+      );
+      expect(output).toContain('"level":"error"');
+      expect(output).toContain('"message":"actual error"');
+    });
+
     it('should track telemetry for --json flag', async () => {
       useRequestLogs([]);
 
@@ -144,6 +173,19 @@ describe('logs', () => {
           value: 'TRUE',
         },
       ]);
+    });
+
+    it('should display help when an invalid flag is provided', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--output', 'json');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      const output = client.getFullOutput();
+      expect(output).toContain('--output');
+      expect(output).toContain('unknown or unexpected option');
+      expect(output).toContain('Display request logs');
+      expect(output).toContain('--json');
     });
 
     it('should display "no logs found" when empty', async () => {

--- a/packages/cli/test/unit/util/logs-v2.test.ts
+++ b/packages/cli/test/unit/util/logs-v2.test.ts
@@ -188,6 +188,66 @@ describe('logs-v2 utility', () => {
         since: isoDate,
       });
     });
+
+    it('should include all request logs in the result', async () => {
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        res.json({
+          rows: [
+            createMockApiLog({
+              logs: [
+                { level: 'info', message: 'first message' },
+                { level: 'error', message: 'actual error' },
+              ],
+            }),
+          ],
+          hasMoreRows: false,
+        });
+      });
+
+      const result = await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        ownerId: 'team_test',
+        level: ['error'],
+      });
+
+      expect(result.logs[0].logs).toEqual([
+        {
+          level: 'info',
+          message: 'first message',
+          messageTruncated: undefined,
+        },
+        {
+          level: 'error',
+          message: 'actual error',
+          messageTruncated: undefined,
+        },
+      ]);
+    });
+
+    it('should use a matching error log as the display log when filtering by level', async () => {
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        res.json({
+          rows: [
+            createMockApiLog({
+              logs: [
+                { level: 'info', message: 'first message' },
+                { level: 'error', message: 'actual error' },
+              ],
+            }),
+          ],
+          hasMoreRows: false,
+        });
+      });
+
+      const result = await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        ownerId: 'team_test',
+        level: ['error'],
+      });
+
+      expect(result.logs[0].level).toEqual('error');
+      expect(result.logs[0].message).toEqual('actual error');
+    });
   });
 
   describe('fetchAllRequestLogs', () => {


### PR DESCRIPTION
## Summary
- keep the existing request-shaped `vc logs` output but include the full `logs[]` array on every row
- choose the top-level `level` and `message` from the best matching request log instead of always using the first log entry
- print `vc logs` help on parse-time invalid flags and return exit code `0` for explicit `--help`

## Testing
- npx vitest run packages/cli/test/unit/util/logs-v2.test.ts packages/cli/test/unit/commands/logs/index.test.ts