### PR TITLE
feat(skills): add microfrontends reference to vercel-cli skill

### DIFF
--- a/.changeset/cool-rules-build.md
+++ b/.changeset/cool-rules-build.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve `vercel microfrontends create-group` non-interactive behavior by allowing free-tier-safe flows with explicit flags, while still blocking non-interactive execution when the action would impact billing. Add support for repeatable `--project-route=<project>=<route>` to configure non-default project routes without prompts.

--- a/packages/cli/src/commands/microfrontends/command.ts
+++ b/packages/cli/src/commands/microfrontends/command.ts
@@ -36,6 +36,14 @@ export const createGroupSubcommand = {
       deprecated: false,
       description: 'Default route for the default application',
     },
+    {
+      name: 'project-route',
+      shorthand: null,
+      type: [String],
+      deprecated: false,
+      description:
+        'Default route for a non-default project in the form "<project>=<route>" (repeatable)',
+    },
   ],
   examples: [
     {
@@ -44,7 +52,7 @@ export const createGroupSubcommand = {
     },
     {
       name: 'Create a microfrontends group with flags',
-      value: `${packageName} mf create-group --name="My Group" --project=web --project=docs --default-app=web`,
+      value: `${packageName} mf create-group --name="My Group" --project=web --project=docs --default-app=web --project-route=docs=/docs`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/microfrontends/command.ts
+++ b/packages/cli/src/commands/microfrontends/command.ts
@@ -37,12 +37,16 @@ export const createGroupSubcommand = {
       description: 'Default route for the default application',
     },
     {
-      name: 'project-route',
+      name: 'project-default-route',
       shorthand: null,
       type: [String],
       deprecated: false,
       description:
         'Default route for a non-default project in the form "<project>=<route>" (repeatable)',
+    },
+    {
+      ...yesOption,
+      description: 'Skip creation confirmation prompt',
     },
   ],
   examples: [
@@ -52,7 +56,7 @@ export const createGroupSubcommand = {
     },
     {
       name: 'Create a microfrontends group with flags',
-      value: `${packageName} mf create-group --name="My Group" --project=web --project=docs --default-app=web --project-route=docs=/docs`,
+      value: `${packageName} mf create-group --name="My Group" --project=web --project=docs --default-app=web --project-default-route=docs=/docs --yes`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/microfrontends/create-group.ts
+++ b/packages/cli/src/commands/microfrontends/create-group.ts
@@ -106,9 +106,10 @@ export default async function createGroup(client: Client): Promise<number> {
   const defaultRouteFlag = parsedArgs.flags['--default-route'] as
     | string
     | undefined;
-  const projectRouteFlags = parsedArgs.flags['--project-route'] as
-    | string[]
-    | undefined;
+  const projectDefaultRouteFlags = parsedArgs.flags[
+    '--project-default-route'
+  ] as string[] | undefined;
+  const autoConfirm = !!parsedArgs.flags['--yes'];
   const isNonInteractive =
     client.nonInteractive || client.argv.includes('--non-interactive');
 
@@ -330,25 +331,25 @@ export default async function createGroup(client: Client): Promise<number> {
   }
 
   const otherProjects = selectedProjects.filter(p => p.id !== defaultApp.id);
-  const parsedProjectRoutes = parseProjectRouteFlags(
-    projectRouteFlags,
+  const parsedProjectDefaultRoutes = parseProjectDefaultRouteFlags(
+    projectDefaultRouteFlags,
     selectedProjects,
     defaultApp
   );
-  if (typeof parsedProjectRoutes === 'string') {
-    output.error(parsedProjectRoutes);
+  if (typeof parsedProjectDefaultRoutes === 'string') {
+    output.error(parsedProjectDefaultRoutes);
     return 1;
   }
   const otherApplications: { projectId: string; defaultRoute: string }[] = [];
 
   for (const project of otherProjects) {
-    const routeFromFlag = parsedProjectRoutes.get(project.id);
+    const routeFromFlag = parsedProjectDefaultRoutes.get(project.id);
     let route: string;
     if (routeFromFlag) {
       route = routeFromFlag;
     } else if (isNonInteractive) {
       output.error(
-        `Missing required flag --project-route for "${project.name}". Use --project-route=${project.name}=/<path> in non-interactive mode.`
+        `Missing required flag --project-default-route for "${project.name}". Use --project-default-route=${project.name}=/<path> in non-interactive mode.`
       );
       return 1;
     } else {
@@ -405,9 +406,15 @@ export default async function createGroup(client: Client): Promise<number> {
   }
   output.log('');
 
-  const confirmed = isNonInteractive
-    ? true
-    : await client.input.confirm('Create microfrontends group?', true);
+  if (!autoConfirm && !client.stdin.isTTY) {
+    output.error(
+      'Confirmation required. Use --yes to confirm group creation in non-interactive mode.'
+    );
+    return 1;
+  }
+  const confirmed =
+    autoConfirm ||
+    (await client.input.confirm('Create microfrontends group?', true));
   if (!confirmed) {
     output.log('Aborted.');
     return 0;
@@ -564,46 +571,46 @@ function isProjectInMicrofrontendsGroup(
   return groups.some(g => g.projects.some(p => p.id === project.id));
 }
 
-function parseProjectRouteFlags(
-  projectRouteFlags: string[] | undefined,
+function parseProjectDefaultRouteFlags(
+  projectDefaultRouteFlags: string[] | undefined,
   selectedProjects: Project[],
   defaultApp: Project
 ): Map<string, string> | string {
   const routeByProjectId = new Map<string, string>();
-  if (!projectRouteFlags || projectRouteFlags.length === 0) {
+  if (!projectDefaultRouteFlags || projectDefaultRouteFlags.length === 0) {
     return routeByProjectId;
   }
 
-  for (const entry of projectRouteFlags) {
+  for (const entry of projectDefaultRouteFlags) {
     const separatorIndex = entry.indexOf('=');
     if (separatorIndex <= 0 || separatorIndex === entry.length - 1) {
-      return `Invalid --project-route value "${entry}". Use "<project>=<route>", for example "docs=/docs".`;
+      return `Invalid --project-default-route value "${entry}". Use "<project>=<route>", for example "docs=/docs".`;
     }
 
     const projectIdentifier = entry.slice(0, separatorIndex).trim();
     const route = entry.slice(separatorIndex + 1).trim();
     if (!projectIdentifier || !route) {
-      return `Invalid --project-route value "${entry}". Use "<project>=<route>", for example "docs=/docs".`;
+      return `Invalid --project-default-route value "${entry}". Use "<project>=<route>", for example "docs=/docs".`;
     }
 
     const project = selectedProjects.find(
       p => p.name === projectIdentifier || p.id === projectIdentifier
     );
     if (!project) {
-      return `Invalid --project-route value "${entry}". Project "${projectIdentifier}" is not one of the selected projects.`;
+      return `Invalid --project-default-route value "${entry}". Project "${projectIdentifier}" is not one of the selected projects.`;
     }
 
     if (project.id === defaultApp.id) {
-      return `Invalid --project-route value "${entry}". Use --default-route for the default app "${defaultApp.name}".`;
+      return `Invalid --project-default-route value "${entry}". Use --default-route for the default app "${defaultApp.name}".`;
     }
 
     const routeValidation = validateDefaultRoute(route);
     if (routeValidation !== true) {
-      return `Invalid --project-route value "${entry}": ${routeValidation}`;
+      return `Invalid --project-default-route value "${entry}": ${routeValidation}`;
     }
 
     if (routeByProjectId.has(project.id)) {
-      return `Duplicate --project-route for project "${project.name}".`;
+      return `Duplicate --project-default-route for project "${project.name}".`;
     }
 
     routeByProjectId.set(project.id, route);

--- a/packages/cli/src/commands/microfrontends/create-group.ts
+++ b/packages/cli/src/commands/microfrontends/create-group.ts
@@ -106,11 +106,41 @@ export default async function createGroup(client: Client): Promise<number> {
   const defaultRouteFlag = parsedArgs.flags['--default-route'] as
     | string
     | undefined;
+  const projectRouteFlags = parsedArgs.flags['--project-route'] as
+    | string[]
+    | undefined;
+  const isNonInteractive =
+    client.nonInteractive || client.argv.includes('--non-interactive');
+
+  if (isNonInteractive) {
+    if (!nameFlag) {
+      output.error(
+        'Missing required flag --name. Use --name in non-interactive mode.'
+      );
+      return 1;
+    }
+
+    if (!projectFlags || projectFlags.length === 0) {
+      output.error(
+        'Missing required flag --project. Use --project in non-interactive mode.'
+      );
+      return 1;
+    }
+
+    if (projectFlags.length > 1 && !defaultAppFlag) {
+      output.error(
+        'Missing required flag --default-app when using multiple --project values in non-interactive mode.'
+      );
+      return 1;
+    }
+  }
 
   // Block agents when adding projects would incur billing charges beyond the free tier.
-  const wouldAffectBilling = existingMfeProjectCount + 1 > freeProjects;
+  const projectsToAddCount = projectFlags?.length ?? 1;
+  const wouldAffectBilling =
+    existingMfeProjectCount + projectsToAddCount > freeProjects;
   if (wouldAffectBilling) {
-    if (client.nonInteractive) {
+    if (isNonInteractive) {
       const flags = getGlobalFlagsOnlyFromArgs(client.argv.slice(2));
       const interactiveCmd = getCommandNamePlain(
         `microfrontends create-group ${flags.filter(f => f !== '--non-interactive').join(' ')}`.trim()
@@ -134,6 +164,7 @@ export default async function createGroup(client: Client): Promise<number> {
         },
         1
       );
+      return 1;
     }
 
     if (!client.stdin.isTTY) {
@@ -299,13 +330,33 @@ export default async function createGroup(client: Client): Promise<number> {
   }
 
   const otherProjects = selectedProjects.filter(p => p.id !== defaultApp.id);
+  const parsedProjectRoutes = parseProjectRouteFlags(
+    projectRouteFlags,
+    selectedProjects,
+    defaultApp
+  );
+  if (typeof parsedProjectRoutes === 'string') {
+    output.error(parsedProjectRoutes);
+    return 1;
+  }
   const otherApplications: { projectId: string; defaultRoute: string }[] = [];
 
   for (const project of otherProjects) {
-    const route = await client.input.text({
-      message: `Default route for "${project.name}":`,
-      validate: validateDefaultRoute,
-    });
+    const routeFromFlag = parsedProjectRoutes.get(project.id);
+    let route: string;
+    if (routeFromFlag) {
+      route = routeFromFlag;
+    } else if (isNonInteractive) {
+      output.error(
+        `Missing required flag --project-route for "${project.name}". Use --project-route=${project.name}=/<path> in non-interactive mode.`
+      );
+      return 1;
+    } else {
+      route = await client.input.text({
+        message: `Default route for "${project.name}":`,
+        validate: validateDefaultRoute,
+      });
+    }
     otherApplications.push({ projectId: project.id, defaultRoute: route });
   }
 
@@ -354,10 +405,9 @@ export default async function createGroup(client: Client): Promise<number> {
   }
   output.log('');
 
-  const confirmed = await client.input.confirm(
-    'Create microfrontends group?',
-    true
-  );
+  const confirmed = isNonInteractive
+    ? true
+    : await client.input.confirm('Create microfrontends group?', true);
   if (!confirmed) {
     output.log('Aborted.');
     return 0;
@@ -416,6 +466,7 @@ export default async function createGroup(client: Client): Promise<number> {
       );
       const shouldCreate =
         client.stdin.isTTY &&
+        !isNonInteractive &&
         (await client.input.confirm('Create a microfrontends.json now?', true));
       if (shouldCreate) {
         const routingPaths: Record<string, string[]> = {};
@@ -511,4 +562,52 @@ function isProjectInMicrofrontendsGroup(
   groups: MicrofrontendsGroupResponse[]
 ): boolean {
   return groups.some(g => g.projects.some(p => p.id === project.id));
+}
+
+function parseProjectRouteFlags(
+  projectRouteFlags: string[] | undefined,
+  selectedProjects: Project[],
+  defaultApp: Project
+): Map<string, string> | string {
+  const routeByProjectId = new Map<string, string>();
+  if (!projectRouteFlags || projectRouteFlags.length === 0) {
+    return routeByProjectId;
+  }
+
+  for (const entry of projectRouteFlags) {
+    const separatorIndex = entry.indexOf('=');
+    if (separatorIndex <= 0 || separatorIndex === entry.length - 1) {
+      return `Invalid --project-route value "${entry}". Use "<project>=<route>", for example "docs=/docs".`;
+    }
+
+    const projectIdentifier = entry.slice(0, separatorIndex).trim();
+    const route = entry.slice(separatorIndex + 1).trim();
+    if (!projectIdentifier || !route) {
+      return `Invalid --project-route value "${entry}". Use "<project>=<route>", for example "docs=/docs".`;
+    }
+
+    const project = selectedProjects.find(
+      p => p.name === projectIdentifier || p.id === projectIdentifier
+    );
+    if (!project) {
+      return `Invalid --project-route value "${entry}". Project "${projectIdentifier}" is not one of the selected projects.`;
+    }
+
+    if (project.id === defaultApp.id) {
+      return `Invalid --project-route value "${entry}". Use --default-route for the default app "${defaultApp.name}".`;
+    }
+
+    const routeValidation = validateDefaultRoute(route);
+    if (routeValidation !== true) {
+      return `Invalid --project-route value "${entry}": ${routeValidation}`;
+    }
+
+    if (routeByProjectId.has(project.id)) {
+      return `Duplicate --project-route for project "${project.name}".`;
+    }
+
+    routeByProjectId.set(project.id, route);
+  }
+
+  return routeByProjectId;
 }

--- a/packages/cli/test/unit/commands/microfrontends/create-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/create-group.test.ts
@@ -718,6 +718,27 @@ describe('microfrontends create-group', () => {
       expect(await exitCodePromise).toBe(1);
     });
 
+    it('errors when --yes is missing and stdin is not a TTY', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--default-app=web'
+      );
+      (client.stdin as any).isTTY = false;
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Confirmation required. Use --yes to confirm group creation in non-interactive mode.'
+      );
+      expect(await exitCodePromise).toBe(1);
+      (client.stdin as any).isTTY = true;
+    });
+
     it('errors in non-interactive mode when creation would affect billing', async () => {
       const mocks = setupMocks({
         groupsResponse: {

--- a/packages/cli/test/unit/commands/microfrontends/create-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/create-group.test.ts
@@ -49,6 +49,13 @@ const defaultProjects = [
     updatedAt: Date.now(),
     createdAt: Date.now(),
   },
+  {
+    id: 'proj_blog',
+    name: 'blog',
+    accountId: 'team_123',
+    updatedAt: Date.now(),
+    createdAt: Date.now(),
+  },
 ];
 
 interface MockOptions {
@@ -507,6 +514,7 @@ describe('microfrontends create-group', () => {
         'microfrontends',
         'create-group',
         '--non-interactive',
+        '--yes',
         '--name=My Group',
         '--project=web',
         '--default-app=web'
@@ -523,7 +531,7 @@ describe('microfrontends create-group', () => {
       });
     });
 
-    it('errors in non-interactive mode when missing project routes', async () => {
+    it('errors in non-interactive mode when missing project default routes', async () => {
       setupMocks();
       client.setArgv(
         'microfrontends',
@@ -538,12 +546,12 @@ describe('microfrontends create-group', () => {
       const exitCodePromise = microfrontends(client);
 
       await expect(client.stderr).toOutput(
-        'Error: Missing required flag --project-route for "docs". Use --project-route=docs=/<path> in non-interactive mode.'
+        'Error: Missing required flag --project-default-route for "docs". Use --project-default-route=docs=/<path> in non-interactive mode.'
       );
       expect(await exitCodePromise).toBe(1);
     });
 
-    it('errors for invalid --project-route format', async () => {
+    it('errors for invalid --project-default-route format', async () => {
       setupMocks();
       client.setArgv(
         'microfrontends',
@@ -553,18 +561,18 @@ describe('microfrontends create-group', () => {
         '--project=web',
         '--project=docs',
         '--default-app=web',
-        '--project-route=docs'
+        '--project-default-route=docs'
       );
 
       const exitCodePromise = microfrontends(client);
 
       await expect(client.stderr).toOutput(
-        'Error: Invalid --project-route value "docs". Use "<project>=<route>", for example "docs=/docs".'
+        'Error: Invalid --project-default-route value "docs". Use "<project>=<route>", for example "docs=/docs".'
       );
       expect(await exitCodePromise).toBe(1);
     });
 
-    it('errors when --project-route points to an unselected project', async () => {
+    it('errors when --project-default-route points to an unselected project', async () => {
       setupMocks();
       client.setArgv(
         'microfrontends',
@@ -574,18 +582,18 @@ describe('microfrontends create-group', () => {
         '--project=web',
         '--project=docs',
         '--default-app=web',
-        '--project-route=shop=/shop'
+        '--project-default-route=shop=/shop'
       );
 
       const exitCodePromise = microfrontends(client);
 
       await expect(client.stderr).toOutput(
-        'Error: Invalid --project-route value "shop=/shop". Project "shop" is not one of the selected projects.'
+        'Error: Invalid --project-default-route value "shop=/shop". Project "shop" is not one of the selected projects.'
       );
       expect(await exitCodePromise).toBe(1);
     });
 
-    it('errors when --project-route is provided for the default app', async () => {
+    it('errors when --project-default-route is provided for the default app', async () => {
       setupMocks();
       client.setArgv(
         'microfrontends',
@@ -595,18 +603,18 @@ describe('microfrontends create-group', () => {
         '--project=web',
         '--project=docs',
         '--default-app=web',
-        '--project-route=web=/'
+        '--project-default-route=web=/'
       );
 
       const exitCodePromise = microfrontends(client);
 
       await expect(client.stderr).toOutput(
-        'Error: Invalid --project-route value "web=/". Use --default-route for the default app "web".'
+        'Error: Invalid --project-default-route value "web=/". Use --default-route for the default app "web".'
       );
       expect(await exitCodePromise).toBe(1);
     });
 
-    it('errors for invalid route value in --project-route', async () => {
+    it('errors for invalid route value in --project-default-route', async () => {
       setupMocks();
       client.setArgv(
         'microfrontends',
@@ -616,28 +624,29 @@ describe('microfrontends create-group', () => {
         '--project=web',
         '--project=docs',
         '--default-app=web',
-        '--project-route=docs=docs'
+        '--project-default-route=docs=docs'
       );
 
       const exitCodePromise = microfrontends(client);
 
       await expect(client.stderr).toOutput(
-        'Error: Invalid --project-route value "docs=docs": Route must start with /'
+        'Error: Invalid --project-default-route value "docs=docs": Route must start with /'
       );
       expect(await exitCodePromise).toBe(1);
     });
 
-    it('creates group in non-interactive mode with multiple projects and project routes', async () => {
+    it('creates group in non-interactive mode with multiple projects and project default routes', async () => {
       const mocks = setupMocks();
       client.setArgv(
         'microfrontends',
         'create-group',
         '--non-interactive',
+        '--yes',
         '--name=My Group',
         '--project=web',
         '--project=docs',
         '--default-app=web',
-        '--project-route=docs=/docs'
+        '--project-default-route=docs=/docs'
       );
 
       const exitCode = await microfrontends(client);
@@ -651,7 +660,7 @@ describe('microfrontends create-group', () => {
       });
     });
 
-    it('accepts multiple --project-route values', async () => {
+    it('accepts multiple --project-default-route values', async () => {
       const mocks = setupMocks();
       client.setArgv(
         'microfrontends',
@@ -661,8 +670,8 @@ describe('microfrontends create-group', () => {
         '--project=docs',
         '--project=blog',
         '--default-app=web',
-        '--project-route=docs=/docs',
-        '--project-route=blog=/blog'
+        '--project-default-route=docs=/docs',
+        '--project-default-route=blog=/blog'
       );
 
       const exitCodePromise = microfrontends(client);
@@ -687,7 +696,7 @@ describe('microfrontends create-group', () => {
       });
     });
 
-    it('errors on duplicate --project-route for the same project', async () => {
+    it('errors on duplicate --project-default-route for the same project', async () => {
       setupMocks();
       client.setArgv(
         'microfrontends',
@@ -697,14 +706,14 @@ describe('microfrontends create-group', () => {
         '--project=web',
         '--project=docs',
         '--default-app=web',
-        '--project-route=docs=/docs',
-        '--project-route=docs=/docs-v2'
+        '--project-default-route=docs=/docs',
+        '--project-default-route=docs=/docs-v2'
       );
 
       const exitCodePromise = microfrontends(client);
 
       await expect(client.stderr).toOutput(
-        'Error: Duplicate --project-route for project "docs".'
+        'Error: Duplicate --project-default-route for project "docs".'
       );
       expect(await exitCodePromise).toBe(1);
     });

--- a/packages/cli/test/unit/commands/microfrontends/create-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/create-group.test.ts
@@ -42,6 +42,13 @@ const defaultProjects = [
     updatedAt: Date.now(),
     createdAt: Date.now(),
   },
+  {
+    id: 'proj_shop',
+    name: 'shop',
+    accountId: 'team_123',
+    updatedAt: Date.now(),
+    createdAt: Date.now(),
+  },
 ];
 
 interface MockOptions {
@@ -436,6 +443,300 @@ describe('microfrontends create-group', () => {
       );
       expect(await exitCodePromise).toBe(1);
       (client.stdin as any).isTTY = true;
+    });
+  });
+
+  describe('non-interactive mode', () => {
+    it('errors when --name is missing', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--project=web',
+        '--default-app=web'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Missing required flag --name. Use --name in non-interactive mode.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('errors when --project is missing', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Missing required flag --project. Use --project in non-interactive mode.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('errors when multiple projects are set without --default-app', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--project=docs'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Missing required flag --default-app when using multiple --project values in non-interactive mode.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('creates group without prompts when billing is not affected', async () => {
+      const mocks = setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--default-app=web'
+      );
+
+      const exitCode = await microfrontends(client);
+
+      expect(exitCode).toBe(0);
+      expect(mocks.getPostCalled()).toBe(true);
+      expect(mocks.getPostBody()).toEqual({
+        groupName: 'My Group',
+        defaultApp: { projectId: 'proj_web', defaultRoute: '/' },
+        otherApplications: [],
+      });
+    });
+
+    it('errors in non-interactive mode when missing project routes', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--project=docs',
+        '--default-app=web'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Missing required flag --project-route for "docs". Use --project-route=docs=/<path> in non-interactive mode.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('errors for invalid --project-route format', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--project=docs',
+        '--default-app=web',
+        '--project-route=docs'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Invalid --project-route value "docs". Use "<project>=<route>", for example "docs=/docs".'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('errors when --project-route points to an unselected project', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--project=docs',
+        '--default-app=web',
+        '--project-route=shop=/shop'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Invalid --project-route value "shop=/shop". Project "shop" is not one of the selected projects.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('errors when --project-route is provided for the default app', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--project=docs',
+        '--default-app=web',
+        '--project-route=web=/'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Invalid --project-route value "web=/". Use --default-route for the default app "web".'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('errors for invalid route value in --project-route', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--project=docs',
+        '--default-app=web',
+        '--project-route=docs=docs'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Invalid --project-route value "docs=docs": Route must start with /'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('creates group in non-interactive mode with multiple projects and project routes', async () => {
+      const mocks = setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--project=docs',
+        '--default-app=web',
+        '--project-route=docs=/docs'
+      );
+
+      const exitCode = await microfrontends(client);
+
+      expect(exitCode).toBe(0);
+      expect(mocks.getPostCalled()).toBe(true);
+      expect(mocks.getPostBody()).toEqual({
+        groupName: 'My Group',
+        defaultApp: { projectId: 'proj_web', defaultRoute: '/' },
+        otherApplications: [{ projectId: 'proj_docs', defaultRoute: '/docs' }],
+      });
+    });
+
+    it('accepts multiple --project-route values', async () => {
+      const mocks = setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--name=My Group',
+        '--project=web',
+        '--project=docs',
+        '--project=blog',
+        '--default-app=web',
+        '--project-route=docs=/docs',
+        '--project-route=blog=/blog'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput('Create microfrontends group?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Create a microfrontends.json now?');
+      client.stdin.write('n\n');
+
+      const exitCode = await exitCodePromise;
+
+      expect(exitCode).toBe(0);
+      expect(mocks.getPostCalled()).toBe(true);
+      expect(mocks.getPostBody()).toEqual({
+        groupName: 'My Group',
+        defaultApp: { projectId: 'proj_web', defaultRoute: '/' },
+        otherApplications: [
+          { projectId: 'proj_docs', defaultRoute: '/docs' },
+          { projectId: 'proj_blog', defaultRoute: '/blog' },
+        ],
+      });
+    });
+
+    it('errors on duplicate --project-route for the same project', async () => {
+      setupMocks();
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--project=docs',
+        '--default-app=web',
+        '--project-route=docs=/docs',
+        '--project-route=docs=/docs-v2'
+      );
+
+      const exitCodePromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Duplicate --project-route for project "docs".'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('errors in non-interactive mode when creation would affect billing', async () => {
+      const mocks = setupMocks({
+        groupsResponse: {
+          ...defaultGroupsResponse,
+          groups: [
+            {
+              group: { id: 'group_1', slug: 'existing', name: 'Existing' },
+              projects: [
+                { id: 'proj_a', name: 'a' },
+                { id: 'proj_b', name: 'b' },
+              ],
+            },
+          ],
+        },
+      });
+      client.setArgv(
+        'microfrontends',
+        'create-group',
+        '--non-interactive',
+        '--name=My Group',
+        '--project=web',
+        '--default-app=web'
+      );
+
+      const exitCode = await microfrontends(client);
+
+      expect(exitCode).toBe(1);
+      expect(mocks.getPostCalled()).toBe(false);
     });
   });
 

--- a/skills/vercel-cli/references/microfrontends.md
+++ b/skills/vercel-cli/references/microfrontends.md
@@ -1,0 +1,175 @@
+# Microfrontends
+
+Split a large application into independently deployable units that render as one cohesive app. The default app hosts `microfrontends.json` and serves unmatched requests; child apps declare `routing` path patterns.
+
+## Quick Start
+
+```bash
+vercel mf create-group       # create a group and add projects
+vercel mf pull               # pull microfrontends.json for local dev
+vercel mf proxy              # start the local dev proxy
+```
+
+## `create-group`
+
+Creates a new microfrontends group. Interactive by default; use `--non-interactive` for scripting.
+
+```bash
+vercel microfrontends create-group
+vercel mf create-group --non-interactive \
+  --name "my-group" \
+  --project web \
+  --project docs \
+  --default-app web \
+  --default-route / \
+  --project-default-route docs=/docs \
+  --yes
+```
+
+| Flag | Description |
+|---|---|
+| `--name` | Group name |
+| `--project` | Vercel project to add (repeatable) |
+| `--default-app` | Which project is the default app |
+| `--default-route` | Default route for the default app |
+| `--project-default-route` | Route for a non-default project, format: `<project>=<route>` (required for each non-default project in `--non-interactive` mode) |
+| `--yes` | Skip confirmation prompt |
+| `--non-interactive` | Fully non-interactive mode (blocked if billing changes require interactive confirmation) |
+
+## `inspect-group`
+
+Returns project names, frameworks, git repos, and root directories — useful for automating `microfrontends.json` generation.
+
+```bash
+vercel mf inspect-group
+vercel mf inspect-group --group="my-group" --format=json
+```
+
+| Flag | Description |
+|---|---|
+| `--group` | Group name, slug, or ID (omit for interactive selection) |
+| `--format` | Use `json` for machine-readable output |
+| `--config-file-name` | Custom config file path/name (must end in `.json` or `.jsonc`) |
+
+## `add-to-group`
+
+Adds the current project to an existing group. Run from the project directory. Requires an interactive terminal.
+
+```bash
+vercel microfrontends add-to-group
+vercel mf add-to-group --group="my-group" --default-route=/docs
+```
+
+| Flag | Description |
+|---|---|
+| `--group` | Pre-select the group |
+| `--default-route` | Default route for this project in its child deployments |
+
+## `remove-from-group`
+
+Removes the current project from its group. Requires an interactive terminal.
+
+```bash
+vercel microfrontends remove-from-group
+vercel mf remove-from-group --yes
+```
+
+The `--yes` flag skips the project-link prompt only, not the removal confirmation. After removal, update `microfrontends.json` in the default app to remove the project's entry.
+
+> The default application can only be removed after all other projects in the group are removed.
+
+## `delete-group`
+
+Deletes a group and all its settings. Irreversible. Projects are removed from the group automatically.
+
+```bash
+vercel microfrontends delete-group
+vercel mf delete-group --group="my-group"
+```
+
+## `pull`
+
+Downloads `microfrontends.json` from the default application. Required in polyrepo setups where each repo doesn't have the config locally. Requires Vercel CLI 44.2.2+.
+
+```bash
+vercel microfrontends pull
+vercel mf pull --dpl <deployment-url>
+```
+
+## Local Development
+
+The `@vercel/microfrontends` proxy routes requests to locally running apps and falls back to production for apps not running locally. Default proxy port: `3024`.
+
+### Monorepo (Turborepo)
+
+The proxy starts automatically when running a dev task with `turbo` (requires turbo ≥ 2.3.6 or ≥ 2.4.2):
+
+```bash
+turbo run dev --filter=web
+```
+
+### Without Turborepo
+
+Start the proxy and dev server separately:
+
+```bash
+# package.json
+{
+  "scripts": {
+    "dev": "next dev --port $(microfrontends port)",
+    "proxy": "microfrontends proxy microfrontends.json --local-apps web"
+  }
+}
+```
+
+### Polyrepo
+
+```bash
+vercel mf pull                                    # get microfrontends.json
+next dev --port $(microfrontends port)            # start your app
+microfrontends proxy --local-apps your-app-name  # start proxy
+```
+
+Or set `VC_MICROFRONTENDS_CONFIG=/path/to/microfrontends.json` instead of pulling.
+
+### `microfrontends proxy`
+
+```
+microfrontends proxy [configPath] --local-apps <names...> [--port <port>]
+```
+
+| Argument/Flag | Description |
+|---|---|
+| `[configPath]` | Path to `microfrontends.json` (auto-detected in monorepos) |
+| `--local-apps` | Space-separated app names running locally |
+| `--port` | Override proxy port |
+
+### `microfrontends port`
+
+Prints the auto-assigned dev port for the current app (deterministic, based on app name):
+
+```bash
+next dev --port $(microfrontends port)
+```
+
+## Deployment
+
+Each app in a group deploys independently with `vercel deploy` or `vercel --prod`. The group routes traffic based on `microfrontends.json` deployed with the default app.
+
+```bash
+# Deploy the default app (with microfrontends.json) to production
+vercel --prod
+
+# Deploy a child app independently
+vercel --prod
+```
+
+Config changes in `microfrontends.json` take effect once the default app is deployed to production.
+
+## Anti-Patterns
+
+- **Using `--non-interactive` when billing limits are exceeded**: The CLI blocks this and requires interactive confirmation — run without `--non-interactive` instead.
+- **Skipping `vercel mf pull` in polyrepo**: Without `microfrontends.json` locally, the proxy can't route correctly.
+- **Forgetting to update `microfrontends.json` after `remove-from-group`**: The CLI warns but won't block — leaving the entry causes routing errors on the next default app deployment.
+- **Running `add-to-group` or `remove-from-group` in a non-interactive terminal**: Both commands require an interactive terminal; use the Vercel Dashboard instead for CI environments.
+- **Deploying only the child app after config changes**: Changes to `microfrontends.json` only take effect when the default app is deployed.


### PR DESCRIPTION
## Summary

- Adds `skills/vercel-cli/references/microfrontends.md` — a CLI-focused reference for the `vercel microfrontends` / `vercel mf` command family
- Covers all subcommands (`create-group`, `inspect-group`, `add-to-group`, `remove-from-group`, `delete-group`, `pull`) with flag tables
- Documents local dev workflow (`microfrontends proxy`, `microfrontends port`) for monorepo, non-Turborepo, and polyrepo setups
- Includes deployment notes and anti-patterns

## Test plan

- [ ] Review flag tables match current CLI behavior
- [ ] Verify anti-patterns reflect known gotchas

🤖 Generated with [Claude Code](https://claude.com/claude-code)