### PR TITLE
[python] Use services orchestrator for single web services in local dev.

### DIFF
--- a/.changeset/brown-ducks-jog.md
+++ b/.changeset/brown-ducks-jog.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Use services orchestrator for single web services in local dev.

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -186,10 +186,7 @@ export default class DevServer {
     if (!this.services || this.services.length === 0) {
       return false;
     }
-    if (this.services.length > 1) {
-      return true;
-    }
-    return this.services[0].type !== 'web';
+    return true;
   }
 
   constructor(cwd: string, options: DevServerOptions) {


### PR DESCRIPTION
When running `vc dev`, single web services (eg. a flask app) were not started, resulting in 404 responses.

This happened because the services orchestrator was skipped for single web services, falling through to the non-services path. However in this path the builder is filtered out by `filterFrontendBuilds` since `@vercel/python` is included in `frontendRuntimeSet`. Since the python frameworks generally have no `devCommand`, they will not be served by default.

Even if the builders are manually re-injected into the fallback path, `startDevServer` would be called without `syncDependencies`. As a result, a new project or checkout will also not be served.