### PR TITLE
chore(ci): update changesets to enable signed commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,11 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@d4c53c294341eec8a419ec2d1927138bfdeec234
         with:
           version: pnpm ci:version
           publish: pnpm ci:publish # npm publish
+          commitMode: "github-api" # allows release commits and tags to be signed using $GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
Updated changesets action version and added commit mode for signed releases.

See PR here https://github.com/changesets/action/pull/391