### PR TITLE
feat(cli): add test:local script for faster local runs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "test": "jest --reporters=default --reporters=jest-junit --env node --verbose --bail",
+    "test:local": "jest --env node --reporters=default",
     "vitest-run": "vitest --config ./vitest.config.mts",
     "vitest-unit": "jest test/unit/ --listTests",
     "test-e2e-node-all-versions": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts test/integration-link-env-pull.test.ts",


### PR DESCRIPTION
## Summary
Adds `pnpm test:local` in `packages/cli` for day-to-day development.

Compared to `pnpm test`, this script:
- Skips `jest-junit` (CI reporting only)
- Omits `--verbose` (less console I/O)
- Omits `--bail` (see every failing test in one run)

`pnpm test` is unchanged and remains what CI uses.

## Context
Follow-up to local ergonomics for CLI Jest runs (ts-jest + large suite).

Made with [Cursor](https://cursor.com)