### PR TITLE
Add Kiro (Amazon) to detect-agent

### DIFF
--- a/.changeset/silent-walls-repair.md
+++ b/.changeset/silent-walls-repair.md
@@ -1,0 +1,5 @@
+---
+'@vercel/detect-agent': patch
+---
+
+Add Kiro (Amazon) to detect-agent

--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -35,6 +35,7 @@ This package can detect the following AI agents and development environments:
 - **GitHub Copilot** (via `AI_AGENT=github-copilot|github-copilot-cli`, `COPILOT_MODEL`, `COPILOT_ALLOW_ALL`, or `COPILOT_GITHUB_TOKEN`)
 - **Replit** (online IDE)
 - **v0** (Vercel's AI assistant, via `AI_AGENT=v0`)
+- **Kiro** (Amazon)
 
 ## The AI_AGENT Standard
 

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -17,6 +17,8 @@ const OPENCODE = 'opencode' as const;
 const GITHUB_COPILOT = 'github-copilot' as const;
 const GITHUB_COPILOT_CLI = 'github-copilot-cli' as const;
 const V0 = 'v0' as const;
+const KIRO = 'kiro' as const;
+const KIRO_CLI = 'kiro-cli' as const;
 
 export type KnownAgentNames =
   | typeof CURSOR
@@ -31,7 +33,9 @@ export type KnownAgentNames =
   | typeof AUGMENT_CLI
   | typeof OPENCODE
   | typeof GITHUB_COPILOT
-  | typeof V0;
+  | typeof V0
+  | typeof KIRO
+  | typeof KIRO_CLI;
 
 export interface KnownAgentDetails {
   name: KnownAgentNames;
@@ -61,6 +65,8 @@ export const KNOWN_AGENTS = {
   OPENCODE,
   GITHUB_COPILOT,
   V0,
+  KIRO,
+  KIRO_CLI,
 } as const;
 
 export async function determineAgent(): Promise<AgentResult> {
@@ -140,6 +146,14 @@ export async function determineAgent(): Promise<AgentResult> {
     process.env.COPILOT_GITHUB_TOKEN
   ) {
     return { isAgent: true, agent: { name: GITHUB_COPILOT } };
+  }
+
+  if (process.env.KIRO_AGENT_PATH) {
+    return { isAgent: true, agent: { name: KIRO_CLI } };
+  }
+
+  if (process.env.TERM_PROGRAM === 'kiro') {
+    return { isAgent: true, agent: { name: KIRO } };
   }
 
   try {

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -25,6 +25,8 @@ describe('determineAgent', () => {
     vi.stubEnv('COPILOT_MODEL', '');
     vi.stubEnv('COPILOT_ALLOW_ALL', '');
     vi.stubEnv('COPILOT_GITHUB_TOKEN', '');
+    vi.stubEnv('KIRO_AGENT_PATH', '');
+    vi.stubEnv('TERM_PROGRAM', '');
   });
 
   afterEach(() => {
@@ -342,6 +344,52 @@ describe('determineAgent', () => {
     });
   });
 
+  describe('kiro cli detection', () => {
+    describe('KIRO_AGENT_PATH not set', () => {
+      it('returns no agent', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({ isAgent: false });
+      });
+    });
+
+    describe('KIRO_AGENT_PATH set', () => {
+      beforeEach(() => {
+        vi.stubEnv('KIRO_AGENT_PATH', '/Users/user/.local/bin/kiro-cli-chat');
+      });
+
+      it('detects kiro cli', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({
+          isAgent: true,
+          agent: { name: KNOWN_AGENTS.KIRO_CLI },
+        });
+      });
+    });
+  });
+
+  describe('kiro detection', () => {
+    describe('TERM_PROGRAM not set to kiro', () => {
+      it('returns no agent', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({ isAgent: false });
+      });
+    });
+
+    describe('TERM_PROGRAM set to kiro', () => {
+      beforeEach(() => {
+        vi.stubEnv('TERM_PROGRAM', 'kiro');
+      });
+
+      it('detects kiro', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({
+          isAgent: true,
+          agent: { name: KNOWN_AGENTS.KIRO },
+        });
+      });
+    });
+  });
+
   describe('claude detection', () => {
     describe('CLAUDE_CODE not set', () => {
       it('returns no agent', async () => {
@@ -501,6 +549,8 @@ describe('determineAgent', () => {
       vi.stubEnv('COPILOT_MODEL', 'gpt-5');
       vi.stubEnv('COPILOT_ALLOW_ALL', 'true');
       vi.stubEnv('COPILOT_GITHUB_TOKEN', 'ghp_xxx');
+      vi.stubEnv('KIRO_AGENT_PATH', '/Users/user/.local/bin/kiro-cli-chat');
+      vi.stubEnv('TERM_PROGRAM', 'kiro');
       mockFs({
         '/opt/.devin': mockFs.directory({
           mode: 0o755,
@@ -527,6 +577,8 @@ describe('determineAgent', () => {
       vi.stubEnv('COPILOT_MODEL', 'gpt-5');
       vi.stubEnv('COPILOT_ALLOW_ALL', 'true');
       vi.stubEnv('COPILOT_GITHUB_TOKEN', 'ghp_xxx');
+      vi.stubEnv('KIRO_AGENT_PATH', '/Users/user/.local/bin/kiro-cli-chat');
+      vi.stubEnv('TERM_PROGRAM', 'kiro');
       mockFs({
         '/opt/.devin': mockFs.directory({
           mode: 0o755,
@@ -552,6 +604,8 @@ describe('determineAgent', () => {
       vi.stubEnv('COPILOT_MODEL', 'gpt-5');
       vi.stubEnv('COPILOT_ALLOW_ALL', 'true');
       vi.stubEnv('COPILOT_GITHUB_TOKEN', 'ghp_xxx');
+      vi.stubEnv('KIRO_AGENT_PATH', '/Users/user/.local/bin/kiro-cli-chat');
+      vi.stubEnv('TERM_PROGRAM', 'kiro');
       mockFs({
         '/opt/.devin': mockFs.directory({
           mode: 0o755,


### PR DESCRIPTION
Hi! 👋 

This PR adds [Kiro](https://kiro.dev/) (Amazon's AI [IDE](https://kiro.dev/docs/) and [CLI](https://kiro.dev/docs/cli/)) to the supported agents in the `detect-agent` package. 

After running a short script to get all environment variables through the CLI and the IDE, these were the ones that better identified Kiro:

- CLI: `"KIRO_AGENT_PATH": "/Users/joao.palmeiro/.local/bin/kiro-cli-chat",`
- IDE: `"TERM_PROGRAM": "kiro",`

Thanks!