### PR TITLE
chore(ci): generate missing changesets via Vercel AI Gateway

### DIFF
--- a/.github/workflows/ci-changeset-ai.yml
+++ b/.github/workflows/ci-changeset-ai.yml
@@ -1,0 +1,118 @@
+# When Lint fails because a changeset is missing, generate one via Vercel AI Gateway and push to the PR branch.
+# Requires repository secrets: AI_GATEWAY_API_KEY, VERCEL_CLI_RELEASE_BOT_TOKEN (push + checkout).
+# Does not run for fork PRs (cannot push to contributor forks).
+
+name: CI — Changeset (AI Gateway)
+
+on:
+  workflow_run:
+    workflows:
+      - Lint
+    types:
+      - completed
+
+concurrency:
+  group: changeset-ai-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  generate-changeset:
+    name: Generate changeset
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    steps:
+      - name: Resolve PR for workflow run
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const { data: pulls } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              });
+            if (!pulls.length) {
+              core.setOutput('found', 'false');
+              return;
+            }
+            const pr = pulls[0];
+            core.setOutput('found', 'true');
+            core.setOutput('number', String(pr.number));
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('title', pr.title || '');
+            core.setOutput('body', pr.body || '');
+
+      - name: Checkout PR head
+        if: steps.pr.outputs.found == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.head_ref }}
+          token: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }}
+
+      - name: Install pnpm
+        if: steps.pr.outputs.found == 'true'
+        run: npm i -g pnpm@8.3.1
+
+      - name: Install dependencies
+        if: steps.pr.outputs.found == 'true'
+        run: pnpm install
+
+      - name: Fetch main for changeset base
+        if: steps.pr.outputs.found == 'true'
+        run: git fetch origin main
+
+      - name: Check whether a changeset is still required
+        id: need
+        if: steps.pr.outputs.found == 'true'
+        run: |
+          set +e
+          pnpm exec changeset status --since=main
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "needs_changeset=false" >> $GITHUB_OUTPUT
+          else
+            echo "needs_changeset=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate changeset with AI Gateway
+        if: steps.pr.outputs.found == 'true' && steps.need.outputs.needs_changeset == 'true'
+        env:
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_BODY: ${{ steps.pr.outputs.body }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          if [ -z "$AI_GATEWAY_API_KEY" ]; then
+            echo "::error::Add repository secret AI_GATEWAY_API_KEY (Vercel AI Gateway API key)."
+            exit 1
+          fi
+          node scripts/ci/generate-changeset-ai.mjs
+
+      - name: Validate changeset
+        if: steps.pr.outputs.found == 'true' && steps.need.outputs.needs_changeset == 'true'
+        run: pnpm exec changeset status --since=main
+
+      - name: Commit and push
+        if: steps.pr.outputs.found == 'true' && steps.need.outputs.needs_changeset == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .changeset
+          if git diff --cached --quiet; then
+            echo "No changeset file to commit"
+            exit 1
+          fi
+          git commit -m "chore: add changeset (ci ai-gateway)"
+          git push origin "HEAD:${{ steps.pr.outputs.head_ref }}"

--- a/scripts/ci/generate-changeset-ai.mjs
+++ b/scripts/ci/generate-changeset-ai.mjs
@@ -1,0 +1,134 @@
+/**
+ * Generates a .changeset file via Vercel AI Gateway when CI requires one.
+ * Requires: AI_GATEWAY_API_KEY, GITHUB_REPOSITORY, PR_TITLE, PR_BODY (optional)
+ */
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const gatewayUrl =
+  process.env.AI_GATEWAY_BASE_URL || 'https://ai-gateway.vercel.sh/v1';
+const model = process.env.CHANGESET_AI_MODEL || 'openai/gpt-5.4';
+
+function getChangedPackageNames() {
+  const out = execSync('git diff --name-only origin/main...HEAD', {
+    encoding: 'utf8',
+    cwd: repoRoot,
+  }).trim();
+  if (!out) return [];
+  const names = new Set();
+  for (const file of out.split('\n').filter(Boolean)) {
+    let dir = path.dirname(path.join(repoRoot, file));
+    while (dir.startsWith(repoRoot)) {
+      const pkgJson = path.join(dir, 'package.json');
+      if (fs.existsSync(pkgJson)) {
+        try {
+          const { name } = JSON.parse(fs.readFileSync(pkgJson, 'utf8'));
+          if (name && typeof name === 'string') names.add(name);
+        } catch {
+          /* ignore */
+        }
+        break;
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+  return [...names].sort();
+}
+
+function extractMarkdown(text) {
+  const fence = /```(?:markdown)?\s*([\s\S]*?)```/;
+  const m = text.match(fence);
+  return (m ? m[1] : text).trim();
+}
+
+async function main() {
+  const apiKey = process.env.AI_GATEWAY_API_KEY;
+  if (!apiKey) {
+    console.error('AI_GATEWAY_API_KEY is not set');
+    process.exit(1);
+  }
+
+  const packages = getChangedPackageNames();
+  const title = process.env.PR_TITLE || '';
+  const body = process.env.PR_BODY || '';
+  const diffStat = execSync('git diff --stat origin/main...HEAD', {
+    encoding: 'utf8',
+    cwd: repoRoot,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  const prompt = `You write @changesets/cli compatible changelog entries for the Vercel monorepo.
+
+Changed workspace package names (npm package names, use exactly as given):
+${packages.length ? packages.map(p => `- ${p}`).join('\n') : '- (infer from diff if none listed; use vercel for packages/cli only changes)'}
+
+PR title: ${title}
+
+PR description (truncated):
+${body.slice(0, 8000)}
+
+Diff stat (truncated):
+${diffStat.slice(0, 12000)}
+
+Rules:
+1. Output ONLY the contents of a single new file — no preamble.
+2. Use this exact shape (YAML frontmatter + summary line(s)):
+---
+'package-name': patch
+---
+Concise imperative summary of user-visible change (one line or short paragraph).
+3. Use patch unless the PR clearly warrants minor/major.
+4. Quote keys that contain special characters (e.g. '@vercel/foo': patch).
+5. Include every changed workspace package that needs versioning; omit tooling-only paths if no package changed.
+6. If only repo-level files changed, you may use "vercel": patch for the CLI package when appropriate.
+
+Generate the changeset file now.`;
+
+  const res = await fetch(`${gatewayUrl.replace(/\/$/, '')}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.2,
+    }),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    console.error('AI Gateway error:', res.status, errText);
+    process.exit(1);
+  }
+
+  const data = await res.json();
+  const text = data?.choices?.[0]?.message?.content;
+  if (!text || typeof text !== 'string') {
+    console.error('Unexpected AI response:', JSON.stringify(data).slice(0, 2000));
+    process.exit(1);
+  }
+
+  const markdown = extractMarkdown(text);
+  if (!markdown.startsWith('---')) {
+    console.error('Model did not return valid frontmatter:', markdown.slice(0, 500));
+    process.exit(1);
+  }
+
+  const outDir = path.join(repoRoot, '.changeset');
+  fs.mkdirSync(outDir, { recursive: true });
+  const pr = process.env.PR_NUMBER || 'manual';
+  const fileName = path.join(outDir, `ci-ai-${pr}-${Date.now()}.md`);
+  fs.writeFileSync(fileName, `${markdown}\n`, 'utf8');
+  console.log('Wrote', path.relative(repoRoot, fileName));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `workflow_run` workflow that runs after the **Lint** workflow completes with a failure, resolves the associated PR, and checks `pnpm exec changeset status --since=main`.
- If a changeset is still required, calls **Vercel AI Gateway** (`https://ai-gateway.vercel.sh/v1/chat/completions`) to draft a `.changeset/*.md` file and pushes to the PR branch.
- Same-repo PRs only (skips forks where push is not possible).

## Repo secrets (add in GitHub → Settings → Secrets)
- **`AI_GATEWAY_API_KEY`** — Vercel AI Gateway API key ([docs](https://vercel.com/docs/ai-gateway)).
- **`VERCEL_CLI_RELEASE_BOT_TOKEN`** — already used elsewhere; needs `contents: write` to push branches.

## Optional env
- `AI_GATEWAY_BASE_URL` (default `https://ai-gateway.vercel.sh/v1`)
- `CHANGESET_AI_MODEL` (default `openai/gpt-5.4`)

## Test plan
- [ ] Merge a failing PR missing a changeset and confirm the bot adds a valid changeset file, or verify `workflow_dispatch` if added later.


Made with [Cursor](https://cursor.com)