### PR TITLE
feat(cli): add alerts groups commands

### DIFF
--- a/.changeset/alerts-groups-cli.md
+++ b/.changeset/alerts-groups-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel alerts groups` with `ls`, `inspect`, `enable`, and `disable` actions for alert-group management workflows.

--- a/packages/cli/src/commands/alerts/command.ts
+++ b/packages/cli/src/commands/alerts/command.ts
@@ -54,13 +54,53 @@ export const inspectSubcommand = {
   ],
 } as const;
 
+export const groupsSubcommand = {
+  name: 'groups',
+  aliases: [],
+  description: 'Manage alert groups',
+  arguments: [
+    {
+      name: 'action',
+      required: false,
+    },
+    {
+      name: 'groupId',
+      required: false,
+    },
+  ],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'List alert groups',
+      value: `${packageName} alerts groups ls`,
+    },
+    {
+      name: 'Inspect an alert group',
+      value: `${packageName} alerts groups inspect grp_abc123`,
+    },
+    {
+      name: 'Disable an alert group',
+      value: `${packageName} alerts groups disable grp_abc123`,
+    },
+    {
+      name: 'Enable an alert group',
+      value: `${packageName} alerts groups enable grp_abc123`,
+    },
+  ],
+} as const;
+
 export const alertsCommand = {
   name: 'alerts',
   aliases: [],
   description:
     'List alert groups, inspect a group, or manage alert rules (see `alerts rules`).',
   arguments: [],
-  subcommands: [listSubcommand, inspectSubcommand, rulesAggregateCommand],
+  subcommands: [
+    listSubcommand,
+    inspectSubcommand,
+    groupsSubcommand,
+    rulesAggregateCommand,
+  ],
   options: [
     {
       name: 'type',

--- a/packages/cli/src/commands/alerts/groups.ts
+++ b/packages/cli/src/commands/alerts/groups.ts
@@ -1,0 +1,91 @@
+import type Client from '../../util/client';
+import { groupsSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { printError } from '../../util/error';
+import { validateJsonOutput } from '../../util/output-format';
+import getScope from '../../util/get-scope';
+import inspect from './inspect';
+import list from './list';
+import type { AlertsTelemetryClient } from '../../util/telemetry/commands/alerts';
+
+export default async function groups(
+  client: Client,
+  argv: string[],
+  telemetry: AlertsTelemetryClient
+): Promise<number> {
+  let parsed;
+  try {
+    parsed = parseArguments(
+      argv,
+      getFlagsSpecification(groupsSubcommand.options)
+    );
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const action = parsed.args[0] ?? 'ls';
+  const groupId = parsed.args[1];
+
+  if (action === 'ls' || action === 'list') {
+    telemetry.trackCliSubcommandGroups('groups ls');
+    return list(client, telemetry);
+  }
+
+  if (action === 'inspect') {
+    if (!groupId) {
+      output.error('Usage: vercel alerts groups inspect <groupId>');
+      return 2;
+    }
+    telemetry.trackCliSubcommandGroups('groups inspect');
+    return inspect(client, [groupId]);
+  }
+
+  if (action !== 'enable' && action !== 'disable') {
+    output.error('Usage: vercel alerts groups ls|inspect|enable|disable');
+    return 2;
+  }
+
+  if (!groupId) {
+    output.error(`Usage: vercel alerts groups ${action} <groupId>`);
+    return 2;
+  }
+
+  const formatResult = validateJsonOutput(parsed.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  try {
+    const { team } = await getScope(client);
+    if (!team) {
+      output.error('No team scope found.');
+      return 1;
+    }
+    const query = new URLSearchParams({ teamId: team.id });
+    const response = await client.fetch<Record<string, unknown>>(
+      `/alerts/v3/groups/${encodeURIComponent(groupId)}?${query.toString()}`,
+      {
+        method: 'PATCH',
+        body: { enabled: action === 'enable' },
+        json: true,
+      }
+    );
+    telemetry.trackCliSubcommandGroups(`groups ${action}`);
+    if (asJson) {
+      client.stdout.write(
+        `${JSON.stringify({ action, groupId, response }, null, 2)}\n`
+      );
+    } else {
+      output.success(`Alert group ${groupId} ${action}d.`);
+    }
+    return 0;
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/alerts/index.ts
+++ b/packages/cli/src/commands/alerts/index.ts
@@ -13,7 +13,12 @@ import {
   shouldEmitNonInteractiveCommandError,
 } from '../../util/agent-output';
 import { AGENT_REASON } from '../../util/agent-output-constants';
-import { alertsCommand, inspectSubcommand, listSubcommand } from './command';
+import {
+  alertsCommand,
+  groupsSubcommand,
+  inspectSubcommand,
+  listSubcommand,
+} from './command';
 import {
   rulesAddSubcommand,
   rulesAggregateCommand,
@@ -25,6 +30,7 @@ import {
 
 const COMMAND_CONFIG = {
   inspect: getCommandAliases(inspectSubcommand),
+  groups: getCommandAliases(groupsSubcommand),
   ls: getCommandAliases(listSubcommand),
   rules: ['rules'],
 };
@@ -148,6 +154,11 @@ export default async function alerts(client: Client): Promise<number> {
       telemetry.trackCliSubcommandInspect(subcommandOriginal);
       const inspectFn = (await import('./inspect')).default;
       return inspectFn(client, args);
+    }
+    case 'groups': {
+      telemetry.trackCliSubcommandGroups(subcommandOriginal);
+      const groupsFn = (await import('./groups')).default;
+      return groupsFn(client, args, telemetry);
     }
     case 'rules': {
       telemetry.trackCliSubcommandRules(args[0] ?? 'ls');

--- a/packages/cli/src/util/telemetry/commands/alerts/index.ts
+++ b/packages/cli/src/util/telemetry/commands/alerts/index.ts
@@ -29,6 +29,15 @@ export class AlertsTelemetryClient
     });
   }
 
+  trackCliSubcommandGroups(actual: string | undefined) {
+    if (actual) {
+      this.trackCliSubcommand({
+        subcommand: 'groups',
+        value: actual,
+      });
+    }
+  }
+
   trackCliOptionType(v: string[] | undefined) {
     if (v && v.length > 0) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/alerts/groups.test.ts
+++ b/packages/cli/test/unit/commands/alerts/groups.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import alerts from '../../../../src/commands/alerts';
+import { client } from '../../../mocks/client';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+describe('alerts groups', () => {
+  const teamId = 'team_alert_groups_test';
+
+  it('disables a group', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.patch('/alerts/v3/groups/grp_123', (_req, res) => {
+      res.json({ id: 'grp_123', enabled: false });
+    });
+
+    client.setArgv('alerts', 'groups', 'disable', 'grp_123');
+    const exitCode = await alerts(client);
+    expect(exitCode).toBe(0);
+  });
+
+  it('enables a group', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.patch('/alerts/v3/groups/grp_123', (_req, res) => {
+      res.json({ id: 'grp_123', enabled: true });
+    });
+
+    client.setArgv('alerts', 'groups', 'enable', 'grp_123');
+    const exitCode = await alerts(client);
+    expect(exitCode).toBe(0);
+  });
+
+  it('errors when group id is missing', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+
+    client.setArgv('alerts', 'groups', 'disable');
+    const exitCode = await alerts(client);
+    expect(exitCode).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `vercel alerts groups` aggregate subcommands: `ls`, `inspect`, `enable`, and `disable`
- wire alerts command routing and telemetry support for group-specific subcommand tracking
- add unit tests and changeset for alert-group command flows

## Test plan
- [x] `pnpm --filter vercel vitest-run --run --reporter=verbose test/unit/commands/alerts/groups.test.ts test/unit/commands/alerts/index.test.ts`
- [x] `pnpm biome lint packages/cli/src/commands/alerts/command.ts packages/cli/src/commands/alerts/index.ts packages/cli/src/commands/alerts/groups.ts packages/cli/src/util/telemetry/commands/alerts/index.ts packages/cli/test/unit/commands/alerts/groups.test.ts`
- [ ] `pnpm --filter vercel type-check` (currently fails on pre-existing `build`/`services-orchestrator` type errors on latest `main`)

Made with [Cursor](https://cursor.com)