### PR TITLE
Print project OIDC token to stdout

### DIFF
--- a/.changeset/project-token-stdout.md
+++ b/.changeset/project-token-stdout.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Print project OIDC tokens to stdout for shell command substitution.

--- a/packages/cli/src/commands/project/token.ts
+++ b/packages/cli/src/commands/project/token.ts
@@ -52,8 +52,7 @@ export default async function getOidcToken(client: Client, argv: string[]) {
         },
       }
     );
-    output.print(res.token);
-    output.print('\n');
+    client.stdout.write(`${res.token}\n`);
     return 0;
   } catch (err: unknown) {
     if (isAPIError(err) && err.status === 404) {

--- a/packages/cli/test/unit/commands/project/token.test.ts
+++ b/packages/cli/test/unit/commands/project/token.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import project from '../../../../src/commands/project';
+import { client } from '../../../mocks/client';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useUser } from '../../../mocks/user';
+
+vi.mock('../../../../src/util/agent/auto-install-agentic', () => ({
+  autoInstallVercelPlugin: vi.fn(),
+}));
+
+describe('project token', () => {
+  it('prints the OIDC token to stdout for a named project', async () => {
+    useUser();
+    useProject(defaultProject);
+    const token = 'oidc-token-for-command-substitution';
+    let requestBody: unknown;
+
+    client.scenario.post(`/projects/${defaultProject.id}/token`, (req, res) => {
+      requestBody = req.body;
+      res.json({ token });
+    });
+
+    client.setArgv('project', 'token', defaultProject.name!);
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe(`${token}\n`);
+    expect(client.stderr.getFullOutput()).not.toContain(token);
+    expect(requestBody).toEqual({ source: 'vercel-cli' });
+  });
+
+  it('prints API errors to stderr without writing a token to stdout', async () => {
+    useUser();
+    useProject(defaultProject);
+
+    client.scenario.post(
+      `/projects/${defaultProject.id}/token`,
+      (_req, res) => {
+        res.status(403).json({
+          error: {
+            code: 'forbidden',
+            message: 'Project token generation is forbidden.',
+          },
+        });
+      }
+    );
+
+    client.setArgv('project', 'token', defaultProject.name!);
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stdout.getFullOutput()).toBe('');
+    expect(client.stderr.getFullOutput()).toContain(
+      'Project token generation is forbidden.'
+    );
+  });
+});


### PR DESCRIPTION
Prints `vc project token <project>` output to stdout so shell command substitution works without redirecting stderr.

Example:
`VERCEL_OIDC_TOKEN=$(vc project token <project>) some-command`