### PR TITLE
[services] Add project manifest to rust builder.

### DIFF
--- a/.changeset/lemon-bags-listen.md
+++ b/.changeset/lemon-bags-listen.md
@@ -1,0 +1,6 @@
+---
+'@vercel/rust': minor
+'vercel': minor
+---
+
+Add project manifest to rust builder.

--- a/packages/rust/src/diagnostics.ts
+++ b/packages/rust/src/diagnostics.ts
@@ -1,0 +1,120 @@
+import {
+  writeProjectManifest,
+  createDiagnostics,
+  MANIFEST_VERSION,
+  type PackageManifest,
+  type PackageManifestDependency,
+} from '@vercel/build-utils';
+import type { CargoMetadataRoot } from './lib/cargo';
+
+function parseSource(source: string | null): {
+  include: boolean;
+  source?: string;
+  sourceUrl?: string;
+} {
+  if (!source) return { include: false };
+  if (source.startsWith('path+file:')) return { include: false };
+  if (
+    source.startsWith('registry+https://github.com/rust-lang/crates.io-index')
+  ) {
+    return {
+      include: true,
+      source: 'registry',
+      sourceUrl: 'https://crates.io',
+    };
+  }
+  if (source.startsWith('registry+')) {
+    const url = source.slice('registry+'.length).split(/[?#]/)[0];
+    return { include: true, source: 'registry', sourceUrl: url };
+  }
+  if (source.startsWith('git+')) {
+    const url = source.slice('git+'.length).split(/[?#]/)[0];
+    return { include: true, source: 'git', sourceUrl: url };
+  }
+  return { include: true };
+}
+
+export async function generateProjectManifest({
+  workPath,
+  cargoMetadata,
+}: {
+  workPath: string;
+  cargoMetadata: CargoMetadataRoot;
+}): Promise<void> {
+  try {
+    const { packages, resolve } = cargoMetadata;
+
+    const pkgById = new Map(packages.map(p => [p.id, p]));
+
+    const rootId = resolve.root;
+    const rootNode = resolve.nodes.find(n => n.id === rootId);
+    if (!rootNode) return;
+
+    const rootPkg = pkgById.get(rootId);
+
+    // Direct deps: root node's deps with scopes from dep_kinds
+    const directMap = new Map<
+      string,
+      { scopes: string[]; requested?: string }
+    >();
+    for (const dep of rootNode.deps) {
+      const scopes = dep.dep_kinds.map(dk =>
+        dk.kind === 'dev' ? 'dev' : dk.kind === 'build' ? 'build' : 'prod'
+      );
+      const depPkg = pkgById.get(dep.pkg);
+      const req = rootPkg?.dependencies.find(d => d.name === depPkg?.name)?.req;
+      directMap.set(dep.pkg, {
+        scopes: [...new Set(scopes)].sort(),
+        requested: req,
+      });
+    }
+
+    const directEntries: PackageManifestDependency[] = [];
+    const transitiveEntries: PackageManifestDependency[] = [];
+
+    for (const node of resolve.nodes) {
+      if (node.id === rootId) continue;
+
+      const pkg = pkgById.get(node.id);
+      if (!pkg) continue;
+
+      const sourceInfo = parseSource(pkg.source);
+      if (!sourceInfo.include) continue;
+
+      const directInfo = directMap.get(node.id);
+      const entry: PackageManifestDependency = {
+        name: pkg.name,
+        type: directInfo ? 'direct' : 'transitive',
+        // Transitive scope would require full graph traversal to trace which
+        // root-level scope pulled this in. 'prod' is a safe default — accurate
+        // scope propagation for transitives is left to future work.
+        scopes: directInfo ? directInfo.scopes : ['prod'],
+        resolved: pkg.version,
+      };
+
+      if (directInfo?.requested) entry.requested = directInfo.requested;
+      if (sourceInfo.source) entry.source = sourceInfo.source;
+      if (sourceInfo.sourceUrl) entry.sourceUrl = sourceInfo.sourceUrl;
+
+      if (directInfo) directEntries.push(entry);
+      else transitiveEntries.push(entry);
+    }
+
+    const manifest: PackageManifest = {
+      version: MANIFEST_VERSION,
+      runtime: 'rust',
+      dependencies: [
+        ...directEntries.sort((a, b) => a.name.localeCompare(b.name)),
+        ...transitiveEntries.sort((a, b) => a.name.localeCompare(b.name)),
+      ],
+    };
+
+    await writeProjectManifest(manifest, workPath, 'rust');
+  } catch {
+    // Never throw — manifest generation is best-effort and must not fail the
+    // build. Possible throws: writeProjectManifest fails on disk full or
+    // permissions; cargoMetadata is malformed or missing expected fields.
+  }
+}
+
+export const diagnostics = createDiagnostics('rust');

--- a/packages/rust/src/diagnostics.ts
+++ b/packages/rust/src/diagnostics.ts
@@ -37,9 +37,13 @@ function parseSource(source: string | null): {
 export async function generateProjectManifest({
   workPath,
   cargoMetadata,
+  framework,
+  serviceType,
 }: {
   workPath: string;
   cargoMetadata: CargoMetadataRoot;
+  framework?: string;
+  serviceType?: string;
 }): Promise<void> {
   try {
     const { packages, resolve } = cargoMetadata;
@@ -103,6 +107,8 @@ export async function generateProjectManifest({
     const manifest: PackageManifest = {
       version: MANIFEST_VERSION,
       runtime: 'rust',
+      ...(framework ? { framework } : {}),
+      ...(serviceType ? { serviceType } : {}),
       dependencies: [
         ...directEntries.sort((a, b) => a.name.localeCompare(b.name)),
         ...transitiveEntries.sort((a, b) => a.name.localeCompare(b.name)),

--- a/packages/rust/src/diagnostics.ts
+++ b/packages/rust/src/diagnostics.ts
@@ -39,11 +39,13 @@ export async function generateProjectManifest({
   cargoMetadata,
   framework,
   serviceType,
+  runtimeVersion,
 }: {
   workPath: string;
   cargoMetadata: CargoMetadataRoot;
   framework?: string;
   serviceType?: string;
+  runtimeVersion?: { requested?: string; resolved: string };
 }): Promise<void> {
   try {
     const { packages, resolve } = cargoMetadata;
@@ -109,6 +111,7 @@ export async function generateProjectManifest({
       runtime: 'rust',
       ...(framework ? { framework } : {}),
       ...(serviceType ? { serviceType } : {}),
+      ...(runtimeVersion ? { runtimeVersion } : {}),
       dependencies: [
         ...directEntries.sort((a, b) => a.name.localeCompare(b.name)),
         ...transitiveEntries.sort((a, b) => a.name.localeCompare(b.name)),

--- a/packages/rust/src/index.ts
+++ b/packages/rust/src/index.ts
@@ -8,6 +8,7 @@ import {
   type BuildOptions,
   type BuildResultV3,
   getLambdaOptionsFromFunction,
+  getReportedServiceType,
 } from '@vercel/build-utils';
 import execa from 'execa';
 import { installRustToolchain } from './lib/rust-toolchain';
@@ -35,7 +36,7 @@ async function buildHandler(options: BuildOptions): Promise<BuildResultV3> {
   const BUILDER_DEBUG = Boolean(process.env.VERCEL_BUILDER_DEBUG ?? false);
   const isVercelBuild = Boolean(process.env.VERCEL_BUILD_IMAGE ?? false);
 
-  const { files, entrypoint, workPath, config, meta } = options;
+  const { files, entrypoint, workPath, config, meta, service } = options;
 
   // If we are not building on Vercel and we are not initiainted from `vercel dev`,
   // we are building for a prebuilt deployment, so we need to cross-compile
@@ -152,7 +153,12 @@ async function buildHandler(options: BuildOptions): Promise<BuildResultV3> {
   });
   lambda.zipBuffer = await lambda.createZip();
 
-  await generateProjectManifest({ workPath, cargoMetadata });
+  await generateProjectManifest({
+    workPath,
+    cargoMetadata,
+    framework: config?.framework ?? undefined,
+    serviceType: service ? getReportedServiceType(service) : undefined,
+  });
 
   debug(`generating function for \`${entrypoint}\``);
 

--- a/packages/rust/src/index.ts
+++ b/packages/rust/src/index.ts
@@ -26,6 +26,8 @@ import {
 } from './lib/utils';
 
 import { startDevServer as rustStartDevServer } from './lib/start-dev-server';
+import { generateProjectManifest } from './diagnostics';
+export { diagnostics } from './diagnostics';
 
 type RustEnv = Record<'RUSTFLAGS' | 'PATH', string>;
 
@@ -82,20 +84,19 @@ async function buildHandler(options: BuildOptions): Promise<BuildResultV3> {
 
   const buildVariant = meta?.isDev ? 'debug' : 'release';
   const buildTarget = cargoBuildConfiguration?.build.target ?? '';
+  const targetTriple =
+    architecture === 'x86_64'
+      ? 'x86_64-unknown-linux-gnu'
+      : 'aarch64-unknown-linux-gnu';
 
   try {
     // If we are not building on Vercel (it means we are building for a prebuilt deployment),
     // We cross-compile it for linux x86_64 using `zigbuild`
     const args = crossCompilationEnabled
-      ? [
-          'zigbuild',
-          '--target',
-          architecture === 'x86_64'
-            ? 'x86_64-unknown-linux-gnu'
-            : 'aarch64-unknown-linux-gnu',
-          '--bin',
-          binaryName,
-        ].concat(BUILDER_DEBUG ? ['--verbose'] : ['--quiet'], ['--release'])
+      ? ['zigbuild', '--target', targetTriple, '--bin', binaryName].concat(
+          BUILDER_DEBUG ? ['--verbose'] : ['--quiet'],
+          ['--release']
+        )
       : ['build', '--bin', binaryName].concat(
           BUILDER_DEBUG ? ['--verbose'] : ['--quiet'],
           meta?.isDev ? [] : ['--release']
@@ -117,19 +118,15 @@ async function buildHandler(options: BuildOptions): Promise<BuildResultV3> {
     `Building \`${binaryName}\` for \`${process.platform}\` (\`${architecture}\`) completed`
   );
 
-  let { target_directory: targetDirectory } = await getCargoMetadata({
-    cwd: workPath,
-    env: rustEnv,
-  });
+  const cargoMetadata = await getCargoMetadata(
+    { cwd: workPath, env: rustEnv },
+    targetTriple
+  );
+  let { target_directory: targetDirectory } = cargoMetadata;
 
   // If we are building for a prebuilt deployment, adjust the target directory to the cross compilation dir
   if (crossCompilationEnabled) {
-    targetDirectory = path.join(
-      targetDirectory,
-      architecture === 'x86_64'
-        ? 'x86_64-unknown-linux-gnu'
-        : 'aarch64-unknown-linux-gnu'
-    );
+    targetDirectory = path.join(targetDirectory, targetTriple);
   }
   targetDirectory = path.join(targetDirectory, buildTarget);
 
@@ -154,6 +151,8 @@ async function buildHandler(options: BuildOptions): Promise<BuildResultV3> {
     runtimeLanguage: 'rust',
   });
   lambda.zipBuffer = await lambda.createZip();
+
+  await generateProjectManifest({ workPath, cargoMetadata });
 
   debug(`generating function for \`${entrypoint}\``);
 

--- a/packages/rust/src/index.ts
+++ b/packages/rust/src/index.ts
@@ -153,11 +153,34 @@ async function buildHandler(options: BuildOptions): Promise<BuildResultV3> {
   });
   lambda.zipBuffer = await lambda.createZip();
 
+  let resolvedRustVersion: string | undefined;
+  try {
+    const { stdout: rustcOut } = await execa('rustc', ['--version'], {
+      env: rustEnv,
+      cwd: workPath,
+    });
+    // "rustc 1.87.0 (17067e9ac 2025-05-09)" → "1.87.0"
+    resolvedRustVersion = rustcOut.split(' ')[1];
+  } catch {
+    debug('Failed to determine rustc version');
+  }
+
+  const rootPkg = cargoMetadata.packages.find(
+    p => p.id === cargoMetadata.resolve.root
+  );
+  const requestedRustVersion = rootPkg?.rust_version || undefined;
+
   await generateProjectManifest({
     workPath,
     cargoMetadata,
     framework: config?.framework ?? undefined,
     serviceType: service ? getReportedServiceType(service) : undefined,
+    runtimeVersion: resolvedRustVersion
+      ? {
+          ...(requestedRustVersion ? { requested: requestedRustVersion } : {}),
+          resolved: resolvedRustVersion,
+        }
+      : undefined,
   });
 
   debug(`generating function for \`${entrypoint}\``);

--- a/packages/rust/src/lib/cargo.ts
+++ b/packages/rust/src/lib/cargo.ts
@@ -21,7 +21,7 @@ interface CargoPackage {
   license: string;
   license_file: string;
   description: string;
-  source: unknown;
+  source: string | null;
   dependencies: CargoDependency[];
   targets: CargoTarget[];
   features: CargoFeatures;
@@ -45,7 +45,7 @@ interface CargoDependency {
   name: string;
   source: string;
   req: string;
-  kind: unknown;
+  kind: null | 'dev' | 'build';
   rename: unknown;
   optional: boolean;
   uses_default_features: boolean;
@@ -104,8 +104,8 @@ interface Dep {
 }
 
 interface DepKind {
-  kind: unknown;
-  target: string;
+  kind: null | 'dev' | 'build';
+  target: string | null;
 }
 
 interface CargoMetadata {
@@ -121,15 +121,12 @@ interface Rs2 {
 }
 
 export async function getCargoMetadata(
-  options: execa.Options
+  options: execa.Options,
+  filterPlatform?: string
 ): Promise<CargoMetadataRoot> {
-  const { stdout: cargoMetaData } = await execa(
-    'cargo',
-    ['metadata', '--format-version', '1'],
-
-    options
-  );
-
+  const args = ['metadata', '--format-version', '1'];
+  if (filterPlatform) args.push('--filter-platform', filterPlatform);
+  const { stdout: cargoMetaData } = await execa('cargo', args, options);
   return JSON.parse(cargoMetaData) as CargoMetadataRoot;
 }
 

--- a/packages/rust/test/unit/diagnostics.test.ts
+++ b/packages/rust/test/unit/diagnostics.test.ts
@@ -385,6 +385,30 @@ describe('generateProjectManifest', () => {
     }
   });
 
+  it('writes framework and serviceType when passed', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({}),
+      framework: 'axum',
+      serviceType: 'web',
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.framework).toBe('axum');
+    expect(manifest.serviceType).toBe('web');
+  });
+
+  it('omits framework and serviceType when not passed', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({}),
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.framework).toBeUndefined();
+    expect(manifest.serviceType).toBeUndefined();
+  });
+
   it('does not throw on empty metadata', async () => {
     await expect(
       generateProjectManifest({

--- a/packages/rust/test/unit/diagnostics.test.ts
+++ b/packages/rust/test/unit/diagnostics.test.ts
@@ -1,0 +1,452 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { FileBlob, MANIFEST_FILENAME, manifestPath } from '@vercel/build-utils';
+import type { CargoMetadataRoot } from '../../src/lib/cargo';
+import { generateProjectManifest, diagnostics } from '../../src/diagnostics';
+
+const DIAGNOSTICS_PATH = manifestPath('rust');
+const CRATES_IO = 'registry+https://github.com/rust-lang/crates.io-index';
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(tmpdir(), 'vc-rust-diag-test-'));
+}
+
+function rmTempDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function readManifest(workPath: string): any {
+  return JSON.parse(
+    fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+  );
+}
+
+// ── fixture helpers ──────────────────────────────────────────────────────────
+
+type PkgSpec = {
+  name: string;
+  version: string;
+  source?: string | null;
+  deps?: string[]; // names of direct deps within this fixture
+};
+
+type DirectSpec = PkgSpec & {
+  kind?: null | 'dev' | 'build';
+  kinds?: Array<null | 'dev' | 'build'>; // multiple dep_kinds entries
+  req?: string;
+};
+
+function pkgId(p: PkgSpec): string {
+  const src = p.source === undefined ? CRATES_IO : p.source;
+  return src
+    ? `${p.name} ${p.version} (${src})`
+    : `${p.name} ${p.version} (path+file:///workspace)`;
+}
+
+/**
+ * Build a minimal CargoMetadataRoot for testing.
+ * `directDeps` are deps of the root package.
+ * `otherPkgs` are any other packages in the resolve graph (transitive, workspace members, etc.).
+ */
+function makeMetadata(opts: {
+  root?: { name?: string; version?: string };
+  directDeps?: DirectSpec[];
+  otherPkgs?: PkgSpec[];
+}): CargoMetadataRoot {
+  const root = { name: 'myapp', version: '0.1.0', ...opts.root };
+  const direct = opts.directDeps ?? [];
+  const others = opts.otherPkgs ?? [];
+
+  const rootSpec: PkgSpec = {
+    name: root.name,
+    version: root.version,
+    source: null,
+    deps: direct.map(d => d.name),
+  };
+
+  const all: PkgSpec[] = [rootSpec, ...direct, ...others];
+
+  const idOf = (name: string): string => {
+    const p = all.find(x => x.name === name);
+    return p ? pkgId(p) : `${name} 0.0.0 (${CRATES_IO})`;
+  };
+
+  const rootId = pkgId({
+    name: root.name,
+    version: root.version,
+    source: null,
+  });
+
+  const packages = all.map(p => ({
+    name: p.name,
+    version: p.version,
+    id: pkgId(p),
+    source: p.source === undefined ? CRATES_IO : p.source,
+    dependencies: (p.deps ?? []).map(depName => {
+      const directEntry = direct.find(d => d.name === depName);
+      return {
+        name: depName,
+        source: CRATES_IO,
+        req: directEntry?.req ?? '*',
+        kind: directEntry?.kind ?? null,
+        target: null,
+        rename: null,
+        optional: false,
+        uses_default_features: true,
+        features: [],
+        path: '',
+        registry: null,
+      };
+    }),
+    // unused fields — cast away
+    license: '',
+    license_file: '',
+    description: '',
+    targets: [],
+    features: {},
+    manifest_path: '',
+    metadata: {} as any,
+    publish: [],
+    authors: [],
+    categories: [],
+    default_run: null,
+    rust_version: '',
+    keywords: [],
+    readme: '',
+    repository: '',
+    homepage: '',
+    documentation: '',
+    edition: '2021',
+    links: null,
+  }));
+
+  // Root package dependencies (used for req lookup)
+  packages[0].dependencies = direct.map(d => ({
+    name: d.name,
+    source: d.source === undefined ? CRATES_IO : (d.source ?? ''),
+    req: d.req ?? '*',
+    kind: d.kind ?? null,
+    target: null,
+    rename: null,
+    optional: false,
+    uses_default_features: true,
+    features: [],
+    path: '',
+    registry: null,
+  }));
+
+  const nodes = all.map(p => ({
+    id: pkgId(p),
+    dependencies: (p.deps ?? []).map(idOf),
+    deps: (p.deps ?? []).map(depName => {
+      const directEntry = direct.find(d => d.name === depName);
+      return {
+        name: depName.replace(/-/g, '_'),
+        pkg: idOf(depName),
+        dep_kinds: (directEntry?.kinds ?? [directEntry?.kind ?? null]).map(
+          k => ({ kind: k, target: null })
+        ),
+      };
+    }),
+    features: [],
+  }));
+
+  return {
+    packages,
+    workspace_members: [rootId],
+    resolve: { nodes, root: rootId },
+    target_directory: '/tmp/target',
+    version: 1,
+    workspace_root: '/tmp',
+    metadata: {} as any,
+  };
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmTempDir(tempDir);
+  });
+
+  it('writes manifest with correct version and runtime', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({}),
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.version).toBe('20260304');
+    expect(manifest.runtime).toBe('rust');
+    expect(manifest.dependencies).toEqual([]);
+  });
+
+  it('classifies crates.io packages as registry with crates.io url', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [{ name: 'actix-web', version: '4.4.0' }],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const dep = manifest.dependencies.find((d: any) => d.name === 'actix-web');
+    expect(dep.source).toBe('registry');
+    expect(dep.sourceUrl).toBe('https://crates.io');
+  });
+
+  it('classifies git source packages correctly', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [
+          {
+            name: 'mylib',
+            version: '0.2.0',
+            source: 'git+https://github.com/org/mylib?rev=abc123',
+          },
+        ],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const dep = manifest.dependencies.find((d: any) => d.name === 'mylib');
+    expect(dep.source).toBe('git');
+    expect(dep.sourceUrl).toBe('https://github.com/org/mylib');
+  });
+
+  it('excludes workspace/path crates (null source)', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [{ name: 'actix-web', version: '4.4.0' }],
+        otherPkgs: [{ name: 'shared-utils', version: '0.1.0', source: null }],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const names = manifest.dependencies.map((d: any) => d.name);
+    expect(names).not.toContain('shared-utils');
+    expect(names).toContain('actix-web');
+  });
+
+  it('excludes path dependencies', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [{ name: 'actix-web', version: '4.4.0' }],
+        otherPkgs: [
+          {
+            name: 'local-helper',
+            version: '0.1.0',
+            source: 'path+file:///workspace/local-helper',
+          },
+        ],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const names = manifest.dependencies.map((d: any) => d.name);
+    expect(names).not.toContain('local-helper');
+  });
+
+  it('excludes the root crate itself', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        root: { name: 'myapp' },
+        directDeps: [{ name: 'serde', version: '1.0.197' }],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const names = manifest.dependencies.map((d: any) => d.name);
+    expect(names).not.toContain('myapp');
+    expect(names).toContain('serde');
+  });
+
+  it('deps under [dependencies] are direct with prod scope', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [
+          { name: 'serde', version: '1.0.197' },
+          { name: 'actix-web', version: '4.4.0' },
+        ],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const direct = manifest.dependencies.filter(
+      (d: any) => d.type === 'direct'
+    );
+    expect(direct).toHaveLength(2);
+    for (const dep of direct) {
+      expect(dep.scopes).toEqual(['prod']);
+    }
+  });
+
+  it('stores the Cargo.toml version requirement as requested for direct deps', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [
+          { name: 'serde', version: '1.0.197', req: '^1' },
+          { name: 'actix-web', version: '4.4.0', req: '^4' },
+        ],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const serde = manifest.dependencies.find((d: any) => d.name === 'serde');
+    expect(serde.requested).toBe('^1');
+    const actix = manifest.dependencies.find(
+      (d: any) => d.name === 'actix-web'
+    );
+    expect(actix.requested).toBe('^4');
+  });
+
+  it('deps under [dev-dependencies] get scope dev from dep_kinds kind', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [{ name: 'tokio-test', version: '0.4.3', kind: 'dev' }],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const dep = manifest.dependencies.find((d: any) => d.name === 'tokio-test');
+    expect(dep.type).toBe('direct');
+    expect(dep.scopes).toEqual(['dev']);
+  });
+
+  it('deps under [build-dependencies] get scope build from dep_kinds kind', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [{ name: 'cc', version: '1.0.90', kind: 'build' }],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const dep = manifest.dependencies.find((d: any) => d.name === 'cc');
+    expect(dep.type).toBe('direct');
+    expect(dep.scopes).toEqual(['build']);
+  });
+
+  it('direct dep in both [dependencies] and [dev-dependencies] gets both scopes', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [
+          { name: 'serde', version: '1.0.197', kinds: [null, 'dev'] },
+        ],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const serde = manifest.dependencies.find((d: any) => d.name === 'serde');
+    expect(serde.type).toBe('direct');
+    expect(serde.scopes).toEqual(['dev', 'prod']);
+  });
+
+  it('transitive deps always get prod scope regardless of what pulls them in', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [
+          { name: 'web', version: '1.0.0', deps: ['shared'] },
+          {
+            name: 'tokio-test',
+            version: '0.4.3',
+            kind: 'dev',
+            deps: ['tokio'],
+          },
+        ],
+        otherPkgs: [
+          { name: 'shared', version: '0.5.0' },
+          { name: 'tokio', version: '1.36.0' },
+        ],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    for (const name of ['shared', 'tokio']) {
+      const dep = manifest.dependencies.find((d: any) => d.name === name);
+      expect(dep.type).toBe('transitive');
+      expect(dep.scopes).toEqual(['prod']);
+    }
+  });
+
+  it('does not throw on empty metadata', async () => {
+    await expect(
+      generateProjectManifest({
+        workPath: tempDir,
+        cargoMetadata: makeMetadata({}),
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('direct deps are sorted alphabetically before transitive', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({
+        directDeps: [
+          { name: 'zlib', version: '1.0.0', deps: ['ztransitive'] },
+          { name: 'alpha', version: '1.0.0' },
+        ],
+        otherPkgs: [{ name: 'ztransitive', version: '0.1.0' }],
+      }),
+    });
+
+    const manifest = readManifest(tempDir);
+    const deps = manifest.dependencies;
+    expect(deps[0].name).toBe('alpha');
+    expect(deps[0].type).toBe('direct');
+    expect(deps[1].name).toBe('zlib');
+    expect(deps[1].type).toBe('direct');
+    expect(deps[2].name).toBe('ztransitive');
+    expect(deps[2].type).toBe('transitive');
+  });
+});
+
+describe('diagnostics callback', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmTempDir(tempDir);
+  });
+
+  it('returns manifest FileBlob when present', async () => {
+    const manifestFilePath = path.join(tempDir, DIAGNOSTICS_PATH);
+    fs.mkdirSync(path.dirname(manifestFilePath), { recursive: true });
+    const content = JSON.stringify({ version: '20260304', runtime: 'rust' });
+    fs.writeFileSync(manifestFilePath, content);
+
+    const files = await diagnostics({ workPath: tempDir } as any);
+
+    expect(files).toHaveProperty([MANIFEST_FILENAME]);
+    const blob = files[MANIFEST_FILENAME] as FileBlob;
+    expect(blob).toBeInstanceOf(FileBlob);
+    expect(JSON.parse(blob.data as string)).toEqual({
+      version: '20260304',
+      runtime: 'rust',
+    });
+  });
+
+  it('returns empty object when no manifest exists', async () => {
+    const files = await diagnostics({ workPath: tempDir } as any);
+    expect(files).toEqual({});
+  });
+});

--- a/packages/rust/test/unit/diagnostics.test.ts
+++ b/packages/rust/test/unit/diagnostics.test.ts
@@ -385,6 +385,38 @@ describe('generateProjectManifest', () => {
     }
   });
 
+  it('writes runtimeVersion with both resolved and requested', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({}),
+      runtimeVersion: { requested: '1.70', resolved: '1.87.0' },
+    });
+    const manifest = readManifest(tempDir);
+    expect(manifest.runtimeVersion).toEqual({
+      requested: '1.70',
+      resolved: '1.87.0',
+    });
+  });
+
+  it('writes runtimeVersion with resolved only when requested is absent', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({}),
+      runtimeVersion: { resolved: '1.87.0' },
+    });
+    const manifest = readManifest(tempDir);
+    expect(manifest.runtimeVersion).toEqual({ resolved: '1.87.0' });
+  });
+
+  it('omits runtimeVersion when not passed', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({}),
+    });
+    const manifest = readManifest(tempDir);
+    expect(manifest.runtimeVersion).toBeUndefined();
+  });
+
   it('writes framework and serviceType when passed', async () => {
     await generateProjectManifest({
       workPath: tempDir,
@@ -392,7 +424,6 @@ describe('generateProjectManifest', () => {
       framework: 'axum',
       serviceType: 'web',
     });
-
     const manifest = readManifest(tempDir);
     expect(manifest.framework).toBe('axum');
     expect(manifest.serviceType).toBe('web');
@@ -403,9 +434,28 @@ describe('generateProjectManifest', () => {
       workPath: tempDir,
       cargoMetadata: makeMetadata({}),
     });
-
     const manifest = readManifest(tempDir);
     expect(manifest.framework).toBeUndefined();
+    expect(manifest.serviceType).toBeUndefined();
+  });
+
+  it('omits framework from manifest when empty string provided', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({}),
+      framework: '',
+    });
+    const manifest = readManifest(tempDir);
+    expect(manifest.framework).toBeUndefined();
+  });
+
+  it('omits serviceType from manifest when empty string provided', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      cargoMetadata: makeMetadata({}),
+      serviceType: '',
+    });
+    const manifest = readManifest(tempDir);
     expect(manifest.serviceType).toBeUndefined();
   });
 


### PR DESCRIPTION
Emit project manifest from `rust` builder, similar to existing behaviour in `backends`, `python`, and `node`.

The manifest includes:
- `framework` and `serviceType` from services framework
- `runtimeVersion` with `resolved` from `rustc --version` and `requested` from cargo metadata
- `dependencies` from cargo metadata generated during build
