### PR TITLE
Add package manifest for Node deployments

### DIFF
--- a/.changeset/stupid-pears-punch.md
+++ b/.changeset/stupid-pears-punch.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': minor
+'@vercel/backends': minor
+'@vercel/python': minor
+---
+
+Generate PROJECTMANIFEST in @vercel/backends for Node deployments.

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -32,7 +32,8 @@
   ],
   "dependencies": {
     "@vercel/build-utils": "workspace:*",
-    "js-yaml": "^4.1.0",
+    "@yarnpkg/parsers": "^3.0.0",
+    "js-yaml": "^3.13.1",
     "@vercel/nft": "1.5.0",
     "execa": "3.2.0",
     "fs-extra": "11.1.0",
@@ -49,7 +50,7 @@
   },
   "devDependencies": {
     "@types/express": "5.0.3",
-    "@types/js-yaml": "^4.0.9",
+    "@types/js-yaml": "3.12.1",
     "@types/fs-extra": "11",
     "@types/jest": "27.5.1",
     "@types/node": "20.11.0",

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "@vercel/build-utils": "workspace:*",
+    "js-yaml": "^4.1.0",
     "@vercel/nft": "1.5.0",
     "execa": "3.2.0",
     "fs-extra": "11.1.0",
@@ -48,6 +49,7 @@
   },
   "devDependencies": {
     "@types/express": "5.0.3",
+    "@types/js-yaml": "^4.0.9",
     "@types/fs-extra": "11",
     "@types/jest": "27.5.1",
     "@types/node": "20.11.0",

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -317,9 +317,9 @@ async function parseLockfile(
   lockfileVersion: number | undefined
 ): Promise<Map<string, LockEntry>> {
   // bun.lockb is a binary format — not parseable without invoking bun
-  if (cliType === 'bun' && lockfileVersion === 0) {
-    return new Map();
-  }
+  if (cliType === 'bun' && lockfileVersion === 0) return new Map();
+  // vlt-lock.json format is undocumented — emit direct deps only
+  if (cliType === 'vlt') return new Map();
 
   const content = await fs.promises.readFile(lockfilePath, 'utf-8');
   switch (cliType) {

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -76,11 +76,13 @@ function parseNpmLock(
       const resolved = entry.resolved as string | undefined;
       if (resolved?.startsWith('file:')) continue; // local/workspace package
 
-      if (lockMap.has(rest)) continue; // keep first occurrence
+      const version = (entry.version as string) ?? '';
+      const existing = lockMap.get(rest);
+      if (existing && !isHigherVersion(version, existing.resolved)) continue;
 
       const { source, sourceUrl } = classifySource(resolved);
       const lockEntry: LockEntry = {
-        resolved: (entry.version as string) ?? '',
+        resolved: version,
         scopes: npmEntryScopes(entry),
       };
       if (source) lockEntry.source = source;
@@ -97,11 +99,13 @@ function parseNpmLock(
     const walk = (deps: Record<string, Record<string, unknown>>) => {
       for (const [name, entry] of Object.entries(deps)) {
         const resolved = entry.resolved as string | undefined;
-        if (!lockMap.has(name)) {
-          if (!resolved?.startsWith('file:')) {
+        if (!resolved?.startsWith('file:')) {
+          const version = (entry.version as string) ?? '';
+          const existing = lockMap.get(name);
+          if (!existing || isHigherVersion(version, existing.resolved)) {
             const { source, sourceUrl } = classifySource(resolved);
             const lockEntry: LockEntry = {
-              resolved: (entry.version as string) ?? '',
+              resolved: version,
               scopes: npmEntryScopes(entry),
             };
             if (source) lockEntry.source = source;
@@ -119,6 +123,19 @@ function parseNpmLock(
   }
 
   return lockMap;
+}
+
+// Returns true if version a is higher than version b using numeric segment comparison.
+// Good enough for semver; does not handle pre-release ordering.
+function isHigherVersion(a: string, b: string): boolean {
+  const seg = (v: string) => v.split(/[.\-+]/).map(s => parseInt(s, 10) || 0);
+  const pa = seg(a);
+  const pb = seg(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
+    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
+  }
+  return false;
 }
 
 // Shared: extract package name from a versioned specifier, stripping any peer
@@ -141,7 +158,8 @@ function parsePnpmV9Key(key: string): { name: string; version: string } | null {
   return { name, version: withoutPeers.slice(name.length + 1) };
 }
 
-function parsePnpmV6Key(key: string): { name: string; version: string } | null {
+// pnpm v5.x: /name/version(_peers) or /@scope/pkg/version(_peers)
+function parsePnpmV5Key(key: string): { name: string; version: string } | null {
   if (!key.startsWith('/')) return null;
   const rest = key.slice(1);
   if (rest.startsWith('@')) {
@@ -159,6 +177,29 @@ function parsePnpmV6Key(key: string): { name: string; version: string } | null {
   if (slashIndex === -1) return null;
   const name = rest.slice(0, slashIndex);
   const version = rest.slice(slashIndex + 1).split('_')[0];
+  return { name, version };
+}
+
+// pnpm v6.x: /name@version(_peers) or /@scope/pkg@version(_peers)
+// Peer dep variants use '_' suffix (unlike v9 which uses '()')
+function parsePnpmV6Key(key: string): { name: string; version: string } | null {
+  if (!key.startsWith('/')) return null;
+  const rest = key.slice(1); // strip leading '/'
+  let atIdx: number;
+  if (rest.startsWith('@')) {
+    // Scoped: @scope/pkg@version_peers
+    atIdx = rest.indexOf('@', 1);
+  } else {
+    // Non-scoped: pkg@version_peers
+    atIdx = rest.indexOf('@');
+  }
+  if (atIdx === -1) return null;
+  const name = rest.slice(0, atIdx);
+  // pnpm v6 uses both '_peerinfo' and '(peerinfo)' suffixes
+  const version = rest
+    .slice(atIdx + 1)
+    .split('_')[0]
+    .replace(/\(.*\)$/, '');
   return { name, version };
 }
 
@@ -184,7 +225,9 @@ function parsePnpmLock(
   lockfileVersion: number | undefined
 ): Map<string, LockEntry> {
   const lockMap = new Map<string, LockEntry>();
-  const parsedYaml = yaml.load(content) as Record<string, unknown> | null;
+  // pnpm lockfiles may have multiple YAML documents (starts with '---')
+  const docs = yaml.loadAll(content) as Array<Record<string, unknown> | null>;
+  const parsedYaml = docs[0];
   if (!parsedYaml) return lockMap;
 
   const lv =
@@ -194,7 +237,12 @@ function parsePnpmLock(
     | undefined;
   if (!packages) return lockMap;
 
-  const parseKey = lv >= 9 ? parsePnpmV9Key : parsePnpmV6Key;
+  const parseKey =
+    lv >= 9
+      ? parsePnpmV9Key // name@version
+      : lv >= 6
+        ? parsePnpmV6Key // /name@version
+        : parsePnpmV5Key; // /name/version
 
   for (const [key, entry] of Object.entries(packages)) {
     const keyParsed = parseKey(key);
@@ -205,7 +253,8 @@ function parsePnpmLock(
     const { local, source, sourceUrl } = classifyPnpmResolution(resolution);
     if (local) continue;
 
-    if (lockMap.has(name)) continue; // keep first occurrence (dedup by name)
+    const existing = lockMap.get(name);
+    if (existing && !isHigherVersion(version, existing.resolved)) continue;
 
     const lockEntry: LockEntry = { resolved: version, scopes: ['prod'] };
     if (source) lockEntry.source = source;
@@ -270,7 +319,10 @@ function parseYarnLock(
       name = extractPackageName(spec);
       if (name) break;
     }
-    if (!name || lockMap.has(name)) continue;
+    if (!name) continue;
+    const existingYarn = lockMap.get(name);
+    if (existingYarn && !isHigherVersion(version, existingYarn.resolved))
+      continue;
 
     const lockEntry: LockEntry = { resolved: version, scopes: ['prod'] };
     if (source) lockEntry.source = source;
@@ -283,7 +335,9 @@ function parseYarnLock(
 
 function parseBunLock(content: string): Map<string, LockEntry> {
   const lockMap = new Map<string, LockEntry>();
-  const parsed = JSON.parse(content) as Record<string, unknown>;
+  // bun.lock is JSONC — strip trailing commas before JSON.parse
+  const json = content.replace(/,(\s*[}\]])/g, '$1');
+  const parsed = JSON.parse(json) as Record<string, unknown>;
 
   // packages keys are plain package names; value[0] is "name@resolved-version"
   const packages = parsed.packages as Record<string, unknown[]> | undefined;
@@ -304,7 +358,9 @@ function parseBunLock(content: string): Map<string, LockEntry> {
     if (version.startsWith('file:') || version.startsWith('workspace:'))
       continue;
 
-    if (lockMap.has(name)) continue;
+    const existingBun = lockMap.get(name);
+    if (existingBun && !isHigherVersion(version, existingBun.resolved))
+      continue;
     lockMap.set(name, { resolved: version, scopes: ['prod'] });
   }
 

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -121,24 +121,24 @@ function parseNpmLock(
   return lockMap;
 }
 
-function parsePnpmV9Key(key: string): { name: string; version: string } | null {
-  // Strip peer dep suffix: foo@1.2.3(react@18.0.0) → foo@1.2.3
-  const withoutPeers = key.replace(/\(.*\)$/, '');
-  if (withoutPeers.startsWith('@')) {
-    // Scoped: @scope/pkg@1.2.3 — find the @ after the initial one
-    const atIndex = withoutPeers.indexOf('@', 1);
-    if (atIndex === -1) return null;
-    return {
-      name: withoutPeers.slice(0, atIndex),
-      version: withoutPeers.slice(atIndex + 1),
-    };
+// Shared: extract package name from a versioned specifier, stripping any peer
+// dep suffix first. Works for: foo@1.2.3, @scope/pkg@1.2.3, foo@1.2.3(react@18),
+// express@npm:^4.18.0 (yarn berry), @scope/pkg@npm:^1.0.0.
+function extractPackageName(spec: string): string | null {
+  const s = spec.replace(/\(.*\)$/, ''); // strip peer dep suffix
+  if (s.startsWith('@')) {
+    const i = s.indexOf('@', 1);
+    return i === -1 ? null : s.slice(0, i);
   }
-  const atIndex = withoutPeers.lastIndexOf('@');
-  if (atIndex === -1) return null;
-  return {
-    name: withoutPeers.slice(0, atIndex),
-    version: withoutPeers.slice(atIndex + 1),
-  };
+  const i = s.lastIndexOf('@');
+  return i <= 0 ? null : s.slice(0, i);
+}
+
+function parsePnpmV9Key(key: string): { name: string; version: string } | null {
+  const name = extractPackageName(key);
+  if (!name) return null;
+  const withoutPeers = key.replace(/\(.*\)$/, '');
+  return { name, version: withoutPeers.slice(name.length + 1) };
 }
 
 function parsePnpmV6Key(key: string): { name: string; version: string } | null {
@@ -216,6 +216,71 @@ function parsePnpmLock(
   return lockMap;
 }
 
+function parseYarnLock(
+  content: string,
+  lockfileVersion: number | undefined
+): Map<string, LockEntry> {
+  const lockMap = new Map<string, LockEntry>();
+  const isBerry = (lockfileVersion ?? 1) >= 2;
+
+  for (const block of content.split(/\n\n+/)) {
+    const trimmed = block.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const firstLine = trimmed.split('\n')[0];
+    if (!firstLine.endsWith(':')) continue;
+    if (firstLine === '__metadata:') continue;
+
+    // Berry: skip workspace/linked packages
+    if (isBerry && /\blinkType:\s+soft\b/.test(block)) continue;
+
+    // Extract resolved version
+    let version: string | undefined;
+    if (isBerry) {
+      const m = block.match(/^\s+version:\s+(.+)$/m);
+      if (!m) continue;
+      version = m[1].trim().replace(/^["']|["']$/g, '');
+    } else {
+      const m = block.match(/^\s+version\s+"([^"]+)"/m);
+      if (!m) continue;
+      version = m[1];
+    }
+
+    // Extract source from resolved URL (v1 only — berry has no registry URL)
+    let source: string | undefined;
+    let sourceUrl: string | undefined;
+    if (!isBerry) {
+      const m = block.match(/^\s+resolved\s+"([^"]+)/m);
+      if (m) {
+        if (m[1].startsWith('file:')) continue; // local package, skip
+        const classified = classifySource(m[1]);
+        source = classified.source;
+        sourceUrl = classified.sourceUrl;
+      }
+    }
+
+    // Get package name from the first specifier in the header
+    const specifiers = firstLine
+      .slice(0, -1) // strip trailing ':'
+      .split(',')
+      .map(s => s.trim().replace(/^"|"$/g, ''));
+
+    let name: string | null = null;
+    for (const spec of specifiers) {
+      name = extractPackageName(spec);
+      if (name) break;
+    }
+    if (!name || lockMap.has(name)) continue;
+
+    const lockEntry: LockEntry = { resolved: version, scopes: ['prod'] };
+    if (source) lockEntry.source = source;
+    if (sourceUrl) lockEntry.sourceUrl = sourceUrl;
+    lockMap.set(name, lockEntry);
+  }
+
+  return lockMap;
+}
+
 async function parseLockfile(
   cliType: CliType,
   lockfilePath: string,
@@ -227,6 +292,8 @@ async function parseLockfile(
       return parseNpmLock(content, lockfileVersion);
     case 'pnpm':
       return parsePnpmLock(content, lockfileVersion);
+    case 'yarn':
+      return parseYarnLock(content, lockfileVersion);
     default:
       return new Map();
   }

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -1,0 +1,15 @@
+import { createDiagnostics } from '@vercel/build-utils';
+import type { NodeVersion } from '@vercel/build-utils';
+
+type CliType = 'yarn' | 'npm' | 'pnpm' | 'bun' | 'vlt';
+
+export async function generateProjectManifest(_args: {
+  workPath: string;
+  entrypointDir: string;
+  nodeVersion: NodeVersion;
+  cliType: CliType;
+  lockfilePath: string | undefined;
+  lockfileVersion: number | undefined;
+}): Promise<void> {}
+
+export const diagnostics = createDiagnostics('node');

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import yaml from 'js-yaml';
 import {
   writeProjectManifest,
   createDiagnostics,
@@ -120,6 +121,101 @@ function parseNpmLock(
   return lockMap;
 }
 
+function parsePnpmV9Key(key: string): { name: string; version: string } | null {
+  // Strip peer dep suffix: foo@1.2.3(react@18.0.0) → foo@1.2.3
+  const withoutPeers = key.replace(/\(.*\)$/, '');
+  if (withoutPeers.startsWith('@')) {
+    // Scoped: @scope/pkg@1.2.3 — find the @ after the initial one
+    const atIndex = withoutPeers.indexOf('@', 1);
+    if (atIndex === -1) return null;
+    return {
+      name: withoutPeers.slice(0, atIndex),
+      version: withoutPeers.slice(atIndex + 1),
+    };
+  }
+  const atIndex = withoutPeers.lastIndexOf('@');
+  if (atIndex === -1) return null;
+  return {
+    name: withoutPeers.slice(0, atIndex),
+    version: withoutPeers.slice(atIndex + 1),
+  };
+}
+
+function parsePnpmV6Key(key: string): { name: string; version: string } | null {
+  if (!key.startsWith('/')) return null;
+  const rest = key.slice(1);
+  if (rest.startsWith('@')) {
+    // Scoped: @scope/pkg/1.2.3(_peers)
+    const firstSlash = rest.indexOf('/');
+    if (firstSlash === -1) return null;
+    const secondSlash = rest.indexOf('/', firstSlash + 1);
+    if (secondSlash === -1) return null;
+    const name = rest.slice(0, secondSlash);
+    const version = rest.slice(secondSlash + 1).split('_')[0];
+    return { name, version };
+  }
+  // Non-scoped: pkg/1.2.3(_peers)
+  const slashIndex = rest.indexOf('/');
+  if (slashIndex === -1) return null;
+  const name = rest.slice(0, slashIndex);
+  const version = rest.slice(slashIndex + 1).split('_')[0];
+  return { name, version };
+}
+
+function classifyPnpmResolution(
+  resolution: Record<string, unknown> | undefined
+): { source?: string; sourceUrl?: string; local?: boolean } {
+  if (!resolution) return {};
+  if (resolution.type === 'directory' || resolution.directory)
+    return { local: true };
+  if (typeof resolution.tarball === 'string')
+    return classifySource(resolution.tarball);
+  if (resolution.type === 'git' || typeof resolution.repo === 'string') {
+    return {
+      source: 'git',
+      sourceUrl: (resolution.repo as string) ?? undefined,
+    };
+  }
+  return {};
+}
+
+function parsePnpmLock(
+  content: string,
+  lockfileVersion: number | undefined
+): Map<string, LockEntry> {
+  const lockMap = new Map<string, LockEntry>();
+  const parsedYaml = yaml.load(content) as Record<string, unknown> | null;
+  if (!parsedYaml) return lockMap;
+
+  const lv =
+    lockfileVersion ?? Number((parsedYaml.lockfileVersion as string) ?? '0');
+  const packages = parsedYaml.packages as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!packages) return lockMap;
+
+  const parseKey = lv >= 9 ? parsePnpmV9Key : parsePnpmV6Key;
+
+  for (const [key, entry] of Object.entries(packages)) {
+    const keyParsed = parseKey(key);
+    if (!keyParsed) continue;
+    const { name, version } = keyParsed;
+
+    const resolution = entry.resolution as Record<string, unknown> | undefined;
+    const { local, source, sourceUrl } = classifyPnpmResolution(resolution);
+    if (local) continue;
+
+    if (lockMap.has(name)) continue; // keep first occurrence (dedup by name)
+
+    const lockEntry: LockEntry = { resolved: version, scopes: ['prod'] };
+    if (source) lockEntry.source = source;
+    if (sourceUrl) lockEntry.sourceUrl = sourceUrl;
+    lockMap.set(name, lockEntry);
+  }
+
+  return lockMap;
+}
+
 async function parseLockfile(
   cliType: CliType,
   lockfilePath: string,
@@ -129,6 +225,8 @@ async function parseLockfile(
   switch (cliType) {
     case 'npm':
       return parseNpmLock(content, lockfileVersion);
+    case 'pnpm':
+      return parsePnpmLock(content, lockfileVersion);
     default:
       return new Map();
   }

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -434,12 +434,39 @@ export async function generateProjectManifest({
       transitiveDeps.push(dep);
     }
 
+    const runtimeVersion: PackageManifest['runtimeVersion'] = {
+      resolved: String(nodeVersion.major),
+    };
+
+    // Populate requested/requestedSource from engines.node, .node-version, .nvmrc
+    const enginesNode = (pkgJson.engines as Record<string, string> | undefined)
+      ?.node;
+    if (enginesNode) {
+      runtimeVersion.requested = enginesNode;
+      runtimeVersion.requestedSource = 'package.json';
+    } else {
+      for (const filename of ['.node-version', '.nvmrc'] as const) {
+        try {
+          const val = await fs.promises.readFile(
+            path.join(workPath, filename),
+            'utf-8'
+          );
+          const trimmed = val.trim();
+          if (trimmed) {
+            runtimeVersion.requested = trimmed;
+            runtimeVersion.requestedSource = filename;
+            break;
+          }
+        } catch {
+          // file not present, try next
+        }
+      }
+    }
+
     const manifest: PackageManifest = {
       version: MANIFEST_VERSION,
       runtime: 'node',
-      runtimeVersion: {
-        resolved: String(nodeVersion.major),
-      },
+      runtimeVersion,
       dependencies: [
         ...directDeps.sort((a, b) => a.name.localeCompare(b.name)),
         ...transitiveDeps.sort((a, b) => a.name.localeCompare(b.name)),

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -281,11 +281,46 @@ function parseYarnLock(
   return lockMap;
 }
 
+function parseBunLock(content: string): Map<string, LockEntry> {
+  const lockMap = new Map<string, LockEntry>();
+  const parsed = JSON.parse(content) as Record<string, unknown>;
+
+  // packages keys are plain package names; value[0] is "name@resolved-version"
+  const packages = parsed.packages as Record<string, unknown[]> | undefined;
+  if (!packages) return lockMap;
+
+  for (const [name, value] of Object.entries(packages)) {
+    if (!Array.isArray(value)) continue;
+    const ref = value[0] as string | undefined;
+    if (!ref || typeof ref !== 'string') continue;
+
+    // Extract resolved version from "name@version" ref string
+    const pkgName = extractPackageName(ref);
+    if (!pkgName) continue;
+    const version = ref.slice(pkgName.length + 1);
+    if (!version) continue;
+
+    // Skip local/workspace packages
+    if (version.startsWith('file:') || version.startsWith('workspace:'))
+      continue;
+
+    if (lockMap.has(name)) continue;
+    lockMap.set(name, { resolved: version, scopes: ['prod'] });
+  }
+
+  return lockMap;
+}
+
 async function parseLockfile(
   cliType: CliType,
   lockfilePath: string,
   lockfileVersion: number | undefined
 ): Promise<Map<string, LockEntry>> {
+  // bun.lockb is a binary format — not parseable without invoking bun
+  if (cliType === 'bun' && lockfileVersion === 0) {
+    return new Map();
+  }
+
   const content = await fs.promises.readFile(lockfilePath, 'utf-8');
   switch (cliType) {
     case 'npm':
@@ -294,6 +329,8 @@ async function parseLockfile(
       return parsePnpmLock(content, lockfileVersion);
     case 'yarn':
       return parseYarnLock(content, lockfileVersion);
+    case 'bun':
+      return parseBunLock(content);
     default:
       return new Map();
   }

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -1,15 +1,255 @@
-import { createDiagnostics } from '@vercel/build-utils';
+import fs from 'fs';
+import path from 'path';
+import {
+  writeProjectManifest,
+  createDiagnostics,
+  debug,
+  MANIFEST_VERSION,
+  type PackageManifest,
+  type PackageManifestDependency,
+} from '@vercel/build-utils';
 import type { NodeVersion } from '@vercel/build-utils';
 
 type CliType = 'yarn' | 'npm' | 'pnpm' | 'bun' | 'vlt';
 
-export async function generateProjectManifest(_args: {
+interface LockEntry {
+  resolved: string;
+  scopes: string[];
+  source?: string;
+  sourceUrl?: string;
+}
+
+function classifySource(resolvedUrl: string | undefined): {
+  source?: string;
+  sourceUrl?: string;
+} {
+  if (!resolvedUrl) return {};
+  if (resolvedUrl.startsWith('file:')) {
+    return { source: 'file', sourceUrl: resolvedUrl.slice('file:'.length) };
+  }
+  if (resolvedUrl.startsWith('git+') || resolvedUrl.startsWith('git://')) {
+    return { source: 'git', sourceUrl: resolvedUrl.replace(/^git\+/, '') };
+  }
+  try {
+    const url = new URL(resolvedUrl);
+    return { source: 'registry', sourceUrl: url.origin };
+  } catch {
+    return {};
+  }
+}
+
+function npmEntryScopes(entry: Record<string, unknown>): string[] {
+  const scopes: string[] = [];
+  if (entry.dev) scopes.push('dev');
+  if (entry.peer) scopes.push('peer');
+  if (entry.optional) scopes.push('optional');
+  if (scopes.length === 0) scopes.push('prod');
+  return scopes;
+}
+
+function parseNpmLock(
+  content: string,
+  lockfileVersion: number | undefined
+): Map<string, LockEntry> {
+  const lockMap = new Map<string, LockEntry>();
+  const parsed = JSON.parse(content) as Record<string, unknown>;
+  const lv = lockfileVersion ?? (parsed.lockfileVersion as number) ?? 1;
+
+  if (lv >= 2) {
+    const packages = parsed.packages as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    if (!packages) return lockMap;
+
+    for (const [key, entry] of Object.entries(packages)) {
+      if (key === '') continue; // root package
+      if (!key.startsWith('node_modules/')) continue;
+      if (entry.link === true) continue; // workspace symlink
+
+      const rest = key.slice('node_modules/'.length);
+      // Keep only top-level entries: 'foo' or '@scope/pkg', not 'foo/node_modules/bar'
+      const isScoped = rest.startsWith('@');
+      const slashCount = (rest.match(/\//g) ?? []).length;
+      if (isScoped ? slashCount !== 1 : slashCount !== 0) continue;
+
+      const resolved = entry.resolved as string | undefined;
+      if (resolved?.startsWith('file:')) continue; // local/workspace package
+
+      if (lockMap.has(rest)) continue; // keep first occurrence
+
+      const { source, sourceUrl } = classifySource(resolved);
+      const lockEntry: LockEntry = {
+        resolved: (entry.version as string) ?? '',
+        scopes: npmEntryScopes(entry),
+      };
+      if (source) lockEntry.source = source;
+      if (sourceUrl) lockEntry.sourceUrl = sourceUrl;
+      lockMap.set(rest, lockEntry);
+    }
+  } else {
+    // v1: flat dependencies object, potentially nested for workspaces
+    const dependencies = parsed.dependencies as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    if (!dependencies) return lockMap;
+
+    const walk = (deps: Record<string, Record<string, unknown>>) => {
+      for (const [name, entry] of Object.entries(deps)) {
+        const resolved = entry.resolved as string | undefined;
+        if (!lockMap.has(name)) {
+          if (!resolved?.startsWith('file:')) {
+            const { source, sourceUrl } = classifySource(resolved);
+            const lockEntry: LockEntry = {
+              resolved: (entry.version as string) ?? '',
+              scopes: npmEntryScopes(entry),
+            };
+            if (source) lockEntry.source = source;
+            if (sourceUrl) lockEntry.sourceUrl = sourceUrl;
+            lockMap.set(name, lockEntry);
+          }
+        }
+        const nested = entry.dependencies as
+          | Record<string, Record<string, unknown>>
+          | undefined;
+        if (nested) walk(nested);
+      }
+    };
+    walk(dependencies);
+  }
+
+  return lockMap;
+}
+
+async function parseLockfile(
+  cliType: CliType,
+  lockfilePath: string,
+  lockfileVersion: number | undefined
+): Promise<Map<string, LockEntry>> {
+  const content = await fs.promises.readFile(lockfilePath, 'utf-8');
+  switch (cliType) {
+    case 'npm':
+      return parseNpmLock(content, lockfileVersion);
+    default:
+      return new Map();
+  }
+}
+
+async function readPackageJson(
+  startDir: string
+): Promise<Record<string, unknown> | null> {
+  let current = startDir;
+  for (;;) {
+    try {
+      const content = await fs.promises.readFile(
+        path.join(current, 'package.json'),
+        'utf-8'
+      );
+      return JSON.parse(content) as Record<string, unknown>;
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) return null;
+      current = parent;
+    }
+  }
+}
+
+function buildDirectMaps(pkgJson: Record<string, unknown>): {
+  directScopes: Map<string, Set<string>>;
+  directRequested: Map<string, string>;
+} {
+  const directScopes = new Map<string, Set<string>>();
+  const directRequested = new Map<string, string>();
+
+  const add = (deps: unknown, scope: string) => {
+    if (!deps || typeof deps !== 'object') return;
+    for (const [name, specifier] of Object.entries(
+      deps as Record<string, string>
+    )) {
+      if (!directScopes.has(name)) directScopes.set(name, new Set());
+      directScopes.get(name)!.add(scope);
+      if (!directRequested.has(name)) directRequested.set(name, specifier);
+    }
+  };
+
+  add(pkgJson.dependencies, 'prod');
+  add(pkgJson.devDependencies, 'dev');
+  add(pkgJson.peerDependencies, 'peer');
+  add(pkgJson.optionalDependencies, 'optional');
+
+  return { directScopes, directRequested };
+}
+
+export async function generateProjectManifest({
+  workPath,
+  nodeVersion,
+  cliType,
+  lockfilePath,
+  lockfileVersion,
+}: {
   workPath: string;
-  entrypointDir: string;
   nodeVersion: NodeVersion;
   cliType: CliType;
   lockfilePath: string | undefined;
   lockfileVersion: number | undefined;
-}): Promise<void> {}
+}): Promise<void> {
+  try {
+    const pkgJson = await readPackageJson(workPath);
+    if (!pkgJson) return;
+
+    const { directScopes, directRequested } = buildDirectMaps(pkgJson);
+
+    const lockMap = lockfilePath
+      ? await parseLockfile(cliType, lockfilePath, lockfileVersion)
+      : new Map<string, LockEntry>();
+
+    const directDeps: PackageManifestDependency[] = [];
+    const transitiveDeps: PackageManifestDependency[] = [];
+
+    for (const [name, scopes] of directScopes) {
+      const lock = lockMap.get(name);
+      const dep: PackageManifestDependency = {
+        name,
+        type: 'direct',
+        scopes: [...scopes].sort(),
+        requested: directRequested.get(name),
+        resolved: lock?.resolved ?? '',
+      };
+      if (lock?.source) dep.source = lock.source;
+      if (lock?.sourceUrl) dep.sourceUrl = lock.sourceUrl;
+      directDeps.push(dep);
+    }
+
+    for (const [name, lock] of lockMap) {
+      if (directScopes.has(name)) continue;
+      const dep: PackageManifestDependency = {
+        name,
+        type: 'transitive',
+        scopes: lock.scopes,
+        resolved: lock.resolved,
+      };
+      if (lock.source) dep.source = lock.source;
+      if (lock.sourceUrl) dep.sourceUrl = lock.sourceUrl;
+      transitiveDeps.push(dep);
+    }
+
+    const manifest: PackageManifest = {
+      version: MANIFEST_VERSION,
+      runtime: 'node',
+      runtimeVersion: {
+        resolved: String(nodeVersion.major),
+      },
+      dependencies: [
+        ...directDeps.sort((a, b) => a.name.localeCompare(b.name)),
+        ...transitiveDeps.sort((a, b) => a.name.localeCompare(b.name)),
+      ],
+    };
+
+    await writeProjectManifest(manifest, workPath, 'node');
+  } catch (err) {
+    debug(
+      `generateProjectManifest: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
 
 export const diagnostics = createDiagnostics('node');

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
+import { parseSyml } from '@yarnpkg/parsers';
 import {
   writeProjectManifest,
   createDiagnostics,
@@ -226,7 +227,10 @@ function parsePnpmLock(
 ): Map<string, LockEntry> {
   const lockMap = new Map<string, LockEntry>();
   // pnpm lockfiles may have multiple YAML documents (starts with '---')
-  const docs = yaml.loadAll(content) as Array<Record<string, unknown> | null>;
+  const docs: Array<Record<string, unknown> | null> = [];
+  yaml.safeLoadAll(content, doc =>
+    docs.push(doc as Record<string, unknown> | null)
+  );
   const parsedYaml = docs[0];
   if (!parsedYaml) return lockMap;
 
@@ -272,57 +276,41 @@ function parseYarnLock(
   const lockMap = new Map<string, LockEntry>();
   const isBerry = (lockfileVersion ?? 1) >= 2;
 
-  for (const block of content.split(/\n\n+/)) {
-    const trimmed = block.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
+  const parsed = parseSyml(content) as Record<
+    string,
+    Record<string, string> | undefined
+  >;
 
-    const firstLine = trimmed.split('\n')[0];
-    if (!firstLine.endsWith(':')) continue;
-    if (firstLine === '__metadata:') continue;
+  for (const [key, entry] of Object.entries(parsed)) {
+    if (key === '__metadata' || !entry) continue;
 
     // Berry: skip workspace/linked packages
-    if (isBerry && /\blinkType:\s+soft\b/.test(block)) continue;
+    if (isBerry && entry.linkType === 'soft') continue;
 
-    // Extract resolved version
-    let version: string | undefined;
-    if (isBerry) {
-      const m = block.match(/^\s+version:\s+(.+)$/m);
-      if (!m) continue;
-      version = m[1].trim().replace(/^["']|["']$/g, '');
-    } else {
-      const m = block.match(/^\s+version\s+"([^"]+)"/m);
-      if (!m) continue;
-      version = m[1];
-    }
+    const version = entry.version;
+    if (!version) continue;
 
     // Extract source from resolved URL (v1 only — berry has no registry URL)
     let source: string | undefined;
     let sourceUrl: string | undefined;
-    if (!isBerry) {
-      const m = block.match(/^\s+resolved\s+"([^"]+)/m);
-      if (m) {
-        if (m[1].startsWith('file:')) continue; // local package, skip
-        const classified = classifySource(m[1]);
-        source = classified.source;
-        sourceUrl = classified.sourceUrl;
-      }
+    if (!isBerry && entry.resolved) {
+      if (entry.resolved.startsWith('file:')) continue;
+      const classified = classifySource(entry.resolved);
+      source = classified.source;
+      sourceUrl = classified.sourceUrl;
     }
 
-    // Get package name from the first specifier in the header
-    const specifiers = firstLine
-      .slice(0, -1) // strip trailing ':'
-      .split(',')
-      .map(s => s.trim().replace(/^"|"$/g, ''));
-
+    // Get package name from the first specifier in the (possibly comma-joined) key
+    const specifiers = key.split(',').map(s => s.trim().replace(/^"|"$/g, ''));
     let name: string | null = null;
     for (const spec of specifiers) {
       name = extractPackageName(spec);
       if (name) break;
     }
     if (!name) continue;
-    const existingYarn = lockMap.get(name);
-    if (existingYarn && !isHigherVersion(version, existingYarn.resolved))
-      continue;
+
+    const existing = lockMap.get(name);
+    if (existing && !isHigherVersion(version, existing.resolved)) continue;
 
     const lockEntry: LockEntry = { resolved: version, scopes: ['prod'] };
     if (source) lockEntry.source = source;

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -159,7 +159,6 @@ export const build: BuildV2 = async args => {
     try {
       await generateProjectManifest({
         workPath: args.workPath,
-        entrypointDir: downloadResult.entrypointFsDirname,
         nodeVersion,
         cliType: downloadResult.cliType,
         lockfilePath: downloadResult.lockfilePath,

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,4 +1,5 @@
 import { downloadInstallAndBundle } from './utils.js';
+import { generateProjectManifest } from './diagnostics.js';
 import {
   defaultCachePathGlob,
   glob,
@@ -39,6 +40,7 @@ import { Colors as c } from './cervel/utils.js';
 
 // Re-export introspection functions
 export { introspectApp } from './introspection/index.js';
+export { diagnostics } from './diagnostics.js';
 
 export const version = 2;
 
@@ -153,6 +155,21 @@ export const build: BuildV2 = async args => {
       conditions: isBun ? ['bun'] : undefined,
       span: buildSpan,
     });
+
+    try {
+      await generateProjectManifest({
+        workPath: args.workPath,
+        entrypointDir: downloadResult.entrypointFsDirname,
+        nodeVersion,
+        cliType: downloadResult.cliType,
+        lockfilePath: downloadResult.lockfilePath,
+        lockfileVersion: downloadResult.lockfileVersion,
+      });
+    } catch (err) {
+      debug(
+        `Failed to write node manifest: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
 
     const baseDir = args.repoRootPath || args.workPath;
     const includeResults = await Promise.all(

--- a/packages/backends/src/utils.ts
+++ b/packages/backends/src/utils.ts
@@ -18,6 +18,9 @@ export async function downloadInstallAndBundle(
     [x: string]: string | undefined;
   };
   entrypointFsDirname: string;
+  cliType: Awaited<ReturnType<typeof scanParentDirs>>['cliType'];
+  lockfilePath: string | undefined;
+  lockfileVersion: number | undefined;
 }> {
   const { entrypoint, files, workPath, meta, config, repoRootPath } = args;
   await download(files, workPath, meta);
@@ -26,6 +29,7 @@ export async function downloadInstallAndBundle(
 
   const {
     cliType,
+    lockfilePath,
     lockfileVersion,
     packageJsonPackageManager,
     turboSupportsCorepackHome,
@@ -62,7 +66,13 @@ export async function downloadInstallAndBundle(
       config.projectSettings?.createdAt
     );
   }
-  return { entrypointFsDirname, spawnEnv };
+  return {
+    entrypointFsDirname,
+    spawnEnv,
+    cliType,
+    lockfilePath,
+    lockfileVersion,
+  };
 }
 
 export async function maybeExecBuildCommand(

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -1,0 +1,616 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import { tmpdir } from 'os';
+import {
+  FileBlob,
+  MANIFEST_FILENAME,
+  MANIFEST_VERSION,
+  manifestPath,
+} from '@vercel/build-utils';
+import { generateProjectManifest, diagnostics } from '../src/diagnostics';
+
+const DIAGNOSTICS_PATH = manifestPath('node');
+
+// Minimal NodeVersion shape — only `major` is used by generateProjectManifest
+const nodeVersion = { major: 20, range: '20.x', runtime: 'nodejs20.x' } as any;
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(tmpdir(), 'vc-node-diag-test-'));
+}
+
+function writePackageJson(dir: string, pkg: object): void {
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify(pkg, null, 2)
+  );
+}
+
+function writeNpmLock(dir: string, lock: object): string {
+  const lockPath = path.join(dir, 'package-lock.json');
+  fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2));
+  return lockPath;
+}
+
+function readManifest(dir: string): any {
+  return JSON.parse(fs.readFileSync(path.join(dir, DIAGNOSTICS_PATH), 'utf-8'));
+}
+
+// ─── npm v2/v3 ────────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — npm v2/v3', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('writes manifest with correct metadata', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/express': {
+          version: '4.18.2',
+          resolved: 'https://registry.npmjs.org/express/-/express-4.18.2.tgz',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.version).toBe(MANIFEST_VERSION);
+    expect(manifest.runtime).toBe('node');
+  });
+
+  it('classifies direct dep with correct scope, requested, and resolved', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/express': {
+          version: '4.18.2',
+          resolved: 'https://registry.npmjs.org/express/-/express-4.18.2.tgz',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies).toEqual([
+      {
+        name: 'express',
+        type: 'direct',
+        scopes: ['prod'],
+        requested: '^4.18.0',
+        resolved: '4.18.2',
+        source: 'registry',
+        sourceUrl: 'https://registry.npmjs.org',
+      },
+    ]);
+  });
+
+  it('classifies dev dependency with dev scope', async () => {
+    writePackageJson(tempDir, { devDependencies: { vitest: '^2.0.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/vitest': {
+          version: '2.0.1',
+          resolved: 'https://registry.npmjs.org/vitest/-/vitest-2.0.1.tgz',
+          dev: true,
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const dep = dependencies.find((d: any) => d.name === 'vitest');
+    expect(dep.type).toBe('direct');
+    expect(dep.scopes).toEqual(['dev']);
+  });
+
+  it('includes transitive deps', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/express': {
+          version: '4.18.2',
+          resolved: 'https://registry.npmjs.org/express/-/express-4.18.2.tgz',
+        },
+        'node_modules/accepts': {
+          version: '1.3.8',
+          resolved: 'https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const accepts = dependencies.find((d: any) => d.name === 'accepts');
+    expect(accepts.type).toBe('transitive');
+    expect(accepts.resolved).toBe('1.3.8');
+    expect(accepts.source).toBe('registry');
+    expect(accepts.sourceUrl).toBe('https://registry.npmjs.org');
+  });
+
+  it('assigns dev scope to transitive dep flagged dev in lockfile', async () => {
+    writePackageJson(tempDir, { dependencies: { foo: '^1.0.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/foo': {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+        },
+        'node_modules/bar': {
+          version: '2.0.0',
+          resolved: 'https://registry.npmjs.org/bar/-/bar-2.0.0.tgz',
+          dev: true,
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const bar = readManifest(tempDir).dependencies.find(
+      (d: any) => d.name === 'bar'
+    );
+    expect(bar.type).toBe('transitive');
+    expect(bar.scopes).toEqual(['dev']);
+  });
+
+  it('handles @org/pkg namespaced packages', async () => {
+    writePackageJson(tempDir, {
+      dependencies: { '@vercel/node': '^3.0.0' },
+    });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/@vercel/node': {
+          version: '3.0.7',
+          resolved: 'https://registry.npmjs.org/@vercel/node/-/node-3.0.7.tgz',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies).toEqual([
+      {
+        name: '@vercel/node',
+        type: 'direct',
+        scopes: ['prod'],
+        requested: '^3.0.0',
+        resolved: '3.0.7',
+        source: 'registry',
+        sourceUrl: 'https://registry.npmjs.org',
+      },
+    ]);
+  });
+
+  it('excludes nested node_modules entries', async () => {
+    writePackageJson(tempDir, { dependencies: { foo: '^1.0.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/foo': {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+        },
+        'node_modules/foo/node_modules/bar': {
+          version: '2.0.0',
+          resolved: 'https://registry.npmjs.org/bar/-/bar-2.0.0.tgz',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).toContain('foo');
+    expect(names).not.toContain('bar');
+  });
+
+  it('excludes symlinked packages (link: true)', async () => {
+    writePackageJson(tempDir, { dependencies: { real: '^1.0.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/real': {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/real/-/real-1.0.0.tgz',
+        },
+        'node_modules/workspace-pkg': {
+          link: true,
+          resolved: '../workspace-pkg',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).not.toContain('workspace-pkg');
+  });
+
+  it('excludes packages resolved to local file paths', async () => {
+    writePackageJson(tempDir, { dependencies: { real: '^1.0.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/real': {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/real/-/real-1.0.0.tgz',
+        },
+        'node_modules/local-pkg': {
+          version: '0.0.1',
+          resolved: 'file:../local-pkg',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).not.toContain('local-pkg');
+  });
+
+  it('classifies packages resolved from git URLs', async () => {
+    writePackageJson(tempDir, {
+      dependencies: { mylib: 'github:org/mylib' },
+    });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/mylib': {
+          version: '1.2.3',
+          resolved: 'git+https://github.com/org/mylib.git#abc123',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const dep = readManifest(tempDir).dependencies.find(
+      (d: any) => d.name === 'mylib'
+    );
+    expect(dep.source).toBe('git');
+    expect(dep.sourceUrl).toBe('https://github.com/org/mylib.git#abc123');
+  });
+
+  it('direct dep in multiple package.json fields gets all scopes', async () => {
+    writePackageJson(tempDir, {
+      dependencies: { react: '^18.0.0' },
+      peerDependencies: { react: '>=17.0.0' },
+    });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 3,
+      packages: {
+        '': {},
+        'node_modules/react': {
+          version: '18.2.0',
+          resolved: 'https://registry.npmjs.org/react/-/react-18.2.0.tgz',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 3,
+    });
+
+    const dep = readManifest(tempDir).dependencies.find(
+      (d: any) => d.name === 'react'
+    );
+    expect(dep.type).toBe('direct');
+    expect(dep.scopes).toEqual(['peer', 'prod']);
+  });
+
+  it('handles missing lockfile gracefully', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: undefined,
+      lockfileVersion: undefined,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies).toEqual([
+      {
+        name: 'express',
+        type: 'direct',
+        scopes: ['prod'],
+        requested: '^4.18.0',
+        resolved: '',
+      },
+    ]);
+  });
+
+  it('writes no manifest when package.json is not found', async () => {
+    // tempDir has no package.json
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: undefined,
+      lockfileVersion: undefined,
+    });
+
+    expect(fs.existsSync(path.join(tempDir, DIAGNOSTICS_PATH))).toBe(false);
+  });
+});
+
+// ─── npm v1 ───────────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — npm v1', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('resolves direct and transitive dependencies from v1 lockfile', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 1,
+      dependencies: {
+        express: {
+          version: '4.18.2',
+          resolved: 'https://registry.npmjs.org/express/-/express-4.18.2.tgz',
+        },
+        accepts: {
+          version: '1.3.8',
+          resolved: 'https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const express = dependencies.find((d: any) => d.name === 'express');
+    expect(express.type).toBe('direct');
+    expect(express.resolved).toBe('4.18.2');
+
+    const accepts = dependencies.find((d: any) => d.name === 'accepts');
+    expect(accepts.type).toBe('transitive');
+    expect(accepts.resolved).toBe('1.3.8');
+  });
+
+  it('walks nested dependencies in v1 lockfile', async () => {
+    writePackageJson(tempDir, { dependencies: { foo: '^1.0.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 1,
+      dependencies: {
+        foo: {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+          dependencies: {
+            bar: {
+              version: '2.0.0',
+              resolved: 'https://registry.npmjs.org/bar/-/bar-2.0.0.tgz',
+            },
+          },
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).toContain('foo');
+    expect(names).toContain('bar');
+  });
+
+  it('deduplicates same package appearing at multiple nesting levels', async () => {
+    writePackageJson(tempDir, {
+      dependencies: { foo: '^1.0.0', baz: '^1.0.0' },
+    });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 1,
+      dependencies: {
+        foo: {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+          dependencies: {
+            bar: {
+              version: '2.0.0',
+              resolved: 'https://registry.npmjs.org/bar/-/bar-2.0.0.tgz',
+            },
+          },
+        },
+        baz: {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/baz/-/baz-1.0.0.tgz',
+          dependencies: {
+            bar: {
+              version: '2.0.0',
+              resolved: 'https://registry.npmjs.org/bar/-/bar-2.0.0.tgz',
+            },
+          },
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const barEntries = readManifest(tempDir).dependencies.filter(
+      (d: any) => d.name === 'bar'
+    );
+    expect(barEntries).toHaveLength(1);
+  });
+
+  it('excludes file: deps from v1 lockfile', async () => {
+    writePackageJson(tempDir, { dependencies: { real: '^1.0.0' } });
+    const lockPath = writeNpmLock(tempDir, {
+      lockfileVersion: 1,
+      dependencies: {
+        real: {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/real/-/real-1.0.0.tgz',
+        },
+        'local-pkg': {
+          version: '0.0.1',
+          resolved: 'file:../local-pkg',
+        },
+      },
+    });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).not.toContain('local-pkg');
+  });
+});
+
+// ─── diagnostics callback ─────────────────────────────────────────────────────
+
+describe('diagnostics callback', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('returns manifest FileBlob when present', async () => {
+    const manifestFilePath = path.join(tempDir, DIAGNOSTICS_PATH);
+    fs.mkdirSync(path.dirname(manifestFilePath), { recursive: true });
+    const content = JSON.stringify({ version: '20260304', runtime: 'node' });
+    fs.writeFileSync(manifestFilePath, content);
+
+    const files = await diagnostics({ workPath: tempDir } as any);
+
+    expect(files).toHaveProperty(MANIFEST_FILENAME);
+    const blob = files[MANIFEST_FILENAME] as FileBlob;
+    expect(blob).toBeInstanceOf(FileBlob);
+    expect(JSON.parse(blob.data as string)).toEqual({
+      version: '20260304',
+      runtime: 'node',
+    });
+  });
+
+  it('returns empty object when no manifest exists', async () => {
+    const files = await diagnostics({ workPath: tempDir } as any);
+    expect(files).toEqual({});
+  });
+});

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -1373,6 +1373,83 @@ describe('generateProjectManifest — vlt fallback', () => {
   });
 });
 
+// ─── runtimeVersion ───────────────────────────────────────────────────────────
+
+describe('runtimeVersion', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  async function getVersion(dir: string) {
+    await generateProjectManifest({
+      workPath: dir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: undefined,
+      lockfileVersion: undefined,
+    });
+    return readManifest(dir).runtimeVersion;
+  }
+
+  it('resolved comes from nodeVersion.major', async () => {
+    writePackageJson(tempDir, {});
+    const rv = await getVersion(tempDir);
+    expect(rv.resolved).toBe('20');
+  });
+
+  it('reads requested from engines.node in package.json', async () => {
+    writePackageJson(tempDir, { engines: { node: '>=20.0.0' } });
+    const rv = await getVersion(tempDir);
+    expect(rv.requested).toBe('>=20.0.0');
+    expect(rv.requestedSource).toBe('package.json');
+  });
+
+  it('reads requested from .node-version when no engines.node', async () => {
+    writePackageJson(tempDir, {});
+    fs.writeFileSync(path.join(tempDir, '.node-version'), '20.11.0\n');
+    const rv = await getVersion(tempDir);
+    expect(rv.requested).toBe('20.11.0');
+    expect(rv.requestedSource).toBe('.node-version');
+  });
+
+  it('reads requested from .nvmrc when no engines.node or .node-version', async () => {
+    writePackageJson(tempDir, {});
+    fs.writeFileSync(path.join(tempDir, '.nvmrc'), 'lts/iron\n');
+    const rv = await getVersion(tempDir);
+    expect(rv.requested).toBe('lts/iron');
+    expect(rv.requestedSource).toBe('.nvmrc');
+  });
+
+  it('engines.node takes priority over .node-version', async () => {
+    writePackageJson(tempDir, { engines: { node: '>=20.0.0' } });
+    fs.writeFileSync(path.join(tempDir, '.node-version'), '18.0.0');
+    const rv = await getVersion(tempDir);
+    expect(rv.requested).toBe('>=20.0.0');
+    expect(rv.requestedSource).toBe('package.json');
+  });
+
+  it('.node-version takes priority over .nvmrc', async () => {
+    writePackageJson(tempDir, {});
+    fs.writeFileSync(path.join(tempDir, '.node-version'), '20.11.0');
+    fs.writeFileSync(path.join(tempDir, '.nvmrc'), '18.0.0');
+    const rv = await getVersion(tempDir);
+    expect(rv.requested).toBe('20.11.0');
+    expect(rv.requestedSource).toBe('.node-version');
+  });
+
+  it('omits requested when none of the sources are present', async () => {
+    writePackageJson(tempDir, {});
+    const rv = await getVersion(tempDir);
+    expect(rv).toEqual({ resolved: '20' });
+  });
+});
+
 // ─── diagnostics callback ─────────────────────────────────────────────────────
 
 describe('diagnostics callback', () => {

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -801,9 +801,9 @@ describe('generateProjectManifest — pnpm v6', () => {
 lockfileVersion: '6.0'
 
 packages:
-  /express/4.18.2:
+  /express@4.18.2:
     resolution: {integrity: sha512-abc}
-  /accepts/1.3.8:
+  /accepts@1.3.8:
     resolution: {integrity: sha512-def}
 `
     );
@@ -834,7 +834,7 @@ packages:
 lockfileVersion: '6.0'
 
 packages:
-  /@vercel/node/3.0.7:
+  /@vercel/node@3.0.7:
     resolution: {integrity: sha512-abc}
 `
     );
@@ -860,7 +860,7 @@ packages:
 lockfileVersion: '6.0'
 
 packages:
-  /foo/1.0.0_react@18.0.0:
+  /foo@1.0.0_react@18.0.0:
     resolution: {integrity: sha512-abc}
 `
     );
@@ -886,9 +886,9 @@ packages:
 lockfileVersion: '6.0'
 
 packages:
-  /real/1.0.0:
+  /real@1.0.0:
     resolution: {integrity: sha512-abc}
-  /local-pkg/0.0.1:
+  /local-pkg@0.0.1:
     resolution: {directory: ../local-pkg, type: directory}
 `
     );

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -1050,7 +1050,7 @@ real@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/real/-/real-1.0.0.tgz#abc"
 
-local-pkg@file:../local-pkg:
+"local-pkg@file:../local-pkg":
   version "0.0.1"
   resolved "file:../local-pkg"
 `

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -32,6 +32,12 @@ function writeNpmLock(dir: string, lock: object): string {
   return lockPath;
 }
 
+function writePnpmLock(dir: string, content: string): string {
+  const lockPath = path.join(dir, 'pnpm-lock.yaml');
+  fs.writeFileSync(lockPath, content);
+  return lockPath;
+}
+
 function readManifest(dir: string): any {
   return JSON.parse(fs.readFileSync(path.join(dir, DIAGNOSTICS_PATH), 'utf-8'));
 }
@@ -575,6 +581,322 @@ describe('generateProjectManifest — npm v1', () => {
     });
 
     const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).not.toContain('local-pkg');
+  });
+});
+
+// ─── pnpm v9 ──────────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — pnpm v9', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('resolves direct and transitive deps', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '9.0'
+
+packages:
+  express@4.18.2:
+    resolution: {integrity: sha512-abc}
+  accepts@1.3.8:
+    resolution: {integrity: sha512-def}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 9,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const express = dependencies.find((d: any) => d.name === 'express');
+    expect(express.type).toBe('direct');
+    expect(express.resolved).toBe('4.18.2');
+
+    const accepts = dependencies.find((d: any) => d.name === 'accepts');
+    expect(accepts.type).toBe('transitive');
+    expect(accepts.resolved).toBe('1.3.8');
+  });
+
+  it('handles @org/pkg namespaced packages', async () => {
+    writePackageJson(tempDir, { dependencies: { '@vercel/node': '^3.0.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '9.0'
+
+packages:
+  '@vercel/node@3.0.7':
+    resolution: {integrity: sha512-abc}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 9,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies).toEqual([
+      {
+        name: '@vercel/node',
+        type: 'direct',
+        scopes: ['prod'],
+        requested: '^3.0.0',
+        resolved: '3.0.7',
+      },
+    ]);
+  });
+
+  it('strips peer dep suffixes from keys', async () => {
+    writePackageJson(tempDir, { dependencies: { foo: '^1.0.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '9.0'
+
+packages:
+  'foo@1.0.0(react@18.0.0)':
+    resolution: {integrity: sha512-abc}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 9,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies[0].name).toBe('foo');
+    expect(dependencies[0].resolved).toBe('1.0.0');
+  });
+
+  it('deduplicates packages with different peer dep variants', async () => {
+    writePackageJson(tempDir, { dependencies: { foo: '^1.0.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '9.0'
+
+packages:
+  'foo@1.0.0(react@17.0.0)':
+    resolution: {integrity: sha512-abc}
+  'foo@1.0.0(react@18.0.0)':
+    resolution: {integrity: sha512-def}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 9,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const fooEntries = dependencies.filter((d: any) => d.name === 'foo');
+    expect(fooEntries).toHaveLength(1);
+    expect(fooEntries[0].resolved).toBe('1.0.0');
+  });
+
+  it('excludes local directory packages', async () => {
+    writePackageJson(tempDir, { dependencies: { real: '^1.0.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '9.0'
+
+packages:
+  real@1.0.0:
+    resolution: {integrity: sha512-abc}
+  local-pkg@0.0.1:
+    resolution: {directory: ../local-pkg, type: directory}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 9,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).toContain('real');
+    expect(names).not.toContain('local-pkg');
+  });
+
+  it('classifies tarball URL source', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '9.0'
+
+packages:
+  express@4.18.2:
+    resolution: {integrity: sha512-abc, tarball: https://registry.npmjs.org/express/-/express-4.18.2.tgz}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 9,
+    });
+
+    const dep = readManifest(tempDir).dependencies[0];
+    expect(dep.source).toBe('registry');
+    expect(dep.sourceUrl).toBe('https://registry.npmjs.org');
+  });
+});
+
+// ─── pnpm v6 ──────────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — pnpm v6', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('resolves direct and transitive deps', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '6.0'
+
+packages:
+  /express/4.18.2:
+    resolution: {integrity: sha512-abc}
+  /accepts/1.3.8:
+    resolution: {integrity: sha512-def}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 6,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const express = dependencies.find((d: any) => d.name === 'express');
+    expect(express.type).toBe('direct');
+    expect(express.resolved).toBe('4.18.2');
+
+    const accepts = dependencies.find((d: any) => d.name === 'accepts');
+    expect(accepts.type).toBe('transitive');
+    expect(accepts.resolved).toBe('1.3.8');
+  });
+
+  it('handles @org/pkg namespaced packages', async () => {
+    writePackageJson(tempDir, { dependencies: { '@vercel/node': '^3.0.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '6.0'
+
+packages:
+  /@vercel/node/3.0.7:
+    resolution: {integrity: sha512-abc}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 6,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies[0].name).toBe('@vercel/node');
+    expect(dependencies[0].resolved).toBe('3.0.7');
+  });
+
+  it('strips peer dep suffixes from keys', async () => {
+    writePackageJson(tempDir, { dependencies: { foo: '^1.0.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '6.0'
+
+packages:
+  /foo/1.0.0_react@18.0.0:
+    resolution: {integrity: sha512-abc}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 6,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies[0].name).toBe('foo');
+    expect(dependencies[0].resolved).toBe('1.0.0');
+  });
+
+  it('excludes local directory packages', async () => {
+    writePackageJson(tempDir, { dependencies: { real: '^1.0.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+lockfileVersion: '6.0'
+
+packages:
+  /real/1.0.0:
+    resolution: {integrity: sha512-abc}
+  /local-pkg/0.0.1:
+    resolution: {directory: ../local-pkg, type: directory}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 6,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).toContain('real');
     expect(names).not.toContain('local-pkg');
   });
 });

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -1189,6 +1189,151 @@ __metadata:
   });
 });
 
+// ─── bun text ─────────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — bun text (bun.lock)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('resolves direct and transitive deps', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = path.join(tempDir, 'bun.lock');
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({
+        lockfileVersion: 0,
+        packages: {
+          express: ['express@4.18.2', {}, 'hash'],
+          accepts: ['accepts@1.3.8', {}, 'hash'],
+        },
+      })
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'bun',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const express = dependencies.find((d: any) => d.name === 'express');
+    expect(express.type).toBe('direct');
+    expect(express.resolved).toBe('4.18.2');
+
+    const accepts = dependencies.find((d: any) => d.name === 'accepts');
+    expect(accepts.type).toBe('transitive');
+    expect(accepts.resolved).toBe('1.3.8');
+  });
+
+  it('handles @org/pkg namespaced packages', async () => {
+    writePackageJson(tempDir, { dependencies: { '@vercel/node': '^3.0.0' } });
+    const lockPath = path.join(tempDir, 'bun.lock');
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({
+        lockfileVersion: 0,
+        packages: {
+          '@vercel/node': ['@vercel/node@3.0.7', {}, 'hash'],
+        },
+      })
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'bun',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies[0].name).toBe('@vercel/node');
+    expect(dependencies[0].resolved).toBe('3.0.7');
+  });
+
+  it('excludes file: and workspace: linked packages', async () => {
+    writePackageJson(tempDir, { dependencies: { real: '^1.0.0' } });
+    const lockPath = path.join(tempDir, 'bun.lock');
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({
+        lockfileVersion: 0,
+        packages: {
+          real: ['real@1.0.0', {}, 'hash'],
+          'local-pkg': ['local-pkg@file:../local-pkg', {}, null],
+          'workspace-pkg': [
+            'workspace-pkg@workspace:packages/workspace-pkg',
+            {},
+            null,
+          ],
+        },
+      })
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'bun',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).toContain('real');
+    expect(names).not.toContain('local-pkg');
+    expect(names).not.toContain('workspace-pkg');
+  });
+});
+
+// ─── bun binary fallback ──────────────────────────────────────────────────────
+
+describe('generateProjectManifest — bun binary (bun.lockb)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('emits direct deps with empty resolved, no transitive', async () => {
+    writePackageJson(tempDir, {
+      dependencies: { express: '^4.18.0' },
+      devDependencies: { vitest: '^2.0.0' },
+    });
+    // Content is irrelevant — binary lockfiles are never read
+    const lockPath = path.join(tempDir, 'bun.lockb');
+    fs.writeFileSync(lockPath, Buffer.from([0x00, 0x01, 0x02]));
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'bun',
+      lockfilePath: lockPath,
+      lockfileVersion: 0,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies.every((d: any) => d.type === 'direct')).toBe(true);
+    expect(dependencies.every((d: any) => d.resolved === '')).toBe(true);
+
+    const names = dependencies.map((d: any) => d.name);
+    expect(names).toContain('express');
+    expect(names).toContain('vitest');
+  });
+});
+
 // ─── diagnostics callback ─────────────────────────────────────────────────────
 
 describe('diagnostics callback', () => {

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -38,6 +38,12 @@ function writePnpmLock(dir: string, content: string): string {
   return lockPath;
 }
 
+function writeYarnLock(dir: string, content: string): string {
+  const lockPath = path.join(dir, 'yarn.lock');
+  fs.writeFileSync(lockPath, content);
+  return lockPath;
+}
+
 function readManifest(dir: string): any {
   return JSON.parse(fs.readFileSync(path.join(dir, DIAGNOSTICS_PATH), 'utf-8'));
 }
@@ -893,6 +899,288 @@ packages:
       cliType: 'pnpm',
       lockfilePath: lockPath,
       lockfileVersion: 6,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).toContain('real');
+    expect(names).not.toContain('local-pkg');
+  });
+});
+
+// ─── yarn v1 ─────────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — yarn v1', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('resolves direct and transitive deps', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writeYarnLock(
+      tempDir,
+      `\
+# yarn lockfile v1
+
+express@^4.18.0:
+  version "4.18.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#abc"
+
+accepts@^1.3.7:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#def"
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'yarn',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const express = dependencies.find((d: any) => d.name === 'express');
+    expect(express.type).toBe('direct');
+    expect(express.resolved).toBe('4.18.2');
+    expect(express.source).toBe('registry');
+    expect(express.sourceUrl).toBe('https://registry.yarnpkg.com');
+
+    const accepts = dependencies.find((d: any) => d.name === 'accepts');
+    expect(accepts.type).toBe('transitive');
+    expect(accepts.resolved).toBe('1.3.8');
+  });
+
+  it('handles @org/pkg namespaced packages', async () => {
+    writePackageJson(tempDir, { dependencies: { '@vercel/node': '^3.0.0' } });
+    const lockPath = writeYarnLock(
+      tempDir,
+      `\
+# yarn lockfile v1
+
+"@vercel/node@^3.0.0":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@vercel/node/-/node-3.0.7.tgz#abc"
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'yarn',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies[0].name).toBe('@vercel/node');
+    expect(dependencies[0].resolved).toBe('3.0.7');
+  });
+
+  it('deduplicates multiple specifiers for the same package', async () => {
+    writePackageJson(tempDir, { dependencies: { foo: '^1.0.0' } });
+    const lockPath = writeYarnLock(
+      tempDir,
+      `\
+# yarn lockfile v1
+
+foo@^1.0.0, foo@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/foo/-/foo-1.1.0.tgz#abc"
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'yarn',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const fooEntries = readManifest(tempDir).dependencies.filter(
+      (d: any) => d.name === 'foo'
+    );
+    expect(fooEntries).toHaveLength(1);
+    expect(fooEntries[0].resolved).toBe('1.1.0');
+  });
+
+  it('classifies git-resolved packages', async () => {
+    writePackageJson(tempDir, { dependencies: { mylib: 'org/mylib' } });
+    const lockPath = writeYarnLock(
+      tempDir,
+      `\
+# yarn lockfile v1
+
+mylib@org/mylib:
+  version "1.2.3"
+  resolved "git+https://github.com/org/mylib.git#abc123"
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'yarn',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const dep = readManifest(tempDir).dependencies.find(
+      (d: any) => d.name === 'mylib'
+    );
+    expect(dep.source).toBe('git');
+    expect(dep.sourceUrl).toBe('https://github.com/org/mylib.git#abc123');
+  });
+
+  it('excludes file: resolved packages', async () => {
+    writePackageJson(tempDir, { dependencies: { real: '^1.0.0' } });
+    const lockPath = writeYarnLock(
+      tempDir,
+      `\
+# yarn lockfile v1
+
+real@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/real/-/real-1.0.0.tgz#abc"
+
+local-pkg@file:../local-pkg:
+  version "0.0.1"
+  resolved "file:../local-pkg"
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'yarn',
+      lockfilePath: lockPath,
+      lockfileVersion: 1,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).toContain('real');
+    expect(names).not.toContain('local-pkg');
+  });
+});
+
+// ─── yarn berry ───────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — yarn berry', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('resolves direct and transitive deps', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writeYarnLock(
+      tempDir,
+      `\
+__metadata:
+  version: 8
+  cacheKey: 10c0
+
+"express@npm:^4.18.0":
+  version: 4.18.2
+  resolution: "express@npm:4.18.2"
+  languageName: node
+  linkType: hard
+
+"accepts@npm:^1.3.7":
+  version: 1.3.8
+  resolution: "accepts@npm:1.3.8"
+  languageName: node
+  linkType: hard
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'yarn',
+      lockfilePath: lockPath,
+      lockfileVersion: 8,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const express = dependencies.find((d: any) => d.name === 'express');
+    expect(express.type).toBe('direct');
+    expect(express.resolved).toBe('4.18.2');
+
+    const accepts = dependencies.find((d: any) => d.name === 'accepts');
+    expect(accepts.type).toBe('transitive');
+    expect(accepts.resolved).toBe('1.3.8');
+  });
+
+  it('handles @org/pkg namespaced packages', async () => {
+    writePackageJson(tempDir, { dependencies: { '@vercel/node': '^3.0.0' } });
+    const lockPath = writeYarnLock(
+      tempDir,
+      `\
+__metadata:
+  version: 8
+
+"@vercel/node@npm:^3.0.0":
+  version: 3.0.7
+  resolution: "@vercel/node@npm:3.0.7"
+  languageName: node
+  linkType: hard
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'yarn',
+      lockfilePath: lockPath,
+      lockfileVersion: 8,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies[0].name).toBe('@vercel/node');
+    expect(dependencies[0].resolved).toBe('3.0.7');
+  });
+
+  it('excludes workspace packages (linkType: soft)', async () => {
+    writePackageJson(tempDir, { dependencies: { real: '^1.0.0' } });
+    const lockPath = writeYarnLock(
+      tempDir,
+      `\
+__metadata:
+  version: 8
+
+"real@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "real@npm:1.0.0"
+  languageName: node
+  linkType: hard
+
+"local-pkg@workspace:packages/local-pkg":
+  version: 0.0.0-use.local
+  resolution: "local-pkg@workspace:packages/local-pkg"
+  languageName: unknown
+  linkType: soft
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'yarn',
+      lockfilePath: lockPath,
+      lockfileVersion: 8,
     });
 
     const names = readManifest(tempDir).dependencies.map((d: any) => d.name);

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -1334,6 +1334,45 @@ describe('generateProjectManifest — bun binary (bun.lockb)', () => {
   });
 });
 
+// ─── vlt fallback ────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — vlt fallback', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('emits direct deps with empty resolved, no transitive', async () => {
+    writePackageJson(tempDir, {
+      dependencies: { express: '^4.18.0' },
+      devDependencies: { vitest: '^2.0.0' },
+    });
+    // File is never read — vlt format is undocumented
+    const lockPath = path.join(tempDir, 'vlt-lock.json');
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'vlt',
+      lockfilePath: lockPath,
+      lockfileVersion: undefined,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies.every((d: any) => d.type === 'direct')).toBe(true);
+    expect(dependencies.every((d: any) => d.resolved === '')).toBe(true);
+
+    const names = dependencies.map((d: any) => d.name);
+    expect(names).toContain('express');
+    expect(names).toContain('vitest');
+  });
+});
+
 // ─── diagnostics callback ─────────────────────────────────────────────────────
 
 describe('diagnostics callback', () => {

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -132,6 +132,7 @@ export { getOsRelease, getProvidedRuntime } from './os';
 
 export * from './should-serve';
 export * from './schemas';
+export * from './package-manifest';
 export * from './types';
 export * from './errors';
 

--- a/packages/build-utils/src/package-manifest.ts
+++ b/packages/build-utils/src/package-manifest.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import { join, dirname } from 'path';
+import FileBlob from './file-blob';
+import type { Files, Diagnostics, BuildOptions } from './types';
+
+export interface PackageManifestDependency {
+  name: string;
+  type: 'direct' | 'transitive' | 'peer';
+  scopes: string[];
+  requested?: string;
+  resolved: string;
+  source?: string;
+  sourceUrl?: string;
+}
+
+export interface PackageManifest {
+  version?: string;
+  runtime: string;
+  runtimeVersion?: {
+    requested?: string;
+    requestedSource?: string;
+    resolved: string;
+  };
+  dependencies: PackageManifestDependency[];
+}
+
+export const MANIFEST_FILENAME = 'package-manifest.json';
+
+export function manifestPath(runtime: string): string {
+  return join('.vercel', runtime, MANIFEST_FILENAME);
+}
+
+export async function writeProjectManifest(
+  manifest: PackageManifest,
+  workPath: string,
+  runtime: string
+): Promise<void> {
+  const outPath = join(workPath, manifestPath(runtime));
+  await fs.promises.mkdir(dirname(outPath), { recursive: true });
+  await fs.promises.writeFile(outPath, JSON.stringify(manifest, null, 2));
+}
+
+export function createDiagnostics(runtime: string): Diagnostics {
+  return async ({ workPath }: BuildOptions): Promise<Files> => {
+    try {
+      const filePath = join(workPath, manifestPath(runtime));
+      const data = await fs.promises.readFile(filePath, 'utf-8');
+      return {
+        [MANIFEST_FILENAME]: new FileBlob({ data }),
+      };
+    } catch {
+      return {};
+    }
+  };
+}

--- a/packages/build-utils/src/package-manifest.ts
+++ b/packages/build-utils/src/package-manifest.ts
@@ -24,6 +24,7 @@ export interface PackageManifest {
   dependencies: PackageManifestDependency[];
 }
 
+export const MANIFEST_VERSION = '20260304';
 export const MANIFEST_FILENAME = 'package-manifest.json';
 
 export function manifestPath(runtime: string): string {

--- a/packages/python/src/diagnostics.ts
+++ b/packages/python/src/diagnostics.ts
@@ -1,10 +1,9 @@
 import fs from 'fs';
-import { join, dirname } from 'path';
 import {
-  FileBlob,
-  debug,
-  type BuildOptions,
-  type Files,
+  writeProjectManifest,
+  createDiagnostics,
+  type PackageManifest,
+  type PackageManifestDependency,
 } from '@vercel/build-utils';
 import {
   parseUvLock,
@@ -18,32 +17,7 @@ import {
 import type { PythonVersion } from './version';
 import { pythonVersionString } from './version';
 
-export const MANIFEST_FILENAME = 'package-manifest.json';
-
-export const DIAGNOSTICS_PATH = join('.vercel', 'python', MANIFEST_FILENAME);
-
-interface DependencyEntry {
-  name: string;
-  type: 'direct' | 'transitive';
-  scopes: string[];
-  requested?: string;
-  resolved?: string;
-  source?: string;
-  sourceUrl?: string;
-}
-
 const MANIFEST_VERSION = '20260304';
-
-interface ProjectManifest {
-  version: string;
-  runtime: string;
-  runtimeVersion: {
-    requested?: string;
-    requestedSource?: string;
-    resolved: string;
-  };
-  dependencies: DependencyEntry[];
-}
 
 function isDependencyGroupInclude(
   entry: DependencyGroupEntry
@@ -260,14 +234,14 @@ export async function generateProjectManifest({
     // Build direct entries
     for (const [name, scopes] of directScopesMap) {
       const info = lockMap.get(name);
-      const entry: DependencyEntry = {
+      const entry: PackageManifestDependency = {
         name,
         type: 'direct',
         scopes: [...scopes].sort(),
         requested: directRequested.get(name),
+        resolved: info?.version ?? '',
       };
       if (info) {
-        entry.resolved = info.version;
         const src = mapSource(info.source);
         if (src.source) entry.source = src.source;
         if (src.sourceUrl) entry.sourceUrl = src.sourceUrl;
@@ -292,7 +266,7 @@ export async function generateProjectManifest({
     }
   }
 
-  const manifest: ProjectManifest = {
+  const manifest: PackageManifest = {
     version: MANIFEST_VERSION,
     runtime: 'python',
     runtimeVersion: {
@@ -306,27 +280,7 @@ export async function generateProjectManifest({
     ],
   };
 
-  const outPath = join(workPath, DIAGNOSTICS_PATH);
-  await fs.promises.mkdir(dirname(outPath), { recursive: true });
-  await fs.promises.writeFile(outPath, JSON.stringify(manifest, null, 2));
+  await writeProjectManifest(manifest, workPath, 'python');
 }
 
-/**
- * Diagnostics callback — returns the project manifest cached during build().
- */
-export const diagnostics = async ({
-  workPath,
-}: BuildOptions): Promise<Files> => {
-  try {
-    const manifestPath = join(workPath, DIAGNOSTICS_PATH);
-    const data = await fs.promises.readFile(manifestPath, 'utf-8');
-    return {
-      [MANIFEST_FILENAME]: new FileBlob({ data }),
-    };
-  } catch (err) {
-    debug(
-      `Diagnostics: no cached manifest found: ${err instanceof Error ? err.message : String(err)}`
-    );
-    return {};
-  }
-};
+export const diagnostics = createDiagnostics('python');

--- a/packages/python/src/diagnostics.ts
+++ b/packages/python/src/diagnostics.ts
@@ -163,8 +163,8 @@ export async function generateProjectManifest({
   }
 
   // Resolve versions and source info from the lock file
-  const directEntries: DependencyEntry[] = [];
-  const transitiveEntries: DependencyEntry[] = [];
+  const directEntries: PackageManifestDependency[] = [];
+  const transitiveEntries: PackageManifestDependency[] = [];
 
   {
     const content = await fs.promises.readFile(uvLockPath, 'utf-8');

--- a/packages/python/src/diagnostics.ts
+++ b/packages/python/src/diagnostics.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import {
   writeProjectManifest,
   createDiagnostics,
+  MANIFEST_VERSION,
   type PackageManifest,
   type PackageManifestDependency,
 } from '@vercel/build-utils';
@@ -16,8 +17,6 @@ import {
 } from '@vercel/python-analysis';
 import type { PythonVersion } from './version';
 import { pythonVersionString } from './version';
-
-const MANIFEST_VERSION = '20260304';
 
 function isDependencyGroupInclude(
   entry: DependencyGroupEntry

--- a/packages/python/test/diagnostics.test.ts
+++ b/packages/python/test/diagnostics.test.ts
@@ -2,18 +2,15 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs-extra';
 import path from 'path';
 import { tmpdir } from 'os';
-import { FileBlob } from '@vercel/build-utils';
+import { FileBlob, MANIFEST_FILENAME, manifestPath } from '@vercel/build-utils';
 import type {
   DependencyGroupEntry,
   PythonPackage,
 } from '@vercel/python-analysis';
 import type { PythonVersion } from '../src/version';
-import {
-  generateProjectManifest,
-  diagnostics,
-  DIAGNOSTICS_PATH,
-  MANIFEST_FILENAME,
-} from '../src/diagnostics';
+import { generateProjectManifest, diagnostics } from '../src/diagnostics';
+
+const DIAGNOSTICS_PATH = manifestPath('python');
 
 const pythonVersion: PythonVersion = {
   major: 3,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       '@vercel/nft':
         specifier: 1.5.0
         version: 1.5.0
+      '@yarnpkg/parsers':
+        specifier: ^3.0.0
+        version: 3.0.0
       execa:
         specifier: 3.2.0
         version: 3.2.0
@@ -223,8 +226,8 @@ importers:
         specifier: 11.1.0
         version: 11.1.0
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^3.13.1
+        version: 3.13.1
       oxc-transform:
         specifier: 0.111.0
         version: 0.111.0
@@ -257,8 +260,8 @@ importers:
         specifier: 27.5.1
         version: 27.5.1
       '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
+        specifier: 3.12.1
+        version: 3.12.1
       '@types/node':
         specifier: 20.11.0
         version: 20.11.0
@@ -10578,6 +10581,14 @@ packages:
       loupe: 3.1.3
       tinyrainbow: 1.2.0
     dev: true
+
+  /@yarnpkg/parsers@3.0.0:
+    resolution: {integrity: sha512-jVZa3njBv6tcOUw34nlUdUM/40wwtm/gnVF8rtk0tA6vNcokqYI8CFU1BZjlpFwUSZaXxYkrtuPE/f2MMFlTxQ==}
+    engines: {node: '>=18.12.0'}
+    dependencies:
+      js-yaml: 3.13.1
+      tslib: 2.8.1
+    dev: false
 
   /abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       fs-extra:
         specifier: 11.1.0
         version: 11.1.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       oxc-transform:
         specifier: 0.111.0
         version: 0.111.0
@@ -253,6 +256,9 @@ importers:
       '@types/jest':
         specifier: 27.5.1
         version: 27.5.1
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: 20.11.0
         version: 20.11.0


### PR DESCRIPTION
Generate `PROJECTMANIFEST` to `@vercel/backends`, similar to `@vercel/python` but for node services.

- `generateProjectManifest` reads `package.json` and the lock file to produce `package-manifest.json`
- adds a `diagnostics` hook which is used to collect the manifest

Supports:
- `npm`: v1, v2, v3
- `pnpm`: v5-6, v9
- `yarn`: v1, berry
- `bun`: text, (binary falls back to direct deps only)
- `vlt`: falls back to direct deps only

Validated against a collection of public repos that use a variety of package managers:
https://github.com/dnwpark/node-package-benchmarks