### PR TITLE
[codex] Emit private Next server source maps

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -75,6 +75,8 @@ import {
   getImagesManifest,
   getNextConfig,
   getPageLambdaGroups,
+  getPrivateServerSourceMapRoute,
+  getPrivateServerSourceMaps,
   getPrerenderManifest,
   getPrivateOutputs,
   getRequiredServerFilesManifest,
@@ -612,6 +614,47 @@ export const build: BuildV2 = async buildOptions => {
       }
     }
 
+    const privateServerSourceMaps = await getPrivateServerSourceMaps(
+      path.join(entryPath, outputDirectory)
+    );
+
+    for (const [outputFile, file] of Object.entries(
+      privateServerSourceMaps.files
+    )) {
+      if (!(file instanceof FileFsRef)) {
+        continue;
+      }
+
+      const destPath = path.join(staticOutputDir, outputFile);
+      await copy(file.fsPath, destPath);
+    }
+
+    if (privateServerSourceMaps.routes.length > 0) {
+      const buildOutputConfigPath = path.join(
+        entryPath,
+        outputDirectory,
+        'output/config.json'
+      );
+      const buildOutputConfig = await readJSON(buildOutputConfigPath);
+      const privateServerSourceMapRoute = getPrivateServerSourceMapRoute();
+
+      buildOutputConfig.routes = [
+        privateServerSourceMapRoute,
+        ...(Array.isArray(buildOutputConfig.routes)
+          ? buildOutputConfig.routes.filter(
+              (route: Route) =>
+                JSON.stringify(route) !==
+                JSON.stringify(privateServerSourceMapRoute)
+            )
+          : []),
+      ];
+
+      await writeFile(
+        buildOutputConfigPath,
+        JSON.stringify(buildOutputConfig, null, 2)
+      );
+    }
+
     return {
       buildOutputPath: path.join(entryPath, outputDirectory, 'output'),
       buildOutputVersion,
@@ -713,13 +756,26 @@ export const build: BuildV2 = async buildOptions => {
         })
       : undefined;
 
-  const privateOutputs = await getPrivateOutputs(
+  const defaultPrivateOutputs = await getPrivateOutputs(
     path.join(entryPath, outputDirectory),
     {
       'next-stats.json': '_next/__private/stats.json',
       trace: '_next/__private/trace',
     }
   );
+  const privateServerSourceMaps = await getPrivateServerSourceMaps(
+    path.join(entryPath, outputDirectory)
+  );
+  const privateOutputs = {
+    files: {
+      ...defaultPrivateOutputs.files,
+      ...privateServerSourceMaps.files,
+    },
+    routes: [
+      ...defaultPrivateOutputs.routes,
+      ...privateServerSourceMaps.routes,
+    ],
+  };
 
   const headers: Route[] = [];
   const onMatchHeaders: Route[] = [];

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3643,6 +3643,58 @@ export async function getPrivateOutputs(
   return { files, routes };
 }
 
+const PRIVATE_SERVER_SOURCE_MAP_OUTPUT_PREFIX =
+  '_next/__private/server-source-maps';
+
+export function getPrivateServerSourceMapRoute(): Route {
+  return {
+    src: `^/${escapeStringRegexp(
+      PRIVATE_SERVER_SOURCE_MAP_OUTPUT_PREFIX
+    )}/.+\\.map$`,
+    dest: '/404',
+    status: 404,
+    continue: true,
+  };
+}
+
+export async function getPrivateServerSourceMaps(dir: string) {
+  const files: Files = {};
+  const serverSourceMaps = await glob('server/**/*.map', dir);
+
+  for (const existingFile of Object.keys(serverSourceMaps)) {
+    const fsPath = path.join(dir, existingFile);
+
+    try {
+      const { mode, size } = await stat(fsPath);
+      if (size > 30 * 1024 * 1024) {
+        throw new Error(`Exceeds maximum file size: ${size}`);
+      }
+
+      const normalizedFile = existingFile.split(path.sep).join(path.posix.sep);
+      const outputFile = path.posix.join(
+        PRIVATE_SERVER_SOURCE_MAP_OUTPUT_PREFIX,
+        normalizedFile.replace(/^server\/+/, '')
+      );
+
+      files[outputFile] = new FileFsRef({
+        mode,
+        fsPath,
+        contentType: 'application/json',
+      });
+    } catch (error) {
+      debug(
+        `Private server source map ${existingFile} had an error and will not be uploaded: ${error}`
+      );
+    }
+  }
+
+  return {
+    files,
+    routes:
+      Object.keys(files).length > 0 ? [getPrivateServerSourceMapRoute()] : [],
+  };
+}
+
 export {
   excludeFiles,
   validateEntrypoint,

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -8,7 +8,7 @@ const {
   createRunBuildLambda,
 } = require('../../../../test/lib/run-build-lambda');
 const { duplicateWithConfig } = require('../utils');
-const { streamToBuffer } = require('@vercel/build-utils');
+const { glob, streamToBuffer } = require('@vercel/build-utils');
 const { createHash } = require('crypto');
 
 const runBuildLambda = createRunBuildLambda(builder);
@@ -154,6 +154,34 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
     // expect(buildResult.output['dashboard/index.rsc'].fallback.fsPath).toMatch(
     //   /server\/app\/dashboard\/index\.rsc$/
     // );
+  });
+
+  it('should expose Next.js server source maps as private outputs', async () => {
+    const fixturePath = path.join(__dirname, '../fixtures/00-app-dir-no-ppr');
+    const { buildResult, workPath } = await runBuildLambda(fixturePath);
+    const emittedServerSourceMaps = await glob(
+      'server/**/*.map',
+      path.join(workPath, '.next')
+    );
+    const emittedSourceMapPaths = Object.keys(emittedServerSourceMaps).map(
+      sourceMapPath =>
+        path.posix.join(
+          '_next/__private/server-source-maps',
+          sourceMapPath.replace(/^server\/+/, '')
+        )
+    );
+
+    expect(emittedSourceMapPaths.length).toBeGreaterThan(0);
+    emittedSourceMapPaths.forEach(sourceMapPath => {
+      expect(buildResult.output[sourceMapPath]).toBeDefined();
+    });
+
+    expect(buildResult.routes).toContainEqual({
+      src: '^/_next/__private/server\\-source\\-maps/.+\\.map$',
+      dest: '/404',
+      status: 404,
+      continue: true,
+    });
   });
 
   it('should not generate /_next/data routes for pure App Router apps', async () => {

--- a/packages/next/test/unit/utils.test.ts
+++ b/packages/next/test/unit/utils.test.ts
@@ -2,6 +2,8 @@ import path from 'path';
 import os from 'os';
 import {
   excludeFiles,
+  getPrivateServerSourceMapRoute,
+  getPrivateServerSourceMaps,
   validateEntrypoint,
   normalizePackageJson,
   getImagesConfig,
@@ -416,6 +418,44 @@ describe('getServerlessPages', () => {
 
     expect(Object.keys(pages)).toEqual(['_app.js', '_error.js']);
     expect(Object.keys(appPaths)).toEqual(['favicon.ico.js', 'index.js']);
+  });
+});
+
+describe('getPrivateServerSourceMaps', () => {
+  it('should expose Next.js server source maps as private outputs', async () => {
+    const dir = await genDir({
+      'server/chunks/app/api/route.js.map': '{"version":3}',
+      'server/chunks/ssr/_0izskry._.js.map': '{"version":3}',
+      'server/app/page.js': 'compiled output',
+    });
+
+    const result = await getPrivateServerSourceMaps(dir);
+
+    expect(result.files).toMatchObject({
+      '_next/__private/server-source-maps/chunks/app/api/route.js.map':
+        expect.any(FileFsRef),
+      '_next/__private/server-source-maps/chunks/ssr/_0izskry._.js.map':
+        expect.any(FileFsRef),
+    });
+    expect(
+      result.files[
+        '_next/__private/server-source-maps/chunks/app/api/route.js.map'
+      ]
+    ).toMatchObject({
+      contentType: 'application/json',
+    });
+    expect(result.routes).toEqual([getPrivateServerSourceMapRoute()]);
+  });
+
+  it('should not emit routes when no server source maps exist', async () => {
+    const dir = await genDir({
+      'server/app/page.js': 'compiled output',
+    });
+
+    const result = await getPrivateServerSourceMaps(dir);
+
+    expect(result.files).toEqual({});
+    expect(result.routes).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- emit Next server sourcemaps as protected deployment outputs under `_next/__private/server-source-maps`
- thread those private outputs through both classic output handling and build output mode
- add focused unit and integration coverage for the private sourcemap path

## Testing
- pnpm --filter @vercel/next test -- --runInBand test/unit/utils.test.ts -t "getPrivateServerSourceMaps"
- pnpm --filter @vercel/next test -- --runInBand test/integration/integration-1.test.js -t "should expose Next.js server source maps as private outputs"
- pnpm exec biome lint packages/next/src/index.ts packages/next/src/utils.ts packages/next/test/integration/integration-1.test.js packages/next/test/unit/utils.test.ts
- pnpm --filter @vercel/next type-check

## Linked work
- pairs with vercel/front#67352 for logs-side lazy symbolication
