### PR TITLE
fix(cli): replace git-last-commit with direct git commands for deployment metadata

### DIFF
--- a/.changeset/cli-deploy-git-metadata.md
+++ b/.changeset/cli-deploy-git-metadata.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Replace the `git-last-commit` dependency with direct `git` commands for collecting deployment Git metadata. The old library chained `git log`, `git rev-parse`, and `git tag --contains HEAD` with `&&` and treated any stderr output as a fatal error, which caused Git metadata to silently disappear whenever `git` printed a warning (e.g. on newer Git versions, repos with many tags, or missing notes refs). The CLI now runs only the two commands it needs (`git log` and `git rev-parse`) independently via `execFile`, so a warning on one command does not suppress all metadata. Fixes #15577.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -153,7 +153,6 @@
     "find-up": "4.1.0",
     "fs-extra": "10.0.0",
     "get-port": "5.1.1",
-    "git-last-commit": "1.0.1",
     "http-proxy-node16": "1.0.6",
     "ini": "3.0.0",
     "is-docker": "2.2.1",

--- a/packages/cli/src/util/create-git-meta.ts
+++ b/packages/cli/src/util/create-git-meta.ts
@@ -1,10 +1,9 @@
 import fs from 'fs-extra';
 import { join } from 'path';
 import ini from 'ini';
-import git from 'git-last-commit';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import type { GitMetadata, Project } from '@vercel-internals/types';
-import { errorToString, normalizeError } from '@vercel/error-utils';
+import { errorToString } from '@vercel/error-utils';
 import output from '../output-manager';
 
 export async function createGitMeta(
@@ -56,8 +55,8 @@ export async function createGitMeta(
 
   return {
     remoteUrl: remoteUrl || undefined,
-    commitAuthorName: commit.author.name,
-    commitAuthorEmail: commit.author.email,
+    commitAuthorName: commit.authorName,
+    commitAuthorEmail: commit.authorEmail,
     commitMessage: commit.subject,
     commitRef: commit.branch,
     commitSha: commit.hash,
@@ -65,17 +64,44 @@ export async function createGitMeta(
   };
 }
 
-function getLastCommit(directory: string): Promise<git.Commit> {
+interface CommitInfo {
+  hash: string;
+  subject: string;
+  authorName: string;
+  authorEmail: string;
+  branch: string;
+}
+
+function getLastCommit(directory: string): Promise<CommitInfo> {
   return new Promise((resolve, reject) => {
-    git.getLastCommit(
-      (err, commit) => {
-        if (err) {
-          return reject(normalizeError(err));
+    // Fetch commit metadata and branch name with two separate commands
+    // instead of the old `git-last-commit` package, which chained three
+    // commands (`git log && git rev-parse && git tag --contains HEAD`)
+    // with `&&` and treated ANY stderr as a fatal error.  That made
+    // metadata collection silently fail whenever git printed a warning
+    // (e.g. newer git versions, large repos, missing notes refs).
+    execFile(
+      'git',
+      ['log', '-1', '--format=%H%n%s%n%an%n%ae'],
+      { cwd: directory },
+      (logErr, logStdout) => {
+        if (logErr || !logStdout.trim()) {
+          return reject(logErr || new Error('No git commits found'));
         }
 
-        resolve(commit);
-      },
-      { dst: directory }
+        const lines = logStdout.trimEnd().split('\n');
+        const [hash, subject, authorName, authorEmail] = lines;
+
+        execFile(
+          'git',
+          ['rev-parse', '--abbrev-ref', 'HEAD'],
+          { cwd: directory },
+          (branchErr, branchStdout) => {
+            const branch = branchErr ? '' : branchStdout.trim();
+            resolve({ hash, subject, authorName, authorEmail, branch });
+          }
+        );
+      }
     );
   });
 }


### PR DESCRIPTION
## Summary
- Replaces the fragile `git-last-commit` npm package (v1.0.1) with two direct `execFile` calls for collecting deployment Git metadata
- The old library chained `git log`, `git rev-parse`, and `git tag --contains HEAD` with `&&` and treated **any** stderr as fatal — a single git warning silently dropped all commit metadata from deployments
- Now runs only `git log -1 --format=%H%n%s%n%an%n%ae` and `git rev-parse --abbrev-ref HEAD` independently via `execFile`, so warnings on one command don't suppress all metadata
- Removes the unnecessary `git tag --contains HEAD` call (never used by the CLI, slow on repos with many tags)

Fixes #15577

## Test plan
- [x] All 31 existing `create-git-meta` unit tests pass
- [x] Verified commit hash, subject, author name, author email, and branch are correctly parsed
- [x] Verified corrupt `.git` directory still produces debug message and returns `undefined`
- [x] Verified dirty/not-dirty detection still works
- [x] Verified connected repo remote URL resolution still works