### PR TITLE
[cli] validate repository_dispatch CI wiring

### DIFF
--- a/.changeset/validate-ci-dispatch.md
+++ b/.changeset/validate-ci-dispatch.md
@@ -1,0 +1,4 @@
+---
+---
+
+No-op change to validate the repository_dispatch CI workflow and Summary/Summary (e2e) status reporting introduced in #16032.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { isErrnoException, isError, errorToString } from '@vercel/error-utils';
 try {
   // Test to see if cwd has been deleted before
   // importing 3rd party packages that might need cwd.
+  // (no-op edit to validate repository_dispatch CI wiring)
   process.cwd();
 } catch (err: unknown) {
   if (isError(err) && err.message.includes('uv_cwd')) {


### PR DESCRIPTION
## Summary

No-op change (a single comment in `packages/cli/src/index.ts`) used to validate the CI workflow migration from `pull_request` to `repository_dispatch` introduced in #16032.

Once Vercel dispatches `deployment.ready` for this PR's commit, the new `test.yml` / `test-e2e.yml` workflows should run and post `Summary` / `Summary (e2e)` commit statuses directly to the PR SHA via the `Report status to PR commit` step.

## Test plan

- [ ] `Lint`, `Lint GitHub Actions`, `Summary (lint)` pass as normal (these are still `pull_request`-triggered on main).
- [ ] Vercel deployment completes for this commit.
- [ ] `Unit Tests` / `E2E Tests` runs appear under Actions with `event: repository_dispatch` and `headSha` matching this PR's commit context.
- [ ] `Report status to PR commit` step inside each `summary` job succeeds (no 403 from the Statuses API).
- [ ] `Summary` and `Summary (e2e)` commit statuses appear on this PR's head commit.
- [ ] Branch protection resolves and the PR becomes mergeable (assuming no underlying test flakiness).

If any check fails, delete the branch — no need to merge.