### PR TITLE
ci: add fast-lane matrix for earlier test signal

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -282,7 +282,6 @@ jobs:
     if: ${{ needs.setup.outputs['tests'] != '[]' }}
     needs:
       - setup
-      - test-fast
     strategy:
       fail-fast: false
       max-parallel: 75

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps['set-tests'].outputs['tests'] }}
+      fastTests: ${{ steps['set-fast-tests'].outputs['tests'] }}
       dplUrl: ${{ steps.resolveTarball.outputs.url }}
       affectedPackages: ${{ steps['affected-packages'].outputs['packages'] }}
       testStrategy: ${{ steps['affected-packages'].outputs['strategy'] }}
@@ -88,6 +89,16 @@ jobs:
         env:
           TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           TEST_TYPE: e2e
+      - id: set-fast-tests
+        run: |
+          TESTS_ARRAY=$(node utils/chunk-tests.js)
+          echo "Fast-lane E2E tests to run:"
+          echo "$TESTS_ARRAY"
+          echo "tests=$TESTS_ARRAY" >> $GITHUB_OUTPUT
+        env:
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          TEST_TYPE: e2e
+          FAST_LANE: 'true'
       - uses: patrickedqvist/wait-for-vercel-preview@bfdff514ff78a669f2536e9f4dd4ef5813a704a2
         id: waitForTarball
         continue-on-error: true
@@ -168,6 +179,107 @@ jobs:
               'No Vercel preview deployment found for any commit in this PR.'
             );
 
+  test-fast:
+    timeout-minutes: 120
+    runs-on: ${{ matrix.runner }}
+    name: fast-lane (${{matrix.scriptName}}, ${{matrix.packageName}}, chunk ${{matrix.chunkNumber}})
+    if: ${{ needs.setup.outputs['fastTests'] != '[]' }}
+    needs:
+      - setup
+    strategy:
+      fail-fast: true
+      max-parallel: 75
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs['fastTests']) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Check out the PR commit directly instead of a merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.nodeVersion }}
+
+      - name: install yarn@1.22.19
+        run: npm i -g yarn@1.22.19
+
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.10.11'
+
+      - run: pnpm install
+
+      - name: Build ${{matrix.packageName}} and all its dependencies
+        run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...
+        env:
+          FORCE_COLOR: '1'
+      - name: Resolve Python wheel URLs
+        shell: bash
+        run: |
+          DEPLOYMENT_URL="${{ needs.setup.outputs.dplUrl }}"
+
+          PACKAGES_JSON="$(node utils/get-python-packages.js)"
+          if [ -z "$PACKAGES_JSON" ] || [ "$PACKAGES_JSON" = "[]" ]; then
+            echo "No Python packages discovered; skipping wheel URL resolution."
+            exit 0
+          fi
+
+          echo "$PACKAGES_JSON" | jq -c '.[]' | while IFS= read -r package; do
+            package_slug="$(echo "$package" | jq -r '.packageDir')"
+            package_name="$(echo "$package" | jq -r '.packageName')"
+
+            wheel_name="$(curl -sf "$DEPLOYMENT_URL/tarballs/$package_slug-wheel.json" | jq -r '.filename' || echo "")"
+            if [ -z "$wheel_name" ]; then
+              continue
+            fi
+
+            env_var="$(printf '%s' "$package_name" | tr -c '[:alnum:]' '_' | tr '[:lower:]' '[:upper:]')_PYTHON"
+            echo "$env_var=$package_name @ $DEPLOYMENT_URL/tarballs/$wheel_name" >> "$GITHUB_ENV"
+          done
+      - name: Test ${{matrix.packageName}}
+        run: |
+          set -o pipefail
+          attempt=1
+          max_attempts=2
+
+          while [ "$attempt" -le "$max_attempts" ]; do
+            echo "Running tests (attempt $attempt/$max_attempts): ${{matrix.testScript}} ${{matrix.packageName}}"
+            test_log="$(mktemp)"
+
+            if node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }} 2>&1 | tee "$test_log"; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "Tests failed after $max_attempts attempts."
+              exit 1
+            fi
+
+            retry_reason=$(node utils/should-retry-ci-test-failure.js "$test_log") || {
+              echo "Tests failed with non-retryable signature; skipping retry."
+              exit 1
+            }
+            echo "Tests failed due to retryable issue: $retry_reason"
+            echo "Retrying once..."
+            attempt=$((attempt+1))
+          done
+        shell: bash
+        env:
+          # Per-package pip install specs (e.g. VERCEL_RUNTIME_PYTHON,
+          # VERCEL_WORKERS_PYTHON) are also available here, injected into
+          # $GITHUB_ENV by the "Resolve Python wheel URLs" step above.
+          JEST_JUNIT_OUTPUT_FILE: ${{github.workspace}}/.junit-reports/fast-lane-${{matrix.scriptName}}-${{matrix.packageName}}-${{matrix.chunkNumber}}.xml
+          VERCEL_CLI_VERSION: ${{ needs.setup.outputs.dplUrl }}/tarballs/vercel.tgz
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FORCE_COLOR: '1'
+
   test:
     timeout-minutes: 120
     runs-on: ${{ matrix.runner }}
@@ -175,6 +287,7 @@ jobs:
     if: ${{ needs.setup.outputs['tests'] != '[]' }}
     needs:
       - setup
+      - test-fast
     strategy:
       fail-fast: false
       max-parallel: 75
@@ -283,6 +396,7 @@ jobs:
     if: always()
     needs:
       - setup
+      - test-fast
       - test
     steps:
       - name: Check All

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -260,12 +260,7 @@ jobs:
               exit 1
             fi
 
-            retry_reason=$(node utils/should-retry-ci-test-failure.js "$test_log") || {
-              echo "Tests failed with non-retryable signature; skipping retry."
-              exit 1
-            }
-            echo "Tests failed due to retryable issue: $retry_reason"
-            echo "Retrying once..."
+            echo "Tests failed; retrying once..."
             attempt=$((attempt+1))
           done
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -410,7 +410,6 @@ jobs:
     if: ${{ needs.setup.outputs['tests'] != '[]' }}
     needs:
       - setup
-      - test-fast
     strategy:
       fail-fast: false
       max-parallel: 75

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
     if: github.event_name == 'pull_request'
     outputs:
       tests: ${{ steps['set-tests'].outputs['tests'] }}
+      fastTests: ${{ steps['set-fast-tests'].outputs['tests'] }}
       dplUrl: ${{ steps.resolveTarball.outputs.url }}
       affectedPackages: ${{ steps['affected-packages'].outputs['packages'] }}
       testStrategy: ${{ steps['affected-packages'].outputs['strategy'] }}
@@ -86,6 +87,16 @@ jobs:
         env:
           TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           TEST_TYPE: unit
+      - id: set-fast-tests
+        run: |
+          TESTS_ARRAY=$(node utils/chunk-tests.js)
+          echo "Fast-lane unit tests to run:"
+          echo "$TESTS_ARRAY"
+          echo "tests=$TESTS_ARRAY" >> $GITHUB_OUTPUT
+        env:
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          TEST_TYPE: unit
+          FAST_LANE: 'true'
       - uses: patrickedqvist/wait-for-vercel-preview@bfdff514ff78a669f2536e9f4dd4ef5813a704a2
         id: waitForTarball
         continue-on-error: true
@@ -288,6 +299,115 @@ jobs:
               });
             }
 
+  test-fast:
+    timeout-minutes: 120
+    runs-on: ${{ matrix.runner }}
+    name: fast-lane (${{matrix.scriptName}}, ${{matrix.packageName}}, chunk ${{matrix.chunkNumber}})
+    if: ${{ needs.setup.outputs['fastTests'] != '[]' }}
+    needs:
+      - setup
+    strategy:
+      fail-fast: true
+      max-parallel: 75
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs['fastTests']) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Need full history for turbo query to work
+          # Check out the PR commit directly instead of a merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.nodeVersion }}
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16
+        with:
+          toolchain: stable
+          targets: wasm32-wasip2
+
+      # yarn 1.22.21 introduced a Corepack bug when running tests.
+      # this can be removed once https://github.com/yarnpkg/yarn/issues/9015 is resolved
+      - name: install yarn@1.22.19
+        run: npm i -g yarn@1.22.19
+
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+
+      - name: install uv@0.10.11
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.10.11'
+
+      - run: pnpm install
+
+      - name: Build ${{matrix.packageName}} and all its dependencies
+        run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...
+        env:
+          FORCE_COLOR: '1'
+      - name: Resolve Python wheel URLs
+        shell: bash
+        run: |
+          DEPLOYMENT_URL="${{ needs.setup.outputs.dplUrl }}"
+
+          PACKAGES_JSON="$(node utils/get-python-packages.js)"
+          if [ -z "$PACKAGES_JSON" ] || [ "$PACKAGES_JSON" = "[]" ]; then
+            echo "No Python packages discovered; skipping wheel URL resolution."
+            exit 0
+          fi
+
+          echo "$PACKAGES_JSON" | jq -c '.[]' | while IFS= read -r package; do
+            package_slug="$(echo "$package" | jq -r '.packageDir')"
+            package_name="$(echo "$package" | jq -r '.packageName')"
+
+            wheel_name="$(curl -sf "$DEPLOYMENT_URL/tarballs/$package_slug-wheel.json" | jq -r '.filename' || echo "")"
+            if [ -z "$wheel_name" ]; then
+              continue
+            fi
+
+            env_var="$(printf '%s' "$package_name" | tr -c '[:alnum:]' '_' | tr '[:lower:]' '[:upper:]')_PYTHON"
+            echo "$env_var=$package_name @ $DEPLOYMENT_URL/tarballs/$wheel_name" >> "$GITHUB_ENV"
+          done
+      - name: Test ${{matrix.packageName}}
+        run: |
+          set -o pipefail
+          attempt=1
+          max_attempts=2
+
+          while [ "$attempt" -le "$max_attempts" ]; do
+            echo "Running tests (attempt $attempt/$max_attempts): ${{matrix.testScript}} ${{matrix.packageName}}"
+            test_log="$(mktemp)"
+
+            if node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }} 2>&1 | tee "$test_log"; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "Tests failed after $max_attempts attempts."
+              exit 1
+            fi
+
+            retry_reason=$(node utils/should-retry-ci-test-failure.js "$test_log") || {
+              echo "Tests failed with non-retryable signature; skipping retry."
+              exit 1
+            }
+            echo "Tests failed due to retryable issue: $retry_reason"
+            echo "Retrying once..."
+            attempt=$((attempt+1))
+          done
+        shell: bash
+        env:
+          # Per-package pip install specs (e.g. VERCEL_RUNTIME_PYTHON,
+          # VERCEL_WORKERS_PYTHON) are also available here, injected into
+          # $GITHUB_ENV by the "Resolve Python wheel URLs" step above.
+          JEST_JUNIT_OUTPUT_FILE: ${{github.workspace}}/.junit-reports/fast-lane-${{matrix.scriptName}}-${{matrix.packageName}}-${{matrix.chunkNumber}}.xml
+          VERCEL_CLI_VERSION: ${{ needs.setup.outputs.dplUrl }}/tarballs/vercel.tgz
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FORCE_COLOR: '1'
+
   test:
     timeout-minutes: 120
     runs-on: ${{ matrix.runner }}
@@ -295,6 +415,7 @@ jobs:
     if: ${{ needs.setup.outputs['tests'] != '[]' }}
     needs:
       - setup
+      - test-fast
     strategy:
       fail-fast: false
       max-parallel: 75
@@ -411,6 +532,7 @@ jobs:
     if: always()
     needs:
       - setup
+      - test-fast
       - test
     steps:
       - name: Check All

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -388,12 +388,7 @@ jobs:
               exit 1
             fi
 
-            retry_reason=$(node utils/should-retry-ci-test-failure.js "$test_log") || {
-              echo "Tests failed with non-retryable signature; skipping retry."
-              exit 1
-            }
-            echo "Tests failed due to retryable issue: $retry_reason"
-            echo "Retrying once..."
+            echo "Tests failed; retrying once..."
             attempt=$((attempt+1))
           done
         shell: bash

--- a/test/utils/chunk-tests/index.test.js
+++ b/test/utils/chunk-tests/index.test.js
@@ -1,0 +1,41 @@
+const { applyFastLaneRunnerOptions } = require('../../../utils/chunk-tests');
+
+describe('applyFastLaneRunnerOptions', () => {
+  const originalFastLane = process.env.FAST_LANE;
+
+  afterEach(() => {
+    process.env.FAST_LANE = originalFastLane;
+  });
+
+  it('returns original options when FAST_LANE is disabled', () => {
+    process.env.FAST_LANE = 'false';
+
+    const options = {
+      min: 1,
+      max: 7,
+      testScript: 'test',
+      runners: ['ubuntu-latest', 'macos-14', 'windows-latest'],
+      nodeVersions: ['20', '22', '24'],
+    };
+
+    expect(applyFastLaneRunnerOptions(options)).toEqual(options);
+  });
+
+  it('reduces runners and node versions when FAST_LANE is enabled', () => {
+    process.env.FAST_LANE = 'true';
+
+    const options = {
+      min: 1,
+      max: 7,
+      testScript: 'test',
+      runners: ['ubuntu-latest', 'macos-14', 'windows-latest'],
+      nodeVersions: ['20', '22', '24'],
+    };
+
+    expect(applyFastLaneRunnerOptions(options)).toEqual({
+      ...options,
+      runners: ['ubuntu-latest'],
+      nodeVersions: ['22'],
+    });
+  });
+});

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -123,7 +123,24 @@ function getRunnerOptions(scriptName, packageName) {
       `Unable to find runner options for package "${packageName}" and script ${scriptName}`
     );
   }
-  return runnerOptions;
+  return applyFastLaneRunnerOptions(runnerOptions);
+}
+
+function applyFastLaneRunnerOptions(runnerOptions) {
+  const isFastLane = process.env.FAST_LANE === 'true';
+  if (!isFastLane) {
+    return runnerOptions;
+  }
+
+  const filteredRunners = runnerOptions.runners.includes('ubuntu-latest')
+    ? ['ubuntu-latest']
+    : runnerOptions.runners;
+
+  return {
+    ...runnerOptions,
+    runners: filteredRunners,
+    nodeVersions: ['22'],
+  };
 }
 
 async function getChunkedTests() {
@@ -322,5 +339,6 @@ if (module === require.main || !module.parent) {
 }
 
 module.exports = {
+  applyFastLaneRunnerOptions,
   intoChunks,
 };


### PR DESCRIPTION
## Summary
- add a dedicated `fastTests` matrix output in both unit and e2e setup jobs via `FAST_LANE=true`
- add a new `test-fast` job (ubuntu + node 22 + affected packages) that runs before the full matrix
- keep full matrix coverage in `test` while separating early signal from broader confidence
- add unit tests for `utils/chunk-tests` fast-lane runner filtering

## Test plan
- [x] `pnpm test test/utils/chunk-tests/index.test.js`
- [x] `pnpm lint`
- [ ] `pnpm type-check` *(currently failing on latest `main` due to unrelated workspace errors in `@vercel/build-utils`, `@vercel/fs-detectors`, `@vercel/python`, and `packages/cli`)*


Made with [Cursor](https://cursor.com)