### PR TITLE
[cli] Fetch check run logs inline and use checkRunLog deep-link

### DIFF
--- a/.changeset/deploy-check-run-logs.md
+++ b/.changeset/deploy-check-run-logs.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fetch check run logs inline and use `checkRunLog` deep-link for failed deployment checks.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -2128,40 +2128,49 @@ async function handleFailedCheckRuns(
       message,
     });
 
-    const failedCheckRunsWithLogs = await Promise.all(
-      failedRuns.map(async run => {
-        let logs: { level: string; timestamp: number; message: string }[] = [];
-        try {
-          logs = await getDeploymentCheckRunLogs(client, deployment.id, run.id);
-        } catch {
-          // best-effort: if log fetching fails, continue without logs
-        }
-        return {
-          id: run.id,
-          name: run.name,
-          conclusion: run.conclusion,
-          source: run.source,
-          url: getCheckRunUrl(run),
-          logs,
-        };
-      })
-    );
+    let payload;
+    if (client.nonInteractive) {
+      const failedCheckRunsWithLogs = await Promise.all(
+        failedRuns.map(async run => {
+          let logs: { level: string; timestamp: number; message: string }[] =
+            [];
+          try {
+            logs = await getDeploymentCheckRunLogs(
+              client,
+              deployment.id,
+              run.id
+            );
+          } catch {
+            // best-effort: if log fetching fails, continue without logs
+          }
+          return {
+            id: run.id,
+            name: run.name,
+            conclusion: run.conclusion,
+            source: run.source,
+            url: getCheckRunUrl(run),
+            logs,
+          };
+        })
+      );
 
-    const payload = client.nonInteractive
-      ? {
-          status: AGENT_STATUS.ERROR,
-          reason: 'checks_failed',
-          message,
-          deployment: deploymentJson,
-          failedCheckRuns: failedCheckRunsWithLogs,
-          next: [
-            {
-              command: getCommandNameWithGlobalFlags('deploy', client.argv),
-              when: 'retry deploy after fixing check failures',
-            },
-          ],
-        }
-      : deploymentJson;
+      payload = {
+        status: AGENT_STATUS.ERROR,
+        reason: 'checks_failed',
+        message,
+        deployment: deploymentJson,
+        failedCheckRuns: failedCheckRunsWithLogs,
+        next: [
+          {
+            command: getCommandNameWithGlobalFlags('deploy', client.argv),
+            when: 'retry deploy after fixing check failures',
+          },
+        ],
+      };
+    } else {
+      payload = deploymentJson;
+    }
+
     client.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else {
     output.error(message);

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -25,6 +25,7 @@ import { createGitMeta } from '../../util/create-git-meta';
 import createDeploy from '../../util/deploy/create-deploy';
 import { getDeploymentChecks } from '../../util/deploy/get-deployment-checks';
 import { getDeploymentCheckRuns } from '../../util/deploy/get-deployment-check-runs';
+import { getDeploymentCheckRunLogs } from '../../util/deploy/get-deployment-check-run-logs';
 import getPrebuiltJson from '../../util/deploy/get-prebuilt-json';
 import { printDeploymentStatus } from '../../util/deploy/print-deployment-status';
 import { isValidArchive } from '../../util/deploy/validate-archive-format';
@@ -2108,11 +2109,17 @@ async function handleFailedCheckRuns(
 
   const message = `Running Checks: ${counterList}`;
 
-  const getSourceKind = (run: { source: { kind: string } | string }) =>
-    typeof run.source === 'object' ? run.source.kind : run.source;
-  const getJobName = (run: {
-    source: { kind: string; jobName?: string } | string;
-  }) => (typeof run.source === 'object' ? run.source.jobName : undefined);
+  const getCheckRunUrl = (run: {
+    id: string;
+    externalUrl?: string | null;
+    detailsUrl?: string | null;
+  }) => {
+    if (run.externalUrl) return run.externalUrl;
+    if (run.detailsUrl) return run.detailsUrl;
+    return deployment.inspectorUrl
+      ? `${deployment.inspectorUrl}?checkRunLog=${encodeURIComponent(run.id)}`
+      : null;
+  };
 
   if (asJson) {
     output.stopSpinner();
@@ -2120,19 +2127,33 @@ async function handleFailedCheckRuns(
       name: 'CHECKS_FAILED',
       message,
     });
+
+    const failedCheckRunsWithLogs = await Promise.all(
+      failedRuns.map(async run => {
+        let logs: { level: string; timestamp: number; message: string }[] = [];
+        try {
+          logs = await getDeploymentCheckRunLogs(client, deployment.id, run.id);
+        } catch {
+          // best-effort: if log fetching fails, continue without logs
+        }
+        return {
+          id: run.id,
+          name: run.name,
+          conclusion: run.conclusion,
+          source: run.source,
+          url: getCheckRunUrl(run),
+          logs,
+        };
+      })
+    );
+
     const payload = client.nonInteractive
       ? {
           status: AGENT_STATUS.ERROR,
           reason: 'checks_failed',
           message,
           deployment: deploymentJson,
-          failedCheckRuns: failedRuns.map(run => ({
-            id: run.id,
-            name: run.name,
-            conclusion: run.conclusion,
-            source: run.source,
-            logsEndpoint: `/v2/deployments/${deployment.id}/check-runs/${run.id}/logs${client.config.currentTeam ? `?teamId=${client.config.currentTeam}` : ''}`,
-          })),
+          failedCheckRuns: failedCheckRunsWithLogs,
           next: [
             {
               command: getCommandNameWithGlobalFlags('deploy', client.argv),
@@ -2145,11 +2166,7 @@ async function handleFailedCheckRuns(
   } else {
     output.error(message);
     for (const run of failedRuns) {
-      const jobName = getJobName(run);
-      const dashboardUrl =
-        getSourceKind(run) === 'vercel' && deployment.inspectorUrl && jobName
-          ? `${deployment.inspectorUrl}?logsTab=${encodeURIComponent(jobName)}`
-          : (deployment.inspectorUrl ?? null);
+      const dashboardUrl = getCheckRunUrl(run);
       const label = dashboardUrl
         ? output.link(run.name, dashboardUrl)
         : run.name;

--- a/packages/cli/src/util/deploy/get-deployment-check-run-logs.ts
+++ b/packages/cli/src/util/deploy/get-deployment-check-run-logs.ts
@@ -1,0 +1,61 @@
+import type Client from '../client';
+
+export interface CheckRunLog {
+  level: string;
+  timestamp: number;
+  message: string;
+}
+
+const MAX_ATTEMPTS = 5;
+const POLL_INTERVAL_MS = 2000;
+
+function parseNdjson(
+  text: string
+): { level: string; timestamp: number; message: string }[] {
+  const entries: { level: string; timestamp: number; message: string }[] = [];
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      entries.push(JSON.parse(line));
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return entries;
+}
+
+export async function getDeploymentCheckRunLogs(
+  client: Client,
+  deploymentId: string,
+  checkRunId: string
+): Promise<CheckRunLog[]> {
+  const url = `/v2/deployments/${encodeURIComponent(deploymentId)}/check-runs/${encodeURIComponent(checkRunId)}/logs`;
+
+  // The log stream is NDJSON terminated by an `eof` entry. Logs may not be
+  // flushed immediately after a check run completes, so we wait briefly then
+  // poll until we see the `eof` marker confirming all logs have been written.
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    if (attempt > 0)
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+
+    const res = await client.fetch(url, { json: false });
+    const text: string =
+      typeof res === 'string' ? res : await (res as any).text();
+    const entries = parseNdjson(text);
+
+    const hasEof = entries.some(e => e.level === 'eof');
+    if (hasEof) {
+      return entries
+        .filter(e => e.level !== 'eof' && e.level !== 'debug')
+        .map(({ level, timestamp, message }) => ({
+          level,
+          timestamp,
+          message,
+        }));
+    }
+  }
+
+  return [];
+}

--- a/packages/cli/src/util/deploy/get-deployment-check-runs.ts
+++ b/packages/cli/src/util/deploy/get-deployment-check-runs.ts
@@ -12,6 +12,8 @@ export interface CheckRun {
     | 'skipped'
     | 'stale';
   source: { kind: string; jobName?: string } | string;
+  externalUrl?: string | null;
+  detailsUrl?: string | null;
   startedAt?: number;
   completedAt?: number;
 }

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -2478,6 +2478,20 @@ describe('deploy', () => {
       );
 
       client.scenario.get(
+        `/v2/deployments/dpl_checks_ni/check-runs/cr_fail/logs`,
+        (_req, res) => {
+          res.type('text/plain');
+          res.send(
+            [
+              '{"level":"command","timestamp":1700000000000,"message":"npm run lint"}',
+              '{"level":"error","timestamp":1700000001000,"message":"Exited with code 1."}',
+              '{"level":"eof","timestamp":1700000002000,"message":""}',
+            ].join('\n')
+          );
+        }
+      );
+
+      client.scenario.get(
         `/v3/now/deployments/dpl_checks_ni/events`,
         (_req, res) => {
           res.end();
@@ -2497,9 +2511,17 @@ describe('deploy', () => {
       expect(json.reason).toBe('checks_failed');
       expect(json.failedCheckRuns).toHaveLength(1);
       expect(json.failedCheckRuns[0].name).toBe('Lint');
-      expect(json.failedCheckRuns[0].logsEndpoint).toContain(
-        '/check-runs/cr_fail/logs'
+      expect(json.failedCheckRuns[0].url).toBe(
+        'https://vercel.com/test/dpl_checks_ni?checkRunLog=cr_fail'
       );
+      expect(json.failedCheckRuns[0].logs).toEqual([
+        { level: 'command', timestamp: 1700000000000, message: 'npm run lint' },
+        {
+          level: 'error',
+          timestamp: 1700000001000,
+          message: 'Exited with code 1.',
+        },
+      ]);
     });
 
     // v2 checks pending → shows "Running Checks..." spinner

--- a/packages/cli/test/unit/util/deploy/get-deployment-check-run-logs.test.ts
+++ b/packages/cli/test/unit/util/deploy/get-deployment-check-run-logs.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getDeploymentCheckRunLogs } from '../../../../src/util/deploy/get-deployment-check-run-logs';
+
+function ndjson(...entries: Record<string, unknown>[]): string {
+  return entries.map(e => JSON.stringify(e)).join('\n') + '\n';
+}
+
+function createMockClient(responses: string[]) {
+  let callCount = 0;
+  return {
+    fetch: vi.fn(async () => ({
+      text: async () => responses[Math.min(callCount++, responses.length - 1)],
+    })),
+  } as any;
+}
+
+describe('getDeploymentCheckRunLogs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('should parse NDJSON logs and filter out eof and debug entries', async () => {
+    const body = ndjson(
+      { level: 'debug', timestamp: 1000, message: 'Provisioning sandbox...' },
+      { level: 'command', timestamp: 2000, message: 'npm run lint' },
+      { level: 'info', timestamp: 3000, message: '> eslint .' },
+      { level: 'error', timestamp: 4000, message: 'Exited with code 1.' },
+      { level: 'eof', timestamp: 5000, message: '' }
+    );
+    const client = createMockClient([body]);
+
+    const promise = getDeploymentCheckRunLogs(client, 'dpl_123', 'ckr_456');
+    await vi.advanceTimersByTimeAsync(1000);
+    const logs = await promise;
+
+    expect(logs).toEqual([
+      { level: 'command', timestamp: 2000, message: 'npm run lint' },
+      { level: 'info', timestamp: 3000, message: '> eslint .' },
+      { level: 'error', timestamp: 4000, message: 'Exited with code 1.' },
+    ]);
+    expect(client.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should poll until eof is present', async () => {
+    const partialBody = ndjson({
+      level: 'command',
+      timestamp: 2000,
+      message: 'npm run lint',
+    });
+    const fullBody = ndjson(
+      { level: 'command', timestamp: 2000, message: 'npm run lint' },
+      { level: 'error', timestamp: 3000, message: 'Exited with code 1.' },
+      { level: 'eof', timestamp: 4000, message: '' }
+    );
+    const client = createMockClient([partialBody, fullBody]);
+
+    const promise = getDeploymentCheckRunLogs(client, 'dpl_123', 'ckr_456');
+    // initial 1s delay
+    await vi.advanceTimersByTimeAsync(1000);
+    // first attempt returns no eof, wait 2s poll interval
+    await vi.advanceTimersByTimeAsync(2000);
+    const logs = await promise;
+
+    expect(logs).toEqual([
+      { level: 'command', timestamp: 2000, message: 'npm run lint' },
+      { level: 'error', timestamp: 3000, message: 'Exited with code 1.' },
+    ]);
+    expect(client.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return empty array after exhausting all attempts without eof', async () => {
+    const noEof = ndjson({
+      level: 'command',
+      timestamp: 2000,
+      message: 'npm run lint',
+    });
+    const client = createMockClient([noEof]);
+
+    const promise = getDeploymentCheckRunLogs(client, 'dpl_123', 'ckr_456');
+    // initial 1s + 5 attempts with 2s intervals between retries
+    for (let i = 0; i < 12; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+    const logs = await promise;
+
+    expect(logs).toEqual([]);
+    expect(client.fetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('should skip malformed NDJSON lines', async () => {
+    const body = [
+      JSON.stringify({
+        level: 'command',
+        timestamp: 1000,
+        message: 'npm run lint',
+      }),
+      'not valid json {{{',
+      JSON.stringify({ level: 'eof', timestamp: 2000, message: '' }),
+    ].join('\n');
+    const client = createMockClient([body]);
+
+    const promise = getDeploymentCheckRunLogs(client, 'dpl_123', 'ckr_456');
+    await vi.advanceTimersByTimeAsync(1000);
+    const logs = await promise;
+
+    expect(logs).toEqual([
+      { level: 'command', timestamp: 1000, message: 'npm run lint' },
+    ]);
+  });
+
+  it('should encode deployment and check run IDs in the URL', async () => {
+    const body = ndjson({ level: 'eof', timestamp: 1000, message: '' });
+    const client = createMockClient([body]);
+
+    const promise = getDeploymentCheckRunLogs(
+      client,
+      'dpl_abc/123',
+      'ckr_def/456'
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(client.fetch).toHaveBeenCalledWith(
+      '/v2/deployments/dpl_abc%2F123/check-runs/ckr_def%2F456/logs',
+      { json: false }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Failed check run hyperlinks now use `?checkRunLog=<checkRunId>` for direct deep-linking, with fallback to `externalUrl`/`detailsUrl` when available (matching front's link resolution pattern)
- In non-interactive/JSON mode, the CLI fetches check run logs from the NDJSON log stream and includes them inline in the output, replacing the previous `logsEndpoint` hint
- Polls for log availability with EOF detection since logs may not be flushed immediately after check completion

## Test plan

- [x] 4 integration tests for deploy checks pass (v1, v2 interactive, v2 non-interactive, v2 pending)
- [x] 5 dedicated unit tests for `getDeploymentCheckRunLogs` (NDJSON parsing, EOF polling, max attempts, malformed lines, URL encoding)
- [x] Verified end-to-end with real deployment against `no-git` project with failing ESLint check