### PR TITLE
[test] [services] move Python workers to v2beta triggers with private routing

### DIFF
--- a/.changeset/swift-feet-attend.md
+++ b/.changeset/swift-feet-attend.md
@@ -1,0 +1,9 @@
+---
+'@vercel/fs-detectors': minor
+'@vercel/build-utils': minor
+'@vercel/python': minor
+'vercel': minor
+'@vercel/python-workers': patch
+---
+
+[services] move Python workers to v2beta triggers with private routing

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -587,7 +587,6 @@ export interface Service {
   handlerFunction?: string;
   /* worker service config */
   topics?: string[];
-  consumer?: string;
   /** custom prefix to inject service URL env vars */
   envPrefix?: string;
 }
@@ -830,7 +829,6 @@ export interface ExperimentalServiceConfig {
 
   /* Worker service config */
   topics?: string[];
-  consumer?: string;
 
   /** Custom prefix to use to inject service URL env vars */
   envPrefix?: string;

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -38,6 +38,7 @@ import {
   isBackendBuilder,
   type Lambda,
   type TriggerEvent,
+  sanitizeConsumerName,
   downloadFile,
 } from '@vercel/build-utils';
 import type { VercelConfig } from '@vercel/client';
@@ -49,6 +50,7 @@ import {
   detectFrameworkVersion,
   detectInstrumentation,
   getInternalServiceCronPath,
+  getInternalServiceFunctionPath,
   LocalFileSystemDetector,
 } from '@vercel/fs-detectors';
 import {
@@ -2047,11 +2049,19 @@ function attachWorkerServiceTrigger(
   service: Service
 ): void {
   const topics = getWorkerTopics(service);
-  const consumer = service.consumer || 'default';
+  const consumer = sanitizeConsumerName(
+    getInternalServiceFunctionPath(service.name)
+  );
+
+  if (service.builder.use !== '@vercel/python' && topics.length > 1) {
+    throw new Error(
+      `Worker service "${service.name}" has ${topics.length} topics, but multiple topics are only supported for Python workers.`
+    );
+  }
 
   for (const topic of topics) {
     const trigger: TriggerEvent = {
-      type: 'queue/v1beta',
+      type: 'queue/v2beta',
       topic,
       consumer,
     };

--- a/packages/cli/src/util/dev/queue-broker.ts
+++ b/packages/cli/src/util/dev/queue-broker.ts
@@ -362,29 +362,35 @@ export class QueueBroker {
     state.deliveryCount++;
     state.leaseExpiresAt = Date.now() + DEFAULT_VISIBILITY_TIMEOUT;
 
-    const cloudEvent = JSON.stringify({
-      type: 'com.vercel.queue.v1beta',
-      specversion: '1.0',
-      source: 'vc-dev',
-      id: message.messageId,
-      time: new Date().toISOString(),
-      datacontenttype: 'application/json',
-      data: {
-        queueName: message.queueName,
-        consumerGroup: group.name,
-        messageId: message.messageId,
-      },
-    });
+    const now = new Date().toISOString();
+    const expiresAt = new Date(
+      new Date(message.createdAt).getTime() + message.retentionMs
+    ).toISOString();
 
     output.debug(
-      `queues: dispatching CloudEvent to worker "${group.name}" at ${upstream}`
+      `queues: dispatching v2beta callback to worker "${group.name}" at ${upstream}`
     );
 
     try {
       const response = await nodeFetch(`${upstream}/`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/cloudevents+json' },
-        body: cloudEvent,
+        headers: {
+          'content-type': message.contentType,
+          'ce-type': 'com.vercel.queue.v2beta',
+          'ce-specversion': '1.0',
+          'ce-source': `/topic/${message.queueName}/consumer/${group.name}`,
+          'ce-id': message.messageId,
+          'ce-time': now,
+          'ce-vqsmessageid': message.messageId,
+          'ce-vqsqueuename': message.queueName,
+          'ce-vqsconsumergroup': group.name,
+          'ce-vqsreceipthandle': receiptHandle,
+          'ce-vqsdeliverycount': String(state.deliveryCount),
+          'ce-vqscreatedat': message.createdAt,
+          'ce-vqsexpiresat': expiresAt,
+          'ce-vqsregion': 'dev1',
+        },
+        body: message.payload,
       });
 
       if (!response.ok) {

--- a/packages/cli/test/unit/util/dev/queue-broker.test.ts
+++ b/packages/cli/test/unit/util/dev/queue-broker.test.ts
@@ -40,11 +40,11 @@ function makeWebService(name: string): Service {
   } as Service;
 }
 
-/** Parse the CloudEvent JSON body from a specific mockFetch call. */
-function findCloudEvent(index?: number): any {
+/** Extract headers from a specific mockFetch call (defaults to the last one). */
+function callHeaders(index?: number): Record<string, string> {
   const i = index ?? mockFetch.mock.calls.length - 1;
   const call = mockFetch.mock.calls[i];
-  return JSON.parse((call[1] as any).body);
+  return (call[1] as any).headers;
 }
 
 describe('topicPatternToRegex', () => {
@@ -149,17 +149,13 @@ describe('QueueBroker', () => {
       expect(url).toBe('http://localhost:3001/');
       expect((opts as any).method).toBe('POST');
 
-      expect((opts as any).headers['Content-Type']).toBe(
-        'application/cloudevents+json'
-      );
-
-      const body = findCloudEvent();
-      expect(body.type).toBe('com.vercel.queue.v1beta');
-      expect(body.data).toMatchObject({
-        queueName: 'orders',
-        consumerGroup: 'worker-a',
-        messageId,
-      });
+      const headers = callHeaders();
+      expect(headers['ce-type']).toBe('com.vercel.queue.v2beta');
+      expect(headers['ce-vqsqueuename']).toBe('orders');
+      expect(headers['ce-vqsconsumergroup']).toBe('worker-a');
+      expect(headers['ce-vqsmessageid']).toBe(messageId);
+      expect(headers['ce-vqsreceipthandle']).toBeTruthy();
+      expect(headers['content-type']).toBe('application/json');
     });
 
     it('dispatches to multiple matching consumer groups', async () => {
@@ -189,8 +185,8 @@ describe('QueueBroker', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
 
-      expect(findCloudEvent(0).data.queueName).toBe('orders');
-      expect(findCloudEvent(1).data.queueName).toBe('events');
+      expect(callHeaders(0)['ce-vqsqueuename']).toBe('orders');
+      expect(callHeaders(1)['ce-vqsqueuename']).toBe('events');
     });
 
     it('does not cross-dispatch across topics during tick()', async () => {

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -636,10 +636,6 @@ export interface VercelConfig {
        */
       topics?: string[];
       /**
-       * Consumer group name for worker subscription.
-       */
-      consumer?: string;
-      /**
        * Custom prefix to use to inject service URL env vars.
        */
       envPrefix?: string;

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -16,7 +16,6 @@ import {
 import {
   getInternalServiceCronPath,
   getInternalServiceFunctionPath,
-  getInternalServiceWorkerPath,
   isFrontendFramework,
   isRouteOwningBuilder,
   isStaticBuild,
@@ -265,8 +264,7 @@ export async function detectServices(
  * Build Output API builders, etc.) are not given synthetic routes here.
  *
  * - Worker services:
- *   Internal queue callback routes under `/_svc/{serviceName}/workers/{entry}/{handler}`
- *   that rewrite to `/_svc/{serviceName}/index`.
+ *   Use private path routing. The generated function is not publicly acceptable.
  *
  * - Cron services:
  *   Internal cron callback routes under `/_svc/{serviceName}/crons/{entry}/{handler}`
@@ -363,22 +361,6 @@ export function generateServicesRoutes(services: Service[]): ServicesRoutes {
         });
       }
     }
-  }
-
-  const workerServices = services.filter(s => s.type === 'worker');
-  for (const service of workerServices) {
-    const workerEntrypoint =
-      service.entrypoint || service.builder.src || 'index';
-    const workerPath = getInternalServiceWorkerPath(
-      service.name,
-      workerEntrypoint
-    );
-    const functionPath = getInternalServiceFunctionPath(service.name);
-    workers.push({
-      src: `^${escapeRegex(workerPath)}$`,
-      dest: functionPath,
-      check: true,
-    });
   }
 
   const cronServices = services.filter(s => s.type === 'cron');

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -575,8 +575,6 @@ export async function resolveConfiguredService(
   }
 
   const topics = type === 'worker' ? getWorkerTopics(config) : config.topics;
-  const consumer =
-    type === 'worker' ? config.consumer || 'default' : config.consumer;
 
   let builderUse: string;
   let builderSrc: string;
@@ -700,7 +698,6 @@ export async function resolveConfiguredService(
     schedule: config.schedule,
     handlerFunction: moduleAttrParsed?.attrName,
     topics,
-    consumer,
     envPrefix: config.envPrefix,
   };
 }

--- a/packages/fs-detectors/test/fixtures/e2e/10-services-worker-dramatiq/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/10-services-worker-dramatiq/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/10-services-worker-dramatiq/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/10-services-worker-dramatiq/vercel.json
@@ -12,8 +12,7 @@
     "worker": {
       "type": "worker",
       "entrypoint": "worker/run.py",
-      "topics": ["jobs"],
-      "consumer": "default"
+      "topics": ["jobs"]
     }
   }
 }

--- a/packages/fs-detectors/test/fixtures/e2e/13-services-worker-django-tasks/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/13-services-worker-django-tasks/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Django web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/13-services-worker-django-tasks/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/13-services-worker-django-tasks/vercel.json
@@ -12,8 +12,7 @@
     "worker": {
       "type": "worker",
       "entrypoint": "worker/run.py",
-      "topics": ["jobs"],
-      "consumer": "default"
+      "topics": ["jobs"]
     }
   }
 }

--- a/packages/fs-detectors/test/fixtures/e2e/14-services-worker-wildcard-topic/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/14-services-worker-wildcard-topic/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/14-services-worker-wildcard-topic/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/14-services-worker-wildcard-topic/vercel.json
@@ -12,8 +12,7 @@
     "worker": {
       "type": "worker",
       "entrypoint": "worker/run.py",
-      "topics": ["job-*"],
-      "consumer": "default"
+      "topics": ["job-*"]
     }
   }
 }

--- a/packages/fs-detectors/test/fixtures/e2e/15-services-worker-celery/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/15-services-worker-celery/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/15-services-worker-celery/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/15-services-worker-celery/vercel.json
@@ -12,8 +12,7 @@
     "worker": {
       "type": "worker",
       "entrypoint": "worker/run.py",
-      "topics": ["jobs"],
-      "consumer": "default"
+      "topics": ["jobs"]
     }
   }
 }

--- a/packages/fs-detectors/test/fixtures/e2e/16-services-worker-shared-source/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/16-services-worker-shared-source/probes.json
@@ -25,18 +25,18 @@
       "mustContain": "reports"
     },
     {
-      "path": "/_svc/worker-emails/workers/worker/run/worker",
+      "path": "/_svc/worker-emails/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
-      "path": "/_svc/worker-reports/workers/worker/run/worker",
+      "path": "/_svc/worker-reports/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/17-services-worker-multiple-topics/app.py
+++ b/packages/fs-detectors/test/fixtures/e2e/17-services-worker-multiple-topics/app.py
@@ -14,7 +14,7 @@ INDEX_HTML = """
 <html>
   <body>
     <h1>Hello from Flask web service (multiple topics)</h1>
-    <button id="enqueue-btn" type="button">Enqueue Order</button>
+    <button id="enqueue-btn" type="button">Enqueue Jobs</button>
     <p id="status"></p>
 
     <script>
@@ -28,13 +28,13 @@ INDEX_HTML = """
           const response = await fetch('/enqueue', {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ orderId: '12345', action: 'ship' }),
+            body: JSON.stringify({ orderId: '12345', eventId: '54321', action: 'ship' }),
           });
           const data = await response.json();
           if (!response.ok || !data.ok) {
             throw new Error(data.error || String(response.status));
           }
-          status.textContent = `Job id: ${data.jobId}`;
+          status.textContent = `Job IDs: ${data.jobs[0].jobId}, ${data.jobs[1].jobId}`;
         } catch (error) {
           status.textContent = `Failed: ${String(error)}`;
         } finally {
@@ -56,11 +56,16 @@ def root():
 def enqueue():
     payload = request.get_json(silent=True)
     if not isinstance(payload, dict):
-        payload = {}
+        payload = {'orderId': 12345, 'eventId': 54321}
 
     try:
-        order_msg = process_order.send(payload)
-        event_msg = process_event.send(payload)
+        order_payload = payload.copy()
+        order_payload.pop('eventId')
+        order_msg = process_order.send(order_payload)
+
+        event_payload = payload.copy()
+        event_payload.pop('orderId')
+        event_msg = process_event.send(event_payload)
     except Exception as exc:
         logger.error(f"Failed to enqueue job: {exc}")
         return jsonify({"ok": False, "error": str(exc)}), 500

--- a/packages/fs-detectors/test/fixtures/e2e/17-services-worker-multiple-topics/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/17-services-worker-multiple-topics/probes.json
@@ -18,11 +18,11 @@
       "mustContain": "ok"
     },
     {
-      "path": "/_svc/worker/workers/worker/run/worker",
+      "path": "/_svc/worker/index",
       "method": "POST",
       "body": {},
-      "status": 400,
-      "mustContain": "error"
+      "status": 404,
+      "mustContain": "404 from Flask web service"
     },
     {
       "path": "/does-not-exist",

--- a/packages/fs-detectors/test/fixtures/e2e/17-services-worker-multiple-topics/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/17-services-worker-multiple-topics/vercel.json
@@ -12,8 +12,7 @@
     "worker": {
       "type": "worker",
       "entrypoint": "worker/run.py",
-      "topics": ["orders", "events"],
-      "consumer": "default"
+      "topics": ["orders", "events"]
     }
   }
 }

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -928,7 +928,7 @@ describe('detectServices', () => {
       expect(result.services[0].builder.config?.framework).toBe('express');
     });
 
-    it('should default topics and consumer to "default" for workers', async () => {
+    it('should default topics to ["default"] for workers', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({
           experimentalServices: {
@@ -945,7 +945,6 @@ describe('detectServices', () => {
       expect(result.services[0]).toMatchObject({
         type: 'worker',
         topics: ['default'],
-        consumer: 'default',
       });
     });
 
@@ -970,7 +969,7 @@ describe('detectServices', () => {
       });
     });
 
-    it('should not set topics/consumer defaults for non-workers', async () => {
+    it('should not set topics defaults for non-workers', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({
           experimentalServices: {
@@ -986,7 +985,6 @@ describe('detectServices', () => {
       const result = await detectServices({ fs });
 
       expect(result.services[0].topics).toBeUndefined();
-      expect(result.services[0].consumer).toBeUndefined();
     });
 
     it.each([
@@ -1423,7 +1421,7 @@ describe('detectServices', () => {
   });
 
   describe('worker services', () => {
-    it('should generate internal worker callback routes', async () => {
+    it('should not generate public routes for worker services', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({
           experimentalServices: {
@@ -1440,12 +1438,7 @@ describe('detectServices', () => {
 
       expect(result.errors).toEqual([]);
       expect(result.services).toHaveLength(1);
-      expect(result.routes.workers).toHaveLength(1);
-      expect(result.routes.workers[0]).toEqual({
-        src: '^/_svc/processor/workers/worker/processor/worker$',
-        dest: '/_svc/processor/index',
-        check: true,
-      });
+      expect(result.routes.workers).toHaveLength(0);
     });
 
     it('should error if worker service has routePrefix', async () => {

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -789,6 +789,12 @@ from vercel_runtime.vc_init import vc_handler
     ? await glob('**', { cwd: djangoStatic.cdnOutputDir })
     : {};
 
+  // Worker services use private path routing, so no public routes needed
+  const routes =
+    service?.type === 'worker'
+      ? []
+      : [{ handle: 'filesystem' }, { src: '/(.*)', dest: `/${lambdaPath}` }];
+
   return {
     resultVersion: 2,
     result: {
@@ -796,10 +802,7 @@ from vercel_runtime.vc_init import vc_handler
         [lambdaPath]: output,
         ...staticFiles,
       },
-      routes: [
-        { handle: 'filesystem' },
-        { src: '/(.*)', dest: `/${lambdaPath}` },
-      ],
+      routes,
     },
   };
 };

--- a/python/vercel-workers/src/vercel/workers/asgi.py
+++ b/python/vercel-workers/src/vercel/workers/asgi.py
@@ -13,7 +13,7 @@ ASGI = Callable[
     Awaitable[None],
 ]
 
-Handler = Callable[[bytes], tuple[int, list[tuple[str, str]], bytes]]
+Handler = Callable[[bytes, dict[str, Any]], tuple[int, list[tuple[str, str]], bytes]]
 
 
 def _get_header(scope: dict[str, Any], name: str) -> str | None:
@@ -111,8 +111,11 @@ def build_asgi_app(
 
         # Queue callback
         if method == "POST":
-            content_type = _get_header(scope, "content-type")
-            if not content_type or "application/cloudevents+json" not in content_type:
+            content_type = _get_header(scope, "content-type") or ""
+            ce_type = _get_header(scope, "ce-type") or ""
+            is_v1beta = "application/cloudevents+json" in content_type
+            is_v2beta = ce_type == "com.vercel.queue.v2beta"
+            if not is_v1beta and not is_v2beta:
                 body = (
                     b'{"error":"Invalid content type: expected \\"application/cloudevents+json\\""}'
                 )
@@ -129,8 +132,25 @@ def build_asgi_app(
                 await send({"type": "http.response.body", "body": body})
                 return
 
+            # Build a WSGI-style environ dict from ASGI scope headers so the
+            # handler can inspect headers uniformly.
+            environ: dict[str, Any] = {
+                "REQUEST_METHOD": scope.get("method", "POST"),
+            }
+            for header_name, header_value in scope.get("headers", []):
+                name = (
+                    header_name.decode("latin1") if isinstance(header_name, bytes) else header_name
+                )
+                value = (
+                    header_value.decode("latin1")
+                    if isinstance(header_value, bytes)
+                    else header_value
+                )
+                key = "HTTP_" + name.upper().replace("-", "_")
+                environ[key] = value
+
             raw_body = await _read_body(receive)
-            status_code, headers, body = await asyncio.to_thread(handler, raw_body)
+            status_code, headers, body = await asyncio.to_thread(handler, raw_body, environ)
             asgi_headers: list[tuple[bytes, bytes]] = [
                 (k.lower().encode("latin1"), v.encode("latin1")) for (k, v) in headers
             ]

--- a/python/vercel-workers/src/vercel/workers/callback.py
+++ b/python/vercel-workers/src/vercel/workers/callback.py
@@ -22,6 +22,81 @@ from .exceptions import (
     UnauthorizedError,
 )
 
+CLOUD_EVENT_TYPE_V2BETA = "com.vercel.queue.v2beta"
+
+
+def _get_environ_header(environ: dict[str, Any], name: str, default: str = "") -> str:
+    # WSGI (PEP 3333) stores most HTTP headers with an HTTP_ prefix, but
+    # Content-Type and Content-Length are special: they are stored without the
+    # prefix as CONTENT_TYPE and CONTENT_LENGTH respectively.
+    key = "HTTP_" + name.upper().replace("-", "_")
+    value = environ.get(key)
+    if value is None:
+        # Fall back to the non-prefixed key for Content-Type / Content-Length
+        wsgi_key = name.upper().replace("-", "_")
+        value = environ.get(wsgi_key)
+    if value is None:
+        return default
+    if isinstance(value, bytes):
+        return value.decode("latin1")
+    return str(value)
+
+
+class ParsedV2BetaCallback(TypedDict):
+    queueName: str
+    consumerGroup: str
+    messageId: str
+    receiptHandle: str
+    deliveryCount: int
+    createdAt: str
+    payload: Any
+
+
+def is_v2beta_callback(environ: dict[str, Any]) -> bool:
+    return _get_environ_header(environ, "Ce-Type") == CLOUD_EVENT_TYPE_V2BETA
+
+
+def parse_v2beta_callback(
+    raw_body: bytes,
+    environ: dict[str, Any],
+) -> ParsedV2BetaCallback:
+    """Parse a v2beta binary content mode callback."""
+    queue_name = _get_environ_header(environ, "Ce-Vqsqueuename")
+    consumer_group = _get_environ_header(environ, "Ce-Vqsconsumergroup")
+    message_id = _get_environ_header(environ, "Ce-Vqsmessageid")
+    receipt_handle = _get_environ_header(environ, "Ce-Vqsreceipthandle")
+
+    if not queue_name or not consumer_group or not message_id:
+        raise ValueError("missing required ce-vqs* headers")
+
+    delivery_count_raw = _get_environ_header(environ, "Ce-Vqsdeliverycount", "1")
+    try:
+        delivery_count = int(delivery_count_raw)
+    except ValueError:
+        delivery_count = 1
+
+    created_at = _get_environ_header(environ, "Ce-Vqscreatedat")
+
+    content_type = _get_environ_header(environ, "Content-Type")
+    payload: Any
+    if "application/json" in content_type.lower():
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except Exception:  # noqa: BLE001
+            payload = raw_body
+    else:
+        payload = raw_body
+
+    return {
+        "queueName": queue_name,
+        "consumerGroup": consumer_group,
+        "messageId": message_id,
+        "receiptHandle": receipt_handle,
+        "deliveryCount": delivery_count,
+        "createdAt": created_at,
+        "payload": payload,
+    }
+
 
 class CloudEventData(TypedDict):
     messageId: str

--- a/python/vercel-workers/src/vercel/workers/celery/app.py
+++ b/python/vercel-workers/src/vercel/workers/celery/app.py
@@ -33,18 +33,23 @@ WSGI = Callable[[dict[str, Any], Callable[..., Any]], list[bytes]]
 def get_wsgi_app(celery_app: CeleryApp) -> WSGI:
     """Return a WSGI app that executes Celery tasks from Vercel Queue callbacks."""
 
-    return build_wsgi_app(lambda raw_body: handle_queue_callback(celery_app, raw_body))
+    return build_wsgi_app(
+        lambda raw_body, environ: handle_queue_callback(celery_app, raw_body, environ)
+    )
 
 
 def get_asgi_app(celery_app: CeleryApp) -> ASGI:
     """Return an ASGI app that executes Celery tasks from Vercel Queue callbacks."""
 
-    return build_asgi_app(lambda raw_body: handle_queue_callback(celery_app, raw_body))
+    return build_asgi_app(
+        lambda raw_body, environ: handle_queue_callback(celery_app, raw_body, environ)
+    )
 
 
 def handle_queue_callback(
     celery_app: CeleryApp,
     raw_body: bytes,
+    environ: dict[str, Any] | None = None,
 ) -> tuple[int, list[tuple[str, str]], bytes]:
     """
     Core callback handler shared by WSGI/ASGI wrappers.
@@ -54,21 +59,37 @@ def handle_queue_callback(
 
     extender: queue_callback.VisibilityExtender | None = None
     try:
-        queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
-
         conf = getattr(celery_app, "conf", None)
         transport_options = getattr(conf, "broker_transport_options", None)
         cfg = TransportConfig.from_transport_options(
             transport_options if isinstance(transport_options, dict) else {},
         )
 
-        payload, delivery_count, created_at, receipt_handle = queue_callback.receive_message_by_id(
-            queue_name,
-            consumer_group,
-            message_id,
-            visibility_timeout_seconds=cfg.visibility_timeout_seconds,
-            timeout=cfg.timeout,
-        )
+        is_v2beta = queue_callback.is_v2beta_callback(environ or {})
+
+        if is_v2beta:
+            v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
+            queue_name = v2["queueName"]
+            consumer_group = v2["consumerGroup"]
+            message_id = v2["messageId"]
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload: Any = v2["payload"]
+        else:
+            queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
+            (
+                payload,
+                delivery_count,
+                created_at,
+                receipt_handle,
+            ) = queue_callback.receive_message_by_id(
+                queue_name,
+                consumer_group,
+                message_id,
+                visibility_timeout_seconds=cfg.visibility_timeout_seconds,
+                timeout=cfg.timeout,
+            )
 
         extender = queue_callback.VisibilityExtender(
             queue_name,

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -279,7 +279,10 @@ def _send_in_process(queue_name: str, payload: Any) -> SendMessageResult:
     return {"messageId": message_id}
 
 
-def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], bytes]:
+def handle_queue_callback(
+    raw_body: bytes,
+    environ: dict[str, Any] | None = None,
+) -> tuple[int, list[tuple[str, str]], bytes]:
     """
     Core callback handler used by both WSGI/ASGI wrappers.
 
@@ -295,7 +298,19 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
         visibility_timeout_seconds = int(os.environ.get("VQS_VISIBILITY_TIMEOUT", "30"))
         refresh_interval_seconds = float(os.environ.get("VQS_VISIBILITY_REFRESH_INTERVAL", "10"))
 
-        queue_name, consumer_group, message_id = callback.parse_cloudevent(raw_body)
+        is_v2beta = callback.is_v2beta_callback(environ or {})
+
+        if is_v2beta:
+            v2 = callback.parse_v2beta_callback(raw_body, environ or {})
+            queue_name = v2["queueName"]
+            consumer_group = v2["consumerGroup"]
+            message_id = v2["messageId"]
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload: Any = v2["payload"]
+        else:
+            queue_name, consumer_group, message_id = callback.parse_cloudevent(raw_body)
 
         # Fail fast if no workers match this topic/consumer.
         if not _select_subscriptions(queue_name, consumer_group):
@@ -308,12 +323,13 @@ def handle_queue_callback(raw_body: bytes) -> tuple[int, list[tuple[str, str]], 
                 },
             )
 
-        payload, delivery_count, created_at, receipt_handle = callback.receive_message_by_id(
-            queue_name,
-            consumer_group,
-            message_id,
-            visibility_timeout_seconds=visibility_timeout_seconds,
-        )
+        if not is_v2beta:
+            payload, delivery_count, created_at, receipt_handle = callback.receive_message_by_id(
+                queue_name,
+                consumer_group,
+                message_id,
+                visibility_timeout_seconds=visibility_timeout_seconds,
+            )
 
         metadata: MessageMetadata = {
             "messageId": message_id,
@@ -414,9 +430,19 @@ def get_queue_base_url() -> str:
 
     Mirrors the JS client behaviour:
       - VERCEL_QUEUE_BASE_URL environment variable
-      - default to "https://vercel-queue.com"
+      - if VERCEL_REGION environment variable is set then routes to
+        region specific endpoint, e.g. "https://iad1.vercel-queue.com"
+      - otherwise to "https://vercel-queue.com"
     """
-    return os.environ.get("VERCEL_QUEUE_BASE_URL", "https://vercel-queue.com").rstrip("/")
+    base_url = os.environ.get("VERCEL_QUEUE_BASE_URL")
+    if base_url:
+        return base_url.rstrip("/")
+
+    region = os.environ.get("VERCEL_REGION")
+    if region:
+        return f"https://{region}.vercel-queue.com"
+    else:
+        return "https://vercel-queue.com"
 
 
 def get_queue_base_path() -> str:

--- a/python/vercel-workers/src/vercel/workers/django/app.py
+++ b/python/vercel-workers/src/vercel/workers/django/app.py
@@ -96,13 +96,17 @@ def get_wsgi_app(*, backend_alias: str = "default") -> WSGI:
     Usage: configure a Vercel Queue trigger to POST CloudEvents to this route.
     """
     backend = _resolve_backend(backend_alias)
-    return build_wsgi_app(lambda raw_body: handle_queue_callback(backend, raw_body))
+    return build_wsgi_app(
+        lambda raw_body, environ: handle_queue_callback(backend, raw_body, environ)
+    )
 
 
 def get_asgi_app(*, backend_alias: str = "default") -> ASGI:
     """ASGI variant of get_wsgi_app()."""
     backend = _resolve_backend(backend_alias)
-    return build_asgi_app(lambda raw_body: handle_queue_callback(backend, raw_body))
+    return build_asgi_app(
+        lambda raw_body, environ: handle_queue_callback(backend, raw_body, environ)
+    )
 
 
 def _resolve_backend(alias: str) -> VercelQueuesBackend:
@@ -146,6 +150,7 @@ def _parse_envelope(payload: Any) -> DjangoTaskEnvelope:
 def handle_queue_callback(
     backend: VercelQueuesBackend,
     raw_body: bytes,
+    environ: dict[str, Any] | None = None,
 ) -> tuple[int, list[tuple[str, str]], bytes]:
     """
     Core callback handler shared by WSGI/ASGI wrappers.
@@ -158,7 +163,19 @@ def handle_queue_callback(
     )
 
     try:
-        queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
+        is_v2beta = queue_callback.is_v2beta_callback(environ or {})
+
+        if is_v2beta:
+            v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
+            queue_name = v2["queueName"]
+            consumer_group = v2["consumerGroup"]
+            message_id = v2["messageId"]
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload: Any = v2["payload"]
+        else:
+            queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
 
         # Fail fast on unexpected queues to avoid executing arbitrary payloads.
         if backend.queues and queue_name not in backend.queues:
@@ -171,13 +188,19 @@ def handle_queue_callback(
                 body,
             )
 
-        payload, delivery_count, created_at, receipt_handle = queue_callback.receive_message_by_id(
-            queue_name,
-            consumer_group,
-            message_id,
-            visibility_timeout_seconds=cfg.visibility_timeout_seconds,
-            timeout=cfg.timeout,
-        )
+        if not is_v2beta:
+            (
+                payload,
+                delivery_count,
+                created_at,
+                receipt_handle,
+            ) = queue_callback.receive_message_by_id(
+                queue_name,
+                consumer_group,
+                message_id,
+                visibility_timeout_seconds=cfg.visibility_timeout_seconds,
+                timeout=cfg.timeout,
+            )
 
         # Keep the message locked while executing.
         if receipt_handle:

--- a/python/vercel-workers/src/vercel/workers/dramatiq/app.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/app.py
@@ -95,7 +95,9 @@ def get_wsgi_app(broker: VercelQueuesBroker) -> WSGI:
     # WSGI has no lifespan protocol, so emit worker_boot eagerly.
     broker.emit_before("worker_boot", None)
     broker.emit_after("worker_boot", None)
-    return build_wsgi_app(lambda raw_body: handle_queue_callback(broker, raw_body))
+    return build_wsgi_app(
+        lambda raw_body, environ: handle_queue_callback(broker, raw_body, environ)
+    )
 
 
 def get_asgi_app(broker: VercelQueuesBroker) -> ASGI:
@@ -110,7 +112,7 @@ def get_asgi_app(broker: VercelQueuesBroker) -> ASGI:
         broker.emit_after("worker_shutdown", None)
 
     return build_asgi_app(
-        lambda raw_body: handle_queue_callback(broker, raw_body),
+        lambda raw_body, environ: handle_queue_callback(broker, raw_body, environ),
         on_startup=_on_startup,
         on_shutdown=_on_shutdown,
     )
@@ -137,6 +139,7 @@ def _retry_delay_ms(cfg: DramatiqWorkerConfig, attempt: int) -> int:
 def handle_queue_callback(
     broker: VercelQueuesBroker,
     raw_body: bytes,
+    environ: dict[str, Any] | None = None,
 ) -> tuple[int, list[tuple[str, str]], bytes]:
     """
     Core callback handler shared by WSGI/ASGI wrappers.
@@ -147,15 +150,31 @@ def handle_queue_callback(
     cfg = DramatiqWorkerConfig.from_broker_options(broker)
 
     try:
-        queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
+        is_v2beta = queue_callback.is_v2beta_callback(environ or {})
 
-        payload, delivery_count, created_at, receipt_handle = queue_callback.receive_message_by_id(
-            queue_name,
-            consumer_group,
-            message_id,
-            visibility_timeout_seconds=cfg.visibility_timeout_seconds,
-            timeout=cfg.timeout,
-        )
+        if is_v2beta:
+            v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
+            queue_name = v2["queueName"]
+            consumer_group = v2["consumerGroup"]
+            message_id = v2["messageId"]
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload: Any = v2["payload"]
+        else:
+            queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
+            (
+                payload,
+                delivery_count,
+                created_at,
+                receipt_handle,
+            ) = queue_callback.receive_message_by_id(
+                queue_name,
+                consumer_group,
+                message_id,
+                visibility_timeout_seconds=cfg.visibility_timeout_seconds,
+                timeout=cfg.timeout,
+            )
 
         # Keep the message locked while executing.
         if receipt_handle:

--- a/python/vercel-workers/src/vercel/workers/wsgi.py
+++ b/python/vercel-workers/src/vercel/workers/wsgi.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any
 
 WSGI = Callable[[dict[str, Any], Callable[..., Any]], list[bytes]]
-Handler = Callable[[bytes], tuple[int, list[tuple[str, str]], bytes]]
+Handler = Callable[[bytes, dict[str, Any]], tuple[int, list[tuple[str, str]], bytes]]
 
 
 _STATUS_REASONS: dict[int, str] = {
@@ -64,8 +64,11 @@ def build_wsgi_app(handler: Handler) -> WSGI:
 
         # Queue callback
         if method == "POST":
-            content_type = str(environ.get("CONTENT_TYPE") or "")
-            if "application/cloudevents+json" not in content_type:
+            content_type = environ.get("CONTENT_TYPE", "")
+            ce_type = environ.get("HTTP_CE_TYPE", "")
+            is_v1beta = "application/cloudevents+json" in content_type
+            is_v2beta = ce_type == "com.vercel.queue.v2beta"
+            if not is_v1beta and not is_v2beta:
                 err = (
                     b'{"error":"Invalid content type: expected \\"application/cloudevents+json\\""}'
                 )
@@ -79,7 +82,7 @@ def build_wsgi_app(handler: Handler) -> WSGI:
                 return [err]
 
             raw_body = _read_body(environ)
-            status_code, headers, body = handler(raw_body)
+            status_code, headers, body = handler(raw_body, environ)
             start_response(f"{int(status_code)} {status_reason(int(status_code))}", headers)
             return [body]
 


### PR DESCRIPTION
Adds support for v2beta triggers for Python workers, and the build now uses these instead of v1beta. Additionally, support for multiple topics is now limited to Python only, where we can handle this in our runtime. Other runtimes can currently use only 1 topic, similar to how `functions.experimentalTriggers` config behave