### PR TITLE
fix(cli): align repo.json with .vercel/project.json for monorepo links

### DIFF
--- a/.changeset/cli-repo-json-project-json-consistency.md
+++ b/.changeset/cli-repo-json-project-json-consistency.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Align `repo.json` and `.vercel/project.json`: prefer repo mapping for `rootDirectory` when reading pulled settings, resolve stale per-directory links against the repository config, and always persist project ids when writing pulled settings.

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -446,6 +446,11 @@ export interface ProjectLink {
    */
   projectRootDirectory?: string;
   /**
+   * When linked via `repo.json`, true if that entry uses the suggested local
+   * directory without updating the Vercel project's root directory setting.
+   */
+  directorySpecifiedManually?: boolean;
+  /**
    * Name of the Vercel Project.
    */
   projectName?: string;

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -88,7 +88,11 @@ import stamp from '../../util/output/stamp';
 import parseTarget from '../../util/parse-target';
 import cliPkg from '../../util/pkg';
 import * as cli from '../../util/pkg-name';
-import { getProjectLink, VERCEL_DIR } from '../../util/projects/link';
+import {
+  getProjectLink,
+  repoLinkedFilesystemSegment,
+  VERCEL_DIR,
+} from '../../util/projects/link';
 import { resolveProjectCwd } from '../../util/projects/find-project-root';
 import {
   pickOverrides,
@@ -253,7 +257,7 @@ export default async function main(client: Client): Promise<number> {
   const link = await rootSpan
     .child('vc.getProjectLink')
     .trace(() => getProjectLink(client, cwd));
-  const projectRootDirectory = link?.projectRootDirectory ?? '';
+  const projectRootDirectory = repoLinkedFilesystemSegment(link);
   if (link?.repoRoot) {
     cwd = client.cwd = link.repoRoot;
   }
@@ -340,6 +344,10 @@ export default async function main(client: Client): Promise<number> {
     client.cwd = cwd;
     client.argv = originalArgv;
     project = await readProjectSettings(vercelDir);
+  }
+
+  if (!project || !project.settings) {
+    return 1;
   }
 
   // Delete output directory from potential previous build
@@ -452,7 +460,15 @@ export default async function main(client: Client): Promise<number> {
       await rootSpan
         .child('vc.doBuild')
         .trace(span =>
-          doBuild(client, project, buildsJson, cwd, outputDir, span, standalone)
+          doBuild(
+            client,
+            project as ProjectLinkAndSettings,
+            buildsJson,
+            cwd,
+            outputDir,
+            span,
+            standalone
+          )
         );
     } finally {
       await rootSpan.stop();

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -126,7 +126,8 @@ export async function pullCommandLogic(
 
   let currentDirectory: string;
   if (repoRoot) {
-    currentDirectory = join(repoRoot, project.rootDirectory || '');
+    const segment = project.rootDirectory ?? '';
+    currentDirectory = join(repoRoot, segment);
   } else {
     currentDirectory = cwd;
   }
@@ -146,8 +147,7 @@ export async function pullCommandLogic(
 
   output.print('\n');
   output.log('Downloading project settings');
-  const isRepoLinked = typeof repoRoot === 'string';
-  await writeProjectSettings(currentDirectory, project, org, isRepoLinked);
+  await writeProjectSettings(currentDirectory, project, org);
 
   const settingsStamp = stamp();
   output.print(

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -30,6 +30,11 @@ export interface RepoProjectConfig {
   name: string;
   directory: string;
   orgId?: string;
+  /**
+   * When set, this entry was linked with a suggested local directory without
+   * updating the Vercel project's root directory setting.
+   */
+  directorySpecifiedManually?: boolean;
 }
 
 export interface RepoProjectsConfig {

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -18,7 +18,11 @@ import type {
 } from '@vercel-internals/types';
 import { prependEmoji, emoji, type EmojiLabel } from '../emoji';
 import { isDirectory } from '../config/global-path';
-import { NowBuildError, getPlatformEnv } from '@vercel/build-utils';
+import {
+  NowBuildError,
+  getPlatformEnv,
+  normalizePath,
+} from '@vercel/build-utils';
 import outputCode from '../output/code';
 import { isErrnoException, isError } from '@vercel/error-utils';
 import { findProjectsFromPath, getRepoLink } from '../link/repo';
@@ -30,6 +34,46 @@ import { resolveProjectCwd } from './find-project-root';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
+
+/** Maps `repo.json` `directory` to `Project.rootDirectory` (null = app at repo root). */
+function repoDirectoryToProjectRootDirectory(dir: string): string | null {
+  if (dir === '' || dir === '.') return null;
+  return normalizePath(dir);
+}
+
+/**
+ * When linked via `repo.json`, the API project’s `rootDirectory` can differ from
+ * the repo mapping; use the repo path for all CLI filesystem routing.
+ */
+function projectWithRepoLinkedRootDirectory(
+  project: Project,
+  link: ProjectLink
+): Project {
+  if (!link.repoRoot || link.projectRootDirectory === undefined) {
+    return project;
+  }
+  return {
+    ...project,
+    rootDirectory: repoDirectoryToProjectRootDirectory(
+      link.projectRootDirectory
+    ),
+  };
+}
+
+/**
+ * Relative path from the Git repo root to the linked app (for `join(repoRoot, …)`).
+ * Empty string when the app is at the repo root or when not repo-linked.
+ */
+export function repoLinkedFilesystemSegment(
+  link: ProjectLink | null | undefined
+): string {
+  if (!link?.repoRoot || link.projectRootDirectory === undefined) {
+    return '';
+  }
+  const d = link.projectRootDirectory;
+  if (d === '' || d === '.') return '';
+  return normalizePath(d);
+}
 
 export const VERCEL_DIR = '.vercel';
 export const VERCEL_DIR_FALLBACK = '.now';
@@ -79,28 +123,153 @@ export function getVercelDirectory(cwd: string): string {
 export async function getProjectLink(
   client: Client,
   path: string,
-  projectName?: string
+  projectName?: string | null
 ): Promise<ProjectLink | null> {
   // Prefer an explicit per-directory link (`.vercel/project.json`) over a
   // repository-level link (`.vercel/repo.json`). This prevents scenarios where
   // a freshly-created local link (e.g. after `vc link`) is ignored and the
   // user is re-prompted to select a repo-linked project again.
-  const dirLink = await getLinkFromDir(getVercelDirectory(path));
+  //
+  // When both exist, `project.json` must agree with `repo.json` for this path
+  // (org + project). If `project.json` references a project that appears in
+  // `repo.json` under a different path or org, treat it as stale and resolve
+  // from `repo.json` again (e.g. after switching which project maps to cwd).
+  const vercelDir = getVercelDirectory(path);
+  const dirLink = await getLinkFromDir(vercelDir);
   if (dirLink) {
+    const repoLink = await getRepoLink(client, path);
+    if (repoLink?.repoConfig) {
+      const rel = relative(repoLink.rootPath, path);
+      const candidates = findProjectsFromPath(
+        repoLink.repoConfig.projects,
+        rel
+      );
+      const topOrg = repoLink.repoConfig.orgId;
+
+      const matchingRow = candidates.find(
+        row =>
+          row.id === dirLink.projectId &&
+          (row.orgId ?? topOrg) === dirLink.orgId
+      );
+
+      if (matchingRow) {
+        return {
+          orgId: dirLink.orgId,
+          projectId: dirLink.projectId,
+          repoRoot: repoLink.rootPath,
+          projectRootDirectory: matchingRow.directory,
+          directorySpecifiedManually:
+            matchingRow.directorySpecifiedManually === true,
+        };
+      }
+
+      const dirLinkRow = repoLink.repoConfig.projects.find(
+        p => p.id === dirLink.projectId
+      );
+      if (dirLinkRow) {
+        const rowOrg = dirLinkRow.orgId ?? topOrg;
+        const orgMismatch = rowOrg !== dirLink.orgId;
+        const appliesHere = findProjectsFromPath([dirLinkRow], rel).length > 0;
+        if (orgMismatch || !appliesHere) {
+          output.debug(
+            '`.vercel/project.json` does not match `repo.json` for this path; re-resolving link from the repository mapping'
+          );
+          return await getProjectLinkFromRepoLink(client, path, projectName);
+        }
+      }
+
+      return dirLink;
+    }
+
     return dirLink;
   }
+
   return await getProjectLinkFromRepoLink(client, path, projectName);
+}
+
+function choiceLabelsForRepoProjectSelect(
+  selectableProjects: RepoProjectConfig[]
+): Array<{ name: string; value: RepoProjectConfig }> {
+  const countByName = new Map<string, number>();
+  for (const p of selectableProjects) {
+    countByName.set(p.name, (countByName.get(p.name) ?? 0) + 1);
+  }
+  const choices: Array<{ name: string; value: RepoProjectConfig }> = [];
+  for (const p of selectableProjects) {
+    let label = p.name;
+    const dup = (countByName.get(p.name) ?? 0) > 1;
+    if (dup && p.orgId) {
+      label = `${p.name}${chalk.dim(` (${p.orgId})`)}`;
+    }
+    choices.push({ name: label, value: p });
+  }
+  return choices;
+}
+
+/**
+ * After resolving a project from `repo.json`, persist `orgId` / `projectId` /
+ * `projectName` to `.vercel/project.json`. If the file already pointed at a
+ * different project, drop `settings` so stale pulled settings are not reused.
+ */
+async function persistRepoResolvedProjectJson(
+  projectCwd: string,
+  next: { orgId: string; projectId: string; projectName: string }
+): Promise<void> {
+  const vercelDir = getVercelDirectory(projectCwd);
+  const projectPath = join(vercelDir, VERCEL_DIR_PROJECT);
+  let existing: Record<string, unknown> | null = null;
+  try {
+    existing = JSON.parse(await readFile(projectPath, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+  } catch (err: unknown) {
+    if (
+      isErrnoException(err) &&
+      err.code &&
+      ['ENOENT', 'ENOTDIR'].includes(err.code)
+    ) {
+      existing = null;
+    } else if (isError(err) && err.name === 'SyntaxError') {
+      existing = null;
+    } else {
+      throw err;
+    }
+  }
+
+  const same =
+    existing &&
+    existing.orgId === next.orgId &&
+    existing.projectId === next.projectId;
+  if (same) {
+    return;
+  }
+
+  await ensureDir(vercelDir);
+  await writeFile(
+    projectPath,
+    JSON.stringify(
+      {
+        orgId: next.orgId,
+        projectId: next.projectId,
+        projectName: next.projectName,
+      },
+      null,
+      2
+    )
+  );
 }
 
 async function getProjectLinkFromRepoLink(
   client: Client,
   path: string,
-  projectName?: string
+  projectName?: string | null
 ): Promise<ProjectLink | null> {
   const repoLink = await getRepoLink(client, path);
   if (!repoLink?.repoConfig) {
     return null;
   }
+  const topOrg = repoLink.repoConfig.orgId;
   const projects = findProjectsFromPath(
     repoLink.repoConfig.projects,
     relative(repoLink.rootPath, path)
@@ -128,17 +297,14 @@ async function getProjectLinkFromRepoLink(
       } else {
         project = await client.input.select({
           message: `Please select a Project:`,
-          choices: selectableProjects.map(p => ({
-            value: p,
-            name: p.name,
-          })),
+          choices: choiceLabelsForRepoProjectSelect(selectableProjects),
         });
       }
     }
   }
   if (project) {
     // Prefer project-level orgId, fall back to top-level for backwards compat
-    const orgId = project.orgId ?? repoLink.repoConfig.orgId;
+    const orgId = project.orgId ?? topOrg;
     if (!orgId) {
       const projectInfo = [
         project.name ? `name: "${project.name}"` : '',
@@ -151,11 +317,17 @@ async function getProjectLinkFromRepoLink(
         `Could not determine org ID from repo.json config at "${repoLink.repoConfigPath}".${details} Please re-link the repository.`
       );
     }
+    await persistRepoResolvedProjectJson(path, {
+      orgId,
+      projectId: project.id,
+      projectName: project.name,
+    });
     return {
       repoRoot: repoLink.rootPath,
       orgId,
       projectId: project.id,
       projectRootDirectory: project.directory,
+      directorySpecifiedManually: project.directorySpecifiedManually === true,
     };
   }
   return null;
@@ -180,9 +352,8 @@ export async function getLinkFromDir<T = ProjectLink>(
         typeof orgId === 'string' &&
         orgId.length > 0;
       if (!hasPlainLinkIds) {
-        // `vercel pull` with a repo-level link writes settings-only `project.json`
-        // (see writeProjectSettings). Treat as no per-directory link and fall
-        // back to `.vercel/repo.json` resolution.
+        // Legacy: older `vercel pull` omitted ids for repo-linked paths. Treat as
+        // no per-directory link and fall back to `.vercel/repo.json` resolution.
         return null;
       }
       throw new Error(
@@ -289,7 +460,7 @@ async function hasProjectLink(
 export async function getLinkedProject(
   client: Client,
   path = client.cwd,
-  projectName?: string
+  projectName?: string | null
 ): Promise<ProjectLinkResult> {
   path = await resolveProjectCwd(path);
 
@@ -394,7 +565,12 @@ export async function getLinkedProject(
     return { status: 'not_linked', org: null, project: null };
   }
 
-  return { status: 'linked', org, project, repoRoot: link.repoRoot };
+  return {
+    status: 'linked',
+    org,
+    project: projectWithRepoLinkedRootDirectory(project, link),
+    repoRoot: link.repoRoot,
+  };
 }
 
 const VERCEL_DIR_README_CONTENT = `> Why do I have a folder named ".vercel" in my project?

--- a/packages/cli/src/util/projects/project-settings.ts
+++ b/packages/cli/src/util/projects/project-settings.ts
@@ -1,7 +1,13 @@
-import { join } from 'path';
-import { outputJSON, readFile } from 'fs-extra';
+import { dirname, join, relative } from 'path';
+import { normalizePath } from '@vercel/build-utils';
+import { outputJSON, readFile, readJSON } from 'fs-extra';
 import type { VercelConfig } from '@vercel/client';
-import { VERCEL_DIR, VERCEL_DIR_PROJECT } from './link';
+import { VERCEL_DIR, VERCEL_DIR_PROJECT, VERCEL_DIR_REPO } from './link';
+import {
+  findProjectsFromPath,
+  findRepoRoot,
+  type RepoProjectsConfig,
+} from '../link/repo';
 import type { PartialProjectSettings } from '../input/edit-project-settings';
 import type { Org, Project, ProjectLink } from '@vercel-internals/types';
 import { isErrnoException, isError } from '@vercel/error-utils';
@@ -23,12 +29,13 @@ export type ProjectLinkAndSettings = Partial<ProjectLink> & {
 
 // writeProjectSettings writes the project configuration to `vercel/project.json`
 // Write the project configuration to `.vercel/project.json`
-// that is needed for `vercel build` and `vercel dev` commands
+// that is needed for `vercel build` and `vercel dev` commands.
+// Always records `orgId` / `projectId` / `projectName` so monorepo paths can tell
+// which Vercel project the pulled settings belong to (see `getProjectLink`).
 export async function writeProjectSettings(
   cwd: string,
   project: Project,
-  org: Org,
-  isRepoLinked: boolean
+  org: Org
 ) {
   let analyticsId: string | undefined;
   if (
@@ -41,9 +48,9 @@ export async function writeProjectSettings(
   }
 
   const projectLinkAndSettings: ProjectLinkAndSettings = {
-    projectId: isRepoLinked ? undefined : project.id,
-    orgId: isRepoLinked ? undefined : org.id,
-    projectName: isRepoLinked ? undefined : project.name,
+    projectId: project.id,
+    orgId: org.id,
+    projectName: project.name,
     settings: {
       createdAt: project.createdAt,
       framework: project.framework,
@@ -63,9 +70,12 @@ export async function writeProjectSettings(
   });
 }
 
-export async function readProjectSettings(vercelDir: string) {
+export async function readProjectSettings(
+  vercelDir: string
+): Promise<ProjectLinkAndSettings | null> {
+  let parsed: unknown;
   try {
-    return JSON.parse(
+    parsed = JSON.parse(
       await readFile(join(vercelDir, VERCEL_DIR_PROJECT), 'utf8')
     );
   } catch (err: unknown) {
@@ -85,6 +95,76 @@ export async function readProjectSettings(vercelDir: string) {
 
     throw err;
   }
+
+  return (await preferRepoJsonRootDirectory(
+    vercelDir,
+    parsed
+  )) as ProjectLinkAndSettings | null;
+}
+
+/**
+ * When `.vercel/repo.json` maps the same project (`projectId` / `orgId`) as
+ * `project.json`, use that entry's `directory` as `settings.rootDirectory`
+ * so local repo link wins over stale dashboard values from pull.
+ */
+async function preferRepoJsonRootDirectory(
+  vercelDir: string,
+  parsed: unknown
+): Promise<unknown> {
+  if (!parsed || typeof parsed !== 'object') {
+    return parsed;
+  }
+  const raw = parsed as ProjectLinkAndSettings & {
+    projectId?: string;
+    orgId?: string;
+  };
+  if (!raw.settings) {
+    return parsed;
+  }
+  const projectId = raw.projectId;
+  const orgId = raw.orgId;
+  if (typeof projectId !== 'string' || typeof orgId !== 'string') {
+    return parsed;
+  }
+
+  const projectDir = dirname(vercelDir);
+  const rootPath = await findRepoRoot(projectDir);
+  if (!rootPath) {
+    return parsed;
+  }
+
+  const repoConfigPath = join(rootPath, VERCEL_DIR, VERCEL_DIR_REPO);
+  const repoConfig: RepoProjectsConfig | undefined = await readJSON(
+    repoConfigPath
+  ).catch((err: unknown) => {
+    if (isErrnoException(err) && err.code === 'ENOENT') return undefined;
+    throw err;
+  });
+  if (!repoConfig?.projects?.length) {
+    return parsed;
+  }
+
+  const rel = normalizePath(relative(rootPath, projectDir));
+  const topOrg = repoConfig.orgId;
+  const matchesForPath = findProjectsFromPath(repoConfig.projects, rel);
+  const row = matchesForPath.find(
+    p => p.id === projectId && (p.orgId ?? topOrg) === orgId
+  );
+  if (!row) {
+    return parsed;
+  }
+
+  const fromRepo = row.directory;
+  const rootDirectory =
+    fromRepo === '' || fromRepo === '.' ? null : normalizePath(fromRepo);
+
+  return {
+    ...raw,
+    settings: {
+      ...raw.settings,
+      rootDirectory,
+    },
+  };
 }
 
 export function pickOverrides(

--- a/packages/cli/test/fixtures/unit/monorepo-link-legacy/dashboard/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/monorepo-link-legacy/dashboard/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "orgId": "team_dummy",
+  "projectId": "QmbKpqpiUqbcke",
+  "projectName": "monorepo-dashboard"
+}

--- a/packages/cli/test/fixtures/unit/monorepo-link/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/monorepo-link/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "orgId": "team_dummy",
+  "projectId": "QmScb7GPQt6gsS",
+  "projectName": "monorepo-blog"
+}

--- a/packages/cli/test/fixtures/unit/monorepo-link/marketing/subdir/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/monorepo-link/marketing/subdir/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "orgId": "team_dummy",
+  "projectId": "QmX6P93ChNDoZP",
+  "projectName": "monorepo-marketing"
+}

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
+import stripAnsi from 'strip-ansi';
 import { join } from 'path';
-import { mkdirp, writeJSON } from 'fs-extra';
+import { mkdirp, readJSON, writeJSON } from 'fs-extra';
 import {
   getLinkFromDir,
   getLinkedProject,
@@ -207,6 +208,7 @@ describe('getLinkedProject', () => {
     expect(link.org.id).toEqual('team_dummy');
     expect(link.org.type).toEqual('team');
     expect(link.project.id).toEqual('QmbKpqpiUqbcke');
+    // When `project.json` ids match the `repo.json` row for this path, the link includes `repoRoot`.
     expect(link.repoRoot).toEqual(cwd);
 
     // marketing
@@ -222,6 +224,7 @@ describe('getLinkedProject', () => {
     expect(link.org.id).toEqual('team_dummy');
     expect(link.org.type).toEqual('team');
     expect(link.project.id).toEqual('QmX6P93ChNDoZP');
+    // `marketing/subdir` has no `.vercel/project.json`; resolution uses `repo.json` at the repo root.
     expect(link.repoRoot).toEqual(cwd);
 
     // blog
@@ -387,5 +390,184 @@ describe('getLinkedProject', () => {
     expect(link.org.type).toEqual('team');
     expect(link.project.id).toEqual('QmScb7GPQt6gsS');
     expect(link.repoRoot).toEqual(cwd);
+  });
+
+  it('should include scope slug in repo project picker when project names collide', async () => {
+    const repoRoot = setupTmpDir('repo-link-dup-names');
+    const cwd = join(repoRoot, 'apps', 'web');
+    await mkdirp(cwd);
+    await mkdirp(join(repoRoot, '.vercel'));
+    await writeJSON(join(repoRoot, '.vercel', 'repo.json'), {
+      remoteName: 'origin',
+      projects: [
+        {
+          id: 'proj-a',
+          name: 'web-23',
+          directory: 'apps/web',
+          orgId: 'team_alpha',
+        },
+        {
+          id: 'proj-b',
+          name: 'web-23',
+          directory: 'apps/web',
+          orgId: 'team_bravo',
+        },
+      ],
+    });
+
+    useUser();
+    useTeams('team_alpha');
+    useProject({
+      ...defaultProject,
+      id: 'proj-a',
+      name: 'web-23',
+      accountId: 'team_alpha',
+    });
+
+    const selectSpy = vi
+      .spyOn(client.input, 'select')
+      .mockImplementation((async (opts: { choices: readonly unknown[] }) => {
+        const choices = opts.choices.filter(
+          (c: unknown): c is { name: string; value: unknown } =>
+            typeof c === 'object' && c !== null && 'value' in c && 'name' in c
+        );
+        expect(choices.map(c => stripAnsi(c.name))).toEqual([
+          'web-23 (team_alpha)',
+          'web-23 (team_bravo)',
+        ]);
+        return choices[0].value;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- match inquirer `select` signature
+      }) as any);
+
+    const link = await getLinkedProject(client, cwd);
+    selectSpy.mockRestore();
+
+    if (link.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.project.id).toEqual('proj-a');
+    expect(link.repoRoot).toEqual(repoRoot);
+  });
+
+  it('writes project.json when resolving duplicate repo rows and skips a second project prompt', async () => {
+    const repoRoot = setupTmpDir('repo-link-persist-dup');
+    const cwd = join(repoRoot, 'apps', 'web');
+    await mkdirp(cwd);
+    await mkdirp(join(repoRoot, '.vercel'));
+    await writeJSON(join(repoRoot, '.vercel', 'repo.json'), {
+      remoteName: 'origin',
+      projects: [
+        {
+          id: 'proj-a',
+          name: 'web-23',
+          directory: 'apps/web',
+          orgId: 'team_alpha',
+        },
+        {
+          id: 'proj-b',
+          name: 'web-23',
+          directory: 'apps/web',
+          orgId: 'team_bravo',
+        },
+      ],
+    });
+
+    useUser();
+    useTeams('team_alpha');
+    useProject({
+      ...defaultProject,
+      id: 'proj-a',
+      name: 'web-23',
+      accountId: 'team_alpha',
+    });
+
+    const selectSpy = vi
+      .spyOn(client.input, 'select')
+      .mockImplementation((async (opts: { choices: readonly unknown[] }) => {
+        const choices = opts.choices.filter(
+          (c: unknown): c is { name: string; value: unknown } =>
+            typeof c === 'object' && c !== null && 'value' in c && 'name' in c
+        );
+        return choices[0].value;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- match inquirer `select` signature
+      }) as any);
+
+    const link = await getLinkedProject(client, cwd);
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+
+    const written = await readJSON(join(cwd, '.vercel', 'project.json'));
+    expect(written).toMatchObject({
+      orgId: 'team_alpha',
+      projectId: 'proj-a',
+      projectName: 'web-23',
+    });
+    expect(written.settings).toBeUndefined();
+
+    selectSpy.mockClear();
+    const link2 = await getLinkedProject(client, cwd);
+    expect(selectSpy).not.toHaveBeenCalled();
+    selectSpy.mockRestore();
+
+    if (link.status !== 'linked' || link2.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.project.id).toEqual('proj-a');
+    expect(link2.project.id).toEqual('proj-a');
+    expect(link.repoRoot).toEqual(repoRoot);
+  });
+
+  it('re-resolves from repo.json when project.json points at a repo project mapped to another path', async () => {
+    const repoRoot = setupTmpDir('stale-project-json-vs-repo');
+    const cwd = join(repoRoot, 'apps', 'web');
+    await mkdirp(cwd);
+    await mkdirp(join(repoRoot, '.vercel'));
+    await writeJSON(join(repoRoot, '.vercel', 'repo.json'), {
+      remoteName: 'origin',
+      projects: [
+        {
+          id: 'for-web',
+          name: 'web-app',
+          directory: 'apps/web',
+          orgId: 'team_dummy',
+        },
+        {
+          id: 'for-docs',
+          name: 'docs',
+          directory: 'apps/docs',
+          orgId: 'team_dummy',
+        },
+      ],
+    });
+    await mkdirp(join(cwd, '.vercel'));
+    await writeJSON(join(cwd, '.vercel', 'project.json'), {
+      orgId: 'team_dummy',
+      projectId: 'for-docs',
+      projectName: 'docs',
+      settings: {},
+    });
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'for-web',
+      name: 'web-app',
+    });
+    useProject({
+      ...defaultProject,
+      id: 'for-docs',
+      name: 'docs',
+    });
+
+    const prevNi = client.nonInteractive;
+    client.nonInteractive = true;
+    const link = await getLinkedProject(client, cwd);
+    client.nonInteractive = prevNi;
+
+    if (link.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.project.id).toEqual('for-web');
+    expect(link.repoRoot).toEqual(repoRoot);
   });
 });


### PR DESCRIPTION
## Summary

This PR lands the **consistency layer** between repository-level `repo.json` and per-directory `.vercel/project.json` ahead of the larger experimental `vc link --repo` work.

### Behavior

- **Read:** When both files reference the same project (`projectId` / `orgId`), `readProjectSettings` prefers `repo.json`'s `directory` for `settings.rootDirectory` so local repo mapping wins over stale dashboard values from `vercel pull`.
- **Resolve:** `getProjectLink` reconciles mismatches: if `project.json` points at a project that no longer matches `repo.json` for the current path, re-resolve from the repo config.
- **Write:** After resolving from `repo.json`, persist `orgId` / `projectId` / `projectName` to `project.json`; if the linked project changed, drop `settings` so old pulled settings are not reused.
- **Build / pull:** `vercel build` uses `repoLinkedFilesystemSegment` for repo-linked roots; `vercel pull` always writes ids in `project.json` with pulled settings.

### Types

- Optional `directorySpecifiedManually` on `ProjectLink` and `RepoProjectConfig`.

Includes changeset for `vercel` (patch).

Made with [Cursor](https://cursor.com)