### PR TITLE
feat(cli): add billing invoices ls/inspect

### DIFF
--- a/.changeset/billing-invoices-cli.md
+++ b/.changeset/billing-invoices-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel billing invoices ls` and `vercel billing invoices inspect <invoiceId>` by introducing `billing` as an alias for the existing contract command group.

--- a/packages/cli/src/commands/contract/command.ts
+++ b/packages/cli/src/commands/contract/command.ts
@@ -3,7 +3,7 @@ import { packageName } from '../../util/pkg-name';
 
 export const contractCommand = {
   name: 'contract',
-  aliases: [],
+  aliases: ['billing'],
   description: 'Show contract information for all billing periods',
   arguments: [],
   options: [formatOption, jsonOption],

--- a/packages/cli/src/commands/contract/index.ts
+++ b/packages/cli/src/commands/contract/index.ts
@@ -18,6 +18,7 @@ import {
   formatQuantity,
   extractDatePortion,
 } from '../../util/billing/format';
+import { inspectInvoice, listInvoices } from './invoices';
 
 export default async function contract(client: Client): Promise<number> {
   const { print, log, error, spinner } = output;
@@ -50,6 +51,37 @@ export default async function contract(client: Client): Promise<number> {
     return 1;
   }
   const asJson = formatResult.jsonOutput;
+  const billingAction = parsedArgs.args[1];
+
+  if (billingAction === 'invoices') {
+    const invoiceAction = parsedArgs.args[2] ?? 'ls';
+    let teamScope: string | undefined;
+    try {
+      const scope = await getScope(client);
+      teamScope = scope.team?.id;
+    } catch {
+      teamScope = client.config.currentTeam;
+    }
+
+    try {
+      if (invoiceAction === 'ls' || invoiceAction === 'list') {
+        return await listInvoices(client, teamScope, asJson);
+      }
+      if (invoiceAction === 'inspect') {
+        const invoiceId = parsedArgs.args[3];
+        if (!invoiceId) {
+          error('Usage: vercel billing invoices inspect <invoiceId>');
+          return 2;
+        }
+        return await inspectInvoice(client, invoiceId, teamScope, asJson);
+      }
+      error('Usage: vercel billing invoices ls | inspect <invoiceId>');
+      return 2;
+    } catch (err) {
+      output.prettyError(err);
+      return 1;
+    }
+  }
 
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
 

--- a/packages/cli/src/commands/contract/invoices.ts
+++ b/packages/cli/src/commands/contract/invoices.ts
@@ -1,0 +1,44 @@
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import chalk from 'chalk';
+
+export async function listInvoices(
+  client: Client,
+  teamId: string | undefined,
+  asJson: boolean
+): Promise<number> {
+  const query = new URLSearchParams();
+  if (teamId) query.set('teamId', teamId);
+  const path = query.size ? `/v1/invoices?${query}` : '/v1/invoices';
+  const invoices = await client.fetch<Record<string, unknown>>(path);
+
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify({ invoices }, null, 2)}\n`);
+  } else {
+    output.log(chalk.bold('Invoices'));
+    client.stdout.write(`${JSON.stringify(invoices, null, 2)}\n`);
+  }
+  return 0;
+}
+
+export async function inspectInvoice(
+  client: Client,
+  invoiceId: string,
+  teamId: string | undefined,
+  asJson: boolean
+): Promise<number> {
+  const query = new URLSearchParams();
+  if (teamId) query.set('teamId', teamId);
+  const path = query.size
+    ? `/v1/invoices/${encodeURIComponent(invoiceId)}?${query}`
+    : `/v1/invoices/${encodeURIComponent(invoiceId)}`;
+  const invoice = await client.fetch<Record<string, unknown>>(path);
+
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify({ invoice }, null, 2)}\n`);
+  } else {
+    output.log(`${chalk.bold('Invoice')} ${invoiceId}`);
+    client.stdout.write(`${JSON.stringify(invoice, null, 2)}\n`);
+  }
+  return 0;
+}

--- a/packages/cli/test/unit/commands/contract/invoices.test.ts
+++ b/packages/cli/test/unit/commands/contract/invoices.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import contract from '../../../../src/commands/contract';
+import { client } from '../../../mocks/client';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+describe('billing invoices', () => {
+  const teamId = 'team_billing_test';
+
+  it('lists invoices', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.get('/v1/invoices', (_req, res) => {
+      res.json([{ id: 'inv_1' }]);
+    });
+
+    client.setArgv('contract', 'invoices', 'ls', '--format', 'json');
+    const exitCode = await contract(client);
+    expect(exitCode).toBe(0);
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out.invoices[0].id).toBe('inv_1');
+  });
+
+  it('inspects an invoice', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.get('/v1/invoices/inv_1', (_req, res) => {
+      res.json({ id: 'inv_1', amount: 10 });
+    });
+
+    client.setArgv(
+      'contract',
+      'invoices',
+      'inspect',
+      'inv_1',
+      '--format',
+      'json'
+    );
+    const exitCode = await contract(client);
+    expect(exitCode).toBe(0);
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out.invoice.id).toBe('inv_1');
+  });
+});


### PR DESCRIPTION
## Summary
- add `billing` alias for the contract command surface
- implement `billing invoices ls` and `billing invoices inspect <invoiceId>` in CLI
- add unit coverage and a changeset for invoice list/inspect workflows

## Test plan
- [x] `pnpm --filter vercel vitest-run --run --reporter=verbose test/unit/commands/contract/invoices.test.ts test/unit/commands/contract/index.test.ts`
- [x] `pnpm biome lint packages/cli/src/commands/contract/command.ts packages/cli/src/commands/contract/index.ts packages/cli/src/commands/contract/invoices.ts packages/cli/test/unit/commands/contract/invoices.test.ts`
- [ ] `pnpm --filter vercel type-check` (currently fails on pre-existing `build`/`services-orchestrator` type errors on latest `main`)

Made with [Cursor](https://cursor.com)