### PR TITLE
[vercel] fix: return 3xx responses when redirect is manual in client.fetch()

### DIFF
--- a/.changeset/client-fetch-manual-redirect.md
+++ b/.changeset/client-fetch-manual-redirect.md
@@ -1,0 +1,5 @@
+---
+vercel: patch
+---
+
+Return 3xx responses directly in `client.fetch()` when `redirect: 'manual'` is passed, instead of entering the error/retry path.

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -408,6 +408,15 @@ export default class Client extends EventEmitter implements Stdio {
       printIndications(res);
 
       if (!res.ok) {
+        // Return 3xx responses directly when manual redirect is requested
+        if (
+          opts.redirect === 'manual' &&
+          res.status >= 300 &&
+          res.status < 400
+        ) {
+          return res;
+        }
+
         const error = await responseError(res);
 
         // we should force reauth only if error has a teamId

--- a/packages/cli/test/unit/util/client.test.ts
+++ b/packages/cli/test/unit/util/client.test.ts
@@ -90,9 +90,9 @@ describe('Client', () => {
 
       // Without redirect:'manual', node-fetch follows the redirect and
       // we get the target response (200 JSON)
-      const data = await client.fetch<{ followed: boolean }>(
-        '/v1/test-redirect-default'
-      );
+      const data = (await client.fetch('/v1/test-redirect-default')) as {
+        followed: boolean;
+      };
       expect(data.followed).toEqual(true);
     });
   });

--- a/packages/cli/test/unit/util/client.test.ts
+++ b/packages/cli/test/unit/util/client.test.ts
@@ -12,6 +12,7 @@ describe('Client', () => {
       delete process.env.HTTP_PROXY;
       client.agent?.destroy();
       client.agent = undefined;
+      client.reset();
     });
 
     it('should respect the `HTTP_PROXY` env var', async () => {
@@ -53,6 +54,46 @@ describe('Client', () => {
           mockServer.close(() => resolve());
         });
       }
+    });
+
+    it('should return 3xx responses directly when redirect is manual', async () => {
+      client.scenario.get('/v1/test-redirect', (_req, res) => {
+        res.writeHead(302, { Location: 'https://example.com/target' });
+        res.end();
+      });
+
+      const res = await client.fetch('/v1/test-redirect', {
+        json: false,
+        redirect: 'manual',
+      });
+
+      expect(res.status).toEqual(302);
+      expect(res.headers.get('location')).toEqual('https://example.com/target');
+    });
+
+    it('should treat 3xx as errors when redirect is not manual', async () => {
+      // When redirect is not set to 'manual', node-fetch follows the
+      // redirect by default. If the redirect target doesn't exist, the
+      // fetch will fail. This test verifies the default behavior is
+      // unchanged — 3xx without redirect:'manual' doesn't return the
+      // raw response.
+      client.scenario.get('/v1/test-redirect-default', (_req, res) => {
+        // Redirect to the same mock server's /v1/test-redirect-target
+        res.writeHead(302, {
+          Location: `${client.apiUrl}/v1/test-redirect-target`,
+        });
+        res.end();
+      });
+      client.scenario.get('/v1/test-redirect-target', (_req, res) => {
+        res.json({ followed: true });
+      });
+
+      // Without redirect:'manual', node-fetch follows the redirect and
+      // we get the target response (200 JSON)
+      const data = await client.fetch<{ followed: boolean }>(
+        '/v1/test-redirect-default'
+      );
+      expect(data.followed).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

- `client.fetch()` now returns 3xx responses directly when `redirect: 'manual'` is passed, instead of entering the error/retry path
- This is opt-in — no existing behavior changes since no code currently passes `redirect: 'manual'` through `client.fetch()`

## Why
This enables CLI commands that need to extract `Location` headers from redirect-based API endpoints (e.g., endpoints that initialize server-side state and redirect to a browser URL).

Today, the 3xx response hits `!res.ok` (302 is outside 200-299), doesn't match the 400-499 bail condition, and falls through to `throw error` — causing infinite retries.



## Test plan

- [x] New test: 302 with `redirect: 'manual'` returns raw response with Location header
- [x] New test: 302 without `redirect: 'manual'` follows the redirect (default behavior unchanged)
- [x] Existing proxy test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)