### PR TITLE
Add v0 to detect-agent supported agents

### DIFF
--- a/.changeset/add-v0-detect-agent.md
+++ b/.changeset/add-v0-detect-agent.md
@@ -1,0 +1,5 @@
+---
+'@vercel/detect-agent': patch
+---
+
+Add v0 to detect-agent supported agents

--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -34,6 +34,7 @@ This package can detect the following AI agents and development environments:
 - **Antigravity** (Google DeepMind)
 - **GitHub Copilot** (via `AI_AGENT=github-copilot|github-copilot-cli`, `COPILOT_MODEL`, `COPILOT_ALLOW_ALL`, or `COPILOT_GITHUB_TOKEN`)
 - **Replit** (online IDE)
+- **v0** (Vercel's AI assistant, via `AI_AGENT=v0`)
 
 ## The AI_AGENT Standard
 

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -16,6 +16,7 @@ const AUGMENT_CLI = 'augment-cli' as const;
 const OPENCODE = 'opencode' as const;
 const GITHUB_COPILOT = 'github-copilot' as const;
 const GITHUB_COPILOT_CLI = 'github-copilot-cli' as const;
+const V0 = 'v0' as const;
 
 export type KnownAgentNames =
   | typeof CURSOR
@@ -29,7 +30,8 @@ export type KnownAgentNames =
   | typeof ANTIGRAVITY
   | typeof AUGMENT_CLI
   | typeof OPENCODE
-  | typeof GITHUB_COPILOT;
+  | typeof GITHUB_COPILOT
+  | typeof V0;
 
 export interface KnownAgentDetails {
   name: KnownAgentNames;
@@ -58,6 +60,7 @@ export const KNOWN_AGENTS = {
   AUGMENT_CLI,
   OPENCODE,
   GITHUB_COPILOT,
+  V0,
 } as const;
 
 export async function determineAgent(): Promise<AgentResult> {
@@ -68,6 +71,13 @@ export async function determineAgent(): Promise<AgentResult> {
         return {
           isAgent: true,
           agent: { name: GITHUB_COPILOT },
+        };
+      }
+
+      if (name === V0) {
+        return {
+          isAgent: true,
+          agent: { name: V0 },
         };
       }
 

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -55,6 +55,18 @@ describe('determineAgent', () => {
     });
   });
 
+  describe('v0 detection', () => {
+    it('detects v0 from AI_AGENT=v0', async () => {
+      vi.stubEnv('AI_AGENT', 'v0');
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: KNOWN_AGENTS.V0 },
+      });
+    });
+  });
+
   describe('github copilot detection', () => {
     it('detects github copilot from AI_AGENT=github-copilot', async () => {
       vi.stubEnv('AI_AGENT', 'github-copilot');


### PR DESCRIPTION
Adds v0 (Vercel's AI assistant) as a known agent that can be detected via `AI_AGENT=v0`.

### What changed
- Added `V0` constant and type to the known agents list
- Added explicit detection logic for `AI_AGENT=v0` in `determineAgent()`
- Added v0 to the README supported agents list
- Added test case for v0 detection

<a href="https://vercel.slack.com/archives/C0AJXH91CAE/p1776378320205859?thread_ts=1776378320.205859&cid=C0AJXH91CAE"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>