### PR TITLE
fix(cli): honor VERCEL_ORG_ID in `vercel redeploy`

### DIFF
--- a/.changeset/cli-redeploy-vercel-org-id.md
+++ b/.changeset/cli-redeploy-vercel-org-id.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Fix `vercel redeploy` to honor `VERCEL_ORG_ID` environment variable for team context. Previously, `redeploy` only used `getScope()` which resolves the default team, ignoring `VERCEL_ORG_ID`. This caused "Not authorized" errors in CI workflows that rely on env-var-based team configuration. The command now reads `VERCEL_ORG_ID` before resolving scope, consistent with `vercel list`, `vercel deploy`, and other commands. Fixes #16073.

--- a/packages/cli/src/commands/redeploy/index.ts
+++ b/packages/cli/src/commands/redeploy/index.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { checkDeploymentStatus } from '@vercel/client';
+import { getPlatformEnv } from '@vercel/build-utils';
 import type Client from '../../util/client';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { parseArguments } from '../../util/get-args';
@@ -73,6 +74,14 @@ export default async function redeploy(client: Client): Promise<number> {
   telemetry.trackCliArgumentUrlOrDeploymentId(deployIdOrUrl);
   telemetry.trackCliFlagNoWait(parsedArgs.flags['--no-wait']);
   telemetry.trackCliOptionTarget(parsedArgs.flags['--target']);
+
+  // Honor VERCEL_ORG_ID so that CI workflows using env-var-based
+  // configuration get the correct team context, consistent with
+  // `vercel list`, `vercel deploy`, and other commands.
+  const VERCEL_ORG_ID = getPlatformEnv('ORG_ID');
+  if (VERCEL_ORG_ID) {
+    client.config.currentTeam = VERCEL_ORG_ID;
+  }
 
   const { contextName } = await getScope(client);
   const noWait = !!parsedArgs.flags['--no-wait'];

--- a/packages/cli/test/unit/commands/redeploy/index.test.ts
+++ b/packages/cli/test/unit/commands/redeploy/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { client } from '../../../mocks/client';
 import { defaultProject, useProject } from '../../../mocks/project';
 import redeploy from '../../../../src/commands/redeploy';
@@ -231,6 +231,27 @@ describe('redeploy', () => {
       );
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "redeploy"').toEqual(1);
+    });
+  });
+
+  describe('VERCEL_ORG_ID', () => {
+    afterEach(() => {
+      delete process.env.VERCEL_ORG_ID;
+    });
+
+    it('should use VERCEL_ORG_ID for team context when set', async () => {
+      const teamId = 'team_dummy';
+      const { fromDeployment, toDeployment } = initRedeployTest();
+      // The deployment must belong to the same team for the scope check to pass
+      fromDeployment.team = { id: teamId, name: 'dummy', slug: 'dummy' };
+      toDeployment.readyState = 'READY';
+
+      process.env.VERCEL_ORG_ID = teamId;
+      client.setArgv('redeploy', fromDeployment.id, '--no-wait');
+
+      const exitCode = await redeploy(client);
+      expect(exitCode).toEqual(0);
+      expect(client.config.currentTeam).toEqual(teamId);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `vercel redeploy` now reads `VERCEL_ORG_ID` and sets `client.config.currentTeam` before calling `getScope()`, consistent with `vercel list`, `vercel deploy`, and other commands
- Previously, `redeploy` only used `getScope()` which resolves the user's default team, ignoring env-var-based team configuration — causing "Not authorized" errors in CI workflows that use `VERCEL_ORG_ID` + `VERCEL_TOKEN` scoped to a different team

Fixes #16073

## Test plan
- [x] Added unit test verifying `VERCEL_ORG_ID` is used for team context in `redeploy`
- [x] All 14 existing redeploy tests pass
- [x] Lint and pre-commit hooks pass