### PR TITLE
use sha for changeset/action which has a dist

### DIFF
--- a/.changeset/empty-files-behave.md
+++ b/.changeset/empty-files-behave.md
@@ -1,0 +1,4 @@
+---
+---
+
+use sha for changeset/action which has a dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@d4c53c294341eec8a419ec2d1927138bfdeec234
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf
         with:
           version: pnpm ci:version
           publish: pnpm ci:publish # npm publish


### PR DESCRIPTION
This fixes an issue where the sha we were pinned to didn't actually have a dist folder. I think on `tag` commits has a dist in their setup. This [sha is pinned to the 1.7 tag](https://github.com/changesets/action/commit/6a0a831ff30acef54f2c6aa1cbbc1096b066edaf)