### PR TITLE
Revert: restore pull_request trigger for CI workflows

### DIFF
--- a/.github/workflows/comment-cli-tarball.yml
+++ b/.github/workflows/comment-cli-tarball.yml
@@ -1,42 +1,35 @@
 name: Comment CLI Tarball Instructions
 
 on:
-  repository_dispatch:
-    types:
-      - vercel.project.QmcQ2AGNAWeR6ZJCWAhqhbixxvWbgvsR2LMT4fzmTfY9SK.deployment.ready
+  pull_request:
 
 env:
   VERCEL_TELEMETRY_DISABLED: '1'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.client_payload.git.ref }}
-  cancel-in-progress: ${{ github.event.client_payload.git.ref != 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   comment-cli-tarball:
     name: Comment CLI Tarball Instructions
     runs-on: ubuntu-latest
-    if: github.event.client_payload.environment == 'preview'
+    if: github.event_name == 'pull_request' && github.event.pull_request.title != 'Version Packages'
     steps:
-      - name: Resolve PR context
-        id: pr-context
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SHA="${{ github.event.client_payload.git.sha }}"
-          PR_JSON=$(gh api "repos/${{ github.repository }}/commits/${SHA}/pulls" --jq '.[0]')
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
-          echo "prNumber=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "prTitle=$PR_TITLE" >> $GITHUB_OUTPUT
+      - name: Wait for Vercel deployment
+        uses: patrickedqvist/wait-for-vercel-preview@bfdff514ff78a669f2536e9f4dd4ef5813a704a2
+        id: waitForDeployment
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 360
+          check_interval: 5
 
       - uses: actions/checkout@v4
-        if: steps.pr-context.outputs.prTitle != 'Version Packages'
         with:
-          ref: ${{ github.event.client_payload.git.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Discover Python packages
-        if: steps.pr-context.outputs.prTitle != 'Version Packages'
         id: discoverPythonPackages
         run: |
           PACKAGES="$(node utils/get-python-packages.js)"
@@ -44,14 +37,13 @@ jobs:
           echo "Discovered Python packages: $PACKAGES"
 
       - name: Comment PR with CLI tarball instructions
-        if: steps.pr-context.outputs.prTitle != 'Version Packages'
         uses: actions/github-script@v7
         env:
           PYTHON_PACKAGES: ${{ steps.discoverPythonPackages.outputs.packages }}
         with:
           script: |
-            const deploymentUrl = '${{ github.event.client_payload.url }}';
-            const prNumber = ${{ steps.pr-context.outputs.prNumber }};
+            const deploymentUrl = '${{ steps.waitForDeployment.outputs.url }}';
+            const prNumber = context.issue.number;
 
             // Validate deployment URL before posting
             if (!deploymentUrl || deploymentUrl === '') {

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -5,9 +5,7 @@ name: E2E Tests
 # cache buster: 2
 
 on:
-  repository_dispatch:
-    types:
-      - vercel.project.QmcQ2AGNAWeR6ZJCWAhqhbixxvWbgvsR2LMT4fzmTfY9SK.deployment.ready
+  pull_request:
 
 env:
   VERCEL_TELEMETRY_DISABLED: '1'
@@ -16,41 +14,27 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.client_payload.git.ref }}
-  cancel-in-progress: ${{ github.event.client_payload.git.ref != 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   setup:
     name: Find Changes
-    if: github.event.client_payload.environment == 'preview'
     runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps['set-tests'].outputs['tests'] }}
-      dplUrl: ${{ github.event.client_payload.url }}
-      baseSha: ${{ steps.pr-context.outputs.baseSha }}
-      headSha: ${{ github.event.client_payload.git.sha }}
-      prNumber: ${{ steps.pr-context.outputs.prNumber }}
+      dplUrl: ${{ steps.resolveTarball.outputs.url }}
       affectedPackages: ${{ steps['affected-packages'].outputs['packages'] }}
       testStrategy: ${{ steps['affected-packages'].outputs['strategy'] }}
       affectedCount: ${{ steps['affected-packages'].outputs['count'] }}
       totalCount: ${{ steps['affected-packages'].outputs['total'] }}
       allPackages: ${{ steps['affected-packages'].outputs['allPackages'] }}
     steps:
-      - name: Resolve PR context
-        id: pr-context
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SHA="${{ github.event.client_payload.git.sha }}"
-          PR_JSON=$(gh api "repos/${{ github.repository }}/commits/${SHA}/pulls" --jq '.[0]')
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          BASE_SHA=$(echo "$PR_JSON" | jq -r '.base.sha')
-          echo "prNumber=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "baseSha=$BASE_SHA" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.client_payload.git.sha }}
+          # Check out the PR commit directly instead of a merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }}
       - uses: actions/setup-node@v4
         with:
@@ -65,9 +49,9 @@ jobs:
       - run: pnpm install
       - id: affected-packages
         run: |
-          export TURBO_BASE_SHA="${{ steps.pr-context.outputs.baseSha }}"
+          export TURBO_BASE_SHA="${{ github.event.pull_request.base.sha }}"
 
-          AFFECTED_OUTPUT=$(node utils/test-affected.js "${{ steps.pr-context.outputs.baseSha }}" 2>&1)
+          AFFECTED_OUTPUT=$(node utils/test-affected.js "${{ github.event.pull_request.base.sha }}" 2>&1)
 
           PACKAGE_COUNT=$(echo "$AFFECTED_OUTPUT" | grep -o "Found [0-9]* affected packages" | grep -o "[0-9]*" | head -1 || echo "0")
           TOTAL_COUNT=$(echo "$AFFECTED_OUTPUT" | grep -o "Total packages with tests: [0-9]*" | grep -o "[0-9]*" | head -1 || echo "0")
@@ -102,8 +86,87 @@ jobs:
           echo "$TESTS_ARRAY"
           echo "tests=$TESTS_ARRAY" >> $GITHUB_OUTPUT
         env:
-          TURBO_BASE_SHA: ${{ steps.pr-context.outputs.baseSha }}
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           TEST_TYPE: e2e
+      - uses: patrickedqvist/wait-for-vercel-preview@bfdff514ff78a669f2536e9f4dd4ef5813a704a2
+        id: waitForTarball
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 360
+          check_interval: 5
+      - name: Resolve Vercel tarball URL
+        id: resolveTarball
+        uses: actions/github-script@v7
+        env:
+          WAIT_URL: ${{ steps.waitForTarball.outputs.url }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber =
+              context.payload.pull_request?.number ?? context.issue.number;
+
+            const waitUrl = process.env.WAIT_URL || '';
+            if (waitUrl) {
+              core.info(`Using deployment URL from wait step: ${waitUrl}`);
+              core.setOutput('url', waitUrl);
+              return;
+            }
+
+            core.info(
+              'No deployment found for the current HEAD commit. Falling back to the most recent successful Vercel preview deployment for this PR.'
+            );
+
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+
+            const shas = commits.map(c => c.sha).reverse();
+
+            for (const sha of shas) {
+              core.info(`Checking deployments for ${sha}...`);
+
+              const { data: deployments } =
+                await github.rest.repos.listDeployments({
+                  owner,
+                  repo,
+                  sha,
+                  environment: 'Preview',
+                  per_page: 5,
+                });
+
+              for (const deployment of deployments) {
+                if (deployment.creator?.login !== 'vercel[bot]') {
+                  continue;
+                }
+
+                const { data: statuses } =
+                  await github.rest.repos.listDeploymentStatuses({
+                    owner,
+                    repo,
+                    deployment_id: deployment.id,
+                    per_page: 10,
+                  });
+
+                const success = statuses.find(
+                  s => s.state === 'success' && s.environment_url
+                );
+
+                if (success?.environment_url) {
+                  core.info(`Resolved deployment URL: ${success.environment_url}`);
+                  core.setOutput('url', success.environment_url);
+                  return;
+                }
+              }
+            }
+
+            core.setFailed(
+              'No Vercel preview deployment found for any commit in this PR.'
+            );
 
   test:
     timeout-minutes: 120
@@ -121,7 +184,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.setup.outputs.headSha }}
+          # Check out the PR commit directly instead of a merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
@@ -195,7 +259,7 @@ jobs:
           VERCEL_CLI_VERSION: ${{ needs.setup.outputs.dplUrl }}/tarballs/vercel.tgz
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-          TURBO_BASE_SHA: ${{ needs.setup.outputs.baseSha }}
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           FORCE_COLOR: '1'
       - name: 'Determine Turbo HIT or MISS'
         if: ${{ !cancelled() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,7 @@
 name: Unit Tests
 
 on:
-  repository_dispatch:
-    types:
-      - vercel.project.QmcQ2AGNAWeR6ZJCWAhqhbixxvWbgvsR2LMT4fzmTfY9SK.deployment.ready
+  pull_request:
 
 env:
   VERCEL_TELEMETRY_DISABLED: '1'
@@ -12,41 +10,28 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.client_payload.git.ref }}
-  cancel-in-progress: ${{ github.event.client_payload.git.ref != 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   setup:
     name: Find Changes
     runs-on: ubuntu-latest
-    if: github.event.client_payload.environment == 'preview'
+    if: github.event_name == 'pull_request'
     outputs:
       tests: ${{ steps['set-tests'].outputs['tests'] }}
-      dplUrl: ${{ github.event.client_payload.url }}
-      baseSha: ${{ steps.pr-context.outputs.baseSha }}
-      headSha: ${{ github.event.client_payload.git.sha }}
-      prNumber: ${{ steps.pr-context.outputs.prNumber }}
+      dplUrl: ${{ steps.resolveTarball.outputs.url }}
       affectedPackages: ${{ steps['affected-packages'].outputs['packages'] }}
       testStrategy: ${{ steps['affected-packages'].outputs['strategy'] }}
       affectedCount: ${{ steps['affected-packages'].outputs['count'] }}
       totalCount: ${{ steps['affected-packages'].outputs['total'] }}
       allPackages: ${{ steps['affected-packages'].outputs['allPackages'] }}
     steps:
-      - name: Resolve PR context
-        id: pr-context
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SHA="${{ github.event.client_payload.git.sha }}"
-          PR_JSON=$(gh api "repos/${{ github.repository }}/commits/${SHA}/pulls" --jq '.[0]')
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          BASE_SHA=$(echo "$PR_JSON" | jq -r '.base.sha')
-          echo "prNumber=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "baseSha=$BASE_SHA" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Need full history for turbo query to work
-          ref: ${{ github.event.client_payload.git.sha }}
+          # Check out the PR commit directly instead of a merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }}
       - uses: actions/setup-node@v4
         with:
@@ -57,10 +42,10 @@ jobs:
       - id: affected-packages
         run: |
           # Set base SHA for affected package detection
-          export TURBO_BASE_SHA="${{ steps.pr-context.outputs.baseSha }}"
+          export TURBO_BASE_SHA="${{ github.event.pull_request.base.sha }}"
 
           # Get affected packages info for PR comment
-          AFFECTED_OUTPUT=$(node utils/test-affected.js "${{ steps.pr-context.outputs.baseSha }}" 2>&1)
+          AFFECTED_OUTPUT=$(node utils/test-affected.js "${{ github.event.pull_request.base.sha }}" 2>&1)
 
           # Extract affected packages count and total packages count
           PACKAGE_COUNT=$(echo "$AFFECTED_OUTPUT" | grep -o "Found [0-9]* affected packages" | grep -o "[0-9]*" | head -1 || echo "0")
@@ -99,12 +84,93 @@ jobs:
           echo "$TESTS_ARRAY"
           echo "tests=$TESTS_ARRAY" >> $GITHUB_OUTPUT
         env:
-          TURBO_BASE_SHA: ${{ steps.pr-context.outputs.baseSha }}
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           TEST_TYPE: unit
+      - uses: patrickedqvist/wait-for-vercel-preview@bfdff514ff78a669f2536e9f4dd4ef5813a704a2
+        id: waitForTarball
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 360
+          check_interval: 5
+      - name: Resolve Vercel tarball URL
+        id: resolveTarball
+        uses: actions/github-script@v7
+        env:
+          WAIT_URL: ${{ steps.waitForTarball.outputs.url }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber =
+              context.payload.pull_request?.number ?? context.issue.number;
+
+            const waitUrl = process.env.WAIT_URL || '';
+            if (waitUrl) {
+              core.info(`Using deployment URL from wait step: ${waitUrl}`);
+              core.setOutput('url', waitUrl);
+              return;
+            }
+
+            core.info(
+              'No deployment found for the current HEAD commit. Falling back to the most recent successful Vercel preview deployment for this PR.'
+            );
+
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+
+            // API returns commits oldest->newest; prefer newest first.
+            const shas = commits.map(c => c.sha).reverse();
+
+            for (const sha of shas) {
+              core.info(`Checking deployments for ${sha}...`);
+
+              const { data: deployments } =
+                await github.rest.repos.listDeployments({
+                  owner,
+                  repo,
+                  sha,
+                  environment: 'Preview',
+                  per_page: 5,
+                });
+
+              for (const deployment of deployments) {
+                if (deployment.creator?.login !== 'vercel[bot]') {
+                  continue;
+                }
+
+                const { data: statuses } =
+                  await github.rest.repos.listDeploymentStatuses({
+                    owner,
+                    repo,
+                    deployment_id: deployment.id,
+                    per_page: 10,
+                  });
+
+                const success = statuses.find(
+                  s => s.state === 'success' && s.environment_url
+                );
+
+                if (success?.environment_url) {
+                  core.info(`Resolved deployment URL: ${success.environment_url}`);
+                  core.setOutput('url', success.environment_url);
+                  return;
+                }
+              }
+            }
+
+            core.setFailed(
+              'No Vercel preview deployment found for any commit in this PR.'
+            );
 
   comment-test-strategy:
     name: Comment Test Strategy
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     needs:
       - setup
     steps:
@@ -117,8 +183,8 @@ jobs:
             const allPackages = '${{ needs.setup.outputs.allPackages }}';
             const affectedCount = parseInt('${{ needs.setup.outputs.affectedCount }}') || 0;
             const totalCount = parseInt('${{ needs.setup.outputs.totalCount }}') || 0;
-            const baseSha = '${{ needs.setup.outputs.baseSha }}';
-            const headSha = '${{ needs.setup.outputs.headSha }}';
+            const baseSha = '${{ github.event.pull_request.base.sha }}';
+            const headSha = '${{ github.event.pull_request.head.sha }}';
 
             // Calculate percentage and unaffected packages
             const percentage = totalCount > 0 ? Math.round((affectedCount / totalCount) * 100) : 0;
@@ -198,7 +264,7 @@ jobs:
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ needs.setup.outputs.prNumber }},
+              issue_number: context.issue.number,
             });
 
             const existingComment = comments.find(comment =>
@@ -217,7 +283,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: ${{ needs.setup.outputs.prNumber }},
+                issue_number: context.issue.number,
                 body: message
               });
             }
@@ -238,7 +304,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Need full history for turbo query to work
-          ref: ${{ needs.setup.outputs.headSha }}
+          # Check out the PR commit directly instead of a merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
@@ -256,6 +323,11 @@ jobs:
 
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1
+
+      - name: install uv@0.10.11
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.10.11'
 
       - run: pnpm install
 
@@ -315,7 +387,7 @@ jobs:
           VERCEL_CLI_VERSION: ${{ needs.setup.outputs.dplUrl }}/tarballs/vercel.tgz
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-          TURBO_BASE_SHA: ${{ needs.setup.outputs.baseSha }}
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           FORCE_COLOR: '1'
       - name: 'Determine Turbo HIT or MISS'
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

Reverts #15984 — restores the `pull_request` trigger for `test-e2e.yml`, `test.yml`, and `comment-cli-tarball.yml`.

Use this PR if the `repository_dispatch` migration causes issues (workflows not firing, incorrect payload shape, missing checks on PRs).

**Do not merge unless #15984 has been merged and needs to be rolled back.**