### PR TITLE
[CLI] Adding the ability to rename projects

### DIFF
--- a/.changeset/project-rename-cli.md
+++ b/.changeset/project-rename-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add a `project rename` command to rename projects from the CLI.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -193,6 +193,29 @@ export const removeSubcommand = {
   examples: [],
 } as const;
 
+export const renameSubcommand = {
+  name: 'rename',
+  aliases: [],
+  description: 'Rename a project',
+  arguments: [
+    {
+      name: 'name',
+      required: true,
+    },
+    {
+      name: 'new-name',
+      required: true,
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'Rename a project',
+      value: `${packageName} project rename my-project my-renamed-project`,
+    },
+  ],
+} as const;
+
 export const tokenSubcommand = {
   name: 'token',
   aliases: [],
@@ -526,6 +549,7 @@ export const projectCommand = {
     protectionSubcommand,
     webAnalyticsSubcommand,
     speedInsightsSubcommand,
+    renameSubcommand,
     removeSubcommand,
     tokenSubcommand,
   ],

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -10,6 +10,7 @@ import inspect from './inspect';
 import list from './list';
 import members from './members';
 import accessGroups from './access-groups';
+import rename from './rename';
 import rm from './rm';
 import getOidcToken from './token';
 import speedInsights from './speed-insights';
@@ -25,6 +26,7 @@ import {
   membersSubcommand,
   projectCommand,
   protectionSubcommand,
+  renameSubcommand,
   removeSubcommand,
   speedInsightsSubcommand,
   tokenSubcommand,
@@ -45,6 +47,7 @@ const COMMAND_CONFIG = {
   'access-summary': getCommandAliases(accessSummarySubcommand),
   checks: getCommandAliases(checksSubcommand),
   protection: getCommandAliases(protectionSubcommand),
+  rename: getCommandAliases(renameSubcommand),
   remove: getCommandAliases(removeSubcommand),
   token: getCommandAliases(tokenSubcommand),
   speedInsights: getCommandAliases(speedInsightsSubcommand),
@@ -183,6 +186,13 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandToken(subcommandOriginal);
       return getOidcToken(client, args);
+    case 'rename':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('project', subcommandOriginal);
+        return printHelp(renameSubcommand);
+      }
+      telemetry.trackCliSubcommandRename(subcommandOriginal);
+      return rename(client, args);
     case 'remove':
       if (needHelp) {
         telemetry.trackCliFlagHelp('project', subcommandOriginal);

--- a/packages/cli/src/commands/project/rename.ts
+++ b/packages/cli/src/commands/project/rename.ts
@@ -1,0 +1,86 @@
+import chalk from 'chalk';
+import ms from 'ms';
+import type { Project } from '@vercel-internals/types';
+import type Client from '../../util/client';
+import { isAPIError, ProjectNotFound } from '../../util/errors-ts';
+import { getCommandName } from '../../util/pkg-name';
+import output from '../../output-manager';
+import { ProjectRenameTelemetryClient } from '../../util/telemetry/commands/project/rename';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { renameSubcommand } from './command';
+
+export default async function rename(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetryClient = new ProjectRenameTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(renameSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args } = parsedArgs;
+
+  if (args.length !== 2) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        `${getCommandName('project rename <name> <new-name>')}`
+      )}`
+    );
+    return 2;
+  }
+
+  const [projectNameOrId, newName] = args;
+  telemetryClient.trackCliArgumentName(projectNameOrId);
+  telemetryClient.trackCliArgumentNewName(newName);
+
+  const project = await getProjectByNameOrId(client, projectNameOrId);
+  if (project instanceof ProjectNotFound) {
+    output.error('No such project exists');
+    return 1;
+  }
+
+  const start = Date.now();
+
+  let renamedProject: Project;
+  try {
+    renamedProject = await client.fetch<Project>(
+      `/v9/projects/${encodeURIComponent(project.id)}`,
+      {
+        method: 'PATCH',
+        body: { name: newName },
+      }
+    );
+  } catch (err: unknown) {
+    if (isAPIError(err) && err.status === 409) {
+      output.error(`A project named "${newName}" already exists`);
+      return 1;
+    }
+    if (isAPIError(err) && err.status === 403) {
+      output.error(err.message);
+      return 1;
+    }
+    throw err;
+  }
+
+  const elapsed = ms(Date.now() - start);
+  output.log(
+    `${chalk.cyan('Success!')} Project ${chalk.bold(
+      project.name
+    )} renamed to ${chalk.bold(renamedProject.name)} ${chalk.gray(
+      `[${elapsed}]`
+    )}`
+  );
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -48,6 +48,13 @@ export class ProjectTelemetryClient
     });
   }
 
+  trackCliSubcommandRename(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'rename',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandToken(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'token',

--- a/packages/cli/src/util/telemetry/commands/project/rename.ts
+++ b/packages/cli/src/util/telemetry/commands/project/rename.ts
@@ -1,0 +1,26 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { renameSubcommand } from '../../../../commands/project/command';
+
+export class ProjectRenameTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof renameSubcommand>
+{
+  trackCliArgumentName(name: string | undefined) {
+    if (name) {
+      this.trackCliArgument({
+        arg: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentNewName(newName: string | undefined) {
+    if (newName) {
+      this.trackCliArgument({
+        arg: 'new-name',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -4728,6 +4728,9 @@ exports[`help command > project help output snapshots > project help column widt
                                    …
                                    a
                                    …
+  rename          name new-name    …
+                                   a
+                                   …
   remove          name             …
                                    a
                                    …
@@ -4816,6 +4819,7 @@ exports[`help command > project help output snapshots > project help column widt
                                    settings for a project                   
   web-analytics   [name]           Enable Web Analytics for a project       
   speed-insights  [name]           Enable Speed Insights for a project      
+  rename          name new-name    Rename a project                         
   remove          name             Delete a project                         
   token           [name]           Get a development OIDC token for a       
                                    project                                  
@@ -4860,6 +4864,7 @@ exports[`help command > project help output snapshots > project help column widt
   protection      [action] [name]  Show or toggle deployment protection settings for a project                      
   web-analytics   [name]           Enable Web Analytics for a project                                               
   speed-insights  [name]           Enable Speed Insights for a project                                              
+  rename          name new-name    Rename a project                                                                 
   remove          name             Delete a project                                                                 
   token           [name]           Get a development OIDC token for a project                                       
 
@@ -4978,6 +4983,35 @@ exports[`help command > project help output snapshots > project remove help outp
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
 
+
+"
+`;
+
+exports[`help command > project help output snapshots > project rename help output snapshots > project rename help column width 120 1`] = `
+"
+  ▲ vercel project rename name new-name
+
+  Rename a project                                                                                                      
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Rename a project
+
+    $ vercel project rename my-project my-renamed-project
 
 "
 `;

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -647,6 +647,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('project rename help output snapshots', () => {
+      it('project rename help column width 120', () => {
+        expect(
+          help(project.renameSubcommand, {
+            columns: 120,
+            parent: project.projectCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('promote help output snapshots', () => {

--- a/packages/cli/test/unit/commands/project/rename.test.ts
+++ b/packages/cli/test/unit/commands/project/rename.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { client } from '../../../mocks/client';
+import projects from '../../../../src/commands/project';
+import { useUser } from '../../../mocks/user';
+
+describe('rename', () => {
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'project';
+      const subcommand = 'rename';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = projects(client);
+      await expect(exitCodePromise).resolves.toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  describe('[name] [new-name]', () => {
+    it('should rename a project', async () => {
+      useUser();
+      useProject({
+        ...defaultProject,
+        id: 'test-project',
+        name: 'test-project',
+      });
+
+      client.setArgv('project', 'rename', 'test-project', 'renamed-project');
+      await projects(client);
+
+      expect(client.stderr).toOutput(
+        'Success! Project test-project renamed to renamed-project'
+      );
+    });
+
+    it('tracks arguments', async () => {
+      useUser();
+      useProject({
+        ...defaultProject,
+        id: 'test-project',
+        name: 'test-project',
+      });
+
+      client.setArgv('project', 'rename', 'test-project', 'renamed-project');
+      await projects(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:rename',
+          value: 'rename',
+        },
+        {
+          key: 'argument:name',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'argument:new-name',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the ability to append the `rename` flag on the existing `project` flag to rename. 
This does not break linking between projects and applies the `PATCH` method for upserting