### PR TITLE
[flags] Add `vercel flags rollout` for progressive rollouts

### DIFF
--- a/.changeset/lovely-cameras-roll.md
+++ b/.changeset/lovely-cameras-roll.md
@@ -2,7 +2,7 @@
 'vercel': patch
 ---
 
-Add `vercel flags rollout` for staged, time-based progressive rollouts.
+Add `vercel flags rollout` for progressive rollouts.
 
 Examples:
 

--- a/.changeset/lovely-cameras-roll.md
+++ b/.changeset/lovely-cameras-roll.md
@@ -1,0 +1,47 @@
+---
+'vercel': patch
+---
+
+Add `vercel flags rollout` for staged, time-based progressive rollouts.
+
+Examples:
+
+```bash
+vercel flags rollout redesigned-checkout \
+  --environment production \
+  --by user.userId \
+  --stage 5,6h \
+  --stage 10,6h \
+  --stage 25,12h \
+  --stage 50,1d
+```
+
+```bash
+vercel flags rollout redesigned-checkout \
+  --environment production \
+  --by user.userId \
+  --stage 5,30m \
+  --stage 25,2h \
+  --stage 50,8h \
+  --start now
+```
+
+```bash
+vercel flags rollout welcome-message \
+  --environment production \
+  --by user.userId \
+  --from-variant control \
+  --to-variant treatment \
+  --default-variant control \
+  --stage 10,2h \
+  --stage 50,12h \
+  --start 2026-04-16T09:00:00Z
+```
+
+```bash
+vercel flags rollout redesigned-checkout \
+  --environment production \
+  --stage 10,6h \
+  --stage 50,1d \
+  --message "Adjust production rollout schedule"
+```

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -253,6 +253,106 @@ export const setSubcommand = {
   ],
 } as const;
 
+export const rolloutSubcommand = {
+  name: 'rollout',
+  aliases: [],
+  description:
+    'Configure a progressive rollout for a feature flag in an environment',
+  arguments: [
+    {
+      name: 'flag',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'environment',
+      shorthand: 'e',
+      type: String,
+      deprecated: false,
+      description:
+        'The environment to configure (production, preview, or development)',
+      argument: 'ENV',
+    },
+    {
+      name: 'from-variant',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'The variant to roll away from (defaults to false for boolean flags)',
+      argument: 'VARIANT',
+    },
+    {
+      name: 'to-variant',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'The variant to roll towards (defaults to true for boolean flags)',
+      argument: 'VARIANT',
+    },
+    {
+      name: 'default-variant',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'The fallback variant to serve when the rollout attribute is unavailable',
+      argument: 'VARIANT',
+    },
+    {
+      name: 'by',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Entity attribute used for bucketing, in the form entity.attribute',
+      argument: 'ENTITY.ATTRIBUTE',
+    },
+    {
+      name: 'stage',
+      shorthand: 's',
+      type: [String],
+      deprecated: false,
+      description:
+        'Add a rollout stage as PERCENTAGE,DURATION (e.g. "5,6h"). Can be specified multiple times. 100% is implied at the end.',
+      argument: 'PERCENTAGE,DURATION',
+    },
+    {
+      name: 'start',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'When the rollout should start: "now", a future relative time like "1h", or an ISO 8601 datetime',
+      argument: 'TIME',
+    },
+    {
+      name: 'message',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Optional revision message for the update',
+      argument: 'TEXT',
+    },
+  ],
+  examples: [
+    {
+      name: 'Start a progressive boolean rollout in production',
+      value: `${packageName} flags rollout redesigned-checkout --environment production --by user.userId --stage 5,6h --stage 10,6h --stage 25,12h --stage 50,1d`,
+    },
+    {
+      name: 'Schedule a string-flag rollout for later',
+      value: `${packageName} flags rollout welcome-message -e production --by user.userId --from-variant control --to-variant treatment --default-variant control --stage 10,2h --stage 50,12h --start 2026-04-16T09:00:00Z`,
+    },
+    {
+      name: 'Update only the rollout schedule while keeping current variants',
+      value: `${packageName} flags rollout redesigned-checkout -e production --stage 5,30m --stage 25,2h --stage 50,8h`,
+    },
+  ],
+} as const;
+
 export const removeSubcommand = {
   name: 'remove',
   aliases: ['rm'],
@@ -588,6 +688,7 @@ export const flagsCommand = {
     openSubcommand,
     updateSubcommand,
     setSubcommand,
+    rolloutSubcommand,
     removeSubcommand,
     archiveSubcommand,
     disableSubcommand,

--- a/packages/cli/src/commands/flags/index.ts
+++ b/packages/cli/src/commands/flags/index.ts
@@ -13,6 +13,7 @@ import create from './add';
 import openFlag from './open';
 import update from './update';
 import set from './set';
+import rollout from './rollout';
 import rm from './rm';
 import archive from './archive';
 import disable from './disable';
@@ -26,6 +27,7 @@ import {
   openSubcommand,
   updateSubcommand,
   setSubcommand,
+  rolloutSubcommand,
   removeSubcommand,
   archiveSubcommand,
   disableSubcommand,
@@ -44,6 +46,7 @@ const COMMAND_CONFIG = {
   open: getCommandAliases(openSubcommand),
   update: getCommandAliases(updateSubcommand),
   set: getCommandAliases(setSubcommand),
+  rollout: getCommandAliases(rolloutSubcommand),
   rm: getCommandAliases(removeSubcommand),
   archive: getCommandAliases(archiveSubcommand),
   disable: getCommandAliases(disableSubcommand),
@@ -140,6 +143,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandSet(subcommandOriginal);
       return set(client, args);
+    case 'rollout':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('flags', subcommandOriginal);
+        printHelp(rolloutSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRollout(subcommandOriginal);
+      return rollout(client, args);
     case 'rm':
       if (needHelp) {
         telemetry.trackCliFlagHelp('flags', subcommandOriginal);

--- a/packages/cli/src/commands/flags/rollout.ts
+++ b/packages/cli/src/commands/flags/rollout.ts
@@ -1,0 +1,225 @@
+import chalk from 'chalk';
+import deepEqual from 'fast-deep-equal';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getLinkedProject } from '../../util/projects/link';
+import { getCommandName } from '../../util/pkg-name';
+import { getFlag, getFlagSettings } from '../../util/flags/get-flags';
+import { updateFlag } from '../../util/flags/update-flag';
+import { normalizeOptionalInput } from '../../util/flags/normalize-optional-input';
+import {
+  resolveFlagEnvironment,
+  resolveFlagUpdateMessage,
+} from '../../util/flags/environment-variant';
+import {
+  resolveFlagRollout,
+  type ResolvedFlagRollout,
+} from '../../util/flags/rollout';
+import type { Flag } from '../../util/flags/types';
+import output from '../../output-manager';
+import { FlagsRolloutTelemetryClient } from '../../util/telemetry/commands/flags/rollout';
+import { rolloutSubcommand } from './command';
+
+export default async function rollout(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetryClient = new FlagsRolloutTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(rolloutSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { args, flags } = parsedArgs;
+  const [flagArg] = args;
+  const environment = flags['--environment'] as string | undefined;
+  const rollFromVariantSelector = normalizeOptionalInput(
+    flags['--from-variant'] as string | undefined
+  );
+  const rollToVariantSelector = normalizeOptionalInput(
+    flags['--to-variant'] as string | undefined
+  );
+  const defaultVariantSelector = normalizeOptionalInput(
+    flags['--default-variant'] as string | undefined
+  );
+  const baseSelector = normalizeOptionalInput(
+    flags['--by'] as string | undefined
+  );
+  const stageInputs = ((flags['--stage'] as string[] | undefined) || []).map(
+    input => input.trim()
+  );
+  const start = normalizeOptionalInput(flags['--start'] as string | undefined);
+  const message = normalizeOptionalInput(
+    flags['--message'] as string | undefined
+  );
+
+  if (!flagArg) {
+    output.error('Please provide a flag slug or ID to roll out');
+    output.log(
+      `Example: ${getCommandName('flags rollout my-feature --environment production --by user.userId --stage 5,6h --stage 25,1d')}`
+    );
+    return 1;
+  }
+
+  telemetryClient.trackCliArgumentFlag(flagArg);
+  telemetryClient.trackCliOptionEnvironment(environment);
+  telemetryClient.trackCliOptionFromVariant(rollFromVariantSelector);
+  telemetryClient.trackCliOptionToVariant(rollToVariantSelector);
+  telemetryClient.trackCliOptionDefaultVariant(defaultVariantSelector);
+  telemetryClient.trackCliOptionBy(baseSelector);
+  telemetryClient.trackCliOptionStage(
+    stageInputs.length > 0 ? [stageInputs[0]] : undefined
+  );
+  telemetryClient.trackCliOptionStart(start);
+  telemetryClient.trackCliOptionMessage(message);
+
+  const link = await getLinkedProject(client);
+  if (link.status === 'error') {
+    return link.exitCode;
+  } else if (link.status === 'not_linked') {
+    output.error(
+      `Your codebase isn't linked to a project on Vercel. Run ${getCommandName('link')} to begin.`
+    );
+    return 1;
+  }
+
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+
+  const { project } = link;
+
+  try {
+    output.spinner('Fetching flag...');
+    const [flag, settings] = await Promise.all([
+      getFlag(client, project.id, flagArg),
+      getFlagSettings(client, project.id),
+    ]);
+    output.stopSpinner();
+
+    if (flag.state === 'archived') {
+      output.error(
+        `Flag ${chalk.bold(flag.slug)} is archived and cannot be rolled out`
+      );
+      return 1;
+    }
+
+    const selectedEnvironment = await resolveFlagEnvironment(
+      client,
+      flag,
+      environment,
+      'Select an environment to roll out in:',
+      {
+        showEnvironmentDetails: true,
+        decorateChoices: false,
+      }
+    );
+
+    const rolloutConfig = resolveFlagRollout(flag, settings, {
+      stageInputs,
+      baseSelector,
+      rollFromVariantSelector,
+      rollToVariantSelector,
+      defaultVariantSelector,
+      start,
+      currentOutcome: flag.environments[selectedEnvironment].fallthrough,
+    });
+    const nextEnvironmentConfig = buildRolloutEnvironmentConfig(
+      flag.environments[selectedEnvironment],
+      rolloutConfig
+    );
+
+    if (
+      flag.environments[selectedEnvironment].active &&
+      deepEqual(
+        flag.environments[selectedEnvironment].fallthrough,
+        rolloutConfig.outcome
+      ) &&
+      deepEqual(flag.environments[selectedEnvironment], nextEnvironmentConfig)
+    ) {
+      output.warn(
+        `Flag ${chalk.bold(flag.slug)} is already configured with this rollout in ${selectedEnvironment}`
+      );
+      return 0;
+    }
+
+    const updateMessage = await resolveFlagUpdateMessage(
+      client,
+      message,
+      getDefaultRolloutMessage(selectedEnvironment, rolloutConfig)
+    );
+
+    output.spinner(`Updating rollout in ${selectedEnvironment}...`);
+    await updateFlag(client, project.id, flagArg, {
+      environments: {
+        [selectedEnvironment]: nextEnvironmentConfig,
+      },
+      message: updateMessage,
+    });
+    output.stopSpinner();
+
+    output.success(
+      `Feature flag ${chalk.bold(flag.slug)} rollout has been updated in ${chalk.bold(selectedEnvironment)}`
+    );
+    output.log(`  ${chalk.dim('Based on:')} ${rolloutConfig.baseLabel}`);
+    output.log(
+      `  ${chalk.dim('Roll from:')} ${formatVariantLabel(rolloutConfig.rollFromVariant)}`
+    );
+    output.log(
+      `  ${chalk.dim('Roll to:')} ${formatVariantLabel(rolloutConfig.rollToVariant)}`
+    );
+    output.log(
+      `  ${chalk.dim('Fallback:')} ${formatVariantLabel(rolloutConfig.defaultVariant)}`
+    );
+    output.log(`  ${chalk.dim('Start:')} ${rolloutConfig.startLabel}`);
+    output.log(`  ${chalk.dim('Stages:')} ${rolloutConfig.summary}`);
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+
+  return 0;
+}
+
+function buildRolloutEnvironmentConfig(
+  envConfig: Flag['environments'][string],
+  rolloutConfig: ResolvedFlagRollout
+) {
+  return {
+    ...envConfig,
+    active: true,
+    reuse: envConfig.reuse
+      ? {
+          ...envConfig.reuse,
+          active: false,
+        }
+      : undefined,
+    pausedOutcome: envConfig.pausedOutcome || {
+      type: 'variant' as const,
+      variantId: rolloutConfig.defaultVariant.id,
+    },
+    fallthrough: rolloutConfig.outcome,
+  };
+}
+
+function getDefaultRolloutMessage(
+  environment: string,
+  rolloutConfig: ResolvedFlagRollout
+): string {
+  return `Configure rollout for ${environment}: ${rolloutConfig.summary}`;
+}
+
+function formatVariantLabel(variant: { label?: string; id: string }) {
+  return variant.label || variant.id;
+}

--- a/packages/cli/src/util/flags/print-flag-details.ts
+++ b/packages/cli/src/util/flags/print-flag-details.ts
@@ -161,7 +161,7 @@ export function printFlagEnvironmentDetails(
           output.print(`      ${chalk.dim('Default split:')} ${weights}\n`);
         } else if (fallthrough.type === 'rollout') {
           output.print(
-            `      ${chalk.dim('Default rollout:')} ${formatRolloutOutcome(
+            `      ${chalk.dim('Rollout:')} ${formatRolloutOutcome(
               fallthrough,
               flag.variants
             )}\n`

--- a/packages/cli/src/util/flags/print-flag-details.ts
+++ b/packages/cli/src/util/flags/print-flag-details.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import ms from 'ms';
 import output from '../../output-manager';
 import formatDate from '../format-date';
 import { getFlagDashboardUrl } from './dashboard-url';
@@ -8,6 +9,7 @@ import type {
   FlagCondition,
   FlagEnvironmentConfig,
   FlagOutcome,
+  FlagRolloutOutcome,
   FlagSettings,
   FlagSplitOutcome,
   FlagVariant,
@@ -157,6 +159,13 @@ export function printFlagEnvironmentDetails(
             flag.variants
           );
           output.print(`      ${chalk.dim('Default split:')} ${weights}\n`);
+        } else if (fallthrough.type === 'rollout') {
+          output.print(
+            `      ${chalk.dim('Default rollout:')} ${formatRolloutOutcome(
+              fallthrough,
+              flag.variants
+            )}\n`
+          );
         }
       }
     } else {
@@ -231,12 +240,13 @@ function hasCustomConfigurationEnabled(
   return (
     Boolean(envConfig.targets && Object.keys(envConfig.targets).length > 0) ||
     envConfig.rules.length > 0 ||
-    envConfig.fallthrough.type === 'split'
+    envConfig.fallthrough.type === 'split' ||
+    envConfig.fallthrough.type === 'rollout'
   );
 }
 
 function formatEnvironmentOutcome(
-  outcome: FlagOutcome | FlagSplitOutcome,
+  outcome: FlagOutcome | FlagSplitOutcome | FlagRolloutOutcome,
   variants: FlagVariant[]
 ): string {
   if (outcome.type === 'variant') {
@@ -247,6 +257,10 @@ function formatEnvironmentOutcome(
   if (outcome.type === 'split') {
     const weights = formatSplitWeights(outcome.weights, variants);
     return `split (${weights})`;
+  }
+
+  if (outcome.type === 'rollout') {
+    return formatRolloutOutcome(outcome, variants);
   }
 
   return 'unknown';
@@ -285,6 +299,31 @@ function formatEnvironmentVariantSummary(
   }
 
   return chalk.bold(formatVariantValue(variant.value));
+}
+
+function formatRolloutOutcome(
+  outcome: FlagRolloutOutcome,
+  variants: FlagVariant[]
+): string {
+  const fromVariant = variants.find(v => v.id === outcome.rollFromVariantId);
+  const toVariant = variants.find(v => v.id === outcome.rollToVariantId);
+  const stages = outcome.slots
+    .map(slot => {
+      const percentage = slot.promille / 1000;
+      const formattedPercentage = Number.isInteger(percentage)
+        ? String(percentage)
+        : String(Number(percentage.toFixed(3)));
+      return `${formattedPercentage}% for ${ms(slot.durationMs, { long: true })}`;
+    })
+    .join(', ');
+
+  return `rollout (${formatEnvironmentVariantSummary(
+    fromVariant,
+    outcome.rollFromVariantId
+  )} -> ${formatEnvironmentVariantSummary(
+    toVariant,
+    outcome.rollToVariantId
+  )}; ${stages}; then 100%)`;
 }
 
 function formatVariantListSummary(variant: FlagVariant): string {

--- a/packages/cli/src/util/flags/print-flag-details.ts
+++ b/packages/cli/src/util/flags/print-flag-details.ts
@@ -307,6 +307,7 @@ function formatRolloutOutcome(
 ): string {
   const fromVariant = variants.find(v => v.id === outcome.rollFromVariantId);
   const toVariant = variants.find(v => v.id === outcome.rollToVariantId);
+  const defaultVariant = variants.find(v => v.id === outcome.defaultVariantId);
   const stages = outcome.slots
     .map(slot => {
       const percentage = slot.promille / 1000;
@@ -317,13 +318,16 @@ function formatRolloutOutcome(
     })
     .join(', ');
 
-  return `rollout (${formatEnvironmentVariantSummary(
+  return `${formatEnvironmentVariantSummary(
     fromVariant,
     outcome.rollFromVariantId
   )} -> ${formatEnvironmentVariantSummary(
     toVariant,
     outcome.rollToVariantId
-  )}; ${stages}; then 100%)`;
+  )}; ${stages}; then 100%; Fallback: ${formatEnvironmentVariantSummary(
+    defaultVariant,
+    outcome.defaultVariantId
+  )}`;
 }
 
 function formatVariantListSummary(variant: FlagVariant): string {

--- a/packages/cli/src/util/flags/rollout.ts
+++ b/packages/cli/src/util/flags/rollout.ts
@@ -383,10 +383,10 @@ function formatStartLabel(
   if (start === undefined) {
     return currentStartTimestamp
       ? 'preserve current start time'
-      : 'start immediately';
+      : 'immediately';
   }
   if (start === 'now') {
-    return 'start immediately';
+    return 'immediately';
   }
   return `start at ${start}`;
 }

--- a/packages/cli/src/util/flags/rollout.ts
+++ b/packages/cli/src/util/flags/rollout.ts
@@ -1,0 +1,408 @@
+import chalk from 'chalk';
+import ms from 'ms';
+import type { FlagSettings } from './types';
+import { resolveVariant } from './resolve-variant';
+import type {
+  Flag,
+  FlagRolloutOutcome,
+  FlagVariant,
+  FlagSplitOutcome,
+} from './types';
+
+interface ResolveRolloutOptions {
+  stageInputs: string[];
+  baseSelector: string | undefined;
+  rollFromVariantSelector: string | undefined;
+  rollToVariantSelector: string | undefined;
+  defaultVariantSelector: string | undefined;
+  start: string | undefined;
+  currentOutcome?: FlagOutcomeForRollout;
+}
+
+type FlagOutcomeForRollout =
+  | FlagRolloutOutcome
+  | FlagSplitOutcome
+  | { type: 'variant'; variantId: string };
+
+export interface ResolvedFlagRollout {
+  outcome: FlagRolloutOutcome;
+  defaultVariant: FlagVariant;
+  rollFromVariant: FlagVariant;
+  rollToVariant: FlagVariant;
+  baseLabel: string;
+  summary: string;
+  startLabel: string;
+}
+
+export function resolveFlagRollout(
+  flag: Flag,
+  settings: FlagSettings,
+  options: ResolveRolloutOptions
+): ResolvedFlagRollout {
+  const currentRollout =
+    options.currentOutcome?.type === 'rollout'
+      ? options.currentOutcome
+      : undefined;
+
+  const baseSelector =
+    options.baseSelector || formatBaseSelector(currentRollout?.base);
+  if (!baseSelector) {
+    throw new Error(
+      'Missing required flag --by. Use --by <entity.attribute> to choose how users are bucketed.'
+    );
+  }
+  const base = resolveRolloutBase(settings, baseSelector);
+
+  const rollFromVariant = resolveRollFromVariant(
+    flag,
+    options.rollFromVariantSelector,
+    currentRollout
+  );
+  const rollToVariant = resolveRollToVariant(
+    flag,
+    options.rollToVariantSelector,
+    currentRollout
+  );
+
+  if (rollFromVariant.id === rollToVariant.id) {
+    throw new Error(
+      '`--from-variant` and `--to-variant` must resolve to different variants.'
+    );
+  }
+
+  const defaultVariant = resolveDefaultVariant(
+    flag,
+    options.defaultVariantSelector,
+    currentRollout,
+    rollFromVariant
+  );
+
+  const slots =
+    options.stageInputs.length > 0
+      ? parseStageInputs(options.stageInputs)
+      : currentRollout?.slots;
+
+  if (!slots || slots.length === 0) {
+    throw new Error(
+      'At least one --stage is required. Use --stage <PERCENTAGE,DURATION>, for example --stage 5,6h.'
+    );
+  }
+
+  const startTimestamp = resolveRolloutStartTimestamp(
+    options.start,
+    currentRollout?.startTimestamp
+  );
+
+  return {
+    outcome: {
+      type: 'rollout',
+      base,
+      startTimestamp,
+      rollFromVariantId: rollFromVariant.id,
+      rollToVariantId: rollToVariant.id,
+      defaultVariantId: defaultVariant.id,
+      slots,
+    },
+    defaultVariant,
+    rollFromVariant,
+    rollToVariant,
+    baseLabel: `${base.kind}.${base.attribute}`,
+    summary: formatRolloutStages(slots),
+    startLabel: formatStartLabel(options.start, currentRollout?.startTimestamp),
+  };
+}
+
+function resolveRolloutBase(settings: FlagSettings, selector: string) {
+  const separatorIndex = selector.indexOf('.');
+  if (separatorIndex <= 0 || separatorIndex === selector.length - 1) {
+    throw new Error(
+      'Invalid value for --by. Use the format <entity.attribute>, for example --by user.userId.'
+    );
+  }
+
+  const kind = selector.slice(0, separatorIndex);
+  const attribute = selector.slice(separatorIndex + 1);
+  const entity = settings.entities.find(candidate => candidate.kind === kind);
+
+  if (!entity) {
+    const availableKinds = settings.entities.map(candidate => candidate.kind);
+    throw new Error(
+      `Unknown entity ${chalk.bold(kind)}. Available entities: ${availableKinds.join(', ')}`
+    );
+  }
+
+  const matchingAttribute = entity.attributes.find(
+    candidate => candidate.key === attribute
+  );
+  if (!matchingAttribute) {
+    const availableAttributes = entity.attributes.map(
+      candidate => candidate.key
+    );
+    throw new Error(
+      `Unknown attribute ${chalk.bold(selector)}. Available attributes for ${kind}: ${availableAttributes.join(', ')}`
+    );
+  }
+
+  return {
+    type: 'entity' as const,
+    kind,
+    attribute,
+  };
+}
+
+function resolveRollFromVariant(
+  flag: Flag,
+  selector: string | undefined,
+  currentRollout: FlagRolloutOutcome | undefined
+): FlagVariant {
+  if (selector) {
+    return resolveVariantSelector(flag, selector, '--from-variant');
+  }
+
+  if (currentRollout) {
+    return resolveVariantById(
+      flag,
+      currentRollout.rollFromVariantId,
+      '--from-variant'
+    );
+  }
+
+  return inferBooleanVariant(flag, false, '--from-variant');
+}
+
+function resolveRollToVariant(
+  flag: Flag,
+  selector: string | undefined,
+  currentRollout: FlagRolloutOutcome | undefined
+): FlagVariant {
+  if (selector) {
+    return resolveVariantSelector(flag, selector, '--to-variant');
+  }
+
+  if (currentRollout) {
+    return resolveVariantById(
+      flag,
+      currentRollout.rollToVariantId,
+      '--to-variant'
+    );
+  }
+
+  return inferBooleanVariant(flag, true, '--to-variant');
+}
+
+function resolveDefaultVariant(
+  flag: Flag,
+  selector: string | undefined,
+  currentRollout: FlagRolloutOutcome | undefined,
+  rollFromVariant: FlagVariant
+): FlagVariant {
+  if (selector) {
+    return resolveVariantSelector(flag, selector, '--default-variant');
+  }
+
+  if (currentRollout) {
+    return resolveVariantById(
+      flag,
+      currentRollout.defaultVariantId,
+      '--default-variant'
+    );
+  }
+
+  return rollFromVariant;
+}
+
+function resolveVariantSelector(
+  flag: Flag,
+  selector: string,
+  optionName: string
+): FlagVariant {
+  const result = resolveVariant(selector, flag.variants);
+  if (result.error || !result.variant) {
+    throw new Error(
+      `${optionName} ${chalk.bold(selector)} is invalid. ${result.error || 'Variant not found.'}`
+    );
+  }
+
+  return result.variant;
+}
+
+function resolveVariantById(
+  flag: Flag,
+  variantId: string,
+  optionName: string
+): FlagVariant {
+  const variant = flag.variants.find(candidate => candidate.id === variantId);
+  if (!variant) {
+    throw new Error(
+      `${optionName} references an unknown variant ${chalk.bold(variantId)}.`
+    );
+  }
+  return variant;
+}
+
+function inferBooleanVariant(
+  flag: Flag,
+  value: boolean,
+  optionName: string
+): FlagVariant {
+  if (flag.kind !== 'boolean') {
+    throw new Error(
+      `Missing required flag ${optionName}. Use ${optionName} <VARIANT> for non-boolean rollouts.`
+    );
+  }
+
+  const variant = flag.variants.find(candidate => candidate.value === value);
+  if (!variant) {
+    throw new Error(
+      `Flag ${chalk.bold(flag.slug)} is missing the standard boolean variants`
+    );
+  }
+
+  return variant;
+}
+
+function parseStageInputs(stageInputs: string[]) {
+  const slots = stageInputs.map(parseStageInput);
+
+  for (let index = 1; index < slots.length; index++) {
+    if (slots[index].promille <= slots[index - 1].promille) {
+      throw new Error('Stage percentages must be in ascending order.');
+    }
+  }
+
+  return slots;
+}
+
+function parseStageInput(input: string): FlagRolloutOutcome['slots'][number] {
+  const parts = input.split(',').map(part => part.trim());
+  if (parts.length !== 2) {
+    throw new Error(
+      `Invalid stage ${chalk.bold(input)}. Use --stage <PERCENTAGE,DURATION>, for example --stage 5,6h.`
+    );
+  }
+
+  const percentage = Number(parts[0]);
+  if (
+    !Number.isFinite(percentage) ||
+    percentage <= 0 ||
+    percentage >= 100 ||
+    !Number.isInteger(percentage * 1000)
+  ) {
+    throw new Error(
+      `Invalid stage percentage "${parts[0]}". Use a number greater than 0 and less than 100 with up to 3 decimal places.`
+    );
+  }
+
+  const durationMs = parseStageDuration(parts[1]);
+  if (durationMs === undefined) {
+    throw new Error(
+      `Invalid duration "${parts[1]}". Use minutes (e.g. "30m"), hours (e.g. "6h"), or days (e.g. "1d"). Seconds are not supported.`
+    );
+  }
+
+  return {
+    durationMs,
+    promille: Math.round(percentage * 1000),
+  };
+}
+
+function parseStageDuration(value: string): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (/^\d+(s|ms)$/i.test(value)) {
+    return undefined;
+  }
+
+  const durationMs = ms(/^\d+$/.test(value) ? `${value}m` : value);
+  if (durationMs === undefined || durationMs <= 0) {
+    return undefined;
+  }
+
+  const roundedMinutes = Math.round(durationMs / 60000);
+  if (roundedMinutes <= 0) {
+    return undefined;
+  }
+
+  return roundedMinutes * 60000;
+}
+
+function resolveRolloutStartTimestamp(
+  start: string | undefined,
+  currentStartTimestamp: number | undefined
+): number {
+  if (start === undefined) {
+    return currentStartTimestamp ?? Date.now();
+  }
+
+  if (start === 'now') {
+    return Date.now();
+  }
+
+  const relativeDurationMs = ms(start);
+  if (relativeDurationMs !== undefined) {
+    if (relativeDurationMs <= 0) {
+      throw new Error(
+        `Invalid start time "${start}". Use "now", a future relative duration such as "1h", or an ISO 8601 datetime.`
+      );
+    }
+    return Date.now() + relativeDurationMs;
+  }
+
+  const absoluteTime = new Date(start).getTime();
+  if (Number.isNaN(absoluteTime)) {
+    throw new Error(
+      `Invalid start time "${start}". Use "now", a future relative duration such as "1h", or an ISO 8601 datetime.`
+    );
+  }
+
+  return absoluteTime;
+}
+
+function formatRolloutStages(slots: FlagRolloutOutcome['slots']): string {
+  return `${slots
+    .map(
+      slot =>
+        `${formatPromille(slot.promille)} for ${ms(slot.durationMs, { long: true })}`
+    )
+    .join(', ')}, then 100% indefinitely`;
+}
+
+function formatPromille(promille: number): string {
+  const percentage = promille / 1000;
+  return Number.isInteger(percentage)
+    ? `${percentage}%`
+    : `${Number(percentage.toFixed(3))}%`;
+}
+
+function formatStartLabel(
+  start: string | undefined,
+  currentStartTimestamp: number | undefined
+): string {
+  if (start === undefined) {
+    return currentStartTimestamp
+      ? 'preserve current start time'
+      : 'start immediately';
+  }
+  if (start === 'now') {
+    return 'start immediately';
+  }
+  return `start at ${start}`;
+}
+
+function formatBaseSelector(
+  base:
+    | {
+        type: 'entity';
+        kind: string;
+        attribute: string;
+      }
+    | undefined
+): string | undefined {
+  if (!base) {
+    return undefined;
+  }
+
+  return `${base.kind}.${base.attribute}`;
+}

--- a/packages/cli/src/util/flags/types.ts
+++ b/packages/cli/src/util/flags/types.ts
@@ -27,6 +27,23 @@ export interface FlagSplitOutcome {
   defaultVariantId: string;
 }
 
+export interface FlagRolloutOutcome {
+  type: 'rollout';
+  base: {
+    type: 'entity';
+    kind: string;
+    attribute: string;
+  };
+  startTimestamp: number;
+  rollFromVariantId: string;
+  rollToVariantId: string;
+  defaultVariantId: string;
+  slots: Array<{
+    durationMs: number;
+    promille: number;
+  }>;
+}
+
 export interface FlagCondition {
   lhs:
     | { type: 'segment' }
@@ -41,7 +58,7 @@ export interface FlagCondition {
 export interface FlagRule {
   id: string;
   conditions: FlagCondition[];
-  outcome: FlagOutcome | FlagSplitOutcome;
+  outcome: FlagOutcome | FlagSplitOutcome | FlagRolloutOutcome;
 }
 
 export interface FlagEnvironmentConfig {
@@ -51,7 +68,7 @@ export interface FlagEnvironmentConfig {
     environment: string;
   };
   pausedOutcome?: FlagOutcome;
-  fallthrough: FlagOutcome | FlagSplitOutcome;
+  fallthrough: FlagOutcome | FlagSplitOutcome | FlagRolloutOutcome;
   rules: FlagRule[];
   targets?: Record<
     string,

--- a/packages/cli/src/util/telemetry/commands/flags/index.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/index.ts
@@ -47,6 +47,14 @@ export class FlagsTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandRollout(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'rollout',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandRemove(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'rm',

--- a/packages/cli/src/util/telemetry/commands/flags/rollout.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/rollout.ts
@@ -1,0 +1,96 @@
+import { TelemetryClient } from '../..';
+import { STANDARD_ENVIRONMENTS } from '../../../target/standard-environments';
+import type { rolloutSubcommand } from '../../../../commands/flags/command';
+import type { TelemetryMethods } from '../../types';
+
+type StandardEnvironment = (typeof STANDARD_ENVIRONMENTS)[number];
+
+export class FlagsRolloutTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof rolloutSubcommand>
+{
+  trackCliArgumentFlag(flag: string | undefined) {
+    if (flag) {
+      this.trackCliArgument({
+        arg: 'flag',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEnvironment(environment: string | undefined) {
+    if (environment) {
+      this.trackCliOption({
+        option: 'environment',
+        value: STANDARD_ENVIRONMENTS.includes(
+          environment as StandardEnvironment
+        )
+          ? environment
+          : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionFromVariant(variant: string | undefined) {
+    if (variant) {
+      this.trackCliOption({
+        option: 'from-variant',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionToVariant(variant: string | undefined) {
+    if (variant) {
+      this.trackCliOption({
+        option: 'to-variant',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDefaultVariant(variant: string | undefined) {
+    if (variant) {
+      this.trackCliOption({
+        option: 'default-variant',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionBy(base: string | undefined) {
+    if (base) {
+      this.trackCliOption({
+        option: 'by',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionStage(stages: [string] | undefined) {
+    if (stages?.length) {
+      this.trackCliOption({
+        option: 'stage',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionStart(start: string | undefined) {
+    if (start) {
+      this.trackCliOption({
+        option: 'start',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionMessage(message: string | undefined) {
+    if (message) {
+      this.trackCliOption({
+        option: 'message',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/flags/index.test.ts
+++ b/packages/cli/test/unit/commands/flags/index.test.ts
@@ -2,17 +2,20 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import flags from '../../../../src/commands/flags';
 import * as ls from '../../../../src/commands/flags/ls';
 import * as openFlag from '../../../../src/commands/flags/open';
+import * as rolloutFlag from '../../../../src/commands/flags/rollout';
 import * as updateFlag from '../../../../src/commands/flags/update';
 import { client } from '../../../mocks/client';
 
 describe('flags', () => {
   const lsSpy = vi.spyOn(ls, 'default').mockResolvedValue(0);
   const openSpy = vi.spyOn(openFlag, 'default').mockResolvedValue(0);
+  const rolloutSpy = vi.spyOn(rolloutFlag, 'default').mockResolvedValue(0);
   const updateSpy = vi.spyOn(updateFlag, 'default').mockResolvedValue(0);
 
   afterEach(() => {
     lsSpy.mockClear();
     openSpy.mockClear();
+    rolloutSpy.mockClear();
     updateSpy.mockClear();
   });
 
@@ -71,5 +74,21 @@ describe('flags', () => {
     client.setArgv('flags', 'update', ...args);
     await flags(client);
     expect(updateSpy).toHaveBeenCalledWith(client, args);
+  });
+
+  it('routes to rollout subcommand', async () => {
+    const args: string[] = [
+      'my-feature',
+      '--environment',
+      'production',
+      '--by',
+      'user.userId',
+      '--stage',
+      '5,6h',
+    ];
+
+    client.setArgv('flags', 'rollout', ...args);
+    await flags(client);
+    expect(rolloutSpy).toHaveBeenCalledWith(client, args);
   });
 });

--- a/packages/cli/test/unit/commands/flags/rollout.test.ts
+++ b/packages/cli/test/unit/commands/flags/rollout.test.ts
@@ -1,0 +1,426 @@
+import stripAnsi from 'strip-ansi';
+import { beforeEach, describe, expect, it } from 'vitest';
+import flags from '../../../../src/commands/flags';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import { client } from '../../../mocks/client';
+import { useFlags } from '../../../mocks/flags';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+import type { Flag } from '../../../../src/util/flags/types';
+
+function createTestFlags(): Flag[] {
+  return [
+    {
+      id: 'flag_bool123',
+      slug: 'my-feature',
+      description: 'My awesome feature flag',
+      kind: 'boolean',
+      state: 'active',
+      variants: [
+        { id: 'off', value: false, label: 'Off' },
+        { id: 'on', value: true, label: 'On' },
+      ],
+      environments: {
+        production: {
+          active: false,
+          fallthrough: { type: 'variant', variantId: 'off' },
+          pausedOutcome: { type: 'variant', variantId: 'off' },
+          rules: [],
+        },
+        preview: {
+          active: true,
+          fallthrough: { type: 'variant', variantId: 'off' },
+          pausedOutcome: { type: 'variant', variantId: 'off' },
+          rules: [],
+        },
+        development: {
+          active: true,
+          fallthrough: { type: 'variant', variantId: 'on' },
+          pausedOutcome: { type: 'variant', variantId: 'off' },
+          rules: [],
+        },
+      },
+      createdAt: Date.now() - 86400000,
+      updatedAt: Date.now() - 3600000,
+      createdBy: 'user_123',
+      projectId: 'vercel-flags-test',
+      ownerId: 'team_dummy',
+      revision: 1,
+      seed: 12345,
+      typeName: 'flag',
+    },
+    {
+      id: 'flag_string456',
+      slug: 'welcome-message',
+      description: 'A string feature flag',
+      kind: 'string',
+      state: 'active',
+      variants: [
+        { id: 'control', value: 'control', label: 'Control' },
+        { id: 'treatment', value: 'treatment', label: 'Treatment' },
+      ],
+      environments: {
+        production: {
+          active: true,
+          fallthrough: { type: 'variant', variantId: 'control' },
+          pausedOutcome: { type: 'variant', variantId: 'control' },
+          rules: [],
+        },
+        preview: {
+          active: true,
+          fallthrough: { type: 'variant', variantId: 'control' },
+          pausedOutcome: { type: 'variant', variantId: 'control' },
+          rules: [],
+        },
+        development: {
+          active: true,
+          fallthrough: { type: 'variant', variantId: 'control' },
+          pausedOutcome: { type: 'variant', variantId: 'control' },
+          rules: [],
+        },
+      },
+      createdAt: Date.now() - 172800000,
+      updatedAt: Date.now() - 7200000,
+      createdBy: 'user_123',
+      projectId: 'vercel-flags-test',
+      ownerId: 'team_dummy',
+      revision: 2,
+      seed: 67890,
+      typeName: 'flag',
+    },
+  ];
+}
+
+describe('flags rollout', () => {
+  let testFlags: Flag[];
+
+  beforeEach(() => {
+    testFlags = createTestFlags();
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-flags-test',
+      name: 'vercel-flags-test',
+    });
+    useFlags(testFlags);
+    const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+    client.cwd = cwd;
+    (client.stdin as any).isTTY = false;
+  });
+
+  it('tracks rollout usage', async () => {
+    client.setArgv(
+      'flags',
+      'rollout',
+      testFlags[0].slug,
+      '--environment',
+      'production',
+      '--by',
+      'user.userId',
+      '--stage',
+      '5,6h'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:rollout',
+        value: 'rollout',
+      },
+      {
+        key: 'argument:flag',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:environment',
+        value: 'production',
+      },
+      {
+        key: 'option:by',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:stage',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('configures a boolean staged rollout with inferred variants', async () => {
+    client.setArgv(
+      'flags',
+      'rollout',
+      testFlags[0].slug,
+      '--environment',
+      'production',
+      '--by',
+      'user.userId',
+      '--stage',
+      '5,6h',
+      '--stage',
+      '10,12h'
+    );
+
+    const before = Date.now();
+    const exitCode = await flags(client);
+    const after = Date.now();
+
+    expect(exitCode).toEqual(0);
+    expect(testFlags[0].environments.production).toMatchObject({
+      active: true,
+      pausedOutcome: { type: 'variant', variantId: 'off' },
+      fallthrough: {
+        type: 'rollout',
+        base: {
+          type: 'entity',
+          kind: 'user',
+          attribute: 'userId',
+        },
+        rollFromVariantId: 'off',
+        rollToVariantId: 'on',
+        defaultVariantId: 'off',
+        slots: [
+          { promille: 5000, durationMs: 21_600_000 },
+          { promille: 10000, durationMs: 43_200_000 },
+        ],
+      },
+    });
+    const rollout = testFlags[0].environments.production.fallthrough;
+    expect(rollout.type).toBe('rollout');
+    if (rollout.type === 'rollout') {
+      expect(rollout.startTimestamp).toBeGreaterThanOrEqual(before);
+      expect(rollout.startTimestamp).toBeLessThanOrEqual(after);
+    }
+
+    const output = stripAnsi(client.stderr.getFullOutput());
+    expect(output).toContain('rollout has been updated in production');
+    expect(output).toContain('Roll from: Off');
+    expect(output).toContain('Roll to: On');
+    expect(output).toContain('Fallback: Off');
+    expect(output).toContain(
+      'Stages: 5% for 6 hours, 10% for 12 hours, then 100% indefinitely'
+    );
+  });
+
+  it('configures a scheduled rollout for non-boolean flags', async () => {
+    client.setArgv(
+      'flags',
+      'rollout',
+      testFlags[1].slug,
+      '--environment',
+      'production',
+      '--by',
+      'user.userId',
+      '--from-variant',
+      'control',
+      '--to-variant',
+      'treatment',
+      '--default-variant',
+      'control',
+      '--stage',
+      '10,2h',
+      '--stage',
+      '50,12h',
+      '--start',
+      '2026-04-16T09:00:00.000Z'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    expect(testFlags[1].environments.production).toMatchObject({
+      active: true,
+      pausedOutcome: { type: 'variant', variantId: 'control' },
+      fallthrough: {
+        type: 'rollout',
+        base: {
+          type: 'entity',
+          kind: 'user',
+          attribute: 'userId',
+        },
+        startTimestamp: new Date('2026-04-16T09:00:00.000Z').getTime(),
+        rollFromVariantId: 'control',
+        rollToVariantId: 'treatment',
+        defaultVariantId: 'control',
+        slots: [
+          { promille: 10000, durationMs: 7_200_000 },
+          { promille: 50000, durationMs: 43_200_000 },
+        ],
+      },
+    });
+  });
+
+  it('preserves the current rollout start time when updating an existing rollout', async () => {
+    testFlags[0].environments.production.fallthrough = {
+      type: 'rollout',
+      base: {
+        type: 'entity',
+        kind: 'user',
+        attribute: 'userId',
+      },
+      startTimestamp: 1_700_000_000_000,
+      rollFromVariantId: 'off',
+      rollToVariantId: 'on',
+      defaultVariantId: 'off',
+      slots: [{ promille: 5000, durationMs: 3_600_000 }],
+    };
+    testFlags[0].environments.production.active = true;
+
+    client.setArgv(
+      'flags',
+      'rollout',
+      testFlags[0].slug,
+      '--environment',
+      'production',
+      '--stage',
+      '25,6h'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const rollout = testFlags[0].environments.production.fallthrough;
+    expect(rollout.type).toBe('rollout');
+    if (rollout.type === 'rollout') {
+      expect(rollout.startTimestamp).toBe(1_700_000_000_000);
+      expect(rollout.base).toEqual({
+        type: 'entity',
+        kind: 'user',
+        attribute: 'userId',
+      });
+    }
+
+    const output = stripAnsi(client.stderr.getFullOutput());
+    expect(output).toContain('Based on: user.userId');
+  });
+
+  it('preserves custom rules and targets while disabling reuse', async () => {
+    testFlags[0].environments.production = {
+      active: true,
+      reuse: {
+        active: true,
+        environment: 'preview',
+      },
+      fallthrough: { type: 'variant', variantId: 'off' },
+      pausedOutcome: { type: 'variant', variantId: 'off' },
+      rules: [
+        {
+          id: 'rule_custom',
+          conditions: [],
+          outcome: { type: 'variant', variantId: 'on' },
+        },
+      ],
+      targets: {
+        on: {
+          user: {
+            userId: [{ value: 'user_123' }],
+          },
+        },
+      },
+    };
+    client.setArgv(
+      'flags',
+      'rollout',
+      testFlags[0].slug,
+      '--environment',
+      'production',
+      '--by',
+      'user.userId',
+      '--stage',
+      '20,6h'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    expect(testFlags[0].environments.production).toMatchObject({
+      active: true,
+      reuse: {
+        active: false,
+        environment: 'preview',
+      },
+      rules: [
+        {
+          id: 'rule_custom',
+          outcome: { type: 'variant', variantId: 'on' },
+        },
+      ],
+      targets: {
+        on: {
+          user: {
+            userId: [{ value: 'user_123' }],
+          },
+        },
+      },
+    });
+  });
+
+  it('errors when --by is missing for a new rollout', async () => {
+    client.setArgv(
+      'flags',
+      'rollout',
+      testFlags[0].slug,
+      '--environment',
+      'production',
+      '--stage',
+      '10,6h'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing required flag --by'
+    );
+  });
+
+  it('errors when a non-boolean rollout omits --to-variant', async () => {
+    client.setArgv(
+      'flags',
+      'rollout',
+      testFlags[1].slug,
+      '--environment',
+      'production',
+      '--by',
+      'user.userId',
+      '--from-variant',
+      'control',
+      '--stage',
+      '10,6h'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing required flag --to-variant'
+    );
+  });
+
+  it('errors when the stage schedule is not ascending', async () => {
+    client.setArgv(
+      'flags',
+      'rollout',
+      testFlags[0].slug,
+      '--environment',
+      'production',
+      '--by',
+      'user.userId',
+      '--stage',
+      '25,6h',
+      '--stage',
+      '10,6h'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Stage percentages must be in ascending order.'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/flags/rollout.test.ts
+++ b/packages/cli/test/unit/commands/flags/rollout.test.ts
@@ -201,6 +201,7 @@ describe('flags rollout', () => {
     expect(output).toContain('Roll from: Off');
     expect(output).toContain('Roll to: On');
     expect(output).toContain('Fallback: Off');
+    expect(output).toContain('Start: immediately');
     expect(output).toContain(
       'Stages: 5% for 6 hours, 10% for 12 hours, then 100% indefinitely'
     );

--- a/packages/cli/test/unit/util/flags/print-flag-details.test.ts
+++ b/packages/cli/test/unit/util/flags/print-flag-details.test.ts
@@ -173,7 +173,7 @@ describe('printFlagEnvironmentDetails', () => {
 
     expect(printed).toContain('production: custom');
     expect(printed).toContain(
-      'Rollout: rollout (Off -> On; 5% for 6 hours, 10% for 6 hours; then 100%)'
+      'Rollout: Off -> On; 5% for 6 hours, 10% for 6 hours; then 100%; Fallback: Off'
     );
   });
 });

--- a/packages/cli/test/unit/util/flags/print-flag-details.test.ts
+++ b/packages/cli/test/unit/util/flags/print-flag-details.test.ts
@@ -173,7 +173,7 @@ describe('printFlagEnvironmentDetails', () => {
 
     expect(printed).toContain('production: custom');
     expect(printed).toContain(
-      'Default rollout: rollout (Off -> On; 5% for 6 hours, 10% for 6 hours; then 100%)'
+      'Rollout: rollout (Off -> On; 5% for 6 hours, 10% for 6 hours; then 100%)'
     );
   });
 });

--- a/packages/cli/test/unit/util/flags/print-flag-details.test.ts
+++ b/packages/cli/test/unit/util/flags/print-flag-details.test.ts
@@ -129,4 +129,51 @@ describe('printFlagEnvironmentDetails', () => {
 
     expect(printed).toContain('if user.plan is (case-insensitive) pro');
   });
+
+  it('shows rollout schedules', () => {
+    const flag: Flag = {
+      ...testFlag,
+      variants: [
+        { id: 'off', value: false, label: 'Off' },
+        { id: 'on', value: true, label: 'On' },
+      ],
+      environments: {
+        production: {
+          active: true,
+          pausedOutcome: { type: 'variant', variantId: 'off' },
+          fallthrough: {
+            type: 'rollout',
+            base: {
+              type: 'entity',
+              kind: 'user',
+              attribute: 'userId',
+            },
+            startTimestamp: 1,
+            rollFromVariantId: 'off',
+            rollToVariantId: 'on',
+            defaultVariantId: 'off',
+            slots: [
+              { promille: 5000, durationMs: 21_600_000 },
+              { promille: 10000, durationMs: 21_600_000 },
+            ],
+          },
+          rules: [],
+        },
+      },
+    };
+
+    printFlagEnvironmentDetails(flag);
+
+    const printed = stripAnsi(
+      vi
+        .mocked(output.print)
+        .mock.calls.map(([message]) => message)
+        .join('')
+    );
+
+    expect(printed).toContain('production: custom');
+    expect(printed).toContain(
+      'Default rollout: rollout (Off -> On; 5% for 6 hours, 10% for 6 hours; then 100%)'
+    );
+  });
 });


### PR DESCRIPTION
Adds `vercel flags rollout` for progressive rollouts.

Examples:

```bash
vercel flags rollout redesigned-checkout \
  --environment production \
  --by user.userId \
  --stage 5,6h \
  --stage 10,6h \
  --stage 25,12h \
  --stage 50,1d
```

```bash
vercel flags rollout redesigned-checkout \
  --environment production \
  --by user.userId \
  --stage 5,30m \
  --stage 25,2h \
  --stage 50,8h \
  --start now
```

```bash
vercel flags rollout welcome-message \
  --environment production \
  --by user.userId \
  --from-variant control \
  --to-variant treatment \
  --default-variant control \
  --stage 10,2h \
  --stage 50,12h \
  --start 2026-04-16T09:00:00Z
```

```bash
vercel flags rollout redesigned-checkout \
  --environment production \
  --stage 10,6h \
  --stage 50,1d \
  --message "Adjust production rollout schedule"
```
