### PR TITLE
fix(cli): check VERCEL_TOKEN env var before login prompt

### DIFF
--- a/.changeset/fix-vercel-token-env-order.md
+++ b/.changeset/fix-vercel-token-env-order.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fixed `VERCEL_TOKEN` environment variable not being checked before the login prompt, causing the CLI to always ask for credentials even when the env var was set.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -501,6 +501,16 @@ const main = async () => {
     subcommandsWithoutToken.push('flags');
   }
 
+  // Check for VERCEL_TOKEN environment variable if --token flag not provided
+  // Track where the token came from for better error messages
+  let tokenSource: 'flag' | 'env' | undefined;
+  if (typeof parsedArgs.flags['--token'] === 'string') {
+    tokenSource = 'flag';
+  } else if (process.env.VERCEL_TOKEN) {
+    parsedArgs.flags['--token'] = process.env.VERCEL_TOKEN;
+    tokenSource = 'env';
+  }
+
   // Prompt for login if there is no current token
   if (
     (!authConfig || !authConfig.token) &&
@@ -544,16 +554,6 @@ const main = async () => {
       });
       return 1;
     }
-  }
-
-  // Check for VERCEL_TOKEN environment variable if --token flag not provided
-  // Track where the token came from for better error messages
-  let tokenSource: 'flag' | 'env' | undefined;
-  if (typeof parsedArgs.flags['--token'] === 'string') {
-    tokenSource = 'flag';
-  } else if (process.env.VERCEL_TOKEN) {
-    parsedArgs.flags['--token'] = process.env.VERCEL_TOKEN;
-    tokenSource = 'env';
   }
 
   if (

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -945,9 +945,28 @@ test('default command should prompt login with empty auth.json', async () => {
   const output = await execCli(binaryPath, ['-Q', '/tmp'], {
     // execCli passes the token automatically, undo that functionality for this test
     token: false,
+    env: {
+      // Unset VERCEL_TOKEN so the env var doesn't bypass the login prompt
+      VERCEL_TOKEN: '',
+    },
   });
   expect(output.stderr, formatOutput(output)).toBeTruthy();
   expect(output.stderr).toContain(
     'Error: No existing credentials found. Please run `vercel login` or pass "--token"'
   );
+});
+
+test('VERCEL_TOKEN env var should skip login prompt', async () => {
+  const [user] = await Promise.all([userPromise]);
+  const output = await execCli(binaryPath, ['whoami'], {
+    // Do not pass --token flag
+    token: false,
+    env: {
+      // Provide token via environment variable instead
+      VERCEL_TOKEN: process.env.VERCEL_TOKEN,
+    },
+  });
+  expect(output.exitCode, formatOutput(output)).toBe(0);
+  expect(output.stderr).not.toContain('No existing credentials found');
+  expect(output.stdout).toContain(user.username);
 });


### PR DESCRIPTION
## Context

The `VERCEL_TOKEN` environment variable support was added in #14831 but it wasn't working because the env var check was positioned **after** the login prompt logic. When the CLI evaluates whether to show the login prompt, it checks `parsedArgs.flags['--token']` — but at that point `VERCEL_TOKEN` hasn't been read into `parsedArgs.flags['--token']` yet, so the login prompt always triggers.

## Changes

Moved the `VERCEL_TOKEN` environment variable check to run **before** the login prompt check, so the token from the env var is properly considered when deciding whether credentials are available.

Also updated the existing "empty auth.json" integration test to explicitly unset `VERCEL_TOKEN` in the child process env, since the test runner's own `VERCEL_TOKEN` would otherwise leak through and bypass the login prompt (which is exactly what the test is verifying doesn't happen).

## References

- Fixes [CICD-2410](https://linear.app/vercel/issue/CICD-2410/vercel-token-environment-variable-not-working-in-vercel-cli-50382-oror)
- Related to #14831 (original PR that added `VERCEL_TOKEN` env var support)