### PR TITLE
feat(cli): add peer dependency resolution logic for builders

### DIFF
--- a/.changeset/peer-dep-builder-resolution.md
+++ b/.changeset/peer-dep-builder-resolution.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add peer dependency resolution logic for builders, preparing for a future change where builders move from dependencies to peerDependencies.

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -42,6 +42,39 @@ type ResolveBuildersResult =
 // Get a real `require()` reference that esbuild won't mutate
 const require_ = createRequire(__filename);
 
+// Cache for CLI package.json peerDependencies
+let peerDependencies: Record<string, string> | undefined;
+
+export function getPeerDependencies(): Record<string, string> {
+  if (!peerDependencies) {
+    try {
+      const cliPkgPath = require_.resolve('vercel/package.json', {
+        paths: [__dirname],
+      });
+      const cliPkg = require_(cliPkgPath) as PackageJson;
+      peerDependencies =
+        (cliPkg.peerDependencies as Record<string, string>) || {};
+    } catch {
+      peerDependencies = {};
+    }
+  }
+  return peerDependencies;
+}
+
+/**
+ * Reset the cached peerDependencies (for testing).
+ */
+export function resetPeerDependenciesCache() {
+  peerDependencies = undefined;
+}
+
+/**
+ * Override the cached peerDependencies (for testing).
+ */
+export function setPeerDependenciesForTesting(deps: Record<string, string>) {
+  peerDependencies = deps;
+}
+
 /**
  * Imports the specified Vercel Builders, installing any missing ones
  * into `.vercel/builders` if necessary.
@@ -53,7 +86,7 @@ export async function importBuilders(
 ): Promise<Map<string, BuilderWithPkg>> {
   const buildersDir = join(cwd, VERCEL_DIR, 'builders');
 
-  let importResult = await resolveBuilders(buildersDir, builderSpecs);
+  let importResult = await resolveBuilders(cwd, buildersDir, builderSpecs);
 
   if ('buildersToAdd' in importResult) {
     const { buildersToAdd } = importResult;
@@ -64,6 +97,7 @@ export async function importBuilders(
     );
 
     importResult = await resolveBuilders(
+      cwd,
       buildersDir,
       builderSpecs,
       installResult
@@ -84,13 +118,15 @@ export async function importBuilders(
   return importResult.builders;
 }
 
-async function resolveBuilders(
+export async function resolveBuilders(
+  cwd: string,
   buildersDir: string,
   builderSpecs: Set<string>,
   resolvedSpecs?: Map<string, string>
 ): Promise<ResolveBuildersResult> {
   const builders = new Map<string, BuilderWithPkg>();
   const buildersToAdd = new Set<string>();
+  const peerDeps = getPeerDependencies();
 
   for (const spec of builderSpecs) {
     const resolvedSpec = resolvedSpecs?.get(spec) || spec;
@@ -116,95 +152,153 @@ async function resolveBuilders(
       continue;
     }
 
-    try {
-      let pkgPath: string | undefined;
-      let builderPkg: PackageJson | undefined;
+    // Resolution priority:
+    // 1. Peer dependency location (cwd's node_modules) — for when CLI is a project dependency
+    // 2. .vercel/builders (dynamically installed builders cache)
+    // 3. CLI's bundled node_modules (where CLI itself is installed)
+    // 4. Install into .vercel/builders from npm
 
+    let pkgPath: string | undefined;
+    let builderPkg: PackageJson | undefined;
+    const peerVersion = peerDeps[name];
+
+    output.debug(
+      `Resolving "${name}" (peerDep: ${peerVersion ? `"${peerVersion}"` : 'none'})`
+    );
+
+    // 1. Try peer dependency location (cwd's node_modules)
+    if (peerVersion) {
       try {
-        // First try `.vercel/builders`. The package name should always be available
-        // at the top-level of `node_modules` since CLI is installing those directly.
-        pkgPath = join(buildersDir, 'node_modules', name, 'package.json');
-        builderPkg = await readJSON(pkgPath);
-      } catch (error: unknown) {
-        if (!isErrnoException(error)) {
-          throw error;
+        const cwdRequire = createRequire(join(cwd, 'noop.js'));
+        const candidatePkgPath = cwdRequire.resolve(`${name}/package.json`);
+        const candidatePkg: PackageJson = await readJSON(candidatePkgPath);
+
+        if (candidatePkg.version === peerVersion) {
+          output.debug(
+            `Found "${name}@${candidatePkg.version}" in peer dependencies location (matches peerDep "${peerVersion}")`
+          );
+          pkgPath = candidatePkgPath;
+          builderPkg = candidatePkg;
+        } else {
+          output.debug(
+            `Found "${name}@${candidatePkg.version}" in peer dependencies location, but does not match peerDep "${peerVersion}", skipping`
+          );
         }
-        if (error.code !== 'ENOENT') {
-          throw error;
+      } catch (err: unknown) {
+        if (!isErrnoException(err) || err.code !== 'MODULE_NOT_FOUND') {
+          throw err;
+        }
+        output.debug(
+          `"${name}" not found in peer dependencies location (cwd: ${cwd})`
+        );
+      }
+    }
+
+    // 2. Try .vercel/builders (dynamically installed cache)
+    if (!builderPkg) {
+      output.debug(`[resolve] "${name}" step 2: trying .vercel/builders`);
+      try {
+        const candidatePkgPath = join(
+          buildersDir,
+          'node_modules',
+          name,
+          'package.json'
+        );
+        const candidatePkg: PackageJson = await readJSON(candidatePkgPath);
+        output.debug(
+          `Found "${name}@${candidatePkg.version}" in .vercel/builders`
+        );
+
+        // If there's a peer dep version, verify cache matches it
+        if (peerVersion && candidatePkg.version !== peerVersion) {
+          output.debug(
+            `"${name}@${candidatePkg.version}" in .vercel/builders does not match peerDep "${peerVersion}", will reinstall`
+          );
+          buildersToAdd.add(`${name}@${peerVersion}`);
+          continue;
         }
 
-        // If `pkgPath` wasn't found in `.vercel/builders` then try as a CLI local
-        // dependency. `require.resolve()` will throw if the Builder is not a CLI
-        // dep, in which case we'll install it into `.vercel/builders`.
+        pkgPath = candidatePkgPath;
+        builderPkg = candidatePkg;
+      } catch (err: unknown) {
+        if (!isErrnoException(err) || err.code !== 'ENOENT') {
+          throw err;
+        }
+      }
+    }
+
+    // 3. Try CLI's bundled node_modules
+    if (!builderPkg) {
+      output.debug(`[resolve] "${name}" step 3: trying CLI bundle`);
+      try {
         pkgPath = require_.resolve(`${name}/package.json`, {
           paths: [__dirname],
         });
         builderPkg = await readJSON(pkgPath);
-      }
-
-      if (!builderPkg || !pkgPath) {
-        throw new Error(`Failed to load \`package.json\` for "${name}"`);
-      }
-
-      if (typeof builderPkg.version !== 'string') {
-        throw new Error(
-          `\`package.json\` for "${name}" does not contain a "version" field`
-        );
-      }
-
-      if (parsed.type === 'version' && parsed.rawSpec !== builderPkg.version) {
-        // An explicit Builder version was specified but it does
-        // not match the version that is currently installed
-        output.debug(
-          `Installed version "${name}@${builderPkg.version}" does not match "${parsed.rawSpec}"`
-        );
-        buildersToAdd.add(spec);
+        output.debug(`Found "${name}@${builderPkg.version}" in CLI bundle`);
+      } catch (err: unknown) {
+        if (!isErrnoException(err) || err.code !== 'MODULE_NOT_FOUND') {
+          throw err;
+        }
+        // Not found in any local location — mark for install
+        if (resolvedSpecs) {
+          // This is the 2nd pass after install — don't try again
+          throw new Error(`Builder "${name}" not found after installation`);
+        }
+        output.debug(`"${name}" not found anywhere, will install`);
+        buildersToAdd.add(peerVersion ? `${name}@${peerVersion}` : spec);
         continue;
-      }
-
-      if (
-        parsed.type === 'range' &&
-        !satisfies(builderPkg.version, parsed.rawSpec)
-      ) {
-        // An explicit Builder range was specified but it is not
-        // compatible with the version that is currently installed
-        output.debug(
-          `Installed version "${name}@${builderPkg.version}" is not compatible with "${parsed.rawSpec}"`
-        );
-        buildersToAdd.add(spec);
-        continue;
-      }
-
-      // TODO: handle `parsed.type === 'tag'` ("latest" vs. anything else?)
-      const path = join(dirname(pkgPath), builderPkg.main || 'index.js');
-
-      const builder = require_(path);
-
-      const dynamicallyInstalled = pkgPath.startsWith(buildersDir);
-
-      builders.set(spec, {
-        builder,
-        pkg: {
-          name,
-          ...builderPkg,
-        },
-        path,
-        pkgPath,
-        dynamicallyInstalled,
-      });
-      output.debug(`Imported Builder "${name}" from "${dirname(pkgPath)}"`);
-    } catch (err: any) {
-      // `resolvedSpecs` is only passed into this function on the 2nd run,
-      // so if MODULE_NOT_FOUND happens in that case then we don't want to
-      // try to install again. Instead just pass through the error to the user
-      if (err.code === 'MODULE_NOT_FOUND' && !resolvedSpecs) {
-        output.debug(`Failed to import "${name}": ${err}`);
-        buildersToAdd.add(spec);
-      } else {
-        err.message = `Importing "${name}": ${err.message}`;
-        throw err;
       }
     }
+
+    if (!builderPkg || !pkgPath) {
+      throw new Error(`Failed to load \`package.json\` for "${name}"`);
+    }
+
+    if (typeof builderPkg.version !== 'string') {
+      throw new Error(
+        `\`package.json\` for "${name}" does not contain a "version" field`
+      );
+    }
+
+    // Validate explicit version/range requirements from the spec
+    if (parsed.type === 'version' && parsed.rawSpec !== builderPkg.version) {
+      output.debug(
+        `Installed version "${name}@${builderPkg.version}" does not match "${parsed.rawSpec}"`
+      );
+      buildersToAdd.add(spec);
+      continue;
+    }
+
+    if (
+      parsed.type === 'range' &&
+      !satisfies(builderPkg.version, parsed.rawSpec)
+    ) {
+      output.debug(
+        `Installed version "${name}@${builderPkg.version}" is not compatible with "${parsed.rawSpec}"`
+      );
+      buildersToAdd.add(spec);
+      continue;
+    }
+
+    // TODO: handle `parsed.type === 'tag'` ("latest" vs. anything else?)
+    const path = join(dirname(pkgPath), builderPkg.main || 'index.js');
+
+    const builder = require_(path);
+
+    const dynamicallyInstalled = pkgPath.startsWith(buildersDir);
+
+    builders.set(spec, {
+      builder,
+      pkg: {
+        name,
+        ...builderPkg,
+      },
+      path,
+      pkgPath,
+      dynamicallyInstalled,
+    });
+    output.debug(`Imported Builder "${name}" from "${dirname(pkgPath)}"`);
   }
 
   // Add any Builders that are not yet present into `.vercel/builders`

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -235,7 +235,7 @@ export async function resolveBuilders(
           paths: [__dirname],
         });
         builderPkg = await readJSON(pkgPath);
-        output.debug(`Found "${name}@${builderPkg.version}" in CLI bundle`);
+        output.debug(`Found "${name}@${builderPkg?.version}" in CLI bundle`);
       } catch (err: unknown) {
         if (!isErrnoException(err) || err.code !== 'MODULE_NOT_FOUND') {
           throw err;

--- a/packages/cli/test/e2e/builders/helpers.ts
+++ b/packages/cli/test/e2e/builders/helpers.ts
@@ -1,0 +1,142 @@
+import { join } from 'path';
+import { mkdirp, outputJSON, writeFile, remove, realpath } from 'fs-extra';
+import { tmpdir } from 'os';
+import { mkdtemp } from 'fs/promises';
+import execa from 'execa';
+
+const REPO_ROOT = join(__dirname, '../../../../..');
+const CLI_START = join(REPO_ROOT, 'packages/cli/scripts/start.js');
+
+interface IsolatedProject {
+  dir: string;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Creates an isolated project directory in the OS temp directory.
+ * This ensures require() won't crawl up to the repo's node_modules.
+ *
+ * Sets up a minimal project structure:
+ * - .vercel/project.json (required for `vc build`)
+ * - index.html (a simple static file so @vercel/static can build it)
+ */
+export async function createIsolatedProject(): Promise<IsolatedProject> {
+  // Use realpath to resolve symlinks (e.g. macOS /var -> /private/var)
+  const raw = await mkdtemp(join(tmpdir(), 'vc-e2e-builders-'));
+  const dir = await realpath(raw);
+
+  // Minimal project config
+  await mkdirp(join(dir, '.vercel'));
+  await outputJSON(join(dir, '.vercel', 'project.json'), {
+    orgId: '.',
+    projectId: '.',
+    settings: {
+      framework: null,
+    },
+  });
+
+  // A simple static file so @vercel/static has something to build
+  await writeFile(join(dir, 'index.html'), '<h1>test</h1>\n');
+
+  return {
+    dir,
+    cleanup: () => remove(dir),
+  };
+}
+
+interface PlaceBuilderOptions {
+  /** The builder package name, e.g. "@vercel/node" */
+  name: string;
+  /** The version string to put in package.json */
+  version: string;
+  /**
+   * The directory under which to create node_modules/<name>/.
+   * For peer deps: the project dir itself.
+   * For .vercel/builders cache: <projectDir>/.vercel/builders
+   */
+  baseDir: string;
+}
+
+/**
+ * Places a minimal fake builder at a given node_modules location.
+ * The builder exports `{ version: 3, build }` — enough for `vc build`
+ * to consider it valid.
+ */
+export async function placeBuilder({
+  name,
+  version,
+  baseDir,
+}: PlaceBuilderOptions): Promise<string> {
+  const builderDir = join(baseDir, 'node_modules', name);
+  await mkdirp(builderDir);
+
+  await outputJSON(join(builderDir, 'package.json'), {
+    name,
+    version,
+    main: 'index.js',
+  });
+
+  // Minimal builder that satisfies the Builder interface
+  await writeFile(
+    join(builderDir, 'index.js'),
+    `
+exports.version = 3;
+exports.build = async function build({ entrypoint, files, config }) {
+  return { output: {} };
+};
+`.trim()
+  );
+
+  return builderDir;
+}
+
+interface RunVercelBuildOptions {
+  cwd: string;
+  env?: Record<string, string>;
+}
+
+interface RunVercelBuildResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  /** Combined stdout + stderr for easier grep */
+  combined: string;
+}
+
+/**
+ * Runs `node <repo>/packages/cli/scripts/start.js build --debug`
+ * from the given cwd. Uses --debug so we can inspect resolution logs.
+ *
+ * The --token and --scope flags are set to dummy values since
+ * `vc build` doesn't need real API credentials.
+ */
+export async function runVercelBuild(
+  opts: RunVercelBuildOptions
+): Promise<RunVercelBuildResult> {
+  const result = await execa(
+    process.execPath,
+    [CLI_START, 'build', '--debug', '--yes'],
+    {
+      cwd: opts.cwd,
+      reject: false,
+      env: {
+        // Start with a clean env — don't inherit VERCEL_TOKEN, etc.
+        // that could interfere with the test
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        NODE_PATH: process.env.NODE_PATH,
+        ...opts.env,
+        NO_COLOR: '1',
+        FORCE_COLOR: '0',
+        NO_UPDATE_NOTIFIER: '1',
+      },
+    }
+  );
+
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    combined: result.stdout + '\n' + result.stderr,
+  };
+}

--- a/packages/cli/test/e2e/builders/import-builders.test.ts
+++ b/packages/cli/test/e2e/builders/import-builders.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { join } from 'path';
+import { mkdirp, writeFile } from 'fs-extra';
+import { createIsolatedProject, placeBuilder, runVercelBuild } from './helpers';
+
+import vercelNodePkg from '@vercel/node/package.json';
+
+// These tests run the built CLI binary against isolated temp dirs.
+// They require `pnpm build --filter vercel` to have been run first.
+vi.setConfig({ testTimeout: 60_000 });
+
+describe('builder resolution (e2e)', () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+    cleanups.length = 0;
+  });
+
+  it('should resolve @vercel/node from CLI bundle', async () => {
+    const project = await createIsolatedProject();
+    cleanups.push(project.cleanup);
+
+    // Add an API route so @vercel/node gets detected
+    await mkdirp(join(project.dir, 'api'));
+    await writeFile(
+      join(project.dir, 'api', 'index.js'),
+      'export default function handler(req, res) { res.end("ok"); }\n'
+    );
+
+    const result = await runVercelBuild({ cwd: project.dir });
+
+    expect(result.exitCode).toBe(0);
+
+    // Should show the step-by-step resolution in debug output
+    expect(result.combined).toContain(
+      'Resolving "@vercel/node" (peerDep: none)'
+    );
+    expect(result.combined).toContain(
+      '[resolve] "@vercel/node" step 3: trying CLI bundle'
+    );
+    expect(result.combined).toContain(
+      `Found "@vercel/node@${vercelNodePkg.version}" in CLI bundle`
+    );
+    // The resolved builders string includes @vercel/static too
+    expect(result.combined).toContain(
+      `@vercel/node => ${vercelNodePkg.version}`
+    );
+  });
+
+  it('should resolve builder from .vercel/builders cache', async () => {
+    const project = await createIsolatedProject();
+    cleanups.push(project.cleanup);
+
+    // Add an API route that would normally use @vercel/node
+    await mkdirp(join(project.dir, 'api'));
+    await writeFile(
+      join(project.dir, 'api', 'index.js'),
+      'export default function handler(req, res) { res.end("ok"); }\n'
+    );
+
+    // Place a fake @vercel/node in the .vercel/builders cache.
+    // We use a fake builder with the real version number so resolution succeeds.
+    // The build itself will succeed since our fake builder returns empty output.
+    await placeBuilder({
+      name: '@vercel/node',
+      version: vercelNodePkg.version,
+      baseDir: join(project.dir, '.vercel', 'builders'),
+    });
+
+    const result = await runVercelBuild({ cwd: project.dir });
+
+    // The build may fail because the fake builder doesn't produce real output,
+    // but we only care about the resolution step here.
+    expect(result.combined).toContain(
+      `Found "@vercel/node@${vercelNodePkg.version}" in .vercel/builders`
+    );
+    // Should NOT reach step 3
+    expect(result.combined).not.toContain(
+      '"@vercel/node" step 3: trying CLI bundle'
+    );
+  });
+
+  describe('peer dependency resolution (scaffolding)', () => {
+    // These tests set up the scaffolding for when builders move to peerDependencies.
+    // Currently the peer dep code path is a no-op since no builders are in peerDependencies.
+    // When we move builders to peerDependencies, remove the .todo markers.
+
+    it.todo(
+      'should resolve builder from cwd node_modules when peerDep version matches'
+      // When builders are in peerDependencies, this test should:
+      // 1. Place the correct version of @vercel/node in project/node_modules/
+      // 2. Run vc build --debug
+      // 3. Assert: combined output contains 'in peer dependencies location (matches peerDep'
+      // 4. Assert: combined output does NOT contain 'step 2: trying .vercel/builders'
+    );
+
+    it.todo(
+      'should fall through when peer dep version does not match'
+      // When builders are in peerDependencies, this test should:
+      // 1. Place a WRONG version of @vercel/node in project/node_modules/
+      // 2. Run vc build --debug
+      // 3. Assert: combined output contains 'does not match peerDep'
+      // 4. Assert: build still succeeds (falls through to CLI bundle)
+    );
+
+    it.todo(
+      'should fall through when builder not found in cwd node_modules'
+      // When builders are in peerDependencies, this test should:
+      // 1. Don't place any builder in project/node_modules/
+      // 2. Run vc build --debug
+      // 3. Assert: combined output contains 'not found in peer dependencies location'
+      // 4. Assert: build still succeeds (falls through to CLI bundle)
+    );
+  });
+});

--- a/packages/cli/test/unit/util/build/import-builders.test.ts
+++ b/packages/cli/test/unit/util/build/import-builders.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { join } from 'path';
-import { ensureDir, remove, outputJSON, writeFile } from 'fs-extra';
+import { ensureDir, realpath, remove, outputJSON, writeFile } from 'fs-extra';
 import { getWriteableDirectory } from '@vercel/build-utils';
 import { client } from '../../../mocks/client';
-import { importBuilders } from '../../../../src/util/build/import-builders';
+import {
+  importBuilders,
+  resolveBuilders,
+  setPeerDependenciesForTesting,
+  resetPeerDependenciesCache,
+} from '../../../../src/util/build/import-builders';
 import * as installBuildersModule from '../../../../src/util/build/install-builders';
 import vercelNextPkg from '@vercel/next/package.json';
 
@@ -231,7 +236,9 @@ describe('importBuilders()', () => {
       throw new Error('Expected `err` to be defined');
     }
     expect(
-      err.message.startsWith('Importing "@vercel/does-not-exist": Cannot')
+      err.message.startsWith(
+        'Builder "@vercel/does-not-exist" not found after installation'
+      )
     ).toBe(true);
   });
 
@@ -272,5 +279,196 @@ describe('importBuilders()', () => {
     } finally {
       await remove(cwd);
     }
+  });
+
+  describe('peer dependency resolution', () => {
+    afterEach(() => {
+      resetPeerDependenciesCache();
+    });
+
+    it('should resolve builder from cwd node_modules when peerDep version matches', async () => {
+      // Use realpath to resolve macOS /var -> /private/var symlink
+      const cwd = await realpath(await getWriteableDirectory());
+      const buildersDir = join(cwd, '.vercel', 'builders');
+      const pkgName = 'fake-peer-builder';
+      const peerVersion = '2.0.0';
+
+      // Set up a fake builder in cwd's node_modules
+      const builderDir = join(cwd, 'node_modules', pkgName);
+      await ensureDir(builderDir);
+      await outputJSON(join(builderDir, 'package.json'), {
+        name: pkgName,
+        version: peerVersion,
+        main: 'index.js',
+      });
+      await writeFile(
+        join(builderDir, 'index.js'),
+        `exports.version = 3; exports.build = async function() { return { output: {} }; };`
+      );
+
+      setPeerDependenciesForTesting({ [pkgName]: peerVersion });
+
+      try {
+        const result = await resolveBuilders(
+          cwd,
+          buildersDir,
+          new Set([pkgName])
+        );
+        expect('builders' in result).toBe(true);
+        if ('builders' in result) {
+          expect(result.builders.size).toBe(1);
+          const builder = result.builders.get(pkgName);
+          expect(builder?.pkg.name).toBe(pkgName);
+          expect(builder?.pkg.version).toBe(peerVersion);
+          expect(builder?.pkgPath).toBe(join(builderDir, 'package.json'));
+          expect(builder?.dynamicallyInstalled).toBe(false);
+        }
+      } finally {
+        await remove(cwd);
+      }
+    });
+
+    it('should fall through to CLI bundle when peerDep version does not match cwd', async () => {
+      const cwd = await getWriteableDirectory();
+      const buildersDir = join(cwd, '.vercel', 'builders');
+
+      // Set up @vercel/node in cwd with a WRONG version
+      const builderDir = join(cwd, 'node_modules', '@vercel', 'node');
+      await ensureDir(builderDir);
+      await outputJSON(join(builderDir, 'package.json'), {
+        name: '@vercel/node',
+        version: '0.0.1-wrong',
+        main: 'index.js',
+      });
+      await writeFile(
+        join(builderDir, 'index.js'),
+        `exports.version = 3; exports.build = async function() {};`
+      );
+
+      // peerDeps expect a version that doesn't match what's in cwd
+      setPeerDependenciesForTesting({ '@vercel/node': '99.99.99' });
+
+      try {
+        const result = await resolveBuilders(
+          cwd,
+          buildersDir,
+          new Set(['@vercel/node'])
+        );
+
+        // Should still resolve since @vercel/node is in CLI bundle (step 3)
+        expect('builders' in result).toBe(true);
+        if ('builders' in result) {
+          const builder = result.builders.get('@vercel/node');
+          expect(builder?.pkg.name).toBe('@vercel/node');
+          // Should NOT be the wrong version from cwd
+          expect(builder?.pkg.version).not.toBe('0.0.1-wrong');
+          // Should come from CLI bundle, not cwd
+          expect(builder?.pkgPath).not.toContain(cwd);
+        }
+      } finally {
+        await remove(cwd);
+      }
+    });
+
+    it('should resolve from CLI bundle when no peerDeps exist (current behavior)', async () => {
+      const cwd = await getWriteableDirectory();
+      const buildersDir = join(cwd, '.vercel', 'builders');
+
+      setPeerDependenciesForTesting({});
+
+      try {
+        const result = await resolveBuilders(
+          cwd,
+          buildersDir,
+          new Set(['@vercel/node'])
+        );
+        expect('builders' in result).toBe(true);
+        if ('builders' in result) {
+          const builder = result.builders.get('@vercel/node');
+          expect(builder?.pkg.name).toBe('@vercel/node');
+          expect(builder?.pkg.version).toBe(vercelNodePkg.version);
+        }
+      } finally {
+        await remove(cwd);
+      }
+    });
+
+    it('should prefer .vercel/builders cache over CLI bundle when no peerDep specified', async () => {
+      const cwd = await getWriteableDirectory();
+      const buildersDir = join(cwd, '.vercel', 'builders');
+      const pkgName = 'cached-builder';
+      const cachedVersion = '3.0.0';
+
+      // Set up builder in .vercel/builders cache
+      const cachedBuilderDir = join(buildersDir, 'node_modules', pkgName);
+      await ensureDir(cachedBuilderDir);
+      await outputJSON(join(cachedBuilderDir, 'package.json'), {
+        name: pkgName,
+        version: cachedVersion,
+        main: 'index.js',
+      });
+      await writeFile(
+        join(cachedBuilderDir, 'index.js'),
+        `exports.version = 3; exports.build = async function() { return { output: {} }; };`
+      );
+
+      // No peer deps for this builder
+      setPeerDependenciesForTesting({});
+
+      try {
+        const result = await resolveBuilders(
+          cwd,
+          buildersDir,
+          new Set([pkgName])
+        );
+        expect('builders' in result).toBe(true);
+        if ('builders' in result) {
+          const builder = result.builders.get(pkgName);
+          expect(builder?.pkg.name).toBe(pkgName);
+          expect(builder?.pkg.version).toBe(cachedVersion);
+          expect(builder?.pkgPath).toBe(join(cachedBuilderDir, 'package.json'));
+          expect(builder?.dynamicallyInstalled).toBe(true);
+        }
+      } finally {
+        await remove(cwd);
+      }
+    });
+
+    it('should reinstall when .vercel/builders cache version does not match peerDep', async () => {
+      const cwd = await getWriteableDirectory();
+      const buildersDir = join(cwd, '.vercel', 'builders');
+      const pkgName = 'stale-cached-builder';
+
+      // Set up builder in .vercel/builders cache with old version
+      const cachedBuilderDir = join(buildersDir, 'node_modules', pkgName);
+      await ensureDir(cachedBuilderDir);
+      await outputJSON(join(cachedBuilderDir, 'package.json'), {
+        name: pkgName,
+        version: '1.0.0',
+        main: 'index.js',
+      });
+      await writeFile(
+        join(cachedBuilderDir, 'index.js'),
+        `exports.version = 3; exports.build = async function() {};`
+      );
+
+      // peerDep says we want 2.0.0
+      setPeerDependenciesForTesting({ [pkgName]: '2.0.0' });
+
+      try {
+        const result = await resolveBuilders(
+          cwd,
+          buildersDir,
+          new Set([pkgName])
+        );
+        // Should return buildersToAdd since cached version doesn't match peerDep
+        expect('buildersToAdd' in result).toBe(true);
+        if ('buildersToAdd' in result) {
+          expect(result.buildersToAdd.has(`${pkgName}@2.0.0`)).toBe(true);
+        }
+      } finally {
+        await remove(cwd);
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds peer dependency resolution logic to `import-builders.ts` without moving any builders yet. Resolution priority:

1. Peer dep location (`cwd/node_modules`) — version must match exactly
2. `.vercel/builders` cache
3. CLI's bundled `node_modules`
4. npm install

Since no builders are in `peerDependencies` yet, step 1 is a no-op.

Also adds e2e tests that run the built CLI binary from isolated temp dirs, with `.todo` scaffolding for when builders move to peer deps.

## Test plan

- [x] 14 unit tests pass
- [x] 2 e2e tests pass (CLI bundle resolution, `.vercel/builders` cache)
- [x] 3 e2e tests scaffolded as `.todo` for future peer dep work
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)