### PR TITLE
feat(cli): add masked token value column to `edge-config tokens` table

### DIFF
--- a/.changeset/edge-config-tokens-value-column.md
+++ b/.changeset/edge-config-tokens-value-column.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add masked token value column to `vercel edge-config tokens` table output.

--- a/packages/cli/src/commands/edge-config/tokens.ts
+++ b/packages/cli/src/commands/edge-config/tokens.ts
@@ -21,6 +21,7 @@ interface TokenRow {
   id?: string;
   label?: string;
   token?: string;
+  partialToken?: string;
   createdAt?: number;
 }
 
@@ -227,10 +228,11 @@ export default async function tokensCmd(
     }
 
     const tableRows = [
-      ['id', 'label', 'created'].map(h => gray(h)),
+      ['id', 'label', 'value', 'created'].map(h => gray(h)),
       ...rows.map(t => [
         t.id ?? '',
         t.label ?? '',
+        t.partialToken ?? '',
         t.createdAt != null ? new Date(t.createdAt).toISOString() : '',
       ]),
     ];

--- a/packages/cli/test/unit/commands/edge-config/edge-config.test.ts
+++ b/packages/cli/test/unit/commands/edge-config/edge-config.test.ts
@@ -246,9 +246,10 @@ describe('edge-config', () => {
     client.setArgv('edge-config', 'tokens', 'my-store');
     const exitCode = await edgeConfig(client);
     expect(exitCode).toBe(0);
-    await expect(client.stderr).toOutput('tok_abc123');
-    await expect(client.stderr).toOutput('ecr********');
-    await expect(client.stderr).toOutput('production');
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('tok_abc123');
+    expect(output).toContain('ecr********');
+    expect(output).toContain('production');
   });
 
   it('lists tokens with partialToken in JSON output', async () => {

--- a/packages/cli/test/unit/commands/edge-config/edge-config.test.ts
+++ b/packages/cli/test/unit/commands/edge-config/edge-config.test.ts
@@ -228,6 +228,58 @@ describe('edge-config', () => {
     expect(out).toEqual({ status: 'ok', revoked: 2 });
   });
 
+  it('lists tokens with partialToken (masked value) in table output', async () => {
+    client.scenario.get('/v1/edge-config', (_req, res) => {
+      res.json([{ id: 'ecfg_tok', slug: 'my-store' }]);
+    });
+    client.scenario.get('/v1/edge-config/ecfg_tok/tokens', (_req, res) => {
+      res.json([
+        {
+          id: 'tok_abc123',
+          label: 'production',
+          partialToken: 'ecr********',
+          createdAt: 1_713_528_000_000,
+        },
+      ]);
+    });
+
+    client.setArgv('edge-config', 'tokens', 'my-store');
+    const exitCode = await edgeConfig(client);
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('tok_abc123');
+    await expect(client.stderr).toOutput('ecr********');
+    await expect(client.stderr).toOutput('production');
+  });
+
+  it('lists tokens with partialToken in JSON output', async () => {
+    client.scenario.get('/v1/edge-config', (_req, res) => {
+      res.json([{ id: 'ecfg_tok', slug: 'my-store' }]);
+    });
+    client.scenario.get('/v1/edge-config/ecfg_tok/tokens', (_req, res) => {
+      res.json([
+        {
+          id: 'tok_abc123',
+          label: 'production',
+          partialToken: 'ecr********',
+          createdAt: 1_713_528_000_000,
+        },
+      ]);
+    });
+
+    client.setArgv('edge-config', 'tokens', 'my-store', '--format', 'json');
+    const exitCode = await edgeConfig(client);
+    expect(exitCode).toBe(0);
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out).toEqual([
+      {
+        id: 'tok_abc123',
+        label: 'production',
+        partialToken: 'ecr********',
+        createdAt: 1_713_528_000_000,
+      },
+    ]);
+  });
+
   it('validates --patch before slug rename when both --slug and --patch are provided', async () => {
     let putCalled = false;
     client.scenario.put('/v1/edge-config/ecfg_update_order', (_req, res) => {


### PR DESCRIPTION
## Summary

- Surfaces the API's `partialToken` field as a **value** column in the `vercel edge-config tokens` table output, placed between `label` and `created`
- JSON output (`--format json`) continues to pass through the API response verbatim, automatically including `partialToken`
- Adds unit tests for both table and JSON output with the new field

> **Note:** The full `token` field will be removed from the API response in a follow-up PR on the API side. This PR does not touch `token` — it only adds the new masked column.

## Test plan

- [ ] `vercel edge-config tokens <id>` table output includes the new `value` column with masked tokens
- [ ] `vercel edge-config tokens <id> --format json` includes `partialToken` in the response
- [ ] Tokens without `partialToken` (older API responses) render an empty value column gracefully