### PR TITLE
feat(cli): OpenAPI infrastructure types, cache, and CLI utilities

### DIFF
--- a/packages/cli/src/util/openapi/column-label.ts
+++ b/packages/cli/src/util/openapi/column-label.ts
@@ -1,0 +1,53 @@
+const LABEL_OVERRIDES: Record<string, string> = {
+  createdAt: 'Created',
+  updatedAt: 'Updated',
+  deletedAt: 'Deleted',
+  expiredAt: 'Expired',
+  verifiedAt: 'Verified',
+  deployedAt: 'Deployed',
+  created_at: 'Created',
+  updated_at: 'Updated',
+  accountId: 'Account Id',
+  projectId: 'Project Id',
+  teamId: 'Team Id',
+  nodeVersion: 'Node Version',
+};
+
+/**
+ * Turn a single identifier segment (camelCase, snake_case, kebab-case, etc.)
+ * into Title Case words.
+ */
+export function humanizeIdentifier(raw: string): string {
+  const s = raw.trim();
+  if (!s) {
+    return raw;
+  }
+  const withSpaces = s
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
+  const words = withSpaces.split(/[\s_-]+/).filter(Boolean);
+  return words
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/**
+ * Human-readable label for a column dot-path: each segment is humanized,
+ * segments joined with ` › ` (e.g. `softBlock.blockedAt` → `Soft Block › Blocked At`).
+ * Common fields like `updatedAt` are mapped to shorter labels (e.g. "Updated").
+ */
+export function humanReadableColumnLabel(columnPath: string): string {
+  const override = LABEL_OVERRIDES[columnPath];
+  if (override) return override;
+
+  const parts = columnPath.split('.').filter(Boolean);
+  if (parts.length === 0) {
+    return columnPath;
+  }
+  if (parts.length === 1) {
+    return LABEL_OVERRIDES[parts[0]] ?? humanizeIdentifier(parts[0]);
+  }
+  return parts
+    .map(p => LABEL_OVERRIDES[p] ?? humanizeIdentifier(p))
+    .join(' › ');
+}

--- a/packages/cli/src/util/openapi/constants.ts
+++ b/packages/cli/src/util/openapi/constants.ts
@@ -1,5 +1,6 @@
 /**
- * URL for the Vercel OpenAPI specification
+ * Published OpenAPI document URL. The CLI fetches this (with a disk cache) for
+ * `vercel api`, `vercel openapi`, interactive endpoint search, and webhooks.
  */
 export const OPENAPI_URL = 'https://openapi.vercel.sh/';
 
@@ -17,3 +18,8 @@ export const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
  * Timeout for fetching the OpenAPI spec in milliseconds (10 seconds)
  */
 export const FETCH_TIMEOUT_MS = 10 * 1000;
+
+/**
+ * Sentinel `displayProperty` when the CLI renders the whole JSON object (no wrapper key).
+ */
+export const VERCEL_CLI_ROOT_DISPLAY_KEY = '__root__';

--- a/packages/cli/src/util/openapi/fetch-public-openapi-spec.ts
+++ b/packages/cli/src/util/openapi/fetch-public-openapi-spec.ts
@@ -1,0 +1,116 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import XDGAppPaths from 'xdg-app-paths';
+import type Client from '../client';
+import {
+  CACHE_FILE,
+  CACHE_TTL_MS,
+  FETCH_TIMEOUT_MS,
+  OPENAPI_URL,
+} from './constants';
+import output from '../../output-manager';
+
+export type PublicOpenApiLoadResult = { raw: string } | { error: string };
+
+function getCacheDirAndPath(): { cacheDir: string; cachePath: string } {
+  const cacheDir = XDGAppPaths('com.vercel.cli').cache();
+  return { cacheDir, cachePath: join(cacheDir, CACHE_FILE) };
+}
+
+/**
+ * Load the published OpenAPI document from {@link OPENAPI_URL}, using a
+ * disk cache under the XDG cache directory (see {@link CACHE_TTL_MS}).
+ */
+export async function readPublicOpenApiSpecFromCacheOrNetwork(
+  forceRefresh: boolean,
+  client?: Client
+): Promise<PublicOpenApiLoadResult> {
+  const { cacheDir, cachePath } = getCacheDirAndPath();
+
+  try {
+    mkdirSync(cacheDir, { recursive: true });
+  } catch {
+    // ignore
+  }
+
+  if (!forceRefresh && existsSync(cachePath)) {
+    const age = Date.now() - statSync(cachePath).mtimeMs;
+    if (age < CACHE_TTL_MS) {
+      try {
+        return { raw: readFileSync(cachePath, 'utf-8') };
+      } catch (err) {
+        output.debug(`Failed to read cached OpenAPI spec: ${err}`);
+      }
+    }
+  }
+
+  try {
+    const res = await fetchOpenApiSpec(client);
+
+    if (!res.ok) {
+      return useStaleCacheOrError(
+        cachePath,
+        `Failed to fetch OpenAPI spec: HTTP ${res.status}`
+      );
+    }
+
+    const raw = await res.text();
+    try {
+      writeFileSync(cachePath, raw, 'utf-8');
+    } catch (err) {
+      output.debug(`Could not write OpenAPI spec cache: ${err}`);
+    }
+    return { raw };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return useStaleCacheOrError(
+      cachePath,
+      `Failed to fetch OpenAPI spec: ${message}`
+    );
+  }
+}
+
+async function fetchOpenApiSpec(
+  client?: Client
+): Promise<{ ok: boolean; status: number; text: () => Promise<string> }> {
+  if (client) {
+    const res = await client.fetch(OPENAPI_URL, {
+      json: false,
+      useCurrentTeam: false,
+    });
+    return {
+      ok: res.ok,
+      status: res.status,
+      text: () => res.text(),
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(OPENAPI_URL, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function useStaleCacheOrError(
+  cachePath: string,
+  errMessage: string
+): PublicOpenApiLoadResult {
+  if (existsSync(cachePath)) {
+    try {
+      output.debug(`${errMessage}; using stale cached OpenAPI spec.`);
+      return { raw: readFileSync(cachePath, 'utf-8') };
+    } catch {
+      // fall through
+    }
+  }
+  return { error: errMessage };
+}

--- a/packages/cli/src/util/openapi/fold-naming-style.ts
+++ b/packages/cli/src/util/openapi/fold-naming-style.ts
@@ -1,0 +1,32 @@
+/**
+ * Collapses camelCase, kebab-case, and snake_case to a single lowercase string
+ * so identifiers that differ only by naming style compare equal, e.g.:
+ * `project-routes`, `project_routes`, `projectRoutes`, `ProjectRoutes`.
+ */
+export function foldNamingStyle(input: string): string {
+  return input
+    .trim()
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')
+    .replace(/[-_\s]+/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '');
+}
+
+/**
+ * Display form for `--describe`: normalize operationId to kebab-case (e.g. `getAuthUser` → `get-auth-user`).
+ */
+export function operationIdToKebabCase(operationId: string): string {
+  const s = operationId.trim();
+  if (!s) {
+    return 'unnamed';
+  }
+  return s
+    .replace(/([a-z\d])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .replace(/[-_\s]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase();
+}

--- a/packages/cli/src/util/openapi/index.ts
+++ b/packages/cli/src/util/openapi/index.ts
@@ -1,7 +1,28 @@
 export { OpenApiCache } from './openapi-cache';
 export * from './types';
 export * from './constants';
+export { foldNamingStyle, operationIdToKebabCase } from './fold-naming-style';
+export {
+  formatVercelCliTable,
+  getByPath,
+} from './vercel-cli-table';
+export {
+  humanizeIdentifier,
+  humanReadableColumnLabel,
+} from './column-label';
+export {
+  buildOpenapiInvocationUrlAfterPathSubstitution,
+  composeOpenapiInvocationUrl,
+  resolveOpenapiInvocationUrl,
+  splitOpenapiInvocationPositionals,
+  extractBracePathParamNames,
+  parameterNameToCliOptionFlag,
+  getParameterCliKind,
+  operationDeclaresTeamOrSlugQueryParam,
+  substitutePathTemplate,
+} from './openapi-operation-cli';
 export * from './resolve-by-tag-operation';
+export { inferCliSubcommandAliases } from './infer-cli-aliases';
 export {
   matchesCliApiTag,
   resolveOpenApiTagForProjectsCli,

--- a/packages/cli/src/util/openapi/infer-cli-aliases.ts
+++ b/packages/cli/src/util/openapi/infer-cli-aliases.ts
@@ -1,0 +1,35 @@
+import type { EndpointInfo } from './types';
+
+/**
+ * Infer standard CLI subcommand aliases from an endpoint's HTTP method and path parameters.
+ *
+ * Maps REST semantics to familiar CLI verbs so that `vercel api <tag> ls` works the
+ * same as `vercel <tag> ls`:
+ *
+ *   GET  (no path params) → ls, list
+ *   GET  (with path params) → inspect, get
+ *   POST → add, create
+ *   DELETE → rm, remove
+ *   PUT / PATCH → update
+ *
+ * These are used for resolution only and do NOT override display names
+ * (which come from explicit `x-vercel-cli.aliases` or the `operationId`).
+ */
+export function inferCliSubcommandAliases(ep: EndpointInfo): string[] {
+  const upper = ep.method.toUpperCase();
+  const hasPathParams = ep.parameters.some(p => p.in === 'path');
+
+  switch (upper) {
+    case 'GET':
+      return hasPathParams ? ['inspect', 'get'] : ['ls', 'list'];
+    case 'POST':
+      return ['add', 'create'];
+    case 'DELETE':
+      return ['rm', 'remove'];
+    case 'PUT':
+    case 'PATCH':
+      return ['update'];
+    default:
+      return [];
+  }
+}

--- a/packages/cli/src/util/openapi/openapi-cache.ts
+++ b/packages/cli/src/util/openapi/openapi-cache.ts
@@ -1,20 +1,17 @@
-import { join } from 'path';
-import { readFile, writeFile, mkdir } from 'fs/promises';
-import getGlobalPathConfig from '../config/global-path';
 import output from '../../output-manager';
-import {
-  OPENAPI_URL,
-  CACHE_FILE,
-  CACHE_TTL_MS,
-  FETCH_TIMEOUT_MS,
-} from './constants';
+import { readPublicOpenApiSpecFromCacheOrNetwork } from './fetch-public-openapi-spec';
+import type Client from '../client';
 import type {
   OpenApiSpec,
-  CachedSpec,
   EndpointInfo,
+  Operation,
   Schema,
   BodyField,
+  VercelCliTableDisplay,
 } from './types';
+import { foldNamingStyle } from './fold-naming-style';
+import { inferCliSubcommandAliases } from './infer-cli-aliases';
+import { VERCEL_CLI_ROOT_DISPLAY_KEY } from './constants';
 
 /**
  * Manages OpenAPI spec fetching, caching, and parsing.
@@ -26,13 +23,15 @@ import type {
  * const endpoints = cache.getEndpoints();
  * const bodyFields = cache.getBodyFields(endpoint);
  * ```
+ *
+ * Loads from the published spec URL (with disk cache).
  */
 export class OpenApiCache {
-  private readonly cachePath: string;
   private spec: OpenApiSpec | null = null;
+  private client?: Client;
 
-  constructor() {
-    this.cachePath = join(getGlobalPathConfig(), CACHE_FILE);
+  constructor(client?: Client) {
+    this.client = client;
   }
 
   /**
@@ -43,42 +42,28 @@ export class OpenApiCache {
   }
 
   /**
-   * Load the OpenAPI spec, using cache if available and fresh.
-   * Returns true if successful, false otherwise.
+   * Load the OpenAPI document from the published URL (with disk cache).
    */
   async load(forceRefresh = false): Promise<boolean> {
-    // Try to read from cache
-    if (!forceRefresh) {
-      const cached = await this.readCache();
-      if (cached && !this.isExpired(cached.fetchedAt)) {
-        output.debug('Using cached OpenAPI spec');
-        this.spec = cached.spec;
-        return true;
-      }
+    const result = await readPublicOpenApiSpecFromCacheOrNetwork(
+      forceRefresh,
+      this.client
+    );
+    if ('error' in result) {
+      output.debug(result.error);
+      return false;
     }
-
-    // Fetch fresh spec
     try {
-      output.debug('Fetching OpenAPI spec from ' + OPENAPI_URL);
-      this.spec = await this.fetchSpec();
-      await this.saveCache(this.spec);
+      this.spec = JSON.parse(result.raw) as OpenApiSpec;
       return true;
     } catch (err) {
-      output.debug(`Failed to fetch OpenAPI spec: ${err}`);
-      // If fetch fails, try to use stale cache
-      const stale = await this.readCache();
-      if (stale) {
-        output.debug('Using stale cached OpenAPI spec');
-        this.spec = stale.spec;
-        return true;
-      }
+      output.debug(`Failed to parse OpenAPI spec: ${err}`);
       return false;
     }
   }
 
   /**
    * Load the OpenAPI spec with spinner UI.
-   * Returns true if successful, false otherwise.
    */
   async loadWithSpinner(forceRefresh = false): Promise<boolean> {
     output.spinner(
@@ -97,6 +82,703 @@ export class OpenApiCache {
     this.ensureLoaded();
     const endpoints = this.extractEndpoints();
     return this.sortEndpoints(endpoints);
+  }
+
+  /**
+   * Endpoints with `x-vercel-cli.supportedSubcommands: true` (or legacy `supported: true`)
+   * on the operation (for `vercel api` / `vercel openapi` tag mode).
+   */
+  getCliSupportedEndpoints(): EndpointInfo[] {
+    return this.getEndpoints().filter(ep => ep.vercelCliSupported);
+  }
+
+  /**
+   * Endpoints with `x-vercel-cli.supportedProduction: true` — these replace
+   * native CLI commands at `vercel <command> <subcommand>`.
+   */
+  getProductionReadyEndpoints(): EndpointInfo[] {
+    return this.getEndpoints().filter(ep => ep.vercelCliProductionReady);
+  }
+
+  /**
+   * Find an operation by tag and operation hint (operationId or alias) that
+   * has `supportedProduction: true`.
+   */
+  findProductionReadyByTagAndHint(
+    tag: string,
+    hint: string
+  ): EndpointInfo | undefined {
+    const hintFold = foldNamingStyle(hint);
+    for (const ep of this.getProductionReadyEndpoints()) {
+      if (!this.tagsInclude(ep.tags, tag)) {
+        continue;
+      }
+      if (this.operationIdOrAliasMatches(ep, hintFold)) {
+        return ep;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Tags that have at least one production-ready operation.
+   */
+  getAllProductionReadyTags(): string[] {
+    const found = new Set<string>();
+    for (const ep of this.getProductionReadyEndpoints()) {
+      for (const t of ep.tags || []) {
+        found.add(t);
+      }
+    }
+    return [...found].sort((a, b) => a.localeCompare(b));
+  }
+
+  /**
+   * Whether `requested` matches a tag on the operation (case-insensitive; camel /
+   * kebab / snake folds match, e.g. `access-groups` and `accessGroups`).
+   */
+  private tagsInclude(
+    epTags: string[] | undefined,
+    requested: string
+  ): boolean {
+    if (!epTags?.length) {
+      return false;
+    }
+    const want = foldNamingStyle(requested);
+    return epTags.some(t => foldNamingStyle(t) === want);
+  }
+
+  /** `operationId`, any `x-vercel-cli.aliases` entry, or any auto-inferred CLI alias. */
+  private operationIdOrAliasMatches(
+    ep: EndpointInfo,
+    requestedFold: string
+  ): boolean {
+    if (foldNamingStyle(ep.operationId) === requestedFold) {
+      return true;
+    }
+    for (const a of ep.vercelCliAliases) {
+      if (foldNamingStyle(a) === requestedFold) {
+        return true;
+      }
+    }
+    for (const a of inferCliSubcommandAliases(ep)) {
+      if (foldNamingStyle(a) === requestedFold) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private cliSortName(ep: EndpointInfo): string {
+    return ep.vercelCliAliases[0] ?? ep.operationId ?? '';
+  }
+
+  /**
+   * Resolve tag + operationId (including unsupported operations).
+   * `operationId` may be an `x-vercel-cli` alias (e.g. `list` for `getProjects`).
+   */
+  findEndpointByTagAndOperationId(
+    tag: string,
+    operationId: string
+  ): EndpointInfo | undefined {
+    const opFold = foldNamingStyle(operationId);
+    for (const ep of this.getEndpoints()) {
+      if (!this.operationIdOrAliasMatches(ep, opFold)) {
+        continue;
+      }
+      if (this.tagsInclude(ep.tags, tag)) {
+        return ep;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Find an operation by tag and `operationId` that is opted into `vercel openapi`
+   * (`x-vercel-cli.supportedSubcommands` or legacy `supported`).
+   */
+  findByTagAndOperationId(
+    tag: string,
+    operationId: string
+  ): EndpointInfo | undefined {
+    const ep = this.findEndpointByTagAndOperationId(tag, operationId);
+    if (ep?.vercelCliSupported) {
+      return ep;
+    }
+    return undefined;
+  }
+
+  /**
+   * Distinct tag names from the loaded spec (for suggestions when lookup fails).
+   */
+  getAllTags(): string[] {
+    const found = new Set<string>();
+    for (const ep of this.getEndpoints()) {
+      for (const t of ep.tags || []) {
+        found.add(t);
+      }
+    }
+    return [...found].sort((a, b) => a.localeCompare(b));
+  }
+
+  /**
+   * Tags that have at least one `vercel openapi`-supported operation.
+   */
+  getAllCliTags(): string[] {
+    const found = new Set<string>();
+    for (const ep of this.getCliSupportedEndpoints()) {
+      for (const t of ep.tags || []) {
+        found.add(t);
+      }
+    }
+    return [...found].sort((a, b) => a.localeCompare(b));
+  }
+
+  /**
+   * All operations that list `tag` in `tags`, sorted by operationId then path.
+   * Matching is case-insensitive and treats camel / kebab / snake as equivalent.
+   * Only operations opted in via `supportedSubcommands` (or legacy `supported`) are included.
+   */
+  findEndpointsByTag(tag: string): EndpointInfo[] {
+    const list = this.getCliSupportedEndpoints().filter(ep =>
+      this.tagsInclude(ep.tags, tag)
+    );
+    return list.sort((a, b) => {
+      const nameA = this.cliSortName(a);
+      const nameB = this.cliSortName(b);
+      const cmp = nameA.localeCompare(nameB);
+      if (cmp !== 0) {
+        return cmp;
+      }
+      const pathCmp = a.path.localeCompare(b.path);
+      if (pathCmp !== 0) {
+        return pathCmp;
+      }
+      return a.method.localeCompare(b.method);
+    });
+  }
+
+  /**
+   * All tags that declare this `operationId` (operations may appear under multiple tags).
+   * `operationId` matches case-insensitively and across camel / kebab / snake.
+   */
+  findTagsForOperationId(operationId: string): string[] {
+    const want = foldNamingStyle(operationId);
+    const found = new Set<string>();
+    for (const ep of this.getEndpoints()) {
+      if (!this.operationIdOrAliasMatches(ep, want)) {
+        continue;
+      }
+      for (const t of ep.tags || []) {
+        found.add(t);
+      }
+    }
+    return [...found].sort();
+  }
+
+  /**
+   * Like {@link findTagsForOperationId} but only for `vercel openapi`-supported operations.
+   */
+  findTagsForCliSupportedOperationId(operationId: string): string[] {
+    const want = foldNamingStyle(operationId);
+    const found = new Set<string>();
+    for (const ep of this.getCliSupportedEndpoints()) {
+      if (!this.operationIdOrAliasMatches(ep, want)) {
+        continue;
+      }
+      for (const t of ep.tags || []) {
+        found.add(t);
+      }
+    }
+    return [...found].sort();
+  }
+
+  /**
+   * Resolve `$ref` and shallow `allOf` merge for schema display (same rules as request body).
+   */
+  resolveSchemaForDisplay(schema: Schema | undefined): Schema | undefined {
+    return this.resolveSchemaRef(schema);
+  }
+
+  /**
+   * Resolved CLI table layout plus schemas used to derive per-column types for `--describe`.
+   */
+  private resolveVercelCliTableLayout(endpoint: EndpointInfo): {
+    display: VercelCliTableDisplay;
+    typeSchemaDefault: Schema | undefined;
+    typeSchemaLimited?: Schema | undefined;
+  } | null {
+    this.ensureLoaded();
+    const schema = this.pickSuccessJsonBodySchema(endpoint.responses);
+    if (!schema) {
+      return null;
+    }
+    const outer = this.unwrapJsonResponseSchema(schema);
+    if (!outer?.properties) {
+      return null;
+    }
+    const displayProperty =
+      outer['x-vercel-cli']?.displayProperty ??
+      this.inferPaginatedListDisplayProperty(outer) ??
+      this.inferWrapperDisplayProperty(outer);
+
+    if (!displayProperty && this.inferFlatRootEntity(outer)) {
+      const direct = this.resolveSchemaRef(outer);
+      let cols = direct?.['x-vercel-cli']?.displayColumns;
+      if (!cols?.length) {
+        cols = this.inferColumnsFromBranchSchema(direct, false);
+      }
+      if (!cols?.length) {
+        return null;
+      }
+      return {
+        display: {
+          displayProperty: VERCEL_CLI_ROOT_DISPLAY_KEY,
+          columnsDefault: cols,
+        },
+        typeSchemaDefault: direct,
+      };
+    }
+
+    if (!displayProperty || !outer.properties[displayProperty]) {
+      return null;
+    }
+    const innerRaw = outer.properties[displayProperty];
+    const inner = this.resolveSchemaRef(innerRaw);
+
+    if (inner?.type === 'array') {
+      const item = this.resolveSchemaRef(inner.items);
+      let cols = item?.['x-vercel-cli']?.displayColumns;
+      if (!cols?.length) {
+        cols = this.inferColumnsFromBranchSchema(item, false);
+      }
+      if (!cols?.length) {
+        return null;
+      }
+      return {
+        display: { displayProperty, columnsDefault: cols },
+        typeSchemaDefault: item,
+      };
+    }
+
+    if (inner?.oneOf?.length) {
+      let columnsDefault: string[] = [];
+      let columnsWhenLimited: string[] | undefined;
+      let typeSchemaDefault: Schema | undefined;
+      let typeSchemaLimited: Schema | undefined;
+      for (const branch of inner.oneOf) {
+        const resolved = this.resolveSchemaRef(branch);
+        const ref = branch.$ref || '';
+        const isLimited = Boolean(
+          ref.includes('Limited') ||
+            (resolved?.properties &&
+              Object.prototype.hasOwnProperty.call(
+                resolved.properties,
+                'limited'
+              ))
+        );
+        let cols = resolved?.['x-vercel-cli']?.displayColumns;
+        if (!cols?.length) {
+          cols = this.inferColumnsFromBranchSchema(resolved, isLimited);
+        }
+        if (!cols?.length) {
+          continue;
+        }
+        if (isLimited) {
+          columnsWhenLimited = cols;
+          typeSchemaLimited = resolved;
+        } else {
+          columnsDefault = cols;
+          typeSchemaDefault = resolved;
+        }
+      }
+      if (!columnsDefault.length && inner.oneOf.length > 0) {
+        const firstBranch = inner.oneOf[0];
+        const first = this.resolveSchemaRef(firstBranch);
+        const isLimited = Boolean(
+          (firstBranch.$ref || '').includes('Limited') ||
+            (first?.properties &&
+              Object.prototype.hasOwnProperty.call(first.properties, 'limited'))
+        );
+        columnsDefault =
+          first?.['x-vercel-cli']?.displayColumns ??
+          this.inferColumnsFromBranchSchema(first, isLimited);
+        typeSchemaDefault = first;
+      }
+      if (!columnsDefault.length) {
+        return null;
+      }
+      const display: VercelCliTableDisplay = {
+        displayProperty,
+        columnsDefault,
+        ...(columnsWhenLimited?.length ? { columnsWhenLimited } : {}),
+      };
+      return {
+        display,
+        typeSchemaDefault,
+        ...(columnsWhenLimited?.length && typeSchemaLimited
+          ? { typeSchemaLimited }
+          : {}),
+      };
+    }
+
+    const direct = inner ? this.resolveSchemaRef(inner) : undefined;
+    let cols = direct?.['x-vercel-cli']?.displayColumns;
+    if (!cols?.length) {
+      cols = this.inferColumnsFromBranchSchema(direct, false);
+    }
+    if (!cols?.length) {
+      return null;
+    }
+    return {
+      display: { displayProperty, columnsDefault: cols },
+      typeSchemaDefault: direct,
+    };
+  }
+
+  /**
+   * Resolve `x-vercel-cli` table layout for a successful `application/json` response, if defined.
+   */
+  getVercelCliTableDisplay(
+    endpoint: EndpointInfo
+  ): VercelCliTableDisplay | null {
+    return this.resolveVercelCliTableLayout(endpoint)?.display ?? null;
+  }
+
+  /**
+   * Column paths and OpenAPI-style type strings for `vercel openapi <tag> <op> --describe`,
+   * mirroring the CLI card / table column layout (second column is type, not a response value).
+   */
+  describeResponseCliColumns(endpoint: EndpointInfo): {
+    displayProperty: string;
+    defaultColumns: Array<{ path: string; type: string }>;
+    limitedColumns?: Array<{ path: string; type: string }>;
+  } | null {
+    const layout = this.resolveVercelCliTableLayout(endpoint);
+    if (!layout) {
+      return null;
+    }
+    const { display, typeSchemaDefault, typeSchemaLimited } = layout;
+    const defaultColumns = display.columnsDefault.map(path => ({
+      path,
+      type: this.schemaTypeStringAtPath(typeSchemaDefault, path),
+    }));
+    let limitedColumns: Array<{ path: string; type: string }> | undefined;
+    if (
+      display.columnsWhenLimited?.length &&
+      typeSchemaLimited &&
+      display.columnsWhenLimited.length > 0
+    ) {
+      limitedColumns = display.columnsWhenLimited.map(path => ({
+        path,
+        type: this.schemaTypeStringAtPath(typeSchemaLimited, path),
+      }));
+    }
+    return {
+      displayProperty: display.displayProperty,
+      defaultColumns,
+      ...(limitedColumns?.length ? { limitedColumns } : {}),
+    };
+  }
+
+  /**
+   * Type string for a leaf schema (used in `--describe` column tables).
+   */
+  private formatSchemaAsTypeString(schema: Schema | undefined): string {
+    if (!schema) {
+      return 'unknown';
+    }
+    const resolved = this.resolveSchemaRef(schema);
+    if (!resolved) {
+      return 'unknown';
+    }
+    if (resolved.$ref) {
+      const match = resolved.$ref.match(/^#\/components\/schemas\/(.+)$/);
+      return match ? match[1] : 'object';
+    }
+    if (resolved.enum?.length && !resolved.properties) {
+      const raw = resolved.enum.map(v => JSON.stringify(v)).join(' | ');
+      return raw.length <= 48 ? raw : `${resolved.type ?? 'string'}`;
+    }
+    if (resolved.type === 'array') {
+      const it = this.resolveSchemaRef(resolved.items);
+      return `Array<${this.formatSchemaAsTypeString(it)}>`;
+    }
+    if (resolved.oneOf?.length) {
+      return resolved.oneOf
+        .map(s => this.formatSchemaAsTypeString(s))
+        .join(' | ');
+    }
+    if (resolved.anyOf?.length) {
+      return resolved.anyOf
+        .map(s => this.formatSchemaAsTypeString(s))
+        .join(' | ');
+    }
+    const nullable = Boolean(
+      (resolved as Schema & { nullable?: boolean }).nullable
+    );
+    const base = resolved.type ?? (resolved.properties ? 'object' : 'unknown');
+    const nullSuffix = nullable ? ' | null' : '';
+    if (base === 'object' && resolved.properties) {
+      return `object${nullSuffix}`;
+    }
+    return `${base}${nullSuffix}`;
+  }
+
+  /**
+   * Type of the property at `dotPath` on an object schema (e.g. `softBlock.blockedAt`).
+   */
+  private schemaTypeStringAtPath(
+    root: Schema | undefined,
+    dotPath: string
+  ): string {
+    if (!root || !dotPath) {
+      return 'unknown';
+    }
+    const segments = dotPath.split('.').filter(Boolean);
+    let cur: Schema | undefined = this.resolveSchemaRef(root);
+    for (let i = 0; i < segments.length; i++) {
+      if (!cur) {
+        return 'unknown';
+      }
+      const seg = segments[i]!;
+      if (i === segments.length - 1) {
+        const prop = cur.properties?.[seg];
+        return this.formatSchemaAsTypeString(prop);
+      }
+      const next = cur.properties?.[seg];
+      cur = this.resolveSchemaRef(next);
+    }
+    return 'unknown';
+  }
+
+  /**
+   * Success bodies often use `oneOf` (e.g. raw array vs `{ projects, pagination }`).
+   * Pick an object branch with `projects` + `pagination` when present, else the first
+   * branch that defines `properties`.
+   */
+  private unwrapJsonResponseSchema(
+    schema: Schema | undefined
+  ): Schema | undefined {
+    let s = this.resolveSchemaRef(schema);
+    for (let i = 0; i < 8 && s; i++) {
+      if (s.properties && !s.oneOf && !s.anyOf) {
+        return s;
+      }
+      const branches = s.oneOf ?? s.anyOf;
+      if (!branches?.length) {
+        return s;
+      }
+      let picked: Schema | undefined;
+      for (const b of branches) {
+        const r = this.resolveSchemaRef(b);
+        if (!r?.properties) {
+          continue;
+        }
+        const p = r.properties;
+        const paginatedEnvelope =
+          p.pagination &&
+          (p.projects ||
+            p.deployments ||
+            p.domains ||
+            p.teams ||
+            p.aliases ||
+            p.tokens ||
+            p.accessGroups);
+        const eventsOnly =
+          p.events &&
+          this.resolveSchemaRef(p.events as Schema)?.type === 'array';
+        if (paginatedEnvelope || eventsOnly) {
+          picked = r;
+          break;
+        }
+      }
+      if (!picked) {
+        for (const b of branches) {
+          const r = this.resolveSchemaRef(b);
+          if (r?.properties) {
+            picked = r;
+            break;
+          }
+        }
+      }
+      if (!picked) {
+        picked = this.resolveSchemaRef(branches[0]);
+      }
+      s = picked;
+    }
+    return s;
+  }
+
+  /**
+   * Paginated list envelopes: `{ <itemsKey>: [...], pagination }` (e.g. projects, deployments, teams).
+   */
+  private inferPaginatedListDisplayProperty(outer: Schema): string | undefined {
+    const keys = [
+      'projects',
+      'deployments',
+      'domains',
+      'teams',
+      'aliases',
+      'tokens',
+      'accessGroups',
+      'events',
+    ] as const;
+    for (const key of keys) {
+      const p = outer.properties?.[key];
+      const arr = this.resolveSchemaRef(p);
+      if (arr?.type === 'array') {
+        return key;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Top-level object responses with no wrapper property (project, team, deployment, …).
+   */
+  private inferFlatRootEntity(outer: Schema): boolean {
+    if (this.inferPaginatedListDisplayProperty(outer)) {
+      return false;
+    }
+    if (this.inferWrapperDisplayProperty(outer)) {
+      return false;
+    }
+    if (outer.properties?.pagination) {
+      return false;
+    }
+    const direct = this.resolveSchemaRef(outer);
+    const cols = this.inferColumnsFromBranchSchema(direct, false);
+    return cols.length >= 2;
+  }
+
+  /**
+   * When the published spec omits `x-vercel-cli.displayProperty`, infer it from a
+   * `{ singleKey: { oneOf: [...] } }` wrapper (e.g. `{ user: AuthUser | AuthUserLimited }`).
+   */
+  private inferWrapperDisplayProperty(outer: Schema): string | undefined {
+    if (!outer.properties) {
+      return undefined;
+    }
+    const keys = Object.keys(outer.properties);
+    if (keys.length !== 1) {
+      return undefined;
+    }
+    const only = keys[0];
+    const inner = this.resolveSchemaRef(outer.properties[only]);
+    if (inner?.oneOf && inner.oneOf.length >= 2) {
+      return only;
+    }
+    return undefined;
+  }
+
+  /**
+   * Infer table columns when component schemas omit `x-vercel-cli.displayColumns`
+   * (e.g. openapi.vercel.sh does not ship CLI extensions).
+   */
+  private inferColumnsFromBranchSchema(
+    resolved: Schema | undefined,
+    limitedBranch: boolean
+  ): string[] {
+    if (!resolved?.properties) {
+      return [];
+    }
+    const props = resolved.properties;
+    const preferredLimited = [
+      'limited',
+      'id',
+      'email',
+      'name',
+      'username',
+      'defaultTeamId',
+      'avatar',
+    ];
+    const preferredFull = [
+      'id',
+      'uid',
+      'accessGroupId',
+      'slug',
+      'name',
+      'text',
+      'alias',
+      'url',
+      'accountId',
+      'email',
+      'username',
+      'framework',
+      'readyState',
+      'state',
+      'source',
+      'type',
+      'projectId',
+      'teamId',
+      'verified',
+      'serviceType',
+      'created',
+      'createdAt',
+      'updatedAt',
+      'version',
+      'avatar',
+    ];
+    const preferred = limitedBranch ? preferredLimited : preferredFull;
+    const cols: string[] = [];
+    for (const key of preferred) {
+      if (!props[key]) {
+        continue;
+      }
+      const pr = this.resolveSchemaRef(props[key]);
+      if (this.isScalarishPropertySchema(pr)) {
+        cols.push(key);
+      }
+    }
+    if (!limitedBranch) {
+      const sb = props.softBlock;
+      if (sb) {
+        const sbr = this.resolveSchemaRef(sb);
+        if (sbr?.properties?.blockedAt) {
+          cols.push('softBlock.blockedAt');
+        }
+        if (sbr?.properties?.reason) {
+          cols.push('softBlock.reason');
+        }
+      }
+    }
+    return cols.slice(0, 14);
+  }
+
+  private isScalarishPropertySchema(s: Schema | undefined): boolean {
+    if (!s) {
+      return false;
+    }
+    const t = s.type;
+    if (
+      t === 'string' ||
+      t === 'number' ||
+      t === 'integer' ||
+      t === 'boolean'
+    ) {
+      return true;
+    }
+    if (s.enum && !s.properties) {
+      return true;
+    }
+    return false;
+  }
+
+  private pickSuccessJsonBodySchema(
+    responses: EndpointInfo['responses']
+  ): Schema | undefined {
+    if (!responses) {
+      return undefined;
+    }
+    for (const code of ['200', '201', '202'] as const) {
+      const r = responses[code];
+      const s = r?.content?.['application/json']?.schema;
+      if (s) {
+        return s;
+      }
+    }
+    return undefined;
   }
 
   /**
@@ -213,58 +895,21 @@ export class OpenApiCache {
     }
   }
 
-  /**
-   * Read cached spec from disk
-   */
-  private async readCache(): Promise<CachedSpec | null> {
-    try {
-      const content = await readFile(this.cachePath, 'utf-8');
-      return JSON.parse(content) as CachedSpec;
-    } catch {
-      return null;
+  private isVercelCliOperationSupported(operation: Operation): boolean {
+    const ext = operation['x-vercel-cli'];
+    if (!ext) {
+      return false;
     }
+    return ext.supportedSubcommands === true || ext.supported === true;
   }
 
-  /**
-   * Save spec to disk cache
-   */
-  private async saveCache(spec: OpenApiSpec): Promise<void> {
-    const cached: CachedSpec = {
-      fetchedAt: Date.now(),
-      spec,
-    };
-
-    // Ensure directory exists
-    const dir = join(this.cachePath, '..');
-    await mkdir(dir, { recursive: true });
-
-    await writeFile(this.cachePath, JSON.stringify(cached));
-    output.debug('Saved OpenAPI spec to cache');
-  }
-
-  /**
-   * Fetch OpenAPI spec from remote with timeout
-   */
-  private async fetchSpec(): Promise<OpenApiSpec> {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-    try {
-      const response = await fetch(OPENAPI_URL, { signal: controller.signal });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch OpenAPI spec: ${response.status}`);
-      }
-      return (await response.json()) as OpenApiSpec;
-    } finally {
-      clearTimeout(timeoutId);
+  private normalizeVercelCliAliases(operation: Operation): string[] {
+    const raw = operation['x-vercel-cli']?.aliases;
+    if (raw == null) {
+      return [];
     }
-  }
-
-  /**
-   * Check if cached spec is expired
-   */
-  private isExpired(fetchedAt: number): boolean {
-    return Date.now() - fetchedAt > CACHE_TTL_MS;
+    const list = Array.isArray(raw) ? raw : [raw];
+    return list.map(a => String(a).trim()).filter(Boolean);
   }
 
   /**
@@ -304,6 +949,13 @@ export class OpenApiCache {
             tags: operation.tags || [],
             parameters: allParams,
             requestBody: operation.requestBody,
+            responses: operation.responses,
+            vercelCliSupported: this.isVercelCliOperationSupported(operation),
+            vercelCliProductionReady:
+              operation['x-vercel-cli']?.supportedProduction === true,
+            vercelCliAliases: this.normalizeVercelCliAliases(operation),
+            vercelCliBodyArguments:
+              operation['x-vercel-cli']?.bodyArguments ?? [],
           });
         }
       }

--- a/packages/cli/src/util/openapi/openapi-operation-cli.ts
+++ b/packages/cli/src/util/openapi/openapi-operation-cli.ts
@@ -1,0 +1,321 @@
+import type { EndpointInfo, Parameter } from './types';
+import { foldNamingStyle, operationIdToKebabCase } from './fold-naming-style';
+
+/**
+ * Path placeholders `{paramName}` in order of first appearance.
+ */
+export function extractBracePathParamNames(pathTemplate: string): string[] {
+  const names: string[] = [];
+  const re = /\{([^}]+)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(pathTemplate)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+export function getParameterCliKind(param: Parameter): 'argument' | 'option' {
+  const explicit = param['x-vercel-cli']?.kind;
+  if (explicit === 'argument' || explicit === 'option') {
+    return explicit;
+  }
+  if (param.in === 'path') {
+    return 'argument';
+  }
+  return 'option';
+}
+
+/**
+ * True when the operation documents `teamId` or `slug` as query parameters.
+ * Used to decide whether the CLI may append scope query params (some endpoints
+ * return 400 if `teamId`/`slug` are present but not supported).
+ */
+export function operationDeclaresTeamOrSlugQueryParam(
+  endpoint: EndpointInfo
+): boolean {
+  return endpoint.parameters.some(
+    p => p.in === 'query' && (p.name === 'teamId' || p.name === 'slug')
+  );
+}
+
+/** CLI flag segment for an OpenAPI parameter name (e.g. `teamId` → `team-id`). */
+export function parameterNameToCliOptionFlag(paramName: string): string {
+  return operationIdToKebabCase(paramName);
+}
+
+function findParameterForFlagName(
+  flagName: string,
+  optionParams: Parameter[]
+): Parameter | undefined {
+  const fold = foldNamingStyle(flagName);
+  return optionParams.find(p => {
+    if (foldNamingStyle(p.name) === fold) {
+      return true;
+    }
+    return parameterNameToCliOptionFlag(p.name) === flagName;
+  });
+}
+
+function isBooleanParameter(param: Parameter): boolean {
+  const t = param.schema?.type;
+  if (t === 'boolean') {
+    return true;
+  }
+  const en = param.schema?.enum;
+  return (
+    Array.isArray(en) && en.length > 0 && en.every(v => typeof v === 'boolean')
+  );
+}
+
+function normalizeQueryValue(raw: string, param: Parameter): string {
+  if (isBooleanParameter(param)) {
+    const lower = raw.toLowerCase();
+    if (lower === 'true' || lower === 'false') {
+      return lower;
+    }
+  }
+  return raw;
+}
+
+/**
+ * Positional values after `<operationId>` (until the first `--…` token), and the
+ * remainder for OpenAPI-driven `--option` parsing.
+ *
+ * `positionalArgs` is `parseArguments().args` where `[0]` is the subcommand (`openapi`).
+ */
+export function splitOpenapiInvocationPositionals(positionalArgs: string[]): {
+  pathValues: string[];
+  optionArgvTail: string[];
+} {
+  const afterOp = positionalArgs.slice(3);
+  const pathValues: string[] = [];
+  let i = 0;
+  for (; i < afterOp.length; i++) {
+    const t = afterOp[i];
+    if (t.startsWith('-')) {
+      break;
+    }
+    pathValues.push(t);
+  }
+  return { pathValues, optionArgvTail: afterOp.slice(i) };
+}
+
+/**
+ * Parse `--name` / `--name=value` tokens for query (and header/cookie) parameters
+ * that use CLI `kind: option`.
+ */
+export function parseOpenapiOptionFlagTokens(
+  optionArgvTail: string[],
+  optionParams: Parameter[]
+): { values: Record<string, string>; error?: string } {
+  const values: Record<string, string> = {};
+  let i = 0;
+
+  while (i < optionArgvTail.length) {
+    const token = optionArgvTail[i];
+    if (!token.startsWith('--')) {
+      return {
+        values,
+        error: `Unexpected argument ${JSON.stringify(token)}. Place path arguments before any --options.`,
+      };
+    }
+
+    const body = token.slice(2);
+    const eq = body.indexOf('=');
+    let flagName: string;
+    let inlineValue: string | undefined;
+    if (eq >= 0) {
+      flagName = body.slice(0, eq);
+      inlineValue = body.slice(eq + 1);
+    } else {
+      flagName = body;
+    }
+
+    const param = findParameterForFlagName(flagName, optionParams);
+    if (!param) {
+      return {
+        values,
+        error: `Unknown option --${flagName} for this operation.`,
+      };
+    }
+
+    if (inlineValue !== undefined) {
+      values[param.name] = normalizeQueryValue(inlineValue, param);
+      i += 1;
+      continue;
+    }
+
+    if (isBooleanParameter(param)) {
+      values[param.name] = 'true';
+      i += 1;
+      continue;
+    }
+
+    const next = optionArgvTail[i + 1];
+    if (next === undefined || next.startsWith('-')) {
+      return {
+        values,
+        error: `Option --${parameterNameToCliOptionFlag(param.name)} requires a value.`,
+      };
+    }
+    values[param.name] = normalizeQueryValue(next, param);
+    i += 2;
+  }
+
+  return { values };
+}
+
+function buildQueryString(query: Record<string, string>): string {
+  const parts = Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== '')
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`);
+  return parts.join('&');
+}
+
+export function substitutePathTemplate(
+  pathTemplate: string,
+  pathPlaceholderNames: string[],
+  pathValues: string[]
+): { path: string; error?: string } {
+  if (pathPlaceholderNames.length !== pathValues.length) {
+    const need = pathPlaceholderNames.length;
+    const got = pathValues.length;
+    const names = pathPlaceholderNames.map(n => `{${n}}`).join(', ');
+    return {
+      path: pathTemplate,
+      error:
+        need === 0
+          ? `This operation takes no path arguments; remove the extra ${got} positional value(s).`
+          : got < need
+            ? `Missing path argument(s): expected ${need} (${names}), got ${got}.`
+            : `Too many path arguments: expected ${need} (${names}), got ${got}.`,
+    };
+  }
+
+  let out = pathTemplate;
+  for (let i = 0; i < pathPlaceholderNames.length; i++) {
+    const name = pathPlaceholderNames[i];
+    const value = pathValues[i];
+    const key = `{${name}}`;
+    if (!out.includes(key)) {
+      return {
+        path: pathTemplate,
+        error: `Path template does not contain placeholder ${key}.`,
+      };
+    }
+    out = out.replace(key, encodeURIComponent(value));
+  }
+  if (/\{[^}]+\}/.test(out)) {
+    return {
+      path: out,
+      error: 'Path still contains unresolved placeholders after substitution.',
+    };
+  }
+  return { path: out };
+}
+
+/**
+ * Parameters exposed as CLI options (not path positionals), e.g. `in: query` with
+ * `kind: option` (the default for query params).
+ */
+export function getOpenapiOptionParameters(
+  endpoint: EndpointInfo
+): Parameter[] {
+  return endpoint.parameters.filter(p => getParameterCliKind(p) === 'option');
+}
+
+/** Query parameters driven by `--kebab-name` flags for `vercel openapi`. */
+export function getOpenapiQueryOptionParameters(
+  endpoint: EndpointInfo
+): Parameter[] {
+  return getOpenapiOptionParameters(endpoint).filter(p => p.in === 'query');
+}
+
+/**
+ * After path template substitution succeeds, validate required query options and
+ * append the query string.
+ */
+export function buildOpenapiInvocationUrlAfterPathSubstitution(
+  substitutedPath: string,
+  endpoint: EndpointInfo,
+  queryValues: Record<string, string>
+): { url: string } | { error: string } {
+  const optionParams = getOpenapiQueryOptionParameters(endpoint);
+  for (const param of optionParams) {
+    if (param.in !== 'query') {
+      continue;
+    }
+    if (param.required && queryValues[param.name] === undefined) {
+      return {
+        error: `Missing required option --${parameterNameToCliOptionFlag(param.name)}.`,
+      };
+    }
+  }
+
+  const query = buildQueryString(queryValues);
+  const url = query ? `${substitutedPath}?${query}` : substitutedPath;
+  return { url };
+}
+
+/**
+ * Build the request path (including `?query`) from resolved path values and query
+ * flag values (same validation as {@link resolveOpenapiInvocationUrl}).
+ */
+export function composeOpenapiInvocationUrl(
+  endpoint: EndpointInfo,
+  pathValues: string[],
+  queryValues: Record<string, string>
+): { url: string } | { error: string } {
+  const pathNames = extractBracePathParamNames(endpoint.path);
+  const substituted = substitutePathTemplate(
+    endpoint.path,
+    pathNames,
+    pathValues
+  );
+  if (substituted.error) {
+    return { error: substituted.error };
+  }
+
+  return buildOpenapiInvocationUrlAfterPathSubstitution(
+    substituted.path,
+    endpoint,
+    queryValues
+  );
+}
+
+/**
+ * Build the request path (including `?query`) for `vercel openapi` from OpenAPI
+ * metadata and argv positionals / `--option` tokens.
+ */
+export function resolveOpenapiInvocationUrl(input: {
+  endpoint: EndpointInfo;
+  /** `parseArguments().args` where `[0]` is `openapi` */
+  positionalArgs: string[];
+}): { url: string } | { error: string } {
+  const { pathValues, optionArgvTail } = splitOpenapiInvocationPositionals(
+    input.positionalArgs
+  );
+
+  const pathNames = extractBracePathParamNames(input.endpoint.path);
+  const substituted = substitutePathTemplate(
+    input.endpoint.path,
+    pathNames,
+    pathValues
+  );
+  if (substituted.error) {
+    return { error: substituted.error };
+  }
+
+  const optionParams = getOpenapiQueryOptionParameters(input.endpoint);
+  const parsed = parseOpenapiOptionFlagTokens(optionArgvTail, optionParams);
+  if (parsed.error) {
+    return { error: parsed.error };
+  }
+
+  return buildOpenapiInvocationUrlAfterPathSubstitution(
+    substituted.path,
+    input.endpoint,
+    parsed.values
+  );
+}

--- a/packages/cli/src/util/openapi/types.ts
+++ b/packages/cli/src/util/openapi/types.ts
@@ -23,6 +23,51 @@ export interface PathItem {
   parameters?: Parameter[];
 }
 
+/**
+ * `x-vercel-cli` on an **operation** (GET/POST/…). Distinct from schema-level `x-vercel-cli`.
+ */
+export interface VercelCliOperationExtension {
+  /**
+   * Opt this operation into `vercel api` / `vercel openapi` tag subcommands (list,
+   * describe, invoke under `vercel api <tag> <operationId>`).
+   */
+  supportedSubcommands?: boolean;
+  /**
+   * When `true`, the operation replaces the native CLI command at
+   * `vercel <command> <subcommand>` (not nested under `vercel api`).
+   */
+  supportedProduction?: boolean;
+  /**
+   * @deprecated Prefer `supportedSubcommands`. When `true`, same as
+   * `supportedSubcommands: true`.
+   */
+  supported?: boolean;
+  /**
+   * Alternate names for the second CLI argument (in addition to `operationId`), e.g.
+   * `["list"]` so `vercel openapi projects list` works alongside `getProjects`.
+   * Matched with the same folding rules as `operationId`.
+   */
+  aliases?: string[];
+  /**
+   * Request-body property names exposed as ordered positional arguments after any
+   * path-template positionals, e.g. `["name"]` lets
+   * `vercel api domains add example.com` map to `{ name: "example.com" }`.
+   */
+  bodyArguments?: string[];
+}
+
+/**
+ * `x-vercel-cli` on an OpenAPI **parameter** (path/query/header).
+ */
+export interface VercelCliParameterExtension {
+  /**
+   * How the parameter is exposed for `vercel openapi <tag> <operationId> ...`:
+   * - **argument** — positional value after `<operationId>`, in `{pathTemplate}` order (default for `in: path`).
+   * - **option** — `--kebab-param-name` (and `--name=value`), default for `in: query` / `in: header` / `in: cookie`.
+   */
+  kind?: 'argument' | 'option';
+}
+
 export interface Operation {
   summary?: string;
   description?: string;
@@ -32,6 +77,7 @@ export interface Operation {
   responses?: Record<string, Response>;
   tags?: string[];
   security?: Array<Record<string, string[]>>;
+  'x-vercel-cli'?: VercelCliOperationExtension;
 }
 
 export interface Parameter {
@@ -40,6 +86,7 @@ export interface Parameter {
   required?: boolean;
   description?: string;
   schema?: Schema;
+  'x-vercel-cli'?: VercelCliParameterExtension;
 }
 
 export interface RequestBody {
@@ -50,6 +97,36 @@ export interface RequestBody {
 
 export interface MediaType {
   schema?: Schema;
+}
+
+/**
+ * CLI-only OpenAPI extension (`x-vercel-cli` on schemas). Ignored by standard OpenAPI tooling.
+ */
+/** Resolved `x-vercel-cli` layout for a successful JSON response. */
+export interface VercelCliTableDisplay {
+  /**
+   * Top-level response property whose value is rendered:
+   * - **Object** → key/value card (label | value).
+   * - **Array** of objects → table with one row per element (and these column paths).
+   */
+  displayProperty: string;
+  /** Column dot-paths for each row object (e.g. full AuthUser). */
+  columnsDefault: string[];
+  /** When a row has `limited: true`, use these columns (e.g. AuthUserLimited). */
+  columnsWhenLimited?: string[];
+}
+
+export interface VercelCliSchemaExtension {
+  /**
+   * On a **response wrapper** object schema: name of the property to render. If its
+   * schema is an object, the CLI uses a card layout; if an array of objects, a table.
+   */
+  displayProperty?: string;
+  /**
+   * On **AuthUser** (or similar) component schemas: dot-paths into the row object for
+   * table columns (e.g. `["email", "softUser.blockedAt"]`).
+   */
+  displayColumns?: string[];
 }
 
 export interface Schema {
@@ -65,6 +142,7 @@ export interface Schema {
   oneOf?: Schema[];
   anyOf?: Schema[];
   allOf?: Schema[];
+  'x-vercel-cli'?: VercelCliSchemaExtension;
 }
 
 export interface Response {
@@ -86,6 +164,22 @@ export interface EndpointInfo {
   tags: string[];
   parameters: Parameter[];
   requestBody?: RequestBody;
+  /** HTTP status code → response (for documentation / `--describe`) */
+  responses?: Record<string, Response>;
+  /**
+   * True when the operation opts into `vercel api` tag mode (`x-vercel-cli.supportedSubcommands`,
+   * or legacy `x-vercel-cli.supported`).
+   */
+  vercelCliSupported: boolean;
+  /**
+   * True when the operation should replace the native CLI command at
+   * `vercel <command> <subcommand>` (`x-vercel-cli.supportedProduction`).
+   */
+  vercelCliProductionReady: boolean;
+  /** `x-vercel-cli.aliases` from the OpenAPI document (trimmed, non-empty). */
+  vercelCliAliases: string[];
+  /** `x-vercel-cli.bodyArguments` — body property names exposed as positionals. */
+  vercelCliBodyArguments: string[];
 }
 
 export interface BodyField {

--- a/packages/cli/src/util/openapi/vercel-cli-table.ts
+++ b/packages/cli/src/util/openapi/vercel-cli-table.ts
@@ -1,0 +1,150 @@
+import ms from 'ms';
+import chalk from 'chalk';
+import table from '../output/table';
+import { humanReadableColumnLabel } from './column-label';
+import { VERCEL_CLI_ROOT_DISPLAY_KEY } from './constants';
+import type { VercelCliTableDisplay } from './types';
+
+/** Dot-path read for table cells (e.g. `softBlock.blockedAt`). */
+export function getByPath(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.').filter(Boolean);
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (cur === null || typeof cur !== 'object') {
+      return undefined;
+    }
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
+const TIMESTAMP_FIELD_PATTERN =
+  /(?:^|\.)(created|updated|deleted|expired|blocked|completed|started|finished|modified|verified|published|cancelled|revoked|invited|accepted|accessed|deployed)(?:At|_at|On|_on)?$/i;
+
+const MIN_TIMESTAMP_MS = 1_000_000_000_000; // Sep 2001
+const MAX_TIMESTAMP_MS = 4_102_444_800_000; // Jan 2100
+
+function isTimestampValue(value: unknown, columnPath: string): value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return false;
+  if (value < MIN_TIMESTAMP_MS || value > MAX_TIMESTAMP_MS) return false;
+  return TIMESTAMP_FIELD_PATTERN.test(columnPath);
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  if (diff < 0) return 'just now';
+  return chalk.gray(ms(diff));
+}
+
+function stringifyCell(value: unknown, columnPath?: string): string {
+  if (value === undefined || value === null) {
+    return chalk.gray('--');
+  }
+  if (columnPath && isTimestampValue(value, columnPath)) {
+    return formatRelativeTime(value);
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function styleColumnKey(plainLabel: string): string {
+  return chalk.gray(plainLabel);
+}
+
+function columnsForRow(
+  r: Record<string, unknown>,
+  display: VercelCliTableDisplay
+): string[] {
+  const limited = r['limited'] === true;
+  return limited && display.columnsWhenLimited?.length
+    ? display.columnsWhenLimited
+    : display.columnsDefault;
+}
+
+/**
+ * Key / value card: label left, value right (two columns, no header row).
+ */
+function formatAsCard(
+  r: Record<string, unknown>,
+  display: VercelCliTableDisplay
+): string | null {
+  const columns = columnsForRow(r, display);
+  if (!columns.length) {
+    return null;
+  }
+  const rows: string[][] = columns.map(colPath => [
+    styleColumnKey(humanReadableColumnLabel(colPath)),
+    stringifyCell(getByPath(r, colPath), colPath),
+  ]);
+  return table(rows, { align: ['l', 'l'], hsep: 2 });
+}
+
+/**
+ * Multi-row table when `displayProperty` resolves to an array of objects.
+ */
+function formatAsDataTable(
+  items: unknown[],
+  display: VercelCliTableDisplay
+): string | null {
+  if (items.length === 0) {
+    return '(empty)';
+  }
+  const first = items[0];
+  if (first === null || typeof first !== 'object' || Array.isArray(first)) {
+    const headers = [
+      styleColumnKey(humanReadableColumnLabel('#')),
+      styleColumnKey(humanReadableColumnLabel('value')),
+    ];
+    const rows: string[][] = items.map((v, i) => [
+      String(i),
+      stringifyCell(v, 'value'),
+    ]);
+    return table([headers, ...rows]);
+  }
+  const columns = columnsForRow(first as Record<string, unknown>, display);
+  if (!columns.length) {
+    return null;
+  }
+  const headers = columns.map(p => styleColumnKey(humanReadableColumnLabel(p)));
+  const dataRows = items.map(item => {
+    const row =
+      item !== null && typeof item === 'object' && !Array.isArray(item)
+        ? (item as Record<string, unknown>)
+        : {};
+    const cols = columnsForRow(row, display);
+    return cols.map(colPath => stringifyCell(getByPath(row, colPath), colPath));
+  });
+  return table([headers, ...dataRows]);
+}
+
+/**
+ * Format a JSON response using `x-vercel-cli` metadata.
+ * - If `displayProperty` is an **array** of objects: tabular rows (header + one row per item).
+ * - If it is a **single object**: two-column card (field label | value).
+ * Returns `null` if the body shape does not match or columns are empty.
+ */
+export function formatVercelCliTable(
+  body: unknown,
+  display: VercelCliTableDisplay
+): string | null {
+  if (body === null || typeof body !== 'object') {
+    return null;
+  }
+  const root = body as Record<string, unknown>;
+  const value =
+    display.displayProperty === VERCEL_CLI_ROOT_DISPLAY_KEY
+      ? root
+      : root[display.displayProperty];
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return formatAsDataTable(value, display);
+  }
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return formatAsCard(value as Record<string, unknown>, display);
+  }
+  return null;
+}

--- a/packages/cli/test/fixtures/unit/openapi/minimal-openapi.json
+++ b/packages/cli/test/fixtures/unit/openapi/minimal-openapi.json
@@ -1,0 +1,102 @@
+{
+  "openapi": "3.0.3",
+  "info": { "title": "Test", "version": "1" },
+  "paths": {
+    "/v1/test": {
+      "get": {
+        "x-vercel-cli": { "supportedSubcommands": true, "aliases": ["first"] },
+        "operationId": "testOp",
+        "tags": ["test-tag"],
+        "summary": "First operation",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "ok": { "type": "boolean" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/other": {
+      "post": {
+        "x-vercel-cli": { "supported": true },
+        "operationId": "testOpTwo",
+        "tags": ["test-tag"],
+        "description": "Creates another resource.",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "n": { "type": "number" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/hidden": {
+      "get": {
+        "operationId": "hiddenOp",
+        "tags": ["test-tag"],
+        "summary": "Not opted in",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "x": { "type": "number" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{projectId}/things": {
+      "get": {
+        "x-vercel-cli": { "supportedSubcommands": true },
+        "operationId": "projectThing",
+        "tags": ["test-tag"],
+        "summary": "Path and query params",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "ok": { "type": "boolean" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/api/operation-request-builder.test.ts
+++ b/packages/cli/test/unit/commands/api/operation-request-builder.test.ts
@@ -29,6 +29,10 @@ describe('operation-request-builder', () => {
             description: 'Scope',
           },
         ],
+        vercelCliSupported: false,
+        vercelCliProductionReady: false,
+        vercelCliAliases: [],
+        vercelCliBodyArguments: [],
       };
 
       const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, [
@@ -61,6 +65,10 @@ describe('operation-request-builder', () => {
             description: '',
           },
         ],
+        vercelCliSupported: false,
+        vercelCliProductionReady: false,
+        vercelCliAliases: [],
+        vercelCliBodyArguments: [],
       };
 
       const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, [

--- a/packages/cli/test/unit/util/openapi/column-label.test.ts
+++ b/packages/cli/test/unit/util/openapi/column-label.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  humanizeIdentifier,
+  humanReadableColumnLabel,
+} from '../../../../src/util/openapi/column-label';
+
+describe('humanizeIdentifier', () => {
+  it('splits camelCase', () => {
+    expect(humanizeIdentifier('blockedAt')).toBe('Blocked At');
+    expect(humanizeIdentifier('defaultTeamId')).toBe('Default Team Id');
+  });
+
+  it('splits snake_case', () => {
+    expect(humanizeIdentifier('soft_block')).toBe('Soft Block');
+  });
+
+  it('splits kebab-case', () => {
+    expect(humanizeIdentifier('project-id')).toBe('Project Id');
+  });
+
+  it('handles single word', () => {
+    expect(humanizeIdentifier('email')).toBe('Email');
+  });
+});
+
+describe('humanReadableColumnLabel', () => {
+  it('joins path segments with a separator', () => {
+    expect(humanReadableColumnLabel('softBlock.blockedAt')).toBe(
+      'Soft Block › Blocked At'
+    );
+  });
+
+  it('uses short label for updatedAt', () => {
+    expect(humanReadableColumnLabel('updatedAt')).toBe('Updated');
+  });
+
+  it('uses short label for createdAt', () => {
+    expect(humanReadableColumnLabel('createdAt')).toBe('Created');
+  });
+
+  it('uses override for nodeVersion', () => {
+    expect(humanReadableColumnLabel('nodeVersion')).toBe('Node Version');
+  });
+
+  it('falls back to humanizeIdentifier for unknown fields', () => {
+    expect(humanReadableColumnLabel('someCustomField')).toBe(
+      'Some Custom Field'
+    );
+  });
+
+  it('applies overrides per-segment in dot paths', () => {
+    expect(humanReadableColumnLabel('project.updatedAt')).toBe(
+      'Project › Updated'
+    );
+  });
+});

--- a/packages/cli/test/unit/util/openapi/fetch-public-openapi-spec.test.ts
+++ b/packages/cli/test/unit/util/openapi/fetch-public-openapi-spec.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type Client from '../../../../src/util/client';
+import { readPublicOpenApiSpecFromCacheOrNetwork } from '../../../../src/util/openapi/fetch-public-openapi-spec';
+
+const { mockedCacheDir } = vi.hoisted(() => {
+  return { mockedCacheDir: { value: '' } };
+});
+
+vi.mock('xdg-app-paths', () => ({
+  default: () => ({
+    cache: () => mockedCacheDir.value,
+  }),
+}));
+
+describe('readPublicOpenApiSpecFromCacheOrNetwork', () => {
+  beforeEach(() => {
+    mockedCacheDir.value = mkdtempSync(join(tmpdir(), 'vercel-openapi-cache-'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(mockedCacheDir.value, { recursive: true, force: true });
+  });
+
+  it('uses client.fetch when a client is provided', async () => {
+    const clientFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '{"openapi":"3.1.0"}',
+    });
+    const client = { fetch: clientFetch } as unknown as Client;
+
+    const globalFetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('global fetch should not be called'));
+
+    const result = await readPublicOpenApiSpecFromCacheOrNetwork(true, client);
+
+    expect('raw' in result).toBe(true);
+    if ('raw' in result) {
+      expect(result.raw).toContain('"openapi":"3.1.0"');
+    }
+    expect(clientFetch).toHaveBeenCalledOnce();
+    expect(globalFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to global fetch when no client is provided', async () => {
+    const globalFetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '{"openapi":"3.1.0"}',
+    } as Response);
+
+    const result = await readPublicOpenApiSpecFromCacheOrNetwork(true);
+
+    expect('raw' in result).toBe(true);
+    expect(globalFetchSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/test/unit/util/openapi/fold-naming-style.test.ts
+++ b/packages/cli/test/unit/util/openapi/fold-naming-style.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  foldNamingStyle,
+  operationIdToKebabCase,
+} from '../../../../src/util/openapi/fold-naming-style';
+
+describe('foldNamingStyle', () => {
+  it('treats kebab, snake, and camel as equivalent', () => {
+    const a = foldNamingStyle('project-routes');
+    expect(foldNamingStyle('project_routes')).toBe(a);
+    expect(foldNamingStyle('projectRoutes')).toBe(a);
+    expect(foldNamingStyle('ProjectRoutes')).toBe(a);
+  });
+
+  it('handles access-groups vs accessGroups', () => {
+    expect(foldNamingStyle('access-groups')).toBe(
+      foldNamingStyle('accessGroups')
+    );
+  });
+
+  it('handles listEventTypes vs list-event-types', () => {
+    expect(foldNamingStyle('listEventTypes')).toBe(
+      foldNamingStyle('list-event-types')
+    );
+  });
+
+  it('is case-insensitive', () => {
+    expect(foldNamingStyle('User')).toBe(foldNamingStyle('user'));
+  });
+});
+
+describe('operationIdToKebabCase', () => {
+  it('converts camelCase operationIds to kebab-case', () => {
+    expect(operationIdToKebabCase('getAuthUser')).toBe('get-auth-user');
+    expect(operationIdToKebabCase('listEventTypes')).toBe('list-event-types');
+  });
+
+  it('normalizes existing separators', () => {
+    expect(operationIdToKebabCase('list_event_types')).toBe('list-event-types');
+    expect(operationIdToKebabCase('list-event-types')).toBe('list-event-types');
+  });
+
+  it('uses unnamed for empty input', () => {
+    expect(operationIdToKebabCase('')).toBe('unnamed');
+  });
+});

--- a/packages/cli/test/unit/util/openapi/infer-cli-aliases.test.ts
+++ b/packages/cli/test/unit/util/openapi/infer-cli-aliases.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { inferCliSubcommandAliases } from '../../../../src/util/openapi/infer-cli-aliases';
+import type {
+  EndpointInfo,
+  Parameter,
+} from '../../../../src/util/openapi/types';
+
+const ep = (method: string, params: Parameter[] = []): EndpointInfo => ({
+  path: '/v1/x',
+  method,
+  summary: '',
+  description: '',
+  operationId: 'op',
+  tags: ['t'],
+  parameters: params,
+  vercelCliSupported: true,
+  vercelCliProductionReady: false,
+  vercelCliAliases: [],
+  vercelCliBodyArguments: [],
+});
+
+describe('inferCliSubcommandAliases', () => {
+  it('GET without path params → ls, list', () => {
+    expect(inferCliSubcommandAliases(ep('GET'))).toEqual(['ls', 'list']);
+  });
+
+  it('GET with query-only params → ls, list', () => {
+    const e = ep('GET', [{ name: 'filter', in: 'query' as const }]);
+    expect(inferCliSubcommandAliases(e)).toEqual(['ls', 'list']);
+  });
+
+  it('GET with path params → inspect, get', () => {
+    const e = ep('GET', [{ name: 'id', in: 'path' as const }]);
+    expect(inferCliSubcommandAliases(e)).toEqual(['inspect', 'get']);
+  });
+
+  it('POST → add, create', () => {
+    expect(inferCliSubcommandAliases(ep('POST'))).toEqual(['add', 'create']);
+  });
+
+  it('DELETE → rm, remove', () => {
+    expect(inferCliSubcommandAliases(ep('DELETE'))).toEqual(['rm', 'remove']);
+  });
+
+  it('PUT → update', () => {
+    expect(inferCliSubcommandAliases(ep('PUT'))).toEqual(['update']);
+  });
+
+  it('PATCH → update', () => {
+    expect(inferCliSubcommandAliases(ep('PATCH'))).toEqual(['update']);
+  });
+
+  it('unknown method → empty', () => {
+    expect(inferCliSubcommandAliases(ep('OPTIONS'))).toEqual([]);
+  });
+});

--- a/packages/cli/test/unit/util/openapi/matches-cli-api-tag.test.ts
+++ b/packages/cli/test/unit/util/openapi/matches-cli-api-tag.test.ts
@@ -14,6 +14,10 @@ const sampleEndpoint: EndpointInfo = {
   description: '',
   tags: ['projects'],
   parameters: [],
+  vercelCliSupported: false,
+  vercelCliProductionReady: false,
+  vercelCliAliases: [],
+  vercelCliBodyArguments: [],
 };
 
 describe('matchesCliApiTag', () => {

--- a/packages/cli/test/unit/util/openapi/openapi-operation-cli.test.ts
+++ b/packages/cli/test/unit/util/openapi/openapi-operation-cli.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildOpenapiInvocationUrlAfterPathSubstitution,
+  composeOpenapiInvocationUrl,
+  extractBracePathParamNames,
+  getOpenapiQueryOptionParameters,
+  operationDeclaresTeamOrSlugQueryParam,
+  parameterNameToCliOptionFlag,
+  parseOpenapiOptionFlagTokens,
+  resolveOpenapiInvocationUrl,
+  splitOpenapiInvocationPositionals,
+} from '../../../../src/util/openapi/openapi-operation-cli';
+import type { EndpointInfo } from '../../../../src/util/openapi/types';
+
+describe('openapi-operation-cli', () => {
+  it('operationDeclaresTeamOrSlugQueryParam detects teamId/slug query params', () => {
+    const withTeam: EndpointInfo = {
+      path: '/x',
+      method: 'GET',
+      summary: '',
+      description: '',
+      operationId: 'a',
+      tags: [],
+      parameters: [
+        {
+          name: 'teamId',
+          in: 'query',
+          schema: { type: 'string' },
+        },
+      ],
+      responses: {},
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    expect(operationDeclaresTeamOrSlugQueryParam(withTeam)).toBe(true);
+
+    const noScope: EndpointInfo = {
+      ...withTeam,
+      parameters: [
+        {
+          name: 'limit',
+          in: 'query',
+          schema: { type: 'number' },
+        },
+      ],
+    };
+    expect(operationDeclaresTeamOrSlugQueryParam(noScope)).toBe(false);
+  });
+
+  it('extractBracePathParamNames preserves template order', () => {
+    expect(extractBracePathParamNames('/v1/{a}/{b}/x')).toEqual(['a', 'b']);
+  });
+
+  it('parameterNameToCliOptionFlag uses kebab-case', () => {
+    expect(parameterNameToCliOptionFlag('teamId')).toBe('team-id');
+  });
+
+  it('splitOpenapiInvocationPositionals separates path values and option tail', () => {
+    const pos = [
+      'openapi',
+      'tag',
+      'op',
+      'p1',
+      'p2',
+      '--team-id=x',
+      '--verbose',
+    ];
+    expect(splitOpenapiInvocationPositionals(pos)).toEqual({
+      pathValues: ['p1', 'p2'],
+      optionArgvTail: ['--team-id=x', '--verbose'],
+    });
+  });
+
+  it('parseOpenapiOptionFlagTokens parses = and separate value', () => {
+    const q = [
+      {
+        name: 'teamId',
+        in: 'query' as const,
+        schema: { type: 'string' },
+      },
+      {
+        name: 'slug',
+        in: 'query' as const,
+        schema: { type: 'string' },
+      },
+    ];
+    expect(
+      parseOpenapiOptionFlagTokens(['--team-id=a', '--slug', 's'], q).values
+    ).toEqual({ teamId: 'a', slug: 's' });
+  });
+
+  it('resolveOpenapiInvocationUrl substitutes path and query', () => {
+    const endpoint: EndpointInfo = {
+      path: '/v1/projects/{projectId}/rolling-release',
+      method: 'DELETE',
+      summary: '',
+      description: '',
+      operationId: 'x',
+      tags: ['rolling-release'],
+      parameters: [
+        {
+          name: 'projectId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+        {
+          name: 'teamId',
+          in: 'query',
+          schema: { type: 'string' },
+        },
+      ],
+      responses: {},
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    const r = resolveOpenapiInvocationUrl({
+      endpoint,
+      positionalArgs: [
+        'openapi',
+        'rolling-release',
+        'x',
+        'my-proj',
+        '--team-id=t1',
+      ],
+    });
+    expect(r).toEqual({
+      url: '/v1/projects/my-proj/rolling-release?teamId=t1',
+    });
+  });
+
+  it('composeOpenapiInvocationUrl matches resolveOpenapiInvocationUrl for full argv', () => {
+    const endpoint: EndpointInfo = {
+      path: '/v1/projects/{projectId}/rolling-release',
+      method: 'DELETE',
+      summary: '',
+      description: '',
+      operationId: 'x',
+      tags: ['rolling-release'],
+      parameters: [
+        {
+          name: 'projectId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+        {
+          name: 'teamId',
+          in: 'query',
+          schema: { type: 'string' },
+        },
+      ],
+      responses: {},
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    const positionalArgs = [
+      'openapi',
+      'rolling-release',
+      'x',
+      'my-proj',
+      '--team-id=t1',
+    ];
+    const { pathValues, optionArgvTail } =
+      splitOpenapiInvocationPositionals(positionalArgs);
+    const parsed = parseOpenapiOptionFlagTokens(
+      optionArgvTail,
+      getOpenapiQueryOptionParameters(endpoint)
+    );
+    expect(parsed.error).toBeUndefined();
+    const composed = composeOpenapiInvocationUrl(
+      endpoint,
+      pathValues,
+      parsed.values
+    );
+    const resolved = resolveOpenapiInvocationUrl({ endpoint, positionalArgs });
+    expect(composed).toEqual(resolved);
+  });
+
+  it('buildOpenapiInvocationUrlAfterPathSubstitution requires query options', () => {
+    const endpoint: EndpointInfo = {
+      path: '/x',
+      method: 'GET',
+      summary: '',
+      description: '',
+      operationId: 'op',
+      tags: ['t'],
+      parameters: [
+        {
+          name: 'q',
+          in: 'query',
+          required: true,
+          schema: { type: 'string' },
+        },
+      ],
+      responses: {},
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    expect(
+      buildOpenapiInvocationUrlAfterPathSubstitution('/x', endpoint, {})
+    ).toEqual({
+      error: 'Missing required option --q.',
+    });
+    expect(
+      buildOpenapiInvocationUrlAfterPathSubstitution('/x', endpoint, { q: '1' })
+    ).toEqual({ url: '/x?q=1' });
+  });
+
+  it('resolveOpenapiInvocationUrl errors on path arity mismatch', () => {
+    const endpoint: EndpointInfo = {
+      path: '/v1/projects/{projectId}/rolling-release',
+      method: 'DELETE',
+      summary: '',
+      description: '',
+      operationId: 'x',
+      tags: ['t'],
+      parameters: [
+        {
+          name: 'projectId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+      ],
+      responses: {},
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    const r = resolveOpenapiInvocationUrl({
+      endpoint,
+      positionalArgs: ['openapi', 't', 'x'],
+    });
+    expect(r).toEqual({
+      error: 'Missing path argument(s): expected 1 ({projectId}), got 0.',
+    });
+  });
+});

--- a/packages/cli/test/unit/util/openapi/resolve-by-tag-operation.test.ts
+++ b/packages/cli/test/unit/util/openapi/resolve-by-tag-operation.test.ts
@@ -10,6 +10,10 @@ const base = (overrides: Partial<EndpointInfo>): EndpointInfo => ({
   operationId: '',
   tags: [],
   parameters: [],
+  vercelCliSupported: false,
+  vercelCliProductionReady: false,
+  vercelCliAliases: [],
+  vercelCliBodyArguments: [],
   ...overrides,
 });
 

--- a/packages/cli/test/unit/util/openapi/vercel-cli-table-display.test.ts
+++ b/packages/cli/test/unit/util/openapi/vercel-cli-table-display.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from 'vitest';
+import { OpenApiCache } from '../../../../src/util/openapi/openapi-cache';
+import type { EndpointInfo } from '../../../../src/util/openapi/types';
+
+const miniSpec = {
+  openapi: '3.0.3',
+  info: { title: 't', version: '1' },
+  paths: {
+    '/v2/user': {
+      get: {
+        operationId: 'getAuthUser',
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  'x-vercel-cli': { displayProperty: 'user' },
+                  properties: {
+                    user: {
+                      oneOf: [
+                        { $ref: '#/components/schemas/AuthUser' },
+                        { $ref: '#/components/schemas/AuthUserLimited' },
+                      ],
+                    },
+                  },
+                  required: ['user'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      AuthUser: {
+        type: 'object',
+        'x-vercel-cli': { displayColumns: ['id', 'email'] },
+        properties: {
+          id: { type: 'string' },
+          email: { type: 'string' },
+        },
+      },
+      AuthUserLimited: {
+        type: 'object',
+        'x-vercel-cli': { displayColumns: ['limited', 'id'] },
+        properties: {
+          limited: { type: 'boolean', enum: [true] },
+          id: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+/** Published openapi.vercel.sh shape: no `x-vercel-cli` anywhere. */
+const publishedStyleSpec = {
+  openapi: '3.0.3',
+  info: { title: 't', version: '1' },
+  paths: {
+    '/v2/user': {
+      get: {
+        operationId: 'getAuthUser',
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    user: {
+                      oneOf: [
+                        { $ref: '#/components/schemas/AuthUser' },
+                        { $ref: '#/components/schemas/AuthUserLimited' },
+                      ],
+                    },
+                  },
+                  required: ['user'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      AuthUser: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          email: { type: 'string' },
+          name: { type: 'string', nullable: true },
+          username: { type: 'string' },
+          defaultTeamId: { type: 'string', nullable: true },
+          createdAt: { type: 'number' },
+          softBlock: {
+            type: 'object',
+            properties: {
+              blockedAt: { type: 'number' },
+              reason: { type: 'string' },
+            },
+          },
+        },
+      },
+      AuthUserLimited: {
+        type: 'object',
+        properties: {
+          limited: { type: 'boolean', enum: [true] },
+          id: { type: 'string' },
+          email: { type: 'string' },
+          name: { type: 'string', nullable: true },
+          username: { type: 'string' },
+          defaultTeamId: { type: 'string', nullable: true },
+          avatar: { type: 'string', nullable: true },
+        },
+      },
+    },
+  },
+};
+
+const getProjectsListSpec = {
+  openapi: '3.0.3',
+  info: { title: 't', version: '1' },
+  paths: {
+    '/v10/projects': {
+      get: {
+        operationId: 'getProjects',
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  nullable: true,
+                  oneOf: [
+                    {
+                      type: 'array',
+                      items: { type: 'string' },
+                    },
+                    {
+                      type: 'object',
+                      required: ['pagination', 'projects'],
+                      properties: {
+                        projects: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              id: { type: 'string' },
+                              name: { type: 'string' },
+                              accountId: { type: 'string' },
+                              framework: { type: 'string', nullable: true },
+                              createdAt: { type: 'number' },
+                            },
+                          },
+                        },
+                        pagination: {
+                          type: 'object',
+                          properties: {
+                            count: { type: 'number' },
+                            next: { type: 'string', nullable: true },
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('OpenApiCache.getVercelCliTableDisplay', () => {
+  it('resolves oneOf AuthUser / AuthUserLimited columns', async () => {
+    const cache = new OpenApiCache();
+    (cache as unknown as { spec: typeof miniSpec }).spec = miniSpec;
+    const ep: EndpointInfo = {
+      path: '/v2/user',
+      method: 'GET',
+      summary: '',
+      description: '',
+      operationId: 'getAuthUser',
+      tags: ['user'],
+      parameters: [],
+      responses: miniSpec.paths['/v2/user'].get.responses,
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    const d = cache.getVercelCliTableDisplay(ep);
+    expect(d).toEqual({
+      displayProperty: 'user',
+      columnsDefault: ['id', 'email'],
+      columnsWhenLimited: ['limited', 'id'],
+    });
+  });
+
+  it('infers table layout when the spec omits x-vercel-cli (published OpenAPI)', async () => {
+    const cache = new OpenApiCache();
+    (cache as unknown as { spec: typeof publishedStyleSpec }).spec =
+      publishedStyleSpec;
+    const ep: EndpointInfo = {
+      path: '/v2/user',
+      method: 'GET',
+      summary: '',
+      description: '',
+      operationId: 'getAuthUser',
+      tags: ['user'],
+      parameters: [],
+      responses: publishedStyleSpec.paths['/v2/user'].get.responses,
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    const d = cache.getVercelCliTableDisplay(ep);
+    expect(d?.displayProperty).toBe('user');
+    expect(d?.columnsDefault?.length).toBeGreaterThan(0);
+    expect(d?.columnsDefault).toContain('id');
+    expect(d?.columnsWhenLimited?.length).toBeGreaterThan(0);
+    expect(d?.columnsWhenLimited).toContain('limited');
+  });
+
+  it('unwraps oneOf and resolves list projects ({ projects, pagination }) columns', () => {
+    const cache = new OpenApiCache();
+    (cache as unknown as { spec: typeof getProjectsListSpec }).spec =
+      getProjectsListSpec;
+    const ep: EndpointInfo = {
+      path: '/v10/projects',
+      method: 'GET',
+      summary: '',
+      description: '',
+      operationId: 'getProjects',
+      tags: ['projects'],
+      parameters: [],
+      responses: getProjectsListSpec.paths['/v10/projects'].get.responses,
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    const d = cache.getVercelCliTableDisplay(ep);
+    expect(d?.displayProperty).toBe('projects');
+    expect(d?.columnsDefault).toEqual([
+      'id',
+      'name',
+      'accountId',
+      'framework',
+      'createdAt',
+    ]);
+  });
+});
+
+describe('OpenApiCache.describeResponseCliColumns', () => {
+  it('returns types for list projects columns', () => {
+    const cache = new OpenApiCache();
+    (cache as unknown as { spec: typeof getProjectsListSpec }).spec =
+      getProjectsListSpec;
+    const ep: EndpointInfo = {
+      path: '/v10/projects',
+      method: 'GET',
+      summary: '',
+      description: '',
+      operationId: 'getProjects',
+      tags: ['projects'],
+      parameters: [],
+      responses: getProjectsListSpec.paths['/v10/projects'].get.responses,
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    const d = cache.describeResponseCliColumns(ep);
+    expect(d?.displayProperty).toBe('projects');
+    expect(d?.defaultColumns).toEqual([
+      { path: 'id', type: 'string' },
+      { path: 'name', type: 'string' },
+      { path: 'accountId', type: 'string' },
+      { path: 'framework', type: 'string | null' },
+      { path: 'createdAt', type: 'number' },
+    ]);
+  });
+
+  it('returns default and limited column types for oneOf user response', () => {
+    const cache = new OpenApiCache();
+    (cache as unknown as { spec: typeof miniSpec }).spec = miniSpec;
+    const ep: EndpointInfo = {
+      path: '/v2/user',
+      method: 'GET',
+      summary: '',
+      description: '',
+      operationId: 'getAuthUser',
+      tags: ['user'],
+      parameters: [],
+      responses: miniSpec.paths['/v2/user'].get.responses,
+      vercelCliSupported: true,
+      vercelCliProductionReady: false,
+      vercelCliAliases: [],
+      vercelCliBodyArguments: [],
+    };
+    const d = cache.describeResponseCliColumns(ep);
+    expect(d?.displayProperty).toBe('user');
+    expect(d?.defaultColumns).toEqual([
+      { path: 'id', type: 'string' },
+      { path: 'email', type: 'string' },
+    ]);
+    expect(d?.limitedColumns).toEqual([
+      { path: 'limited', type: 'true' },
+      { path: 'id', type: 'string' },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/util/openapi/vercel-cli-table.test.ts
+++ b/packages/cli/test/unit/util/openapi/vercel-cli-table.test.ts
@@ -1,0 +1,166 @@
+import stripAnsi from 'strip-ansi';
+import { describe, expect, it } from 'vitest';
+import {
+  formatVercelCliTable,
+  getByPath,
+} from '../../../../src/util/openapi/vercel-cli-table';
+import { VERCEL_CLI_ROOT_DISPLAY_KEY } from '../../../../src/util/openapi/constants';
+import type { VercelCliTableDisplay } from '../../../../src/util/openapi/types';
+
+describe('getByPath', () => {
+  it('reads nested keys', () => {
+    const row = {
+      softBlock: { blockedAt: 123, reason: 'X' },
+    };
+    expect(getByPath(row, 'softBlock.blockedAt')).toBe(123);
+  });
+});
+
+describe('formatVercelCliTable', () => {
+  const display: VercelCliTableDisplay = {
+    displayProperty: 'user',
+    columnsDefault: ['id', 'email', 'softBlock.blockedAt'],
+  };
+
+  it('formats a singular object as a key/value card', () => {
+    const body = {
+      user: {
+        id: 'u_1',
+        email: 'a@b.com',
+        softBlock: { blockedAt: 99 },
+      },
+    };
+    const out = formatVercelCliTable(body, display);
+    expect(out).toBeTruthy();
+    const plain = stripAnsi(out!);
+    expect(plain).toContain('u_1');
+    expect(plain).toContain('a@b.com');
+    expect(plain).toContain('99');
+    expect(plain).toContain('Id');
+    expect(plain).toContain('Email');
+    expect(plain).toContain('Blocked At');
+  });
+
+  it('formats an array as a multi-row table', () => {
+    const body = {
+      items: [
+        { id: 'a', email: 'one@test.com' },
+        { id: 'b', email: 'two@test.com' },
+      ],
+    };
+    const out = formatVercelCliTable(body, {
+      displayProperty: 'items',
+      columnsDefault: ['id', 'email'],
+    });
+    expect(out).toBeTruthy();
+    const plain = stripAnsi(out!);
+    expect(plain).toContain('Id');
+    expect(plain).toContain('Email');
+    expect(plain).toContain('one@test.com');
+    expect(plain).toContain('two@test.com');
+  });
+
+  it('shows (empty) for an empty array', () => {
+    expect(
+      formatVercelCliTable(
+        { items: [] },
+        { displayProperty: 'items', columnsDefault: ['id'] }
+      )
+    ).toBe('(empty)');
+  });
+
+  it('uses columnsWhenLimited when limited is true', () => {
+    const limitedDisplay: VercelCliTableDisplay = {
+      displayProperty: 'user',
+      columnsDefault: ['id', 'email'],
+      columnsWhenLimited: ['limited', 'id', 'email'],
+    };
+    const body = {
+      user: {
+        limited: true,
+        id: 'u_1',
+        email: 'a@b.com',
+      },
+    };
+    const out = formatVercelCliTable(body, limitedDisplay);
+    expect(stripAnsi(out!)).toContain('true');
+  });
+
+  it('returns null when display property is missing', () => {
+    expect(formatVercelCliTable({}, display)).toBeNull();
+  });
+
+  it('formats the whole body as a card when displayProperty is __root__', () => {
+    const body = {
+      id: 'team_1',
+      slug: 'acme',
+      name: 'Acme',
+    };
+    const out = formatVercelCliTable(body, {
+      displayProperty: VERCEL_CLI_ROOT_DISPLAY_KEY,
+      columnsDefault: ['id', 'slug', 'name'],
+    });
+    expect(out).toBeTruthy();
+    const plain = stripAnsi(out!);
+    expect(plain).toContain('team_1');
+    expect(plain).toContain('acme');
+    expect(plain).toContain('Acme');
+  });
+
+  it('renders null/undefined values as "--"', () => {
+    const body = {
+      items: [{ id: 'a', email: null }, { id: 'b' }],
+    };
+    const out = formatVercelCliTable(body, {
+      displayProperty: 'items',
+      columnsDefault: ['id', 'email'],
+    });
+    expect(out).toBeTruthy();
+    const plain = stripAnsi(out!);
+    const dashes = plain.match(/--/g);
+    expect(dashes?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('formats timestamp fields as relative time', () => {
+    const now = Date.now();
+    const twoHoursAgo = now - 2 * 60 * 60 * 1000;
+    const body = {
+      items: [{ id: 'p1', name: 'my-project', updatedAt: twoHoursAgo }],
+    };
+    const out = formatVercelCliTable(body, {
+      displayProperty: 'items',
+      columnsDefault: ['id', 'name', 'updatedAt'],
+    });
+    expect(out).toBeTruthy();
+    const plain = stripAnsi(out!);
+    expect(plain).toContain('2h');
+    expect(plain).not.toContain(String(twoHoursAgo));
+  });
+
+  it('does not format non-timestamp number fields as time', () => {
+    const body = {
+      items: [{ id: 'p1', port: 3000 }],
+    };
+    const out = formatVercelCliTable(body, {
+      displayProperty: 'items',
+      columnsDefault: ['id', 'port'],
+    });
+    expect(out).toBeTruthy();
+    const plain = stripAnsi(out!);
+    expect(plain).toContain('3000');
+  });
+
+  it('shows "Updated" header for updatedAt column', () => {
+    const body = {
+      items: [{ id: 'p1', updatedAt: Date.now() - 60000 }],
+    };
+    const out = formatVercelCliTable(body, {
+      displayProperty: 'items',
+      columnsDefault: ['id', 'updatedAt'],
+    });
+    expect(out).toBeTruthy();
+    const plain = stripAnsi(out!);
+    expect(plain).toContain('Updated');
+    expect(plain).not.toContain('Updated At');
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `EndpointInfo` with `vercelCliSupported`, `vercelCliProductionReady`, `vercelCliAliases`, and `vercelCliBodyArguments` fields extracted from `x-vercel-cli` OpenAPI extensions
- Rewrites `OpenApiCache` with endpoint metadata extraction, table display layout inference (`getVercelCliTableDisplay`), and production-ready endpoint lookup methods
- Adds human-readable table formatting: relative timestamps (e.g. `2d` instead of `1776186874626`), `--` for null/undefined values, and column label overrides (`updatedAt` → `Updated`)
- Introduces utilities: `fold-naming-style` (camelCase/kebab-case/snake_case matching), `infer-cli-aliases` (auto-generate `ls`/`add`/`rm` from HTTP methods), `openapi-operation-cli` (path param extraction, URL composition), `fetch-public-openapi-spec` (disk-cached spec loading)

## Test plan

- [x] 65 unit tests passing across 10 test files
- [x] Type check passing (no new errors)
- [ ] Verify `vercel api projects ls` still works with updated cache
- [ ] Verify table output formatting matches native CLI style


Made with [Cursor](https://cursor.com)