### PR TITLE
chore(ci): auto-apply Biome fixes when Lint fails

### DIFF
--- a/.github/workflows/ci-lint-autofix.yml
+++ b/.github/workflows/ci-lint-autofix.yml
@@ -1,0 +1,103 @@
+# When Lint fails, apply Biome lint/format fixes and push to the PR branch.
+# Skips entirely if a changeset is still required (same check as Enforce Changeset) so it does not
+# fight the changeset workflow or mask missing-changeset failures.
+# Requires VERCEL_CLI_RELEASE_BOT_TOKEN for push. Fork PRs are skipped.
+
+name: CI — Lint autofix
+
+on:
+  workflow_run:
+    workflows:
+      - Lint
+    types:
+      - completed
+
+concurrency:
+  group: lint-autofix-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  lint-autofix:
+    name: Apply Biome fixes
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    steps:
+      - name: Resolve PR for workflow run
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const { data: pulls } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              });
+            if (!pulls.length) {
+              core.setOutput('found', 'false');
+              return;
+            }
+            const pr = pulls[0];
+            core.setOutput('found', 'true');
+            core.setOutput('head_ref', pr.head.ref);
+
+      - name: Checkout PR head
+        if: steps.pr.outputs.found == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.head_ref }}
+          token: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }}
+
+      - name: Install pnpm
+        if: steps.pr.outputs.found == 'true'
+        run: npm i -g pnpm@8.3.1
+
+      - name: Install dependencies
+        if: steps.pr.outputs.found == 'true'
+        run: pnpm install
+
+      - name: Fetch main for changeset check
+        if: steps.pr.outputs.found == 'true'
+        run: git fetch origin main
+
+      - name: Skip when changeset is missing
+        id: gate
+        if: steps.pr.outputs.found == 'true'
+        run: |
+          set +e
+          pnpm exec changeset status --since=main
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Skipping lint autofix: a changeset is required first."
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Apply Biome check (lint + format fixes)
+        if: steps.pr.outputs.found == 'true' && steps.gate.outputs.skip != 'true'
+        run: pnpm exec biome check --write api internals packages test utils
+
+      - name: Commit and push
+        if: steps.pr.outputs.found == 'true' && steps.gate.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add api internals packages test utils
+          if git diff --cached --quiet; then
+            echo "No Biome fixes to commit."
+            exit 0
+          fi
+          git commit -m "chore: apply biome lint and format fixes (ci)"
+          git push origin "HEAD:${{ steps.pr.outputs.head_ref }}"


### PR DESCRIPTION
## Summary
- After **Lint** fails, checks out the PR head, runs `pnpm exec changeset status --since=main` first.
- **If the changeset check fails** (missing changeset), the job exits without applying fixes so it does not overlap with changeset enforcement or the AI changeset workflow.
- Otherwise runs `pnpm exec biome check --write` on the same paths as `pnpm run lint` and commits/pushes only under `api/` `internals/` `packages/` `test/` `utils/`.

## Secrets
- **`VERCEL_CLI_RELEASE_BOT_TOKEN`** — push access to PR branches (same as other workflows).

## Test plan
- [ ] Fail Lint on biome only → expect autofix commit.
- [ ] Fail Lint only on missing changeset → expect **no** autofix commit.


Made with [Cursor](https://cursor.com)