### PR TITLE
[cli] validate pending Summary (e2e) PR status

### DIFF
--- a/.changeset/validate-pending-e2e-status.md
+++ b/.changeset/validate-pending-e2e-status.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] dummy change to validate pending Summary (e2e) PR status (no functional change)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,6 +8,8 @@
 
 [Join the Vercel Community](https://community.vercel.com/)
 
+<!-- ci: dummy change to validate pending Summary (e2e) status appears on PR -->
+
 ## Usage
 
 Vercel's frontend cloud gives developers frameworks, workflows, and infrastructure to build a faster, more personalized web.


### PR DESCRIPTION
## Summary

Dummy PR to validate that PR #16123 works as intended: a clickable 🟡 `Summary (e2e)` row should appear on the Checks panel shortly after the workflow run dispatches, transitioning to ✅/❌ at the end.

Will not be merged.