### PR TITLE
fix(config): return Route format when rewrite/redirect uses deploymentEnv()

### DIFF
--- a/.changeset/config-rewrite-env-route-format.md
+++ b/.changeset/config-rewrite-env-route-format.md
@@ -1,0 +1,5 @@
+---
+"@vercel/config": patch
+---
+
+Fix `routes.rewrite()` and `routes.redirect()` to return Route-format objects (`{ src, dest, env }`) instead of Rewrite/Redirect-format objects (`{ source, destination, env }`) when the destination contains `deploymentEnv()` values. The `env` field requires the `routes` format and is rejected by the build system when placed in the `rewrites` or `redirects` config arrays. Fixes #15031.

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -87,16 +87,20 @@ describe('Router', () => {
       expect(rewrite).toHaveProperty('destination');
     });
 
-    it('should return Rewrite type when destination has env vars', () => {
-      const rewrite = router.rewrite(
+    it('should return Route type when destination has env vars', () => {
+      const route = router.rewrite(
         '/api/:path*',
         `https://${deploymentEnv('API_HOST')}/$path*`
       );
-      expect(rewrite).toEqual({
-        source: '/api/:path*',
-        destination: 'https://$API_HOST/$path*',
+      expect(route).toMatchObject({
+        src: expect.any(String),
+        dest: expect.any(String),
         env: ['API_HOST'],
       });
+      // Must NOT have source/destination (Rewrite format) — env vars
+      // require the routes format
+      expect(route).not.toHaveProperty('source');
+      expect(route).not.toHaveProperty('destination');
     });
   });
 
@@ -131,16 +135,21 @@ describe('Router', () => {
       });
     });
 
-    it('should return Redirect type when destination has env vars', () => {
-      const redirect = router.redirect(
+    it('should return Route type when destination has env vars', () => {
+      const route = router.redirect(
         '/old/:path*',
         `https://${deploymentEnv('NEW_HOST')}/$path*`
       );
-      expect(redirect).toEqual({
-        source: '/old/:path*',
-        destination: 'https://$NEW_HOST/$path*',
+      expect(route).toMatchObject({
+        src: expect.any(String),
+        dest: expect.any(String),
         env: ['NEW_HOST'],
+        status: 307,
       });
+      // Must NOT have source/destination (Redirect format) — env vars
+      // require the routes format
+      expect(route).not.toHaveProperty('source');
+      expect(route).not.toHaveProperty('destination');
     });
   });
 

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -721,13 +721,19 @@ export class Router {
       respectOriginCacheControl,
     } = options || {};
 
-    // Check if any transforms were provided
+    // Check if any transforms or env vars were provided.
+    // Env vars in the destination (from `deploymentEnv()`) require the `routes`
+    // format — they are rejected in the `rewrites` array.  Treat them the same
+    // as transforms and produce a Route object.
+    const pathParams = this.extractPathParams(source);
+    const destEnvVars = extractEnvVars(destination, pathParams);
     const hasTransforms = requestHeaders || responseHeaders || requestQuery;
 
-    if (hasTransforms) {
-      // Build a Route object with transforms
+    if (hasTransforms || destEnvVars.length > 0) {
+      // Build a Route object with transforms and/or env vars.
+      // The `env` field (from `deploymentEnv()`) requires the `routes` format;
+      // it is rejected when placed in the `rewrites` array.
       const transforms: Transform[] = [];
-      const pathParams = this.extractPathParams(source);
 
       if (requestHeaders) {
         for (const [key, value] of Object.entries(requestHeaders)) {
@@ -784,32 +790,23 @@ export class Router {
       const route: Route = {
         src: regexSrc,
         dest: convertedDest,
-        transforms,
       };
+      if (transforms.length > 0) route.transforms = transforms;
       if (has) route.has = has;
       if (missing) route.missing = missing;
       if (respectOriginCacheControl !== undefined)
         route.respectOriginCacheControl = respectOriginCacheControl;
-
-      // Extract env vars from destination
-      const destEnvVars = extractEnvVars(destination, pathParams);
-      if (destEnvVars.length > 0) {
-        route.env = destEnvVars;
-      }
+      if (destEnvVars.length > 0) route.env = destEnvVars;
 
       return route;
     }
 
-    // Simple rewrite without transforms
-    const pathParams = this.extractPathParams(source);
-    const destEnvVars = extractEnvVars(destination, pathParams);
-
+    // Simple rewrite without transforms or env vars
     const rewrite: Rewrite = {
       source,
       destination,
     };
 
-    if (destEnvVars.length > 0) rewrite.env = destEnvVars;
     if (has) rewrite.has = has;
     if (missing) rewrite.missing = missing;
     if (respectOriginCacheControl !== undefined)
@@ -916,24 +913,30 @@ export class Router {
     const { permanent, statusCode, has, missing, requestHeaders } =
       options || {};
 
-    // Check if transforms were provided
-    if (requestHeaders) {
-      // Build a Route object with transforms
-      const transforms: Transform[] = [];
-      const pathParams = this.extractPathParams(source);
+    const pathParams = this.extractPathParams(source);
+    const destEnvVars = extractEnvVars(destination, pathParams);
 
-      for (const [key, value] of Object.entries(requestHeaders)) {
-        const transform: Transform = {
-          type: 'request.headers',
-          op: 'set',
-          target: { key },
-          args: value,
-        };
-        const envVars = extractEnvVars(value, pathParams);
-        if (envVars.length > 0) {
-          transform.env = envVars;
+    // Check if transforms or env vars were provided.
+    // Env vars in the destination (from `deploymentEnv()`) require the `routes`
+    // format — they are rejected in the `redirects` array.
+    if (requestHeaders || destEnvVars.length > 0) {
+      // Build a Route object with transforms and/or env vars
+      const transforms: Transform[] = [];
+
+      if (requestHeaders) {
+        for (const [key, value] of Object.entries(requestHeaders)) {
+          const transform: Transform = {
+            type: 'request.headers',
+            op: 'set',
+            target: { key },
+            args: value,
+          };
+          const envVars = extractEnvVars(value, pathParams);
+          if (envVars.length > 0) {
+            transform.env = envVars;
+          }
+          transforms.push(transform);
         }
-        transforms.push(transform);
       }
 
       // Convert path-to-regexp patterns to regex for routes format
@@ -944,30 +947,21 @@ export class Router {
         src: regexSrc,
         dest: convertedDest,
         status: statusCode || (permanent ? 308 : 307),
-        transforms,
       };
+      if (transforms.length > 0) route.transforms = transforms;
       if (has) route.has = has;
       if (missing) route.missing = missing;
-
-      // Extract env vars from destination
-      const destEnvVars = extractEnvVars(destination, pathParams);
-      if (destEnvVars.length > 0) {
-        route.env = destEnvVars;
-      }
+      if (destEnvVars.length > 0) route.env = destEnvVars;
 
       return route;
     }
 
-    // Simple redirect without transforms
-    const pathParams = this.extractPathParams(source);
-    const destEnvVars = extractEnvVars(destination, pathParams);
-
+    // Simple redirect without transforms or env vars
     const redirect: Redirect = {
       source,
       destination,
     };
 
-    if (destEnvVars.length > 0) redirect.env = destEnvVars;
     if (permanent !== undefined) redirect.permanent = permanent;
     if (statusCode !== undefined) redirect.statusCode = statusCode;
     if (has) redirect.has = has;


### PR DESCRIPTION
## Summary
- `routes.rewrite()` and `routes.redirect()` now return Route-format objects (`{ src, dest, env }`) instead of Rewrite/Redirect-format objects (`{ source, destination, env }`) when the destination contains `deploymentEnv()` values
- The `env` field requires the `routes` format — placing it in the `rewrites` or `redirects` config arrays causes the build to fail with: `Transforms require the routes format, which cannot be used alongside rewrites, redirects, or headers`
- Both methods already returned Route objects when transforms were present; this extends that behavior to also trigger when env vars are detected in the destination

Fixes #15031

## Test plan
- [x] All 49 existing router tests pass
- [x] Updated tests to verify Route format (src/dest) is returned when env vars are present
- [x] Verified Rewrite/Redirect format is still returned for simple cases without env vars
- [x] Lint and pre-commit hooks pass