### PR TITLE
feat(cli): `edge-config tokens --remove` accepts ids or plaintext tokens

### DIFF
--- a/.changeset/edge-config-tokens-remove-by-id.md
+++ b/.changeset/edge-config-tokens-remove-by-id.md
@@ -1,0 +1,15 @@
+---
+'vercel': minor
+---
+
+`vercel edge-config tokens --remove <ID_OR_TOKEN>` now accepts either a token id (as shown in the `id` column of `vercel edge-config tokens <id-or-slug>`) or a plaintext token string. The CLI transparently consults the store's own token list to classify each value and sends `{ ids }`, `{ tokens }`, or both to `DELETE /v1/edge-config/:id/tokens` accordingly.
+
+- Backward compatible: existing scripts passing plaintext tokens keep working.
+- Forward compatible: once plaintext is no longer listed server-side, users can revoke by id with no CLI changes.
+- No new flag: everything stays on `--remove`, which is repeatable.
+
+```bash
+vercel edge-config tokens my-store --remove <token-id> --yes
+vercel edge-config tokens my-store --remove <plaintext-token> --yes
+vercel edge-config tokens my-store --remove <id-1> --remove <plaintext-2> --yes
+```

--- a/packages/cli/src/commands/edge-config/command.ts
+++ b/packages/cli/src/commands/edge-config/command.ts
@@ -158,10 +158,10 @@ export const tokensSubcommand = {
       name: 'remove',
       shorthand: null,
       type: [String],
-      argument: 'TOKEN',
+      argument: 'ID_OR_TOKEN',
       deprecated: false,
       description:
-        'Revoke one or more token strings (repeatable). Requires `--yes` in non-interactive mode',
+        'Revoke one or more tokens by id or plaintext token (repeatable). Requires `--yes` in non-interactive mode',
     },
   ],
   examples: [],

--- a/packages/cli/src/commands/edge-config/tokens.ts
+++ b/packages/cli/src/commands/edge-config/tokens.ts
@@ -49,12 +49,13 @@ export default async function tokensCmd(
   const { args, flags } = parsedArgs;
   const [idOrSlug] = args;
   const addLabel = flags['--add'];
-  const removeTokens = flags['--remove'];
+  const removeValues = flags['--remove'];
+  const removeCount = removeValues?.length ?? 0;
   const skipConfirmation = flags['--yes'] === true;
 
   telemetry.trackCliArgumentIdOrSlug(idOrSlug);
   telemetry.trackCliOptionAdd(addLabel);
-  telemetry.trackCliOptionRemove(removeTokens);
+  telemetry.trackCliOptionRemove(removeValues);
   telemetry.trackCliFlagYes(flags['--yes']);
   telemetry.trackCliOptionFormat(flags['--format']);
 
@@ -85,12 +86,12 @@ export default async function tokensCmd(
     return 1;
   }
 
-  if (addLabel && removeTokens?.length) {
+  if (addLabel && removeCount > 0) {
     output.error('Use either `--add` or `--remove`, not both.');
     return 1;
   }
 
-  if (removeTokens?.length && client.nonInteractive && !skipConfirmation) {
+  if (removeCount > 0 && client.nonInteractive && !skipConfirmation) {
     outputAgentError(
       client,
       {
@@ -167,11 +168,11 @@ export default async function tokensCmd(
       return 0;
     }
 
-    if (removeTokens?.length) {
+    if (removeValues?.length) {
       if (
         !skipConfirmation &&
         !(await client.input.confirm(
-          `Revoke ${removeTokens.length} token(s) on ${chalk.bold(id)}?`,
+          `Revoke ${removeValues.length} token(s) on ${chalk.bold(id)}?`,
           false
         ))
       ) {
@@ -179,18 +180,38 @@ export default async function tokensCmd(
         return 0;
       }
 
+      // Disambiguate ids from plaintext tokens by consulting the store's own
+      // list. The DELETE endpoint accepts `tokens` and `ids` independently,
+      // but both are opaque UUID-shaped strings with no reliable client-side
+      // distinguishing feature, so we let the server's source of truth
+      // classify each value.
+      const rows = await client.fetch<TokenRow[]>(`${base}/tokens`);
+      const knownIds = new Set(
+        rows.map(r => r.id).filter((v): v is string => Boolean(v))
+      );
+      const ids: string[] = [];
+      const tokens: string[] = [];
+      for (const value of removeValues) {
+        if (knownIds.has(value)) ids.push(value);
+        else tokens.push(value);
+      }
+
+      const body: { tokens?: string[]; ids?: string[] } = {};
+      if (tokens.length) body.tokens = tokens;
+      if (ids.length) body.ids = ids;
+
       await client.fetch(`${base}/tokens`, {
         method: 'DELETE',
-        body: { tokens: removeTokens },
+        body,
       });
 
       if (asJson) {
         client.stdout.write(
-          `${JSON.stringify({ status: 'ok', revoked: removeTokens.length }, null, 2)}\n`
+          `${JSON.stringify({ status: 'ok', revoked: removeValues.length }, null, 2)}\n`
         );
         return 0;
       }
-      output.success(`Revoked ${removeTokens.length} token(s).`);
+      output.success(`Revoked ${removeValues.length} token(s).`);
       return 0;
     }
 

--- a/packages/cli/test/unit/commands/edge-config/edge-config.test.ts
+++ b/packages/cli/test/unit/commands/edge-config/edge-config.test.ts
@@ -110,6 +110,124 @@ describe('edge-config', () => {
     ]);
   });
 
+  it('revokes by id when --remove values match known token ids', async () => {
+    client.scenario.get('/v1/edge-config', (_req, res) => {
+      res.json([{ id: 'ecfg_rm_id', slug: 's' }]);
+    });
+    let listCount = 0;
+    client.scenario.get('/v1/edge-config/ecfg_rm_id/tokens', (_req, res) => {
+      listCount += 1;
+      res.json([
+        { id: 'tokid_a', label: 'prod', partialToken: 'aaaa********' },
+        { id: 'tokid_b', label: 'dev', partialToken: 'bbbb********' },
+      ]);
+    });
+    let deleteBody: unknown;
+    client.scenario.delete('/v1/edge-config/ecfg_rm_id/tokens', (req, res) => {
+      deleteBody = req.body;
+      res.status(204).end();
+    });
+
+    client.setArgv(
+      'edge-config',
+      'tokens',
+      'ecfg_rm_id',
+      '--remove',
+      'tokid_a',
+      '--remove',
+      'tokid_b',
+      '--yes',
+      '--format',
+      'json'
+    );
+    const exitCode = await edgeConfig(client);
+    expect(exitCode).toBe(0);
+    expect(listCount).toBe(1);
+    expect(deleteBody).toEqual({ ids: ['tokid_a', 'tokid_b'] });
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out).toEqual({ status: 'ok', revoked: 2 });
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:tokens', value: 'tokens' },
+      { key: 'argument:id-or-slug', value: 'ecfg_rm_id' },
+      { key: 'option:remove', value: '[REDACTED]' },
+      { key: 'flag:yes', value: 'TRUE' },
+      { key: 'option:format', value: 'json' },
+    ]);
+  });
+
+  it('revokes by token string when --remove values do not match known ids', async () => {
+    client.scenario.get('/v1/edge-config', (_req, res) => {
+      res.json([{ id: 'ecfg_rm_tok', slug: 's' }]);
+    });
+    client.scenario.get('/v1/edge-config/ecfg_rm_tok/tokens', (_req, res) => {
+      res.json([
+        { id: 'tokid_x', label: 'prod', partialToken: 'xxxx********' },
+      ]);
+    });
+    let deleteBody: unknown;
+    client.scenario.delete('/v1/edge-config/ecfg_rm_tok/tokens', (req, res) => {
+      deleteBody = req.body;
+      res.status(204).end();
+    });
+
+    client.setArgv(
+      'edge-config',
+      'tokens',
+      'ecfg_rm_tok',
+      '--remove',
+      'plaintext_a',
+      '--remove',
+      'plaintext_b',
+      '--yes',
+      '--format',
+      'json'
+    );
+    const exitCode = await edgeConfig(client);
+    expect(exitCode).toBe(0);
+    expect(deleteBody).toEqual({
+      tokens: ['plaintext_a', 'plaintext_b'],
+    });
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out).toEqual({ status: 'ok', revoked: 2 });
+  });
+
+  it('splits a mixed --remove list into ids and tokens', async () => {
+    client.scenario.get('/v1/edge-config', (_req, res) => {
+      res.json([{ id: 'ecfg_rm_mix', slug: 's' }]);
+    });
+    client.scenario.get('/v1/edge-config/ecfg_rm_mix/tokens', (_req, res) => {
+      res.json([
+        { id: 'tokid_known', label: 'prod', partialToken: 'kkkk********' },
+      ]);
+    });
+    let deleteBody: unknown;
+    client.scenario.delete('/v1/edge-config/ecfg_rm_mix/tokens', (req, res) => {
+      deleteBody = req.body;
+      res.status(204).end();
+    });
+
+    client.setArgv(
+      'edge-config',
+      'tokens',
+      'ecfg_rm_mix',
+      '--remove',
+      'tokid_known',
+      '--remove',
+      'plaintext_legacy',
+      '--yes',
+      '--format',
+      'json'
+    );
+    const exitCode = await edgeConfig(client);
+    expect(exitCode).toBe(0);
+    expect(deleteBody).toEqual({
+      tokens: ['plaintext_legacy'],
+      ids: ['tokid_known'],
+    });
+    const out = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(out).toEqual({ status: 'ok', revoked: 2 });
+  });
+
   it('validates --patch before slug rename when both --slug and --patch are provided', async () => {
     let putCalled = false;
     client.scenario.put('/v1/edge-config/ecfg_update_order', (_req, res) => {


### PR DESCRIPTION
## Summary

`vercel edge-config tokens --remove <ID_OR_TOKEN>` is now polymorphic — it accepts either a token id (shown in the `id` column of `vercel edge-config tokens <id-or-slug>`) or a plaintext token string, and the CLI figures out which is which.

- Before sending `DELETE /v1/edge-config/:id/tokens`, the CLI lists the store's tokens and partitions each supplied value against the known `id`s.
- Matches against an id → sent in `{ ids }`.
- Everything else → sent in `{ tokens }`.
- Both arrays may be sent together in a single DELETE request if the user mixed inputs.
- Single repeatable flag, no new telemetry option, no breaking change.

## Why this shape

Token ids and plaintext tokens are both opaque UUID-shaped strings with no reliable client-side distinguishing feature, so regex-sniffing is fragile. Using the server's own list as the source of truth is robust in both directions: scripts still pasting plaintext keep working today, and id-only workflows work seamlessly once plaintext stops being surfaced by the list endpoint.

Cost: one extra `GET /tokens` per `--remove` invocation. For a destructive op this is essentially free, and token counts per store are low.

## Test plan

- [x] Unit: `revokes by id when --remove values match known token ids` — asserts body is `{ ids: [...] }` and the list endpoint is hit exactly once.
- [x] Unit: `revokes by token string when --remove values do not match known ids` — asserts body is `{ tokens: [...] }`.
- [x] Unit: `splits a mixed --remove list into ids and tokens` — asserts the DELETE body carries both arrays partitioned correctly.
- [ ] Manual smoke on a real Edge Config store: single id, single plaintext, mixed.
- [ ] `vercel edge-config tokens --help` shows `--remove <ID_OR_TOKEN>`.

## History

This branch cycled through a few designs before landing on the above:

1. `feat(cli)!: switch edge-config tokens --remove to token ids` — breaking rename, rejected for compat reasons.
2. `feat(cli): add edge-config tokens --remove-id for deletion by id` — additive second flag, rejected for awkward UX.
3. `refactor(cli): collapse edge-config tokens --remove to a single flag` (current) — single polymorphic flag via list-based disambiguation.

Squash-merging will land only the final design in history.