### PR TITLE
[cli] Forward API error responses in extension proxy

### DIFF
--- a/.changeset/proxy-forward-api-errors.md
+++ b/.changeset/proxy-forward-api-errors.md
@@ -1,0 +1,5 @@
+---
+vercel: patch
+---
+
+Forward API error responses (status code and body) in the extension proxy instead of converting them to generic 500s.

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -8,6 +8,7 @@ import {
 } from '@edge-runtime/node-utils';
 import type { Server } from 'http';
 import type Client from '../client';
+import { APIError } from '../errors-ts';
 import output from '../../output-manager';
 
 const toHeaders = buildToHeaders({
@@ -42,10 +43,38 @@ export function createProxy(client: Client): Server {
       mergeIntoServerResponse(outgoingHeaders, res);
       fetchRes.body.pipe(res);
     } catch (err: unknown) {
-      output.prettyError(err);
       if (!res.headersSent) {
-        res.statusCode = 500;
-        res.end('Unexpected error during API call');
+        // client.fetch throws APIError for non-2xx responses before the
+        // `json: false` return path is reached.  Forward the original status
+        // and error body so extensions see the real API error instead of 500.
+        if (err instanceof APIError) {
+          res.statusCode = err.status;
+          res.setHeader('Content-Type', 'application/json');
+
+          const errorBody: Record<string, unknown> = {
+            message: err.serverMessage,
+          };
+          // Recover fields that the APIError constructor copied from the
+          // response body (code, meta fields, etc.).
+          const internal = new Set([
+            'message',
+            'status',
+            'serverMessage',
+            'retryAfterMs',
+            'stack',
+          ]);
+          for (const key of Object.keys(err)) {
+            if (!internal.has(key)) {
+              errorBody[key] = (err as Record<string, unknown>)[key];
+            }
+          }
+
+          res.end(JSON.stringify({ error: errorBody }));
+        } else {
+          output.prettyError(err);
+          res.statusCode = 500;
+          res.end('Unexpected error during API call');
+        }
       }
     }
   });

--- a/packages/cli/test/unit/util/extension/proxy.test.ts
+++ b/packages/cli/test/unit/util/extension/proxy.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { listen } from 'async-listen';
+import fetch, { Response } from 'node-fetch';
+import { Readable } from 'stream';
+import type { Server } from 'http';
+import { createProxy } from '../../../../src/util/extension/proxy';
+
+// Mock output-manager to avoid side-effects and heavy transitive imports.
+vi.mock('../../../../src/output-manager', () => ({
+  default: { prettyError: vi.fn() },
+}));
+
+// Mock errors-ts so we can use APIError without pulling in build-utils /
+// python-analysis (which requires a Rust toolchain to build locally).
+vi.mock('../../../../src/util/errors-ts', () => {
+  class APIError extends Error {
+    status: number;
+    serverMessage: string;
+    [key: string]: unknown;
+    constructor(message: string, status: number, body?: object) {
+      super(message);
+      this.status = status;
+      this.serverMessage = message;
+      if (body) {
+        for (const [key, value] of Object.entries(body)) {
+          if (key !== 'message') {
+            this[key] = value;
+          }
+        }
+      }
+    }
+  }
+  return { APIError };
+});
+
+// Re-import so the proxy module picks up the mocked APIError.
+const { APIError } = await import('../../../../src/util/errors-ts');
+
+function makeClient(
+  fetchImpl: (...args: unknown[]) => Promise<Response>
+): Parameters<typeof createProxy>[0] {
+  return { fetch: fetchImpl } as Parameters<typeof createProxy>[0];
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  const json = JSON.stringify(body);
+  const readable = Readable.from([json]);
+  return new Response(readable as any, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('createProxy', () => {
+  let proxy: Server;
+  let proxyUrl: URL;
+
+  async function startProxy(
+    fetchImpl: (...args: unknown[]) => Promise<Response>
+  ) {
+    proxy = createProxy(makeClient(fetchImpl));
+    proxyUrl = await listen(proxy, { port: 0, host: '127.0.0.1' });
+  }
+
+  afterEach(async () => {
+    if (proxy) {
+      await new Promise<void>(resolve => {
+        proxy.close(() => resolve());
+      });
+    }
+  });
+
+  it('should forward successful 200 responses', async () => {
+    await startProxy(async () => jsonResponse(200, { ok: true }));
+
+    const res = await fetch(new URL('/v1/test', proxyUrl).href);
+    expect(res.status).toEqual(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+  });
+
+  it('should forward APIError with original status code and error body', async () => {
+    const apiError = new APIError(
+      'Deployment integrations are still provisioning. Wait for integrations to complete.',
+      // @ts-expect-error — mocked constructor takes (message, status, body)
+      400,
+      {
+        code: 'deployment_not_ready_integrations_pending',
+        integrationsStatus: 'pending',
+      }
+    );
+
+    await startProxy(async () => {
+      throw apiError;
+    });
+
+    const res = await fetch(new URL('/v1/test-error', proxyUrl).href, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toEqual(400);
+    const body = (await res.json()) as {
+      error: { code: string; message: string; integrationsStatus: string };
+    };
+    expect(body.error.code).toEqual(
+      'deployment_not_ready_integrations_pending'
+    );
+    expect(body.error.message).toEqual(
+      'Deployment integrations are still provisioning. Wait for integrations to complete.'
+    );
+    expect(body.error.integrationsStatus).toEqual('pending');
+  });
+
+  it('should forward 404 APIError', async () => {
+    // @ts-expect-error — mocked constructor takes (message, status, body)
+    const apiError = new APIError('Resource not found', 404, {
+      code: 'not_found',
+    });
+
+    await startProxy(async () => {
+      throw apiError;
+    });
+
+    const res = await fetch(new URL('/v1/not-found', proxyUrl).href);
+
+    expect(res.status).toEqual(404);
+    const body = (await res.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toEqual('not_found');
+    expect(body.error.message).toEqual('Resource not found');
+  });
+
+  it('should return 500 for non-API errors', async () => {
+    await startProxy(async () => {
+      throw new Error('connection refused');
+    });
+
+    const res = await fetch(new URL('/v1/broken', proxyUrl).href);
+
+    expect(res.status).toEqual(500);
+    const text = await res.text();
+    expect(text).toEqual('Unexpected error during API call');
+  });
+});


### PR DESCRIPTION
## Context

The CLI extension proxy (`createProxy`) uses `client.fetch(url, { json: false })` to forward API requests from extensions. However, `client.fetch()` throws an `APIError` for all non-2xx responses _before_ the `json: false` return path is reached (the `!res.ok` check at line 410 runs before the `json: false` check at line 452). This causes the proxy's catch block to convert all API errors (including 400s) into generic `500 Unexpected error during API call` responses, hiding the real error code and message from extensions.

This is needed to support retry logic in the BYOF extension when deployment integrations are still provisioning — the API now returns a specific `deployment_not_ready_integrations_pending` error code that the extension needs to see.

## Changes

- When the caught error is an `APIError`, forward the original HTTP status code and reconstruct the JSON error body (including `code`, `message`, and any meta fields) instead of returning a generic 500
- Non-API errors still return 500 as before

## References

- Depends on https://github.com/vercel/api/pull/68554 (API error code change)
- Related to https://github.com/vercel/byof/pull/21 (retry logic in BYOF extension)