### PR TITLE
feat(cli): add test:unit script

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "test": "jest --reporters=default --reporters=jest-junit --env node --verbose --bail",
+    "test:unit": "jest --env node test/unit/",
     "vitest-run": "vitest --config ./vitest.config.mts",
     "vitest-unit": "jest test/unit/ --listTests",
     "test-e2e-node-all-versions": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts test/integration-link-env-pull.test.ts",


### PR DESCRIPTION
## Summary
Adds `pnpm test:unit`, which runs Jest only against `test/unit/`.

## Why
The full `pnpm test` suite includes integration and other directories under `test/`. Developers often only need unit coverage while iterating.

## Note
Existing `vitest-unit` lists unit test paths (`--listTests`); `test:unit` actually executes them under Jest.

Made with [Cursor](https://cursor.com)