### PR TITLE
python(vercel-workers): Avoid `test` script

### DIFF
--- a/.changeset/selfish-pens-design.md
+++ b/.changeset/selfish-pens-design.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stop publishing the generic `test` console script from `vercel-workers` so installs no longer shadow the system `test` command.

--- a/python/vercel-workers/pyproject.toml
+++ b/python/vercel-workers/pyproject.toml
@@ -16,9 +16,6 @@ dependencies = [
     "vercel>=0.3.7",
 ]
 
-[project.scripts]
-test = "pytest:main"
-
 [project.optional-dependencies]
 dev = [
     "ruff~=0.15.1",


### PR DESCRIPTION
This shadows the built-in `test` which a downstream consumer was using in some unit test scenarios instead of `[ [expr] ]` style testing. Since we already direct agents to call `pytest` via `uv` directly, I'm just dropping project script.

If we want to keep a script for running `pytest`, we can add a `scripts/` directory and call it from there.