### PR TITLE
fix(functions): detect ioredis in attachDatabasePoo

### DIFF
--- a/packages/functions/src/db-connections/index.ts
+++ b/packages/functions/src/db-connections/index.ts
@@ -300,9 +300,7 @@ export function attachDatabasePool(dbPool: DbPool) {
   if (
     'on' in dbPool &&
     dbPool.on &&
-    'options' in dbPool &&
-    dbPool.options &&
-    'socket' in dbPool.options
+    (('options' in dbPool && dbPool.options && 'socket' in dbPool.options) || 'status' in dbPool)
   ) {
     const redisPool = dbPool as RedisPool;
     redisPool.on!('end', () => {


### PR DESCRIPTION
## Problem

`attachDatabasePool` throws `Unsupported database pool type` when passed an [`ioredis`](https://github.com/redis/ioredis) client, even though the docstring and the `RedisPool` interface in this file both advertise ioredis support:

```ts
// Based on ioredis.Redis
interface RedisPool {
  options?: any;
  on?: (event: 'ready' | 'end' | 'error' | 'connect', ...) => void;
  status?: string; // From Redis.status
}
```

The Redis branch in `attachDatabasePool` only matches on `options.socket`, which is the **node-redis** shape. `ioredis` stores `host`/`port` flat on `options` and exposes a top-level `status` property instead, so the duck-type check falls through to the `throw`.

## Fix

- node-redis: still matched via `options.socket` — no regression.
- ioredis: now matched via `status` — consistent with `getIdleTimeout`.
- Unknown shapes: still fall through to the `Unsupported database pool type` throw.

The temporary fix:

```ts
export const redis = new Redis(redisOptions)
// @vercel/functions duck-types node-redis (`options.socket`); shim ioredis so its Fluid Compute
// idle handler binds. Without this, attachDatabasePool throws "Unsupported database pool type".
Object.assign(redis.options, {
  socket: { host: redisOptions.host, port: redisOptions.port },
})
attachDatabasePool(redis)
```