### PR TITLE
Fix relative Markdown links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 ## Contributing
 
-See the [Contributing Guidelines](../README.md#contributing) for more details.
+See the [Contributing Guidelines](https://github.com/vercel/vercel/blob/HEAD/README.md#contributing) for more details.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd ./packages/cli
 pnpm vercel <cli-commands...>
 ```
 
-See [CLI Local Development](../packages/cli#local-development) for more details.
+See [CLI Local Development](./packages/cli/README.md#local-development) for more details.
 
 ### Verifying your change
 


### PR DESCRIPTION
Fix two relative Markdown links in assorted README files, which currently lead to error pages when clicked on github.com/vercel/vercel

Examples:
- https://github.com/vercel/vercel/?tab=contributing-ov-file, accessed by clicking Contributing tab or in right sidebar) 
- Click "CLI Local Development" in https://github.com/vercel/vercel/

The first is reported to GitHub in December 2025 and tracked as GitHub personal ticket https://support.github.com/ticket/personal/0/3963440, but not yet fixed:

> We’re tracking this as a product issue with how the Contributing tab resolves relative links. If you’d like, I can associate your example with the internal report and follow up when it’s addressed.
