### PR TITLE
Use Node 24 in release workflow to fix npm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16


### PR DESCRIPTION
## Summary

`npm i -g npm@11` fails on Node 22.22.2 due to a [known bug](https://github.com/nodejs/node/issues/62430) (`Cannot find module 'promise-retry'`). This broke the release workflow after #16042.

Fix: bump Node from `22` to `24` in the release workflow. Node 24 ships with npm 11 built-in.