### PR TITLE
feat(cli): add billing payment-methods commands

### DIFF
--- a/.changeset/billing-payment-methods-cli.md
+++ b/.changeset/billing-payment-methods-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel billing payment-methods ls` and `vercel billing payment-methods set-default` for marketplace installation payment method management.

--- a/packages/cli/src/commands/contract/command.ts
+++ b/packages/cli/src/commands/contract/command.ts
@@ -3,10 +3,29 @@ import { packageName } from '../../util/pkg-name';
 
 export const contractCommand = {
   name: 'contract',
-  aliases: [],
+  aliases: ['billing'],
   description: 'Show contract information for all billing periods',
   arguments: [],
-  options: [formatOption, jsonOption],
+  options: [
+    formatOption,
+    jsonOption,
+    {
+      name: 'installation-id',
+      shorthand: null,
+      type: String,
+      argument: 'ID',
+      description: 'Marketplace installation id for payment-method commands',
+      deprecated: false,
+    },
+    {
+      name: 'payment-method-id',
+      shorthand: null,
+      type: String,
+      argument: 'ID',
+      description: 'Payment method id for payment-method commands',
+      deprecated: false,
+    },
+  ],
   examples: [
     {
       name: 'Show contract information for all billing periods',

--- a/packages/cli/src/commands/contract/index.ts
+++ b/packages/cli/src/commands/contract/index.ts
@@ -18,6 +18,7 @@ import {
   formatQuantity,
   extractDatePortion,
 } from '../../util/billing/format';
+import { listPaymentMethods, setDefaultPaymentMethod } from './payment-methods';
 
 export default async function contract(client: Client): Promise<number> {
   const { print, log, error, spinner } = output;
@@ -50,6 +51,45 @@ export default async function contract(client: Client): Promise<number> {
     return 1;
   }
   const asJson = formatResult.jsonOutput;
+  const billingAction = parsedArgs.args[1];
+
+  if (billingAction === 'payment-methods') {
+    const paymentAction = parsedArgs.args[2] ?? 'ls';
+    try {
+      if (paymentAction === 'ls' || paymentAction === 'list') {
+        return await listPaymentMethods(client, asJson);
+      }
+      if (paymentAction === 'set-default') {
+        const installationId = parsedArgs.flags['--installation-id'] as
+          | string
+          | undefined;
+        const paymentMethodId = parsedArgs.flags['--payment-method-id'] as
+          | string
+          | undefined;
+        telemetry.trackCliOptionInstallationId(installationId);
+        telemetry.trackCliOptionPaymentMethodId(paymentMethodId);
+        if (!installationId || !paymentMethodId) {
+          error(
+            'Usage: vercel billing payment-methods set-default --installation-id <id> --payment-method-id <id>'
+          );
+          return 2;
+        }
+        return await setDefaultPaymentMethod(
+          client,
+          installationId,
+          paymentMethodId,
+          asJson
+        );
+      }
+      error(
+        'Usage: vercel billing payment-methods ls | set-default --installation-id <id> --payment-method-id <id>'
+      );
+      return 2;
+    } catch (err) {
+      output.prettyError(err);
+      return 1;
+    }
+  }
 
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
 

--- a/packages/cli/src/commands/contract/payment-methods.ts
+++ b/packages/cli/src/commands/contract/payment-methods.ts
@@ -1,0 +1,37 @@
+import type Client from '../../util/client';
+import output from '../../output-manager';
+
+export async function listPaymentMethods(
+  client: Client,
+  asJson: boolean
+): Promise<number> {
+  const paymentMethods = await client.fetch<Record<string, unknown>>(
+    '/v1/integrations/installations/payment-methods'
+  );
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify({ paymentMethods }, null, 2)}\n`);
+  } else {
+    client.stdout.write(`${JSON.stringify(paymentMethods, null, 2)}\n`);
+  }
+  return 0;
+}
+
+export async function setDefaultPaymentMethod(
+  client: Client,
+  installationId: string,
+  paymentMethodId: string,
+  asJson: boolean
+): Promise<number> {
+  const response = await client.fetch<Record<string, unknown>>(
+    `/v1/integrations/installations/${encodeURIComponent(installationId)}/payment-method`,
+    { method: 'POST', body: { paymentMethodId }, json: true }
+  );
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify({ response, installationId, paymentMethodId }, null, 2)}\n`
+    );
+  } else {
+    output.success('Default payment method updated.');
+  }
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/contract/index.ts
+++ b/packages/cli/src/util/telemetry/commands/contract/index.ts
@@ -6,9 +6,36 @@ export class ContractTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof contractCommand>
 {
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'format',
+        value,
+      });
+    }
+  }
+
   trackCliFlagJson(json: boolean | undefined) {
     if (json) {
       this.trackCliFlag('json');
+    }
+  }
+
+  trackCliOptionInstallationId(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'installation-id',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionPaymentMethodId(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'payment-method-id',
+        value,
+      });
     }
   }
 }

--- a/packages/cli/test/unit/commands/contract/payment-methods.test.ts
+++ b/packages/cli/test/unit/commands/contract/payment-methods.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import contract from '../../../../src/commands/contract';
+import { client } from '../../../mocks/client';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+describe('billing payment-methods', () => {
+  const teamId = 'team_billing_pm_test';
+
+  it('lists payment methods', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.get(
+      '/v1/integrations/installations/payment-methods',
+      (_req, res) => {
+        res.json([{ id: 'pm_1' }]);
+      }
+    );
+
+    client.setArgv('contract', 'payment-methods', 'ls', '--format', 'json');
+    const exitCode = await contract(client);
+    expect(exitCode).toBe(0);
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out.paymentMethods[0].id).toBe('pm_1');
+  });
+
+  it('sets default payment method', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.post(
+      '/v1/integrations/installations/icfg_1/payment-method',
+      (_req, res) => {
+        res.json({ ok: true });
+      }
+    );
+
+    client.setArgv(
+      'contract',
+      'payment-methods',
+      'set-default',
+      '--installation-id',
+      'icfg_1',
+      '--payment-method-id',
+      'pm_1'
+    );
+    const exitCode = await contract(client);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `billing` alias for contract command usage and implement `billing payment-methods` actions
- add `billing payment-methods ls` and `billing payment-methods set-default`
- include telemetry updates, unit tests, and changeset

## Test plan
- [x] `pnpm --filter vercel vitest-run --run --reporter=verbose test/unit/commands/contract/payment-methods.test.ts test/unit/commands/contract/index.test.ts`
- [x] `pnpm biome lint packages/cli/src/commands/contract/command.ts packages/cli/src/commands/contract/index.ts packages/cli/src/commands/contract/payment-methods.ts packages/cli/src/util/telemetry/commands/contract/index.ts packages/cli/test/unit/commands/contract/payment-methods.test.ts`
- [ ] `pnpm --filter vercel type-check` (currently fails on pre-existing `build`/`services-orchestrator` type errors on latest `main`)

Made with [Cursor](https://cursor.com)