### PR TITLE
test(cli): fix windows and non-interactive token unit test regressions

### DIFF
--- a/.changeset/clever-gifts-decide.md
+++ b/.changeset/clever-gifts-decide.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve CLI unit test portability and argument fixture handling by replacing a POSIX-only `mkdir -p` call with Node's cross-platform `mkdirSync(..., { recursive: true })`, and by passing a token fixture as `--token=<value>` so values beginning with `-` are parsed correctly in non-interactive token tests.

--- a/packages/cli/test/unit/commands/tokens/add.test.ts
+++ b/packages/cli/test/unit/commands/tokens/add.test.ts
@@ -100,8 +100,7 @@ describe('tokens add', () => {
         'tokens',
         'add',
         'my-token',
-        '--token',
-        '-secret-token',
+        '--token=-secret-token',
         '--non-interactive'
       );
 
@@ -161,8 +160,7 @@ describe('tokens add', () => {
         'tokens',
         'add',
         'my-token',
-        '--token',
-        '-secret-token',
+        '--token=-secret-token',
         '--non-interactive'
       );
 

--- a/packages/cli/test/unit/util/git-helpers.test.ts
+++ b/packages/cli/test/unit/util/git-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeAll, afterAll } from 'vitest';
 import { execSync } from 'node:child_process';
 import {
   mkdtempSync,
+  mkdirSync,
   rmSync,
   writeFileSync,
   readFileSync,
@@ -90,7 +91,7 @@ describe('git-helpers', () => {
 
     it('getGitRootDirectory should return the repo root from a subdirectory', () => {
       const subDir = join(repoDir, 'subdir');
-      execSync(`mkdir -p "${subDir}"`);
+      mkdirSync(subDir, { recursive: true });
       const root = getGitRootDirectory({ cwd: subDir });
       expect(normalizePath(root)).toEqual(normalizePath(repoDir));
     });


### PR DESCRIPTION
## Summary
- replace shell-based `mkdir -p` with `mkdirSync(..., { recursive: true })` in `git-helpers` unit tests so Windows does not fail on POSIX flags
- update `tokens add` non-interactive tests to pass token fixtures via `--token=<value>` so values that start with `-` are not parsed as missing option arguments
- keep assertions validating that rerun guidance redacts `--token` and token values from agent output

## Test plan
- [x] `pnpm --dir packages/cli vitest-run --run test/unit/util/git-helpers.test.ts test/unit/commands/tokens/add.test.ts`

Made with [Cursor](https://cursor.com)