### PR TITLE
[build-utils] Update zipPath type to support existing callers

### DIFF
--- a/.changeset/flat-oranges-itch.md
+++ b/.changeset/flat-oranges-itch.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Restore `finalizeLambda()` to return `zipPath: null` for the default in-memory path, preserving the existing caller-facing result contract while keeping custom ZIP strategies supported.

--- a/packages/build-utils/src/finalize-lambda.ts
+++ b/packages/build-utils/src/finalize-lambda.ts
@@ -70,8 +70,8 @@ export interface FinalizeLambdaParams {
 export interface FinalizeLambdaResult {
   /** The zip as a Buffer, or null when a custom createZip returns a disk path. */
   buffer: Buffer | null;
-  /** Path to zip on disk (set by custom createZip), undefined for in-memory. */
-  zipPath?: string;
+  /** Path to zip on disk (set by custom createZip), null for in-memory. */
+  zipPath: string | null;
   /** SHA-256 hex digest. */
   digest: string;
   /** Compressed size in bytes. */
@@ -194,7 +194,7 @@ export async function finalizeLambda(
 
   return {
     buffer: zipResult.buffer,
-    zipPath: zipResult.zipPath,
+    zipPath: zipResult.zipPath ?? null,
     digest: zipResult.digest,
     size: zipResult.size,
     uncompressedBytes,

--- a/packages/build-utils/test/unit.finalize-lambda.test.ts
+++ b/packages/build-utils/test/unit.finalize-lambda.test.ts
@@ -47,6 +47,7 @@ describe('finalizeLambda()', () => {
 
     expect(result.buffer).toBeInstanceOf(Buffer);
     expect(result.buffer.length).toBeGreaterThan(0);
+    expect(result.zipPath).toBeNull();
     expect(result.digest).toEqual(sha256(result.buffer));
     expect(result.uncompressedBytes).toEqual(0);
   });
@@ -208,5 +209,25 @@ describe('finalizeLambda()', () => {
     });
 
     expect(result.buffer).toBeInstanceOf(Buffer);
+  });
+
+  it('returns a zipPath for custom createZip strategies', async () => {
+    const lambda = createBasicLambda();
+    const result = await finalizeLambda({
+      lambda,
+      bytecodeCachingOptions: NO_BYTECODE,
+      forceStreamingRuntime: false,
+      createZip: async () => ({
+        buffer: null,
+        zipPath: '/tmp/lambda.zip',
+        digest: 'abc123',
+        size: 123,
+      }),
+    });
+
+    expect(result.buffer).toBeNull();
+    expect(result.zipPath).toEqual('/tmp/lambda.zip');
+    expect(result.digest).toEqual('abc123');
+    expect(result.size).toEqual(123);
   });
 });


### PR DESCRIPTION
Follow up to: 
- https://github.com/vercel/vercel/pull/15856

After using the exported functions for existing callers, I realized we didn't get the `zipPath` type correct.

As the goal is to avoid any semantic changes for existing callers, we have to fix it here.