### PR TITLE
[build-utils] Align deserialize logic with existing callers

### DIFF
--- a/.changeset/align-deserialize-build-utils.md
+++ b/.changeset/align-deserialize-build-utils.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Align deserialize logic with existing callers.

--- a/packages/build-utils/src/collect-build-result/prerender-to-build-output-file.ts
+++ b/packages/build-utils/src/collect-build-result/prerender-to-build-output-file.ts
@@ -47,6 +47,9 @@ export interface ExtendedPayload {
 
 const CRLF = '\r\n';
 const MULTIPART_HEADER = 'multipart/x-nextjs-extended-payload';
+// Keep a single boundary per process to preserve existing callers'
+// prerender fallback digests and headers.
+const boundary = randomBytes(8).toString('hex');
 
 function getExtendedPayload({
   initialHeaders,
@@ -56,7 +59,6 @@ function getExtendedPayload({
     return { initialHeaders: undefined, fallback, extendedBody: undefined };
   }
 
-  const boundary = randomBytes(8).toString('hex');
   return {
     initialHeaders: {
       ...(fallback ? {} : { 'x-vercel-empty-fallback': 'true' }),

--- a/packages/build-utils/src/deserialize/serialized-types.ts
+++ b/packages/build-utils/src/deserialize/serialized-types.ts
@@ -21,13 +21,13 @@ type FilesMapProp = {
  * Type for the `.vc-config.json` file of a serialized
  * `ServerlessFunction` instance.
  */
-export type SerializedLambda = Properties<Omit<Lambda, 'files' | 'zipBuffer'>> &
-  FilesMapProp;
-
-export type SerializedNodejsLambda = Properties<
-  Omit<NodejsLambda, 'files' | 'zipBuffer'>
+export type SerializedLambda<T extends Lambda = Lambda> = Properties<
+  Omit<T, 'files' | 'zipBuffer'>
 > &
   FilesMapProp;
+
+export type SerializedNodejsLambda<T extends NodejsLambda = NodejsLambda> =
+  Properties<Omit<T, 'files' | 'zipBuffer'>> & FilesMapProp;
 
 export type SerializedFileFsRef = Properties<FileFsRef>;
 

--- a/packages/build-utils/test/unit.collect-build-result.test.ts
+++ b/packages/build-utils/test/unit.collect-build-result.test.ts
@@ -3,12 +3,14 @@ import { getBuildResultMetadata } from '../src/collect-build-result/get-build-re
 import { getLambdaByOutputPath } from '../src/collect-build-result/get-lambda-by-output-path';
 import { isRouteMiddleware } from '../src/collect-build-result/is-route-middleware';
 import { getPrerenderChain } from '../src/collect-build-result/get-prerender-chain';
+import { prerenderToBuildOutputFile } from '../src/collect-build-result/prerender-to-build-output-file';
 import {
   streamWithExtendedPayload,
   type ExtendedBodyData,
 } from '../src/collect-build-result/stream-with-extended-payload';
 import { Readable } from 'stream';
 import streamToBuffer from '../src/fs/stream-to-buffer';
+import FileBlob from '../src/file-blob';
 import { Lambda } from '../src/lambda';
 import { Prerender } from '../src/prerender';
 import { EdgeFunction } from '../src/edge-function';
@@ -41,6 +43,10 @@ function createEdgeFunction(
     files: {},
     ...overrides,
   });
+}
+
+function getBoundary(prefix?: string) {
+  return prefix?.split('\r\n')[0]?.replace('--', '');
 }
 
 describe('getLambdaByOutputPath', () => {
@@ -205,5 +211,41 @@ describe('streamWithExtendedPayload', () => {
     const result = streamWithExtendedPayload(stream, data);
     const buf = await streamToBuffer(result);
     expect(buf.toString()).toBe('PRE:body:POST');
+  });
+});
+
+describe('prerenderToBuildOutputFile', () => {
+  it('reuses the multipart boundary across prerender fallbacks', async () => {
+    const initialHeaders = {
+      'content-type': 'text/html',
+      'x-test': 'value',
+    };
+
+    const first = await prerenderToBuildOutputFile({
+      buildResult: createPrerender({
+        fallback: new FileBlob({ data: 'first' }),
+        initialHeaders,
+      }),
+      outputPath: 'first',
+    });
+    const second = await prerenderToBuildOutputFile({
+      buildResult: createPrerender({
+        fallback: new FileBlob({ data: 'second' }),
+        initialHeaders,
+      }),
+      outputPath: 'second',
+    });
+
+    const firstBoundary = getBoundary(first?.extended.extendedBody?.prefix);
+    const secondBoundary = getBoundary(second?.extended.extendedBody?.prefix);
+
+    expect(firstBoundary).toBeDefined();
+    expect(secondBoundary).toBe(firstBoundary);
+    expect(first?.extended.initialHeaders).toEqual({
+      'content-type': `multipart/x-nextjs-extended-payload; boundary=${firstBoundary}`,
+    });
+    expect(second?.extended.initialHeaders).toEqual({
+      'content-type': `multipart/x-nextjs-extended-payload; boundary=${firstBoundary}`,
+    });
   });
 });

--- a/packages/build-utils/test/unit.deserialize-lambda.test.ts
+++ b/packages/build-utils/test/unit.deserialize-lambda.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { deserializeLambda } from '../src/deserialize/deserialize-lambda';
+import type {
+  SerializedLambda,
+  SerializedNodejsLambda,
+} from '../src/deserialize/serialized-types';
+import { Lambda } from '../src/lambda';
+import { NodejsLambda } from '../src/nodejs-lambda';
+
+interface ExternalConfig {
+  awsAccountId: string;
+  digest: string;
+  size: number;
+}
+
+class ExternalLambda extends Lambda {
+  external?: ExternalConfig;
+
+  constructor({
+    external,
+    ...props
+  }: ConstructorParameters<typeof Lambda>[0] & {
+    external?: ExternalConfig;
+  }) {
+    super(props);
+    this.external = external;
+  }
+}
+
+class ExternalNodejsLambda extends NodejsLambda {
+  external?: ExternalConfig;
+
+  constructor({
+    external,
+    ...props
+  }: ConstructorParameters<typeof NodejsLambda>[0] & {
+    external?: ExternalConfig;
+  }) {
+    super(props);
+    this.external = external;
+  }
+}
+
+describe('deserializeLambda', () => {
+  const external: ExternalConfig = {
+    awsAccountId: 'aws-account-id',
+    digest: 'digest',
+    size: 123,
+  };
+
+  it('preserves subclass fields for LambdaClass', async () => {
+    const config: SerializedLambda<ExternalLambda> = {
+      handler: 'index.handler',
+      runtime: 'nodejs20.x',
+      external,
+    };
+
+    const lambda = await deserializeLambda({}, config, '', new Map(), {
+      LambdaClass: ExternalLambda,
+      NodejsLambdaClass: ExternalNodejsLambda,
+    });
+
+    expect(lambda).toBeInstanceOf(ExternalLambda);
+    expect((lambda as ExternalLambda).external).toEqual(external);
+  });
+
+  it('preserves subclass fields for NodejsLambdaClass', async () => {
+    const config: SerializedNodejsLambda<ExternalNodejsLambda> = {
+      handler: 'index.handler',
+      runtime: 'nodejs20.x',
+      launcherType: 'Nodejs',
+      shouldAddHelpers: true,
+      shouldAddSourcemapSupport: true,
+      external,
+    };
+
+    const lambda = await deserializeLambda({}, config, '', new Map(), {
+      LambdaClass: ExternalLambda,
+      NodejsLambdaClass: ExternalNodejsLambda,
+    });
+
+    expect(lambda).toBeInstanceOf(ExternalNodejsLambda);
+    expect((lambda as ExternalNodejsLambda).external).toEqual(external);
+  });
+});


### PR DESCRIPTION
While I was integrating https://github.com/vercel/vercel/pull/15961 for existing callers, I saw that we are slightly changing the behavior of prerenders.

This PR fixes the differing semantics and unblocks this migration work.