### PR TITLE
feat(cli): buy analytics Vercel add-on

### DIFF
--- a/packages/cli/src/commands/buy/command.ts
+++ b/packages/cli/src/commands/buy/command.ts
@@ -49,12 +49,13 @@ export const creditsSubcommand = {
 } as const;
 
 // TODO(mingchungx): Add other addons
-export const SUPPORTED_ADDON_ALIASES = ['siem'] as const;
+export const SUPPORTED_ADDON_ALIASES = ['siem', 'analytics'] as const;
 export type AddonAlias = (typeof SUPPORTED_ADDON_ALIASES)[number];
 
 // TODO(mingchungx): Add other labels
 export const ADDON_LABELS: Record<AddonAlias, string> = {
   siem: 'SIEM',
+  analytics: 'Analytics',
 };
 
 export const addonSubcommand = {


### PR DESCRIPTION
## Summary

Add the product alias `analytics` to make available for subscription add-on