### PR TITLE
[CLI] fixing trailing /n issue with vc env add

### DIFF
--- a/.changeset/tiny-kings-yawn.md
+++ b/.changeset/tiny-kings-yawn.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+---
+
+Normalize single-line stdin env values by removing a trailing newline before
+saving them.

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -13,6 +13,7 @@ import { emoji, prependEmoji } from '../../util/emoji';
 import { isKnownError } from '../../util/env/known-error';
 import {
   getEnvKeyWarnings,
+  normalizeStdinEnvValue,
   removePublicPrefix,
   validateEnvValue,
 } from '../../util/env/validate-env';
@@ -524,7 +525,11 @@ export default async function add(client: Client, argv: string[]) {
   let envValue: string;
 
   if (stdInput) {
-    envValue = stdInput;
+    const normalizedStdinValue = normalizeStdinEnvValue(stdInput);
+    envValue = normalizedStdinValue.value;
+    if (normalizedStdinValue.strippedTrailingNewline) {
+      output.log('Removed trailing newline from stdin input');
+    }
   } else if (valueFromFlag !== undefined) {
     envValue = valueFromFlag;
   } else {

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -8,7 +8,10 @@ import readStandardInput from '../../util/input/read-standard-input';
 import param from '../../util/output/param';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { isKnownError } from '../../util/env/known-error';
-import { validateEnvValue } from '../../util/env/validate-env';
+import {
+  normalizeStdinEnvValue,
+  validateEnvValue,
+} from '../../util/env/validate-env';
 import formatEnvironments from '../../util/env/format-environments';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import { isAPIError } from '../../util/errors-ts';
@@ -354,7 +357,11 @@ export default async function update(client: Client, argv: string[]) {
   let envValue: string;
 
   if (stdInput) {
-    envValue = stdInput;
+    const normalizedStdinValue = normalizeStdinEnvValue(stdInput);
+    envValue = normalizedStdinValue.value;
+    if (normalizedStdinValue.strippedTrailingNewline) {
+      output.log('Removed trailing newline from stdin input');
+    }
   } else if (valueFromFlag !== undefined) {
     envValue = valueFromFlag;
   } else {

--- a/packages/cli/src/util/env/validate-env.ts
+++ b/packages/cli/src/util/env/validate-env.ts
@@ -114,6 +114,48 @@ export function trimValue(value: string): string {
   return value.replace(/\n$/, '').trim();
 }
 
+export interface NormalizeStdinEnvValueResult {
+  value: string;
+  strippedTrailingNewline: boolean;
+}
+
+/**
+ * Normalize a single trailing line ending from stdin when the payload is
+ * otherwise a single line. This preserves intentional multiline secrets while
+ * fixing the common `echo "secret" | vercel env add ...` case.
+ */
+export function normalizeStdinEnvValue(
+  value: string
+): NormalizeStdinEnvValueResult {
+  let valueWithoutTrailingNewline = value;
+
+  if (value.endsWith('\r\n')) {
+    valueWithoutTrailingNewline = value.slice(0, -2);
+  } else if (value.endsWith('\n')) {
+    valueWithoutTrailingNewline = value.slice(0, -1);
+  } else {
+    return {
+      value,
+      strippedTrailingNewline: false,
+    };
+  }
+
+  if (
+    valueWithoutTrailingNewline.includes('\n') ||
+    valueWithoutTrailingNewline.includes('\r')
+  ) {
+    return {
+      value,
+      strippedTrailingNewline: false,
+    };
+  }
+
+  return {
+    value: valueWithoutTrailingNewline,
+    strippedTrailingNewline: true,
+  };
+}
+
 /**
  * Returns the public prefix if the key starts with one, null otherwise.
  */

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -517,6 +517,34 @@ describe('env add', () => {
     });
 
     describe('non-interactive mode', () => {
+      it('strips a trailing newline from single-line stdin values', async () => {
+        const cwd = setupUnitFixture('vercel-env-pull');
+        client.cwd = cwd;
+        client.stdin.isTTY = false;
+        const envName = 'STDIN_SINGLE_LINE_TRIMMED';
+
+        try {
+          client.setArgv('env', 'add', envName, 'production');
+          const exitCodePromise = env(client);
+          setImmediate(() => client.stdin.emit('data', 'my-api-key\n'));
+
+          await expect(client.stderr).toOutput(
+            'Removed trailing newline from stdin input'
+          );
+          await expect(exitCodePromise).resolves.toBe(0);
+
+          const savedEnv = envs.find(currentEnv => currentEnv.key === envName);
+          expect(savedEnv?.value).toBe('my-api-key');
+        } finally {
+          const savedEnvIndex = envs.findIndex(
+            currentEnv => currentEnv.key === envName
+          );
+          if (savedEnvIndex !== -1) {
+            envs.splice(savedEnvIndex, 1);
+          }
+        }
+      });
+
       it('outputs action_required when name is missing', async () => {
         const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
           throw new Error('exit');

--- a/packages/cli/test/unit/util/env/validate-env.test.ts
+++ b/packages/cli/test/unit/util/env/validate-env.test.ts
@@ -4,6 +4,7 @@ import {
   getEnvKeyWarnings,
   formatWarnings,
   hasOnlyWhitespaceWarnings,
+  normalizeStdinEnvValue,
   trimValue,
   getPublicPrefix,
   removePublicPrefix,
@@ -660,6 +661,22 @@ describe('validate-env', () => {
 
       expect(opts.promptForValue).toHaveBeenCalledTimes(2);
       expect(result.finalValue).toBe('good');
+    });
+  });
+
+  describe('normalizeStdinEnvValue', () => {
+    it('strips a trailing newline from a single-line stdin value', () => {
+      expect(normalizeStdinEnvValue('my-api-key\n')).toEqual({
+        value: 'my-api-key',
+        strippedTrailingNewline: true,
+      });
+    });
+
+    it('preserves multiline stdin values', () => {
+      expect(normalizeStdinEnvValue('line1\nline2\n')).toEqual({
+        value: 'line1\nline2\n',
+        strippedTrailingNewline: false,
+      });
     });
   });
 });


### PR DESCRIPTION
This is addressing issue #14371 
There was already a partial solution implemented but not fully complete. Normalized piped stdin for vercel env add/env update so a single trailing newline from echo gets stripped before saving, and print a small notice when that happens.
Multiline stdin values are left alone.

Tests cover the exact regression case for env add and the helper behavior for both “strip single-line trailing newline” and “preserve multiline input.”