### PR TITLE
[cli] validate pending Summary (unit + e2e) PR status

### DIFF
--- a/.changeset/validate-pending-summary-status.md
+++ b/.changeset/validate-pending-summary-status.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] dummy change to validate pending Summary PR status (no functional change)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,6 +8,8 @@
 
 [Join the Vercel Community](https://community.vercel.com/)
 
+<!-- ci: dummy change to validate pending Summary unit status appears on PR -->
+
 ## Usage
 
 Vercel's frontend cloud gives developers frameworks, workflows, and infrastructure to build a faster, more personalized web.


### PR DESCRIPTION
## Summary

Dummy PR to validate that PR #16130 works as intended: a clickable 🟡 `Summary` row should appear on the Checks panel shortly after the unit-tests workflow run dispatches, transitioning to ✅/❌ at the end. (Same shape as `Summary (e2e)` from PR #16123.)

Will not be merged.