### PR TITLE
fix(cli): clean up test projects in env var E2E tests

### DIFF
--- a/.changeset/cleanup-e2e-env-var-projects.md
+++ b/.changeset/cleanup-e2e-env-var-projects.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clean up test projects in env var E2E tests to prevent leaking orphaned projects on the test team.

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -550,6 +550,8 @@ test('add a sensitive env var', async () => {
   expect(output.stderr).toContain(
     'Added Environment Variable envVarName to Project'
   );
+
+  await apiFetch(`/v2/projects/${projectName}`, { method: 'DELETE' });
 });
 
 test('override an existing env var', async () => {
@@ -612,6 +614,8 @@ test('override an existing env var', async () => {
   expect(outputOverride.stderr).toContain(
     'Overrode Environment Variable envVarName to Project'
   );
+
+  await apiFetch(`/v2/projects/${projectName}`, { method: 'DELETE' });
 });
 
 test('whoami with `VERCEL_ORG_ID` should favor `--scope` and should error', async () => {


### PR DESCRIPTION
## Summary

- The `add a sensitive env var` and `override an existing env var` tests in `integration-2.test.ts` create new Vercel projects with random suffixes (`project-sensitive-env-vars-*`, `project-override-env-vars-*`) but never delete them after the test completes
- This has leaked 1,000+ orphaned projects on the test team, each with a dummy `envVarName=test` env var
- Adds `apiFetch DELETE` cleanup at the end of both tests, matching the pattern already used by other tests in the same file (e.g. `use rootDirectory from project`, the Vercel Auth tests)

## Test plan

- [ ] Existing E2E tests pass (the two modified tests should still pass with the added cleanup)
- [ ] Verify no new `project-override-env-vars-*` or `project-sensitive-env-vars-*` projects are left on the test team after a CI run


Made with [Cursor](https://cursor.com)