### PR TITLE
fix(cli): remove deprecated local `--team` option from `vercel link`

### DIFF
--- a/.changeset/fix-link-team-deprecation.md
+++ b/.changeset/fix-link-team-deprecation.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): remove deprecated local `--team` option from `vercel link` and update example to use `--scope`

--- a/packages/cli/src/commands/link/command.ts
+++ b/packages/cli/src/commands/link/command.ts
@@ -46,15 +46,6 @@ export const linkCommand = {
       deprecated: false,
     },
     {
-      name: 'team',
-      description:
-        'Scope: team ID or slug (use with --project for non-interactive)',
-      shorthand: null,
-      argument: 'TEAM_ID_OR_SLUG',
-      type: String,
-      deprecated: false,
-    },
-    {
       ...yesOption,
       description:
         'Skip questions when setting up new project using default scope and settings',
@@ -72,7 +63,7 @@ export const linkCommand = {
     },
     {
       name: 'Non-interactive: link to an existing project (CI/agents)',
-      value: `${packageName} link --yes --team <team-id> --project <project-name-or-id>`,
+      value: `${packageName} link --yes --scope <team-id> --project <project-name-or-id>`,
     },
     {
       name: 'Link a specific directory to a Vercel Project',

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -4,7 +4,6 @@ import getSubcommand from '../../util/get-subcommand';
 import cmd from '../../util/output/cmd';
 import { ensureLink } from '../../util/link/ensure-link';
 import { addRepoLink, ensureRepoLink } from '../../util/link/repo';
-import getTeams from '../../util/teams/get-teams';
 import { type Command, help } from '../help';
 import { addSubcommand, linkCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -125,25 +124,6 @@ export default async function link(client: Client) {
       return 1;
     }
   } else {
-    // Prefer the validated team ID set by the global handler (--team/--scope). When it is not set
-    // (e.g. no scope passed), currentTeam may be undefined or from saved config. If the user passed
-    // --team to link but currentTeam is still unset, resolve to a team ID and set it so selectOrg
-    // has a default; never set a raw slug (always use team ID).
-    const teamFlag = parsedArgs.flags['--team'];
-    if (typeof teamFlag === 'string' && !client.config.currentTeam) {
-      try {
-        const teams = await getTeams(client);
-        const related = teams.find(
-          t => t.id === teamFlag || t.slug === teamFlag
-        );
-        if (related) {
-          client.config.currentTeam = related.id;
-        }
-      } catch {
-        // Let ensureLink/selectOrg handle missing team or API errors
-      }
-    }
-
     // Non-interactive when flag is passed or when agent (e.g. no TTY) so JSON is output when confirmation needed
     const linkNonInteractive =
       client.nonInteractive || client.argv.includes('--non-interactive');


### PR DESCRIPTION
## Summary

Fixes #16099

The `vercel link --help` output advertised `--team` as a valid option (with `deprecated: false`) and even included it in a non-interactive example, while actually using `--team` prints:

```
WARN! The `--team` option is deprecated. Please use `--scope` instead.
```

## Changes

- **`packages/cli/src/commands/link/command.ts`**: Remove the local `--team` option from `linkCommand.options`. Update the non-interactive example to use `--scope <team-id>` instead.
- **`packages/cli/src/commands/link/index.ts`**: Remove the redundant `teamFlag` resolution block — the global CLI handler already resolves `--scope`/`--team` to `client.config.currentTeam` before any subcommand runs, so this local block was dead code.
- **`.changeset/fix-link-team-deprecation.md`**: Patch changeset for the `vercel` package.

## Reproduction

```sh
vercel link --help        # example shows --team (misleading)
vercel link --team <id>   # prints: The `--team` option is deprecated. Please use `--scope` instead.
```

After this fix:

```sh
vercel link --help        # example now shows --scope (correct)
vercel link --scope <id>  # works without deprecation warning
```