### PR TITLE
feat(cli): policy + Development guards on `env update`

### DIFF
--- a/.changeset/env-update-policy-guards.md
+++ b/.changeset/env-update-policy-guards.md
@@ -1,0 +1,10 @@
+---
+'vercel': patch
+---
+
+`vercel env update` now applies the same Development guards as `vercel env add`:
+
+- Errors with a docs-linked message when the selected record targets Development and the team has the Sensitive Environment Variables Policy enabled. No PATCH is attempted.
+- Errors when `--sensitive` is used on a record that targets Development (regardless of policy). Sensitive is not allowed on Development.
+
+Other `env update` behavior is unchanged.

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -20,7 +20,14 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { updateSubcommand } from './command';
 import { getLinkedProject } from '../../util/projects/link';
+import getTeamById from '../../util/teams/get-team-by-id';
 import type { ProjectEnvVariable } from '@vercel-internals/types';
+
+function selectedEnvTargetsDevelopment(env: ProjectEnvVariable): boolean {
+  if (typeof env.target === 'string') return env.target === 'development';
+  if (Array.isArray(env.target)) return env.target.includes('development');
+  return false;
+}
 import {
   outputActionRequired,
   outputAgentError,
@@ -349,6 +356,53 @@ export default async function update(client: Client, argv: string[]) {
     });
 
     selectedEnv = matchingEnvs[selectedIndex];
+  }
+
+  // Detect team-level sensitive env var policy. Cached in getTeamById.
+  let policyOn = false;
+  if (link.org.type === 'team') {
+    try {
+      const team = await getTeamById(client, link.org.id);
+      policyOn = team?.sensitiveEnvironmentVariablePolicy === 'on';
+    } catch {
+      // Non-fatal — policy detection is best-effort.
+    }
+  }
+
+  const selectedIsDevelopment = selectedEnvTargetsDevelopment(selectedEnv);
+
+  if (policyOn && selectedIsDevelopment) {
+    const msg = `Your team has enabled the Sensitive Environment Variables Policy and the Development Environment does not support sensitive values. https://vercel.com/docs/environment-variables/sensitive-environment-variables#environment-variables-policy`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'development_disallowed_by_team_policy',
+          message: msg,
+        },
+        1
+      );
+    }
+    output.error(msg);
+    return 1;
+  }
+
+  if (opts['--sensitive'] && selectedIsDevelopment) {
+    const msg = `--sensitive is not allowed with the Development Environment. Sensitive Environment Variables are only supported on Production and Preview.`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'sensitive_not_allowed_on_development',
+          message: msg,
+        },
+        1
+      );
+    }
+    output.error(msg);
+    return 1;
   }
 
   let envValue: string;

--- a/packages/cli/test/unit/commands/env/update.test.ts
+++ b/packages/cli/test/unit/commands/env/update.test.ts
@@ -5,6 +5,7 @@ import { client } from '../../../mocks/client';
 import { defaultProject, envs, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
+import type { ProjectEnvVariable } from '@vercel-internals/types';
 
 describe('env update', () => {
   beforeEach(() => {
@@ -357,6 +358,97 @@ describe('env update', () => {
       await expect(client.stderr).toOutput('Updated Environment Variable');
       const exitCode = await updatePromise;
       expect(exitCode).toBe(0);
+    });
+  });
+
+  describe('Development guards', () => {
+    const devEnv: ProjectEnvVariable = {
+      type: 'encrypted',
+      id: 'test-env-id-dev-123',
+      key: 'TEST_VAR_DEV',
+      value: 'dev-value',
+      target: ['development'],
+      gitBranch: undefined,
+      configurationId: null,
+      updatedAt: 1557241361455,
+      createdAt: 1557241361455,
+      customEnvironmentIds: [],
+    };
+
+    beforeEach(() => {
+      client.reset();
+      useUser();
+      useTeams('team_dummy');
+      useProject(
+        {
+          ...defaultProject,
+          id: 'vercel-env-pull',
+          name: 'vercel-env-pull',
+        },
+        [
+          ...envs,
+          {
+            type: 'encrypted',
+            id: 'test-env-id-123',
+            key: 'TEST_VAR',
+            value: 'test-value',
+            target: ['production'],
+            gitBranch: undefined,
+            configurationId: null,
+            updatedAt: 1557241361455,
+            createdAt: 1557241361455,
+            customEnvironmentIds: [],
+          },
+          devEnv,
+        ]
+      );
+    });
+
+    it('errors when --sensitive is used on a Development record', async () => {
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv(
+        'env',
+        'update',
+        'TEST_VAR_DEV',
+        '--sensitive',
+        '--value',
+        'new-value',
+        '--yes'
+      );
+      const exitCodePromise = env(client);
+      await expect(client.stderr).toOutput(
+        '--sensitive is not allowed with the Development Environment'
+      );
+      await expect(exitCodePromise).resolves.toBe(1);
+    });
+
+    it('errors when the team enforces sensitive and the record targets Development', async () => {
+      const teamModule = await import(
+        '../../../../src/util/teams/get-team-by-id'
+      );
+      const teamSpy = vi.spyOn(teamModule, 'default').mockResolvedValue({
+        sensitiveEnvironmentVariablePolicy: 'on',
+        // biome-ignore lint/suspicious/noExplicitAny: partial team shape
+      } as any);
+
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv(
+        'env',
+        'update',
+        'TEST_VAR_DEV',
+        '--value',
+        'new-value',
+        '--yes'
+      );
+      const exitCodePromise = env(client);
+      await expect(client.stderr).toOutput(
+        'Your team has enabled the Sensitive Environment Variables Policy and the Development Environment does not support sensitive values.'
+      );
+      await expect(exitCodePromise).resolves.toBe(1);
+
+      teamSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mirrors the two Development guards from `vercel env add` (shipped in #16041) onto `vercel env update`, so both subcommands behave consistently under the Sensitive Environment Variables Policy.

## Behavior change

`vercel env update` now:

1. **Errors when the selected record targets Development and the team has the policy enabled**, with the same docs-linked message as `env add`. No PATCH is attempted.
2. **Errors when `--sensitive` is used on a Development record**, regardless of policy. Sensitive is not allowed on Development.

Both checks run **after** the record is resolved (so interactive multi-match selection still works) and **before** value entry, so the error lands as soon as the target is knowable.

No other behavior on `env update` changes: no new flags, no new defaults, no new prompts.

## Why this matters

The `env add` PR (#16041) introduced policy awareness and blocked Development writes on policy-on teams. `env update` was untouched, so a user on a policy-on team could still `vercel env update DEV_VAR --sensitive --value …`, the CLI would send `type: sensitive` in the PATCH, and the API would either silently reject or behave inconsistently. These guards close that gap.

## Files touched

- `packages/cli/src/commands/env/update.ts` — new `selectedEnvTargetsDevelopment` helper, team policy detection via `getTeamById`, two new error paths.
- `packages/cli/test/unit/commands/env/update.test.ts` — new `Development guards` describe with two tests covering both error paths.
- `.changeset/env-update-policy-guards.md` — `vercel: patch`.

## Tests

- `pnpm vitest run test/unit/commands/env/ test/unit/commands/help.test.ts` — 8 files, 235 tests, all pass.
- `pnpm lint` — clean.
- `prettier --check` — clean.

## Follow-up candidates (not in this PR)

- `--no-sensitive` on `env update` so `sensitive → encrypted` is CLI-reachable on policy-off teams (unverified whether the API allows the downgrade).
- Warning on `env update` when the record is on a policy-covered target and its effective type will be silently promoted to sensitive by the server.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80fd2759-df06-4af1-9dce-3ff5989cee49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80fd2759-df06-4af1-9dce-3ff5989cee49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

