### PR TITLE
test: trigger deployment to validate v2 CI workflows

### DIFF
--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -1,6 +1,7 @@
 import { isError } from '@vercel/error-utils';
 import type Client from './client';
 import { isAPIError, LinkRequiredError, ProjectNotFound } from './errors-ts';
+// v2 workflow validation — safe to remove
 import { packageName } from './pkg-name';
 
 /**


### PR DESCRIPTION
## Summary

Adds a no-op comment to `packages/cli/src/util/agent-output.ts` to trigger a Vercel deployment and validate that the v2 CI workflows (`test-e2e-v2.yml`, `test-v2.yml`, `comment-cli-tarball-v2.yml`) fire correctly via `repository_dispatch`.

**This PR is intentionally trivial — close it after validation.**

## What to check

- [ ] All three v2 workflows trigger after deployment
- [ ] `📦 CLI Tarball Ready (v2)` comment appears on this PR
- [ ] `🧪 Unit Test Strategy (v2)` comment appears on this PR
- [ ] E2E Tests (v2) summary job passes
- [ ] Results match the v1 workflow outputs