### PR TITLE
feat(cli)!: drop plaintext `token` from `edge-config tokens` JSON list output

### DIFF
--- a/.changeset/edge-config-tokens-drop-plaintext-from-list-json.md
+++ b/.changeset/edge-config-tokens-drop-plaintext-from-list-json.md
@@ -2,11 +2,8 @@
 'vercel': major
 ---
 
-`vercel edge-config tokens <id-or-slug> --format json` no longer emits a plaintext `token` field for each listed token. The JSON payload now only contains `id`, `label`, `partialToken`, and `createdAt` per row.
+`vercel edge-config tokens <id-or-slug> --format json` no longer includes plaintext `token` values. Each row now contains `id`, `label`, `partialToken`, and `createdAt`.
 
-**Breaking change for JSON consumers.** Scripts or CI jobs reading `.[].token` from this output need to migrate:
+If your scripts read the `token` field to identify or remove a token, switch to `id` instead. For example, `vercel edge-config tokens <id-or-slug> --remove <id> --yes`.
 
-- Use `.[].id` to address a specific token in follow-up commands (for example `vercel edge-config tokens <id-or-slug> --remove <id> --yes`).
-- Use `.[].partialToken` (e.g. `aaaa********`) to identify a token to a human.
-
-Plaintext tokens are still printed once at creation time via `vercel edge-config tokens <id-or-slug> --add <label>`; that flow is unchanged. This aligns the CLI with the upcoming Edge Config API change that stops returning plaintext `token` values from `GET /v1/edge-config/:id/tokens`.
+Plaintext tokens are still printed once at creation via `--add <label>`.

--- a/.changeset/edge-config-tokens-drop-plaintext-from-list-json.md
+++ b/.changeset/edge-config-tokens-drop-plaintext-from-list-json.md
@@ -1,0 +1,12 @@
+---
+'vercel': minor
+---
+
+`vercel edge-config tokens <id-or-slug> --format json` no longer emits a plaintext `token` field for each listed token. The JSON payload now only contains `id`, `label`, `partialToken`, and `createdAt` per row.
+
+**Breaking change for JSON consumers.** Scripts or CI jobs reading `.[].token` from this output need to migrate:
+
+- Use `.[].id` to address a specific token in follow-up commands (for example `vercel edge-config tokens <id-or-slug> --remove <id> --yes`).
+- Use `.[].partialToken` (e.g. `aaaa********`) to identify a token to a human.
+
+Plaintext tokens are still printed once at creation time via `vercel edge-config tokens <id-or-slug> --add <label>`; that flow is unchanged. This aligns the CLI with the upcoming Edge Config API change that stops returning plaintext `token` values from `GET /v1/edge-config/:id/tokens`.

--- a/.changeset/edge-config-tokens-drop-plaintext-from-list-json.md
+++ b/.changeset/edge-config-tokens-drop-plaintext-from-list-json.md
@@ -1,5 +1,5 @@
 ---
-'vercel': minor
+'vercel': major
 ---
 
 `vercel edge-config tokens <id-or-slug> --format json` no longer emits a plaintext `token` field for each listed token. The JSON payload now only contains `id`, `label`, `partialToken`, and `createdAt` per row.

--- a/packages/cli/src/commands/edge-config/tokens.ts
+++ b/packages/cli/src/commands/edge-config/tokens.ts
@@ -20,7 +20,6 @@ import { resolveEdgeConfigId } from './resolve-edge-config-id';
 interface TokenRow {
   id?: string;
   label?: string;
-  token?: string;
   partialToken?: string;
   createdAt?: number;
 }
@@ -218,7 +217,17 @@ export default async function tokensCmd(
 
     const rows = await client.fetch<TokenRow[]>(`${base}/tokens`);
     if (asJson) {
-      client.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+      // Pick an explicit allowlist of fields so we never forward a plaintext
+      // `token` in `--format json`, even if an older API deploy still returns
+      // it during FLA-2777 rollout. `--add` output is unchanged and still
+      // reveals the token once on creation.
+      const sanitized = rows.map(row => ({
+        id: row.id,
+        label: row.label,
+        partialToken: row.partialToken,
+        createdAt: row.createdAt,
+      }));
+      client.stdout.write(`${JSON.stringify(sanitized, null, 2)}\n`);
       return 0;
     }
 

--- a/packages/cli/test/unit/commands/edge-config/edge-config.test.ts
+++ b/packages/cli/test/unit/commands/edge-config/edge-config.test.ts
@@ -281,6 +281,67 @@ describe('edge-config', () => {
     ]);
   });
 
+  it('does not emit plaintext `token` in --format json list output', async () => {
+    client.scenario.get('/v1/edge-config', (_req, res) => {
+      res.json([{ id: 'ecfg_list_tokens', slug: 's' }]);
+    });
+    // Simulate a mixed-version window where the API still returns plaintext
+    // `token` on the list endpoint (pre-FLA-2777). The CLI must strip it from
+    // JSON output regardless.
+    client.scenario.get(
+      '/v1/edge-config/ecfg_list_tokens/tokens',
+      (_req, res) => {
+        res.json([
+          {
+            id: 'tokid_a',
+            label: 'prod',
+            partialToken: 'aaaa********',
+            token: 'plaintext_leak_a',
+            createdAt: 1_700_000_000_000,
+          },
+          {
+            id: 'tokid_b',
+            label: 'dev',
+            partialToken: 'bbbb********',
+            token: 'plaintext_leak_b',
+            createdAt: 1_700_000_001_000,
+          },
+        ]);
+      }
+    );
+
+    client.setArgv(
+      'edge-config',
+      'tokens',
+      'ecfg_list_tokens',
+      '--format',
+      'json'
+    );
+    const exitCode = await edgeConfig(client);
+    expect(exitCode).toBe(0);
+    const raw = client.stdout.getFullOutput();
+    expect(raw).not.toContain('plaintext_leak_a');
+    expect(raw).not.toContain('plaintext_leak_b');
+    const out = JSON.parse(raw.trim());
+    expect(out).toEqual([
+      {
+        id: 'tokid_a',
+        label: 'prod',
+        partialToken: 'aaaa********',
+        createdAt: 1_700_000_000_000,
+      },
+      {
+        id: 'tokid_b',
+        label: 'dev',
+        partialToken: 'bbbb********',
+        createdAt: 1_700_000_001_000,
+      },
+    ]);
+    for (const row of out) {
+      expect(row).not.toHaveProperty('token');
+    }
+  });
+
   it('validates --patch before slug rename when both --slug and --patch are provided', async () => {
     let putCalled = false;
     client.scenario.put('/v1/edge-config/ecfg_update_order', (_req, res) => {


### PR DESCRIPTION
## Summary

- `vercel edge-config tokens <id-or-slug> --format json` now emits only `id`, `label`, `partialToken`, `createdAt` via an explicit allowlist pick, so a plaintext `token` can never leak through `--format json` regardless of what the API returns.
- The API no longer returns `token` on this endpoint. The CLI-side filter stays as a permanent hardening: `client.fetch<TokenRow[]>` is a TS assertion only and doesn't strip unknown runtime fields, so owning the JSON contract on the CLI side protects against any future regression that re-adds `token`.
- `--add <label>` is unchanged — full token still revealed once on creation.
- `TokenRow` loses `token?: string`, gains `partialToken?: string`.

## Breaking change

JSON consumers reading `.[].token` from `vercel edge-config tokens <id> --format json` must migrate:

- `.[].id` for operations (e.g. `--remove <id>`).
- `.[].partialToken` (e.g. `aaaa********`) to identify a token to a human.

## Test plan

- [x] Unit test asserting `--format json` output contains no plaintext `token` value and no `token` property, even when the API mock returns one.
- [x] `npx vitest run test/unit/commands/edge-config/edge-config.test.ts` — 9/9 pass.
- [x] `pnpm lint`, `tsc --noEmit`, `prettier --check` — clean on touched files.
- [x] Manual smoke against a dev Edge Config: JSON shape correct, `--add` still reveals the token once.

Made with [Cursor](https://cursor.com)