### PR TITLE
feat(@vercel/oidc): add ESM build (.mjs) for ESM bundler compatibility

### DIFF
--- a/.changeset/golden-eagles-dance.md
+++ b/.changeset/golden-eagles-dance.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+Add ESM build (.mjs) for compatibility with ESM bundlers (esbuild, Rollup, Vite, etc.)

--- a/packages/oidc/build.mjs
+++ b/packages/oidc/build.mjs
@@ -1,0 +1,20 @@
+import { tsc, esbuild } from '../../utils/build.mjs';
+
+await Promise.all([
+  // Type definitions
+  tsc(),
+
+  // CJS build — unbundled, same as current behavior
+  esbuild(),
+
+  // ESM build — bundled to avoid .js → .mjs import resolution issues.
+  // With bundle:true, esbuild inlines all internal imports so no relative
+  // imports remain in the .mjs output. This sidesteps the extension mismatch
+  // that caused PR #13784 to fail.
+  esbuild({
+    entryPoints: ['src/index.ts', 'src/index-browser.ts'],
+    format: 'esm',
+    bundle: true,
+    outExtension: { '.js': '.mjs' },
+  }),
+]);

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -2,18 +2,21 @@
   "name": "@vercel/oidc",
   "description": "Runtime OIDC helpers intended for use with Vercel Functions",
   "homepage": "https://vercel.com",
+  "type": "commonjs",
   "files": [
     "**/*.js",
+    "**/*.mjs",
     "**/*.d.ts",
     "**/*.md"
   ],
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "browser": "./dist/index-browser.js",
-      "react-native": "./dist/index-browser.js",
-      "workflow": "./dist/index-browser.js",
-      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "browser": "./dist/index-browser.mjs",
+      "react-native": "./dist/index-browser.mjs",
+      "workflow": "./dist/index-browser.mjs",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },
@@ -42,7 +45,7 @@
     "pretest": "pnpm run build:code",
     "test": "vitest",
     "build": "pnpm run build:code && pnpm run build:docs",
-    "build:code": "node ../../utils/build.mjs",
+    "build:code": "node build.mjs",
     "build:docs": "typedoc && prettier --write docs/**/*.md docs/*.md"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Adds a bundled ESM build (`.mjs` files) to `@vercel/oidc` alongside the existing CJS build. This enables ESM bundlers like esbuild, Rollup, and Vite to properly inline the package.

## Background

`@vercel/oidc` is currently CJS-only. When downstream code imports it through an ESM bundler chain (e.g. `ai-sdk` → Vercel Gateway → `@vercel/oidc`), the bundler cannot inline the `require()` calls, breaking ESM bundles.

## Why Previous PRs Failed

Two previous PRs (#14119, #13784) attempted this fix using `outExtension: { '.js': '.mjs' }` **without bundling**. This renames output files but does NOT rewrite internal import paths, so `dist/index.mjs` still imports `./get-context.js` (the CJS version). gr2m caught this in the final review of #13784.

## This Fix

Uses `bundle: true` in esbuild for the ESM output. This inlines all internal imports into self-contained `.mjs` files — no relative import statements remain in the output, completely avoiding the extension mismatch issue.

```js
// NEW packages/oidc/build.mjs
esbuild({
  entryPoints: ['src/index.ts', 'src/index-browser.ts'],
  format: 'esm',
  bundle: true,  // ← key: inlines all internal imports
  outExtension: { '.js': '.mjs' },
})
```

## Changes

- `packages/oidc/build.mjs` — new dedicated build script  
- `packages/oidc/package.json` — add `"type": "commonjs"`, update exports map, add `**/*.mjs` to files, change `build:code` to `node build.mjs`
- `.changeset/` — patch changeset

Closes #16093