### PR TITLE
[CLI] Adding better telemetry

### DIFF
--- a/.changeset/cli-telemetry-session.md
+++ b/.changeset/cli-telemetry-session.md
@@ -1,0 +1,5 @@
+---
+vercel: patch
+---
+
+Persist CLI telemetry sessions across invocations using inactivity and max lifetime rotation.

--- a/.changeset/cli-telemetry-session.md
+++ b/.changeset/cli-telemetry-session.md
@@ -2,4 +2,4 @@
 vercel: patch
 ---
 
-Persist CLI telemetry sessions across invocations using inactivity and max lifetime rotation.
+Persist CLI telemetry across invocations with bounded-time sessions, stable installation device IDs, and per-invocation identifiers.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -331,6 +331,12 @@ const main = async () => {
   const telemetryEventStore = new TelemetryEventStore({
     isDebug: process.env.VERCEL_TELEMETRY_DEBUG === '1',
     config: config.telemetry,
+    cliSession:
+      process.argv[2] === 'telemetry' && process.argv[3] === 'flush'
+        ? undefined
+        : {
+            filePath: join(VERCEL_DIR, 'telemetry-session.json'),
+          },
   });
 
   checkTelemetryStatus({
@@ -350,6 +356,7 @@ const main = async () => {
   });
 
   const { isAgent, agent: detectedAgent } = await determineAgent();
+  telemetry.trackInvocationId(telemetryEventStore.currentInvocationId);
   telemetry.trackAgenticUse(detectedAgent?.name);
   telemetry.trackCPUs();
   telemetry.trackPlatform();
@@ -1114,6 +1121,7 @@ const main = async () => {
   } catch {
     // best-effort for telemetry — project may not be linked
   }
+  telemetry.trackProjectId(telemetryEventStore.currentProjectId);
 
   await telemetryEventStore.save();
   postCommandSpan.stop();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -174,6 +174,8 @@ class InMemoryReporter implements Reporter {
 const main = async () => {
   const traceReporter = new InMemoryReporter();
   const rootSpan = new Span({ name: 'vc.cli', reporter: traceReporter });
+  const isTelemetryFlushCommand =
+    process.argv[2] === 'telemetry' && process.argv[3] === 'flush';
 
   if (process.env.FORCE_TTY === '1') {
     isTTY = true;
@@ -334,12 +336,16 @@ const main = async () => {
   const telemetryEventStore = new TelemetryEventStore({
     isDebug: process.env.VERCEL_TELEMETRY_DEBUG === '1',
     config: config.telemetry,
-    cliSession:
-      process.argv[2] === 'telemetry' && process.argv[3] === 'flush'
-        ? undefined
-        : {
-            filePath: join(VERCEL_DIR, 'telemetry-session.json'),
-          },
+    cliDevice: isTelemetryFlushCommand
+      ? undefined
+      : {
+          filePath: join(VERCEL_DIR, 'telemetry-device.json'),
+        },
+    cliSession: isTelemetryFlushCommand
+      ? undefined
+      : {
+          filePath: join(VERCEL_DIR, 'telemetry-session.json'),
+        },
   });
 
   checkTelemetryStatus({
@@ -360,6 +366,7 @@ const main = async () => {
 
   const { isAgent, agent: detectedAgent } = await determineAgent();
   telemetry.trackInvocationId(telemetryEventStore.currentInvocationId);
+  telemetry.trackDeviceId(telemetryEventStore.currentDeviceId);
   telemetry.trackAgenticUse(detectedAgent?.name);
   telemetry.trackCPUs();
   telemetry.trackPlatform();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -374,6 +374,110 @@ const main = async () => {
   telemetry.trackCliOptionTeam(parsedArgs.flags['--team']);
   telemetry.trackCliOptionApi(parsedArgs.flags['--api']);
 
+  let earlyGetUserPromise: Promise<User | undefined> | undefined;
+  let telemetrySaved = false;
+
+  const getStringProperty = (
+    value: unknown,
+    key: string
+  ): string | undefined => {
+    if (typeof value === 'object' && value !== null && key in value) {
+      const property = (value as Record<string, unknown>)[key];
+      if (typeof property === 'string') {
+        return property;
+      }
+    }
+
+    return undefined;
+  };
+
+  const getNumberProperty = (
+    value: unknown,
+    key: string
+  ): number | undefined => {
+    if (typeof value === 'object' && value !== null && key in value) {
+      const property = (value as Record<string, unknown>)[key];
+      if (typeof property === 'number') {
+        return property;
+      }
+    }
+
+    return undefined;
+  };
+
+  const trackAgenticErrorTelemetry = (err: unknown) => {
+    if (!isAgent) {
+      return;
+    }
+
+    telemetry.trackErrorStatus(getNumberProperty(err, 'status'));
+    telemetry.trackErrorCode(getStringProperty(err, 'code'));
+    telemetry.trackErrorSlug(getStringProperty(err, 'slug'));
+    telemetry.trackErrorAction(getStringProperty(err, 'action'));
+
+    const serverMessage =
+      getStringProperty(err, 'serverMessage') ??
+      (isError(err) ? err.message : undefined);
+    telemetry.trackErrorServerMessage(serverMessage);
+  };
+
+  const saveTelemetry = async () => {
+    if (telemetrySaved) {
+      return;
+    }
+
+    const postCommandSpan = rootSpan.child('vc.postCommand');
+
+    telemetryEventStore.updateTeamId(
+      client?.config.currentTeam ?? config.currentTeam
+    );
+    telemetryEventStore.updateUserId(
+      client?.authConfig.userId ?? authConfig.userId
+    );
+    if (!telemetryEventStore.hasUserId) {
+      const getUserSpan = postCommandSpan.child('vc.postCommand.getUser');
+      try {
+        const user = await earlyGetUserPromise;
+        if (user) {
+          telemetryEventStore.updateUserId(user.id);
+        }
+      } catch {
+        // best-effort for telemetry
+      } finally {
+        getUserSpan.stop();
+      }
+    }
+
+    try {
+      const envProjectId = getPlatformEnv('PROJECT_ID');
+      if (envProjectId) {
+        telemetryEventStore.updateProjectId(envProjectId);
+      } else {
+        const cwdForProjectId =
+          client?.cwd ||
+          (typeof parsedArgs.flags['--cwd'] === 'string'
+            ? parsedArgs.flags['--cwd']
+            : process.cwd());
+        const link = await getLinkFromDir(getVercelDirectory(cwdForProjectId));
+        if (link) {
+          telemetryEventStore.updateProjectId(link.projectId);
+        }
+      }
+    } catch {
+      // best-effort for telemetry — project may not be linked
+    }
+    telemetry.trackProjectId(telemetryEventStore.currentProjectId);
+
+    await telemetryEventStore.save();
+    postCommandSpan.stop();
+    telemetrySaved = true;
+  };
+
+  const finishWithExitCode = async (code: number) => {
+    await saveTelemetry();
+    return code;
+  };
+
   if (typeof parsedArgs.flags['--api'] === 'string') {
     apiUrl = parsedArgs.flags['--api'];
   } else if (config && config.api) {
@@ -384,7 +488,7 @@ const main = async () => {
     new URL(apiUrl);
   } catch (_err: unknown) {
     output.error(`Please provide a valid URL instead of ${highlight(apiUrl)}.`);
-    return 1;
+    return finishWithExitCode(1);
   }
 
   // Shared API `Client` instance for all sub-commands to utilize.
@@ -521,10 +625,11 @@ const main = async () => {
       try {
         const result = await login(client, { shouldParseArgs: false });
         // The login function failed, so it returned an exit code
-        if (result !== 0) return result;
+        if (result !== 0) return finishWithExitCode(result);
       } catch (error) {
         printError(error);
-        return 1;
+        trackAgenticErrorTelemetry(error);
+        return finishWithExitCode(1);
       }
 
       output.debug(`Saved credentials in "${hp(VERCEL_DIR)}"`);
@@ -534,10 +639,11 @@ const main = async () => {
       output.log('No existing credentials found. Starting login flow...');
       try {
         const result = await login(client, { shouldParseArgs: false });
-        if (result !== 0) return result;
+        if (result !== 0) return finishWithExitCode(result);
       } catch (error) {
         printError(error);
-        return 1;
+        trackAgenticErrorTelemetry(error);
+        return finishWithExitCode(1);
       }
 
       output.debug(`Saved credentials in "${hp(VERCEL_DIR)}"`);
@@ -548,7 +654,7 @@ const main = async () => {
           `${getCommandName('login')} or pass ${param('--token')}`,
         link: 'https://err.sh/vercel/no-credentials-found',
       });
-      return 1;
+      return finishWithExitCode(1);
     }
   }
 
@@ -573,7 +679,7 @@ const main = async () => {
       link: 'https://err.sh/vercel/no-token-allowed',
     });
 
-    return 1;
+    return finishWithExitCode(1);
   }
 
   if (typeof parsedArgs.flags['--token'] === 'string') {
@@ -585,7 +691,7 @@ const main = async () => {
         link: 'https://err.sh/vercel/missing-token-value',
       });
 
-      return 1;
+      return finishWithExitCode(1);
     }
 
     const invalid = token.match(/(\W)/g);
@@ -600,7 +706,7 @@ const main = async () => {
         link: 'https://err.sh/vercel/invalid-token-value',
       });
 
-      return 1;
+      return finishWithExitCode(1);
     }
 
     client.authConfig = { token, skipWrite: true, tokenSource };
@@ -648,19 +754,21 @@ const main = async () => {
           link: 'https://err.sh/vercel/scope-not-accessible',
         });
 
-        return 1;
+        trackAgenticErrorTelemetry(err);
+        return finishWithExitCode(1);
       }
 
       output.error(
         `Not able to load user because of unexpected error: ${errorToString(err)}`
       );
-      return 1;
+      trackAgenticErrorTelemetry(err);
+      return finishWithExitCode(1);
     }
 
     if (user.id === scope || user.email === scope || user.username === scope) {
       if (user.version === 'northstar') {
         output.error('You cannot set your Personal Account as the scope.');
-        return 1;
+        return finishWithExitCode(1);
       }
 
       delete client.config.currentTeam;
@@ -676,7 +784,8 @@ const main = async () => {
             link: 'https://err.sh/vercel/scope-not-accessible',
           });
 
-          return 1;
+          trackAgenticErrorTelemetry(err);
+          return finishWithExitCode(1);
         }
 
         if (isErrnoException(err) && err.code === 'rate_limited') {
@@ -685,11 +794,13 @@ const main = async () => {
               'Rate limited. Too many requests to the same endpoint: /teams',
           });
 
-          return 1;
+          trackAgenticErrorTelemetry(err);
+          return finishWithExitCode(1);
         }
 
         output.error('Not able to load teams');
-        return 1;
+        trackAgenticErrorTelemetry(err);
+        return finishWithExitCode(1);
       }
 
       const related =
@@ -701,7 +812,7 @@ const main = async () => {
           link: 'https://err.sh/vercel/scope-not-existent',
         });
 
-        return 1;
+        return finishWithExitCode(1);
       }
 
       client.config.currentTeam = related.id;
@@ -709,7 +820,6 @@ const main = async () => {
   }
 
   let exitCode;
-  let earlyGetUserPromise: Promise<User | undefined> | undefined;
 
   try {
     if (!targetCommand) {
@@ -1022,6 +1132,8 @@ const main = async () => {
         .trace(() => func(client));
     }
   } catch (err: unknown) {
+    trackAgenticErrorTelemetry(err);
+
     if (isErrnoException(err) && err.code === 'ENOTFOUND') {
       // Error message will look like the following:
       // "request to https://api.vercel.com/v2/user failed, reason: getaddrinfo ENOTFOUND api.vercel.com"
@@ -1037,7 +1149,7 @@ const main = async () => {
       if (typeof err.stack === 'string') {
         output.debug(err.stack);
       }
-      return 1;
+      return finishWithExitCode(1);
     }
 
     if (isErrnoException(err) && err.code === 'ECONNRESET') {
@@ -1052,7 +1164,7 @@ const main = async () => {
           )} interrupted. Please verify your internet connectivity and DNS configuration.`
         );
       }
-      return 1;
+      return finishWithExitCode(1);
     }
 
     if (
@@ -1060,13 +1172,13 @@ const main = async () => {
       (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED')
     ) {
       output.prettyError(err);
-      return 1;
+      return finishWithExitCode(1);
     }
 
     if (err instanceof APIError && 400 <= err.status && err.status <= 499) {
       err.message = err.serverMessage;
       output.prettyError(err);
-      return 1;
+      return finishWithExitCode(1);
     }
 
     // If there is a code we should not consider the error unexpected
@@ -1086,45 +1198,10 @@ const main = async () => {
       output.error(`An unexpected error occurred in ${subcommand}: ${err}`);
     }
 
-    return 1;
+    return finishWithExitCode(1);
   }
 
-  const postCommandSpan = rootSpan.child('vc.postCommand');
-
-  telemetryEventStore.updateTeamId(client.config.currentTeam);
-  telemetryEventStore.updateUserId(client.authConfig.userId);
-  if (!telemetryEventStore.hasUserId) {
-    const getUserSpan = postCommandSpan.child('vc.postCommand.getUser');
-    try {
-      const user = await earlyGetUserPromise;
-      if (user) {
-        telemetryEventStore.updateUserId(user.id);
-      }
-    } catch {
-      // best-effort for telemetry
-    } finally {
-      getUserSpan.stop();
-    }
-  }
-
-  // Resolve project_id from VERCEL_PROJECT_ID env var or .vercel/project.json
-  try {
-    const envProjectId = getPlatformEnv('PROJECT_ID');
-    if (envProjectId) {
-      telemetryEventStore.updateProjectId(envProjectId);
-    } else {
-      const link = await getLinkFromDir(getVercelDirectory(client.cwd));
-      if (link) {
-        telemetryEventStore.updateProjectId(link.projectId);
-      }
-    }
-  } catch {
-    // best-effort for telemetry — project may not be linked
-  }
-  telemetry.trackProjectId(telemetryEventStore.currentProjectId);
-
-  await telemetryEventStore.save();
-  postCommandSpan.stop();
+  await saveTelemetry();
 
   rootSpan.stop();
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -181,10 +181,8 @@ const main = async () => {
     process.stdin.isTTY = true;
   }
 
-  let parsedArgs;
-
-  try {
-    parsedArgs = parseArguments(
+  const parseInitialArgs = () =>
+    parseArguments(
       process.argv,
       {
         '--version': Boolean,
@@ -193,6 +191,11 @@ const main = async () => {
       },
       { permissive: true }
     );
+
+  let parsedArgs: ReturnType<typeof parseInitialArgs>;
+
+  try {
+    parsedArgs = parseInitialArgs();
     const isDebugging = parsedArgs.flags['--debug'];
     const isNoColor = parsedArgs.flags['--no-color'];
     output.initialize({

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -6,7 +6,10 @@ import { spawn } from 'node:child_process';
 import { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
 import { cloneEnv } from '@vercel/build-utils';
 import {
+  getOrCreatePersistedCliDevice,
   getOrCreatePersistedCliSession,
+  type PersistedCliDevice,
+  type PersistedCliDeviceOptions,
   touchPersistedCliSession,
   type PersistedCliSession,
   type PersistedCliSessionOptions,
@@ -213,6 +216,15 @@ export class TelemetryClient {
     }
   }
 
+  protected trackDeviceId(deviceId: string | undefined) {
+    if (deviceId) {
+      this.track({
+        key: 'device_id',
+        value: deviceId,
+      });
+    }
+  }
+
   protected trackErrorStatus(status: number | string | undefined) {
     if (typeof status !== 'undefined') {
       this.track({
@@ -314,23 +326,34 @@ export class TelemetryEventStore {
   private isDebug: boolean;
   private sessionId: string;
   private invocationId: string;
+  private deviceId: string;
   private teamId = 'NO_TEAM_ID';
   private userId = 'NO_USER_ID';
   private projectId = 'NO_PROJECT_ID';
   private config: GlobalConfig['telemetry'];
+  private cliDevice?: PersistedCliDevice;
   private cliSession?: PersistedCliSession;
+  private cliDeviceOptions?: PersistedCliDeviceOptions;
   private cliSessionOptions?: PersistedCliSessionOptions;
 
   constructor(opts?: {
     isDebug?: boolean;
     config: GlobalConfig['telemetry'];
+    cliDevice?: PersistedCliDeviceOptions;
     cliSession?: PersistedCliSessionOptions;
   }) {
     this.isDebug = opts?.isDebug || false;
     this.events = [];
     this.config = opts?.config;
+    this.cliDeviceOptions = opts?.cliDevice;
     this.cliSessionOptions = opts?.cliSession;
     this.invocationId = randomUUID();
+    this.deviceId = randomUUID();
+
+    if (this.cliDeviceOptions) {
+      this.cliDevice = getOrCreatePersistedCliDevice(this.cliDeviceOptions);
+      this.deviceId = this.cliDevice.id;
+    }
 
     if (this.cliSessionOptions) {
       this.cliSession = getOrCreatePersistedCliSession(this.cliSessionOptions);
@@ -376,6 +399,10 @@ export class TelemetryEventStore {
 
   get currentInvocationId() {
     return this.invocationId;
+  }
+
+  get currentDeviceId() {
+    return this.deviceId;
   }
 
   get readonlyEvents() {

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -13,6 +13,7 @@ import {
 } from './session';
 
 const LogLabel = `['telemetry']:`;
+const MAX_ERROR_SERVER_MESSAGE_LENGTH = 500;
 
 interface Args {
   opts: Options;
@@ -208,6 +209,55 @@ export class TelemetryClient {
       this.track({
         key: 'invocation_id',
         value: invocationId,
+      });
+    }
+  }
+
+  protected trackErrorStatus(status: number | string | undefined) {
+    if (typeof status !== 'undefined') {
+      this.track({
+        key: 'error_status',
+        value: String(status),
+      });
+    }
+  }
+
+  protected trackErrorCode(code: string | undefined) {
+    if (code) {
+      this.track({
+        key: 'error_code',
+        value: code,
+      });
+    }
+  }
+
+  protected trackErrorSlug(slug: string | undefined) {
+    if (slug) {
+      this.track({
+        key: 'error_slug',
+        value: slug,
+      });
+    }
+  }
+
+  protected trackErrorAction(action: string | undefined) {
+    if (action) {
+      this.track({
+        key: 'error_action',
+        value: action,
+      });
+    }
+  }
+
+  protected trackErrorServerMessage(serverMessage: string | undefined) {
+    if (serverMessage) {
+      const normalizedServerMessage = serverMessage.trim().replace(/\s+/g, ' ');
+      this.track({
+        key: 'error_server_message',
+        value: normalizedServerMessage.slice(
+          0,
+          MAX_ERROR_SERVER_MESSAGE_LENGTH
+        ),
       });
     }
   }

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -5,6 +5,12 @@ import output from '../../output-manager';
 import { spawn } from 'node:child_process';
 import { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
 import { cloneEnv } from '@vercel/build-utils';
+import {
+  getOrCreatePersistedCliSession,
+  touchPersistedCliSession,
+  type PersistedCliSession,
+  type PersistedCliSessionOptions,
+} from './session';
 
 const LogLabel = `['telemetry']:`;
 
@@ -188,6 +194,24 @@ export class TelemetryClient {
     });
   }
 
+  protected trackProjectId(projectId: string | undefined) {
+    if (projectId) {
+      this.track({
+        key: 'project_id',
+        value: projectId,
+      });
+    }
+  }
+
+  protected trackInvocationId(invocationId: string | undefined) {
+    if (invocationId) {
+      this.track({
+        key: 'invocation_id',
+        value: invocationId,
+      });
+    }
+  }
+
   protected trackExtension() {
     this.track({
       key: 'extension',
@@ -239,16 +263,31 @@ export class TelemetryEventStore {
   private events: Event[];
   private isDebug: boolean;
   private sessionId: string;
+  private invocationId: string;
   private teamId = 'NO_TEAM_ID';
   private userId = 'NO_USER_ID';
   private projectId = 'NO_PROJECT_ID';
   private config: GlobalConfig['telemetry'];
+  private cliSession?: PersistedCliSession;
+  private cliSessionOptions?: PersistedCliSessionOptions;
 
-  constructor(opts?: { isDebug?: boolean; config: GlobalConfig['telemetry'] }) {
+  constructor(opts?: {
+    isDebug?: boolean;
+    config: GlobalConfig['telemetry'];
+    cliSession?: PersistedCliSessionOptions;
+  }) {
     this.isDebug = opts?.isDebug || false;
-    this.sessionId = randomUUID();
     this.events = [];
     this.config = opts?.config;
+    this.cliSessionOptions = opts?.cliSession;
+    this.invocationId = randomUUID();
+
+    if (this.cliSessionOptions) {
+      this.cliSession = getOrCreatePersistedCliSession(this.cliSessionOptions);
+      this.sessionId = this.cliSession.id;
+    } else {
+      this.sessionId = randomUUID();
+    }
   }
 
   add(event: Event) {
@@ -281,6 +320,14 @@ export class TelemetryEventStore {
     return this.userId !== 'NO_USER_ID';
   }
 
+  get currentProjectId() {
+    return this.projectId;
+  }
+
+  get currentInvocationId() {
+    return this.invocationId;
+  }
+
   get readonlyEvents() {
     return Array.from(this.events);
   }
@@ -298,6 +345,13 @@ export class TelemetryEventStore {
   }
 
   async save() {
+    if (this.cliSession && this.cliSessionOptions) {
+      this.cliSession = touchPersistedCliSession(
+        this.cliSessionOptions,
+        this.cliSession
+      );
+    }
+
     if (this.isDebug) {
       // Intentionally not using `output.debug` as it will
       // not write to stderr unless it is run with `--debug`

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -432,6 +432,14 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackVersion(version);
   }
 
+  trackProjectId(projectId: string | undefined) {
+    super.trackProjectId(projectId);
+  }
+
+  trackInvocationId(invocationId: string | undefined) {
+    super.trackInvocationId(invocationId);
+  }
+
   trackCliOptionCwd(cwd: string | undefined) {
     if (cwd) {
       this.trackCliOption({ option: 'cwd', value: this.redactedValue });

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -440,6 +440,10 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackInvocationId(invocationId);
   }
 
+  trackDeviceId(deviceId: string | undefined) {
+    super.trackDeviceId(deviceId);
+  }
+
   trackErrorStatus(status: number | string | undefined) {
     super.trackErrorStatus(status);
   }

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -440,6 +440,26 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackInvocationId(invocationId);
   }
 
+  trackErrorStatus(status: number | string | undefined) {
+    super.trackErrorStatus(status);
+  }
+
+  trackErrorCode(code: string | undefined) {
+    super.trackErrorCode(code);
+  }
+
+  trackErrorSlug(slug: string | undefined) {
+    super.trackErrorSlug(slug);
+  }
+
+  trackErrorAction(action: string | undefined) {
+    super.trackErrorAction(action);
+  }
+
+  trackErrorServerMessage(serverMessage: string | undefined) {
+    super.trackErrorServerMessage(serverMessage);
+  }
+
   trackCliOptionCwd(cwd: string | undefined) {
     if (cwd) {
       this.trackCliOption({ option: 'cwd', value: this.redactedValue });

--- a/packages/cli/src/util/telemetry/session.ts
+++ b/packages/cli/src/util/telemetry/session.ts
@@ -13,11 +13,19 @@ export interface PersistedCliSession {
   lastSeenAt: number;
 }
 
+export interface PersistedCliDevice {
+  id: string;
+}
+
 export interface PersistedCliSessionOptions {
   filePath: string;
   inactivityTimeoutMs?: number;
   maxLifetimeMs?: number;
   now?: () => number;
+}
+
+export interface PersistedCliDeviceOptions {
+  filePath: string;
 }
 
 function isPersistedCliSession(value: unknown): value is PersistedCliSession {
@@ -33,6 +41,15 @@ function isPersistedCliSession(value: unknown): value is PersistedCliSession {
     typeof session.lastSeenAt === 'number' &&
     Number.isFinite(session.lastSeenAt)
   );
+}
+
+function isPersistedCliDevice(value: unknown): value is PersistedCliDevice {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const device = value as Partial<PersistedCliDevice>;
+  return typeof device.id === 'string';
 }
 
 function readPersistedCliSession(filePath: string): PersistedCliSession | null {
@@ -51,6 +68,27 @@ function writePersistedCliSession(
   try {
     mkdirSync(dirname(filePath), { recursive: true });
     writeJSON.sync(filePath, session, { indent: 2 });
+  } catch {
+    // best-effort for telemetry
+  }
+}
+
+function readPersistedCliDevice(filePath: string): PersistedCliDevice | null {
+  try {
+    const device = loadJSON.sync(filePath);
+    return isPersistedCliDevice(device) ? device : null;
+  } catch {
+    return null;
+  }
+}
+
+function writePersistedCliDevice(
+  filePath: string,
+  device: PersistedCliDevice
+): void {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeJSON.sync(filePath, device, { indent: 2 });
   } catch {
     // best-effort for telemetry
   }
@@ -96,4 +134,21 @@ export function touchPersistedCliSession(
   };
   writePersistedCliSession(opts.filePath, nextSession);
   return nextSession;
+}
+
+export function getOrCreatePersistedCliDevice(
+  opts: PersistedCliDeviceOptions
+): PersistedCliDevice {
+  const existing = readPersistedCliDevice(opts.filePath);
+
+  if (existing) {
+    return existing;
+  }
+
+  const device = {
+    id: randomUUID(),
+  };
+
+  writePersistedCliDevice(opts.filePath, device);
+  return device;
 }

--- a/packages/cli/src/util/telemetry/session.ts
+++ b/packages/cli/src/util/telemetry/session.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import loadJSON from 'load-json-file';
+import writeJSON from 'write-json-file';
+
+export const DEFAULT_CLI_SESSION_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
+export const DEFAULT_CLI_SESSION_MAX_LIFETIME_MS = 24 * 60 * 60 * 1000;
+
+export interface PersistedCliSession {
+  id: string;
+  createdAt: number;
+  lastSeenAt: number;
+}
+
+export interface PersistedCliSessionOptions {
+  filePath: string;
+  inactivityTimeoutMs?: number;
+  maxLifetimeMs?: number;
+  now?: () => number;
+}
+
+function isPersistedCliSession(value: unknown): value is PersistedCliSession {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const session = value as Partial<PersistedCliSession>;
+  return (
+    typeof session.id === 'string' &&
+    typeof session.createdAt === 'number' &&
+    Number.isFinite(session.createdAt) &&
+    typeof session.lastSeenAt === 'number' &&
+    Number.isFinite(session.lastSeenAt)
+  );
+}
+
+function readPersistedCliSession(filePath: string): PersistedCliSession | null {
+  try {
+    const session = loadJSON.sync(filePath);
+    return isPersistedCliSession(session) ? session : null;
+  } catch {
+    return null;
+  }
+}
+
+function writePersistedCliSession(
+  filePath: string,
+  session: PersistedCliSession
+): void {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeJSON.sync(filePath, session, { indent: 2 });
+  } catch {
+    // best-effort for telemetry
+  }
+}
+
+export function getOrCreatePersistedCliSession(
+  opts: PersistedCliSessionOptions
+): PersistedCliSession {
+  const now = opts.now?.() ?? Date.now();
+  const inactivityTimeoutMs =
+    opts.inactivityTimeoutMs ?? DEFAULT_CLI_SESSION_INACTIVITY_TIMEOUT_MS;
+  const maxLifetimeMs =
+    opts.maxLifetimeMs ?? DEFAULT_CLI_SESSION_MAX_LIFETIME_MS;
+  const existing = readPersistedCliSession(opts.filePath);
+
+  const shouldReuseExisting =
+    existing &&
+    now - existing.lastSeenAt <= inactivityTimeoutMs &&
+    now - existing.createdAt <= maxLifetimeMs;
+
+  const session = shouldReuseExisting
+    ? {
+        ...existing,
+        lastSeenAt: now,
+      }
+    : {
+        id: randomUUID(),
+        createdAt: now,
+        lastSeenAt: now,
+      };
+
+  writePersistedCliSession(opts.filePath, session);
+  return session;
+}
+
+export function touchPersistedCliSession(
+  opts: PersistedCliSessionOptions,
+  session: PersistedCliSession
+): PersistedCliSession {
+  const nextSession = {
+    ...session,
+    lastSeenAt: opts.now?.() ?? Date.now(),
+  };
+  writePersistedCliSession(opts.filePath, nextSession);
+  return nextSession;
+}

--- a/packages/cli/test/unit/telemetry/device-id.test.ts
+++ b/packages/cli/test/unit/telemetry/device-id.test.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+
+describe('persisted cli telemetry device id', () => {
+  let deviceFilePath: string;
+
+  beforeEach(() => {
+    deviceFilePath = join(
+      tmpdir(),
+      `vercel-cli-telemetry-device-${randomUUID()}.json`
+    );
+    rmSync(deviceFilePath, { force: true });
+  });
+
+  it('reuses the same device id across invocations', () => {
+    const firstStore = new TelemetryEventStore({
+      config: { enabled: true },
+      isDebug: true,
+      cliDevice: {
+        filePath: deviceFilePath,
+      },
+    });
+    const secondStore = new TelemetryEventStore({
+      config: { enabled: true },
+      isDebug: true,
+      cliDevice: {
+        filePath: deviceFilePath,
+      },
+    });
+
+    expect(secondStore.currentDeviceId).toBe(firstStore.currentDeviceId);
+  });
+
+  it('tracks device_id as a regular telemetry event', () => {
+    const telemetryEventStore = new TelemetryEventStore({
+      config: { enabled: true },
+      isDebug: true,
+      cliDevice: {
+        filePath: deviceFilePath,
+      },
+    });
+    const telemetry = new RootTelemetryClient({
+      opts: {
+        store: telemetryEventStore,
+      },
+    });
+
+    telemetry.trackDeviceId(telemetryEventStore.currentDeviceId);
+
+    expect(telemetryEventStore.readonlyEvents).toMatchObject([
+      {
+        key: 'device_id',
+        value: telemetryEventStore.currentDeviceId,
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/telemetry/error-fields.test.ts
+++ b/packages/cli/test/unit/telemetry/error-fields.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+
+describe('error telemetry fields', () => {
+  let telemetry: RootTelemetryClient;
+  let telemetryEventStore: TelemetryEventStore;
+
+  beforeEach(() => {
+    telemetryEventStore = new TelemetryEventStore({
+      isDebug: true,
+      config: {
+        enabled: true,
+      },
+    });
+
+    telemetry = new RootTelemetryClient({
+      opts: {
+        store: telemetryEventStore,
+      },
+    });
+  });
+
+  it('tracks structured error fields as regular telemetry events', () => {
+    telemetry.trackErrorStatus(429);
+    telemetry.trackErrorCode('TOO_MANY_REQUESTS');
+    telemetry.trackErrorSlug('rate_limited');
+    telemetry.trackErrorAction('retry');
+    telemetry.trackErrorServerMessage('Rate limited on the requested endpoint');
+
+    expect(telemetryEventStore.readonlyEvents).toMatchObject([
+      { key: 'error_status', value: '429' },
+      { key: 'error_code', value: 'TOO_MANY_REQUESTS' },
+      { key: 'error_slug', value: 'rate_limited' },
+      { key: 'error_action', value: 'retry' },
+      {
+        key: 'error_server_message',
+        value: 'Rate limited on the requested endpoint',
+      },
+    ]);
+  });
+
+  it('normalizes and truncates error server messages', () => {
+    const longMessage = `${'too-long '.repeat(80)}done`;
+
+    telemetry.trackErrorServerMessage(`  line one\n${longMessage}  `);
+
+    expect(telemetryEventStore.readonlyEvents).toHaveLength(1);
+    expect(telemetryEventStore.readonlyEvents[0]?.key).toBe(
+      'error_server_message'
+    );
+    expect(telemetryEventStore.readonlyEvents[0]?.value).not.toContain('\n');
+    expect(telemetryEventStore.readonlyEvents[0]?.value.length).toBe(500);
+  });
+});

--- a/packages/cli/test/unit/telemetry/invocation-id.test.ts
+++ b/packages/cli/test/unit/telemetry/invocation-id.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+
+describe('invocation_id tracking', () => {
+  let telemetry: RootTelemetryClient;
+  let telemetryEventStore: TelemetryEventStore;
+
+  beforeEach(() => {
+    telemetryEventStore = new TelemetryEventStore({
+      isDebug: true,
+      config: {
+        enabled: true,
+      },
+    });
+
+    telemetry = new RootTelemetryClient({
+      opts: {
+        store: telemetryEventStore,
+      },
+    });
+  });
+
+  it('tracks invocation_id as a regular telemetry event', () => {
+    telemetry.trackInvocationId(telemetryEventStore.currentInvocationId);
+
+    expect(telemetryEventStore.readonlyEvents).toMatchObject([
+      {
+        key: 'invocation_id',
+        value: telemetryEventStore.currentInvocationId,
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/telemetry/project-id.test.ts
+++ b/packages/cli/test/unit/telemetry/project-id.test.ts
@@ -58,4 +58,29 @@ describe('project_id tracking', () => {
       projectId: 'prj_xyz',
     });
   });
+
+  it('tracks project_id as a regular telemetry event', () => {
+    telemetryEventStore.updateProjectId('prj_xyz');
+    telemetry.trackProjectId('prj_xyz');
+
+    expect(telemetryEventStore.readonlyEvents).toMatchObject([
+      {
+        key: 'project_id',
+        value: 'prj_xyz',
+        projectId: 'prj_xyz',
+      },
+    ]);
+  });
+
+  it('tracks project_id with a sentinel when no project is linked', () => {
+    telemetry.trackProjectId(telemetryEventStore.currentProjectId);
+
+    expect(telemetryEventStore.readonlyEvents).toMatchObject([
+      {
+        key: 'project_id',
+        value: 'NO_PROJECT_ID',
+        projectId: 'NO_PROJECT_ID',
+      },
+    ]);
+  });
 });

--- a/packages/cli/test/unit/telemetry/session.test.ts
+++ b/packages/cli/test/unit/telemetry/session.test.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+
+describe('persisted cli telemetry session', () => {
+  let sessionFilePath: string;
+
+  beforeEach(() => {
+    sessionFilePath = join(
+      tmpdir(),
+      `vercel-cli-telemetry-session-${randomUUID()}.json`
+    );
+    rmSync(sessionFilePath, { force: true });
+  });
+
+  it('reuses the same session within the inactivity timeout', async () => {
+    let now = 0;
+    const nowFn = () => now;
+
+    const firstStore = new TelemetryEventStore({
+      config: { enabled: true },
+      isDebug: true,
+      cliSession: {
+        filePath: sessionFilePath,
+        now: nowFn,
+      },
+    });
+    const firstTelemetry = new RootTelemetryClient({
+      opts: {
+        store: firstStore,
+      },
+    });
+    firstTelemetry.trackVersion('1.0.0');
+    const firstSessionId = firstStore.readonlyEvents[0]?.sessionId;
+
+    now = 20 * 60 * 1000;
+    await firstStore.save();
+
+    now = 45 * 60 * 1000;
+    const secondStore = new TelemetryEventStore({
+      config: { enabled: true },
+      isDebug: true,
+      cliSession: {
+        filePath: sessionFilePath,
+        now: nowFn,
+      },
+    });
+    const secondTelemetry = new RootTelemetryClient({
+      opts: {
+        store: secondStore,
+      },
+    });
+    secondTelemetry.trackPlatform();
+    const secondSessionId = secondStore.readonlyEvents[0]?.sessionId;
+
+    expect(secondSessionId).toBe(firstSessionId);
+  });
+
+  it('rotates the session after the inactivity timeout', () => {
+    let now = 0;
+    const nowFn = () => now;
+
+    const firstStore = new TelemetryEventStore({
+      config: { enabled: true },
+      isDebug: true,
+      cliSession: {
+        filePath: sessionFilePath,
+        now: nowFn,
+      },
+    });
+    const firstTelemetry = new RootTelemetryClient({
+      opts: {
+        store: firstStore,
+      },
+    });
+    firstTelemetry.trackVersion('1.0.0');
+    const firstSessionId = firstStore.readonlyEvents[0]?.sessionId;
+
+    now = 31 * 60 * 1000;
+    const secondStore = new TelemetryEventStore({
+      config: { enabled: true },
+      isDebug: true,
+      cliSession: {
+        filePath: sessionFilePath,
+        now: nowFn,
+      },
+    });
+    const secondTelemetry = new RootTelemetryClient({
+      opts: {
+        store: secondStore,
+      },
+    });
+    secondTelemetry.trackPlatform();
+    const secondSessionId = secondStore.readonlyEvents[0]?.sessionId;
+
+    expect(secondSessionId).not.toBe(firstSessionId);
+  });
+
+  it('rotates the session after the max lifetime even with activity', async () => {
+    let now = 0;
+    const nowFn = () => now;
+
+    const firstStore = new TelemetryEventStore({
+      config: { enabled: true },
+      isDebug: true,
+      cliSession: {
+        filePath: sessionFilePath,
+        now: nowFn,
+      },
+    });
+    const firstTelemetry = new RootTelemetryClient({
+      opts: {
+        store: firstStore,
+      },
+    });
+    firstTelemetry.trackVersion('1.0.0');
+    const firstSessionId = firstStore.readonlyEvents[0]?.sessionId;
+
+    now = 23 * 60 * 60 * 1000;
+    await firstStore.save();
+
+    now = 25 * 60 * 60 * 1000;
+    const secondStore = new TelemetryEventStore({
+      config: { enabled: true },
+      isDebug: true,
+      cliSession: {
+        filePath: sessionFilePath,
+        now: nowFn,
+      },
+    });
+    const secondTelemetry = new RootTelemetryClient({
+      opts: {
+        store: secondStore,
+      },
+    });
+    secondTelemetry.trackPlatform();
+    const secondSessionId = secondStore.readonlyEvents[0]?.sessionId;
+
+    expect(secondSessionId).not.toBe(firstSessionId);
+  });
+});


### PR DESCRIPTION
This PR adds better telemetry handling for the Vercel CLI:
- includes project ID
- errors/failures in agentic mode
- new session_id definition
- invocation_id