### PR TITLE
python(vercel-workers): Fix changeset frontmatter

### DIFF
--- a/.changeset/selfish-pens-design.md
+++ b/.changeset/selfish-pens-design.md
@@ -1,4 +1,5 @@
 ---
+'@vercel/python-workers': patch
 ---
 
 Stop publishing the generic `test` console script from `vercel-workers` so installs no longer shadow the system `test` command.


### PR DESCRIPTION
Didn't realize we have a special JS<->Python system for using changesets from Python.