### PR TITLE
fix(ci/frameworks): verify demo public access via logs redirect

### DIFF
--- a/.changeset/fresh-carrots-fail.md
+++ b/.changeset/fresh-carrots-fail.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Fix the frameworks demo URL public-access test to check the public `/_logs` route instead of looking up alias hosts through the deployments API.

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { isString } from 'util';
 import nodeFetch from 'node-fetch';
-import { URL, URLSearchParams } from 'url';
+import { URL } from 'url';
 import frameworkList from '../src/frameworks';
 
 // bump timeout for Windows as network can be slower
@@ -206,14 +206,18 @@ const Schema = {
   },
 };
 
-async function getDeployment(host: string) {
-  const query = new URLSearchParams();
-  query.set('url', host);
-  const res = await nodeFetch(
-    `https://api.vercel.com/v11/deployments/get?${query}`
+async function isDemoPublic(demoUrl: string) {
+  const logsUrl = new URL('/_logs', demoUrl);
+  const res = await nodeFetch(logsUrl.toString(), {
+    redirect: 'manual',
+  });
+  const location = res.headers.get('location');
+
+  return (
+    res.status >= 300 &&
+    res.status < 400 &&
+    location === `https://vercel.com/deployments/${logsUrl.host}/logs`
   );
-  const body = await res.json();
-  return body;
 }
 
 describe('frameworks', () => {
@@ -315,10 +319,8 @@ describe('frameworks', () => {
       frameworkList
         .filter(f => typeof f.demo === 'string')
         .map(async f => {
-          const url = new URL(f.demo!);
-          const deployment = await getDeployment(url.hostname);
           assert.equal(
-            deployment.public,
+            await isDemoPublic(f.demo!),
             true,
             `Demo URL ${f.demo} is not "public". Disable "build logs and source protection" in project settings.`
           );


### PR DESCRIPTION
Stop relying on API access and query build logs endpoint directly to
check if a framework demo is public.
