### PR TITLE
cli: fix 'occured' -> 'occurred' typo in global-path error comment

### DIFF
--- a/packages/cli/src/util/config/global-path.ts
+++ b/packages/cli/src/util/config/global-path.ts
@@ -9,7 +9,7 @@ export const isDirectory = (path: string): boolean => {
   try {
     return fs.lstatSync(path).isDirectory();
   } catch (_) {
-    // We don't care which kind of error occured, it isn't a directory anyway.
+    // We don't care which kind of error occurred, it isn't a directory anyway.
     return false;
   }
 };


### PR DESCRIPTION
Inline comment in `packages/cli/src/util/config/global-path.ts:12` explained why the ENOENT branch ignores the error category with `We don't care which kind of error occured`. Doc-only TS change.