### PR TITLE
[python] Support specifying in vercel.tool.entrypoint in pyproject.toml

### DIFF
--- a/.changeset/old-jokes-change.md
+++ b/.changeset/old-jokes-change.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Support specifying entrypoint in vercel.tool.entrypoint in pyproject.toml

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -73,31 +73,17 @@ async function checkEntrypoint(
   return findAppOrHandler(content);
 }
 
-export async function getPyprojectEntrypoint(
-  workPath: string
+async function resolveModuleAttrEntrypoint(
+  workPath: string,
+  value: string
 ): Promise<PythonEntrypoint | null> {
-  const pyprojectData = await readConfigFile<{
-    project?: { scripts?: Record<string, unknown> };
-  }>(join(workPath, 'pyproject.toml'));
-  if (!pyprojectData) return null;
-
-  // If `pyproject.toml` has a [project.scripts] table and contains a script
-  // named "app", parse the value (format: "module:attr") to determine the
-  // module and map it to a file path.
-  const scripts = pyprojectData.project?.scripts as
-    | Record<string, unknown>
-    | undefined;
-  const appScript = scripts?.app;
-  if (typeof appScript !== 'string') return null;
-
   // Expect values like "package.module:app". Extract the module portion.
-  const match = appScript.match(/([A-Za-z_][\w.]*)\s*:\s*([A-Za-z_][\w]*)/);
+  const match = value.match(/([A-Za-z_][\w.]*)\s*:\s*([A-Za-z_][\w]*)/);
   if (!match) return null;
   const modulePath = match[1];
   const variableName = match[2];
   const relPath = modulePath.replace(/\./g, '/');
 
-  // Prefer an existing file match if present; otherwise fall back to "<module>.py".
   const candidates = [`${relPath}.py`, `${relPath}/__init__.py`];
   for (const candidate of candidates) {
     if (await fileExists(join(workPath, candidate))) {
@@ -105,6 +91,34 @@ export async function getPyprojectEntrypoint(
     }
   }
   return null;
+}
+
+export async function getPyprojectEntrypoint(
+  workPath: string
+): Promise<PythonEntrypoint | null> {
+  const pyprojectData = await readConfigFile<{
+    project?: { scripts?: Record<string, unknown> };
+    tool?: { vercel?: { entrypoint?: unknown } };
+  }>(join(workPath, 'pyproject.toml'));
+  if (!pyprojectData) return null;
+
+  // Prefer `[tool.vercel] entrypoint = "module:attr"` if present.
+  const vercelEntrypoint = pyprojectData.tool?.vercel?.entrypoint;
+  if (typeof vercelEntrypoint === 'string') {
+    const resolved = await resolveModuleAttrEntrypoint(
+      workPath,
+      vercelEntrypoint
+    );
+    if (resolved) return resolved;
+  }
+
+  // Fall back to `[project.scripts] app = "module:attr"`.
+  const scripts = pyprojectData.project?.scripts as
+    | Record<string, unknown>
+    | undefined;
+  const appScript = scripts?.app;
+  if (typeof appScript !== 'string') return null;
+  return resolveModuleAttrEntrypoint(workPath, appScript);
 }
 
 async function findValidEntrypoint(
@@ -157,7 +171,7 @@ function makeDetectError(framework: string): NowBuildError {
   const searchedList = PYTHON_CANDIDATE_ENTRYPOINTS.join(', ');
   return new NowBuildError({
     code: `${framework!.toUpperCase()}_ENTRYPOINT_NOT_FOUND`,
-    message: `No ${framework} entrypoint found. Add an 'app' script in pyproject.toml or define an entrypoint in one of: ${searchedList}.`,
+    message: `No ${framework} entrypoint found. Set \`tool.vercel.entrypoint\` in pyproject.toml or define an entrypoint in one of: ${searchedList}.`,
     link: `https://vercel.com/docs/frameworks/backend/${framework}#exporting-the-${framework}-application`,
     action: 'Learn More',
   });

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -93,26 +93,28 @@ async function resolveModuleAttrEntrypoint(
   return null;
 }
 
-export async function getPyprojectEntrypoint(
+export async function getVercelToolsEntrypoint(
   workPath: string
 ): Promise<PythonEntrypoint | null> {
   const pyprojectData = await readConfigFile<{
-    project?: { scripts?: Record<string, unknown> };
     tool?: { vercel?: { entrypoint?: unknown } };
   }>(join(workPath, 'pyproject.toml'));
   if (!pyprojectData) return null;
 
-  // Prefer `[tool.vercel] entrypoint = "module:attr"` if present.
   const vercelEntrypoint = pyprojectData.tool?.vercel?.entrypoint;
-  if (typeof vercelEntrypoint === 'string') {
-    const resolved = await resolveModuleAttrEntrypoint(
-      workPath,
-      vercelEntrypoint
-    );
-    if (resolved) return resolved;
-  }
+  if (typeof vercelEntrypoint !== 'string') return null;
+  return resolveModuleAttrEntrypoint(workPath, vercelEntrypoint);
+}
 
-  // Fall back to `[project.scripts] app = "module:attr"`.
+// Legacy: kept for compatibility. Prefer tool.vercel.entrypoint.
+export async function getPyprojectScriptsEntrypoint(
+  workPath: string
+): Promise<PythonEntrypoint | null> {
+  const pyprojectData = await readConfigFile<{
+    project?: { scripts?: Record<string, unknown> };
+  }>(join(workPath, 'pyproject.toml'));
+  if (!pyprojectData) return null;
+
   const scripts = pyprojectData.project?.scripts as
     | Record<string, unknown>
     | undefined;
@@ -279,14 +281,20 @@ export async function detectPythonEntrypoint(
     return null;
   }
 
-  // Otherwise do a search
+  // Check `tool.vercel.entrypoint` in pyproject.toml first.
+  const vercelEntry = await getVercelToolsEntrypoint(workPath);
+  if (vercelEntry) return { entrypoint: vercelEntry };
+
+  // Then do a framework-specific search.
   const result =
     framework === 'django'
       ? await detectDjangoPythonEntrypoint(workPath)
       : await detectGenericPythonEntrypoint(workPath);
   if (result) return result;
-  const pyprojectEntry = await getPyprojectEntrypoint(workPath);
-  return pyprojectEntry
-    ? { entrypoint: pyprojectEntry }
+
+  // Fall back to `project.scripts.app` in pyproject.toml.
+  const scriptsEntry = await getPyprojectScriptsEntrypoint(workPath);
+  return scriptsEntry
+    ? { entrypoint: scriptsEntry }
     : { error: makeDetectError(framework) };
 }

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1789,6 +1789,60 @@ describe('pyproject.toml entrypoint detection', () => {
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
+
+  it('prefers [tool.vercel] entrypoint over [project.scripts] app', async () => {
+    const realUv =
+      await vi.importActual<typeof import('../src/uv')>('../src/uv');
+    vi.doMock('../src/uv', () => ({
+      ...realUv,
+      UvRunner: createMockUvRunner(),
+    }));
+
+    const { build: buildWithMocks } = await import('../src/index');
+
+    const workPath = path.join(
+      tmpdir(),
+      `python-pyproject-tool-vercel-${Date.now()}`
+    );
+    fs.mkdirSync(path.join(workPath, 'backend', 'api'), { recursive: true });
+    fs.mkdirSync(path.join(workPath, 'other'), { recursive: true });
+
+    const files = {
+      'pyproject.toml': new FileBlob({
+        data:
+          '[project]\nname = "x"\nversion = "0.0.1"\n\n' +
+          '[project.scripts]\napp = "other.server:main"\n\n' +
+          '[tool.vercel]\nentrypoint = "backend.api.server:app"\n',
+      }),
+      'backend/api/server.py': new FileBlob({
+        data: 'from fastapi import FastAPI\napp = FastAPI()\n',
+      }),
+      'other/server.py': new FileBlob({
+        data: 'from fastapi import FastAPI\nmain = FastAPI()\n',
+      }),
+    } as Record<string, FileBlob>;
+    await download(files, workPath);
+
+    const result = await buildWithMocks({
+      workPath,
+      files,
+      entrypoint: '<detect>',
+      meta: { isDev: true },
+      config: { framework: 'fastapi' },
+      repoRootPath: workPath,
+    });
+
+    const handler =
+      getBuildOutputV2Lambda(result).files?.['vc__handler__python.py'];
+    if (!handler || !('data' in handler)) {
+      throw new Error('handler bootstrap not found');
+    }
+    const content = handler.data.toString();
+    expect(content.includes('backend/api/server.py')).toBe(true);
+    expect(content.includes('other/server.py')).toBe(false);
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
 });
 
 describe('vercel.json entrypoint configuration', () => {


### PR DESCRIPTION
This is more canonical of a way to specify this kind of thing than
`project.scripts`, which is kind of an abuse--`project.scripts` is
supposed to specify functions that can be a script's entry point, and
on package install a script is installed for each of them, which is
close to never the right thing for a web app. (You *can* write a
function that's a valid entrypoint and a valid WSGI app... but I don't
think many have!)

If people want to argue naming about `entrypoint`, I'm not married to
it. We could call it `app` if we wanted to, idk.
