### PR TITLE
feat(cli): add partial key value column to `flags sdk-keys ls`

### DIFF
--- a/.changeset/flags-sdk-keys-partial-key-value.md
+++ b/.changeset/flags-sdk-keys-partial-key-value.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+`vercel flags sdk-keys ls` now surfaces the server-masked `partialKeyValue` preview (e.g. `vf_server_abc********`) in a new column of the default table output, between `Label` and `Created`. The `--json` output also includes `partialKeyValue` on each row.

--- a/packages/cli/src/commands/flags/sdk-keys-ls.ts
+++ b/packages/cli/src/commands/flags/sdk-keys-ls.ts
@@ -93,6 +93,7 @@ function outputSdkKeysJson(client: Client, keys: SdkKey[]) {
       type: key.type,
       environment: key.environment,
       label: key.label ?? null,
+      partialKeyValue: key.partialKeyValue ?? null,
       createdAt: key.createdAt,
       updatedAt: key.updatedAt,
     })),
@@ -101,7 +102,14 @@ function outputSdkKeysJson(client: Client, keys: SdkKey[]) {
 }
 
 function printSdkKeysTable(keys: SdkKey[]) {
-  const headers = ['Hash Key', 'Type', 'Environment', 'Label', 'Created'];
+  const headers = [
+    'Hash Key',
+    'Type',
+    'Environment',
+    'Label',
+    'Partial Key Value',
+    'Created',
+  ];
   const now = Date.now();
 
   const rows = keys.map(key => [
@@ -109,12 +117,13 @@ function printSdkKeysTable(keys: SdkKey[]) {
     getTypeLabel(key.type),
     key.environment,
     key.label || chalk.dim('-'),
+    key.partialKeyValue || chalk.dim('-'),
     ms(now - key.createdAt) + ' ago',
   ]);
 
   const table = formatTable(
     headers,
-    ['l', 'l', 'l', 'l', 'l'],
+    ['l', 'l', 'l', 'l', 'l', 'l'],
     [{ name: '', rows }]
   );
   output.print(`\n${table}\n`);

--- a/packages/cli/src/util/flags/types.ts
+++ b/packages/cli/src/util/flags/types.ts
@@ -135,6 +135,9 @@ export interface SdkKey {
   keyValue?: string;
   tokenValue?: string;
   connectionString?: string;
+  // Server-masked preview of the key value, e.g. `vf_server_abc********`.
+  // Safe to display; never contains the full secret.
+  partialKeyValue?: string;
 }
 
 export interface SdkKeysListResponse {

--- a/packages/cli/test/mocks/flags.ts
+++ b/packages/cli/test/mocks/flags.ts
@@ -145,6 +145,7 @@ export const defaultSdkKeys: SdkKey[] = [
     createdAt: Date.now() - 86400000,
     updatedAt: Date.now() - 86400000,
     label: 'Production Server',
+    partialKeyValue: 'vf_server_abc********',
   },
   {
     hashKey: 'sdk_key_def456',
@@ -154,6 +155,7 @@ export const defaultSdkKeys: SdkKey[] = [
     createdBy: 'user_123',
     createdAt: Date.now() - 172800000,
     updatedAt: Date.now() - 172800000,
+    partialKeyValue: 'vf_client_def********',
   },
 ];
 

--- a/packages/cli/test/unit/commands/flags/sdk-keys.test.ts
+++ b/packages/cli/test/unit/commands/flags/sdk-keys.test.ts
@@ -6,6 +6,7 @@ import { defaultProject, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 import { useFlags, defaultSdkKeys } from '../../../mocks/flags';
+import type { SdkKey } from '../../../../src/util/flags/types';
 
 describe('flags sdk-keys', () => {
   beforeEach(() => {
@@ -70,6 +71,58 @@ describe('flags sdk-keys', () => {
       expect(exitCode).toEqual(0);
     });
 
+    it('renders the partial key value in the default table output', async () => {
+      client.setArgv('flags', 'sdk-keys', 'ls');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const stderr = client.stderr.getFullOutput();
+      const stdout = client.stdout.getFullOutput();
+      const combined = `${stderr}\n${stdout}`;
+
+      expect(combined).toContain('Partial Key Value');
+      expect(combined).toContain('vf_server_abc********');
+      expect(combined).toContain('vf_client_def********');
+    });
+
+    it('never leaks cleartext secrets in the default table output', async () => {
+      const sdkKeysWithSecrets: SdkKey[] = [
+        {
+          ...defaultSdkKeys[0],
+          keyValue: 'vf_server_fullsecretvalue_should_not_leak',
+          tokenValue: 'tok_fullsecrettoken_should_not_leak',
+          connectionString:
+            'https://flags.vercel.com/v1/flags/secret_should_not_leak',
+        },
+      ];
+      client.reset();
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'vercel-flags-test',
+        name: 'vercel-flags-test',
+      });
+      useFlags(undefined, sdkKeysWithSecrets);
+      const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+      client.cwd = cwd;
+      client.stdin.isTTY = false;
+
+      client.setArgv('flags', 'sdk-keys', 'ls');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const stderr = client.stderr.getFullOutput();
+      const stdout = client.stdout.getFullOutput();
+      const combined = `${stderr}\n${stdout}`;
+
+      expect(combined).not.toContain(
+        'vf_server_fullsecretvalue_should_not_leak'
+      );
+      expect(combined).not.toContain('tok_fullsecrettoken_should_not_leak');
+      expect(combined).not.toContain('secret_should_not_leak');
+    });
+
     describe('--json', () => {
       it('outputs valid JSON with SDK key data', async () => {
         client.setArgv('flags', 'sdk-keys', 'ls', '--json');
@@ -85,6 +138,10 @@ describe('flags sdk-keys', () => {
         expect(parsed.sdkKeys[0]).toHaveProperty('type');
         expect(parsed.sdkKeys[0]).toHaveProperty('environment');
         expect(parsed.sdkKeys[0]).toHaveProperty('createdAt');
+        expect(parsed.sdkKeys[0]).toHaveProperty(
+          'partialKeyValue',
+          'vf_server_abc********'
+        );
       });
 
       it('tracks telemetry for --json', async () => {


### PR DESCRIPTION
## Summary
- Adds a `Partial Key Value` column to the default `vercel flags sdk-keys ls` table output (between `Label` and `Created`), surfacing the server-masked preview returned by the API (e.g. `vf_server_abc********`).
- Passes `partialKeyValue` through the `--json` output.
- Cleartext fields (`keyValue`/`tokenValue`/`connectionString`) are still never shown.

## Test plan
- [x] `pnpm vitest run packages/cli/test/unit/commands/flags/sdk-keys.test.ts`
- [ ] Manual: `vercel flags sdk-keys ls` against a linked project — confirm the masked preview renders

Made with [Cursor](https://cursor.com)