### PR TITLE
feat(cli): unhide firewall command

### DIFF
--- a/.changeset/firewall-launch.md
+++ b/.changeset/firewall-launch.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel firewall` command for managing project firewall configuration. Supports custom rules (add, edit, delete, enable, disable, reorder), IP blocking, system bypass rules, attack challenge mode, and system mitigations.

--- a/packages/cli/src/commands/firewall/command.ts
+++ b/packages/cli/src/commands/firewall/command.ts
@@ -927,7 +927,7 @@ export const firewallCommand = {
   aliases: [],
   description:
     "Manage your project's firewall rules, IP blocks, and system bypass configuration",
-  hidden: true as const,
+
   arguments: [],
   subcommands: [
     overviewSubcommand,

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -59,6 +59,7 @@ export const help = () => `
       deploy-hooks         [cmd]       Manage deploy hooks for Git-triggered builds
       dns                  [name]      Manages your DNS records
       domains              [name]      Manages your domain names
+      firewall             [cmd]       Manages your project's firewall rules and IP blocks
       httpstat             path        Visualize HTTP timing statistics for deployments
       logs                 [url]       Displays the logs for a deployment
       metrics              <metric>    Queries observability metrics for your project or team

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -50,6 +50,7 @@ exports[`base level help output > help 1`] = `
       deploy-hooks         [cmd]       Manage deploy hooks for Git-triggered builds
       dns                  [name]      Manages your DNS records
       domains              [name]      Manages your domain names
+      firewall             [cmd]       Manages your project's firewall rules and IP blocks
       httpstat             path        Visualize HTTP timing statistics for deployments
       logs                 [url]       Displays the logs for a deployment
       metrics              <metric>    Queries observability metrics for your project or team


### PR DESCRIPTION
## Summary

- Remove `hidden: true` from the `firewall` command definition, making `vercel firewall` visible in `vercel --help`
- Add `firewall` entry to global help output and snapshot
- Add changeset with `minor` version bump

## What ships

- `vercel firewall overview` / `diff` / `publish` / `discard` — draft management
- `vercel firewall rules list` / `inspect` / `add` / `edit` / `enable` / `disable` / `remove` / `reorder` — custom rules
- `vercel firewall ip-blocks list` / `block` / `unblock` — IP blocking
- `vercel firewall system-bypass list` / `add` / `remove` — system bypass
- `vercel firewall attack-mode enable` / `disable` — attack challenge mode
- `vercel firewall system-mitigations pause` / `resume` — DDoS mitigations
- `--ai` flag on `rules add` and `rules edit` — AI-powered rule generation

## Do not merge

This PR should not be merged until:
- Docs PR [vercel/front#67489](https://github.com/vercel/front/pull/67489) is merged
- We are ready to release the firewall CLI to users