### PR TITLE
Add v0 as a known agent in detect-agent

### DIFF
--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -34,6 +34,7 @@ This package can detect the following AI agents and development environments:
 - **Antigravity** (Google DeepMind)
 - **GitHub Copilot** (via `AI_AGENT=github-copilot|github-copilot-cli`, `COPILOT_MODEL`, `COPILOT_ALLOW_ALL`, or `COPILOT_GITHUB_TOKEN`)
 - **Replit** (online IDE)
+- **v0** (Vercel's AI assistant, via `AI_AGENT=v0`)
 
 ## The AI_AGENT Standard
 

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -16,6 +16,7 @@ const AUGMENT_CLI = 'augment-cli' as const;
 const OPENCODE = 'opencode' as const;
 const GITHUB_COPILOT = 'github-copilot' as const;
 const GITHUB_COPILOT_CLI = 'github-copilot-cli' as const;
+const V0 = 'v0' as const;
 
 export type KnownAgentNames =
   | typeof CURSOR
@@ -29,7 +30,8 @@ export type KnownAgentNames =
   | typeof ANTIGRAVITY
   | typeof AUGMENT_CLI
   | typeof OPENCODE
-  | typeof GITHUB_COPILOT;
+  | typeof GITHUB_COPILOT
+  | typeof V0;
 
 export interface KnownAgentDetails {
   name: KnownAgentNames;
@@ -58,6 +60,7 @@ export const KNOWN_AGENTS = {
   AUGMENT_CLI,
   OPENCODE,
   GITHUB_COPILOT,
+  V0,
 } as const;
 
 export async function determineAgent(): Promise<AgentResult> {

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -55,6 +55,19 @@ describe('determineAgent', () => {
     });
   });
 
+
+  describe('v0 detection', () => {
+    it('detects v0 from AI_AGENT=v0', async () => {
+      vi.stubEnv('AI_AGENT', 'v0');
+
+      const result = await determineAgent();
+      expect(result).toEqual({
+        isAgent: true,
+        agent: { name: KNOWN_AGENTS.V0 },
+      });
+    });
+  });
+
   describe('github copilot detection', () => {
     it('detects github copilot from AI_AGENT=github-copilot', async () => {
       vi.stubEnv('AI_AGENT', 'github-copilot');


### PR DESCRIPTION
## What changed

- Add `V0` constant and export it in `KNOWN_AGENTS`
- Add `V0` to the `KnownAgentNames` type union
- Add a test case for v0 detection via `AI_AGENT=v0`
- Update README to list v0 as a supported agent

## Context

v0 (Vercel's AI assistant) sets `AI_AGENT=v0` in its sandbox environment. This PR adds v0 to the list of known agents so it can be detected natively.

Related: https://github.com/vercel/v0/pull/7135 (sets `AI_AGENT=v0` in v0 sandbox)