### PR TITLE
feat(cli): add `vercel connex token` command

### DIFF
--- a/.changeset/connex-token-command.md
+++ b/.changeset/connex-token-command.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel connex token` command to fetch tokens for Connex clients, with auto-authorize / auto-install recovery on actionable 422 errors.

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -88,7 +88,7 @@ export const tokenSubcommand = {
   description: 'Get a token for a Connex client',
   arguments: [
     {
-      name: 'clientId',
+      name: 'clientIdOrUid',
       required: true,
     },
   ],
@@ -117,15 +117,19 @@ export const tokenSubcommand = {
       type: String,
       argument: 'SCOPES',
       deprecated: false,
-      description: 'Comma-separated scopes',
+      description: 'Scopes (comma- or space-separated)',
     },
     yesOption,
     formatOption,
   ],
   examples: [
     {
-      name: 'Get a user token for the current user (default)',
+      name: 'Get a user token by client ID',
       value: `${packageName} connex token scl_abc123`,
+    },
+    {
+      name: 'Get a token by client UID',
+      value: `${packageName} connex token slack/my-bot`,
     },
     {
       name: 'Get an app token (default installation)',
@@ -136,7 +140,11 @@ export const tokenSubcommand = {
       value: `${packageName} connex token scl_abc123 --subject app --installation-id inst_1`,
     },
     {
-      name: 'Output as JSON',
+      name: 'Open the browser automatically if authorization/installation is required',
+      value: `${packageName} connex token scl_abc123 --yes`,
+    },
+    {
+      name: 'Output as JSON (includes expiresAt, installationId, etc.)',
       value: `${packageName} connex token scl_abc123 --format=json`,
     },
   ],

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -89,7 +89,7 @@ export const tokenSubcommand = {
     'Get a token for a Connex client (accepts a client ID like scl_abc or a UID like slack/my-bot)',
   arguments: [
     {
-      name: 'clientIdOrUid',
+      name: 'id',
       required: true,
     },
   ],

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -99,7 +99,8 @@ export const tokenSubcommand = {
       type: String,
       argument: 'TYPE',
       deprecated: false,
-      description: 'Subject type: app or user',
+      description:
+        'Subject type: "user" (default, acts on behalf of you) or "app" (uses the client\'s default installation)',
     },
     {
       name: 'installation-id',
@@ -107,7 +108,8 @@ export const tokenSubcommand = {
       type: String,
       argument: 'ID',
       deprecated: false,
-      description: 'Target installation ID',
+      description:
+        "Target a specific installation (only useful with --subject app; defaults to the client's default installation)",
     },
     {
       name: 'scopes',
@@ -122,16 +124,16 @@ export const tokenSubcommand = {
   ],
   examples: [
     {
-      name: 'Get a token for a client',
+      name: 'Get a user token for the current user (default)',
       value: `${packageName} connex token scl_abc123`,
     },
     {
-      name: 'Get an app token',
+      name: 'Get an app token (default installation)',
       value: `${packageName} connex token scl_abc123 --subject app`,
     },
     {
-      name: 'Get a token for a specific installation',
-      value: `${packageName} connex token scl_abc123 --installation-id inst_1`,
+      name: 'Get an app token for a specific installation',
+      value: `${packageName} connex token scl_abc123 --subject app --installation-id inst_1`,
     },
     {
       name: 'Output as JSON',

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -85,7 +85,8 @@ export const listSubcommand = {
 export const tokenSubcommand = {
   name: 'token',
   aliases: [],
-  description: 'Get a token for a Connex client',
+  description:
+    'Get a token for a Connex client (accepts a client ID like scl_abc or a UID like slack/my-bot)',
   arguments: [
     {
       name: 'clientIdOrUid',

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -1,4 +1,4 @@
-import { formatOption } from '../../util/arg-common';
+import { formatOption, yesOption } from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
 
 export const createSubcommand = {
@@ -82,13 +82,71 @@ export const listSubcommand = {
   ],
 } as const;
 
+export const tokenSubcommand = {
+  name: 'token',
+  aliases: [],
+  description: 'Get a token for a Connex client',
+  arguments: [
+    {
+      name: 'clientId',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'subject',
+      shorthand: 's',
+      type: String,
+      argument: 'TYPE',
+      deprecated: false,
+      description: 'Subject type: app or user',
+    },
+    {
+      name: 'installation-id',
+      shorthand: null,
+      type: String,
+      argument: 'ID',
+      deprecated: false,
+      description: 'Target installation ID',
+    },
+    {
+      name: 'scopes',
+      shorthand: null,
+      type: String,
+      argument: 'SCOPES',
+      deprecated: false,
+      description: 'Comma-separated scopes',
+    },
+    yesOption,
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Get a token for a client',
+      value: `${packageName} connex token scl_abc123`,
+    },
+    {
+      name: 'Get an app token',
+      value: `${packageName} connex token scl_abc123 --subject app`,
+    },
+    {
+      name: 'Get a token for a specific installation',
+      value: `${packageName} connex token scl_abc123 --installation-id inst_1`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} connex token scl_abc123 --format=json`,
+    },
+  ],
+} as const;
+
 export const connexCommand = {
   name: 'connex',
   aliases: [],
   description: 'Manage Vercel Connect clients',
   arguments: [],
   options: [],
-  subcommands: [createSubcommand, listSubcommand],
+  subcommands: [createSubcommand, listSubcommand, tokenSubcommand],
   examples: [
     {
       name: 'Create a Slack app',
@@ -97,6 +155,10 @@ export const connexCommand = {
     {
       name: 'List Connex clients on the current team',
       value: `${packageName} connex list`,
+    },
+    {
+      name: 'Get a token',
+      value: `${packageName} connex token scl_abc123`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -53,13 +53,13 @@ export async function create(
   }
 
   // Generate request code and attempt to create the managed client directly
-  const { original, hash } = generateRequestCode();
+  const { verifier, requestCode } = generateRequestCode();
   const link = await getProjectLink(client, client.cwd);
 
   const body: JSONObject = {
     service: serviceType,
     name,
-    request_code: hash,
+    request_code: requestCode,
   };
   if (link?.projectId) {
     body.projectId = link.projectId;
@@ -101,7 +101,7 @@ export async function create(
     );
 
     output.spinner('Waiting for you to complete setup in the browser...');
-    const resultFromBrowser = await awaitConnexResult(client, original);
+    const resultFromBrowser = await awaitConnexResult(client, verifier);
     output.stopSpinner();
 
     if (

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -112,11 +112,7 @@ export default async function connex(client: Client): Promise<number> {
 
         const tokenFlagsSpec = getFlagsSpecification(tokenSubcommand.options);
         const tokenParsedArgs = parseArguments(subArgs, tokenFlagsSpec);
-        return await token(
-          client,
-          tokenParsedArgs.args,
-          tokenParsedArgs.flags
-        );
+        return await token(client, tokenParsedArgs.args, tokenParsedArgs.flags);
       }
       default: {
         const validSubcommands = Object.keys(COMMAND_CONFIG).join(' | ');

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -7,9 +7,15 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import getSubcommand from '../../util/get-subcommand';
 import { ConnexTelemetryClient } from '../../util/telemetry/commands/connex';
 import { type Command, help } from '../help';
-import { createSubcommand, listSubcommand, connexCommand } from './command';
+import {
+  createSubcommand,
+  listSubcommand,
+  tokenSubcommand,
+  connexCommand,
+} from './command';
 import { create } from './create';
 import { list } from './list';
+import { token } from './token';
 import {
   buildCommandWithGlobalFlags,
   outputAgentError,
@@ -20,6 +26,7 @@ import { packageName } from '../../util/pkg-name';
 const COMMAND_CONFIG = {
   create: getCommandAliases(createSubcommand),
   list: getCommandAliases(listSubcommand),
+  token: getCommandAliases(tokenSubcommand),
 };
 
 export default async function connex(client: Client): Promise<number> {
@@ -94,6 +101,22 @@ export default async function connex(client: Client): Promise<number> {
         telemetry.trackCliOptionNext(listParsedArgs.flags['--next']);
         telemetry.trackCliOptionFormat(listParsedArgs.flags['--format']);
         return await list(client, listParsedArgs.flags);
+      }
+      case 'token': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex', subcommandOriginal);
+          printHelp(tokenSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandToken(subcommandOriginal);
+
+        const tokenFlagsSpec = getFlagsSpecification(tokenSubcommand.options);
+        const tokenParsedArgs = parseArguments(subArgs, tokenFlagsSpec);
+        return await token(
+          client,
+          tokenParsedArgs.args,
+          tokenParsedArgs.flags
+        );
       }
       default: {
         const validSubcommands = Object.keys(COMMAND_CONFIG).join(' | ');

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -1,0 +1,279 @@
+import open from 'open';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { validateJsonOutput } from '../../util/output-format';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import {
+  generateRequestCode,
+  awaitConnexResult,
+} from '../../util/connex/request-code';
+
+interface ConnexTokenResponse {
+  token: string;
+  expiresAt: number;
+  name?: string;
+  installationId?: string;
+  tenantId?: string;
+  externalSubject?: string;
+  data?: Record<string, unknown>;
+}
+
+interface AutoInstallResponse {
+  action: string;
+  url: string;
+}
+
+function isAutoInstallResponse(body: unknown): body is AutoInstallResponse {
+  return (
+    typeof body === 'object' &&
+    body !== null &&
+    'action' in body &&
+    'url' in body &&
+    typeof (body as AutoInstallResponse).url === 'string'
+  );
+}
+
+export async function token(
+  client: Client,
+  args: string[],
+  flags: {
+    '--subject'?: string;
+    '--installation-id'?: string;
+    '--scopes'?: string;
+    '--format'?: string;
+    '--json'?: boolean;
+    '--yes'?: boolean;
+  }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const clientId = args[0];
+  if (!clientId) {
+    output.error('Missing client ID. Usage: vercel connex token <clientId>');
+    return 1;
+  }
+
+  const subject = flags['--subject'];
+  if (subject && subject !== 'app' && subject !== 'user') {
+    output.error('Invalid --subject value. Must be "app" or "user".');
+    return 1;
+  }
+
+  // Resolve team
+  await selectConnexTeam(client, 'Select the team for this token request');
+
+  // Build token request body
+  const body: Record<string, unknown> = {};
+  if (subject) {
+    body.subject = subject === 'app' ? { type: 'app' } : { type: 'user' };
+  }
+  if (flags['--installation-id']) {
+    body.installationId = flags['--installation-id'];
+  }
+  if (flags['--scopes']) {
+    body.scopes = flags['--scopes'].split(',').map(s => s.trim());
+  }
+
+  // Attempt 1: simple token request
+  output.spinner('Fetching token...');
+  const result = await fetchToken(client, clientId, body);
+  output.stopSpinner();
+
+  if (result.ok) {
+    return printTokenResult(client, result.data, asJson);
+  }
+
+  // Check if auto-install/authorize is possible
+  const errorCode = result.errorCode;
+  if (errorCode === 'not_found') {
+    output.error('Client not found or Connex is not enabled for this team.');
+    return 1;
+  }
+  if (
+    errorCode !== 'no_valid_token' &&
+    errorCode !== 'client_installation_required'
+  ) {
+    output.error(result.errorMessage ?? 'Failed to get token');
+    return 1;
+  }
+
+  // Auto-install/authorize requires TTY
+  if (!client.stdin.isTTY) {
+    const action = errorCode === 'no_valid_token' ? 'authorize' : 'install';
+    output.error(
+      `${result.errorMessage}. Run \`vercel connex token ${clientId}\` interactively to ${action}.`
+    );
+    return 1;
+  }
+
+  // Prompt user before opening browser (unless --yes)
+  const actionLabel =
+    errorCode === 'no_valid_token' ? 'Authorization' : 'Installation';
+
+  if (!flags['--yes']) {
+    const confirmed = await client.input.confirm(
+      `${actionLabel} required. Open browser to continue?`,
+      true
+    );
+    if (!confirmed) {
+      output.log('Aborted.');
+      return 0;
+    }
+  }
+
+  // Attempt 2: request with autoinstall + request_code
+  const { original, hash } = generateRequestCode();
+
+  output.spinner('Setting up...');
+  const autoResult = await fetchTokenAutoInstall(client, clientId, body, hash);
+  output.stopSpinner();
+
+  if (!autoResult.ok) {
+    output.error(autoResult.errorMessage ?? 'Failed to initiate setup');
+    return 1;
+  }
+
+  // If the API returned a token directly (no action needed), we're done
+  if (autoResult.token) {
+    return printTokenResult(client, autoResult.token, asJson);
+  }
+
+  // Open browser for the action
+  if (!autoResult.url) {
+    output.error('Unexpected response: no action URL returned');
+    return 1;
+  }
+
+  output.log(`Opening browser for ${actionLabel.toLowerCase()}...`);
+  output.log(`If the browser doesn't open, visit:\n${autoResult.url}`);
+  open(autoResult.url).catch((err: unknown) =>
+    output.debug(`Failed to open browser: ${err}`)
+  );
+
+  // Poll for result
+  output.spinner(
+    `Waiting for you to complete ${actionLabel.toLowerCase()} in the browser...`
+  );
+  const pollData = await awaitConnexResult(client, original);
+  output.stopSpinner();
+
+  if (!pollData) {
+    return 1;
+  }
+
+  // Retry token request with any returned installationId
+  const retryBody = { ...body };
+  if (pollData.installationId) {
+    retryBody.installationId = pollData.installationId as string;
+  }
+
+  output.spinner('Fetching token...');
+  const retryResult = await fetchToken(client, clientId, retryBody);
+  output.stopSpinner();
+
+  if (retryResult.ok) {
+    return printTokenResult(client, retryResult.data, asJson);
+  }
+
+  output.error(retryResult.errorMessage ?? 'Failed to get token after setup');
+  return 1;
+}
+
+function printTokenResult(
+  client: Client,
+  data: ConnexTokenResponse,
+  asJson: boolean
+): number {
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+  } else {
+    // Plain output: just the token value (pipeable)
+    client.stdout.write(`${data.token}\n`);
+  }
+  return 0;
+}
+
+type TokenResult =
+  | { ok: true; data: ConnexTokenResponse }
+  | { ok: false; errorCode?: string; errorMessage?: string };
+
+async function fetchToken(
+  client: Client,
+  clientId: string,
+  body: Record<string, unknown>
+): Promise<TokenResult> {
+  try {
+    const data = await client.fetch<ConnexTokenResponse>(
+      `/v1/connex/token/${encodeURIComponent(clientId)}`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+    return { ok: true, data };
+  } catch (err: unknown) {
+    const serverError = extractApiError(err);
+    return {
+      ok: false,
+      errorCode: serverError.code,
+      errorMessage: serverError.message,
+    };
+  }
+}
+
+type AutoInstallResult =
+  | { ok: true; token?: ConnexTokenResponse; url?: string }
+  | { ok: false; errorMessage?: string };
+
+async function fetchTokenAutoInstall(
+  client: Client,
+  clientId: string,
+  body: Record<string, unknown>,
+  requestCodeHash: string
+): Promise<AutoInstallResult> {
+  try {
+    const res = await client.fetch<ConnexTokenResponse | AutoInstallResponse>(
+      `/v1/connex/token/${encodeURIComponent(clientId)}?autoinstall=true&request_code=${encodeURIComponent(requestCodeHash)}`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    if (isAutoInstallResponse(res)) {
+      return { ok: true, url: res.url };
+    }
+
+    // API returned a token directly
+    return { ok: true, token: res as ConnexTokenResponse };
+  } catch (err: unknown) {
+    const serverError = extractApiError(err);
+    return { ok: false, errorMessage: serverError.message };
+  }
+}
+
+function extractApiError(err: unknown): {
+  code?: string;
+  message?: string;
+} {
+  if (typeof err === 'object' && err !== null) {
+    const errObj = err as Record<string, unknown>;
+    // client.fetch wraps API errors with serverMessage and code
+    const code = typeof errObj.code === 'string' ? errObj.code : undefined;
+    const message =
+      typeof errObj.serverMessage === 'string'
+        ? errObj.serverMessage
+        : typeof errObj.message === 'string'
+          ? errObj.message
+          : 'Unknown error';
+    return { code, message };
+  }
+  return { message: 'Unknown error' };
+}

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -56,8 +56,14 @@ export async function token(
   await selectConnexTeam(client, 'Select the team for this token request');
 
   const body: Record<string, unknown> = {};
-  if (subject) {
-    body.subject = subject === 'app' ? { type: 'app' } : { type: 'user' };
+  if (subject === 'app') {
+    body.subject = { type: 'app' };
+  } else if (subject === 'user') {
+    const userId = client.authConfig.userId;
+    if (userId) {
+      body.subject = { type: 'user', id: userId };
+    }
+    // If userId is not available, omit subject and let the API default.
   }
   if (flags['--installation-id']) {
     body.installationId = flags['--installation-id'];

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -111,11 +111,12 @@ export async function token(
       ? 'authorization'
       : 'installation';
 
-  const isInteractive = Boolean(client.stdin.isTTY && client.stdout.isTTY);
-  // The recovery flow opens a browser a human must complete, so skip it
-  // whenever we don't have (or shouldn't assume) a human at the terminal.
+  // Recovery opens a browser a human must complete. Only attempt it when
+  // the session is fully interactive AND the user hasn't declared
+  // non-interactive mode.
   const attemptRecovery =
-    !client.nonInteractive && (Boolean(flags['--yes']) || isInteractive);
+    !client.nonInteractive &&
+    Boolean(client.stdin.isTTY && client.stdout.isTTY);
 
   if (!attemptRecovery) {
     const { requestCode } = generateRequestCode();
@@ -123,7 +124,7 @@ export async function token(
     output.error(errorMessage);
     output.log(`To ${actionLabel}, open: ${actionUrl}`);
     output.log(
-      `Or re-run with --yes to open the browser automatically: vercel connex token ${clientId} --yes`
+      `Or re-run \`vercel connex token ${clientId}\` in an interactive terminal.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -86,7 +86,7 @@ export async function token(
     return 1;
   }
 
-  if (errorCode === 'no_token') {
+  if (errorCode === 'unresolved_token') {
     output.error(
       `${errorMessage} This client does not support getting a token for the requested subject.`
     );
@@ -112,13 +112,14 @@ export async function token(
       : 'installation';
 
   const isInteractive = Boolean(client.stdin.isTTY && client.stdout.isTTY);
-  // Only open a browser + poll when the user asked for it (--yes) or when
-  // we're clearly in a human-driven session — otherwise fail fast.
-  const attemptRecovery = Boolean(flags['--yes']) || isInteractive;
+  // The recovery flow opens a browser a human must complete, so skip it
+  // whenever we don't have (or shouldn't assume) a human at the terminal.
+  const attemptRecovery =
+    !client.nonInteractive && (Boolean(flags['--yes']) || isInteractive);
 
   if (!attemptRecovery) {
-    const { hash } = generateRequestCode();
-    const actionUrl = buildActionUrl(errorCode, clientId, teamId, hash);
+    const { requestCode } = generateRequestCode();
+    const actionUrl = buildActionUrl(errorCode, clientId, teamId, requestCode);
     output.error(errorMessage);
     output.log(`To ${actionLabel}, open: ${actionUrl}`);
     output.log(
@@ -138,8 +139,8 @@ export async function token(
     }
   }
 
-  const { original, hash } = generateRequestCode();
-  const actionUrl = buildActionUrl(errorCode, clientId, teamId, hash);
+  const { verifier, requestCode } = generateRequestCode();
+  const actionUrl = buildActionUrl(errorCode, clientId, teamId, requestCode);
 
   output.log(`Opening browser for ${actionLabel}...`);
   output.log(`If the browser doesn't open, visit:\n${actionUrl}`);
@@ -148,7 +149,7 @@ export async function token(
   );
 
   output.spinner(`Waiting for ${actionLabel} to complete in the browser...`);
-  const pollData = await awaitConnexResult(client, original);
+  const pollData = await awaitConnexResult(client, verifier);
   output.stopSpinner();
 
   if (!pollData) {
@@ -194,12 +195,12 @@ function buildActionUrl(
   code: ActionableErrorCode,
   clientId: string,
   teamId: string,
-  requestCodeHash: string
+  requestCode: string
 ): string {
   const path = code === 'user_authorization_required' ? 'authorize' : 'install';
   const params = new URLSearchParams({
     teamId,
-    request_code: requestCodeHash,
+    request_code: requestCode,
   });
   return `https://vercel.com/api/v1/connex/${path}/${encodeURIComponent(clientId)}?${params.toString()}`;
 }

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -18,20 +18,9 @@ interface ConnexTokenResponse {
   data?: Record<string, unknown>;
 }
 
-interface AutoInstallResponse {
-  action: string;
-  url: string;
-}
-
-function isAutoInstallResponse(body: unknown): body is AutoInstallResponse {
-  return (
-    typeof body === 'object' &&
-    body !== null &&
-    'action' in body &&
-    'url' in body &&
-    typeof (body as AutoInstallResponse).url === 'string'
-  );
-}
+type ActionableErrorCode =
+  | 'user_authorization_required'
+  | 'client_installation_required';
 
 export async function token(
   client: Client,
@@ -64,10 +53,8 @@ export async function token(
     return 1;
   }
 
-  // Resolve team
   await selectConnexTeam(client, 'Select the team for this token request');
 
-  // Build token request body
   const body: Record<string, unknown> = {};
   if (subject) {
     body.subject = subject === 'app' ? { type: 'app' } : { type: 'user' };
@@ -79,7 +66,6 @@ export async function token(
     body.scopes = flags['--scopes'].split(',').map(s => s.trim());
   }
 
-  // Attempt 1: simple token request
   output.spinner('Fetching token...');
   const result = await fetchToken(client, clientId, body);
   output.stopSpinner();
@@ -88,77 +74,73 @@ export async function token(
     return printTokenResult(client, result.data, asJson);
   }
 
-  // Check if auto-install/authorize is possible
   const errorCode = result.errorCode;
+  const errorMessage = result.errorMessage ?? 'Failed to get token';
+
   if (errorCode === 'not_found') {
     output.error('Client not found or Connex is not enabled for this team.');
     return 1;
   }
-  if (
-    errorCode !== 'no_valid_token' &&
-    errorCode !== 'client_installation_required'
-  ) {
-    output.error(result.errorMessage ?? 'Failed to get token');
-    return 1;
-  }
 
-  // Auto-install/authorize requires TTY
-  if (!client.stdin.isTTY) {
-    const action = errorCode === 'no_valid_token' ? 'authorize' : 'install';
+  if (errorCode === 'no_token') {
     output.error(
-      `${result.errorMessage}. Run \`vercel connex token ${clientId}\` interactively to ${action}.`
+      `${errorMessage} This client does not support getting a token for the requested subject.`
     );
     return 1;
   }
 
-  // Prompt user before opening browser (unless --yes)
-  const actionLabel =
-    errorCode === 'no_valid_token' ? 'Authorization' : 'Installation';
+  if (!isActionable(errorCode)) {
+    output.error(errorMessage);
+    return 1;
+  }
 
+  const teamId = client.config.currentTeam;
+  if (!teamId) {
+    output.error(
+      `${errorMessage} Unable to build recovery URL: no team resolved.`
+    );
+    return 1;
+  }
+
+  const actionLabel =
+    errorCode === 'user_authorization_required'
+      ? 'authorization'
+      : 'installation';
+
+  // Non-TTY: print URL and exit — can't open a browser interactively in CI
+  if (!client.stdin.isTTY) {
+    const { hash } = generateRequestCode();
+    const actionUrl = buildActionUrl(errorCode, clientId, teamId, hash);
+    output.error(errorMessage);
+    output.log(`To ${actionLabel}, open: ${actionUrl}`);
+    output.log(
+      `Or run \`vercel connex token ${clientId}\` in an interactive terminal.`
+    );
+    return 1;
+  }
+
+  // TTY: show error, prompt to open browser (Enter = yes)
+  output.error(errorMessage);
   if (!flags['--yes']) {
     const confirmed = await client.input.confirm(
-      `${actionLabel} required. Open browser to continue?`,
+      `Open browser to ${actionLabel}?`,
       true
     );
     if (!confirmed) {
-      output.log('Aborted.');
       return 0;
     }
   }
 
-  // Attempt 2: request with autoinstall + request_code
   const { original, hash } = generateRequestCode();
+  const actionUrl = buildActionUrl(errorCode, clientId, teamId, hash);
 
-  output.spinner('Setting up...');
-  const autoResult = await fetchTokenAutoInstall(client, clientId, body, hash);
-  output.stopSpinner();
-
-  if (!autoResult.ok) {
-    output.error(autoResult.errorMessage ?? 'Failed to initiate setup');
-    return 1;
-  }
-
-  // If the API returned a token directly (no action needed), we're done
-  if (autoResult.token) {
-    return printTokenResult(client, autoResult.token, asJson);
-  }
-
-  // Open browser for the action
-  if (!autoResult.url) {
-    output.error('Unexpected response: no action URL returned');
-    return 1;
-  }
-
-  output.log(`Opening browser for ${actionLabel.toLowerCase()}...`);
-  output.log(`If the browser doesn't open, visit:\n${autoResult.url}`);
-  open(autoResult.url).catch((err: unknown) =>
+  output.log(`Opening browser for ${actionLabel}...`);
+  output.log(`If the browser doesn't open, visit:\n${actionUrl}`);
+  open(actionUrl).catch((err: unknown) =>
     output.debug(`Failed to open browser: ${err}`)
   );
 
-  // Poll for result
-  output.spinner(
-    `Waiting for you to complete ${actionLabel.toLowerCase()} in the browser...`
-  );
+  output.spinner(`Waiting for ${actionLabel} to complete in the browser...`);
   const pollData = await awaitConnexResult(client, original);
   output.stopSpinner();
 
@@ -166,9 +148,9 @@ export async function token(
     return 1;
   }
 
-  // Retry token request with any returned installationId
+  // Carry forward installationId if returned by the install flow
   const retryBody = { ...body };
-  if (pollData.installationId) {
+  if (pollData.installationId && !retryBody.installationId) {
     retryBody.installationId = pollData.installationId as string;
   }
 
@@ -180,8 +162,31 @@ export async function token(
     return printTokenResult(client, retryResult.data, asJson);
   }
 
-  output.error(retryResult.errorMessage ?? 'Failed to get token after setup');
+  output.error(
+    retryResult.errorMessage ?? `Failed to get token after ${actionLabel}`
+  );
   return 1;
+}
+
+function isActionable(code: string | undefined): code is ActionableErrorCode {
+  return (
+    code === 'user_authorization_required' ||
+    code === 'client_installation_required'
+  );
+}
+
+function buildActionUrl(
+  code: ActionableErrorCode,
+  clientId: string,
+  teamId: string,
+  requestCodeHash: string
+): string {
+  const path = code === 'user_authorization_required' ? 'authorize' : 'install';
+  const params = new URLSearchParams({
+    teamId,
+    request_code: requestCodeHash,
+  });
+  return `https://vercel.com/api/v1/connex/${path}/${encodeURIComponent(clientId)}?${params.toString()}`;
 }
 
 function printTokenResult(
@@ -192,7 +197,6 @@ function printTokenResult(
   if (asJson) {
     client.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
   } else {
-    // Plain output: just the token value (pipeable)
     client.stdout.write(`${data.token}\n`);
   }
   return 0;
@@ -227,45 +231,12 @@ async function fetchToken(
   }
 }
 
-type AutoInstallResult =
-  | { ok: true; token?: ConnexTokenResponse; url?: string }
-  | { ok: false; errorMessage?: string };
-
-async function fetchTokenAutoInstall(
-  client: Client,
-  clientId: string,
-  body: Record<string, unknown>,
-  requestCodeHash: string
-): Promise<AutoInstallResult> {
-  try {
-    const res = await client.fetch<ConnexTokenResponse | AutoInstallResponse>(
-      `/v1/connex/token/${encodeURIComponent(clientId)}?autoinstall=true&request_code=${encodeURIComponent(requestCodeHash)}`,
-      {
-        method: 'POST',
-        body: JSON.stringify(body),
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
-
-    if (isAutoInstallResponse(res)) {
-      return { ok: true, url: res.url };
-    }
-
-    // API returned a token directly
-    return { ok: true, token: res as ConnexTokenResponse };
-  } catch (err: unknown) {
-    const serverError = extractApiError(err);
-    return { ok: false, errorMessage: serverError.message };
-  }
-}
-
 function extractApiError(err: unknown): {
   code?: string;
   message?: string;
 } {
   if (typeof err === 'object' && err !== null) {
     const errObj = err as Record<string, unknown>;
-    // client.fetch wraps API errors with serverMessage and code
     const code = typeof errObj.code === 'string' ? errObj.code : undefined;
     const message =
       typeof errObj.serverMessage === 'string'

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -43,9 +43,7 @@ export async function token(
 
   const clientId = args[0];
   if (!clientId) {
-    output.error(
-      'Missing client ID or UID. Usage: vercel connex token <clientIdOrUid>'
-    );
+    output.error('Missing client ID or UID. Usage: vercel connex token <id>');
     return 1;
   }
 
@@ -113,10 +111,9 @@ export async function token(
       ? 'authorization'
       : 'installation';
 
-  // Treat the session as interactive only if BOTH stdin and stdout are TTYs.
-  // `TOKEN=$(vc connex token ...)` leaves stdin as a TTY but captures stdout,
-  // so checking stdout too avoids blocking on a prompt in that case.
   const isInteractive = Boolean(client.stdin.isTTY && client.stdout.isTTY);
+  // Only open a browser + poll when the user asked for it (--yes) or when
+  // we're clearly in a human-driven session — otherwise fail fast.
   const attemptRecovery = Boolean(flags['--yes']) || isInteractive;
 
   if (!attemptRecovery) {
@@ -215,8 +212,6 @@ function printTokenResult(
   if (asJson) {
     client.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
   } else {
-    // Default output is the raw token value, safe for `TOKEN=$(vc connex token ...)`.
-    // Use --format=json to get structured metadata (expiresAt, installationId, etc.).
     client.stdout.write(`${data.token}\n`);
   }
   return 0;

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -210,13 +210,13 @@ function printTokenResult(
     ['Expires', formatExpiresAt(data.expiresAt)],
   ];
   if (data.installationId) {
-    rows.push(['Installation', data.installationId]);
+    rows.push(['Installation ID', data.installationId]);
   }
   if (data.tenantId) {
-    rows.push(['Tenant', data.tenantId]);
+    rows.push(['Tenant ID', data.tenantId]);
   }
   if (data.externalSubject) {
-    rows.push(['Subject', data.externalSubject]);
+    rows.push(['External ID', data.externalSubject]);
   }
   if (data.name) {
     rows.push(['Name', data.name]);

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -43,7 +43,9 @@ export async function token(
 
   const clientId = args[0];
   if (!clientId) {
-    output.error('Missing client ID. Usage: vercel connex token <clientId>');
+    output.error(
+      'Missing client ID or UID. Usage: vercel connex token <clientIdOrUid>'
+    );
     return 1;
   }
 
@@ -59,17 +61,15 @@ export async function token(
   if (subject === 'app') {
     body.subject = { type: 'app' };
   } else if (subject === 'user') {
-    const userId = client.authConfig.userId;
-    if (userId) {
-      body.subject = { type: 'user', id: userId };
-    }
-    // If userId is not available, omit subject and let the API default.
+    // selectConnexTeam → selectOrg → getUser populates authConfig.userId, so
+    // it's reliably available here for authenticated callers.
+    body.subject = { type: 'user', id: client.authConfig.userId };
   }
   if (flags['--installation-id']) {
     body.installationId = flags['--installation-id'];
   }
   if (flags['--scopes']) {
-    body.scopes = flags['--scopes'].split(',').map(s => s.trim());
+    body.scopes = parseScopes(flags['--scopes']);
   }
 
   output.spinner('Fetching token...');
@@ -113,19 +113,23 @@ export async function token(
       ? 'authorization'
       : 'installation';
 
-  // Non-TTY: print URL and exit — can't open a browser interactively in CI
-  if (!client.stdin.isTTY) {
+  // Treat the session as interactive only if BOTH stdin and stdout are TTYs.
+  // `TOKEN=$(vc connex token ...)` leaves stdin as a TTY but captures stdout,
+  // so checking stdout too avoids blocking on a prompt in that case.
+  const isInteractive = Boolean(client.stdin.isTTY && client.stdout.isTTY);
+  const attemptRecovery = Boolean(flags['--yes']) || isInteractive;
+
+  if (!attemptRecovery) {
     const { hash } = generateRequestCode();
     const actionUrl = buildActionUrl(errorCode, clientId, teamId, hash);
     output.error(errorMessage);
     output.log(`To ${actionLabel}, open: ${actionUrl}`);
     output.log(
-      `Or run \`vercel connex token ${clientId}\` in an interactive terminal.`
+      `Or re-run with --yes to open the browser automatically: vercel connex token ${clientId} --yes`
     );
     return 1;
   }
 
-  // TTY: show error, prompt to open browser (Enter = yes)
   output.error(errorMessage);
   if (!flags['--yes']) {
     const confirmed = await client.input.confirm(
@@ -154,7 +158,6 @@ export async function token(
     return 1;
   }
 
-  // Carry forward installationId if returned by the install flow
   const retryBody = { ...body };
   if (pollData.installationId && !retryBody.installationId) {
     retryBody.installationId = pollData.installationId as string;
@@ -172,6 +175,15 @@ export async function token(
     retryResult.errorMessage ?? `Failed to get token after ${actionLabel}`
   );
   return 1;
+}
+
+function parseScopes(raw: string): string[] {
+  // Accept either commas or whitespace as separators so users can paste
+  // scopes directly from provider docs (e.g., Slack uses space-separated).
+  return raw
+    .split(/[\s,]+/)
+    .map(s => s.trim())
+    .filter(Boolean);
 }
 
 function isActionable(code: string | undefined): code is ActionableErrorCode {
@@ -202,52 +214,12 @@ function printTokenResult(
 ): number {
   if (asJson) {
     client.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
-    return 0;
+  } else {
+    // Default output is the raw token value, safe for `TOKEN=$(vc connex token ...)`.
+    // Use --format=json to get structured metadata (expiresAt, installationId, etc.).
+    client.stdout.write(`${data.token}\n`);
   }
-
-  const rows: Array<[string, string]> = [
-    ['Token', data.token],
-    ['Expires', formatExpiresAt(data.expiresAt)],
-  ];
-  if (data.installationId) {
-    rows.push(['Installation ID', data.installationId]);
-  }
-  if (data.tenantId) {
-    rows.push(['Tenant ID', data.tenantId]);
-  }
-  if (data.externalSubject) {
-    rows.push(['External ID', data.externalSubject]);
-  }
-  if (data.name) {
-    rows.push(['Name', data.name]);
-  }
-
-  const labelWidth = Math.max(...rows.map(([label]) => label.length));
-  const lines = rows
-    .map(([label, value]) => `${label.padEnd(labelWidth)}  ${value}`)
-    .join('\n');
-  client.stdout.write(`${lines}\n`);
   return 0;
-}
-
-function formatExpiresAt(expiresAt: number): string {
-  // API returns seconds (matches frontend convention)
-  const date = new Date(expiresAt * 1000);
-  const iso = date.toISOString();
-  const deltaMs = date.getTime() - Date.now();
-  if (deltaMs <= 0) {
-    return `${iso} (expired)`;
-  }
-  const minutes = Math.round(deltaMs / 60000);
-  if (minutes < 60) {
-    return `${iso} (in ${minutes}m)`;
-  }
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) {
-    return `${iso} (in ${hours}h ${minutes % 60}m)`;
-  }
-  const days = Math.floor(hours / 24);
-  return `${iso} (in ${days}d)`;
 }
 
 type TokenResult =

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -196,10 +196,52 @@ function printTokenResult(
 ): number {
   if (asJson) {
     client.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
-  } else {
-    client.stdout.write(`${data.token}\n`);
+    return 0;
   }
+
+  const rows: Array<[string, string]> = [
+    ['Token', data.token],
+    ['Expires', formatExpiresAt(data.expiresAt)],
+  ];
+  if (data.installationId) {
+    rows.push(['Installation', data.installationId]);
+  }
+  if (data.tenantId) {
+    rows.push(['Tenant', data.tenantId]);
+  }
+  if (data.externalSubject) {
+    rows.push(['Subject', data.externalSubject]);
+  }
+  if (data.name) {
+    rows.push(['Name', data.name]);
+  }
+
+  const labelWidth = Math.max(...rows.map(([label]) => label.length));
+  const lines = rows
+    .map(([label, value]) => `${label.padEnd(labelWidth)}  ${value}`)
+    .join('\n');
+  client.stdout.write(`${lines}\n`);
   return 0;
+}
+
+function formatExpiresAt(expiresAt: number): string {
+  // API returns seconds (matches frontend convention)
+  const date = new Date(expiresAt * 1000);
+  const iso = date.toISOString();
+  const deltaMs = date.getTime() - Date.now();
+  if (deltaMs <= 0) {
+    return `${iso} (expired)`;
+  }
+  const minutes = Math.round(deltaMs / 60000);
+  if (minutes < 60) {
+    return `${iso} (in ${minutes}m)`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${iso} (in ${hours}h ${minutes % 60}m)`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${iso} (in ${days}d)`;
 }
 
 type TokenResult =

--- a/packages/cli/src/util/connex/request-code.ts
+++ b/packages/cli/src/util/connex/request-code.ts
@@ -14,14 +14,22 @@ const POLL_INTERVAL_MS = 2000;
 const MAX_POLL_DURATION_MS = 30 * 60 * 1000;
 const MAX_EARLY_404_COUNT = 3;
 
-export function generateRequestCode(): { original: string; hash: string } {
-  const original = randomBytes(37).toString('base64url');
-  const hash = createHash('sha256').update(original).digest('base64url');
-  return { original, hash };
+/**
+ * Generates a PKCE-like pair: `verifier` is the random secret kept by the
+ * CLI and used to poll for the result; `requestCode` is its SHA-256 hash
+ * sent to the API and used as the Redis lookup key.
+ */
+export function generateRequestCode(): {
+  verifier: string;
+  requestCode: string;
+} {
+  const verifier = randomBytes(37).toString('base64url');
+  const requestCode = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, requestCode };
 }
 
 /**
- * Polls `GET /v1/connex/result/{code}` until the request code resolves
+ * Polls `GET /v1/connex/result/{verifier}` until the request code resolves
  * to success or error, or the timeout is reached.
  *
  * Returns the result data on success, or null on failure (error is
@@ -29,7 +37,7 @@ export function generateRequestCode(): { original: string; hash: string } {
  */
 export async function awaitConnexResult(
   client: Client,
-  originalCode: string
+  verifier: string
 ): Promise<Record<string, unknown> | null> {
   const deadline = Date.now() + MAX_POLL_DURATION_MS;
   let early404Count = 0;
@@ -39,7 +47,7 @@ export async function awaitConnexResult(
     await sleep(POLL_INTERVAL_MS);
     try {
       const result = await client.fetch<ConnexResult>(
-        `/v1/connex/result/${encodeURIComponent(originalCode)}`
+        `/v1/connex/result/${encodeURIComponent(verifier)}`
       );
 
       if (result.status === 'success' && result.data) {

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -20,6 +20,13 @@ export class ConnexTelemetryClient
     });
   }
 
+  trackCliSubcommandToken(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'token',
+      value: actual,
+    });
+  }
+
   trackCliOptionLimit(v: number | undefined) {
     if (v !== undefined) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -806,6 +806,8 @@ exports[`help command > connex help output snapshots > connex help column width 
 
   create  type  Create a new Connex client                              
   list          List Connex clients for the current team                
+  token   id    Get a token for a Connex client (accepts a client ID    
+                like scl_abc or a UID like slack/my-bot)                
 
 
   Global Options:
@@ -833,6 +835,10 @@ exports[`help command > connex help output snapshots > connex help column width 
   - List Connex clients on the current team
 
     $ vercel connex list
+
+  - Get a token
+
+    $ vercel connex token scl_abc123
 
 "
 `;
@@ -881,6 +887,66 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
   - Output as JSON
 
     $ vercel connex list --format=json
+
+"
+`;
+
+exports[`help command > connex help output snapshots > connex token subcommand > connex token subcommand help column width 120 1`] = `
+"
+  ▲ vercel connex token id [options]
+
+  Get a token for a Connex client (accepts a client ID like scl_abc or a UID like slack/my-bot)                         
+
+  Options:
+
+  -F,  --format <FORMAT>       Specify the output format (json)                                                              
+       --installation-id <ID>  Target a specific installation (only useful with --subject app; defaults to the client's      
+                               default installation)                                                                         
+       --scopes <SCOPES>       Scopes (comma- or space-separated)                                                            
+  -s,  --subject <TYPE>        Subject type: "user" (default, acts on behalf of you) or "app" (uses the client's default     
+                               installation)                                                                                 
+  -y,  --yes                   Accept default value for all prompts                                                          
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Get a user token by client ID
+
+    $ vercel connex token scl_abc123
+
+  - Get a token by client UID
+
+    $ vercel connex token slack/my-bot
+
+  - Get an app token (default installation)
+
+    $ vercel connex token scl_abc123 --subject app
+
+  - Get an app token for a specific installation
+
+    $ vercel connex token scl_abc123 --subject app --installation-id inst_1
+
+  - Open the browser automatically if authorization/installation is required
+
+    $ vercel connex token scl_abc123 --yes
+
+  - Output as JSON (includes expiresAt, installationId, etc.)
+
+    $ vercel connex token scl_abc123 --format=json
 
 "
 `;

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -34,7 +34,7 @@ describe('connex token', () => {
     expect(exitCode).toBe(1);
   });
 
-  it('should return token on success', async () => {
+  it('should return token on success with labeled fields', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
       res.json({
         token: 'xoxb-test-token-123',
@@ -48,7 +48,7 @@ describe('connex token', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(0);
-    await expect(client.stdout).toOutput('xoxb-test-token-123');
+    await expect(client.stdout).toOutput('Token         xoxb-test-token-123');
   });
 
   it('should output JSON when --format=json is used', async () => {

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -1,0 +1,337 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import connex from '../../../../src/commands/connex';
+
+vi.mock('open', () => ({ default: vi.fn(() => Promise.resolve()) }));
+
+describe('connex token', () => {
+  let team: { id: string; slug: string };
+
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    team = useTeam();
+    client.config.currentTeam = team.id;
+  });
+
+  it('should error when no clientId argument is provided', async () => {
+    client.setArgv('connex', 'token');
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('Missing client ID');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should error with invalid --subject value', async () => {
+    client.setArgv('connex', 'token', 'scl_abc', '--subject', 'invalid');
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('Invalid --subject value');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should return token on success', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.json({
+        token: 'xoxb-test-token-123',
+        expiresAt: 1712345678,
+        installationId: 'inst_1',
+      });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    await expect(client.stdout).toOutput('xoxb-test-token-123');
+  });
+
+  it('should output JSON when --format=json is used', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.json({
+        token: 'xoxb-json-token',
+        expiresAt: 1712345678,
+        name: 'My Bot',
+        installationId: 'inst_1',
+      });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123', '--format=json');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    await expect(client.stdout).toOutput('"token": "xoxb-json-token"');
+  });
+
+  it('should pass subject and installationId in request body', async () => {
+    let requestBody: Record<string, unknown> = {};
+    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
+      requestBody = req.body;
+      res.json({ token: 'xoxb-app-token', expiresAt: 1712345678 });
+    });
+
+    client.setArgv(
+      'connex',
+      'token',
+      'scl_abc123',
+      '--subject',
+      'app',
+      '--installation-id',
+      'inst_42'
+    );
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestBody.subject).toEqual({ type: 'app' });
+    expect(requestBody.installationId).toBe('inst_42');
+  });
+
+  it('should pass scopes in request body', async () => {
+    let requestBody: Record<string, unknown> = {};
+    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
+      requestBody = req.body;
+      res.json({ token: 'xoxb-scoped', expiresAt: 1712345678 });
+    });
+
+    client.setArgv(
+      'connex',
+      'token',
+      'scl_abc123',
+      '--scopes',
+      'chat:write,channels:read'
+    );
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestBody.scopes).toEqual(['chat:write', 'channels:read']);
+  });
+
+  it('should show friendly error when connex feature flag is off (404)', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123');
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('Client not found');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should fail in non-TTY mode when auto-install is needed', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.statusCode = 404;
+      res.json({
+        error: {
+          code: 'client_installation_required',
+          message: 'Client installation is required',
+        },
+      });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123');
+    (client.stdin as any).isTTY = false;
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('install');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should fail in non-TTY mode when authorization is needed', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.statusCode = 404;
+      res.json({
+        error: {
+          code: 'no_valid_token',
+          message: 'User token is not valid',
+        },
+      });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123');
+    (client.stdin as any).isTTY = false;
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('authorize');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should auto-install when client_installation_required and --yes', async () => {
+    let postCount = 0;
+    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
+      postCount++;
+      const url = req.url ?? '';
+      if (postCount === 1) {
+        // First attempt: installation required
+        res.statusCode = 404;
+        res.json({
+          error: {
+            code: 'client_installation_required',
+            message: 'Client installation is required',
+          },
+        });
+      } else if (url.includes('autoinstall=true')) {
+        // Second attempt: return action URL
+        res.json({
+          action: 'install',
+          url: 'https://vercel.com/test/~/connex/install/scl_abc123',
+        });
+      } else {
+        // Third attempt: token after install
+        res.json({
+          token: 'xoxb-after-install',
+          expiresAt: 1712345678,
+          installationId: 'inst_new',
+        });
+      }
+    });
+
+    let pollCount = 0;
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      pollCount++;
+      if (pollCount < 2) {
+        res.json({ status: 'pending' });
+      } else {
+        res.json({
+          status: 'success',
+          data: { clientId: 'scl_abc123', installationId: 'inst_new' },
+        });
+      }
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123', '--yes');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(postCount).toBe(3);
+    await expect(client.stdout).toOutput('xoxb-after-install');
+  });
+
+  it('should auto-authorize when no_valid_token and --yes', async () => {
+    let postCount = 0;
+    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
+      postCount++;
+      const url = req.url ?? '';
+      if (postCount === 1) {
+        res.statusCode = 404;
+        res.json({
+          error: {
+            code: 'no_valid_token',
+            message: 'User token is not valid',
+          },
+        });
+      } else if (url.includes('autoinstall=true')) {
+        res.json({
+          action: 'authorize',
+          url: 'https://vercel.com/test/~/connex/authorize/scl_abc123',
+        });
+      } else {
+        res.json({
+          token: 'xoxp-after-auth',
+          expiresAt: 1712345678,
+        });
+      }
+    });
+
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      res.json({
+        status: 'success',
+        data: { clientId: 'scl_abc123' },
+      });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123', '--yes');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(postCount).toBe(3);
+    await expect(client.stdout).toOutput('xoxp-after-auth');
+  });
+
+  it('should handle autoinstall response that returns token directly', async () => {
+    let postCount = 0;
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      postCount++;
+      if (postCount === 1) {
+        res.statusCode = 404;
+        res.json({
+          error: {
+            code: 'client_installation_required',
+            message: 'Client installation is required',
+          },
+        });
+      } else {
+        // Autoinstall call returns a token directly
+        res.json({
+          token: 'xoxb-direct-token',
+          expiresAt: 1712345678,
+        });
+      }
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123', '--yes');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(postCount).toBe(2);
+    await expect(client.stdout).toOutput('xoxb-direct-token');
+  });
+
+  it('should abort when user declines the auto-install prompt', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.statusCode = 404;
+      res.json({
+        error: {
+          code: 'client_installation_required',
+          message: 'Client installation is required',
+        },
+      });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123');
+
+    const exitCodePromise = connex(client);
+
+    await expect(client.stderr).toOutput('Open browser');
+    client.stdin.write('n\n');
+
+    const exitCode = await exitCodePromise;
+
+    await expect(client.stderr).toOutput('Aborted');
+    expect(exitCode).toBe(0);
+  });
+
+  it('should handle generic API errors', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.statusCode = 500;
+      res.json({
+        error: {
+          code: 'internal_server_error',
+          message: 'Something went wrong',
+        },
+      });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123');
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('Something went wrong');
+    expect(exitCode).toBe(1);
+  });
+});

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -183,12 +183,12 @@ describe('connex token', () => {
     expect(exitCode).toBe(1);
   });
 
-  it('should handle no_token as terminal error', async () => {
+  it('should handle unresolved_token as terminal error', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
       res.statusCode = 422;
       res.json({
         error: {
-          code: 'no_token',
+          code: 'unresolved_token',
           message: 'No token available',
         },
       });
@@ -243,6 +243,28 @@ describe('connex token', () => {
 
     await expect(client.stderr).toOutput(
       'https://vercel.com/api/v1/connex/install/scl_abc123'
+    );
+    expect(exitCode).toBe(1);
+  });
+
+  it('should fail fast when client.nonInteractive is true, even with --yes', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.statusCode = 422;
+      res.json({
+        error: {
+          code: 'user_authorization_required',
+          message: 'User authorization required',
+        },
+      });
+    });
+
+    client.nonInteractive = true;
+    client.setArgv('connex', 'token', 'scl_abc123', '--yes');
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput(
+      'https://vercel.com/api/v1/connex/authorize/scl_abc123'
     );
     expect(exitCode).toBe(1);
   });

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -11,9 +11,10 @@ describe('connex token', () => {
 
   beforeEach(() => {
     client.reset();
-    useUser();
+    const user = useUser();
     team = useTeam();
     client.config.currentTeam = team.id;
+    client.authConfig.userId = user.id;
   });
 
   it('should error when no clientId argument is provided', async () => {
@@ -91,6 +92,39 @@ describe('connex token', () => {
     expect(exitCode).toBe(0);
     expect(requestBody.subject).toEqual({ type: 'app' });
     expect(requestBody.installationId).toBe('inst_42');
+  });
+
+  it('should include requester userId when --subject user', async () => {
+    let requestBody: Record<string, unknown> = {};
+    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
+      requestBody = req.body;
+      res.json({ token: 'xoxp-user-token', expiresAt: 1712345678 });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123', '--subject', 'user');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestBody.subject).toEqual({
+      type: 'user',
+      id: client.authConfig.userId,
+    });
+  });
+
+  it('should omit subject when no --subject flag is provided', async () => {
+    let requestBody: Record<string, unknown> = {};
+    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
+      requestBody = req.body;
+      res.json({ token: 'xoxp-default', expiresAt: 1712345678 });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123');
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestBody.subject).toBeUndefined();
   });
 
   it('should pass scopes in request body', async () => {

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -247,7 +247,7 @@ describe('connex token', () => {
     expect(exitCode).toBe(1);
   });
 
-  it('should fail fast when client.nonInteractive is true, even with --yes', async () => {
+  it('should fail fast when client.nonInteractive is true', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
       res.statusCode = 422;
       res.json({
@@ -259,7 +259,7 @@ describe('connex token', () => {
     });
 
     client.nonInteractive = true;
-    client.setArgv('connex', 'token', 'scl_abc123', '--yes');
+    client.setArgv('connex', 'token', 'scl_abc123');
 
     const exitCode = await connex(client);
 

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -49,7 +49,9 @@ describe('connex token', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(0);
-    await expect(client.stdout).toOutput('Token         xoxb-test-token-123');
+    await expect(client.stdout).toOutput(
+      `${'Token'.padEnd(15)}  xoxb-test-token-123`
+    );
   });
 
   it('should output JSON when --format=json is used', async () => {

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -114,7 +114,7 @@ describe('connex token', () => {
     expect(requestBody.scopes).toEqual(['chat:write', 'channels:read']);
   });
 
-  it('should show friendly error when connex feature flag is off (404)', async () => {
+  it('should show friendly error when client is not found (404)', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
       res.statusCode = 404;
       res.json({ error: { code: 'not_found', message: 'Not Found' } });
@@ -128,13 +128,54 @@ describe('connex token', () => {
     expect(exitCode).toBe(1);
   });
 
-  it('should fail in non-TTY mode when auto-install is needed', async () => {
+  it('should handle no_token as terminal error', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
-      res.statusCode = 404;
+      res.statusCode = 422;
+      res.json({
+        error: {
+          code: 'no_token',
+          message: 'No token available',
+        },
+      });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123');
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput('does not support');
+    expect(exitCode).toBe(1);
+  });
+
+  it('should print authorize URL in non-TTY mode', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.statusCode = 422;
+      res.json({
+        error: {
+          code: 'user_authorization_required',
+          message: 'User authorization required',
+        },
+      });
+    });
+
+    client.setArgv('connex', 'token', 'scl_abc123');
+    (client.stdin as any).isTTY = false;
+
+    const exitCode = await connex(client);
+
+    await expect(client.stderr).toOutput(
+      'https://vercel.com/api/v1/connex/authorize/scl_abc123'
+    );
+    expect(exitCode).toBe(1);
+  });
+
+  it('should print install URL in non-TTY mode', async () => {
+    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+      res.statusCode = 422;
       res.json({
         error: {
           code: 'client_installation_required',
-          message: 'Client installation is required',
+          message: 'Client installation required',
         },
       });
     });
@@ -144,99 +185,23 @@ describe('connex token', () => {
 
     const exitCode = await connex(client);
 
-    await expect(client.stderr).toOutput('install');
+    await expect(client.stderr).toOutput(
+      'https://vercel.com/api/v1/connex/install/scl_abc123'
+    );
     expect(exitCode).toBe(1);
   });
 
-  it('should fail in non-TTY mode when authorization is needed', async () => {
+  it('should auto-authorize when user_authorization_required and --yes', async () => {
+    let postCount = 0;
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
-      res.statusCode = 404;
-      res.json({
-        error: {
-          code: 'no_valid_token',
-          message: 'User token is not valid',
-        },
-      });
-    });
-
-    client.setArgv('connex', 'token', 'scl_abc123');
-    (client.stdin as any).isTTY = false;
-
-    const exitCode = await connex(client);
-
-    await expect(client.stderr).toOutput('authorize');
-    expect(exitCode).toBe(1);
-  });
-
-  it('should auto-install when client_installation_required and --yes', async () => {
-    let postCount = 0;
-    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
       postCount++;
-      const url = req.url ?? '';
       if (postCount === 1) {
-        // First attempt: installation required
-        res.statusCode = 404;
+        res.statusCode = 422;
         res.json({
           error: {
-            code: 'client_installation_required',
-            message: 'Client installation is required',
+            code: 'user_authorization_required',
+            message: 'User authorization required',
           },
-        });
-      } else if (url.includes('autoinstall=true')) {
-        // Second attempt: return action URL
-        res.json({
-          action: 'install',
-          url: 'https://vercel.com/test/~/connex/install/scl_abc123',
-        });
-      } else {
-        // Third attempt: token after install
-        res.json({
-          token: 'xoxb-after-install',
-          expiresAt: 1712345678,
-          installationId: 'inst_new',
-        });
-      }
-    });
-
-    let pollCount = 0;
-    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
-      pollCount++;
-      if (pollCount < 2) {
-        res.json({ status: 'pending' });
-      } else {
-        res.json({
-          status: 'success',
-          data: { clientId: 'scl_abc123', installationId: 'inst_new' },
-        });
-      }
-    });
-
-    client.setArgv('connex', 'token', 'scl_abc123', '--yes');
-
-    const exitCode = await connex(client);
-
-    expect(exitCode).toBe(0);
-    expect(postCount).toBe(3);
-    await expect(client.stdout).toOutput('xoxb-after-install');
-  });
-
-  it('should auto-authorize when no_valid_token and --yes', async () => {
-    let postCount = 0;
-    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
-      postCount++;
-      const url = req.url ?? '';
-      if (postCount === 1) {
-        res.statusCode = 404;
-        res.json({
-          error: {
-            code: 'no_valid_token',
-            message: 'User token is not valid',
-          },
-        });
-      } else if (url.includes('autoinstall=true')) {
-        res.json({
-          action: 'authorize',
-          url: 'https://vercel.com/test/~/connex/authorize/scl_abc123',
         });
       } else {
         res.json({
@@ -258,29 +223,38 @@ describe('connex token', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(0);
-    expect(postCount).toBe(3);
+    expect(postCount).toBe(2);
     await expect(client.stdout).toOutput('xoxp-after-auth');
   });
 
-  it('should handle autoinstall response that returns token directly', async () => {
+  it('should auto-install when client_installation_required and --yes, and carry forward installationId', async () => {
     let postCount = 0;
-    client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
+    let secondRequestBody: Record<string, unknown> = {};
+    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
       postCount++;
       if (postCount === 1) {
-        res.statusCode = 404;
+        res.statusCode = 422;
         res.json({
           error: {
             code: 'client_installation_required',
-            message: 'Client installation is required',
+            message: 'Client installation required',
           },
         });
       } else {
-        // Autoinstall call returns a token directly
+        secondRequestBody = req.body;
         res.json({
-          token: 'xoxb-direct-token',
+          token: 'xoxb-after-install',
           expiresAt: 1712345678,
+          installationId: 'inst_new',
         });
       }
+    });
+
+    client.scenario.get('/v1/connex/result/:code', (_req, res) => {
+      res.json({
+        status: 'success',
+        data: { clientId: 'scl_abc123', installationId: 'inst_new' },
+      });
     });
 
     client.setArgv('connex', 'token', 'scl_abc123', '--yes');
@@ -289,16 +263,17 @@ describe('connex token', () => {
 
     expect(exitCode).toBe(0);
     expect(postCount).toBe(2);
-    await expect(client.stdout).toOutput('xoxb-direct-token');
+    expect(secondRequestBody.installationId).toBe('inst_new');
+    await expect(client.stdout).toOutput('xoxb-after-install');
   });
 
-  it('should abort when user declines the auto-install prompt', async () => {
+  it('should abort cleanly when user declines the prompt', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
-      res.statusCode = 404;
+      res.statusCode = 422;
       res.json({
         error: {
           code: 'client_installation_required',
-          message: 'Client installation is required',
+          message: 'Client installation required',
         },
       });
     });
@@ -312,7 +287,6 @@ describe('connex token', () => {
 
     const exitCode = await exitCodePromise;
 
-    await expect(client.stderr).toOutput('Aborted');
     expect(exitCode).toBe(0);
   });
 

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -22,7 +22,7 @@ describe('connex token', () => {
 
     const exitCode = await connex(client);
 
-    await expect(client.stderr).toOutput('Missing client ID');
+    await expect(client.stderr).toOutput('Missing client ID or UID');
     expect(exitCode).toBe(1);
   });
 
@@ -35,7 +35,7 @@ describe('connex token', () => {
     expect(exitCode).toBe(1);
   });
 
-  it('should return token on success with labeled fields', async () => {
+  it('should print the raw token value in plain mode', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
       res.json({
         token: 'xoxb-test-token-123',
@@ -49,9 +49,7 @@ describe('connex token', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(0);
-    await expect(client.stdout).toOutput(
-      `${'Token'.padEnd(15)}  xoxb-test-token-123`
-    );
+    await expect(client.stdout).toOutput('xoxb-test-token-123\n');
   });
 
   it('should output JSON when --format=json is used', async () => {
@@ -129,7 +127,7 @@ describe('connex token', () => {
     expect(requestBody.subject).toBeUndefined();
   });
 
-  it('should pass scopes in request body', async () => {
+  it('should accept comma-separated scopes', async () => {
     let requestBody: Record<string, unknown> = {};
     client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
       requestBody = req.body;
@@ -142,6 +140,27 @@ describe('connex token', () => {
       'scl_abc123',
       '--scopes',
       'chat:write,channels:read'
+    );
+
+    const exitCode = await connex(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestBody.scopes).toEqual(['chat:write', 'channels:read']);
+  });
+
+  it('should accept space-separated scopes', async () => {
+    let requestBody: Record<string, unknown> = {};
+    client.scenario.post('/v1/connex/token/:clientId', (req, res) => {
+      requestBody = req.body;
+      res.json({ token: 'xoxb-scoped', expiresAt: 1712345678 });
+    });
+
+    client.setArgv(
+      'connex',
+      'token',
+      'scl_abc123',
+      '--scopes',
+      'chat:write channels:read'
     );
 
     const exitCode = await connex(client);
@@ -183,7 +202,7 @@ describe('connex token', () => {
     expect(exitCode).toBe(1);
   });
 
-  it('should print authorize URL in non-TTY mode', async () => {
+  it('should fail fast and print authorize URL when stdout is not a TTY', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
       res.statusCode = 422;
       res.json({
@@ -195,7 +214,8 @@ describe('connex token', () => {
     });
 
     client.setArgv('connex', 'token', 'scl_abc123');
-    (client.stdin as any).isTTY = false;
+    // Simulate `TOKEN=$(vc connex token ...)` — stdout captured, stdin is still a TTY
+    (client.stdout as any).isTTY = false;
 
     const exitCode = await connex(client);
 
@@ -205,7 +225,7 @@ describe('connex token', () => {
     expect(exitCode).toBe(1);
   });
 
-  it('should print install URL in non-TTY mode', async () => {
+  it('should fail fast and print install URL when stdin is not a TTY', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
       res.statusCode = 422;
       res.json({
@@ -303,7 +323,7 @@ describe('connex token', () => {
     await expect(client.stdout).toOutput('xoxb-after-install');
   });
 
-  it('should abort cleanly when user declines the prompt', async () => {
+  it('should prompt in fully interactive mode and abort cleanly when user declines', async () => {
     client.scenario.post('/v1/connex/token/:clientId', (_req, res) => {
       res.statusCode = 422;
       res.json({

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -450,6 +450,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('connex token subcommand', () => {
+      it('connex token subcommand help column width 120', () => {
+        expect(
+          help(connex.tokenSubcommand, {
+            columns: 120,
+            parent: connex.connexCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('integration help output snapshots', () => {


### PR DESCRIPTION
## Summary

Adds `vercel connex token <clientId>` subcommand that fetches a token for a Connex client via `POST /v1/connex/token/:clientId`. Gated behind `FF_CONNEX_ENABLED`

Supports flags:
- `--subject app|user` — token subject type
- `--installation-id <id>` — target a specific installation
- `--scopes <a,b,c>` — comma-separated scopes
- `--yes` — skip the interactive browser prompt
- `--format json` — machine-readable output

Plain output writes just the token to stdout (pipeable). JSON output writes the full response (`token`, `expiresAt`, `installationId`, etc.).

## Actionable error handling

The token endpoint (per [vercel/api#69012](https://github.com/vercel/api/pull/69012)) returns three distinct 422 codes when a token doesn't exist:

- `user_authorization_required` → open `/api/v1/connex/authorize/:clientId`
- `client_installation_required` → open `/api/v1/connex/install/:clientId`
- `no_token` → terminal (subject not supported for this client)

For the two actionable codes, the CLI:
1. Shows the error message
2. In TTY mode, prompts `Open browser to authorize? (Y/n)` — Enter accepts
3. Generates a request-code hash, constructs `https://vercel.com/api/v1/connex/{authorize|install}/:clientId?teamId=X&request_code=HASH`, opens the browser
4. Polls `GET /v1/connex/result/:code` until the user completes the flow
5. Re-runs `POST /v1/connex/token/:clientId` (carrying forward `installationId` from the install flow) and prints the resulting token

In non-TTY mode (CI), the URL is printed so the user can complete the action from a different shell and re-run the command.

## Test plan

- [x] `should error when no clientId argument is provided`
- [x] `should error with invalid --subject value`
- [x] `should return token on success`
- [x] `should output JSON when --format=json is used`
- [x] `should pass subject and installationId in request body`
- [x] `should pass scopes in request body`
- [x] `should show friendly error when client is not found (404)`
- [x] `should handle no_token as terminal error`
- [x] `should print authorize URL in non-TTY mode`
- [x] `should print install URL in non-TTY mode`
- [x] `should auto-authorize when user_authorization_required and --yes`
- [x] `should auto-install when client_installation_required and --yes, and carry forward installationId`
- [x] `should abort cleanly when user declines the prompt`
- [x] `should handle generic API errors`

Run: `npx vitest run packages/cli/test/unit/commands/connex/token.test.ts` — 14/14 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)