### PR TITLE
[cli] CI/AI-friendly flags for blob store commands

### DIFF
--- a/.changeset/blob-list-stores-all-flag.md
+++ b/.changeset/blob-list-stores-all-flag.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+feat(cli): add --all flag to blob list-stores
+
+When in a linked project directory, `blob list-stores` now hints about `--all` when no stores are connected to the project. Use `--all` to list all team stores regardless of project connection, matching the pattern from `integration list --all`.

--- a/.changeset/blob-list-stores-all-flag.md
+++ b/.changeset/blob-list-stores-all-flag.md
@@ -1,5 +1,5 @@
 ---
-'vercel': patch
+'vercel': minor
 ---
 
 feat(cli): add --all flag to blob list-stores, --yes flag to blob delete-store

--- a/.changeset/blob-list-stores-all-flag.md
+++ b/.changeset/blob-list-stores-all-flag.md
@@ -2,6 +2,7 @@
 'vercel': patch
 ---
 
-feat(cli): add --all flag to blob list-stores
+feat(cli): add --all flag to blob list-stores, --yes flag to blob delete-store
 
-When in a linked project directory, `blob list-stores` now hints about `--all` when no stores are connected to the project. Use `--all` to list all team stores regardless of project connection, matching the pattern from `integration list --all`.
+- `blob list-stores --all`: list all team stores regardless of project connection. Hints about `--all` when no stores are connected to the current project.
+- `blob delete-store --yes`: skip confirmation prompt for CI/scripts.

--- a/.changeset/blob-list-stores-all-flag.md
+++ b/.changeset/blob-list-stores-all-flag.md
@@ -2,7 +2,9 @@
 'vercel': minor
 ---
 
-feat(cli): add --all flag to blob list-stores, --yes flag to blob delete-store
+feat(cli): CI-friendly flags for blob store commands
 
 - `blob list-stores --all`: list all team stores regardless of project connection. Hints about `--all` when no stores are connected to the current project.
 - `blob delete-store --yes`: skip confirmation prompt for CI/scripts.
+- `blob create-store --yes`: auto-connect to linked project with all environments, skip prompts.
+- `blob create-store --environment`: specify which environments to connect (repeatable, e.g. `--environment production --environment preview`).

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -277,7 +277,7 @@ export const removeStoreSubcommand = {
       required: false,
     },
   ],
-  options: [],
+  options: [yesOption],
   examples: [],
 } as const;
 
@@ -343,7 +343,7 @@ export const deleteStoreSubcommand = {
       required: false,
     },
   ],
-  options: [],
+  options: [yesOption],
   examples: [],
 } as const;
 

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -375,7 +375,16 @@ export const listStoresSubcommand = {
   aliases: ['ls-stores'],
   description: 'List all Blob stores',
   arguments: [],
-  options: [],
+  options: [
+    {
+      name: 'all',
+      shorthand: 'a',
+      type: Boolean,
+      deprecated: false,
+      description:
+        'List all blob stores for the team, not just the ones connected to the current project',
+    },
+  ],
   examples: [],
 } as const;
 

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -30,6 +30,16 @@ const accessOption = {
 
 import { yesOption } from '../../util/arg-common';
 
+const environmentOption = {
+  name: 'environment',
+  shorthand: 'e',
+  type: [String],
+  deprecated: false,
+  argument: 'ENV',
+  description:
+    'Environment to connect (can be repeated: production, preview, development). Defaults to all when --yes is used.',
+} as const;
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -250,6 +260,8 @@ export const addStoreSubcommand = {
         'Region to create the Blob store in (default: "iad1"). See https://vercel.com/docs/edge-network/regions#region-list for all available regions',
       argument: 'STRING',
     },
+    yesOption,
+    environmentOption,
   ],
   examples: [
     {
@@ -316,19 +328,22 @@ export const createStoreSubcommand = {
         'Region to create the Blob store in (default: "iad1"). See https://vercel.com/docs/edge-network/regions#region-list for all available regions',
       argument: 'STRING',
     },
+    yesOption,
+    environmentOption,
   ],
   examples: [
     {
       name: 'Create a blob store (uses default region "iad1")',
-      value: 'vercel blob create-store my-store',
+      value: 'vercel blob create-store my-store --access private',
     },
     {
       name: 'Create a blob store in a specific region',
-      value: 'vercel blob create-store my-store --region cdg1',
+      value: 'vercel blob create-store my-store --access private --region cdg1',
     },
     {
-      name: 'Create a private blob store',
-      value: 'vercel blob create-store my-private-store --access private',
+      name: 'Create and connect to project in CI',
+      value:
+        'vercel blob create-store my-store --access private --yes --environment production --environment preview',
     },
   ],
 } as const;

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -10,6 +10,10 @@ import { addStoreSubcommand } from './command';
 import { BlobAddStoreTelemetryClient } from '../../util/telemetry/commands/blob/store-add';
 import { printError } from '../../util/error';
 import { parseAccessFlag } from '../../util/blob/access';
+import {
+  VALID_ENVIRONMENTS,
+  validateEnvironments,
+} from '../../util/integration/post-provision-setup';
 
 export default async function addStore(
   client: Client,
@@ -35,6 +39,20 @@ export default async function addStore(
     args: [nameArg],
     flags,
   } = parsedArgs;
+
+  const yes = flags['--yes'] ?? false;
+  const environmentFlags = flags['--environment'];
+
+  // Validate --environment values early
+  if (environmentFlags?.length) {
+    const envValidation = validateEnvironments(environmentFlags);
+    if (!envValidation.valid) {
+      output.error(
+        `Invalid environment value: ${envValidation.invalid.map(e => `"${e}"`).join(', ')}. Must be one of: ${VALID_ENVIRONMENTS.join(', ')}`
+      );
+      return 1;
+    }
+  }
 
   let accessFlag = flags['--access'];
   if (!accessFlag && client.stdin.isTTY) {
@@ -115,20 +133,30 @@ export default async function addStore(
   output.log(`Access: ${access}. Learn more: ${output.link(docsUrl, docsUrl)}`);
 
   if (link.status === 'linked') {
-    const res = await client.input.confirm(
-      `Would you like to link this blob store to ${link.project.name}?`,
-      true
-    );
+    let shouldLink = yes;
+    if (!shouldLink) {
+      shouldLink = await client.input.confirm(
+        `Would you like to link this blob store to ${link.project.name}?`,
+        true
+      );
+    }
 
-    if (res) {
-      const environments = await client.input.checkbox({
-        message: 'Select environments',
-        choices: [
-          { name: 'Production', value: 'production', checked: true },
-          { name: 'Preview', value: 'preview', checked: true },
-          { name: 'Development', value: 'development', checked: true },
-        ],
-      });
+    if (shouldLink) {
+      let environments: string[];
+      if (environmentFlags?.length) {
+        environments = environmentFlags;
+      } else if (yes) {
+        environments = [...VALID_ENVIRONMENTS];
+      } else {
+        environments = await client.input.checkbox({
+          message: 'Select environments',
+          choices: [
+            { name: 'Production', value: 'production', checked: true },
+            { name: 'Preview', value: 'preview', checked: true },
+            { name: 'Development', value: 'development', checked: true },
+          ],
+        });
+      }
 
       output.spinner(
         `Connecting ${chalk.bold(name)} to ${chalk.bold(link.project.name)}...`

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -81,6 +81,10 @@ export default async function addStore(
 
   let name = nameArg;
   if (!name) {
+    if (!client.stdin.isTTY) {
+      output.error('Missing required argument: name');
+      return 1;
+    }
     name = await client.input.text({
       message: 'Enter a name for your blob store',
       validate: value => {

--- a/packages/cli/src/commands/blob/store-get.ts
+++ b/packages/cli/src/commands/blob/store-get.ts
@@ -46,6 +46,10 @@ export default async function getStore(
   }
 
   if (!storeId) {
+    if (!client.stdin.isTTY) {
+      output.error('Missing required argument: storeId');
+      return 1;
+    }
     storeId = await client.input.text({
       message: 'Enter the ID of the blob store you want to get info about',
       validate: value => {

--- a/packages/cli/src/commands/blob/store-list.ts
+++ b/packages/cli/src/commands/blob/store-list.ts
@@ -30,22 +30,26 @@ export default async function listStores(
   client: Client,
   argv: string[]
 ): Promise<number> {
-  new BlobListStoresTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
   const flagsSpecification = getFlagsSpecification(
     listStoresSubcommand.options
   );
 
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
   try {
-    parseArguments(argv, flagsSpecification);
+    parsedArgs = parseArguments(argv, flagsSpecification);
   } catch (err) {
     printError(err);
     return 1;
   }
+
+  const showAll = parsedArgs.flags['--all'] ?? false;
+
+  const telemetryClient = new BlobListStoresTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+  telemetryClient.trackCliFlagAll(showAll || undefined);
 
   try {
     // Resolve team and optional project context without interactive prompts.
@@ -63,7 +67,7 @@ export default async function listStores(
         dirLink.projectId,
         dirLink.orgId
       );
-      if (project && !(project instanceof ProjectNotFound)) {
+      if (project && !(project instanceof ProjectNotFound) && !showAll) {
         linkedProject = { id: project.id, name: project.name };
       }
     } else {
@@ -101,7 +105,13 @@ export default async function listStores(
     }
 
     if (stores.length === 0) {
-      output.log('No blob stores found');
+      if (linkedProject) {
+        output.log(
+          `No blob stores connected to ${chalk.bold(linkedProject.name)}. Use ${chalk.cyan('--all')} to list all team stores.`
+        );
+      } else {
+        output.log('No blob stores found');
+      }
       return 0;
     }
 

--- a/packages/cli/src/commands/blob/store-remove.ts
+++ b/packages/cli/src/commands/blob/store-remove.ts
@@ -80,6 +80,13 @@ export default async function removeStore(
     );
 
     if (!yes) {
+      if (!client.stdin.isTTY) {
+        output.error(
+          'Confirmation required. Use --yes to skip confirmation in non-interactive environments.'
+        );
+        return 1;
+      }
+
       const res = await client.input.confirm(
         `Are you sure you want to remove ${label}?${projectsInfo} This action cannot be undone.`,
         false

--- a/packages/cli/src/commands/blob/store-remove.ts
+++ b/packages/cli/src/commands/blob/store-remove.ts
@@ -29,9 +29,12 @@ export default async function removeStore(
     return 1;
   }
 
-  let {
-    args: [storeId],
+  const {
+    args: [storeIdArg],
+    flags: { '--yes': yes },
   } = parsedArgs;
+
+  let storeId = storeIdArg;
 
   if (!storeId && rwToken.success) {
     const [, , , id] = rwToken.token.split('_');
@@ -76,14 +79,16 @@ export default async function removeStore(
       connectionsResponse.connections
     );
 
-    const res = await client.input.confirm(
-      `Are you sure you want to remove ${label}?${projectsInfo} This action cannot be undone.`,
-      false
-    );
+    if (!yes) {
+      const res = await client.input.confirm(
+        `Are you sure you want to remove ${label}?${projectsInfo} This action cannot be undone.`,
+        false
+      );
 
-    if (!res) {
-      output.success('Blob store not removed');
-      return 0;
+      if (!res) {
+        output.success('Blob store not removed');
+        return 0;
+      }
     }
 
     output.debug('Deleting blob store');

--- a/packages/cli/src/commands/blob/store-remove.ts
+++ b/packages/cli/src/commands/blob/store-remove.ts
@@ -43,6 +43,10 @@ export default async function removeStore(
   }
 
   if (!storeId) {
+    if (!client.stdin.isTTY) {
+      output.error('Missing required argument: storeId');
+      return 1;
+    }
     storeId = await client.input.text({
       message: 'Enter the ID of the blob store you want to remove',
       validate: value => {

--- a/packages/cli/src/util/telemetry/commands/blob/store-add.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-add.ts
@@ -32,4 +32,19 @@ export class BlobAddStoreTelemetryClient
       });
     }
   }
+
+  trackCliFlagYes(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('yes');
+    }
+  }
+
+  trackCliOptionEnvironment(value: string[] | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'environment',
+        value: value.join(','),
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/blob/store-list.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-list.ts
@@ -4,4 +4,11 @@ import type { TelemetryMethods } from '../../types';
 
 export class BlobListStoresTelemetryClient
   extends TelemetryClient
-  implements TelemetryMethods<typeof listStoresSubcommand> {}
+  implements TelemetryMethods<typeof listStoresSubcommand>
+{
+  trackCliFlagAll(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('all');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/blob/store-remove.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-remove.ts
@@ -14,4 +14,10 @@ export class BlobRemoveStoreTelemetryClient
       });
     }
   }
+
+  trackCliFlagYes(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('yes');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/blob/store-add.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-add.test.ts
@@ -388,6 +388,63 @@ describe('blob store add', () => {
       );
     });
 
+    it('should auto-link with all environments when --yes is passed', async () => {
+      const exitCode = await addStore(client, [
+        '--access',
+        'private',
+        'ci-store',
+        '--yes',
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(client.input.checkbox).not.toHaveBeenCalled();
+      expect(mockedConnectResourceToProject).toHaveBeenCalledWith(
+        client,
+        'proj_123',
+        'store_test123',
+        ['production', 'preview', 'development'],
+        { accountId: 'org_123' }
+      );
+    });
+
+    it('should use --environment flags when provided with --yes', async () => {
+      const exitCode = await addStore(client, [
+        '--access',
+        'private',
+        'ci-store',
+        '--yes',
+        '--environment',
+        'production',
+        '--environment',
+        'preview',
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(mockedConnectResourceToProject).toHaveBeenCalledWith(
+        client,
+        'proj_123',
+        'store_test123',
+        ['production', 'preview'],
+        { accountId: 'org_123' }
+      );
+    });
+
+    it('should reject invalid --environment values', async () => {
+      const exitCode = await addStore(client, [
+        '--access',
+        'private',
+        'ci-store',
+        '--environment',
+        'staging',
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.error).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid environment value')
+      );
+    });
+
     it('should skip linking when project is not linked', async () => {
       mockedGetLinkedProject.mockResolvedValue({
         org: null,

--- a/packages/cli/test/unit/commands/blob/store-list.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-list.test.ts
@@ -220,13 +220,34 @@ describe('blob list-stores', () => {
   });
 
   describe('empty store list', () => {
-    it('should show message when no stores found', async () => {
+    it('should show generic message when no stores found without linked project', async () => {
+      mockedGetLinkFromDir.mockResolvedValue(null);
+      mockedGetScope.mockResolvedValue({
+        contextName: 'my-team',
+        team: { id: 'team_123', slug: 'my-team' } as any,
+        user: {} as any,
+      });
       client.fetch = vi.fn().mockResolvedValue({ stores: [] });
 
       const exitCode = await listStores(client, []);
 
       expect(exitCode).toBe(0);
       expect(mockedOutput.log).toHaveBeenCalledWith('No blob stores found');
+      expect(selectInputMock).not.toHaveBeenCalled();
+    });
+
+    it('should hint about --all when no stores found in linked project', async () => {
+      client.fetch = vi.fn().mockResolvedValue({ stores: [] });
+
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('No blob stores connected to')
+      );
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('--all')
+      );
       expect(selectInputMock).not.toHaveBeenCalled();
     });
 

--- a/packages/cli/test/unit/commands/blob/store-list.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-list.test.ts
@@ -230,7 +230,7 @@ describe('blob list-stores', () => {
       expect(selectInputMock).not.toHaveBeenCalled();
     });
 
-    it('should show message when no stores match linked project', async () => {
+    it('should hint about --all when no stores match linked project', async () => {
       client.fetch = vi.fn().mockResolvedValue({
         stores: [
           {
@@ -246,7 +246,41 @@ describe('blob list-stores', () => {
       const exitCode = await listStores(client, []);
 
       expect(exitCode).toBe(0);
-      expect(mockedOutput.log).toHaveBeenCalledWith('No blob stores found');
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('No blob stores connected to')
+      );
+      expect(mockedOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('--all')
+      );
+    });
+  });
+
+  describe('--all flag', () => {
+    it('should show all team stores when --all is used in a linked project', async () => {
+      const exitCode = await listStores(client, ['--all']);
+
+      expect(exitCode).toBe(0);
+
+      // Should show all stores, not just those connected to proj_123
+      const choices = selectInputMock.mock.calls[0][0].choices;
+      const storeValues = choices.map((c: { value: string }) => c.value);
+      expect(storeValues).toContain('store_abc123def456ghij');
+      expect(storeValues).toContain('store_xyz789uvw012klmn');
+      expect(storeValues).toContain('store_shared123456789');
+    });
+
+    it('should show generic header with --all', async () => {
+      await listStores(client, ['--all']);
+
+      expect(mockedOutput.log).toHaveBeenCalledWith('Blob stores:');
+    });
+
+    it('should track --all flag in telemetry', async () => {
+      await listStores(client, ['--all']);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:all', value: 'TRUE' },
+      ]);
     });
   });
 

--- a/packages/cli/test/unit/commands/blob/store-remove.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-remove.test.ts
@@ -523,6 +523,22 @@ describe('blob store remove', () => {
       expect(exitCode).toBe(0);
       expect(confirmInputMock).toHaveBeenCalled();
     });
+
+    it('should error in non-TTY without --yes', async () => {
+      (client.stdin as any).isTTY = false;
+
+      const exitCode = await removeStore(
+        client,
+        ['store_1234567890123456'],
+        noToken
+      );
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.error).toHaveBeenCalledWith(
+        'Confirmation required. Use --yes to skip confirmation in non-interactive environments.'
+      );
+      expect(confirmInputMock).not.toHaveBeenCalled();
+    });
   });
 
   describe('interactive prompt behavior', () => {

--- a/packages/cli/test/unit/commands/blob/store-remove.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-remove.test.ts
@@ -500,6 +500,31 @@ describe('blob store remove', () => {
     });
   });
 
+  describe('--yes flag', () => {
+    it('should skip confirmation prompt when --yes is passed', async () => {
+      const exitCode = await removeStore(
+        client,
+        ['store_1234567890123456', '--yes'],
+        noToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(confirmInputMock).not.toHaveBeenCalled();
+      expect(mockedOutput.success).toHaveBeenCalledWith('Blob store deleted');
+    });
+
+    it('should still prompt without --yes', async () => {
+      const exitCode = await removeStore(
+        client,
+        ['store_1234567890123456'],
+        noToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(confirmInputMock).toHaveBeenCalled();
+    });
+  });
+
   describe('interactive prompt behavior', () => {
     it('should show correct prompt message', async () => {
       const exitCode = await removeStore(client, [], noToken);


### PR DESCRIPTION
## Summary

Make blob store commands fully usable in CI/scripts without interactive prompts.

**`blob create-store --yes [--environment]`**
Auto-connect to linked project, skip confirmation. Defaults to all environments. Use `--environment` to specify a subset (repeatable).

```bash
vercel blob create-store my-store --access private --yes
vercel blob create-store my-store --access private --yes --environment production --environment preview
```

**`blob delete-store --yes`**
Skip confirmation prompt. Matches `blob empty-store --yes`.

```bash
vercel blob delete-store store_abc123 --yes
```

**`blob list-stores --all`**
In a linked project, show all team stores instead of only connected ones. Shows a hint when the filtered list is empty.

```bash
vercel blob list-stores --all
```

## Companion PR

Docs: vercel/front#62744

🤖 Generated with [Claude Code](https://claude.com/claude-code)