### PR TITLE
cli: enhance OpenAPI fallback with aliases, context inference, and display columns

### DIFF
--- a/.changeset/api-tag-operationid.md
+++ b/.changeset/api-tag-operationid.md
@@ -2,8 +2,13 @@
 'vercel': patch
 ---
 
-Add OpenAPI-driven subcommand fallback behind `VERCEL_AUTO_API=1`.
+Enhance OpenAPI-driven CLI fallback (`VERCEL_AUTO_API=1`).
 
-When the env var is set, unrecognized CLI tokens are matched against OpenAPI tags and operation IDs from `openapi.vercel.sh`. This enables `vercel <tag> <operationId>` (e.g. `vercel user getAuthUser`) at the top level, and per-command fallthrough (e.g. `vercel projects getProject`) when a token doesn't match a native subcommand.
-
-When `x-vercel-cli.displayColumns` is present in the OpenAPI response schema, results render as a card (single object) or table (array) instead of raw JSON.
+- **Alias resolution**: Operations with `x-vercel-cli.aliases` (e.g. `list` → `getTeams`) are now matched as subcommands.
+- **Bidirectional context inference**: Bare positional args (e.g. `vercel teams members team_xxx`) auto-fill path params and sync CLI scope; missing `teamId`/`projectId` auto-fill from current context.
+- **Top-level OpenAPI override**: When the env var is set, OpenAPI routing runs before native command handlers for all commands, not just fallback.
+- **`VERCEL_AUTO_API_TEST=1`**: Loads the OpenAPI spec from the local test fixture instead of the remote endpoint, while still using real credentials.
+- **`show-inferred-commands`**: New command listing all OpenAPI-backed commands in a copy-pasteable format.
+- **Improved error output**: 401/403 errors now show request details (method, URL, scope) and a hint to switch teams.
+- **`displayColumns`**: Added to 16 list operations in the test spec for tabular output.
+- **Test infra fix**: Mock `writeToConfigFile` in switch tests to prevent leaking test team IDs to the real global config.

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -24,6 +24,7 @@ import {
 import type { CliContext } from './operation-request-builder';
 import { getLinkFromDir } from '../../util/projects/link';
 import { getVercelDirectory } from '../../util/projects/link';
+import getTeamById from '../../util/teams/get-team-by-id';
 import {
   OpenApiCache,
   resolveEndpointByTagAndOperationId,
@@ -589,6 +590,41 @@ function printTagOperationResolveError(
   );
 }
 
+async function printContextHeader(client: Client): Promise<void> {
+  const teamId = client.config.currentTeam;
+  if (!teamId) return;
+
+  let teamLabel = teamId;
+  try {
+    const team = await getTeamById(client, teamId);
+    if (team?.slug) {
+      teamLabel = `${team.name || team.slug} ${chalk.dim(`(${team.slug})`)}`;
+    }
+  } catch {
+    // Fall back to raw ID
+  }
+
+  output.log(chalk.gray('Team: ') + chalk.cyan(teamLabel));
+
+  let projectId: string | undefined;
+  try {
+    const link = await getLinkFromDir<{ projectId: string; orgId: string }>(
+      getVercelDirectory(client.cwd)
+    );
+    if (link?.projectId) {
+      projectId = link.projectId;
+    }
+  } catch {
+    // No linked project
+  }
+
+  if (projectId) {
+    output.log(chalk.gray('Project: ') + chalk.cyan(projectId));
+  }
+
+  output.log('');
+}
+
 async function executeApiRequest(
   client: Client,
   requestConfig: RequestConfig,
@@ -596,6 +632,10 @@ async function executeApiRequest(
   displayColumns?: Record<string, string> | null,
   options?: { tagOperation?: boolean }
 ): Promise<number> {
+  if (options?.tagOperation && !flags['--raw'] && !flags['--silent']) {
+    await printContextHeader(client);
+  }
+
   // Verbose mode: show request details
   if (flags['--verbose']) {
     output.debug(`Request: ${requestConfig.method} ${requestConfig.url}`);

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -17,8 +17,13 @@ import {
   getMissingRequiredOperationParams,
   getUnsetOptionalOperationParams,
   parseOperationKeyValuePairs,
+  applyContextDefaults,
   GLOBAL_CLI_QUERY_PARAMS,
+  CONTEXT_PARAM_MAP,
 } from './operation-request-builder';
+import type { CliContext } from './operation-request-builder';
+import { getLinkFromDir } from '../../util/projects/link';
+import { getVercelDirectory } from '../../util/projects/link';
 import {
   OpenApiCache,
   resolveEndpointByTagAndOperationId,
@@ -363,7 +368,8 @@ async function promptMissingParamsForTagOperation(
   endpoint: EndpointInfo,
   bodyFields: BodyField[],
   flags: ParsedFlags,
-  positionalKeyValues: string[]
+  positionalKeyValues: string[],
+  skipOptionalPrompts?: boolean
 ): Promise<string[] | null> {
   const pos = [...positionalKeyValues];
 
@@ -430,6 +436,10 @@ async function promptMissingParamsForTagOperation(
       const value = await promptForBodyField(client, field, true);
       pos.push(`${field.name}=${value}`);
     }
+  }
+
+  if (skipOptionalPrompts) {
+    return pos;
   }
 
   return promptUnsetOptionalParamsForTagOperation(
@@ -645,7 +655,7 @@ async function executeSingleRequest(
       options
     );
   } catch (err) {
-    output.prettyError(err);
+    printRequestError(err, config, client);
     return 1;
   }
 }
@@ -683,7 +693,7 @@ async function executePaginatedRequest(
     // Output combined results
     return outputResults(client, results, flags);
   } catch (err) {
-    output.prettyError(err);
+    printRequestError(err, config, client);
     return 1;
   }
 }
@@ -823,6 +833,55 @@ function outputMutationResult(
       : `${statusLine}\n`
   );
   return 1;
+}
+
+function printRequestError(
+  err: unknown,
+  config: RequestConfig,
+  client: Client
+): void {
+  output.prettyError(err);
+
+  const scope = client.config.currentTeam;
+  const status =
+    err && typeof err === 'object' && 'status' in err
+      ? (err as { status: number }).status
+      : undefined;
+  const lines: string[] = [
+    '',
+    chalk.dim('Request details:'),
+    chalk.dim(`  ${config.method} ${config.url}`),
+  ];
+  if (scope) {
+    lines.push(chalk.dim(`  scope: ${scope}`));
+  }
+  if (config.body) {
+    const bodyStr =
+      typeof config.body === 'string'
+        ? config.body
+        : JSON.stringify(config.body);
+    if (bodyStr.length <= 200) {
+      lines.push(chalk.dim(`  body: ${bodyStr}`));
+    }
+  }
+
+  if (status === 403 || status === 401) {
+    lines.push('');
+    if (scope) {
+      lines.push(
+        chalk.yellow(
+          `Hint: Your current scope (${scope}) may not have access to this resource.`
+        )
+      );
+    }
+    lines.push(
+      chalk.yellow(
+        `Try a different team with ${chalk.bold(`${packageName} switch`)} or ${chalk.bold('--scope <team>')}`
+      )
+    );
+  }
+
+  output.log(lines.join('\n'));
 }
 
 function extractErrorMessage(body: unknown): string | null {
@@ -1214,6 +1273,7 @@ export async function runTagOperation(
     operationId: string;
     flags: ParsedFlags;
     positionalOperationFields: string[];
+    skipOptionalPrompts?: boolean;
   }
 ): Promise<number> {
   const { tag, operationId, flags, positionalOperationFields } = options;
@@ -1254,37 +1314,52 @@ export async function runTagOperation(
       resolved.endpoint,
       bodyFields,
       finalFlags,
-      tagOperationPositional
+      tagOperationPositional,
+      options.skipOptionalPrompts
     );
     if (prompted === null) {
       return 1;
     }
     tagOperationPositional = prompted;
-  } else {
-    try {
-      const parsed = await parseOperationKeyValuePairs(
-        resolved.endpoint,
-        bodyFields,
-        finalFlags,
-        tagOperationPositional
-      );
-      const missing = getMissingRequiredOperationParams(
-        resolved.endpoint,
-        bodyFields,
-        parsed,
-        finalFlags
-      );
-      if (
-        missing.path.length > 0 ||
-        missing.query.length > 0 ||
-        missing.header.length > 0 ||
-        missing.body.length > 0
-      ) {
-        printMissingOperationParamsHelp(resolved.endpoint, missing);
-        return 1;
-      }
-    } catch (err) {
-      printError(err);
+  }
+
+  // Parse positionals (handles both key=value and bare positional args)
+  // to discover explicit values *before* applying context defaults.
+  let earlyParsed;
+  try {
+    earlyParsed = await parseOperationKeyValuePairs(
+      resolved.endpoint,
+      bodyFields,
+      finalFlags,
+      tagOperationPositional
+    );
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  // If a scope-mapped param (teamId) was provided, sync it to client so
+  // _fetch uses it for auth.
+  syncScopeFromParsedValues(client, earlyParsed.pathValues, resolved.endpoint);
+
+  // Resolve context *after* scope sync so it picks up the explicit teamId.
+  const cliContext = await resolveCliContext(client);
+  applyContextDefaults(resolved.endpoint, earlyParsed, cliContext);
+
+  if (!client.stdin.isTTY) {
+    const missing = getMissingRequiredOperationParams(
+      resolved.endpoint,
+      bodyFields,
+      earlyParsed,
+      finalFlags
+    );
+    if (
+      missing.path.length > 0 ||
+      missing.query.length > 0 ||
+      missing.header.length > 0 ||
+      missing.body.length > 0
+    ) {
+      printMissingOperationParamsHelp(resolved.endpoint, missing);
       return 1;
     }
   }
@@ -1295,7 +1370,8 @@ export async function runTagOperation(
       resolved.endpoint,
       bodyFields,
       finalFlags,
-      tagOperationPositional
+      tagOperationPositional,
+      cliContext
     );
   } catch (err) {
     printError(err);
@@ -1333,4 +1409,47 @@ export async function runTagOperation(
   return executeApiRequest(client, requestConfig, finalFlags, displayColumns, {
     tagOperation: true,
   });
+}
+
+async function resolveCliContext(client: Client): Promise<CliContext> {
+  const scope = client.config.currentTeam || undefined;
+
+  let projectId: string | undefined;
+  try {
+    const link = await getLinkFromDir<{ projectId: string; orgId: string }>(
+      getVercelDirectory(client.cwd)
+    );
+    if (link?.projectId) {
+      projectId = link.projectId;
+    }
+  } catch {
+    // No linked project
+  }
+
+  return { scope, projectId };
+}
+
+/**
+ * If the user explicitly provided a scope-mapped param (e.g. `teamId=team_xxx`
+ * or bare positional assigned to `teamId`), update `client.config.currentTeam`
+ * so `_fetch` injects the correct teamId query param for auth.
+ *
+ * Must be called *after* parsing so bare positionals are already resolved.
+ */
+function syncScopeFromParsedValues(
+  client: Client,
+  pathValues: Record<string, string>,
+  endpoint: EndpointInfo
+): void {
+  const endpointParamNames = new Set(endpoint.parameters.map(p => p.name));
+
+  for (const [paramName, source] of Object.entries(CONTEXT_PARAM_MAP)) {
+    if (source !== 'scope') continue;
+    if (!endpointParamNames.has(paramName)) continue;
+    const value = pathValues[paramName];
+    if (value) {
+      client.config.currentTeam = value;
+      return;
+    }
+  }
 }

--- a/packages/cli/src/commands/api/operation-request-builder.ts
+++ b/packages/cli/src/commands/api/operation-request-builder.ts
@@ -8,6 +8,31 @@ import type { ParsedFlags, RequestConfig } from './types';
 /** Query params usually supplied by `vercel` scope / team context */
 export const GLOBAL_CLI_QUERY_PARAMS = new Set(['teamId', 'slug']);
 
+/**
+ * Maps OpenAPI parameter names to CLI context sources.
+ * These params can be auto-filled when the user hasn't provided them explicitly.
+ */
+export const CONTEXT_PARAM_MAP: Record<string, 'scope' | 'projectId'> = {
+  teamId: 'scope',
+  projectId: 'projectId',
+  projectIdOrName: 'projectId',
+};
+
+/** Tags where an `idOrName` path param refers to a project (not another resource type) */
+export const PROJECT_IDORNAME_TAGS = new Set([
+  'projects',
+  'projectMembers',
+  'environment',
+  'rolling-release',
+  'connect',
+  'static-ips',
+]);
+
+export type CliContext = {
+  scope?: string;
+  projectId?: string;
+};
+
 export type ParsedOperationInputs = {
   pathValues: Record<string, string>;
   queryValues: Record<string, string>;
@@ -39,6 +64,10 @@ export async function parseOperationKeyValuePairs(
   const queryValues: Record<string, string> = {};
   const headerValues: Record<string, string> = {};
   const body: JSONObject = {};
+
+  const requiredPathParams = endpoint.parameters
+    .filter(p => p.in === 'path' && p.required !== false)
+    .map(p => p.name);
 
   async function dispatchPair(field: string, typed: boolean) {
     const eqIndex = field.indexOf('=');
@@ -104,6 +133,19 @@ export async function parseOperationKeyValuePairs(
     );
   }
 
+  function assignBarePositional(value: string): void {
+    const nextPathParam = requiredPathParams.find(
+      name => pathValues[name] === undefined
+    );
+    if (nextPathParam) {
+      pathValues[nextPathParam] = value;
+      return;
+    }
+    throw new Error(
+      `Unexpected positional argument "${value}" for operation ${endpoint.operationId}. All path parameters are already set. Use key=value syntax for query/body fields.`
+    );
+  }
+
   for (const field of flags['--field'] || []) {
     await dispatchPair(field, true);
   }
@@ -111,7 +153,11 @@ export async function parseOperationKeyValuePairs(
     await dispatchPair(field, false);
   }
   for (const field of positionalKeyValues) {
-    await dispatchPair(field, true);
+    if (field.indexOf('=') === -1) {
+      assignBarePositional(field);
+    } else {
+      await dispatchPair(field, true);
+    }
   }
 
   return { pathValues, queryValues, headerValues, body };
@@ -200,6 +246,47 @@ export function getUnsetOptionalOperationParams(
 }
 
 /**
+ * Fill missing path/query params from CLI context (scope, linked project).
+ * Mutates `parsed.pathValues` and `parsed.queryValues` in place.
+ * Returns the set of param names that were auto-filled (for scope sync).
+ */
+export function applyContextDefaults(
+  endpoint: EndpointInfo,
+  parsed: ParsedOperationInputs,
+  context?: CliContext
+): Set<string> {
+  const filled = new Set<string>();
+  if (!context) return filled;
+
+  for (const param of endpoint.parameters) {
+    const { name } = param;
+    const target = param.in === 'path' ? parsed.pathValues : parsed.queryValues;
+
+    if (param.in !== 'path' && param.in !== 'query') continue;
+    if (target[name] !== undefined) continue;
+
+    let contextSource = CONTEXT_PARAM_MAP[name];
+    if (
+      !contextSource &&
+      name === 'idOrName' &&
+      param.in === 'path' &&
+      endpoint.tags.some(t => PROJECT_IDORNAME_TAGS.has(t))
+    ) {
+      contextSource = 'projectId';
+    }
+    if (!contextSource) continue;
+
+    const value = context[contextSource];
+    if (value) {
+      target[name] = value;
+      filled.add(name);
+    }
+  }
+
+  return filled;
+}
+
+/**
  * Build a {@link RequestConfig} for a resolved OpenAPI operation, routing
  * key=value arguments to path, query, header, or JSON body based on the spec.
  */
@@ -207,7 +294,8 @@ export async function buildRequestForResolvedOperation(
   endpoint: EndpointInfo,
   bodyFields: BodyField[],
   flags: ParsedFlags,
-  positionalKeyValues: string[]
+  positionalKeyValues: string[],
+  context?: CliContext
 ): Promise<RequestConfig> {
   const headers: Record<string, string> = {};
 
@@ -235,6 +323,8 @@ export async function buildRequestForResolvedOperation(
     flags,
     positionalKeyValues
   );
+
+  applyContextDefaults(endpoint, parsed, context);
 
   const { pathValues, queryValues, headerValues, body } = parsed;
 

--- a/packages/cli/src/commands/teams/index.ts
+++ b/packages/cli/src/commands/teams/index.ts
@@ -1,4 +1,3 @@
-import list from './list';
 import add from './add';
 import change from './switch';
 import invite from './invite';
@@ -9,7 +8,6 @@ import { parseArguments } from '../../util/get-args';
 import {
   addSubcommand,
   inviteSubcommand,
-  listSubcommand,
   requestSubcommand,
   membersSubcommand,
   ssoSubcommand,
@@ -90,15 +88,15 @@ export default async function teams(client: Client) {
   }
 
   switch (subcommand) {
-    case 'list': {
-      if (needHelp) {
-        telemetry.trackCliFlagHelp('teams', subcommandOriginal);
-        printHelp(listSubcommand);
-        return 2;
-      }
-      telemetry.trackCliSubcommandList(subcommandOriginal);
-      return list(client, args);
-    }
+    // case 'list': {
+    //   if (needHelp) {
+    //     telemetry.trackCliFlagHelp('teams', subcommandOriginal);
+    //     printHelp(listSubcommand);
+    //     return 2;
+    //   }
+    //   telemetry.trackCliSubcommandList(subcommandOriginal);
+    //   return list(client, args);
+    // }
     case 'switch': {
       if (needHelp) {
         telemetry.trackCliFlagHelp('teams', subcommandOriginal);

--- a/packages/cli/src/commands/teams/index.ts
+++ b/packages/cli/src/commands/teams/index.ts
@@ -1,6 +1,7 @@
 import add from './add';
 import change from './switch';
 import invite from './invite';
+import list from './list';
 import request from './request';
 import members from './members';
 import sso from './sso';
@@ -8,6 +9,7 @@ import { parseArguments } from '../../util/get-args';
 import {
   addSubcommand,
   inviteSubcommand,
+  listSubcommand,
   requestSubcommand,
   membersSubcommand,
   ssoSubcommand,
@@ -88,15 +90,15 @@ export default async function teams(client: Client) {
   }
 
   switch (subcommand) {
-    // case 'list': {
-    //   if (needHelp) {
-    //     telemetry.trackCliFlagHelp('teams', subcommandOriginal);
-    //     printHelp(listSubcommand);
-    //     return 2;
-    //   }
-    //   telemetry.trackCliSubcommandList(subcommandOriginal);
-    //   return list(client, args);
-    // }
+    case 'list': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('teams', subcommandOriginal);
+        printHelp(listSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return list(client, args);
+    }
     case 'switch': {
       if (needHelp) {
         telemetry.trackCliFlagHelp('teams', subcommandOriginal);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -69,7 +69,12 @@ import getUpdateCommand from './util/get-update-command';
 import { executeUpgrade } from './util/upgrade';
 import { getCommandName, getTitleName } from './util/pkg-name';
 import login from './commands/login';
-import type { AuthConfig, GlobalConfig, User } from '@vercel-internals/types';
+import type {
+  AuthConfig,
+  GlobalConfig,
+  Team,
+  User,
+} from '@vercel-internals/types';
 import type { VercelConfig } from '@vercel/client';
 import { Agent as HttpsAgent } from 'https';
 import box from './util/output/box';
@@ -216,6 +221,56 @@ class InMemoryReporter implements Reporter {
   report(event: TraceEvent) {
     this.events.push(event);
   }
+}
+
+/**
+ * Resolve `--scope` / `--team` flag to a team ID and set
+ * `client.config.currentTeam`.  Returns an exit code when it needs to
+ * abort, or `undefined` to continue normally.
+ */
+async function resolveScope(
+  client: Client,
+  parsedArgs: { flags: Record<string, unknown> }
+): Promise<number | undefined> {
+  const scope =
+    (parsedArgs.flags['--scope'] as string | undefined) ||
+    (parsedArgs.flags['--team'] as string | undefined);
+  if (!scope) return undefined;
+
+  let user;
+  try {
+    user = await getUser(client);
+  } catch {
+    return undefined;
+  }
+
+  if (user.id === scope || user.email === scope || user.username === scope) {
+    if (user.version === 'northstar') {
+      output.error('You cannot set your Personal Account as the scope.');
+      return 1;
+    }
+    delete client.config.currentTeam;
+    return undefined;
+  }
+
+  let teams: Team[] = [];
+  try {
+    teams = await getTeams(client);
+  } catch {
+    return undefined;
+  }
+
+  const related = teams.find(t => t.id === scope || t.slug === scope);
+  if (related) {
+    client.config.currentTeam = related.id;
+    return undefined;
+  }
+
+  output.prettyError({
+    message: 'The specified scope does not exist',
+    link: 'https://err.sh/vercel/scope-not-existent',
+  });
+  return 1;
 }
 
 const main = async () => {
@@ -642,6 +697,12 @@ const main = async () => {
         output.debug(
           `first token "${targetOrSubcommand}" matches an OpenAPI tag; routing to api`
         );
+
+        // Resolve --scope / --team before routing to OpenAPI since the normal
+        // scope resolution later in the function won't be reached.
+        const scopeExit = await resolveScope(client, parsedArgs);
+        if (scopeExit !== undefined) return finishWithExitCode(scopeExit);
+
         const tag = targetOrSubcommand;
         const result = await tryOpenApiFallback(
           client,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,7 +41,10 @@ import { getSentry } from './util/get-sentry';
 import hp from './util/humanize-path';
 import { commands, commandNames } from './commands';
 import { handleCommandTypo } from './util/handle-command-typo';
-import { matchesCliApiTag } from './util/openapi/matches-cli-api-tag';
+import {
+  matchesCliApiTag,
+  resolveOpenApiTagForCommand,
+} from './util/openapi/matches-cli-api-tag';
 import { tryOpenApiFallback } from './util/openapi';
 import pkg from './util/pkg';
 import cmd from './util/output/cmd';
@@ -103,6 +106,48 @@ function hasProxyConfig(): boolean {
     'ALL_PROXY',
     'all_proxy',
   ].some(v => process.env[v]);
+}
+
+async function showInferredCommands(client: Client): Promise<number> {
+  const { OpenApiCache } = await import('./util/openapi/openapi-cache.js');
+
+  const cache = new OpenApiCache();
+  const loaded = await cache.loadWithSpinner();
+  if (!loaded) {
+    output.error('Could not load API specification');
+    return 1;
+  }
+
+  const endpoints = cache.getEndpoints();
+  const byTag = new Map<string, typeof endpoints>();
+  for (const ep of endpoints) {
+    if (ep.aliases.length === 0) continue;
+    for (const tag of ep.tags) {
+      const list = byTag.get(tag) || [];
+      list.push(ep);
+      byTag.set(tag, list);
+    }
+  }
+
+  const sortedTags = [...byTag.keys()].sort();
+  const lines: string[] = [];
+
+  for (const tag of sortedTags) {
+    const tagEndpoints = byTag.get(tag)!;
+    for (const ep of tagEndpoints) {
+      const names = ep.aliases.length > 0 ? ep.aliases : [ep.operationId];
+      const pathParams = ep.parameters
+        .filter(p => p.in === 'path')
+        .map(p => `<${p.name}>`);
+      const suffix = pathParams.length > 0 ? ` ${pathParams.join(' ')}` : '';
+      for (const name of names) {
+        lines.push(`vercel ${tag} ${name}${suffix}`);
+      }
+    }
+  }
+
+  output.print(lines.join('\n') + '\n');
+  return 0;
 }
 
 /*
@@ -575,6 +620,13 @@ const main = async () => {
       );
     }
 
+    if (
+      targetOrSubcommand === 'show-inferred-commands' &&
+      (process.env.VERCEL_AUTO_API || process.env.VERCEL_AUTO_API_TEST)
+    ) {
+      return finishWithExitCode(await showInferredCommands(client));
+    }
+
     if (subcommandExists) {
       output.debug(`user supplied known subcommand: "${targetOrSubcommand}"`);
       subcommand = targetOrSubcommand;
@@ -584,7 +636,7 @@ const main = async () => {
         'user supplied a possible target for deployment or an extension'
       );
       if (
-        process.env.VERCEL_AUTO_API &&
+        (process.env.VERCEL_AUTO_API || process.env.VERCEL_AUTO_API_TEST) &&
         (await matchesCliApiTag(targetOrSubcommand))
       ) {
         output.debug(
@@ -891,6 +943,21 @@ const main = async () => {
     // Not using an `else` here because if the CLI extension
     // was not found then we have to fall back to `vc deploy`
     if (subcommand) {
+      // When opted in, try OpenAPI first for any command before native handlers.
+      if (process.env.VERCEL_AUTO_API || process.env.VERCEL_AUTO_API_TEST) {
+        const tag = await resolveOpenApiTagForCommand(subcommand);
+        if (tag) {
+          const fallback = await tryOpenApiFallback(
+            client,
+            parsedArgs.args.slice(3),
+            async () => tag
+          );
+          if (fallback !== null) {
+            return finishWithExitCode(fallback);
+          }
+        }
+      }
+
       let func: any;
       switch (targetCommand) {
         // Priority commands - separate bundles for fast loading

--- a/packages/cli/src/util/openapi/index.ts
+++ b/packages/cli/src/util/openapi/index.ts
@@ -4,6 +4,7 @@ export * from './constants';
 export * from './resolve-by-tag-operation';
 export {
   matchesCliApiTag,
+  resolveOpenApiTagForCommand,
   resolveOpenApiTagForProjectsCli,
 } from './matches-cli-api-tag';
 export { tryOpenApiFallback } from './try-openapi-fallback';

--- a/packages/cli/src/util/openapi/matches-cli-api-tag.ts
+++ b/packages/cli/src/util/openapi/matches-cli-api-tag.ts
@@ -25,30 +25,22 @@ export async function matchesCliApiTag(tagHint: string): Promise<boolean> {
 }
 
 /**
- * OpenAPI tag string to use when routing `vercel project[s] …` to `vercel api …`.
- * Prefer `projects` (common in the public spec); fall back to `project` if present.
+ * Resolve a CLI command name (e.g. `alias`, `project`, `teams`) to its
+ * OpenAPI tag, trying the exact name, with trailing 's' appended, and
+ * with trailing 's' stripped.  Returns `null` when no tag matches.
  */
-export async function resolveOpenApiTagForProjectsCli(): Promise<
-  string | null
-> {
-  if (await matchesCliApiTag('projects')) {
-    return 'projects';
-  }
-  if (await matchesCliApiTag('project')) {
-    return 'project';
-  }
+export async function resolveOpenApiTagForCommand(
+  command: string
+): Promise<string | null> {
+  if (await matchesCliApiTag(command)) return command;
+  if (await matchesCliApiTag(command + 's')) return command + 's';
+  if (command.endsWith('s') && (await matchesCliApiTag(command.slice(0, -1))))
+    return command.slice(0, -1);
   return null;
 }
 
-/**
- * OpenAPI tag string to use when routing `vercel team[s] …` to the API fallback.
- */
-export async function resolveOpenApiTagForTeamsCli(): Promise<string | null> {
-  if (await matchesCliApiTag('teams')) {
-    return 'teams';
-  }
-  if (await matchesCliApiTag('team')) {
-    return 'team';
-  }
-  return null;
-}
+export const resolveOpenApiTagForProjectsCli = () =>
+  resolveOpenApiTagForCommand('project');
+
+export const resolveOpenApiTagForTeamsCli = () =>
+  resolveOpenApiTagForCommand('teams');

--- a/packages/cli/src/util/openapi/openapi-cache.ts
+++ b/packages/cli/src/util/openapi/openapi-cache.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import getGlobalPathConfig from '../config/global-path';
 import output from '../../output-manager';
@@ -44,9 +44,20 @@ export class OpenApiCache {
 
   /**
    * Load the OpenAPI spec, using cache if available and fresh.
+   * When `VERCEL_AUTO_API_TEST` is set to a file path, loads from that file
+   * instead of the network, for local iteration without API-side changes.
    * Returns true if successful, false otherwise.
    */
   async load(forceRefresh = false): Promise<boolean> {
+    const testSpecEnv = process.env.VERCEL_AUTO_API_TEST;
+    if (testSpecEnv) {
+      const testSpecPath =
+        testSpecEnv === '1'
+          ? resolve(__dirname, '../../test/fixtures/unit/openapi-spec.json')
+          : testSpecEnv;
+      return this.loadFromFile(testSpecPath);
+    }
+
     // Try to read from cache
     if (!forceRefresh) {
       const cached = await this.readCache();
@@ -72,6 +83,21 @@ export class OpenApiCache {
         this.spec = stale.spec;
         return true;
       }
+      return false;
+    }
+  }
+
+  /**
+   * Load spec directly from a local JSON file (for VERCEL_AUTO_API_TEST).
+   */
+  private async loadFromFile(filePath: string): Promise<boolean> {
+    try {
+      output.debug('Loading OpenAPI spec from local file: ' + filePath);
+      const content = await readFile(filePath, 'utf-8');
+      this.spec = JSON.parse(content) as OpenApiSpec;
+      return true;
+    } catch (err) {
+      output.debug(`Failed to load OpenAPI spec from ${filePath}: ${err}`);
       return false;
     }
   }
@@ -295,6 +321,10 @@ export class OpenApiCache {
           const opParams = operation.parameters || [];
           const allParams = [...pathParams, ...opParams];
 
+          const xCli = (operation as Record<string, unknown>)['x-vercel-cli'] as
+            | { aliases?: string[] }
+            | undefined;
+
           endpoints.push({
             path,
             method: method.toUpperCase(),
@@ -304,6 +334,7 @@ export class OpenApiCache {
             tags: operation.tags || [],
             parameters: allParams,
             requestBody: operation.requestBody,
+            aliases: xCli?.aliases ?? [],
           });
         }
       }

--- a/packages/cli/src/util/openapi/resolve-by-tag-operation.ts
+++ b/packages/cli/src/util/openapi/resolve-by-tag-operation.ts
@@ -78,6 +78,22 @@ export function resolveEndpointByTagAndOperationId(
     };
   }
 
+  const aliasCi = withOpId.filter(ep =>
+    ep.aliases.some(a => a.toLowerCase() === hintLower)
+  );
+  if (aliasCi.length === 1) {
+    return { ok: true, endpoint: aliasCi[0] };
+  }
+  if (aliasCi.length > 1) {
+    return {
+      ok: false,
+      reason: 'ambiguous_operation',
+      tag,
+      tagMatches: aliasCi,
+      operationHint: hint,
+    };
+  }
+
   return {
     ok: false,
     reason: 'no_operation',

--- a/packages/cli/src/util/openapi/try-openapi-fallback.ts
+++ b/packages/cli/src/util/openapi/try-openapi-fallback.ts
@@ -25,7 +25,7 @@ export async function tryOpenApiFallback(
   cliArgs: string[],
   resolveTag: () => Promise<string | null>
 ): Promise<number | null> {
-  if (!process.env.VERCEL_AUTO_API) {
+  if (!process.env.VERCEL_AUTO_API && !process.env.VERCEL_AUTO_API_TEST) {
     return null;
   }
 
@@ -63,5 +63,6 @@ export async function tryOpenApiFallback(
     operationId: operationHint,
     flags,
     positionalOperationFields: cliArgs.slice(1),
+    skipOptionalPrompts: true,
   });
 }

--- a/packages/cli/src/util/openapi/types.ts
+++ b/packages/cli/src/util/openapi/types.ts
@@ -86,6 +86,7 @@ export interface EndpointInfo {
   tags: string[];
   parameters: Parameter[];
   requestBody?: RequestBody;
+  aliases: string[];
 }
 
 export interface BodyField {

--- a/packages/cli/test/unit/commands/api/operation-request-builder.test.ts
+++ b/packages/cli/test/unit/commands/api/operation-request-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyContextDefaults,
   getUnsetOptionalOperationParams,
   parseOperationKeyValuePairs,
 } from '../../../../src/commands/api/operation-request-builder';
@@ -15,6 +16,7 @@ describe('operation-request-builder', () => {
         summary: '',
         description: '',
         tags: ['projects'],
+        aliases: [],
         parameters: [
           {
             name: 'idOrName',
@@ -47,6 +49,7 @@ describe('operation-request-builder', () => {
         summary: '',
         description: '',
         tags: ['projects'],
+        aliases: [],
         parameters: [
           {
             name: 'idOrName',
@@ -70,6 +73,274 @@ describe('operation-request-builder', () => {
 
       const unset = getUnsetOptionalOperationParams(endpoint, [], parsed, {});
       expect(unset.query.map(p => p.name)).not.toContain('teamId');
+    });
+  });
+
+  describe('bare positional args', () => {
+    it('assigns bare positional to first unfilled required path param', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v3/teams/{teamId}/members',
+        method: 'GET',
+        operationId: 'getTeamMembers',
+        summary: '',
+        description: '',
+        tags: ['teams'],
+        aliases: ['members'],
+        parameters: [
+          { name: 'teamId', in: 'path', required: true, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, [
+        'team_abc123',
+      ]);
+      expect(parsed.pathValues['teamId']).toBe('team_abc123');
+    });
+
+    it('assigns multiple bare positionals to path params in order', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v1/teams/{teamId}/members/{uid}',
+        method: 'PATCH',
+        operationId: 'updateTeamMember',
+        summary: '',
+        description: '',
+        tags: ['teams'],
+        aliases: [],
+        parameters: [
+          { name: 'teamId', in: 'path', required: true, description: '' },
+          { name: 'uid', in: 'path', required: true, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, [
+        'team_abc',
+        'user_xyz',
+      ]);
+      expect(parsed.pathValues['teamId']).toBe('team_abc');
+      expect(parsed.pathValues['uid']).toBe('user_xyz');
+    });
+
+    it('mixes bare positionals and key=value pairs', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v1/teams/{teamId}/members/{uid}',
+        method: 'PATCH',
+        operationId: 'updateTeamMember',
+        summary: '',
+        description: '',
+        tags: ['teams'],
+        aliases: [],
+        parameters: [
+          { name: 'teamId', in: 'path', required: true, description: '' },
+          { name: 'uid', in: 'path', required: true, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, [
+        'teamId=team_abc',
+        'user_xyz',
+      ]);
+      expect(parsed.pathValues['teamId']).toBe('team_abc');
+      expect(parsed.pathValues['uid']).toBe('user_xyz');
+    });
+
+    it('throws when bare positional has no unfilled path params', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v3/teams/{teamId}/members',
+        method: 'GET',
+        operationId: 'getTeamMembers',
+        summary: '',
+        description: '',
+        tags: ['teams'],
+        aliases: ['members'],
+        parameters: [
+          { name: 'teamId', in: 'path', required: true, description: '' },
+        ],
+      };
+
+      await expect(
+        parseOperationKeyValuePairs(endpoint, [], {}, [
+          'team_abc',
+          'extra_value',
+        ])
+      ).rejects.toThrow(/Unexpected positional argument "extra_value"/);
+    });
+  });
+
+  describe('applyContextDefaults', () => {
+    it('fills missing teamId path param from scope context', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v3/teams/{teamId}/members',
+        method: 'GET',
+        operationId: 'getTeamMembers',
+        summary: '',
+        description: '',
+        tags: ['teams'],
+        aliases: ['members'],
+        parameters: [
+          { name: 'teamId', in: 'path', required: true, description: '' },
+          { name: 'slug', in: 'query', required: false, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, []);
+      expect(parsed.pathValues['teamId']).toBeUndefined();
+
+      applyContextDefaults(endpoint, parsed, {
+        scope: 'team_abc',
+      });
+      expect(parsed.pathValues['teamId']).toBe('team_abc');
+    });
+
+    it('does not overwrite explicit teamId with context', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v3/teams/{teamId}/members',
+        method: 'GET',
+        operationId: 'getTeamMembers',
+        summary: '',
+        description: '',
+        tags: ['teams'],
+        aliases: ['members'],
+        parameters: [
+          { name: 'teamId', in: 'path', required: true, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, [
+        'teamId=team_explicit',
+      ]);
+      applyContextDefaults(endpoint, parsed, {
+        scope: 'team_default',
+      });
+      expect(parsed.pathValues['teamId']).toBe('team_explicit');
+    });
+
+    it('fills missing teamId query param from scope context', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v10/projects',
+        method: 'GET',
+        operationId: 'getProjects',
+        summary: '',
+        description: '',
+        tags: ['projects'],
+        aliases: ['list'],
+        parameters: [
+          { name: 'teamId', in: 'query', required: false, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, []);
+      applyContextDefaults(endpoint, parsed, { scope: 'team_abc' });
+      expect(parsed.queryValues['teamId']).toBe('team_abc');
+    });
+
+    it('fills idOrName from projectId context for projects tag', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v9/projects/{idOrName}',
+        method: 'GET',
+        operationId: 'getProject',
+        summary: '',
+        description: '',
+        tags: ['projects'],
+        aliases: ['get'],
+        parameters: [
+          { name: 'idOrName', in: 'path', required: true, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, []);
+      applyContextDefaults(endpoint, parsed, {
+        projectId: 'prj_linked123',
+      });
+      expect(parsed.pathValues['idOrName']).toBe('prj_linked123');
+    });
+
+    it('does not fill idOrName for access-groups tag', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v1/access-groups/{idOrName}',
+        method: 'GET',
+        operationId: 'readAccessGroup',
+        summary: '',
+        description: '',
+        tags: ['access-groups'],
+        aliases: ['read', 'get'],
+        parameters: [
+          { name: 'idOrName', in: 'path', required: true, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, []);
+      applyContextDefaults(endpoint, parsed, {
+        projectId: 'prj_linked123',
+      });
+      expect(parsed.pathValues['idOrName']).toBeUndefined();
+    });
+
+    it('fills projectIdOrName from projectId context', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v2/projects/{projectIdOrName}/checks',
+        method: 'GET',
+        operationId: 'listProjectChecks',
+        summary: '',
+        description: '',
+        tags: ['checks-v2'],
+        aliases: [],
+        parameters: [
+          {
+            name: 'projectIdOrName',
+            in: 'path',
+            required: true,
+            description: '',
+          },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, []);
+      applyContextDefaults(endpoint, parsed, {
+        projectId: 'prj_linked123',
+      });
+      expect(parsed.pathValues['projectIdOrName']).toBe('prj_linked123');
+    });
+
+    it('does nothing when no context is provided', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v3/teams/{teamId}/members',
+        method: 'GET',
+        operationId: 'getTeamMembers',
+        summary: '',
+        description: '',
+        tags: ['teams'],
+        aliases: ['members'],
+        parameters: [
+          { name: 'teamId', in: 'path', required: true, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, []);
+      applyContextDefaults(endpoint, parsed, undefined);
+      expect(parsed.pathValues['teamId']).toBeUndefined();
+    });
+
+    it('returns set of auto-filled param names', async () => {
+      const endpoint: EndpointInfo = {
+        path: '/v3/teams/{teamId}/members',
+        method: 'GET',
+        operationId: 'getTeamMembers',
+        summary: '',
+        description: '',
+        tags: ['teams'],
+        aliases: ['members'],
+        parameters: [
+          { name: 'teamId', in: 'path', required: true, description: '' },
+          { name: 'slug', in: 'query', required: false, description: '' },
+        ],
+      };
+
+      const parsed = await parseOperationKeyValuePairs(endpoint, [], {}, []);
+      const filled = applyContextDefaults(endpoint, parsed, {
+        scope: 'team_abc',
+      });
+      expect(filled.has('teamId')).toBe(true);
+      expect(filled.has('slug')).toBe(false);
     });
   });
 });

--- a/packages/cli/test/unit/commands/teams/switch.test.ts
+++ b/packages/cli/test/unit/commands/teams/switch.test.ts
@@ -6,6 +6,9 @@ import teams from '../../../../src/commands/teams';
 import { useUser } from '../../../mocks/user';
 import { useTeam, createTeam } from '../../../mocks/team';
 import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import * as configFiles from '../../../../src/util/config/files';
+
+vi.spyOn(configFiles, 'writeToConfigFile').mockImplementation(() => {});
 
 describe('teams switch', () => {
   describe('non-northstar', () => {

--- a/packages/cli/test/unit/util/openapi/matches-cli-api-tag.test.ts
+++ b/packages/cli/test/unit/util/openapi/matches-cli-api-tag.test.ts
@@ -14,6 +14,7 @@ const sampleEndpoint: EndpointInfo = {
   description: '',
   tags: ['projects'],
   parameters: [],
+  aliases: [],
 };
 
 describe('matchesCliApiTag', () => {

--- a/packages/cli/test/unit/util/openapi/openapi-spec.test.ts
+++ b/packages/cli/test/unit/util/openapi/openapi-spec.test.ts
@@ -125,9 +125,9 @@ describe('OpenAPI spec fixture', () => {
       expect(cli!.aliases).toEqual(['read', 'get']);
     });
 
-    it('getAuthUser has no aliases', () => {
+    it('getAuthUser has alias "whoami"', () => {
       const cli = getXVercelCli(spec, '/v2/user', 'get');
-      expect(cli!.aliases).toBeUndefined();
+      expect(cli!.aliases).toEqual(['whoami']);
     });
   });
 
@@ -208,6 +208,30 @@ describe('OpenAPI spec fixture', () => {
         'getteam'
       );
       expect(result.ok).toBe(true);
+    });
+
+    it('resolves getTeams via "list" alias', () => {
+      const result = resolveEndpointByTagAndOperationId(
+        endpoints,
+        'teams',
+        'list'
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.endpoint.operationId).toBe('getTeams');
+      }
+    });
+
+    it('resolves getTeam via "get" alias', () => {
+      const result = resolveEndpointByTagAndOperationId(
+        endpoints,
+        'teams',
+        'get'
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.endpoint.operationId).toBe('getTeam');
+      }
     });
   });
 });

--- a/packages/cli/test/unit/util/openapi/resolve-by-tag-operation.test.ts
+++ b/packages/cli/test/unit/util/openapi/resolve-by-tag-operation.test.ts
@@ -10,6 +10,7 @@ const base = (overrides: Partial<EndpointInfo>): EndpointInfo => ({
   operationId: '',
   tags: [],
   parameters: [],
+  aliases: [],
   ...overrides,
 });
 
@@ -81,11 +82,79 @@ describe('resolveEndpointByTagAndOperationId', () => {
     }
   });
 
-  it('returns no_operation when hint is not an exact operationId', () => {
-    const r = resolveEndpointByTagAndOperationId(endpoints, 'user', 'list');
+  it('returns no_operation when hint is not an exact operationId or alias', () => {
+    const r = resolveEndpointByTagAndOperationId(endpoints, 'user', 'deploy');
     expect(r.ok).toBe(false);
     if (!r.ok) {
       expect(r.reason).toBe('no_operation');
+    }
+  });
+
+  it('matches by x-vercel-cli alias', () => {
+    const epsWithAlias: EndpointInfo[] = [
+      base({
+        path: '/v2/teams',
+        method: 'GET',
+        operationId: 'getTeams',
+        tags: ['teams'],
+        aliases: ['list'],
+      }),
+      base({
+        path: '/v1/teams',
+        method: 'POST',
+        operationId: 'createTeam',
+        tags: ['teams'],
+        aliases: ['create'],
+      }),
+    ];
+
+    const r = resolveEndpointByTagAndOperationId(epsWithAlias, 'teams', 'list');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.endpoint.operationId).toBe('getTeams');
+    }
+  });
+
+  it('matches alias case-insensitively', () => {
+    const epsWithAlias: EndpointInfo[] = [
+      base({
+        path: '/v2/teams',
+        method: 'GET',
+        operationId: 'getTeams',
+        tags: ['teams'],
+        aliases: ['list'],
+      }),
+    ];
+
+    const r = resolveEndpointByTagAndOperationId(epsWithAlias, 'teams', 'List');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.endpoint.operationId).toBe('getTeams');
+    }
+  });
+
+  it('prefers exact operationId over alias match', () => {
+    const eps: EndpointInfo[] = [
+      base({
+        path: '/v2/teams',
+        method: 'GET',
+        operationId: 'list',
+        tags: ['teams'],
+        aliases: [],
+      }),
+      base({
+        path: '/v1/teams',
+        method: 'POST',
+        operationId: 'createTeam',
+        tags: ['teams'],
+        aliases: ['list'],
+      }),
+    ];
+
+    const r = resolveEndpointByTagAndOperationId(eps, 'teams', 'list');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.endpoint.operationId).toBe('list');
     }
   });
 });


### PR DESCRIPTION
## Summary

### TLDR play with this with `VERCEL_AUTO_API_TEST=1 pnpm vercel show-inferred-commands`

- **Alias resolution**: Operations with `x-vercel-cli.aliases` (e.g. `list` → `getTeams`) are now matched as subcommands in the OpenAPI fallback, so `vercel teams list` resolves via OpenAPI when `VERCEL_AUTO_API` is set.
- **Bidirectional context inference**: Bare positional args (e.g. `vercel teams members team_xxx`) auto-fill required path params in order and sync CLI scope for auth. Missing `teamId`/`projectId` params auto-fill from the current CLI context.
- **Top-level OpenAPI override**: When `VERCEL_AUTO_API` or `VERCEL_AUTO_API_TEST` is set, OpenAPI routing runs at the top of the command dispatch — before native handlers — for all commands (not just as a fallback within individual subcommand handlers).
- **`VERCEL_AUTO_API_TEST=1`**: Loads the OpenAPI spec from the local test fixture (`test/fixtures/unit/openapi-spec.json`) instead of the remote endpoint, while using real credentials. If set to a file path, loads from that path.
- **`show-inferred-commands`**: New command (`vercel show-inferred-commands`) listing all OpenAPI-backed commands with their aliases and path params in a copy-pasteable format.
- **Improved error output**: 401/403 errors now show request details (method, URL, scope, body) and a hint to try `vercel switch` or `--scope <team>`.
- **`displayColumns`**: Added `x-vercel-cli.displayColumns` to 16 list operations in the test OpenAPI spec for tabular output (aliases, teams, domains, deployments, projects, etc.).
- **Test infra fix**: Mock `writeToConfigFile` in switch tests to prevent test team IDs (`team_bbb`) from leaking to the real global config file.

## Test plan

- [x] `vercel teams list` resolves via OpenAPI alias
- [x] `vercel teams members <teamId>` fills path param and syncs scope
- [x] `VERCEL_AUTO_API_TEST=1 vercel show-inferred-commands` lists test spec commands
- [x] `VERCEL_AUTO_API_TEST=1 vercel aliases list` renders tabular output with displayColumns
- [x] `VERCEL_AUTO_API_TEST=1 vercel domains list` / `teams list` / `deployments list` render tables
- [x] 403 errors show request details and scope-switch hint
- [x] Existing unit tests pass (`openapi-spec.test.ts`, `operation-request-builder.test.ts`, `switch.test.ts`, `resolve-by-tag-operation.test.ts`)


Made with [Cursor](https://cursor.com)