### PR TITLE
feat(cli): add `vercel connex create` command behind FF_CONNEX_ENABLED

### DIFF
--- a/.changeset/cli-connex-create.md
+++ b/.changeset/cli-connex-create.md
@@ -1,0 +1,5 @@
+---
+vercel: minor
+---
+
+Add `vercel connex create` command

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -15,6 +15,7 @@ export { default as bisect } from './commands/bisect';
 export { default as blob } from './commands/blob';
 export { default as buy } from './commands/buy';
 export { default as cache } from './commands/cache';
+export { default as connex } from './commands/connex';
 export { default as contract } from './commands/contract';
 export { default as certs } from './commands/certs';
 export { default as crons } from './commands/crons';

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -1,0 +1,54 @@
+import { formatOption } from '../../util/arg-common';
+import { packageName } from '../../util/pkg-name';
+
+export const createSubcommand = {
+  name: 'create',
+  aliases: [],
+  description: 'Create a new Connex client',
+  arguments: [
+    {
+      name: 'type',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'name',
+      shorthand: 'n',
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+      description: 'Name of the Connex client',
+    },
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Create a Slack app',
+      value: `${packageName} connex create slack`,
+    },
+    {
+      name: 'Create with a custom name',
+      value: `${packageName} connex create slack --name my-bot`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} connex create slack --format=json`,
+    },
+  ],
+} as const;
+
+export const connexCommand = {
+  name: 'connex',
+  aliases: [],
+  description: 'Manage Vercel Connect clients',
+  arguments: [],
+  options: [],
+  subcommands: [createSubcommand],
+  examples: [
+    {
+      name: 'Create a Slack app',
+      value: `${packageName} connex create slack`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -1,0 +1,112 @@
+import open from 'open';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { validateJsonOutput } from '../../util/output-format';
+import { printError } from '../../util/error';
+import { getProjectLink } from '../../util/projects/link';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import {
+  generateRequestCode,
+  awaitConnexResult,
+} from '../../util/connex/request-code';
+
+export async function create(
+  client: Client,
+  args: string[],
+  flags: { '--name'?: string; '--format'?: string; '--json'?: boolean }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const serviceType = args[0];
+  if (!serviceType) {
+    output.error('Missing service type. Usage: vercel connex create <type>');
+    return 1;
+  }
+
+  // Resolve team
+  await selectConnexTeam(
+    client,
+    'Select the team where you want to create this client'
+  );
+
+  // Get app name from flag or interactive prompt
+  let name = flags['--name'];
+  if (!name) {
+    if (!client.stdin.isTTY) {
+      output.error(
+        'Missing required flag --name. In non-interactive mode, provide --name for the client.'
+      );
+      return 1;
+    }
+    name = await client.input.text({
+      message: `What would you like to name your ${serviceType} app?`,
+      validate: (val: string) =>
+        val.trim().length > 0 || 'Name cannot be empty',
+    });
+  }
+
+  // Generate request code and call the managed create redirect endpoint
+  const { original, hash } = generateRequestCode();
+  const link = await getProjectLink(client, client.cwd);
+
+  output.spinner('Setting up...');
+  let browserUrl: string;
+  try {
+    let url = `/v1/connex/clients/managed?service=${encodeURIComponent(serviceType)}&name=${encodeURIComponent(name)}&request_code=${encodeURIComponent(hash)}&autoinstall=true`;
+    if (link?.projectId) {
+      url += `&projectId=${encodeURIComponent(link.projectId)}`;
+    }
+    const res = await client.fetch(url, { json: false, redirect: 'manual' });
+
+    const location = res.headers.get('location');
+    if (!location) {
+      output.stopSpinner();
+      output.error('Unexpected response from API: no redirect URL');
+      return 1;
+    }
+    browserUrl = location;
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 404) {
+      output.error(
+        'Connex is not enabled for this team. Contact support to enable it.'
+      );
+      return 1;
+    }
+    printError(err);
+    return 1;
+  }
+  output.stopSpinner();
+
+  // Open browser
+  output.log(`Opening browser for ${serviceType} app setup...`);
+  output.log(`If the browser doesn't open, visit:\n${browserUrl}`);
+  open(browserUrl).catch((err: unknown) =>
+    output.debug(`Failed to open browser: ${err}`)
+  );
+
+  // Poll for result
+  output.spinner('Waiting for you to complete setup in the browser...');
+  const data = await awaitConnexResult(client, original);
+  output.stopSpinner();
+
+  if (!data) {
+    return 1;
+  }
+
+  const clientId = data.clientId as string;
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+  } else if (data.installationId) {
+    output.success(`${serviceType} client created and installed: ${clientId}`);
+  } else {
+    output.success(`${serviceType} client created: ${clientId}`);
+  }
+  return 0;
+}

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -1,0 +1,118 @@
+import { getCommandAliases } from '..';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import getSubcommand from '../../util/get-subcommand';
+import { ConnexTelemetryClient } from '../../util/telemetry/commands/connex';
+import { type Command, help } from '../help';
+import { createSubcommand, connexCommand } from './command';
+import { create } from './create';
+import {
+  buildCommandWithGlobalFlags,
+  outputAgentError,
+} from '../../util/agent-output';
+import { AGENT_REASON } from '../../util/agent-output-constants';
+import { packageName } from '../../util/pkg-name';
+
+const COMMAND_CONFIG = {
+  create: getCommandAliases(createSubcommand),
+};
+
+export default async function connex(client: Client): Promise<number> {
+  const telemetry = new ConnexTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const { args, flags } = parseArguments(
+    client.argv.slice(2),
+    getFlagsSpecification(connexCommand.options),
+    { permissive: true }
+  );
+
+  const {
+    subcommand,
+    subcommandOriginal,
+    args: subArgs,
+  } = getSubcommand(args.slice(1), COMMAND_CONFIG);
+
+  const needHelp = flags['--help'];
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        columns: client.stderr.columns,
+        parent: connexCommand,
+      })
+    );
+  }
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('connex');
+    output.print(
+      help(connexCommand, {
+        columns: client.stderr.columns,
+      })
+    );
+    return 0;
+  }
+
+  try {
+    switch (subcommand) {
+      case 'create': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex', subcommandOriginal);
+          printHelp(createSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandCreate(subcommandOriginal);
+
+        const createFlagsSpec = getFlagsSpecification(createSubcommand.options);
+        const createParsedArgs = parseArguments(subArgs, createFlagsSpec);
+        return await create(
+          client,
+          createParsedArgs.args,
+          createParsedArgs.flags
+        );
+      }
+      default: {
+        const validSubcommands = Object.keys(COMMAND_CONFIG).join(' | ');
+        const missingSubcommand = subArgs.length === 0;
+        const message = missingSubcommand
+          ? `Please specify a valid subcommand: ${validSubcommands}`
+          : `Unknown subcommand "${subArgs[0]}". Valid subcommands: ${validSubcommands}`;
+
+        outputAgentError(
+          client,
+          {
+            status: 'error',
+            reason: missingSubcommand
+              ? AGENT_REASON.MISSING_ARGUMENTS
+              : AGENT_REASON.INVALID_ARGUMENTS,
+            message,
+            next: [
+              {
+                command: buildCommandWithGlobalFlags(
+                  client.argv,
+                  'connex --help',
+                  packageName,
+                  { prependGlobalFlags: true }
+                ),
+                when: 'Show all connex subcommands and options',
+              },
+            ],
+          },
+          2
+        );
+        output.error(message);
+        return 2;
+      }
+    }
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -76,7 +76,6 @@ const commandsStructs = [
   buyCommand,
   cacheCommand,
   certsCommand,
-  connexCommand,
   contractCommand,
   cronsCommand,
   curlCommand,
@@ -134,6 +133,10 @@ if (process.env.FF_GUIDANCE_MODE) {
 
 if (process.env.FF_METRICS) {
   commandsStructs.push(metricsCommand);
+}
+
+if (process.env.FF_CONNEX_ENABLED) {
+  commandsStructs.push(connexCommand);
 }
 
 export function getCommandAliases(command: Pick<Command, 'name' | 'aliases'>) {

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -9,6 +9,7 @@ import { buildCommand } from './build/command';
 import { buyCommand } from './buy/command';
 import { cacheCommand } from './cache/command';
 import { certsCommand } from './certs/command';
+import { connexCommand } from './connex/command';
 import { contractCommand } from './contract/command';
 import { cronsCommand } from './crons/command';
 import { curlCommand } from './curl/command';
@@ -75,6 +76,7 @@ const commandsStructs = [
   buyCommand,
   cacheCommand,
   certsCommand,
+  connexCommand,
   contractCommand,
   cronsCommand,
   curlCommand,

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -4,6 +4,10 @@ import chalk from 'chalk';
 const packageName = 'vercel';
 const logo = '▲';
 
+const connexLine = process.env.FF_CONNEX_ENABLED
+  ? '\n      connex               [cmd]       Manage Vercel Connect OAuth clients'
+  : '';
+
 const metricsLine = process.env.FF_METRICS
   ? '\n      metrics                          Queries observability metrics for your project or team'
   : '';
@@ -52,7 +56,7 @@ export const help = () => `
       bisect                           Use binary search to find the deployment that introduced a bug
       blob                 [cmd]       Manages your Blob stores and files
       buy                  [cmd]       Purchase Vercel products for your team
-      certs                [cmd]       Manages your SSL certificates
+      certs                [cmd]       Manages your SSL certificates${connexLine}
       contract                         Show contract information for billing periods
       cron | crons         [cmd]       Manage cron jobs for a project [beta]
       curl                 [path]      cURL requests to your linked project's deployment [beta]

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -943,9 +943,14 @@ const main = async () => {
           func = (await import('./commands-bulk.js')).cache;
           break;
         case 'connex':
-          telemetry.trackCliCommandConnex(userSuppliedSubCommand);
-          func = (await import('./commands-bulk.js')).connex;
-          break;
+          if (process.env.FF_CONNEX_ENABLED) {
+            telemetry.trackCliCommandConnex(userSuppliedSubCommand);
+            func = (await import('./commands-bulk.js')).connex;
+            break;
+          } else {
+            func = null;
+            break;
+          }
         case 'contract':
           telemetry.trackCliCommandContract(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).contract;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -942,6 +942,10 @@ const main = async () => {
           telemetry.trackCliCommandCache(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).cache;
           break;
+        case 'connex':
+          telemetry.trackCliCommandConnex(userSuppliedSubCommand);
+          func = (await import('./commands-bulk.js')).connex;
+          break;
         case 'contract':
           telemetry.trackCliCommandContract(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).contract;

--- a/packages/cli/src/util/connex/request-code.ts
+++ b/packages/cli/src/util/connex/request-code.ts
@@ -1,0 +1,87 @@
+import { randomBytes, createHash } from 'node:crypto';
+import output from '../../output-manager';
+import type Client from '../client';
+import sleep from '../sleep';
+
+export interface ConnexResult {
+  status: 'pending' | 'partial' | 'success' | 'error';
+  progress?: string;
+  data?: Record<string, unknown>;
+  error?: { code: string; message: string };
+}
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLL_DURATION_MS = 30 * 60 * 1000;
+const MAX_EARLY_404_COUNT = 3;
+
+export function generateRequestCode(): { original: string; hash: string } {
+  const original = randomBytes(37).toString('base64url');
+  const hash = createHash('sha256').update(original).digest('base64url');
+  return { original, hash };
+}
+
+/**
+ * Polls `GET /v1/connex/result/{code}` until the request code resolves
+ * to success or error, or the timeout is reached.
+ *
+ * Returns the result data on success, or null on failure (error is
+ * printed to output).
+ */
+export async function awaitConnexResult(
+  client: Client,
+  originalCode: string
+): Promise<Record<string, unknown> | null> {
+  const deadline = Date.now() + MAX_POLL_DURATION_MS;
+  let early404Count = 0;
+  let lastProgress: string | undefined;
+
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    try {
+      const result = await client.fetch<ConnexResult>(
+        `/v1/connex/result/${encodeURIComponent(originalCode)}`
+      );
+
+      if (result.status === 'success' && result.data) {
+        return result.data;
+      }
+
+      if (result.status === 'partial' && result.data) {
+        if (result.progress && result.progress !== lastProgress) {
+          lastProgress = result.progress;
+          output.stopSpinner();
+          const clientId = result.data.clientId as string | undefined;
+          if (clientId) {
+            output.log(`Client created: ${clientId}`);
+          }
+          output.spinner(`${result.progress}...`);
+        }
+        continue;
+      }
+
+      if (result.status === 'error' && result.error) {
+        output.error(
+          `Setup failed: ${result.error.message} (${result.error.code})`
+        );
+        return null;
+      }
+    } catch (err: unknown) {
+      const status = (err as { status?: number }).status;
+      if (status === 404) {
+        early404Count++;
+        if (early404Count > MAX_EARLY_404_COUNT) {
+          output.error('Setup request expired. Please try again.');
+          return null;
+        }
+        output.debug(
+          `Polling 404 (${early404Count}/${MAX_EARLY_404_COUNT}), will retry`
+        );
+        continue;
+      }
+      output.debug(`Polling error (will retry): ${err}`);
+    }
+  }
+
+  output.error('Timed out waiting for setup to complete. Please try again.');
+  return null;
+}

--- a/packages/cli/src/util/connex/select-team.ts
+++ b/packages/cli/src/util/connex/select-team.ts
@@ -1,0 +1,16 @@
+import type Client from '../client';
+import selectOrg from '../input/select-org';
+
+/**
+ * Resolves the team for Connex commands. Skips the interactive prompt
+ * if a team is already set (via --scope, vercel switch, or defaultTeamId).
+ * Prompts the user to pick a team otherwise.
+ */
+export async function selectConnexTeam(
+  client: Client,
+  message: string
+): Promise<void> {
+  const hasTeam = Boolean(client.config.currentTeam);
+  const org = await selectOrg(client, message, hasTeam);
+  client.config.currentTeam = org.type === 'team' ? org.id : undefined;
+}

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -1,0 +1,15 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { connexCommand } from '../../../../commands/connex/command';
+
+export class ConnexTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof connexCommand>
+{
+  trackCliSubcommandCreate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'create',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -96,6 +96,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandConnex(actual: string) {
+    this.trackCliCommand({
+      command: 'connex',
+      value: actual,
+    });
+  }
+
   trackCliCommandContract(actual: string) {
     this.trackCliCommand({
       command: 'contract',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -753,6 +753,85 @@ exports[`help command > certs help output snapshots > certs remove help output s
 "
 `;
 
+exports[`help command > connex help output snapshots > connex create subcommand > connex create subcommand help column width 120 1`] = `
+"
+  ▲ vercel connex create type [options]
+
+  Create a new Connex client                                                                                            
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+  -n,  --name <NAME>      Name of the Connex client                                                                     
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Create a Slack app
+
+    $ vercel connex create slack
+
+  - Create with a custom name
+
+    $ vercel connex create slack --name my-bot
+
+  - Output as JSON
+
+    $ vercel connex create slack --format=json
+
+"
+`;
+
+exports[`help command > connex help output snapshots > connex help column width 80 1`] = `
+"
+  ▲ vercel connex command
+
+  Manage Vercel Connect clients                                                 
+
+  Commands:
+
+  create  type  Create a new Connex client                              
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single   
+                              run of a command                                  
+  -d,  --debug                Debug mode (default off)                          
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory            
+  -h,  --help                 Output usage information                          
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file              
+       --no-color             No color mode (default off)                       
+       --non-interactive      Run without interactive prompts; when an agent is 
+                              detected this is the default                      
+  -S,  --scope                Set a custom scope                                
+  -t,  --token <TOKEN>        Login token                                       
+  -v,  --version              Output the version number                         
+
+
+  Examples:
+
+  - Create a Slack app
+
+    $ vercel connex create slack
+
+"
+`;
+
 exports[`help command > deploy help output snapshots > deploy help column width 40 1`] = `
 "
   ▲ vercel deploy [project-path] [options]

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -1,0 +1,228 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import connex from '../../../../src/commands/connex';
+
+vi.mock('open', () => ({ default: vi.fn(() => Promise.resolve()) }));
+
+describe('connex create', () => {
+  let team: { id: string; slug: string };
+
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    team = useTeam();
+    client.config.currentTeam = team.id;
+  });
+
+  it('should error when no type argument is provided', async () => {
+    client.setArgv('connex', 'create');
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('Missing service type');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should error in non-interactive mode without --name', async () => {
+    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
+      res.writeHead(302, {
+        Location: 'https://vercel.com/test/~/connex/create?type=slack',
+      });
+      res.end();
+    });
+
+    client.setArgv('connex', 'create', 'slack');
+    (client.stdin as any).isTTY = false;
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('Missing required flag --name');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should show friendly error when connex feature flag is off (404)', async () => {
+    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv('connex', 'create', 'slack', '--name', 'test-app');
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('Connex is not enabled');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should open browser and poll for result on success', async () => {
+    let requestUrl = '';
+    client.scenario.get('/v1/connex/clients/managed', (req, res) => {
+      requestUrl = req.url ?? '';
+      res.writeHead(302, {
+        Location: 'https://vercel.com/test/~/connex/create?type=slack',
+      });
+      res.end();
+    });
+
+    let pollCount = 0;
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      pollCount++;
+      if (pollCount < 2) {
+        res.json({ status: 'pending' });
+      } else {
+        res.json({ status: 'success', data: { clientId: 'scl_test123' } });
+      }
+    });
+
+    client.setArgv('connex', 'create', 'slack', '--name', 'my-bot');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestUrl).toContain('service=slack');
+    expect(requestUrl).toContain('name=my-bot');
+    expect(requestUrl).toContain('request_code=');
+    expect(requestUrl).toContain('autoinstall=true');
+    expect(pollCount).toBeGreaterThanOrEqual(2);
+    await expect(client.stderr).toOutput('scl_test123');
+  });
+
+  it('should pass any type to the server without validation', async () => {
+    let requestUrl = '';
+    client.scenario.get('/v1/connex/clients/managed', (req, res) => {
+      requestUrl = req.url ?? '';
+      res.writeHead(302, {
+        Location: 'https://vercel.com/test/~/connex/create?type=jira',
+      });
+      res.end();
+    });
+
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      res.json({ status: 'success', data: { clientId: 'scl_jira1' } });
+    });
+
+    client.setArgv('connex', 'create', 'jira', '--name', 'my-jira');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestUrl).toContain('service=jira');
+  });
+
+  it('should output JSON when --format=json is used', async () => {
+    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
+      res.writeHead(302, {
+        Location: 'https://vercel.com/test/~/connex/create?type=slack',
+      });
+      res.end();
+    });
+
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      res.json({ status: 'success', data: { clientId: 'scl_json123' } });
+    });
+
+    client.setArgv(
+      'connex',
+      'create',
+      'slack',
+      '--name',
+      'my-bot',
+      '--format=json'
+    );
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    await expect(client.stdout).toOutput('"clientId": "scl_json123"');
+  });
+
+  it('should keep polling through partial status until success', async () => {
+    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
+      res.writeHead(302, {
+        Location: 'https://vercel.com/test/~/connex/create?type=slack',
+      });
+      res.end();
+    });
+
+    let pollCount = 0;
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      pollCount++;
+      if (pollCount === 1) {
+        res.json({ status: 'pending' });
+      } else if (pollCount === 2) {
+        res.json({
+          status: 'partial',
+          progress: 'installing',
+          data: { clientId: 'scl_partial1' },
+        });
+      } else {
+        res.json({
+          status: 'success',
+          progress: 'installed',
+          data: { clientId: 'scl_partial1', installationId: 'T123' },
+        });
+      }
+    });
+
+    client.setArgv('connex', 'create', 'slack', '--name', 'my-bot');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(pollCount).toBe(3);
+    await expect(client.stderr).toOutput('scl_partial1');
+  });
+
+  it('should handle error status from polling', async () => {
+    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
+      res.writeHead(302, {
+        Location: 'https://vercel.com/test/~/connex/create?type=slack',
+      });
+      res.end();
+    });
+
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      res.json({
+        status: 'error',
+        error: { code: 'creation_failed', message: 'Slack API error' },
+      });
+    });
+
+    client.setArgv('connex', 'create', 'slack', '--name', 'my-bot');
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('Slack API error');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should tolerate early 404s during polling', async () => {
+    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
+      res.writeHead(302, {
+        Location: 'https://vercel.com/test/~/connex/create?type=slack',
+      });
+      res.end();
+    });
+
+    let pollCount = 0;
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      pollCount++;
+      if (pollCount <= 2) {
+        res.statusCode = 404;
+        res.json({ error: { code: 'not_found', message: 'Not Found' } });
+      } else {
+        res.json({ status: 'success', data: { clientId: 'scl_after404' } });
+      }
+    });
+
+    client.setArgv('connex', 'create', 'slack', '--name', 'my-bot');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(pollCount).toBe(3);
+    await expect(client.stderr).toOutput('scl_after404');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -14,6 +14,7 @@ import * as env from '../../../src/commands/env/command';
 import * as git from '../../../src/commands/git/command';
 import { initCommand } from '../../../src/commands/init/command';
 import { inspectCommand } from '../../../src/commands/inspect/command';
+import * as connex from '../../../src/commands/connex/command';
 import * as integration from '../../../src/commands/integration/command';
 import * as integrationResource from '../../../src/commands/integration-resource/command';
 import { linkCommand } from '../../../src/commands/link/command';
@@ -422,6 +423,22 @@ describe('help command', () => {
     });
     it('inspect help column width 120', () => {
       expect(help(inspectCommand, { columns: 120 })).toMatchSnapshot();
+    });
+  });
+
+  describe('connex help output snapshots', () => {
+    it('connex help column width 80', () => {
+      expect(help(connex.connexCommand, { columns: 80 })).toMatchSnapshot();
+    });
+    describe('connex create subcommand', () => {
+      it('connex create subcommand help column width 120', () => {
+        expect(
+          help(connex.createSubcommand, {
+            columns: 120,
+            parent: connex.connexCommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -18,6 +18,7 @@ describe('index', () => {
         ['cache', 'cache'],
         ['cert', 'certs'],
         ['certs', 'certs'],
+        ['connex', 'connex'],
         ['contract', 'contract'],
         ['cron', 'crons'],
         ['crons', 'crons'],

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -18,7 +18,6 @@ describe('index', () => {
         ['cache', 'cache'],
         ['cert', 'certs'],
         ['certs', 'certs'],
-        ['connex', 'connex'],
         ['contract', 'contract'],
         ['cron', 'crons'],
         ['crons', 'crons'],


### PR DESCRIPTION
## Summary
- Ports the `vercel connex create` command from the `vercel/vercel-connex` into `vercel/vercel`. https://github.com/vercel/vercel-connex/pull/2
- Command is gated behind `FF_CONNEX_ENABLED` environment variable feature flag

## Test plan
- [x] `packages/cli/test/unit/commands/index.test.ts` — passes (connex removed from unconditional registration)
- [x] `packages/cli/test/unit/commands/help.test.ts` — 134 tests pass (snapshots valid)
- [x] `packages/cli/test/unit/commands/connex/create.test.ts`
- [x] Manual: `FF_CONNEX_ENABLED=1 node packages/cli/dist/index.js connex create` works
- [x] Manual: without env var, `vercel connex` shows "subcommand does not exist"

🤖 Generated with [Claude Code](https://claude.com/claude-code)