### PR TITLE
[CLI] Bubble up action + resource from 403 errors to agent output

### DIFF
--- a/.changeset/agent-403-action-resource.md
+++ b/.changeset/agent-403-action-resource.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Include `action` and `resource` fields from API 403 responses in non-interactive agent error payloads.

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -72,6 +72,10 @@ export interface AgentErrorPayload {
     integration_privacy_policy?: string;
     integration_eula?: string;
   };
+  /** ACL action the caller lacks permission for (e.g. "read", "create", "delete"). Present on 403 when the API provides it. */
+  action?: string;
+  /** ACL resource the permission applies to (e.g. "project", "deployment"). Present on 403 when the API provides it. */
+  resource?: string;
 }
 
 /**
@@ -721,6 +725,8 @@ export function exitWithNonInteractiveError(
         status: 'error',
         reason,
         message,
+        ...(err.action && { action: err.action }),
+        ...(err.resource && { resource: err.resource }),
       },
       exitCode,
       variant

--- a/packages/cli/test/unit/util/agent-output.test.ts
+++ b/packages/cli/test/unit/util/agent-output.test.ts
@@ -540,6 +540,97 @@ describe('exitWithNonInteractiveError', () => {
 
     vi.restoreAllMocks();
   });
+
+  it('includes action and resource from a 403 APIError', async () => {
+    const { Response } = await import('node-fetch');
+    const res = new Response(
+      JSON.stringify({
+        error: {
+          code: 'forbidden',
+          message: "You don't have permission to read the project.",
+          action: 'read',
+          resource: 'project',
+        },
+      }),
+      { status: 403 }
+    );
+    const err = new APIError(
+      "You don't have permission to read the project.",
+      res,
+      { action: 'read', resource: 'project' }
+    );
+
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as () => never);
+
+    const chunks: string[] = [];
+    const stdout = {
+      write: (s: string) => {
+        chunks.push(s);
+        return true;
+      },
+    };
+
+    const client = {
+      nonInteractive: true,
+      argv: ['node', 'vc.js', 'project', 'members', '--non-interactive'],
+      stdout,
+    } as unknown as Client;
+
+    expect(() => exitWithNonInteractiveError(client, err, 1)).toThrow('exit:1');
+    const payload = JSON.parse(chunks.join('').trim());
+    expect(payload).toMatchObject({
+      status: 'error',
+      reason: 'forbidden',
+      message: "You don't have permission to read the project.",
+      action: 'read',
+      resource: 'project',
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it('omits action and resource from a 404 APIError', async () => {
+    const { Response } = await import('node-fetch');
+    const res = new Response(
+      JSON.stringify({
+        error: { code: 'not_found', message: 'Not found.' },
+      }),
+      { status: 404 }
+    );
+    const err = new APIError('Not found.', res);
+
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as () => never);
+
+    const chunks: string[] = [];
+    const stdout = {
+      write: (s: string) => {
+        chunks.push(s);
+        return true;
+      },
+    };
+
+    const client = {
+      nonInteractive: true,
+      argv: ['node', 'vc.js', 'project', 'members', '--non-interactive'],
+      stdout,
+    } as unknown as Client;
+
+    expect(() => exitWithNonInteractiveError(client, err, 1)).toThrow('exit:1');
+    const payload = JSON.parse(chunks.join('').trim());
+    expect(payload).toMatchObject({
+      status: 'error',
+      reason: 'project_not_found',
+      message: 'Not found.',
+    });
+    expect(payload).not.toHaveProperty('action');
+    expect(payload).not.toHaveProperty('resource');
+
+    vi.restoreAllMocks();
+  });
 });
 
 describe('getGlobalFlagsFromArgv', () => {


### PR DESCRIPTION
## Summary

- Forward `action` and `resource` fields from API 403 responses into the `AgentErrorPayload` JSON, so agents know which ACL permission to request
- Add `action?` and `resource?` optional fields to `AgentErrorPayload` interface