### PR TITLE
chore: bump vercel_runtime version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vercel_runtime"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/crates/vercel_runtime/Cargo.toml
+++ b/crates/vercel_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vercel_runtime"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2024"
 description = "Vercel Runtime for Rust"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps rust crate due to failing action https://github.com/vercel/vercel/actions/runs/24445384045/job/71420296251