### PR TITLE
feat(cli): add --permission and --expiry flags to tokens add

### DIFF
--- a/packages/cli/src/commands/tokens/add.ts
+++ b/packages/cli/src/commands/tokens/add.ts
@@ -1,4 +1,5 @@
 import open from 'open';
+import ms from 'ms';
 import { KNOWN_AGENTS } from '@vercel/detect-agent';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
@@ -15,11 +16,57 @@ import {
 } from '../../util/agent-output';
 import { AGENT_REASON } from '../../util/agent-output-constants';
 import { getCommandNamePlain } from '../../util/pkg-name';
+import { TokensAddTelemetryClient } from '../../util/telemetry/commands/tokens/add';
 
 interface CreateTokenResponse {
   token?: { id?: string; name?: string };
   bearerToken?: string;
 }
+
+interface Permission {
+  resource: string;
+  action: string;
+}
+
+interface AuthorizationDetail {
+  type: 'permissions';
+  permissions: Permission[];
+}
+
+const VALID_ACTIONS = ['create', 'delete', 'read', 'update', 'list'] as const;
+
+const MAX_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+const COMMON_PERMISSIONS: Array<{
+  name: string;
+  value: string;
+}> = [
+  { name: 'project:read (Read project details)', value: 'project:read' },
+  { name: 'project:list (List projects)', value: 'project:list' },
+  {
+    name: 'deployment:create (Create deployments)',
+    value: 'deployment:create',
+  },
+  {
+    name: 'deployment:read (Read deployment details)',
+    value: 'deployment:read',
+  },
+  { name: 'deployment:list (List deployments)', value: 'deployment:list' },
+  {
+    name: 'projectEnvVars:read (Read environment variables)',
+    value: 'projectEnvVars:read',
+  },
+  {
+    name: 'projectEnvVars:create (Create environment variables)',
+    value: 'projectEnvVars:create',
+  },
+  {
+    name: 'projectEnvVars:update (Update environment variables)',
+    value: 'projectEnvVars:update',
+  },
+  { name: 'domain:read (Read domain details)', value: 'domain:read' },
+  { name: 'domain:list (List domains)', value: 'domain:list' },
+];
 
 const VERCEL_ACCOUNT_TOKENS_URL = 'https://vercel.com/account/tokens';
 
@@ -103,6 +150,107 @@ async function openTokensDashboardInBrowser(client: Client): Promise<void> {
   }
 }
 
+function parsePermission(raw: string): Permission | string {
+  const colonIndex = raw.indexOf(':');
+  if (colonIndex === -1) {
+    return `Invalid permission format "${raw}". Expected resource:action (e.g. project:read).`;
+  }
+  const resource = raw.slice(0, colonIndex);
+  const action = raw.slice(colonIndex + 1);
+  if (!resource) {
+    return `Invalid permission format "${raw}". Resource cannot be empty.`;
+  }
+  if (!(VALID_ACTIONS as readonly string[]).includes(action)) {
+    return `Invalid action "${action}" in "${raw}". Valid actions: ${VALID_ACTIONS.join(', ')}.`;
+  }
+  return { resource, action };
+}
+
+function parseExpiry(raw: string): number | string {
+  const duration = ms(raw);
+  if (duration === undefined || duration <= 0) {
+    return `Invalid expiry duration "${raw}". Use a duration like "7d", "1h", or "30m".`;
+  }
+  return duration;
+}
+
+async function promptPermissionsInteractive(
+  client: Client
+): Promise<{ permissions: Permission[]; expiresAt: number } | null> {
+  const shouldScope = await client.input.confirm(
+    'Scope this token to specific permissions?',
+    false
+  );
+  if (!shouldScope) {
+    return null;
+  }
+
+  const selected = await client.input.checkbox({
+    message: 'Select permissions',
+    choices: COMMON_PERMISSIONS.map(p => ({
+      name: p.name,
+      value: p.value,
+      checked: false,
+    })),
+  });
+
+  const additional = await client.input.text({
+    message:
+      'Enter additional permissions (comma-separated resource:action), or press Enter to skip:',
+  });
+
+  const permissions: Permission[] = [];
+  for (const raw of selected) {
+    const parsed = parsePermission(raw);
+    if (typeof parsed === 'string') {
+      output.error(parsed);
+      return null;
+    }
+    permissions.push(parsed);
+  }
+
+  if (additional.trim()) {
+    for (const raw of additional.split(',').map(s => s.trim())) {
+      if (!raw) {
+        continue;
+      }
+      const parsed = parsePermission(raw);
+      if (typeof parsed === 'string') {
+        output.error(parsed);
+        return null;
+      }
+      permissions.push(parsed);
+    }
+  }
+
+  if (permissions.length === 0) {
+    output.error('No permissions selected. Cannot create a scoped token.');
+    return null;
+  }
+
+  const expiryInput = await client.input.text({
+    message: 'Token expiry (e.g. 7d, 1h, 30m):',
+    validate: (value: string) => {
+      const duration = ms(value);
+      if (duration === undefined || duration <= 0) {
+        return 'Invalid duration. Use a format like "7d", "1h", or "30m".';
+      }
+      if (duration > MAX_EXPIRY_MS) {
+        return 'Expiry cannot exceed 7 days for scoped tokens.';
+      }
+      return true;
+    },
+  });
+
+  const duration = ms(expiryInput);
+  if (duration === undefined || duration <= 0) {
+    output.error('Invalid expiry duration.');
+    return null;
+  }
+
+  return { permissions, expiresAt: Date.now() + duration };
+}
+
 export default async function add(
   client: Client,
   argv: string[]
@@ -115,6 +263,12 @@ export default async function add(
     printError(error);
     return 1;
   }
+
+  const telemetryClient = new TokensAddTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
 
   const { args } = parsedArgs;
   const name = args[0]?.trim();
@@ -148,10 +302,79 @@ export default async function add(
   }
   const asJson = validation.jsonOutput;
 
+  const permissionFlags = parsedArgs.flags['--permission'];
+  const expiryFlag = parsedArgs.flags['--expiry'];
+
+  telemetryClient.trackCliOptionPermission(permissionFlags);
+  telemetryClient.trackCliOptionExpiry(expiryFlag);
+
+  let permissions: Permission[] = [];
+  let expiresAt: number | undefined;
+  let authorizationDetails: AuthorizationDetail[] | undefined;
+
+  if (permissionFlags && permissionFlags.length > 0) {
+    // Flag-based flow
+    for (const raw of permissionFlags) {
+      const parsed = parsePermission(raw);
+      if (typeof parsed === 'string') {
+        output.error(parsed);
+        return 1;
+      }
+      permissions.push(parsed);
+    }
+
+    if (!expiryFlag) {
+      output.error(
+        '--expiry is required when --permission is used. Scoped tokens must have an expiry (max 7 days).'
+      );
+      return 1;
+    }
+
+    const duration = parseExpiry(expiryFlag);
+    if (typeof duration === 'string') {
+      output.error(duration);
+      return 1;
+    }
+
+    if (duration > MAX_EXPIRY_MS) {
+      output.error(
+        'Expiry cannot exceed 7 days for scoped tokens. Use a duration of 7d or less.'
+      );
+      return 1;
+    }
+
+    expiresAt = Date.now() + duration;
+  } else if (expiryFlag) {
+    output.error(
+      '--expiry can only be used with --permission. To create a token without permissions, omit both flags.'
+    );
+    return 1;
+  } else if (client.stdin.isTTY) {
+    // Interactive flow
+    const interactive = await promptPermissionsInteractive(client);
+    if (interactive) {
+      permissions = interactive.permissions;
+      expiresAt = interactive.expiresAt;
+    }
+  }
+
+  if (permissions.length > 0 && expiresAt) {
+    authorizationDetails = [{ type: 'permissions', permissions }];
+  }
+
   const projectId = parsedArgs.flags['--project'];
-  const body: { name: string; projectId?: string } = { name };
+  const body: {
+    name: string;
+    projectId?: string;
+    authorizationDetails?: AuthorizationDetail[];
+    expiresAt?: number;
+  } = { name };
   if (typeof projectId === 'string' && projectId.length > 0) {
     body.projectId = projectId;
+  }
+  if (authorizationDetails) {
+    body.authorizationDetails = authorizationDetails;
+    body.expiresAt = expiresAt;
   }
 
   let result: CreateTokenResponse;
@@ -235,6 +458,14 @@ export default async function add(
   }
   if (result.token?.id) {
     output.log(`id: ${result.token.id}`);
+  }
+  if (permissions.length > 0) {
+    output.log(
+      `permissions: ${permissions.map(p => `${p.resource}:${p.action}`).join(', ')}`
+    );
+  }
+  if (expiresAt) {
+    output.log(`expires: ${new Date(expiresAt).toISOString()}`);
   }
   return 0;
 }

--- a/packages/cli/src/commands/tokens/command.ts
+++ b/packages/cli/src/commands/tokens/command.ts
@@ -44,11 +44,32 @@ export const addSubcommand = {
       description: 'Optional project ID to scope the token to',
       deprecated: false,
     },
+    {
+      name: 'permission',
+      shorthand: null,
+      type: [String],
+      deprecated: false,
+      description:
+        'Permission in resource:action format (repeatable). Constrains the token to only these permissions. Valid actions: create, delete, read, update, list. Requires --expiry (max 7 days).',
+    },
+    {
+      name: 'expiry',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Token lifetime as a duration (e.g. "7d", "1h", "30m"). Required when --permission is used. Max 7 days.',
+      argument: 'DURATION',
+    },
   ],
   examples: [
     {
       name: 'Create a token',
       value: `${packageName} tokens add "CI deploy"`,
+    },
+    {
+      name: 'Create a scoped token',
+      value: `${packageName} tokens add "CI deploy" --permission deployment:create --permission project:read --expiry 7d`,
     },
   ],
 } as const;

--- a/packages/cli/src/util/telemetry/commands/tokens/add.ts
+++ b/packages/cli/src/util/telemetry/commands/tokens/add.ts
@@ -1,0 +1,44 @@
+import { TelemetryClient } from '../..';
+import type { addSubcommand } from '../../../../commands/tokens/command';
+import type { TelemetryMethods } from '../../types';
+
+export class TokensAddTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof addSubcommand>
+{
+  trackCliArgumentName(value: string | undefined) {
+    if (value) {
+      this.trackCliArgument({
+        arg: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionPermission(value: string[] | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'permission',
+        value: value.join(','),
+      });
+    }
+  }
+
+  trackCliOptionExpiry(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'expiry',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionProject(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/tokens/add.test.ts
+++ b/packages/cli/test/unit/commands/tokens/add.test.ts
@@ -11,6 +11,7 @@ vi.mock('open', () => ({
 describe('tokens add', () => {
   it('creates a token', async () => {
     useUser();
+    (client.stdin as any).isTTY = false;
     client.scenario.post('/v3/user/tokens', (req, res) => {
       expect((req.body as { name: string }).name).toBe('My CI');
       res.json({
@@ -46,10 +47,187 @@ describe('tokens add', () => {
     await expect(client.stderr).toOutput('Too many arguments');
   });
 
+  describe('permissions and expiry', () => {
+    it('creates a token with permissions and expiry', async () => {
+      useUser();
+      let requestBody: any;
+      client.scenario.post('/v3/user/tokens', (req, res) => {
+        requestBody = req.body;
+        res.json({
+          token: { id: 'tok_scoped', name: 'CI deploy' },
+          bearerToken: 'scoped_secret',
+        });
+      });
+      client.setArgv(
+        'tokens',
+        'add',
+        'CI deploy',
+        '--permission',
+        'deployment:create',
+        '--permission',
+        'project:read',
+        '--expiry',
+        '7d'
+      );
+
+      const exitCode = await tokens(client);
+      expect(exitCode).toBe(0);
+      expect(requestBody.authorizationDetails).toEqual([
+        {
+          type: 'permissions',
+          permissions: [
+            { resource: 'deployment', action: 'create' },
+            { resource: 'project', action: 'read' },
+          ],
+        },
+      ]);
+      expect(requestBody.expiresAt).toBeTypeOf('number');
+      expect(requestBody.expiresAt).toBeGreaterThan(Date.now());
+      expect(requestBody.expiresAt).toBeLessThanOrEqual(
+        Date.now() + 7 * 24 * 60 * 60 * 1000 + 1000
+      );
+      await expect(client.stderr).toOutput('scoped_secret');
+      await expect(client.stderr).toOutput(
+        'permissions: deployment:create, project:read'
+      );
+      await expect(client.stderr).toOutput('expires:');
+    });
+
+    it('rejects --permission without --expiry', async () => {
+      useUser();
+      client.setArgv('tokens', 'add', 'test', '--permission', 'project:read');
+
+      const exitCode = await tokens(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput(
+        '--expiry is required when --permission is used'
+      );
+    });
+
+    it('rejects --expiry without --permission', async () => {
+      useUser();
+      client.setArgv('tokens', 'add', 'test', '--expiry', '1d');
+
+      const exitCode = await tokens(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput(
+        '--expiry can only be used with --permission'
+      );
+    });
+
+    it('rejects expiry > 7 days with permissions', async () => {
+      useUser();
+      client.setArgv(
+        'tokens',
+        'add',
+        'test',
+        '--permission',
+        'project:read',
+        '--expiry',
+        '8d'
+      );
+
+      const exitCode = await tokens(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Expiry cannot exceed 7 days');
+    });
+
+    it('rejects malformed permission (no colon)', async () => {
+      useUser();
+      client.setArgv(
+        'tokens',
+        'add',
+        'test',
+        '--permission',
+        'projectread',
+        '--expiry',
+        '1d'
+      );
+
+      const exitCode = await tokens(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput(
+        'Invalid permission format "projectread"'
+      );
+    });
+
+    it('rejects invalid action', async () => {
+      useUser();
+      client.setArgv(
+        'tokens',
+        'add',
+        'test',
+        '--permission',
+        'project:execute',
+        '--expiry',
+        '1d'
+      );
+
+      const exitCode = await tokens(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid action "execute"');
+    });
+
+    it('includes authorizationDetails in JSON output', async () => {
+      useUser();
+      client.scenario.post('/v3/user/tokens', (_req, res) => {
+        res.json({
+          token: { id: 'tok_json', name: 'json test' },
+          bearerToken: 'json_secret',
+        });
+      });
+      client.setArgv(
+        'tokens',
+        'add',
+        'json test',
+        '--permission',
+        'project:read',
+        '--expiry',
+        '1h',
+        '--format',
+        'json'
+      );
+
+      const exitCode = await tokens(client);
+      expect(exitCode).toBe(0);
+      const payload = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(payload.token.id).toBe('tok_json');
+      expect(payload.bearerToken).toBe('json_secret');
+    });
+
+    it('tracks telemetry for permission and expiry options', async () => {
+      useUser();
+      client.scenario.post('/v3/user/tokens', (_req, res) => {
+        res.json({
+          token: { id: 'tok_tel', name: 'telemetry' },
+          bearerToken: 'tel_secret',
+        });
+      });
+      client.setArgv(
+        'tokens',
+        'add',
+        'telemetry',
+        '--permission',
+        'project:read',
+        '--expiry',
+        '1d'
+      );
+
+      await tokens(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:add', value: 'add' },
+        { key: 'option:permission', value: 'project:read' },
+        { key: 'option:expiry', value: '[REDACTED]' },
+      ]);
+    });
+  });
+
   describe('classic token required (API 403)', () => {
     beforeEach(() => {
       // `open` is skipped when CI is set (see `openTokensDashboardInBrowser`); clear it so we assert the open path.
       vi.stubEnv('CI', '');
+      // Disable TTY to skip the interactive permissions prompt
+      (client.stdin as any).isTTY = false;
     });
 
     afterEach(() => {
@@ -57,6 +235,7 @@ describe('tokens add', () => {
       vi.mocked(open).mockClear();
       vi.restoreAllMocks();
       client.nonInteractive = false;
+      (client.stdin as any).isTTY = true;
     });
 
     it('prints guidance and opens the tokens dashboard', async () => {


### PR DESCRIPTION
## Summary

- Add `--permission resource:action` (repeatable) and `--expiry DURATION` flags to `vercel tokens add` for minting fine-grained, time-limited personal access tokens
- Interactive TTY flow: checkbox with common permissions + free-text entry + expiry prompt when no `--permission` flags are passed
- Validation: action must be one of create/delete/read/update/list, expiry required with permissions, max 7 days
- Enhanced output shows granted permissions and expiry timestamp after token creation
- Telemetry tracking for new options via `TokensAddTelemetryClient`
- 8 new test cases covering flag-based flows, validation errors, JSON output, and telemetry