### PR TITLE
ci: reduce test setup overhead with cache reuse

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,6 +36,9 @@ jobs:
           # Check out the PR commit directly instead of a merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.3.1
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -46,8 +49,6 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-wasip2
-      - name: install pnpm@8.3.1
-        run: npm i -g pnpm@8.3.1
       - run: pnpm install
       - id: affected-packages
         run: |
@@ -188,6 +189,9 @@ jobs:
           fetch-depth: 0
           # Check out the PR commit directly instead of a merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.3.1
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
@@ -196,9 +200,6 @@ jobs:
 
       - name: install yarn@1.22.19
         run: npm i -g yarn@1.22.19
-
-      - name: install pnpm@8.3.1
-        run: npm i -g pnpm@8.3.1
 
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,6 +39,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16
         with:
@@ -189,6 +191,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: install yarn@1.22.19
         run: npm i -g yarn@1.22.19
@@ -202,6 +206,15 @@ jobs:
           version: '0.10.11'
 
       - run: pnpm install
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ github.workflow }}-${{ runner.os }}-${{ matrix.packageName }}-${{ matrix.scriptName }}-${{ matrix.nodeVersion }}-${{ github.event.pull_request.base.sha }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ github.workflow }}-${{ runner.os }}-${{ matrix.packageName }}-${{ matrix.scriptName }}-${{ matrix.nodeVersion }}-${{ github.event.pull_request.base.sha }}-
+            turbo-${{ github.workflow }}-${{ runner.os }}-${{ matrix.packageName }}-${{ matrix.scriptName }}-${{ matrix.nodeVersion }}-
 
       - name: Build ${{matrix.packageName}} and all its dependencies
         run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1
       - run: pnpm install
@@ -309,6 +311,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16
@@ -330,6 +334,15 @@ jobs:
           version: '0.10.11'
 
       - run: pnpm install
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ github.workflow }}-${{ runner.os }}-${{ matrix.packageName }}-${{ matrix.scriptName }}-${{ matrix.nodeVersion }}-${{ github.event.pull_request.base.sha }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ github.workflow }}-${{ runner.os }}-${{ matrix.packageName }}-${{ matrix.scriptName }}-${{ matrix.nodeVersion }}-${{ github.event.pull_request.base.sha }}-
+            turbo-${{ github.workflow }}-${{ runner.os }}-${{ matrix.packageName }}-${{ matrix.scriptName }}-${{ matrix.nodeVersion }}-
 
       - name: Build ${{matrix.packageName}} and all its dependencies
         run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,15 @@ jobs:
           # Check out the PR commit directly instead of a merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }}
+      # pnpm must exist before setup-node cache: pnpm (see actions/setup-node docs)
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.3.1
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-      - name: install pnpm@8.3.1
-        run: npm i -g pnpm@8.3.1
       - run: pnpm install
       - id: affected-packages
         run: |
@@ -308,6 +310,9 @@ jobs:
           fetch-depth: 0 # Need full history for turbo query to work
           # Check out the PR commit directly instead of a merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.3.1
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
@@ -324,9 +329,6 @@ jobs:
       # this can be removed once https://github.com/yarnpkg/yarn/issues/9015 is resolved
       - name: install yarn@1.22.19
         run: npm i -g yarn@1.22.19
-
-      - name: install pnpm@8.3.1
-        run: npm i -g pnpm@8.3.1
 
       - name: install uv@0.10.11
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0


### PR DESCRIPTION
## Summary
- enable built-in pnpm dependency caching in `actions/setup-node` for both unit and e2e workflows
- restore `.turbo` cache per matrix job with branch/base-aware keys to improve cache reuse across PR runs
- keep existing test behavior while reducing repeated install/build setup overhead

## Test plan
- [x] `pnpm lint`
- [ ] `pnpm type-check` *(currently failing on latest `main` due to unrelated workspace errors in `@vercel/build-utils`, `@vercel/fs-detectors`, `@vercel/python`, and `packages/cli`)*
- [ ] Observe CI workflow timing deltas on cache-hit PR runs


Made with [Cursor](https://cursor.com)