### PR TITLE
[cli] Add v2 deployment checks handling to deploy --prod

### DIFF
--- a/.changeset/add-v2-checks-deploy.md
+++ b/.changeset/add-v2-checks-deploy.md
@@ -1,0 +1,6 @@
+---
+'vercel': minor
+'@vercel/client': minor
+---
+
+Add Deployment Checks support to `deploy --prod`. Shows "Running Checks..." spinner when checks are pending, detects check failures before alias promotion, and displays failed check run details with links to logs.

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -184,6 +184,14 @@ export type Deployment = {
   buildErrorAt?: number;
   buildingAt: number;
   canceledAt?: number;
+  checks?: Record<
+    string,
+    {
+      state: 'pending' | 'succeeded' | 'failed';
+      startedAt?: string;
+      completedAt?: string;
+    }
+  >;
   checksState?: 'completed' | 'registered' | 'running';
   checksConclusion?: 'canceled' | 'failed' | 'skipped' | 'succeeded';
   createdAt: number;

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -24,6 +24,7 @@ import { compileVercelConfig } from '../../util/compile-vercel-config';
 import { createGitMeta } from '../../util/create-git-meta';
 import createDeploy from '../../util/deploy/create-deploy';
 import { getDeploymentChecks } from '../../util/deploy/get-deployment-checks';
+import { getDeploymentCheckRuns } from '../../util/deploy/get-deployment-check-runs';
 import getPrebuiltJson from '../../util/deploy/get-prebuilt-json';
 import { printDeploymentStatus } from '../../util/deploy/print-deployment-status';
 import { isValidArchive } from '../../util/deploy/validate-archive-format';
@@ -585,6 +586,12 @@ async function handleInitDeployment(
       return 1;
     }
 
+    // Deployment Checks: deployment-alias check failed
+    if (deployment.checks?.['deployment-alias']?.state === 'failed') {
+      return handleFailedCheckRuns(client, deployment, asJson);
+    }
+
+    // v1 checks: uses checksConclusion from the deployment object
     if (deployment.checksConclusion === 'failed') {
       const { checks } = await getDeploymentChecks(client, deployment.id);
       const counters = new Map<string, number>();
@@ -1445,6 +1452,12 @@ async function handleDefaultDeploy(
       return 1;
     }
 
+    // Deployment Checks: deployment-alias check failed
+    if (deployment.checks?.['deployment-alias']?.state === 'failed') {
+      return handleFailedCheckRuns(client, deployment, asJson);
+    }
+
+    // v1 checks: uses checksConclusion from the deployment object
     if (deployment.checksConclusion === 'failed') {
       const { checks } = await getDeploymentChecks(client, deployment.id);
       const counters = new Map<string, number>();
@@ -2017,6 +2030,11 @@ async function handleContinueDeployment({
         }
       }
 
+      if (event.type === 'checks-v2-failed') {
+        output.stopSpinner();
+        return handleFailedCheckRuns(client, event.payload, false);
+      }
+
       if (event.type === 'error') {
         output.stopSpinner();
         const payload = event.payload;
@@ -2063,4 +2081,81 @@ function getDeploymentOutputJson(
     deploymentApiUrl: `${apiUrl}/v13/deployments/${deployment.id}`,
     ...(error ? { error } : {}),
   };
+}
+
+// v2 checks: fetch check runs and print failures
+async function handleFailedCheckRuns(
+  client: Client,
+  deployment: {
+    id: string;
+    url: string;
+    inspectorUrl?: string | null;
+    readyState: string;
+    target?: string | null;
+  },
+  asJson: boolean
+): Promise<number> {
+  const { runs } = await getDeploymentCheckRuns(client, deployment.id);
+
+  const failedRuns = (runs ?? []).filter(run => run.conclusion === 'failed');
+  const counters = new Map<string, number>();
+  (runs ?? []).forEach(r => {
+    counters.set(r.conclusion, (counters.get(r.conclusion) ?? 0) + 1);
+  });
+  const counterList = Array.from(counters)
+    .map(([name, no]) => `${no} ${name}`)
+    .join(', ');
+
+  const message = `Running Checks: ${counterList}`;
+
+  const getSourceKind = (run: { source: { kind: string } | string }) =>
+    typeof run.source === 'object' ? run.source.kind : run.source;
+  const getJobName = (run: {
+    source: { kind: string; jobName?: string } | string;
+  }) => (typeof run.source === 'object' ? run.source.jobName : undefined);
+
+  if (asJson) {
+    output.stopSpinner();
+    const deploymentJson = getDeploymentOutputJson(deployment, client.apiUrl, {
+      name: 'CHECKS_FAILED',
+      message,
+    });
+    const payload = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.ERROR,
+          reason: 'checks_failed',
+          message,
+          deployment: deploymentJson,
+          failedCheckRuns: failedRuns.map(run => ({
+            id: run.id,
+            name: run.name,
+            conclusion: run.conclusion,
+            source: run.source,
+            logsEndpoint: `/v2/deployments/${deployment.id}/check-runs/${run.id}/logs${client.config.currentTeam ? `?teamId=${client.config.currentTeam}` : ''}`,
+          })),
+          next: [
+            {
+              command: getCommandNameWithGlobalFlags('deploy', client.argv),
+              when: 'retry deploy after fixing check failures',
+            },
+          ],
+        }
+      : deploymentJson;
+    client.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    output.error(message);
+    for (const run of failedRuns) {
+      const jobName = getJobName(run);
+      const dashboardUrl =
+        getSourceKind(run) === 'vercel' && deployment.inspectorUrl && jobName
+          ? `${deployment.inspectorUrl}?logsTab=${encodeURIComponent(jobName)}`
+          : (deployment.inspectorUrl ?? null);
+      const label = dashboardUrl
+        ? output.link(run.name, dashboardUrl)
+        : run.name;
+      output.print(`  ${chalk.red('✗')} ${label}\n`);
+    }
+  }
+
+  return 1;
 }

--- a/packages/cli/src/util/deploy/get-deployment-check-runs.ts
+++ b/packages/cli/src/util/deploy/get-deployment-check-runs.ts
@@ -1,0 +1,31 @@
+import type Client from '../client';
+
+export interface CheckRun {
+  id: string;
+  name: string;
+  status: 'registered' | 'running' | 'completed';
+  conclusion:
+    | 'canceled'
+    | 'failed'
+    | 'neutral'
+    | 'succeeded'
+    | 'skipped'
+    | 'stale';
+  source: { kind: string; jobName?: string } | string;
+  startedAt?: number;
+  completedAt?: number;
+}
+
+interface CheckRunsResponse {
+  runs: CheckRun[];
+}
+
+export async function getDeploymentCheckRuns(
+  client: Client,
+  deploymentId: string
+) {
+  const response = await client.fetch<CheckRunsResponse>(
+    `/v2/deployments/${encodeURIComponent(deploymentId)}/check-runs`
+  );
+  return response;
+}

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -287,15 +287,13 @@ export default async function processDeployment({
         return event.payload;
       }
 
-      // If `checksState` is present, we can only continue to "Completing" if the checks finished,
-      // otherwise we might show "Completing" before "Running Checks".
-      if (
-        event.type === 'ready' &&
-        (event.payload.checksState
-          ? event.payload.checksState === 'completed'
-          : true) &&
-        !withFullLogs
-      ) {
+      if (event.type === 'ready' && !withFullLogs) {
+        const v1ChecksPending =
+          event.payload.checksState &&
+          event.payload.checksState !== 'completed';
+        const v2ChecksPending =
+          event.payload.checks?.['deployment-alias']?.state === 'pending';
+
         stopSpinner();
         process.stderr.write(eraseLines(2));
         const isProdDeployment = event.payload.target === 'production';
@@ -308,14 +306,26 @@ export default async function processDeployment({
             emoji('success')
           ) + `\n`
         );
-        output.spinner('Completing...', 0);
+
+        if (v1ChecksPending || v2ChecksPending) {
+          output.spinner('Running Checks...', 0);
+        } else {
+          output.spinner('Completing...', 0);
+        }
       }
 
+      // v1 checks running
       if (event.type === 'checks-running' && !withFullLogs) {
         output.spinner('Running Checks...', 0);
       }
 
+      // v1 checks failed
       if (event.type === 'checks-conclusion-failed') {
+        stopSpinner();
+        return event.payload;
+      }
+
+      if (event.type === 'checks-v2-failed') {
         stopSpinner();
         return event.payload;
       }

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -2246,4 +2246,323 @@ describe('deploy', () => {
       });
     });
   });
+
+  describe('deployment checks', () => {
+    // v1 checks: checksConclusion === 'failed'
+    it('should error when v1 checks fail', async () => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.post(`/v13/deployments`, (_req, res) => {
+        res.json({
+          creator: { uid: user.id, username: user.username },
+          id: 'dpl_checks_v1',
+          url: 'checks-v1.vercel.app',
+          target: 'production',
+        });
+      });
+
+      let callCount = 0;
+      client.scenario.get(`/v13/deployments/dpl_checks_v1`, (_req, res) => {
+        callCount++;
+        res.json({
+          creator: { uid: user.id, username: user.username },
+          id: 'dpl_checks_v1',
+          url: 'checks-v1.vercel.app',
+          readyState: callCount === 1 ? 'BUILDING' : 'READY',
+          aliasAssigned: false,
+          checksState: callCount > 1 ? 'completed' : 'running',
+          checksConclusion: callCount > 1 ? 'failed' : undefined,
+          target: 'production',
+          alias: [],
+        });
+      });
+
+      client.scenario.get(
+        `/v1/deployments/dpl_checks_v1/checks`,
+        (_req, res) => {
+          res.json({
+            checks: [
+              {
+                id: 'chk_1',
+                name: 'Lint',
+                status: 'completed',
+                conclusion: 'failed',
+                startedAt: Date.now(),
+                completedAt: Date.now(),
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+                integrationId: 'int_1',
+                rerequestable: false,
+              },
+              {
+                id: 'chk_2',
+                name: 'Tests',
+                status: 'completed',
+                conclusion: 'succeeded',
+                startedAt: Date.now(),
+                completedAt: Date.now(),
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+                integrationId: 'int_2',
+                rerequestable: false,
+              },
+            ],
+          });
+        }
+      );
+
+      client.scenario.get(
+        `/v3/now/deployments/dpl_checks_v1/events`,
+        (_req, res) => {
+          res.end();
+        }
+      );
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--prod', '--yes');
+
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(1);
+
+      const stderrOutput = client.stderr.read().toString();
+      expect(stderrOutput).toContain('1 failed');
+      expect(stderrOutput).toContain('1 succeeded');
+    });
+
+    // v2 checks: deployment.checks['deployment-alias'].state === 'failed'
+    it('should error when v2 deployment checks fail', async () => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.post(`/v13/deployments`, (_req, res) => {
+        res.json({
+          creator: { uid: user.id, username: user.username },
+          id: 'dpl_checks_v2',
+          url: 'checks-v2.vercel.app',
+          target: 'production',
+          checks: { 'deployment-alias': { state: 'pending' } },
+        });
+      });
+
+      let callCount = 0;
+      client.scenario.get(`/v13/deployments/dpl_checks_v2`, (_req, res) => {
+        callCount++;
+        const isFailed = callCount > 2;
+        res.json({
+          creator: { uid: user.id, username: user.username },
+          id: 'dpl_checks_v2',
+          url: 'checks-v2.vercel.app',
+          readyState: callCount === 1 ? 'BUILDING' : 'READY',
+          aliasAssigned: false,
+          target: 'production',
+          alias: [],
+          checks: {
+            'deployment-alias': {
+              state: isFailed ? 'failed' : 'pending',
+            },
+          },
+        });
+      });
+
+      client.scenario.get(
+        `/v2/deployments/dpl_checks_v2/check-runs`,
+        (_req, res) => {
+          res.json({
+            runs: [
+              {
+                id: 'cr_1',
+                name: 'E2E Tests',
+                status: 'completed',
+                conclusion: 'failed',
+                source: 'vercel',
+              },
+              {
+                id: 'cr_2',
+                name: 'Smoke Test',
+                status: 'completed',
+                conclusion: 'skipped',
+                source: 'github',
+              },
+            ],
+          });
+        }
+      );
+
+      client.scenario.get(
+        `/v3/now/deployments/dpl_checks_v2/events`,
+        (_req, res) => {
+          res.end();
+        }
+      );
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--prod', '--yes');
+
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(1);
+
+      const stderrOutput = client.stderr.read().toString();
+      expect(stderrOutput).toContain('Running Checks');
+      expect(stderrOutput).toContain('1 failed');
+      expect(stderrOutput).toContain('1 skipped');
+      expect(stderrOutput).toContain('E2E Tests');
+    });
+
+    // v2 checks failure in non-interactive mode
+    it('should output failed check runs as JSON in non-interactive mode', async () => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.post(`/v13/deployments`, (_req, res) => {
+        res.json({
+          creator: { uid: user.id, username: user.username },
+          id: 'dpl_checks_ni',
+          url: 'checks-ni.vercel.app',
+          inspectorUrl: 'https://vercel.com/test/dpl_checks_ni',
+          target: 'production',
+          checks: { 'deployment-alias': { state: 'pending' } },
+        });
+      });
+
+      let callCount = 0;
+      client.scenario.get(`/v13/deployments/dpl_checks_ni`, (_req, res) => {
+        callCount++;
+        res.json({
+          creator: { uid: user.id, username: user.username },
+          id: 'dpl_checks_ni',
+          url: 'checks-ni.vercel.app',
+          inspectorUrl: 'https://vercel.com/test/dpl_checks_ni',
+          readyState: callCount === 1 ? 'BUILDING' : 'READY',
+          aliasAssigned: false,
+          target: 'production',
+          alias: [],
+          checks: {
+            'deployment-alias': {
+              state: callCount > 2 ? 'failed' : 'pending',
+            },
+          },
+        });
+      });
+
+      client.scenario.get(
+        `/v2/deployments/dpl_checks_ni/check-runs`,
+        (_req, res) => {
+          res.json({
+            runs: [
+              {
+                id: 'cr_fail',
+                name: 'Lint',
+                status: 'completed',
+                conclusion: 'failed',
+                source: 'vercel',
+              },
+            ],
+          });
+        }
+      );
+
+      client.scenario.get(
+        `/v3/now/deployments/dpl_checks_ni/events`,
+        (_req, res) => {
+          res.end();
+        }
+      );
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--prod', '--yes', '--non-interactive');
+      (client as { nonInteractive: boolean }).nonInteractive = true;
+
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(1);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const json = JSON.parse(stdoutOutput);
+      expect(json.status).toBe('error');
+      expect(json.reason).toBe('checks_failed');
+      expect(json.failedCheckRuns).toHaveLength(1);
+      expect(json.failedCheckRuns[0].name).toBe('Lint');
+      expect(json.failedCheckRuns[0].logsEndpoint).toContain(
+        '/check-runs/cr_fail/logs'
+      );
+    });
+
+    // v2 checks pending → shows "Running Checks..." spinner
+    it('should show Running Checks spinner when v2 checks are pending', async () => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.post(`/v13/deployments`, (_req, res) => {
+        res.json({
+          creator: { uid: user.id, username: user.username },
+          id: 'dpl_checks_pending',
+          url: 'checks-pending.vercel.app',
+          target: 'production',
+          checks: { 'deployment-alias': { state: 'pending' } },
+        });
+      });
+
+      let callCount = 0;
+      client.scenario.get(
+        `/v13/deployments/dpl_checks_pending`,
+        (_req, res) => {
+          callCount++;
+          const isReady = callCount > 1;
+          const isAliased = callCount > 2;
+          res.json({
+            creator: { uid: user.id, username: user.username },
+            id: 'dpl_checks_pending',
+            url: 'checks-pending.vercel.app',
+            readyState: isReady ? 'READY' : 'BUILDING',
+            aliasAssigned: isAliased,
+            target: 'production',
+            alias: isAliased ? ['my-app.vercel.app'] : [],
+            checks: {
+              'deployment-alias': {
+                state: isAliased ? 'succeeded' : 'pending',
+              },
+            },
+          });
+        }
+      );
+
+      client.scenario.get(
+        `/v3/now/deployments/dpl_checks_pending/events`,
+        (_req, res) => {
+          res.end();
+        }
+      );
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--prod', '--yes');
+
+      const exitCodePromise = deploy(client);
+
+      await expect(client.stderr).toOutput('Running Checks...');
+      await expect(client.stderr).toOutput('Aliased:');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+  });
 });

--- a/packages/client/src/check-deployment-status.ts
+++ b/packages/client/src/check-deployment-status.ts
@@ -198,6 +198,19 @@ export async function* checkDeploymentStatus(
       }
     }
 
+    // v2 checks: if deployment-alias check has failed, exit immediately
+    if (
+      deploymentUpdate.checks?.['deployment-alias']?.state === 'failed' &&
+      !finishedEvents.has('checks-v2-failed')
+    ) {
+      debug('v2 deployment-alias check failed');
+      finishedEvents.add('checks-v2-failed');
+      return yield {
+        type: 'checks-v2-failed',
+        payload: deploymentUpdate,
+      };
+    }
+
     if (isAliasAssigned(deploymentUpdate)) {
       debug('Deployment alias assigned');
       return yield { type: 'alias-assigned', payload: deploymentUpdate };

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -106,6 +106,14 @@ export interface Deployment {
   alias: string[];
   aliasAssigned: boolean;
   aliasError: string | null;
+  checks?: Record<
+    string,
+    {
+      state: 'pending' | 'succeeded' | 'failed';
+      startedAt?: string;
+      completedAt?: string;
+    }
+  >;
   expiration?: number;
   proposedExpiration?: number;
   undeletedAt?: number;

--- a/packages/client/src/upload.ts
+++ b/packages/client/src/upload.ts
@@ -59,9 +59,16 @@ export async function* upload(
         return yield event;
       }
     } else {
-      // If the deployment has succeeded here, don't continue
-      if (event.type === 'alias-assigned') {
-        debug('Deployment succeeded on file check');
+      // If the deployment has succeeded or v2 checks failed, don't continue
+      if (
+        event.type === 'alias-assigned' ||
+        event.type === 'checks-v2-failed'
+      ) {
+        debug(
+          event.type === 'alias-assigned'
+            ? 'Deployment succeeded on file check'
+            : 'v2 deployment-alias check failed on file check'
+        );
 
         return yield event;
       }
@@ -105,7 +112,10 @@ export async function* upload(
   try {
     debug('Starting deployment creation');
     for await (const event of deploy(files, clientOptions, deploymentOptions)) {
-      if (event.type === 'alias-assigned') {
+      if (
+        event.type === 'alias-assigned' ||
+        event.type === 'checks-v2-failed'
+      ) {
         debug('Deployment is ready');
         return yield event;
       }

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -36,7 +36,7 @@ const EVENTS_ARRAY = [
   'notice',
   'tip',
   'canceled',
-  // Checks events
+  // v1 Checks events
   'checks-registered',
   'checks-completed',
   'checks-running',
@@ -44,6 +44,8 @@ const EVENTS_ARRAY = [
   'checks-conclusion-failed',
   'checks-conclusion-skipped',
   'checks-conclusion-canceled',
+  // v2 Checks events
+  'checks-v2-failed',
 ] as const;
 
 export type DeploymentEventType = (typeof EVENTS_ARRAY)[number];


### PR DESCRIPTION
## Summary

- Add support for Deployment Checks (`deployment.checks['deployment-alias']`) in `vc deploy --prod`
- Show "Running Checks..." spinner when the deployment-alias check is pending after build completes
- Detect `deployment-alias` check failure via polling and exit with error details
- Fetch check run details from `GET /v2/deployments/{id}/check-runs` and display failed runs with hyperlinked names to logs endpoint (vercel source) or deployment page (external source)
- Include `failedCheckRuns` with per-run details (id, name, source, logsUrl) in non-interactive JSON output
- Existing v1 checks (`checksConclusion`) and `aliasError` handling preserved

### How success/failure paths work

- **Success**: Server sets `aliasAssigned: true` after checks pass → existing `alias-assigned` event handles it (no new code path needed)
- **Failure**: Polling detects `checks['deployment-alias'].state === 'failed'` → emits `checks-v2-completed` event → CLI fetches check runs and prints failures

## Test plan

- Unit tests for v1 checks failure, v2 checks failure, v2 non-interactive JSON output, and v2 checks pending → success flow



![CleanShot 2026-04-08 at 15.51.16.png](https://app.graphite.com/user-attachments/assets/554fbd87-9b7e-4596-b5c8-4a86d416004e.png)

