### PR TITLE
[services] Add service type to project manifest.

### DIFF
--- a/.changeset/eighty-dots-cover.md
+++ b/.changeset/eighty-dots-cover.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': minor
+'@vercel/backends': minor
+'@vercel/python': minor
+---
+
+Add service type to project manifest.

--- a/packages/backends/src/diagnostics.ts
+++ b/packages/backends/src/diagnostics.ts
@@ -432,6 +432,7 @@ export async function generateProjectManifest({
   lockfilePath,
   lockfileVersion,
   framework,
+  serviceType,
 }: {
   workPath: string;
   nodeVersion: NodeVersion;
@@ -439,6 +440,7 @@ export async function generateProjectManifest({
   lockfilePath: string | undefined;
   lockfileVersion: number | undefined;
   framework?: string;
+  serviceType?: string;
 }): Promise<void> {
   try {
     const pkgJson = await readPackageJson(workPath);
@@ -513,6 +515,7 @@ export async function generateProjectManifest({
       version: MANIFEST_VERSION,
       runtime: 'node',
       ...(framework ? { framework } : {}),
+      ...(serviceType ? { serviceType } : {}),
       runtimeVersion,
       dependencies: [
         ...directDeps.sort((a, b) => a.name.localeCompare(b.name)),

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -2,6 +2,7 @@ import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
 import {
   defaultCachePathGlob,
+  getReportedServiceType,
   glob,
   NodejsLambda,
   debug,
@@ -164,7 +165,9 @@ export const build: BuildV2 = async args => {
         lockfilePath: downloadResult.lockfilePath,
         lockfileVersion: downloadResult.lockfileVersion,
         framework: rolldownResult.framework.slug || undefined,
-        serviceType: args.service?.type,
+        serviceType: args.service
+          ? getReportedServiceType(args.service)
+          : undefined,
       });
     } catch (err) {
       debug(

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -164,6 +164,7 @@ export const build: BuildV2 = async args => {
         lockfilePath: downloadResult.lockfilePath,
         lockfileVersion: downloadResult.lockfileVersion,
         framework: rolldownResult.framework.slug || undefined,
+        serviceType: args.service?.type,
       });
     } catch (err) {
       debug(

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -1546,3 +1546,62 @@ describe('generateProjectManifest — framework field', () => {
     expect(manifest.framework).toBeUndefined();
   });
 });
+
+describe('generateProjectManifest — serviceType field', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('includes serviceType in manifest when provided', async () => {
+    writePackageJson(tempDir, { dependencies: { hono: '^4.0.0' } });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: undefined,
+      lockfileVersion: undefined,
+      serviceType: 'worker',
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.serviceType).toBe('worker');
+  });
+
+  it('omits serviceType from manifest when not provided', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.0.0' } });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: undefined,
+      lockfileVersion: undefined,
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.serviceType).toBeUndefined();
+  });
+
+  it('omits serviceType from manifest when empty string provided', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.0.0' } });
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'npm',
+      lockfilePath: undefined,
+      lockfileVersion: undefined,
+      serviceType: '',
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.serviceType).toBeUndefined();
+  });
+});

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -1567,11 +1567,11 @@ describe('generateProjectManifest — serviceType field', () => {
       cliType: 'npm',
       lockfilePath: undefined,
       lockfileVersion: undefined,
-      serviceType: 'worker',
+      serviceType: 'queue',
     });
 
     const manifest = readManifest(tempDir);
-    expect(manifest.serviceType).toBe('worker');
+    expect(manifest.serviceType).toBe('queue');
   });
 
   it('omits serviceType from manifest when not provided', async () => {

--- a/packages/build-utils/src/package-manifest.ts
+++ b/packages/build-utils/src/package-manifest.ts
@@ -17,6 +17,7 @@ export interface PackageManifest {
   version?: string;
   runtime: string;
   framework?: string;
+  serviceType?: string;
   runtimeVersion?: {
     requested?: string;
     requestedSource?: string;

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -177,6 +177,10 @@ export const packageManifestSchema = {
       type: 'string',
       description: 'Detected framework slug, e.g. "fastapi", "flask", "hono".',
     },
+    serviceType: {
+      type: 'string',
+      description: 'Service type, e.g. "web", "worker", "cron".',
+    },
     runtimeVersion: {
       type: 'object',
       additionalProperties: false,

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -179,7 +179,8 @@ export const packageManifestSchema = {
     },
     serviceType: {
       type: 'string',
-      description: 'Service type, e.g. "web", "worker", "cron".',
+      description:
+        'Service type: one of "web", "schedule", "queue", "workflow".',
     },
     runtimeVersion: {
       type: 'object',

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -652,6 +652,29 @@ export function isScheduleTriggeredService(service: {
   );
 }
 
+export type ReportedServiceType = 'web' | 'schedule' | 'queue' | 'workflow';
+
+export function getReportedServiceType(service: {
+  type?: ServiceType;
+  trigger?: JobTrigger;
+}): ReportedServiceType | undefined {
+  switch (service.type) {
+    case 'web':
+      return 'web';
+    case 'cron':
+      return 'schedule';
+    case 'worker':
+      return 'queue';
+    case 'job':
+      if (service.trigger === 'schedule') return 'schedule';
+      if (service.trigger === 'queue') return 'queue';
+      if (service.trigger === 'workflow') return 'workflow';
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
 /** The framework which created the function */
 export interface FunctionFramework {
   slug: string;

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -8,6 +8,7 @@ import type {
 } from './types';
 import {
   getServiceQueueTopics,
+  isScheduleTriggeredService,
   JOB_TRIGGERS,
   JobTrigger,
 } from '@vercel/build-utils';
@@ -389,9 +390,10 @@ export function validateServiceConfig(
   }
   const serviceType = config.type || 'web';
   const isJobService = serviceType === 'job' || serviceType === 'cron';
-  const isScheduleJobService =
-    serviceType === 'cron' ||
-    (serviceType === 'job' && config.trigger === 'schedule');
+  const isScheduleJobService = isScheduleTriggeredService({
+    type: serviceType,
+    trigger: config.trigger,
+  });
   const isQueueJobService = serviceType === 'job' && config.trigger === 'queue';
   const isWorkflowService =
     serviceType === 'job' && config.trigger === 'workflow';

--- a/packages/python/src/crons.ts
+++ b/packages/python/src/crons.ts
@@ -3,8 +3,11 @@ import { join } from 'path';
 import execa from 'execa';
 import {
   getInternalServiceCronPath,
+  isScheduleTriggeredService,
   NowBuildError,
   type Cron,
+  type JobTrigger,
+  type ServiceType,
 } from '@vercel/build-utils';
 
 const DYNAMIC_SCHEDULE = '<dynamic>';
@@ -64,8 +67,8 @@ export function buildCronRouteTable(
  */
 export async function getServiceCrons(opts: {
   service?: {
-    type?: string;
-    trigger?: string;
+    type?: ServiceType;
+    trigger?: JobTrigger;
     name?: string;
     schedule?: string;
   };
@@ -77,9 +80,7 @@ export async function getServiceCrons(opts: {
   workPath: string;
 }): Promise<ServiceCronEntry[] | undefined> {
   const { service, entrypoint, rawEntrypoint, handlerFunction } = opts;
-  const isScheduledService =
-    service?.type === 'cron' ||
-    (service?.type === 'job' && service.trigger === 'schedule');
+  const isScheduledService = !!service && isScheduleTriggeredService(service);
 
   if (
     !isScheduledService ||

--- a/packages/python/src/diagnostics.ts
+++ b/packages/python/src/diagnostics.ts
@@ -83,12 +83,14 @@ export async function generateProjectManifest({
   pythonVersion,
   uvLockPath,
   framework,
+  serviceType,
 }: {
   workPath: string;
   pythonPackage: PythonPackage;
   pythonVersion: PythonVersion;
   uvLockPath: string;
   framework?: string | null;
+  serviceType?: string | null;
 }): Promise<void> {
   const resolved = pythonVersionString(pythonVersion) ?? '';
   const constraint = pythonPackage.requiresPython?.[0];
@@ -271,6 +273,7 @@ export async function generateProjectManifest({
     version: MANIFEST_VERSION,
     runtime: 'python',
     ...(framework ? { framework } : {}),
+    ...(serviceType ? { serviceType } : {}),
     runtimeVersion: {
       ...(requested ? { requested } : {}),
       ...(constraint?.source ? { requestedSource: constraint.source } : {}),

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from './package-versions';
 import {
   download,
+  getReportedServiceType,
   glob,
   Lambda,
   FileBlob,
@@ -831,7 +832,7 @@ from vercel_runtime.vc_init import vc_handler
         pythonVersion,
         uvLockPath,
         framework,
-        serviceType: service?.type,
+        serviceType: service ? getReportedServiceType(service) : undefined,
       });
     } catch (err) {
       debug(

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -831,6 +831,7 @@ from vercel_runtime.vc_init import vc_handler
         pythonVersion,
         uvLockPath,
         framework,
+        serviceType: service?.type,
       });
     } catch (err) {
       debug(

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -18,6 +18,7 @@ import {
   scanParentDirs,
   getEnvForPackageManager,
   isPythonFramework,
+  isScheduleTriggeredService,
   Span,
   BUILDER_INSTALLER_STEP,
   BUILDER_COMPILE_STEP,
@@ -286,8 +287,7 @@ export const build: BuildVX = async ({
             // For schedule-triggered jobs, the WSGI variable is always 'app' (created dynamically).
             // For other services, handlerFunction is used as the entrypoint variable name.
             varName:
-              service?.type === 'cron' ||
-              (service?.type === 'job' && service.trigger === 'schedule')
+              service && isScheduleTriggeredService(service)
                 ? undefined
                 : handlerFunction,
           }

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -3,7 +3,11 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join, delimiter, dirname, basename } from 'path';
 import type { ChildProcess } from 'child_process';
 import type { PythonFramework, StartDevServer } from '@vercel/build-utils';
-import { debug, NowBuildError } from '@vercel/build-utils';
+import {
+  debug,
+  isScheduleTriggeredService,
+  NowBuildError,
+} from '@vercel/build-utils';
 import { buildCronRouteTable, getServiceCrons } from './crons';
 import getPort from 'get-port';
 import isPortReachable from 'is-port-reachable';
@@ -787,8 +791,7 @@ export const startDevServer: StartDevServer = async opts => {
           // Schedule-triggered services create their own "app" wrapper dynamically.
           // Other services use handlerFunction as the entrypoint variable name.
           varName:
-            service?.type === 'cron' ||
-            (service?.type === 'job' && service.trigger === 'schedule')
+            service && isScheduleTriggeredService(service)
               ? undefined
               : handlerFunction,
         }

--- a/packages/python/test/diagnostics.test.ts
+++ b/packages/python/test/diagnostics.test.ts
@@ -792,12 +792,12 @@ describe('generateProjectManifest', () => {
       pythonPackage: pkg,
       pythonVersion,
       uvLockPath,
-      serviceType: 'worker',
+      serviceType: 'queue',
     });
 
     const manifestPath = path.join(tempDir, DIAGNOSTICS_PATH);
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-    expect(manifest.serviceType).toBe('worker');
+    expect(manifest.serviceType).toBe('queue');
   });
 
   it('omits serviceType from manifest when not provided', async () => {

--- a/packages/python/test/diagnostics.test.ts
+++ b/packages/python/test/diagnostics.test.ts
@@ -780,6 +780,62 @@ describe('generateProjectManifest', () => {
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
     expect(manifest.framework).toBeUndefined();
   });
+
+  it('includes serviceType in manifest when provided', async () => {
+    const pkg = makePackage({ dependencies: ['fastapi'] });
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'fastapi', version: '0.115.0', dependencies: [] },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+      serviceType: 'worker',
+    });
+
+    const manifestPath = path.join(tempDir, DIAGNOSTICS_PATH);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.serviceType).toBe('worker');
+  });
+
+  it('omits serviceType from manifest when not provided', async () => {
+    const pkg = makePackage({ dependencies: ['requests'] });
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'requests', version: '2.32.0', dependencies: [] },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+    });
+
+    const manifestPath = path.join(tempDir, DIAGNOSTICS_PATH);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.serviceType).toBeUndefined();
+  });
+
+  it('omits serviceType from manifest when null provided', async () => {
+    const pkg = makePackage({ dependencies: ['requests'] });
+    const uvLockPath = writeUvLock(tempDir, [
+      { name: 'requests', version: '2.32.0', dependencies: [] },
+    ]);
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      pythonPackage: pkg,
+      pythonVersion,
+      uvLockPath,
+      serviceType: null,
+    });
+
+    const manifestPath = path.join(tempDir, DIAGNOSTICS_PATH);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.serviceType).toBeUndefined();
+  });
 });
 
 describe('diagnostics callback', () => {


### PR DESCRIPTION
Adds a serviceType field to the project manifest (currently emitted by the python and backends builders).

Service type comes from the services framework via `BuildOptions.service` and is set to one of `'web'`, `'schedule'`, `'queue'`, or `'workflow'`. The field is omitted from the manifest when the build is not part of a multi-service project, or if a job service has an invalid trigger.