### PR TITLE
[build-utils] Extract main deserialize-build-output file

### DIFF
--- a/.changeset/fair-rules-sit.md
+++ b/.changeset/fair-rules-sit.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+Add shared build output deserialization helpers for existing callers.

--- a/packages/build-utils/src/deserialize/deserialize-build-output-types.ts
+++ b/packages/build-utils/src/deserialize/deserialize-build-output-types.ts
@@ -1,0 +1,95 @@
+import type FileFsRef from '../file-fs-ref';
+import type { Lambda } from '../lambda';
+import type { Prerender } from '../prerender';
+import type { BuildResultV2Typical, Files } from '../types';
+import type {
+  SerializedEdgeFunction,
+  SerializedLambda,
+  SerializedNodejsLambda,
+  SerializedPrerender,
+} from './serialized-types';
+
+export interface DeserializeBuildOutputPathOverride {
+  contentType?: string;
+  mode?: number;
+  path?: string;
+}
+
+export interface DeserializeBuildOutputConfig<TFlags = unknown> {
+  version?: 3;
+  wildcard?: BuildResultV2Typical['wildcard'];
+  images?: BuildResultV2Typical['images'];
+  routes?: BuildResultV2Typical['routes'];
+  overrides?: Record<string, DeserializeBuildOutputPathOverride>;
+  framework?: BuildResultV2Typical['framework'];
+  crons?: BuildResultV2Typical['crons'];
+  flags?: TFlags;
+  deploymentId?: string;
+}
+
+export type DeserializeBuildOutputResult<
+  TFlags = unknown,
+  TMeta = unknown,
+> = Omit<BuildResultV2Typical, 'flags'> & {
+  flags?: TFlags;
+  meta?: TMeta;
+};
+
+export type DeserializeBuildOutputLambdaOptions = {
+  forceNodejsStreaming?: boolean;
+  useOnlyStreamingLambda?: boolean;
+};
+
+export type GroupLambdasOptions = {
+  force: 'all' | undefined;
+  maxBundleSizeMb: number | undefined;
+  debug: boolean | undefined;
+};
+
+export type DeserializeBuildOutputLambda<TLambda extends Lambda> = (
+  files: Files,
+  config: SerializedLambda | SerializedNodejsLambda,
+  repoRootPath: string,
+  fileFsRefsCache: Map<string, FileFsRef>,
+  options?: DeserializeBuildOutputLambdaOptions
+) => Promise<TLambda>;
+
+export type GroupLambdas<TLambda extends Lambda> = (
+  lambdas: Record<string, TLambda>,
+  options: GroupLambdasOptions
+) => Promise<Record<string, TLambda>>;
+
+export type InspectSerializedLambda = (
+  path: string,
+  config: SerializedLambda | SerializedNodejsLambda,
+  repoRootPath: string,
+  hasServerActions: boolean
+) => Promise<boolean>;
+
+export interface DeserializeBuildOutputOptions<
+  TResult extends DeserializeBuildOutputResult = DeserializeBuildOutputResult,
+  TLambda extends Lambda = Lambda,
+> {
+  outputDir: string;
+  repoRootPath: string;
+  maxBundleSizeMb?: number;
+  debugGroupLambdas?: boolean;
+  useOnlyStreamingLambda?: boolean;
+  forceNodejsStreaming?: boolean;
+  deserializeLambda: DeserializeBuildOutputLambda<TLambda>;
+  groupLambdas: GroupLambdas<TLambda>;
+  inspectSerializedLambda?: InspectSerializedLambda;
+  warn?: (message: string) => void;
+  includeDeploymentId?: boolean;
+  getMeta?: (
+    hasServerActions: boolean
+  ) => TResult extends { meta?: infer TMeta } ? TMeta : never;
+}
+
+export type DeserializeBuildOutputFiles = BuildResultV2Typical['output'];
+export type DeserializeBuildOutputPrerenderFallback = Prerender['fallback'];
+export type DeserializeBuildOutputSerializedConfig =
+  | SerializedEdgeFunction
+  | SerializedLambda
+  | SerializedNodejsLambda;
+export type DeserializeBuildOutputSerializedPrerender = SerializedPrerender;

--- a/packages/build-utils/src/deserialize/deserialize-build-output.ts
+++ b/packages/build-utils/src/deserialize/deserialize-build-output.ts
@@ -1,0 +1,356 @@
+import * as fs from 'fs-extra';
+import { dirname, join } from 'path';
+import type { EdgeFunction } from '../edge-function';
+import { NowBuildError } from '../errors';
+import FileFsRef from '../file-fs-ref';
+import glob from '../fs/glob';
+import type { Lambda } from '../lambda';
+import { Prerender } from '../prerender';
+import type { BuildResultV2Typical } from '../types';
+import { createFunctionsIterator } from './create-functions-iterator';
+import { deserializeEdgeFunction } from './deserialize-edge-function';
+import type {
+  DeserializeBuildOutputConfig,
+  DeserializeBuildOutputFiles,
+  DeserializeBuildOutputOptions,
+  DeserializeBuildOutputResult,
+  DeserializeBuildOutputSerializedConfig,
+  DeserializeBuildOutputSerializedPrerender,
+  DeserializeBuildOutputPathOverride,
+} from './deserialize-build-output-types';
+import { maybeReadJSON } from './maybe-read-json';
+import { validateFrameworkVersion } from './validate-framework-version';
+
+const MAX_DEPLOYMENT_ID_LENGTH = 32;
+const VALID_DEPLOYMENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export function validateDeploymentId(deploymentId?: string): void {
+  if (deploymentId && deploymentId.length > MAX_DEPLOYMENT_ID_LENGTH) {
+    throw new NowBuildError({
+      message: `The configured deploymentId "${deploymentId}" exceeds the maximum length of ${MAX_DEPLOYMENT_ID_LENGTH} characters. Please use a shorter deploymentId.`,
+      code: 'VC_BUILD_INVALID_DEPLOYMENT_ID_LENGTH',
+    });
+  }
+
+  if (deploymentId && !VALID_DEPLOYMENT_ID_PATTERN.test(deploymentId)) {
+    throw new NowBuildError({
+      message: `The configured deploymentId "${deploymentId}" contains invalid characters. Only alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), and underscores (_) are allowed.`,
+      code: 'VC_BUILD_INVALID_DEPLOYMENT_ID_CHARACTERS',
+    });
+  }
+}
+
+function applyOutputOverrides(
+  output: DeserializeBuildOutputFiles,
+  overrides: Record<string, DeserializeBuildOutputPathOverride> | undefined,
+  warn?: (message: string) => void
+): void {
+  for (const [name, override] of Object.entries(overrides || {})) {
+    const entry = output[name] as FileFsRef | undefined;
+    if (entry) {
+      if (override.contentType) {
+        entry.contentType = override.contentType;
+      }
+      if (override.mode) {
+        entry.mode = override.mode;
+      }
+      if (override.path) {
+        output[override.path] = entry;
+        delete output[name];
+      }
+    } else {
+      warn?.(
+        `Warning: Override path "${name}" was not detected as an output path`
+      );
+    }
+  }
+}
+
+async function deserializePrerenderFallback(
+  prerenderConfigPath: string,
+  fallbackConfig: DeserializeBuildOutputSerializedPrerender['fallback']
+): Promise<Prerender['fallback']> {
+  if (typeof fallbackConfig === 'string') {
+    return FileFsRef.fromFsPath({
+      fsPath: join(dirname(prerenderConfigPath), fallbackConfig),
+    });
+  }
+
+  if (fallbackConfig) {
+    return FileFsRef.fromFsPath({
+      mode: fallbackConfig.mode,
+      contentType: fallbackConfig.contentType,
+      fsPath: join(dirname(prerenderConfigPath), fallbackConfig.fsPath),
+    });
+  }
+
+  return null;
+}
+
+function applyFunctionSymlinks(
+  output: DeserializeBuildOutputFiles,
+  prerenders: Map<string, Prerender>,
+  functionSymlinks: Map<string, string>
+): void {
+  for (const [path, target] of functionSymlinks.entries()) {
+    const targetOutput = prerenders.get(target) || output[target];
+    let targetFunction: Lambda | EdgeFunction | undefined;
+    if (targetOutput?.type === 'Prerender') {
+      targetFunction = targetOutput.lambda;
+    } else if (
+      targetOutput?.type === 'Lambda' ||
+      targetOutput?.type === 'EdgeFunction'
+    ) {
+      targetFunction = targetOutput;
+    }
+    if (!targetFunction) {
+      throw new Error(
+        `Could not find target "${target}" Lambda or EdgeFunction for path "${path}"`
+      );
+    }
+
+    // TODO: Revert to `output[path]`. This is part of temporary
+    // code to put `Prerenders` at the end of "output" object.
+    // const srcOutput = output[path];
+    const srcOutput = prerenders.get(path);
+    if (srcOutput) {
+      if (srcOutput.type === 'Prerender') {
+        if (targetFunction.type === 'Lambda') {
+          srcOutput.lambda = targetFunction;
+        } else {
+          throw new Error(
+            `Unexpected function type "${targetFunction.type}" at path "${path}"`
+          );
+        }
+      } else {
+        throw new Error(
+          `Unexpected output type "${srcOutput.type}" at path "${path}"`
+        );
+      }
+    } else {
+      output[path] = targetFunction;
+    }
+  }
+}
+
+function appendSortedPrerenders(
+  output: DeserializeBuildOutputFiles,
+  prerenders: Map<string, Prerender>
+): void {
+  const sortedPrerenders = Array.from(prerenders.entries())
+    .sort((a, b) => {
+      return (a[1].group ?? 0) - (b[1].group ?? 0);
+    })
+    .reduce<Record<string, Prerender>>((o, [path, prerender]) => {
+      o[path] = prerender;
+      return o;
+    }, {});
+
+  // TODO: Remove. This is part of temporary code to put `Prerenders`
+  // at the end of "output" object. See note above.
+  Object.assign(output, sortedPrerenders);
+}
+
+function getBundleableLambdas<TLambda extends Lambda>(
+  output: DeserializeBuildOutputFiles
+): Record<string, TLambda> {
+  const bundleableLambdas: Record<string, TLambda> = {};
+
+  for (const [outputName, curOutput] of Object.entries(output)) {
+    if (curOutput.type === 'Lambda' && curOutput.experimentalAllowBundling) {
+      bundleableLambdas[outputName] = curOutput as TLambda;
+    } else if (
+      curOutput.type === 'Prerender' &&
+      curOutput.lambda &&
+      curOutput.lambda.experimentalAllowBundling
+    ) {
+      bundleableLambdas[outputName] = curOutput.lambda as TLambda;
+    }
+  }
+
+  return bundleableLambdas;
+}
+
+function applyGroupedLambdas<TLambda extends Lambda>(
+  output: DeserializeBuildOutputFiles,
+  groupedLambdas: Record<string, TLambda>
+): void {
+  for (const outputName of Object.keys(groupedLambdas)) {
+    const groupedLambda = groupedLambdas[outputName];
+    const origOutput = output[outputName];
+
+    if (origOutput.type === 'Lambda') {
+      output[outputName] = groupedLambda;
+    } else if (origOutput.type === 'Prerender' && origOutput.lambda) {
+      origOutput.lambda = groupedLambda;
+    }
+  }
+}
+
+export async function deserializeBuildOutput<
+  TConfig extends DeserializeBuildOutputConfig = DeserializeBuildOutputConfig,
+  TResult extends DeserializeBuildOutputResult = DeserializeBuildOutputResult,
+  TLambda extends Lambda = Lambda,
+>(options: DeserializeBuildOutputOptions<TResult, TLambda>): Promise<TResult> {
+  const {
+    outputDir,
+    repoRootPath,
+    maxBundleSizeMb,
+    debugGroupLambdas,
+    useOnlyStreamingLambda,
+    forceNodejsStreaming,
+    deserializeLambda,
+    groupLambdas,
+    inspectSerializedLambda,
+    warn,
+    includeDeploymentId,
+    getMeta,
+  } = options;
+  let hasServerActions = false;
+  const configPath = join(outputDir, 'config.json');
+  const config = await maybeReadJSON<TConfig>(configPath);
+
+  if (!config) {
+    throw new Error(`Config file was not found at "${configPath}"`);
+  }
+
+  if (config.version !== 3) {
+    throw new Error(
+      `Expected \`version: 3\` in "${configPath}" file (received \`${config.version}\`)`
+    );
+  }
+
+  validateDeploymentId(config.deploymentId);
+
+  const flags = await maybeReadJSON<TResult['flags']>(
+    join(outputDir, 'flags.json')
+  );
+
+  const staticDir = join(outputDir, 'static');
+  const output: BuildResultV2Typical['output'] = await glob('**', {
+    cwd: staticDir,
+    follow: true,
+  });
+
+  applyOutputOverrides(output, config.overrides, warn);
+
+  const fileFsRefsCache = new Map<string, FileFsRef>();
+
+  // Note: There is a bug in existing callers which requires Prerenders
+  // to come *after* regular Lambdas in the `output` object, otherwise
+  // Lambdas that share a reference to a Prerender will be treated like
+  // a Prerender.
+  // This is a temporary hack to ensure prerenders are placed at the end
+  // of the `output` object to work around that issue, until it's fixed
+  // more properly in existing callers.
+  const prerenders = new Map<string, Prerender>();
+
+  const functionsDir = join(outputDir, 'functions');
+  const functionSymlinks: Map<string, string> = new Map();
+  for await (const path of createFunctionsIterator(functionsDir)) {
+    let lambda: TLambda | undefined = undefined;
+    const fnDir = join(functionsDir, `${path}.func`);
+
+    try {
+      const link = await fs.readlink(fnDir);
+      const target = join(dirname(path), link).slice(0, -5);
+      functionSymlinks.set(path, target);
+    } catch (err: any) {
+      if (err.code !== 'EINVAL') throw err;
+
+      const funcConfigPath = join(fnDir, '.vc-config.json');
+      const funcConfig =
+        await maybeReadJSON<DeserializeBuildOutputSerializedConfig>(
+          funcConfigPath
+        );
+
+      if (!funcConfig) {
+        throw new Error(`Could not load function config: "${funcConfigPath}"`);
+      }
+
+      const files = await glob('**', { cwd: fnDir, includeDirectories: true });
+      delete files['.vc-config.json'];
+
+      if (funcConfig.type === 'EdgeFunction' || funcConfig.runtime === 'edge') {
+        output[path] = await deserializeEdgeFunction(
+          files,
+          funcConfig as DeserializeBuildOutputSerializedConfig & {
+            type: 'EdgeFunction';
+          },
+          repoRootPath,
+          fileFsRefsCache
+        );
+        continue;
+      }
+
+      lambda = await deserializeLambda(
+        files,
+        funcConfig,
+        repoRootPath,
+        fileFsRefsCache,
+        { useOnlyStreamingLambda, forceNodejsStreaming }
+      );
+
+      if (inspectSerializedLambda) {
+        hasServerActions = await inspectSerializedLambda(
+          path,
+          funcConfig,
+          repoRootPath,
+          hasServerActions
+        );
+      }
+    }
+
+    const prerenderConfigPath = join(
+      functionsDir,
+      `${path}.prerender-config.json`
+    );
+    const prerenderConfig =
+      await maybeReadJSON<DeserializeBuildOutputSerializedPrerender>(
+        prerenderConfigPath
+      );
+    if (prerenderConfig) {
+      const fallback = await deserializePrerenderFallback(
+        prerenderConfigPath,
+        prerenderConfig.fallback
+      );
+
+      const prerender = new Prerender({
+        ...prerenderConfig,
+        lambda,
+        fallback,
+      });
+
+      prerenders.set(path, prerender);
+    } else if (lambda) {
+      output[path] = lambda;
+    }
+  }
+
+  applyFunctionSymlinks(output, prerenders, functionSymlinks);
+  appendSortedPrerenders(output, prerenders);
+
+  const groupedLambdas = await groupLambdas(
+    getBundleableLambdas<TLambda>(output),
+    {
+      force: undefined,
+      maxBundleSizeMb,
+      debug: debugGroupLambdas,
+    }
+  );
+  applyGroupedLambdas(output, groupedLambdas);
+
+  const framework = validateFrameworkVersion(config?.framework?.version);
+  const meta = getMeta?.(hasServerActions);
+  return {
+    wildcard: config.wildcard,
+    images: config.images,
+    crons: config.crons,
+    flags: flags ? flags : config.flags,
+    routes: config.routes,
+    output,
+    framework,
+    ...(includeDeploymentId ? { deploymentId: config.deploymentId } : {}),
+    ...(meta !== undefined ? { meta } : {}),
+  } as TResult;
+}

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -230,6 +230,20 @@ export { validateFrameworkVersion } from './deserialize/validate-framework-versi
 export { hydrateFilesMap } from './deserialize/hydrate-files-map';
 export { createFunctionsIterator } from './deserialize/create-functions-iterator';
 export { maybeReadJSON } from './deserialize/maybe-read-json';
+export {
+  deserializeBuildOutput,
+  validateDeploymentId,
+} from './deserialize/deserialize-build-output';
+export type {
+  DeserializeBuildOutputConfig,
+  DeserializeBuildOutputResult,
+  DeserializeBuildOutputPathOverride,
+  DeserializeBuildOutputOptions,
+  DeserializeBuildOutputLambdaOptions,
+  GroupLambdasOptions,
+  DeserializeBuildOutputSerializedConfig,
+  DeserializeBuildOutputSerializedPrerender,
+} from './deserialize/deserialize-build-output-types';
 
 export {
   deserializeLambda,

--- a/packages/build-utils/test/unit.deserialize-build-output.test.ts
+++ b/packages/build-utils/test/unit.deserialize-build-output.test.ts
@@ -1,0 +1,234 @@
+import * as fs from 'fs-extra';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { Lambda } from '../src/lambda';
+import type {
+  DeserializeBuildOutputConfig,
+  DeserializeBuildOutputResult,
+} from '../src/deserialize/deserialize-build-output-types';
+import { deserializeBuildOutput } from '../src/deserialize/deserialize-build-output';
+
+type LegacyFlag = {
+  key: string;
+  defaultValue?: unknown;
+  metadata: Record<string, unknown>;
+};
+
+type TestConfig = DeserializeBuildOutputConfig<LegacyFlag[]>;
+type TestResult = DeserializeBuildOutputResult<
+  { definitions: Record<string, unknown> } | LegacyFlag[],
+  { hasServerActions?: boolean }
+>;
+
+async function createOutputFixture(config: Partial<TestConfig> = {}) {
+  const repoRootPath = await fs.mkdtemp(join(tmpdir(), 'deserialize-build-'));
+  const outputDir = join(repoRootPath, '.vercel', 'output');
+
+  await fs.ensureDir(join(outputDir, 'static'));
+  await fs.ensureDir(join(outputDir, 'functions'));
+  await fs.outputJSON(join(outputDir, 'config.json'), {
+    version: 3,
+    ...config,
+  });
+
+  return {
+    outputDir,
+    repoRootPath,
+    async cleanup() {
+      await fs.remove(repoRootPath);
+    },
+  };
+}
+
+async function writeNodeFunction(outputDir: string, outputPath: string) {
+  const functionDir = join(outputDir, 'functions', `${outputPath}.func`);
+  await fs.outputJSON(join(functionDir, '.vc-config.json'), {
+    handler: 'index.handler',
+    launcherType: 'Nodejs',
+    runtime: 'nodejs20.x',
+    shouldAddHelpers: false,
+    shouldAddSourcemapSupport: false,
+  });
+  await fs.outputFile(
+    join(functionDir, 'index.js'),
+    'exports.handler = () => "ok";'
+  );
+}
+
+async function writePrerenderConfig(outputDir: string, outputPath: string) {
+  await fs.outputJSON(
+    join(outputDir, 'functions', `${outputPath}.prerender-config.json`),
+    {
+      expiration: 60,
+      fallback: null,
+    }
+  );
+}
+
+function createLambda(handler: string, experimentalAllowBundling = false) {
+  return new Lambda({
+    files: {},
+    handler,
+    runtime: 'nodejs20.x',
+    experimentalAllowBundling,
+  });
+}
+
+class TestLambda extends Lambda {}
+
+describe('deserializeBuildOutput()', () => {
+  it.each([
+    {
+      deploymentId: 'x'.repeat(33),
+      expectedCode: 'VC_BUILD_INVALID_DEPLOYMENT_ID_LENGTH',
+    },
+    {
+      deploymentId: 'invalid deployment id?',
+      expectedCode: 'VC_BUILD_INVALID_DEPLOYMENT_ID_CHARACTERS',
+    },
+  ])('validates deploymentId: $expectedCode', async ({
+    deploymentId,
+    expectedCode,
+  }) => {
+    const fixture = await createOutputFixture({ deploymentId });
+
+    try {
+      await expect(
+        deserializeBuildOutput<TestConfig, TestResult>({
+          outputDir: fixture.outputDir,
+          repoRootPath: fixture.repoRootPath,
+          deserializeLambda: async () => createLambda('noop.handler'),
+          groupLambdas: async () => ({}),
+        })
+      ).rejects.toMatchObject({
+        code: expectedCode,
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it('warns on missing overrides, remaps output paths, and supports caller-provided meta and deploymentId', async () => {
+    const fixture = await createOutputFixture({
+      deploymentId: 'dpl_custom',
+      overrides: {
+        'static/hello.txt': {
+          path: 'static/renamed.txt',
+        },
+        'static/missing.txt': {
+          path: 'static/never-created.txt',
+        },
+      },
+    });
+    const warn = vi.fn();
+
+    try {
+      await fs.outputFile(
+        join(fixture.outputDir, 'static', 'static', 'hello.txt'),
+        'hello'
+      );
+      await writeNodeFunction(fixture.outputDir, 'api/server-actions');
+
+      const result = await deserializeBuildOutput<TestConfig, TestResult>({
+        outputDir: fixture.outputDir,
+        repoRootPath: fixture.repoRootPath,
+        deserializeLambda: async () => createLambda('server-actions.handler'),
+        groupLambdas: async () => ({}),
+        inspectSerializedLambda: async path => path === 'api/server-actions',
+        warn,
+        includeDeploymentId: true,
+        getMeta: hasServerActions => ({ hasServerActions }),
+      });
+
+      expect(result.output['static/renamed.txt']).toBeDefined();
+      expect(result.output['static/hello.txt']).toBeUndefined();
+      expect(result.deploymentId).toBe('dpl_custom');
+      expect(result.meta).toEqual({ hasServerActions: true });
+      expect(warn).toHaveBeenCalledWith(
+        'Warning: Override path "static/missing.txt" was not detected as an output path'
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it('replaces grouped lambdas for plain lambdas and prerenders without adding meta or deploymentId by default', async () => {
+    const fixture = await createOutputFixture({
+      deploymentId: 'dpl_custom',
+    });
+
+    try {
+      await writeNodeFunction(fixture.outputDir, 'api/plain');
+      await writeNodeFunction(fixture.outputDir, 'api/prerendered');
+      await writePrerenderConfig(fixture.outputDir, 'api/prerendered');
+
+      const result = await deserializeBuildOutput<TestConfig>({
+        outputDir: fixture.outputDir,
+        repoRootPath: fixture.repoRootPath,
+        deserializeLambda: async (_files, _config, _repoRootPath, _cache) =>
+          createLambda('original.handler', true),
+        groupLambdas: async lambdas => ({
+          ...lambdas,
+          'api/plain': createLambda('grouped-plain.handler'),
+          'api/prerendered': createLambda('grouped-prerender.handler'),
+        }),
+      });
+
+      expect(result.output['api/plain']).toEqual(
+        expect.objectContaining({
+          type: 'Lambda',
+          handler: 'grouped-plain.handler',
+        })
+      );
+
+      const prerenderOutput = result.output['api/prerendered'];
+      expect(prerenderOutput.type).toBe('Prerender');
+      if (prerenderOutput.type !== 'Prerender') {
+        throw new Error('Expected prerender output');
+      }
+      expect(prerenderOutput.lambda).toEqual(
+        expect.objectContaining({
+          type: 'Lambda',
+          handler: 'grouped-prerender.handler',
+        })
+      );
+      expect(result.meta).toBeUndefined();
+      expect(result.deploymentId).toBeUndefined();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it('supports caller-provided Lambda subclasses through grouping callbacks', async () => {
+    const fixture = await createOutputFixture();
+
+    try {
+      await writeNodeFunction(fixture.outputDir, 'api/custom-lambda');
+
+      const result = await deserializeBuildOutput<
+        TestConfig,
+        DeserializeBuildOutputResult,
+        TestLambda
+      >({
+        outputDir: fixture.outputDir,
+        repoRootPath: fixture.repoRootPath,
+        deserializeLambda: async () =>
+          new TestLambda({
+            files: {},
+            handler: 'custom.handler',
+            runtime: 'nodejs20.x',
+            experimentalAllowBundling: true,
+          }),
+        groupLambdas: async lambdas => {
+          expect(lambdas['api/custom-lambda']).toBeInstanceOf(TestLambda);
+          return lambdas;
+        },
+      });
+
+      expect(result.output['api/custom-lambda']).toBeInstanceOf(TestLambda);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});

--- a/packages/build-utils/test/unit.deserialize-build-output.test.ts
+++ b/packages/build-utils/test/unit.deserialize-build-output.test.ts
@@ -21,6 +21,25 @@ type TestResult = DeserializeBuildOutputResult<
   { hasServerActions?: boolean }
 >;
 
+function normalizeOutputPath(path: string): string {
+  return path.replaceAll('\\', '/');
+}
+
+function getOutputKey(
+  output: Record<string, unknown>,
+  expectedPath: string
+): string {
+  const matchingKey = Object.keys(output).find(
+    path => normalizeOutputPath(path) === expectedPath
+  );
+
+  if (!matchingKey) {
+    throw new Error(`Could not find output path "${expectedPath}"`);
+  }
+
+  return matchingKey;
+}
+
 async function createOutputFixture(config: Partial<TestConfig> = {}) {
   const repoRootPath = await fs.mkdtemp(join(tmpdir(), 'deserialize-build-'));
   const outputDir = join(repoRootPath, '.vercel', 'output');
@@ -135,7 +154,8 @@ describe('deserializeBuildOutput()', () => {
         repoRootPath: fixture.repoRootPath,
         deserializeLambda: async () => createLambda('server-actions.handler'),
         groupLambdas: async () => ({}),
-        inspectSerializedLambda: async path => path === 'api/server-actions',
+        inspectSerializedLambda: async path =>
+          normalizeOutputPath(path) === 'api/server-actions',
         warn,
         includeDeploymentId: true,
         getMeta: hasServerActions => ({ hasServerActions }),
@@ -163,26 +183,33 @@ describe('deserializeBuildOutput()', () => {
       await writeNodeFunction(fixture.outputDir, 'api/prerendered');
       await writePrerenderConfig(fixture.outputDir, 'api/prerendered');
 
+      let plainKey = '';
+      let prerenderedKey = '';
       const result = await deserializeBuildOutput<TestConfig>({
         outputDir: fixture.outputDir,
         repoRootPath: fixture.repoRootPath,
         deserializeLambda: async (_files, _config, _repoRootPath, _cache) =>
           createLambda('original.handler', true),
-        groupLambdas: async lambdas => ({
-          ...lambdas,
-          'api/plain': createLambda('grouped-plain.handler'),
-          'api/prerendered': createLambda('grouped-prerender.handler'),
-        }),
+        groupLambdas: async lambdas => {
+          plainKey = getOutputKey(lambdas, 'api/plain');
+          prerenderedKey = getOutputKey(lambdas, 'api/prerendered');
+
+          return {
+            ...lambdas,
+            [plainKey]: createLambda('grouped-plain.handler'),
+            [prerenderedKey]: createLambda('grouped-prerender.handler'),
+          };
+        },
       });
 
-      expect(result.output['api/plain']).toEqual(
+      expect(result.output[plainKey]).toEqual(
         expect.objectContaining({
           type: 'Lambda',
           handler: 'grouped-plain.handler',
         })
       );
 
-      const prerenderOutput = result.output['api/prerendered'];
+      const prerenderOutput = result.output[prerenderedKey];
       expect(prerenderOutput.type).toBe('Prerender');
       if (prerenderOutput.type !== 'Prerender') {
         throw new Error('Expected prerender output');
@@ -206,6 +233,7 @@ describe('deserializeBuildOutput()', () => {
     try {
       await writeNodeFunction(fixture.outputDir, 'api/custom-lambda');
 
+      let customLambdaKey = '';
       const result = await deserializeBuildOutput<
         TestConfig,
         DeserializeBuildOutputResult,
@@ -221,12 +249,13 @@ describe('deserializeBuildOutput()', () => {
             experimentalAllowBundling: true,
           }),
         groupLambdas: async lambdas => {
-          expect(lambdas['api/custom-lambda']).toBeInstanceOf(TestLambda);
+          customLambdaKey = getOutputKey(lambdas, 'api/custom-lambda');
+          expect(lambdas[customLambdaKey]).toBeInstanceOf(TestLambda);
           return lambdas;
         },
       });
 
-      expect(result.output['api/custom-lambda']).toBeInstanceOf(TestLambda);
+      expect(result.output[customLambdaKey]).toBeInstanceOf(TestLambda);
     } finally {
       await fixture.cleanup();
     }


### PR DESCRIPTION
Building on previous PRs:
- https://github.com/vercel/vercel/pull/15927
- https://github.com/vercel/vercel/pull/15961
- https://github.com/vercel/vercel/pull/16002


We are extracting the core `deserialize-build-output.ts` file here. This is following refactor efforts in the existing caller codebases to make this extraction simpler.

After shipping this extraction, we'll delete the duplicated code and import `deserializeBuildOutput` from this PR. Doing this should introduce zero semantic changes for those callers.

Note: callers must inject their own `groupLambdas` strategy.

Note2: some existing TODO comments have been left in-place as code documentation.