### PR TITLE
[cli] Pass integrationConfigurationId when fetching billing plans

### DIFF
--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -436,7 +436,8 @@ async function provisionResourceViaCLI(
       client,
       integration,
       product,
-      metadata
+      metadata,
+      installation.id
     );
     billingPlans = billingPlansResponse.plans;
   } catch (error) {

--- a/packages/cli/src/util/integration/fetch-billing-plans.ts
+++ b/packages/cli/src/util/integration/fetch-billing-plans.ts
@@ -10,10 +10,14 @@ export async function fetchBillingPlans(
   client: Client,
   integration: Integration,
   product: IntegrationProduct,
-  metadata: Metadata
+  metadata: Metadata,
+  installationId?: string
 ) {
   const searchParams = new URLSearchParams();
   searchParams.set('metadata', JSON.stringify(metadata));
+  if (installationId) {
+    searchParams.set('integrationConfigurationId', installationId);
+  }
 
   return client.fetch<{ plans: BillingPlan[] }>(
     `/v1/integrations/integration/${integration.id}/products/${product.id}/plans?${searchParams}`,


### PR DESCRIPTION
## Summary
- During `vercel integration add` / `install`, the CLI omitted `integrationConfigurationId` when fetching billing plans from the API, even though the installation is always resolved before that point in the provisioning flow
- Without the ID, the API falls back to a DB lookup to find the installation. When the lookup fails (e.g. eventual consistency after a fresh install), the API calls the partner's billing plans endpoint without installation context — for installation-only integrations, this causes partner-side errors (see vercel/api#68246 for the server-side fix)
- This change passes the installation ID so the API can skip the fallback lookup entirely

## Validation
- All 85 existing `integration add` tests pass
- All 14 `install` tests pass
- `fix` passes (format, lint, typecheck)
- The parameter is optional, so `add-help.ts` (which has no installation context) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)