### PR TITLE
Fix doubled tarball path in npm-publish.sh

### DIFF
--- a/utils/npm-publish.sh
+++ b/utils/npm-publish.sh
@@ -38,9 +38,9 @@ while IFS=$'\t' read -r name pkg_path; do
 
   echo "publishing: $name@$version"
 
-  # pnpm pack resolves workspace:* to real versions in the tarball
+  # pnpm pack resolves workspace:* to real versions and outputs the full path
   tarball=$(pnpm pack --pack-destination="$TARBALL_DIR" -C "$pkg_path" 2>/dev/null | tail -1)
-  npm publish "$TARBALL_DIR/$tarball" --access public --provenance
+  npm publish "$tarball" --access public --provenance
 
   published=$((published + 1))
 done <<< "$packages"


### PR DESCRIPTION
## Summary

`pnpm pack --pack-destination=DIR` outputs the **full path** to the tarball. The script was prepending `TARBALL_DIR/` again, resulting in a doubled path like `/tmp/tmp.X/tmp/tmp.X/file.tgz`.

Fixes the publish failure from #16042.

Made with [Cursor](https://cursor.com)