### PR TITLE
[ci] post pending Summary (e2e) status to PR at start of run

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -38,6 +38,11 @@ jobs:
       totalCount: ${{ steps['affected-packages'].outputs['total'] }}
       allPackages: ${{ steps['affected-packages'].outputs['allPackages'] }}
     steps:
+      # The `context` here MUST exactly match the one written by the
+      # `Report status to PR commit` step in the `summary` job below.
+      # GitHub commit statuses are upserted by `(sha, context)`, so a
+      # mismatch would create a second row instead of overwriting this
+      # pending one with the final result.
       - name: Post pending Summary (e2e) status to PR commit
         if: ${{ github.event.client_payload.git.sha }}
         uses: actions/github-script@v7
@@ -260,6 +265,10 @@ jobs:
             fi
           done
           echo "state=success" >> $GITHUB_OUTPUT
+      # The `context` here MUST exactly match the one written by the
+      # `Post pending Summary (e2e) status to PR commit` step in the
+      # `setup` job above so this final write overwrites that pending
+      # row instead of creating a duplicate.
       - name: Report status to PR commit
         if: ${{ always() && github.event.client_payload.git.sha }}
         uses: actions/github-script@v7

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -24,6 +24,8 @@ jobs:
     name: Find Changes
     if: github.event.client_payload.environment == 'preview'
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     outputs:
       tests: ${{ steps['set-tests'].outputs['tests'] }}
       dplUrl: ${{ github.event.client_payload.url }}
@@ -36,6 +38,20 @@ jobs:
       totalCount: ${{ steps['affected-packages'].outputs['total'] }}
       allPackages: ${{ steps['affected-packages'].outputs['allPackages'] }}
     steps:
+      - name: Post pending Summary (e2e) status to PR commit
+        if: ${{ github.event.client_payload.git.sha }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.client_payload.git.sha }}',
+              state: 'pending',
+              context: 'Summary (e2e)',
+              target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`,
+              description: 'E2E tests in progress',
+            });
       - name: Resolve PR context
         id: pr-context
         env:


### PR DESCRIPTION
## Summary

Replaces the **non-clickable** `Summary (e2e) — Expected — Waiting for status to be reported` placeholder on PR Checks with a **clickable** 🟡 `Summary (e2e) — E2E tests in progress` row that links to the in-flight workflow run.

Same row, same context, same required-check gating — just appears at the start of the run instead of only at the end.

### How

Posts a `state: pending` commit status from the start of the `setup` job in `test-e2e.yml`. The existing end-of-run write in `summary` overwrites it with the final ✅/❌ state.

## Test plan
- Open a follow-up PR that produces a Vercel preview deployment.
- Verify the PR Checks panel shows a clickable 🟡 `Summary (e2e)` row shortly after dispatch fires.
- Verify it transitions to ✅/❌ when `summary` completes.