### PR TITLE
fix(node): scope entrypoint filter to `api/` directory only

### DIFF
--- a/.changeset/sharp-lemons-camp.md
+++ b/.changeset/sharp-lemons-camp.md
@@ -1,0 +1,5 @@
+---
+"@vercel/fs-detectors": patch
+---
+
+fix(node): scope entrypoint filter to `api/` directory only

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -469,9 +469,13 @@ async function maybeGetApiBuilder(
     }
   }
 
-  // For Node.js files, verify they are valid entrypoints before creating a builder
+  // For Node.js files under api/, verify they are valid entrypoints before
+  // creating a builder. This only applies to api/ files — root-level platform
+  // files (middleware.js, proxy.js, etc.) use different export signatures and
+  // must not be filtered by API handler pattern detection.
   const nodeExtensions = ['.js', '.mjs', '.ts', '.tsx'];
   if (
+    fileName.startsWith('api/') &&
     process.env.VERCEL_NODE_FILTER_ENTRYPOINTS === '1' &&
     nodeExtensions.some(ext => fileName.endsWith(ext)) &&
     options.workPath

--- a/packages/fs-detectors/test/fixtures/70-node-api-dir-files/middleware.ts
+++ b/packages/fs-detectors/test/fixtures/70-node-api-dir-files/middleware.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  return NextResponse.next();
+}

--- a/packages/fs-detectors/test/fixtures/71-node-monorepo/apps/web/api/helper.ts
+++ b/packages/fs-detectors/test/fixtures/71-node-monorepo/apps/web/api/helper.ts
@@ -1,0 +1,3 @@
+export function formatDate(d: Date): string {
+  return d.toISOString();
+}

--- a/packages/fs-detectors/test/fixtures/71-node-monorepo/apps/web/api/index.ts
+++ b/packages/fs-detectors/test/fixtures/71-node-monorepo/apps/web/api/index.ts
@@ -1,0 +1,3 @@
+export default function handler(req: any, res: any) {
+  res.json({ ok: true });
+}

--- a/packages/fs-detectors/test/fixtures/71-node-monorepo/apps/web/middleware.ts
+++ b/packages/fs-detectors/test/fixtures/71-node-monorepo/apps/web/middleware.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  return NextResponse.next();
+}

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -4109,6 +4109,21 @@ describe('Test `detectApiExtensions`', () => {
       expect(apiBuilders[0].src).toBe('api/index.ts');
     });
 
+    it('should not filter middleware files that export middleware function', async () => {
+      const files = ['api/index.ts', 'middleware.ts'];
+
+      const { builders } = await detectBuilders(files, null, { workPath });
+
+      const middlewareBuilders = (builders || []).filter(
+        b => b.config?.middleware === true
+      );
+
+      // Middleware file should still get a builder even though it doesn't
+      // match standard API handler export patterns
+      expect(middlewareBuilders).toHaveLength(1);
+      expect(middlewareBuilders[0].src).toBe('middleware.ts');
+    });
+
     it('should not filter entrypoints when env var is not set', async () => {
       delete process.env.VERCEL_NODE_FILTER_ENTRYPOINTS;
 
@@ -4122,6 +4137,61 @@ describe('Test `detectApiExtensions`', () => {
 
       // Without the env var, all files get builders (existing behavior)
       expect(apiBuilders).toHaveLength(2);
+    });
+  });
+
+  describe('Node.js entrypoint detection in monorepo', () => {
+    // Simulates a monorepo where workPath points to a nested workspace
+    // (e.g., apps/web). File paths passed to detectBuilders are always
+    // relative to workPath, mirroring how the CLI resolves them.
+    const workPath = join(
+      __dirname,
+      'fixtures',
+      '71-node-monorepo',
+      'apps',
+      'web'
+    );
+
+    beforeEach(() => {
+      process.env.VERCEL_NODE_FILTER_ENTRYPOINTS = '1';
+    });
+
+    afterEach(() => {
+      delete process.env.VERCEL_NODE_FILTER_ENTRYPOINTS;
+    });
+
+    it('should filter helpers and keep entrypoints in monorepo workspace', async () => {
+      const files = ['api/index.ts', 'api/helper.ts'];
+
+      const { builders } = await detectBuilders(files, null, { workPath });
+
+      const apiBuilders = (builders || []).filter(
+        b => b.src?.startsWith('api/') && b.use === '@vercel/node'
+      );
+
+      expect(apiBuilders).toHaveLength(1);
+      expect(apiBuilders[0].src).toBe('api/index.ts');
+    });
+
+    it('should not filter middleware in monorepo workspace', async () => {
+      const files = ['api/index.ts', 'api/helper.ts', 'middleware.ts'];
+
+      const { builders } = await detectBuilders(files, null, { workPath });
+
+      const apiBuilders = (builders || []).filter(
+        b => b.src?.startsWith('api/') && b.use === '@vercel/node'
+      );
+      const middlewareBuilders = (builders || []).filter(
+        b => b.config?.middleware === true
+      );
+
+      // Helper filtered, entrypoint kept
+      expect(apiBuilders).toHaveLength(1);
+      expect(apiBuilders[0].src).toBe('api/index.ts');
+
+      // Middleware preserved
+      expect(middlewareBuilders).toHaveLength(1);
+      expect(middlewareBuilders[0].src).toBe('middleware.ts');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes a bug introduced in #15873 where `VERCEL_NODE_FILTER_ENTRYPOINTS=1` incorrectly filters out root-level platform files like `middleware.ts`
- Root cause: `isNodeEntrypoint()` checks for standard API handler exports (`export default`, HTTP methods, `fetch`, `module.exports`), but root-level platform files use different signatures (e.g., `export function middleware()`). Files that don't match any pattern are silently dropped.
- Fix: scope the Node.js entrypoint filter to `fileName.startsWith('api/')` — the filter was only ever intended for helper files inside `api/`, and `maybeGetApiBuilder()` already gates entry to `api/` files + root-level platform files at line 443. This avoids needing to enumerate every platform file pattern (middleware, proxy, etc.) as a negation.

## What was affected

Any non-Next.js project with `VERCEL_NODE_FILTER_ENTRYPOINTS=1` that uses root-level `middleware.ts`/`middleware.js`. Next.js projects are unaffected because `@vercel/next` handles middleware via its own manifest-based pipeline, and root-level middleware is already excluded for Next.js at line 439.

## Test plan

- [x] `middleware.ts` is preserved when entrypoint filter is active
- [x] Monorepo workspace: helpers under `api/` are correctly filtered
- [x] Monorepo workspace: middleware is preserved alongside filtered helpers
- [x] Existing tests pass (entrypoint filtering, env var gating)
- [x] Prettier and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)