### PR TITLE
[python-workers] fix UUID/Decimal/datetime serialization for dramatiq

### DIFF
--- a/.changeset/chilled-experts-ring.md
+++ b/.changeset/chilled-experts-ring.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-workers': patch
+---
+
+[python-workers] fix UUID/Decimal/datetime serialization for dramatiq

--- a/python/vercel-workers/src/vercel/workers/dramatiq/__init__.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/__init__.py
@@ -65,6 +65,7 @@ from .app import (
 )
 from .broker import (
     DramatiqTaskEnvelope,
+    VercelDramatiqEncoder,
     VercelQueuesBroker,
     VercelQueuesBrokerOptions,
 )
@@ -72,6 +73,7 @@ from .worker import PollingWorker
 
 __all__ = [
     # Broker
+    "VercelDramatiqEncoder",
     "VercelQueuesBroker",
     "VercelQueuesBrokerOptions",
     "DramatiqTaskEnvelope",

--- a/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
@@ -6,11 +6,13 @@ from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from typing import Any
 
-from ..client import send
+from ..client import WorkerJSONEncoder, send
 
 try:
+    import dramatiq
     from dramatiq.broker import Broker, Consumer, MessageProxy
     from dramatiq.common import current_millis
+    from dramatiq.encoder import Encoder
     from dramatiq.message import Message
 except Exception as e:
     raise RuntimeError(
@@ -20,10 +22,33 @@ except Exception as e:
 
 
 __all__ = [
+    "VercelDramatiqEncoder",
     "VercelQueuesBroker",
     "VercelQueuesBrokerOptions",
     "DramatiqTaskEnvelope",
 ]
+
+
+class VercelDramatiqEncoder(Encoder):
+    """Dramatiq message encoder that handles common Python types."""
+
+    _json_encoder: type[json.JSONEncoder]
+
+    def __init__(self, json_encoder: type[json.JSONEncoder] | None = None) -> None:
+        self._json_encoder = json_encoder or WorkerJSONEncoder
+
+    def encode(self, data: dict[str, Any]) -> bytes:
+        return json.dumps(
+            data,
+            cls=self._json_encoder,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+    def decode(self, data: bytes) -> dict[str, Any]:
+        try:
+            return json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            raise dramatiq.DecodeError(f"could not decode message: {data!r}", data, e) from None
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,8 +72,8 @@ class VercelQueuesBrokerOptions:
     # Use message_id as idempotency key by default
     use_message_id_as_idempotency_key: bool = True
 
-    # Use custom JSON encoder class to send data
-    json_encoder: type[json.JSONEncoder] | None = None
+    # Custom dramatiq Encoder instance (overrides the default VercelDramatiqEncoder)
+    encoder: Encoder | None = None
 
     @classmethod
     def from_dict(cls, options: dict[str, Any]) -> VercelQueuesBrokerOptions:
@@ -93,9 +118,9 @@ class VercelQueuesBrokerOptions:
         if isinstance(use_msg_id, bool):
             cfg = replace(cfg, use_message_id_as_idempotency_key=use_msg_id)
 
-        json_encoder = options.get("json_encoder")
-        if isinstance(json_encoder, type) and issubclass(json_encoder, json.JSONEncoder):
-            cfg = replace(cfg, json_encoder=json_encoder)
+        encoder = options.get("encoder")
+        if isinstance(encoder, Encoder):
+            cfg = replace(cfg, encoder=encoder)
 
         return cfg
 
@@ -120,14 +145,21 @@ class DramatiqTaskEnvelope(dict):
     pass
 
 
-def _message_to_envelope(message: Message, queue_name: str) -> DramatiqTaskEnvelope:
+def _message_to_envelope(
+    message: Message,
+    queue_name: str,
+    encoder: Encoder | None = None,
+) -> DramatiqTaskEnvelope:
     """
     Convert a Dramatiq Message to a Vercel Queues envelope.
 
-    Serialization goes through configured dramatiq's encoder so
-    ephemeral options or custom types can be handled by the encoder.
+    Serialization goes through the provided `encoder` or the global
+    dramatiq encoder when `encoder` is None so that ephemeral
+    options and custom types are handled correctly.
     """
-    data = json.loads(message.encode())
+    if encoder is None:
+        encoder = dramatiq.get_encoder()
+    data = json.loads(encoder.encode(message.asdict()))
     data["queue_name"] = queue_name
     data["vercel"] = {"kind": "dramatiq", "version": 1}
     return DramatiqTaskEnvelope(data)
@@ -219,6 +251,11 @@ class VercelQueuesBroker(Broker):
         # may call get_declared_queues() during initialization.
         self._queues: set[str] = set()
         self._cfg = VercelQueuesBrokerOptions.from_dict(options or {})
+
+        # Per-instance encoder that handles UUID, datetime, Decimal out of
+        # the box.
+        self.encoder: Encoder = self._cfg.encoder or VercelDramatiqEncoder()
+
         super().__init__(middleware=middleware)
 
     @property
@@ -291,7 +328,7 @@ class VercelQueuesBroker(Broker):
 
         self.emit_before("enqueue", message, delay)
 
-        envelope = _message_to_envelope(message, queue_name)
+        envelope = _message_to_envelope(message, queue_name, encoder=self.encoder)
 
         # Use message_id for idempotency by default
         idempotency_key = (
@@ -321,7 +358,6 @@ class VercelQueuesBroker(Broker):
             base_url=self._cfg.base_url,
             base_path=self._cfg.base_path,
             timeout=self._cfg.timeout,
-            json_encoder=self._cfg.json_encoder,
         )
 
         self.emit_after("enqueue", message, delay)

--- a/python/vercel-workers/tests/test_dramatiq_adapter.py
+++ b/python/vercel-workers/tests/test_dramatiq_adapter.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 
@@ -15,6 +18,7 @@ from dramatiq.message import Message
 from vercel.workers.dramatiq import (
     DramatiqWorkerConfig,
     PollingWorker,
+    VercelDramatiqEncoder,
     VercelQueuesBroker,
     VercelQueuesBrokerOptions,
 )
@@ -428,6 +432,28 @@ class TestEncoderIntegration:
         assert envelope["kwargs"] == {"x": 10}
         assert envelope["options"]["retries"] == 3
 
+    def test_default_encoder_handles_uuid_datetime_decimal(self):
+        broker = VercelQueuesBroker()
+
+        uid = uuid4()
+        dt = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+        dec = Decimal("3.14")
+
+        message = Message(
+            queue_name="test-q",
+            actor_name="test_actor",
+            args=({"request_id": uid, "ts": dt, "price": dec},),
+            kwargs={},
+            options={},
+        )
+
+        envelope = _message_to_envelope(message, "test-q", encoder=broker.encoder)
+
+        payload = envelope["args"][0]
+        assert payload["request_id"] == str(uid)
+        assert payload["ts"] == dt.isoformat()
+        assert payload["price"] == float(dec)
+
     def test_custom_encoder_strips_options(self):
         original_encoder = dramatiq.get_encoder()
 
@@ -458,6 +484,28 @@ class TestEncoderIntegration:
             assert envelope["options"]["retries"] == 1
         finally:
             dramatiq.set_encoder(original_encoder)
+
+    def test_broker_accepts_custom_encoder_option(self):
+        calls = []
+
+        class TrackingEncoder(VercelDramatiqEncoder):
+            def encode(self, data):
+                calls.append("encode")
+                return super().encode(data)
+
+        encoder = TrackingEncoder()
+        broker = VercelQueuesBroker(options={"encoder": encoder})
+        assert broker.encoder is encoder
+
+        message = Message(
+            queue_name="test-q",
+            actor_name="test_actor",
+            args=(1,),
+            kwargs={},
+            options={},
+        )
+        _message_to_envelope(message, "test-q", encoder=broker.encoder)
+        assert "encode" in calls
 
     @patch("vercel.workers.dramatiq.broker.send")
     def test_enqueue_uses_encoder(self, mock_send):


### PR DESCRIPTION
#15754 changed the encoding behaviour for Dramatiq to perform the encoding using `dramatiq.Encoder`. This is required to not encode custom message options that can make sense only for middlewares

This fixes encoding by adding an option to set `dramatiq.Encoder` instead of just `json.JSONEncoder` so by default all common types could be handled from the box, but user still has an ability to provide a custom encoder