### PR TITLE
Add `workflowRunId` query example to `vercel logs` help

### DIFF
--- a/.changeset/logs-workflow-run-id-example.md
+++ b/.changeset/logs-workflow-run-id-example.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Added `workflowRunId` filter example to the `vercel logs --query` help text and examples.

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -110,7 +110,7 @@ export const logsCommand = {
       type: String,
       deprecated: false,
       description:
-        'Advanced search query (supports filter syntax, e.g. "status:500 error")',
+        'Advanced search query (supports filter syntax, e.g. "status:500 error", "workflowRunId:run_xxxxx")',
     },
     {
       name: 'search',
@@ -202,6 +202,10 @@ export const logsCommand = {
     {
       name: 'Display logs for all branches (disable auto-detection)',
       value: `${packageName} logs --no-branch`,
+    },
+    {
+      name: 'Display logs for a specific workflow run',
+      value: `${packageName} logs --query 'workflowRunId:run_xxxxx' --json`,
     },
   ],
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `workflowRunId` filter example to the `vercel logs` command so that agents and users know they can look up logs by workflow run ID.

### Changes

- Updated the `--query` option description to include `workflowRunId:run_xxxxx` as a supported filter syntax example
- Added a new CLI example: `vercel logs --query 'workflowRunId:run_xxxxx' --json` ("Display logs for a specific workflow run")

### Context

Per the [Vercel changelog](https://vercel.com/changelog/logs-filtering-for-vercel-workflows-now-available), Vercel now supports filtering workflow run logs. This change ensures the CLI help text surfaces the `workflowRunId` filter so agents and users can discover it.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0ABAP6LH3K/p1776332145061059?thread_ts=1776332145.061059&cid=C0ABAP6LH3K)

<div><a href="https://cursor.com/agents/bc-e7815b0e-ac33-5cb1-8e55-7f77c4e43b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7815b0e-ac33-5cb1-8e55-7f77c4e43b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

