### PR TITLE
feat(cli): add integration transfers commands

### DIFF
--- a/.changeset/integration-transfers-cli.md
+++ b/.changeset/integration-transfers-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel integration transfers` with `ls`, `accept`, `reject`, and `discard` actions, including non-interactive confirmation handling for destructive transfer actions.

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -289,6 +289,42 @@ export const installationsSubcommand = {
   ],
 } as const;
 
+export const transfersSubcommand = {
+  name: 'transfers',
+  aliases: [],
+  description: 'Manage marketplace transfer requests for an installation',
+  arguments: [
+    { name: 'action', required: true },
+    { name: 'transferId', required: false },
+  ],
+  options: [
+    {
+      name: 'installation-id',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      argument: 'ID',
+      description: 'Installation configuration id',
+    },
+    formatOption,
+    yesOption,
+  ],
+  examples: [
+    {
+      name: 'List transfer requests for an installation',
+      value: `${packageName} integration transfers ls --installation-id icfg_123`,
+    },
+    {
+      name: 'Accept transfer from marketplace',
+      value: `${packageName} integration transfers accept --installation-id icfg_123`,
+    },
+    {
+      name: 'Discard a transfer request',
+      value: `${packageName} integration transfers discard --installation-id icfg_123 --yes`,
+    },
+  ],
+} as const;
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -586,6 +622,7 @@ export const integrationCommand = {
     discoverSubcommand,
     guideSubcommand,
     installationsSubcommand,
+    transfersSubcommand,
     listSubcommand,
     openSubcommand,
     updateSubcommand,

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -20,6 +20,7 @@ import {
   listSubcommand,
   openSubcommand,
   removeSubcommand,
+  transfersSubcommand,
   updateSubcommand,
 } from './command';
 import { list } from './list';
@@ -30,6 +31,7 @@ import { discover } from './discover';
 import { guide } from './guide';
 import { printAddDynamicHelp } from './add-help';
 import installationsList from './installations-list';
+import transfers from './transfers';
 import acceptTerms from './accept-terms';
 import {
   buildCommandWithGlobalFlags,
@@ -44,6 +46,7 @@ const COMMAND_CONFIG = {
   open: getCommandAliases(openSubcommand),
   list: getCommandAliases(listSubcommand),
   installations: getCommandAliases(installationsSubcommand),
+  transfers: getCommandAliases(transfersSubcommand),
   discover: getCommandAliases(discoverSubcommand),
   guide: getCommandAliases(guideSubcommand),
   balance: getCommandAliases(balanceSubcommand),
@@ -153,6 +156,15 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandInstallations(subcommandOriginal);
       return installationsList(client, subArgs);
+    }
+    case 'transfers': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('integration', subcommandOriginal);
+        printHelp(transfersSubcommand);
+        return 0;
+      }
+      telemetry.trackCliSubcommandTransfers(subcommandOriginal);
+      return transfers(client, subArgs);
     }
     case 'discover': {
       if (needHelp) {

--- a/packages/cli/src/commands/integration/transfers.ts
+++ b/packages/cli/src/commands/integration/transfers.ts
@@ -1,0 +1,114 @@
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { transfersSubcommand } from './command';
+import { validateJsonOutput } from '../../util/output-format';
+import { outputAgentError } from '../../util/agent-output';
+
+export default async function transfers(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsed;
+  try {
+    parsed = parseArguments(
+      argv,
+      getFlagsSpecification(transfersSubcommand.options)
+    );
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const action = parsed.args[0];
+  const installationId = parsed.flags['--installation-id'] as
+    | string
+    | undefined;
+  if (!installationId) {
+    output.error('Missing --installation-id.');
+    return 2;
+  }
+
+  const formatResult = validateJsonOutput(parsed.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  try {
+    if (action === 'ls' || action === 'list') {
+      const transfersList = await client.fetch<Record<string, unknown>>(
+        `/v1/integrations/installations/${encodeURIComponent(installationId)}/transfers`
+      );
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify({ transfers: transfersList }, null, 2)}\n`
+        );
+      } else {
+        client.stdout.write(`${JSON.stringify(transfersList, null, 2)}\n`);
+      }
+      return 0;
+    }
+
+    if (action === 'accept') {
+      const response = await client.fetch<Record<string, unknown>>(
+        `/v1/integrations/installations/${encodeURIComponent(installationId)}/transfers/from-marketplace`,
+        { method: 'POST', body: {}, json: true }
+      );
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify({ action, response }, null, 2)}\n`
+        );
+      } else {
+        output.success('Transfer accepted.');
+      }
+      return 0;
+    }
+
+    if (action === 'reject' || action === 'discard') {
+      const yes = Boolean(parsed.flags['--yes']);
+      if (!yes) {
+        if (client.nonInteractive) {
+          outputAgentError(
+            client,
+            {
+              status: 'error',
+              reason: 'confirmation_required',
+              message:
+                'Rejecting/discarding a transfer requires --yes in non-interactive mode.',
+            },
+            1
+          );
+          return 1;
+        }
+        const confirmed = await client.input.confirm(
+          'Discard this transfer request?',
+          false
+        );
+        if (!confirmed) return 0;
+      }
+
+      const response = await client.fetch<Record<string, unknown>>(
+        `/v1/integrations/installations/${encodeURIComponent(installationId)}/transfers/discard`,
+        { method: 'POST', body: {}, json: true }
+      );
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify({ action, response }, null, 2)}\n`
+        );
+      } else {
+        output.success('Transfer discarded.');
+      }
+      return 0;
+    }
+
+    output.error('Invalid action. Use: ls | accept | reject | discard');
+    return 2;
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/integration/index.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/index.ts
@@ -34,6 +34,13 @@ export class IntegrationTelemetryClient
     });
   }
 
+  trackCliSubcommandTransfers(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'transfers',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandDiscover(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'discover',

--- a/packages/cli/test/unit/commands/integration/transfers.test.ts
+++ b/packages/cli/test/unit/commands/integration/transfers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import integration from '../../../../src/commands/integration';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+
+describe('integration transfers', () => {
+  const teamId = 'team_integration_transfer';
+  const installationId = 'icfg_123';
+
+  it('lists transfers', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.get(
+      `/v1/integrations/installations/${installationId}/transfers`,
+      (_req, res) => {
+        res.json({ items: [] });
+      }
+    );
+
+    client.setArgv(
+      'integration',
+      'transfers',
+      'ls',
+      '--installation-id',
+      installationId
+    );
+    const exitCode = await integration(client);
+    expect(exitCode).toBe(0);
+  });
+
+  it('accepts transfer', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.post(
+      `/v1/integrations/installations/${installationId}/transfers/from-marketplace`,
+      (_req, res) => {
+        res.json({ ok: true });
+      }
+    );
+
+    client.setArgv(
+      'integration',
+      'transfers',
+      'accept',
+      '--installation-id',
+      installationId
+    );
+    const exitCode = await integration(client);
+    expect(exitCode).toBe(0);
+  });
+
+  it('discards transfer with --yes', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.post(
+      `/v1/integrations/installations/${installationId}/transfers/discard`,
+      (_req, res) => {
+        res.json({ ok: true });
+      }
+    );
+
+    client.setArgv(
+      'integration',
+      'transfers',
+      'discard',
+      '--installation-id',
+      installationId,
+      '--yes'
+    );
+    const exitCode = await integration(client);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `vercel integration transfers` with `ls`, `accept`, `reject`, and `discard`
- integrate help/dispatch/telemetry support in `integration` command routing
- add tests for transfer list/accept/discard and a changeset

## Test plan
- [x] `pnpm --filter vercel vitest-run --run --reporter=verbose test/unit/commands/integration/transfers.test.ts test/unit/commands/integration/index.test.ts`
- [x] `pnpm biome lint packages/cli/src/commands/integration/command.ts packages/cli/src/commands/integration/index.ts packages/cli/src/commands/integration/transfers.ts packages/cli/src/util/telemetry/commands/integration/index.ts packages/cli/test/unit/commands/integration/transfers.test.ts`
- [ ] `pnpm --filter vercel type-check` (currently fails on pre-existing `build`/`services-orchestrator` type errors on latest `main`)

Made with [Cursor](https://cursor.com)