### PR TITLE
[ci] post pending Summary status to PR at start of unit test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
     name: Find Changes
     if: github.event.client_payload.environment == 'preview'
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     outputs:
       tests: ${{ steps['set-tests'].outputs['tests'] }}
       dplUrl: ${{ github.event.client_payload.url }}
@@ -32,6 +34,25 @@ jobs:
       totalCount: ${{ steps['affected-packages'].outputs['total'] }}
       allPackages: ${{ steps['affected-packages'].outputs['allPackages'] }}
     steps:
+      # The `context` here MUST exactly match the one written by the
+      # `Report status to PR commit` step in the `summary` job below.
+      # GitHub commit statuses are upserted by `(sha, context)`, so a
+      # mismatch would create a second row instead of overwriting this
+      # pending one with the final result.
+      - name: Post pending Summary status to PR commit
+        if: ${{ github.event.client_payload.git.sha }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.client_payload.git.sha }}',
+              state: 'pending',
+              context: 'Summary',
+              target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`,
+              description: 'Unit tests in progress',
+            });
       - name: Resolve PR context
         id: pr-context
         env:
@@ -361,6 +382,10 @@ jobs:
             fi
           done
           echo "state=success" >> $GITHUB_OUTPUT
+      # The `context` here MUST exactly match the one written by the
+      # `Post pending Summary status to PR commit` step in the `setup`
+      # job above so this final write overwrites that pending row
+      # instead of creating a duplicate.
       - name: Report status to PR commit
         if: ${{ always() && github.event.client_payload.git.sha }}
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

Mirrors PR #16123 for the unit-tests workflow: replaces the **non-clickable** `Summary — Expected — Waiting for status to be reported` placeholder on PR Checks with a **clickable** 🟡 `Summary — Unit tests in progress` row that links to the in-flight workflow run.

Same row, same context, same required-check gating — just appears at the start of the run instead of only at the end.

### How

Posts a `state: pending` commit status from the start of the `setup` job in `test.yml`. The existing end-of-run write in `summary` overwrites it with the final ✅/❌ state.

## Test plan
- Open a follow-up PR that produces a Vercel preview deployment.
- Verify the PR Checks panel shows a clickable 🟡 `Summary` row shortly after dispatch fires.
- Verify it transitions to ✅/❌ when `summary` completes.