### PR TITLE
[services] switch workers to V3 Queues API and V2 triggers

### DIFF
--- a/.changeset/afraid-cherries-leave.md
+++ b/.changeset/afraid-cherries-leave.md
@@ -1,0 +1,8 @@
+---
+'@vercel/python': minor
+'@vercel/python-workers': minor
+'@vercel/fs-detectors': minor
+'vercel': minor
+---
+
+[services] switch workers to V3 Queues API and V2 triggers

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -362,14 +362,6 @@ export class Lambda {
           `${prefix}.consumer cannot be empty`
         );
 
-        // v2beta allows only one trigger per function
-        if (trigger.type === 'queue/v2beta') {
-          assert(
-            experimentalTriggers.length === 1,
-            '"experimentalTriggers" can only have one item for queue/v2beta'
-          );
-        }
-
         // Validate optional queue configuration
         if (trigger.maxDeliveries !== undefined) {
           assert(

--- a/packages/build-utils/test/unit.lambda.test.ts
+++ b/packages/build-utils/test/unit.lambda.test.ts
@@ -270,29 +270,25 @@ describe('Lambda', () => {
         expect(lambda.experimentalTriggers![0].maxConcurrency).toBe(5);
       });
 
-      it('should throw error when v2beta has multiple triggers', () => {
-        expect(
-          () =>
-            new Lambda({
-              files,
-              handler: 'index.handler',
-              runtime: 'nodejs22.x',
-              experimentalTriggers: [
-                {
-                  type: 'queue/v2beta',
-                  topic: 'test-topic-1',
-                  consumer: 'consumer-1',
-                },
-                {
-                  type: 'queue/v2beta',
-                  topic: 'test-topic-2',
-                  consumer: 'consumer-2',
-                },
-              ],
-            })
-        ).toThrow(
-          '"experimentalTriggers" can only have one item for queue/v2beta'
-        );
+      it('should allow v2beta with multiple triggers', () => {
+        const lambda = new Lambda({
+          files,
+          handler: 'index.handler',
+          runtime: 'nodejs22.x',
+          experimentalTriggers: [
+            {
+              type: 'queue/v2beta',
+              topic: 'test-topic-1',
+              consumer: 'consumer-1',
+            },
+            {
+              type: 'queue/v2beta',
+              topic: 'test-topic-2',
+              consumer: 'consumer-2',
+            },
+          ],
+        });
+        expect(lambda.experimentalTriggers).toHaveLength(2);
       });
     });
 

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -38,6 +38,7 @@ import {
   isBackendBuilder,
   type Lambda,
   type TriggerEvent,
+  sanitizeConsumerName,
   downloadFile,
 } from '@vercel/build-utils';
 import type { VercelConfig } from '@vercel/client';
@@ -49,6 +50,7 @@ import {
   detectFrameworkVersion,
   detectInstrumentation,
   getInternalServiceCronPath,
+  getInternalServiceFunctionPath,
   LocalFileSystemDetector,
 } from '@vercel/fs-detectors';
 import {
@@ -2047,11 +2049,13 @@ function attachWorkerServiceTrigger(
   service: Service
 ): void {
   const topics = getWorkerTopics(service);
-  const consumer = service.consumer || 'default';
+  const consumer = sanitizeConsumerName(
+    getInternalServiceFunctionPath(service.name)
+  );
 
   for (const topic of topics) {
     const trigger: TriggerEvent = {
-      type: 'queue/v1beta',
+      type: 'queue/v2beta',
       topic,
       consumer,
     };

--- a/packages/cli/src/util/dev/queue-broker.ts
+++ b/packages/cli/src/util/dev/queue-broker.ts
@@ -231,6 +231,22 @@ export class QueueBroker {
     return true;
   }
 
+  findMessageByTicket(consumerGroup: string, ticket: string): string | null {
+    for (const group of this.consumerGroups) {
+      if (group.name !== consumerGroup) continue;
+
+      const deliveries = this.deliveryState.get(group.id);
+      if (!deliveries) continue;
+
+      for (const [messageId, state] of deliveries) {
+        if (state.ticket === ticket) {
+          return messageId;
+        }
+      }
+    }
+    return null;
+  }
+
   private findDeliveryState(
     messageId: string,
     serviceName: string
@@ -280,29 +296,35 @@ export class QueueBroker {
     state.deliveryCount++;
     state.leaseExpiresAt = Date.now() + DEFAULT_VISIBILITY_TIMEOUT;
 
-    const cloudEvent = JSON.stringify({
-      type: 'com.vercel.queue.v1beta',
-      specversion: '1.0',
-      source: 'vc-dev',
-      id: message.messageId,
-      time: new Date().toISOString(),
-      datacontenttype: 'application/json',
-      data: {
-        queueName: message.queueName,
-        consumerGroup: group.name,
-        messageId: message.messageId,
-      },
-    });
+    const now = new Date().toISOString();
+    const expiresAt = new Date(
+      new Date(message.createdAt).getTime() + message.retentionMs
+    ).toISOString();
 
     output.debug(
-      `queues: dispatching CloudEvent to worker "${group.name}" at ${upstream}`
+      `queues: dispatching v2beta callback to worker "${group.name}" at ${upstream}`
     );
 
     try {
       const response = await nodeFetch(`${upstream}/`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/cloudevents+json' },
-        body: cloudEvent,
+        headers: {
+          'content-type': message.contentType,
+          'ce-type': 'com.vercel.queue.v2beta',
+          'ce-specversion': '1.0',
+          'ce-source': `/topic/${message.queueName}/consumer/${group.name}`,
+          'ce-id': message.messageId,
+          'ce-time': now,
+          'ce-vqsmessageid': message.messageId,
+          'ce-vqsqueuename': message.queueName,
+          'ce-vqsconsumergroup': group.name,
+          'ce-vqsreceipthandle': ticket,
+          'ce-vqsdeliverycount': String(state.deliveryCount),
+          'ce-vqscreatedat': message.createdAt,
+          'ce-vqsexpiresat': expiresAt,
+          'ce-vqsregion': 'dev1',
+        },
+        body: message.payload,
       });
 
       if (!response.ok) {

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -107,6 +107,7 @@ const frontendRuntimeSet = new Set(
 );
 
 const DEV_SERVER_PORT_BIND_TIMEOUT = ms('5m');
+const DEV_QUEUES_DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 60;
 
 interface FSEvent {
   type: string;
@@ -1453,7 +1454,7 @@ export default class DevServer {
 
   /**
    * Handle /_svc/_queues/* routes for the dev queue broker, which mimics
-   * the Vercel Queues API so workers can be used in vc dev unchanged.
+   * the Vercel Queues v3 API so workers can be used in vc dev unchanged.
    */
   private handleQueuesRoute = async (
     req: http.IncomingMessage,
@@ -1466,9 +1467,21 @@ export default class DevServer {
       return;
     }
 
-    // POST api/v2/messages - enqueue a message
-    if (req.method === 'POST' && pathname === '/_svc/_queues/api/v2/messages') {
-      const queueName = (req.headers['vqs-queue-name'] as string) || 'default';
+    // `/_svc/_queues` is an internal dev queues broker path,
+    // `/api/v3/topic` is the base path for all Queues V3 routes
+    // if any of those don't match, that's a wrong route that could be skipped
+    const TOPIC_PREFIX = '/_svc/_queues/api/v3/topic/';
+    if (!pathname.startsWith(TOPIC_PREFIX)) {
+      res.writeHead(404);
+      res.end('Not Found');
+      return;
+    }
+    const topicPath = pathname.slice(TOPIC_PREFIX.length);
+
+    // POST {topic} - send a message
+    const sendMatch = topicPath.match(/^([A-Za-z0-9_-]+)$/);
+    if (req.method === 'POST' && sendMatch) {
+      const topic = sendMatch[1];
       const contentType =
         (req.headers['content-type'] as string) || 'application/json';
       const payload = await rawBody(req);
@@ -1481,33 +1494,36 @@ export default class DevServer {
           ? parseInt(retentionHeader, 10)
           : undefined;
 
+      const delayHeader = req.headers['vqs-delay-seconds'] as
+        | string
+        | undefined;
+      const delaySeconds =
+        delayHeader && !isNaN(parseInt(delayHeader, 10))
+          ? parseInt(delayHeader, 10)
+          : undefined;
+
       const { messageId } = this.queueBroker.enqueue(
-        queueName,
+        topic,
         payload,
         contentType,
-        { retentionSeconds }
+        { retentionSeconds, delaySeconds }
       );
 
-      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.writeHead(201, {
+        'Content-Type': 'application/json',
+        'Vqs-Message-Id': messageId,
+      });
       res.end(JSON.stringify({ messageId }));
       return;
     }
 
-    // GET/DELETE/PATCH /api/v2/messages/:messageId
-    const messageMatch = pathname.match(
-      /^\/_svc\/_queues\/api\/v2\/messages\/([a-f0-9]+)$/
+    // POST {topic}/consumer/{consumer}/id/{messageId} - receive by ID
+    const receiveByIdMatch = topicPath.match(
+      /^([A-Za-z0-9_-]+)\/consumer\/([A-Za-z0-9_-]+)\/id\/([^/]+)$/
     );
-    if (!messageMatch) {
-      res.writeHead(404);
-      res.end('Not Found');
-      return;
-    }
-    const messageId = messageMatch[1];
-    const consumerGroup =
-      (req.headers['vqs-consumer-group'] as string) || 'default';
-
-    if (req.method === 'GET') {
-      const result = this.queueBroker.receiveById(messageId, consumerGroup);
+    if (req.method === 'POST' && receiveByIdMatch) {
+      const [, , consumer, messageId] = receiveByIdMatch;
+      const result = this.queueBroker.receiveById(messageId, consumer);
 
       if (!result) {
         res.writeHead(404);
@@ -1520,7 +1536,7 @@ export default class DevServer {
         `Vqs-Message-Id: ${messageId}`,
         `Vqs-Delivery-Count: ${result.deliveryCount}`,
         `Vqs-Timestamp: ${result.createdAt}`,
-        `Vqs-Ticket: ${result.ticket}`,
+        `Vqs-Receipt-Handle: ${result.ticket}`,
         `Content-Type: ${result.contentType}`,
       ].join('\r\n');
 
@@ -1538,32 +1554,74 @@ export default class DevServer {
       return;
     }
 
-    if (req.method === 'DELETE') {
-      const ticket = (req.headers['vqs-ticket'] as string) || '';
-      this.queueBroker.acknowledge(messageId, consumerGroup, ticket);
+    // POST {topic}/consumer/{consumer} - receive messages (batch)
+    const receiveMatch = topicPath.match(
+      /^([A-Za-z0-9_-]+)\/consumer\/([A-Za-z0-9_-]+)$/
+    );
+    if (req.method === 'POST' && receiveMatch) {
+      // For dev, treat batch receive as 204 (no pending messages to pull)
+      // Messages are pushed via CloudEvent dispatch, not pulled
       res.writeHead(204);
       res.end();
       return;
     }
 
-    if (req.method === 'PATCH') {
-      const ticket = (req.headers['vqs-ticket'] as string) || '';
-      const timeoutHeader = req.headers['vqs-visibility-timeout'] as string;
-      const timeoutSeconds = timeoutHeader ? parseInt(timeoutHeader, 10) : 60;
+    // DELETE/PATCH
+    // {topic}/consumer/{consumer}/lease/{receiptHandle} or
+    // {topic}/consumer/{consumer}/lease/{receiptHandle}/visibility -
+    // acknowledge message or extend its lease
+    const leaseMatch = topicPath.match(
+      /^([A-Za-z0-9_-]+)\/consumer\/([A-Za-z0-9_-]+)\/lease\/([^/]+)(?:\/visibility)?$/
+    );
+    if (leaseMatch && (req.method === 'DELETE' || req.method === 'PATCH')) {
+      const [, , consumer, receiptHandle] = leaseMatch;
+      const messageId = this.queueBroker.findMessageByTicket(
+        consumer,
+        receiptHandle
+      );
+
+      if (!messageId) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Message not found' }));
+        return;
+      }
+
+      // acknowledge the message
+      if (req.method === 'DELETE') {
+        this.queueBroker.acknowledge(messageId, consumer, receiptHandle);
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      // otherwise it's PATCH, so we need to extend the lease
+      const body = await rawBody(req);
+      let timeoutSeconds = DEV_QUEUES_DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
+      try {
+        const parsed = JSON.parse(body.toString());
+        if (
+          typeof parsed.visibilityTimeoutSeconds === 'number' &&
+          parsed.visibilityTimeoutSeconds >= 0
+        ) {
+          timeoutSeconds = parsed.visibilityTimeoutSeconds;
+        }
+      } catch (err) {
+        output.debug(`queues: failed to parse visibility timeout body: ${err}`);
+      }
 
       this.queueBroker.changeVisibility(
         messageId,
-        consumerGroup,
-        ticket,
+        consumer,
+        receiptHandle,
         timeoutSeconds
       );
-      res.writeHead(200);
-      res.end();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true }));
       return;
     }
 
-    res.writeHead(405);
-    res.end('Method Not Allowed');
+    res.writeHead(404);
+    res.end('Not Found');
   };
 
   /**

--- a/packages/cli/test/unit/util/dev/queue-broker.test.ts
+++ b/packages/cli/test/unit/util/dev/queue-broker.test.ts
@@ -40,10 +40,11 @@ function makeWebService(name: string): Service {
   } as Service;
 }
 
-/** Extract the CloudEvent body from the most recent mockFetch call. */
-function lastCloudEvent(): Record<string, unknown> {
-  const call = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
-  return JSON.parse((call[1] as any).body);
+/** Extract headers from a specific mockFetch call (defaults to the last one). */
+function callHeaders(index?: number): Record<string, string> {
+  const i = index ?? mockFetch.mock.calls.length - 1;
+  const call = mockFetch.mock.calls[i];
+  return (call[1] as any).headers;
 }
 
 describe('topicPatternToRegex', () => {
@@ -147,17 +148,14 @@ describe('QueueBroker', () => {
       const [url, opts] = mockFetch.mock.calls[0];
       expect(url).toBe('http://localhost:3001/');
       expect((opts as any).method).toBe('POST');
-      expect((opts as any).headers['Content-Type']).toBe(
-        'application/cloudevents+json'
-      );
 
-      const body = lastCloudEvent();
-      expect(body.type).toBe('com.vercel.queue.v1beta');
-      expect(body.data).toMatchObject({
-        queueName: 'orders',
-        consumerGroup: 'worker-a',
-        messageId,
-      });
+      const headers = callHeaders();
+      expect(headers['ce-type']).toBe('com.vercel.queue.v2beta');
+      expect(headers['ce-vqsqueuename']).toBe('orders');
+      expect(headers['ce-vqsconsumergroup']).toBe('worker-a');
+      expect(headers['ce-vqsmessageid']).toBe(messageId);
+      expect(headers['ce-vqsreceipthandle']).toBeTruthy();
+      expect(headers['content-type']).toBe('application/json');
     });
 
     it('dispatches to multiple matching consumer groups', async () => {
@@ -187,11 +185,8 @@ describe('QueueBroker', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
 
-      const bodies = mockFetch.mock.calls.map(c =>
-        JSON.parse((c[1] as any).body)
-      );
-      expect(bodies[0].data.queueName).toBe('orders');
-      expect(bodies[1].data.queueName).toBe('events');
+      expect(callHeaders(0)['ce-vqsqueuename']).toBe('orders');
+      expect(callHeaders(1)['ce-vqsqueuename']).toBe('events');
     });
 
     it('does not cross-dispatch across topics during tick()', async () => {

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -16,7 +16,6 @@ import {
 import {
   getInternalServiceCronPath,
   getInternalServiceFunctionPath,
-  getInternalServiceWorkerPath,
   isFrontendFramework,
   isRouteOwningBuilder,
   isStaticBuild,
@@ -265,8 +264,7 @@ export async function detectServices(
  * Build Output API builders, etc.) are not given synthetic routes here.
  *
  * - Worker services:
- *   Internal queue callback routes under `/_svc/{serviceName}/workers/{entry}/{handler}`
- *   that rewrite to `/_svc/{serviceName}/index`.
+ *   Use private path routing. The generated function is not publicly acceptable.
  *
  * - Cron services:
  *   Internal cron callback routes under `/_svc/{serviceName}/crons/{entry}/{handler}`
@@ -363,22 +361,6 @@ export function generateServicesRoutes(services: Service[]): ServicesRoutes {
         });
       }
     }
-  }
-
-  const workerServices = services.filter(s => s.type === 'worker');
-  for (const service of workerServices) {
-    const workerEntrypoint =
-      service.entrypoint || service.builder.src || 'index';
-    const workerPath = getInternalServiceWorkerPath(
-      service.name,
-      workerEntrypoint
-    );
-    const functionPath = getInternalServiceFunctionPath(service.name);
-    workers.push({
-      src: `^${escapeRegex(workerPath)}$`,
-      dest: functionPath,
-      check: true,
-    });
   }
 
   const cronServices = services.filter(s => s.type === 'cron');

--- a/packages/fs-detectors/test/fixtures/e2e/10-services-worker-dramatiq/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/10-services-worker-dramatiq/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/13-services-worker-django-tasks/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/13-services-worker-django-tasks/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Django web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/14-services-worker-wildcard-topic/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/14-services-worker-wildcard-topic/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/15-services-worker-celery/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/15-services-worker-celery/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/16-services-worker-shared-source/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/16-services-worker-shared-source/probes.json
@@ -25,18 +25,18 @@
       "mustContain": "reports"
     },
     {
-      "path": "/_svc/worker-emails/workers/worker/run/worker",
+      "path": "/_svc/worker-emails/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
-      "path": "/_svc/worker-reports/workers/worker/run/worker",
+      "path": "/_svc/worker-reports/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/17-services-worker-multiple-topics/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/17-services-worker-multiple-topics/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -1314,7 +1314,7 @@ describe('detectServices', () => {
   });
 
   describe('worker services', () => {
-    it('should generate internal worker callback routes', async () => {
+    it('should not generate public routes for worker services', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({
           experimentalServices: {
@@ -1331,12 +1331,7 @@ describe('detectServices', () => {
 
       expect(result.errors).toEqual([]);
       expect(result.services).toHaveLength(1);
-      expect(result.routes.workers).toHaveLength(1);
-      expect(result.routes.workers[0]).toEqual({
-        src: '^/_svc/processor/workers/worker/processor/worker$',
-        dest: '/_svc/processor/index',
-        check: true,
-      });
+      expect(result.routes.workers).toHaveLength(0);
     });
 
     it('should error if worker service has routePrefix', async () => {

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -741,6 +741,12 @@ from vercel_runtime.vc_init import vc_handler
     ? await glob('**', { cwd: djangoStatic.cdnOutputDir })
     : {};
 
+  // Worker services use private path routing, so no public routes needed
+  const routes =
+    service?.type === 'worker'
+      ? []
+      : [{ handle: 'filesystem' }, { src: '/(.*)', dest: `/${lambdaPath}` }];
+
   return {
     resultVersion: 2,
     result: {
@@ -748,10 +754,7 @@ from vercel_runtime.vc_init import vc_handler
         [lambdaPath]: output,
         ...staticFiles,
       },
-      routes: [
-        { handle: 'filesystem' },
-        { src: '/(.*)', dest: `/${lambdaPath}` },
-      ],
+      routes,
     },
   };
 };

--- a/python/vercel-workers/src/vercel/workers/asgi.py
+++ b/python/vercel-workers/src/vercel/workers/asgi.py
@@ -13,7 +13,7 @@ ASGI = Callable[
     Awaitable[None],
 ]
 
-Handler = Callable[[bytes], tuple[int, list[tuple[str, str]], bytes]]
+Handler = Callable[[bytes, dict[str, Any]], tuple[int, list[tuple[str, str]], bytes]]
 
 
 def _get_header(scope: dict[str, Any], name: str) -> str | None:
@@ -102,11 +102,12 @@ def build_asgi_app(handler: Handler) -> ASGI:
 
         # Queue callback
         if method == "POST":
-            content_type = _get_header(scope, "content-type")
-            if not content_type or "application/cloudevents+json" not in content_type:
-                body = (
-                    b'{"error":"Invalid content type: expected \\"application/cloudevents+json\\""}'
-                )
+            content_type = _get_header(scope, "content-type") or ""
+            ce_type = _get_header(scope, "ce-type") or ""
+            is_v1beta = "application/cloudevents+json" in content_type
+            is_v2beta = ce_type == "com.vercel.queue.v2beta"
+            if not is_v1beta and not is_v2beta:
+                body = b'{"error":"unsupported callback format"}'
                 await send(
                     {
                         "type": "http.response.start",
@@ -121,7 +122,19 @@ def build_asgi_app(handler: Handler) -> ASGI:
                 return
 
             raw_body = await _read_body(receive)
-            status_code, headers, body = await asyncio.to_thread(handler, raw_body)
+
+            # build WSGI-style environ from ASGI scope headers so the
+            # handler has a uniform interface regardless of server type.
+            environ: dict[str, Any] = {
+                "CONTENT_TYPE": content_type,
+            }
+            for hdr_name, hdr_value in scope.get("headers") or []:
+                name = bytes(hdr_name).decode("latin1")
+                value = bytes(hdr_value).decode("latin1")
+                key = "HTTP_" + name.upper().replace("-", "_")
+                environ[key] = value
+
+            status_code, headers, body = await asyncio.to_thread(handler, raw_body, environ)
             asgi_headers: list[tuple[bytes, bytes]] = [
                 (k.lower().encode("latin1"), v.encode("latin1")) for (k, v) in headers
             ]

--- a/python/vercel-workers/src/vercel/workers/callback.py
+++ b/python/vercel-workers/src/vercel/workers/callback.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 from collections.abc import Callable
 from email.parser import BytesParser
@@ -16,12 +17,13 @@ from .exceptions import (
     ForbiddenError,
     InternalServerError,
     MessageCorruptedError,
-    MessageLockedError,
     MessageNotAvailableError,
     MessageNotFoundError,
     ThrottledError,
     UnauthorizedError,
 )
+
+CLOUD_EVENT_TYPE_V2BETA = "com.vercel.queue.v2beta"
 
 
 class CloudEventData(TypedDict):
@@ -40,6 +42,84 @@ class CloudEvent(TypedDict, total=False):
     specversion: str
 
 
+def _get_environ_header(environ: dict[str, Any], name: str, default: str = "") -> str:
+    # WSGI (PEP 3333) stores most HTTP headers with an HTTP_ prefix, but
+    # Content-Type and Content-Length are special: they are stored without the
+    # prefix as CONTENT_TYPE and CONTENT_LENGTH respectively.
+    key = "HTTP_" + name.upper().replace("-", "_")
+    value = environ.get(key)
+    if value is None:
+        # Fall back to the non-prefixed key for Content-Type / Content-Length
+        # which PEP 3333 stores without the HTTP_ prefix.
+        wsgi_key = name.upper().replace("-", "_")
+        value = environ.get(wsgi_key)
+    if value is None:
+        return default
+    if isinstance(value, bytes):
+        return value.decode("latin1")
+    return str(value)
+
+
+class ParsedV2BetaCallback(TypedDict):
+    queueName: str
+    consumerGroup: str
+    messageId: str
+    receiptHandle: str
+    deliveryCount: int
+    createdAt: str
+    payload: Any
+
+
+def is_v2beta_callback(environ: dict[str, Any]) -> bool:
+    return _get_environ_header(environ, "Ce-Type") == CLOUD_EVENT_TYPE_V2BETA
+
+
+def parse_v2beta_callback(
+    raw_body: bytes,
+    environ: dict[str, Any],
+) -> ParsedV2BetaCallback:
+    """
+    Parse a v2beta binary content mode callback.
+
+    Raises ``ValueError`` if required headers are missing.
+    """
+    queue_name = _get_environ_header(environ, "Ce-Vqsqueuename")
+    consumer_group = _get_environ_header(environ, "Ce-Vqsconsumergroup")
+    message_id = _get_environ_header(environ, "Ce-Vqsmessageid")
+    receipt_handle = _get_environ_header(environ, "Ce-Vqsreceipthandle")
+
+    if not queue_name or not consumer_group or not message_id:
+        raise ValueError("missing required ce-vqs* headers")
+
+    delivery_count_raw = _get_environ_header(environ, "Ce-Vqsdeliverycount", "1")
+    try:
+        delivery_count = int(delivery_count_raw)
+    except ValueError:
+        delivery_count = 1
+
+    created_at = _get_environ_header(environ, "Ce-Vqscreatedat")
+
+    content_type = _get_environ_header(environ, "Content-Type")
+    payload: Any
+    if "application/json" in content_type.lower():
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except Exception:  # noqa: BLE001
+            payload = raw_body
+    else:
+        payload = raw_body
+
+    return {
+        "queueName": queue_name,
+        "consumerGroup": consumer_group,
+        "messageId": message_id,
+        "receiptHandle": receipt_handle,
+        "deliveryCount": delivery_count,
+        "createdAt": created_at,
+        "payload": payload,
+    }
+
+
 def parse_cloudevent(body: bytes) -> tuple[str, str, str]:
     if not body:
         raise ValueError("Empty request body")
@@ -52,9 +132,9 @@ def parse_cloudevent(body: bytes) -> tuple[str, str, str]:
     if not isinstance(data, dict):
         raise ValueError("Invalid CloudEvent: body must be a JSON object")
 
-    if data.get("type") != "com.vercel.queue.v1beta":
+    if data.get("type") != "com.vercel.queue.v2beta":
         raise ValueError(
-            f"Invalid CloudEvent type: expected 'com.vercel.queue.v1beta', got {data.get('type')!r}"
+            f"Invalid CloudEvent type: expected 'com.vercel.queue.v2beta', got {data.get('type')!r}"
         )
 
     ce_data = data.get("data")
@@ -153,7 +233,7 @@ class ReceivedMessage(TypedDict):
     messageId: str
     deliveryCount: int
     createdAt: str
-    ticket: str
+    receiptHandle: str
     contentType: str
     payload: Any
 
@@ -169,7 +249,7 @@ def receive_messages(
     """
     Receive one or more messages from a queue.
 
-    GET {base_url}{base_path}
+    POST {base_url}{base_path}/{topic}/consumer/{consumer}
     Accept: multipart/mixed
 
     Returns a list of messages (possibly empty).
@@ -181,19 +261,23 @@ def receive_messages(
 
     headers: dict[str, str] = {
         "Authorization": f"Bearer {auth_token}",
-        "Vqs-Queue-Name": queue_name,
-        "Vqs-Consumer-Group": consumer_group,
         "Accept": "multipart/mixed",
     }
 
-    if visibility_timeout_seconds is not None:
-        headers["Vqs-Visibility-Timeout"] = str(int(visibility_timeout_seconds))
-    if limit is not None:
-        headers["Vqs-Limit"] = str(int(limit))
+    deployment_id = os.environ.get("VERCEL_DEPLOYMENT_ID")
+    if deployment_id:
+        headers["Vqs-Deployment-Id"] = deployment_id
 
-    url = f"{base_url}{base_path}"
+    if visibility_timeout_seconds is not None:
+        headers["Vqs-Visibility-Timeout-Seconds"] = str(int(visibility_timeout_seconds))
+    if limit is not None:
+        headers["Vqs-Max-Messages"] = str(int(limit))
+
+    topic_path = quote(queue_name, safe="")
+    consumer_path = quote(consumer_group, safe="")
+    url = f"{base_url}{base_path}/{topic_path}/consumer/{consumer_path}"
     with httpx.Client(timeout=timeout) as client:
-        response = client.get(url, headers=headers)
+        response = client.post(url, headers=headers)
 
     if response.status_code == 204:
         return []
@@ -205,8 +289,6 @@ def receive_messages(
         raise ForbiddenError()
     if response.status_code == 429:
         raise ThrottledError(parse_retry_after(response))
-    if response.status_code == 423:
-        raise MessageLockedError("next message", parse_retry_after(response))
     if response.status_code >= 500:
         raise InternalServerError(
             response.text or f"Server error: {response.status_code} {response.reason_phrase}"
@@ -217,12 +299,12 @@ def receive_messages(
     messages: list[ReceivedMessage] = []
     for part_headers, payload_bytes in parse_multipart_messages(response):
         message_id = part_headers.get("Vqs-Message-Id")
-        ticket = part_headers.get("Vqs-Ticket")
+        receipt_handle = part_headers.get("Vqs-Receipt-Handle")
         timestamp = part_headers.get("Vqs-Timestamp") or ""
         delivery_count_raw = part_headers.get("Vqs-Delivery-Count") or "0"
         content_type = part_headers.get("Content-Type", "")
 
-        if not message_id or not ticket:
+        if not message_id or not receipt_handle:
             # Skip malformed parts
             continue
 
@@ -246,7 +328,7 @@ def receive_messages(
                 "messageId": str(message_id),
                 "deliveryCount": delivery_count,
                 "createdAt": str(timestamp),
-                "ticket": str(ticket),
+                "receiptHandle": str(receipt_handle),
                 "contentType": str(content_type),
                 "payload": payload,
             }
@@ -266,28 +348,33 @@ def receive_message_by_id(
     """
     Minimal receive-by-id:
 
-      GET {base_url}{base_path}/{messageId}
+      POST {base_url}{base_path}/{topic}/consumer/{consumer}/id/{messageId}
       Accept: multipart/mixed
 
-    Returns (payload, delivery_count, created_at, ticket).
+    Returns (payload, delivery_count, created_at, receipt_handle).
     """
     base_url = _client.get_queue_base_url().rstrip("/")  # type: ignore[attr-defined]
-    base_path = _client.get_queue_base_path()  # type: ignore[attr-defined]
     auth_token = _client.get_queue_token(None)  # type: ignore[attr-defined]
 
     headers: dict[str, str] = {
         "Authorization": f"Bearer {auth_token}",
-        "Vqs-Queue-Name": queue_name,
-        "Vqs-Consumer-Group": consumer_group,
         "Accept": "multipart/mixed",
     }
 
-    if visibility_timeout_seconds is not None:
-        headers["Vqs-Visibility-Timeout"] = str(int(visibility_timeout_seconds))
+    deployment_id = os.environ.get("VERCEL_DEPLOYMENT_ID")
+    if deployment_id:
+        headers["Vqs-Deployment-Id"] = deployment_id
 
-    url = f"{base_url}{base_path}/{quote(message_id, safe='')}"
+    if visibility_timeout_seconds is not None:
+        headers["Vqs-Visibility-Timeout-Seconds"] = str(int(visibility_timeout_seconds))
+
+    topic_path = quote(queue_name, safe="")
+    consumer_path = quote(consumer_group, safe="")
+    message_path = quote(message_id, safe="")
+    base_path = _client.get_queue_base_path()
+    url = f"{base_url}{base_path}/{topic_path}/consumer/{consumer_path}/id/{message_path}"
     with httpx.Client(timeout=timeout) as client:
-        response = client.get(url, headers=headers)
+        response = client.post(url, headers=headers)
 
     if response.status_code == 400:
         raise BadRequestError(response.text or "Invalid parameters")
@@ -297,10 +384,12 @@ def receive_message_by_id(
         raise ForbiddenError()
     if response.status_code == 404:
         raise MessageNotFoundError(message_id)
-    if response.status_code == 423:
-        raise MessageLockedError(message_id, parse_retry_after(response))
     if response.status_code == 409:
         raise MessageNotAvailableError(message_id)
+    if response.status_code == 410:
+        raise MessageNotFoundError(message_id)
+    if response.status_code == 429:
+        raise ThrottledError(parse_retry_after(response))
     if response.status_code >= 500:
         raise InternalServerError(
             response.text or f"Server error: {response.status_code} {response.reason_phrase}"
@@ -317,12 +406,12 @@ def receive_message_by_id(
         ) from exc
     delivery_count_raw = part_headers.get("Vqs-Delivery-Count") or "0"
     timestamp = part_headers.get("Vqs-Timestamp") or ""
-    ticket = part_headers.get("Vqs-Ticket")
+    receipt_handle = part_headers.get("Vqs-Receipt-Handle")
 
-    if not ticket:
+    if not receipt_handle:
         raise MessageCorruptedError(
             message_id,
-            "Missing required queue header 'Vqs-Ticket' in multipart response",
+            "Missing required queue header 'Vqs-Receipt-Handle' in multipart response",
         )
 
     try:
@@ -340,42 +429,46 @@ def receive_message_by_id(
                 message_id,
                 f"Failed to parse payload as JSON: {exc}",
             ) from exc
-    return payload, delivery_count, timestamp, ticket  # type: ignore[return-value]
+    return payload, delivery_count, timestamp, receipt_handle  # type: ignore[return-value]
 
 
 def delete_message(
     queue_name: str,
     consumer_group: str,
     message_id: str,
-    ticket: str,
+    receipt_handle: str,
     *,
     timeout: float | None = 10.0,
 ) -> None:
     base_url = _client.get_queue_base_url().rstrip("/")  # type: ignore[attr-defined]
-    base_path = _client.get_queue_base_path()  # type: ignore[attr-defined]
     auth_token = _client.get_queue_token(None)  # type: ignore[attr-defined]
 
     headers: dict[str, str] = {
         "Authorization": f"Bearer {auth_token}",
-        "Vqs-Queue-Name": queue_name,
-        "Vqs-Consumer-Group": consumer_group,
-        "Vqs-Ticket": ticket,
     }
 
-    url = f"{base_url}{base_path}/{quote(message_id, safe='')}"
+    deployment_id = os.environ.get("VERCEL_DEPLOYMENT_ID")
+    if deployment_id:
+        headers["Vqs-Deployment-Id"] = deployment_id
+
+    topic_path = quote(queue_name, safe="")
+    consumer_path = quote(consumer_group, safe="")
+    handle_path = quote(receipt_handle, safe="")
+    base_path = _client.get_queue_base_path()
+    url = f"{base_url}{base_path}/{topic_path}/consumer/{consumer_path}/lease/{handle_path}"
     with httpx.Client(timeout=timeout) as client:
         response = client.delete(url, headers=headers)
 
     if response.status_code == 400:
-        raise BadRequestError("Missing or invalid ticket")
+        raise BadRequestError("Missing or invalid receipt handle")
     if response.status_code == 401:
         raise UnauthorizedError()
-    if response.status_code == 403:
-        raise ForbiddenError()
     if response.status_code == 404:
         raise MessageNotFoundError(message_id)
     if response.status_code == 409:
-        raise MessageNotAvailableError(message_id, "not available for deletion")
+        raise MessageNotAvailableError(message_id, "lease expired or receipt handle mismatch")
+    if response.status_code == 429:
+        raise ThrottledError(parse_retry_after(response))
     if response.status_code >= 500:
         raise InternalServerError(
             response.text or f"Server error: {response.status_code} {response.reason_phrase}"
@@ -388,37 +481,42 @@ def change_visibility(
     queue_name: str,
     consumer_group: str,
     message_id: str,
-    ticket: str,
+    receipt_handle: str,
     visibility_timeout_seconds: int,
     *,
     timeout: float | None = 10.0,
 ) -> None:
     base_url = _client.get_queue_base_url().rstrip("/")  # type: ignore[attr-defined]
-    base_path = _client.get_queue_base_path()  # type: ignore[attr-defined]
     auth_token = _client.get_queue_token(None)  # type: ignore[attr-defined]
 
     headers: dict[str, str] = {
         "Authorization": f"Bearer {auth_token}",
-        "Vqs-Queue-Name": queue_name,
-        "Vqs-Consumer-Group": consumer_group,
-        "Vqs-Ticket": ticket,
-        "Vqs-Visibility-Timeout": str(visibility_timeout_seconds),
+        "Content-Type": "application/json",
     }
 
-    url = f"{base_url}{base_path}/{quote(message_id, safe='')}"
+    deployment_id = os.environ.get("VERCEL_DEPLOYMENT_ID")
+    if deployment_id:
+        headers["Vqs-Deployment-Id"] = deployment_id
+
+    topic_path = quote(queue_name, safe="")
+    consumer_path = quote(consumer_group, safe="")
+    handle_path = quote(receipt_handle, safe="")
+    base_path = _client.get_queue_base_path()
+    url = f"{base_url}{base_path}/{topic_path}/consumer/{consumer_path}/lease/{handle_path}"
+    body = json.dumps({"visibilityTimeoutSeconds": visibility_timeout_seconds})
     with httpx.Client(timeout=timeout) as client:
-        response = client.patch(url, headers=headers)
+        response = client.patch(url, headers=headers, content=body)
 
     if response.status_code == 400:
-        raise BadRequestError("Missing ticket or invalid visibility timeout")
+        raise BadRequestError("Missing receipt handle or invalid visibility timeout")
     if response.status_code == 401:
         raise UnauthorizedError()
-    if response.status_code == 403:
-        raise ForbiddenError()
     if response.status_code == 404:
         raise MessageNotFoundError(message_id)
     if response.status_code == 409:
-        raise MessageNotAvailableError(message_id, "not available for visibility change")
+        raise MessageNotAvailableError(message_id, "lease expired or receipt handle mismatch")
+    if response.status_code == 429:
+        raise ThrottledError(parse_retry_after(response))
     if response.status_code >= 500:
         raise InternalServerError(
             response.text or f"Server error: {response.status_code} {response.reason_phrase}"
@@ -444,7 +542,7 @@ class VisibilityExtender:
         queue_name: str,
         consumer_group: str,
         message_id: str,
-        ticket: str,
+        receipt_handle: str,
         *,
         visibility_timeout_seconds: int,
         refresh_interval_seconds: float,
@@ -454,7 +552,7 @@ class VisibilityExtender:
         self.queue_name = queue_name
         self.consumer_group = consumer_group
         self.message_id = message_id
-        self.ticket = ticket
+        self.receipt_handle = receipt_handle
         self.visibility_timeout_seconds = int(visibility_timeout_seconds)
         self.refresh_interval_seconds = float(refresh_interval_seconds)
         self.timeout = timeout
@@ -497,7 +595,7 @@ class VisibilityExtender:
                         self.queue_name,
                         self.consumer_group,
                         self.message_id,
-                        self.ticket,
+                        self.receipt_handle,
                         int(self.visibility_timeout_seconds),
                         timeout=self.timeout,
                     )

--- a/python/vercel-workers/src/vercel/workers/celery/app.py
+++ b/python/vercel-workers/src/vercel/workers/celery/app.py
@@ -33,18 +33,23 @@ WSGI = Callable[[dict[str, Any], Callable[..., Any]], list[bytes]]
 def get_wsgi_app(celery_app: CeleryApp) -> WSGI:
     """Return a WSGI app that executes Celery tasks from Vercel Queue callbacks."""
 
-    return build_wsgi_app(lambda raw_body: handle_queue_callback(celery_app, raw_body))
+    return build_wsgi_app(
+        lambda raw_body, environ: handle_queue_callback(celery_app, raw_body, environ)
+    )
 
 
 def get_asgi_app(celery_app: CeleryApp) -> ASGI:
     """Return an ASGI app that executes Celery tasks from Vercel Queue callbacks."""
 
-    return build_asgi_app(lambda raw_body: handle_queue_callback(celery_app, raw_body))
+    return build_asgi_app(
+        lambda raw_body, environ: handle_queue_callback(celery_app, raw_body, environ)
+    )
 
 
 def handle_queue_callback(
     celery_app: CeleryApp,
     raw_body: bytes,
+    environ: dict[str, Any] | None = None,
 ) -> tuple[int, list[tuple[str, str]], bytes]:
     """
     Core callback handler shared by WSGI/ASGI wrappers.
@@ -54,27 +59,44 @@ def handle_queue_callback(
 
     extender: queue_callback.VisibilityExtender | None = None
     try:
-        queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
-
         conf = getattr(celery_app, "conf", None)
         transport_options = getattr(conf, "broker_transport_options", None)
         cfg = TransportConfig.from_transport_options(
             transport_options if isinstance(transport_options, dict) else {},
         )
 
-        payload, delivery_count, created_at, ticket = queue_callback.receive_message_by_id(
-            queue_name,
-            consumer_group,
-            message_id,
-            visibility_timeout_seconds=cfg.visibility_timeout_seconds,
-            timeout=cfg.timeout,
-        )
+        is_v2beta = queue_callback.is_v2beta_callback(environ or {})
+
+        if is_v2beta:
+            v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
+            queue_name = v2["queueName"]
+            consumer_group = v2["consumerGroup"]
+            message_id = v2["messageId"]
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload: Any = v2["payload"]
+        else:
+            queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
+
+            (
+                payload,
+                delivery_count,
+                created_at,
+                receipt_handle,
+            ) = queue_callback.receive_message_by_id(
+                queue_name,
+                consumer_group,
+                message_id,
+                visibility_timeout_seconds=cfg.visibility_timeout_seconds,
+                timeout=cfg.timeout,
+            )
 
         extender = queue_callback.VisibilityExtender(
             queue_name,
             consumer_group,
             message_id,
-            ticket,
+            receipt_handle,
             visibility_timeout_seconds=cfg.visibility_timeout_seconds,
             refresh_interval_seconds=cfg.visibility_refresh_interval_seconds,
             timeout=cfg.timeout,
@@ -86,7 +108,7 @@ def handle_queue_callback(
         timeout_seconds = outcome.get("timeoutSeconds")
 
         # Ack or delay
-        if ticket:
+        if receipt_handle:
             if timeout_seconds is not None:
                 if extender is not None:
                     extender.finalize(
@@ -94,7 +116,7 @@ def handle_queue_callback(
                             queue_name,
                             consumer_group,
                             message_id,
-                            ticket,
+                            receipt_handle,
                             int(timeout_seconds),
                             timeout=cfg.timeout,
                         ),
@@ -104,7 +126,7 @@ def handle_queue_callback(
                         queue_name,
                         consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         int(timeout_seconds),
                         timeout=cfg.timeout,
                     )
@@ -115,7 +137,7 @@ def handle_queue_callback(
                             queue_name,
                             consumer_group,
                             message_id,
-                            ticket,
+                            receipt_handle,
                             timeout=cfg.timeout,
                         ),
                     )
@@ -124,7 +146,7 @@ def handle_queue_callback(
                         queue_name,
                         consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         timeout=cfg.timeout,
                     )
 

--- a/python/vercel-workers/src/vercel/workers/celery/transport.py
+++ b/python/vercel-workers/src/vercel/workers/celery/transport.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any, Literal
 
 from ..client import send
@@ -69,7 +70,7 @@ class TransportConfig:
                 "use_task_id_as_idempotency_key": True,
                 "token": "...",
                 "base_url": "https://vercel-queue.com",
-                "base_path": "/api/v2/messages",
+                "base_path": "/api/v3/topic",
                 "retention_seconds": 86400,
                 "deployment_id": "...",
                 "timeout": 10.0,
@@ -178,11 +179,26 @@ class Channel(virtual.Channel):
             except Exception:
                 print("[vercel publish] debug print failed")
 
+        # Compute send-time delay from eta if present.
+        delay_seconds: int | None = None
+        eta_raw = envelope.get("eta")
+        if isinstance(eta_raw, str):
+            try:
+                eta_dt = datetime.fromisoformat(eta_raw)
+                if eta_dt.tzinfo is None:
+                    eta_dt = eta_dt.replace(tzinfo=UTC)
+                delta = (eta_dt - datetime.now(UTC)).total_seconds()
+                if delta > 0:
+                    delay_seconds = int(delta)
+            except (TypeError, ValueError):
+                pass
+
         send(
             queue,
             envelope,
             idempotency_key=idempotency_key,
             retention_seconds=self._cfg.retention_seconds,
+            delay_seconds=delay_seconds,
             deployment_id=self._cfg.deployment_id,
             token=self._cfg.token,
             base_url=self._cfg.base_url,

--- a/python/vercel-workers/src/vercel/workers/celery/utils.py
+++ b/python/vercel-workers/src/vercel/workers/celery/utils.py
@@ -277,22 +277,11 @@ def _execute_envelope(celery_app: CeleryApp, payload: Any) -> ExecutionOutcome:
     task_id = cast(str, env.get("id"))
     args = env.get("args") or []
     kwargs = env.get("kwargs") or {}
-    eta_dt = _parse_iso_datetime(env.get("eta"))
     expires_dt = _parse_iso_datetime(env.get("expires"))
 
-    # Message-level scheduling:
-    # - If expires is in the past, acknowledge without executing.
-    # - If eta is in the future, ask the queue to retry later (delay visibility).
-    #
-    # We do this here (instead of at publish time) because Vercel Queues v2 is
-    # callback-driven and does not expose a dedicated "delay on send" API that
-    # Celery can target generically via Kombu.
-    now = _now_utc()
-    if expires_dt is not None and expires_dt <= now:
+    # If expires is in the past, acknowledge without executing.
+    if expires_dt is not None and expires_dt <= _now_utc():
         return {"ack": True}
-    if eta_dt is not None and eta_dt > now:
-        delay_seconds = int(max(0.0, (eta_dt - now).total_seconds()))
-        return {"timeoutSeconds": delay_seconds}
 
     task = celery_app.tasks.get(task_name)
     if task is None:

--- a/python/vercel-workers/src/vercel/workers/celery/worker.py
+++ b/python/vercel-workers/src/vercel/workers/celery/worker.py
@@ -74,7 +74,7 @@ class PollingWorker:
 
     def _process_message(self, msg: queue_callback.ReceivedMessage) -> None:
         message_id = msg["messageId"]
-        ticket = msg["ticket"]
+        receipt_handle = msg["receiptHandle"]
         payload = msg["payload"]
 
         try:
@@ -90,7 +90,7 @@ class PollingWorker:
                                 "deliveryCount": msg.get("deliveryCount"),
                                 "createdAt": msg.get("createdAt"),
                                 "contentType": msg.get("contentType"),
-                                "ticket": ticket,
+                                "receiptHandle": receipt_handle,
                                 "payload": payload,
                             },
                             indent=2,
@@ -117,7 +117,7 @@ class PollingWorker:
                     self.queue_name,
                     self.consumer_group,
                     message_id,
-                    ticket,
+                    receipt_handle,
                     int(timeout_seconds),
                 )
             else:
@@ -125,7 +125,7 @@ class PollingWorker:
                     self.queue_name,
                     self.consumer_group,
                     message_id,
-                    ticket,
+                    receipt_handle,
                 )
         except Exception:
             if self.debug:
@@ -145,7 +145,7 @@ class PollingWorker:
                         self.queue_name,
                         self.consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                     )
                 except Exception:
                     pass
@@ -157,7 +157,7 @@ class PollingWorker:
                         self.queue_name,
                         self.consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         int(self.on_error_visibility_timeout_seconds),
                     )
                 except Exception:

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -9,6 +9,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from functools import wraps
 from typing import Any, Protocol, TypedDict, overload
+from urllib.parse import quote
 from uuid import UUID, uuid4
 
 import httpx
@@ -182,7 +183,7 @@ def _get_header(environ: dict[str, Any], name: str) -> str | None:
     """
     Look up a HTTP header from the WSGI environ by its canonical name.
 
-    Example: name="Vqs-Queue-Name" -> environ["HTTP_VQS_QUEUE_NAME"].
+    Example: name="Vqs-Message-Id" -> environ["HTTP_VQS_MESSAGE_ID"].
     """
     key = "HTTP_" + name.upper().replace("-", "_")
     value = environ.get(key)
@@ -290,7 +291,9 @@ def _send_in_process(queue_name: str, payload: Any) -> SendMessageResult:
     return {"messageId": message_id}
 
 
-def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], bytes]:
+def handle_queue_callback(
+    raw_body: bytes, environ: dict[str, Any] | None = None
+) -> tuple[int, list[tuple[str, str]], bytes]:
     """
     Core callback handler used by both WSGI/ASGI wrappers.
 
@@ -306,7 +309,19 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
         visibility_timeout_seconds = int(os.environ.get("VQS_VISIBILITY_TIMEOUT", "30"))
         refresh_interval_seconds = float(os.environ.get("VQS_VISIBILITY_REFRESH_INTERVAL", "10"))
 
-        queue_name, consumer_group, message_id = callback.parse_cloudevent(raw_body)
+        is_v2beta = callback.is_v2beta_callback(environ or {})
+
+        if is_v2beta:
+            v2 = callback.parse_v2beta_callback(raw_body, environ or {})
+            queue_name = v2["queueName"]
+            consumer_group = v2["consumerGroup"]
+            message_id = v2["messageId"]
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload: Any = v2["payload"]
+        else:
+            queue_name, consumer_group, message_id = callback.parse_cloudevent(raw_body)
 
         # Fail fast if no workers match this topic/consumer.
         if not _select_subscriptions(queue_name, consumer_group):
@@ -319,12 +334,14 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
                 },
             )
 
-        payload, delivery_count, created_at, ticket = callback.receive_message_by_id(
-            queue_name,
-            consumer_group,
-            message_id,
-            visibility_timeout_seconds=visibility_timeout_seconds,
-        )
+        # for v2beta the payload is in the body, so we need to get only for v1beta cases
+        if not is_v2beta:
+            payload, delivery_count, created_at, receipt_handle = callback.receive_message_by_id(
+                queue_name,
+                consumer_group,
+                message_id,
+                visibility_timeout_seconds=visibility_timeout_seconds,
+            )
 
         metadata: MessageMetadata = {
             "messageId": message_id,
@@ -334,12 +351,12 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
             "consumer": consumer_group,
         }
 
-        if ticket:
+        if receipt_handle:
             extender = callback.VisibilityExtender(
                 queue_name,
                 consumer_group,
                 message_id,
-                ticket,
+                receipt_handle,
                 visibility_timeout_seconds=visibility_timeout_seconds,
                 refresh_interval_seconds=refresh_interval_seconds,
             )
@@ -347,7 +364,7 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
 
         # Execute subscribers and ack/delay accordingly.
         timeout_seconds = _invoke_subscriptions(payload, metadata)
-        if ticket:
+        if receipt_handle:
             if timeout_seconds is not None:
                 if extender is not None:
                     extender.finalize(
@@ -355,7 +372,7 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
                             queue_name,
                             consumer_group,
                             message_id,
-                            ticket,
+                            receipt_handle,
                             int(timeout_seconds),
                         ),
                     )
@@ -364,7 +381,7 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
                         queue_name,
                         consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         int(timeout_seconds),
                     )
             else:
@@ -374,7 +391,7 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
                             queue_name,
                             consumer_group,
                             message_id,
-                            ticket,
+                            receipt_handle,
                         ),
                     )
                 else:
@@ -382,7 +399,7 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
                         queue_name,
                         consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                     )
 
         return json_response(200, {"ok": True})
@@ -432,16 +449,17 @@ def get_queue_base_url() -> str:
 
 def get_queue_base_path() -> str:
     """
-    Return the base path for the queue API endpoints.
+    Return the base path for the v3 queue API endpoints.
 
-    Mirrors the JS client behaviour:
+    All v3 endpoints are prefixed with ``/api/v3/topic``.
+
       - VERCEL_QUEUE_BASE_PATH environment variable
-      - default to "/api/v2/messages"
+      - default to "/api/v3/topic"
     """
-    base_path = os.environ.get("VERCEL_QUEUE_BASE_PATH", "/api/v2/messages")
+    base_path = os.environ.get("VERCEL_QUEUE_BASE_PATH", "/api/v3/topic")
     if not base_path.startswith("/"):
         base_path = "/" + base_path
-    return base_path
+    return base_path.rstrip("/")
 
 
 def get_queue_token(explicit_token: str | None = None) -> str:
@@ -520,6 +538,7 @@ def send(
     *,
     idempotency_key: str | None = None,
     retention_seconds: int | None = None,
+    delay_seconds: int | None = None,
     deployment_id: str | None = None,
     token: str | None = None,
     base_url: str | None = None,
@@ -545,12 +564,13 @@ def send(
         payload: Message payload. For the default JSON content type this must be JSON-serialisable.
         idempotency_key: Optional key to deduplicate submissions (``Vqs-Idempotency-Key`` header).
         retention_seconds: Optional message retention time in seconds (``Vqs-Retention-Seconds``).
+        delay_seconds: Optional delay before the message becomes visible (``Vqs-Delay-Seconds``).
         deployment_id: Optional deployment identifier (``Vqs-Deployment-Id``).
         token: Authentication token. If omitted, falls back to ``VERCEL_QUEUE_TOKEN`` env var.
         base_url: Override base URL for the queue API. Defaults to ``VERCEL_QUEUE_BASE_URL`` or
             ``https://vercel-queue.com``.
-        base_path: Override base path for the messages endpoint. Defaults to
-            ``VERCEL_QUEUE_BASE_PATH`` or ``/api/v2/messages``.
+        base_path: Override base path for the v3 API. Defaults to ``VERCEL_QUEUE_BASE_PATH`` or
+            ``/api/v3/topic``.
         content_type: MIME type of the payload. Defaults to ``application/json``.
         timeout: Optional request timeout in seconds.
         headers: Additional headers to include in all requests.
@@ -574,7 +594,6 @@ def send(
         "Authorization": f"Bearer {auth_token}",
         "Content-Type": content_type,
     } | (headers or {})
-    headers["Vqs-Queue-Name"] = queue_name
 
     deployment_id = deployment_id or os.environ.get("VERCEL_DEPLOYMENT_ID")
     if deployment_id:
@@ -585,6 +604,9 @@ def send(
 
     if retention_seconds is not None:
         headers["Vqs-Retention-Seconds"] = str(retention_seconds)
+
+    if delay_seconds is not None:
+        headers["Vqs-Delay-Seconds"] = str(delay_seconds)
 
     # Basic payload handling: default to JSON, but allow callers to provide their own
     # serialisation if they change the content type.
@@ -598,7 +620,7 @@ def send(
             "for structured data use the default JSON content type.",
         )
 
-    url = f"{resolved_base_url}{resolved_base_path}"
+    url = f"{resolved_base_url}{resolved_base_path}/{quote(queue_name, safe='')}"
 
     with httpx.Client(timeout=timeout) as client:
         response = client.post(url, content=body, headers=headers)
@@ -616,14 +638,19 @@ def send(
         msg = response.text or f"Server error: {response.status_code} {response.reason_phrase}"
         raise InternalServerError(msg)
 
-    try:
-        response.raise_for_status()
-    except httpx.HTTPStatusError as exc:  # pragma: no cover - defensive
-        raise RuntimeError(
-            f"Failed to send message: {exc.response.status_code} {exc.response.reason_phrase}",
-        ) from exc
+    if response.status_code not in {201, 202}:
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - defensive
+            raise RuntimeError(
+                f"Failed to send message: {exc.response.status_code} {exc.response.reason_phrase}",
+            ) from exc
 
     data = response.json()
+
+    if response.status_code == 202:
+        raise RuntimeError("message deferred: the message was stored but delivery is delayed")
+
     if not isinstance(data, dict) or "messageId" not in data:
         raise RuntimeError("Queue API returned an unexpected response: missing 'messageId'")
 
@@ -636,6 +663,7 @@ async def send_async(
     *,
     idempotency_key: str | None = None,
     retention_seconds: int | None = None,
+    delay_seconds: int | None = None,
     deployment_id: str | None = None,
     token: str | None = None,
     base_url: str | None = None,
@@ -654,12 +682,13 @@ async def send_async(
         payload: Message payload. For the default JSON content type this must be JSON-serialisable.
         idempotency_key: Optional key to deduplicate submissions (``Vqs-Idempotency-Key`` header).
         retention_seconds: Optional message retention time in seconds (``Vqs-Retention-Seconds``).
+        delay_seconds: Optional delay before the message becomes visible (``Vqs-Delay-Seconds``).
         deployment_id: Optional deployment identifier (``Vqs-Deployment-Id``).
         token: Authentication token. If omitted, falls back to ``VERCEL_QUEUE_TOKEN`` env var.
         base_url: Override base URL for the queue API. Defaults to ``VERCEL_QUEUE_BASE_URL`` or
             ``https://vercel-queue.com``.
-        base_path: Override base path for the messages endpoint. Defaults to
-            ``VERCEL_QUEUE_BASE_PATH`` or ``/api/v2/messages``.
+        base_path: Override base path for the v3 API. Defaults to ``VERCEL_QUEUE_BASE_PATH`` or
+            ``/api/v3/topic``.
         content_type: MIME type of the payload. Defaults to ``application/json``.
         timeout: Optional request timeout in seconds.
         headers: Additional headers to include in all requests.
@@ -676,7 +705,6 @@ async def send_async(
         "Authorization": f"Bearer {auth_token}",
         "Content-Type": content_type,
     } | (headers or {})
-    headers["Vqs-Queue-Name"] = queue_name
 
     deployment_id = deployment_id or os.environ.get("VERCEL_DEPLOYMENT_ID")
     if deployment_id:
@@ -687,6 +715,9 @@ async def send_async(
 
     if retention_seconds is not None:
         headers["Vqs-Retention-Seconds"] = str(retention_seconds)
+
+    if delay_seconds is not None:
+        headers["Vqs-Delay-Seconds"] = str(delay_seconds)
 
     # Basic payload handling: default to JSON, but allow callers to provide their own
     # serialisation if they change the content type.
@@ -700,7 +731,7 @@ async def send_async(
             "for structured data use the default JSON content type.",
         )
 
-    url = f"{resolved_base_url}{resolved_base_path}"
+    url = f"{resolved_base_url}{resolved_base_path}/{quote(queue_name, safe='')}"
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         response = await client.post(url, content=body, headers=headers)
@@ -718,14 +749,19 @@ async def send_async(
         msg = response.text or f"Server error: {response.status_code} {response.reason_phrase}"
         raise InternalServerError(msg)
 
-    try:
-        response.raise_for_status()
-    except httpx.HTTPStatusError as exc:  # pragma: no cover - defensive
-        raise RuntimeError(
-            f"Failed to send message: {exc.response.status_code} {exc.response.reason_phrase}",
-        ) from exc
+    if response.status_code not in {201, 202}:
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - defensive
+            raise RuntimeError(
+                f"Failed to send message: {exc.response.status_code} {exc.response.reason_phrase}",
+            ) from exc
 
     data = response.json()
+
+    if response.status_code == 202:
+        raise RuntimeError("message deferred: the message was stored but delivery is delayed")
+
     if not isinstance(data, dict) or "messageId" not in data:
         raise RuntimeError("Queue API returned an unexpected response: missing 'messageId'")
 

--- a/python/vercel-workers/src/vercel/workers/django/app.py
+++ b/python/vercel-workers/src/vercel/workers/django/app.py
@@ -4,7 +4,6 @@ import json
 import math
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
 from traceback import format_exception
 from typing import Any, cast
 
@@ -15,7 +14,6 @@ try:
         TaskResultStatus,
     )
     from django.tasks.signals import task_finished, task_started  # type: ignore[import-untyped]
-    from django.utils import timezone as dj_timezone  # type: ignore[import-untyped]
 except Exception as e:  # pragma: no cover
     raise RuntimeError(
         "django is required to use vercel.workers.django. "
@@ -26,7 +24,7 @@ from .. import callback as queue_callback
 from ..asgi import build_asgi_app
 from ..exceptions import VQSError
 from ..wsgi import build_wsgi_app, status_reason
-from .backend import DjangoTaskEnvelope, VercelQueuesBackend, _parse_iso_datetime
+from .backend import DjangoTaskEnvelope, VercelQueuesBackend
 
 ASGI = Callable[
     [
@@ -44,13 +42,6 @@ __all__ = [
     "get_asgi_app",
     "handle_queue_callback",
 ]
-
-
-def _now_utc() -> datetime:
-    try:
-        return dj_timezone.now()
-    except Exception:
-        return datetime.now(UTC)
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,13 +96,17 @@ def get_wsgi_app(*, backend_alias: str = "default") -> WSGI:
     Usage: configure a Vercel Queue trigger to POST CloudEvents to this route.
     """
     backend = _resolve_backend(backend_alias)
-    return build_wsgi_app(lambda raw_body: handle_queue_callback(backend, raw_body))
+    return build_wsgi_app(
+        lambda raw_body, environ: handle_queue_callback(backend, raw_body, environ)
+    )
 
 
 def get_asgi_app(*, backend_alias: str = "default") -> ASGI:
     """ASGI variant of get_wsgi_app()."""
     backend = _resolve_backend(backend_alias)
-    return build_asgi_app(lambda raw_body: handle_queue_callback(backend, raw_body))
+    return build_asgi_app(
+        lambda raw_body, environ: handle_queue_callback(backend, raw_body, environ)
+    )
 
 
 def _resolve_backend(alias: str) -> VercelQueuesBackend:
@@ -155,6 +150,7 @@ def _parse_envelope(payload: Any) -> DjangoTaskEnvelope:
 def handle_queue_callback(
     backend: VercelQueuesBackend,
     raw_body: bytes,
+    environ: dict[str, Any] | None = None,
 ) -> tuple[int, list[tuple[str, str]], bytes]:
     """
     Core callback handler shared by WSGI/ASGI wrappers.
@@ -167,7 +163,19 @@ def handle_queue_callback(
     )
 
     try:
-        queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
+        is_v2beta = queue_callback.is_v2beta_callback(environ or {})
+
+        if is_v2beta:
+            v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
+            queue_name = v2["queueName"]
+            consumer_group = v2["consumerGroup"]
+            message_id = v2["messageId"]
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload: Any = v2["payload"]
+        else:
+            queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
 
         # Fail fast on unexpected queues to avoid executing arbitrary payloads.
         if backend.queues and queue_name not in backend.queues:
@@ -180,21 +188,28 @@ def handle_queue_callback(
                 body,
             )
 
-        payload, delivery_count, created_at, ticket = queue_callback.receive_message_by_id(
-            queue_name,
-            consumer_group,
-            message_id,
-            visibility_timeout_seconds=cfg.visibility_timeout_seconds,
-            timeout=cfg.timeout,
-        )
+        # for v2beta the payload is in the body, so we need to get only for v1beta cases
+        if not is_v2beta:
+            (
+                payload,
+                delivery_count,
+                created_at,
+                receipt_handle,
+            ) = queue_callback.receive_message_by_id(
+                queue_name,
+                consumer_group,
+                message_id,
+                visibility_timeout_seconds=cfg.visibility_timeout_seconds,
+                timeout=cfg.timeout,
+            )
 
         # Keep the message locked while executing.
-        if ticket:
+        if receipt_handle:
             extender = queue_callback.VisibilityExtender(
                 queue_name,
                 consumer_group,
                 message_id,
-                ticket,
+                receipt_handle,
                 visibility_timeout_seconds=cfg.visibility_timeout_seconds,
                 refresh_interval_seconds=cfg.visibility_refresh_interval_seconds,
                 timeout=cfg.timeout,
@@ -205,46 +220,6 @@ def handle_queue_callback(
         task_info: dict[str, Any] = cast(dict[str, Any], env.get("task") or {})
         module_path = str(task_info.get("module_path") or "")
         takes_context = bool(task_info.get("takes_context", False))
-        run_after_raw = task_info.get("run_after")
-        run_after = _parse_iso_datetime(run_after_raw) if isinstance(run_after_raw, str) else None
-
-        # Support `run_after` by delaying the message when it becomes visible too early.
-        if run_after is not None:
-            now = _now_utc()
-            if run_after > now:
-                delay_seconds = int(max(0.0, (run_after - now).total_seconds()))
-                if ticket:
-                    _finalize_visibility(
-                        extender,
-                        lambda: queue_callback.change_visibility(
-                            queue_name,
-                            consumer_group,
-                            message_id,
-                            ticket,
-                            delay_seconds,
-                            timeout=cfg.timeout,
-                        ),
-                    )
-                body = json.dumps(
-                    {
-                        "ok": True,
-                        "delayed": True,
-                        "timeoutSeconds": delay_seconds,
-                        "queue": queue_name,
-                        "consumer": consumer_group,
-                        "messageId": message_id,
-                        "deliveryCount": delivery_count,
-                        "createdAt": created_at,
-                    }
-                ).encode("utf-8")
-                return (
-                    200,
-                    [
-                        ("Content-Type", "application/json"),
-                        ("Content-Length", str(len(body))),
-                    ],
-                    body,
-                )
 
         # Load or create TaskResult record.
         task_result = backend._load_or_init_result_from_envelope(
@@ -300,14 +275,14 @@ def handle_queue_callback(
                 # Don't set finished_at for non-terminal failures.
                 object.__setattr__(task_result, "finished_at", None)
                 backend._store_result(task_result)
-                if ticket:
+                if receipt_handle:
                     _finalize_visibility(
                         extender,
                         lambda: queue_callback.change_visibility(
                             queue_name,
                             consumer_group,
                             message_id,
-                            ticket,
+                            receipt_handle,
                             int(delay_seconds),
                             timeout=cfg.timeout,
                         ),
@@ -334,14 +309,14 @@ def handle_queue_callback(
             # Terminal failure: mark FAILED and ack (delete).
             backend._mark_failed(task_result, exc)
             task_finished.send(sender=type(backend), task_result=task_result)
-            if ticket:
+            if receipt_handle:
                 _finalize_visibility(
                     extender,
                     lambda: queue_callback.delete_message(
                         queue_name,
                         consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         timeout=cfg.timeout,
                     ),
                 )
@@ -366,14 +341,14 @@ def handle_queue_callback(
         backend._mark_finished_success(task_result, raw_return_value)
         task_finished.send(sender=type(backend), task_result=task_result)
 
-        if ticket:
+        if receipt_handle:
             _finalize_visibility(
                 extender,
                 lambda: queue_callback.delete_message(
                     queue_name,
                     consumer_group,
                     message_id,
-                    ticket,
+                    receipt_handle,
                     timeout=cfg.timeout,
                 ),
             )

--- a/python/vercel-workers/src/vercel/workers/django/worker.py
+++ b/python/vercel-workers/src/vercel/workers/django/worker.py
@@ -4,7 +4,6 @@ import json
 import math
 import time
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
 from traceback import format_exception
 from typing import TYPE_CHECKING, Any, cast
 
@@ -21,7 +20,6 @@ try:
         TaskResultStatus,
     )
     from django.tasks.signals import task_finished, task_started  # type: ignore[import-untyped]
-    from django.utils import timezone as dj_timezone  # type: ignore[import-untyped]
 except Exception as e:
     raise RuntimeError(
         "django is required to use vercel.workers.django.worker. "
@@ -30,30 +28,6 @@ except Exception as e:
 
 
 __all__ = ["PollingWorker", "PollingWorkerConfig"]
-
-
-def _now_utc() -> datetime:
-    try:
-        return dj_timezone.now()
-    except Exception:
-        return datetime.now(UTC)
-
-
-def _parse_iso_datetime(value: str | None) -> datetime | None:
-    if not value or not isinstance(value, str):
-        return None
-    s = value.strip()
-    if not s:
-        return None
-    if s.endswith("Z"):
-        s = s[:-1] + "+00:00"
-    try:
-        dt = datetime.fromisoformat(s)
-    except Exception:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=UTC)
-    return dt
 
 
 @dataclass(frozen=True, slots=True)
@@ -231,7 +205,7 @@ class PollingWorker:
 
     def _process_message(self, msg: queue_callback.ReceivedMessage) -> None:
         message_id = msg["messageId"]
-        ticket = msg["ticket"]
+        receipt_handle = msg["receiptHandle"]
         payload = msg["payload"]
 
         try:
@@ -240,30 +214,6 @@ class PollingWorker:
 
             env = self._parse_envelope(payload)
             task_info: dict[str, Any] = env.get("task") or {}
-            run_after_raw = task_info.get("run_after")
-            run_after = (
-                _parse_iso_datetime(run_after_raw) if isinstance(run_after_raw, str) else None
-            )
-
-            # Handle run_after delay.
-            if run_after is not None:
-                now = _now_utc()
-                if run_after > now:
-                    delay_seconds = int(max(0.0, (run_after - now).total_seconds()))
-                    queue_callback.change_visibility(
-                        self.cfg.queue_name,
-                        self.cfg.consumer_group,
-                        message_id,
-                        ticket,
-                        delay_seconds,
-                        timeout=self.cfg.timeout,
-                    )
-                    if self.cfg.debug:
-                        print(
-                            f"[django-tasks polling] delaying message {message_id} "
-                            f"for {delay_seconds}s (run_after)"
-                        )
-                    return
 
             # Load or init TaskResult.
             task_result = self.backend._load_or_init_result_from_envelope(
@@ -308,7 +258,7 @@ class PollingWorker:
                     task_result=task_result,
                     exc=exc,
                     message_id=message_id,
-                    ticket=ticket,
+                    receipt_handle=receipt_handle,
                 )
                 return
 
@@ -320,7 +270,7 @@ class PollingWorker:
                 self.cfg.queue_name,
                 self.cfg.consumer_group,
                 message_id,
-                ticket,
+                receipt_handle,
                 timeout=self.cfg.timeout,
             )
 
@@ -348,7 +298,7 @@ class PollingWorker:
                         self.cfg.queue_name,
                         self.cfg.consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         timeout=self.cfg.timeout,
                     )
                 except Exception:
@@ -361,7 +311,7 @@ class PollingWorker:
                         self.cfg.queue_name,
                         self.cfg.consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         int(self.cfg.on_error_visibility_timeout_seconds),
                         timeout=self.cfg.timeout,
                     )
@@ -377,7 +327,7 @@ class PollingWorker:
         task_result: Any,  # TaskResult
         exc: BaseException,
         message_id: str,
-        ticket: str,
+        receipt_handle: str,
     ) -> None:
         """Handle task execution error with retry logic."""
         # Record the error.
@@ -401,7 +351,7 @@ class PollingWorker:
                 self.cfg.queue_name,
                 self.cfg.consumer_group,
                 message_id,
-                ticket,
+                receipt_handle,
                 int(delay_seconds),
                 timeout=self.cfg.timeout,
             )
@@ -421,7 +371,7 @@ class PollingWorker:
                 self.cfg.queue_name,
                 self.cfg.consumer_group,
                 message_id,
-                ticket,
+                receipt_handle,
                 timeout=self.cfg.timeout,
             )
 
@@ -453,7 +403,7 @@ class PollingWorker:
                         "deliveryCount": msg.get("deliveryCount"),
                         "createdAt": msg.get("createdAt"),
                         "contentType": msg.get("contentType"),
-                        "ticket": msg["ticket"],
+                        "receiptHandle": msg["receiptHandle"],
                     },
                     indent=2,
                     default=str,

--- a/python/vercel-workers/src/vercel/workers/dramatiq/app.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/app.py
@@ -14,7 +14,6 @@ from .broker import VercelQueuesBroker, _envelope_to_message
 
 try:
     import dramatiq
-    from dramatiq.common import current_millis
     from dramatiq.message import Message
 except Exception as e:
     raise RuntimeError(
@@ -93,12 +92,16 @@ def get_wsgi_app(broker: VercelQueuesBroker) -> WSGI:
 
         app = get_wsgi_app(broker)
     """
-    return build_wsgi_app(lambda raw_body: handle_queue_callback(broker, raw_body))
+    return build_wsgi_app(
+        lambda raw_body, environ: handle_queue_callback(broker, raw_body, environ)
+    )
 
 
 def get_asgi_app(broker: VercelQueuesBroker) -> ASGI:
     """ASGI variant of get_wsgi_app()."""
-    return build_asgi_app(lambda raw_body: handle_queue_callback(broker, raw_body))
+    return build_asgi_app(
+        lambda raw_body, environ: handle_queue_callback(broker, raw_body, environ)
+    )
 
 
 def _retry_delay_ms(cfg: DramatiqWorkerConfig, attempt: int) -> int:
@@ -147,6 +150,7 @@ def _execute_message(broker: VercelQueuesBroker, message: Message) -> dict[str, 
 def handle_queue_callback(
     broker: VercelQueuesBroker,
     raw_body: bytes,
+    environ: dict[str, Any] | None = None,
 ) -> tuple[int, list[tuple[str, str]], bytes]:
     """
     Core callback handler shared by WSGI/ASGI wrappers.
@@ -157,23 +161,40 @@ def handle_queue_callback(
     cfg = DramatiqWorkerConfig.from_broker_options(broker)
 
     try:
-        queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
+        is_v2beta = queue_callback.is_v2beta_callback(environ or {})
 
-        payload, delivery_count, created_at, ticket = queue_callback.receive_message_by_id(
-            queue_name,
-            consumer_group,
-            message_id,
-            visibility_timeout_seconds=cfg.visibility_timeout_seconds,
-            timeout=cfg.timeout,
-        )
+        if is_v2beta:
+            v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
+            queue_name = v2["queueName"]
+            consumer_group = v2["consumerGroup"]
+            message_id = v2["messageId"]
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload: Any = v2["payload"]
+        else:
+            queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
+
+            (
+                payload,
+                delivery_count,
+                created_at,
+                receipt_handle,
+            ) = queue_callback.receive_message_by_id(
+                queue_name,
+                consumer_group,
+                message_id,
+                visibility_timeout_seconds=cfg.visibility_timeout_seconds,
+                timeout=cfg.timeout,
+            )
 
         # Keep the message locked while executing.
-        if ticket:
+        if receipt_handle:
             extender = queue_callback.VisibilityExtender(
                 queue_name,
                 consumer_group,
                 message_id,
-                ticket,
+                receipt_handle,
                 visibility_timeout_seconds=cfg.visibility_timeout_seconds,
                 refresh_interval_seconds=cfg.visibility_refresh_interval_seconds,
                 timeout=cfg.timeout,
@@ -183,59 +204,20 @@ def handle_queue_callback(
         # Parse the envelope and convert to Dramatiq message
         dramatiq_message = _envelope_to_message(payload)
 
-        # Handle eta (delayed messages)
-        eta = dramatiq_message.options.get("eta")
-        if eta is not None:
-            now = current_millis()
-            if eta > now:
-                delay_seconds = int((eta - now) / 1000)
-                if ticket:
-                    _finalize_visibility(
-                        extender,
-                        lambda: queue_callback.change_visibility(
-                            queue_name,
-                            consumer_group,
-                            message_id,
-                            ticket,
-                            delay_seconds,
-                            timeout=cfg.timeout,
-                        ),
-                    )
-                body = json.dumps(
-                    {
-                        "ok": True,
-                        "delayed": True,
-                        "timeoutSeconds": delay_seconds,
-                        "queue": queue_name,
-                        "consumer": consumer_group,
-                        "messageId": message_id,
-                        "deliveryCount": delivery_count,
-                        "createdAt": created_at,
-                    }
-                ).encode("utf-8")
-                return (
-                    200,
-                    [
-                        ("Content-Type", "application/json"),
-                        ("Content-Length", str(len(body))),
-                    ],
-                    body,
-                )
-
         try:
             # Execute the task
             outcome = _execute_message(broker, dramatiq_message)
             timeout_seconds = outcome.get("timeoutSeconds")
 
             if timeout_seconds is not None:
-                if ticket:
+                if receipt_handle:
                     _finalize_visibility(
                         extender,
                         lambda: queue_callback.change_visibility(
                             queue_name,
                             consumer_group,
                             message_id,
-                            ticket,
+                            receipt_handle,
                             int(timeout_seconds),
                             timeout=cfg.timeout,
                         ),
@@ -259,14 +241,14 @@ def handle_queue_callback(
                 )
 
             # Success: ack (delete) the message
-            if ticket:
+            if receipt_handle:
                 _finalize_visibility(
                     extender,
                     lambda: queue_callback.delete_message(
                         queue_name,
                         consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         timeout=cfg.timeout,
                     ),
                 )
@@ -297,14 +279,14 @@ def handle_queue_callback(
                 delay_ms = _retry_delay_ms(cfg, attempt)
                 delay_seconds = int(delay_ms / 1000)
 
-                if ticket:
+                if receipt_handle:
                     _finalize_visibility(
                         extender,
                         lambda: queue_callback.change_visibility(
                             queue_name,
                             consumer_group,
                             message_id,
-                            ticket,
+                            receipt_handle,
                             int(delay_seconds),
                             timeout=cfg.timeout,
                         ),
@@ -331,14 +313,14 @@ def handle_queue_callback(
                 )
 
             # Terminal failure: ack (delete) to prevent infinite retries
-            if ticket:
+            if receipt_handle:
                 _finalize_visibility(
                     extender,
                     lambda: queue_callback.delete_message(
                         queue_name,
                         consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         timeout=cfg.timeout,
                     ),
                 )

--- a/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
@@ -310,11 +310,15 @@ class VercelQueuesBroker(Broker):
             except Exception:
                 print("[vercelqueue dramatiq publish] debug print failed")
 
+        # Convert delay (milliseconds) to seconds for the v3 API.
+        delay_seconds = int(delay / 1000) if delay is not None and delay > 0 else None
+
         send(
             queue_name,
             envelope,
             idempotency_key=idempotency_key,
             retention_seconds=self._cfg.retention_seconds,
+            delay_seconds=delay_seconds,
             deployment_id=self._cfg.deployment_id,
             token=self._cfg.token,
             base_url=self._cfg.base_url,

--- a/python/vercel-workers/src/vercel/workers/dramatiq/worker.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/worker.py
@@ -106,7 +106,7 @@ class PollingWorker:
 
     def _process_message(self, msg: queue_callback.ReceivedMessage) -> None:
         message_id = msg["messageId"]
-        ticket = msg["ticket"]
+        receipt_handle = msg["receiptHandle"]
         payload = msg["payload"]
 
         try:
@@ -115,29 +115,6 @@ class PollingWorker:
 
             # Parse the envelope and convert to Dramatiq message
             dramatiq_message = _envelope_to_message(payload)
-
-            # Handle eta (delayed messages)
-            eta = dramatiq_message.options.get("eta")
-            if eta is not None:
-                from dramatiq.common import current_millis
-
-                now = current_millis()
-                if eta > now:
-                    delay_seconds = int((eta - now) / 1000)
-                    queue_callback.change_visibility(
-                        self.queue_name,
-                        self.consumer_group,
-                        message_id,
-                        ticket,
-                        delay_seconds,
-                        timeout=self.timeout,
-                    )
-                    if self.debug:
-                        print(
-                            f"[dramatiq polling] delaying message {message_id} "
-                            f"for {delay_seconds}s (eta)"
-                        )
-                    return
 
             # Execute the task
             outcome = self._execute_message(dramatiq_message)
@@ -148,7 +125,7 @@ class PollingWorker:
                     self.queue_name,
                     self.consumer_group,
                     message_id,
-                    ticket,
+                    receipt_handle,
                     int(timeout_seconds),
                     timeout=self.timeout,
                 )
@@ -157,7 +134,7 @@ class PollingWorker:
                     self.queue_name,
                     self.consumer_group,
                     message_id,
-                    ticket,
+                    receipt_handle,
                     timeout=self.timeout,
                 )
 
@@ -185,7 +162,7 @@ class PollingWorker:
                         self.queue_name,
                         self.consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         timeout=self.timeout,
                     )
                 except Exception:
@@ -198,7 +175,7 @@ class PollingWorker:
                         self.queue_name,
                         self.consumer_group,
                         message_id,
-                        ticket,
+                        receipt_handle,
                         int(self.on_error_visibility_timeout_seconds),
                         timeout=self.timeout,
                     )
@@ -243,7 +220,7 @@ class PollingWorker:
                         "deliveryCount": msg.get("deliveryCount"),
                         "createdAt": msg.get("createdAt"),
                         "contentType": msg.get("contentType"),
-                        "ticket": msg["ticket"],
+                        "receiptHandle": msg["receiptHandle"],
                     },
                     indent=2,
                     default=str,

--- a/python/vercel-workers/src/vercel/workers/wsgi.py
+++ b/python/vercel-workers/src/vercel/workers/wsgi.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any
 
 WSGI = Callable[[dict[str, Any], Callable[..., Any]], list[bytes]]
-Handler = Callable[[bytes], tuple[int, list[tuple[str, str]], bytes]]
+Handler = Callable[[bytes, dict[str, Any]], tuple[int, list[tuple[str, str]], bytes]]
 
 
 _STATUS_REASONS: dict[int, str] = {
@@ -65,10 +65,11 @@ def build_wsgi_app(handler: Handler) -> WSGI:
         # Queue callback
         if method == "POST":
             content_type = str(environ.get("CONTENT_TYPE") or "")
-            if "application/cloudevents+json" not in content_type:
-                err = (
-                    b'{"error":"Invalid content type: expected \\"application/cloudevents+json\\""}'
-                )
+            ce_type = environ.get("HTTP_CE_TYPE", "")
+            is_v1beta = "application/cloudevents+json" in content_type
+            is_v2beta = ce_type == "com.vercel.queue.v2beta"
+            if not is_v1beta and not is_v2beta:
+                err = b'{"error":"unsupported callback format"}'
                 start_response(
                     "400 Bad Request",
                     [
@@ -79,7 +80,7 @@ def build_wsgi_app(handler: Handler) -> WSGI:
                 return [err]
 
             raw_body = _read_body(environ)
-            status_code, headers, body = handler(raw_body)
+            status_code, headers, body = handler(raw_body, environ)
             start_response(f"{int(status_code)} {status_reason(int(status_code))}", headers)
             return [body]
 

--- a/python/vercel-workers/tests/test_celery_adapter.py
+++ b/python/vercel-workers/tests/test_celery_adapter.py
@@ -142,11 +142,11 @@ class TestCeleryAdapter(unittest.TestCase):
         )
         self.assertEqual(sent[0]["type"], "http.response.start")
         self.assertEqual(sent[0]["status"], 400)
-        self.assertIn(b"Invalid content type", sent[1]["body"])
+        self.assertIn(b"unsupported callback format", sent[1]["body"])
 
     def test_get_asgi_app_post_callback_executes_task_and_deletes_message(self) -> None:
         raw_body = (
-            b'{"type":"com.vercel.queue.v1beta","data":'
+            b'{"type":"com.vercel.queue.v2beta","data":'
             b'{"queueName":"q","consumerGroup":"c","messageId":"m"}}'
         )
 
@@ -197,7 +197,7 @@ class TestCeleryAdapter(unittest.TestCase):
             with patch.object(
                 vwc_app.queue_callback,
                 "receive_message_by_id",
-                return_value=(payload, 1, "t", "ticket"),
+                return_value=(payload, 1, "t", "receipt-handle"),
             ):
                 with patch.object(
                     vwc_app.queue_callback,
@@ -233,9 +233,10 @@ class TestCeleryAdapter(unittest.TestCase):
         self.assertTrue(body["ok"])
         self.assertFalse(body["delayed"])
 
-    def test_get_asgi_app_post_callback_delays_until_eta_by_changing_visibility(self) -> None:
+    def test_get_asgi_app_post_callback_executes_task_with_eta_normally(self) -> None:
+        """Eta is handled at send time now, so receive side just executes the task."""
         raw_body = (
-            b'{"type":"com.vercel.queue.v1beta","data":'
+            b'{"type":"com.vercel.queue.v2beta","data":'
             b'{"queueName":"q","consumerGroup":"c","messageId":"m"}}'
         )
         fixed_now = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -257,10 +258,10 @@ class TestCeleryAdapter(unittest.TestCase):
 
         class DummyTask:
             def __init__(self):
-                self.calls = []
+                self.calls: list[tuple[list[Any], dict[str, Any], str, bool]] = []
 
             def apply(self, *, args, kwargs, task_id, throw):
-                self.calls.append((args, kwargs, task_id, throw))
+                self.calls.append((list(args), dict(kwargs), str(task_id), bool(throw)))
 
         task = DummyTask()
 
@@ -280,50 +281,48 @@ class TestCeleryAdapter(unittest.TestCase):
             "eta": eta.isoformat().replace("+00:00", "Z"),
         }
 
-        with patch.object(vwc_utils, "_now_utc", return_value=fixed_now):
+        with patch.object(
+            vwc_app.queue_callback,
+            "parse_cloudevent",
+            return_value=("q", "c", "m"),
+        ):
             with patch.object(
                 vwc_app.queue_callback,
-                "parse_cloudevent",
-                return_value=("q", "c", "m"),
+                "receive_message_by_id",
+                return_value=(payload, 1, "t", "receipt-handle"),
             ):
                 with patch.object(
                     vwc_app.queue_callback,
-                    "receive_message_by_id",
-                    return_value=(payload, 1, "t", "ticket"),
+                    "VisibilityExtender",
+                    FakeVisibilityExtender,
                 ):
                     with patch.object(
                         vwc_app.queue_callback,
-                        "VisibilityExtender",
-                        FakeVisibilityExtender,
-                    ):
+                        "delete_message",
+                    ) as delete_message:
                         with patch.object(
                             vwc_app.queue_callback,
                             "change_visibility",
                         ) as change_visibility:
-                            with patch.object(
-                                vwc_app.queue_callback,
-                                "delete_message",
-                            ) as delete_message:
-                                sent = asyncio.run(
-                                    self._asgi_request(
-                                        vwc.get_asgi_app(cast(Any, DummyCelery())),
-                                        method="POST",
-                                        path="/anything",
-                                        headers=[
-                                            (b"content-type", b"application/cloudevents+json"),
-                                        ],
-                                        body=raw_body,
-                                    ),
-                                )
+                            sent = asyncio.run(
+                                self._asgi_request(
+                                    vwc.get_asgi_app(cast(Any, DummyCelery())),
+                                    method="POST",
+                                    path="/anything",
+                                    headers=[
+                                        (b"content-type", b"application/cloudevents+json"),
+                                    ],
+                                    body=raw_body,
+                                ),
+                            )
 
-        self.assertEqual(task.calls, [])  # eta scheduling should not execute the task
-        change_visibility.assert_called()
-        delete_message.assert_not_called()
+        # Task should be executed normally despite having an eta
+        self.assertEqual(task.calls, [([1, 2], {}, "task-eta", True)])
+        delete_message.assert_called_once()
+        change_visibility.assert_not_called()
 
         body = json.loads(sent[1]["body"].decode("utf-8"))
         self.assertTrue(body["ok"])
-        self.assertTrue(body["delayed"])
-        self.assertEqual(body["timeoutSeconds"], 123)
 
 
 if __name__ == "__main__":

--- a/python/vercel-workers/tests/test_client_and_callback.py
+++ b/python/vercel-workers/tests/test_client_and_callback.py
@@ -15,8 +15,8 @@ from vercel.workers.exceptions import TokenResolutionError
 
 
 class _FakeResponse:
-    status_code = 200
-    reason_phrase = "OK"
+    status_code = 201
+    reason_phrase = "Created"
     text = ""
 
     def raise_for_status(self) -> None:
@@ -45,10 +45,11 @@ class _FakeHttpxClient:
         self,
         url: str,  # noqa: ARG002
         *,
-        content: bytes,
-        headers: dict,  # noqa: ARG002  # pyright: ignore[reportMissingTypeArgument]
+        content: bytes | None = None,
+        headers: dict | None = None,  # noqa: ARG002  # pyright: ignore[reportMissingTypeArgument]
     ) -> _FakeResponse:
-        _FakeHttpxClient.captured_bodies.append(content)
+        if content is not None:
+            _FakeHttpxClient.captured_bodies.append(content)
         return self.response
 
 
@@ -62,7 +63,7 @@ class TestCallbackAndClientEdgeCases(unittest.TestCase):
             with patch.object(
                 queue_callback._client,
                 "get_queue_base_path",
-                return_value="/api/v2/messages",
+                return_value="/api/v3/topic",
             ):
                 with patch.object(
                     queue_callback._client,
@@ -78,12 +79,12 @@ class TestCallbackAndClientEdgeCases(unittest.TestCase):
                                     "Content-Type": "text/plain",
                                     "Vqs-Delivery-Count": "2",
                                     "Vqs-Timestamp": "2025-01-01T00:00:00Z",
-                                    "Vqs-Ticket": "ticket-123",
+                                    "Vqs-Receipt-Handle": "ticket-123",
                                 },
                                 b"not-json",
                             ),
                         ):
-                            payload, delivery_count, created_at, ticket = (
+                            payload, delivery_count, created_at, receipt_handle = (
                                 queue_callback.receive_message_by_id(
                                     "q",
                                     "c",
@@ -94,7 +95,7 @@ class TestCallbackAndClientEdgeCases(unittest.TestCase):
         self.assertEqual(payload, b"not-json")
         self.assertEqual(delivery_count, 2)
         self.assertEqual(created_at, "2025-01-01T00:00:00Z")
-        self.assertEqual(ticket, "ticket-123")
+        self.assertEqual(receipt_handle, "ticket-123")
 
     def test_get_queue_token_error_message_is_string(self) -> None:
         with patch.dict(queue_client.os.environ, {}, clear=True):

--- a/python/vercel-workers/tests/test_django_adapter.py
+++ b/python/vercel-workers/tests/test_django_adapter.py
@@ -296,12 +296,12 @@ class TestDjangoAsgiApp(unittest.TestCase):
         sent = asyncio.run(run())
         self.assertEqual(sent[0]["type"], "http.response.start")
         self.assertEqual(sent[0]["status"], 400)
-        self.assertIn(b"Invalid content type", sent[1]["body"])
+        self.assertIn(b"unsupported callback format", sent[1]["body"])
 
     def test_post_callback_executes_task_and_deletes_message(self) -> None:
         """Test that a valid callback executes the task and deletes the message."""
         raw_body = (
-            b'{"type":"com.vercel.queue.v1beta","data":'
+            b'{"type":"com.vercel.queue.v2beta","data":'
             b'{"queueName":"q","consumerGroup":"c","messageId":"m"}}'
         )
 
@@ -380,7 +380,7 @@ class TestDjangoAsgiApp(unittest.TestCase):
                     with patch.object(
                         vwd_app.queue_callback,
                         "receive_message_by_id",
-                        return_value=(payload, 1, "2025-01-01T00:00:00Z", "ticket"),
+                        return_value=(payload, 1, "2025-01-01T00:00:00Z", "receipt-handle"),
                     ):
                         with patch.object(
                             vwd_app.queue_callback,
@@ -426,33 +426,62 @@ class TestDjangoAsgiApp(unittest.TestCase):
         body = json.loads(sent[1]["body"].decode("utf-8"))
         self.assertTrue(body["ok"])
 
-    def test_post_callback_delays_until_run_after_by_changing_visibility(self) -> None:
-        """Test that run_after in the future delays the message."""
+    def test_post_callback_executes_task_with_run_after_normally(self) -> None:
+        """run_after is handled at send time now, so receive side just executes the task."""
         raw_body = (
-            b'{"type":"com.vercel.queue.v1beta","data":'
+            b'{"type":"com.vercel.queue.v2beta","data":'
             b'{"queueName":"q","consumerGroup":"c","messageId":"m"}}'
         )
         fixed_now = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
         run_after = fixed_now + timedelta(seconds=123)
 
         class FakeVisibilityExtender:
+            instances: list[FakeVisibilityExtender] = []
+
             def __init__(self, *args, **kwargs):
                 self.started = False
+                self.finalized = False
                 self.stopped = False
+                FakeVisibilityExtender.instances.append(self)
 
             def start(self) -> None:
                 self.started = True
 
             def finalize(self, fn) -> None:
+                self.finalized = True
                 fn()
 
             def stop(self) -> None:
                 self.stopped = True
 
+        # Track task execution
+        task_executed = []
+
+        def fake_task_func(*args, **kwargs):
+            task_executed.append((args, kwargs))
+            return "success"
+
+        mock_task = MagicMock()
+        mock_task.module_path = "myapp.tasks.my_task"
+        mock_task.takes_context = False
+        mock_task.queue_name = "q"
+        mock_task.priority = 0
+        mock_task.call = fake_task_func
+
+        mock_task_result = MagicMock()
+        mock_task_result.task = mock_task
+        mock_task_result.args = [1, 2]
+        mock_task_result.kwargs = {}
+        mock_task_result.errors = []
+        mock_task_result.worker_ids = []
+
         mock_backend = MagicMock()
         mock_backend.options = {}
         mock_backend.queues = None
         mock_backend.alias = "default"
+        mock_backend.worker_id = "worker-123"
+        mock_backend._load_or_init_result_from_envelope.return_value = mock_task_result
+        mock_backend._task_from_module_path.return_value = mock_task
 
         payload: vwd_backend.DjangoTaskEnvelope = {
             "vercel": {"kind": "django-tasks", "version": 1},
@@ -469,59 +498,59 @@ class TestDjangoAsgiApp(unittest.TestCase):
         }
 
         async def run():
-            with patch.object(vwd_app, "_now_utc", return_value=fixed_now):
-                with patch.object(vwd_app, "_resolve_backend", return_value=mock_backend):
+            FakeVisibilityExtender.instances.clear()
+
+            with patch.object(vwd_app, "_resolve_backend", return_value=mock_backend):
+                with patch.object(
+                    vwd_app.queue_callback,
+                    "parse_cloudevent",
+                    return_value=("q", "c", "m"),
+                ):
                     with patch.object(
                         vwd_app.queue_callback,
-                        "parse_cloudevent",
-                        return_value=("q", "c", "m"),
+                        "receive_message_by_id",
+                        return_value=(payload, 1, "2025-01-01T00:00:00Z", "receipt-handle"),
                     ):
                         with patch.object(
                             vwd_app.queue_callback,
-                            "receive_message_by_id",
-                            return_value=(payload, 1, "2025-01-01T00:00:00Z", "ticket"),
+                            "VisibilityExtender",
+                            FakeVisibilityExtender,
                         ):
                             with patch.object(
                                 vwd_app.queue_callback,
-                                "VisibilityExtender",
-                                FakeVisibilityExtender,
-                            ):
+                                "delete_message",
+                            ) as delete_message:
                                 with patch.object(
                                     vwd_app.queue_callback,
                                     "change_visibility",
                                 ) as change_visibility:
-                                    with patch.object(
-                                        vwd_app.queue_callback,
-                                        "delete_message",
-                                    ) as delete_message:
-                                        app = vwd_app.get_asgi_app(backend_alias="default")
-                                        sent = await self._asgi_request(
-                                            app,
-                                            method="POST",
-                                            path="/callback",
-                                            headers=[
-                                                (b"content-type", b"application/cloudevents+json"),
-                                            ],
-                                            body=raw_body,
-                                        )
-                                        return sent, change_visibility, delete_message
+                                    app = vwd_app.get_asgi_app(backend_alias="default")
+                                    sent = await self._asgi_request(
+                                        app,
+                                        method="POST",
+                                        path="/callback",
+                                        headers=[
+                                            (b"content-type", b"application/cloudevents+json"),
+                                        ],
+                                        body=raw_body,
+                                    )
+                                    return sent, delete_message, change_visibility
 
-        sent, change_visibility, delete_message = asyncio.run(run())
+        sent, delete_message, change_visibility = asyncio.run(run())
 
-        # Task should NOT have been executed (delayed)
-        # Visibility should have been changed, not deleted
-        change_visibility.assert_called()
-        delete_message.assert_not_called()
+        # Task should be executed normally despite having a run_after
+        self.assertEqual(len(task_executed), 1)
+        self.assertEqual(task_executed[0], ((1, 2), {}))
+        delete_message.assert_called_once()
+        change_visibility.assert_not_called()
 
         body = json.loads(sent[1]["body"].decode("utf-8"))
         self.assertTrue(body["ok"])
-        self.assertTrue(body["delayed"])
-        self.assertEqual(body["timeoutSeconds"], 123)
 
     def test_rejects_wrong_queue(self) -> None:
         """Test that messages from unexpected queues are rejected."""
         raw_body = (
-            b'{"type":"com.vercel.queue.v1beta","data":'
+            b'{"type":"com.vercel.queue.v2beta","data":'
             b'{"queueName":"wrong-queue","consumerGroup":"c","messageId":"m"}}'
         )
 
@@ -586,7 +615,7 @@ class TestDjangoTaskRetryBehavior(unittest.TestCase):
     def test_task_failure_retries_with_backoff(self) -> None:
         """Test that task failure triggers retry with visibility change."""
         raw_body = (
-            b'{"type":"com.vercel.queue.v1beta","data":'
+            b'{"type":"com.vercel.queue.v2beta","data":'
             b'{"queueName":"q","consumerGroup":"c","messageId":"m"}}'
         )
 
@@ -652,7 +681,7 @@ class TestDjangoTaskRetryBehavior(unittest.TestCase):
                     with patch.object(
                         vwd_app.queue_callback,
                         "receive_message_by_id",
-                        return_value=(payload, 1, "2025-01-01T00:00:00Z", "ticket"),
+                        return_value=(payload, 1, "2025-01-01T00:00:00Z", "receipt-handle"),
                     ):
                         with patch.object(
                             vwd_app.queue_callback,
@@ -721,8 +750,8 @@ class TestDjangoEnqueueSerializesNonPrimitiveTypes(unittest.TestCase):
         captured: list[bytes] = []
 
         class _FakeResponse:
-            status_code = 200
-            reason_phrase = "OK"
+            status_code = 201
+            reason_phrase = "Created"
             text = ""
 
             def raise_for_status(self) -> None:


### PR DESCRIPTION
Switches `worker` services to use `v2beta` triggers and V3 Queues API with additional changes for dev broker and `vercel-workers`