### PR TITLE
Add missing prettier devDependency to packages that rely on it

### DIFF
--- a/.changeset/slow-pugs-hunt.md
+++ b/.changeset/slow-pugs-hunt.md
@@ -1,0 +1,10 @@
+---
+'@vercel/oidc-aws-credentials-provider': patch
+'@vercel/functions': patch
+'@vercel/cli-auth': patch
+'@vercel/firewall': patch
+'@vercel/edge': patch
+'@vercel/oidc': patch
+---
+
+add missing prettier dev dependency

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -26,6 +26,7 @@
     "@edge-runtime/jest-environment": "2.3.7",
     "@types/jest": "27.4.1",
     "jest-junit": "16.0.0",
+    "prettier": "3.8.3",
     "ts-node": "8.9.1",
     "tsup": "7.2.0",
     "typedoc": "0.24.6",

--- a/packages/firewall/package.json
+++ b/packages/firewall/package.json
@@ -22,8 +22,9 @@
     "url": "https://github.com/vercel/vercel/issues"
   },
   "devDependencies": {
-    "@types/node": "20.11.0",
     "@smithy/types": "3.3.0",
+    "@types/node": "20.11.0",
+    "prettier": "3.8.3",
     "tinyspawn": "1.3.1",
     "typedoc": "0.24.6",
     "typedoc-plugin-markdown": "3.15.2",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -49,6 +49,7 @@
     "mariadb": "3.4.5",
     "mongodb": "6.18.0",
     "mysql2": "3.14.2",
+    "prettier": "3.8.3",
     "tinyspawn": "1.3.1",
     "typedoc": "0.24.6",
     "typedoc-plugin-markdown": "3.15.2",

--- a/packages/oidc-aws-credentials-provider/package.json
+++ b/packages/oidc-aws-credentials-provider/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@aws-sdk/credential-provider-web-identity": "3.609.0",
     "@smithy/types": "3.3.0",
+    "prettier": "3.8.3",
     "tinyspawn": "1.3.1",
     "typedoc": "0.24.6",
     "typedoc-plugin-markdown": "3.15.2",

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/vercel/vercel/issues"
   },
   "devDependencies": {
+    "prettier": "3.8.3",
     "tinyspawn": "1.3.1",
     "typedoc": "0.24.6",
     "typedoc-plugin-markdown": "3.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1108,6 +1108,9 @@ importers:
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
       ts-node:
         specifier: 8.9.1
         version: 8.9.1(typescript@4.9.5)
@@ -1273,6 +1276,9 @@ importers:
       '@types/node':
         specifier: 20.11.0
         version: 20.11.0
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
       tinyspawn:
         specifier: 1.3.1
         version: 1.3.1
@@ -1420,6 +1426,9 @@ importers:
       mysql2:
         specifier: 3.14.2
         version: 3.14.2
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
       tinyspawn:
         specifier: 1.3.1
         version: 1.3.1
@@ -1998,6 +2007,9 @@ importers:
 
   packages/oidc:
     devDependencies:
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
       tinyspawn:
         specifier: 1.3.1
         version: 1.3.1
@@ -2029,6 +2041,9 @@ importers:
       '@smithy/types':
         specifier: 3.3.0
         version: 3.3.0
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
       tinyspawn:
         specifier: 1.3.1
         version: 1.3.1
@@ -17847,6 +17862,12 @@ packages:
 
   /prettier@3.3.3:
     resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
+  /prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true


### PR DESCRIPTION
There are packages that rely on prettier in build tasks but do not
declare it as a dependency.
