### PR TITLE
fix(cli): resolve SSH config Host aliases in `vercel link --repo`

### DIFF
--- a/.changeset/cli-link-repo-ssh-aliases.md
+++ b/.changeset/cli-link-repo-ssh-aliases.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Resolve SSH config `Host` aliases when parsing git remote URLs in `vercel link --repo`. Remotes that use a custom `Host` mapping (e.g. `git@github-golden:org/repo.git` for users with multi-identity SSH configs) are now expanded via `ssh -G` before the provider classifier runs, instead of failing with `Failed to parse Git URL`.

--- a/packages/cli/src/util/git/connect-git-provider.ts
+++ b/packages/cli/src/util/git/connect-git-provider.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'child_process';
 import { URL } from 'url';
 import type Client from '../client';
 import chalk from 'chalk';
@@ -105,6 +106,33 @@ export function buildRepoUrl(
   }
 }
 
+function resolveSshHostAlias(host: string): string {
+  // SSH `Host` aliases (e.g. `github-golden` mapped to `HostName github.com`
+  // in ~/.ssh/config) produce remote URLs with single-token hostnames that
+  // can't be classified as a Git provider. Ask `ssh -G` for the resolved
+  // hostname; this is the canonical way to read SSH config and works on
+  // every platform that has an OpenSSH client (including Windows, where
+  // OpenSSH ships by default since Win10 1809).
+  if (host.includes('.')) {
+    return host;
+  }
+  try {
+    const out = execFileSync('ssh', ['-G', host], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    });
+    const match = out.match(/^hostname\s+(\S+)$/m);
+    if (match && match[1] && match[1] !== host) {
+      return match[1];
+    }
+  } catch {
+    // ssh not on PATH, no SSH config entry, or process timed out — fall
+    // through and let the caller deal with the unresolved hostname.
+  }
+  return host;
+}
+
 function getURL(input: string) {
   let url: URL | null = null;
 
@@ -118,6 +146,16 @@ function getURL(input: string) {
     try {
       url = new URL(`ssh://${input.replace(':', '/')}`);
     } catch {}
+  }
+
+  if (url && !url.hostname.includes('.')) {
+    // Likely an SSH config `Host` alias. Try to resolve it to the real
+    // hostname before the provider classifier in `parseRepoUrl` rejects
+    // it for having fewer than two dot-separated parts.
+    const resolved = resolveSshHostAlias(url.hostname);
+    if (resolved !== url.hostname) {
+      url.hostname = resolved;
+    }
   }
 
   return url;

--- a/packages/cli/test/unit/util/git/connect-git-provider.test.ts
+++ b/packages/cli/test/unit/util/git/connect-git-provider.test.ts
@@ -5,6 +5,15 @@ import {
 } from '../../../../src/util/git/connect-git-provider';
 import { client } from '../../../mocks/client';
 
+vi.mock('child_process', async () => {
+  const actual =
+    await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
+
 describe('parseRepoUrl()', () => {
   it('should parse GitHub HTTPS URL', () => {
     const result = parseRepoUrl('https://github.com/vercel/next.js.git');
@@ -60,6 +69,60 @@ describe('parseRepoUrl()', () => {
     expect(parseRepoUrl('')).toBeNull();
     expect(parseRepoUrl('not-a-url')).toBeNull();
     expect(parseRepoUrl('https://example.com')).toBeNull();
+  });
+
+  describe('SSH config Host alias resolution', () => {
+    beforeEach(async () => {
+      const { execFileSync } = await import('child_process');
+      vi.mocked(execFileSync).mockReset();
+    });
+
+    it('should resolve SSH Host alias via `ssh -G`', async () => {
+      const { execFileSync } = await import('child_process');
+      vi.mocked(execFileSync).mockReturnValue(
+        'user git\nhostname github.com\nport 22\n'
+      );
+
+      const result = parseRepoUrl('git@github-golden:vercel/next.js.git');
+
+      expect(execFileSync).toHaveBeenCalledWith(
+        'ssh',
+        ['-G', 'github-golden'],
+        expect.objectContaining({ encoding: 'utf8' })
+      );
+      expect(result).toEqual({
+        url: 'git@github-golden:vercel/next.js.git',
+        provider: 'github',
+        org: 'vercel',
+        repo: 'next.js',
+      });
+    });
+
+    it('should not call `ssh -G` when hostname already contains a dot', async () => {
+      const { execFileSync } = await import('child_process');
+
+      parseRepoUrl('git@github.com:vercel/next.js.git');
+
+      expect(execFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should return null when `ssh -G` is unavailable or throws', async () => {
+      const { execFileSync } = await import('child_process');
+      vi.mocked(execFileSync).mockImplementation(() => {
+        throw new Error('spawn ssh ENOENT');
+      });
+
+      expect(parseRepoUrl('git@github-golden:vercel/next.js.git')).toBeNull();
+    });
+
+    it('should return null when `ssh -G` resolves the alias to itself', async () => {
+      const { execFileSync } = await import('child_process');
+      vi.mocked(execFileSync).mockReturnValue(
+        'user git\nhostname github-golden\nport 22\n'
+      );
+
+      expect(parseRepoUrl('git@github-golden:vercel/next.js.git')).toBeNull();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Resolves SSH config `Host` aliases (e.g. `git@github-golden:org/repo.git`) when parsing git remote URLs in `vercel link --repo`
- Uses `ssh -G <alias>` to expand single-token hostnames to real hostnames before the provider classifier runs
- Falls through gracefully when `ssh` is unavailable or the alias doesn't resolve

Closes #15439

## Test plan
- [x] Added unit tests for alias resolution via mocked `ssh -G`
- [x] Verified no regression when hostname already contains a dot
- [x] Tested fallback when `ssh -G` is unavailable or resolves alias to itself