### PR TITLE
[build-utils] Extract deserialization types and helpers

### DIFF
--- a/.changeset/serious-kids-enjoy.md
+++ b/.changeset/serious-kids-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Export shared build output deserialize helpers for existing callers.

--- a/packages/build-utils/src/deserialize/deserialize-build-output.ts
+++ b/packages/build-utils/src/deserialize/deserialize-build-output.ts
@@ -54,6 +54,12 @@ export interface DeserializeBuildOutputCoreResult {
   meta?: DeserializeBuildOutputMeta;
 }
 
+export type FinalizeBuildOutputCoreResult = BuildResultV2TypicalWithCron;
+
+export interface FinalizeBuildOutputCoreResultOptions {
+  defaultMeta?: DeserializeBuildOutputMeta;
+}
+
 export interface DeserializeBuildOutputCoreOptions<
   TLambda extends Lambda = Lambda,
   TEdgeFunction extends EdgeFunction = EdgeFunction,
@@ -233,6 +239,24 @@ async function defaultGroupLambdas({
   lambdas,
 }: DeserializeBuildOutputGroupLambdasOptions): Promise<Record<string, Lambda>> {
   return lambdas;
+}
+
+export function finalizeBuildOutputCoreResult(
+  { config, flags, output, framework, meta }: DeserializeBuildOutputCoreResult,
+  options: FinalizeBuildOutputCoreResultOptions = {}
+): FinalizeBuildOutputCoreResult {
+  return {
+    wildcard: config.wildcard,
+    images: config.images,
+    crons: config.crons,
+    // TODO: Remove `config.flags` once removed from existing callers.
+    flags: flags ? flags : config.flags,
+    routes: config.routes,
+    output,
+    framework,
+    deploymentId: config.deploymentId,
+    meta: meta ?? options.defaultMeta,
+  };
 }
 
 export async function deserializeBuildOutputCore<

--- a/packages/build-utils/src/deserialize/deserialize-build-output.ts
+++ b/packages/build-utils/src/deserialize/deserialize-build-output.ts
@@ -1,0 +1,399 @@
+import * as fs from 'fs-extra';
+import { dirname, join } from 'path';
+import type { BuildResultV2Typical } from '../types';
+import { createFunctionsIterator } from './create-functions-iterator';
+import {
+  deserializeEdgeFunction,
+  type DeserializeEdgeFunctionOptions,
+} from './deserialize-edge-function';
+import {
+  deserializeLambda,
+  type DeserializeLambdaOptions,
+} from './deserialize-lambda';
+import FileFsRef from '../file-fs-ref';
+import glob from '../fs/glob';
+import { EdgeFunction } from '../edge-function';
+import { Lambda } from '../lambda';
+import { Prerender } from '../prerender';
+import { maybeReadJSON } from './maybe-read-json';
+import { validateFrameworkVersion } from './validate-framework-version';
+import type {
+  BuildOutputConfig,
+  BuildResultV2TypicalWithCron,
+  DeploymentFlags,
+  SerializedEdgeFunction,
+  SerializedLambda,
+  SerializedNodejsLambda,
+  SerializedPrerender,
+} from './types';
+
+export type DeserializeBuildOutputMeta = NonNullable<
+  BuildResultV2TypicalWithCron['meta']
+>;
+
+export interface DeserializeBuildOutputInspectLambdaOptions<
+  TLambda extends Lambda = Lambda,
+> {
+  path: string;
+  config: SerializedLambda | SerializedNodejsLambda;
+  lambda: TLambda;
+  repoRootPath: string;
+}
+
+export interface DeserializeBuildOutputGroupLambdasOptions {
+  lambdas: Record<string, Lambda>;
+  maxBundleSizeMb?: number;
+  debug?: boolean;
+}
+
+export interface DeserializeBuildOutputCoreResult {
+  config: BuildOutputConfig;
+  flags?: DeploymentFlags;
+  output: BuildResultV2Typical['output'];
+  framework?: BuildResultV2Typical['framework'];
+  meta?: DeserializeBuildOutputMeta;
+}
+
+export interface DeserializeBuildOutputCoreOptions<
+  TLambda extends Lambda = Lambda,
+  TEdgeFunction extends EdgeFunction = EdgeFunction,
+> {
+  outputDir: string;
+  repoRootPath: string;
+  maxBundleSizeMb?: number;
+  debugGroupLambdas?: boolean;
+  useOnlyStreamingLambda?: boolean;
+  forceNodejsStreaming?: boolean;
+  createLambda?: DeserializeLambdaOptions<TLambda>['createLambda'];
+  createNodejsLambda?: DeserializeLambdaOptions<TLambda>['createNodejsLambda'];
+  createEdgeFunction?: DeserializeEdgeFunctionOptions<TEdgeFunction>['createEdgeFunction'];
+  groupLambdas?: (
+    options: DeserializeBuildOutputGroupLambdasOptions
+  ) => Promise<Record<string, Lambda>> | Record<string, Lambda>;
+  inspectLambda?: (
+    options: DeserializeBuildOutputInspectLambdaOptions<TLambda>
+  ) =>
+    | Promise<Partial<DeserializeBuildOutputMeta> | void>
+    | Partial<DeserializeBuildOutputMeta>
+    | void;
+  validateConfig?: (config: BuildOutputConfig) => Promise<void> | void;
+  warn?: (message: string) => void;
+}
+
+function applyOutputOverrides(
+  output: BuildResultV2Typical['output'],
+  overrides: BuildOutputConfig['overrides'],
+  warn: (message: string) => void
+): void {
+  for (const [name, override] of Object.entries(overrides || {})) {
+    const entry = output[name] as FileFsRef | undefined;
+    if (entry) {
+      if (override.contentType) {
+        entry.contentType = override.contentType;
+      }
+      if (override.mode) {
+        entry.mode = override.mode;
+      }
+      if (override.path) {
+        output[override.path] = entry;
+        delete output[name];
+      }
+    } else {
+      warn(
+        `Warning: Override path "${name}" was not detected as an output path`
+      );
+    }
+  }
+}
+
+async function deserializePrerenderFallback(
+  prerenderConfigPath: string,
+  fallbackConfig: SerializedPrerender['fallback']
+): Promise<Prerender['fallback']> {
+  if (typeof fallbackConfig === 'string') {
+    return FileFsRef.fromFsPath({
+      fsPath: join(dirname(prerenderConfigPath), fallbackConfig),
+    });
+  }
+
+  if (fallbackConfig) {
+    return FileFsRef.fromFsPath({
+      mode: fallbackConfig.mode,
+      contentType: fallbackConfig.contentType,
+      fsPath: join(dirname(prerenderConfigPath), fallbackConfig.fsPath),
+    });
+  }
+
+  return null;
+}
+
+function applyFunctionSymlinks(
+  output: BuildResultV2Typical['output'],
+  prerenders: Map<string, Prerender>,
+  functionSymlinks: Map<string, string>
+): void {
+  for (const [path, target] of functionSymlinks.entries()) {
+    const targetOutput = prerenders.get(target) || output[target];
+    let targetFunction: Lambda | EdgeFunction | undefined;
+    if (targetOutput?.type === 'Prerender') {
+      targetFunction = targetOutput.lambda;
+    } else if (
+      targetOutput?.type === 'Lambda' ||
+      targetOutput?.type === 'EdgeFunction'
+    ) {
+      targetFunction = targetOutput;
+    }
+    if (!targetFunction) {
+      throw new Error(
+        `Could not find target "${target}" Lambda or EdgeFunction for path "${path}"`
+      );
+    }
+
+    const srcOutput = prerenders.get(path);
+    if (srcOutput) {
+      if (srcOutput.type === 'Prerender') {
+        if (targetFunction.type === 'Lambda') {
+          srcOutput.lambda = targetFunction;
+        } else {
+          throw new Error(
+            `Unexpected function type "${targetFunction.type}" at path "${path}"`
+          );
+        }
+      } else {
+        throw new Error(
+          `Unexpected output type "${srcOutput.type}" at path "${path}"`
+        );
+      }
+    } else {
+      output[path] = targetFunction;
+    }
+  }
+}
+
+function appendSortedPrerenders(
+  output: BuildResultV2Typical['output'],
+  prerenders: Map<string, Prerender>
+): void {
+  const sortedPrerenders = Array.from(prerenders.entries())
+    .sort((a, b) => {
+      return (a[1].group ?? 0) - (b[1].group ?? 0);
+    })
+    .reduce<Record<string, Prerender>>((result, [path, prerender]) => {
+      result[path] = prerender;
+      return result;
+    }, {});
+
+  Object.assign(output, sortedPrerenders);
+}
+
+function getBundleableLambdas(
+  output: BuildResultV2Typical['output']
+): Record<string, Lambda> {
+  const bundleableLambdas: Record<string, Lambda> = {};
+
+  for (const [outputName, curOutput] of Object.entries(output)) {
+    if (curOutput.type === 'Lambda' && curOutput.experimentalAllowBundling) {
+      bundleableLambdas[outputName] = curOutput;
+    } else if (
+      curOutput.type === 'Prerender' &&
+      curOutput.lambda &&
+      curOutput.lambda.experimentalAllowBundling
+    ) {
+      bundleableLambdas[outputName] = curOutput.lambda;
+    }
+  }
+
+  return bundleableLambdas;
+}
+
+function applyGroupedLambdas(
+  output: BuildResultV2Typical['output'],
+  groupedLambdas: Record<string, Lambda>
+): void {
+  for (const outputName of Object.keys(groupedLambdas)) {
+    const groupedLambda = groupedLambdas[outputName];
+    const origOutput = output[outputName];
+
+    if (origOutput.type === 'Lambda') {
+      output[outputName] = groupedLambda;
+    } else if (origOutput.type === 'Prerender' && origOutput.lambda) {
+      origOutput.lambda = groupedLambda;
+    }
+  }
+}
+
+function getErrorCode(error: unknown): unknown {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    return (error as { code?: unknown }).code;
+  }
+  return undefined;
+}
+
+async function defaultGroupLambdas({
+  lambdas,
+}: DeserializeBuildOutputGroupLambdasOptions): Promise<Record<string, Lambda>> {
+  return lambdas;
+}
+
+export async function deserializeBuildOutputCore<
+  TLambda extends Lambda = Lambda,
+  TEdgeFunction extends EdgeFunction = EdgeFunction,
+>({
+  outputDir,
+  repoRootPath,
+  maxBundleSizeMb,
+  debugGroupLambdas,
+  useOnlyStreamingLambda,
+  forceNodejsStreaming,
+  createLambda,
+  createNodejsLambda,
+  createEdgeFunction,
+  groupLambdas,
+  inspectLambda,
+  validateConfig,
+  warn = console.warn,
+}: DeserializeBuildOutputCoreOptions<
+  TLambda,
+  TEdgeFunction
+>): Promise<DeserializeBuildOutputCoreResult> {
+  const configPath = join(outputDir, 'config.json');
+  const config = await maybeReadJSON<BuildOutputConfig>(configPath);
+
+  if (!config) {
+    throw new Error(`Config file was not found at "${configPath}"`);
+  }
+
+  if (config.version !== 3) {
+    throw new Error(
+      `Expected \`version: 3\` in "${configPath}" file (received \`${config.version}\`)`
+    );
+  }
+
+  await validateConfig?.(config);
+
+  const flags = await maybeReadJSON<DeploymentFlags>(
+    join(outputDir, 'flags.json')
+  );
+
+  const staticDir = join(outputDir, 'static');
+  const output: BuildResultV2Typical['output'] = await glob('**', {
+    cwd: staticDir,
+    follow: true,
+  });
+
+  applyOutputOverrides(output, config.overrides, warn);
+
+  const fileFsRefsCache = new Map<string, FileFsRef>();
+
+  // Existing callers require Prerenders to be appended after regular Lambdas.
+  // Without that ordering, shared references can be reconstructed incorrectly.
+  const prerenders = new Map<string, Prerender>();
+  let meta: DeserializeBuildOutputMeta | undefined;
+
+  const functionsDir = join(outputDir, 'functions');
+  const functionSymlinks = new Map<string, string>();
+
+  for await (const path of createFunctionsIterator(functionsDir)) {
+    let lambda: TLambda | undefined;
+    const fnDir = join(functionsDir, `${path}.func`);
+
+    try {
+      const link = await fs.readlink(fnDir);
+      const target = join(dirname(path), link).slice(0, -5);
+      functionSymlinks.set(path, target);
+    } catch (error: unknown) {
+      if (getErrorCode(error) !== 'EINVAL') {
+        throw error;
+      }
+
+      const funcConfigPath = join(fnDir, '.vc-config.json');
+      const funcConfig = await maybeReadJSON<
+        SerializedEdgeFunction | SerializedLambda | SerializedNodejsLambda
+      >(funcConfigPath);
+
+      if (!funcConfig) {
+        throw new Error(`Could not load function config: "${funcConfigPath}"`);
+      }
+
+      const files = await glob('**', { cwd: fnDir, includeDirectories: true });
+      delete files['.vc-config.json'];
+
+      if (funcConfig.type === 'EdgeFunction' || funcConfig.runtime === 'edge') {
+        output[path] = await deserializeEdgeFunction({
+          files,
+          config: funcConfig as SerializedEdgeFunction,
+          repoRootPath,
+          fileFsRefsCache,
+          createEdgeFunction,
+        });
+        continue;
+      }
+
+      lambda = await deserializeLambda({
+        files,
+        config: funcConfig,
+        repoRootPath,
+        fileFsRefsCache,
+        useOnlyStreamingLambda,
+        forceNodejsStreaming,
+        createLambda,
+        createNodejsLambda,
+      });
+
+      const lambdaMeta = await inspectLambda?.({
+        path,
+        config: funcConfig,
+        lambda,
+        repoRootPath,
+      });
+      if (lambdaMeta) {
+        meta = {
+          ...meta,
+          ...lambdaMeta,
+        };
+      }
+    }
+
+    const prerenderConfigPath = join(
+      functionsDir,
+      `${path}.prerender-config.json`
+    );
+    const prerenderConfig =
+      await maybeReadJSON<SerializedPrerender>(prerenderConfigPath);
+    if (prerenderConfig) {
+      const fallback = await deserializePrerenderFallback(
+        prerenderConfigPath,
+        prerenderConfig.fallback
+      );
+
+      prerenders.set(
+        path,
+        new Prerender({
+          ...prerenderConfig,
+          lambda,
+          fallback,
+        })
+      );
+    } else if (lambda) {
+      output[path] = lambda;
+    }
+  }
+
+  applyFunctionSymlinks(output, prerenders, functionSymlinks);
+  appendSortedPrerenders(output, prerenders);
+
+  const groupedLambdas = await (groupLambdas ?? defaultGroupLambdas)({
+    lambdas: getBundleableLambdas(output),
+    maxBundleSizeMb,
+    debug: debugGroupLambdas,
+  });
+  applyGroupedLambdas(output, groupedLambdas);
+
+  return {
+    config,
+    flags,
+    output,
+    framework: validateFrameworkVersion(config.framework?.version),
+    meta,
+  };
+}

--- a/packages/build-utils/src/deserialize/deserialize-edge-function.ts
+++ b/packages/build-utils/src/deserialize/deserialize-edge-function.ts
@@ -1,0 +1,55 @@
+import type { Files } from '../types';
+import FileFsRef from '../file-fs-ref';
+import { EdgeFunction } from '../edge-function';
+import { hydrateFilesMap } from './hydrate-files-map';
+import type { SerializedEdgeFunction } from './types';
+
+export type DeserializeEdgeFunctionParams = SerializedEdgeFunction & {
+  files: Files;
+  deploymentTarget: 'v8-worker';
+};
+
+export interface DeserializeEdgeFunctionOptions<
+  TEdgeFunction extends EdgeFunction = EdgeFunction,
+> {
+  files: Files;
+  config: SerializedEdgeFunction;
+  repoRootPath: string;
+  fileFsRefsCache: Map<string, FileFsRef>;
+  createEdgeFunction?: (params: DeserializeEdgeFunctionParams) => TEdgeFunction;
+}
+
+function defaultCreateEdgeFunction(
+  params: DeserializeEdgeFunctionParams
+): EdgeFunction {
+  return new EdgeFunction(params);
+}
+
+export async function deserializeEdgeFunction<
+  TEdgeFunction extends EdgeFunction = EdgeFunction,
+>({
+  files,
+  config,
+  repoRootPath,
+  fileFsRefsCache,
+  createEdgeFunction,
+}: DeserializeEdgeFunctionOptions<TEdgeFunction>): Promise<TEdgeFunction> {
+  if (config.filePathMap) {
+    await hydrateFilesMap(
+      files,
+      config.filePathMap,
+      repoRootPath,
+      fileFsRefsCache
+    );
+  }
+
+  const params: DeserializeEdgeFunctionParams = {
+    deploymentTarget: 'v8-worker',
+    ...config,
+    files,
+  };
+
+  return createEdgeFunction
+    ? createEdgeFunction(params)
+    : (defaultCreateEdgeFunction(params) as TEdgeFunction);
+}

--- a/packages/build-utils/src/deserialize/deserialize-lambda.ts
+++ b/packages/build-utils/src/deserialize/deserialize-lambda.ts
@@ -1,0 +1,90 @@
+import type { Files } from '../types';
+import FileFsRef from '../file-fs-ref';
+import { Lambda } from '../lambda';
+import { NodejsLambda } from '../nodejs-lambda';
+import { hydrateFilesMap } from './hydrate-files-map';
+import type { SerializedLambda, SerializedNodejsLambda } from './types';
+
+export type DeserializeLambdaParams = SerializedLambda & {
+  files: Files;
+  supportsResponseStreaming?: boolean;
+};
+
+export type DeserializeNodejsLambdaParams = SerializedNodejsLambda & {
+  files: Files;
+  supportsResponseStreaming?: boolean;
+};
+
+export interface DeserializeLambdaOptions<TLambda extends Lambda = Lambda> {
+  files: Files;
+  config: SerializedLambda | SerializedNodejsLambda;
+  repoRootPath: string;
+  fileFsRefsCache: Map<string, FileFsRef>;
+  useOnlyStreamingLambda?: boolean;
+  forceNodejsStreaming?: boolean;
+  createLambda?: (params: DeserializeLambdaParams) => TLambda;
+  createNodejsLambda?: (params: DeserializeNodejsLambdaParams) => TLambda;
+}
+
+function defaultCreateLambda(params: DeserializeLambdaParams): Lambda {
+  return new Lambda(params as ConstructorParameters<typeof Lambda>[0]);
+}
+
+function defaultCreateNodejsLambda(
+  params: DeserializeNodejsLambdaParams
+): Lambda {
+  return new NodejsLambda(
+    params as ConstructorParameters<typeof NodejsLambda>[0]
+  );
+}
+
+export async function deserializeLambda<TLambda extends Lambda = Lambda>({
+  files,
+  config,
+  repoRootPath,
+  fileFsRefsCache,
+  useOnlyStreamingLambda,
+  forceNodejsStreaming,
+  createLambda,
+  createNodejsLambda,
+}: DeserializeLambdaOptions<TLambda>): Promise<TLambda> {
+  if (config.filePathMap) {
+    await hydrateFilesMap(
+      files,
+      config.filePathMap,
+      repoRootPath,
+      fileFsRefsCache
+    );
+  }
+
+  // Keep checking the deprecated field because older producers still use it.
+  const supportsResponseStreaming =
+    config.supportsResponseStreaming ?? config.experimentalResponseStreaming;
+
+  if ('launcherType' in config && config.launcherType === 'Nodejs') {
+    const overrideResponseStreaming =
+      (useOnlyStreamingLambda || forceNodejsStreaming) &&
+      (config.awsLambdaHandler === undefined || config.awsLambdaHandler === '');
+
+    const params: DeserializeNodejsLambdaParams = {
+      ...config,
+      supportsResponseStreaming:
+        overrideResponseStreaming || supportsResponseStreaming,
+      files,
+    };
+
+    return createNodejsLambda
+      ? createNodejsLambda(params)
+      : (defaultCreateNodejsLambda(params) as TLambda);
+  }
+
+  const params: DeserializeLambdaParams = {
+    ...config,
+    supportsResponseStreaming,
+    files,
+  };
+
+  return createLambda
+    ? createLambda(params)
+    : (defaultCreateLambda(params) as TLambda);
+}

--- a/packages/build-utils/src/deserialize/types.ts
+++ b/packages/build-utils/src/deserialize/types.ts
@@ -1,0 +1,125 @@
+import type { EdgeFunction } from '../edge-function';
+import type FileFsRef from '../file-fs-ref';
+import type { Lambda } from '../lambda';
+import type { NodejsLambda } from '../nodejs-lambda';
+import type { Prerender } from '../prerender';
+import type { BuildResultV2Typical, FlagDefinitions, Service } from '../types';
+
+export interface DeploymentFlags {
+  definitions: FlagDefinitions;
+}
+
+/**
+ * Note: type is not yet complete and will be more restrictive.
+ * @deprecated Replaced by variants.
+ */
+export interface DeploymentFlagLegacy {
+  key: string;
+  defaultValue?: unknown;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Additional lambda metadata used by existing callers when a function is
+ * provisioned outside of Vercel infrastructure.
+ */
+export interface ExternalConfig {
+  awsAccountId: string;
+  digest: string;
+  size: number;
+}
+
+/**
+ * Maps a type to a new type that does not contain any functions on it.
+ * Useful for typing serialized `class` types, which will not contain
+ * functions when serialized to JSON.
+ */
+export type Properties<T> = {
+  [P in keyof T as T[P] extends (...args: any[]) => any ? never : P]: T[P];
+};
+
+type FilesMapProp = {
+  filePathMap?: Record<string, string>;
+};
+
+/**
+ * Type for the `.vc-config.json` file of a serialized `Lambda` instance.
+ */
+export type SerializedLambda = Properties<Omit<Lambda, 'files' | 'zipBuffer'>> &
+  FilesMapProp & {
+    external?: ExternalConfig;
+  };
+
+/**
+ * Type for the `.vc-config.json` file of a serialized `NodejsLambda` instance.
+ */
+export type SerializedNodejsLambda = Properties<
+  Omit<NodejsLambda, 'files' | 'zipBuffer'>
+> &
+  FilesMapProp & {
+    external?: ExternalConfig;
+  };
+
+export type SerializedFileFsRef = Properties<FileFsRef>;
+
+export type SerializedPrerender = Properties<
+  Omit<Prerender, 'lambda' | 'fallback'>
+> & {
+  fallback: SerializedFileFsRef | null;
+};
+
+export type SerializedEdgeFunction = Properties<
+  Omit<EdgeFunction, 'name' | 'files' | 'deploymentTarget'>
+> &
+  FilesMapProp;
+
+export interface PathOverride {
+  contentType?: string;
+  mode?: number;
+  path?: string;
+}
+
+export interface BuildOutputCron {
+  schedule: string;
+  path: string;
+}
+
+export type BuildResultV2TypicalWithCron = BuildResultV2Typical & {
+  crons?: BuildOutputCron[];
+  flags?: DeploymentFlags | DeploymentFlagLegacy[];
+  deploymentId?: string;
+  meta?: {
+    hasServerActions?: boolean;
+  };
+};
+
+/**
+ * Build Output API `config.json` file interface.
+ */
+export interface BuildOutputConfig {
+  version?: 3;
+  wildcard?: BuildResultV2Typical['wildcard'];
+  images?: BuildResultV2Typical['images'];
+  routes?: BuildResultV2Typical['routes'];
+  overrides?: Record<string, PathOverride>;
+  framework?: {
+    version: string;
+  };
+  crons?: BuildOutputCron[];
+  /** @deprecated In its own file now */
+  flags?: DeploymentFlagLegacy[];
+  /**
+   * User-configured deployment ID for skew protection.
+   * This allows users to specify a custom deployment identifier
+   * in their next.config.js that will be used for version skew protection
+   * with pre-built deployments.
+   * @example "abc123"
+   */
+  deploymentId?: string;
+  /**
+   * Services detected during build from vercel.json experimentalServices
+   * or auto-detected from project structure.
+   * Used to inject service URLs as environment variables at runtime.
+   */
+  services?: Service[];
+}

--- a/packages/build-utils/src/deserialize/types.ts
+++ b/packages/build-utils/src/deserialize/types.ts
@@ -3,10 +3,31 @@ import type FileFsRef from '../file-fs-ref';
 import type { Lambda } from '../lambda';
 import type { NodejsLambda } from '../nodejs-lambda';
 import type { Prerender } from '../prerender';
-import type { BuildResultV2Typical, FlagDefinitions, Service } from '../types';
+import type { BuildResultV2Typical, Service } from '../types';
+
+type FlagJSONArray = readonly FlagJSONValue[];
+
+type FlagJSONValue =
+  | string
+  | boolean
+  | number
+  | null
+  | FlagJSONArray
+  | { [key: string]: FlagJSONValue };
+
+interface FlagOption {
+  value: FlagJSONValue;
+  label?: string;
+}
+
+interface FlagDefinition {
+  options?: FlagOption[];
+  url?: string;
+  description?: string;
+}
 
 export interface DeploymentFlags {
-  definitions: FlagDefinitions;
+  definitions: Record<string, FlagDefinition>;
 }
 
 /**
@@ -84,7 +105,10 @@ export interface BuildOutputCron {
   path: string;
 }
 
-export type BuildResultV2TypicalWithCron = BuildResultV2Typical & {
+export type BuildResultV2TypicalWithCron = Omit<
+  BuildResultV2Typical,
+  'flags'
+> & {
   crons?: BuildOutputCron[];
   flags?: DeploymentFlags | DeploymentFlagLegacy[];
   deploymentId?: string;

--- a/packages/build-utils/src/deserialize/validate-deployment-id.ts
+++ b/packages/build-utils/src/deserialize/validate-deployment-id.ts
@@ -1,0 +1,20 @@
+import { NowBuildError } from '../errors';
+
+export const MAX_DEPLOYMENT_ID_LENGTH = 32;
+export const VALID_DEPLOYMENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export function validateDeploymentId(deploymentId?: string): void {
+  if (deploymentId && deploymentId.length > MAX_DEPLOYMENT_ID_LENGTH) {
+    throw new NowBuildError({
+      message: `The configured deploymentId "${deploymentId}" exceeds the maximum length of ${MAX_DEPLOYMENT_ID_LENGTH} characters. Please use a shorter deploymentId.`,
+      code: 'VC_BUILD_INVALID_DEPLOYMENT_ID_LENGTH',
+    });
+  }
+
+  if (deploymentId && !VALID_DEPLOYMENT_ID_PATTERN.test(deploymentId)) {
+    throw new NowBuildError({
+      message: `The configured deploymentId "${deploymentId}" contains invalid characters. Only alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), and underscores (_) are allowed.`,
+      code: 'VC_BUILD_INVALID_DEPLOYMENT_ID_CHARACTERS',
+    });
+  }
+}

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -240,11 +240,14 @@ export {
 } from './deserialize/deserialize-edge-function';
 export {
   deserializeBuildOutputCore,
+  finalizeBuildOutputCoreResult,
   type DeserializeBuildOutputCoreOptions,
   type DeserializeBuildOutputCoreResult,
   type DeserializeBuildOutputGroupLambdasOptions,
   type DeserializeBuildOutputInspectLambdaOptions,
   type DeserializeBuildOutputMeta,
+  type FinalizeBuildOutputCoreResultOptions,
+  type FinalizeBuildOutputCoreResult,
 } from './deserialize/deserialize-build-output';
 export type {
   BuildOutputConfig,

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -219,6 +219,45 @@ export {
 } from './validate-lambda-size';
 
 export { validateFrameworkVersion } from './deserialize/validate-framework-version';
+export {
+  MAX_DEPLOYMENT_ID_LENGTH,
+  VALID_DEPLOYMENT_ID_PATTERN,
+  validateDeploymentId,
+} from './deserialize/validate-deployment-id';
 export { hydrateFilesMap } from './deserialize/hydrate-files-map';
 export { createFunctionsIterator } from './deserialize/create-functions-iterator';
 export { maybeReadJSON } from './deserialize/maybe-read-json';
+export {
+  deserializeLambda,
+  type DeserializeLambdaOptions,
+  type DeserializeLambdaParams,
+  type DeserializeNodejsLambdaParams,
+} from './deserialize/deserialize-lambda';
+export {
+  deserializeEdgeFunction,
+  type DeserializeEdgeFunctionOptions,
+  type DeserializeEdgeFunctionParams,
+} from './deserialize/deserialize-edge-function';
+export {
+  deserializeBuildOutputCore,
+  type DeserializeBuildOutputCoreOptions,
+  type DeserializeBuildOutputCoreResult,
+  type DeserializeBuildOutputGroupLambdasOptions,
+  type DeserializeBuildOutputInspectLambdaOptions,
+  type DeserializeBuildOutputMeta,
+} from './deserialize/deserialize-build-output';
+export type {
+  BuildOutputConfig,
+  BuildOutputCron,
+  BuildResultV2TypicalWithCron,
+  DeploymentFlagLegacy,
+  DeploymentFlags,
+  ExternalConfig,
+  PathOverride,
+  Properties,
+  SerializedEdgeFunction,
+  SerializedFileFsRef,
+  SerializedLambda,
+  SerializedNodejsLambda,
+  SerializedPrerender,
+} from './deserialize/types';

--- a/packages/build-utils/test/unit.deserialize-core.test.ts
+++ b/packages/build-utils/test/unit.deserialize-core.test.ts
@@ -6,10 +6,13 @@ import { describe, expect, it } from 'vitest';
 import {
   deserializeBuildOutputCore,
   deserializeLambda,
+  finalizeBuildOutputCoreResult,
   Lambda,
   NowBuildError,
   validateDeploymentId,
+  type DeploymentFlagLegacy,
   type DeserializeNodejsLambdaParams,
+  type DeploymentFlags,
   type SerializedNodejsLambda,
 } from '../src';
 
@@ -185,5 +188,87 @@ describe('deserialize shared core', () => {
     } finally {
       await fs.remove(root);
     }
+  });
+
+  it('finalizes the core result into the existing caller shape', () => {
+    const flags: DeploymentFlags = {
+      definitions: {
+        foo: {
+          url: 'https://example.com/flags/foo',
+        },
+      },
+    };
+
+    const result = finalizeBuildOutputCoreResult({
+      config: {
+        version: 3,
+        wildcard: [{ domain: 'example.com', value: '1' }],
+        images: {
+          sizes: [16],
+          domains: ['example.com'],
+        },
+        crons: [{ path: '/api/cron', schedule: '0 0 * * *' }],
+        routes: [{ src: '/(.*)', dest: '/api' }],
+        deploymentId: 'dpl_123',
+      },
+      flags,
+      output: {},
+      framework: { version: 'nextjs@14.0.0' },
+      meta: { hasServerActions: true },
+    });
+
+    expect(result).toEqual({
+      wildcard: [{ domain: 'example.com', value: '1' }],
+      images: {
+        sizes: [16],
+        domains: ['example.com'],
+      },
+      crons: [{ path: '/api/cron', schedule: '0 0 * * *' }],
+      flags,
+      routes: [{ src: '/(.*)', dest: '/api' }],
+      output: {},
+      framework: { version: 'nextjs@14.0.0' },
+      deploymentId: 'dpl_123',
+      meta: { hasServerActions: true },
+    });
+  });
+
+  it('applies default metadata when the core result does not set meta', () => {
+    const result = finalizeBuildOutputCoreResult(
+      {
+        config: {
+          version: 3,
+        },
+        output: {},
+      },
+      {
+        defaultMeta: {
+          hasServerActions: false,
+        },
+      }
+    );
+
+    expect(result.meta).toEqual({ hasServerActions: false });
+  });
+
+  it('falls back to legacy config flags when flags.json is absent', () => {
+    const legacyFlags: DeploymentFlagLegacy[] = [
+      {
+        key: 'foo',
+        metadata: {
+          description: 'flag',
+        },
+      },
+    ];
+
+    const result = finalizeBuildOutputCoreResult({
+      config: {
+        version: 3,
+        flags: legacyFlags,
+      },
+      output: {},
+    });
+
+    expect(result.flags).toEqual(legacyFlags);
   });
 });

--- a/packages/build-utils/test/unit.deserialize-core.test.ts
+++ b/packages/build-utils/test/unit.deserialize-core.test.ts
@@ -1,0 +1,189 @@
+import * as fs from 'fs-extra';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  deserializeBuildOutputCore,
+  deserializeLambda,
+  Lambda,
+  NowBuildError,
+  validateDeploymentId,
+  type DeserializeNodejsLambdaParams,
+  type SerializedNodejsLambda,
+} from '../src';
+
+function getThrownError(fn: () => void): Error {
+  try {
+    fn();
+  } catch (error) {
+    return error as Error;
+  }
+  throw new Error('Expected function to throw');
+}
+
+describe('validateDeploymentId', () => {
+  it('throws on too-long deployment IDs', () => {
+    const error = getThrownError(() => validateDeploymentId('x'.repeat(33)));
+
+    expect(error).toBeInstanceOf(NowBuildError);
+    expect((error as NowBuildError).code).toBe(
+      'VC_BUILD_INVALID_DEPLOYMENT_ID_LENGTH'
+    );
+  });
+
+  it('throws on deployment IDs with invalid characters', () => {
+    const error = getThrownError(() =>
+      validateDeploymentId('invalid deployment id?')
+    );
+
+    expect(error).toBeInstanceOf(NowBuildError);
+    expect((error as NowBuildError).code).toBe(
+      'VC_BUILD_INVALID_DEPLOYMENT_ID_CHARACTERS'
+    );
+  });
+});
+
+describe('deserialize shared core', () => {
+  it('normalizes streaming before invoking custom lambda creators', async () => {
+    const created: DeserializeNodejsLambdaParams[] = [];
+
+    const lambda = await deserializeLambda({
+      files: {},
+      config: {
+        type: 'Lambda',
+        architecture: 'x86_64',
+        environment: {},
+        handler: 'index.handler',
+        launcherType: 'Nodejs',
+        runtime: 'nodejs20.x',
+        shouldAddHelpers: false,
+        shouldAddSourcemapSupport: false,
+        awsLambdaHandler: '',
+        external: {
+          awsAccountId: '123',
+          digest: 'abc',
+          size: 1,
+        },
+      } as SerializedNodejsLambda,
+      repoRootPath: '',
+      fileFsRefsCache: new Map(),
+      forceNodejsStreaming: true,
+      createNodejsLambda(params) {
+        created.push(params);
+        return new Lambda(params as ConstructorParameters<typeof Lambda>[0]);
+      },
+    });
+
+    expect(created).toHaveLength(1);
+    expect(created[0]?.supportsResponseStreaming).toBe(true);
+    expect(created[0]?.external?.digest).toBe('abc');
+    expect(lambda.supportsResponseStreaming).toBe(true);
+  });
+
+  it('applies grouping, warnings, metadata inspection, and config validation', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'deserialize-core-'));
+    const outputDir = join(root, '.vercel', 'output');
+    const warnings: string[] = [];
+    const validatedConfigs: string[] = [];
+
+    try {
+      await fs.outputJSON(join(outputDir, 'config.json'), {
+        version: 3,
+        framework: { version: 'nextjs@14.0.0' },
+        overrides: {
+          'hello.txt': { path: 'renamed.txt' },
+          'missing.txt': { path: 'missing-renamed.txt' },
+        },
+      });
+      await fs.outputFile(join(outputDir, 'static', 'hello.txt'), 'hello');
+      await fs.outputJSON(
+        join(outputDir, 'functions', 'api', 'hello.func', '.vc-config.json'),
+        {
+          type: 'Lambda',
+          architecture: 'x86_64',
+          environment: {},
+          handler: 'index.handler',
+          launcherType: 'Nodejs',
+          runtime: 'nodejs20.x',
+          shouldAddHelpers: false,
+          shouldAddSourcemapSupport: false,
+          experimentalAllowBundling: true,
+        }
+      );
+      await fs.outputFile(
+        join(outputDir, 'functions', 'api', 'hello.func', 'index.js'),
+        'exports.handler = () => {};'
+      );
+
+      const result = await deserializeBuildOutputCore({
+        outputDir,
+        repoRootPath: root,
+        warn(message) {
+          warnings.push(message);
+        },
+        validateConfig(config) {
+          validatedConfigs.push(config.version?.toString() ?? 'unknown');
+        },
+        inspectLambda({ path }) {
+          return {
+            hasServerActions: path === 'api/hello',
+          };
+        },
+        groupLambdas({ lambdas }) {
+          expect(Object.keys(lambdas)).toEqual(['api/hello']);
+          return {
+            'api/hello': new Lambda({
+              files: {},
+              handler: 'grouped.handler',
+              runtime: 'nodejs20.x',
+            }),
+          };
+        },
+      });
+
+      expect(validatedConfigs).toEqual(['3']);
+      expect(warnings).toEqual([
+        'Warning: Override path "missing.txt" was not detected as an output path',
+      ]);
+      expect(result.meta?.hasServerActions).toBe(true);
+      expect(result.output['renamed.txt']).toBeDefined();
+      expect(result.output['hello.txt']).toBeUndefined();
+      expect(result.framework).toEqual({ version: 'nextjs@14.0.0' });
+
+      const groupedOutput = result.output['api/hello'];
+      expect(groupedOutput?.type).toBe('Lambda');
+      if (groupedOutput?.type !== 'Lambda') {
+        throw new Error('Expected grouped lambda output');
+      }
+      expect(groupedOutput.handler).toBe('grouped.handler');
+    } finally {
+      await fs.remove(root);
+    }
+  });
+
+  it('surfaces config validation errors before deserializing output', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'deserialize-core-'));
+    const outputDir = join(root, '.vercel', 'output');
+
+    try {
+      await fs.outputJSON(join(outputDir, 'config.json'), {
+        version: 3,
+      });
+      await fs.ensureDir(join(outputDir, 'static'));
+      await fs.ensureDir(join(outputDir, 'functions'));
+
+      await expect(
+        deserializeBuildOutputCore({
+          outputDir,
+          repoRootPath: root,
+          validateConfig() {
+            throw new Error('invalid config');
+          },
+        })
+      ).rejects.toThrow('invalid config');
+    } finally {
+      await fs.remove(root);
+    }
+  });
+});

--- a/packages/build-utils/test/unit.deserialize-types.test.ts
+++ b/packages/build-utils/test/unit.deserialize-types.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  BuildOutputConfig,
+  BuildResultV2TypicalWithCron,
+  DeploymentFlagLegacy,
+  DeploymentFlags,
+  SerializedLambda,
+  Service,
+} from '../src';
+
+describe('deserialize shared types', () => {
+  it('allows deploymentId and services on BuildOutputConfig', () => {
+    const service: Service = {
+      name: 'api',
+      type: 'web',
+      workspace: 'services/api',
+      builder: {
+        use: '@vercel/node',
+      },
+    };
+
+    const config: BuildOutputConfig = {
+      version: 3,
+      deploymentId: 'dpl_123',
+      services: [service],
+      crons: [
+        {
+          path: '/api/cron',
+          schedule: '0 0 * * *',
+        },
+      ],
+    };
+
+    expect(config.deploymentId).toBe('dpl_123');
+    expect(config.services?.[0]?.name).toBe('api');
+    expect(config.crons?.[0]?.schedule).toBe('0 0 * * *');
+  });
+
+  it('supports both current and legacy flags on BuildResultV2TypicalWithCron', () => {
+    const currentFlags: DeploymentFlags = {
+      definitions: {
+        foo: {
+          description: 'flag',
+        },
+      },
+    };
+
+    const legacyFlags: DeploymentFlagLegacy[] = [
+      {
+        key: 'foo',
+        metadata: {
+          description: 'flag',
+        },
+      },
+    ];
+
+    const currentBuildResult: BuildResultV2TypicalWithCron = {
+      output: {},
+      flags: currentFlags,
+      deploymentId: 'dpl_123',
+      meta: {
+        hasServerActions: true,
+      },
+    };
+
+    const legacyBuildResult: BuildResultV2TypicalWithCron = {
+      output: {},
+      flags: legacyFlags,
+    };
+
+    expect(currentBuildResult.meta?.hasServerActions).toBe(true);
+    expect(currentBuildResult.deploymentId).toBe('dpl_123');
+    expect(Array.isArray(legacyBuildResult.flags)).toBe(true);
+  });
+
+  it('supports filePathMap on serialized lambdas', () => {
+    const serializedLambda: SerializedLambda = {
+      type: 'Lambda',
+      architecture: 'x86_64',
+      environment: {},
+      runtime: 'nodejs20.x',
+      handler: 'index.handler',
+      supportsResponseStreaming: false,
+      filePathMap: {
+        'index.js': 'apps/api/index.js',
+      },
+    };
+
+    expect(serializedLambda.filePathMap?.['index.js']).toBe(
+      'apps/api/index.js'
+    );
+  });
+});

--- a/packages/build-utils/test/unit.deserialize-types.test.ts
+++ b/packages/build-utils/test/unit.deserialize-types.test.ts
@@ -42,6 +42,7 @@ describe('deserialize shared types', () => {
       definitions: {
         foo: {
           description: 'flag',
+          url: 'https://example.com/flags/foo',
         },
       },
     };
@@ -71,6 +72,9 @@ describe('deserialize shared types', () => {
 
     expect(currentBuildResult.meta?.hasServerActions).toBe(true);
     expect(currentBuildResult.deploymentId).toBe('dpl_123');
+    expect(currentFlags.definitions.foo?.url).toBe(
+      'https://example.com/flags/foo'
+    );
     expect(Array.isArray(legacyBuildResult.flags)).toBe(true);
   });
 


### PR DESCRIPTION
This PR extracts the shared deserialize logic from the build pipeline into `@vercel/build-utils` so it can be called in multiple places, while keeping the existing caller behavior as the source of truth.

This is effectively moved code. Once it merges and we import it in the existing caller, there should be no semantic changes.

Later, we’ll import and use this code in multiple places.