### PR TITLE
feat(cli): add integration provisioning status/trigger

### DIFF
--- a/.changeset/integration-provisioning-cli.md
+++ b/.changeset/integration-provisioning-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel integration provisioning` with `status` and `trigger` actions for marketplace installation billing provisioning workflows.

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -289,6 +289,34 @@ export const installationsSubcommand = {
   ],
 } as const;
 
+export const provisioningSubcommand = {
+  name: 'provisioning',
+  aliases: [],
+  description: 'Check or trigger installation billing provisioning',
+  arguments: [{ name: 'action', required: true }],
+  options: [
+    {
+      name: 'installation-id',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      argument: 'ID',
+      description: 'Installation configuration id',
+    },
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Get provisioning status',
+      value: `${packageName} integration provisioning status --installation-id icfg_123`,
+    },
+    {
+      name: 'Trigger provisioning',
+      value: `${packageName} integration provisioning trigger --installation-id icfg_123`,
+    },
+  ],
+} as const;
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -586,6 +614,7 @@ export const integrationCommand = {
     discoverSubcommand,
     guideSubcommand,
     installationsSubcommand,
+    provisioningSubcommand,
     listSubcommand,
     openSubcommand,
     updateSubcommand,

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -19,6 +19,7 @@ import {
   integrationCommand,
   listSubcommand,
   openSubcommand,
+  provisioningSubcommand,
   removeSubcommand,
   updateSubcommand,
 } from './command';
@@ -30,6 +31,7 @@ import { discover } from './discover';
 import { guide } from './guide';
 import { printAddDynamicHelp } from './add-help';
 import installationsList from './installations-list';
+import provisioning from './provisioning';
 import acceptTerms from './accept-terms';
 import {
   buildCommandWithGlobalFlags,
@@ -44,6 +46,7 @@ const COMMAND_CONFIG = {
   open: getCommandAliases(openSubcommand),
   list: getCommandAliases(listSubcommand),
   installations: getCommandAliases(installationsSubcommand),
+  provisioning: getCommandAliases(provisioningSubcommand),
   discover: getCommandAliases(discoverSubcommand),
   guide: getCommandAliases(guideSubcommand),
   balance: getCommandAliases(balanceSubcommand),
@@ -153,6 +156,15 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandInstallations(subcommandOriginal);
       return installationsList(client, subArgs);
+    }
+    case 'provisioning': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('integration', subcommandOriginal);
+        printHelp(provisioningSubcommand);
+        return 0;
+      }
+      telemetry.trackCliSubcommandProvisioning(subcommandOriginal);
+      return provisioning(client, subArgs);
     }
     case 'discover': {
       if (needHelp) {

--- a/packages/cli/src/commands/integration/provisioning.ts
+++ b/packages/cli/src/commands/integration/provisioning.ts
@@ -1,0 +1,77 @@
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { provisioningSubcommand } from './command';
+import { validateJsonOutput } from '../../util/output-format';
+
+export default async function provisioning(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsed;
+  try {
+    parsed = parseArguments(
+      argv,
+      getFlagsSpecification(provisioningSubcommand.options)
+    );
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const action = parsed.args[0];
+  const installationId = parsed.flags['--installation-id'] as
+    | string
+    | undefined;
+  if (!installationId) {
+    output.error('Missing --installation-id.');
+    return 2;
+  }
+
+  const formatResult = validateJsonOutput(parsed.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  try {
+    if (action === 'status') {
+      const response = await client.fetch<Record<string, unknown>>(
+        `/v1/integrations/installations/${encodeURIComponent(installationId)}/billing/provision`,
+        { method: 'GET' }
+      );
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify({ action, response }, null, 2)}\n`
+        );
+      } else {
+        client.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
+      }
+      return 0;
+    }
+
+    if (action === 'trigger') {
+      const response = await client.fetch<Record<string, unknown>>(
+        `/v1/integrations/installations/${encodeURIComponent(installationId)}/billing/provision`,
+        { method: 'POST', body: {}, json: true }
+      );
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify({ action, response }, null, 2)}\n`
+        );
+      } else {
+        output.success('Provisioning triggered.');
+      }
+      return 0;
+    }
+
+    output.error('Invalid action. Use: status | trigger');
+    return 2;
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/integration/index.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/index.ts
@@ -34,6 +34,13 @@ export class IntegrationTelemetryClient
     });
   }
 
+  trackCliSubcommandProvisioning(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'provisioning',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandDiscover(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'discover',

--- a/packages/cli/test/unit/commands/integration/provisioning.test.ts
+++ b/packages/cli/test/unit/commands/integration/provisioning.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import integration from '../../../../src/commands/integration';
+import { client } from '../../../mocks/client';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+describe('integration provisioning', () => {
+  const teamId = 'team_integration_provisioning';
+  const installationId = 'icfg_123';
+
+  it('gets provisioning status', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.get(
+      `/v1/integrations/installations/${installationId}/billing/provision`,
+      (_req, res) => {
+        res.json({ status: 'ready' });
+      }
+    );
+
+    client.setArgv(
+      'integration',
+      'provisioning',
+      'status',
+      '--installation-id',
+      installationId,
+      '--format',
+      'json'
+    );
+    const exitCode = await integration(client);
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(client.stdout.getFullOutput().trim()).action).toBe(
+      'status'
+    );
+  });
+
+  it('triggers provisioning', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.post(
+      `/v1/integrations/installations/${installationId}/billing/provision`,
+      (_req, res) => {
+        res.json({ queued: true });
+      }
+    );
+
+    client.setArgv(
+      'integration',
+      'provisioning',
+      'trigger',
+      '--installation-id',
+      installationId
+    );
+    const exitCode = await integration(client);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `vercel integration provisioning` with `status` and `trigger` actions
- wire command parsing/help/telemetry support in `integration` command routing
- add focused unit tests and a changeset for the new subcommands

## Test plan
- [x] `pnpm --filter vercel vitest-run --run --reporter=verbose test/unit/commands/integration/provisioning.test.ts test/unit/commands/integration/index.test.ts`
- [x] `pnpm biome lint packages/cli/src/commands/integration/command.ts packages/cli/src/commands/integration/index.ts packages/cli/src/commands/integration/provisioning.ts packages/cli/src/util/telemetry/commands/integration/index.ts packages/cli/test/unit/commands/integration/provisioning.test.ts`
- [ ] `pnpm --filter vercel type-check` (currently fails on pre-existing `build`/`services-orchestrator` type errors on latest `main`)

Made with [Cursor](https://cursor.com)