### PR TITLE
fix(cli): prevent token leaks in non-interactive next commands

### DIFF
--- a/.changeset/smart-cameras-divide.md
+++ b/.changeset/smart-cameras-divide.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Prevent non-interactive command suggestions from ever echoing auth tokens. The CLI now strips `--token` / `-t` flags (including inline `=value` forms) before building `next.command` payloads, so automation output cannot leak credentials copied from invocation args.

--- a/.changeset/smart-cameras-divide.md
+++ b/.changeset/smart-cameras-divide.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Prevent non-interactive command suggestions from ever echoing auth tokens. The CLI now strips `--token` / `-t` flags (including inline `=value` forms) before building `next.command` payloads, so automation output cannot leak credentials copied from invocation args.
+Prevent non-interactive `next.command` suggestions from echoing auth tokens across CLI flows, not just `tokens add`. The CLI now strips `--token` / `-t` flags (including inline `=value` forms) before building suggested rerun commands, so automation output cannot leak credentials copied from invocation args; `VERCEL_TOKEN` from environment variables was not affected.

--- a/packages/cli/src/commands/tokens/add.ts
+++ b/packages/cli/src/commands/tokens/add.ts
@@ -15,6 +15,7 @@ import {
 } from '../../util/agent-output';
 import { AGENT_REASON } from '../../util/agent-output-constants';
 import { getCommandNamePlain } from '../../util/pkg-name';
+import { stripSensitiveAuthArgs } from '../../util/redact-args';
 
 interface CreateTokenResponse {
   token?: { id?: string; name?: string };
@@ -41,30 +42,12 @@ Common cases:
 
 const USER_SCOPE_AGENT_HINT = `Creating a personal token requires a classic token that includes full user account scope. Team-scoped, project-scoped, or narrow product tokens are rejected with HTTP 403. Create a classic personal access token at ${VERCEL_ACCOUNT_TOKENS_URL} with account-level access, set VERCEL_TOKEN or --token, then re-run.`;
 
-const SENSITIVE_TOKEN_FLAGS = new Set(['--token', '-t']);
-
 function normalizeApiMessage(message: string): string {
   return message.replace(/\s*\(\d{3}\)\s*$/, '').trim();
 }
 
-function stripSensitiveTokenFlags(args: string[]): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    const name = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg;
-    if (SENSITIVE_TOKEN_FLAGS.has(name)) {
-      if (!arg.includes('=') && i + 1 < args.length) {
-        i++;
-      }
-      continue;
-    }
-    out.push(arg);
-  }
-  return out;
-}
-
 function getSanitizedRerunCommand(client: Client): string {
-  const rerunArgs = stripSensitiveTokenFlags(client.argv.slice(2));
+  const rerunArgs = stripSensitiveAuthArgs(client.argv.slice(2));
   return getCommandNamePlain(rerunArgs.join(' ').trim());
 }
 

--- a/packages/cli/src/commands/tokens/add.ts
+++ b/packages/cli/src/commands/tokens/add.ts
@@ -41,8 +41,35 @@ Common cases:
 
 const USER_SCOPE_AGENT_HINT = `Creating a personal token requires a classic token that includes full user account scope. Team-scoped, project-scoped, or narrow product tokens are rejected with HTTP 403. Create a classic personal access token at ${VERCEL_ACCOUNT_TOKENS_URL} with account-level access, set VERCEL_TOKEN or --token, then re-run.`;
 
+const SENSITIVE_TOKEN_FLAGS = new Set(['--token', '-t']);
+
 function normalizeApiMessage(message: string): string {
   return message.replace(/\s*\(\d{3}\)\s*$/, '').trim();
+}
+
+function stripSensitiveTokenFlags(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const name = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg;
+    if (SENSITIVE_TOKEN_FLAGS.has(name)) {
+      if (
+        !arg.includes('=') &&
+        i + 1 < args.length &&
+        !args[i + 1].startsWith('-')
+      ) {
+        i++;
+      }
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
+function getSanitizedRerunCommand(client: Client): string {
+  const rerunArgs = stripSensitiveTokenFlags(client.argv.slice(2));
+  return getCommandNamePlain(rerunArgs.join(' ').trim());
 }
 
 function isClassicTokenRequiredForCreateError(err: unknown): boolean {
@@ -164,7 +191,7 @@ export default async function add(
   } catch (err: unknown) {
     if (isClassicTokenRequiredForCreateError(err)) {
       await openTokensDashboardInBrowser(client);
-      const rerun = getCommandNamePlain(client.argv.slice(2).join(' ').trim());
+      const rerun = getSanitizedRerunCommand(client);
       if (shouldEmitNonInteractiveCommandError(client)) {
         outputAgentError(
           client,
@@ -190,7 +217,7 @@ export default async function add(
     }
     if (isTokenUserScopeRequiredError(err)) {
       await openTokensDashboardInBrowser(client);
-      const rerun = getCommandNamePlain(client.argv.slice(2).join(' ').trim());
+      const rerun = getSanitizedRerunCommand(client);
       const apiMessage = normalizeApiMessage(
         isAPIError(err) ? err.serverMessage || err.message : String(err)
       );

--- a/packages/cli/src/commands/tokens/add.ts
+++ b/packages/cli/src/commands/tokens/add.ts
@@ -53,11 +53,7 @@ function stripSensitiveTokenFlags(args: string[]): string[] {
     const arg = args[i];
     const name = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg;
     if (SENSITIVE_TOKEN_FLAGS.has(name)) {
-      if (
-        !arg.includes('=') &&
-        i + 1 < args.length &&
-        !args[i + 1].startsWith('-')
-      ) {
+      if (!arg.includes('=') && i + 1 < args.length) {
         i++;
       }
       continue;

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -86,7 +86,7 @@ export function buildCommandWithYes(
   argv: string[],
   pkgName: string = packageName
 ): string {
-  const args = argv.slice(2);
+  const args = stripTokenFlagArgs(argv.slice(2));
   const hasYes = args.some(a => a === '--yes' || a === '-y');
   const out = hasYes ? [...args] : [...args, '--yes'];
   return `${pkgName} ${out.join(' ')}`;
@@ -103,7 +103,6 @@ const GLOBAL_FLAG_NAMES = new Set([
   '--team',
   '-S',
   '-T',
-  '--token',
 ]);
 
 /** Boolean globals: the next argv token is never their value (avoids eating a subcommand like `oauth-apps`). */
@@ -135,20 +134,43 @@ export function getGlobalFlagsFromArgv(argv: string[]): string[] {
 }
 
 /**
+ * Removes token flags (`--token`, `--token=<value>`, `-t`, `-t=<value>`) and
+ * their values from argument lists before they are emitted in JSON payloads.
+ */
+function stripTokenFlagArgs(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--token' || arg === '-t') {
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        i++;
+      }
+      continue;
+    }
+    if (arg.startsWith('--token=') || arg.startsWith('-t=')) {
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
+/**
  * Removes global CLI flags from a token list (e.g. to build a subcommand template
  * for {@link buildCommandWithGlobalFlags} without duplicating `--cwd`, etc.).
  */
 export function omitGlobalFlagsFromArgs(args: string[]): string[] {
+  const safeArgs = stripTokenFlagArgs(args);
   const out: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
+  for (let i = 0; i < safeArgs.length; i++) {
+    const arg = safeArgs[i];
     const name = arg.startsWith('--') ? arg.split('=')[0] : arg;
     if (GLOBAL_FLAG_NAMES.has(name)) {
       const skipSeparateValue =
         !BOOLEAN_GLOBAL_FLAG_NAMES.has(name) &&
         !arg.includes('=') &&
-        i + 1 < args.length &&
-        !args[i + 1].startsWith('-');
+        i + 1 < safeArgs.length &&
+        !safeArgs[i + 1].startsWith('-');
       if (skipSeparateValue) {
         i++;
       }
@@ -230,14 +252,15 @@ export function buildCommandWithGlobalFlags(
 export function getPreservedArgsForEnvAdd(argv: string[]): string[] {
   const args = argv.slice(2);
   const addIdx = args.indexOf('add');
-  if (addIdx === -1 || args[addIdx - 1] !== 'env') return args;
+  if (addIdx === -1 || args[addIdx - 1] !== 'env')
+    return stripTokenFlagArgs(args);
   let i = addIdx + 1;
   let positionals = 0;
   while (i < args.length && positionals < 3 && !args[i].startsWith('-')) {
     positionals++;
     i++;
   }
-  return args.slice(i);
+  return stripTokenFlagArgs(args.slice(i));
 }
 
 /**
@@ -279,10 +302,11 @@ export function buildEnvAddCommandWithPreservedArgs(
 export function getPreservedArgsForEnvPull(argv: string[]): string[] {
   const args = argv.slice(2);
   const pullIdx = args.indexOf('pull');
-  if (pullIdx === -1 || args[pullIdx - 1] !== 'env') return args;
+  if (pullIdx === -1 || args[pullIdx - 1] !== 'env')
+    return stripTokenFlagArgs(args);
   let i = pullIdx + 1;
   if (i < args.length && !args[i].startsWith('-')) i++;
-  return args.slice(i);
+  return stripTokenFlagArgs(args.slice(i));
 }
 
 /**
@@ -291,14 +315,15 @@ export function getPreservedArgsForEnvPull(argv: string[]): string[] {
 export function getPreservedArgsForEnvRm(argv: string[]): string[] {
   const args = argv.slice(2);
   const rmIdx = args.indexOf('rm');
-  if (rmIdx === -1 || args[rmIdx - 1] !== 'env') return args;
+  if (rmIdx === -1 || args[rmIdx - 1] !== 'env')
+    return stripTokenFlagArgs(args);
   let i = rmIdx + 1;
   let positionals = 0;
   while (i < args.length && positionals < 3 && !args[i].startsWith('-')) {
     positionals++;
     i++;
   }
-  return args.slice(i);
+  return stripTokenFlagArgs(args.slice(i));
 }
 
 /**
@@ -324,14 +349,15 @@ export function buildEnvRmCommandWithPreservedArgs(
 export function getPreservedArgsForEnvUpdate(argv: string[]): string[] {
   const args = argv.slice(2);
   const updateIdx = args.indexOf('update');
-  if (updateIdx === -1 || args[updateIdx - 1] !== 'env') return args;
+  if (updateIdx === -1 || args[updateIdx - 1] !== 'env')
+    return stripTokenFlagArgs(args);
   let i = updateIdx + 1;
   let positionals = 0;
   while (i < args.length && positionals < 3 && !args[i].startsWith('-')) {
     positionals++;
     i++;
   }
-  return args.slice(i);
+  return stripTokenFlagArgs(args.slice(i));
 }
 
 /**
@@ -372,7 +398,7 @@ export function buildCommandWithScope(
   scopeSlug: string,
   pkgName: string = packageName
 ): string {
-  const args = argv.slice(2);
+  const args = stripTokenFlagArgs(argv.slice(2));
   const out: string[] = [];
   for (let i = 0; i < args.length; i++) {
     // Handle space-separated: --scope VALUE, --team VALUE, -S VALUE, -T VALUE

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -142,7 +142,7 @@ function stripTokenFlagArgs(args: string[]): string[] {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === '--token' || arg === '-t') {
-      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+      if (i + 1 < args.length) {
         i++;
       }
       continue;

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -2,6 +2,7 @@ import { isError } from '@vercel/error-utils';
 import type Client from './client';
 import { isAPIError, LinkRequiredError, ProjectNotFound } from './errors-ts';
 import { packageName } from './pkg-name';
+import { stripSensitiveAuthArgs } from './redact-args';
 
 /**
  * Structured payload for "action required" (e.g. scope choice, login passcode).
@@ -86,10 +87,10 @@ export function buildCommandWithYes(
   argv: string[],
   pkgName: string = packageName
 ): string {
-  const args = stripTokenFlagArgs(argv.slice(2));
+  const args = stripSensitiveAuthArgs(argv.slice(2));
   const hasYes = args.some(a => a === '--yes' || a === '-y');
-  const out = hasYes ? [...args] : [...args, '--yes'];
-  return `${pkgName} ${out.join(' ')}`;
+  const out = hasYes ? args : [...args, '--yes'];
+  return `${pkgName} ${out.join(' ')}`.trim();
 }
 
 /** Global flags that should be preserved in suggested "next" commands (e.g. --cwd, --non-interactive). */
@@ -103,6 +104,7 @@ const GLOBAL_FLAG_NAMES = new Set([
   '--team',
   '-S',
   '-T',
+  // --token/-t are intentionally excluded and stripped via stripSensitiveAuthArgs.
 ]);
 
 /** Boolean globals: the next argv token is never their value (avoids eating a subcommand like `oauth-apps`). */
@@ -112,7 +114,7 @@ const BOOLEAN_GLOBAL_FLAG_NAMES = new Set(['--yes', '-y', '--non-interactive']);
  * Returns global flag args from argv so suggested commands can include them (e.g. --cwd, --non-interactive).
  */
 export function getGlobalFlagsFromArgv(argv: string[]): string[] {
-  const args = argv.slice(2);
+  const args = stripSensitiveAuthArgs(argv.slice(2));
   const out: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -134,33 +136,11 @@ export function getGlobalFlagsFromArgv(argv: string[]): string[] {
 }
 
 /**
- * Removes token flags (`--token`, `--token=<value>`, `-t`, `-t=<value>`) and
- * their values from argument lists before they are emitted in JSON payloads.
- */
-function stripTokenFlagArgs(args: string[]): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === '--token' || arg === '-t') {
-      if (i + 1 < args.length) {
-        i++;
-      }
-      continue;
-    }
-    if (arg.startsWith('--token=') || arg.startsWith('-t=')) {
-      continue;
-    }
-    out.push(arg);
-  }
-  return out;
-}
-
-/**
  * Removes global CLI flags from a token list (e.g. to build a subcommand template
  * for {@link buildCommandWithGlobalFlags} without duplicating `--cwd`, etc.).
  */
 export function omitGlobalFlagsFromArgs(args: string[]): string[] {
-  const safeArgs = stripTokenFlagArgs(args);
+  const safeArgs = stripSensitiveAuthArgs(args);
   const out: string[] = [];
   for (let i = 0; i < safeArgs.length; i++) {
     const arg = safeArgs[i];
@@ -253,14 +233,14 @@ export function getPreservedArgsForEnvAdd(argv: string[]): string[] {
   const args = argv.slice(2);
   const addIdx = args.indexOf('add');
   if (addIdx === -1 || args[addIdx - 1] !== 'env')
-    return stripTokenFlagArgs(args);
+    return stripSensitiveAuthArgs(args);
   let i = addIdx + 1;
   let positionals = 0;
   while (i < args.length && positionals < 3 && !args[i].startsWith('-')) {
     positionals++;
     i++;
   }
-  return stripTokenFlagArgs(args.slice(i));
+  return stripSensitiveAuthArgs(args.slice(i));
 }
 
 /**
@@ -303,10 +283,10 @@ export function getPreservedArgsForEnvPull(argv: string[]): string[] {
   const args = argv.slice(2);
   const pullIdx = args.indexOf('pull');
   if (pullIdx === -1 || args[pullIdx - 1] !== 'env')
-    return stripTokenFlagArgs(args);
+    return stripSensitiveAuthArgs(args);
   let i = pullIdx + 1;
   if (i < args.length && !args[i].startsWith('-')) i++;
-  return stripTokenFlagArgs(args.slice(i));
+  return stripSensitiveAuthArgs(args.slice(i));
 }
 
 /**
@@ -316,14 +296,14 @@ export function getPreservedArgsForEnvRm(argv: string[]): string[] {
   const args = argv.slice(2);
   const rmIdx = args.indexOf('rm');
   if (rmIdx === -1 || args[rmIdx - 1] !== 'env')
-    return stripTokenFlagArgs(args);
+    return stripSensitiveAuthArgs(args);
   let i = rmIdx + 1;
   let positionals = 0;
   while (i < args.length && positionals < 3 && !args[i].startsWith('-')) {
     positionals++;
     i++;
   }
-  return stripTokenFlagArgs(args.slice(i));
+  return stripSensitiveAuthArgs(args.slice(i));
 }
 
 /**
@@ -350,14 +330,14 @@ export function getPreservedArgsForEnvUpdate(argv: string[]): string[] {
   const args = argv.slice(2);
   const updateIdx = args.indexOf('update');
   if (updateIdx === -1 || args[updateIdx - 1] !== 'env')
-    return stripTokenFlagArgs(args);
+    return stripSensitiveAuthArgs(args);
   let i = updateIdx + 1;
   let positionals = 0;
   while (i < args.length && positionals < 3 && !args[i].startsWith('-')) {
     positionals++;
     i++;
   }
-  return stripTokenFlagArgs(args.slice(i));
+  return stripSensitiveAuthArgs(args.slice(i));
 }
 
 /**
@@ -398,7 +378,7 @@ export function buildCommandWithScope(
   scopeSlug: string,
   pkgName: string = packageName
 ): string {
-  const args = stripTokenFlagArgs(argv.slice(2));
+  const args = stripSensitiveAuthArgs(argv.slice(2));
   const out: string[] = [];
   for (let i = 0; i < args.length; i++) {
     // Handle space-separated: --scope VALUE, --team VALUE, -S VALUE, -T VALUE

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -131,6 +131,19 @@ const SUBCOMMAND_FLAG_TAKES_VALUE = new Set([
   '--per-page',
 ]);
 
+const SENSITIVE_FLAG_NAMES = new Set(['--token', '-t']);
+
+function normalizeFlagName(flag: string): string {
+  if (flag.includes('=')) {
+    return flag.slice(0, flag.indexOf('='));
+  }
+  return flag;
+}
+
+function isSensitiveFlag(flag: string): boolean {
+  return SENSITIVE_FLAG_NAMES.has(normalizeFlagName(flag));
+}
+
 function suggestionFlagTakesSeparateValue(flagName: string): boolean {
   const name = flagName.includes('=')
     ? flagName.slice(0, flagName.indexOf('='))
@@ -153,6 +166,16 @@ export function getSameSubcommandSuggestionFlags(args: string[]): string[] {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (!a.startsWith('-')) continue;
+    if (isSensitiveFlag(a)) {
+      if (
+        !a.includes('=') &&
+        i + 1 < args.length &&
+        !args[i + 1].startsWith('-')
+      ) {
+        i++;
+      }
+      continue;
+    }
     out.push(a);
     if (a.includes('=')) continue;
     const name = a;
@@ -263,6 +286,16 @@ export function getGlobalFlagsOnlyFromArgs(args: string[]): string[] {
   const out: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
+    if (isSensitiveFlag(a)) {
+      if (
+        !a.includes('=') &&
+        i + 1 < args.length &&
+        !args[i + 1].startsWith('-')
+      ) {
+        i++;
+      }
+      continue;
+    }
     let opt: GlobalOpt | undefined;
     if (a.startsWith('--') && a.includes('=')) {
       const name = a.slice(2).split('=')[0];

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -1,5 +1,6 @@
 import { getFlagsSpecification } from './get-flags-specification';
 import { getCommandNamePlain } from './pkg-name';
+import { normalizeFlagName, stripSensitiveAuthArgs } from './redact-args';
 
 export const globalCommandOptions = [
   {
@@ -101,9 +102,7 @@ export const GLOBAL_CLI_FLAG_NAMES: ReadonlySet<string> = (() => {
  * Whether a global CLI flag expects a separate argv token (String type).
  */
 export function globalCliFlagTakesValue(flagName: string): boolean {
-  const normalized = flagName.includes('=')
-    ? flagName.slice(0, flagName.indexOf('='))
-    : flagName;
+  const normalized = normalizeFlagName(flagName);
   for (const opt of globalCommandOptions) {
     if (`--${opt.name}` === normalized) {
       return opt.type === String;
@@ -131,23 +130,8 @@ const SUBCOMMAND_FLAG_TAKES_VALUE = new Set([
   '--per-page',
 ]);
 
-const SENSITIVE_FLAG_NAMES = new Set(['--token', '-t']);
-
-function normalizeFlagName(flag: string): string {
-  if (flag.includes('=')) {
-    return flag.slice(0, flag.indexOf('='));
-  }
-  return flag;
-}
-
-function isSensitiveFlag(flag: string): boolean {
-  return SENSITIVE_FLAG_NAMES.has(normalizeFlagName(flag));
-}
-
 function suggestionFlagTakesSeparateValue(flagName: string): boolean {
-  const name = flagName.includes('=')
-    ? flagName.slice(0, flagName.indexOf('='))
-    : flagName;
+  const name = normalizeFlagName(flagName);
   if (globalCliFlagTakesValue(name)) return true;
   return SUBCOMMAND_FLAG_TAKES_VALUE.has(name);
 }
@@ -162,25 +146,20 @@ function suggestionFlagTakesSeparateValue(flagName: string): boolean {
  * getGlobalFlagsOnlyFromArgs so flags that don't apply are not forwarded.
  */
 export function getSameSubcommandSuggestionFlags(args: string[]): string[] {
+  const safeArgs = stripSensitiveAuthArgs(args);
   const out: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i];
+  for (let i = 0; i < safeArgs.length; i++) {
+    const a = safeArgs[i];
     if (!a.startsWith('-')) continue;
-    if (isSensitiveFlag(a)) {
-      if (!a.includes('=') && i + 1 < args.length) {
-        i++;
-      }
-      continue;
-    }
     out.push(a);
     if (a.includes('=')) continue;
     const name = a;
     if (
       suggestionFlagTakesSeparateValue(name) &&
-      i + 1 < args.length &&
-      !args[i + 1].startsWith('-')
+      i + 1 < safeArgs.length &&
+      !safeArgs[i + 1].startsWith('-')
     ) {
-      out.push(args[++i]);
+      out.push(safeArgs[++i]);
     }
   }
   return out;
@@ -279,15 +258,10 @@ for (const opt of globalCommandOptions) {
  * Collects only global CLI flags from argv for suggested next commands.
  */
 export function getGlobalFlagsOnlyFromArgs(args: string[]): string[] {
+  const safeArgs = stripSensitiveAuthArgs(args);
   const out: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i];
-    if (isSensitiveFlag(a)) {
-      if (!a.includes('=') && i + 1 < args.length) {
-        i++;
-      }
-      continue;
-    }
+  for (let i = 0; i < safeArgs.length; i++) {
+    const a = safeArgs[i];
     let opt: GlobalOpt | undefined;
     if (a.startsWith('--') && a.includes('=')) {
       const name = a.slice(2).split('=')[0];
@@ -299,7 +273,7 @@ export function getGlobalFlagsOnlyFromArgs(args: string[]): string[] {
     if (!opt) continue;
     out.push(a);
     if (opt.type === String && !a.includes('=')) {
-      const next = args[i + 1];
+      const next = safeArgs[i + 1];
       if (next && !next.startsWith('-')) {
         out.push(next);
         i++;

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -167,11 +167,7 @@ export function getSameSubcommandSuggestionFlags(args: string[]): string[] {
     const a = args[i];
     if (!a.startsWith('-')) continue;
     if (isSensitiveFlag(a)) {
-      if (
-        !a.includes('=') &&
-        i + 1 < args.length &&
-        !args[i + 1].startsWith('-')
-      ) {
+      if (!a.includes('=') && i + 1 < args.length) {
         i++;
       }
       continue;
@@ -287,11 +283,7 @@ export function getGlobalFlagsOnlyFromArgs(args: string[]): string[] {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (isSensitiveFlag(a)) {
-      if (
-        !a.includes('=') &&
-        i + 1 < args.length &&
-        !args[i + 1].startsWith('-')
-      ) {
+      if (!a.includes('=') && i + 1 < args.length) {
         i++;
       }
       continue;

--- a/packages/cli/src/util/redact-args.ts
+++ b/packages/cli/src/util/redact-args.ts
@@ -1,0 +1,33 @@
+const SENSITIVE_AUTH_FLAG_NAMES = new Set(['--token', '-t']);
+
+/**
+ * Normalizes a flag token to just its flag name (e.g. "--token=abc" -> "--token").
+ */
+export function normalizeFlagName(flag: string): string {
+  if (flag.includes('=')) {
+    return flag.slice(0, flag.indexOf('='));
+  }
+  return flag;
+}
+
+/**
+ * Removes sensitive auth flags and their values from argv-like lists.
+ *
+ * Note: `--token`/`-t` are String flags and always consume the next argv token
+ * when passed without "=", even if that token starts with "-".
+ */
+export function stripSensitiveAuthArgs(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const name = normalizeFlagName(arg);
+    if (SENSITIVE_AUTH_FLAG_NAMES.has(name)) {
+      if (!arg.includes('=') && i + 1 < args.length) {
+        i++;
+      }
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}

--- a/packages/cli/test/unit/commands/tokens/add.test.ts
+++ b/packages/cli/test/unit/commands/tokens/add.test.ts
@@ -101,7 +101,7 @@ describe('tokens add', () => {
         'add',
         'my-token',
         '--token',
-        'secret-token',
+        '-secret-token',
         '--non-interactive'
       );
 
@@ -136,7 +136,7 @@ describe('tokens add', () => {
         payload.next.every(
           (n: { command?: string }) =>
             !String(n.command).includes('--token') &&
-            !String(n.command).includes('secret-token')
+            !String(n.command).includes('-secret-token')
         )
       ).toBe(true);
     });

--- a/packages/cli/test/unit/commands/tokens/add.test.ts
+++ b/packages/cli/test/unit/commands/tokens/add.test.ts
@@ -157,7 +157,14 @@ describe('tokens add', () => {
       });
 
       client.nonInteractive = true;
-      client.setArgv('tokens', 'add', 'my-token', '--non-interactive');
+      client.setArgv(
+        'tokens',
+        'add',
+        'my-token',
+        '--token',
+        '-secret-token',
+        '--non-interactive'
+      );
 
       await expect(tokens(client)).rejects.toThrow('exit:1');
 
@@ -169,6 +176,13 @@ describe('tokens add', () => {
         verification_uri: 'https://vercel.com/account/tokens',
       });
       expect(payload.message).toContain('authenticated to scope');
+      expect(
+        payload.next.every(
+          (n: { command?: string }) =>
+            !String(n.command).includes('--token') &&
+            !String(n.command).includes('-secret-token')
+        )
+      ).toBe(true);
     });
   });
 });

--- a/packages/cli/test/unit/commands/tokens/add.test.ts
+++ b/packages/cli/test/unit/commands/tokens/add.test.ts
@@ -96,7 +96,14 @@ describe('tokens add', () => {
       });
 
       client.nonInteractive = true;
-      client.setArgv('tokens', 'add', 'my-token', '--non-interactive');
+      client.setArgv(
+        'tokens',
+        'add',
+        'my-token',
+        '--token',
+        'secret-token',
+        '--non-interactive'
+      );
 
       await expect(tokens(client)).rejects.toThrow('exit:1');
 
@@ -118,6 +125,18 @@ describe('tokens add', () => {
           (n: { command?: string }) =>
             String(n.command).includes('VERCEL_TOKEN') &&
             String(n.command).includes('<class_access_token>')
+        )
+      ).toBe(true);
+      expect(
+        payload.next.some((n: { command?: string }) =>
+          String(n.command).includes('tokens add my-token')
+        )
+      ).toBe(true);
+      expect(
+        payload.next.every(
+          (n: { command?: string }) =>
+            !String(n.command).includes('--token') &&
+            !String(n.command).includes('secret-token')
         )
       ).toBe(true);
     });

--- a/packages/cli/test/unit/util/agent-output.test.ts
+++ b/packages/cli/test/unit/util/agent-output.test.ts
@@ -237,6 +237,11 @@ describe('buildCommandWithYes', () => {
     expect(buildCommandWithYes(argv)).toBe('vercel deploy --yes');
   });
 
+  it('removes bare --token value even when it starts with a dash', () => {
+    const argv = ['/node', '/vc.js', 'deploy', '--token', '-secret-token'];
+    expect(buildCommandWithYes(argv)).toBe('vercel deploy --yes');
+  });
+
   it('removes --token=<value> from suggested command', () => {
     const argv = ['/node', '/vc.js', 'deploy', '--token=secret-token'];
     expect(buildCommandWithYes(argv)).toBe('vercel deploy --yes');
@@ -302,6 +307,13 @@ describe('buildCommandWithScope', () => {
       'secret-token',
       '--yes',
     ];
+    expect(buildCommandWithScope(argv, 'new-team')).toBe(
+      'vercel deploy --yes --scope new-team'
+    );
+  });
+
+  it('strips shorthand token value when it starts with a dash', () => {
+    const argv = ['/node', '/vc.js', 'deploy', '-t', '-secret-token', '--yes'];
     expect(buildCommandWithScope(argv, 'new-team')).toBe(
       'vercel deploy --yes --scope new-team'
     );

--- a/packages/cli/test/unit/util/agent-output.test.ts
+++ b/packages/cli/test/unit/util/agent-output.test.ts
@@ -231,6 +231,16 @@ describe('buildCommandWithYes', () => {
     const argv = ['/node', '/vc.js', 'deploy', '-y'];
     expect(buildCommandWithYes(argv)).toBe('vercel deploy -y');
   });
+
+  it('removes --token from suggested command', () => {
+    const argv = ['/node', '/vc.js', 'deploy', '--token', 'secret-token'];
+    expect(buildCommandWithYes(argv)).toBe('vercel deploy --yes');
+  });
+
+  it('removes --token=<value> from suggested command', () => {
+    const argv = ['/node', '/vc.js', 'deploy', '--token=secret-token'];
+    expect(buildCommandWithYes(argv)).toBe('vercel deploy --yes');
+  });
 });
 
 describe('buildCommandWithScope', () => {
@@ -280,6 +290,20 @@ describe('buildCommandWithScope', () => {
     const argv = ['/node', '/vc.js', 'deploy', '-T', 'old-team'];
     expect(buildCommandWithScope(argv, 'new-team')).toBe(
       'vercel deploy --scope new-team'
+    );
+  });
+
+  it('strips token flags before adding scope', () => {
+    const argv = [
+      '/node',
+      '/vc.js',
+      'deploy',
+      '--token',
+      'secret-token',
+      '--yes',
+    ];
+    expect(buildCommandWithScope(argv, 'new-team')).toBe(
+      'vercel deploy --yes --scope new-team'
     );
   });
 });
@@ -658,6 +682,20 @@ describe('getGlobalFlagsFromArgv', () => {
         '--name',
         'display-name',
         '--cwd=/tmp/proj',
+        '--non-interactive',
+      ])
+    ).toEqual(['--cwd=/tmp/proj', '--non-interactive']);
+  });
+
+  it('never includes token flags from argv', () => {
+    expect(
+      getGlobalFlagsFromArgv([
+        'node',
+        'vc.js',
+        'deploy',
+        '--cwd=/tmp/proj',
+        '--token',
+        'secret-token',
         '--non-interactive',
       ])
     ).toEqual(['--cwd=/tmp/proj', '--non-interactive']);

--- a/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
+++ b/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
@@ -41,6 +41,12 @@ describe('getSameSubcommandSuggestionFlags', () => {
     const out = getSameSubcommandSuggestionFlags(args);
     expect(out).toEqual(['--slug', 'acme', '--yes']);
   });
+
+  it('strips bare --token values that start with a dash', () => {
+    const args = ['--slug', 'acme', '--token', '-secret-token', '--yes'];
+    const out = getSameSubcommandSuggestionFlags(args);
+    expect(out).toEqual(['--slug', 'acme', '--yes']);
+  });
 });
 
 describe('getGlobalFlagsOnlyFromArgs', () => {
@@ -67,5 +73,11 @@ describe('getGlobalFlagsOnlyFromArgs', () => {
     ];
     const out = getGlobalFlagsOnlyFromArgs(afterAdd);
     expect(out).toEqual(['--cwd', '/tmp', '--non-interactive']);
+  });
+
+  it('strips shorthand -t values that start with a dash', () => {
+    const afterAdd = ['--cwd', '/tmp', '-t', '-secret-token', '--yes'];
+    const out = getGlobalFlagsOnlyFromArgs(afterAdd);
+    expect(out).toEqual(['--cwd', '/tmp']);
   });
 });

--- a/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
+++ b/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
@@ -66,6 +66,6 @@ describe('getGlobalFlagsOnlyFromArgs', () => {
       '--yes',
     ];
     const out = getGlobalFlagsOnlyFromArgs(afterAdd);
-    expect(out).toEqual(['--cwd', '/tmp', '--non-interactive', '--yes']);
+    expect(out).toEqual(['--cwd', '/tmp', '--non-interactive']);
   });
 });

--- a/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
+++ b/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
@@ -28,6 +28,19 @@ describe('getSameSubcommandSuggestionFlags', () => {
     const out = getSameSubcommandSuggestionFlags(args);
     expect(out).toEqual(['--status', '301', '--yes']);
   });
+
+  it('strips token flags and values', () => {
+    const args = [
+      '--slug',
+      'acme',
+      '--token',
+      'secret-token',
+      '-t=other-secret',
+      '--yes',
+    ];
+    const out = getSameSubcommandSuggestionFlags(args);
+    expect(out).toEqual(['--slug', 'acme', '--yes']);
+  });
 });
 
 describe('getGlobalFlagsOnlyFromArgs', () => {
@@ -40,5 +53,19 @@ describe('getGlobalFlagsOnlyFromArgs', () => {
     expect(out).not.toContain('acme');
     expect(out).not.toContain('--status');
     expect(out).not.toContain('301');
+  });
+
+  it('strips token flags from preserved globals', () => {
+    const afterAdd = [
+      '--cwd',
+      '/tmp',
+      '--non-interactive',
+      '--token',
+      'secret-token',
+      '-t=other-secret',
+      '--yes',
+    ];
+    const out = getGlobalFlagsOnlyFromArgs(afterAdd);
+    expect(out).toEqual(['--cwd', '/tmp', '--non-interactive', '--yes']);
   });
 });


### PR DESCRIPTION
## Summary
- strip `--token` / `-t` arguments (including `--token=<value>`) from all non-interactive command suggestion builders in `agent-output`
- stop treating `--token` as a preserved global flag for `next.command` generation
- add unit tests that assert suggested commands never include token flags

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] pre-commit hooks (`lint-staged`, biome format/lint) on commit
- [ ] `pnpm --filter vercel test -- test/unit/util/agent-output.test.ts` *(fails in this checkout due existing vitest/jest mismatch in this file path)*
- [ ] `pnpm --filter vercel vitest-run test/unit/util/agent-output.test.ts` *(fails in this checkout due unresolved workspace package entry during vite import analysis)*

Made with [Cursor](https://cursor.com)