### PR TITLE
[python] Skip the --python flag when running uv venv in vercel dev

### DIFF
--- a/.changeset/six-ears-switch.md
+++ b/.changeset/six-ears-switch.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Don't pass --python 3.0 to uv venv when running vc dev

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -57,8 +57,8 @@ interface PythonDependencyExternalizerOptions {
   uvLockPath: string | null;
   uvProjectDir: string | null;
   projectName: string | undefined;
-  pythonMajor: number;
-  pythonMinor: number;
+  pythonMajor: number | undefined;
+  pythonMinor: number | undefined;
   pythonPath: string;
   hasCustomCommand: boolean;
   alwaysBundlePackages?: string[];
@@ -77,8 +77,8 @@ export class PythonDependencyExternalizer {
   private uvLockPath: string | null;
   private uvProjectDir: string | null;
   private projectName: string | undefined;
-  private pythonMajor: number;
-  private pythonMinor: number;
+  private pythonMajor: number | undefined;
+  private pythonMinor: number | undefined;
   private pythonPath: string;
   private hasCustomCommand: boolean;
   private alwaysBundlePackages: string[];
@@ -541,6 +541,12 @@ export class PythonDependencyExternalizer {
     publicPackageNames: string[]
   ): Promise<string[]> {
     const platform = detectPlatform();
+
+    // Skip wheel-compat filtering in dev; the bundle isn't deployed.
+    if (this.pythonMajor === undefined || this.pythonMinor === undefined) {
+      debug('Skipping wheel compatibility check: dev mode');
+      return [];
+    }
 
     // Determine which packages are actually reachable on the target platform
     // by traversing the dependency graph and evaluating environment markers.

--- a/packages/python/src/diagnostics.ts
+++ b/packages/python/src/diagnostics.ts
@@ -88,7 +88,7 @@ export async function generateProjectManifest({
   pythonVersion: PythonVersion;
   uvLockPath: string;
 }): Promise<void> {
-  const resolved = pythonVersionString(pythonVersion);
+  const resolved = pythonVersionString(pythonVersion) ?? '';
   const constraint = pythonPackage.requiresPython?.[0];
   const requested = constraint?.specifier;
 

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -794,8 +794,9 @@ from vercel_runtime.vc_init import vc_handler
   });
 
   // Write project manifest for diagnostics (best-effort, never fails the build).
-  // Requires uv.lock to resolve versions and dependency graph.
-  if (uvLockPath) {
+  // Requires uv.lock to resolve versions and dependency graph.  Skipped in
+  // `vercel dev` since the CLI only reads the manifest in `vercel build`.
+  if (uvLockPath && !meta.isDev) {
     try {
       await generateProjectManifest({
         workPath,

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -305,20 +305,19 @@ export const build: BuildVX = async ({
         rootDir,
       });
       versionSpan.setAttributes({
-        'python.version': pythonVersionString(resolution.pythonVersion),
+        'python.version':
+          pythonVersionString(resolution.pythonVersion) ?? 'unknown',
         'python.versionSource': resolution.versionSource,
       });
       return resolution;
     });
 
   if (pinVersionFilePath) {
-    console.log(
-      `Writing .python-version file with version ${pythonVersionString(pythonVersion)}`
-    );
-    await writeFile(
-      pinVersionFilePath,
-      `${pythonVersionString(pythonVersion)}\n`
-    );
+    const versionToPin = pythonVersionString(pythonVersion);
+    if (versionToPin) {
+      console.log(`Writing .python-version file with version ${versionToPin}`);
+      await writeFile(pinVersionFilePath, `${versionToPin}\n`);
+    }
   }
 
   // Create a virtual environment so dependencies can be installed via

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -240,7 +240,7 @@ interface EnsureUvProjectParams {
   rootDir: string;
   venvPath: string;
   pythonPackage: PythonPackage;
-  pythonVersion: string;
+  pythonVersion: string | undefined;
   uv: UvRunner;
   /**
    * When true, generate lock files with --no-build --upgrade to ensure
@@ -325,7 +325,7 @@ export async function ensureUvProject({
       // so that `uv lock` and `uv sync` agree on the Python constraint.
       // For converted manifests the original constraint (e.g. from Pipfile.lock)
       // may specify an older version that the builder has auto-upgraded.
-      if (manifest.data.project) {
+      if (manifest.data.project && pythonVersion !== undefined) {
         manifest.data.project['requires-python'] = `~=${pythonVersion}.0`;
       }
       const content = stringifyManifest(manifest.data);
@@ -361,7 +361,10 @@ export async function ensureUvProject({
       'No Python manifest found; creating an empty pyproject.toml and uv.lock...'
     );
 
-    const requiresPython = `~=${pythonVersion}.0`;
+    const requiresPython =
+      pythonVersion !== undefined
+        ? `~=${pythonVersion}.0`
+        : `>=${DEFAULT_PYTHON_VERSION_STRING}`;
     const minimalManifest = createMinimalManifest({
       name: 'app',
       requiresPython,

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -134,12 +134,7 @@ export async function ensureVenv({
     // --seed installs pip into the venv so custom install commands can use it
     const args = ['venv', venvPath, '--allow-existing', '--seed'];
     if (pythonVersion.major != null && pythonVersion.minor != null) {
-      // dev python passes 3.0 which uv interprets as python3.0, so pass "python3" instead of "python3.0" in that case
-      if (pythonVersion.minor < 0) {
-        args.push('--python', `python${pythonVersion.major}`);
-      } else {
-        args.push('--python', `${pythonVersion.major}.${pythonVersion.minor}`);
-      }
+      args.push('--python', `${pythonVersion.major}.${pythonVersion.minor}`);
     }
     await execa(uvPath, args, {
       env: getProtectedUvEnv(process.env, uvCacheDir),

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -133,9 +133,13 @@ export async function ensureVenv({
     // --allow-existing allows uv to reuse a cached venv
     // --seed installs pip into the venv so custom install commands can use it
     const args = ['venv', venvPath, '--allow-existing', '--seed'];
-    // vc dev uses system python so we skip passing the python version to uv
     if (pythonVersion.major != null && pythonVersion.minor != null) {
-      args.push('--python', `${pythonVersion.major}.${pythonVersion.minor}`);
+      // dev python passes 3.0 which uv interprets as python3.0, so pass "python3" instead of "python3.0" in that case
+      if (pythonVersion.minor === 0) {
+        args.push('--python', `python${pythonVersion.major}`);
+      } else {
+        args.push('--python', `${pythonVersion.major}.${pythonVersion.minor}`);
+      }
     }
     await execa(uvPath, args, {
       env: getProtectedUvEnv(process.env, uvCacheDir),

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -135,7 +135,7 @@ export async function ensureVenv({
     const args = ['venv', venvPath, '--allow-existing', '--seed'];
     if (pythonVersion.major != null && pythonVersion.minor != null) {
       // dev python passes 3.0 which uv interprets as python3.0, so pass "python3" instead of "python3.0" in that case
-      if (pythonVersion.minor === 0) {
+      if (pythonVersion.minor < 0) {
         args.push('--python', `python${pythonVersion.major}`);
       } else {
         args.push('--python', `${pythonVersion.major}.${pythonVersion.minor}`);

--- a/packages/python/src/version.ts
+++ b/packages/python/src/version.ts
@@ -7,8 +7,9 @@ import { UvRunner, findUvInPath, UV_PYTHON_PATH_PREFIX } from './uv';
 import { detectPlatform } from './utils';
 
 export interface PythonVersion {
-  major: number;
-  minor: number;
+  // Undefined in `vercel dev` where we defer to the system `python3`.
+  major?: number;
+  minor?: number;
   pipPath: string;
   pythonPath: string;
   runtime: string;
@@ -29,14 +30,15 @@ export interface PythonVersionResolution {
   pinVersionFilePath?: string;
 }
 
-export function pythonVersionString(pv: PythonVersion): string {
+export function pythonVersionString(pv: PythonVersion): string | undefined {
+  if (pv.major === undefined || pv.minor === undefined) return undefined;
   return `${pv.major}.${pv.minor}`;
 }
 
 const DEFAULT_PYTHON_VERSION: PythonVersion = makePythonVersion(3, 12);
-export const DEFAULT_PYTHON_VERSION_STRING = pythonVersionString(
+export const DEFAULT_PYTHON_VERSION_STRING: string = pythonVersionString(
   DEFAULT_PYTHON_VERSION
-);
+)!;
 
 function makePythonVersion(
   major: number,
@@ -65,11 +67,10 @@ const allOptions: PythonVersion[] = [
 ];
 
 function getDevPythonVersion(): PythonVersion {
-  // Use the system-installed version of `python3` when running `vercel dev`.
-  // minor is set to 0 as a placeholder — it is not used in dev mode.
+  // Omitting major/minor lets uv resolve the interpreter via its own
+  // chain (`.python-version`, managed default, system `python3`) instead
+  // of the old `--python 3.0` placeholder that uv >= 0.10.11 rejects.
   return {
-    major: 3,
-    minor: -1,
     pipPath: 'pip3',
     pythonPath: 'python3',
     runtime: 'python3',
@@ -113,14 +114,18 @@ function versionsEqual(a: PythonVersion, b: PythonVersion): boolean {
 }
 
 function versionLessOrEqual(a: PythonVersion, b: PythonVersion): boolean {
-  if (a.major !== b.major) return a.major < b.major;
-  return a.minor <= b.minor;
+  const am = a.major ?? 0;
+  const bm = b.major ?? 0;
+  if (am !== bm) return am < bm;
+  return (a.minor ?? 0) <= (b.minor ?? 0);
 }
 
-/**
- * Convert a local PythonVersion entry to a python-analysis PythonBuild.
- */
 function toPythonBuild(opt: PythonVersion): PythonBuild {
+  if (opt.major === undefined || opt.minor === undefined) {
+    throw new Error(
+      'toPythonBuild called with PythonVersion missing `major`/`minor`; this is a bug.'
+    );
+  }
   const platform = detectPlatform();
   return {
     version: { major: opt.major, minor: opt.minor },
@@ -334,9 +339,11 @@ export function getInstalledPythonsFromFilesystem(
 ): Set<string> {
   const result = new Set<string>();
   for (const opt of allOptions) {
-    const binPath = join(basePath, 'bin', `python${opt.major}.${opt.minor}`);
+    const version = pythonVersionString(opt);
+    if (!version) continue;
+    const binPath = join(basePath, 'bin', `python${version}`);
     if (existsSync(binPath)) {
-      result.add(pythonVersionString(opt));
+      result.add(version);
     }
   }
   return result;
@@ -377,7 +384,9 @@ export function resetInstalledPythonsCache(): void {
 function isInstalled(pv: PythonVersion): boolean {
   try {
     const installed = getInstalledPythons();
-    return installed.has(pythonVersionString(pv));
+    const version = pythonVersionString(pv);
+    if (!version) return false;
+    return installed.has(version);
   } catch (err) {
     throw new NowBuildError({
       code: 'UV_ERROR',

--- a/packages/python/src/version.ts
+++ b/packages/python/src/version.ts
@@ -69,7 +69,7 @@ function getDevPythonVersion(): PythonVersion {
   // minor is set to 0 as a placeholder — it is not used in dev mode.
   return {
     major: 3,
-    minor: 0,
+    minor: -1,
     pipPath: 'pip3',
     pythonPath: 'python3',
     runtime: 'python3',

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -298,25 +298,23 @@ it('should only match supported versions, otherwise throw an error', () => {
   expect(result).toHaveProperty('runtime', 'python3.9');
 });
 
-it('should ignore minor version in vercel dev', () => {
-  expect(
-    selectVersion({
-      constraints: [makeConstraint('3.9', 'Pipfile.lock')],
+it('defers to system python3 in vercel dev, regardless of declared version', () => {
+  for (const constraint of ['3.9', '3.6', '999']) {
+    const { pythonVersion } = selectVersion({
+      constraints: [makeConstraint(constraint, 'Pipfile.lock')],
       isDev: true,
-    }).pythonVersion
-  ).toHaveProperty('runtime', 'python3');
-  expect(
-    selectVersion({
-      constraints: [makeConstraint('3.6', 'Pipfile.lock')],
-      isDev: true,
-    }).pythonVersion
-  ).toHaveProperty('runtime', 'python3');
-  expect(
-    selectVersion({
-      constraints: [makeConstraint('999', 'Pipfile.lock')],
-      isDev: true,
-    }).pythonVersion
-  ).toHaveProperty('runtime', 'python3');
+    });
+    expect(pythonVersion).toMatchObject({
+      runtime: 'python3',
+      pythonPath: 'python3',
+      pipPath: 'pip3',
+    });
+    // Dev mode must leave `major` and `minor` undefined so every
+    // downstream `!= null` guard (ensureVenv, ensureUvProject, cached-
+    // venv invalidation) correctly skips version-sensitive logic.
+    expect(pythonVersion.major).toBeUndefined();
+    expect(pythonVersion.minor).toBeUndefined();
+  }
   expect(warningMessages).toStrictEqual([]);
 });
 
@@ -3399,5 +3397,76 @@ describe('UV_PYTHON_DOWNLOADS environment variable protection', () => {
       expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
       expect(env.UV_CACHE_DIR).toBe(cacheDir);
     });
+  });
+});
+
+describe('ensureVenv uv invocation', () => {
+  // The top-level `vi.mock('../src/utils', ...)` replaces `ensureVenv` with
+  // a no-op for build-pipeline tests.  This suite needs the real
+  // implementation, so it resets modules and unmocks `../src/utils` before
+  // re-importing.
+  let mockExeca: ReturnType<typeof vi.fn>;
+  let ensureVenvReal: typeof import('../src/utils').ensureVenv;
+  let venvDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockExeca = vi.fn(async () => ({ stdout: '' }) as any);
+    vi.doMock('execa', () => ({ default: mockExeca }));
+    vi.doUnmock('../src/utils');
+    ({ ensureVenv: ensureVenvReal } = await import('../src/utils'));
+    venvDir = path.join(
+      tmpdir(),
+      `vc-test-ensure-venv-${Math.floor(Math.random() * 1e6)}`
+    );
+  });
+
+  afterEach(() => {
+    vi.doUnmock('execa');
+    if (fs.existsSync(venvDir)) {
+      fs.removeSync(venvDir);
+    }
+  });
+
+  it('omits --python when major/minor are undefined (vercel dev)', async () => {
+    // Simulates `getDevPythonVersion()` which now leaves major/minor
+    // undefined so uv resolves the interpreter via its own chain
+    // (`.python-version`, managed default, system `python3`).  uv >= 0.10.11
+    // rejects `--python 3.0`, so passing no `--python` here is required.
+    await ensureVenvReal({
+      pythonVersion: { pythonPath: 'python3' },
+      venvPath: venvDir,
+      uvPath: '/mock/uv',
+    });
+
+    expect(mockExeca).toHaveBeenCalledTimes(1);
+    const [cmd, args] = mockExeca.mock.calls[0];
+    expect(cmd).toBe('/mock/uv');
+    expect(args).toEqual(['venv', venvDir, '--allow-existing', '--seed']);
+    expect(args).not.toContain('--python');
+  });
+
+  it('passes --python <major>.<minor> for a pinned production version', async () => {
+    await ensureVenvReal({
+      pythonVersion: {
+        pythonPath: 'python3.12',
+        major: 3,
+        minor: 12,
+      },
+      venvPath: venvDir,
+      uvPath: '/mock/uv',
+    });
+
+    expect(mockExeca).toHaveBeenCalledTimes(1);
+    const [cmd, args] = mockExeca.mock.calls[0];
+    expect(cmd).toBe('/mock/uv');
+    expect(args).toEqual([
+      'venv',
+      venvDir,
+      '--allow-existing',
+      '--seed',
+      '--python',
+      '3.12',
+    ]);
   });
 });


### PR DESCRIPTION
In #15634 I added the `--python` flag to `ensureVenv` so that changes to python versions would correctly update the cached venv. This introduced a bug #16014. This PR addresses the bug by removing the python major and minor versions in `getDevPythonVersion()`.