### PR TITLE
[build-utils] Extend finalizeLambda with pluggable ZIP strategy and pre-digest validation hook

### DIFF
--- a/.changeset/build-utils-finalize-lambda-zip-strategy.md
+++ b/.changeset/build-utils-finalize-lambda-zip-strategy.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": minor
+---
+
+Extend `finalizeLambda` with pluggable ZIP strategy (`createZip`), pre-digest validation hook (`validateZip`), and optional trace tags. Widen `getLambdaEnvironment` buffer param to `{ byteLength: number }`.

--- a/packages/build-utils/src/finalize-lambda.ts
+++ b/packages/build-utils/src/finalize-lambda.ts
@@ -12,9 +12,36 @@ import { collectUncompressedSize } from './collect-uncompressed-size';
  * Optional wrapper around async work, allowing callers to inject tracing
  * (e.g. dd-trace spans) without coupling the shared code to a tracer.
  */
-export type TraceFn = <T>(name: string, fn: () => Promise<T>) => Promise<T>;
+export type TraceFn = <T>(
+  name: string,
+  fn: () => Promise<T>,
+  tags?: Record<string, string>
+) => Promise<T>;
 
 const defaultTrace: TraceFn = (_name, fn) => fn();
+
+/**
+ * Result of a custom ZIP creation strategy.
+ */
+export interface CreateZipResult {
+  /** The zip as a Buffer (in-memory), or null for disk-based paths. */
+  buffer: Buffer | null;
+  /** Path to the zip file on disk, or undefined for in-memory. */
+  zipPath?: string;
+  /** SHA-256 hex digest of the zip contents. */
+  digest: string;
+  /** Compressed size in bytes. */
+  size: number;
+}
+
+/**
+ * Custom ZIP creation strategy. When provided, replaces the default
+ * in-memory `lambda.createZip()` + `sha256()` path. This allows callers
+ * to stream large zips to disk instead.
+ */
+export type CreateZipFn = (
+  lambda: Lambda | NodejsLambda
+) => Promise<CreateZipResult>;
 
 export interface FinalizeLambdaParams {
   lambda: Lambda | NodejsLambda;
@@ -26,11 +53,29 @@ export interface FinalizeLambdaParams {
   enableUncompressedLambdaSizeCheck?: boolean;
   /** Optional tracing wrapper for `collectUncompressedSize` and `createZip`. */
   trace?: TraceFn;
+  /** Custom ZIP creation strategy. Defaults to in-memory lambda.createZip(). */
+  createZip?: CreateZipFn;
+  /**
+   * Called after ZIP creation but before digest/environment/streaming.
+   * Throw to abort (e.g. size validation). For the default in-memory path,
+   * this runs before sha256.
+   */
+  validateZip?: (zip: {
+    buffer: Buffer | null;
+    zipPath?: string;
+    size: number;
+  }) => void;
 }
 
 export interface FinalizeLambdaResult {
-  buffer: Buffer;
+  /** The zip as a Buffer, or null when a custom createZip returns a disk path. */
+  buffer: Buffer | null;
+  /** Path to zip on disk (set by custom createZip), undefined for in-memory. */
+  zipPath?: string;
+  /** SHA-256 hex digest. */
   digest: string;
+  /** Compressed size in bytes. */
+  size: number;
   uncompressedBytes: number;
   /** Non-fatal streaming detection error, if any. Caller decides how to log. */
   streamingError?: SupportsStreamingResult['error'];
@@ -42,10 +87,11 @@ export interface FinalizeLambdaResult {
  * This function:
  * 1. Injects encrypted env file into lambda.files when provided
  * 2. Collects uncompressed size when enabled
- * 3. Creates the ZIP buffer
- * 4. Computes SHA-256 digest
- * 5. Merges environment variables (bytecode caching, helpers, etc.)
- * 6. Detects streaming support
+ * 3. Creates the ZIP (in-memory or via custom strategy)
+ * 4. Runs optional validateZip hook (e.g. size check)
+ * 5. Computes SHA-256 digest (default path only; custom path provides its own)
+ * 6. Merges environment variables (bytecode caching, helpers, etc.)
+ * 7. Detects streaming support
  *
  * Note: This function mutates the `lambda` (files, environment,
  * supportsResponseStreaming).
@@ -61,6 +107,8 @@ export async function finalizeLambda(
     forceStreamingRuntime,
     enableUncompressedLambdaSizeCheck,
     trace = defaultTrace,
+    createZip: createZipOverride,
+    validateZip,
   } = params;
 
   // 1. Encrypted env injection
@@ -87,20 +135,57 @@ export async function finalizeLambda(
     }
   }
 
-  // 3. ZIP creation
-  const buffer =
-    lambda.zipBuffer || (await trace('createZip', () => lambda.createZip()));
-
-  // 4. Digest
-  const digest = sha256(buffer);
-
-  // 5. Lambda environment
-  lambda.environment = {
-    ...lambda.environment,
-    ...getLambdaEnvironment(lambda, buffer, bytecodeCachingOptions),
+  // 3. ZIP creation (pluggable strategy)
+  const zipTags: Record<string, string> = {
+    fileCount: String(Object.keys(lambda.files ?? {}).length),
+    uncompressedBytes: String(uncompressedBytes),
   };
 
-  // 6. Streaming detection
+  let zipResult: CreateZipResult;
+  if (createZipOverride) {
+    // Custom path (e.g. file-based): digest already computed by callback
+    zipResult = await trace(
+      'createZip',
+      () => createZipOverride(lambda),
+      zipTags
+    );
+  } else {
+    // Default in-memory path: create buffer first, digest deferred to step 5
+    const buffer =
+      lambda.zipBuffer ||
+      (await trace('createZip', () => lambda.createZip(), zipTags));
+    zipResult = {
+      buffer,
+      digest: '', // computed in step 5
+      size: buffer.byteLength,
+    };
+  }
+
+  // 4. Optional validation (e.g. size check)
+  if (validateZip) {
+    validateZip({
+      buffer: zipResult.buffer,
+      zipPath: zipResult.zipPath,
+      size: zipResult.size,
+    });
+  }
+
+  // 5. Digest (deferred for default path so validateZip can abort first)
+  if (!createZipOverride && zipResult.buffer) {
+    zipResult.digest = sha256(zipResult.buffer);
+  }
+
+  // 6. Lambda environment
+  lambda.environment = {
+    ...lambda.environment,
+    ...getLambdaEnvironment(
+      lambda,
+      zipResult.buffer ?? { byteLength: zipResult.size },
+      bytecodeCachingOptions
+    ),
+  };
+
+  // 7. Streaming detection
   const streamingResult = await getLambdaSupportsStreaming(
     lambda,
     forceStreamingRuntime
@@ -108,8 +193,10 @@ export async function finalizeLambda(
   lambda.supportsResponseStreaming = streamingResult.supportsStreaming;
 
   return {
-    buffer,
-    digest,
+    buffer: zipResult.buffer,
+    zipPath: zipResult.zipPath,
+    digest: zipResult.digest,
+    size: zipResult.size,
     uncompressedBytes,
     streamingError: streamingResult.error,
   };

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -200,6 +200,8 @@ export { collectUncompressedSize } from './collect-uncompressed-size';
 
 export {
   finalizeLambda,
+  type CreateZipResult,
+  type CreateZipFn,
   type FinalizeLambdaParams,
   type FinalizeLambdaResult,
   type TraceFn,

--- a/packages/build-utils/src/process-serverless/get-lambda-environment.ts
+++ b/packages/build-utils/src/process-serverless/get-lambda-environment.ts
@@ -20,7 +20,7 @@ interface LambdaLike {
  */
 export function getLambdaEnvironment(
   lambda: LambdaLike,
-  buffer: Buffer,
+  buffer: { byteLength: number },
   options: BytecodeCachingOptions
 ) {
   const environment: Record<string, string> = {};

--- a/packages/build-utils/src/process-serverless/get-lambda-preload-scripts.ts
+++ b/packages/build-utils/src/process-serverless/get-lambda-preload-scripts.ts
@@ -18,7 +18,7 @@ interface LambdaLike {
  */
 export function getLambdaPreloadScripts(
   lambda: LambdaLike,
-  buffer: Buffer,
+  buffer: { byteLength: number },
   options: BytecodeCachingOptions
 ) {
   const scripts: string[] = [];


### PR DESCRIPTION
Callers that handle large functions (multi-GiB) need to stream zips to disk instead of holding them in memory. The current `finalizeLambda` always creates an in-memory `Buffer`, forcing callers to duplicate the entire finalization pipeline (encrypted env, environment setup, streaming detection) just to swap out the zip step.

Additionally, callers need to validate zip size before `sha256` runs so the size check must come first.

### How

- Add optional `createZip` callback to `FinalizeLambdaParams`. Callers can provide a custom ZIP strategy (e.g. streaming to disk) and the shared function handles everything else
- Add optional `validateZip` hook that runs after zip creation but before digest computation
- Add `size` and `zipPath to `FinalizeLambdaResult` so callers don't need to re-derive them
- Extend `TraceFn` with optional tags param so callers can attach tracing metadata
- Widen `getLambdaEnvironment` / `getLambdaPreloadScripts` `buffer` param from `Buffer` to `{ byteLength: number }` (this is what was actually used, removes the need for `as Buffer` casts when the zip is on disk.
- Export new types: `CreateZipResult`, `CreateZipFn`

### Notes

- No behavioral change for callers that don't use the new params
- All new params are optional with backward-compatible defaults