### PR TITLE
auth: Make it possible to store CLI credentials in OS keychain

### DIFF
--- a/.changeset/green-mayflies-jam.md
+++ b/.changeset/green-mayflies-jam.md
@@ -1,0 +1,7 @@
+---
+'vercel': minor
+'@vercel/cli-auth': minor
+'@vercel/oidc': minor
+---
+
+Add configurable auth token storage with keyring-backed persistence and file fallback support.

--- a/errors/invalid-token-value.md
+++ b/errors/invalid-token-value.md
@@ -8,4 +8,4 @@ The `--token` flag was specified, but its contents are invalid.
 
 The `--token` flag must only contain numbers (0-9) and letters from the alphabet (a-z and A-Z). This needs to be the token of the user account as which you'd like to act.
 
-You can either get the token from the `./vercel/auth.json` file located in your user directory or [from the dashboard](https://vercel.com/account/tokens).
+You can get the token [from the dashboard](https://vercel.com/account/tokens).

--- a/errors/missing-token-value.md
+++ b/errors/missing-token-value.md
@@ -8,4 +8,4 @@ The `--token` flag was specified, but there's no value for it available.
 
 In order to make it work, you need to specify a value for the `--token` flag. This needs to be the token of the user account as which you'd like to act.
 
-You can either get the token from the `./vercel/auth.json` file located in your user directory or [from the dashboard](https://vercel.com/account/tokens).
+You can get the token [from the dashboard](https://vercel.com/account/tokens).

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -2,6 +2,7 @@ import type { BuilderFunctions } from '@vercel/build-utils';
 import type { Readable, Writable } from 'stream';
 import type * as tty from 'tty';
 import type { Route } from '@vercel/routing-utils';
+import type { AuthTokenStorage } from '@vercel/cli-auth/credentials-store.js';
 import type { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
 
 export type ProjectEnvTarget = (typeof PROJECT_ENV_TARGET)[number];
@@ -51,6 +52,7 @@ export interface AuthConfig {
 export interface GlobalConfig {
   '// Note'?: string;
   '// Docs'?: string;
+  authTokenStorage?: AuthTokenStorage;
   currentTeam?: string;
   api?: string;
 

--- a/internals/types/package.json
+++ b/internals/types/package.json
@@ -9,6 +9,7 @@
   ],
   "dependencies": {
     "@types/node": "20.11.0",
+    "@vercel/cli-auth": "workspace:*",
     "@vercel-internals/constants": "workspace:*",
     "@vercel/build-utils": "workspace:*",
     "@vercel/routing-utils": "workspace:*"

--- a/packages/cli-auth/credentials-store.test.ts
+++ b/packages/cli-auth/credentials-store.test.ts
@@ -1,39 +1,132 @@
-import { vi, test, describe, expect } from 'vitest';
+import { afterEach, beforeEach, vi, test, describe, expect } from 'vitest';
 import {
+  clearAllCredentialsStrict,
+  getAuthConfigFilePath,
+  getConfigFilePath,
+  getAuthTokenStorage,
+  getGlobalPathConfig,
+  readCredentials,
   type Credentials,
   CredentialsStore,
-  getGlobalPathConfig,
+  readGlobalConfig,
+  setLoadKeyringModuleForTesting,
+  writeCredentials,
 } from './credentials-store';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import {
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  mkdtempSync,
+  rmSync,
+} from 'node:fs';
 import * as path from 'node:path';
+import { tmpdir } from 'node:os';
 
-vi.mock('fs', async () => {
-  const memfs = await import('memfs');
-  return memfs.createFsFromVolume(memfs.Volume.fromJSON({}));
+const keyringState = vi.hoisted(() => ({
+  values: new Map<string, string>(),
+  failConstruct: false,
+  failGet: false,
+  failSet: false,
+  failDelete: false,
+}));
+
+function createMockKeyringModule() {
+  class Entry {
+    private key: string;
+
+    constructor(service: string, account: string) {
+      if (keyringState.failConstruct) {
+        throw new Error('keyring unavailable');
+      }
+
+      this.key = `${service}:${account}`;
+    }
+
+    getPassword() {
+      if (keyringState.failGet) {
+        throw new Error('keyring get failed');
+      }
+
+      return keyringState.values.get(this.key) ?? null;
+    }
+
+    setPassword(password: string) {
+      if (keyringState.failSet) {
+        throw new Error('keyring set failed');
+      }
+
+      keyringState.values.set(this.key, password);
+    }
+
+    deleteCredential() {
+      if (keyringState.failDelete) {
+        throw new Error('keyring delete failed');
+      }
+
+      return keyringState.values.delete(this.key);
+    }
+  }
+
+  return { Entry };
+}
+
+beforeEach(() => {
+  keyringState.values.clear();
+  keyringState.failConstruct = false;
+  keyringState.failGet = false;
+  keyringState.failSet = false;
+  keyringState.failDelete = false;
+  setLoadKeyringModuleForTesting(() => createMockKeyringModule());
 });
+
+const configDirs: string[] = [];
+
+afterEach(() => {
+  setLoadKeyringModuleForTesting();
+  for (const configDir of configDirs.splice(0)) {
+    rmSync(configDir, { recursive: true, force: true });
+  }
+});
+
+function createConfigDir() {
+  const configDir = mkdtempSync(path.join(tmpdir(), 'cli-auth-'));
+  configDirs.push(configDir);
+  return configDir;
+}
 
 test('getGlobalPathConfig', () => {
   // NOTE: We are pinned on xdg-app-paths v5 because newer versions behave differently
   // when there are dots in the application name, eg. `com.vercel.cli` becomes `com.vercel`
-  const dir = crypto.randomUUID().replaceAll('-', '.');
-  const path = getGlobalPathConfig(dir);
-  expect(path).toMatch(new RegExp(`.*${dir}$`));
+  const appName = crypto.randomUUID().replaceAll('-', '.');
+  const path = getGlobalPathConfig(appName);
+  expect(path).toMatch(new RegExp(`.*${appName}$`));
+});
+
+test('getConfigFilePath uses the provided config directory', () => {
+  const configDir = createConfigDir();
+  expect(getConfigFilePath(configDir)).toBe(
+    path.join(configDir, 'config.json')
+  );
 });
 
 describe('CredentialsStore', () => {
   test('can read credentials store', () => {
-    const dir = crypto.randomUUID();
-    const configPath = path.join(getGlobalPathConfig(dir), 'auth.json');
+    const configDir = createConfigDir();
+    const configPath = path.join(configDir, 'auth.json');
     mkdirSync(path.dirname(configPath), { recursive: true });
     const config = { token: 'test-token' } satisfies Credentials;
     writeFileSync(configPath, JSON.stringify(config));
 
-    const store = CredentialsStore(dir);
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'file',
+    });
     expect(store.get()).toEqual(config);
   });
 
   test('can write credentials store', () => {
-    const store = CredentialsStore(crypto.randomUUID());
+    const store = CredentialsStore(createConfigDir(), {
+      authTokenStorage: 'file',
+    });
     const config = {
       token: 'test-access-token',
       refreshToken: 'test-refresh-token',
@@ -44,24 +137,307 @@ describe('CredentialsStore', () => {
   });
 
   test('can clear credentials store', () => {
-    const store = CredentialsStore(crypto.randomUUID());
-    store.update({});
-    expect(store.get()).toEqual({});
+    const store = CredentialsStore(createConfigDir(), {
+      authTokenStorage: 'file',
+    });
+    store.update({ token: 'test-token' });
+    store.delete();
+
+    expect(() => store.get()).toThrow(/ENOENT/);
+  });
+
+  test('file storage delete removes stale keyring credentials', () => {
+    const configDir = createConfigDir();
+    CredentialsStore(configDir, {
+      authTokenStorage: 'keyring',
+    }).update({ token: 'keyring-token' });
+
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'file',
+    });
+
+    store.delete();
+
+    expect(keyringState.values.size).toBe(0);
+    expect(() => store.get()).toThrow(/ENOENT/);
+  });
+
+  test('file storage delete surfaces keyring deletion failures', () => {
+    const configDir = createConfigDir();
+    CredentialsStore(configDir, {
+      authTokenStorage: 'keyring',
+    }).update({ token: 'keyring-token' });
+
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'file',
+    });
+
+    keyringState.failDelete = true;
+
+    expect(() => store.delete()).toThrow('keyring delete failed');
   });
 
   test('do not write when `skipWrite` is true', () => {
-    const dir = crypto.randomUUID();
-    const configPath = path.join(getGlobalPathConfig(dir), 'auth.json');
+    const configDir = createConfigDir();
+    const configPath = path.join(configDir, 'auth.json');
     mkdirSync(path.dirname(configPath), { recursive: true });
     const oldConfig = { token: 'test-token' } satisfies Credentials;
     writeFileSync(configPath, JSON.stringify(oldConfig));
 
-    const store = CredentialsStore(dir);
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'file',
+    });
     store.update({
       token: 'new-token',
       refreshToken: 'new-refresh-token',
       skipWrite: true,
     });
     expect(store.get()).toEqual(oldConfig);
+  });
+
+  test('reads authTokenStorage from global config.json', () => {
+    const configDir = createConfigDir();
+    const configPath = getConfigFilePath(configDir);
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ authTokenStorage: 'keyring' }));
+
+    expect(readGlobalConfig(configDir)).toEqual({
+      authTokenStorage: 'keyring',
+    });
+    expect(getAuthTokenStorage(configDir)).toBe('keyring');
+  });
+
+  test('defaults authTokenStorage to file when unset', () => {
+    const configDir = createConfigDir();
+
+    expect(readGlobalConfig(configDir)).toEqual({});
+    expect(getAuthTokenStorage(configDir)).toBe('file');
+  });
+
+  test('rejects invalid authTokenStorage from global config.json', () => {
+    const configDir = createConfigDir();
+    const configPath = getConfigFilePath(configDir);
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ authTokenStorage: 'keychain' }));
+
+    expect(() => readGlobalConfig(configDir)).toThrow(
+      'Invalid value for `authTokenStorage`: "keychain". Expected one of: "auto", "file", "keyring".'
+    );
+    expect(() => getAuthTokenStorage(configDir)).toThrow(
+      'Invalid value for `authTokenStorage`: "keychain". Expected one of: "auto", "file", "keyring".'
+    );
+  });
+
+  test('rejects malformed global config.json instead of defaulting to file storage', () => {
+    const configDir = createConfigDir();
+    const configPath = getConfigFilePath(configDir);
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(configPath, '{');
+
+    expect(() => readGlobalConfig(configDir)).toThrow(SyntaxError);
+    expect(() => getAuthTokenStorage(configDir)).toThrow(SyntaxError);
+  });
+
+  test('low-level reads and writes fail closed when global config.json is malformed', () => {
+    const configDir = createConfigDir();
+    const configPath = getConfigFilePath(configDir);
+    const authPath = getAuthConfigFilePath(configDir);
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(configPath, '{');
+
+    expect(() => readCredentials(configDir)).toThrow(SyntaxError);
+    expect(() => writeCredentials(configDir, { token: 'test-token' })).toThrow(
+      SyntaxError
+    );
+    expect(existsSync(authPath)).toBe(false);
+  });
+
+  test('auto storage prefers keyring and removes fallback auth.json', () => {
+    const configDir = createConfigDir();
+    const authPath = getAuthConfigFilePath(configDir);
+    mkdirSync(path.dirname(authPath), { recursive: true });
+    writeFileSync(authPath, JSON.stringify({ token: 'stale-token' }));
+
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'auto',
+    });
+    const config = { token: 'fresh-token', refreshToken: 'refresh-token' };
+
+    store.update(config);
+
+    expect(store.get()).toEqual(config);
+    expect(existsSync(authPath)).toBe(false);
+  });
+
+  test('auto storage falls back to auth.json when keyring writes fail', () => {
+    const configDir = createConfigDir();
+    CredentialsStore(configDir, {
+      authTokenStorage: 'keyring',
+    }).update({
+      userId: 'user_stale',
+      token: 'stale-keyring-token',
+      refreshToken: 'stale-refresh-token',
+    });
+
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'auto',
+    });
+    const config = { token: 'fallback-token', refreshToken: 'refresh-token' };
+
+    keyringState.failSet = true;
+
+    store.update(config);
+
+    expect(keyringState.values.size).toBe(0);
+    expect(store.get()).toEqual(config);
+  });
+
+  test('file storage migrates existing keyring credentials into auth.json', () => {
+    const configDir = createConfigDir();
+    const authPath = getAuthConfigFilePath(configDir);
+    const config = {
+      '// Note': 'This is your Vercel credentials file. DO NOT SHARE!',
+      userId: 'user_123',
+      token: 'keyring-token',
+      refreshToken: 'refresh-token',
+    };
+
+    CredentialsStore(configDir, {
+      authTokenStorage: 'keyring',
+    }).update(config);
+
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'file',
+    });
+
+    expect(store.get()).toEqual(config);
+    expect(existsSync(authPath)).toBe(true);
+    expect(keyringState.values.size).toBe(0);
+  });
+
+  test('file storage works when keyring is unavailable', () => {
+    keyringState.failConstruct = true;
+
+    const store = CredentialsStore(createConfigDir(), {
+      authTokenStorage: 'file',
+    });
+    const config = { token: 'file-token', refreshToken: 'refresh-token' };
+
+    store.update(config);
+
+    expect(store.get()).toEqual(config);
+  });
+
+  test('auto storage falls back when keyring is unavailable', () => {
+    keyringState.failConstruct = true;
+
+    const store = CredentialsStore(createConfigDir(), {
+      authTokenStorage: 'auto',
+    });
+    const config = { token: 'auto-file-token', refreshToken: 'refresh-token' };
+
+    store.update(config);
+
+    expect(store.get()).toEqual(config);
+  });
+
+  test('keyring storage surfaces friendly error when keyring is unavailable', () => {
+    keyringState.failConstruct = true;
+
+    const store = CredentialsStore(createConfigDir(), {
+      authTokenStorage: 'keyring',
+    });
+
+    expect(() => store.get()).toThrow(
+      'OS keyring support is unavailable. Set `authTokenStorage` to `auto` or `file` to store credentials in auth.json instead.'
+    );
+  });
+
+  test('keyring storage reads from keyring without auth.json', () => {
+    const configDir = createConfigDir();
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'keyring',
+    });
+    const config = {
+      '// Note': 'This is your Vercel credentials file. DO NOT SHARE!',
+      userId: 'user_123',
+      token: 'keyring-token',
+      refreshToken: 'refresh-token',
+    };
+
+    store.update(config);
+
+    expect(store.get()).toEqual(config);
+  });
+
+  test('keyring storage migrates existing auth.json credentials into keyring', () => {
+    const configDir = createConfigDir();
+    const authPath = getAuthConfigFilePath(configDir);
+    const config = {
+      '// Note': 'This is your Vercel credentials file. DO NOT SHARE!',
+      userId: 'user_123',
+      token: 'file-token',
+      refreshToken: 'refresh-token',
+    };
+
+    mkdirSync(path.dirname(authPath), { recursive: true });
+    writeFileSync(authPath, JSON.stringify(config));
+
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'keyring',
+    });
+
+    expect(store.get()).toEqual(config);
+    expect(existsSync(authPath)).toBe(false);
+    expect(keyringState.values.size).toBe(1);
+  });
+
+  test('keyring storage persists metadata without credentials', () => {
+    const configDir = createConfigDir();
+    const store = CredentialsStore(configDir, {
+      authTokenStorage: 'keyring',
+    });
+    const config = {
+      '// Note': 'This is your Vercel credentials file. DO NOT SHARE!',
+      '// Docs':
+        'https://vercel.com/docs/projects/project-configuration/global-configuration#auth.json',
+      userId: 'user_123',
+    } satisfies Credentials;
+
+    store.update(config);
+
+    expect(store.get()).toEqual(config);
+  });
+
+  test('strict clear ignores unavailable keyring support', () => {
+    const configDir = createConfigDir();
+    const authPath = getAuthConfigFilePath(configDir);
+
+    mkdirSync(path.dirname(authPath), { recursive: true });
+    writeFileSync(authPath, JSON.stringify({ token: 'file-token' }));
+
+    keyringState.failConstruct = true;
+
+    expect(() => clearAllCredentialsStrict(configDir)).not.toThrow();
+    expect(existsSync(authPath)).toBe(false);
+  });
+
+  test('strict clear surfaces keyring deletion failures', () => {
+    const configDir = createConfigDir();
+    const authPath = getAuthConfigFilePath(configDir);
+
+    mkdirSync(path.dirname(authPath), { recursive: true });
+    writeFileSync(authPath, JSON.stringify({ token: 'file-token' }));
+
+    CredentialsStore(configDir, {
+      authTokenStorage: 'keyring',
+    }).update({ token: 'keyring-token' });
+
+    keyringState.failDelete = true;
+
+    expect(() => clearAllCredentialsStrict(configDir)).toThrow(
+      'keyring delete failed'
+    );
+    expect(existsSync(authPath)).toBe(false);
   });
 });

--- a/packages/cli-auth/credentials-store.ts
+++ b/packages/cli-auth/credentials-store.ts
@@ -1,14 +1,63 @@
 import path from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import { homedir } from 'node:os';
 // NOTE: We are pinned on v5 because newer versions behave differently
 // when there are dots in the application name, eg. `com.vercel.cli` becomes `com.vercel`
 import XDGAppPaths from 'xdg-app-paths';
-import { z } from 'zod/mini';
 
-const Credentials = z.object({
+// Avoid exposing zod v4 types to TS 4.9 workspace consumers during type-check.
+const { z } = require('zod/mini') as { z: any };
+
+const AUTH_TOKEN_STORAGE = {
+  AUTO: 'auto',
+  FILE: 'file',
+  KEYRING: 'keyring',
+} as const;
+const AUTH_TOKEN_STORAGE_VALUES = Object.values(AUTH_TOKEN_STORAGE);
+const DEFAULT_AUTH_TOKEN_STORAGE = AUTH_TOKEN_STORAGE.FILE;
+const KEYRING_SERVICE = 'Vercel Auth';
+const KEYRING_UNAVAILABLE_ERROR =
+  'OS keyring support is unavailable. Set `authTokenStorage` to `auto` or `file` to store credentials in auth.json instead.';
+
+type KeyringEntry = {
+  getPassword(): string | null;
+  setPassword(password: string): void;
+  deleteCredential(): boolean;
+};
+
+type KeyringEntryConstructor = new (
+  service: string,
+  account: string
+) => KeyringEntry;
+
+type LoadKeyringModule = () => {
+  Entry: KeyringEntryConstructor;
+};
+
+const defaultLoadKeyringModule: LoadKeyringModule = () =>
+  require('@napi-rs/keyring') as {
+    Entry: KeyringEntryConstructor;
+  };
+
+let loadKeyringModule = defaultLoadKeyringModule;
+
+export type AuthTokenStorage =
+  (typeof AUTH_TOKEN_STORAGE)[keyof typeof AUTH_TOKEN_STORAGE];
+export type CredentialsStorageLocation = Exclude<
+  AuthTokenStorage,
+  (typeof AUTH_TOKEN_STORAGE)['AUTO']
+>;
+
+export interface GlobalConfig {
+  authTokenStorage?: AuthTokenStorage;
+}
+
+const CredentialsSchema = z.object({
   /** An `access_token` obtained using the OAuth Device Authorization flow. */
   token: z.optional(z.string()),
+  /** The ID of the currently authenticated user, cached from `/v2/user`. */
+  userId: z.optional(z.string()),
   /** A `refresh_token` obtained using the OAuth Device Authorization flow. */
   refreshToken: z.optional(z.string()),
   /**
@@ -22,7 +71,56 @@ const Credentials = z.object({
   '// Docs': z.optional(z.string()),
 });
 
-export type Credentials = z.infer<typeof Credentials>;
+export interface Credentials {
+  /** An `access_token` obtained using the OAuth Device Authorization flow. */
+  token?: string;
+  /** A `refresh_token` obtained using the OAuth Device Authorization flow. */
+  refreshToken?: string;
+  /**
+   * The absolute time (seconds) when the {@link Credentials.token} expires.
+   * Used to optimistically check if the token is still valid.
+   */
+  expiresAt?: number;
+  /** Whether to skip writing the credentials to disk during {@link CredentialsStore.update} */
+  skipWrite?: boolean;
+  '// Note'?: string;
+  '// Docs'?: string;
+}
+
+export function hasCredentials(credentials: Partial<Credentials>): boolean {
+  return Boolean(
+    credentials.token ||
+      credentials.refreshToken ||
+      typeof credentials.expiresAt === 'number'
+  );
+}
+
+function parseCredentials(value: unknown): Credentials {
+  return CredentialsSchema.parse(value) as Credentials;
+}
+
+function isAuthTokenStorage(value: unknown): value is AuthTokenStorage {
+  return (
+    typeof value === 'string' &&
+    AUTH_TOKEN_STORAGE_VALUES.some(storage => storage === value)
+  );
+}
+
+export function resolveAuthTokenStorage(value: unknown): AuthTokenStorage {
+  if (typeof value === 'undefined') {
+    return DEFAULT_AUTH_TOKEN_STORAGE;
+  }
+
+  if (isAuthTokenStorage(value)) {
+    return value;
+  }
+
+  throw new Error(
+    `Invalid value for \`authTokenStorage\`: ${JSON.stringify(
+      value
+    )}. Expected one of: ${AUTH_TOKEN_STORAGE_VALUES.map(storage => JSON.stringify(storage)).join(', ')}.`
+  );
+}
 
 /** Returns whether a directory exists */
 function isDirectory(path: string): boolean {
@@ -38,8 +136,8 @@ function isDirectory(path: string): boolean {
  * Returns in which directory the config should be present
  * @internal Should only be used in {@link CredentialsStore} or tests.
  */
-export function getGlobalPathConfig(dir: string): string {
-  const vercelDirectories = XDGAppPaths(dir).dataDirs();
+export function getGlobalPathConfig(appName: string): string {
+  const vercelDirectories = XDGAppPaths(appName).dataDirs();
 
   const possibleConfigPaths = [
     ...vercelDirectories, // latest vercel directory
@@ -57,23 +155,403 @@ export function getGlobalPathConfig(dir: string): string {
   );
 }
 
-export function CredentialsStore(dir: string) {
-  const configPath = path.join(getGlobalPathConfig(dir), 'auth.json');
+export function getConfigFilePath(dir: string): string {
+  return path.join(dir, 'config.json');
+}
+
+export function getAuthConfigFilePath(dir: string): string {
+  return path.join(dir, 'auth.json');
+}
+
+export function readGlobalConfig(dir: string): GlobalConfig {
+  const configPath = getConfigFilePath(dir);
+  let config: {
+    authTokenStorage?: unknown;
+  };
+
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+      authTokenStorage?: unknown;
+    };
+  } catch (error) {
+    if (isENOENTError(error)) {
+      return {};
+    }
+
+    throw error;
+  }
+
+  return {
+    authTokenStorage:
+      typeof config.authTokenStorage === 'undefined'
+        ? undefined
+        : resolveAuthTokenStorage(config.authTokenStorage),
+  };
+}
+
+export function getAuthTokenStorage(
+  dir: string,
+  config?: GlobalConfig
+): AuthTokenStorage {
+  if (config?.authTokenStorage) {
+    return resolveAuthTokenStorage(config.authTokenStorage);
+  }
+
+  return resolveAuthTokenStorage(readGlobalConfig(dir).authTokenStorage);
+}
+
+function getKeyringAccount(configPath: string): string {
+  const digest = createHash('sha256').update(configPath).digest('hex');
+  return `cli:${digest.slice(0, 16)}`;
+}
+
+export function setLoadKeyringModuleForTesting(
+  nextLoadKeyringModule?: LoadKeyringModule
+) {
+  loadKeyringModule = nextLoadKeyringModule ?? defaultLoadKeyringModule;
+}
+
+function createKeyringEntry(configPath: string): KeyringEntry {
+  try {
+    const { Entry } = loadKeyringModule();
+
+    return new Entry(KEYRING_SERVICE, getKeyringAccount(configPath));
+  } catch (error) {
+    const wrappedError = new Error(KEYRING_UNAVAILABLE_ERROR);
+    (wrappedError as Error & { cause?: unknown }).cause = error;
+    throw wrappedError;
+  }
+}
+
+function isKeyringUnavailableError(error: unknown): boolean {
+  return error instanceof Error && error.message === KEYRING_UNAVAILABLE_ERROR;
+}
+
+function readCredentialsFromFile(configPath: string): Credentials {
+  return parseCredentials(JSON.parse(fs.readFileSync(configPath, 'utf8')));
+}
+
+function isENOENTError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'ENOENT'
+  );
+}
+
+function createMissingCredentialsError(configPath: string): Error {
+  const error = new Error(
+    `ENOENT: no such file or directory, open '${configPath}'`
+  );
+  Object.assign(error, { code: 'ENOENT' });
+  return error;
+}
+
+function writeCredentialsToFile(configPath: string, config: Credentials): void {
+  const directory = path.dirname(configPath);
+  const temporaryPath = path.join(
+    directory,
+    `${path.basename(configPath)}.${process.pid}.${randomUUID()}.tmp`
+  );
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+
+  try {
+    fs.writeFileSync(temporaryPath, JSON.stringify(config, null, 2) + '\n', {
+      mode: 0o600,
+    });
+    fs.renameSync(temporaryPath, configPath);
+  } catch (error) {
+    fs.rmSync(temporaryPath, { force: true });
+    throw error;
+  }
+}
+
+function readCredentialsFromKeyring(configPath: string): Credentials | null {
+  const entry = createKeyringEntry(configPath);
+  const value = entry.getPassword();
+
+  if (value === null) {
+    return null;
+  }
+
+  return parseCredentials(JSON.parse(value));
+}
+
+function writeCredentialsToKeyring(
+  configPath: string,
+  config: Credentials
+): void {
+  const entry = createKeyringEntry(configPath);
+  entry.setPassword(JSON.stringify(config));
+}
+
+function deleteCredentialsFromKeyring(configPath: string): boolean {
+  const entry = createKeyringEntry(configPath);
+  return entry.deleteCredential();
+}
+
+function deleteCredentialsFile(configPath: string): void {
+  fs.rmSync(configPath, { force: true });
+}
+
+function tryDeleteCredentialsFromKeyring(configPath: string): void {
+  try {
+    deleteCredentialsFromKeyring(configPath);
+  } catch {}
+}
+
+function deleteCredentialsFromKeyringIfAvailable(configPath: string): void {
+  try {
+    deleteCredentialsFromKeyring(configPath);
+  } catch (error) {
+    if (!isKeyringUnavailableError(error)) {
+      throw error;
+    }
+  }
+}
+
+function migrateCredentialsToFile(
+  configPath: string,
+  credentials: Credentials
+): Credentials {
+  writeCredentialsToFile(configPath, credentials);
+  tryDeleteCredentialsFromKeyring(configPath);
+  return credentials;
+}
+
+function tryReadKeyringCredentialsIntoFile(
+  configPath: string
+): Credentials | null {
+  try {
+    const credentials = readCredentialsFromKeyring(configPath);
+
+    if (credentials === null) {
+      return null;
+    }
+
+    return migrateCredentialsToFile(configPath, credentials);
+  } catch {
+    return null;
+  }
+}
+
+function readFileStorageCredentials(configPath: string): Credentials {
+  try {
+    const credentials = readCredentialsFromFile(configPath);
+
+    if (hasCredentials(credentials)) {
+      return credentials;
+    }
+
+    // File mode treats keyring contents as stale-but-authoritative backup only
+    // when auth.json has no usable credentials.
+    return tryReadKeyringCredentialsIntoFile(configPath) ?? credentials;
+  } catch (error) {
+    if (!isENOENTError(error)) {
+      throw error;
+    }
+
+    const credentials = tryReadKeyringCredentialsIntoFile(configPath);
+
+    if (credentials !== null) {
+      return credentials;
+    }
+
+    throw error;
+  }
+}
+
+function migrateCredentialsToKeyring(
+  configPath: string,
+  credentials: Credentials
+): Credentials {
+  writeCredentialsToKeyring(configPath, credentials);
+  deleteCredentialsFile(configPath);
+  return credentials;
+}
+
+function readKeyringStorageCredentials(configPath: string): Credentials {
+  const credentials = readCredentialsFromKeyring(configPath);
+
+  if (credentials !== null) {
+    return credentials;
+  }
+
+  try {
+    const fileCredentials = readCredentialsFromFile(configPath);
+
+    // Keyring mode eagerly migrates any remaining plaintext credentials out of
+    // auth.json after the first successful read.
+    return migrateCredentialsToKeyring(configPath, fileCredentials);
+  } catch (error) {
+    if (isENOENTError(error)) {
+      throw createMissingCredentialsError(configPath);
+    }
+
+    throw error;
+  }
+}
+
+function readAutoStorageCredentials(configPath: string): Credentials {
+  try {
+    const credentials = readCredentialsFromKeyring(configPath);
+
+    if (credentials !== null) {
+      return credentials;
+    }
+  } catch {}
+
+  // Auto mode intentionally avoids read-time migration so that machines
+  // without usable keyring support can keep working off auth.json.
+  return readCredentialsFromFile(configPath);
+}
+
+function writeFileStorageCredentials(
+  configPath: string,
+  credentials: Credentials
+): CredentialsStorageLocation {
+  writeCredentialsToFile(configPath, credentials);
+  tryDeleteCredentialsFromKeyring(configPath);
+  return 'file';
+}
+
+function writeKeyringStorageCredentials(
+  configPath: string,
+  credentials: Credentials
+): CredentialsStorageLocation {
+  writeCredentialsToKeyring(configPath, credentials);
+  deleteCredentialsFile(configPath);
+  return 'keyring';
+}
+
+function writeAutoStorageCredentials(
+  configPath: string,
+  credentials: Credentials
+): CredentialsStorageLocation {
+  try {
+    return writeKeyringStorageCredentials(configPath, credentials);
+  } catch {
+    tryDeleteCredentialsFromKeyring(configPath);
+    return writeFileStorageCredentials(configPath, credentials);
+  }
+}
+
+function deleteFileStorageCredentials(configPath: string): void {
+  deleteCredentialsFile(configPath);
+  deleteCredentialsFromKeyringIfAvailable(configPath);
+}
+
+function deleteKeyringStorageCredentials(configPath: string): void {
+  deleteCredentialsFromKeyring(configPath);
+  deleteCredentialsFile(configPath);
+}
+
+function deleteAutoStorageCredentials(configPath: string): void {
+  try {
+    deleteCredentialsFromKeyring(configPath);
+  } catch {}
+  deleteCredentialsFile(configPath);
+}
+
+export function CredentialsStore(dir: string, config: GlobalConfig = {}) {
+  const configPath = getAuthConfigFilePath(dir);
+  const tokenStorage = getAuthTokenStorage(dir, config);
+
   return {
     configPath,
     get(): Credentials {
-      return Credentials.parse(JSON.parse(fs.readFileSync(configPath, 'utf8')));
+      switch (tokenStorage) {
+        case AUTH_TOKEN_STORAGE.FILE:
+          return readFileStorageCredentials(configPath);
+        case AUTH_TOKEN_STORAGE.KEYRING:
+          return readKeyringStorageCredentials(configPath);
+        case AUTH_TOKEN_STORAGE.AUTO:
+          return readAutoStorageCredentials(configPath);
+      }
     },
     /** Update the credentials store. If `skipWrite` is set, the update will be skipped. */
-    update(config: Partial<Credentials>): void {
+    update(config: Partial<Credentials>): CredentialsStorageLocation | void {
       if (config.skipWrite) return;
-      const parsedConfig = Credentials.parse(config);
-      fs.mkdirSync(path.dirname(configPath), { recursive: true });
-      fs.writeFileSync(
-        configPath,
-        JSON.stringify(parsedConfig, null, 2) + '\n',
-        { mode: 0o600 }
-      );
+      const parsedConfig = parseCredentials(config);
+      switch (tokenStorage) {
+        case AUTH_TOKEN_STORAGE.FILE:
+          return writeFileStorageCredentials(configPath, parsedConfig);
+        case AUTH_TOKEN_STORAGE.KEYRING:
+          return writeKeyringStorageCredentials(configPath, parsedConfig);
+        case AUTH_TOKEN_STORAGE.AUTO:
+          return writeAutoStorageCredentials(configPath, parsedConfig);
+      }
+    },
+    delete(): void {
+      switch (tokenStorage) {
+        case AUTH_TOKEN_STORAGE.FILE:
+          deleteFileStorageCredentials(configPath);
+          break;
+        case AUTH_TOKEN_STORAGE.KEYRING:
+          deleteKeyringStorageCredentials(configPath);
+          break;
+        case AUTH_TOKEN_STORAGE.AUTO:
+          deleteAutoStorageCredentials(configPath);
+          break;
+      }
     },
   };
+}
+
+export function readCredentials(dir: string, config: GlobalConfig = {}) {
+  return CredentialsStore(dir, config).get();
+}
+
+export function writeCredentials(
+  dir: string,
+  credentials: Partial<Credentials>,
+  config: GlobalConfig = {}
+) {
+  return CredentialsStore(dir, config).update(credentials);
+}
+
+export function clearCredentials(dir: string, config: GlobalConfig = {}) {
+  CredentialsStore(dir, config).delete();
+}
+
+export function clearAllCredentials(dir: string) {
+  for (const authTokenStorage of [
+    AUTH_TOKEN_STORAGE.FILE,
+    AUTH_TOKEN_STORAGE.KEYRING,
+  ] as const) {
+    try {
+      clearCredentials(dir, { authTokenStorage });
+    } catch {}
+  }
+}
+
+export function clearAllCredentialsStrict(dir: string) {
+  const configPath = getAuthConfigFilePath(dir);
+
+  let fileError: unknown;
+  let keyringError: unknown;
+
+  try {
+    deleteCredentialsFile(configPath);
+  } catch (error) {
+    fileError = error;
+  }
+
+  try {
+    deleteCredentialsFromKeyring(configPath);
+  } catch (error) {
+    if (!isKeyringUnavailableError(error)) {
+      keyringError = error;
+    }
+  }
+
+  if (keyringError) {
+    throw keyringError;
+  }
+
+  if (fileError) {
+    throw fileError;
+  }
 }

--- a/packages/cli-auth/package.json
+++ b/packages/cli-auth/package.json
@@ -25,6 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@napi-rs/keyring": "1.2.0",
     "async-listen": "3.0.0",
     "open": "8.4.0",
     "xdg-app-paths": "5",

--- a/packages/cli/evals/evals/marketplace/install-neon-postgres/EVAL.ts
+++ b/packages/cli/evals/evals/marketplace/install-neon-postgres/EVAL.ts
@@ -1,34 +1,7 @@
 import { test, expect, beforeAll, afterAll } from 'vitest';
 import { readFileSync } from 'fs';
-import { homedir } from 'os';
-import { join } from 'path';
 import { Vercel } from '@vercel/sdk';
-
-function getToken(): string {
-  const home = homedir();
-  const paths = [
-    join(home, '.local/share/com.vercel.cli/auth.json'),
-    join(home, '.vercel/auth.json'),
-  ];
-  for (const p of paths) {
-    try {
-      const auth = JSON.parse(readFileSync(p, 'utf-8'));
-      if (auth.token) return auth.token;
-    } catch {
-      // Auth file not found or unreadable; try next location
-    }
-  }
-
-  try {
-    const bashrc = readFileSync(join(home, '.bashrc'), 'utf-8');
-    const match = bashrc.match(/export VERCEL_TOKEN="([^"]+)"/);
-    if (match) return match[1];
-  } catch {
-    // .bashrc not found or unreadable
-  }
-
-  throw new Error('No Vercel auth token found');
-}
+import { getToken } from '../../../setup/get-token';
 
 function getProjectConfig(): { projectId: string; orgId: string } {
   return JSON.parse(readFileSync('.vercel/project.json', 'utf-8'));

--- a/packages/cli/evals/evals/marketplace/multi-product-install/EVAL.ts
+++ b/packages/cli/evals/evals/marketplace/multi-product-install/EVAL.ts
@@ -1,33 +1,6 @@
 import { test, expect, beforeAll, afterAll } from 'vitest';
 import { readFileSync } from 'fs';
-import { homedir } from 'os';
-import { join } from 'path';
-
-function getToken(): string {
-  const home = homedir();
-  const paths = [
-    join(home, '.local/share/com.vercel.cli/auth.json'),
-    join(home, '.vercel/auth.json'),
-  ];
-  for (const p of paths) {
-    try {
-      const auth = JSON.parse(readFileSync(p, 'utf-8'));
-      if (auth.token) return auth.token;
-    } catch {
-      // Auth file not found or unreadable; try next location
-    }
-  }
-
-  try {
-    const bashrc = readFileSync(join(home, '.bashrc'), 'utf-8');
-    const match = bashrc.match(/export VERCEL_TOKEN="([^"]+)"/);
-    if (match) return match[1];
-  } catch {
-    // .bashrc not found or unreadable
-  }
-
-  throw new Error('No Vercel auth token found');
-}
+import { getToken } from '../../../setup/get-token';
 
 function getProjectConfig(): { projectId: string; orgId: string } {
   return JSON.parse(readFileSync('.vercel/project.json', 'utf-8'));

--- a/packages/cli/evals/setup/auth-and-config.ts
+++ b/packages/cli/evals/setup/auth-and-config.ts
@@ -37,6 +37,7 @@ export const setupAuthAndConfig = async (sandbox: Sandbox) => {
   }
   try {
     const configJson = JSON.stringify({
+      authTokenStorage: 'file',
       telemetry: { enabled: false },
       currentTeam:
         process.env.CLI_EVAL_TEAM_ID ?? 'team_KhlEYrm473sP7ybEytVDlfyj',

--- a/packages/cli/evals/setup/get-token.ts
+++ b/packages/cli/evals/setup/get-token.ts
@@ -1,0 +1,42 @@
+import {
+  CredentialsStore,
+  getGlobalPathConfig,
+} from '@vercel/cli-auth/credentials-store.js';
+import { readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+export function getToken(): string {
+  if (process.env.VERCEL_TOKEN) {
+    return process.env.VERCEL_TOKEN;
+  }
+
+  const dirs = [
+    getGlobalPathConfig('com.vercel.cli'),
+    join(homedir(), '.vercel'),
+  ];
+
+  for (const dir of dirs) {
+    try {
+      const token = CredentialsStore(dir, { authTokenStorage: 'file' }).get()
+        .token;
+      if (token) {
+        return token;
+      }
+    } catch {
+      // Best-effort fallback below
+    }
+  }
+
+  try {
+    const bashrc = readFileSync(join(homedir(), '.bashrc'), 'utf-8');
+    const match = bashrc.match(/export VERCEL_TOKEN="([^"]+)"/);
+    if (match) {
+      return match[1];
+    }
+  } catch {
+    // .bashrc not found or unreadable
+  }
+
+  throw new Error('No Vercel auth token found');
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "node": ">= 18"
   },
   "dependencies": {
+    "@vercel/cli-auth": "workspace:*",
     "@vercel/blob": "2.3.0",
     "@vercel/build-utils": "workspace:*",
     "@vercel/detect-agent": "workspace:*",

--- a/packages/cli/src/commands/login/future.ts
+++ b/packages/cli/src/commands/login/future.ts
@@ -224,7 +224,7 @@ export async function login(
     await updateCurrentTeamAfterLogin(client);
   }
 
-  client.writeToAuthConfigFile();
+  client.persistAuthConfig();
   client.writeToConfigFile();
 
   o.debug(`Saved credentials in "${hp(getGlobalPathConfig())}"`);

--- a/packages/cli/src/commands/logout/future.ts
+++ b/packages/cli/src/commands/logout/future.ts
@@ -6,6 +6,7 @@ import o from '../../output-manager';
 
 export async function logout(client: Client): Promise<number> {
   const { authConfig } = client;
+  const skipWrite = authConfig.skipWrite === true;
 
   if (!authConfig.token) {
     o.note(
@@ -33,10 +34,12 @@ export async function logout(client: Client): Promise<number> {
 
   try {
     client.updateConfig({ currentTeam: undefined });
-    client.writeToConfigFile();
-
     client.emptyAuthConfig();
-    client.writeToAuthConfigFile();
+
+    if (!skipWrite) {
+      client.writeToConfigFile();
+      client.persistAuthConfig();
+    }
     o.debug('Configuration has been deleted');
 
     if (!logoutError) {

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -1,8 +1,5 @@
 import { printError } from '../../util/error';
-import {
-  writeToConfigFile,
-  writeToAuthConfigFile,
-} from '../../util/config/files';
+import { persistAuthConfig, writeToConfigFile } from '../../util/config/files';
 import { parseArguments } from '../../util/get-args';
 import type Client from '../../util/client';
 import { getCommandName } from '../../util/pkg-name';
@@ -81,8 +78,10 @@ export default async function logout(client: Client): Promise<number> {
   delete authConfig.userId;
 
   try {
-    writeToConfigFile(config);
-    writeToAuthConfigFile(authConfig);
+    if (!authConfig.skipWrite) {
+      writeToConfigFile(config);
+      persistAuthConfig(authConfig, config);
+    }
     output.debug('Configuration has been deleted');
   } catch (err: unknown) {
     output.debug(errorToString(err));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -57,7 +57,7 @@ import earlyGetConfig from './util/get-config';
 import * as configFiles from './util/config/files';
 import getGlobalPathConfig from './util/config/global-path';
 import {
-  defaultAuthConfig,
+  getDefaultAuthConfig,
   defaultGlobalConfig,
 } from './util/config/get-default';
 import * as ERRORS from './util/errors-ts';
@@ -311,20 +311,10 @@ const main = async () => {
 
   let authConfig: AuthConfig;
   try {
-    authConfig = configFiles.readAuthConfigFile();
+    authConfig = configFiles.readAuthConfigFile(config);
   } catch (err: unknown) {
     if (isErrnoException(err) && err.code === 'ENOENT') {
-      authConfig = defaultAuthConfig;
-      try {
-        configFiles.writeToAuthConfigFile(authConfig);
-      } catch (err: unknown) {
-        output.error(
-          `An unexpected error occurred while trying to write the auth config to "${hp(
-            VERCEL_AUTH_CONFIG_PATH
-          )}" ${errorToString(err)}`
-        );
-        return 1;
-      }
+      authConfig = getDefaultAuthConfig();
     } else {
       output.error(
         `An unexpected error occurred while trying to read the auth config in "${hp(

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -24,7 +24,7 @@ import responseError from './response-error';
 import printIndications from './print-indications';
 import reauthenticate from './login/reauthenticate';
 import type { SAMLError } from './login/types';
-import { writeToAuthConfigFile, writeToConfigFile } from './config/files';
+import { persistAuthConfig, writeToConfigFile } from './config/files';
 import type { TelemetryEventStore } from './telemetry';
 import type { Span } from '@vercel/build-utils';
 import type {
@@ -224,7 +224,7 @@ export default class Client extends EventEmitter implements Stdio {
     if (!hasRefreshToken(authConfig)) {
       output.debug('No refresh token found, emptying auth config.');
       this.emptyAuthConfig();
-      this.writeToAuthConfigFile();
+      this.persistAuthConfig();
       return;
     }
 
@@ -239,7 +239,7 @@ export default class Client extends EventEmitter implements Stdio {
     if (tokensError) {
       output.debug('Error refreshing token, emptying auth config.');
       this.emptyAuthConfig();
-      this.writeToAuthConfigFile();
+      this.persistAuthConfig();
       return;
     }
 
@@ -254,7 +254,7 @@ export default class Client extends EventEmitter implements Stdio {
       this.updateAuthConfig({ refreshToken: tokens.refresh_token });
     }
 
-    this.writeToAuthConfigFile();
+    this.persistAuthConfig();
     this.writeToConfigFile();
 
     output.debug('Tokens refreshed successfully.');
@@ -276,8 +276,8 @@ export default class Client extends EventEmitter implements Stdio {
     this.authConfig = this.authConfig.skipWrite ? { skipWrite: true } : {};
   }
 
-  writeToAuthConfigFile() {
-    writeToAuthConfigFile(this.authConfig);
+  persistAuthConfig() {
+    persistAuthConfig(this.authConfig, this.config);
   }
 
   /**

--- a/packages/cli/src/util/config/files.ts
+++ b/packages/cli/src/util/config/files.ts
@@ -3,6 +3,13 @@ import loadJSON from 'load-json-file';
 import writeJSON from 'write-json-file';
 import { accessSync, constants } from 'fs';
 import { fileNameSymbol } from '@vercel/client';
+import {
+  clearAllCredentialsStrict,
+  hasCredentials,
+  readCredentials,
+  resolveAuthTokenStorage,
+  writeCredentials,
+} from '@vercel/cli-auth/credentials-store.js';
 import getGlobalPathConfig from './global-path';
 import getLocalPathConfig from './local-path';
 import { NowError } from '../now-error';
@@ -10,12 +17,14 @@ import highlight from '../output/highlight';
 import type { VercelConfig } from '../dev/types';
 import { isVercelTomlEnabled } from '../is-vercel-toml-enabled';
 import type { AuthConfig, GlobalConfig } from '@vercel-internals/types';
-import { isErrnoException, isError } from '@vercel/error-utils';
+import { errorToString, isErrnoException, isError } from '@vercel/error-utils';
 import { VERCEL_DIR as PROJECT_VERCEL_DIR } from '../projects/link';
 import {
   VERCEL_CONFIG_EXTENSIONS,
   DEFAULT_VERCEL_CONFIG_FILENAME,
 } from '../compile-vercel-config';
+import { getDefaultAuthConfig } from './get-default';
+import hp from '../humanize-path';
 
 import output from '../../output-manager';
 
@@ -25,7 +34,14 @@ const AUTH_CONFIG_FILE_PATH = join(VERCEL_DIR, 'auth.json');
 
 // reads "global config" file atomically
 export const readConfigFile = (): GlobalConfig => {
-  const config = loadJSON.sync(CONFIG_FILE_PATH);
+  const config = loadJSON.sync(CONFIG_FILE_PATH) as GlobalConfig & {
+    authTokenStorage?: unknown;
+  };
+
+  if ('authTokenStorage' in config) {
+    config.authTokenStorage = resolveAuthTokenStorage(config.authTokenStorage);
+  }
+
   return config;
 };
 
@@ -56,41 +72,53 @@ export const writeToConfigFile = (stuff: GlobalConfig): void => {
   }
 };
 
-// reads "auth config" file atomically
-export const readAuthConfigFile = (): AuthConfig => {
-  const config = loadJSON.sync(AUTH_CONFIG_FILE_PATH);
-  return config;
+function getAuthStoreConfig(config: GlobalConfig) {
+  return {
+    authTokenStorage: resolveAuthTokenStorage(config.authTokenStorage),
+  };
+}
+
+function toPersistedAuthConfig(authConfig: AuthConfig): AuthConfig {
+  const { skipWrite, tokenSource, ...persistedAuthConfig } = authConfig;
+  return persistedAuthConfig;
+}
+
+export const readAuthConfigFile = (config: GlobalConfig): AuthConfig => {
+  return {
+    ...getDefaultAuthConfig(),
+    ...readCredentials(VERCEL_DIR, getAuthStoreConfig(config)),
+  };
 };
 
-export const writeToAuthConfigFile = (authConfig: AuthConfig) => {
+export const persistAuthConfig = (
+  authConfig: AuthConfig,
+  config: GlobalConfig
+) => {
   if (authConfig.skipWrite) {
     return;
   }
+
+  const persistedAuthConfig = toPersistedAuthConfig(authConfig);
+
   try {
-    return writeJSON.sync(AUTH_CONFIG_FILE_PATH, authConfig, {
-      indent: 2,
-      mode: 0o600,
-    });
-  } catch (err: unknown) {
-    if (isErrnoException(err)) {
-      if (err.code === 'EPERM') {
-        output.error(
-          `Not able to create ${highlight(
-            AUTH_CONFIG_FILE_PATH
-          )} (operation not permitted).`
-        );
-        process.exit(1);
-      } else if (err.code === 'EBADF') {
-        output.error(
-          `Not able to create ${highlight(
-            AUTH_CONFIG_FILE_PATH
-          )} (bad file descriptor).`
-        );
-        process.exit(1);
-      }
+    if (!hasCredentials(persistedAuthConfig)) {
+      clearAllCredentialsStrict(VERCEL_DIR);
+      return;
     }
 
-    throw err;
+    return writeCredentials(
+      VERCEL_DIR,
+      persistedAuthConfig,
+      getAuthStoreConfig(config)
+    );
+  } catch (err: unknown) {
+    const wrappedError = new Error(
+      `An unexpected error occurred while trying to write the auth config to "${hp(
+        AUTH_CONFIG_FILE_PATH
+      )}" ${errorToString(err)}`
+    );
+    (wrappedError as Error & { cause?: unknown }).cause = err;
+    throw wrappedError;
   }
 };
 

--- a/packages/cli/src/util/config/get-default.ts
+++ b/packages/cli/src/util/config/get-default.ts
@@ -7,8 +7,16 @@ export const defaultGlobalConfig: GlobalConfig = {
     'https://vercel.com/docs/projects/project-configuration/global-configuration#config.json',
 };
 
-export const defaultAuthConfig: AuthConfig = {
-  '// Note': 'This is your Vercel credentials file. DO NOT SHARE!',
-  '// Docs':
-    'https://vercel.com/docs/projects/project-configuration/global-configuration#auth.json',
-};
+export function getDefaultAuthConfig(
+  tokenStoredInSystemKeychain: boolean = false
+): AuthConfig {
+  return {
+    '// Note': tokenStoredInSystemKeychain
+      ? 'Your auth token is stored in your system keychain.'
+      : 'This is your Vercel credentials file. DO NOT SHARE!',
+    '// Docs':
+      'https://vercel.com/docs/projects/project-configuration/global-configuration#auth.json',
+  };
+}
+
+export const defaultAuthConfig: AuthConfig = getDefaultAuthConfig();

--- a/packages/cli/src/util/get-user.ts
+++ b/packages/cli/src/util/get-user.ts
@@ -16,7 +16,7 @@ export default async function getUser(client: Client) {
     if (client.authConfig.userId !== res.user.id) {
       client.updateAuthConfig({ userId: res.user.id });
       try {
-        client.writeToAuthConfigFile();
+        client.persistAuthConfig();
       } catch {
         output.debug('Failed to persist cached userId to auth config.');
       }
@@ -30,7 +30,7 @@ export default async function getUser(client: Client) {
       if (client.authConfig.userId) {
         client.updateAuthConfig({ userId: undefined });
         try {
-          client.writeToAuthConfigFile();
+          client.persistAuthConfig();
         } catch {
           output.debug('Failed to persist cached userId to auth config.');
         }

--- a/packages/cli/src/util/login/reauthenticate.ts
+++ b/packages/cli/src/util/login/reauthenticate.ts
@@ -35,7 +35,7 @@ export default async function reauthenticate(
     refreshToken: tokens.refresh_token,
   });
 
-  client.writeToAuthConfigFile();
+  client.persistAuthConfig();
 
   output.success(`Authentication complete for ${bold(error.scope)} scope.`);
 

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -941,18 +941,54 @@ test('should pass through exit code for CLI extension', async () => {
   expect(output.exitCode).toEqual(6);
 });
 
-test('default command should prompt login with empty auth.json', async () => {
-  const output = await execCli(binaryPath, ['-Q', '/tmp'], {
-    // execCli passes the token automatically, undo that functionality for this test
-    token: false,
-    env: {
-      // Unset VERCEL_TOKEN so the env var doesn't bypass the login prompt
-      VERCEL_TOKEN: '',
-    },
+test('default command should prompt login with empty credentials', async () => {
+  const globalConfigDir = getNewTmpDir();
+  await fs.writeJson(path.join(globalConfigDir, 'config.json'), {
+    authTokenStorage: 'file',
   });
+
+  const output = await execCli(
+    binaryPath,
+    ['-Q', '/tmp', '--global-config', globalConfigDir],
+    {
+      // execCli passes the token automatically, undo that functionality for this test
+      token: false,
+      env: {
+        // Unset VERCEL_TOKEN so the env var doesn't bypass the login prompt
+        VERCEL_TOKEN: '',
+      },
+    }
+  );
   expect(output.stderr, formatOutput(output)).toBeTruthy();
   expect(output.stderr).toContain(
     'Error: No existing credentials found. Please run `vercel login` or pass "--token"'
+  );
+});
+
+test('invalid authTokenStorage should fail with a config error', async () => {
+  const globalConfigDir = getNewTmpDir();
+  await fs.writeJson(path.join(globalConfigDir, 'config.json'), {
+    authTokenStorage: 'keychain',
+  });
+
+  const output = await execCli(
+    binaryPath,
+    ['-Q', '/tmp', '--global-config', globalConfigDir],
+    {
+      reject: false,
+      token: false,
+      env: {
+        VERCEL_TOKEN: '',
+      },
+    }
+  );
+
+  expect(output.exitCode, formatOutput(output)).toBe(1);
+  expect(output.stderr).toContain(
+    'An unexpected error occurred while trying to read the config'
+  );
+  expect(output.stderr).toContain(
+    'Invalid value for `authTokenStorage`: "keychain". Expected one of: "auto", "file", "keyring".'
   );
 });
 

--- a/packages/cli/test/unit/commands/logout/index.test.ts
+++ b/packages/cli/test/unit/commands/logout/index.test.ts
@@ -1,22 +1,106 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import logout from '../../../../src/commands/logout';
 import { client } from '../../../mocks/client';
+import {
+  persistAuthConfig,
+  writeToConfigFile,
+} from '../../../../src/util/config/files';
 
-describe.todo('logout', () => {
-  describe('--help', () => {
-    it('tracks telemetry', async () => {
-      const command = 'logout';
+vi.mock('../../../../src/util/config/files', async () => {
+  const actual = await vi.importActual('../../../../src/util/config/files');
 
-      client.setArgv(command, '--help');
-      const exitCodePromise = logout(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+  return {
+    ...actual,
+    persistAuthConfig: vi.fn(),
+    writeToConfigFile: vi.fn(),
+  };
+});
 
-      expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        {
-          key: 'flag:help',
-          value: command,
-        },
-      ]);
+describe('logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+  });
+
+  it('tracks telemetry for --help', async () => {
+    client.setArgv('logout', '--help');
+
+    const exitCode = await logout(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'flag:help',
+        value: 'logout',
+      },
+    ]);
+  });
+
+  it('clears persisted auth state during legacy logout', async () => {
+    client.scenario.delete('/v3/user/tokens/current', (_req, res) => {
+      res.status(200).json({});
     });
+
+    client.setArgv('logout');
+    client.authConfig = {
+      token: 'token_123',
+      userId: 'user_123',
+    };
+    client.config = {
+      currentTeam: 'team_123',
+    };
+
+    const exitCode = await logout(client);
+
+    expect(exitCode).toBe(0);
+    expect(writeToConfigFile).toHaveBeenCalledWith({});
+    expect(persistAuthConfig).toHaveBeenCalledWith({}, {});
+  });
+
+  it('fails logout when clearing persisted auth state fails', async () => {
+    client.scenario.delete('/v3/user/tokens/current', (_req, res) => {
+      res.status(200).json({});
+    });
+
+    vi.mocked(persistAuthConfig).mockImplementation(() => {
+      throw new Error('keyring delete failed');
+    });
+
+    client.setArgv('logout', '--debug');
+    client.authConfig = {
+      token: 'token_123',
+      userId: 'user_123',
+    };
+    client.config = {
+      currentTeam: 'team_123',
+    };
+
+    const exitCode = await logout(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput('Failed during logout');
+  });
+
+  it('does not persist config changes for explicit-token logout', async () => {
+    client.scenario.delete('/v3/user/tokens/current', (_req, res) => {
+      res.status(200).json({});
+    });
+
+    client.setArgv('logout');
+    client.authConfig = {
+      token: 'token_123',
+      userId: 'user_123',
+      skipWrite: true,
+      tokenSource: 'flag',
+    };
+    client.config = {
+      currentTeam: 'team_123',
+    };
+
+    const exitCode = await logout(client);
+
+    expect(exitCode).toBe(0);
+    expect(writeToConfigFile).not.toHaveBeenCalled();
+    expect(persistAuthConfig).not.toHaveBeenCalled();
   });
 });

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -22,9 +22,9 @@
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
-    "@vercel/functions": "workspace:*",
     "@edge-runtime/jest-environment": "2.3.7",
     "@types/jest": "27.4.1",
+    "@vercel/functions": "workspace:*",
     "jest-junit": "16.0.0",
     "ts-node": "8.9.1",
     "tsup": "7.2.0",

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -26,6 +26,9 @@
   "bugs": {
     "url": "https://github.com/vercel/vercel/issues"
   },
+  "dependencies": {
+    "@vercel/cli-auth": "workspace:*"
+  },
   "devDependencies": {
     "tinyspawn": "1.3.1",
     "typedoc": "0.24.6",

--- a/packages/oidc/src/auth-config.ts
+++ b/packages/oidc/src/auth-config.ts
@@ -1,11 +1,26 @@
-import * as fs from 'fs';
-import * as path from 'path';
 import { getVercelDataDir } from './token-util';
 
+// @vercel/oidc emits declarations with the repo's older TypeScript toolchain.
+// Importing cli-auth's generated types pulls in zod v4 declarations that this
+// build cannot parse, so keep the runtime dependency here untyped.
+const {
+  clearAllCredentialsStrict,
+  hasCredentials,
+  readCredentials,
+  writeCredentials,
+}: {
+  clearAllCredentialsStrict: (dir: string) => void;
+  hasCredentials: (credentials: Partial<AuthConfig>) => boolean;
+  readCredentials: (dir: string) => AuthConfig;
+  writeCredentials: (dir: string, credentials: Partial<AuthConfig>) => void;
+} = require('@vercel/cli-auth/credentials-store.js');
+
 /**
- * Auth configuration stored in ~/.../com.vercel.cli/auth.json
+ * Auth configuration stored in ~/.../com.vercel.cli/auth.json or OS keyring
  */
 export interface AuthConfig {
+  '// Note'?: string;
+  '// Docs'?: string;
   /** An `access_token` obtained using the OAuth Device Authorization flow. */
   token?: string;
   /** A `refresh_token` obtained using the OAuth Device Authorization flow. */
@@ -20,16 +35,17 @@ export interface AuthConfig {
 }
 
 /**
- * Get the path to the auth config file
+ * Get the path to the auth config directory
  */
-function getAuthConfigPath(): string {
+function getAuthConfigDir(): string {
   const dataDir = getVercelDataDir();
   if (!dataDir) {
     throw new Error(
       `Unable to find Vercel CLI data directory. Your platform: ${process.platform}. Supported: darwin, linux, win32.`
     );
   }
-  return path.join(dataDir, 'auth.json');
+
+  return dataDir;
 }
 
 /**
@@ -38,15 +54,7 @@ function getAuthConfigPath(): string {
  */
 export function readAuthConfig(): AuthConfig | null {
   try {
-    const authPath = getAuthConfigPath();
-    if (!fs.existsSync(authPath)) {
-      return null;
-    }
-    const content = fs.readFileSync(authPath, 'utf8');
-    if (!content) {
-      return null;
-    }
-    return JSON.parse(content) as AuthConfig;
+    return readCredentials(getAuthConfigDir());
   } catch (_error) {
     return null;
   }
@@ -56,16 +64,12 @@ export function readAuthConfig(): AuthConfig | null {
  * Write the auth config to disk with proper permissions
  */
 export function writeAuthConfig(config: AuthConfig): void {
-  const authPath = getAuthConfigPath();
-  const authDir = path.dirname(authPath);
-
-  // Ensure directory exists with proper permissions
-  if (!fs.existsSync(authDir)) {
-    fs.mkdirSync(authDir, { mode: 0o770, recursive: true });
+  if (hasCredentials(config)) {
+    writeCredentials(getAuthConfigDir(), config);
+    return;
   }
 
-  // Write file with restrictive permissions (owner read/write only)
-  fs.writeFileSync(authPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+  clearAllCredentialsStrict(getAuthConfigDir());
 }
 
 /**

--- a/packages/oidc/src/get-vercel-oidc-token.test.ts
+++ b/packages/oidc/src/get-vercel-oidc-token.test.ts
@@ -40,6 +40,10 @@ describe('getVercelOidcToken - Error Scenarios', () => {
     fs.mkdirSync(path.join(rootDir, '.vercel'), {
       recursive: true,
     });
+    fs.writeFileSync(
+      path.join(cliDataDir, 'config.json'),
+      JSON.stringify({ authTokenStorage: 'file' })
+    );
 
     vi.spyOn(process, 'cwd').mockReturnValue(rootDir);
     vi.mocked(findRootDir).mockReturnValue(rootDir);

--- a/packages/oidc/src/token.test.ts
+++ b/packages/oidc/src/token.test.ts
@@ -36,8 +36,16 @@ describe('refreshToken', () => {
       recursive: true,
     });
 
+    fs.writeFileSync(
+      path.join(cliDataDir, 'config.json'),
+      JSON.stringify({ authTokenStorage: 'file' })
+    );
+
     // write the auth.json file to supply the auth token for the cli
-    fs.writeFileSync(path.join(cliDataDir, 'auth.json'), '{token: "test"}');
+    fs.writeFileSync(
+      path.join(cliDataDir, 'auth.json'),
+      JSON.stringify({ token: 'test' })
+    );
 
     // write the project.json file to supply the projectId
     fs.writeFileSync(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@types/node':
         specifier: 20.11.0
         version: 20.11.0
+      '@vercel/cli-auth':
+        specifier: workspace:*
+        version: link:../../packages/cli-auth
       '@vercel-internals/constants':
         specifier: workspace:*
         version: link:../constants
@@ -453,6 +456,9 @@ importers:
       '@vercel/build-utils':
         specifier: workspace:*
         version: link:../build-utils
+      '@vercel/cli-auth':
+        specifier: workspace:*
+        version: link:../cli-auth
       '@vercel/detect-agent':
         specifier: workspace:*
         version: link:../detect-agent
@@ -940,6 +946,9 @@ importers:
 
   packages/cli-auth:
     dependencies:
+      '@napi-rs/keyring':
+        specifier: 1.2.0
+        version: 1.2.0
       async-listen:
         specifier: 3.0.0
         version: 3.0.0
@@ -1997,6 +2006,10 @@ importers:
         version: 2.1.4(@edge-runtime/vm@3.2.0)(@types/node@20.11.0)
 
   packages/oidc:
+    dependencies:
+      '@vercel/cli-auth':
+        specifier: workspace:*
+        version: link:../cli-auth
     devDependencies:
       tinyspawn:
         specifier: 1.3.1
@@ -6547,6 +6560,132 @@ packages:
     dependencies:
       sparse-bitfield: 3.0.3
     dev: true
+
+  /@napi-rs/keyring-darwin-arm64@1.2.0:
+    resolution: {integrity: sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-darwin-x64@1.2.0:
+    resolution: {integrity: sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-freebsd-x64@1.2.0:
+    resolution: {integrity: sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-arm-gnueabihf@1.2.0:
+    resolution: {integrity: sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-arm64-gnu@1.2.0:
+    resolution: {integrity: sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-arm64-musl@1.2.0:
+    resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-riscv64-gnu@1.2.0:
+    resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-x64-gnu@1.2.0:
+    resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-x64-musl@1.2.0:
+    resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-win32-arm64-msvc@1.2.0:
+    resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-win32-ia32-msvc@1.2.0:
+    resolution: {integrity: sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-win32-x64-msvc@1.2.0:
+    resolution: {integrity: sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring@1.2.0:
+    resolution: {integrity: sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==}
+    engines: {node: '>= 10'}
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.2.0
+      '@napi-rs/keyring-darwin-x64': 1.2.0
+      '@napi-rs/keyring-freebsd-x64': 1.2.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.2.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.2.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-musl': 1.2.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.2.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.2.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.2.0
+    dev: false
 
   /@napi-rs/wasm-runtime@0.2.12:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}


### PR DESCRIPTION
Storing credentials in OS keychain is materially safer than plaintext
files:

- keychains are encrypted at rest by the OS, hence protect from
  cold-boot attacks;
- access to the keychain can be mediated by OS security controls
  (login context, prompts etc);
- credentials are less likely to be exposed by accident (e.g dotfile
  commits, agent reads etc).

Specific changes:

CLI credentials storage is made configurable via the new
`"authTokenStorage"` global config var.  Possible values are

- `"keyring"` -- store credentials in the system keychain, via
  `@napi-rs/keyring` which is a Node binding for `keyring-rs`, both
  of which are widely used (the latter by Codex);

- `"file"` -- store credentials in `<config-dir>/auth.json`, which is the
  current behavior and is still the default;

- `"auto"` -- use keyring, if available, otherwise fall back to "file".

When credentials are successfully written to a keychain, the previous copy in
plaintext file is removed to avoid confusion.  Additionally, credentials
are auto-migrated on storage changes on read, which would allow us to
change the default method in the future without breaking sessions.
