### PR TITLE
feat: support entry point without ext

### DIFF
--- a/.changeset/polite-pens-allow.md
+++ b/.changeset/polite-pens-allow.md
@@ -1,0 +1,5 @@
+---
+'@vercel/rust': patch
+---
+
+Support entry point without extension for dev server

--- a/packages/rust/src/index.ts
+++ b/packages/rust/src/index.ts
@@ -187,7 +187,15 @@ const runtime: Runtime = {
   startDevServer: rustStartDevServer,
   shouldServe: async (options): Promise<boolean> => {
     debug(`Requested ${options.requestPath} for ${options.entrypoint}`);
-    return Promise.resolve(options.requestPath === options.entrypoint);
+    // Match exact path or path without .rs extension
+    const entrypointWithoutExt = options.entrypoint.replace(/\.rs$/, '');
+    const matches =
+      options.requestPath === options.entrypoint ||
+      options.requestPath === entrypointWithoutExt;
+    debug(
+      `shouldServe: ${matches} (entrypointWithoutExt: ${entrypointWithoutExt})`
+    );
+    return Promise.resolve(matches);
   },
 };
 


### PR DESCRIPTION
Fixes `shouldServe` to match paths without .rs extension. This is required for supporting services entrypoints in dev mode.