### PR TITLE
[build-utils] Read fileHashes from .vc-config.json

### DIFF
--- a/.changeset/violet-donkeys-camp.md
+++ b/.changeset/violet-donkeys-camp.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Read fileHashes from .vc-config.json files (next to the existing filePathMap object).

--- a/packages/build-utils/src/deserialize/deserialize-build-output.ts
+++ b/packages/build-utils/src/deserialize/deserialize-build-output.ts
@@ -268,7 +268,12 @@ export async function deserializeBuildOutput<
         throw new Error(`Could not load function config: "${funcConfigPath}"`);
       }
 
-      const files = await glob('**', { cwd: fnDir, includeDirectories: true });
+      const files = await glob(
+        '**',
+        { cwd: fnDir, includeDirectories: true },
+        undefined,
+        funcConfig.fileHashes
+      );
       delete files['.vc-config.json'];
 
       if (funcConfig.type === 'EdgeFunction' || funcConfig.runtime === 'edge') {

--- a/packages/build-utils/src/deserialize/deserialize-build-output.ts
+++ b/packages/build-utils/src/deserialize/deserialize-build-output.ts
@@ -269,7 +269,12 @@ export async function deserializeBuildOutput<
         throw new Error(`Could not load function config: "${funcConfigPath}"`);
       }
 
-      const files = await glob('**', { cwd: fnDir, includeDirectories: true });
+      const files = await glob(
+        '**',
+        { cwd: fnDir, includeDirectories: true },
+        undefined,
+        funcConfig.fileHashes
+      );
       delete files['.vc-config.json'];
 
       if (funcConfig.type === 'EdgeFunction' || funcConfig.runtime === 'edge') {

--- a/packages/build-utils/src/deserialize/deserialize-edge-function.ts
+++ b/packages/build-utils/src/deserialize/deserialize-edge-function.ts
@@ -14,6 +14,7 @@ export async function deserializeEdgeFunction(
     await hydrateFilesMap(
       files,
       config.filePathMap,
+      config.fileHashes,
       repoRootPath,
       fileFsRefsCache
     );

--- a/packages/build-utils/src/deserialize/deserialize-lambda.ts
+++ b/packages/build-utils/src/deserialize/deserialize-lambda.ts
@@ -40,6 +40,7 @@ export async function deserializeLambda(
     await hydrateFilesMap(
       files,
       config.filePathMap,
+      config.fileHashes,
       repoRootPath,
       fileFsRefsCache
     );

--- a/packages/build-utils/src/deserialize/hydrate-files-map.ts
+++ b/packages/build-utils/src/deserialize/hydrate-files-map.ts
@@ -5,21 +5,27 @@ import { join } from 'path';
 export async function hydrateFilesMap(
   files: Files,
   filesMap: Record<string, string>,
+  fileHashes: Record<string, string> | undefined,
   repoRootPath: string,
   fileFsRefsCache: Map<string, FileFsRef>
 ) {
   for (const [funcPath, projectPath] of Object.entries(filesMap)) {
     files[funcPath] = await fileFsRefCached(
       join(repoRootPath, projectPath),
+      fileHashes?.[funcPath],
       fileFsRefsCache
     );
   }
 }
 
-async function fileFsRefCached(fsPath: string, cache: Map<string, FileFsRef>) {
+async function fileFsRefCached(
+  fsPath: string,
+  contentHash: string | undefined,
+  cache: Map<string, FileFsRef>
+) {
   let file = cache.get(fsPath);
   if (!file) {
-    file = await FileFsRef.fromFsPath({ fsPath });
+    file = await FileFsRef.fromFsPath({ fsPath, contentHash });
     cache.set(fsPath, file);
   }
   return file;

--- a/packages/build-utils/src/deserialize/serialized-types.ts
+++ b/packages/build-utils/src/deserialize/serialized-types.ts
@@ -15,6 +15,7 @@ export type Properties<T> = {
 
 type FilesMapProp = {
   filePathMap?: Record<string, string>;
+  fileHashes?: Record<string, string>;
 };
 
 /**

--- a/packages/build-utils/src/deserialize/serialized-types.ts
+++ b/packages/build-utils/src/deserialize/serialized-types.ts
@@ -16,6 +16,7 @@ export type Properties<T> = {
 
 type FilesMapProp = {
   filePathMap?: Record<string, string>;
+  fileHashes?: Record<string, string>;
 };
 
 /**

--- a/packages/build-utils/src/file-blob.ts
+++ b/packages/build-utils/src/file-blob.ts
@@ -6,6 +6,7 @@ interface FileBlobOptions {
   mode?: number;
   contentType?: string;
   data: string | Buffer;
+  contentHash?: string;
 }
 
 interface FromStreamOptions {
@@ -19,14 +20,21 @@ export default class FileBlob implements FileBase {
   public mode: number;
   public data: string | Buffer;
   public contentType: string | undefined;
+  public contentHash?: string;
 
-  constructor({ mode = 0o100644, contentType, data }: FileBlobOptions) {
+  constructor({
+    mode = 0o100644,
+    contentType,
+    data,
+    contentHash,
+  }: FileBlobOptions) {
     assert(typeof mode === 'number');
     assert(typeof data === 'string' || Buffer.isBuffer(data));
     this.type = 'FileBlob';
     this.mode = mode;
     this.contentType = contentType;
     this.data = data;
+    this.contentHash = contentHash;
   }
 
   static async fromStream({

--- a/packages/build-utils/src/file-fs-ref.ts
+++ b/packages/build-utils/src/file-fs-ref.ts
@@ -12,6 +12,7 @@ interface FileFsRefOptions {
   contentType?: string;
   fsPath: string;
   size?: number;
+  contentHash?: string;
 }
 
 interface FromStreamOptions {
@@ -27,12 +28,14 @@ class FileFsRef implements FileBase {
   public fsPath: string;
   public size?: number;
   public contentType: string | undefined;
+  public contentHash?: string;
 
   constructor({
     mode = 0o100644,
     contentType,
     fsPath,
     size,
+    contentHash,
   }: FileFsRefOptions) {
     assert(typeof mode === 'number');
     assert(typeof fsPath === 'string');
@@ -41,6 +44,7 @@ class FileFsRef implements FileBase {
     this.contentType = contentType;
     this.fsPath = fsPath;
     this.size = size;
+    this.contentHash = contentHash;
   }
 
   static async fromFsPath({
@@ -48,6 +52,7 @@ class FileFsRef implements FileBase {
     contentType,
     fsPath,
     size,
+    contentHash,
   }: FileFsRefOptions): Promise<FileFsRef> {
     let m = mode;
     let s = size;
@@ -56,7 +61,13 @@ class FileFsRef implements FileBase {
       m = stat.mode;
       s = stat.size;
     }
-    return new FileFsRef({ mode: m, contentType, fsPath, size: s });
+    return new FileFsRef({
+      mode: m,
+      contentType,
+      fsPath,
+      size: s,
+      contentHash,
+    });
   }
 
   static async fromStream({

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -10,6 +10,7 @@ interface FileRefOptions {
   digest: string;
   contentType?: string;
   mutable?: boolean;
+  contentHash?: string;
 }
 
 const semaToDownloadFromS3 = new Sema(5);
@@ -29,12 +30,14 @@ export default class FileRef implements FileBase {
   public digest: string;
   public contentType: string | undefined;
   private mutable: boolean;
+  public contentHash?: string;
 
   constructor({
     mode = 0o100644,
     digest,
     contentType,
     mutable = false,
+    contentHash,
   }: FileRefOptions) {
     assert(typeof mode === 'number');
     assert(typeof digest === 'string');
@@ -43,6 +46,7 @@ export default class FileRef implements FileBase {
     this.digest = digest;
     this.contentType = contentType;
     this.mutable = mutable;
+    this.contentHash = contentHash;
   }
 
   /**

--- a/packages/build-utils/src/finalize-lambda.ts
+++ b/packages/build-utils/src/finalize-lambda.ts
@@ -32,6 +32,8 @@ export interface CreateZipResult {
   digest: string;
   /** Compressed size in bytes. */
   size: number;
+  /** Number of files in the lambda. */
+  fileCount: number;
 }
 
 /**
@@ -64,6 +66,7 @@ export interface FinalizeLambdaParams {
     buffer: Buffer | null;
     zipPath?: string;
     size: number;
+    fileCount: number;
   }) => void;
 }
 
@@ -76,6 +79,8 @@ export interface FinalizeLambdaResult {
   digest: string;
   /** Compressed size in bytes. */
   size: number;
+  /** Number of files in the lambda. */
+  fileCount: number;
   uncompressedBytes: number;
   /** Non-fatal streaming detection error, if any. Caller decides how to log. */
   streamingError?: SupportsStreamingResult['error'];
@@ -158,6 +163,7 @@ export async function finalizeLambda(
       buffer,
       digest: '', // computed in step 5
       size: buffer.byteLength,
+      fileCount: Object.keys(lambda.files ?? {}).length,
     };
   }
 
@@ -167,6 +173,7 @@ export async function finalizeLambda(
       buffer: zipResult.buffer,
       zipPath: zipResult.zipPath,
       size: zipResult.size,
+      fileCount: zipResult.fileCount,
     });
   }
 
@@ -197,6 +204,7 @@ export async function finalizeLambda(
     zipPath: zipResult.zipPath ?? null,
     digest: zipResult.digest,
     size: zipResult.size,
+    fileCount: zipResult.fileCount,
     uncompressedBytes,
     streamingError: streamingResult.error,
   };

--- a/packages/build-utils/src/finalize-lambda.ts
+++ b/packages/build-utils/src/finalize-lambda.ts
@@ -31,6 +31,8 @@ export interface CreateZipResult {
   digest: string;
   /** Compressed size in bytes. */
   size: number;
+  /** Number of files in the lambda. */
+  fileCount: number;
 }
 
 /**
@@ -63,6 +65,7 @@ export interface FinalizeLambdaParams {
     buffer: Buffer | null;
     zipPath?: string;
     size: number;
+    fileCount: number;
   }) => void;
 }
 
@@ -75,6 +78,8 @@ export interface FinalizeLambdaResult {
   digest: string;
   /** Compressed size in bytes. */
   size: number;
+  /** Number of files in the lambda. */
+  fileCount: number;
   uncompressedBytes: number;
 }
 
@@ -155,6 +160,7 @@ export async function finalizeLambda(
       buffer,
       digest: '', // computed in step 5
       size: buffer.byteLength,
+      fileCount: Object.keys(lambda.files ?? {}).length,
     };
   }
 
@@ -164,6 +170,7 @@ export async function finalizeLambda(
       buffer: zipResult.buffer,
       zipPath: zipResult.zipPath,
       size: zipResult.size,
+      fileCount: zipResult.fileCount,
     });
   }
 
@@ -194,6 +201,7 @@ export async function finalizeLambda(
     zipPath: zipResult.zipPath ?? null,
     digest: zipResult.digest,
     size: zipResult.size,
+    fileCount: zipResult.fileCount,
     uncompressedBytes,
   };
 }

--- a/packages/build-utils/src/fs/glob.ts
+++ b/packages/build-utils/src/fs/glob.ts
@@ -20,7 +20,8 @@ const vanillaGlob = promisify(vanillaGlob_);
 export default async function glob(
   pattern: string,
   opts: GlobOptions | string,
-  mountpoint?: string
+  mountpoint?: string,
+  fileHashes?: Record<string, string>
 ): Promise<Record<string, FileFsRef>> {
   const options = typeof opts === 'string' ? { cwd: opts } : opts;
 
@@ -92,7 +93,11 @@ export default async function glob(
         finalPath = path.join(mountpoint, finalPath);
       }
 
-      results[finalPath] = new FileFsRef({ mode: stat.mode, fsPath });
+      results[finalPath] = new FileFsRef({
+        mode: stat.mode,
+        fsPath,
+        contentHash: fileHashes?.[relativePath],
+      });
     }
   }
 

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -473,6 +473,13 @@ export class Lambda {
       throw new Error('`files` is not defined');
     }
 
+    // Preflight check to ensure all files have content hashes before sorting and concatenating.
+    for (const name in this.files) {
+      if (!this.files[name].contentHash) {
+        return undefined;
+      }
+    }
+
     // It's slightly faster to concat and hash the string as opposed to calling update() repeatedly:
     // 2000 ops/s vs 1850 ops/s. This is likely because it results in fewer calls into the native
     // crypto code.
@@ -480,10 +487,7 @@ export class Lambda {
 
     const names = Object.keys(this.files).sort();
     for (const name of names) {
-      const contentHash = this.files[name].contentHash;
-      if (!contentHash) {
-        return undefined;
-      }
+      const contentHash = this.files[name].contentHash!;
       hashes += `${name}\0${contentHash}\n`;
     }
 

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -14,6 +14,7 @@ import type {
   TriggerEvent,
   TriggerEventInput,
 } from './types';
+import { createHash } from 'crypto';
 
 export type { TriggerEvent, TriggerEventInput };
 
@@ -461,6 +462,32 @@ export class Lambda {
       }
     }
     return zipBuffer;
+  }
+
+  /**
+   * Computes a content hash for the Lambda based on its files. Returns undefined if not all files
+   * have a `.contentHash`.
+   */
+  computeDigest(): string | undefined {
+    if (!this.files) {
+      throw new Error('`files` is not defined');
+    }
+
+    // It's slightly faster to concat and hash the string as opposed to calling update() repeatedly:
+    // 2000 ops/s vs 1850 ops/s. This is likely because it results in fewer calls into the native
+    // crypto code.
+    let hashes = '';
+
+    const names = Object.keys(this.files).sort();
+    for (const name of names) {
+      const contentHash = this.files[name].contentHash;
+      if (!contentHash) {
+        return undefined;
+      }
+      hashes += `${name}\0${contentHash}\n`;
+    }
+
+    return createHash('sha256').update(hashes).digest('hex');
   }
 
   /**

--- a/packages/build-utils/src/process-serverless/get-encrypted-env-file.ts
+++ b/packages/build-utils/src/process-serverless/get-encrypted-env-file.ts
@@ -1,4 +1,5 @@
 import FileBlob from '../file-blob';
+import { sha256 } from '../fs/stream-to-digest-async';
 
 /**
  * A type to represent the encrypted environment file that needs to be
@@ -18,8 +19,12 @@ export function getEncryptedEnv(
     return;
   }
 
+  const data = Buffer.from(envContent, 'base64');
   return [
     envFilename,
-    new FileBlob({ data: Buffer.from(envContent, 'base64') }),
+    new FileBlob({
+      data,
+      contentHash: sha256(data),
+    }),
   ];
 }

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -16,6 +16,7 @@ export interface FileBase {
   type: string;
   mode: number;
   contentType?: string;
+  contentHash?: string;
   toStream: () => NodeJS.ReadableStream;
   toStreamAsync?: () => Promise<NodeJS.ReadableStream>;
 }

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -23,6 +23,7 @@ export interface FileBase {
   type: string;
   mode: number;
   contentType?: string;
+  contentHash?: string;
   toStream: () => NodeJS.ReadableStream;
   toStreamAsync?: () => Promise<NodeJS.ReadableStream>;
 }

--- a/packages/build-utils/test/unit.deserialize-build-output.test.ts
+++ b/packages/build-utils/test/unit.deserialize-build-output.test.ts
@@ -8,6 +8,7 @@ import type {
   DeserializeBuildOutputResult,
 } from '../src/deserialize/deserialize-build-output-types';
 import { deserializeBuildOutput } from '../src/deserialize/deserialize-build-output';
+import { deserializeLambda, type SerializedNodejsLambda } from '../src';
 
 type LegacyFlag = {
   key: string;
@@ -60,7 +61,11 @@ async function createOutputFixture(config: Partial<TestConfig> = {}) {
   };
 }
 
-async function writeNodeFunction(outputDir: string, outputPath: string) {
+async function writeNodeFunction(
+  outputDir: string,
+  outputPath: string,
+  config: Partial<SerializedNodejsLambda> = {}
+) {
   const functionDir = join(outputDir, 'functions', `${outputPath}.func`);
   await fs.outputJSON(join(functionDir, '.vc-config.json'), {
     handler: 'index.handler',
@@ -68,9 +73,10 @@ async function writeNodeFunction(outputDir: string, outputPath: string) {
     runtime: 'nodejs20.x',
     shouldAddHelpers: false,
     shouldAddSourcemapSupport: false,
+    ...config,
   });
   await fs.outputFile(
-    join(functionDir, 'index.js'),
+    join(functionDir, 'index.handler'),
     'exports.handler = () => "ok";'
   );
 }
@@ -256,6 +262,56 @@ describe('deserializeBuildOutput()', () => {
       });
 
       expect(result.output[customLambdaKey]).toBeInstanceOf(TestLambda);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it('reads fileHashes from .vc-config.json', async () => {
+    const fixture = await createOutputFixture();
+
+    try {
+      await fs.outputFile(join(fixture.repoRootPath, 'foo', 'bar.js'), 'hello');
+      await writeNodeFunction(fixture.outputDir, 'api/server-actions', {
+        filePathMap: {
+          'bar.js': 'foo/bar.js',
+        },
+        fileHashes: {
+          'index.handler': 'hash-index',
+          'bar.js': 'hash-barjs',
+        },
+      });
+
+      const result = await deserializeBuildOutput<TestConfig, TestResult>({
+        outputDir: fixture.outputDir,
+        repoRootPath: fixture.repoRootPath,
+        deserializeLambda: deserializeLambda,
+        groupLambdas: async () => ({}),
+        includeDeploymentId: true,
+        getMeta: hasServerActions => ({ hasServerActions }),
+      });
+
+      const lambda = result.output[
+        getOutputKey(result.output, 'api/server-actions')
+      ] as Lambda;
+      expect(lambda.type).toBe('Lambda');
+      const files = lambda.files;
+
+      expect(files).toMatchObject({
+        'bar.js': expect.objectContaining({
+          fsPath: join(fixture.repoRootPath, 'foo', 'bar.js'),
+          contentHash: 'hash-barjs',
+        }),
+        'index.handler': expect.objectContaining({
+          fsPath: normalizeOutputPath(
+            join(
+              fixture.repoRootPath,
+              '.vercel/output/functions/api/server-actions.func/index.handler'
+            )
+          ),
+          contentHash: 'hash-index',
+        }),
+      });
     } finally {
       await fixture.cleanup();
     }

--- a/packages/build-utils/test/unit.finalize-lambda.test.ts
+++ b/packages/build-utils/test/unit.finalize-lambda.test.ts
@@ -37,7 +37,7 @@ function createNodejsLambda(files?: Record<string, FileBlob>) {
 }
 
 describe('finalizeLambda()', () => {
-  it('returns buffer, digest, and uncompressedBytes', async () => {
+  it('returns buffer, digest, fileCount and uncompressedBytes', async () => {
     const lambda = createBasicLambda();
     const result = await finalizeLambda({
       lambda,
@@ -46,9 +46,10 @@ describe('finalizeLambda()', () => {
     });
 
     expect(result.buffer).toBeInstanceOf(Buffer);
-    expect(result.buffer.length).toBeGreaterThan(0);
+    expect(result.buffer!.length).toBeGreaterThan(0);
     expect(result.zipPath).toBeNull();
     expect(result.digest).toEqual(sha256(result.buffer));
+    expect(result.fileCount).toEqual(1);
     expect(result.uncompressedBytes).toEqual(0);
   });
 
@@ -68,7 +69,7 @@ describe('finalizeLambda()', () => {
     const lambda = createBasicLambda();
     const originalFiles = { ...lambda.files };
 
-    await finalizeLambda({
+    const result = await finalizeLambda({
       lambda,
       encryptedEnvFilename: '.env.encrypted',
       encryptedEnvContent: Buffer.from('SECRET=value').toString('base64'),
@@ -81,6 +82,7 @@ describe('finalizeLambda()', () => {
       Object.keys(originalFiles!).length
     );
     expect(lambda.zipBuffer).toBeUndefined();
+    expect(result.fileCount).toBe(Object.keys(originalFiles!).length + 1);
   });
 
   it('skips encrypted env when params are undefined', async () => {
@@ -265,6 +267,7 @@ describe('finalizeLambda()', () => {
         zipPath: '/tmp/lambda.zip',
         digest: 'abc123',
         size: 123,
+        fileCount: 1,
       }),
     });
 
@@ -272,5 +275,6 @@ describe('finalizeLambda()', () => {
     expect(result.zipPath).toEqual('/tmp/lambda.zip');
     expect(result.digest).toEqual('abc123');
     expect(result.size).toEqual(123);
+    expect(result.fileCount).toEqual(1);
   });
 });

--- a/packages/build-utils/test/unit.finalize-lambda.test.ts
+++ b/packages/build-utils/test/unit.finalize-lambda.test.ts
@@ -37,7 +37,7 @@ function createNodejsLambda(files?: Record<string, FileBlob>) {
 }
 
 describe('finalizeLambda()', () => {
-  it('returns buffer, digest, and uncompressedBytes', async () => {
+  it('returns buffer, digest, fileCount and uncompressedBytes', async () => {
     const lambda = createBasicLambda();
     const result = await finalizeLambda({
       lambda,
@@ -49,6 +49,7 @@ describe('finalizeLambda()', () => {
     expect(result.buffer?.length).toBeGreaterThan(0);
     expect(result.zipPath).toBeNull();
     expect(result.digest).toEqual(sha256(result.buffer));
+    expect(result.fileCount).toEqual(1);
     expect(result.uncompressedBytes).toEqual(0);
   });
 
@@ -68,7 +69,7 @@ describe('finalizeLambda()', () => {
     const lambda = createBasicLambda();
     const originalFiles = { ...lambda.files };
 
-    await finalizeLambda({
+    const result = await finalizeLambda({
       lambda,
       encryptedEnvFilename: '.env.encrypted',
       encryptedEnvContent: Buffer.from('SECRET=value').toString('base64'),
@@ -81,6 +82,7 @@ describe('finalizeLambda()', () => {
       Object.keys(originalFiles!).length
     );
     expect(lambda.zipBuffer).toBeUndefined();
+    expect(result.fileCount).toBe(Object.keys(originalFiles!).length + 1);
   });
 
   it('skips encrypted env when params are undefined', async () => {
@@ -263,6 +265,7 @@ describe('finalizeLambda()', () => {
         zipPath: '/tmp/lambda.zip',
         digest: 'abc123',
         size: 123,
+        fileCount: 1,
       }),
     });
 
@@ -270,5 +273,6 @@ describe('finalizeLambda()', () => {
     expect(result.zipPath).toEqual('/tmp/lambda.zip');
     expect(result.digest).toEqual('abc123');
     expect(result.size).toEqual(123);
+    expect(result.fileCount).toEqual(1);
   });
 });

--- a/packages/build-utils/test/unit.lambda.test.ts
+++ b/packages/build-utils/test/unit.lambda.test.ts
@@ -103,6 +103,146 @@ describe('Lambda', () => {
     }
   });
 
+  describe('computeDigest', () => {
+    it('returns undefined if any file is missing a contentHash', async () => {
+      let lambda1 = new Lambda({
+        files: {
+          'index.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+          }),
+        },
+        handler: 'index.js',
+        runtime: 'nodejs22.x',
+      });
+      expect(lambda1.computeDigest()).toBeUndefined();
+    });
+
+    it('returns a hash if all files have a contentHash', async () => {
+      let lambda1 = new Lambda({
+        files: {
+          'index.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+          'other.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'bar',
+          }),
+        },
+        handler: 'index.js',
+        runtime: 'nodejs22.x',
+      });
+      expect(lambda1.computeDigest()).toBeDefined();
+    });
+
+    it('returns a different hash if the content changes', async () => {
+      let lambda1 = new Lambda({
+        files: {
+          'index.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+        },
+        handler: 'index.js',
+        runtime: 'nodejs22.x',
+      });
+      let lambda2 = new Lambda({
+        files: {
+          'index.js': new FileBlob({
+            data: 'contents1',
+            mode: MODE_FILE,
+            contentHash: 'foo1',
+          }),
+        },
+        handler: 'index.js',
+        runtime: 'nodejs22.x',
+      });
+      expect(lambda1.computeDigest()).toBeDefined();
+      expect(lambda2.computeDigest()).toBeDefined();
+      expect(lambda1.computeDigest()).not.toEqual(lambda2.computeDigest());
+    });
+
+    it('returns a different hash if the file path changes', async () => {
+      let lambda1 = new Lambda({
+        files: {
+          'index.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+          'other.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+        },
+        handler: 'index.js',
+        runtime: 'nodejs22.x',
+      });
+      let lambda2 = new Lambda({
+        files: {
+          'index.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+          'another.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+        },
+        handler: 'index.js',
+        runtime: 'nodejs22.x',
+      });
+      expect(lambda1.computeDigest()).toBeDefined();
+      expect(lambda2.computeDigest()).toBeDefined();
+      expect(lambda1.computeDigest()).not.toEqual(lambda2.computeDigest());
+    });
+
+    it('returns the same hash if the file order is different', async () => {
+      let lambda1 = new Lambda({
+        files: {
+          'index.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+          'other.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+        },
+        handler: 'index.js',
+        runtime: 'nodejs22.x',
+      });
+      let lambda2 = new Lambda({
+        files: {
+          'other.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+          'index.js': new FileBlob({
+            data: 'contents',
+            mode: MODE_FILE,
+            contentHash: 'foo',
+          }),
+        },
+        handler: 'index.js',
+        runtime: 'nodejs22.x',
+      });
+      expect(lambda1.computeDigest()).toBeDefined();
+      expect(lambda2.computeDigest()).toBeDefined();
+      expect(lambda1.computeDigest()).toEqual(lambda2.computeDigest());
+    });
+  });
+
   describe('maxDuration', () => {
     const files: Files = {};
 

--- a/packages/cli/test/unit/commands/build/monorepo.test.ts
+++ b/packages/cli/test/unit/commands/build/monorepo.test.ts
@@ -6,7 +6,12 @@ import { mkdtemp, writeFile, rm } from 'fs/promises';
 import { createServer, type Server } from 'http';
 import { pathToFileURL } from 'url';
 import execa from 'execa';
-import { FileFsRef, NodejsLambda, glob } from '@vercel/build-utils';
+import {
+  type FileFsRef,
+  NodejsLambda,
+  glob,
+  hydrateFilesMap,
+} from '@vercel/build-utils';
 import build from '../../../../src/commands/build';
 import { client } from '../../../mocks/client';
 import { defaultProject, useProject } from '../../../mocks/project';
@@ -15,21 +20,6 @@ import { useUser } from '../../../mocks/user';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 
 vi.setConfig({ testTimeout: 6 * 60 * 1000 });
-
-/**
- * Hydrate files map by adding FileFsRef entries for each filePathMap entry.
- * Based on the API's hydrateFilesMap function.
- */
-async function hydrateFilesMap(
-  files: Record<string, FileFsRef>,
-  filePathMap: Record<string, string>,
-  repoRootPath: string
-): Promise<void> {
-  for (const [funcPath, projectPath] of Object.entries(filePathMap)) {
-    const fsPath = join(repoRootPath, projectPath);
-    files[funcPath] = await FileFsRef.fromFsPath({ fsPath });
-  }
-}
 
 /**
  * Create a NodejsLambda from a .func directory in the build output.
@@ -55,7 +45,9 @@ async function createLambdaFromFuncDir(
     await hydrateFilesMap(
       files as Record<string, FileFsRef>,
       filePathMap,
-      workPath
+      {},
+      workPath,
+      new Map()
     );
   }
 

--- a/packages/cli/test/unit/commands/build/monorepo.test.ts
+++ b/packages/cli/test/unit/commands/build/monorepo.test.ts
@@ -7,7 +7,13 @@ import { mkdtemp, writeFile, rm } from 'fs/promises';
 import { createServer, type Server } from 'http';
 import { pathToFileURL } from 'url';
 import execa from 'execa';
-import { FileFsRef, NodejsLambda, download, glob } from '@vercel/build-utils';
+import {
+  type FileFsRef,
+  NodejsLambda,
+  download,
+  glob,
+  hydrateFilesMap,
+} from '@vercel/build-utils';
 import build from '../../../../src/commands/build';
 import { client } from '../../../mocks/client';
 import { defaultProject, useProject } from '../../../mocks/project';
@@ -16,21 +22,6 @@ import { useUser } from '../../../mocks/user';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 
 vi.setConfig({ testTimeout: 6 * 60 * 1000 });
-
-/**
- * Hydrate files map by adding FileFsRef entries for each filePathMap entry.
- * Based on the API's hydrateFilesMap function.
- */
-async function hydrateFilesMap(
-  files: Record<string, FileFsRef>,
-  filePathMap: Record<string, string>,
-  repoRootPath: string
-): Promise<void> {
-  for (const [funcPath, projectPath] of Object.entries(filePathMap)) {
-    const fsPath = join(repoRootPath, projectPath);
-    files[funcPath] = await FileFsRef.fromFsPath({ fsPath });
-  }
-}
 
 /**
  * Create a NodejsLambda from a .func directory in the build output.
@@ -56,7 +47,9 @@ async function createLambdaFromFuncDir(
     await hydrateFilesMap(
       files as Record<string, FileFsRef>,
       filePathMap,
-      workPath
+      {},
+      workPath,
+      new Map()
     );
   }
 


### PR DESCRIPTION
- Add `contentHash` to all the `File` variants.
- Read `fileHashes` from `.vc-config.json` files (next to the existing `filePathMap` object) where a framework can provide per-file hashes.
Emitted by https://github.com/nextjs/adapter-vercel/pull/24
- Add `Lambda#computeDigest` to compute the digest of the lambda's files based on the provided hashes.