### PR TITLE
[CLI] Gating env pull commands behind 2FA

### DIFF
--- a/.changeset/mfa-env-pull-dev.md
+++ b/.changeset/mfa-env-pull-dev.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Require two-factor authentication for `vc env pull`, `vc dev`, and `vc pull` when invoked interactively. Users without MFA enabled on their account are prompted to enable it. Users with MFA enabled are re-authenticated through the device-code login flow to mint a fresh token. Automated contexts (`CI` env var or `VERCEL_TOKEN` set) are unaffected.

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -83,6 +83,7 @@ export type User = {
   limited?: boolean;
   version?: 'northstar';
   defaultTeamId?: string;
+  mfa?: { enabled: boolean; hasTotp?: boolean };
 };
 
 export interface Team {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -8,6 +8,7 @@ import DevServer from '../../util/dev/server';
 import { parseListen } from '../../util/dev/parse-listen';
 import type Client from '../../util/client';
 import { getLinkedProject } from '../../util/projects/link';
+import { requireMfaAuth } from '../../util/login/require-mfa-auth';
 import type { ProjectSettings } from '@vercel-internals/types';
 import setupAndLink from '../../util/link/setup-and-link';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
@@ -45,6 +46,14 @@ export default async function dev(
   const listen = parseListen(opts['--listen'] || '3000');
 
   cwd = await resolveProjectCwd(cwd);
+
+  const isAutomatedContext = Boolean(
+    process.env.VERCEL_TOKEN || process.env.CI
+  );
+  if (!isAutomatedContext) {
+    const gate = await requireMfaAuth(client);
+    if (gate !== true) return gate;
+  }
 
   // retrieve dev command
   let link = await getLinkedProject(client, cwd);

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -29,6 +29,7 @@ import { printError } from '../../util/error';
 import parseTarget from '../../util/parse-target';
 import { getLinkedProject } from '../../util/projects/link';
 import getUser from '../../util/get-user';
+import { performDeviceCodeFlow } from '../login/future';
 import {
   buildCommandWithYes,
   getPreservedArgsForEnvPull,
@@ -117,6 +118,23 @@ export default async function pull(
         'Two-factor authentication is required to pull environment variables. Enable it at https://vercel.com/account/security and try again.'
       );
       return 1;
+    }
+
+    if (!client.justAuthenticated) {
+      output.log('Re-authentication required. Opening your browser...');
+      const tokens = await performDeviceCodeFlow(client);
+      if (!tokens) {
+        output.error('Authentication was not completed.');
+        return 1;
+      }
+      client.updateAuthConfig({
+        token: tokens.access_token,
+        userId: undefined,
+        expiresAt: Math.floor(Date.now() / 1000) + tokens.expires_in,
+        refreshToken: tokens.refresh_token,
+      });
+      client.writeToAuthConfigFile();
+      client.justAuthenticated = true;
     }
   }
 

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -28,8 +28,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import parseTarget from '../../util/parse-target';
 import { getLinkedProject } from '../../util/projects/link';
-import getUser from '../../util/get-user';
-import { performDeviceCodeFlow } from '../login/future';
+import { requireMfaAuth } from '../../util/login/require-mfa-auth';
 import {
   buildCommandWithYes,
   getPreservedArgsForEnvPull,
@@ -112,30 +111,8 @@ export default async function pull(
   );
 
   if (!isAutomatedContext) {
-    const user = await getUser(client);
-    if (!user.mfa?.enabled) {
-      output.error(
-        'Two-factor authentication is required to pull environment variables. Enable it at https://vercel.com/account/security and try again.'
-      );
-      return 1;
-    }
-
-    if (!client.justAuthenticated) {
-      output.log('Re-authentication required. Opening your browser...');
-      const tokens = await performDeviceCodeFlow(client);
-      if (!tokens) {
-        output.error('Authentication was not completed.');
-        return 1;
-      }
-      client.updateAuthConfig({
-        token: tokens.access_token,
-        userId: undefined,
-        expiresAt: Math.floor(Date.now() / 1000) + tokens.expires_in,
-        refreshToken: tokens.refresh_token,
-      });
-      client.writeToAuthConfigFile();
-      client.justAuthenticated = true;
-    }
+    const gate = await requireMfaAuth(client);
+    if (gate !== true) return gate;
   }
 
   const link = await getLinkedProject(client);

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -28,6 +28,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import parseTarget from '../../util/parse-target';
 import { getLinkedProject } from '../../util/projects/link';
+import getUser from '../../util/get-user';
 import {
   buildCommandWithYes,
   getPreservedArgsForEnvPull,
@@ -104,6 +105,20 @@ export default async function pull(
   telemetryClient.trackCliOptionGitBranch(gitBranch);
   telemetryClient.trackCliOptionEnvironment(opts['--environment']);
   telemetryClient.trackCliOptionId(opts['--id']);
+
+  const isAutomatedContext = Boolean(
+    process.env.VERCEL_TOKEN || process.env.CI
+  );
+
+  if (!isAutomatedContext) {
+    const user = await getUser(client);
+    if (!user.mfa?.enabled) {
+      output.error(
+        'Two-factor authentication is required to pull environment variables. Enable it at https://vercel.com/account/security and try again.'
+      );
+      return 1;
+    }
+  }
 
   const link = await getLinkedProject(client);
   if (link.status === 'error') {

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -23,6 +23,7 @@ import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { PullTelemetryClient } from '../../util/telemetry/commands/pull';
 import { autoInstallVercelPlugin } from '../../util/agent/auto-install-agentic';
+import { requireMfaAuth } from '../../util/login/require-mfa-auth';
 
 async function pullAllEnvFiles(
   environment: string,
@@ -97,6 +98,14 @@ export default async function main(client: Client) {
   telemetryClient.trackCliFlagProd(isProduction);
   telemetryClient.trackCliOptionGitBranch(parsedArgs.flags['--git-branch']);
   telemetryClient.trackCliOptionEnvironment(parsedArgs.flags['--environment']);
+
+  const isAutomatedContext = Boolean(
+    process.env.VERCEL_TOKEN || process.env.CI
+  );
+  if (!isAutomatedContext) {
+    const gate = await requireMfaAuth(client);
+    if (gate !== true) return gate;
+  }
 
   const returnCode = await pullCommandLogic(
     client,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -670,6 +670,7 @@ const main = async () => {
         const result = await login(client, { shouldParseArgs: false });
         // The login function failed, so it returned an exit code
         if (result !== 0) return finishWithExitCode(result);
+        client.justAuthenticated = true;
       } catch (error) {
         printError(error);
         trackAgenticErrorTelemetry(error);
@@ -684,6 +685,7 @@ const main = async () => {
       try {
         const result = await login(client, { shouldParseArgs: false });
         if (result !== 0) return finishWithExitCode(result);
+        client.justAuthenticated = true;
       } catch (error) {
         printError(error);
         trackAgenticErrorTelemetry(error);

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -126,6 +126,8 @@ export default class Client extends EventEmitter implements Stdio {
   traceDiagnosticsPath?: string;
   /** Track if we've already logged the token source debug message */
   private _loggedTokenSource: boolean = false;
+  /** True when login/device-flow completed during this CLI invocation */
+  justAuthenticated: boolean = false;
 
   constructor(opts: ClientOptions) {
     super();

--- a/packages/cli/src/util/login/require-mfa-auth.ts
+++ b/packages/cli/src/util/login/require-mfa-auth.ts
@@ -1,0 +1,35 @@
+import type Client from '../client';
+import output from '../../output-manager';
+import getUser from '../get-user';
+import { performDeviceCodeFlow } from '../../commands/login/future';
+
+export async function requireMfaAuth(client: Client): Promise<true | number> {
+  const user = await getUser(client);
+  if (!user.mfa?.enabled) {
+    output.error(
+      'Two-factor authentication is required to run this command. Enable it at https://vercel.com/account/security and try again.'
+    );
+    return 1;
+  }
+
+  if (client.justAuthenticated) {
+    return true;
+  }
+
+  output.log('Re-authentication required. Opening your browser...');
+  const tokens = await performDeviceCodeFlow(client);
+  if (!tokens) {
+    output.error('Authentication was not completed.');
+    return 1;
+  }
+  client.updateAuthConfig({
+    token: tokens.access_token,
+    userId: undefined,
+    expiresAt: Math.floor(Date.now() / 1000) + tokens.expires_in,
+    refreshToken: tokens.refresh_token,
+  });
+  client.writeToAuthConfigFile();
+  client.justAuthenticated = true;
+
+  return true;
+}

--- a/packages/cli/test/unit/commands/dev/index.test.ts
+++ b/packages/cli/test/unit/commands/dev/index.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   // __VERCEL_DEV_RUNNING is set when `vercel dev` runs to act as a lock.
   // It's unset as a side effect of  the process exiting. This won't work under test
   // where `vercel dev` can be invoked several times in a row.
-  vi.stubEnv('__VERCEL_DEV_RUNNING', undefined);
+  delete process.env.__VERCEL_DEV_RUNNING;
   vol.reset();
 });
 
@@ -43,6 +43,7 @@ describe('dev', () => {
   const projectPath = `/user/name/code/${projectName}`;
 
   beforeEach(() => {
+    vi.stubEnv('CI', '1');
     useUser();
     useTeams(orgId);
     useProject({

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -726,4 +726,31 @@ describe('env pull', () => {
       ]);
     });
   });
+
+  describe('mfa pre-flight', () => {
+    it('exits 1 when user has no MFA and no VERCEL_TOKEN/CI set', async () => {
+      const previous = {
+        ci: process.env.CI,
+        token: process.env.VERCEL_TOKEN,
+      };
+      delete process.env.CI;
+      delete process.env.VERCEL_TOKEN;
+
+      try {
+        useUser();
+        client.setArgv('env', 'pull', '--yes');
+
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'Two-factor authentication is required'
+        );
+        expect(await exitCodePromise).toEqual(1);
+      } finally {
+        if (previous.ci !== undefined) process.env.CI = previous.ci;
+        if (previous.token !== undefined) {
+          process.env.VERCEL_TOKEN = previous.token;
+        }
+      }
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs-extra';
 import path from 'path';
 import { parse } from 'dotenv';
@@ -10,6 +10,14 @@ import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 
 describe('env pull', () => {
+  beforeEach(() => {
+    vi.stubEnv('CI', '1');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe('--help', () => {
     it('tracks telemetry', async () => {
       const command = 'env';
@@ -729,28 +737,17 @@ describe('env pull', () => {
 
   describe('mfa pre-flight', () => {
     it('exits 1 when user has no MFA and no VERCEL_TOKEN/CI set', async () => {
-      const previous = {
-        ci: process.env.CI,
-        token: process.env.VERCEL_TOKEN,
-      };
-      delete process.env.CI;
-      delete process.env.VERCEL_TOKEN;
+      vi.stubEnv('CI', '');
+      vi.stubEnv('VERCEL_TOKEN', '');
 
-      try {
-        useUser();
-        client.setArgv('env', 'pull', '--yes');
+      useUser();
+      client.setArgv('env', 'pull', '--yes');
 
-        const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Two-factor authentication is required'
-        );
-        expect(await exitCodePromise).toEqual(1);
-      } finally {
-        if (previous.ci !== undefined) process.env.CI = previous.ci;
-        if (previous.token !== undefined) {
-          process.env.VERCEL_TOKEN = previous.token;
-        }
-      }
+      const exitCodePromise = env(client);
+      await expect(client.stderr).toOutput(
+        'Two-factor authentication is required'
+      );
+      expect(await exitCodePromise).toEqual(1);
     });
   });
 });

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs-extra';
 import path from 'path';
 import pull from '../../../../src/commands/pull';
@@ -10,6 +10,14 @@ import { useTeams, createTeam } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 
 describe('pull', () => {
+  beforeEach(() => {
+    vi.stubEnv('CI', '1');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe('--non-interactive', () => {
     it('outputs action_required JSON and exits when not linked and multiple teams (no --scope)', async () => {
       const cwd = setupUnitFixture('vercel-pull-unlinked');


### PR DESCRIPTION
This does a few things:
- adds a 2FA boolean on user struct from `getUser`
- checks `VERCEL_TOKEN` and `CI` and basically no-op and continue as is 
- Otherwise run MFA check for `env pull` and `vc pull` 