### PR TITLE
feat(cli): use POST for connex create with browser registration fallback

### DIFF
--- a/.changeset/connex-create-post-fallback.md
+++ b/.changeset/connex-create-post-fallback.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+Use POST for `vercel connex create` with a browser registration fallback.
+
+`vercel connex create` now creates the managed client directly via `POST /v1/connex/clients/managed`. When the API responds with `422` and a `registerUrl`, the CLI opens that URL in the browser, polls for the result, and fetches the final client payload.

--- a/.changeset/connex-create-post-fallback.md
+++ b/.changeset/connex-create-post-fallback.md
@@ -3,5 +3,3 @@
 ---
 
 Use POST for `vercel connex create` with a browser registration fallback.
-
-`vercel connex create` now creates the managed client directly via `POST /v1/connex/clients/managed`. When the API responds with `422` and a `registerUrl`, the CLI opens that URL in the browser, polls for the result, and fetches the final client payload.

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -1,6 +1,7 @@
 import open from 'open';
 import output from '../../output-manager';
 import type Client from '../../util/client';
+import type { JSONObject } from '@vercel-internals/types';
 import { validateJsonOutput } from '../../util/output-format';
 import { printError } from '../../util/error';
 import { getProjectLink } from '../../util/projects/link';
@@ -9,6 +10,7 @@ import {
   generateRequestCode,
   awaitConnexResult,
 } from '../../util/connex/request-code';
+import type { ConnexClient } from './types';
 
 export async function create(
   client: Client,
@@ -50,63 +52,103 @@ export async function create(
     });
   }
 
-  // Generate request code and call the managed create redirect endpoint
+  // Generate request code and attempt to create the managed client directly
   const { original, hash } = generateRequestCode();
   const link = await getProjectLink(client, client.cwd);
 
-  output.spinner('Setting up...');
-  let browserUrl: string;
-  try {
-    let url = `/v1/connex/clients/managed?service=${encodeURIComponent(serviceType)}&name=${encodeURIComponent(name)}&request_code=${encodeURIComponent(hash)}&autoinstall=true`;
-    if (link?.projectId) {
-      url += `&projectId=${encodeURIComponent(link.projectId)}`;
-    }
-    const res = await client.fetch(url, { json: false, redirect: 'manual' });
+  const body: JSONObject = {
+    service: serviceType,
+    name,
+    request_code: hash,
+  };
+  if (link?.projectId) {
+    body.projectId = link.projectId;
+  }
 
-    const location = res.headers.get('location');
-    if (!location) {
-      output.stopSpinner();
-      output.error('Unexpected response from API: no redirect URL');
-      return 1;
-    }
-    browserUrl = location;
+  output.spinner('Setting up...');
+  let createdClient: ConnexClient | null = null;
+  let browserUrl: string | undefined;
+  try {
+    createdClient = await client.fetch<ConnexClient>(
+      '/v1/connex/clients/managed?autoinstall=true',
+      { method: 'POST', body }
+    );
   } catch (err: unknown) {
-    output.stopSpinner();
-    const status = (err as { status?: number }).status;
-    if (status === 404) {
+    const apiErr = err as { status?: number; registerUrl?: string };
+    if (apiErr.status === 422 && apiErr.registerUrl) {
+      browserUrl = apiErr.registerUrl;
+    } else if (apiErr.status === 404) {
+      output.stopSpinner();
       output.error(
         'Connex is not enabled for this team. Contact support to enable it.'
       );
       return 1;
+    } else {
+      output.stopSpinner();
+      printError(err);
+      return 1;
     }
-    printError(err);
-    return 1;
   }
   output.stopSpinner();
 
-  // Open browser
-  output.log(`Opening browser for ${serviceType} app setup...`);
-  output.log(`If the browser doesn't open, visit:\n${browserUrl}`);
-  open(browserUrl).catch((err: unknown) =>
-    output.debug(`Failed to open browser: ${err}`)
-  );
+  let hasBeenInstalled = false;
+  if (browserUrl) {
+    // Registration required — open browser and wait for user to complete setup
+    output.log(`Opening browser for ${serviceType} app setup...`);
+    output.log(`If the browser doesn't open, visit:\n${browserUrl}`);
+    open(browserUrl).catch((err: unknown) =>
+      output.debug(`Failed to open browser: ${err}`)
+    );
 
-  // Poll for result
-  output.spinner('Waiting for you to complete setup in the browser...');
-  const data = await awaitConnexResult(client, original);
-  output.stopSpinner();
+    output.spinner('Waiting for you to complete setup in the browser...');
+    const resultFromBrowser = await awaitConnexResult(client, original);
+    output.stopSpinner();
 
-  if (!data) {
+    if (
+      resultFromBrowser &&
+      'clientId' in resultFromBrowser &&
+      typeof resultFromBrowser.clientId === 'string'
+    ) {
+      const clientId = resultFromBrowser.clientId;
+      createdClient = await client.fetch<ConnexClient>(
+        `/v1/connex/clients/${clientId}`
+      );
+    }
+    if (
+      resultFromBrowser &&
+      'installationId' in resultFromBrowser &&
+      resultFromBrowser.installationId
+    ) {
+      hasBeenInstalled = true;
+    }
+  }
+
+  if (!createdClient) {
     return 1;
   }
 
-  const clientId = data.clientId as string;
   if (asJson) {
-    client.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
-  } else if (data.installationId) {
-    output.success(`${serviceType} client created and installed: ${clientId}`);
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          id: createdClient.id,
+          uid: createdClient.uid,
+          type: createdClient.type,
+          name: createdClient.name,
+          supportedSubjectTypes: createdClient.supportedSubjectTypes,
+        },
+        null,
+        2
+      )}\n`
+    );
+  } else if (hasBeenInstalled) {
+    output.success(
+      `${serviceType} client created and installed: ${createdClient.id} (UID ${createdClient.uid})`
+    );
   } else {
-    output.success(`${serviceType} client created: ${clientId}`);
+    output.success(
+      `${serviceType} client created: ${createdClient.id} (UID ${createdClient.uid})`
+    );
   }
   return 0;
 }

--- a/packages/cli/src/commands/connex/types.ts
+++ b/packages/cli/src/commands/connex/types.ts
@@ -1,0 +1,19 @@
+export interface ConnexClient {
+  id: string;
+  ownerId: string;
+  createdAt: number;
+  updatedAt: number;
+  uid: string;
+  type: string;
+  name: string;
+  clientUrl?: string | null;
+  data: object;
+  typeName: string;
+  typeIcon?: string;
+  website?: string;
+  devsite?: string;
+  docsite?: string;
+  icon?: string;
+  supportedSubjectTypes: Array<'user' | 'app'>;
+  supportsInstallation: boolean;
+}

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -5,6 +5,24 @@ import { useTeam } from '../../../mocks/team';
 import connex from '../../../../src/commands/connex';
 
 vi.mock('open', () => ({ default: vi.fn(() => Promise.resolve()) }));
+vi.setConfig({ testTimeout: 15000 });
+
+function fakeConnexClient(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'scl_test123',
+    ownerId: 'team_abc',
+    createdAt: 0,
+    updatedAt: 0,
+    uid: 'uid_abc',
+    type: 'slack',
+    name: 'my-bot',
+    data: {},
+    typeName: 'Slack',
+    supportedSubjectTypes: ['user'],
+    supportsInstallation: false,
+    ...overrides,
+  };
+}
 
 describe('connex create', () => {
   let team: { id: string; slug: string };
@@ -26,13 +44,6 @@ describe('connex create', () => {
   });
 
   it('should error in non-interactive mode without --name', async () => {
-    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
-      res.writeHead(302, {
-        Location: 'https://vercel.com/test/~/connex/create?type=slack',
-      });
-      res.end();
-    });
-
     client.setArgv('connex', 'create', 'slack');
     (client.stdin as any).isTTY = false;
 
@@ -43,7 +54,7 @@ describe('connex create', () => {
   });
 
   it('should show friendly error when connex feature flag is off (404)', async () => {
-    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
+    client.scenario.post('/v1/connex/clients/managed', (_req, res) => {
       res.statusCode = 404;
       res.json({ error: { code: 'not_found', message: 'Not Found' } });
     });
@@ -56,24 +67,16 @@ describe('connex create', () => {
     expect(exitCode).toBe(1);
   });
 
-  it('should open browser and poll for result on success', async () => {
-    let requestUrl = '';
-    client.scenario.get('/v1/connex/clients/managed', (req, res) => {
-      requestUrl = req.url ?? '';
-      res.writeHead(302, {
-        Location: 'https://vercel.com/test/~/connex/create?type=slack',
-      });
-      res.end();
+  it('should create client directly when POST succeeds (no browser)', async () => {
+    let postBody: any;
+    let pollHit = false;
+    client.scenario.post('/v1/connex/clients/managed', (req, res) => {
+      postBody = req.body;
+      res.json(fakeConnexClient({ id: 'scl_direct1', uid: 'uid_direct1' }));
     });
-
-    let pollCount = 0;
     client.scenario.get('/v1/connex/result/:code', (_req, res) => {
-      pollCount++;
-      if (pollCount < 2) {
-        res.json({ status: 'pending' });
-      } else {
-        res.json({ status: 'success', data: { clientId: 'scl_test123' } });
-      }
+      pollHit = true;
+      res.json({ status: 'pending' });
     });
 
     client.setArgv('connex', 'create', 'slack', '--name', 'my-bot');
@@ -81,26 +84,22 @@ describe('connex create', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(0);
-    expect(requestUrl).toContain('service=slack');
-    expect(requestUrl).toContain('name=my-bot');
-    expect(requestUrl).toContain('request_code=');
-    expect(requestUrl).toContain('autoinstall=true');
-    expect(pollCount).toBeGreaterThanOrEqual(2);
-    await expect(client.stderr).toOutput('scl_test123');
+    expect(postBody).toMatchObject({
+      service: 'slack',
+      name: 'my-bot',
+    });
+    expect(typeof postBody.request_code).toBe('string');
+    expect(pollHit).toBe(false);
+    await expect(client.stderr).toOutput('scl_direct1 (UID uid_direct1)');
   });
 
   it('should pass any type to the server without validation', async () => {
-    let requestUrl = '';
-    client.scenario.get('/v1/connex/clients/managed', (req, res) => {
-      requestUrl = req.url ?? '';
-      res.writeHead(302, {
-        Location: 'https://vercel.com/test/~/connex/create?type=jira',
-      });
-      res.end();
-    });
-
-    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
-      res.json({ status: 'success', data: { clientId: 'scl_jira1' } });
+    let postBody: any;
+    client.scenario.post('/v1/connex/clients/managed', (req, res) => {
+      postBody = req.body;
+      res.json(
+        fakeConnexClient({ id: 'scl_jira1', type: 'jira', name: 'my-jira' })
+      );
     });
 
     client.setArgv('connex', 'create', 'jira', '--name', 'my-jira');
@@ -108,19 +107,20 @@ describe('connex create', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(0);
-    expect(requestUrl).toContain('service=jira');
+    expect(postBody.service).toBe('jira');
   });
 
   it('should output JSON when --format=json is used', async () => {
-    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
-      res.writeHead(302, {
-        Location: 'https://vercel.com/test/~/connex/create?type=slack',
-      });
-      res.end();
-    });
-
-    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
-      res.json({ status: 'success', data: { clientId: 'scl_json123' } });
+    client.scenario.post('/v1/connex/clients/managed', (_req, res) => {
+      res.json(
+        fakeConnexClient({
+          id: 'scl_json123',
+          uid: 'uid_json123',
+          type: 'slack',
+          name: 'my-bot',
+          supportedSubjectTypes: ['user', 'app'],
+        })
+      );
     });
 
     client.setArgv(
@@ -135,15 +135,61 @@ describe('connex create', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(0);
-    await expect(client.stdout).toOutput('"clientId": "scl_json123"');
+    await expect(client.stdout).toOutput('"id": "scl_json123"');
+  });
+
+  it('should open browser and poll when POST returns 422 with registerUrl', async () => {
+    let postHits = 0;
+    client.scenario.post('/v1/connex/clients/managed', (_req, res) => {
+      postHits++;
+      res.statusCode = 422;
+      res.json({
+        error: {
+          code: 'registration_required',
+          message: 'Registration required',
+          registerUrl: 'https://vercel.com/test/~/connex/register?type=slack',
+        },
+      });
+    });
+
+    let pollCount = 0;
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      pollCount++;
+      if (pollCount < 2) {
+        res.json({ status: 'pending' });
+      } else {
+        res.json({ status: 'success', data: { clientId: 'scl_after422' } });
+      }
+    });
+
+    client.scenario.get('/v1/connex/clients/:id', (req, res) => {
+      res.json(
+        fakeConnexClient({
+          id: (req.params as any).id,
+          uid: 'uid_after422',
+        })
+      );
+    });
+
+    client.setArgv('connex', 'create', 'slack', '--name', 'my-bot');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(postHits).toBe(1);
+    expect(pollCount).toBeGreaterThanOrEqual(2);
+    await expect(client.stderr).toOutput('scl_after422 (UID uid_after422)');
   });
 
   it('should keep polling through partial status until success', async () => {
-    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
-      res.writeHead(302, {
-        Location: 'https://vercel.com/test/~/connex/create?type=slack',
+    client.scenario.post('/v1/connex/clients/managed', (_req, res) => {
+      res.statusCode = 422;
+      res.json({
+        error: {
+          message: 'Registration required',
+          registerUrl: 'https://vercel.com/test/~/connex/register',
+        },
       });
-      res.end();
     });
 
     let pollCount = 0;
@@ -166,21 +212,36 @@ describe('connex create', () => {
       }
     });
 
+    client.scenario.get('/v1/connex/clients/:id', (req, res) => {
+      res.json(
+        fakeConnexClient({
+          id: (req.params as any).id,
+          uid: 'uid_partial1',
+          supportsInstallation: true,
+        })
+      );
+    });
+
     client.setArgv('connex', 'create', 'slack', '--name', 'my-bot');
 
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(0);
     expect(pollCount).toBe(3);
-    await expect(client.stderr).toOutput('scl_partial1');
+    await expect(client.stderr).toOutput(
+      'created and installed: scl_partial1 (UID uid_partial1)'
+    );
   });
 
-  it('should handle error status from polling', async () => {
-    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
-      res.writeHead(302, {
-        Location: 'https://vercel.com/test/~/connex/create?type=slack',
+  it('should handle error status from polling after 422', async () => {
+    client.scenario.post('/v1/connex/clients/managed', (_req, res) => {
+      res.statusCode = 422;
+      res.json({
+        error: {
+          message: 'Registration required',
+          registerUrl: 'https://vercel.com/test/~/connex/register',
+        },
       });
-      res.end();
     });
 
     client.scenario.get('/v1/connex/result/:code', (_req, res) => {
@@ -198,12 +259,15 @@ describe('connex create', () => {
     expect(exitCode).toBe(1);
   });
 
-  it('should tolerate early 404s during polling', async () => {
-    client.scenario.get('/v1/connex/clients/managed', (_req, res) => {
-      res.writeHead(302, {
-        Location: 'https://vercel.com/test/~/connex/create?type=slack',
+  it('should tolerate early 404s during polling after 422', async () => {
+    client.scenario.post('/v1/connex/clients/managed', (_req, res) => {
+      res.statusCode = 422;
+      res.json({
+        error: {
+          message: 'Registration required',
+          registerUrl: 'https://vercel.com/test/~/connex/register',
+        },
       });
-      res.end();
     });
 
     let pollCount = 0;
@@ -215,6 +279,15 @@ describe('connex create', () => {
       } else {
         res.json({ status: 'success', data: { clientId: 'scl_after404' } });
       }
+    });
+
+    client.scenario.get('/v1/connex/clients/:id', (req, res) => {
+      res.json(
+        fakeConnexClient({
+          id: (req.params as any).id,
+          uid: 'uid_after404',
+        })
+      );
     });
 
     client.setArgv('connex', 'create', 'slack', '--name', 'my-bot');


### PR DESCRIPTION
## Summary
- `vercel connex create` now attempts to create the managed client directly via `POST /v1/connex/clients/managed?autoinstall=true`, avoiding the browser hop for clients the API can provision on its own.
- When the API returns `422` with a `registerUrl` on the error, the CLI falls back to opening that URL, polling for the result, and then fetching the created client via `GET /v1/connex/clients/:id` for the final payload.
- JSON output now returns the `ConnexClient` shape (`id`, `uid`, `type`, `name`, `supportedSubjectTypes`); human output includes both `id` and `uid`.

## Test plan
- [x] `npx vitest run packages/cli/test/unit/commands/connex/create.test.ts` — 10 passed
- [ ] Manual: `vercel connex create slack --name my-bot` against an env where the POST succeeds directly (no browser)
- [ ] Manual: `vercel connex create slack --name my-bot` against an env that returns 422 + registerUrl (browser opens, result polls, client printed)
- [ ] Manual: `--json` output matches the new shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)