### PR TITLE
[experimental-services] new schema: add `mount` support

### DIFF
--- a/.changeset/fuzzy-shirts-rest.md
+++ b/.changeset/fuzzy-shirts-rest.md
@@ -1,0 +1,10 @@
+---
+'@vercel/build-utils': patch
+'@vercel/config': patch
+'@vercel/fs-detectors': patch
+'vercel': patch
+---
+
+Add `mount` support for experimental services across config validation and service resolution.
+
+This allows services to use the RFC-style `mount` field as an alias for `routePrefix` and `subdomain`, including subdomain-only mounts.

--- a/.changeset/fuzzy-shirts-rest.md
+++ b/.changeset/fuzzy-shirts-rest.md
@@ -6,5 +6,3 @@
 ---
 
 Add `mount` support for experimental services across config validation and service resolution.
-
-This allows services to use the RFC-style `mount` field as an alias for `routePrefix` and `subdomain`, including subdomain-only mounts.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -779,6 +779,13 @@ export type ServiceRuntime = 'node' | 'python' | 'go' | 'rust' | 'ruby';
 
 export type ServiceType = 'web' | 'cron' | 'worker';
 
+export interface ServiceMount {
+  /** URL path prefix where the service is mounted. */
+  path?: string;
+  /** Optional subdomain this service is mounted on. */
+  subdomain?: string;
+}
+
 /**
  * Configuration for a service in vercel.json.
  * @experimental This feature is experimental and may change.
@@ -810,7 +817,9 @@ export interface ExperimentalServiceConfig {
   excludeFiles?: string | string[];
 
   /* Web service config */
-  /** URL prefix for routing */
+  /** Preferred routing config alias for routePrefix/subdomain. */
+  mount?: string | ServiceMount;
+  /** URL prefix for routing (deprecated, use mount instead) */
   routePrefix?: string;
   /** Subdomain this service should respond to (web services only). */
   subdomain?: string;

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -155,6 +155,33 @@ const cronsSchema = {
   },
 };
 
+const serviceMountSchema = {
+  oneOf: [
+    {
+      type: 'string',
+      minLength: 1,
+      maxLength: 512,
+    },
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        path: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 512,
+        },
+        subdomain: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 63,
+        },
+      },
+      anyOf: [{ required: ['path'] }, { required: ['subdomain'] }],
+    },
+  ],
+};
+
 const serviceConfigSchema = {
   type: 'object',
   additionalProperties: false,
@@ -167,6 +194,7 @@ const serviceConfigSchema = {
       minLength: 1,
       maxLength: 512,
     },
+    mount: serviceMountSchema,
     routePrefix: {
       type: 'string',
       minLength: 1,

--- a/packages/cli/test/dev/fixtures/services-explicit-config/vercel.json
+++ b/packages/cli/test/dev/fixtures/services-explicit-config/vercel.json
@@ -3,17 +3,17 @@
     "service-next": {
       "framework": "nextjs",
       "entrypoint": "service-next",
-      "routePrefix": "/"
+      "mount": "/"
     },
     "service-fastapi": {
       "framework": "fastapi",
       "entrypoint": "service-fastapi",
-      "routePrefix": "/api/fastapi"
+      "mount": "/api/fastapi"
     },
     "service-flask": {
       "framework": "flask",
       "entrypoint": "service-flask",
-      "routePrefix": "/api/flask"
+      "mount": "/api/flask"
     }
   }
 }

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -25,11 +25,12 @@ describe('validateConfig', () => {
   });
 
   it('should not error with maxDuration set to "max"', async () => {
+    // Runtime allows maxDuration "max"; VercelConfig types expect number only.
     const config = {
       functions: {
-        'api/user.go': { memory: 128, maxDuration: 'max' },
+        'api/user.go': { memory: 128, maxDuration: 'max' as const },
       },
-    } satisfies Parameters<typeof validateConfig>[0];
+    } as unknown as Parameters<typeof validateConfig>[0];
     const error = validateConfig(config);
     expect(error).toBeNull();
   });

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -35,6 +35,25 @@ describe('validateConfig', () => {
     expect(error).toBeNull();
   });
 
+  it('should not error with experimentalServices mount config', async () => {
+    const error = validateConfig({
+      experimentalServices: {
+        frontend: {
+          framework: 'nextjs',
+          mount: '/',
+        },
+        api: {
+          entrypoint: 'api/index.ts',
+          mount: {
+            path: '/api',
+            subdomain: 'api',
+          },
+        },
+      },
+    } as Parameters<typeof validateConfig>[0]);
+    expect(error).toBeNull();
+  });
+
   it('should not error with builds and routes', async () => {
     const config = {
       builds: [{ src: 'api/index.js', use: '@vercel/node' }],

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -25,18 +25,17 @@ describe('validateConfig', () => {
   });
 
   it('should not error with maxDuration set to "max"', async () => {
-    // Runtime allows maxDuration "max"; VercelConfig types expect number only.
     const config = {
       functions: {
-        'api/user.go': { memory: 128, maxDuration: 'max' as const },
+        'api/user.go': { memory: 128, maxDuration: 'max' },
       },
-    } as unknown as Parameters<typeof validateConfig>[0];
+    } satisfies Parameters<typeof validateConfig>[0];
     const error = validateConfig(config);
     expect(error).toBeNull();
   });
 
   it('should not error with experimentalServices mount config', async () => {
-    const error = validateConfig({
+    const config = {
       experimentalServices: {
         frontend: {
           framework: 'nextjs',
@@ -49,8 +48,15 @@ describe('validateConfig', () => {
             subdomain: 'api',
           },
         },
+        docs: {
+          framework: 'nextjs',
+          mount: {
+            subdomain: 'docs',
+          },
+        },
       },
-    } as Parameters<typeof validateConfig>[0]);
+    } satisfies Parameters<typeof validateConfig>[0];
+    const error = validateConfig(config);
     expect(error).toBeNull();
   });
 

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -575,6 +575,15 @@ export interface VercelConfig {
        */
       workspace?: string;
       /**
+       * Preferred routing config alias for routePrefix/subdomain.
+       */
+      mount?:
+        | string
+        | {
+            path?: string;
+            subdomain?: string;
+          };
+      /**
        * URL prefix for routing (web services only).
        */
       routePrefix?: string;

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -58,20 +58,6 @@ interface ResolvedEntrypointPath {
   isDirectory: boolean;
 }
 
-type ServiceMountConfig = {
-  path?: string;
-  subdomain?: string;
-};
-
-type ExperimentalServiceConfigWithMount = ExperimentalServiceConfig & {
-  mount?: string | ServiceMountConfig;
-  consumer?: string;
-};
-
-type ServiceWithConsumer = Service & {
-  consumer?: string;
-};
-
 function normalizeServiceEntrypoint(entrypoint: string): string {
   const normalized = posixPath.normalize(entrypoint);
   return normalized === '' ? '.' : normalized;
@@ -113,7 +99,7 @@ type RoutePrefixSource = 'configured' | 'generated';
 
 interface ResolveConfiguredServiceOptions {
   name: string;
-  config: ExperimentalServiceConfigWithMount;
+  config: ExperimentalServiceConfig;
   fs: DetectorFilesystem;
   group?: string;
   resolvedEntrypoint?: ResolvedEntrypointPath;
@@ -241,7 +227,7 @@ interface ResolvedServiceRoutingConfig {
 
 function resolveServiceRoutingConfig(
   name: string,
-  config: ExperimentalServiceConfigWithMount
+  config: ExperimentalServiceConfig
 ): {
   routing?: ResolvedServiceRoutingConfig;
   error?: ServiceDetectionError;
@@ -344,7 +330,7 @@ function resolveServiceRoutingConfig(
  */
 export function validateServiceConfig(
   name: string,
-  config: ExperimentalServiceConfigWithMount
+  config: ExperimentalServiceConfig
 ): ServiceDetectionError | null {
   if (!SERVICE_NAME_REGEX.test(name)) {
     return {
@@ -512,7 +498,7 @@ export function validateServiceEntrypoint(
  */
 export async function resolveConfiguredService(
   options: ResolveConfiguredServiceOptions
-): Promise<ServiceWithConsumer> {
+): Promise<Service> {
   const {
     name,
     config,

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -58,6 +58,20 @@ interface ResolvedEntrypointPath {
   isDirectory: boolean;
 }
 
+type ServiceMountConfig = {
+  path?: string;
+  subdomain?: string;
+};
+
+type ExperimentalServiceConfigWithMount = ExperimentalServiceConfig & {
+  mount?: string | ServiceMountConfig;
+  consumer?: string;
+};
+
+type ServiceWithConsumer = Service & {
+  consumer?: string;
+};
+
 function normalizeServiceEntrypoint(entrypoint: string): string {
   const normalized = posixPath.normalize(entrypoint);
   return normalized === '' ? '.' : normalized;
@@ -99,7 +113,7 @@ type RoutePrefixSource = 'configured' | 'generated';
 
 interface ResolveConfiguredServiceOptions {
   name: string;
-  config: ExperimentalServiceConfig;
+  config: ExperimentalServiceConfigWithMount;
   fs: DetectorFilesystem;
   group?: string;
   resolvedEntrypoint?: ResolvedEntrypointPath;
@@ -219,12 +233,118 @@ function isReservedServiceRoutePrefix(routePrefix: string): boolean {
   );
 }
 
+interface ResolvedServiceRoutingConfig {
+  routePrefix?: string;
+  subdomain?: string;
+  routePrefixConfigured: boolean;
+}
+
+function resolveServiceRoutingConfig(
+  name: string,
+  config: ExperimentalServiceConfigWithMount
+): {
+  routing?: ResolvedServiceRoutingConfig;
+  error?: ServiceDetectionError;
+} {
+  const hasLegacyRoutePrefix = typeof config.routePrefix === 'string';
+  const hasLegacySubdomain = typeof config.subdomain === 'string';
+
+  if (config.mount === undefined) {
+    return {
+      routing: {
+        routePrefix: config.routePrefix,
+        subdomain: config.subdomain,
+        routePrefixConfigured: hasLegacyRoutePrefix,
+      },
+    };
+  }
+
+  if (hasLegacyRoutePrefix || hasLegacySubdomain) {
+    return {
+      error: {
+        code: 'CONFLICTING_MOUNT_CONFIG',
+        message: `Service "${name}" cannot mix "mount" with "routePrefix" or "subdomain". Use only one routing configuration style.`,
+        serviceName: name,
+      },
+    };
+  }
+
+  if (typeof config.mount === 'string') {
+    return {
+      routing: {
+        routePrefix: config.mount,
+        routePrefixConfigured: true,
+      },
+    };
+  }
+
+  if (
+    !config.mount ||
+    typeof config.mount !== 'object' ||
+    Array.isArray(config.mount)
+  ) {
+    return {
+      error: {
+        code: 'INVALID_MOUNT',
+        message: `Service "${name}" has invalid "mount" config. Use a string path such as "/api" or an object like { path: "/api", subdomain: "api" }.`,
+        serviceName: name,
+      },
+    };
+  }
+
+  const hasInvalidMountKeys = Object.keys(config.mount).some(
+    key => key !== 'path' && key !== 'subdomain'
+  );
+  if (hasInvalidMountKeys) {
+    return {
+      error: {
+        code: 'INVALID_MOUNT',
+        message: `Service "${name}" has invalid "mount" config. Only "path" and "subdomain" are supported.`,
+        serviceName: name,
+      },
+    };
+  }
+
+  const mountPath = config.mount.path;
+  const mountSubdomain = config.mount.subdomain;
+  if (
+    (mountPath !== undefined && typeof mountPath !== 'string') ||
+    (mountSubdomain !== undefined && typeof mountSubdomain !== 'string')
+  ) {
+    return {
+      error: {
+        code: 'INVALID_MOUNT',
+        message: `Service "${name}" has invalid "mount" config. "path" and "subdomain" must be strings when provided.`,
+        serviceName: name,
+      },
+    };
+  }
+
+  if (typeof mountPath !== 'string' && typeof mountSubdomain !== 'string') {
+    return {
+      error: {
+        code: 'INVALID_MOUNT',
+        message: `Service "${name}" has invalid "mount" config. Specify at least one of "mount.path" or "mount.subdomain".`,
+        serviceName: name,
+      },
+    };
+  }
+
+  return {
+    routing: {
+      routePrefix: mountPath,
+      subdomain: mountSubdomain,
+      routePrefixConfigured: typeof mountPath === 'string',
+    },
+  };
+}
+
 /**
  * Validate a service configuration from vercel.json experimentalServices.
  */
 export function validateServiceConfig(
   name: string,
-  config: ExperimentalServiceConfig
+  config: ExperimentalServiceConfigWithMount
 ): ServiceDetectionError | null {
   if (!SERVICE_NAME_REGEX.test(name)) {
     return {
@@ -241,13 +361,19 @@ export function validateServiceConfig(
     };
   }
   const serviceType = config.type || 'web';
-  const hasRoutePrefix = typeof config.routePrefix === 'string';
-  const hasSubdomain = typeof config.subdomain === 'string';
+  const routingResult = resolveServiceRoutingConfig(name, config);
+  if (routingResult.error) {
+    return routingResult.error;
+  }
+  const configuredRoutePrefix = routingResult.routing?.routePrefix;
+  const configuredSubdomain = routingResult.routing?.subdomain;
+  const hasRoutePrefix = typeof configuredRoutePrefix === 'string';
+  const hasSubdomain = typeof configuredSubdomain === 'string';
 
-  if (hasSubdomain && !DNS_LABEL_RE.test(config.subdomain!)) {
+  if (hasSubdomain && !DNS_LABEL_RE.test(configuredSubdomain!)) {
     return {
       code: 'INVALID_SUBDOMAIN',
-      message: `Web service "${name}" has invalid subdomain "${config.subdomain}". Use a single DNS label such as "api".`,
+      message: `Web service "${name}" has invalid subdomain "${configuredSubdomain}". Use a single DNS label such as "api".`,
       serviceName: name,
     };
   }
@@ -255,35 +381,35 @@ export function validateServiceConfig(
   if (serviceType === 'web' && !hasRoutePrefix && !hasSubdomain) {
     return {
       code: 'MISSING_ROUTE_PREFIX',
-      message: `Web service "${name}" must specify at least one of "routePrefix" or "subdomain".`,
+      message: `Web service "${name}" must specify at least one of "mount", "routePrefix", or "subdomain".`,
       serviceName: name,
     };
   }
   if (
     serviceType === 'web' &&
-    config.routePrefix &&
-    isReservedServiceRoutePrefix(config.routePrefix)
+    configuredRoutePrefix &&
+    isReservedServiceRoutePrefix(configuredRoutePrefix)
   ) {
     return {
       code: 'RESERVED_ROUTE_PREFIX',
-      message: `Web service "${name}" cannot use routePrefix "${config.routePrefix}". The "${INTERNAL_SERVICE_PREFIX}" prefix is reserved for internal services routing.`,
+      message: `Web service "${name}" cannot use routePrefix "${configuredRoutePrefix}". The "${INTERNAL_SERVICE_PREFIX}" prefix is reserved for internal services routing.`,
       serviceName: name,
     };
   }
   if (
     (serviceType === 'worker' || serviceType === 'cron') &&
-    config.routePrefix
+    configuredRoutePrefix
   ) {
     return {
       code: 'INVALID_ROUTE_PREFIX',
-      message: `${serviceType === 'worker' ? 'Worker' : 'Cron'} service "${name}" cannot have "routePrefix". Only web services should specify "routePrefix".`,
+      message: `${serviceType === 'worker' ? 'Worker' : 'Cron'} service "${name}" cannot have "routePrefix" or "mount". Only web services should specify path-based routing.`,
       serviceName: name,
     };
   }
   if ((serviceType === 'worker' || serviceType === 'cron') && hasSubdomain) {
     return {
       code: 'INVALID_HOST_ROUTING_CONFIG',
-      message: `${serviceType === 'worker' ? 'Worker' : 'Cron'} service "${name}" cannot have "subdomain". Only web services should specify subdomain routing.`,
+      message: `${serviceType === 'worker' ? 'Worker' : 'Cron'} service "${name}" cannot have "subdomain" or "mount.subdomain". Only web services should specify subdomain routing.`,
       serviceName: name,
     };
   }
@@ -386,7 +512,7 @@ export function validateServiceEntrypoint(
  */
 export async function resolveConfiguredService(
   options: ResolveConfiguredServiceOptions
-): Promise<Service> {
+): Promise<ServiceWithConsumer> {
   const {
     name,
     config,
@@ -402,6 +528,14 @@ export async function resolveConfiguredService(
     typeof rawEntrypoint === 'string' && type === 'cron'
       ? parsePyModuleAttrEntrypoint(rawEntrypoint)
       : null;
+  const routingResult = resolveServiceRoutingConfig(name, config);
+  if (routingResult.error) {
+    throw new Error(routingResult.error.message);
+  }
+  const configuredRoutePrefix = routingResult.routing?.routePrefix;
+  const configuredSubdomain = routingResult.routing?.subdomain;
+  const routePrefixWasConfigured =
+    routingResult.routing?.routePrefixConfigured ?? false;
 
   let resolvedEntrypointPath = resolvedEntrypoint;
   if (!resolvedEntrypointPath && typeof rawEntrypoint === 'string') {
@@ -498,21 +632,21 @@ export async function resolveConfiguredService(
   }
 
   const normalizedSubdomain =
-    type === 'web' && typeof config.subdomain === 'string'
-      ? config.subdomain.toLowerCase()
+    type === 'web' && typeof configuredSubdomain === 'string'
+      ? configuredSubdomain.toLowerCase()
       : undefined;
   const defaultRoutePrefix =
     type === 'web' && normalizedSubdomain ? `/_/${name}` : undefined;
   // routePrefix defaults to /_/serviceName for subdomain-mounted web services.
   const routePrefix =
-    type === 'web' && (config.routePrefix || defaultRoutePrefix)
-      ? (config.routePrefix || defaultRoutePrefix)!.startsWith('/')
-        ? (config.routePrefix || defaultRoutePrefix)!
-        : `/${config.routePrefix || defaultRoutePrefix}`
+    type === 'web' && (configuredRoutePrefix || defaultRoutePrefix)
+      ? (configuredRoutePrefix || defaultRoutePrefix)!.startsWith('/')
+        ? (configuredRoutePrefix || defaultRoutePrefix)!
+        : `/${configuredRoutePrefix || defaultRoutePrefix}`
       : undefined;
   const resolvedRoutePrefixSource =
     type === 'web' && typeof routePrefix === 'string'
-      ? config.routePrefix
+      ? routePrefixWasConfigured
         ? routePrefixSource
         : 'generated'
       : undefined;

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -136,6 +136,66 @@ describe('detectServices', () => {
       expect(result.routes.defaults).toHaveLength(0);
     });
 
+    it('should support mount string as a routePrefix alias', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            api: {
+              entrypoint: 'src/index.ts',
+              mount: '/api',
+            },
+          },
+        }),
+        'src/index.ts': 'export default {}',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0]).toMatchObject({
+        name: 'api',
+        routePrefix: '/api',
+        routePrefixSource: 'configured',
+      });
+    });
+
+    it('should support mount object as routePrefix/subdomain alias', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            api: {
+              entrypoint: 'api/index.go',
+              mount: {
+                path: '/internal-api',
+                subdomain: 'api',
+              },
+            },
+          },
+        }),
+        'api/index.go': 'package main',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0]).toMatchObject({
+        name: 'api',
+        routePrefix: '/internal-api',
+        routePrefixSource: 'configured',
+        subdomain: 'api',
+      });
+      expect(result.routes.hostRewrites).toContainEqual({
+        src: '^/$',
+        dest: '/internal-api',
+        has: [{ type: 'host', value: { pre: 'api.' } }],
+        missing: [
+          { type: 'host', value: { suf: '.vercel.app' } },
+          { type: 'host', value: { suf: '.vercel.dev' } },
+        ],
+        check: true,
+      });
+    });
+
     it('should resolve file entrypoint paths without explicit workspace', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({
@@ -959,6 +1019,29 @@ describe('detectServices', () => {
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0].code).toBe('MISSING_ROUTE_PREFIX');
       expect(result.errors[0].serviceName).toBe('api');
+    });
+
+    it('should error when mount is mixed with legacy routing keys', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            api: {
+              entrypoint: 'api/index.ts',
+              mount: '/api',
+              routePrefix: '/legacy-api',
+            },
+          },
+        }),
+        'api/index.ts': 'export default {}',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.services).toEqual([]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        code: 'CONFLICTING_MOUNT_CONFIG',
+        serviceName: 'api',
+      });
     });
 
     it('should derive routePrefix from subdomain using /_/serviceName', async () => {

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -196,6 +196,32 @@ describe('detectServices', () => {
       });
     });
 
+    it('should support mount object with subdomain only', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            docs: {
+              entrypoint: 'docs/index.ts',
+              mount: {
+                subdomain: 'docs',
+              },
+            },
+          },
+        }),
+        'docs/index.ts': 'export default {}',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0]).toMatchObject({
+        name: 'docs',
+        routePrefix: '/_/docs',
+        routePrefixSource: 'generated',
+        subdomain: 'docs',
+      });
+    });
+
     it('should resolve file entrypoint paths without explicit workspace', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({


### PR DESCRIPTION
Updates the `experimentalServices` routing config to match the new spec
Adds support for `mount` to the `experimentalServices` config