### PR TITLE
fix: pin typedoc-plugin-markdown to 3.15.2 to match typedoc 0.24.6 peer

### DIFF
--- a/.changeset/fix-typedoc-plugin-markdown-peer-mismatch.md
+++ b/.changeset/fix-typedoc-plugin-markdown-peer-mismatch.md
@@ -1,0 +1,8 @@
+---
+'@vercel/oidc': patch
+'@vercel/oidc-aws-credentials-provider': patch
+'@vercel/functions': patch
+'@vercel/firewall': patch
+---
+
+Pin `typedoc-plugin-markdown` to `3.15.2` and `typedoc-plugin-mdn-links` to `3.0.3` to match the version used by `@vercel/edge`. The previous `4.1.2` version requires `typedoc@0.26.x` as a peer dependency but was paired with `typedoc@0.24.6`, which caused CI failures whenever pnpm hoisted the 4.x plugin (the plugin calls `app.internationalization.addTranslations`, which does not exist in typedoc 0.24). The choice of which plugin version got hoisted was non-deterministic, which is why the failure appeared as flaky `Build @vercel/<pkg>` steps in CI.

--- a/packages/firewall/package.json
+++ b/packages/firewall/package.json
@@ -26,8 +26,8 @@
     "@smithy/types": "3.3.0",
     "tinyspawn": "1.3.1",
     "typedoc": "0.24.6",
-    "typedoc-plugin-markdown": "4.1.2",
-    "typedoc-plugin-mdn-links": "3.2.3",
+    "typedoc-plugin-markdown": "3.15.2",
+    "typedoc-plugin-mdn-links": "3.0.3",
     "typescript": "4.9.5",
     "vitest": "2.0.1"
   },

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -51,8 +51,8 @@
     "mysql2": "3.14.2",
     "tinyspawn": "1.3.1",
     "typedoc": "0.24.6",
-    "typedoc-plugin-markdown": "4.1.2",
-    "typedoc-plugin-mdn-links": "3.2.3",
+    "typedoc-plugin-markdown": "3.15.2",
+    "typedoc-plugin-mdn-links": "3.0.3",
     "typescript": "4.9.5",
     "vitest": "2.0.1"
   },

--- a/packages/oidc-aws-credentials-provider/package.json
+++ b/packages/oidc-aws-credentials-provider/package.json
@@ -28,8 +28,8 @@
     "@smithy/types": "3.3.0",
     "tinyspawn": "1.3.1",
     "typedoc": "0.24.6",
-    "typedoc-plugin-markdown": "4.1.2",
-    "typedoc-plugin-mdn-links": "3.2.3",
+    "typedoc-plugin-markdown": "3.15.2",
+    "typedoc-plugin-mdn-links": "3.0.3",
     "typescript": "4.9.5",
     "vitest": "2.0.1"
   },

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -29,8 +29,8 @@
   "devDependencies": {
     "tinyspawn": "1.3.1",
     "typedoc": "0.24.6",
-    "typedoc-plugin-markdown": "4.1.2",
-    "typedoc-plugin-mdn-links": "3.2.3",
+    "typedoc-plugin-markdown": "3.15.2",
+    "typedoc-plugin-mdn-links": "3.0.3",
     "typescript": "4.9.5",
     "vitest": "2.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1280,11 +1280,11 @@ importers:
         specifier: 0.24.6
         version: 0.24.6(typescript@4.9.5)
       typedoc-plugin-markdown:
-        specifier: 4.1.2
-        version: 4.1.2(typedoc@0.24.6)
+        specifier: 3.15.2
+        version: 3.15.2(typedoc@0.24.6)
       typedoc-plugin-mdn-links:
-        specifier: 3.2.3
-        version: 3.2.3(typedoc@0.24.6)
+        specifier: 3.0.3
+        version: 3.0.3(typedoc@0.24.6)
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -1427,11 +1427,11 @@ importers:
         specifier: 0.24.6
         version: 0.24.6(typescript@4.9.5)
       typedoc-plugin-markdown:
-        specifier: 4.1.2
-        version: 4.1.2(typedoc@0.24.6)
+        specifier: 3.15.2
+        version: 3.15.2(typedoc@0.24.6)
       typedoc-plugin-mdn-links:
-        specifier: 3.2.3
-        version: 3.2.3(typedoc@0.24.6)
+        specifier: 3.0.3
+        version: 3.0.3(typedoc@0.24.6)
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -2005,11 +2005,11 @@ importers:
         specifier: 0.24.6
         version: 0.24.6(typescript@4.9.5)
       typedoc-plugin-markdown:
-        specifier: 4.1.2
-        version: 4.1.2(typedoc@0.24.6)
+        specifier: 3.15.2
+        version: 3.15.2(typedoc@0.24.6)
       typedoc-plugin-mdn-links:
-        specifier: 3.2.3
-        version: 3.2.3(typedoc@0.24.6)
+        specifier: 3.0.3
+        version: 3.0.3(typedoc@0.24.6)
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -2036,11 +2036,11 @@ importers:
         specifier: 0.24.6
         version: 0.24.6(typescript@4.9.5)
       typedoc-plugin-markdown:
-        specifier: 4.1.2
-        version: 4.1.2(typedoc@0.24.6)
+        specifier: 3.15.2
+        version: 3.15.2(typedoc@0.24.6)
       typedoc-plugin-mdn-links:
-        specifier: 3.2.3
-        version: 3.2.3(typedoc@0.24.6)
+        specifier: 3.0.3
+        version: 3.0.3(typedoc@0.24.6)
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -13193,7 +13193,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       debug: 3.2.7
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
@@ -13224,7 +13224,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
@@ -13328,7 +13328,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.35.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
     dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.35.0):
@@ -20491,15 +20491,6 @@ packages:
       handlebars: 4.7.8
       typedoc: 0.24.6(typescript@4.9.5)
       typedoc-plugin-mdn-links: 3.2.3(typedoc@0.24.6)
-    dev: true
-
-  /typedoc-plugin-markdown@4.1.2(typedoc@0.24.6):
-    resolution: {integrity: sha512-jZt8jmQLbmg9jmFQyfJrjLf6ljRwJ5fKMeqmFr0oPXmeX5ZRYYtCe6y/058vDESE/R+TwEvNua6SuG43UBbszw==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      typedoc: 0.26.x
-    dependencies:
-      typedoc: 0.24.6(typescript@4.9.5)
     dev: true
 
   /typedoc-plugin-mdn-links@3.0.3(typedoc@0.24.6):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes intermittent "Build @vercel/&lt;pkg&gt; and all its dependencies" failures in the Unit Tests workflow, e.g. [this `vitest-unit (@vercel/fastify, ...)` run](https://github.com/vercel/vercel/actions/runs/24690278211/job/72210797741?pr=16055).

The failure on CI is:

```
@vercel/oidc:build: TypeDoc exiting with unexpected error:
@vercel/oidc:build: TypeError: Cannot read properties of undefined (reading 'addTranslations')
@vercel/oidc:build:     at Converter.<anonymous> (.../typedoc-plugin-markdown@4.1.2_typedoc@0.24.6/.../dist/index.js:94:34)
```

### Root cause

Four packages declared these devDependencies together:

- `typedoc@0.24.6`
- `typedoc-plugin-markdown@4.1.2`
- `typedoc-plugin-mdn-links@3.2.3`

But `typedoc-plugin-markdown@4.1.2` declares `typedoc@0.26.x` as its peer, and its `EVENT_BEGIN` handler calls `app.internationalization.addTranslations(...)` — a method that does not exist on `Application` in typedoc 0.24. Running the plugin against typedoc 0.24 is always broken.

Whether CI noticed depended on which plugin version pnpm hoisted into `.pnpm/node_modules/`. typedoc's plugin loader does a bare `require('typedoc-plugin-markdown')` from inside the typedoc package (`utils/plugins.js`), so Node walks up to the hoisted copy rather than the one listed in the consumer package. `@vercel/edge` has always pinned `typedoc-plugin-markdown@3.15.2`, which is compatible with typedoc 0.24.6. When pnpm hoisted the 3.15.2 copy, `build:docs` succeeded; when it hoisted the 4.1.2 copy, it failed. The choice of which version to hoist is effectively non-deterministic across installs, which is why the failure showed up as flaky — and usually hidden by Turborepo's remote cache.

### Fix

Pin all four packages on the same versions `@vercel/edge` already uses, so only one copy of each plugin (compatible with typedoc 0.24.6) is ever installed:

- `typedoc-plugin-markdown`: `4.1.2` → `3.15.2`
- `typedoc-plugin-mdn-links`: `3.2.3` → `3.0.3`

Affects:

- `@vercel/oidc`
- `@vercel/oidc-aws-credentials-provider`
- `@vercel/functions`
- `@vercel/firewall`

A proper typedoc upgrade (to match plugin 4.x) exists on the `upgrade-typescript` branch (commit `6ce1af4e4`), but that also bumps typedoc to `0.28.14` and typescript to `5.9.3`, which is a much larger change. This patch keeps the footprint minimal and unblocks CI.

## Test plan

- [x] `rm -rf node_modules && pnpm install` then `pnpm --filter @vercel/oidc run build:docs` — docs match the committed output (no `git status` changes).
- [x] Same for `@vercel/oidc-aws-credentials-provider`, `@vercel/functions`, `@vercel/firewall`, and `@vercel/edge`.
- [x] Only one `typedoc-plugin-markdown` version present in `node_modules/.pnpm/` after install (`3.15.2`).
- [x] Changeset added (`patch` bumps for the four affected packages).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d054f34-3fdb-4086-9b4d-5f5be54e42ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d054f34-3fdb-4086-9b4d-5f5be54e42ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

