### PR TITLE
fix(node): replace url.parse() with WHATWG URL API to silence DEP0169 warning

### DIFF
--- a/.changeset/fix-node-url-parse-dep0169.md
+++ b/.changeset/fix-node-url-parse-dep0169.md
@@ -1,0 +1,5 @@
+---
+"@vercel/node": patch
+---
+
+fix(node): replace deprecated `url.parse()` with WHATWG URL API to silence DEP0169 deprecation warning on cold starts

--- a/packages/node/src/serverless-functions/helpers.ts
+++ b/packages/node/src/serverless-functions/helpers.ts
@@ -66,9 +66,9 @@ export function getBodyParser(body: Buffer, contentType: string | undefined) {
   };
 }
 
-function getQueryParser({ url = '/', headers }: IncomingMessage) {
+function getQueryParser({ url = '/' }: IncomingMessage) {
   return function parseQuery(): VercelRequestQuery {
-    const urlObj = new URL(url, `http://${headers?.host ?? 'localhost'}`);
+    const urlObj = new URL(url, 'http://localhost');
     const query: VercelRequestQuery = {};
     urlObj.searchParams.forEach((value, key) => {
       const existing = query[key];

--- a/packages/node/src/serverless-functions/helpers.ts
+++ b/packages/node/src/serverless-functions/helpers.ts
@@ -1,7 +1,6 @@
 import type { ServerResponse, IncomingMessage } from 'http';
 import { serializeBody } from '../utils';
 import { PassThrough } from 'stream';
-import { parse as parseURL } from 'url';
 import { parse as parseContentType } from 'content-type';
 import { parse as parseQS } from 'querystring';
 import etag from 'etag';
@@ -67,9 +66,21 @@ export function getBodyParser(body: Buffer, contentType: string | undefined) {
   };
 }
 
-function getQueryParser({ url = '/' }: IncomingMessage) {
+function getQueryParser({ url = '/', headers }: IncomingMessage) {
   return function parseQuery(): VercelRequestQuery {
-    return parseURL(url, true).query as VercelRequestQuery;
+    const urlObj = new URL(url, `http://${headers?.host ?? 'localhost'}`);
+    const query: VercelRequestQuery = {};
+    urlObj.searchParams.forEach((value, key) => {
+      const existing = query[key];
+      if (existing !== undefined) {
+        query[key] = Array.isArray(existing)
+          ? [...existing, value]
+          : [existing, value];
+      } else {
+        query[key] = value;
+      }
+    });
+    return query;
   };
 }
 

--- a/packages/node/src/start-dev-server.ts
+++ b/packages/node/src/start-dev-server.ts
@@ -1,4 +1,3 @@
-import url from 'url';
 import { createRequire } from 'module';
 import { promises as fsp } from 'fs';
 import { join, dirname, extname } from 'path';
@@ -134,11 +133,8 @@ export const startDevServer: StartDevServer = async opts => {
     // Middleware is a catch-all for all paths unless a `matcher` property is defined
     const matchers = new RegExp(getRegExpFromMatchers(staticConfig?.matcher));
 
-    const parsed = url.parse(meta.requestUrl, true);
-    if (
-      typeof parsed.pathname !== 'string' ||
-      !matchers.test(parsed.pathname)
-    ) {
+    const parsed = new URL(meta.requestUrl, 'http://localhost');
+    if (!matchers.test(parsed.pathname)) {
       // If the "matchers" doesn't say to handle this
       // path then skip middleware invocation
       return null;


### PR DESCRIPTION
## Summary

The Vercel Node.js serverless runtime was calling the deprecated `url.parse()` function, causing a `DEP0169` deprecation warning at `level:error` on every cold start. This warning cannot be silenced from user code.

## Changes

- **`packages/node/src/serverless-functions/helpers.ts`**: Replace `url.parse(url, true).query` with WHATWG `URL` API (`new URL(url, `http://${host}`)` + `searchParams`). Multi-value query params are correctly preserved as arrays.
- **`packages/node/src/start-dev-server.ts`**: Replace `url.parse(meta.requestUrl, true).pathname` with `new URL(meta.requestUrl, 'http://localhost').pathname`.

## Testing

Built successfully (`pnpm --filter @vercel/node run build` exits 0). Lint passes via pre-commit hook.

Fixes #16109