### PR TITLE
[cli] Fetch check run logs inline and use checkRunLog deep-link

### DIFF
--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -25,6 +25,7 @@ import { createGitMeta } from '../../util/create-git-meta';
 import createDeploy from '../../util/deploy/create-deploy';
 import { getDeploymentChecks } from '../../util/deploy/get-deployment-checks';
 import { getDeploymentCheckRuns } from '../../util/deploy/get-deployment-check-runs';
+import { getDeploymentCheckRunLogs } from '../../util/deploy/get-deployment-check-run-logs';
 import getPrebuiltJson from '../../util/deploy/get-prebuilt-json';
 import { printDeploymentStatus } from '../../util/deploy/print-deployment-status';
 import { isValidArchive } from '../../util/deploy/validate-archive-format';
@@ -2083,7 +2084,6 @@ function getDeploymentOutputJson(
   };
 }
 
-// v2 checks: fetch check runs and print failures
 async function handleFailedCheckRuns(
   client: Client,
   deployment: {
@@ -2108,11 +2108,10 @@ async function handleFailedCheckRuns(
 
   const message = `Running Checks: ${counterList}`;
 
-  const getSourceKind = (run: { source: { kind: string } | string }) =>
-    typeof run.source === 'object' ? run.source.kind : run.source;
-  const getJobName = (run: {
-    source: { kind: string; jobName?: string } | string;
-  }) => (typeof run.source === 'object' ? run.source.jobName : undefined);
+  const getCheckRunUrl = (run: { id: string }) =>
+    deployment.inspectorUrl
+      ? `${deployment.inspectorUrl}?checkRunLog=${encodeURIComponent(run.id)}`
+      : null;
 
   if (asJson) {
     output.stopSpinner();
@@ -2120,19 +2119,33 @@ async function handleFailedCheckRuns(
       name: 'CHECKS_FAILED',
       message,
     });
+
+    const failedCheckRunsWithLogs = await Promise.all(
+      failedRuns.map(async run => {
+        let logs: { text: string; createdAt: number }[] = [];
+        try {
+          logs = await getDeploymentCheckRunLogs(client, deployment.id, run.id);
+        } catch {
+          // best-effort: if log fetching fails, continue without logs
+        }
+        return {
+          id: run.id,
+          name: run.name,
+          conclusion: run.conclusion,
+          source: run.source,
+          url: getCheckRunUrl(run),
+          logs,
+        };
+      })
+    );
+
     const payload = client.nonInteractive
       ? {
           status: AGENT_STATUS.ERROR,
           reason: 'checks_failed',
           message,
           deployment: deploymentJson,
-          failedCheckRuns: failedRuns.map(run => ({
-            id: run.id,
-            name: run.name,
-            conclusion: run.conclusion,
-            source: run.source,
-            logsEndpoint: `/v2/deployments/${deployment.id}/check-runs/${run.id}/logs${client.config.currentTeam ? `?teamId=${client.config.currentTeam}` : ''}`,
-          })),
+          failedCheckRuns: failedCheckRunsWithLogs,
           next: [
             {
               command: getCommandNameWithGlobalFlags('deploy', client.argv),
@@ -2145,11 +2158,7 @@ async function handleFailedCheckRuns(
   } else {
     output.error(message);
     for (const run of failedRuns) {
-      const jobName = getJobName(run);
-      const dashboardUrl =
-        getSourceKind(run) === 'vercel' && deployment.inspectorUrl && jobName
-          ? `${deployment.inspectorUrl}?logsTab=${encodeURIComponent(jobName)}`
-          : (deployment.inspectorUrl ?? null);
+      const dashboardUrl = getCheckRunUrl(run);
       const label = dashboardUrl
         ? output.link(run.name, dashboardUrl)
         : run.name;

--- a/packages/cli/src/util/deploy/get-deployment-check-run-logs.ts
+++ b/packages/cli/src/util/deploy/get-deployment-check-run-logs.ts
@@ -1,0 +1,17 @@
+import type Client from '../client';
+
+export interface CheckRunLog {
+  text: string;
+  createdAt: number;
+}
+
+export async function getDeploymentCheckRunLogs(
+  client: Client,
+  deploymentId: string,
+  checkRunId: string
+): Promise<CheckRunLog[]> {
+  const response = await client.fetch<{ logs: CheckRunLog[] }>(
+    `/v2/deployments/${encodeURIComponent(deploymentId)}/check-runs/${encodeURIComponent(checkRunId)}/logs`
+  );
+  return response.logs ?? [];
+}

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -2478,6 +2478,20 @@ describe('deploy', () => {
       );
 
       client.scenario.get(
+        `/v2/deployments/dpl_checks_ni/check-runs/cr_fail/logs`,
+        (_req, res) => {
+          res.json({
+            logs: [
+              {
+                text: 'Error: lint failed on src/index.ts',
+                createdAt: 1700000000000,
+              },
+            ],
+          });
+        }
+      );
+
+      client.scenario.get(
         `/v3/now/deployments/dpl_checks_ni/events`,
         (_req, res) => {
           res.end();
@@ -2497,9 +2511,15 @@ describe('deploy', () => {
       expect(json.reason).toBe('checks_failed');
       expect(json.failedCheckRuns).toHaveLength(1);
       expect(json.failedCheckRuns[0].name).toBe('Lint');
-      expect(json.failedCheckRuns[0].logsEndpoint).toContain(
-        '/check-runs/cr_fail/logs'
+      expect(json.failedCheckRuns[0].url).toBe(
+        'https://vercel.com/test/dpl_checks_ni?checkRunLog=cr_fail'
       );
+      expect(json.failedCheckRuns[0].logs).toEqual([
+        {
+          text: 'Error: lint failed on src/index.ts',
+          createdAt: 1700000000000,
+        },
+      ]);
     });
 
     // v2 checks pending → shows "Running Checks..." spinner


### PR DESCRIPTION
## Summary

- Updated failed check run hyperlinks to use `?checkRunLog=<checkRunId>` instead of `?logsTab=<jobName>`, providing a direct deep-link to the specific check run log in the dashboard
- In non-interactive/JSON mode, the CLI now fetches check run logs from the API and includes them inline in the output (replacing the previous `logsEndpoint` hint)
- Added `getDeploymentCheckRunLogs` utility for fetching logs from `/v2/deployments/:id/check-runs/:runId/logs`

## Test plan

- [x] Existing check-related deploy tests pass (4/4)
- [x] Updated non-interactive test to assert on `url` with `checkRunLog` param and inline `logs` array
- [x] Added mock endpoint for check run logs in test