### PR TITLE
feat(node): filter non-entrypoint Node.js files in `/api` directory

### DIFF
--- a/.changeset/wild-trainers-clean.md
+++ b/.changeset/wild-trainers-clean.md
@@ -1,0 +1,6 @@
+---
+"@vercel/build-utils": patch
+"@vercel/fs-detectors": patch
+---
+
+feat(node): filter non-entrypoint Node.js files in `/api` directory

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -162,6 +162,7 @@ export {
 } from './framework-helpers';
 
 export * from './python';
+export * from './node-entrypoint';
 
 export {
   getEncryptedEnv,

--- a/packages/build-utils/src/node-entrypoint.ts
+++ b/packages/build-utils/src/node-entrypoint.ts
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import debug from './debug';
+import type FileFsRef from './file-fs-ref';
+
+const HTTP_METHODS = 'GET|HEAD|OPTIONS|POST|PUT|DELETE|PATCH';
+
+/**
+ * Regex patterns that indicate a file is a valid Node.js API entrypoint.
+ * A file must match at least one pattern to be considered an entrypoint.
+ */
+const VALID_EXPORT_PATTERNS = [
+  // ESM default export: export default function handler() {}
+  /export\s+default\b/,
+  // CJS default export: module.exports = (req, res) => {}
+  /module\.exports\s*=/,
+  // ESM named HTTP method or fetch exports: export function GET() {}
+  new RegExp(
+    `export\\s+(?:async\\s+)?(?:function|const|let|var)\\s+(?:${HTTP_METHODS}|fetch)\\b`
+  ),
+  // ESM re-exports: export { GET } or export { handler as default }
+  new RegExp(`export\\s*\\{[^}]*\\b(?:${HTTP_METHODS}|fetch|default)\\b`),
+  // CJS named exports: exports.GET = ... or module.exports.GET = ...
+  new RegExp(`(?:module\\.)?exports\\.(?:${HTTP_METHODS}|fetch|default)\\s*=`),
+  // Server handler: http.createServer(...).listen() with no exports
+  /http\.createServer\s*\(/,
+];
+
+/**
+ * Strip single-line (//) and multi-line (/* ... *​/) comments from source code.
+ * This is a simple heuristic to avoid false positives from commented-out exports.
+ */
+function stripComments(content: string): string {
+  return content
+    .replace(/\/\/.*$/gm, '') // single-line comments
+    .replace(/\/\*[\s\S]*?\*\//g, ''); // multi-line comments
+}
+
+/**
+ * Check if a Node.js/TypeScript file is a valid API entrypoint by detecting
+ * export patterns that correspond to supported handler shapes:
+ * - Default function export (req, res handler)
+ * - Named HTTP method exports (GET, POST, etc.)
+ * - Fetch export
+ * - module.exports / exports assignments
+ *
+ * Returns `true` on error as a safe default — if we can't read the file,
+ * let the existing build pipeline handle it.
+ */
+export async function isNodeEntrypoint(
+  file: FileFsRef | { fsPath?: string }
+): Promise<boolean> {
+  try {
+    const fsPath = (file as FileFsRef).fsPath;
+    if (!fsPath) return true;
+    const content = await fs.promises.readFile(fsPath, 'utf-8');
+    if (!content.trim()) return false;
+    const stripped = stripComments(content);
+    return VALID_EXPORT_PATTERNS.some(pattern => pattern.test(stripped));
+  } catch (err) {
+    debug(`Failed to check Node.js entrypoint: ${err}`);
+    return true;
+  }
+}

--- a/packages/build-utils/test/unit.node-entrypoint.test.ts
+++ b/packages/build-utils/test/unit.node-entrypoint.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { isNodeEntrypoint } from '../src/node-entrypoint';
+
+async function createTempFile(content: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'node-entrypoint-'));
+  const fsPath = join(dir, 'test.ts');
+  await writeFile(fsPath, content, 'utf-8');
+  return fsPath;
+}
+
+async function check(content: string): Promise<boolean> {
+  const fsPath = await createTempFile(content);
+  try {
+    return await isNodeEntrypoint({ fsPath });
+  } finally {
+    await rm(fsPath, { force: true });
+  }
+}
+
+describe('isNodeEntrypoint()', () => {
+  describe('returns true for valid entrypoints', () => {
+    it('ESM default function export', async () => {
+      expect(
+        await check(
+          'export default function handler(req, res) { res.end("ok"); }'
+        )
+      ).toBe(true);
+    });
+
+    it('ESM default arrow export', async () => {
+      expect(
+        await check('export default (req, res) => { res.end("ok"); }')
+      ).toBe(true);
+    });
+
+    it('ESM default class export', async () => {
+      expect(await check('export default class Handler {}')).toBe(true);
+    });
+
+    it('CJS module.exports assignment', async () => {
+      expect(
+        await check('module.exports = (req, res) => { res.end("ok"); }')
+      ).toBe(true);
+    });
+
+    it('CJS module.exports with require', async () => {
+      expect(
+        await check(
+          'const handler = require("./handler");\nmodule.exports = handler;'
+        )
+      ).toBe(true);
+    });
+
+    it('ESM named GET export', async () => {
+      expect(
+        await check(
+          'export function GET(request) { return new Response("ok"); }'
+        )
+      ).toBe(true);
+    });
+
+    it('ESM named async POST export', async () => {
+      expect(
+        await check(
+          'export async function POST(request) { return new Response("ok"); }'
+        )
+      ).toBe(true);
+    });
+
+    it('ESM const GET export', async () => {
+      expect(
+        await check('export const GET = async (req) => new Response("ok");')
+      ).toBe(true);
+    });
+
+    it('ESM fetch export', async () => {
+      expect(
+        await check(
+          'export function fetch(request) { return new Response("ok"); }'
+        )
+      ).toBe(true);
+    });
+
+    it('ESM re-export with default', async () => {
+      expect(
+        await check('export { handler as default } from "./handler";')
+      ).toBe(true);
+    });
+
+    it('ESM re-export GET', async () => {
+      expect(await check('export { GET } from "./handlers";')).toBe(true);
+    });
+
+    it('ESM re-export multiple methods', async () => {
+      expect(await check('export { GET, POST } from "./handlers";')).toBe(true);
+    });
+
+    it('CJS exports.GET', async () => {
+      expect(
+        await check('exports.GET = function(req, res) { res.end("ok"); }')
+      ).toBe(true);
+    });
+
+    it('CJS module.exports.default', async () => {
+      expect(
+        await check(
+          'module.exports.default = function(req, res) { res.end("ok"); }'
+        )
+      ).toBe(true);
+    });
+
+    it('CJS exports.fetch', async () => {
+      expect(
+        await check('exports.fetch = async (req) => new Response("ok");')
+      ).toBe(true);
+    });
+
+    it('TypeScript handler with type annotations', async () => {
+      expect(
+        await check(
+          'import type { Request, Response } from "express";\nexport default function handler(req: Request, res: Response) { res.end("ok"); }'
+        )
+      ).toBe(true);
+    });
+
+    it('TypeScript GET with return type', async () => {
+      expect(
+        await check(
+          'export async function GET(request: Request): Promise<Response> { return new Response("ok"); }'
+        )
+      ).toBe(true);
+    });
+
+    it('export default after imports and type declarations', async () => {
+      expect(
+        await check(
+          'import { db } from "./db";\ntype Config = { key: string };\nconst config: Config = { key: "val" };\nexport default async function handler(req, res) { res.end("ok"); }'
+        )
+      ).toBe(true);
+    });
+
+    it('http.createServer without exports', async () => {
+      expect(
+        await check(
+          'const http = require("http");\nhttp.createServer((req, res) => { res.end("ok"); }).listen(3000);'
+        )
+      ).toBe(true);
+    });
+
+    it('http.createServer with variable', async () => {
+      expect(
+        await check(
+          'import http from "http";\nconst server = http.createServer(handler);\nserver.listen(3000);'
+        )
+      ).toBe(true);
+    });
+
+    it('all HTTP methods', async () => {
+      for (const method of [
+        'GET',
+        'HEAD',
+        'OPTIONS',
+        'POST',
+        'PUT',
+        'DELETE',
+        'PATCH',
+      ]) {
+        expect(
+          await check(
+            `export function ${method}(request) { return new Response("ok"); }`
+          )
+        ).toBe(true);
+      }
+    });
+  });
+
+  describe('returns false for non-entrypoints', () => {
+    it('empty file', async () => {
+      expect(await check('')).toBe(false);
+    });
+
+    it('whitespace-only file', async () => {
+      expect(await check('   \n\n  ')).toBe(false);
+    });
+
+    it('utility functions only', async () => {
+      expect(
+        await check(
+          'export function helper() { return "hi"; }\nexport function formatDate(d) { return d.toISOString(); }'
+        )
+      ).toBe(false);
+    });
+
+    it('config-only export', async () => {
+      expect(await check('export const config = { runtime: "edge" };')).toBe(
+        false
+      );
+    });
+
+    it('TypeScript types-only file', async () => {
+      expect(
+        await check(
+          'export interface ApiResponse { status: number; data: unknown; }\nexport type Handler = (req: Request) => Response;'
+        )
+      ).toBe(false);
+    });
+
+    it('commented-out default export', async () => {
+      expect(
+        await check(
+          '// export default function handler(req, res) { res.end("ok"); }\nexport function helper() { return "hi"; }'
+        )
+      ).toBe(false);
+    });
+
+    it('commented-out module.exports', async () => {
+      expect(
+        await check(
+          '// module.exports = handler\nexport function helper() { return "hi"; }'
+        )
+      ).toBe(false);
+    });
+
+    it('commented-out http.createServer', async () => {
+      expect(
+        await check(
+          '// http.createServer((req, res) => { res.end("ok"); }).listen(3000);\nexport function helper() { return "hi"; }'
+        )
+      ).toBe(false);
+    });
+
+    it('block-commented default export', async () => {
+      expect(
+        await check(
+          '/* export default function handler(req, res) { res.end("ok"); } */\nexport function helper() { return "hi"; }'
+        )
+      ).toBe(false);
+    });
+
+    it('named non-handler exports only', async () => {
+      expect(
+        await check(
+          'export const DB_URL = "postgres://localhost";\nexport function connect() { return null; }'
+        )
+      ).toBe(false);
+    });
+
+    it('import-only file', async () => {
+      expect(
+        await check(
+          'import { db } from "./db";\nconst result = db.query("SELECT 1");'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns true when file cannot be read', async () => {
+      expect(await isNodeEntrypoint({ fsPath: '/nonexistent/file.ts' })).toBe(
+        true
+      );
+    });
+
+    it('returns true when fsPath is undefined', async () => {
+      expect(await isNodeEntrypoint({})).toBe(true);
+    });
+  });
+});

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -15,6 +15,7 @@ import type {
 import { isOfficialRuntime } from './is-official-runtime';
 import {
   isPythonEntrypoint,
+  isNodeEntrypoint,
   BACKEND_BUILDERS,
   UNIFIED_BACKEND_BUILDER,
   isExperimentalBackendsEnabled,
@@ -463,6 +464,20 @@ async function maybeGetApiBuilder(
   if (fileName.endsWith('.py') && options.workPath) {
     const fsPath = join(options.workPath, fileName);
     const isEntrypoint = await isPythonEntrypoint({ fsPath });
+    if (!isEntrypoint) {
+      return null;
+    }
+  }
+
+  // For Node.js files, verify they are valid entrypoints before creating a builder
+  const nodeExtensions = ['.js', '.mjs', '.ts', '.tsx'];
+  if (
+    process.env.VERCEL_NODE_FILTER_ENTRYPOINTS === '1' &&
+    nodeExtensions.some(ext => fileName.endsWith(ext)) &&
+    options.workPath
+  ) {
+    const fsPath = join(options.workPath, fileName);
+    const isEntrypoint = await isNodeEntrypoint({ fsPath });
     if (!isEntrypoint) {
       return null;
     }

--- a/packages/fs-detectors/test/fixtures/70-node-api-dir-files/api/get-handler.ts
+++ b/packages/fs-detectors/test/fixtures/70-node-api-dir-files/api/get-handler.ts
@@ -1,0 +1,3 @@
+export function GET(request: Request): Response {
+  return new Response(JSON.stringify({ ok: true }));
+}

--- a/packages/fs-detectors/test/fixtures/70-node-api-dir-files/api/helper.ts
+++ b/packages/fs-detectors/test/fixtures/70-node-api-dir-files/api/helper.ts
@@ -1,0 +1,7 @@
+export function formatDate(d: Date): string {
+  return d.toISOString();
+}
+
+export function sanitizeInput(input: string): string {
+  return input.trim().toLowerCase();
+}

--- a/packages/fs-detectors/test/fixtures/70-node-api-dir-files/api/index.ts
+++ b/packages/fs-detectors/test/fixtures/70-node-api-dir-files/api/index.ts
@@ -1,0 +1,5 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.status(200).json({ message: 'Hello' });
+}

--- a/packages/fs-detectors/test/fixtures/70-node-api-dir-files/api/server.js
+++ b/packages/fs-detectors/test/fixtures/70-node-api-dir-files/api/server.js
@@ -1,0 +1,5 @@
+const http = require('http');
+
+http.createServer((req, res) => {
+  res.end('ok');
+}).listen(3000);

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -4059,4 +4059,69 @@ describe('Test `detectApiExtensions`', () => {
     expect(result.has('.rb')).toBe(true);
     expect(result.has('.rs')).toBe(true);
   });
+
+  describe('Node.js entrypoint detection with workPath', () => {
+    const workPath = join(__dirname, 'fixtures', '70-node-api-dir-files');
+
+    beforeEach(() => {
+      process.env.VERCEL_NODE_FILTER_ENTRYPOINTS = '1';
+    });
+
+    afterEach(() => {
+      delete process.env.VERCEL_NODE_FILTER_ENTRYPOINTS;
+    });
+
+    it('should create builders for valid Node.js entrypoints and skip helpers', async () => {
+      const files = [
+        'api/index.ts',
+        'api/helper.ts',
+        'api/get-handler.ts',
+        'api/server.js',
+      ];
+
+      const { builders } = await detectBuilders(files, null, { workPath });
+
+      const apiBuilders = (builders || []).filter(
+        b => b.src?.startsWith('api/') && b.use === '@vercel/node'
+      );
+
+      const apiSources = apiBuilders.map(b => b.src);
+
+      // Valid entrypoints should get builders
+      expect(apiSources).toContain('api/index.ts');
+      expect(apiSources).toContain('api/get-handler.ts');
+      expect(apiSources).toContain('api/server.js');
+
+      // Helper file should NOT get a builder
+      expect(apiSources).not.toContain('api/helper.ts');
+    });
+
+    it('should skip helpers but still detect api directory', async () => {
+      const files = ['api/index.ts', 'api/helper.ts'];
+
+      const { builders } = await detectBuilders(files, null, { workPath });
+
+      const apiBuilders = (builders || []).filter(
+        b => b.src?.startsWith('api/') && b.use === '@vercel/node'
+      );
+
+      expect(apiBuilders).toHaveLength(1);
+      expect(apiBuilders[0].src).toBe('api/index.ts');
+    });
+
+    it('should not filter entrypoints when env var is not set', async () => {
+      delete process.env.VERCEL_NODE_FILTER_ENTRYPOINTS;
+
+      const files = ['api/index.ts', 'api/helper.ts'];
+
+      const { builders } = await detectBuilders(files, null, { workPath });
+
+      const apiBuilders = (builders || []).filter(
+        b => b.src?.startsWith('api/') && b.use === '@vercel/node'
+      );
+
+      // Without the env var, all files get builders (existing behavior)
+      expect(apiBuilders).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds static entrypoint detection for Node.js files in `/api/`, mirroring #14493 which did the same for Python
- Helper/utility files that don't export a valid handler are no longer treated as API routes, avoiding unnecessary Vercel Function creation
- Gated behind `VERCEL_NODE_FILTER_ENTRYPOINTS=1` environment variable for safe incremental rollout

## How it works

A new `isNodeEntrypoint()` function in `@vercel/build-utils` uses regex-based heuristics to detect valid handler export patterns in `.js`, `.mjs`, `.ts`, and `.tsx` files:

| Pattern | Example |
|---------|---------|
| ESM default export | `export default function handler(req, res) {}` |
| CJS module.exports | `module.exports = (req, res) => {}` |
| Named HTTP method exports | `export function GET(request) {}` |
| Fetch export | `export function fetch(request) {}` |
| Re-exports | `export { handler as default }` |
| Server handler | `http.createServer(...)` |

Files that don't match any pattern (e.g., utility functions, type-only files, config exports) are skipped in `maybeGetApiBuilder()` and won't produce a Vercel Function.

## Test plan

- [ ] 34 unit tests for `isNodeEntrypoint()` covering valid entrypoints, non-entrypoints, and edge cases
- [ ] 3 integration tests in fs-detectors verifying builder creation/skipping with actual files on disk
- [ ] Verified all 116+ existing handler files across Node builder and CLI test fixtures match at least one detection pattern
- [ ] Verified feature is inactive without env var (zero behavior change by default)


🤖 Generated with [Claude Code](https://claude.com/claude-code)