### PR TITLE
[python] Add exclude-newer to vercel generated pyproject.toml files.

### DIFF
--- a/.changeset/tidy-rabbits-wink.md
+++ b/.changeset/tidy-rabbits-wink.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Set exclude-newer when generating a pyproject.toml for the user

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -10,9 +10,15 @@ import {
   PythonLockFileKind,
   PythonManifestConvertedKind,
   type PythonPackage,
+  type PyProjectToml,
 } from '@vercel/python-analysis';
 import { getVenvPythonBin } from './utils';
-import { UvRunner, filterUnsafeUvPipArgs, getProtectedUvEnv } from './uv';
+import {
+  UvRunner,
+  filterUnsafeUvPipArgs,
+  getProtectedUvEnv,
+  UV_EXCLUDE_NEWER,
+} from './uv';
 import { DEFAULT_PYTHON_VERSION_STRING } from './version';
 
 const makeDependencyCheckCode = (dependency: string) => `
@@ -143,6 +149,18 @@ export async function discoverPackage({
     }
     throw error;
   }
+}
+
+// Exclude newer to help mitigate supply chain attacks.
+// This is only used when vercel generates a pyproject.toml for a user's project.
+export function injectExcludeNewer(data: PyProjectToml): void {
+  if (!data.tool) {
+    data.tool = {};
+  }
+  if (!data.tool.uv) {
+    data.tool.uv = {};
+  }
+  (data.tool.uv as Record<string, unknown>)['exclude-newer'] = UV_EXCLUDE_NEWER;
 }
 
 export type ManifestType = 'uv.lock' | 'pylock.toml' | 'pyproject.toml' | null;
@@ -300,6 +318,7 @@ export async function ensureUvProject({
       if (manifest.data.project) {
         manifest.data.project['requires-python'] = `~=${pythonVersion}.0`;
       }
+      injectExcludeNewer(manifest.data);
       const content = stringifyManifest(manifest.data);
       // Write to the same directory as the original manifest
       pyprojectPath = join(projectDir, 'pyproject.toml');
@@ -345,6 +364,8 @@ export async function ensureUvProject({
       requiresPython,
       dependencies: [],
     });
+
+    injectExcludeNewer(minimalManifest);
     const content = stringifyManifest(minimalManifest);
     await fs.promises.writeFile(pyprojectPath, content);
     // When requireBinaryWheels is true, use --no-build --upgrade to ensure

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -10,9 +10,15 @@ import {
   PythonLockFileKind,
   PythonManifestConvertedKind,
   type PythonPackage,
+  type PyProjectToml,
 } from '@vercel/python-analysis';
 import { getVenvPythonBin } from './utils';
-import { UvRunner, filterUnsafeUvPipArgs, getProtectedUvEnv } from './uv';
+import {
+  UvRunner,
+  filterUnsafeUvPipArgs,
+  getProtectedUvEnv,
+  UV_EXCLUDE_NEWER,
+} from './uv';
 import { DEFAULT_PYTHON_VERSION_STRING } from './version';
 
 const makeDependencyCheckCode = (dependency: string) => `
@@ -143,6 +149,44 @@ export async function discoverPackage({
     }
     throw error;
   }
+}
+
+function hasPrivateIndexes(data: PyProjectToml): boolean {
+  const indexes = data.tool?.uv?.index ?? [];
+  return indexes.length > 0;
+}
+
+function hasPrivateIndexEnvVars(): boolean {
+  return !!(
+    process.env.UV_INDEX_URL ||
+    process.env.UV_EXTRA_INDEX_URL ||
+    process.env.UV_INDEX ||
+    process.env.PIP_INDEX_URL ||
+    process.env.PIP_EXTRA_INDEX_URL
+  );
+}
+
+/**
+ * Inject `exclude-newer` into a builder-generated manifest to quarantine
+ * newly-published packages. Skipped when private indexes are detected.
+ */
+export function injectExcludeNewer(data: PyProjectToml): void {
+  if (hasPrivateIndexes(data)) {
+    debug('Skipping exclude-newer: custom package indexes detected');
+    return;
+  }
+  if (hasPrivateIndexEnvVars()) {
+    debug('Skipping exclude-newer: private index env vars detected');
+    return;
+  }
+
+  if (!data.tool) {
+    data.tool = {};
+  }
+  if (!data.tool.uv) {
+    data.tool.uv = {};
+  }
+  (data.tool.uv as Record<string, unknown>)['exclude-newer'] = UV_EXCLUDE_NEWER;
 }
 
 export type ManifestType = 'uv.lock' | 'pylock.toml' | 'pyproject.toml' | null;
@@ -300,6 +344,7 @@ export async function ensureUvProject({
       if (manifest.data.project) {
         manifest.data.project['requires-python'] = `~=${pythonVersion}.0`;
       }
+      injectExcludeNewer(manifest.data);
       const content = stringifyManifest(manifest.data);
       // Write to the same directory as the original manifest
       pyprojectPath = join(projectDir, 'pyproject.toml');
@@ -345,6 +390,8 @@ export async function ensureUvProject({
       requiresPython,
       dependencies: [],
     });
+
+    injectExcludeNewer(minimalManifest);
     const content = stringifyManifest(minimalManifest);
     await fs.promises.writeFile(pyprojectPath, content);
     // When requireBinaryWheels is true, use --no-build --upgrade to ensure

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -11,6 +11,8 @@ import { getVenvPythonBin } from './utils';
 export const UV_VERSION = '0.10.11';
 export const UV_PYTHON_PATH_PREFIX = '/uv/python/';
 export const UV_PYTHON_DOWNLOADS_MODE = 'automatic';
+// Quarantine window for dependency resolution in builder-generated manifests.
+export const UV_EXCLUDE_NEWER = '7 days';
 
 const isWin = process.platform === 'win32';
 const uvExec = isWin ? 'uv.exe' : 'uv';

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -11,6 +11,7 @@ import { getVenvPythonBin } from './utils';
 export const UV_VERSION = '0.10.11';
 export const UV_PYTHON_PATH_PREFIX = '/uv/python/';
 export const UV_PYTHON_DOWNLOADS_MODE = 'automatic';
+export const UV_EXCLUDE_NEWER = '7 days';
 
 const isWin = process.platform === 'win32';
 const uvExec = isWin ? 'uv.exe' : 'uv';

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -52,9 +52,13 @@ import type { PythonConstraint, PythonPackage } from '@vercel/python-analysis';
 import { build } from '../src/index';
 import type { BuildResultV3, BuildResultV2 } from '@vercel/build-utils';
 import { createVenvEnv, getVenvBinDir } from '../src/utils';
-import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
+import {
+  UV_PYTHON_DOWNLOADS_MODE,
+  getProtectedUvEnv,
+  UV_EXCLUDE_NEWER,
+} from '../src/uv';
 import { VERCEL_WORKERS_VERSION } from '../src/package-versions';
-import { createPyprojectToml } from '../src/install';
+import { createPyprojectToml, injectExcludeNewer } from '../src/install';
 import { getDjangoSettings, runDjangoCollectStatic } from '../src/django';
 import { FileBlob, download } from '@vercel/build-utils';
 
@@ -531,6 +535,50 @@ describe('createPyprojectToml', () => {
         fs.removeSync(tempDir);
       }
     }
+  });
+});
+
+describe('injectExcludeNewer', () => {
+  it('adds [tool.uv] exclude-newer to an empty manifest', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBe(UV_EXCLUDE_NEWER);
+  });
+
+  it('preserves existing [tool.uv] settings', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+      tool: {
+        uv: {
+          sources: { flask: { git: 'https://example.com/flask.git' } },
+        },
+      },
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBe(UV_EXCLUDE_NEWER);
+    expect((data as any).tool.uv.sources).toEqual({
+      flask: { git: 'https://example.com/flask.git' },
+    });
+  });
+
+  it('adds [tool] section when missing', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+    };
+    expect(data.tool).toBeUndefined();
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBe(UV_EXCLUDE_NEWER);
+  });
+
+  it('adds [tool.uv] section when tool exists but uv is missing', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+      tool: {},
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBe(UV_EXCLUDE_NEWER);
   });
 });
 

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -52,9 +52,13 @@ import type { PythonConstraint, PythonPackage } from '@vercel/python-analysis';
 import { build } from '../src/index';
 import type { BuildResultV3, BuildResultV2 } from '@vercel/build-utils';
 import { createVenvEnv, getVenvBinDir } from '../src/utils';
-import { UV_PYTHON_DOWNLOADS_MODE, getProtectedUvEnv } from '../src/uv';
+import {
+  UV_PYTHON_DOWNLOADS_MODE,
+  getProtectedUvEnv,
+  UV_EXCLUDE_NEWER,
+} from '../src/uv';
 import { VERCEL_WORKERS_VERSION } from '../src/package-versions';
-import { createPyprojectToml } from '../src/install';
+import { createPyprojectToml, injectExcludeNewer } from '../src/install';
 import { getDjangoSettings, runDjangoCollectStatic } from '../src/django';
 import { FileBlob, download } from '@vercel/build-utils';
 
@@ -531,6 +535,146 @@ describe('createPyprojectToml', () => {
         fs.removeSync(tempDir);
       }
     }
+  });
+});
+
+describe('injectExcludeNewer', () => {
+  it('adds [tool.uv] exclude-newer to an empty manifest', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBe(UV_EXCLUDE_NEWER);
+  });
+
+  it('preserves existing [tool.uv] settings', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+      tool: {
+        uv: {
+          sources: { flask: { git: 'https://example.com/flask.git' } },
+        },
+      },
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBe(UV_EXCLUDE_NEWER);
+    expect((data as any).tool.uv.sources).toEqual({
+      flask: { git: 'https://example.com/flask.git' },
+    });
+  });
+
+  it('adds [tool] section when missing', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+    };
+    expect(data.tool).toBeUndefined();
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBe(UV_EXCLUDE_NEWER);
+  });
+
+  it('adds [tool.uv] section when tool exists but uv is missing', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+      tool: {},
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBe(UV_EXCLUDE_NEWER);
+  });
+
+  it('skips injection when tool.uv.index contains entries', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+      tool: {
+        uv: {
+          index: [
+            { name: 'private', url: 'https://private.registry.com/simple' },
+          ],
+        },
+      },
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBeUndefined();
+  });
+
+  it('skips injection when --index-url is converted to a default index entry', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+      tool: {
+        uv: {
+          index: [
+            {
+              name: 'primary',
+              url: 'https://private.registry.com/simple',
+              default: true,
+            },
+          ],
+        },
+      },
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBeUndefined();
+  });
+
+  it('skips injection when --find-links is converted to a flat index entry', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+      tool: {
+        uv: {
+          index: [
+            {
+              name: 'find-links-1',
+              url: 'https://example.com/wheels/',
+              format: 'flat',
+            },
+          ],
+        },
+      },
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBeUndefined();
+  });
+
+  describe('environment variable detection', () => {
+    const envVars = [
+      'UV_INDEX_URL',
+      'UV_EXTRA_INDEX_URL',
+      'UV_INDEX',
+      'PIP_INDEX_URL',
+      'PIP_EXTRA_INDEX_URL',
+    ];
+
+    for (const envVar of envVars) {
+      it(`skips injection when ${envVar} is set`, () => {
+        const original = process.env[envVar];
+        try {
+          process.env[envVar] = 'https://private.registry.com/simple';
+          const data: Record<string, unknown> = {
+            project: { name: 'app', version: '0.1.0' },
+          };
+          injectExcludeNewer(data as any);
+          expect((data as any).tool?.uv?.['exclude-newer']).toBeUndefined();
+        } finally {
+          if (original === undefined) {
+            delete process.env[envVar];
+          } else {
+            process.env[envVar] = original;
+          }
+        }
+      });
+    }
+  });
+
+  it('injects when tool.uv exists but index is empty', () => {
+    const data: Record<string, unknown> = {
+      project: { name: 'app', version: '0.1.0' },
+      tool: {
+        uv: {
+          index: [],
+        },
+      },
+    };
+    injectExcludeNewer(data as any);
+    expect((data as any).tool.uv['exclude-newer']).toBe(UV_EXCLUDE_NEWER);
   });
 });
 


### PR DESCRIPTION
Set `exclude-newer` to help mitigate supply chain attacks. Only applies when we generate a `pyproject.toml` for the user and they don't have any private indexes specified.