### PR TITLE
[CLI] Add connex list command

### DIFF
--- a/.changeset/cli-connex-list.md
+++ b/.changeset/cli-connex-list.md
@@ -1,0 +1,5 @@
+---
+vercel: minor
+---
+
+Add `vercel connex list` command

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -38,17 +38,65 @@ export const createSubcommand = {
   ],
 } as const;
 
+export const listSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List Connex clients for the current team',
+  arguments: [],
+  options: [
+    {
+      name: 'limit',
+      shorthand: null,
+      type: Number,
+      argument: 'COUNT',
+      deprecated: false,
+      description: 'Number of clients to return per page',
+    },
+    {
+      name: 'next',
+      shorthand: null,
+      type: String,
+      argument: 'CURSOR',
+      deprecated: false,
+      description: 'Cursor for the next page of results',
+    },
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'List Connex clients for the current team',
+      value: `${packageName} connex list`,
+    },
+    {
+      name: 'Limit the number of results',
+      value: `${packageName} connex list --limit 10`,
+    },
+    {
+      name: 'Fetch the next page of results',
+      value: `${packageName} connex list --next <cursor>`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} connex list --format=json`,
+    },
+  ],
+} as const;
+
 export const connexCommand = {
   name: 'connex',
   aliases: [],
   description: 'Manage Vercel Connect clients',
   arguments: [],
   options: [],
-  subcommands: [createSubcommand],
+  subcommands: [createSubcommand, listSubcommand],
   examples: [
     {
       name: 'Create a Slack app',
       value: `${packageName} connex create slack`,
+    },
+    {
+      name: 'List Connex clients on the current team',
+      value: `${packageName} connex list`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -7,8 +7,9 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import getSubcommand from '../../util/get-subcommand';
 import { ConnexTelemetryClient } from '../../util/telemetry/commands/connex';
 import { type Command, help } from '../help';
-import { createSubcommand, connexCommand } from './command';
+import { createSubcommand, listSubcommand, connexCommand } from './command';
 import { create } from './create';
+import { list } from './list';
 import {
   buildCommandWithGlobalFlags,
   outputAgentError,
@@ -18,6 +19,7 @@ import { packageName } from '../../util/pkg-name';
 
 const COMMAND_CONFIG = {
   create: getCommandAliases(createSubcommand),
+  list: getCommandAliases(listSubcommand),
 };
 
 export default async function connex(client: Client): Promise<number> {
@@ -77,6 +79,21 @@ export default async function connex(client: Client): Promise<number> {
           createParsedArgs.args,
           createParsedArgs.flags
         );
+      }
+      case 'list': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex', subcommandOriginal);
+          printHelp(listSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandList(subcommandOriginal);
+
+        const listFlagsSpec = getFlagsSpecification(listSubcommand.options);
+        const listParsedArgs = parseArguments(subArgs, listFlagsSpec);
+        telemetry.trackCliOptionLimit(listParsedArgs.flags['--limit']);
+        telemetry.trackCliOptionNext(listParsedArgs.flags['--next']);
+        telemetry.trackCliOptionFormat(listParsedArgs.flags['--format']);
+        return await list(client, listParsedArgs.flags);
       }
       default: {
         const validSubcommands = Object.keys(COMMAND_CONFIG).join(' | ');

--- a/packages/cli/src/commands/connex/list.ts
+++ b/packages/cli/src/commands/connex/list.ts
@@ -1,0 +1,128 @@
+import chalk from 'chalk';
+import ms from 'ms';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { validateJsonOutput } from '../../util/output-format';
+import { printError } from '../../util/error';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import table from '../../util/output/table';
+import { packageName } from '../../util/pkg-name';
+
+interface ConnexClient {
+  id: string;
+  uid: string;
+  name: string;
+  type: string;
+  typeName?: string;
+  createdAt: number;
+}
+
+interface ListClientsResponse {
+  clients: ConnexClient[];
+  cursor?: string;
+}
+
+export async function list(
+  client: Client,
+  flags: {
+    '--limit'?: number;
+    '--next'?: string;
+    '--format'?: string;
+    '--json'?: boolean;
+  }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  await selectConnexTeam(
+    client,
+    'Select the team whose Connex clients you want to list'
+  );
+
+  const params = new URLSearchParams();
+  if (flags['--limit'] !== undefined) {
+    params.set('limit', String(flags['--limit']));
+  }
+  if (flags['--next']) {
+    params.set('cursor', flags['--next']);
+  }
+  const query = params.toString();
+  const url = `/v1/connex/clients${query ? `?${query}` : ''}`;
+
+  output.spinner('Fetching Connex clients…');
+  let response: ListClientsResponse;
+  try {
+    response = await client.fetch<ListClientsResponse>(url);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 404) {
+      output.error(
+        'Connex is not enabled for this team. Contact support to enable it.'
+      );
+      return 1;
+    }
+    printError(err);
+    return 1;
+  }
+  output.stopSpinner();
+
+  const clients = response.clients ?? [];
+
+  if (asJson) {
+    const jsonClients = clients.map(c => ({
+      uid: c.uid,
+      id: c.id,
+      name: c.name,
+      type: c.type,
+      typeName: c.typeName,
+      createdAt: c.createdAt,
+    }));
+    client.stdout.write(
+      `${JSON.stringify({ clients: jsonClients, cursor: response.cursor }, null, 2)}\n`
+    );
+    return 0;
+  }
+
+  if (clients.length === 0) {
+    output.log(
+      `No Connex clients found. Create one with \`${packageName} connex create <type>\`.`
+    );
+    return 0;
+  }
+
+  const now = Date.now();
+  const rows = clients.map(c => [
+    c.uid || chalk.gray('–'),
+    c.id,
+    c.name || chalk.gray('–'),
+    c.typeName || c.type,
+    c.createdAt
+      ? chalk.gray(`${ms(Math.max(0, now - c.createdAt))} ago`)
+      : chalk.gray('–'),
+  ]);
+
+  output.print(
+    `${table(
+      [
+        ['UID', 'ID', 'Name', 'Type', 'Created'].map(h =>
+          chalk.bold(chalk.cyan(h))
+        ),
+        ...rows,
+      ],
+      { hsep: 4 }
+    )}\n`
+  );
+
+  if (response.cursor) {
+    output.log(
+      `To see more, run \`${packageName} connex list --next ${response.cursor}\``
+    );
+  }
+
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -12,4 +12,38 @@ export class ConnexTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliOptionLimit(v: number | undefined) {
+    if (v !== undefined) {
+      this.trackCliOption({
+        option: 'limit',
+        value: String(v),
+      });
+    }
+  }
+
+  trackCliOptionNext(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'next',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionFormat(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'format',
+        value: v,
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -805,6 +805,7 @@ exports[`help command > connex help output snapshots > connex help column width 
   Commands:
 
   create  type  Create a new Connex client                              
+  list          List Connex clients for the current team                
 
 
   Global Options:
@@ -828,6 +829,58 @@ exports[`help command > connex help output snapshots > connex help column width 
   - Create a Slack app
 
     $ vercel connex create slack
+
+  - List Connex clients on the current team
+
+    $ vercel connex list
+
+"
+`;
+
+exports[`help command > connex help output snapshots > connex list subcommand > connex list subcommand help column width 120 1`] = `
+"
+  ▲ vercel connex list [options]
+
+  List Connex clients for the current team                                                                              
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --limit <COUNT>    Number of clients to return per page                                                          
+       --next <CURSOR>    Cursor for the next page of results                                                           
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - List Connex clients for the current team
+
+    $ vercel connex list
+
+  - Limit the number of results
+
+    $ vercel connex list --limit 10
+
+  - Fetch the next page of results
+
+    $ vercel connex list --next <cursor>
+
+  - Output as JSON
+
+    $ vercel connex list --format=json
 
 "
 `;

--- a/packages/cli/test/unit/commands/connex/list.test.ts
+++ b/packages/cli/test/unit/commands/connex/list.test.ts
@@ -1,0 +1,147 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import connex from '../../../../src/commands/connex';
+
+describe('connex list', () => {
+  let team: { id: string; slug: string };
+
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    team = useTeam();
+    client.config.currentTeam = team.id;
+  });
+
+  it('should render a table of clients on success', async () => {
+    client.scenario.get('/v1/connex/clients', (_req, res) => {
+      res.json({
+        clients: [
+          {
+            id: 'scl_abc123',
+            uid: 'slack/my-bot',
+            name: 'My Bot',
+            type: 'slack',
+            typeName: 'Slack',
+            createdAt: Date.now() - 60_000,
+          },
+        ],
+      });
+    });
+
+    client.setArgv('connex', 'list');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('slack/my-bot');
+    expect(stderr).toContain('scl_abc123');
+    expect(stderr).toContain('My Bot');
+    expect(stderr).toContain('Slack');
+  });
+
+  it('should show empty-state message when no clients exist', async () => {
+    client.scenario.get('/v1/connex/clients', (_req, res) => {
+      res.json({ clients: [] });
+    });
+
+    client.setArgv('connex', 'list');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain('No Connex clients found');
+  });
+
+  it('should show friendly error when connex feature flag is off (404)', async () => {
+    client.scenario.get('/v1/connex/clients', (_req, res) => {
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv('connex', 'list');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Connex is not enabled');
+  });
+
+  it('should output JSON when --format=json is used', async () => {
+    client.scenario.get('/v1/connex/clients', (_req, res) => {
+      res.json({
+        clients: [
+          {
+            id: 'scl_xyz',
+            uid: 'oauth/my-client',
+            name: 'My OAuth',
+            type: 'oauth',
+            typeName: 'OAuth',
+            createdAt: 1_700_000_000_000,
+          },
+        ],
+        cursor: 'next-page',
+      });
+    });
+
+    client.setArgv('connex', 'list', '--format=json');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    const stdout = client.stdout.getFullOutput();
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.cursor).toBe('next-page');
+    expect(parsed.clients).toHaveLength(1);
+    const [first] = parsed.clients;
+    // UID should be first field in each client object
+    expect(Object.keys(first)[0]).toBe('uid');
+    expect(first.uid).toBe('oauth/my-client');
+    expect(first.id).toBe('scl_xyz');
+  });
+
+  it('should print next-page hint when the response has a cursor', async () => {
+    client.scenario.get('/v1/connex/clients', (_req, res) => {
+      res.json({
+        clients: [
+          {
+            id: 'scl_1',
+            uid: 'slack/a',
+            name: 'A',
+            type: 'slack',
+            typeName: 'Slack',
+            createdAt: Date.now(),
+          },
+        ],
+        cursor: 'cursor-abc',
+      });
+    });
+
+    client.setArgv('connex', 'list');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain(
+      'connex list --next cursor-abc'
+    );
+  });
+
+  it('should forward --limit and --next as query params', async () => {
+    let requestUrl = '';
+    client.scenario.get('/v1/connex/clients', (req, res) => {
+      requestUrl = req.url ?? '';
+      res.json({ clients: [] });
+    });
+
+    client.setArgv('connex', 'list', '--limit', '5', '--next', 'prev-cursor');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestUrl).toContain('limit=5');
+    expect(requestUrl).toContain('cursor=prev-cursor');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -440,6 +440,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('connex list subcommand', () => {
+      it('connex list subcommand help column width 120', () => {
+        expect(
+          help(connex.listSubcommand, {
+            columns: 120,
+            parent: connex.connexCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('integration help output snapshots', () => {


### PR DESCRIPTION
## Summary

Adds `vercel connex list` — lists Connex clients for the current team. CLI buildout (gated behind `FF_CONNEX_ENABLED`).

## Design notes

- **No default `--limit` set client-side.** API defaults to 50 
- **No project filtering yet.** Plan is to add an optional `--include-projects` flag later once the API can enrich list responses with project links in a single batched call. For now, this is a flat team-wide list. [MKT-3634](https://linear.app/vercel/issue/MKT-3634/cli-include-projects-in-vc-connex-list)
- **`--next` name** follows Vercel CLI convention for "next page" flags (matching `vercel ls`, `vercel env ls`, etc.), even though the value is a cursor rather than a timestamp.

## Test plan

- [x] `npx vitest run packages/cli/test/unit/commands/connex/list.test.ts` — 6 passing tests: success, empty, 404, JSON, pagination hint, query param forwarding
- [x] `tsc --noEmit` clean
- [x] `FF_CONNEX_ENABLED=1 vercel connex --help` shows `list` under Commands
- [x] Manually
  - [x] `vercel connex list` with several clients → table renders
  - [x] `vercel connex list --format=json` → valid JSON, UID first
  - [x] `vercel connex list --limit 2` with >2 clients → next-page hint appears
  - [x] `vercel connex list --next <cursor>` → fetches the next page

🤖 Generated with [Claude Code](https://claude.com/claude-code)