### PR TITLE
[python/vercel-workers] support omitting deployment id

### DIFF
--- a/.changeset/bright-deployments-pin.md
+++ b/.changeset/bright-deployments-pin.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python-workers": patch
+---
+
+Align queue deployment pinning with the TypeScript SDK by distinguishing automatic pinning, explicit deployment IDs, and explicit unpinned sends.

--- a/python/vercel-workers/src/vercel/workers/celery/transport.py
+++ b/python/vercel-workers/src/vercel/workers/celery/transport.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from ..client import send
+from ..client import _DEPLOYMENT_ID_UNSET, _DeploymentIdOption, send
 from .utils import _extract_task_from_kombu_message, _parse_iso_datetime
 
 try:
@@ -50,7 +50,7 @@ class TransportConfig:
     base_url: str | None = None
     base_path: str | None = None
     retention_seconds: int | None = None
-    deployment_id: str | None = None
+    deployment_id: _DeploymentIdOption = _DEPLOYMENT_ID_UNSET
     timeout: float | None = 10.0
     include_raw_message: bool = False
     # Consumption defaults (serverless callback / local polling)
@@ -106,6 +106,8 @@ class TransportConfig:
         if isinstance(retention, int):
             cfg.retention_seconds = retention
 
+        if "deployment_id" in options and options.get("deployment_id") is None:
+            cfg.deployment_id = None
         deployment_id = options.get("deployment_id")
         if isinstance(deployment_id, str) and deployment_id:
             cfg.deployment_id = deployment_id

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -189,7 +189,7 @@ def _resolve_deployment_id(deployment_id: _DeploymentIdOption) -> str | None:
         "This usually means the code is running outside a Vercel deployment "
         "(for example during build or in a non-Vercel environment).\n\n"
         "To fix this, provide an explicit deployment_id when sending messages, "
-        'or explicitly opt out of deployment pinning with deployment_id=None.'
+        "or explicitly opt out of deployment pinning with deployment_id=None."
     )
 
 

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -163,7 +163,7 @@ def _is_untyped_payload_annotation(annotation: Any) -> bool:
 
 
 def _in_process_mode_enabled() -> bool:
-    return os.environ.get("VERCEL_WORKERS_IN_PROCESS") == "1"
+    return os.environ.get("VERCEL_WORKERS_IN_PROCESS") in {"1", "true", "TRUE", "yes", "YES"}
 
 
 def _deployment_pinning_disabled_for_dev() -> bool:

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -72,6 +72,14 @@ class MessageMetadata(TypedDict, total=False):
     consumer: str
 
 
+class _DeploymentIdUnset:
+    pass
+
+
+_DEPLOYMENT_ID_UNSET = _DeploymentIdUnset()
+type _DeploymentIdOption = str | None | _DeploymentIdUnset
+
+
 class Ack(Exception):
     """Directive that acknowledges a message without retrying it."""
 
@@ -152,6 +160,37 @@ _subscriptions: list[_Subscription] = []
 
 def _is_untyped_payload_annotation(annotation: Any) -> bool:
     return annotation is inspect.Signature.empty or annotation is Any
+
+
+def _in_process_mode_enabled() -> bool:
+    return os.environ.get("VERCEL_WORKERS_IN_PROCESS") == "1"
+
+
+def _deployment_pinning_disabled_for_dev() -> bool:
+    # `vercel dev` configures Python services with this local queue token. Match
+    # the TypeScript SDK behavior: deployment IDs are never sent in development.
+    return _in_process_mode_enabled() or os.environ.get("VERCEL_QUEUE_TOKEN") == "vc-dev-token"
+
+
+def _resolve_deployment_id(deployment_id: _DeploymentIdOption) -> str | None:
+    if _deployment_pinning_disabled_for_dev():
+        return None
+    if deployment_id is None:
+        return None
+    if isinstance(deployment_id, str):
+        return deployment_id or None
+
+    env_deployment_id = os.environ.get("VERCEL_DEPLOYMENT_ID")
+    if env_deployment_id:
+        return env_deployment_id
+
+    raise RuntimeError(
+        "No deployment ID available. VERCEL_DEPLOYMENT_ID is not set.\n\n"
+        "This usually means the code is running outside a Vercel deployment "
+        "(for example during build or in a non-Vercel environment).\n\n"
+        "To fix this, provide an explicit deployment_id when sending messages, "
+        'or explicitly opt out of deployment pinning with deployment_id=None.'
+    )
 
 
 def _build_invocation_plan(func: WorkerCallable) -> _InvocationPlan:
@@ -637,7 +676,7 @@ def send(
     idempotency_key: str | None = None,
     retention_seconds: int | None = None,
     delay_seconds: int | None = None,
-    deployment_id: str | None = None,
+    deployment_id: _DeploymentIdOption = _DEPLOYMENT_ID_UNSET,
     token: str | None = None,
     base_url: str | None = None,
     base_path: str | None = None,
@@ -663,7 +702,9 @@ def send(
         idempotency_key: Optional key to deduplicate submissions (``Vqs-Idempotency-Key`` header).
         retention_seconds: Optional message retention time in seconds (``Vqs-Retention-Seconds``).
         delay_seconds: Optional delay before the message becomes visible (``Vqs-Delay-Seconds``).
-        deployment_id: Optional deployment identifier (``Vqs-Deployment-Id``).
+        deployment_id: Deployment pinning mode. Omit to auto-detect ``VERCEL_DEPLOYMENT_ID``,
+            pass ``None`` to explicitly send without a deployment ID, or pass a string to pin
+            to a specific deployment.
         token: Authentication token. If omitted, falls back to ``VERCEL_QUEUE_TOKEN`` env var.
         base_url: Override base URL for the queue API. Defaults to ``VERCEL_QUEUE_BASE_URL`` or
             ``https://vercel-queue.com``.
@@ -680,7 +721,7 @@ def send(
     #
     # For an explicit in-process dev shortcut (no persistence / retries), set:
     #   VERCEL_WORKERS_IN_PROCESS=1
-    if os.environ.get("VERCEL_WORKERS_IN_PROCESS") in {"1", "true", "TRUE", "yes", "YES"}:
+    if _in_process_mode_enabled():
         return _send_in_process(queue_name, payload)
 
     resolved_base_url = (base_url or get_queue_base_url()).rstrip("/")
@@ -693,9 +734,9 @@ def send(
         "Content-Type": content_type,
     } | (headers or {})
 
-    deployment_id = deployment_id or os.environ.get("VERCEL_DEPLOYMENT_ID")
-    if deployment_id:
-        headers["Vqs-Deployment-Id"] = deployment_id
+    resolved_deployment_id = _resolve_deployment_id(deployment_id)
+    if resolved_deployment_id:
+        headers["Vqs-Deployment-Id"] = resolved_deployment_id
 
     if idempotency_key:
         headers["Vqs-Idempotency-Key"] = idempotency_key
@@ -767,7 +808,7 @@ async def send_async(
     idempotency_key: str | None = None,
     retention_seconds: int | None = None,
     delay_seconds: int | None = None,
-    deployment_id: str | None = None,
+    deployment_id: _DeploymentIdOption = _DEPLOYMENT_ID_UNSET,
     token: str | None = None,
     base_url: str | None = None,
     base_path: str | None = None,
@@ -786,7 +827,9 @@ async def send_async(
         idempotency_key: Optional key to deduplicate submissions (``Vqs-Idempotency-Key`` header).
         retention_seconds: Optional message retention time in seconds (``Vqs-Retention-Seconds``).
         delay_seconds: Optional delay before the message becomes visible (``Vqs-Delay-Seconds``).
-        deployment_id: Optional deployment identifier (``Vqs-Deployment-Id``).
+        deployment_id: Deployment pinning mode. Omit to auto-detect ``VERCEL_DEPLOYMENT_ID``,
+            pass ``None`` to explicitly send without a deployment ID, or pass a string to pin
+            to a specific deployment.
         token: Authentication token. If omitted, falls back to ``VERCEL_QUEUE_TOKEN`` env var.
         base_url: Override base URL for the queue API. Defaults to ``VERCEL_QUEUE_BASE_URL`` or
             ``https://vercel-queue.com``.
@@ -809,9 +852,9 @@ async def send_async(
         "Content-Type": content_type,
     } | (headers or {})
 
-    deployment_id = deployment_id or os.environ.get("VERCEL_DEPLOYMENT_ID")
-    if deployment_id:
-        headers["Vqs-Deployment-Id"] = deployment_id
+    resolved_deployment_id = _resolve_deployment_id(deployment_id)
+    if resolved_deployment_id:
+        headers["Vqs-Deployment-Id"] = resolved_deployment_id
 
     if idempotency_key:
         headers["Vqs-Idempotency-Key"] = idempotency_key

--- a/python/vercel-workers/src/vercel/workers/django/backend.py
+++ b/python/vercel-workers/src/vercel/workers/django/backend.py
@@ -10,7 +10,7 @@ from traceback import format_exception
 from typing import Any, TypedDict, cast
 from uuid import UUID
 
-from ..client import send, send_async
+from ..client import _DEPLOYMENT_ID_UNSET, _DeploymentIdOption, send, send_async
 
 try:
     from django.core.cache import caches  # type: ignore[import-untyped]
@@ -120,7 +120,7 @@ class VercelQueuesBackendOptions:
     base_url: str | None = None
     base_path: str | None = None
     retention_seconds: int | None = None
-    deployment_id: str | None = None
+    deployment_id: _DeploymentIdOption = _DEPLOYMENT_ID_UNSET
     timeout: float | None = 10.0
 
     # Result storage (Django cache).
@@ -144,6 +144,8 @@ class VercelQueuesBackendOptions:
         if isinstance(base_path, str) and base_path:
             cfg = replace(cfg, base_path=base_path)
 
+        if "deployment_id" in options and options.get("deployment_id") is None:
+            cfg = replace(cfg, deployment_id=None)
         deployment_id = options.get("deployment_id")
         if isinstance(deployment_id, str) and deployment_id:
             cfg = replace(cfg, deployment_id=deployment_id)

--- a/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from typing import Any
 
-from ..client import WorkerJSONEncoder, send
+from ..client import _DEPLOYMENT_ID_UNSET, WorkerJSONEncoder, _DeploymentIdOption, send
 
 try:
     import dramatiq
@@ -62,7 +62,7 @@ class VercelQueuesBrokerOptions:
     base_url: str | None = None
     base_path: str | None = None
     retention_seconds: int | None = None
-    deployment_id: str | None = None
+    deployment_id: _DeploymentIdOption = _DEPLOYMENT_ID_UNSET
     timeout: float | None = 10.0
 
     # Consumption defaults (serverless callback / local polling)
@@ -98,6 +98,8 @@ class VercelQueuesBrokerOptions:
         if isinstance(retention, int):
             cfg = replace(cfg, retention_seconds=retention)
 
+        if "deployment_id" in options and options.get("deployment_id") is None:
+            cfg = replace(cfg, deployment_id=None)
         deployment_id = options.get("deployment_id")
         if isinstance(deployment_id, str) and deployment_id:
             cfg = replace(cfg, deployment_id=deployment_id)

--- a/python/vercel-workers/tests/test_client_and_callback.py
+++ b/python/vercel-workers/tests/test_client_and_callback.py
@@ -42,6 +42,7 @@ class _FakeResponse:
 
 class _FakeHttpxClient:
     captured_bodies: list[bytes] = []
+    captured_headers: list[dict[str, str]] = []
 
     def __init__(self, *args, **kwargs):
         self.response = _FakeResponse()
@@ -60,8 +61,9 @@ class _FakeHttpxClient:
         url: str,  # noqa: ARG002
         *,
         content: bytes | None = None,
-        headers: dict | None = None,  # noqa: ARG002  # pyright: ignore[reportMissingTypeArgument]
+        headers: dict | None = None,  # pyright: ignore[reportMissingTypeArgument]
     ) -> _FakeResponse:
+        _FakeHttpxClient.captured_headers.append(dict(headers or {}))
         if content is not None:
             _FakeHttpxClient.captured_bodies.append(content)
         return self.response
@@ -375,6 +377,7 @@ class TestWorkerJSONEncoder(unittest.TestCase):
 class TestSendWithJSONEncoder(unittest.TestCase):
     def setUp(self) -> None:
         _FakeHttpxClient.captured_bodies.clear()
+        _FakeHttpxClient.captured_headers.clear()
 
     def _send(
         self,
@@ -386,7 +389,7 @@ class TestSendWithJSONEncoder(unittest.TestCase):
             patch.dict(queue_client.os.environ, {"VERCEL_QUEUE_TOKEN": "tok"}, clear=False),
             patch.object(queue_client.httpx, "Client", _FakeHttpxClient),
         ):
-            queue_client.send("q", payload, json_encoder=json_encoder)
+            queue_client.send("q", payload, deployment_id=None, json_encoder=json_encoder)
 
         return _FakeHttpxClient.captured_bodies[-1]
 
@@ -417,3 +420,91 @@ class TestSendWithJSONEncoder(unittest.TestCase):
         body = self._send({"tags": {3, 1, 2}}, json_encoder=_CustomEncoder)
         result = json.loads(body)
         self.assertEqual(result["tags"], [1, 2, 3])
+
+
+class TestDeploymentPinning(unittest.TestCase):
+    def setUp(self) -> None:
+        _FakeHttpxClient.captured_bodies.clear()
+        _FakeHttpxClient.captured_headers.clear()
+
+    def _send(self, **kwargs: Any) -> dict[str, str]:
+        with (
+            patch.dict(queue_client.os.environ, {"VERCEL_QUEUE_TOKEN": "tok"}, clear=True),
+            patch.object(queue_client.httpx, "Client", _FakeHttpxClient),
+        ):
+            queue_client.send("q", {"ok": True}, **kwargs)
+        return _FakeHttpxClient.captured_headers[-1]
+
+    def test_send_auto_pins_to_env_deployment_id(self) -> None:
+        with (
+            patch.dict(
+                queue_client.os.environ,
+                {
+                    "VERCEL_QUEUE_TOKEN": "tok",
+                    "VERCEL_DEPLOYMENT_ID": "dpl_env",
+                },
+                clear=True,
+            ),
+            patch.object(queue_client.httpx, "Client", _FakeHttpxClient),
+        ):
+            queue_client.send("q", {"ok": True})
+
+        self.assertEqual(_FakeHttpxClient.captured_headers[-1]["Vqs-Deployment-Id"], "dpl_env")
+
+    def test_send_none_explicitly_unpins_even_with_env_deployment_id(self) -> None:
+        with (
+            patch.dict(
+                queue_client.os.environ,
+                {
+                    "VERCEL_QUEUE_TOKEN": "tok",
+                    "VERCEL_DEPLOYMENT_ID": "dpl_env",
+                },
+                clear=True,
+            ),
+            patch.object(queue_client.httpx, "Client", _FakeHttpxClient),
+        ):
+            queue_client.send("q", {"ok": True}, deployment_id=None)
+
+        self.assertNotIn("Vqs-Deployment-Id", _FakeHttpxClient.captured_headers[-1])
+
+    def test_send_explicit_deployment_id_overrides_env(self) -> None:
+        with (
+            patch.dict(
+                queue_client.os.environ,
+                {
+                    "VERCEL_QUEUE_TOKEN": "tok",
+                    "VERCEL_DEPLOYMENT_ID": "dpl_env",
+                },
+                clear=True,
+            ),
+            patch.object(queue_client.httpx, "Client", _FakeHttpxClient),
+        ):
+            queue_client.send("q", {"ok": True}, deployment_id="dpl_explicit")
+
+        self.assertEqual(
+            _FakeHttpxClient.captured_headers[-1]["Vqs-Deployment-Id"],
+            "dpl_explicit",
+        )
+
+    def test_send_auto_requires_deployment_id_outside_dev(self) -> None:
+        with patch.dict(queue_client.os.environ, {"VERCEL_QUEUE_TOKEN": "tok"}, clear=True):
+            with self.assertRaises(RuntimeError) as err:
+                queue_client.send("q", {"ok": True})
+
+        self.assertIn("No deployment ID available", str(err.exception))
+
+    def test_send_dev_token_omits_deployment_id(self) -> None:
+        with (
+            patch.dict(
+                queue_client.os.environ,
+                {
+                    "VERCEL_QUEUE_TOKEN": "vc-dev-token",
+                    "VERCEL_DEPLOYMENT_ID": "dpl_env",
+                },
+                clear=True,
+            ),
+            patch.object(queue_client.httpx, "Client", _FakeHttpxClient),
+        ):
+            queue_client.send("q", {"ok": True})
+
+        self.assertNotIn("Vqs-Deployment-Id", _FakeHttpxClient.captured_headers[-1])

--- a/python/vercel-workers/tests/test_django_adapter.py
+++ b/python/vercel-workers/tests/test_django_adapter.py
@@ -163,7 +163,7 @@ class TestVercelQueuesBackendOptions(unittest.TestCase):
         self.assertIsNone(cfg.base_url)
         self.assertIsNone(cfg.base_path)
         self.assertIsNone(cfg.retention_seconds)
-        self.assertIsNone(cfg.deployment_id)
+        self.assertIs(cfg.deployment_id, client._DEPLOYMENT_ID_UNSET)
         self.assertEqual(cfg.timeout, 10.0)
         self.assertEqual(cfg.cache_alias, "default")
         self.assertEqual(cfg.cache_key_prefix, "vercel-workers:django-tasks")
@@ -739,7 +739,7 @@ class TestDjangoEnqueueSerializesNonPrimitiveTypes(unittest.TestCase):
         task = self._make_task()
 
         with (
-            patch.dict("os.environ", {"VERCEL_QUEUE_TOKEN": "tok"}),
+            patch.dict("os.environ", {"VERCEL_QUEUE_TOKEN": "tok", "VERCEL_DEPLOYMENT_ID": "dpl"}),
             patch.object(client.httpx, "Client", _FakeClient),
             patch.object(backend, "_store_result"),
         ):

--- a/python/vercel-workers/tests/test_dramatiq_adapter.py
+++ b/python/vercel-workers/tests/test_dramatiq_adapter.py
@@ -15,6 +15,7 @@ pytest.importorskip("dramatiq")
 import dramatiq
 from dramatiq.message import Message
 
+from vercel.workers import client
 from vercel.workers.dramatiq import (
     DramatiqWorkerConfig,
     PollingWorker,
@@ -36,7 +37,7 @@ class TestVercelQueuesBrokerOptions:
         assert opts.base_url is None
         assert opts.base_path is None
         assert opts.retention_seconds is None
-        assert opts.deployment_id is None
+        assert opts.deployment_id is client._DEPLOYMENT_ID_UNSET
         assert opts.timeout == 10.0
         assert opts.visibility_timeout_seconds == 30
         assert opts.visibility_refresh_interval_seconds == 10.0


### PR DESCRIPTION
The deployment ID header for per-deployment isolation is [optional](https://vercel.com/docs/queues/api#common-headers)

Adds an unset sentinel to enable the 3 separate behaviors:

```python
# Auto-pinned
send("q", payload)
# sends Vqs-Deployment-Id from VERCEL_DEPLOYMENT_ID

# Explicitly unpinned
send("q", payload, deployment_id=None)
# sends no Vqs-Deployment-Id header

# Explicit pin
send("q", payload, deployment_id="dpl_123")
# sends Vqs-Deployment-Id: dpl_123
```