### PR TITLE
[python-workers] Fix Dramatiq envelopes for common types

### DIFF
--- a/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
@@ -127,7 +127,24 @@ def _message_to_envelope(message: Message, queue_name: str) -> DramatiqTaskEnvel
     Serialization goes through configured dramatiq's encoder so
     ephemeral options or custom types can be handled by the encoder.
     """
-    data = json.loads(message.encode())
+    # Prefer Dramatiq's configured encoder since it may strip ephemeral options.
+    #
+    # However, Dramatiq's default JSON encoder cannot serialize common Python types
+    # like UUID, datetime, or Decimal. Since our queue client supports these types
+    # (via WorkerJSONEncoder), fall back to building the envelope from raw message
+    # fields when encoding fails.
+    try:
+        data = json.loads(message.encode())
+    except Exception:
+        data = {
+            "queue_name": message.queue_name,
+            "actor_name": message.actor_name,
+            "message_id": message.message_id,
+            "message_timestamp": message.message_timestamp,
+            "args": list(message.args),
+            "kwargs": dict(message.kwargs),
+            "options": dict(message.options),
+        }
     data["queue_name"] = queue_name
     data["vercel"] = {"kind": "dramatiq", "version": 1}
     return DramatiqTaskEnvelope(data)

--- a/python/vercel-workers/tests/test_dramatiq_adapter.py
+++ b/python/vercel-workers/tests/test_dramatiq_adapter.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 
@@ -12,6 +16,7 @@ pytest.importorskip("dramatiq")
 import dramatiq
 from dramatiq.message import Message
 
+from vercel.workers.client import WorkerJSONEncoder
 from vercel.workers.dramatiq import (
     DramatiqWorkerConfig,
     PollingWorker,
@@ -159,6 +164,27 @@ class TestMessageEnvelopeConversion:
         assert envelope["kwargs"] == {"x": 10}
         assert envelope["options"] == {"retries": 3}
 
+    def test_message_to_envelope_serializes_common_python_types(self):
+        uid = uuid4()
+        ts = datetime.now(UTC)
+        priority = Decimal("1.5")
+
+        message = Message(
+            queue_name="test-queue",
+            actor_name="test_actor",
+            args=(),
+            kwargs={"request_id": uid, "enqueued_at": ts, "priority": priority},
+            options={},
+        )
+
+        envelope = _message_to_envelope(message, "test-queue")
+
+        # Ensure the envelope can be serialized by the same encoder used by the queue client.
+        payload = json.loads(json.dumps(envelope, cls=WorkerJSONEncoder))
+        assert payload["kwargs"]["request_id"] == str(uid)
+        assert payload["kwargs"]["enqueued_at"] == ts.isoformat()
+        assert payload["kwargs"]["priority"] == float(priority)
+
     def test_envelope_to_message(self):
         envelope = {
             "vercel": {"kind": "dramatiq", "version": 1},
@@ -298,6 +324,32 @@ class TestActorIntegration:
         assert envelope["vercel"]["kind"] == "dramatiq"
         assert envelope["actor_name"] == "add_numbers_test"
         assert envelope["args"] == [10, 20]
+
+    @patch("vercel.workers.dramatiq.broker.send")
+    def test_actor_send_supports_common_python_types(self, mock_send: MagicMock):
+        mock_send.return_value = {"messageId": "msg-integration-123"}
+
+        broker = VercelQueuesBroker()
+        dramatiq.set_broker(broker)
+
+        @dramatiq.actor(queue_name="send-test", broker=broker)
+        def echo_payload(payload: dict) -> dict:
+            return payload
+
+        uid = uuid4()
+        ts = datetime.now(UTC)
+        priority = Decimal("1.5")
+
+        result = echo_payload.send({"request_id": uid, "enqueued_at": ts, "priority": priority})
+
+        assert result.message_id is not None
+        mock_send.assert_called_once()
+
+        envelope = mock_send.call_args[0][1]
+        payload = json.loads(json.dumps(envelope, cls=WorkerJSONEncoder))
+        assert payload["args"][0]["request_id"] == str(uid)
+        assert payload["args"][0]["enqueued_at"] == ts.isoformat()
+        assert payload["args"][0]["priority"] == float(priority)
 
 
 class TestMiddlewarePipeline:


### PR DESCRIPTION
## Summary
- Fix `vercel.workers.dramatiq` envelope creation to fall back to raw message fields when `message.encode()` fails.
  - Dramatiq's default JSON encoder can't serialize common types like UUID/datetime/Decimal.
- Add tests covering UUID/datetime/Decimal payloads (including the actor `.send()` path).

## Test plan
- `cd python/vercel-workers && uv run ruff check`
- `cd python/vercel-workers && uv run mypy src/vercel/workers`
- `cd python/vercel-workers && uv run pytest`

Made with [Cursor](https://cursor.com)