### PR TITLE
feat(cli): add project transfer request/accept/preflight

### DIFF
--- a/.changeset/project-transfer-cli.md
+++ b/.changeset/project-transfer-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project transfer` subcommands for `request`, `accept`, and `preflight` so transfer request workflows can run from the CLI with JSON output and non-interactive confirmation handling.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -506,6 +506,43 @@ export const webAnalyticsSubcommand = {
   ],
 } as const;
 
+export const transferSubcommand = {
+  name: 'transfer',
+  aliases: [],
+  description: 'Manage project transfer requests',
+  arguments: [
+    { name: 'action', required: true },
+    { name: 'value', required: false },
+  ],
+  options: [
+    formatOption,
+    yesOption,
+    {
+      name: 'callback-url',
+      shorthand: null,
+      type: String,
+      argument: 'URL',
+      description:
+        'Optional callback URL for transfer request notifications (request action only).',
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Create a transfer request for a project',
+      value: `${packageName} project transfer request my-project`,
+    },
+    {
+      name: 'Accept a transfer request code',
+      value: `${packageName} project transfer accept <code> --yes`,
+    },
+    {
+      name: 'Preflight resource transfer checks',
+      value: `${packageName} project transfer preflight <code>`,
+    },
+  ],
+} as const;
+
 export const speedInsightsSubcommand = {
   name: 'speed-insights',
   aliases: [],
@@ -547,6 +584,7 @@ export const projectCommand = {
     membersSubcommand,
     accessGroupsSubcommand,
     protectionSubcommand,
+    transferSubcommand,
     webAnalyticsSubcommand,
     speedInsightsSubcommand,
     renameSubcommand,

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -16,6 +16,7 @@ import getOidcToken from './token';
 import speedInsights from './speed-insights';
 import webAnalytics from './web-analytics';
 import protection from './protection';
+import transfer from './transfer';
 import {
   accessGroupsSubcommand,
   addSubcommand,
@@ -30,6 +31,7 @@ import {
   removeSubcommand,
   speedInsightsSubcommand,
   tokenSubcommand,
+  transferSubcommand,
   webAnalyticsSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -52,6 +54,7 @@ const COMMAND_CONFIG = {
   token: getCommandAliases(tokenSubcommand),
   speedInsights: getCommandAliases(speedInsightsSubcommand),
   webAnalytics: getCommandAliases(webAnalyticsSubcommand),
+  transfer: getCommandAliases(transferSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -186,6 +189,12 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandToken(subcommandOriginal);
       return getOidcToken(client, args);
+    case 'transfer':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('project', subcommandOriginal);
+        return printHelp(transferSubcommand);
+      }
+      return transfer(client, args);
     case 'rename':
       if (needHelp) {
         telemetry.trackCliFlagHelp('project', subcommandOriginal);

--- a/packages/cli/src/commands/project/transfer.ts
+++ b/packages/cli/src/commands/project/transfer.ts
@@ -1,0 +1,158 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import output from '../../output-manager';
+import { transferSubcommand } from './command';
+import { validateJsonOutput } from '../../util/output-format';
+import getScope from '../../util/get-scope';
+import { getLinkedProject } from '../../util/projects/link';
+import { outputAgentError } from '../../util/agent-output';
+
+type TransferAction = 'request' | 'accept' | 'preflight';
+
+function ensureTeamId(client: Client, teamId?: string): string | undefined {
+  if (teamId) return teamId;
+  if (client.config.currentTeam) return client.config.currentTeam;
+  return undefined;
+}
+
+export default async function transfer(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(transferSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const action = parsedArgs.args[0] as TransferAction | undefined;
+  const value = parsedArgs.args[1];
+  if (!action || !['request', 'accept', 'preflight'].includes(action)) {
+    output.error(
+      `Invalid action. Usage: ${chalk.cyan('vercel project transfer request [project]')} | ${chalk.cyan('vercel project transfer accept <code> --yes')} | ${chalk.cyan('vercel project transfer preflight <code>')}`
+    );
+    return 2;
+  }
+
+  const scope = await getScope(client);
+  const teamId = ensureTeamId(client, scope.team?.id);
+  if (!teamId) {
+    output.error('A team scope is required. Run `vercel teams switch <slug>`.');
+    return 1;
+  }
+
+  try {
+    if (action === 'request') {
+      let projectIdOrName = value;
+      if (!projectIdOrName) {
+        const linked = await getLinkedProject(client);
+        if (linked.status !== 'linked') {
+          output.error(
+            'No project provided and no linked project found. Pass a project name/id or run `vercel link`.'
+          );
+          return 1;
+        }
+        projectIdOrName = linked.project.id;
+      }
+
+      const callbackUrl = parsedArgs.flags['--callback-url'] as
+        | string
+        | undefined;
+      const body = callbackUrl ? { callbackUrl } : {};
+      const response = await client.fetch<{ code: string }>(
+        `/v1/projects/${encodeURIComponent(projectIdOrName)}/transfer-request`,
+        { method: 'POST', body, json: true }
+      );
+
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify(
+            { action, projectIdOrName, code: response.code },
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        output.success('Project transfer request created.');
+        output.log(`Transfer code: ${chalk.bold(response.code)}`);
+      }
+      return 0;
+    }
+
+    const code = value;
+    if (!code) {
+      output.error(`Missing transfer code for action "${action}".`);
+      return 2;
+    }
+
+    if (action === 'accept') {
+      const yes = Boolean(parsedArgs.flags['--yes']);
+      if (!yes) {
+        if (client.nonInteractive) {
+          outputAgentError(
+            client,
+            {
+              status: 'error',
+              reason: 'confirmation_required',
+              message:
+                'Accepting a project transfer requires --yes in non-interactive mode.',
+            },
+            1
+          );
+          return 1;
+        }
+        const confirmed = await client.input.confirm(
+          `Accept project transfer request ${code}?`,
+          false
+        );
+        if (!confirmed) {
+          output.error('Canceled');
+          return 0;
+        }
+      }
+
+      const response = await client.fetch<Record<string, unknown>>(
+        `/v1/projects/transfer-request/${encodeURIComponent(code)}`,
+        { method: 'PUT', body: {}, json: true }
+      );
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify({ action, code, response }, null, 2)}\n`
+        );
+      } else {
+        output.success('Project transfer request accepted.');
+      }
+      return 0;
+    }
+
+    const response = await client.fetch<Record<string, unknown>>(
+      `/v1/projects/transfer-request/${encodeURIComponent(code)}/preflight`,
+      { method: 'GET' }
+    );
+    if (asJson) {
+      client.stdout.write(
+        `${JSON.stringify({ action, code, response }, null, 2)}\n`
+      );
+    } else {
+      output.success('Transfer preflight completed.');
+      client.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
+    }
+    return 0;
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -96,4 +96,11 @@ export class ProjectTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandTransfer(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'transfer',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/project/transfer.test.ts
+++ b/packages/cli/test/unit/commands/project/transfer.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import project from '../../../../src/commands/project';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+
+describe('project transfer', () => {
+  const teamId = 'team_transfer_test';
+
+  it('creates a transfer request', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.post(
+      `/v1/projects/my-project/transfer-request`,
+      (_req, res) => {
+        res.json({ code: 'tr_123' });
+      }
+    );
+
+    client.setArgv('project', 'transfer', 'request', 'my-project');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain('tr_123');
+  });
+
+  it('accepts a transfer code with --yes', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.put(
+      `/v1/projects/transfer-request/code_123`,
+      (_req, res) => {
+        res.json({ ok: true });
+      }
+    );
+
+    client.setArgv('project', 'transfer', 'accept', 'code_123', '--yes');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain('accepted');
+  });
+
+  it('preflights a transfer code', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.get(
+      `/v1/projects/transfer-request/code_123/preflight`,
+      (_req, res) => {
+        res.json({ results: {} });
+      }
+    );
+
+    client.setArgv(
+      'project',
+      'transfer',
+      'preflight',
+      'code_123',
+      '--format',
+      'json'
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out.action).toBe('preflight');
+  });
+
+  it('requires --yes for accept in non-interactive mode', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.nonInteractive = true;
+    client.setArgv(
+      'project',
+      'transfer',
+      'accept',
+      'code_123',
+      '--non-interactive'
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `vercel project transfer` subcommand with `request`, `accept`, and `preflight` actions
- wire command parsing/help for project commands and add telemetry support for the new transfer subcommand
- add unit tests for request/accept/preflight and non-interactive `--yes` validation, plus a changeset

## Test plan
- [x] `pnpm --filter vercel vitest-run --run --reporter=verbose test/unit/commands/project/transfer.test.ts test/unit/commands/project/index.test.ts`
- [x] `pnpm biome lint packages/cli/src/commands/project/command.ts packages/cli/src/commands/project/index.ts packages/cli/src/commands/project/transfer.ts packages/cli/src/util/telemetry/commands/project/index.ts packages/cli/test/unit/commands/project/transfer.test.ts`
- [ ] `pnpm --filter vercel type-check` (currently fails on pre-existing `build`/`services-orchestrator` type errors on latest `main`)

Made with [Cursor](https://cursor.com)