### PR TITLE
feat(cli): add billing plan preview/change

### DIFF
--- a/.changeset/billing-plan-cli.md
+++ b/.changeset/billing-plan-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel billing plan preview` and `vercel billing plan change --to <plan>` commands for plan inspection and change workflows.

--- a/packages/cli/src/commands/contract/command.ts
+++ b/packages/cli/src/commands/contract/command.ts
@@ -3,10 +3,21 @@ import { packageName } from '../../util/pkg-name';
 
 export const contractCommand = {
   name: 'contract',
-  aliases: [],
+  aliases: ['billing'],
   description: 'Show contract information for all billing periods',
   arguments: [],
-  options: [formatOption, jsonOption],
+  options: [
+    formatOption,
+    jsonOption,
+    {
+      name: 'to',
+      shorthand: null,
+      type: String,
+      argument: 'PLAN',
+      description: 'Target plan for billing plan change commands',
+      deprecated: false,
+    },
+  ],
   examples: [
     {
       name: 'Show contract information for all billing periods',

--- a/packages/cli/src/commands/contract/index.ts
+++ b/packages/cli/src/commands/contract/index.ts
@@ -18,6 +18,7 @@ import {
   formatQuantity,
   extractDatePortion,
 } from '../../util/billing/format';
+import { changePlan, previewPlan } from './plan';
 
 export default async function contract(client: Client): Promise<number> {
   const { print, log, error, spinner } = output;
@@ -50,6 +51,30 @@ export default async function contract(client: Client): Promise<number> {
     return 1;
   }
   const asJson = formatResult.jsonOutput;
+  const billingAction = parsedArgs.args[1];
+
+  if (billingAction === 'plan') {
+    const planAction = parsedArgs.args[2] ?? 'preview';
+    try {
+      if (planAction === 'preview') {
+        return await previewPlan(client, asJson);
+      }
+      if (planAction === 'change') {
+        const toPlan = parsedArgs.flags['--to'] as string | undefined;
+        telemetry.trackCliOptionTo(toPlan);
+        if (!toPlan) {
+          error('Usage: vercel billing plan change --to <plan>');
+          return 2;
+        }
+        return await changePlan(client, toPlan, asJson);
+      }
+      error('Usage: vercel billing plan preview | change --to <plan>');
+      return 2;
+    } catch (err) {
+      output.prettyError(err);
+      return 1;
+    }
+  }
 
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
 

--- a/packages/cli/src/commands/contract/plan.ts
+++ b/packages/cli/src/commands/contract/plan.ts
@@ -1,0 +1,38 @@
+import type Client from '../../util/client';
+import output from '../../output-manager';
+
+export async function previewPlan(
+  client: Client,
+  asJson: boolean
+): Promise<number> {
+  const plan = await client.fetch<Record<string, unknown>>('/plan');
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify({ plan }, null, 2)}\n`);
+  } else {
+    client.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+  }
+  return 0;
+}
+
+export async function changePlan(
+  client: Client,
+  toPlan: string,
+  asJson: boolean
+): Promise<number> {
+  const response = await client.fetch<Record<string, unknown>>(
+    '/v1/plan/change',
+    {
+      method: 'PUT',
+      body: { plan: toPlan },
+      json: true,
+    }
+  );
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify({ response, plan: toPlan }, null, 2)}\n`
+    );
+  } else {
+    output.success(`Plan change requested: ${toPlan}`);
+  }
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/contract/index.ts
+++ b/packages/cli/src/util/telemetry/commands/contract/index.ts
@@ -6,9 +6,27 @@ export class ContractTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof contractCommand>
 {
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'format',
+        value,
+      });
+    }
+  }
+
   trackCliFlagJson(json: boolean | undefined) {
     if (json) {
       this.trackCliFlag('json');
+    }
+  }
+
+  trackCliOptionTo(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'to',
+        value,
+      });
     }
   }
 }

--- a/packages/cli/test/unit/commands/contract/plan.test.ts
+++ b/packages/cli/test/unit/commands/contract/plan.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import contract from '../../../../src/commands/contract';
+import { client } from '../../../mocks/client';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+describe('billing plan', () => {
+  const teamId = 'team_billing_plan_test';
+
+  it('previews current plan', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.get('/plan', (_req, res) => {
+      res.json({ current: 'pro' });
+    });
+
+    client.setArgv('contract', 'plan', 'preview', '--format', 'json');
+    const exitCode = await contract(client);
+    expect(exitCode).toBe(0);
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out.plan.current).toBe('pro');
+  });
+
+  it('changes plan with --to', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.put('/v1/plan/change', (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    client.setArgv('contract', 'plan', 'change', '--to', 'enterprise');
+    const exitCode = await contract(client);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `billing` alias for contract usage and implement `billing plan preview|change`
- support plan change target via `--to <plan>`
- add contract telemetry option support for `--to`, tests, and a changeset

## Test plan
- [x] `pnpm --filter vercel vitest-run --run --reporter=verbose test/unit/commands/contract/plan.test.ts test/unit/commands/contract/index.test.ts`
- [x] `pnpm biome lint packages/cli/src/commands/contract/command.ts packages/cli/src/commands/contract/index.ts packages/cli/src/commands/contract/plan.ts packages/cli/src/util/telemetry/commands/contract/index.ts packages/cli/test/unit/commands/contract/plan.test.ts`
- [ ] `pnpm --filter vercel type-check` (currently fails on pre-existing `build`/`services-orchestrator` type errors on latest `main`)

Made with [Cursor](https://cursor.com)