### PR TITLE
[vercel flags] allow creating override cookies

### DIFF
--- a/.changeset/thirty-shrimps-kneel.md
+++ b/.changeset/thirty-shrimps-kneel.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+[cli] Add `vercel flags override` subcommand to encrypt and decrypt flag override tokens for the `vercel-flag-overrides` cookie

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -519,6 +519,55 @@ export const prepareSubcommand = {
   examples: [],
 } as const;
 
+export const overrideSubcommand = {
+  name: 'override',
+  aliases: [],
+  description:
+    'Encrypt flag overrides into a secure token for the vercel-flag-overrides cookie',
+  arguments: [
+    {
+      name: 'flag=value',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      name: 'expiration',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Expiration time for the encrypted token (default: 1y)',
+      argument: 'TIME',
+    },
+    {
+      name: 'decrypt',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Decrypt an encrypted override token and print the JSON',
+      argument: 'TOKEN',
+    },
+  ],
+  examples: [
+    {
+      name: 'Encrypt a single flag override',
+      value: `${packageName} flags override my-flag=true`,
+    },
+    {
+      name: 'Encrypt multiple flag overrides',
+      value: `${packageName} flags override flag-a=true flag-b=hello`,
+    },
+    {
+      name: 'Set a custom expiration',
+      value: `${packageName} flags override my-flag=42 --expiration 30d`,
+    },
+    {
+      name: 'Decrypt an override token',
+      value: `${packageName} flags override --decrypt <token>`,
+    },
+  ],
+} as const;
+
 export const flagsCommand = {
   name: 'flags',
   aliases: [],
@@ -540,6 +589,7 @@ export const flagsCommand = {
     enableSubcommand,
     sdkKeysSubcommand,
     prepareSubcommand,
+    overrideSubcommand,
   ],
   options: [],
   examples: [],

--- a/packages/cli/src/commands/flags/index.ts
+++ b/packages/cli/src/commands/flags/index.ts
@@ -32,8 +32,10 @@ import {
   prepareSubcommand,
   enableSubcommand,
   sdkKeysSubcommand,
+  overrideSubcommand,
 } from './command';
 import emitDatafiles from './emit-datafiles';
+import override from './override';
 
 const COMMAND_CONFIG = {
   ls: getCommandAliases(listSubcommand),
@@ -48,6 +50,7 @@ const COMMAND_CONFIG = {
   enable: getCommandAliases(enableSubcommand),
   'sdk-keys': getCommandAliases(sdkKeysSubcommand),
   prepare: getCommandAliases(prepareSubcommand),
+  override: getCommandAliases(overrideSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -180,6 +183,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandPrepare(subcommandOriginal);
       return emitDatafiles(client);
+    case 'override':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('flags', subcommandOriginal);
+        printHelp(overrideSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandOverride(subcommandOriginal);
+      return override(client, args);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('flags', subcommandOriginal);

--- a/packages/cli/src/commands/flags/override.ts
+++ b/packages/cli/src/commands/flags/override.ts
@@ -1,10 +1,9 @@
-import { resolve } from 'node:path';
+import { loadEnvConfig } from '@next/env';
 import { base64url, EncryptJWT, jwtDecrypt } from 'jose';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { createEnvObject } from '../../util/env/diff-env-files';
 import output from '../../output-manager';
 import { overrideSubcommand } from './command';
 
@@ -58,7 +57,7 @@ async function handleEncrypt(
     overrides[key] = parseValue(rawValue);
   }
 
-  const secret = await resolveSecret(client);
+  const secret = resolveSecret(client);
   if (!secret) {
     output.error(
       'FLAGS_SECRET not found. Set it in the environment, .env.local, or .env file.'
@@ -77,7 +76,7 @@ async function handleEncrypt(
 }
 
 async function handleDecrypt(client: Client, token: string): Promise<number> {
-  const secret = await resolveSecret(client);
+  const secret = resolveSecret(client);
   if (!secret) {
     output.error(
       'FLAGS_SECRET not found. Set it in the environment, .env.local, or .env file.'
@@ -107,26 +106,9 @@ function parseValue(raw: string): unknown {
   return raw;
 }
 
-async function resolveSecret(client: Client): Promise<string | undefined> {
-  if (process.env.FLAGS_SECRET) {
-    return process.env.FLAGS_SECRET;
-  }
-
-  try {
-    const env = await createEnvObject(resolve(client.cwd, '.env.local'));
-    if (env?.FLAGS_SECRET) return env.FLAGS_SECRET;
-  } catch {
-    // file not found or unreadable — continue
-  }
-
-  try {
-    const env = await createEnvObject(resolve(client.cwd, '.env'));
-    if (env?.FLAGS_SECRET) return env.FLAGS_SECRET;
-  } catch {
-    // file not found or unreadable — continue
-  }
-
-  return undefined;
+function resolveSecret(client: Client): string | undefined {
+  const { combinedEnv } = loadEnvConfig(client.cwd, true);
+  return combinedEnv.FLAGS_SECRET;
 }
 
 async function encryptOverrides(

--- a/packages/cli/src/commands/flags/override.ts
+++ b/packages/cli/src/commands/flags/override.ts
@@ -1,0 +1,164 @@
+import { resolve } from 'node:path';
+import { base64url, EncryptJWT, jwtDecrypt } from 'jose';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { createEnvObject } from '../../util/env/diff-env-files';
+import output from '../../output-manager';
+import { overrideSubcommand } from './command';
+
+export default async function override(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(overrideSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { args, flags } = parsedArgs;
+  const decryptToken = flags['--decrypt'] as string | undefined;
+
+  if (decryptToken) {
+    return handleDecrypt(client, decryptToken);
+  }
+
+  return handleEncrypt(client, args, flags);
+}
+
+async function handleEncrypt(
+  client: Client,
+  args: string[],
+  flags: Record<string, unknown>
+): Promise<number> {
+  const expiration = (flags['--expiration'] as string | undefined) ?? '1y';
+
+  if (args.length === 0) {
+    output.error(
+      'Please provide at least one flag override as flag=value.\n' +
+        'Example: vercel flags override my-flag=true'
+    );
+    return 1;
+  }
+
+  const overrides: Record<string, unknown> = {};
+  for (const arg of args) {
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex === -1) {
+      output.error(`Invalid override format: "${arg}". Expected flag=value.`);
+      return 1;
+    }
+    const key = arg.slice(0, eqIndex);
+    const rawValue = arg.slice(eqIndex + 1);
+    overrides[key] = parseValue(rawValue);
+  }
+
+  const secret = await resolveSecret(client);
+  if (!secret) {
+    output.error(
+      'FLAGS_SECRET not found. Set it in the environment, .env.local, or .env file.'
+    );
+    return 1;
+  }
+
+  try {
+    const encrypted = await encryptOverrides(overrides, secret, expiration);
+    client.stdout.write(encrypted + '\n');
+    return 0;
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+}
+
+async function handleDecrypt(client: Client, token: string): Promise<number> {
+  const secret = await resolveSecret(client);
+  if (!secret) {
+    output.error(
+      'FLAGS_SECRET not found. Set it in the environment, .env.local, or .env file.'
+    );
+    return 1;
+  }
+
+  try {
+    const overrides = await decryptOverrides(token, secret);
+    if (overrides === undefined) {
+      output.error('Invalid token: not a valid flag overrides token.');
+      return 1;
+    }
+    client.stdout.write(JSON.stringify(overrides, null, 2) + '\n');
+    return 0;
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+}
+
+function parseValue(raw: string): unknown {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  const num = Number(raw);
+  if (!Number.isNaN(num) && raw.trim() !== '') return num;
+  return raw;
+}
+
+async function resolveSecret(client: Client): Promise<string | undefined> {
+  if (process.env.FLAGS_SECRET) {
+    return process.env.FLAGS_SECRET;
+  }
+
+  try {
+    const env = await createEnvObject(resolve(client.cwd, '.env.local'));
+    if (env?.FLAGS_SECRET) return env.FLAGS_SECRET;
+  } catch {
+    // file not found or unreadable — continue
+  }
+
+  try {
+    const env = await createEnvObject(resolve(client.cwd, '.env'));
+    if (env?.FLAGS_SECRET) return env.FLAGS_SECRET;
+  } catch {
+    // file not found or unreadable — continue
+  }
+
+  return undefined;
+}
+
+async function encryptOverrides(
+  overrides: Record<string, unknown>,
+  secret: string,
+  expirationTime: string
+): Promise<string> {
+  const encodedSecret = base64url.decode(secret);
+  if (encodedSecret.length !== 32) {
+    throw new Error(
+      'Invalid FLAGS_SECRET: must be a 256-bit base64url-encoded key (32 bytes).'
+    );
+  }
+  return new EncryptJWT({ o: overrides, pur: 'overrides' })
+    .setExpirationTime(expirationTime)
+    .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+    .encrypt(encodedSecret);
+}
+
+async function decryptOverrides(
+  encryptedData: string,
+  secret: string
+): Promise<Record<string, unknown> | undefined> {
+  const encodedSecret = base64url.decode(secret);
+  if (encodedSecret.length !== 32) {
+    throw new Error(
+      'Invalid FLAGS_SECRET: must be a 256-bit base64url-encoded key (32 bytes).'
+    );
+  }
+  const { payload } = await jwtDecrypt(encryptedData, encodedSecret);
+  if (payload.pur !== 'overrides' || !payload.o) {
+    return undefined;
+  }
+  return payload.o as Record<string, unknown>;
+}

--- a/packages/cli/src/util/telemetry/commands/flags/index.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/index.ts
@@ -88,4 +88,11 @@ export class FlagsTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandOverride(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'override',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/flags/override.test.ts
+++ b/packages/cli/test/unit/commands/flags/override.test.ts
@@ -66,7 +66,6 @@ describe('flags override', () => {
       expect(exitCode).toEqual(0);
 
       const output = client.stdout.getFullOutput().trim();
-      expect(output).toBeTruthy();
 
       // Decrypt and verify
       const secret = base64url.decode(TEST_SECRET);

--- a/packages/cli/test/unit/commands/flags/override.test.ts
+++ b/packages/cli/test/unit/commands/flags/override.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { base64url, EncryptJWT, jwtDecrypt } from 'jose';
+import { join } from 'node:path';
+import fs from 'fs-extra';
+import os from 'node:os';
+import flags from '../../../../src/commands/flags';
+import { client } from '../../../mocks/client';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+// A valid 32-byte base64url-encoded key for testing
+const TEST_SECRET = base64url.encode(
+  new Uint8Array(32).fill(0).map((_, i) => i)
+);
+
+describe('flags override', () => {
+  let tmpDir: string;
+  let originalFlagsSecret: string | undefined;
+
+  beforeEach(async () => {
+    originalFlagsSecret = process.env.FLAGS_SECRET;
+    delete process.env.FLAGS_SECRET;
+
+    tmpDir = await fs.mkdtemp(join(os.tmpdir(), 'flags-override-test-'));
+    client.cwd = tmpDir;
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-flags-test',
+      name: 'vercel-flags-test',
+    });
+  });
+
+  afterEach(async () => {
+    if (originalFlagsSecret !== undefined) {
+      process.env.FLAGS_SECRET = originalFlagsSecret;
+    } else {
+      delete process.env.FLAGS_SECRET;
+    }
+    await fs.remove(tmpDir);
+  });
+
+  describe('--help', () => {
+    it('prints help and returns exit code 2', async () => {
+      client.setArgv('flags', 'override', '--help');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(2);
+    });
+
+    it('tracks telemetry', async () => {
+      client.setArgv('flags', 'override', '--help');
+      await flags(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'flags:override',
+        },
+      ]);
+    });
+  });
+
+  describe('with FLAGS_SECRET in environment', () => {
+    beforeEach(() => {
+      process.env.FLAGS_SECRET = TEST_SECRET;
+    });
+
+    it('encrypts a single boolean override', async () => {
+      client.setArgv('flags', 'override', 'my-flag=true');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput().trim();
+      expect(output).toBeTruthy();
+
+      // Decrypt and verify
+      const secret = base64url.decode(TEST_SECRET);
+      const { payload } = await jwtDecrypt(output, secret);
+      expect(payload.o).toEqual({ 'my-flag': true });
+      expect(payload.pur).toEqual('overrides');
+    });
+
+    it('encrypts multiple overrides with type coercion', async () => {
+      client.setArgv(
+        'flags',
+        'override',
+        'bool-flag=true',
+        'str-flag=hello',
+        'num-flag=42',
+        'false-flag=false'
+      );
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput().trim();
+      const secret = base64url.decode(TEST_SECRET);
+      const { payload } = await jwtDecrypt(output, secret);
+      expect(payload.o).toEqual({
+        'bool-flag': true,
+        'str-flag': 'hello',
+        'num-flag': 42,
+        'false-flag': false,
+      });
+    });
+
+    it('handles values containing = signs', async () => {
+      client.setArgv('flags', 'override', 'my-flag=a=b=c');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput().trim();
+      const secret = base64url.decode(TEST_SECRET);
+      const { payload } = await jwtDecrypt(output, secret);
+      expect(payload.o).toEqual({ 'my-flag': 'a=b=c' });
+    });
+
+    it('errors when no overrides are provided', async () => {
+      client.setArgv('flags', 'override');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Please provide at least one flag override');
+    });
+
+    it('errors on invalid format (no = sign)', async () => {
+      client.setArgv('flags', 'override', 'invalid-arg');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Invalid override format');
+    });
+
+    it('supports custom --expiration', async () => {
+      client.setArgv(
+        'flags',
+        'override',
+        'my-flag=true',
+        '--expiration',
+        '30d'
+      );
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput().trim();
+      const secret = base64url.decode(TEST_SECRET);
+      const { payload } = await jwtDecrypt(output, secret);
+      expect(payload.o).toEqual({ 'my-flag': true });
+      // Verify expiration is roughly 30 days from now
+      expect(payload.exp).toBeDefined();
+      const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
+      const now = Math.floor(Date.now() / 1000);
+      expect(payload.exp).toBeGreaterThan(now + thirtyDaysInSeconds - 60);
+      expect(payload.exp).toBeLessThan(now + thirtyDaysInSeconds + 60);
+    });
+  });
+
+  describe('with FLAGS_SECRET in .env.local', () => {
+    it('reads secret from .env.local', async () => {
+      await fs.writeFile(
+        join(tmpDir, '.env.local'),
+        `FLAGS_SECRET=${TEST_SECRET}\n`
+      );
+
+      client.setArgv('flags', 'override', 'my-flag=true');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput().trim();
+      const secret = base64url.decode(TEST_SECRET);
+      const { payload } = await jwtDecrypt(output, secret);
+      expect(payload.o).toEqual({ 'my-flag': true });
+    });
+  });
+
+  describe('with FLAGS_SECRET in .env', () => {
+    it('reads secret from .env', async () => {
+      await fs.writeFile(join(tmpDir, '.env'), `FLAGS_SECRET=${TEST_SECRET}\n`);
+
+      client.setArgv('flags', 'override', 'my-flag=true');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput().trim();
+      const secret = base64url.decode(TEST_SECRET);
+      const { payload } = await jwtDecrypt(output, secret);
+      expect(payload.o).toEqual({ 'my-flag': true });
+    });
+
+    it('prefers .env.local over .env', async () => {
+      const altSecret = base64url.encode(
+        new Uint8Array(32).fill(0).map((_, i) => i + 100)
+      );
+      await fs.writeFile(
+        join(tmpDir, '.env.local'),
+        `FLAGS_SECRET=${TEST_SECRET}\n`
+      );
+      await fs.writeFile(join(tmpDir, '.env'), `FLAGS_SECRET=${altSecret}\n`);
+
+      client.setArgv('flags', 'override', 'my-flag=true');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      // Should decrypt with the .env.local secret, not .env
+      const output = client.stdout.getFullOutput().trim();
+      const secret = base64url.decode(TEST_SECRET);
+      const { payload } = await jwtDecrypt(output, secret);
+      expect(payload.o).toEqual({ 'my-flag': true });
+    });
+  });
+
+  describe('missing FLAGS_SECRET', () => {
+    it('errors when no secret is available', async () => {
+      client.setArgv('flags', 'override', 'my-flag=true');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('FLAGS_SECRET not found');
+    });
+  });
+
+  describe('invalid FLAGS_SECRET', () => {
+    it('errors when secret is not 32 bytes', async () => {
+      process.env.FLAGS_SECRET = base64url.encode(new Uint8Array(16).fill(0));
+
+      client.setArgv('flags', 'override', 'my-flag=true');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('256-bit');
+    });
+  });
+
+  it('tracks subcommand telemetry', async () => {
+    process.env.FLAGS_SECRET = TEST_SECRET;
+    client.setArgv('flags', 'override', 'my-flag=true');
+    await flags(client);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:override',
+        value: 'override',
+      },
+    ]);
+  });
+
+  describe('--decrypt', () => {
+    async function createToken(
+      overrides: Record<string, unknown>,
+      secret: string = TEST_SECRET
+    ): Promise<string> {
+      const encodedSecret = base64url.decode(secret);
+      return new EncryptJWT({ o: overrides, pur: 'overrides' })
+        .setExpirationTime('1y')
+        .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+        .encrypt(encodedSecret);
+    }
+
+    beforeEach(() => {
+      process.env.FLAGS_SECRET = TEST_SECRET;
+    });
+
+    it('decrypts a token and prints JSON', async () => {
+      const token = await createToken({
+        'my-flag': true,
+        'other-flag': 'hello',
+      });
+      client.setArgv('flags', 'override', '--decrypt', token);
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const output = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(output).toEqual({ 'my-flag': true, 'other-flag': 'hello' });
+    });
+
+    it('decrypts a token with numeric values', async () => {
+      const token = await createToken({ 'num-flag': 42 });
+      client.setArgv('flags', 'override', '--decrypt', token);
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const output = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(output).toEqual({ 'num-flag': 42 });
+    });
+
+    it('errors when FLAGS_SECRET is missing', async () => {
+      delete process.env.FLAGS_SECRET;
+      const token = await createToken({ 'my-flag': true });
+      client.setArgv('flags', 'override', '--decrypt', token);
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('FLAGS_SECRET not found');
+    });
+
+    it('errors on invalid token', async () => {
+      client.setArgv('flags', 'override', '--decrypt', 'not-a-valid-token');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+    });
+
+    it('errors when token has wrong purpose', async () => {
+      const encodedSecret = base64url.decode(TEST_SECRET);
+      const token = await new EncryptJWT({ o: { flag: true }, pur: 'wrong' })
+        .setExpirationTime('1y')
+        .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+        .encrypt(encodedSecret);
+
+      client.setArgv('flags', 'override', '--decrypt', token);
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('not a valid flag overrides token');
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/flags/override.test.ts
+++ b/packages/cli/test/unit/commands/flags/override.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { base64url, EncryptJWT, jwtDecrypt } from 'jose';
-import { join } from 'node:path';
-import fs from 'fs-extra';
-import os from 'node:os';
 import flags from '../../../../src/commands/flags';
 import { client } from '../../../mocks/client';
 import { defaultProject, useProject } from '../../../mocks/project';
@@ -15,15 +12,11 @@ const TEST_SECRET = base64url.encode(
 );
 
 describe('flags override', () => {
-  let tmpDir: string;
   let originalFlagsSecret: string | undefined;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     originalFlagsSecret = process.env.FLAGS_SECRET;
     delete process.env.FLAGS_SECRET;
-
-    tmpDir = await fs.mkdtemp(join(os.tmpdir(), 'flags-override-test-'));
-    client.cwd = tmpDir;
 
     useUser();
     useTeams('team_dummy');
@@ -34,13 +27,12 @@ describe('flags override', () => {
     });
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     if (originalFlagsSecret !== undefined) {
       process.env.FLAGS_SECRET = originalFlagsSecret;
     } else {
       delete process.env.FLAGS_SECRET;
     }
-    await fs.remove(tmpDir);
   });
 
   describe('--help', () => {
@@ -156,60 +148,6 @@ describe('flags override', () => {
       const now = Math.floor(Date.now() / 1000);
       expect(payload.exp).toBeGreaterThan(now + thirtyDaysInSeconds - 60);
       expect(payload.exp).toBeLessThan(now + thirtyDaysInSeconds + 60);
-    });
-  });
-
-  describe('with FLAGS_SECRET in .env.local', () => {
-    it('reads secret from .env.local', async () => {
-      await fs.writeFile(
-        join(tmpDir, '.env.local'),
-        `FLAGS_SECRET=${TEST_SECRET}\n`
-      );
-
-      client.setArgv('flags', 'override', 'my-flag=true');
-      const exitCode = await flags(client);
-      expect(exitCode).toEqual(0);
-
-      const output = client.stdout.getFullOutput().trim();
-      const secret = base64url.decode(TEST_SECRET);
-      const { payload } = await jwtDecrypt(output, secret);
-      expect(payload.o).toEqual({ 'my-flag': true });
-    });
-  });
-
-  describe('with FLAGS_SECRET in .env', () => {
-    it('reads secret from .env', async () => {
-      await fs.writeFile(join(tmpDir, '.env'), `FLAGS_SECRET=${TEST_SECRET}\n`);
-
-      client.setArgv('flags', 'override', 'my-flag=true');
-      const exitCode = await flags(client);
-      expect(exitCode).toEqual(0);
-
-      const output = client.stdout.getFullOutput().trim();
-      const secret = base64url.decode(TEST_SECRET);
-      const { payload } = await jwtDecrypt(output, secret);
-      expect(payload.o).toEqual({ 'my-flag': true });
-    });
-
-    it('prefers .env.local over .env', async () => {
-      const altSecret = base64url.encode(
-        new Uint8Array(32).fill(0).map((_, i) => i + 100)
-      );
-      await fs.writeFile(
-        join(tmpDir, '.env.local'),
-        `FLAGS_SECRET=${TEST_SECRET}\n`
-      );
-      await fs.writeFile(join(tmpDir, '.env'), `FLAGS_SECRET=${altSecret}\n`);
-
-      client.setArgv('flags', 'override', 'my-flag=true');
-      const exitCode = await flags(client);
-      expect(exitCode).toEqual(0);
-
-      // Should decrypt with the .env.local secret, not .env
-      const output = client.stdout.getFullOutput().trim();
-      const secret = base64url.decode(TEST_SECRET);
-      const { payload } = await jwtDecrypt(output, secret);
-      expect(payload.o).toEqual({ 'my-flag': true });
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a new `vercel flags override` subcommand that encrypts and decrypts flag override tokens for the `vercel-flag-overrides` cookie.

**Encrypt:** Takes `flag=value` pairs, reads the `FLAGS_SECRET`, and outputs an encrypted JWE token.

```
vercel flags override my-flag=true other-flag=hello --expiration 30d
```

**Decrypt:** Takes an encrypted token and prints the overrides as JSON.

```
vercel flags override --decrypt <token>
```

### FLAGS_SECRET resolution

The secret is resolved via `@next/env`'s `loadEnvConfig`, which loads from `.env`, `.env.local`, `.env.development.local`, etc. — the same mechanism used by `vercel flags prepare`.

### Value coercion

Positional values are automatically coerced: `true`/`false` → boolean, numeric strings → number, everything else → string.

## Test plan

- [x] Unit tests covering encrypt, decrypt, type coercion, error cases, telemetry (16 tests, all passing)