### PR TITLE
feat(cli): `env add` sensitive by default for Production and Preview

### DIFF
--- a/.changeset/env-add-sensitive-by-default.md
+++ b/.changeset/env-add-sensitive-by-default.md
@@ -16,6 +16,6 @@ Flag summary:
 - `--no-sensitive`: new; opt out of the new default for Production/Preview.
 - `--sensitive --no-sensitive` together: errors.
 
-On teams that enable the "Enforce Sensitive Environment Variables" policy in team settings, the CLI now reads the policy from the team object and notes in the output that the policy is active; the server already promotes Production/Preview variables to sensitive silently, and the CLI's own logs are now honest about it.
+On teams that enable the "Enforce Sensitive Environment Variables" policy in team settings, the CLI now reads the policy from the team object and notes in the output that the policy is active; the server already promotes Production/Preview variables to sensitive silently, and the CLI's own logs are now honest about it. Passing `--no-sensitive` on a policy-on team for Production/Preview now emits a warning — the flag is a no-op because the server promotes the variable regardless — and the CLI sends `type: 'sensitive'` so its own `--debug` output matches what gets stored.
 
 The interactive prompt (`Make it sensitive?`) still fires when you don't pass `--sensitive` or `--no-sensitive`, the targets include Production or Preview, and the team policy is not enforcing. It defaults to yes.

--- a/.changeset/env-add-sensitive-by-default.md
+++ b/.changeset/env-add-sensitive-by-default.md
@@ -1,7 +1,21 @@
 ---
-'vercel': patch
+'vercel': minor
 ---
 
-`vercel env add` now defaults the interactive sensitivity prompt to sensitive. When you are prompted during `vercel env add`, the question is `Make it sensitive? (Y/n)` with a default of yes, and a one-line reminder is printed beforehand that sensitive values cannot be retrieved later.
+`vercel env add` now defaults Environment Variables to **sensitive** on Production and Preview. Sensitive values are encrypted at rest and cannot be retrieved later via the dashboard or CLI; they are still resolved for builds, deployments, `vercel env pull`, and runtime.
 
-All flag behavior is unchanged: the default type when `--sensitive` is not passed is still `encrypted`, and passing `--sensitive` continues to explicitly create a sensitive variable without prompting.
+Behavior per target:
+
+- **Production** or **Preview**: defaults to `sensitive`. Pass `--no-sensitive` to opt back in to the previous `encrypted` behavior (value remains readable later).
+- **Development**: always stored as `encrypted` (sensitive is not supported by the Vercel API for Development). Passing `--sensitive` alongside a Development target now errors up-front instead of silently falling back.
+- **Mixed selection** (e.g., interactive checkbox picks `production + preview + development`): saved as two records — one `sensitive` for Production/Preview and one `encrypted` for Development.
+
+Flag summary:
+
+- `--sensitive`: unchanged in meaning (request a sensitive variable); now errors when combined with Development.
+- `--no-sensitive`: new; opt out of the new default for Production/Preview.
+- `--sensitive --no-sensitive` together: errors.
+
+On teams that enable the "Enforce Sensitive Environment Variables" policy in team settings, the CLI now reads the policy from the team object and notes in the output that the policy is active; the server already promotes Production/Preview variables to sensitive silently, and the CLI's own logs are now honest about it.
+
+The interactive prompt (`Make it sensitive?`) still fires when you don't pass `--sensitive` or `--no-sensitive`, the targets include Production or Preview, and the team policy is not enforcing. It defaults to yes.

--- a/.changeset/env-add-sensitive-by-default.md
+++ b/.changeset/env-add-sensitive-by-default.md
@@ -1,13 +1,7 @@
 ---
-'vercel': minor
+'vercel': patch
 ---
 
-`vercel env add` now creates Environment Variables as sensitive by default. Sensitive values are encrypted at rest and cannot be retrieved later via the dashboard or `vercel env ls`; they are still resolved for builds, deployments, `vercel env pull`, and runtime.
+`vercel env add` now defaults the interactive sensitivity prompt to sensitive. When you are prompted during `vercel env add`, the question is `Keep it sensitive? (Y/n)` with a default of yes, and a one-line reminder is printed beforehand that sensitive values cannot be retrieved later.
 
-Pass `--no-sensitive` to opt out and create a regular (encrypted) Environment Variable whose value remains readable later.
-
-The existing `--sensitive` flag is now deprecated (it is a no-op since sensitive is the default) and prints a deprecation warning. `--force` continues to overwrite an existing variable and, like any other `env add`, defaults to sensitive unless `--no-sensitive` is passed.
-
-The interactive prompt is retained but inverted: "Keep it sensitive?" defaults to yes, and the user can still opt out by answering no.
-
-`vercel env update` is unchanged — it still preserves the existing type unless `--sensitive` is passed.
+All flag behavior is unchanged: the default type when `--sensitive` is not passed is still `encrypted`, and passing `--sensitive` continues to explicitly create a sensitive variable without prompting.

--- a/.changeset/env-add-sensitive-by-default.md
+++ b/.changeset/env-add-sensitive-by-default.md
@@ -2,6 +2,6 @@
 'vercel': patch
 ---
 
-`vercel env add` now defaults the interactive sensitivity prompt to sensitive. When you are prompted during `vercel env add`, the question is `Keep it sensitive? (Y/n)` with a default of yes, and a one-line reminder is printed beforehand that sensitive values cannot be retrieved later.
+`vercel env add` now defaults the interactive sensitivity prompt to sensitive. When you are prompted during `vercel env add`, the question is `Make it sensitive? (Y/n)` with a default of yes, and a one-line reminder is printed beforehand that sensitive values cannot be retrieved later.
 
 All flag behavior is unchanged: the default type when `--sensitive` is not passed is still `encrypted`, and passing `--sensitive` continues to explicitly create a sensitive variable without prompting.

--- a/.changeset/env-add-sensitive-by-default.md
+++ b/.changeset/env-add-sensitive-by-default.md
@@ -1,0 +1,13 @@
+---
+'vercel': minor
+---
+
+`vercel env add` now creates Environment Variables as sensitive by default. Sensitive values are encrypted at rest and cannot be retrieved later via the dashboard or `vercel env ls`; they are still resolved for builds, deployments, `vercel env pull`, and runtime.
+
+Pass `--no-sensitive` to opt out and create a regular (encrypted) Environment Variable whose value remains readable later.
+
+The existing `--sensitive` flag is now deprecated (it is a no-op since sensitive is the default) and prints a deprecation warning. `--force` continues to overwrite an existing variable and, like any other `env add`, defaults to sensitive unless `--no-sensitive` is passed.
+
+The interactive prompt is retained but inverted: "Keep it sensitive?" defaults to yes, and the user can still opt out by answering no.
+
+`vercel env update` is unchanged — it still preserves the existing type unless `--sensitive` is passed.

--- a/.changeset/env-add-sensitive-by-default.md
+++ b/.changeset/env-add-sensitive-by-default.md
@@ -8,7 +8,7 @@ Behavior per target:
 
 - **Production** or **Preview**: defaults to `sensitive`. Pass `--no-sensitive` to opt back in to the previous `encrypted` behavior (value remains readable later).
 - **Development**: always stored as `encrypted` (sensitive is not supported by the Vercel API for Development). Passing `--sensitive` alongside a Development target now errors up-front instead of silently falling back.
-- **Mixed selection** (e.g., interactive checkbox picks `production + preview + development`): saved as two records — one `sensitive` for Production/Preview and one `encrypted` for Development.
+- **Mixed selection** (e.g., interactive checkbox picks `production + preview + development`): errors and asks you to run `vercel env add` separately for Development, because Development cannot share a record type with Production/Preview.
 
 Flag summary:
 

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -101,6 +101,12 @@ export interface Team {
       state: string;
     };
   };
+  /**
+   * Team-wide policy for enforcing sensitive Environment Variables.
+   * When set to "on", the API silently promotes `encrypted` Production and
+   * Preview Environment Variables to `sensitive` on create.
+   */
+  sensitiveEnvironmentVariablePolicy?: 'default' | 'on' | 'off';
 }
 
 export type Domain = {

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -700,7 +700,7 @@ export default async function add(client: Client, argv: string[]) {
   const hasSensitiveCapable = envTargets.some(t => t !== 'development');
 
   if (policyOn && hasDevelopment) {
-    const msg = `Your team requires sensitive Environment Variables and the Development Environment does not support sensitive values.`;
+    const msg = `Your team has enabled the Sensitive Environment Variables Policy and the Development Environment does not support sensitive values. https://vercel.com/docs/environment-variables/sensitive-environment-variables#environment-variables-policy`;
     if (client.nonInteractive) {
       outputAgentError(
         client,

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -548,11 +548,11 @@ export default async function add(client: Client, argv: string[]) {
       output.log(
         `Sensitive values cannot be retrieved later from the dashboard or CLI.`
       );
-      const keepSensitive = await client.input.confirm(
-        `Keep it sensitive?`,
+      const makeSensitive = await client.input.confirm(
+        `Make it sensitive?`,
         true
       );
-      if (keepSensitive) {
+      if (makeSensitive) {
         type = 'sensitive';
       }
     }

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -28,6 +28,7 @@ import { addSubcommand } from './command';
 import { getLinkedProject } from '../../util/projects/link';
 import { determineAgent } from '@vercel/detect-agent';
 import { suggestNextCommands } from '../../util/suggest-next-commands';
+import getTeamById from '../../util/teams/get-team-by-id';
 import {
   outputActionRequired,
   outputAgentError,
@@ -35,6 +36,29 @@ import {
   buildEnvAddCommandWithPreservedArgs,
   getPreservedArgsForEnvAdd,
 } from '../../util/agent-output';
+
+type EnvType = 'encrypted' | 'sensitive';
+
+/**
+ * Per-target type resolution. The server silently promotes encrypted → sensitive
+ * on policy-on teams for Production/Preview, and rejects sensitive on Development.
+ * We mirror that server contract client-side so output and logs are honest.
+ */
+function resolveTypeForTarget(
+  target: string,
+  opts: { forceSensitive: boolean; forceEncrypted: boolean; policyOn: boolean }
+): EnvType {
+  if (target === 'development') {
+    // Development never supports sensitive; caller is expected to have already
+    // rejected --sensitive when only development is selected.
+    return 'encrypted';
+  }
+  if (opts.forceEncrypted) return 'encrypted';
+  if (opts.forceSensitive) return 'sensitive';
+  if (opts.policyOn) return 'sensitive';
+  // Default for Production/Preview/custom environments.
+  return 'sensitive';
+}
 
 /**
  * For use in suggested "next" commands: escapes a value for shell if it contains spaces or quotes.
@@ -108,6 +132,7 @@ export default async function add(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliOptionValue(opts['--value']);
   telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
+  telemetryClient.trackCliFlagNoSensitive(opts['--no-sensitive']);
   telemetryClient.trackCliFlagForce(opts['--force']);
   telemetryClient.trackCliFlagGuidance(opts['--guidance']);
   telemetryClient.trackCliFlagYes(opts['--yes']);
@@ -518,9 +543,28 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
-  let type: 'encrypted' | 'sensitive' = opts['--sensitive']
-    ? 'sensitive'
-    : 'encrypted';
+  const forceSensitive = Boolean(opts['--sensitive']);
+  const forceEncrypted = Boolean(opts['--no-sensitive']);
+
+  if (forceSensitive && forceEncrypted) {
+    output.error(
+      `--sensitive and --no-sensitive cannot be used together. Pick one.`
+    );
+    return 1;
+  }
+
+  // Detect team-level sensitive env var policy. Reads from the team object
+  // (cached). Only relevant when the linked org is a team.
+  let policyOn = false;
+  if (link.org.type === 'team') {
+    try {
+      const team = await getTeamById(client, link.org.id);
+      policyOn = team?.sensitiveEnvironmentVariablePolicy === 'on';
+    } catch {
+      // Non-fatal — policy detection is best-effort.
+    }
+  }
+
   let envValue: string;
 
   if (stdInput) {
@@ -543,18 +587,6 @@ export default async function add(client: Client, argv: string[]) {
           },
         ],
       });
-    }
-    if (type === 'encrypted' && !opts['--sensitive']) {
-      output.log(
-        `Sensitive values cannot be retrieved later from the dashboard or CLI.`
-      );
-      const makeSensitive = await client.input.confirm(
-        `Make it sensitive?`,
-        true
-      );
-      if (makeSensitive) {
-        type = 'sensitive';
-      }
     }
     envValue = await client.input.password({
       message: `What's the value of ${envName}?`,
@@ -646,21 +678,101 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
+  const hasDevelopment = envTargets.includes('development');
+  const hasSensitiveCapable = envTargets.some(t => t !== 'development');
+
+  if (forceSensitive && hasDevelopment) {
+    const msg = `--sensitive is not allowed with the Development Environment. Sensitive Environment Variables are only supported on Production and Preview.`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'sensitive_not_allowed_on_development',
+          message: msg,
+        },
+        1
+      );
+    }
+    output.error(msg);
+    return 1;
+  }
+
+  // Decide the type for prod/preview/custom targets. Development is always
+  // encrypted and handled separately below.
+  let typeForSensitiveCapable: EnvType = resolveTypeForTarget('production', {
+    forceSensitive,
+    forceEncrypted,
+    policyOn,
+  });
+
+  // When the user didn't explicitly choose, the policy isn't enforcing, and
+  // we have at least one prod/preview/custom target, ask whether to keep it
+  // sensitive. Skips for stdin/--value/-y paths and skips when policy forces.
+  const userWasExplicit = forceSensitive || forceEncrypted;
+  const canPromptForType =
+    !client.nonInteractive &&
+    !userWasExplicit &&
+    !policyOn &&
+    hasSensitiveCapable &&
+    !skipConfirm;
+  if (canPromptForType) {
+    output.log(
+      `Sensitive values cannot be retrieved later from the dashboard or CLI.`
+    );
+    const keepSensitive = await client.input.confirm(
+      `Make it sensitive?`,
+      true
+    );
+    if (!keepSensitive) {
+      typeForSensitiveCapable = 'encrypted';
+    }
+  }
+
+  if (policyOn && hasSensitiveCapable && !userWasExplicit) {
+    output.log(
+      `Your team requires sensitive Environment Variables for Production and Preview.`
+    );
+  }
+
+  // Group targets by the type we need to send. Development always goes in its
+  // own group as `encrypted`; everything else shares `typeForSensitiveCapable`.
+  const groups: Array<{ type: EnvType; targets: string[] }> = [];
+  const nonDevTargets = envTargets.filter(t => t !== 'development');
+  if (nonDevTargets.length > 0) {
+    groups.push({ type: typeForSensitiveCapable, targets: nonDevTargets });
+  }
+  if (hasDevelopment) {
+    groups.push({ type: 'encrypted', targets: ['development'] });
+  }
+
+  if (
+    groups.length > 1 &&
+    typeForSensitiveCapable === 'sensitive' &&
+    !client.nonInteractive
+  ) {
+    output.log(
+      `Development cannot store sensitive values; adding ${envName} as encrypted for Development and sensitive for the remaining environments.`
+    );
+  }
+
   const upsert = opts['--force'] ? 'true' : '';
 
   const addStamp = stamp();
   try {
     output.spinner('Saving');
-    await addEnvRecord(
-      client,
-      project.id,
-      upsert,
-      type,
-      envName,
-      finalValue,
-      envTargets,
-      envGitBranch
-    );
+    for (const group of groups) {
+      await addEnvRecord(
+        client,
+        project.id,
+        upsert,
+        group.type,
+        envName,
+        finalValue,
+        group.targets,
+        envGitBranch
+      );
+    }
   } catch (err: unknown) {
     if (client.nonInteractive && isAPIError(err)) {
       const reason =

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -698,17 +698,33 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
-  // Decide the type for prod/preview/custom targets. Development is always
-  // encrypted and handled separately below.
-  let typeForSensitiveCapable: EnvType = resolveTypeForTarget('production', {
-    forceSensitive,
-    forceEncrypted,
-    policyOn,
-  });
+  if (hasDevelopment && hasSensitiveCapable) {
+    const msg = `Development cannot be combined with other Environments because Development does not support sensitive Environment Variables. Run ${getCommandName(
+      'env add'
+    )} separately for Development.`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'mixed_development_and_sensitive_capable_targets',
+          message: msg,
+        },
+        1
+      );
+    }
+    output.error(msg);
+    return 1;
+  }
 
-  // When the user didn't explicitly choose, the policy isn't enforcing, and
-  // we have at least one prod/preview/custom target, ask whether to keep it
-  // sensitive. Skips for stdin/--value/-y paths and skips when policy forces.
+  // At this point envTargets is either all-development or all non-development.
+  let finalType: EnvType = resolveTypeForTarget(
+    hasDevelopment ? 'development' : 'production',
+    { forceSensitive, forceEncrypted, policyOn }
+  );
+
+  // Ask whether to keep it sensitive only when the user didn't say, the
+  // policy isn't enforcing, and at least one target would actually use it.
   const userWasExplicit = forceSensitive || forceEncrypted;
   const canPromptForType =
     !client.nonInteractive &&
@@ -725,7 +741,7 @@ export default async function add(client: Client, argv: string[]) {
       true
     );
     if (!keepSensitive) {
-      typeForSensitiveCapable = 'encrypted';
+      finalType = 'encrypted';
     }
   }
 
@@ -735,44 +751,21 @@ export default async function add(client: Client, argv: string[]) {
     );
   }
 
-  // Group targets by the type we need to send. Development always goes in its
-  // own group as `encrypted`; everything else shares `typeForSensitiveCapable`.
-  const groups: Array<{ type: EnvType; targets: string[] }> = [];
-  const nonDevTargets = envTargets.filter(t => t !== 'development');
-  if (nonDevTargets.length > 0) {
-    groups.push({ type: typeForSensitiveCapable, targets: nonDevTargets });
-  }
-  if (hasDevelopment) {
-    groups.push({ type: 'encrypted', targets: ['development'] });
-  }
-
-  if (
-    groups.length > 1 &&
-    typeForSensitiveCapable === 'sensitive' &&
-    !client.nonInteractive
-  ) {
-    output.log(
-      `Development cannot store sensitive values; adding ${envName} as encrypted for Development and sensitive for the remaining environments.`
-    );
-  }
-
   const upsert = opts['--force'] ? 'true' : '';
 
   const addStamp = stamp();
   try {
     output.spinner('Saving');
-    for (const group of groups) {
-      await addEnvRecord(
-        client,
-        project.id,
-        upsert,
-        group.type,
-        envName,
-        finalValue,
-        group.targets,
-        envGitBranch
-      );
-    }
+    await addEnvRecord(
+      client,
+      project.id,
+      upsert,
+      finalType,
+      envName,
+      finalValue,
+      envTargets,
+      envGitBranch
+    );
   } catch (err: unknown) {
     if (client.nonInteractive && isAPIError(err)) {
       const reason =

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -522,14 +522,18 @@ export default async function add(client: Client, argv: string[]) {
       }
     }
   }
-  const choices = [
-    ...envTargetChoices.filter(c => !existingTargets.has(c.value)),
+  const choices: Array<{
+    name: string;
+    value: string;
+    checked?: boolean;
+    disabled?: boolean | string;
+  }> = [
+    ...envTargetChoices
+      .filter(c => !existingTargets.has(c.value))
+      .map(c => ({ name: c.name, value: c.value })),
     ...customEnvironments
       .filter(c => !existingCustomEnvs.has(c.id))
-      .map(c => ({
-        name: c.slug,
-        value: c.id,
-      })),
+      .map(c => ({ name: c.slug, value: c.id })),
   ];
 
   if (!envGitBranch && choices.length === 0 && !opts['--force']) {
@@ -562,6 +566,20 @@ export default async function add(client: Client, argv: string[]) {
       policyOn = team?.sensitiveEnvironmentVariablePolicy === 'on';
     } catch {
       // Non-fatal — policy detection is best-effort.
+    }
+  }
+
+  // When policy is on, Development is effectively disallowed because the
+  // team policy requires sensitive Environment Variables and Development
+  // does not support sensitive. Pre-check Production/Preview for the user
+  // and mark Development as disallowed in the interactive checkbox.
+  if (policyOn) {
+    for (const choice of choices) {
+      if (choice.value === 'development') {
+        choice.disabled = '(disallowed)';
+      } else if (choice.value === 'production' || choice.value === 'preview') {
+        choice.checked = true;
+      }
     }
   }
 
@@ -680,6 +698,23 @@ export default async function add(client: Client, argv: string[]) {
 
   const hasDevelopment = envTargets.includes('development');
   const hasSensitiveCapable = envTargets.some(t => t !== 'development');
+
+  if (policyOn && hasDevelopment) {
+    const msg = `Your team requires sensitive Environment Variables and the Development Environment does not support sensitive values.`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'development_disallowed_by_team_policy',
+          message: msg,
+        },
+        1
+      );
+    }
+    output.error(msg);
+    return 1;
+  }
 
   if (forceSensitive && hasDevelopment) {
     const msg = `--sensitive is not allowed with the Development Environment. Sensitive Environment Variables are only supported on Production and Preview.`;

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -108,6 +108,7 @@ export default async function add(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliOptionValue(opts['--value']);
   telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
+  telemetryClient.trackCliFlagNoSensitive(opts['--no-sensitive']);
   telemetryClient.trackCliFlagForce(opts['--force']);
   telemetryClient.trackCliFlagGuidance(opts['--guidance']);
   telemetryClient.trackCliFlagYes(opts['--yes']);
@@ -518,9 +519,15 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
-  let type: 'encrypted' | 'sensitive' = opts['--sensitive']
-    ? 'sensitive'
-    : 'encrypted';
+  if (opts['--sensitive'] && !opts['--no-sensitive']) {
+    output.warn(
+      'The --sensitive flag is deprecated. Environment Variables are sensitive by default. Use --no-sensitive to opt out.'
+    );
+  }
+
+  let type: 'encrypted' | 'sensitive' = opts['--no-sensitive']
+    ? 'encrypted'
+    : 'sensitive';
   let envValue: string;
 
   if (stdInput) {
@@ -544,13 +551,20 @@ export default async function add(client: Client, argv: string[]) {
         ],
       });
     }
-    if (type === 'encrypted') {
-      const isSensitive = await client.input.confirm(
-        `Your value will be encrypted. Mark as sensitive?`,
-        false
+    if (
+      type === 'sensitive' &&
+      !opts['--no-sensitive'] &&
+      !opts['--sensitive']
+    ) {
+      output.log(
+        `Sensitive values cannot be retrieved later. Use --no-sensitive to opt out.`
       );
-      if (isSensitive) {
-        type = 'sensitive';
+      const keepSensitive = await client.input.confirm(
+        `Keep it sensitive?`,
+        true
+      );
+      if (!keepSensitive) {
+        type = 'encrypted';
       }
     }
     envValue = await client.input.password({
@@ -692,6 +706,12 @@ export default async function add(client: Client, argv: string[]) {
       emoji('success')
     )}\n`
   );
+
+  if (type === 'sensitive') {
+    output.log(
+      `Variable is sensitive and cannot be retrieved later. Use --no-sensitive next time if you need to view the value after creation.`
+    );
+  }
 
   const { isAgent } = await determineAgent();
   const guidanceMode = parsedArgs.flags['--guidance'] ?? isAgent;

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -745,10 +745,20 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  if (policyOn && hasSensitiveCapable && !userWasExplicit) {
-    output.log(
-      `Your team requires sensitive Environment Variables for Production and Preview.`
-    );
+  if (policyOn && hasSensitiveCapable) {
+    if (forceEncrypted) {
+      // User asked for encrypted on Production/Preview, but the team policy
+      // will promote it to sensitive server-side regardless. Surface that so
+      // the user isn't surprised later.
+      output.warn(
+        `--no-sensitive is ignored: your team enforces sensitive Environment Variables for Production and Preview.`
+      );
+      finalType = 'sensitive';
+    } else if (!userWasExplicit) {
+      output.log(
+        `Your team requires sensitive Environment Variables for Production and Preview.`
+      );
+    }
   }
 
   const upsert = opts['--force'] ? 'true' : '';

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -108,7 +108,6 @@ export default async function add(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliOptionValue(opts['--value']);
   telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
-  telemetryClient.trackCliFlagNoSensitive(opts['--no-sensitive']);
   telemetryClient.trackCliFlagForce(opts['--force']);
   telemetryClient.trackCliFlagGuidance(opts['--guidance']);
   telemetryClient.trackCliFlagYes(opts['--yes']);
@@ -519,15 +518,9 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
-  if (opts['--sensitive'] && !opts['--no-sensitive']) {
-    output.warn(
-      'The --sensitive flag is deprecated. Environment Variables are sensitive by default. Use --no-sensitive to opt out.'
-    );
-  }
-
-  let type: 'encrypted' | 'sensitive' = opts['--no-sensitive']
-    ? 'encrypted'
-    : 'sensitive';
+  let type: 'encrypted' | 'sensitive' = opts['--sensitive']
+    ? 'sensitive'
+    : 'encrypted';
   let envValue: string;
 
   if (stdInput) {
@@ -551,20 +544,16 @@ export default async function add(client: Client, argv: string[]) {
         ],
       });
     }
-    if (
-      type === 'sensitive' &&
-      !opts['--no-sensitive'] &&
-      !opts['--sensitive']
-    ) {
+    if (type === 'encrypted' && !opts['--sensitive']) {
       output.log(
-        `Sensitive values cannot be retrieved later. Use --no-sensitive to opt out.`
+        `Sensitive values cannot be retrieved later from the dashboard or CLI.`
       );
       const keepSensitive = await client.input.confirm(
         `Keep it sensitive?`,
         true
       );
-      if (!keepSensitive) {
-        type = 'encrypted';
+      if (keepSensitive) {
+        type = 'sensitive';
       }
     }
     envValue = await client.input.password({
@@ -706,12 +695,6 @@ export default async function add(client: Client, argv: string[]) {
       emoji('success')
     )}\n`
   );
-
-  if (type === 'sensitive') {
-    output.log(
-      `Variable is sensitive and cannot be retrieved later. Use --no-sensitive next time if you need to view the value after creation.`
-    );
-  }
 
   const { isAgent } = await determineAgent();
   const guidanceMode = parsedArgs.flags['--guidance'] ?? isAgent;

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -52,7 +52,16 @@ export const addSubcommand = {
   options: [
     {
       name: 'sensitive',
-      description: 'Add a sensitive Environment Variable',
+      description:
+        'Deprecated. Environment Variables are sensitive by default. Use --no-sensitive to opt out.',
+      shorthand: null,
+      type: Boolean,
+      deprecated: true,
+    },
+    {
+      name: 'no-sensitive',
+      description:
+        'Add a regular (non-sensitive) Environment Variable whose value remains readable later',
       shorthand: null,
       type: Boolean,
       deprecated: false,
@@ -104,8 +113,8 @@ export const addSubcommand = {
       value: `${packageName} env add API_TOKEN --force`,
     },
     {
-      name: 'Add a sensitive Environment Variable',
-      value: `${packageName} env add API_TOKEN --sensitive`,
+      name: 'Add a non-sensitive Environment Variable (readable later)',
+      value: `${packageName} env add API_TOKEN --no-sensitive`,
     },
     {
       name: 'Add a new Environment Variable for a specific Environment and Git Branch',

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -52,16 +52,7 @@ export const addSubcommand = {
   options: [
     {
       name: 'sensitive',
-      description:
-        'Deprecated. Environment Variables are sensitive by default. Use --no-sensitive to opt out.',
-      shorthand: null,
-      type: Boolean,
-      deprecated: true,
-    },
-    {
-      name: 'no-sensitive',
-      description:
-        'Add a regular (non-sensitive) Environment Variable whose value remains readable later',
+      description: 'Add a sensitive Environment Variable',
       shorthand: null,
       type: Boolean,
       deprecated: false,
@@ -113,8 +104,8 @@ export const addSubcommand = {
       value: `${packageName} env add API_TOKEN --force`,
     },
     {
-      name: 'Add a non-sensitive Environment Variable (readable later)',
-      value: `${packageName} env add API_TOKEN --no-sensitive`,
+      name: 'Add a sensitive Environment Variable',
+      value: `${packageName} env add API_TOKEN --sensitive`,
     },
     {
       name: 'Add a new Environment Variable for a specific Environment and Git Branch',

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -52,7 +52,16 @@ export const addSubcommand = {
   options: [
     {
       name: 'sensitive',
-      description: 'Add a sensitive Environment Variable',
+      description:
+        'Force the Environment Variable to be sensitive, even when adding to Development (will fail server-side)',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    {
+      name: 'no-sensitive',
+      description:
+        'Opt out of the sensitive default on Production and Preview; value remains readable later',
       shorthand: null,
       type: Boolean,
       deprecated: false,
@@ -104,8 +113,8 @@ export const addSubcommand = {
       value: `${packageName} env add API_TOKEN --force`,
     },
     {
-      name: 'Add a sensitive Environment Variable',
-      value: `${packageName} env add API_TOKEN --sensitive`,
+      name: 'Add a regular (non-sensitive) Environment Variable that remains readable later',
+      value: `${packageName} env add API_TOKEN --no-sensitive`,
     },
     {
       name: 'Add a new Environment Variable for a specific Environment and Git Branch',

--- a/packages/cli/src/util/telemetry/commands/env/add.ts
+++ b/packages/cli/src/util/telemetry/commands/env/add.ts
@@ -54,6 +54,12 @@ export class EnvAddTelemetryClient
     }
   }
 
+  trackCliFlagNoSensitive(noSensitive: boolean | undefined) {
+    if (noSensitive) {
+      this.trackCliFlag('no-sensitive');
+    }
+  }
+
   trackCliFlagForce(force: boolean | undefined) {
     if (force) {
       this.trackCliFlag('force');

--- a/packages/cli/src/util/telemetry/commands/env/add.ts
+++ b/packages/cli/src/util/telemetry/commands/env/add.ts
@@ -54,12 +54,6 @@ export class EnvAddTelemetryClient
     }
   }
 
-  trackCliFlagNoSensitive(noSensitive: boolean | undefined) {
-    if (noSensitive) {
-      this.trackCliFlag('no-sensitive');
-    }
-  }
-
   trackCliFlagForce(force: boolean | undefined) {
     if (force) {
       this.trackCliFlag('force');

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2092,7 +2092,7 @@ exports[`help command > env help output snapshots > env add help output snapshot
 
        --force          Force overwrites when a command would normally fail                                                  
        --guidance       Receive command suggestions once command is complete                                                 
-       --no-sensitive   Add a regular (non-sensitive) Environment Variable whose value remains readable later                
+       --sensitive      Add a sensitive Environment Variable                                                                 
        --value <VALUE>  Value for the variable (non-interactive). Otherwise use stdin or you will be prompted.               
   -y,  --yes            Skip the confirmation prompt when adding an Environment Variable                                     
 
@@ -2127,9 +2127,9 @@ exports[`help command > env help output snapshots > env add help output snapshot
 
     $ vercel env add API_TOKEN --force
 
-  - Add a non-sensitive Environment Variable (readable later)
+  - Add a sensitive Environment Variable
 
-    $ vercel env add API_TOKEN --no-sensitive
+    $ vercel env add API_TOKEN --sensitive
 
   - Add a new Environment Variable for a specific Environment and Git Branch
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2092,7 +2092,7 @@ exports[`help command > env help output snapshots > env add help output snapshot
 
        --force          Force overwrites when a command would normally fail                                                  
        --guidance       Receive command suggestions once command is complete                                                 
-       --sensitive      Add a sensitive Environment Variable                                                                 
+       --no-sensitive   Add a regular (non-sensitive) Environment Variable whose value remains readable later                
        --value <VALUE>  Value for the variable (non-interactive). Otherwise use stdin or you will be prompted.               
   -y,  --yes            Skip the confirmation prompt when adding an Environment Variable                                     
 
@@ -2127,9 +2127,9 @@ exports[`help command > env help output snapshots > env add help output snapshot
 
     $ vercel env add API_TOKEN --force
 
-  - Add a sensitive Environment Variable
+  - Add a non-sensitive Environment Variable (readable later)
 
-    $ vercel env add API_TOKEN --sensitive
+    $ vercel env add API_TOKEN --no-sensitive
 
   - Add a new Environment Variable for a specific Environment and Git Branch
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2092,7 +2092,9 @@ exports[`help command > env help output snapshots > env add help output snapshot
 
        --force          Force overwrites when a command would normally fail                                                  
        --guidance       Receive command suggestions once command is complete                                                 
-       --sensitive      Add a sensitive Environment Variable                                                                 
+       --no-sensitive   Opt out of the sensitive default on Production and Preview; value remains readable later             
+       --sensitive      Force the Environment Variable to be sensitive, even when adding to Development (will fail           
+                        server-side)                                                                                         
        --value <VALUE>  Value for the variable (non-interactive). Otherwise use stdin or you will be prompted.               
   -y,  --yes            Skip the confirmation prompt when adding an Environment Variable                                     
 
@@ -2127,9 +2129,9 @@ exports[`help command > env help output snapshots > env add help output snapshot
 
     $ vercel env add API_TOKEN --force
 
-  - Add a sensitive Environment Variable
+  - Add a regular (non-sensitive) Environment Variable that remains readable later
 
-    $ vercel env add API_TOKEN --sensitive
+    $ vercel env add API_TOKEN --no-sensitive
 
   - Add a new Environment Variable for a specific Environment and Git Branch
 

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -94,43 +94,10 @@ describe('env add', () => {
           },
         ]);
       });
-
-      it('prints a deprecation warning but still creates the variable as sensitive', async () => {
-        const addEnvRecordModule = await import(
-          '../../../../src/util/env/add-env-record'
-        );
-        const spy = vi
-          .spyOn(addEnvRecordModule, 'default')
-          .mockResolvedValue(undefined);
-
-        client.setArgv(
-          'env',
-          'add',
-          'DEPRECATED_FLAG',
-          'preview',
-          'branchName',
-          '--sensitive'
-        );
-        const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'The --sensitive flag is deprecated'
-        );
-        await expect(client.stderr).toOutput(
-          "What's the value of DEPRECATED_FLAG?"
-        );
-        client.stdin.write('testvalue\n');
-        await expect(exitCodePromise).resolves.toBe(0);
-
-        expect(spy).toHaveBeenCalled();
-        const type = spy.mock.calls[0][3];
-        expect(type).toBe('sensitive');
-
-        spy.mockRestore();
-      });
     });
 
-    describe('default type', () => {
-      it('adds as sensitive by default when the user keeps it sensitive at the prompt', async () => {
+    describe('sensitive prompt', () => {
+      it('creates the variable as sensitive when the user keeps it at the prompt', async () => {
         const addEnvRecordModule = await import(
           '../../../../src/util/env/add-env-record'
         );
@@ -152,9 +119,6 @@ describe('env add', () => {
           "What's the value of DEFAULT_SENSITIVE?"
         );
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput(
-          'Variable is sensitive and cannot be retrieved later'
-        );
         await expect(exitCodePromise).resolves.toBe(0);
 
         expect(spy).toHaveBeenCalled();
@@ -196,72 +160,6 @@ describe('env add', () => {
       });
     });
 
-    describe('--no-sensitive', () => {
-      it('skips the sensitivity prompt and creates the variable as encrypted', async () => {
-        const addEnvRecordModule = await import(
-          '../../../../src/util/env/add-env-record'
-        );
-        const spy = vi
-          .spyOn(addEnvRecordModule, 'default')
-          .mockResolvedValue(undefined);
-
-        client.setArgv(
-          'env',
-          'add',
-          'PLAIN_VAR',
-          'preview',
-          'branchName',
-          '--no-sensitive'
-        );
-        const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput("What's the value of PLAIN_VAR?");
-        client.stdin.write('testvalue\n');
-        await expect(exitCodePromise).resolves.toBe(0);
-
-        expect(spy).toHaveBeenCalled();
-        const type = spy.mock.calls[0][3];
-        expect(type).toBe('encrypted');
-
-        expect(client.telemetryEventStore).toHaveTelemetryEvents([
-          { key: `subcommand:add`, value: 'add' },
-          { key: `argument:name`, value: '[REDACTED]' },
-          { key: `argument:environment`, value: 'preview' },
-          { key: `argument:git-branch`, value: '[REDACTED]' },
-          { key: `flag:no-sensitive`, value: 'TRUE' },
-        ]);
-
-        spy.mockRestore();
-      });
-
-      it('wins when both --sensitive and --no-sensitive are passed', async () => {
-        const addEnvRecordModule = await import(
-          '../../../../src/util/env/add-env-record'
-        );
-        const spy = vi
-          .spyOn(addEnvRecordModule, 'default')
-          .mockResolvedValue(undefined);
-
-        client.setArgv(
-          'env',
-          'add',
-          'BOTH_FLAGS',
-          'preview',
-          'branchName',
-          '--sensitive',
-          '--no-sensitive'
-        );
-        const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput("What's the value of BOTH_FLAGS?");
-        client.stdin.write('testvalue\n');
-        await expect(exitCodePromise).resolves.toBe(0);
-
-        expect(spy).toHaveBeenCalled();
-        const type = spy.mock.calls[0][3];
-        expect(type).toBe('encrypted');
-
-        spy.mockRestore();
-      });
-    });
     describe('--force', () => {
       it('tracks flag', async () => {
         client.setArgv(

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -267,6 +267,30 @@ describe('env add', () => {
       });
     });
 
+    describe('mixed Development + other Environments', () => {
+      it('errors when the interactive checkbox picks Development alongside Production/Preview', async () => {
+        client.setArgv('env', 'add', 'MIXED_TARGETS');
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          "What's the value of MIXED_TARGETS?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput(
+          'Add MIXED_TARGETS to which Environments (select multiple)?'
+        );
+        // Select Production and Development.
+        client.stdin.write(' '); // toggle Production (first row)
+        client.stdin.write('\x1B[B'); // down to Preview
+        client.stdin.write('\x1B[B'); // down to Development
+        client.stdin.write(' '); // toggle Development
+        client.stdin.write('\r'); // submit
+        await expect(client.stderr).toOutput(
+          'Development cannot be combined with other Environments'
+        );
+        await expect(exitCodePromise).resolves.toBe(1);
+      });
+    });
+
     describe('--force', () => {
       it('tracks flag', async () => {
         client.setArgv(

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -267,6 +267,35 @@ describe('env add', () => {
       });
     });
 
+    describe('Development with team policy on', () => {
+      it('errors when the target is Development and the team enforces sensitive', async () => {
+        const teamModule = await import(
+          '../../../../src/util/teams/get-team-by-id'
+        );
+        const teamSpy = vi.spyOn(teamModule, 'default').mockResolvedValue({
+          sensitiveEnvironmentVariablePolicy: 'on',
+          // biome-ignore lint/suspicious/noExplicitAny: partial team shape
+        } as any);
+
+        client.setArgv(
+          'env',
+          'add',
+          'DEV_UNDER_POLICY',
+          'development',
+          '--value',
+          'foo',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'Your team requires sensitive Environment Variables and the Development Environment does not support sensitive values.'
+        );
+        await expect(exitCodePromise).resolves.toBe(1);
+
+        teamSpy.mockRestore();
+      });
+    });
+
     describe('--no-sensitive with team policy on', () => {
       it('warns that --no-sensitive is ignored and stores as sensitive', async () => {
         const teamModule = await import(

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -94,6 +94,173 @@ describe('env add', () => {
           },
         ]);
       });
+
+      it('prints a deprecation warning but still creates the variable as sensitive', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'DEPRECATED_FLAG',
+          'preview',
+          'branchName',
+          '--sensitive'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'The --sensitive flag is deprecated'
+        );
+        await expect(client.stderr).toOutput(
+          "What's the value of DEPRECATED_FLAG?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(spy).toHaveBeenCalled();
+        const type = spy.mock.calls[0][3];
+        expect(type).toBe('sensitive');
+
+        spy.mockRestore();
+      });
+    });
+
+    describe('default type', () => {
+      it('adds as sensitive by default when the user keeps it sensitive at the prompt', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'DEFAULT_SENSITIVE',
+          'preview',
+          'branchName'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Keep it sensitive?');
+        client.stdin.write('y\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of DEFAULT_SENSITIVE?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput(
+          'Variable is sensitive and cannot be retrieved later'
+        );
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(spy).toHaveBeenCalled();
+        const type = spy.mock.calls[0][3];
+        expect(type).toBe('sensitive');
+
+        spy.mockRestore();
+      });
+
+      it('falls back to encrypted when the user declines at the prompt', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'DECLINED_SENSITIVE',
+          'preview',
+          'branchName'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Keep it sensitive?');
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of DECLINED_SENSITIVE?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(spy).toHaveBeenCalled();
+        const type = spy.mock.calls[0][3];
+        expect(type).toBe('encrypted');
+
+        spy.mockRestore();
+      });
+    });
+
+    describe('--no-sensitive', () => {
+      it('skips the sensitivity prompt and creates the variable as encrypted', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'PLAIN_VAR',
+          'preview',
+          'branchName',
+          '--no-sensitive'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput("What's the value of PLAIN_VAR?");
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(spy).toHaveBeenCalled();
+        const type = spy.mock.calls[0][3];
+        expect(type).toBe('encrypted');
+
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          { key: `subcommand:add`, value: 'add' },
+          { key: `argument:name`, value: '[REDACTED]' },
+          { key: `argument:environment`, value: 'preview' },
+          { key: `argument:git-branch`, value: '[REDACTED]' },
+          { key: `flag:no-sensitive`, value: 'TRUE' },
+        ]);
+
+        spy.mockRestore();
+      });
+
+      it('wins when both --sensitive and --no-sensitive are passed', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'BOTH_FLAGS',
+          'preview',
+          'branchName',
+          '--sensitive',
+          '--no-sensitive'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput("What's the value of BOTH_FLAGS?");
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(spy).toHaveBeenCalled();
+        const type = spy.mock.calls[0][3];
+        expect(type).toBe('encrypted');
+
+        spy.mockRestore();
+      });
     });
     describe('--force', () => {
       it('tracks flag', async () => {
@@ -106,7 +273,7 @@ describe('env add', () => {
           '--force'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
@@ -149,7 +316,7 @@ describe('env add', () => {
           '--guidance'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
@@ -195,7 +362,7 @@ describe('env add', () => {
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of TEST_YES_FLAG?"
@@ -237,7 +404,7 @@ describe('env add', () => {
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of EMPTY_VALUE_YES?"
@@ -263,7 +430,7 @@ describe('env add', () => {
         await expect(client.stderr).toOutput(
           'NEXT_PUBLIC_ variables can be seen by anyone visiting your site'
         );
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of NEXT_PUBLIC_TEST?"
@@ -287,7 +454,7 @@ describe('env add', () => {
         );
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\n'); // Select "Leave as is"
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of NEXT_PUBLIC_API_KEY?"
@@ -312,7 +479,7 @@ describe('env add', () => {
         // Select "Rename to SECRET" (second option)
         client.stdin.write('\x1B[B\n');
         await expect(client.stderr).toOutput('Renamed to SECRET');
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of SECRET?");
         client.stdin.write('testvalue\n');
@@ -322,7 +489,7 @@ describe('env add', () => {
       it('warns for quoted value and allows continue', async () => {
         client.setArgv('env', 'add', 'QUOTED_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of QUOTED_VALUE?"
@@ -337,7 +504,7 @@ describe('env add', () => {
       it('allows re-entering value when warned', async () => {
         client.setArgv('env', 'add', 'REENTER_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of REENTER_VALUE?"
@@ -362,7 +529,7 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of WHITESPACE_VALUE?"
@@ -378,7 +545,7 @@ describe('env add', () => {
       it('re-validates trimmed value when it becomes empty', async () => {
         client.setArgv('env', 'add', 'TRIMMED_EMPTY', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of TRIMMED_EMPTY?"
@@ -418,7 +585,7 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\x1B[B\n'); // Rename again to SECRET
         await expect(client.stderr).toOutput('Renamed to SECRET');
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of SECRET?");
         client.stdin.write('testvalue\n');
@@ -430,7 +597,7 @@ describe('env add', () => {
       it('should redact custom [environment] values', async () => {
         client.setArgv('env', 'add', 'environment-variable', 'custom-env-name');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Mark as sensitive?');
+        await expect(client.stderr).toOutput('Keep it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of environment-variable?"
@@ -464,7 +631,7 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput('Mark as sensitive?');
+          await expect(client.stderr).toOutput('Keep it sensitive?');
           client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             "What's the value of REDIS_CONNECTION_STRING?"
@@ -486,7 +653,7 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput('Mark as sensitive?');
+          await expect(client.stderr).toOutput('Keep it sensitive?');
           client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             "What's the value of TELEMETRY_EVENTS?"

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -288,7 +288,7 @@ describe('env add', () => {
         );
         const exitCodePromise = env(client);
         await expect(client.stderr).toOutput(
-          'Your team requires sensitive Environment Variables and the Development Environment does not support sensitive values.'
+          'Your team has enabled the Sensitive Environment Variables Policy and the Development Environment does not support sensitive values.'
         );
         await expect(exitCodePromise).resolves.toBe(1);
 

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -113,12 +113,12 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('y\n');
         await expect(client.stderr).toOutput(
           "What's the value of DEFAULT_SENSITIVE?"
         );
         client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('y\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
         expect(spy).toHaveBeenCalled();
@@ -144,10 +144,72 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of DECLINED_SENSITIVE?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(spy).toHaveBeenCalled();
+        const type = spy.mock.calls[0][3];
+        expect(type).toBe('encrypted');
+
+        spy.mockRestore();
+      });
+
+      it('does not prompt on Development, stores as encrypted', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv('env', 'add', 'DEV_ONLY', 'development');
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput("What's the value of DEV_ONLY?");
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(spy).toHaveBeenCalled();
+        const [, , , type, , , targets] = spy.mock.calls[0] as unknown as [
+          unknown,
+          unknown,
+          unknown,
+          string,
+          unknown,
+          unknown,
+          string[],
+        ];
+        expect(type).toBe('encrypted');
+        expect(targets).toEqual(['development']);
+
+        spy.mockRestore();
+      });
+    });
+
+    describe('--no-sensitive', () => {
+      it('skips the sensitive prompt and stores as encrypted', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'NO_SENSITIVE_FLAG',
+          'production',
+          '--no-sensitive',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          "What's the value of NO_SENSITIVE_FLAG?"
         );
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
@@ -156,7 +218,52 @@ describe('env add', () => {
         const type = spy.mock.calls[0][3];
         expect(type).toBe('encrypted');
 
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          { key: 'subcommand:add', value: 'add' },
+          { key: 'argument:name', value: '[REDACTED]' },
+          { key: 'argument:environment', value: 'production' },
+          { key: 'flag:no-sensitive', value: 'TRUE' },
+          { key: 'flag:yes', value: 'TRUE' },
+        ]);
+
         spy.mockRestore();
+      });
+
+      it('errors when combined with --sensitive', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'BOTH_FLAGS',
+          'production',
+          '--sensitive',
+          '--no-sensitive',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          '--sensitive and --no-sensitive cannot be used together'
+        );
+        await expect(exitCodePromise).resolves.toBe(1);
+      });
+    });
+
+    describe('--sensitive + Development', () => {
+      it('errors when --sensitive is passed and the target is Development', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'DEV_SENS',
+          'development',
+          '--sensitive',
+          '--value',
+          'foo',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          '--sensitive is not allowed with the Development Environment'
+        );
+        await expect(exitCodePromise).resolves.toBe(1);
       });
     });
 
@@ -171,10 +278,10 @@ describe('env add', () => {
           '--force'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -214,10 +321,10 @@ describe('env add', () => {
           '--guidance'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -260,8 +367,6 @@ describe('env add', () => {
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of TEST_YES_FLAG?"
         );
@@ -302,8 +407,6 @@ describe('env add', () => {
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of EMPTY_VALUE_YES?"
         );
@@ -328,12 +431,12 @@ describe('env add', () => {
         await expect(client.stderr).toOutput(
           'NEXT_PUBLIC_ variables can be seen by anyone visiting your site'
         );
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of NEXT_PUBLIC_TEST?"
         );
         client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
@@ -352,12 +455,12 @@ describe('env add', () => {
         );
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\n'); // Select "Leave as is"
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of NEXT_PUBLIC_API_KEY?"
         );
         client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
@@ -377,18 +480,16 @@ describe('env add', () => {
         // Select "Rename to SECRET" (second option)
         client.stdin.write('\x1B[B\n');
         await expect(client.stderr).toOutput('Renamed to SECRET');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of SECRET?");
         client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
       it('warns for quoted value and allows continue', async () => {
         client.setArgv('env', 'add', 'QUOTED_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of QUOTED_VALUE?"
         );
@@ -396,14 +497,14 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('includes surrounding quotes');
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\n'); // Select "Leave as is"
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
       it('allows re-entering value when warned', async () => {
         client.setArgv('env', 'add', 'REENTER_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of REENTER_VALUE?"
         );
@@ -415,6 +516,8 @@ describe('env add', () => {
           "What's the value of REENTER_VALUE?"
         );
         client.stdin.write('clean-value\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
@@ -427,8 +530,6 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of WHITESPACE_VALUE?"
         );
@@ -437,14 +538,14 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\x1B[B\x1B[B\n'); // Select Trim
         await expect(client.stderr).toOutput('Trimmed whitespace');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
       it('re-validates trimmed value when it becomes empty', async () => {
         client.setArgv('env', 'add', 'TRIMMED_EMPTY', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of TRIMMED_EMPTY?"
         );
@@ -457,6 +558,8 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('Value is empty');
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\n'); // Leave as is
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
@@ -483,10 +586,10 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\x1B[B\n'); // Rename again to SECRET
         await expect(client.stderr).toOutput('Renamed to SECRET');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of SECRET?");
         client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
     });
@@ -495,12 +598,12 @@ describe('env add', () => {
       it('should redact custom [environment] values', async () => {
         client.setArgv('env', 'add', 'environment-variable', 'custom-env-name');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of environment-variable?"
         );
         client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput('Make it sensitive?');
+        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toEqual(0);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -529,12 +632,12 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput('Make it sensitive?');
-          client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             "What's the value of REDIS_CONNECTION_STRING?"
           );
           client.stdin.write('testvalue\n');
+          await expect(client.stderr).toOutput('Make it sensitive?');
+          client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             'Added Environment Variable REDIS_CONNECTION_STRING to Project vercel-env-pull'
           );
@@ -551,12 +654,12 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput('Make it sensitive?');
-          client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             "What's the value of TELEMETRY_EVENTS?"
           );
           client.stdin.write('testvalue\n');
+          await expect(client.stderr).toOutput('Make it sensitive?');
+          client.stdin.write('n\n');
           await expect(exitCodePromise).resolves.toEqual(0);
 
           expect(client.telemetryEventStore).toHaveTelemetryEvents([

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -267,6 +267,48 @@ describe('env add', () => {
       });
     });
 
+    describe('--no-sensitive with team policy on', () => {
+      it('warns that --no-sensitive is ignored and stores as sensitive', async () => {
+        const teamModule = await import(
+          '../../../../src/util/teams/get-team-by-id'
+        );
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+
+        const teamSpy = vi.spyOn(teamModule, 'default').mockResolvedValue({
+          sensitiveEnvironmentVariablePolicy: 'on',
+          // biome-ignore lint/suspicious/noExplicitAny: partial team shape
+        } as any);
+        const addSpy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'POLICY_OVERRIDE',
+          'production',
+          '--value',
+          'foo',
+          '--no-sensitive',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          '--no-sensitive is ignored: your team enforces sensitive Environment Variables for Production and Preview.'
+        );
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(addSpy).toHaveBeenCalled();
+        const type = addSpy.mock.calls[0][3];
+        expect(type).toBe('sensitive');
+
+        teamSpy.mockRestore();
+        addSpy.mockRestore();
+      });
+    });
+
     describe('mixed Development + other Environments', () => {
       it('errors when the interactive checkbox picks Development alongside Production/Preview', async () => {
         client.setArgv('env', 'add', 'MIXED_TARGETS');

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -113,7 +113,7 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('y\n');
         await expect(client.stderr).toOutput(
           "What's the value of DEFAULT_SENSITIVE?"
@@ -144,7 +144,7 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of DECLINED_SENSITIVE?"
@@ -171,7 +171,7 @@ describe('env add', () => {
           '--force'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
@@ -214,7 +214,7 @@ describe('env add', () => {
           '--guidance'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
@@ -260,7 +260,7 @@ describe('env add', () => {
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of TEST_YES_FLAG?"
@@ -302,7 +302,7 @@ describe('env add', () => {
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of EMPTY_VALUE_YES?"
@@ -328,7 +328,7 @@ describe('env add', () => {
         await expect(client.stderr).toOutput(
           'NEXT_PUBLIC_ variables can be seen by anyone visiting your site'
         );
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of NEXT_PUBLIC_TEST?"
@@ -352,7 +352,7 @@ describe('env add', () => {
         );
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\n'); // Select "Leave as is"
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of NEXT_PUBLIC_API_KEY?"
@@ -377,7 +377,7 @@ describe('env add', () => {
         // Select "Rename to SECRET" (second option)
         client.stdin.write('\x1B[B\n');
         await expect(client.stderr).toOutput('Renamed to SECRET');
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of SECRET?");
         client.stdin.write('testvalue\n');
@@ -387,7 +387,7 @@ describe('env add', () => {
       it('warns for quoted value and allows continue', async () => {
         client.setArgv('env', 'add', 'QUOTED_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of QUOTED_VALUE?"
@@ -402,7 +402,7 @@ describe('env add', () => {
       it('allows re-entering value when warned', async () => {
         client.setArgv('env', 'add', 'REENTER_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of REENTER_VALUE?"
@@ -427,7 +427,7 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of WHITESPACE_VALUE?"
@@ -443,7 +443,7 @@ describe('env add', () => {
       it('re-validates trimmed value when it becomes empty', async () => {
         client.setArgv('env', 'add', 'TRIMMED_EMPTY', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of TRIMMED_EMPTY?"
@@ -483,7 +483,7 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\x1B[B\n'); // Rename again to SECRET
         await expect(client.stderr).toOutput('Renamed to SECRET');
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of SECRET?");
         client.stdin.write('testvalue\n');
@@ -495,7 +495,7 @@ describe('env add', () => {
       it('should redact custom [environment] values', async () => {
         client.setArgv('env', 'add', 'environment-variable', 'custom-env-name');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('Keep it sensitive?');
+        await expect(client.stderr).toOutput('Make it sensitive?');
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of environment-variable?"
@@ -529,7 +529,7 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput('Keep it sensitive?');
+          await expect(client.stderr).toOutput('Make it sensitive?');
           client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             "What's the value of REDIS_CONNECTION_STRING?"
@@ -551,7 +551,7 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput('Keep it sensitive?');
+          await expect(client.stderr).toOutput('Make it sensitive?');
           client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             "What's the value of TELEMETRY_EVENTS?"

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -321,7 +321,7 @@ describe('env pull', () => {
       client.setArgv('env', 'add', 'NEW_VAR');
       const addPromise = env(client);
 
-      await expect(client.stderr).toOutput('Keep it sensitive?');
+      await expect(client.stderr).toOutput('Make it sensitive?');
       client.stdin.write('n\n');
       await expect(client.stderr).toOutput("What's the value of NEW_VAR?");
       client.stdin.write('testvalue\n');

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -321,8 +321,6 @@ describe('env pull', () => {
       client.setArgv('env', 'add', 'NEW_VAR');
       const addPromise = env(client);
 
-      await expect(client.stderr).toOutput('Make it sensitive?');
-      client.stdin.write('n\n');
       await expect(client.stderr).toOutput("What's the value of NEW_VAR?");
       client.stdin.write('testvalue\n');
 

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -321,7 +321,7 @@ describe('env pull', () => {
       client.setArgv('env', 'add', 'NEW_VAR');
       const addPromise = env(client);
 
-      await expect(client.stderr).toOutput('Mark as sensitive?');
+      await expect(client.stderr).toOutput('Keep it sensitive?');
       client.stdin.write('n\n');
       await expect(client.stderr).toOutput("What's the value of NEW_VAR?");
       client.stdin.write('testvalue\n');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`vercel env add` now defaults Environment Variables to **sensitive** for Production and Preview. Sensitive values are encrypted at rest and cannot be retrieved later via the dashboard or `vercel env ls`; they are still resolved for builds, deployments, `vercel env pull`, and runtime.

Development targets remain `encrypted` because the Vercel API does not allow sensitive Environment Variables on Development.

## Behavior per target

| Target | Default type | Notes |
| --- | --- | --- |
| Production | `sensitive` | Pass `--no-sensitive` to opt out (subject to team policy, see below). |
| Preview | `sensitive` | Pass `--no-sensitive` to opt out (subject to team policy). |
| Development | `encrypted` | Sensitive is not allowed; `--sensitive` errors up front. |
| Custom environments | `sensitive` | Server decides acceptability. |

**Mixed target selections (Development + Production/Preview) error out** and ask the user to run `vercel env add` separately for Development. No more silent splitting into two records with different types.

## Flag summary

- `--sensitive` — unchanged in meaning; now errors if combined with a Development target.
- `--no-sensitive` — new; opt out of the new default for Production/Preview.
- `--sensitive --no-sensitive` together — errors.

## Team policy awareness

When a team enables **Enforce Sensitive Environment Variables**, the Vercel API silently promotes `encrypted` writes on Production/Preview to `sensitive`. The CLI now reads `sensitiveEnvironmentVariablePolicy` from the team object (cached — no extra HTTP call because `getLinkedProject` already fetches the team) and:

- **Errors when the target is Development** with a message linking to [the Environment Variables Policy docs](https://vercel.com/docs/environment-variables/sensitive-environment-variables#environment-variables-policy). Development cannot hold sensitive values, so under the policy it is disallowed entirely.
- **Pre-checks Production and Preview** in the interactive checkbox and marks Development as `Development (disallowed)` so the user sees at a glance which targets are valid.
- Skips the interactive "Make it sensitive?" prompt (since the outcome is fixed).
- Logs a one-liner when Production/Preview writes are implicitly sensitive, so the user isn't surprised.
- Passes `type: 'sensitive'` explicitly so the CLI's own `--debug` output is honest instead of claiming "Adding encrypted …" while the server stores sensitive.
- When `--no-sensitive` is passed on a policy-on team for Production/Preview, emits `--no-sensitive is ignored: your team enforces sensitive Environment Variables for Production and Preview.` and forces the outgoing type to sensitive so the CLI log matches the stored record.

## Interactive prompt

The `Make it sensitive?` prompt (default: yes) still fires when **all** of these are true:

1. You didn't pass `--sensitive` or `--no-sensitive`.
2. The selected targets include Production or Preview.
3. The team policy is not enforcing.
4. stdin is a TTY and `--yes`, `--value`, or stdin input isn't bypassing confirms.

It runs **after** value entry and target selection so it's informed by the actual target set.

## Verified against a real policy-on team

Probed against a team with the policy enabled:

- `GET /teams/:id` (what the CLI uses) returns `"sensitiveEnvironmentVariablePolicy": "on"`.
- `POST /v10/projects/:id/env` with `type: encrypted, target: [production]` → 201, **stored as `sensitive`** (silent server-side promotion).
- `POST` with `type: encrypted, target: [development]` → 201, stored as `encrypted` (policy does not cover Development).
- `POST` with `type: sensitive, target: [production]` → 201, stored as `sensitive`.

The CLI now reads that policy field, blocks Development with a docs-linked error, suppresses the prompt for Production/Preview, and (when the user passed `--no-sensitive`) warns and sends `type: 'sensitive'` so the observable behavior matches the stored state.

## Tests

- `pnpm vitest run test/unit/commands/env/ test/unit/commands/help.test.ts` — 8 files, 233 tests, all pass locally.
- `pnpm lint` — clean.
- `prettier --check` — clean.

