### PR TITLE
[experimental-services] new schema: implement `routing` key

### DIFF
--- a/.changeset/khaki-lamps-sneeze.md
+++ b/.changeset/khaki-lamps-sneeze.md
@@ -1,0 +1,8 @@
+---
+'@vercel/build-utils': patch
+'@vercel/config': patch
+'@vercel/fs-detectors': patch
+'vercel': patch
+---
+
+Add experimental services `routing` support for simple subtree ownership and validate unsupported frontend or pattern-based configurations.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -601,6 +601,8 @@ export interface Service {
   /* web service config */
   routePrefix?: string;
   routePrefixSource?: 'configured' | 'generated';
+  routingPaths?: string[];
+  stripRoutePrefix?: boolean;
   subdomain?: string;
   /* scheduled job config */
   schedule?: string;
@@ -837,6 +839,11 @@ export interface ServiceMount {
   subdomain?: string;
 }
 
+export interface ServiceRouting {
+  /** URL path subtrees owned by this service. */
+  paths: string[];
+}
+
 /**
  * Configuration for a service in vercel.json.
  * @experimental This feature is experimental and may change.
@@ -877,6 +884,8 @@ export interface ExperimentalServiceConfig {
   /* Web service config */
   /** Preferred routing config alias for routePrefix/subdomain. */
   mount?: string | ServiceMount;
+  /** Simple subtree ownership rules without mount semantics. */
+  routing?: ServiceRouting;
   /** URL prefix for routing (deprecated, use mount instead) */
   routePrefix?: string;
   /** Subdomain this service should respond to (web services only). */

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -884,7 +884,9 @@ async function doBuild(
         ? serviceByBuilder.get(build)
         : undefined;
       const stripServiceRoutePrefix =
-        !!service?.routePrefix && service.routePrefix !== '/';
+        !!service?.stripRoutePrefix &&
+        !!service.routePrefix &&
+        service.routePrefix !== '/';
 
       let buildWorkPath = workPath;
       let buildEntrypoint = build.src;

--- a/packages/cli/src/util/build/service-route-ownership.ts
+++ b/packages/cli/src/util/build/service-route-ownership.ts
@@ -18,8 +18,16 @@ function isWebServiceWithPrefix(
 function getWebRoutePrefixes(services: Service[]): string[] {
   const unique = new Set<string>();
   for (const service of services) {
-    if (!isWebServiceWithPrefix(service)) continue;
-    unique.add(normalizeRoutePrefix(service.routePrefix));
+    if (service.type !== 'web') continue;
+    const ownedPaths =
+      service.routingPaths && service.routingPaths.length > 0
+        ? service.routingPaths
+        : typeof service.routePrefix === 'string'
+          ? [service.routePrefix]
+          : [];
+    for (const ownedPath of ownedPaths) {
+      unique.add(normalizeRoutePrefix(ownedPath));
+    }
   }
   return Array.from(unique);
 }

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -970,9 +970,21 @@ export default class DevServer {
       output.print(`${chalk.cyan('>')} Available at:\n`);
       for (const service of this.services || []) {
         if (service.type !== 'web') continue;
-        const servicePath = service.routePrefix || '/';
-        const serviceUrl = `${addressFormatted}${servicePath === '/' ? '' : servicePath}`;
-        output.print(`  ${chalk.bold(service.name)}: ${link(serviceUrl)}\n`);
+        if (service.routePrefix) {
+          const serviceUrl = `${addressFormatted}${service.routePrefix === '/' ? '' : service.routePrefix}`;
+          output.print(`  ${chalk.bold(service.name)}: ${link(serviceUrl)}\n`);
+          continue;
+        }
+
+        const routingUrls =
+          service.routingPaths?.map(routingPath =>
+            link(`${addressFormatted}${routingPath === '/' ? '' : routingPath}`)
+          ) || [];
+        const renderedTargets =
+          routingUrls.length > 0
+            ? routingUrls.join(', ')
+            : link(addressFormatted);
+        output.print(`  ${chalk.bold(service.name)}: ${renderedTargets}\n`);
       }
     } else {
       devCommandPromise = this.runDevCommand();

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -151,6 +151,9 @@ function getServiceRoutePrefixes(service: Service): string[] {
     return [getInternalServiceCronPathPrefix(service.name)];
   }
   if (service.type === 'web') {
+    if (service.routingPaths && service.routingPaths.length > 0) {
+      return service.routingPaths;
+    }
     return [service.routePrefix || '/'];
   }
   return [];
@@ -369,7 +372,11 @@ export class ServicesOrchestrator {
       env.VERCEL_QUEUE_TOKEN = 'vc-dev-token';
     }
 
-    if (service.routePrefix && service.routePrefix !== '/') {
+    if (
+      service.stripRoutePrefix &&
+      service.routePrefix &&
+      service.routePrefix !== '/'
+    ) {
       env.VERCEL_SERVICE_ROUTE_PREFIX = service.routePrefix;
       env.VERCEL_SERVICE_ROUTE_PREFIX_STRIP = '1';
     }

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -182,6 +182,24 @@ const serviceMountSchema = {
   ],
 };
 
+const serviceRoutingSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['paths'],
+  properties: {
+    paths: {
+      type: 'array',
+      minItems: 1,
+      maxItems: 64,
+      items: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 512,
+      },
+    },
+  },
+};
+
 const serviceScheduleSchema = {
   type: 'string',
   minLength: 9,
@@ -299,6 +317,7 @@ const serviceCommonProperties = {
 
 const serviceRoutableProperties = {
   mount: serviceMountSchema,
+  routing: serviceRoutingSchema,
   routePrefix: {
     type: 'string',
     minLength: 1,

--- a/packages/cli/test/unit/util/build/service-route-ownership.test.ts
+++ b/packages/cli/test/unit/util/build/service-route-ownership.test.ts
@@ -3,12 +3,17 @@ import type { Route } from '@vercel/routing-utils';
 import { describe, expect, test } from 'vitest';
 import { scopeRoutesToServiceOwnership } from '../../../../src/util/build/service-route-ownership';
 
-function createWebService(name: string, routePrefix: string): Service {
+function createWebService(
+  name: string,
+  routePrefix: string,
+  routingPaths?: string[]
+): Service {
   return {
     name,
     type: 'web',
     workspace: '.',
     routePrefix,
+    routingPaths,
     builder: {
       use: '@vercel/next',
       src: 'package.json',
@@ -41,6 +46,21 @@ describe('scopeRoutesToServiceOwnership()', () => {
     expect(regex.test('/docs/')).toBe(true);
     expect(regex.test('/api/fastapi/')).toBe(false);
     expect(regex.test('/api/express/')).toBe(false);
+  });
+
+  test('scopes root service routes to exclude routing-owned service paths', () => {
+    const owner = createWebService('web', '/');
+    const routes: Route[] = [{ src: '^/(.*)$', continue: true }];
+    const scoped = scopeRoutesToServiceOwnership({
+      routes,
+      owner,
+      allServices: [owner, createWebService('api', '/', ['/api'])],
+    });
+
+    const regex = getRegex(scoped[0]);
+    expect(regex.test('/about')).toBe(true);
+    expect(regex.test('/api')).toBe(false);
+    expect(regex.test('/api/users')).toBe(false);
   });
 
   test('scopes parent service routes while excluding descendant prefixes', () => {

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -61,6 +61,22 @@ describe('validateConfig', () => {
     expect(error).toBeNull();
   });
 
+  it('should not error with experimentalServices routing config', async () => {
+    const config = {
+      experimentalServices: {
+        docs: {
+          entrypoint: 'services/docs/main.py',
+          framework: 'fastapi',
+          routing: {
+            paths: ['/docs', '/docs/legacy'],
+          },
+        },
+      },
+    } satisfies Parameters<typeof validateConfig>[0];
+    const error = validateConfig(config);
+    expect(error).toBeNull();
+  });
+
   it('should not error with legacy cron service type', () => {
     const error = validateConfig({
       experimentalServices: {

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -601,6 +601,12 @@ export interface VercelConfig {
             subdomain?: string;
           };
       /**
+       * Simple subtree ownership rules without mount semantics.
+       */
+      routing?: {
+        paths: string[];
+      };
+      /**
        * URL prefix for routing (web services only).
        */
       routePrefix?: string;

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -278,26 +278,27 @@ export function generateServicesRoutes(services: Service[]): ServicesRoutes {
   const crons: Route[] = [];
   const workers: Route[] = [];
 
-  // Filter and sort web services by prefix length (longest first)
-  // so more specific routes match before broader ones.
-  const sortedWebServices = services
-    .filter(
-      (s): s is Service & { routePrefix: string } =>
-        s.type === 'web' && typeof s.routePrefix === 'string'
-    )
-    .sort((a, b) => b.routePrefix.length - a.routePrefix.length);
+  // Expand web services into owned path entries and sort by path length
+  // (longest first) so more specific routes match before broader ones.
+  const sortedWebRoutingEntries = getWebRoutingEntries(services).sort(
+    (a, b) => b.path.length - a.path.length
+  );
 
-  const allWebPrefixes = getWebRoutePrefixes(sortedWebServices);
+  const allWebPrefixes = getWebRoutePrefixes(sortedWebRoutingEntries);
   const explicitHostPrefixGuard =
     getExplicitHostPrefixNegativeLookahead(allWebPrefixes);
 
-  for (const service of sortedWebServices) {
-    const { routePrefix } = service;
+  for (const { service, path: routePrefix } of sortedWebRoutingEntries) {
     const normalizedPrefix = routePrefix.slice(1); // Strip leading /
     const ownershipGuard = getOwnershipGuard(routePrefix, allWebPrefixes);
     const hostCondition = getHostCondition(service);
 
-    if (hostCondition && routePrefix !== '/') {
+    if (
+      hostCondition &&
+      typeof service.routePrefix === 'string' &&
+      service.routePrefix === routePrefix &&
+      routePrefix !== '/'
+    ) {
       const normalizedRoutePrefix = normalizeRoutePrefix(routePrefix);
       hostRewrites.push({
         src: '^/$',
@@ -324,6 +325,8 @@ export function generateServicesRoutes(services: Service[]): ServicesRoutes {
     }
 
     if (isStaticBuild(service)) {
+      const outputRoutePrefix = service.routePrefix || routePrefix;
+      const normalizedOutputPrefix = outputRoutePrefix.slice(1);
       // Static/SPA service: serve index.html for client-side routing
       if (routePrefix === '/') {
         defaults.push({ handle: 'filesystem' });
@@ -337,7 +340,7 @@ export function generateServicesRoutes(services: Service[]): ServicesRoutes {
             `^/${normalizedPrefix}(?:/.*)?$`,
             ownershipGuard
           ),
-          dest: `/${normalizedPrefix}/index.html`,
+          dest: `/${normalizedOutputPrefix}/index.html`,
         });
       }
     } else if (service.runtime) {
@@ -382,13 +385,40 @@ function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function getWebRoutePrefixes(services: Service[]): string[] {
-  const unique = new Set<string>();
-  for (const service of services) {
-    if (service.type !== 'web' || typeof service.routePrefix !== 'string') {
-      continue;
+function getWebRoutingEntries(
+  services: Service[]
+): Array<{ service: Service & { type: 'web' }; path: string }> {
+  const entries: Array<{ service: Service & { type: 'web' }; path: string }> =
+    [];
+
+  for (const service of services.filter(
+    (candidate): candidate is Service & { type: 'web' } =>
+      candidate.type === 'web'
+  )) {
+    const ownedPaths =
+      service.routingPaths && service.routingPaths.length > 0
+        ? service.routingPaths
+        : typeof service.routePrefix === 'string'
+          ? [service.routePrefix]
+          : [];
+
+    for (const ownedPath of ownedPaths) {
+      entries.push({
+        service,
+        path: normalizeRoutePrefix(ownedPath),
+      });
     }
-    unique.add(normalizeRoutePrefix(service.routePrefix));
+  }
+
+  return entries;
+}
+
+function getWebRoutePrefixes(
+  entries: Array<{ service: Service & { type: 'web' }; path: string }>
+): string[] {
+  const unique = new Set<string>();
+  for (const entry of entries) {
+    unique.add(normalizeRoutePrefix(entry.path));
   }
   return Array.from(unique);
 }

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -13,6 +13,7 @@ import {
 } from '@vercel/build-utils';
 import {
   ENTRYPOINT_EXTENSIONS,
+  ROUTE_OWNING_BUILDERS,
   RUNTIME_BUILDERS,
   STATIC_BUILDERS,
   RUNTIME_MANIFESTS,
@@ -260,10 +261,84 @@ function isReservedServiceRoutePrefix(routePrefix: string): boolean {
   );
 }
 
+const ROUTING_PATTERN_HINT_RE = /[:*()[\]?+|^$]/;
+
+function normalizeServiceRoutingPaths(
+  name: string,
+  paths: unknown
+): {
+  paths?: string[];
+  error?: ServiceDetectionError;
+} {
+  if (!Array.isArray(paths) || paths.length === 0) {
+    return {
+      error: {
+        code: 'INVALID_ROUTING',
+        message: `Service "${name}" has invalid "routing" config. "routing.paths" must be a non-empty array of concrete paths like "/docs".`,
+        serviceName: name,
+      },
+    };
+  }
+
+  const normalizedPaths: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of paths) {
+    if (typeof value !== 'string') {
+      return {
+        error: {
+          code: 'INVALID_ROUTING',
+          message: `Service "${name}" has invalid "routing" config. Each entry in "routing.paths" must be a string.`,
+          serviceName: name,
+        },
+      };
+    }
+
+    if (!value.startsWith('/')) {
+      return {
+        error: {
+          code: 'INVALID_ROUTING',
+          message: `Service "${name}" has invalid routing path "${value}". Routing paths must start with "/".`,
+          serviceName: name,
+        },
+      };
+    }
+
+    if (ROUTING_PATTERN_HINT_RE.test(value)) {
+      return {
+        error: {
+          code: 'UNSUPPORTED_ROUTING_PATTERN',
+          message: `Service "${name}" has unsupported routing path "${value}". Services routing only supports concrete subtree paths like "/docs". Use microfrontends for dynamic or pattern-based app composition.`,
+          serviceName: name,
+        },
+      };
+    }
+
+    const normalized = normalizeRoutePrefix(value);
+    if (isReservedServiceRoutePrefix(normalized)) {
+      return {
+        error: {
+          code: 'RESERVED_ROUTE_PREFIX',
+          message: `Web service "${name}" cannot use routing path "${normalized}". The "${INTERNAL_SERVICE_PREFIX}" prefix is reserved for internal services routing.`,
+          serviceName: name,
+        },
+      };
+    }
+
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      normalizedPaths.push(normalized);
+    }
+  }
+
+  return { paths: normalizedPaths };
+}
+
 interface ResolvedServiceRoutingConfig {
   routePrefix?: string;
   subdomain?: string;
   routePrefixConfigured: boolean;
+  routingPaths?: string[];
 }
 
 function resolveServiceRoutingConfig(
@@ -275,8 +350,9 @@ function resolveServiceRoutingConfig(
 } {
   const hasLegacyRoutePrefix = typeof config.routePrefix === 'string';
   const hasLegacySubdomain = typeof config.subdomain === 'string';
+  const hasRouting = config.routing !== undefined;
 
-  if (config.mount === undefined) {
+  if (config.mount === undefined && !hasRouting) {
     return {
       routing: {
         routePrefix: config.routePrefix,
@@ -286,12 +362,69 @@ function resolveServiceRoutingConfig(
     };
   }
 
-  if (hasLegacyRoutePrefix || hasLegacySubdomain) {
+  if (
+    config.mount !== undefined &&
+    (hasLegacyRoutePrefix || hasLegacySubdomain || hasRouting)
+  ) {
     return {
       error: {
         code: 'CONFLICTING_MOUNT_CONFIG',
-        message: `Service "${name}" cannot mix "mount" with "routePrefix" or "subdomain". Use only one routing configuration style.`,
+        message: `Service "${name}" cannot mix "mount" with "routing", "routePrefix", or "subdomain". Use only one routing configuration style.`,
         serviceName: name,
+      },
+    };
+  }
+
+  if (hasRouting) {
+    if (hasLegacyRoutePrefix || hasLegacySubdomain) {
+      return {
+        error: {
+          code: 'CONFLICTING_ROUTING_CONFIG',
+          message: `Service "${name}" cannot mix "routing" with "routePrefix" or "subdomain". Use only one routing configuration style.`,
+          serviceName: name,
+        },
+      };
+    }
+
+    if (
+      !config.routing ||
+      typeof config.routing !== 'object' ||
+      Array.isArray(config.routing)
+    ) {
+      return {
+        error: {
+          code: 'INVALID_ROUTING',
+          message: `Service "${name}" has invalid "routing" config. Use an object like { paths: ["/docs"] }.`,
+          serviceName: name,
+        },
+      };
+    }
+
+    const hasInvalidRoutingKeys = Object.keys(config.routing).some(
+      key => key !== 'paths'
+    );
+    if (hasInvalidRoutingKeys) {
+      return {
+        error: {
+          code: 'INVALID_ROUTING',
+          message: `Service "${name}" has invalid "routing" config. Only "paths" is supported.`,
+          serviceName: name,
+        },
+      };
+    }
+
+    const normalizedRouting = normalizeServiceRoutingPaths(
+      name,
+      config.routing.paths
+    );
+    if (normalizedRouting.error) {
+      return { error: normalizedRouting.error };
+    }
+
+    return {
+      routing: {
+        routePrefixConfigured: false,
+        routingPaths: normalizedRouting.paths,
       },
     };
   }
@@ -407,8 +540,11 @@ export function validateServiceConfig(
   }
   const configuredRoutePrefix = routingResult.routing?.routePrefix;
   const configuredSubdomain = routingResult.routing?.subdomain;
+  const configuredRoutingPaths = routingResult.routing?.routingPaths;
   const hasRoutePrefix = typeof configuredRoutePrefix === 'string';
   const hasSubdomain = typeof configuredSubdomain === 'string';
+  const hasRoutingPaths =
+    Array.isArray(configuredRoutingPaths) && configuredRoutingPaths.length > 0;
 
   if (hasSubdomain && !DNS_LABEL_RE.test(configuredSubdomain!)) {
     return {
@@ -418,10 +554,15 @@ export function validateServiceConfig(
     };
   }
 
-  if (serviceType === 'web' && !hasRoutePrefix && !hasSubdomain) {
+  if (
+    serviceType === 'web' &&
+    !hasRoutePrefix &&
+    !hasSubdomain &&
+    !hasRoutingPaths
+  ) {
     return {
       code: 'MISSING_ROUTE_PREFIX',
-      message: `Web service "${name}" must specify at least one of "mount", "routePrefix", or "subdomain".`,
+      message: `Web service "${name}" must specify at least one of "mount", "routing", "routePrefix", or "subdomain".`,
       serviceName: name,
     };
   }
@@ -436,10 +577,10 @@ export function validateServiceConfig(
       serviceName: name,
     };
   }
-  if (isNonWebService && configuredRoutePrefix) {
+  if (isNonWebService && (configuredRoutePrefix || hasRoutingPaths)) {
     return {
       code: 'INVALID_ROUTE_PREFIX',
-      message: `${serviceTypeLabel} service "${name}" cannot have "routePrefix" or "mount". Only web services should specify path-based routing.`,
+      message: `${serviceTypeLabel} service "${name}" cannot have "routePrefix", "mount", or "routing". Only web services should specify path-based routing.`,
       serviceName: name,
     };
   }
@@ -599,6 +740,37 @@ export function validateServiceEntrypoint(
   return null;
 }
 
+function validateResolvedServiceRoutingSupport(
+  service: Service
+): ServiceDetectionError | null {
+  if (
+    service.type !== 'web' ||
+    !service.routingPaths ||
+    service.routingPaths.length === 0
+  ) {
+    return null;
+  }
+
+  const builderOrFramework = service.framework || service.builder.use;
+  if (STATIC_BUILDERS.has(service.builder.use)) {
+    return {
+      code: 'UNSUPPORTED_ROUTING_BUILDER',
+      message: `Web service "${service.name}" cannot use "routing" with "${builderOrFramework}". Static and frontend services need a canonical public base path. Use "mount" for stable subpath hosting.`,
+      serviceName: service.name,
+    };
+  }
+
+  if (ROUTE_OWNING_BUILDERS.has(service.builder.use)) {
+    return {
+      code: 'UNSUPPORTED_ROUTING_BUILDER',
+      message: `Web service "${service.name}" cannot use "routing" with "${builderOrFramework}" yet. Services routing currently supports simple subtree ownership for non-route-owning backends only. Use "mount" for canonical hosting, or microfrontends for richer app composition.`,
+      serviceName: service.name,
+    };
+  }
+
+  return null;
+}
+
 /**
  * Resolve a single service from user configuration.
  */
@@ -629,6 +801,7 @@ export async function resolveConfiguredService(
   }
   const configuredRoutePrefix = routingResult.routing?.routePrefix;
   const configuredSubdomain = routingResult.routing?.subdomain;
+  const configuredRoutingPaths = routingResult.routing?.routingPaths;
   const routePrefixWasConfigured =
     routingResult.routing?.routePrefixConfigured ?? false;
 
@@ -782,6 +955,9 @@ export async function resolveConfiguredService(
   const isStaticBuild = STATIC_BUILDERS.has(builderUse);
   const runtime = isStaticBuild ? undefined : inferredRuntime;
 
+  const stripRoutePrefix =
+    type === 'web' && typeof routePrefix === 'string' && routePrefix !== '/';
+
   // Pass routePrefix to builder config as a filesystem mountpoint.
   // static-build uses this to prefix output paths: '.' = root, 'admin' = /admin/
   // We strip the leading slash since it's a relative path, not a URL.
@@ -811,6 +987,8 @@ export async function resolveConfiguredService(
     entrypoint: resolvedEntrypointFile,
     routePrefix,
     routePrefixSource: resolvedRoutePrefixSource,
+    routingPaths: configuredRoutingPaths,
+    stripRoutePrefix,
     subdomain: normalizedSubdomain,
     framework: config.framework,
     builder: {
@@ -842,7 +1020,7 @@ export async function resolveAllConfiguredServices(
 }> {
   const resolved: Service[] = [];
   const errors: ServiceDetectionError[] = [];
-  const webServicesByRoutePrefix = new Map<string, string>();
+  const webServicesByOwnedPath = new Map<string, string>();
 
   for (const name of Object.keys(services)) {
     const serviceConfig = services[name];
@@ -960,20 +1138,40 @@ export async function resolveAllConfiguredServices(
       routePrefixSource,
     });
 
-    if (service.type === 'web' && typeof service.routePrefix === 'string') {
-      const normalizedRoutePrefix = normalizeRoutePrefix(service.routePrefix);
-      const existingServiceName = webServicesByRoutePrefix.get(
-        normalizedRoutePrefix
-      );
-      if (existingServiceName) {
-        errors.push({
-          code: 'DUPLICATE_ROUTE_PREFIX',
-          message: `Web services "${existingServiceName}" and "${name}" cannot share routePrefix "${normalizedRoutePrefix}".`,
-          serviceName: name,
-        });
+    const resolvedRoutingError = validateResolvedServiceRoutingSupport(service);
+    if (resolvedRoutingError) {
+      errors.push(resolvedRoutingError);
+      continue;
+    }
+
+    if (service.type === 'web') {
+      const ownedPaths = service.routingPaths?.length
+        ? service.routingPaths
+        : typeof service.routePrefix === 'string'
+          ? [service.routePrefix]
+          : [];
+
+      let hasDuplicateOwnedPath = false;
+      for (const ownedPath of ownedPaths) {
+        const normalizedOwnedPath = normalizeRoutePrefix(ownedPath);
+        const existingServiceName =
+          webServicesByOwnedPath.get(normalizedOwnedPath);
+        if (existingServiceName) {
+          errors.push({
+            code: 'DUPLICATE_ROUTE_PREFIX',
+            message: `Web services "${existingServiceName}" and "${name}" cannot share routing path "${normalizedOwnedPath}".`,
+            serviceName: name,
+          });
+          hasDuplicateOwnedPath = true;
+          break;
+        }
+      }
+      if (hasDuplicateOwnedPath) {
         continue;
       }
-      webServicesByRoutePrefix.set(normalizedRoutePrefix, name);
+      for (const ownedPath of ownedPaths) {
+        webServicesByOwnedPath.set(normalizeRoutePrefix(ownedPath), name);
+      }
     }
 
     resolved.push(service);

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/.gitignore
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/.gitignore
@@ -1,0 +1,9 @@
+.vercel
+
+node_modules
+.next
+
+.venv
+venv
+__pycache__
+*.py[cod]

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/app/layout.js
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/app/not-found.js
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return '404 from Next.js';
+}

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/app/page.js
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'Hello from Next.js';
+}

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/package.json
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "scripts": {
+    "vercel-build": "next build"
+  }
+}

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/probes.json
@@ -1,0 +1,59 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "Hello from Next.js"
+    },
+    {
+      "path": "/does-not-exist",
+      "status": 404,
+      "mustContain": "404 from Next.js"
+    },
+    {
+      "path": "/api/parent",
+      "status": 200,
+      "mustContain": "Hello from Parent FastAPI"
+    },
+    {
+      "path": "/api/parent/health",
+      "status": 200,
+      "mustContain": "parent-ok"
+    },
+    {
+      "path": "/api/parent/child",
+      "status": 200,
+      "mustContain": "Hello from Child FastAPI"
+    },
+    {
+      "path": "/api/parent/child/health",
+      "status": 200,
+      "mustContain": "child-ok"
+    },
+    {
+      "path": "/api/parent/child/legacy",
+      "status": 200,
+      "mustContain": "Hello from Parent FastAPI"
+    },
+    {
+      "path": "/api/parent/child/legacy/health",
+      "status": 200,
+      "mustContain": "legacy-ok"
+    },
+    {
+      "path": "/api/parent/child/does-not-exist",
+      "status": 404,
+      "mustContain": "404 from Child FastAPI"
+    },
+    {
+      "path": "/api/parent/child/legacy/does-not-exist",
+      "status": 404,
+      "mustContain": "404 from Parent FastAPI"
+    },
+    {
+      "path": "/api/parent2",
+      "status": 404,
+      "mustContain": "404 from Next.js"
+    }
+  ]
+}

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/services/child-api/main.py
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/services/child-api/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+
+@app.get("/api/parent/child")
+def child_root():
+    return {"message": "Hello from Child FastAPI"}
+
+
+@app.get("/api/parent/child/health")
+def child_health():
+    return {"status": "child-ok"}
+
+
+@app.exception_handler(404)
+async def not_found_handler(request, exc):
+    return JSONResponse(status_code=404, content={"detail": "404 from Child FastAPI"})

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/services/child-api/pyproject.toml
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/services/child-api/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "child-fastapi"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+  "fastapi",
+]

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/services/parent-api/main.py
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/services/parent-api/main.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+
+@app.get("/api/parent")
+def parent_root():
+    return {"message": "Hello from Parent FastAPI"}
+
+
+@app.get("/api/parent/health")
+def parent_health():
+    return {"status": "parent-ok"}
+
+
+@app.get("/api/parent/child/legacy")
+def parent_legacy_root():
+    return {"message": "Hello from Parent FastAPI"}
+
+
+@app.get("/api/parent/child/legacy/health")
+def parent_legacy_health():
+    return {"status": "legacy-ok"}
+
+
+@app.exception_handler(404)
+async def not_found_handler(request, exc):
+    return JSONResponse(
+        status_code=404, content={"detail": "404 from Parent FastAPI"}
+    )

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/services/parent-api/pyproject.toml
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/services/parent-api/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "parent-fastapi"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+  "fastapi",
+]

--- a/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/18-services-routing-nextjs-fastapi/vercel.json
@@ -1,0 +1,24 @@
+{
+  "uploadNowJson": true,
+  "projectSettings": {
+    "framework": "services"
+  },
+  "experimentalServices": {
+    "web": {
+      "framework": "nextjs",
+      "mount": "/"
+    },
+    "parent-api": {
+      "entrypoint": "services/parent-api/main.py",
+      "routing": {
+        "paths": ["/api/parent", "/api/parent/child/legacy"]
+      }
+    },
+    "child-api": {
+      "entrypoint": "services/child-api/main.py",
+      "routing": {
+        "paths": ["/api/parent/child"]
+      }
+    }
+  }
+}

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -1068,6 +1068,150 @@ describe('detectServices', () => {
       });
     });
 
+    it('should support routing paths for non-route-owning backend services', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            docs: {
+              entrypoint: 'services/docs/main.py',
+              framework: 'fastapi',
+              routing: {
+                paths: ['/docs', '/docs/new-product/legacy'],
+              },
+            },
+            'new-product-docs': {
+              entrypoint: 'services/new-product/main.py',
+              framework: 'fastapi',
+              routing: {
+                paths: ['/docs/new-product'],
+              },
+            },
+          },
+        }),
+        'services/docs/main.py': 'from fastapi import FastAPI',
+        'services/new-product/main.py': 'from fastapi import FastAPI',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(2);
+
+      const docs = result.services.find(s => s.name === 'docs');
+      const newProductDocs = result.services.find(
+        s => s.name === 'new-product-docs'
+      );
+
+      expect(docs).toMatchObject({
+        routePrefix: undefined,
+        routingPaths: ['/docs', '/docs/new-product/legacy'],
+        stripRoutePrefix: false,
+      });
+      expect(newProductDocs).toMatchObject({
+        routePrefix: undefined,
+        routingPaths: ['/docs/new-product'],
+        stripRoutePrefix: false,
+      });
+
+      expect(result.routes.rewrites).toHaveLength(3);
+      expect(
+        findMatchingRoute(result.routes.rewrites, '/docs/getting-started')
+      ).toMatchObject({
+        dest: '/_svc/docs/index',
+        check: true,
+      });
+      expect(
+        findMatchingRoute(result.routes.rewrites, '/docs/new-product/overview')
+      ).toMatchObject({
+        dest: '/_svc/new-product-docs/index',
+        check: true,
+      });
+      expect(
+        findMatchingRoute(
+          result.routes.rewrites,
+          '/docs/new-product/legacy/changelog'
+        )
+      ).toMatchObject({
+        dest: '/_svc/docs/index',
+        check: true,
+      });
+    });
+
+    it('should error when routing is mixed with legacy routing keys', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            api: {
+              entrypoint: 'api/index.py',
+              framework: 'fastapi',
+              routePrefix: '/api',
+              routing: {
+                paths: ['/api'],
+              },
+            },
+          },
+        }),
+        'api/index.py': 'from fastapi import FastAPI',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.services).toEqual([]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        code: 'CONFLICTING_ROUTING_CONFIG',
+        serviceName: 'api',
+      });
+    });
+
+    it('should error when routing uses unsupported dynamic patterns', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            products: {
+              entrypoint: 'services/products/main.py',
+              framework: 'fastapi',
+              routing: {
+                paths: ['/products/:id'],
+              },
+            },
+          },
+        }),
+        'services/products/main.py': 'from fastapi import FastAPI',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.services).toEqual([]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        code: 'UNSUPPORTED_ROUTING_PATTERN',
+        serviceName: 'products',
+      });
+    });
+
+    it('should error when static frontend uses routing instead of mount', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            docs: {
+              entrypoint: 'apps/docs',
+              framework: 'vite',
+              routing: {
+                paths: ['/docs'],
+              },
+            },
+          },
+        }),
+        'apps/docs/package.json': JSON.stringify({ name: 'docs' }),
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.services).toEqual([]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        code: 'UNSUPPORTED_ROUTING_BUILDER',
+        serviceName: 'docs',
+      });
+    });
+
     it('should derive routePrefix from subdomain using /_/serviceName', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({


### PR DESCRIPTION
Updates the experimentalServices routing config to match the new spec
Adds support for routing to the experimentalServices config