### PR TITLE
fix(build-utils): prevent prototype pollution in cloneEnv

### DIFF
--- a/.changeset/clone-env-proto-pollution.md
+++ b/.changeset/clone-env-proto-pollution.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+Fix prototype-pollution vulnerability in `cloneEnv`. Untrusted env objects (e.g. produced by `JSON.parse`) containing a `__proto__` own property could replace the returned object's prototype with attacker-controlled data via the prototype accessor on the merge target. `cloneEnv` now skips the `__proto__`, `constructor`, and `prototype` keys when copying. Fixes #15725.

--- a/packages/build-utils/src/clone-env.ts
+++ b/packages/build-utils/src/clone-env.ts
@@ -2,6 +2,12 @@ import type { Env } from './types';
 
 const hasProp = Object.prototype.hasOwnProperty;
 
+// Keys that, if assigned via `obj[key] = value`, can mutate
+// `Object.prototype` (or otherwise alter object internals) because they
+// trigger the prototype accessor on the target. We skip them when copying
+// untrusted env-shaped input.
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * Clones zero or more objects into a single new object while ensuring that the
  * `PATH` environment variable is defined when the `PATH` or `Path` environment
@@ -16,8 +22,14 @@ export function cloneEnv(...envs: (Env | undefined)[]): Env {
       return obj;
     }
 
-    // mixin the env first
-    obj = Object.assign(obj, env);
+    // Mixin the env first.  Use a manual copy instead of `Object.assign` so
+    // that an attacker-controlled `__proto__` key (e.g. from
+    // `JSON.parse('{"__proto__":{...}}')`) cannot pollute `Object.prototype`
+    // by going through the prototype accessor on `obj`.
+    for (const key of Object.keys(env)) {
+      if (UNSAFE_KEYS.has(key)) continue;
+      obj[key] = (env as Record<string, string | undefined>)[key];
+    }
 
     if (hasProp.call(env, 'Path')) {
       // the system path is called `Path` on Windows and Node.js will

--- a/packages/build-utils/test/unit.clone-env.test.ts
+++ b/packages/build-utils/test/unit.clone-env.test.ts
@@ -116,6 +116,36 @@ it('should overwrite PATH with last value', () => {
   });
 });
 
+it('should not allow prototype pollution via __proto__ key', () => {
+  // Regression test for #15725.  A malicious env containing a `__proto__`
+  // own property (e.g. produced by `JSON.parse`) must not be allowed to
+  // replace the returned object's prototype with attacker-controlled data,
+  // and must not pollute `Object.prototype`.
+  const malicious = JSON.parse(
+    '{"__proto__":{"polluted":"yes"},"GOOD":"keep"}'
+  );
+  const result = cloneEnv(malicious) as Record<string, unknown>;
+
+  // Returned object's prototype must remain Object.prototype.
+  expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  // Looking up `polluted` must not surface the attacker value via the chain.
+  expect(result.polluted).toBeUndefined();
+  // The unsafe key itself must not be copied as a regular own property.
+  expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(false);
+  // Legitimate keys are still copied.
+  expect(result.GOOD).toBe('keep');
+  // `Object.prototype` was not globally polluted.
+  expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+});
+
+it('should not copy other unsafe keys (constructor, prototype)', () => {
+  const malicious = JSON.parse(
+    '{"constructor":"x","prototype":"y","SAFE":"keep"}'
+  );
+  const result = cloneEnv(malicious);
+  expect(result).toEqual({ SAFE: 'keep' });
+});
+
 it('should handle process.env at any argument position', () => {
   expect(
     cloneEnv(


### PR DESCRIPTION
## Summary
- Fixes prototype pollution vulnerability in `cloneEnv` where untrusted env objects containing `__proto__` could replace the returned object's prototype
- Replaces `Object.assign` with manual key iteration that skips `__proto__`, `constructor`, and `prototype`
- No behavior change for legitimate environment variables

Fixes #15725

## Test plan
- [x] Added regression test verifying `__proto__` key does not pollute `Object.prototype`
- [x] Added test verifying `constructor` and `prototype` keys are skipped
- [x] Verified legitimate keys are still copied correctly