### PR TITLE
[python] Fix local builds when pinned Python version is not on PATH.

### DIFF
--- a/.changeset/perfect-peas-breathe.md
+++ b/.changeset/perfect-peas-breathe.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Fix local builds when pinned Python version is not on PATH.

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -315,10 +315,27 @@ export const build: BuildVX = async ({
   // part of a named service, namespace the venv so multiple services sharing
   // the same source don't overwrite each other's artifacts in case of custom
   // installCommand or buildCommand.
+  const uvCacheDir = getUvCacheDir(workPath);
+  let uv: UvRunner;
+  try {
+    const uvPath = await getUvBinaryOrInstall(pythonVersion.pythonPath);
+    uv = new UvRunner(uvPath, uvCacheDir);
+    const uvVersionOutput = execSync(`${uvPath} --version`, {
+      encoding: 'utf8',
+    }).trim();
+    console.log(`Using ${uvVersionOutput}`);
+  } catch (err) {
+    console.log('Failed to install or locate uv');
+    throw new Error(
+      `uv is required for this project but failed to install: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+
   const venvPath = service?.name
     ? join(workPath, '.vercel', 'python', 'services', service.name, '.venv')
     : join(workPath, '.vercel', 'python', '.venv');
-  const uvCacheDir = getUvCacheDir(workPath);
   const hasCachedVenv = fs.existsSync(join(venvPath, 'pyvenv.cfg'));
   const hasCachedUv = fs.existsSync(uvCacheDir);
   if (hasCachedVenv || hasCachedUv) {
@@ -330,6 +347,7 @@ export const build: BuildVX = async ({
     await ensureVenv({
       pythonVersion,
       venvPath,
+      uvPath: uv.getPath(),
       uvCacheDir,
     });
   });
@@ -372,23 +390,6 @@ export const build: BuildVX = async ({
   // virtualenv
   let assumeDepsInstalled = false;
 
-  let uv: UvRunner;
-  try {
-    const uvPath = await getUvBinaryOrInstall(pythonVersion.pythonPath);
-    uv = new UvRunner(uvPath, uvCacheDir);
-    const uvVersionOutput = execSync(`${uvPath} --version`, {
-      encoding: 'utf8',
-    }).trim();
-    console.log(`Using ${uvVersionOutput}`);
-  } catch (err) {
-    console.log('Failed to install or locate uv');
-    throw new Error(
-      `uv is required for this project but failed to install: ${
-        err instanceof Error ? err.message : String(err)
-      }`
-    );
-  }
-
   // Track the lock file path and project info for package classification (used when runtime install is enabled)
   let uvLockPath: string | null = null;
   let uvProjectDir: string | null = null;
@@ -406,6 +407,7 @@ export const build: BuildVX = async ({
         await ensureVenv({
           pythonVersion,
           venvPath,
+          uvPath: uv.getPath(),
           uvCacheDir,
           quiet: true,
         });

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -131,7 +131,8 @@ export async function ensureVenv({
 
   if (uvPath) {
     // --allow-existing allows uv to reuse a cached venv
-    const args = ['venv', venvPath, '--allow-existing'];
+    // --seed installs pip into the venv so custom install commands can use it
+    const args = ['venv', venvPath, '--allow-existing', '--seed'];
     // vc dev uses system python so we skip passing the python version to uv
     if (pythonVersion.major != null && pythonVersion.minor != null) {
       args.push('--python', `${pythonVersion.major}.${pythonVersion.minor}`);


### PR DESCRIPTION
When `.python-version` pins a Python version that isn't available in `PATH` but is available through uv, vercel build fails with `spawn python3.13 ENOENT`. This happens because `ensureVenv` was invoked without uvPath and falls back to `python3.13 -m venv`.

Fixed by always passing `uvPath` to `ensureVenv` and adding `--python` to the `uv venv` call.