### PR TITLE
[build-utils] Extract deserialization utils

### DIFF
--- a/.changeset/slow-snails-hang.md
+++ b/.changeset/slow-snails-hang.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Add deserialization utilities

--- a/packages/build-utils/src/deserialize/create-functions-iterator.ts
+++ b/packages/build-utils/src/deserialize/create-functions-iterator.ts
@@ -1,0 +1,37 @@
+import { join, relative } from 'path';
+import { readdir, stat } from 'fs-extra';
+
+const SUFFIX = '.func';
+
+/**
+ * Creates an async iterator that scans a directory for sub-directories
+ * that end with the suffix `.func`.
+ *
+ * @param dir Absolute path to scan for `.func` directories
+ * @param root The root directory from where the scanning started
+ */
+export async function* createFunctionsIterator(
+  dir: string,
+  root = dir
+): AsyncIterable<string> {
+  let paths: string[];
+  try {
+    paths = await readdir(dir);
+  } catch (err: any) {
+    if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
+      throw err;
+    }
+    paths = [];
+  }
+  for (const path of paths) {
+    const abs = join(dir, path);
+    const s = await stat(abs);
+    if (s.isDirectory()) {
+      if (path.endsWith(SUFFIX)) {
+        yield relative(root, abs.substring(0, abs.length - SUFFIX.length));
+      } else {
+        yield* createFunctionsIterator(abs, root);
+      }
+    }
+  }
+}

--- a/packages/build-utils/src/deserialize/hydrate-files-map.ts
+++ b/packages/build-utils/src/deserialize/hydrate-files-map.ts
@@ -1,0 +1,26 @@
+import type { Files } from '../types';
+import FileFsRef from '../file-fs-ref';
+import { join } from 'path';
+
+export async function hydrateFilesMap(
+  files: Files,
+  filesMap: Record<string, string>,
+  repoRootPath: string,
+  fileFsRefsCache: Map<string, FileFsRef>
+) {
+  for (const [funcPath, projectPath] of Object.entries(filesMap)) {
+    files[funcPath] = await fileFsRefCached(
+      join(repoRootPath, projectPath),
+      fileFsRefsCache
+    );
+  }
+}
+
+async function fileFsRefCached(fsPath: string, cache: Map<string, FileFsRef>) {
+  let file = cache.get(fsPath);
+  if (!file) {
+    file = await FileFsRef.fromFsPath({ fsPath });
+    cache.set(fsPath, file);
+  }
+  return file;
+}

--- a/packages/build-utils/src/deserialize/maybe-read-json.ts
+++ b/packages/build-utils/src/deserialize/maybe-read-json.ts
@@ -1,0 +1,16 @@
+import { readJSON } from 'fs-extra';
+
+/**
+ * Reads the JSON file at `path`.
+ * Returns `undefined` if the file does not exist.
+ */
+export async function maybeReadJSON<T = any>(
+  path: string
+): Promise<T | undefined> {
+  try {
+    return await readJSON(path);
+  } catch (err: any) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+  return undefined;
+}

--- a/packages/build-utils/src/deserialize/validate-framework-version.ts
+++ b/packages/build-utils/src/deserialize/validate-framework-version.ts
@@ -1,0 +1,37 @@
+import { NowBuildError } from '../errors';
+
+type FrameworkMeta = {
+  version: string;
+};
+
+const MAX_FRAMEWORK_VERSION_LENGTH = 50;
+
+export function validateFrameworkVersion(
+  frameworkVersion: string | undefined
+): FrameworkMeta | undefined {
+  if (!frameworkVersion) {
+    return undefined;
+  }
+
+  if (typeof frameworkVersion !== 'string') {
+    throw new NowBuildError({
+      message: `Invalid config.json: "framework.version" type "${typeof frameworkVersion}" should be "string"`,
+      code: 'VC_BUILD_INVALID_CONFIG_JSON_FRAMEWORK_VERSION_TYPE',
+    });
+  }
+
+  if (frameworkVersion.length > MAX_FRAMEWORK_VERSION_LENGTH) {
+    const trimmedFrameworkVersion = frameworkVersion.slice(
+      0,
+      MAX_FRAMEWORK_VERSION_LENGTH
+    );
+    throw new NowBuildError({
+      message: `Invalid config.json: "framework.version" length ${frameworkVersion.length} > ${MAX_FRAMEWORK_VERSION_LENGTH}. "${trimmedFrameworkVersion}..."`,
+      code: 'VC_BUILD_INVALID_CONFIG_JSON_FRAMEWORK_VERSION_LENGTH',
+    });
+  }
+
+  return {
+    version: frameworkVersion,
+  };
+}

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -217,3 +217,8 @@ export {
   validateEnvWrapperSupport,
   ENV_WRAPPER_SUPPORTED_FAMILIES,
 } from './validate-lambda-size';
+
+export { validateFrameworkVersion } from './deserialize/validate-framework-version';
+export { hydrateFilesMap } from './deserialize/hydrate-files-map';
+export { createFunctionsIterator } from './deserialize/create-functions-iterator';
+export { maybeReadJSON } from './deserialize/maybe-read-json';


### PR DESCRIPTION
Extract existing deserialization util functions into `build-utils` so they can be called in multiple places.

These funcs will be implicitly tested via integration tests in my next PR which introduces functions that call these.