### PR TITLE
feat(cli): add observability notebooks commands

### DIFF
--- a/.changeset/observability-notebooks-cli.md
+++ b/.changeset/observability-notebooks-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel observability notebooks` command set with `ls`, `inspect`, `create`, `update`, and `rm` actions for notebook lifecycle workflows.

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -39,6 +39,7 @@ export { default as mcp } from './commands/mcp';
 export { default as metrics } from './commands/metrics';
 export { default as microfrontends } from './commands/microfrontends';
 export { default as oauthApps } from './commands/oauth-apps';
+export { default as observability } from './commands/observability';
 export { default as open } from './commands/open';
 export { default as project } from './commands/project';
 export { default as promote } from './commands/promote';

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -37,6 +37,7 @@ import { mcpCommand } from './mcp/command';
 import { metricsCommand } from './metrics/command';
 import { microfrontendsCommand } from './microfrontends/command';
 import { oauthAppsCommand } from './oauth-apps/command';
+import { observabilityCommand } from './observability/command';
 import { openCommand } from './open/command';
 import { projectCommand } from './project/command';
 import { promoteCommand } from './promote/command';
@@ -100,6 +101,7 @@ const commandsStructs = [
   mcpCommand,
   microfrontendsCommand,
   oauthAppsCommand,
+  observabilityCommand,
   openCommand,
   projectCommand,
   promoteCommand,

--- a/packages/cli/src/commands/observability/command.ts
+++ b/packages/cli/src/commands/observability/command.ts
@@ -1,0 +1,61 @@
+import { formatOption, yesOption } from '../../util/arg-common';
+import { packageName } from '../../util/pkg-name';
+
+export const notebooksSubcommand = {
+  name: 'notebooks',
+  aliases: [],
+  description: 'Manage observability notebooks',
+  arguments: [
+    { name: 'action', required: true },
+    { name: 'id', required: false },
+  ],
+  options: [
+    formatOption,
+    yesOption,
+    {
+      name: 'name',
+      shorthand: null,
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+      description: 'Notebook name for create/update commands',
+    },
+  ],
+  examples: [
+    {
+      name: 'List notebooks',
+      value: `${packageName} observability notebooks ls`,
+    },
+    {
+      name: 'Inspect a notebook',
+      value: `${packageName} observability notebooks inspect ntb_123`,
+    },
+    {
+      name: 'Create a notebook',
+      value: `${packageName} observability notebooks create --name "SLO Overview"`,
+    },
+    {
+      name: 'Update a notebook name',
+      value: `${packageName} observability notebooks update ntb_123 --name "Platform SLOs"`,
+    },
+    {
+      name: 'Delete a notebook',
+      value: `${packageName} observability notebooks rm ntb_123 --yes`,
+    },
+  ],
+} as const;
+
+export const observabilityCommand = {
+  name: 'observability',
+  aliases: [],
+  description: 'Manage observability resources',
+  arguments: [],
+  subcommands: [notebooksSubcommand],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'List notebooks',
+      value: `${packageName} observability notebooks ls`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/observability/index.ts
+++ b/packages/cli/src/commands/observability/index.ts
@@ -1,0 +1,46 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import getSubcommand from '../../util/get-subcommand';
+import { getCommandAliases } from '..';
+import output from '../../output-manager';
+import { help } from '../help';
+import { notebooksSubcommand, observabilityCommand } from './command';
+import notebooks from './notebooks';
+
+const COMMAND_CONFIG = {
+  notebooks: getCommandAliases(notebooksSubcommand),
+};
+
+export default async function observability(client: Client): Promise<number> {
+  let parsed;
+  try {
+    parsed = parseArguments(
+      client.argv.slice(2),
+      getFlagsSpecification(observabilityCommand.options),
+      { permissive: true }
+    );
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const { subcommand, args } = getSubcommand(
+    parsed.args.slice(1),
+    COMMAND_CONFIG
+  );
+  if (parsed.flags['--help']) {
+    output.print(
+      help(observabilityCommand, { columns: client.stderr.columns })
+    );
+    return 0;
+  }
+
+  if (subcommand === 'notebooks') {
+    return notebooks(client, args);
+  }
+
+  output.error('Usage: vercel observability notebooks <action>');
+  return 2;
+}

--- a/packages/cli/src/commands/observability/notebooks.ts
+++ b/packages/cli/src/commands/observability/notebooks.ts
@@ -1,0 +1,150 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import output from '../../output-manager';
+import { validateJsonOutput } from '../../util/output-format';
+import { notebooksSubcommand } from './command';
+import { outputAgentError } from '../../util/agent-output';
+
+export default async function notebooks(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsed;
+  try {
+    parsed = parseArguments(
+      argv,
+      getFlagsSpecification(notebooksSubcommand.options)
+    );
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const action = parsed.args[0];
+  const id = parsed.args[1];
+  const name = parsed.flags['--name'] as string | undefined;
+  const formatResult = validateJsonOutput(parsed.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  try {
+    if (action === 'ls' || action === 'list') {
+      const notebooks = await client.fetch<Record<string, unknown>>(
+        '/v1/observability/notebook'
+      );
+      if (asJson) {
+        client.stdout.write(`${JSON.stringify({ notebooks }, null, 2)}\n`);
+      } else {
+        client.stdout.write(`${JSON.stringify(notebooks, null, 2)}\n`);
+      }
+      return 0;
+    }
+
+    if (action === 'inspect') {
+      if (!id) {
+        output.error('Usage: vercel observability notebooks inspect <id>');
+        return 2;
+      }
+      const notebook = await client.fetch<Record<string, unknown>>(
+        `/v1/observability/notebook/${encodeURIComponent(id)}`
+      );
+      if (asJson) {
+        client.stdout.write(`${JSON.stringify({ notebook }, null, 2)}\n`);
+      } else {
+        client.stdout.write(`${JSON.stringify(notebook, null, 2)}\n`);
+      }
+      return 0;
+    }
+
+    if (action === 'create') {
+      if (!name) {
+        output.error(
+          'Usage: vercel observability notebooks create --name <name>'
+        );
+        return 2;
+      }
+      const notebook = await client.fetch<Record<string, unknown>>(
+        '/v1/observability/notebook',
+        { method: 'POST', body: { name }, json: true }
+      );
+      if (asJson) {
+        client.stdout.write(`${JSON.stringify({ notebook }, null, 2)}\n`);
+      } else {
+        output.success('Notebook created.');
+      }
+      return 0;
+    }
+
+    if (action === 'update') {
+      if (!id || !name) {
+        output.error(
+          'Usage: vercel observability notebooks update <id> --name <name>'
+        );
+        return 2;
+      }
+      const notebook = await client.fetch<Record<string, unknown>>(
+        `/v1/observability/notebook/${encodeURIComponent(id)}`,
+        { method: 'PATCH', body: { name }, json: true }
+      );
+      if (asJson) {
+        client.stdout.write(`${JSON.stringify({ notebook }, null, 2)}\n`);
+      } else {
+        output.success('Notebook updated.');
+      }
+      return 0;
+    }
+
+    if (action === 'rm' || action === 'remove' || action === 'delete') {
+      if (!id) {
+        output.error('Usage: vercel observability notebooks rm <id> --yes');
+        return 2;
+      }
+      const yes = Boolean(parsed.flags['--yes']);
+      if (!yes) {
+        if (client.nonInteractive) {
+          outputAgentError(
+            client,
+            {
+              status: 'error',
+              reason: 'confirmation_required',
+              message:
+                'Notebook removal requires --yes in non-interactive mode.',
+            },
+            1
+          );
+          return 1;
+        }
+        const confirmed = await client.input.confirm(
+          `Delete notebook ${id}?`,
+          false
+        );
+        if (!confirmed) return 0;
+      }
+      await client.fetch(
+        `/v1/observability/notebook/${encodeURIComponent(id)}`,
+        {
+          method: 'DELETE',
+        }
+      );
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify({ deleted: true, id }, null, 2)}\n`
+        );
+      } else {
+        output.success('Notebook deleted.');
+      }
+      return 0;
+    }
+
+    output.error('Usage: observability notebooks ls|inspect|create|update|rm');
+    return 2;
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -62,6 +62,7 @@ export const help = () => `
       logs                 [url]       Displays the logs for a deployment${metricsLine}
       mcp                              Set up MCP agents and configuration
       microfrontends                   Manages your microfrontends
+      observability        [cmd]       Manages observability resources
       projects                         Manages your Projects
       redirects            [cmd]       Manages redirects for your current Project
       rm | remove          [id]        Removes a deployment

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1047,6 +1047,9 @@ const main = async () => {
           telemetry.trackCliCommandOauthApps(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).oauthApps;
           break;
+        case 'observability':
+          func = (await import('./commands-bulk.js')).observability;
+          break;
         case 'open':
           telemetry.trackCliCommandOpen(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).open;

--- a/packages/cli/test/unit/commands/observability/index.test.ts
+++ b/packages/cli/test/unit/commands/observability/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import observability from '../../../../src/commands/observability';
+import { client } from '../../../mocks/client';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+describe('observability notebooks', () => {
+  const teamId = 'team_observability_test';
+
+  it('lists notebooks', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.get('/v1/observability/notebook', (_req, res) => {
+      res.json([{ id: 'ntb_1' }]);
+    });
+
+    client.setArgv('observability', 'notebooks', 'ls', '--format', 'json');
+    const exitCode = await observability(client);
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(client.stdout.getFullOutput().trim())[0].id).toBe(
+      'ntb_1'
+    );
+  });
+
+  it('creates a notebook', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.post('/v1/observability/notebook', (_req, res) => {
+      res.json({ id: 'ntb_2' });
+    });
+
+    client.setArgv(
+      'observability',
+      'notebooks',
+      'create',
+      '--name',
+      'SLO board'
+    );
+    const exitCode = await observability(client);
+    expect(exitCode).toBe(0);
+  });
+
+  it('deletes a notebook with --yes', async () => {
+    useUser();
+    useTeams(teamId);
+    client.config = { currentTeam: teamId };
+    client.scenario.delete('/v1/observability/notebook/ntb_2', (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    client.setArgv('observability', 'notebooks', 'rm', 'ntb_2', '--yes');
+    const exitCode = await observability(client);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add top-level `vercel observability` command and wire it into command registry/help/runtime dispatch
- add `observability notebooks ls|inspect|create|update|rm` workflows
- include non-interactive guardrails for notebook removal, tests, and a changeset

## Test plan
- [x] `pnpm --filter vercel vitest-run --run --reporter=verbose test/unit/commands/observability/index.test.ts`
- [x] `pnpm biome lint packages/cli/src/commands/observability/command.ts packages/cli/src/commands/observability/index.ts packages/cli/src/commands/observability/notebooks.ts packages/cli/src/commands/index.ts packages/cli/src/commands-bulk.ts packages/cli/src/help.ts packages/cli/src/index.ts packages/cli/test/unit/commands/observability/index.test.ts`
- [ ] `pnpm --filter vercel type-check` (currently fails on pre-existing `build`/`services-orchestrator` type errors on latest `main`)

Made with [Cursor](https://cursor.com)