### PR TITLE
fix(cli): limit dev framework auto-detection to runtime frameworks only

### DIFF
--- a/.changeset/fix-dev-framework-autodetect.md
+++ b/.changeset/fix-dev-framework-autodetect.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix dev server framework auto-detection to only detect runtime frameworks (Rust, Python, Go, etc.) instead of all frameworks, preventing incorrect devCommand overrides for projects with explicit builds.

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -147,17 +147,19 @@ export default async function dev(
       .env;
   }
 
-  // Auto-detect framework if not already set in project settings
+  // Auto-detect runtime frameworks (e.g., Rust, Python, Go) if not already set.
+  // Only runtime frameworks are auto-detected to avoid overriding the behavior
+  // of projects that use explicit builds in vercel.json (e.g., @vercel/static-build).
   if (!projectSettings?.framework) {
+    const runtimeFrameworks = frameworkList.filter(f => f.runtimeFramework);
     const fs = new LocalFileSystemDetector(cwd);
     const detectedFramework = await detectFramework({
       fs,
-      frameworkList,
-      // Enable experimental frameworks for runtime frameworks like Rust
+      frameworkList: runtimeFrameworks,
       useExperimentalFrameworks: true,
     });
     if (detectedFramework) {
-      output.debug(`Auto-detected framework: ${detectedFramework}`);
+      output.debug(`Auto-detected runtime framework: ${detectedFramework}`);
       projectSettings = {
         ...projectSettings,
         framework: detectedFramework,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The new framework auto-detection in `vercel dev` (added in the `ecklf/add-dev-framework-preset` branch) was detecting **all** frameworks, not just runtime frameworks. This caused CI test failures across all E2E test-dev runners.

### Root Cause

In `packages/cli/src/commands/dev/dev.ts`, the auto-detection code calls `detectFramework()` with the full `frameworkList`, which includes frontend frameworks like UmiJS, Next.js, Gatsby, etc. When a test fixture like `handle-filesystem-missing` has `umi` as a dependency, the framework is auto-detected as `umijs`, which:

1. Sets `projectSettings.framework` to `'umijs'`
2. The `devCommand` getter in `server.ts` resolves to `'umi dev --port $PORT'`
3. The `filterFrontendBuilds` logic removes the explicit `@vercel/static-build` builder from `vercel.json`
4. The dev server tries to run `umi dev` instead of respecting the explicit build config
5. Result: **404 on `GET /`** instead of the expected 200

### Fix

Filter `frameworkList` to only include runtime frameworks (those with `runtimeFramework: true`) before passing it to `detectFramework()`. This limits auto-detection to frameworks like Rust, Python, Go, Node, Ruby, and Actix Web — which was the original intent of the feature.

### CI Failures Analyzed

- **CLI E2E `[vercel dev] do not recursivly check the path`**: Caused by this bug. The `handle-filesystem-missing` fixture has `umi` as a dependency, triggering unwanted UmiJS detection. **Related to PR changes.**
- **`@vercel/backends` `maps service internal function output without leading slash`**: Timeout on Windows CI. No source/test changes to backends in this PR — only version bumps. First run: 1/7 tests timed out. Retry: 5/7 timed out. Consistent with Windows CI resource contention. **Flake, not related to PR changes.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7be4a95a-0a27-47d2-bd8b-b7000f1b49aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7be4a95a-0a27-47d2-bd8b-b7000f1b49aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

