### PR TITLE
ci: Lint workflows with zizmor, require 3rd party actions to be pinned

### DIFF
--- a/.changeset/khaki-pigs-fry.md
+++ b/.changeset/khaki-pigs-fry.md
@@ -1,0 +1,4 @@
+---
+---
+
+Lint github workflows with zizmor

--- a/.github/workflows/agentics-maintenance.yml
+++ b/.github/workflows/agentics-maintenance.yml
@@ -122,7 +122,7 @@ jobs:
             await main();
 
       - name: Install gh-aw
-        uses: github/gh-aw/actions/setup-cli@v0.57.2
+        uses: github/gh-aw/actions/setup-cli@32b3a711a9ee97d38e3989c90af0385aff0066a7 # v0.57.2
         with:
           version: v0.57.2
 

--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -1177,7 +1177,7 @@ jobs:
             await main();
       - name: Upload threat detection log
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: threat-detection.log
           path: /tmp/gh-aw/threat-detection/detection.log
@@ -1459,4 +1459,3 @@ jobs:
         with:
           key: memory-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
           path: /tmp/gh-aw/cache-memory
-

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
         id: auth
       - run: cargo publish
         working-directory: crates/vercel_runtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,8 @@ jobs:
           node-version: 24
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
-          toolchain: stable
           targets: wasm32-wasip2
 
       - name: Setup Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: 24
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16
+        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100.0
         with:
           toolchain: stable
           targets: wasm32-wasip2

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           node-version: 22
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16
+        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100.0
         with:
           toolchain: stable
           targets: wasm32-wasip2

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -77,9 +77,8 @@ jobs:
         with:
           node-version: 22
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
-          toolchain: stable
           targets: wasm32-wasip2
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -46,9 +46,8 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
-          toolchain: stable
           targets: wasm32-wasip2
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Run zizmor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: zizmor --collect=workflows --color=never .github/workflows/*.yml .github/workflows/*.yaml
+        run: zizmor --collect=workflows --color=never .github/workflows/
 
   summary:
     name: Summary (lint)

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -117,7 +117,9 @@ jobs:
               sys.exit(1)
           print("All actions/checkout steps have a 'ref' specified.")
       - name: Run zizmor
-        run: zizmor --collect=workflows --color=never .github/workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: zizmor --collect=workflows --color=never .github/workflows/*.yml .github/workflows/*.yaml
 
   summary:
     name: Summary (lint)

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install pyyaml
+      - run: python -m pip install pyyaml==6.0.3 zizmor==1.24.1
       - name: Enforce actions/checkout ref
         shell: python
         run: |
@@ -116,6 +116,8 @@ jobs:
               print("\n".join(errors))
               sys.exit(1)
           print("All actions/checkout steps have a 'ref' specified.")
+      - name: Run zizmor
+        run: zizmor --collect=workflows --color=never .github/workflows
 
   summary:
     name: Summary (lint)

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16
+        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100.0
         with:
           toolchain: stable
           targets: wasm32-wasip2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,7 +263,7 @@ jobs:
           node-version: ${{ matrix.nodeVersion }}
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # 2025-12-16
+        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100.0
         with:
           toolchain: stable
           targets: wasm32-wasip2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,9 +263,8 @@ jobs:
           node-version: ${{ matrix.nodeVersion }}
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
-          toolchain: stable
           targets: wasm32-wasip2
 
       # yarn 1.22.21 introduced a Corepack bug when running tests.

--- a/.github/workflows/update-sandbox.yml
+++ b/.github/workflows/update-sandbox.yml
@@ -95,7 +95,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         id: pr
         if: steps.git_status.outputs.changes_detected == 'true'
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,6 +3,9 @@ rules:
     disable: true
   excessive-permissions:
     disable: true
+  ref-version-mismatch:
+    ignore:
+      - ci-doctor.lock.yml
   template-injection:
     disable: true
   unpinned-uses:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+rules:
+  artipacked:
+    disable: true
+  excessive-permissions:
+    disable: true
+  template-injection:
+    disable: true
+  unpinned-uses:
+    config:
+      policies:
+        'actions/*': any


### PR DESCRIPTION
Actions are a massive supply-chain attack vector.  Require all
third-party (non-Github) actions to be pinned.  Enforce this via zizmor
in `lint-actions` job.
