### PR TITLE
feat(cli): show next/previous run in `vercel crons ls`

### DIFF
--- a/.changeset/crons-ls-next-previous-run.md
+++ b/.changeset/crons-ls-next-previous-run.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+`vercel crons ls` now reports the next and previous scheduled run for each cron job. The default table adds `Next Run` and `Previous Run` columns rendered as relative times (e.g. `in 30m`, `2h ago`), and `--format json` adds `nextRun` / `previousRun` ISO 8601 UTC timestamps on every entry under `crons` and `undeployed`. Times are computed locally from the schedule expression, so this works without any new API calls. Schedules that fail to parse fall back to `null` (JSON) or `—` (table) instead of crashing.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "@vercel/detect-agent": "workspace:*",
     "@vercel/fun": "1.3.0",
     "chokidar": "4.0.0",
+    "cron-parser": "5.5.0",
     "smol-toml": "1.5.2",
     "esbuild": "0.27.0",
     "form-data": "^4.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,6 @@
     "@vercel/detect-agent": "workspace:*",
     "@vercel/fun": "1.3.0",
     "chokidar": "4.0.0",
-    "cron-parser": "5.5.0",
     "smol-toml": "1.5.2",
     "esbuild": "0.27.0",
     "form-data": "^4.0.0",

--- a/packages/cli/src/commands/crons/ls.ts
+++ b/packages/cli/src/commands/crons/ls.ts
@@ -1,4 +1,6 @@
 import chalk from 'chalk';
+import { CronExpressionParser } from 'cron-parser';
+import ms from 'ms';
 import type Client from '../../util/client';
 import formatTable from '../../util/format-table';
 import stamp from '../../util/output/stamp';
@@ -18,6 +20,38 @@ import type { CronJobDefinition } from './types';
 interface LocalCron {
   path: string;
   schedule: string;
+}
+
+interface CronTimes {
+  next: Date | null;
+  previous: Date | null;
+}
+
+// Vercel evaluates cron schedules in UTC.
+function computeCronTimes(schedule: string, now: Date): CronTimes {
+  try {
+    const expr = CronExpressionParser.parse(schedule, {
+      currentDate: now,
+      tz: 'UTC',
+    });
+    const next = expr.hasNext() ? expr.next().toDate() : null;
+    expr.reset(now);
+    const previous = expr.hasPrev() ? expr.prev().toDate() : null;
+    return { next, previous };
+  } catch (err) {
+    output.debug(
+      `failed to parse cron schedule "${schedule}": ${(err as Error).message}`
+    );
+    return { next: null, previous: null };
+  }
+}
+
+function formatRelative(target: Date | null, now: Date): string {
+  if (!target) return chalk.dim('—');
+  const delta = target.getTime() - now.getTime();
+  if (delta === 0) return 'now';
+  if (delta > 0) return `in ${ms(delta)}`;
+  return `${ms(-delta)} ago`;
 }
 
 export default async function ls(client: Client, argv: string[]) {
@@ -104,18 +138,30 @@ export default async function ls(client: Client, argv: string[]) {
     }
   }
 
+  const now = new Date();
+
   if (asJson) {
     output.stopSpinner();
     const jsonOutput = {
-      crons: definitions.map(cron => ({
-        path: cron.path,
-        schedule: cron.schedule,
-        host: cron.host,
-      })),
-      undeployed: undeployedCrons.map(cron => ({
-        path: cron.path,
-        schedule: cron.schedule,
-      })),
+      crons: definitions.map(cron => {
+        const { next, previous } = computeCronTimes(cron.schedule, now);
+        return {
+          path: cron.path,
+          schedule: cron.schedule,
+          host: cron.host,
+          nextRun: next ? next.toISOString() : null,
+          previousRun: previous ? previous.toISOString() : null,
+        };
+      }),
+      undeployed: undeployedCrons.map(cron => {
+        const { next, previous } = computeCronTimes(cron.schedule, now);
+        return {
+          path: cron.path,
+          schedule: cron.schedule,
+          nextRun: next ? next.toISOString() : null,
+          previousRun: previous ? previous.toISOString() : null,
+        };
+      }),
       modified: modifiedCrons.map(({ local, deployed }) => ({
         path: local.path,
         localSchedule: local.schedule,
@@ -139,7 +185,10 @@ export default async function ls(client: Client, argv: string[]) {
         `${totalDeployed} cron ${totalDeployed === 1 ? 'job' : 'jobs'} found for ${chalk.bold(`${org.slug}/${project.name}`)}${isDisabled ? chalk.yellow(' (disabled)') : ''} ${chalk.gray(lsStamp())}`
       );
       output.print(
-        formatCronsTable(definitions).replace(/^(.*)/gm, `${' '.repeat(1)}$1`)
+        formatCronsTable(definitions, now).replace(
+          /^(.*)/gm,
+          `${' '.repeat(1)}$1`
+        )
       );
       output.print('\n\n');
     }
@@ -165,13 +214,22 @@ export default async function ls(client: Client, argv: string[]) {
   return 0;
 }
 
-function formatCronsTable(definitions: CronJobDefinition[]) {
-  const rows: string[][] = definitions.map(cron => [
-    chalk.bold(cron.path),
-    cron.schedule,
-  ]);
+function formatCronsTable(definitions: CronJobDefinition[], now: Date) {
+  const rows: string[][] = definitions.map(cron => {
+    const { next, previous } = computeCronTimes(cron.schedule, now);
+    return [
+      chalk.bold(cron.path),
+      cron.schedule,
+      formatRelative(next, now),
+      formatRelative(previous, now),
+    ];
+  });
 
-  return formatTable(['Path', 'Schedule'], ['l', 'l'], [{ rows }]);
+  return formatTable(
+    ['Path', 'Schedule', 'Next Run', 'Previous Run'],
+    ['l', 'l', 'l', 'l'],
+    [{ rows }]
+  );
 }
 
 function formatPendingCronsTable(

--- a/packages/cli/src/commands/crons/ls.ts
+++ b/packages/cli/src/commands/crons/ls.ts
@@ -1,7 +1,11 @@
 import chalk from 'chalk';
-import { CronExpressionParser } from 'cron-parser';
 import ms from 'ms';
 import type Client from '../../util/client';
+import {
+  nextFireAfter,
+  parseCronExpression,
+  previousFireBefore,
+} from '../../util/cron-times';
 import formatTable from '../../util/format-table';
 import stamp from '../../util/output/stamp';
 import { getCommandName } from '../../util/pkg-name';
@@ -29,21 +33,15 @@ interface CronTimes {
 
 // Vercel evaluates cron schedules in UTC.
 function computeCronTimes(schedule: string, now: Date): CronTimes {
-  try {
-    const expr = CronExpressionParser.parse(schedule, {
-      currentDate: now,
-      tz: 'UTC',
-    });
-    const next = expr.hasNext() ? expr.next().toDate() : null;
-    expr.reset(now);
-    const previous = expr.hasPrev() ? expr.prev().toDate() : null;
-    return { next, previous };
-  } catch (err) {
-    output.debug(
-      `failed to parse cron schedule "${schedule}": ${(err as Error).message}`
-    );
+  const fields = parseCronExpression(schedule);
+  if (!fields) {
+    output.debug(`failed to parse cron schedule "${schedule}"`);
     return { next: null, previous: null };
   }
+  return {
+    next: nextFireAfter(now, fields),
+    previous: previousFireBefore(now, fields),
+  };
 }
 
 function formatRelative(target: Date | null, now: Date): string {

--- a/packages/cli/src/util/cron-times.ts
+++ b/packages/cli/src/util/cron-times.ts
@@ -178,7 +178,13 @@ export function previousFireBefore(
   start: Date,
   fields: ExpandedFields
 ): Date | null {
-  let cur = new Date(Math.floor(start.getTime() / 60000) * 60000 - 60000);
+  // Truncate `start` to its enclosing minute. If `start` was mid-minute the
+  // truncated value is already strictly less, so it's a valid candidate; only
+  // subtract another minute when `start` was exactly on a boundary.
+  const truncated = Math.floor(start.getTime() / 60000) * 60000;
+  let cur = new Date(
+    truncated < start.getTime() ? truncated : truncated - 60000
+  );
   const sortedMonths = [...fields.month].sort((a, b) => b - a);
   const sortedHours = [...fields.hour].sort((a, b) => b - a);
   const sortedMinutes = [...fields.minute].sort((a, b) => b - a);

--- a/packages/cli/src/util/cron-times.ts
+++ b/packages/cli/src/util/cron-times.ts
@@ -1,0 +1,228 @@
+// Compute the next and previous fire times for a cron expression in UTC.
+//
+// Supports the strict subset of POSIX cron syntax that Vercel accepts (see
+// `validateCronSchedule` in src/commands/crons/add.ts):
+//
+//     field   range    syntax       e.g.
+//     ──────  ──────── ───────────  ──────────────────
+//     minute  0-59     * /n - ,     `0`, `*/5`, `0,30`
+//     hour    0-23     * /n - ,     `0`, `*/2`, `0-5`
+//     dom     1-31     * /n - ,     `1`, `1,15`, `1-15`
+//     month   1-12     * /n - ,     `1`, `1,6`
+//     dow     0-7      * /n - ,     `0`-`6`, `7` (Sunday)
+//
+// Day-of-month and day-of-week interact via the standard cron OR rule: when
+// both fields are restricted (neither is `*`), a day matches if it satisfies
+// either field. When only one is restricted, only that field is consulted.
+//
+// Names like `MON` and predefined expressions like `@daily` are NOT supported,
+// matching `validateCronSchedule`.
+
+interface ExpandedFields {
+  minute: Set<number>;
+  hour: Set<number>;
+  dom: Set<number>;
+  month: Set<number>;
+  dow: Set<number>;
+  domStar: boolean;
+  dowStar: boolean;
+}
+
+const MAX_LENGTH = 256;
+const MAX_YEAR_OFFSET = 5;
+
+export function parseCronExpression(expression: string): ExpandedFields | null {
+  if (expression.length > MAX_LENGTH) return null;
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) return null;
+  const [minF, hourF, domF, monthF, dowF] = fields;
+  const minute = parseField(minF, 0, 59);
+  const hour = parseField(hourF, 0, 23);
+  const dom = parseField(domF, 1, 31);
+  const month = parseField(monthF, 1, 12);
+  const dow = parseField(dowF, 0, 7);
+  if (!minute || !hour || !dom || !month || !dow) return null;
+  // Cron treats both 0 and 7 as Sunday — collapse onto 0.
+  if (dow.has(7)) {
+    dow.delete(7);
+    dow.add(0);
+  }
+  return {
+    minute,
+    hour,
+    dom,
+    month,
+    dow,
+    domStar: domF === '*',
+    dowStar: dowF === '*',
+  };
+}
+
+function parseField(
+  field: string,
+  min: number,
+  max: number
+): Set<number> | null {
+  const result = new Set<number>();
+  for (const part of field.split(',')) {
+    if (part === '') return null;
+    const [rangePart, stepPart, ...rest] = part.split('/');
+    if (rest.length > 0) return null;
+    let step = 1;
+    if (stepPart !== undefined) {
+      if (stepPart === '') return null;
+      const s = Number(stepPart);
+      if (!Number.isInteger(s) || s < 1) return null;
+      step = s;
+    }
+    let start: number;
+    let end: number;
+    if (rangePart === '*') {
+      start = min;
+      end = max;
+    } else if (rangePart.includes('-')) {
+      const parts = rangePart.split('-');
+      if (parts.length !== 2 || parts[0] === '' || parts[1] === '') {
+        return null;
+      }
+      const a = Number(parts[0]);
+      const b = Number(parts[1]);
+      if (!Number.isInteger(a) || !Number.isInteger(b) || a > b) return null;
+      start = a;
+      end = b;
+    } else {
+      if (rangePart === '') return null;
+      const v = Number(rangePart);
+      if (!Number.isInteger(v)) return null;
+      // `5/3` (single value with step) means: start at 5, step by 3 up to max.
+      start = v;
+      end = stepPart !== undefined ? max : v;
+    }
+    if (start < min || start > max || end < min || end > max) return null;
+    for (let i = start; i <= end; i += step) {
+      result.add(i);
+    }
+  }
+  return result;
+}
+
+function dayMatches(
+  year: number,
+  month0: number,
+  day: number,
+  fields: ExpandedFields
+): boolean {
+  const dowJs = new Date(Date.UTC(year, month0, day)).getUTCDay();
+  if (fields.domStar && fields.dowStar) return true;
+  if (fields.domStar) return fields.dow.has(dowJs);
+  if (fields.dowStar) return fields.dom.has(day);
+  return fields.dom.has(day) || fields.dow.has(dowJs);
+}
+
+// Find the next minute strictly after `start` that satisfies `fields`, or
+// `null` if no occurrence falls within the next `MAX_YEAR_OFFSET` years
+// (e.g. unschedulable expressions like `0 0 30 2 *`).
+export function nextFireAfter(
+  start: Date,
+  fields: ExpandedFields
+): Date | null {
+  let cur = new Date(Math.floor(start.getTime() / 60000 + 1) * 60000);
+  const sortedMonths = [...fields.month].sort((a, b) => a - b);
+  const sortedHours = [...fields.hour].sort((a, b) => a - b);
+  const sortedMinutes = [...fields.minute].sort((a, b) => a - b);
+  const stopYear = cur.getUTCFullYear() + MAX_YEAR_OFFSET;
+
+  while (cur.getUTCFullYear() <= stopYear) {
+    const year = cur.getUTCFullYear();
+    const month0 = cur.getUTCMonth();
+    const day = cur.getUTCDate();
+    const hour = cur.getUTCHours();
+    const minute = cur.getUTCMinutes();
+
+    if (!fields.month.has(month0 + 1)) {
+      const nextMonth = sortedMonths.find(m => m > month0 + 1);
+      cur =
+        nextMonth !== undefined
+          ? new Date(Date.UTC(year, nextMonth - 1, 1))
+          : new Date(Date.UTC(year + 1, sortedMonths[0] - 1, 1));
+      continue;
+    }
+    if (!dayMatches(year, month0, day, fields)) {
+      cur = new Date(Date.UTC(year, month0, day + 1));
+      continue;
+    }
+    if (!fields.hour.has(hour)) {
+      const nextHour = sortedHours.find(h => h > hour);
+      cur =
+        nextHour !== undefined
+          ? new Date(Date.UTC(year, month0, day, nextHour))
+          : new Date(Date.UTC(year, month0, day + 1));
+      continue;
+    }
+    if (!fields.minute.has(minute)) {
+      const nextMin = sortedMinutes.find(m => m > minute);
+      cur =
+        nextMin !== undefined
+          ? new Date(Date.UTC(year, month0, day, hour, nextMin))
+          : new Date(Date.UTC(year, month0, day, hour + 1));
+      continue;
+    }
+    return cur;
+  }
+  return null;
+}
+
+// Find the most recent minute strictly before `start` that satisfies `fields`,
+// or `null` if no occurrence falls within the previous `MAX_YEAR_OFFSET` years.
+export function previousFireBefore(
+  start: Date,
+  fields: ExpandedFields
+): Date | null {
+  let cur = new Date(Math.floor(start.getTime() / 60000) * 60000 - 60000);
+  const sortedMonths = [...fields.month].sort((a, b) => b - a);
+  const sortedHours = [...fields.hour].sort((a, b) => b - a);
+  const sortedMinutes = [...fields.minute].sort((a, b) => b - a);
+  const stopYear = cur.getUTCFullYear() - MAX_YEAR_OFFSET;
+
+  while (cur.getUTCFullYear() >= stopYear) {
+    const year = cur.getUTCFullYear();
+    const month0 = cur.getUTCMonth();
+    const day = cur.getUTCDate();
+    const hour = cur.getUTCHours();
+    const minute = cur.getUTCMinutes();
+
+    if (!fields.month.has(month0 + 1)) {
+      const prevMonth = sortedMonths.find(m => m < month0 + 1);
+      // `Date.UTC(y, m, 0)` is "day 0" of month m, which JS interprets as the
+      // last day of month m-1. Used here to land on the last day of the
+      // previous valid month.
+      cur =
+        prevMonth !== undefined
+          ? new Date(Date.UTC(year, prevMonth, 0, 23, 59))
+          : new Date(Date.UTC(year - 1, sortedMonths[0], 0, 23, 59));
+      continue;
+    }
+    if (!dayMatches(year, month0, day, fields)) {
+      cur = new Date(Date.UTC(year, month0, day - 1, 23, 59));
+      continue;
+    }
+    if (!fields.hour.has(hour)) {
+      const prevHour = sortedHours.find(h => h < hour);
+      cur =
+        prevHour !== undefined
+          ? new Date(Date.UTC(year, month0, day, prevHour, 59))
+          : new Date(Date.UTC(year, month0, day - 1, 23, 59));
+      continue;
+    }
+    if (!fields.minute.has(minute)) {
+      const prevMin = sortedMinutes.find(m => m < minute);
+      cur =
+        prevMin !== undefined
+          ? new Date(Date.UTC(year, month0, day, hour, prevMin))
+          : new Date(Date.UTC(year, month0, day, hour - 1, 59));
+      continue;
+    }
+    return cur;
+  }
+  return null;
+}

--- a/packages/cli/test/unit/commands/crons/ls.test.ts
+++ b/packages/cli/test/unit/commands/crons/ls.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import crons from '../../../../src/commands/crons';
 import * as linkModule from '../../../../src/util/projects/link';
@@ -51,11 +51,24 @@ function mockProjectWithCrons(
   });
 }
 
+// Pinned to 2024-01-15T12:30:00.000Z for deterministic next/previous run
+// times. With this anchor, `0 * * * *` lands at 13:00:00 next and 12:00:00
+// previous, giving 30m on either side.
+const NOW = new Date('2024-01-15T12:30:00.000Z');
+
 describe('crons ls', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Only fake `Date` — the mock-client's `toOutput` helper relies on real
+    // timers to poll stderr, so faking setTimeout/setInterval would hang it.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(NOW);
     client.reset();
     mockedReadLocalConfig.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('--help', () => {
@@ -100,6 +113,11 @@ describe('crons ls', () => {
       const exitCode = await crons(client);
       expect(exitCode).toEqual(0);
       await expect(client.stderr).toOutput('2 cron jobs found');
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Next Run');
+      expect(stderr).toContain('Previous Run');
+      expect(stderr).toContain('in 30m');
+      expect(stderr).toContain('30m ago');
     });
 
     it('shows disabled indicator', async () => {
@@ -151,9 +169,30 @@ describe('crons ls', () => {
           path: '/api/cron',
           schedule: '0 * * * *',
           host: 'example.vercel.app',
+          nextRun: '2024-01-15T13:00:00.000Z',
+          previousRun: '2024-01-15T12:00:00.000Z',
         },
       ]);
       expect(parsed.enabled).toBe(true);
+    });
+
+    it('emits null next/previous for invalid schedules', async () => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        {
+          host: 'example.vercel.app',
+          path: '/api/cron',
+          schedule: 'not a cron',
+        },
+      ]);
+      client.setArgv('crons', 'ls', '--format', 'json');
+      const exitCode = await crons(client);
+      expect(exitCode).toEqual(0);
+
+      const stdout = client.stdout.getFullOutput();
+      const parsed = JSON.parse(stdout);
+      expect(parsed.crons[0].nextRun).toBeNull();
+      expect(parsed.crons[0].previousRun).toBeNull();
     });
 
     it('includes undeployed and modified in JSON', async () => {
@@ -178,7 +217,12 @@ describe('crons ls', () => {
       const stdout = client.stdout.getFullOutput();
       const parsed = JSON.parse(stdout);
       expect(parsed.undeployed).toEqual([
-        { path: '/api/new', schedule: '*/5 * * * *' },
+        {
+          path: '/api/new',
+          schedule: '*/5 * * * *',
+          nextRun: '2024-01-15T12:35:00.000Z',
+          previousRun: '2024-01-15T12:25:00.000Z',
+        },
       ]);
       expect(parsed.modified).toEqual([
         {

--- a/packages/cli/test/unit/commands/crons/ls.test.ts
+++ b/packages/cli/test/unit/commands/crons/ls.test.ts
@@ -358,6 +358,72 @@ describe('crons ls', () => {
     });
   });
 
+  // Locks in the rounding/granularity behavior at and beyond the 24h boundary.
+  // The `ms` package (short mode) rounds to whole days for any delta >= 24h
+  // and never escalates to weeks/months/years, so a yearly schedule renders
+  // as e.g. "in 351d". If we ever swap formatters, these assertions will
+  // surface the change.
+  describe('day-and-longer ranges', () => {
+    it.each([
+      {
+        kind: 'weekly',
+        schedule: '15 3 * * 0',
+        next: '2024-01-21T03:15:00.000Z',
+        previous: '2024-01-14T03:15:00.000Z',
+        tableNext: 'in 6d',
+        tablePrevious: '1d ago',
+      },
+      {
+        kind: 'monthly',
+        schedule: '0 0 1 * *',
+        next: '2024-02-01T00:00:00.000Z',
+        previous: '2024-01-01T00:00:00.000Z',
+        tableNext: 'in 16d',
+        tablePrevious: '15d ago',
+      },
+      {
+        kind: 'yearly',
+        schedule: '0 0 1 1 *',
+        next: '2025-01-01T00:00:00.000Z',
+        previous: '2024-01-01T00:00:00.000Z',
+        tableNext: 'in 351d',
+        tablePrevious: '15d ago',
+      },
+    ])('renders $kind schedule with day granularity', async ({
+      schedule,
+      next,
+      previous,
+      tableNext,
+      tablePrevious,
+    }) => {
+      mockLinkedProject();
+      mockProjectWithCrons([
+        { host: 'example.vercel.app', path: '/api/cron', schedule },
+      ]);
+
+      client.setArgv('crons', 'ls', '--format', 'json');
+      expect(await crons(client)).toEqual(0);
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.crons[0].nextRun).toBe(next);
+      expect(parsed.crons[0].previousRun).toBe(previous);
+
+      // Re-run for the human/table view. `client.reset()` clears the mock
+      // server's routes, so re-register them before the second invocation.
+      client.reset();
+      mockedReadLocalConfig.mockReturnValue(undefined);
+      mockLinkedProject();
+      mockProjectWithCrons([
+        { host: 'example.vercel.app', path: '/api/cron', schedule },
+      ]);
+
+      client.setArgv('crons', 'ls');
+      expect(await crons(client)).toEqual(0);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain(tableNext);
+      expect(stderr).toContain(tablePrevious);
+    });
+  });
+
   describe('extra arguments', () => {
     it('rejects extra arguments', async () => {
       client.setArgv('crons', 'ls', 'extra-arg');

--- a/packages/cli/test/unit/commands/crons/ls.test.ts
+++ b/packages/cli/test/unit/commands/crons/ls.test.ts
@@ -325,6 +325,39 @@ describe('crons ls', () => {
     });
   });
 
+  // Cron times are computed from absolute epoch deltas with `tz: 'UTC'`, so
+  // the system timezone should not influence the result. This guards against
+  // someone accidentally introducing local-time math (e.g. `getHours()` in
+  // place of `getUTCHours()`) in a future change.
+  describe('timezone independence', () => {
+    it.each([
+      'UTC',
+      'America/New_York',
+      'Asia/Tokyo',
+    ])('computes identical next/previous regardless of system TZ (TZ=%s)', async tz => {
+      const originalTz = process.env.TZ;
+      process.env.TZ = tz;
+      try {
+        mockLinkedProject();
+        mockProjectWithCrons([
+          {
+            host: 'example.vercel.app',
+            path: '/api/hourly',
+            schedule: '0 * * * *',
+          },
+        ]);
+        client.setArgv('crons', 'ls', '--format', 'json');
+        const exitCode = await crons(client);
+        expect(exitCode).toEqual(0);
+        const parsed = JSON.parse(client.stdout.getFullOutput());
+        expect(parsed.crons[0].nextRun).toBe('2024-01-15T13:00:00.000Z');
+        expect(parsed.crons[0].previousRun).toBe('2024-01-15T12:00:00.000Z');
+      } finally {
+        process.env.TZ = originalTz;
+      }
+    });
+  });
+
   describe('extra arguments', () => {
     it('rejects extra arguments', async () => {
       client.setArgv('crons', 'ls', 'extra-arg');

--- a/packages/cli/test/unit/util/cron-times.test.ts
+++ b/packages/cli/test/unit/util/cron-times.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  nextFireAfter,
+  parseCronExpression,
+  previousFireBefore,
+} from '../../../src/util/cron-times';
+
+// Anchor used for most cases. 12:30 UTC is mid-hour and a Monday — useful for
+// tests that exercise dom/dow interactions.
+const NOW = new Date('2024-01-15T12:30:00.000Z');
+
+function next(schedule: string, now: Date = NOW): string | null {
+  const fields = parseCronExpression(schedule);
+  if (!fields) throw new Error(`bad schedule: ${schedule}`);
+  return nextFireAfter(now, fields)?.toISOString() ?? null;
+}
+
+function prev(schedule: string, now: Date = NOW): string | null {
+  const fields = parseCronExpression(schedule);
+  if (!fields) throw new Error(`bad schedule: ${schedule}`);
+  return previousFireBefore(now, fields)?.toISOString() ?? null;
+}
+
+describe('parseCronExpression', () => {
+  it.each([
+    '* * * * *',
+    '0 0 * * *',
+    '*/5 * * * *',
+    '0 */2 * * *',
+    '30 8 1 * *',
+    '0 0 * * 0',
+    '0 0 * * 7',
+    '0 9 1-15 * *',
+    '0 9 * 1,6 *',
+    '0,30 * * * *',
+    '1-30/2 * * * *',
+    '0 0-5 * * *',
+    '0 0 * * 1-5',
+    '59 23 31 12 *',
+    '  0 10 * * *  ',
+    '0  10  *  *  *',
+  ])('accepts: "%s"', expr => {
+    expect(parseCronExpression(expr)).not.toBeNull();
+  });
+
+  it.each([
+    '',
+    '* * *',
+    '* * * * * *',
+    '60 * * * *',
+    '0 24 * * *',
+    '0 0 32 * *',
+    '0 0 0 * *',
+    '0 0 * 13 *',
+    '0 0 * 0 *',
+    '0 0 * * 8',
+    '30-10 * * * *',
+    '0 0-25 * * *',
+    'a-b * * * *',
+    '*/0 * * * *',
+    'not a cron',
+    '0 * * * /2',
+    '0 * * * 1/',
+  ])('rejects: "%s"', expr => {
+    expect(parseCronExpression(expr)).toBeNull();
+  });
+
+  it('collapses dow=7 onto 0 (both Sunday)', () => {
+    const a = parseCronExpression('0 0 * * 0')!;
+    const b = parseCronExpression('0 0 * * 7')!;
+    expect([...a.dow]).toEqual([...b.dow]);
+  });
+});
+
+describe('nextFireAfter / previousFireBefore', () => {
+  describe('hourly `0 * * * *`', () => {
+    it('rolls forward and back from mid-hour', () => {
+      expect(next('0 * * * *')).toBe('2024-01-15T13:00:00.000Z');
+      expect(prev('0 * * * *')).toBe('2024-01-15T12:00:00.000Z');
+    });
+
+    it('treats an exact-boundary `now` as strictly outside', () => {
+      const onBoundary = new Date('2024-01-15T12:00:00.000Z');
+      expect(next('0 * * * *', onBoundary)).toBe('2024-01-15T13:00:00.000Z');
+      expect(prev('0 * * * *', onBoundary)).toBe('2024-01-15T11:00:00.000Z');
+    });
+  });
+
+  describe('every 5 minutes `*/5 * * * *`', () => {
+    it('snaps to the surrounding 5-minute marks', () => {
+      expect(next('*/5 * * * *')).toBe('2024-01-15T12:35:00.000Z');
+      expect(prev('*/5 * * * *')).toBe('2024-01-15T12:25:00.000Z');
+    });
+  });
+
+  describe('weekly `15 3 * * 0` (Sundays 03:15Z)', () => {
+    it('walks to the next/previous Sunday', () => {
+      expect(next('15 3 * * 0')).toBe('2024-01-21T03:15:00.000Z');
+      expect(prev('15 3 * * 0')).toBe('2024-01-14T03:15:00.000Z');
+    });
+  });
+
+  describe('monthly `0 0 1 * *`', () => {
+    it('crosses month boundaries', () => {
+      expect(next('0 0 1 * *')).toBe('2024-02-01T00:00:00.000Z');
+      expect(prev('0 0 1 * *')).toBe('2024-01-01T00:00:00.000Z');
+    });
+  });
+
+  describe('yearly `0 0 1 1 *`', () => {
+    it('crosses the year boundary', () => {
+      expect(next('0 0 1 1 *')).toBe('2025-01-01T00:00:00.000Z');
+      expect(prev('0 0 1 1 *')).toBe('2024-01-01T00:00:00.000Z');
+    });
+  });
+
+  describe('dom/dow OR semantics', () => {
+    // `0 0 13 * 5` fires on the 13th OR any Friday (standard cron OR rule
+    // when both fields are restricted).
+    it('fires when EITHER dom or dow matches', () => {
+      // 2024-01-13 is a Saturday but dom=13 → must match.
+      const sat = new Date('2024-01-13T12:00:00.000Z');
+      expect(prev('0 0 13 * 5', sat)).toBe('2024-01-13T00:00:00.000Z');
+      // 2024-01-12 is a Friday → must match via dow.
+      const fri = new Date('2024-01-12T12:00:00.000Z');
+      expect(prev('0 0 13 * 5', fri)).toBe('2024-01-12T00:00:00.000Z');
+    });
+
+    it('uses dow alone when dom is `*`', () => {
+      // dom=`*`, dow=1 → only Mondays.
+      // 2024-01-15 is a Monday; mid-day prev is the same Monday at 00:00.
+      expect(prev('0 0 * * 1')).toBe('2024-01-15T00:00:00.000Z');
+      // Next Monday after Jan 15 12:30 is Jan 22 00:00.
+      expect(next('0 0 * * 1')).toBe('2024-01-22T00:00:00.000Z');
+    });
+
+    it('uses dom alone when dow is `*`', () => {
+      // dom=15, dow=`*` → only the 15th.
+      expect(prev('0 0 15 * *')).toBe('2024-01-15T00:00:00.000Z');
+      expect(next('0 0 15 * *')).toBe('2024-02-15T00:00:00.000Z');
+    });
+  });
+
+  describe('Sunday encoding', () => {
+    it('treats dow=0 and dow=7 identically', () => {
+      expect(next('15 3 * * 0')).toBe(next('15 3 * * 7'));
+      expect(prev('15 3 * * 0')).toBe(prev('15 3 * * 7'));
+    });
+  });
+
+  describe('impossible expressions', () => {
+    it('returns null for `0 0 30 2 *` (Feb 30)', () => {
+      const fields = parseCronExpression('0 0 30 2 *')!;
+      expect(nextFireAfter(NOW, fields)).toBeNull();
+      expect(previousFireBefore(NOW, fields)).toBeNull();
+    });
+  });
+
+  describe('comma-list and range schedules', () => {
+    it('handles `0,30 * * * *`', () => {
+      expect(next('0,30 * * * *')).toBe('2024-01-15T13:00:00.000Z');
+      expect(prev('0,30 * * * *')).toBe('2024-01-15T12:00:00.000Z');
+    });
+
+    it('handles `0 0 * * 1-5` (weekdays at midnight)', () => {
+      // Mon Jan 15 12:30 → next weekday midnight is Tue Jan 16 00:00,
+      // previous is Mon Jan 15 00:00.
+      expect(next('0 0 * * 1-5')).toBe('2024-01-16T00:00:00.000Z');
+      expect(prev('0 0 * * 1-5')).toBe('2024-01-15T00:00:00.000Z');
+    });
+  });
+
+  describe('leap-year handling', () => {
+    it('hits Feb 29 in 2024 (leap year)', () => {
+      const onJan31 = new Date('2024-01-31T12:00:00.000Z');
+      // dom=29 with month=2 — next is Feb 29 2024.
+      expect(next('0 0 29 2 *', onJan31)).toBe('2024-02-29T00:00:00.000Z');
+    });
+
+    it('skips Feb 29 in non-leap years', () => {
+      const onJan31 = new Date('2023-01-31T12:00:00.000Z');
+      // 2023 isn't leap → next Feb 29 is in 2024.
+      expect(next('0 0 29 2 *', onJan31)).toBe('2024-02-29T00:00:00.000Z');
+    });
+  });
+});

--- a/packages/cli/test/unit/util/cron-times.test.ts
+++ b/packages/cli/test/unit/util/cron-times.test.ts
@@ -86,6 +86,29 @@ describe('nextFireAfter / previousFireBefore', () => {
     });
   });
 
+  // Real `new Date()` always carries milliseconds; only tests pin to whole
+  // minutes. This case caught a regression where `previousFireBefore`
+  // unconditionally subtracted a minute upfront and skipped the current
+  // minute even when `now` was already mid-minute (so the firing at the
+  // start of that minute was strictly in the past and should have matched).
+  describe('sub-minute `now`', () => {
+    it('returns the firing in the current minute when `now` is mid-minute', () => {
+      const midMinute = new Date('2024-01-15T12:30:30.000Z');
+      // `30 * * * *` fires at :30 each hour, so the most recent firing
+      // strictly before 12:30:30 is 12:30:00 — not 11:30:00.
+      expect(prev('30 * * * *', midMinute)).toBe('2024-01-15T12:30:00.000Z');
+      // Sanity: next is one hour later.
+      expect(next('30 * * * *', midMinute)).toBe('2024-01-15T13:30:00.000Z');
+    });
+
+    it('matches whole-minute behavior for non-current-minute firings', () => {
+      const midMinute = new Date('2024-01-15T12:30:30.000Z');
+      // `0 * * * *` doesn't fire in this minute, so prev is still 12:00.
+      expect(prev('0 * * * *', midMinute)).toBe('2024-01-15T12:00:00.000Z');
+      expect(next('0 * * * *', midMinute)).toBe('2024-01-15T13:00:00.000Z');
+    });
+  });
+
   describe('every 5 minutes `*/5 * * * *`', () => {
     it('snaps to the surrounding 5-minute marks', () => {
       expect(next('*/5 * * * *')).toBe('2024-01-15T12:35:00.000Z');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,9 +516,6 @@ importers:
       chokidar:
         specifier: 4.0.0
         version: 4.0.0
-      cron-parser:
-        specifier: 5.5.0
-        version: 5.5.0
       esbuild:
         specifier: 0.27.0
         version: 0.27.0
@@ -12187,13 +12184,6 @@ packages:
       prompts: 2.4.2
     dev: true
 
-  /cron-parser@5.5.0:
-    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
-    engines: {node: '>=18'}
-    dependencies:
-      luxon: 3.7.2
-    dev: false
-
   /cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -16441,11 +16431,6 @@ packages:
 
   /luxon@3.4.0:
     resolution: {integrity: sha512-7eDo4Pt7aGhoCheGFIuq4Xa2fJm4ZpmldpGhjTYBNUYNCN6TIEP6v7chwwwt3KRp7YR+rghbfvjyo3V5y9hgBw==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /luxon@3.7.2:
-    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,6 +516,9 @@ importers:
       chokidar:
         specifier: 4.0.0
         version: 4.0.0
+      cron-parser:
+        specifier: 5.5.0
+        version: 5.5.0
       esbuild:
         specifier: 0.27.0
         version: 0.27.0
@@ -12184,6 +12187,13 @@ packages:
       prompts: 2.4.2
     dev: true
 
+  /cron-parser@5.5.0:
+    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
+    engines: {node: '>=18'}
+    dependencies:
+      luxon: 3.7.2
+    dev: false
+
   /cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -13193,7 +13203,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
       debug: 3.2.7
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
@@ -13224,7 +13234,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.5)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
@@ -13328,7 +13338,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.35.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
     dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.35.0):
@@ -16431,6 +16441,11 @@ packages:
 
   /luxon@3.4.0:
     resolution: {integrity: sha512-7eDo4Pt7aGhoCheGFIuq4Xa2fJm4ZpmldpGhjTYBNUYNCN6TIEP6v7chwwwt3KRp7YR+rghbfvjyo3V5y9hgBw==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
     dev: false
 


### PR DESCRIPTION
## Summary

Blocked on https://github.com/vercel/vercel/pull/16112

`vercel crons ls` (and the bare `vercel crons`) now reports when each cron
will next fire and when it last fired:

- Default table gains `Next Run` and `Previous Run` columns rendered as
  relative times (e.g. `in 24m`, `6m ago`).
- `--format json` adds `nextRun` / `previousRun` ISO 8601 UTC timestamps on
  every entry under `crons` and `undeployed`.
- Schedules that fail to parse fall back to `null` (JSON) / `—` (table) and
  a debug log — the command does not crash.

Times are computed locally in UTC from the schedule expression, so there
are no new API calls. Useful for agents (and humans) reasoning about cron
health without round-tripping to the dashboard.

## Test plan

- [x] **140/140 unit tests pass** across `crons add`, `crons run`, `crons ls`, `validate-cron-schedule`, and the new `cron-times` util. Coverage includes JSON/table output, TZ independence (UTC, America/New_York, Asia/Tokyo), day-and-longer-range boundary behavior, dom/dow OR semantics, Sunday=0/7 equivalence, leap-year handling, and impossible-expression bounding.
- [x] Verified live against a real project:

```
  Path                               Schedule            Next Run    Previous Run
  /api/ingest/bills                  */30 * * * *        in 24m      6m ago
  /api/ingest/bills/backfill         15 3 * * 0          in 6d       15h ago
  /api/ingest/embeddings             */15 * * * *        in 9m       6m ago
  /api/ingest/irs                    */30 * * * *        in 24m      6m ago
  /api/ingest/members                0 3 * * *           in 9h       16h ago
  /api/ingest/si                     */30 * * * *        in 24m      6m ago
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)