### PR TITLE
feat(cli): add teams requests ls/approve/reject

### DIFF
--- a/.changeset/teams-requests-cli.md
+++ b/.changeset/teams-requests-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel teams requests` with `ls`, `approve`, and `reject` actions for managing pending team access requests. The new subcommand supports JSON output and requires `--yes` for `reject` in non-interactive mode.

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { formatOption, nextOption } from '../../util/arg-common';
+import { formatOption, nextOption, yesOption } from '../../util/arg-common';
 
 export const requestSubcommand = {
   name: 'request',
@@ -21,6 +21,37 @@ export const requestSubcommand = {
     {
       name: 'Status for another user id',
       value: `${packageName} teams request user_abc123`,
+    },
+  ],
+} as const;
+
+export const requestsSubcommand = {
+  name: 'requests',
+  aliases: [],
+  description: 'Manage pending team access requests',
+  arguments: [
+    {
+      name: 'action',
+      required: false,
+    },
+    {
+      name: 'userId',
+      required: false,
+    },
+  ],
+  options: [formatOption, yesOption],
+  examples: [
+    {
+      name: 'List pending access requests for the current team',
+      value: `${packageName} teams requests ls`,
+    },
+    {
+      name: 'Approve a pending request',
+      value: `${packageName} teams requests approve user_abc123`,
+    },
+    {
+      name: 'Reject a pending request in CI',
+      value: `${packageName} teams requests reject user_abc123 --yes --non-interactive`,
     },
   ],
 } as const;
@@ -173,6 +204,7 @@ export const teamsCommand = {
     inviteSubcommand,
     listSubcommand,
     requestSubcommand,
+    requestsSubcommand,
     switchSubcommand,
     ssoSubcommand,
     membersSubcommand,

--- a/packages/cli/src/commands/teams/index.ts
+++ b/packages/cli/src/commands/teams/index.ts
@@ -3,6 +3,7 @@ import add from './add';
 import change from './switch';
 import invite from './invite';
 import request from './request';
+import requests from './requests';
 import members from './members';
 import sso from './sso';
 import { parseArguments } from '../../util/get-args';
@@ -11,6 +12,7 @@ import {
   inviteSubcommand,
   listSubcommand,
   requestSubcommand,
+  requestsSubcommand,
   membersSubcommand,
   ssoSubcommand,
   switchSubcommand,
@@ -31,6 +33,7 @@ const COMMAND_CONFIG = {
   add: ['create', 'add'],
   invite: ['invite'],
   request: ['request', 'access-request'],
+  requests: ['requests'],
   sso: ['sso'],
   members: ['members', 'member'],
 };
@@ -133,6 +136,15 @@ export default async function teams(client: Client) {
       telemetry.trackCliSubcommandRequest(subcommandOriginal);
       return request(client, args);
     }
+    case 'requests': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('teams', subcommandOriginal);
+        printHelp(requestsSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRequests(subcommandOriginal);
+      return requests(client, args);
+    }
     case 'sso': {
       if (needHelp) {
         telemetry.trackCliFlagHelp('teams', subcommandOriginal);
@@ -153,7 +165,7 @@ export default async function teams(client: Client) {
     }
     default: {
       output.error(
-        'Please specify a valid subcommand: add | ls | switch | invite | request | sso | members'
+        'Please specify a valid subcommand: add | ls | switch | invite | request | requests | sso | members'
       );
       output.print(help(teamsCommand, { columns: client.stderr.columns }));
       return 2;

--- a/packages/cli/src/commands/teams/requests.ts
+++ b/packages/cli/src/commands/teams/requests.ts
@@ -1,0 +1,226 @@
+import type Client from '../../util/client';
+import cmd from '../../util/output/cmd';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { isAPIError, type APIError } from '../../util/errors-ts';
+import { requestsSubcommand } from './command';
+import { validateJsonOutput } from '../../util/output-format';
+import { outputAgentError } from '../../util/agent-output';
+import output from '../../output-manager';
+
+type TeamRequestMember = {
+  uid: string;
+  username?: string;
+  email?: string;
+  name?: string;
+  confirmed: boolean;
+  accessRequestedAt?: number;
+};
+
+type ListResponse = {
+  members?: TeamRequestMember[];
+};
+
+function apiFailureReason(err: APIError): string {
+  if (typeof err.code === 'string' && err.code) {
+    return err.code;
+  }
+  if (typeof err.code === 'number' && Number.isFinite(err.code)) {
+    return String(err.code);
+  }
+  return `http_${err.status}`;
+}
+
+function isPendingAccessRequest(member: TeamRequestMember): boolean {
+  return !member.confirmed && typeof member.accessRequestedAt === 'number';
+}
+
+export default async function requests(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(requestsSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'invalid_arguments',
+          message: error instanceof Error ? error.message : String(error),
+        },
+        1
+      );
+    }
+    printError(error);
+    return 1;
+  }
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'invalid_arguments',
+          message: formatResult.error,
+        },
+        1
+      );
+    }
+    output.error(formatResult.error);
+    return 1;
+  }
+
+  const asJson = formatResult.jsonOutput;
+  const action = parsedArgs.args[0] ?? 'ls';
+  const userId = parsedArgs.args[1];
+  const { currentTeam: teamId } = client.config;
+
+  if (!teamId) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'team_scope_required',
+          message:
+            'Team scope is required for teams requests. Run `vercel teams switch <slug>` or use --scope.',
+          next: [{ command: 'vercel teams switch <slug>' }],
+        },
+        1
+      );
+    }
+    output.error(
+      `This command requires a team scope. Run ${cmd('teams switch')} first.`
+    );
+    return 1;
+  }
+
+  try {
+    if (action === 'ls' || action === 'list') {
+      const response = await client.fetch<ListResponse>(
+        `/v2/teams/${encodeURIComponent(teamId)}/members`
+      );
+      const requests = (response.members ?? []).filter(isPendingAccessRequest);
+
+      if (asJson) {
+        client.stdout.write(`${JSON.stringify({ requests }, null, 2)}\n`);
+        return 0;
+      }
+
+      if (requests.length === 0) {
+        output.log('No pending access requests found.');
+        return 0;
+      }
+
+      output.log(`Found ${requests.length} pending access request(s):`);
+      for (const req of requests) {
+        const id = req.uid;
+        const handle = req.username ? ` @${req.username}` : '';
+        const email = req.email ? ` <${req.email}>` : '';
+        output.print(`- ${id}${handle}${email}`);
+      }
+      return 0;
+    }
+
+    if (action !== 'approve' && action !== 'reject') {
+      output.error(
+        'Invalid action. Use one of: ls | approve <userId> | reject <userId>'
+      );
+      return 2;
+    }
+
+    if (!userId) {
+      output.error(
+        `Missing userId. Usage: vercel teams requests ${action} <userId>`
+      );
+      return 2;
+    }
+
+    if (action === 'approve') {
+      await client.fetch(
+        `/v1/teams/${encodeURIComponent(teamId)}/members/${encodeURIComponent(userId)}`,
+        {
+          method: 'PATCH',
+          body: { confirmed: true },
+        }
+      );
+
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify(
+            { success: true, action: 'approve', teamId, userId },
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        output.success(`Approved access request for ${userId}.`);
+      }
+      return 0;
+    }
+
+    const yes = Boolean(parsedArgs.flags['--yes']);
+    if (!yes) {
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          {
+            status: 'error',
+            reason: 'confirmation_required',
+            message:
+              'Rejecting an access request requires --yes in non-interactive mode.',
+            next: [{ command: `vercel teams requests reject ${userId} --yes` }],
+          },
+          1
+        );
+      }
+      const confirmed = await client.input.confirm(
+        `Reject pending access request for ${userId}?`,
+        false
+      );
+      if (!confirmed) {
+        output.error('Canceled');
+        return 0;
+      }
+    }
+
+    await client.fetch(
+      `/v1/teams/${encodeURIComponent(teamId)}/members/${encodeURIComponent(userId)}`,
+      { method: 'DELETE' }
+    );
+
+    if (asJson) {
+      client.stdout.write(
+        `${JSON.stringify(
+          { success: true, action: 'reject', teamId, userId },
+          null,
+          2
+        )}\n`
+      );
+    } else {
+      output.success(`Rejected access request for ${userId}.`);
+    }
+    return 0;
+  } catch (err: unknown) {
+    if (client.nonInteractive && isAPIError(err)) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: apiFailureReason(err),
+          message: err.serverMessage || err.message,
+        },
+        1
+      );
+    }
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/teams/index.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/index.ts
@@ -51,6 +51,15 @@ export class TeamsTelemetryClient
     }
   }
 
+  trackCliSubcommandRequests(actual?: string) {
+    if (actual) {
+      this.trackCliSubcommand({
+        subcommand: 'requests',
+        value: actual,
+      });
+    }
+  }
+
   trackCliSubcommandSso(actual?: string) {
     if (actual) {
       this.trackCliSubcommand({

--- a/packages/cli/test/unit/commands/teams/requests.test.ts
+++ b/packages/cli/test/unit/commands/teams/requests.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import teams from '../../../../src/commands/teams';
+import { client } from '../../../mocks/client';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+describe('teams requests', () => {
+  const currentTeamId = 'team_requests_test';
+
+  afterEach(() => {
+    client.nonInteractive = false;
+    vi.restoreAllMocks();
+  });
+
+  it('lists pending access requests', async () => {
+    useUser();
+    useTeams(currentTeamId);
+    client.config = { currentTeam: currentTeamId };
+    client.scenario.get(`/v2/teams/${currentTeamId}/members`, (_req, res) => {
+      res.json({
+        members: [
+          {
+            uid: 'user_pending',
+            username: 'pending-user',
+            email: 'pending@example.com',
+            confirmed: false,
+            accessRequestedAt: Date.now(),
+          },
+          {
+            uid: 'user_confirmed',
+            username: 'confirmed-user',
+            confirmed: true,
+          },
+        ],
+      });
+    });
+
+    client.setArgv('teams', 'requests', 'ls');
+    const exitCode = await teams(client);
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain('user_pending');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:requests', value: 'requests' },
+    ]);
+  });
+
+  it('approves a pending request', async () => {
+    useUser();
+    useTeams(currentTeamId);
+    client.config = { currentTeam: currentTeamId };
+    client.scenario.patch(
+      `/v1/teams/${currentTeamId}/members/user_pending`,
+      (_req, res) => {
+        res.json({ ok: true });
+      }
+    );
+
+    client.setArgv('teams', 'requests', 'approve', 'user_pending');
+    const exitCode = await teams(client);
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain('Approved access request');
+  });
+
+  it('rejects a pending request with --yes', async () => {
+    useUser();
+    useTeams(currentTeamId);
+    client.config = { currentTeam: currentTeamId };
+    client.scenario.delete(
+      `/v1/teams/${currentTeamId}/members/user_pending`,
+      (_req, res) => {
+        res.json({ ok: true });
+      }
+    );
+
+    client.setArgv('teams', 'requests', 'reject', 'user_pending', '--yes');
+    const exitCode = await teams(client);
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain('Rejected access request');
+  });
+
+  it('requires --yes for reject in non-interactive mode', async () => {
+    useUser();
+    useTeams(currentTeamId);
+    client.config = { currentTeam: currentTeamId };
+    client.nonInteractive = true;
+
+    client.setArgv('teams', 'requests', 'reject', 'user_pending');
+
+    const exitCode = await teams(client);
+    expect(exitCode).toBe(1);
+    const payload = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(payload).toMatchObject({
+      status: 'error',
+      reason: 'confirmation_required',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `vercel teams requests` aggregate subcommand with `ls`, `approve`, and `reject` actions
- wire new command into teams command parsing/help/telemetry and include non-interactive safety for reject (`--yes` required)
- add unit coverage for list/approve/reject flows plus non-interactive error handling and add a changeset

## Test plan
- [x] `pnpm --filter vercel vitest-run --run --reporter=verbose test/unit/commands/teams/requests.test.ts test/unit/commands/teams/request.test.ts test/unit/commands/teams/index.test.ts`
- [x] `pnpm --filter vercel type-check`
- [x] `pnpm biome lint packages/cli/src/commands/teams/command.ts packages/cli/src/commands/teams/index.ts packages/cli/src/commands/teams/requests.ts packages/cli/src/util/telemetry/commands/teams/index.ts packages/cli/test/unit/commands/teams/requests.test.ts`

Made with [Cursor](https://cursor.com)