### PR TITLE
feat(cli): add naming and formatting utilities for OpenAPI CLI

### DIFF
--- a/.changeset/openapi-naming-utilities.md
+++ b/.changeset/openapi-naming-utilities.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+Add naming and formatting utilities for OpenAPI CLI integration.
+
+Introduces `foldNamingStyle` for case-insensitive matching across camelCase/kebab-case/snake_case, `humanReadableColumnLabel` for converting schema property paths to readable headers, and `inferCliSubcommandAliases` for auto-generating CLI aliases from HTTP methods.

--- a/packages/cli/src/util/openapi/column-label.ts
+++ b/packages/cli/src/util/openapi/column-label.ts
@@ -1,0 +1,53 @@
+const LABEL_OVERRIDES: Record<string, string> = {
+  createdAt: 'Created',
+  updatedAt: 'Updated',
+  deletedAt: 'Deleted',
+  expiredAt: 'Expired',
+  verifiedAt: 'Verified',
+  deployedAt: 'Deployed',
+  created_at: 'Created',
+  updated_at: 'Updated',
+  accountId: 'Account Id',
+  projectId: 'Project Id',
+  teamId: 'Team Id',
+  nodeVersion: 'Node Version',
+};
+
+/**
+ * Turn a single identifier segment (camelCase, snake_case, kebab-case, etc.)
+ * into Title Case words.
+ */
+export function humanizeIdentifier(raw: string): string {
+  const s = raw.trim();
+  if (!s) {
+    return raw;
+  }
+  const withSpaces = s
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
+  const words = withSpaces.split(/[\s_-]+/).filter(Boolean);
+  return words
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/**
+ * Human-readable label for a column dot-path: each segment is humanized,
+ * segments joined with ` › ` (e.g. `softBlock.blockedAt` → `Soft Block › Blocked At`).
+ * Common fields like `updatedAt` are mapped to shorter labels (e.g. "Updated").
+ */
+export function humanReadableColumnLabel(columnPath: string): string {
+  const override = LABEL_OVERRIDES[columnPath];
+  if (override) return override;
+
+  const parts = columnPath.split('.').filter(Boolean);
+  if (parts.length === 0) {
+    return columnPath;
+  }
+  if (parts.length === 1) {
+    return LABEL_OVERRIDES[parts[0]] ?? humanizeIdentifier(parts[0]);
+  }
+  return parts
+    .map(p => LABEL_OVERRIDES[p] ?? humanizeIdentifier(p))
+    .join(' › ');
+}

--- a/packages/cli/src/util/openapi/fold-naming-style.ts
+++ b/packages/cli/src/util/openapi/fold-naming-style.ts
@@ -1,0 +1,32 @@
+/**
+ * Collapses camelCase, kebab-case, and snake_case to a single lowercase string
+ * so identifiers that differ only by naming style compare equal, e.g.:
+ * `project-routes`, `project_routes`, `projectRoutes`, `ProjectRoutes`.
+ */
+export function foldNamingStyle(input: string): string {
+  return input
+    .trim()
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')
+    .replace(/[-_\s]+/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '');
+}
+
+/**
+ * Display form for `--describe`: normalize operationId to kebab-case (e.g. `getAuthUser` → `get-auth-user`).
+ */
+export function operationIdToKebabCase(operationId: string): string {
+  const s = operationId.trim();
+  if (!s) {
+    return 'unnamed';
+  }
+  return s
+    .replace(/([a-z\d])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .replace(/[-_\s]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase();
+}

--- a/packages/cli/src/util/openapi/index.ts
+++ b/packages/cli/src/util/openapi/index.ts
@@ -1,6 +1,12 @@
 export { OpenApiCache } from './openapi-cache';
 export * from './types';
 export * from './constants';
+export { foldNamingStyle, operationIdToKebabCase } from './fold-naming-style';
+export {
+  humanizeIdentifier,
+  humanReadableColumnLabel,
+} from './column-label';
+export { inferCliSubcommandAliases } from './infer-cli-aliases';
 export * from './resolve-by-tag-operation';
 export {
   matchesCliApiTag,

--- a/packages/cli/src/util/openapi/infer-cli-aliases.ts
+++ b/packages/cli/src/util/openapi/infer-cli-aliases.ts
@@ -1,0 +1,35 @@
+import type { EndpointInfo } from './types';
+
+/**
+ * Infer standard CLI subcommand aliases from an endpoint's HTTP method and path parameters.
+ *
+ * Maps REST semantics to familiar CLI verbs so that `vercel api <tag> ls` works the
+ * same as `vercel <tag> ls`:
+ *
+ *   GET  (no path params) → ls, list
+ *   GET  (with path params) → inspect, get
+ *   POST → add, create
+ *   DELETE → rm, remove
+ *   PUT / PATCH → update
+ *
+ * These are used for resolution only and do NOT override display names
+ * (which come from explicit `x-vercel-cli.aliases` or the `operationId`).
+ */
+export function inferCliSubcommandAliases(ep: EndpointInfo): string[] {
+  const upper = ep.method.toUpperCase();
+  const hasPathParams = ep.parameters.some(p => p.in === 'path');
+
+  switch (upper) {
+    case 'GET':
+      return hasPathParams ? ['inspect', 'get'] : ['ls', 'list'];
+    case 'POST':
+      return ['add', 'create'];
+    case 'DELETE':
+      return ['rm', 'remove'];
+    case 'PUT':
+    case 'PATCH':
+      return ['update'];
+    default:
+      return [];
+  }
+}

--- a/packages/cli/test/unit/util/openapi/column-label.test.ts
+++ b/packages/cli/test/unit/util/openapi/column-label.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  humanizeIdentifier,
+  humanReadableColumnLabel,
+} from '../../../../src/util/openapi/column-label';
+
+describe('humanizeIdentifier', () => {
+  it('splits camelCase', () => {
+    expect(humanizeIdentifier('blockedAt')).toBe('Blocked At');
+    expect(humanizeIdentifier('defaultTeamId')).toBe('Default Team Id');
+  });
+
+  it('splits snake_case', () => {
+    expect(humanizeIdentifier('soft_block')).toBe('Soft Block');
+  });
+
+  it('splits kebab-case', () => {
+    expect(humanizeIdentifier('project-id')).toBe('Project Id');
+  });
+
+  it('handles single word', () => {
+    expect(humanizeIdentifier('email')).toBe('Email');
+  });
+});
+
+describe('humanReadableColumnLabel', () => {
+  it('joins path segments with a separator', () => {
+    expect(humanReadableColumnLabel('softBlock.blockedAt')).toBe(
+      'Soft Block › Blocked At'
+    );
+  });
+
+  it('uses short label for updatedAt', () => {
+    expect(humanReadableColumnLabel('updatedAt')).toBe('Updated');
+  });
+
+  it('uses short label for createdAt', () => {
+    expect(humanReadableColumnLabel('createdAt')).toBe('Created');
+  });
+
+  it('uses override for nodeVersion', () => {
+    expect(humanReadableColumnLabel('nodeVersion')).toBe('Node Version');
+  });
+
+  it('falls back to humanizeIdentifier for unknown fields', () => {
+    expect(humanReadableColumnLabel('someCustomField')).toBe(
+      'Some Custom Field'
+    );
+  });
+
+  it('applies overrides per-segment in dot paths', () => {
+    expect(humanReadableColumnLabel('project.updatedAt')).toBe(
+      'Project › Updated'
+    );
+  });
+});

--- a/packages/cli/test/unit/util/openapi/fold-naming-style.test.ts
+++ b/packages/cli/test/unit/util/openapi/fold-naming-style.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  foldNamingStyle,
+  operationIdToKebabCase,
+} from '../../../../src/util/openapi/fold-naming-style';
+
+describe('foldNamingStyle', () => {
+  it('treats kebab, snake, and camel as equivalent', () => {
+    const a = foldNamingStyle('project-routes');
+    expect(foldNamingStyle('project_routes')).toBe(a);
+    expect(foldNamingStyle('projectRoutes')).toBe(a);
+    expect(foldNamingStyle('ProjectRoutes')).toBe(a);
+  });
+
+  it('handles access-groups vs accessGroups', () => {
+    expect(foldNamingStyle('access-groups')).toBe(
+      foldNamingStyle('accessGroups')
+    );
+  });
+
+  it('handles listEventTypes vs list-event-types', () => {
+    expect(foldNamingStyle('listEventTypes')).toBe(
+      foldNamingStyle('list-event-types')
+    );
+  });
+
+  it('is case-insensitive', () => {
+    expect(foldNamingStyle('User')).toBe(foldNamingStyle('user'));
+  });
+});
+
+describe('operationIdToKebabCase', () => {
+  it('converts camelCase operationIds to kebab-case', () => {
+    expect(operationIdToKebabCase('getAuthUser')).toBe('get-auth-user');
+    expect(operationIdToKebabCase('listEventTypes')).toBe('list-event-types');
+  });
+
+  it('normalizes existing separators', () => {
+    expect(operationIdToKebabCase('list_event_types')).toBe('list-event-types');
+    expect(operationIdToKebabCase('list-event-types')).toBe('list-event-types');
+  });
+
+  it('uses unnamed for empty input', () => {
+    expect(operationIdToKebabCase('')).toBe('unnamed');
+  });
+});

--- a/packages/cli/test/unit/util/openapi/infer-cli-aliases.test.ts
+++ b/packages/cli/test/unit/util/openapi/infer-cli-aliases.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { inferCliSubcommandAliases } from '../../../../src/util/openapi/infer-cli-aliases';
+import type {
+  EndpointInfo,
+  Parameter,
+} from '../../../../src/util/openapi/types';
+
+const ep = (method: string, params: Parameter[] = []): EndpointInfo => ({
+  path: '/v1/x',
+  method,
+  summary: '',
+  description: '',
+  operationId: 'op',
+  tags: ['t'],
+  parameters: params,
+});
+
+describe('inferCliSubcommandAliases', () => {
+  it('GET without path params → ls, list', () => {
+    expect(inferCliSubcommandAliases(ep('GET'))).toEqual(['ls', 'list']);
+  });
+
+  it('GET with query-only params → ls, list', () => {
+    const e = ep('GET', [{ name: 'filter', in: 'query' as const }]);
+    expect(inferCliSubcommandAliases(e)).toEqual(['ls', 'list']);
+  });
+
+  it('GET with path params → inspect, get', () => {
+    const e = ep('GET', [{ name: 'id', in: 'path' as const }]);
+    expect(inferCliSubcommandAliases(e)).toEqual(['inspect', 'get']);
+  });
+
+  it('POST → add, create', () => {
+    expect(inferCliSubcommandAliases(ep('POST'))).toEqual(['add', 'create']);
+  });
+
+  it('DELETE → rm, remove', () => {
+    expect(inferCliSubcommandAliases(ep('DELETE'))).toEqual(['rm', 'remove']);
+  });
+
+  it('PUT → update', () => {
+    expect(inferCliSubcommandAliases(ep('PUT'))).toEqual(['update']);
+  });
+
+  it('PATCH → update', () => {
+    expect(inferCliSubcommandAliases(ep('PATCH'))).toEqual(['update']);
+  });
+
+  it('unknown method → empty', () => {
+    expect(inferCliSubcommandAliases(ep('OPTIONS'))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- **fold-naming-style**: case-insensitive matching across camelCase, kebab-case, and snake_case (e.g. `getProjects` matches `get-projects`)
- **column-label**: converts schema property paths to human-readable headers (`updatedAt` → `Updated`, `softBlock.blockedAt` → `Soft Block › Blocked At`)
- **infer-cli-aliases**: auto-generates CLI subcommand aliases from HTTP methods (`GET` → `ls`, `POST` → `add`, `DELETE` → `rm`)

Pure utility functions with no side effects or external dependencies.

## Test plan

- [x] 25 unit tests passing
- [x] Type check clean


Made with [Cursor](https://cursor.com)