### PR TITLE
[services] Add static schedule cron services for js/ts.

### DIFF
--- a/.changeset/seven-geese-attack.md
+++ b/.changeset/seven-geese-attack.md
@@ -1,0 +1,7 @@
+---
+'@vercel/fs-detectors': minor
+'@vercel/backends': minor
+'vercel': minor
+---
+
+Implement scheduled jobs for JS/TS.

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -28,7 +28,8 @@
     "type-check": "tsc --noEmit"
   },
   "files": [
-    "dist"
+    "dist",
+    "templates"
   ],
   "dependencies": {
     "@vercel/build-utils": "workspace:*",

--- a/packages/backends/src/cron-dispatch.ts
+++ b/packages/backends/src/cron-dispatch.ts
@@ -94,6 +94,10 @@ async function resolveShimFormat(args: {
   const { format } = await resolveEntrypointAndFormat({
     entrypoint: args.handler,
     workPath: args.workPath,
+    // Cron-service users may have a tiny project with just an entrypoint
+    // and a vercel.json, but no package.json. Node would treat that file
+    // as CJS and we should too.
+    defaultFormat: 'cjs',
   });
   const extension =
     extname(args.handler) || (format === 'esm' ? '.mjs' : '.cjs');

--- a/packages/backends/src/cron-dispatch.ts
+++ b/packages/backends/src/cron-dispatch.ts
@@ -1,6 +1,6 @@
 import { FileBlob, type Files } from '@vercel/build-utils';
 import { readFileSync } from 'node:fs';
-import { basename, dirname, extname, join } from 'node:path';
+import { dirname, extname, join, posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveEntrypointAndFormat } from './rolldown/resolve-format.js';
 
@@ -50,13 +50,15 @@ export async function applyCronDispatch(args: {
   routes: Record<string, string>;
 }): Promise<{ files: Files; handler: string }> {
   const { format, extension } = await resolveShimFormat(args);
-  const handlerDir = dirname(args.handler);
-  const handlerBaseName = basename(args.handler, extname(args.handler));
+  // Use POSIX path utilities — lambda `files` map keys are always
+  // forward-slash separated regardless of build host OS.
+  const handlerDir = posix.dirname(args.handler);
+  const handlerBaseName = posix.basename(args.handler, extname(args.handler));
   const dispatchName = `${handlerBaseName}.__vc_cron_dispatch${extension}`;
   const dispatchHandler =
-    handlerDir === '.' ? dispatchName : join(handlerDir, dispatchName);
+    handlerDir === '.' ? dispatchName : posix.join(handlerDir, dispatchName);
 
-  const handlerImportPath = `./${basename(args.handler)}`;
+  const handlerImportPath = `./${posix.basename(args.handler)}`;
 
   // Single-quote the route JSON so embedded double quotes don't need
   // escaping. Cron paths and handler names only contain

--- a/packages/backends/src/cron-dispatch.ts
+++ b/packages/backends/src/cron-dispatch.ts
@@ -1,0 +1,80 @@
+import { FileBlob, type Files } from '@vercel/build-utils';
+import { readFileSync } from 'node:fs';
+import { basename, dirname, extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveEntrypointAndFormat } from './rolldown/resolve-format.js';
+
+type ModuleFormat = 'esm' | 'cjs';
+
+const TEMPLATES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'templates'
+);
+
+const ESM_TEMPLATE = readFileSync(
+  join(TEMPLATES_DIR, 'vc_cron_dispatch.mjs'),
+  'utf-8'
+);
+const CJS_TEMPLATE = readFileSync(
+  join(TEMPLATES_DIR, 'vc_cron_dispatch.cjs'),
+  'utf-8'
+);
+
+const USER_MODULE_PLACEHOLDER = /['"]__VC_USER_MODULE_PATH__['"]/g;
+
+/**
+ * Wrap a cron service handler with a dispatcher shim that:
+ *   - reads `__VC_CRON_ROUTES` (JSON: cron path → handler-function name)
+ *   - verifies `CRON_SECRET` via `Authorization: Bearer ...` when set
+ *   - looks up the inbound request path in the route table and invokes
+ *     the named export on the user module (or the default export when
+ *     the table value is `"default"`)
+ *
+ * The dispatcher source lives in templates/vc_cron_dispatch.{mjs,cjs};
+ * this function only picks the right template, swaps in the user module
+ * import path, and writes the result into the lambda files.
+ */
+export async function applyCronDispatch(args: {
+  files: Files;
+  handler: string;
+  workPath: string;
+}): Promise<{ files: Files; handler: string }> {
+  const { format, extension } = await resolveShimFormat(args);
+  const handlerDir = dirname(args.handler);
+  const handlerBaseName = basename(args.handler, extname(args.handler));
+  const dispatchName = `${handlerBaseName}.__vc_cron_dispatch${extension}`;
+  const dispatchHandler =
+    handlerDir === '.' ? dispatchName : join(handlerDir, dispatchName);
+
+  const handlerImportPath = `./${basename(args.handler)}`;
+  const template = format === 'esm' ? ESM_TEMPLATE : CJS_TEMPLATE;
+  const dispatchSource = template.replace(
+    USER_MODULE_PLACEHOLDER,
+    JSON.stringify(handlerImportPath)
+  );
+
+  return {
+    handler: dispatchHandler,
+    files: {
+      ...args.files,
+      [dispatchHandler]: new FileBlob({
+        data: dispatchSource,
+        mode: 0o644,
+      }),
+    },
+  };
+}
+
+async function resolveShimFormat(args: {
+  handler: string;
+  workPath: string;
+}): Promise<{ format: ModuleFormat; extension: string }> {
+  const { format } = await resolveEntrypointAndFormat({
+    entrypoint: args.handler,
+    workPath: args.workPath,
+  });
+  const extension =
+    extname(args.handler) || (format === 'esm' ? '.mjs' : '.cjs');
+  return { format, extension };
+}

--- a/packages/backends/src/cron-dispatch.ts
+++ b/packages/backends/src/cron-dispatch.ts
@@ -22,23 +22,32 @@ const CJS_TEMPLATE = readFileSync(
 );
 
 const USER_MODULE_PLACEHOLDER = /['"]__VC_USER_MODULE_PATH__['"]/g;
+const ROUTES_PLACEHOLDER = /'__VC_ROUTES_JSON__'/g;
 
 /**
  * Wrap a cron service handler with a dispatcher shim that:
- *   - reads `__VC_CRON_ROUTES` (JSON: cron path → handler-function name)
+ *   - looks up the inbound request path in a route table baked into the
+ *     shim at build time and invokes the named export on the user module
+ *     (or the default export when the table value is `"default"`)
  *   - verifies `CRON_SECRET` via `Authorization: Bearer ...` when set
- *   - looks up the inbound request path in the route table and invokes
- *     the named export on the user module (or the default export when
- *     the table value is `"default"`)
  *
  * The dispatcher source lives in templates/vc_cron_dispatch.{mjs,cjs};
- * this function only picks the right template, swaps in the user module
- * import path, and writes the result into the lambda files.
+ * this function picks the right template, swaps in the user module
+ * import path and the cron route table, and writes the result into the
+ * lambda files.
+ *
+ * The route table is embedded inline rather than passed via a lambda
+ * env var because AWS Lambda rejects env var names that don't start
+ * with a letter — `__VC_CRON_ROUTES` would fail at deploy time. The
+ * Python builder works around the same constraint by writing the route
+ * table into its trampoline source.
  */
 export async function applyCronDispatch(args: {
   files: Files;
   handler: string;
   workPath: string;
+  /** Cron path → handler-function-name on the user module. */
+  routes: Record<string, string>;
 }): Promise<{ files: Files; handler: string }> {
   const { format, extension } = await resolveShimFormat(args);
   const handlerDir = dirname(args.handler);
@@ -48,11 +57,23 @@ export async function applyCronDispatch(args: {
     handlerDir === '.' ? dispatchName : join(handlerDir, dispatchName);
 
   const handlerImportPath = `./${basename(args.handler)}`;
+
+  // Single-quote the route JSON so embedded double quotes don't need
+  // escaping. Cron paths and handler names only contain
+  // [a-zA-Z0-9_./:-] so JSON.stringify won't produce backslashes — but
+  // assert defensively so any future change that introduces them
+  // surfaces here rather than at runtime.
+  const routesJson = JSON.stringify(args.routes);
+  if (routesJson.includes('\\') || routesJson.includes("'")) {
+    throw new Error(
+      `cron route table contains characters that need JS-string escaping: ${routesJson}`
+    );
+  }
+
   const template = format === 'esm' ? ESM_TEMPLATE : CJS_TEMPLATE;
-  const dispatchSource = template.replace(
-    USER_MODULE_PLACEHOLDER,
-    JSON.stringify(handlerImportPath)
-  );
+  const dispatchSource = template
+    .replace(USER_MODULE_PLACEHOLDER, JSON.stringify(handlerImportPath))
+    .replace(ROUTES_PLACEHOLDER, `'${routesJson}'`);
 
   return {
     handler: dispatchHandler,

--- a/packages/backends/src/crons.ts
+++ b/packages/backends/src/crons.ts
@@ -1,0 +1,73 @@
+import {
+  type BuildOptions,
+  type Cron,
+  getInternalServiceCronPath,
+  isScheduleTriggeredService,
+} from '@vercel/build-utils';
+
+const DYNAMIC_SCHEDULE = '<dynamic>';
+
+/** Function name to invoke on the imported user module. */
+const DEFAULT_HANDLER_NAME = 'default';
+
+export interface ServiceCronEntry extends Cron {
+  /**
+   * The function to invoke on the user's module. For v1 this is always
+   * `'default'`; multi-handler / `<dynamic>` support will populate this
+   * from the user's registry.
+   */
+  resolvedHandler: string;
+}
+
+/** Build the JSON route table embedded in `__VC_CRON_ROUTES`. */
+export function buildCronRouteTable(
+  crons: ServiceCronEntry[]
+): Record<string, string> {
+  const table: Record<string, string> = {};
+  for (const cron of crons) {
+    table[cron.path] = cron.resolvedHandler;
+  }
+  return table;
+}
+
+/**
+ * Compute cron entries for a JS/TS cron service build.
+ *
+ * Mirrors `packages/python/src/crons.ts` for static schedules. Returns
+ * `undefined` when the service is not schedule-triggered. Throws on
+ * `<dynamic>` schedules — that path is reserved for a follow-up.
+ */
+export function getServiceCrons(opts: {
+  service?: BuildOptions['service'];
+  entrypoint?: string;
+}): ServiceCronEntry[] | undefined {
+  const { service, entrypoint } = opts;
+
+  if (!service || !isScheduleTriggeredService(service)) {
+    return undefined;
+  }
+  if (!service.name || typeof service.schedule !== 'string') {
+    return undefined;
+  }
+
+  if (!entrypoint) {
+    throw new Error('Cron service is missing an entrypoint');
+  }
+
+  if (service.schedule === DYNAMIC_SCHEDULE) {
+    // Dynamic schedules aren't yet supported for JS/TS services. Return
+    // undefined so the CLI's downstream check (build/index.ts:1235-1260)
+    // fires its existing CRON_SERVICE_NO_CRONS error, preserving the
+    // legacy message and regression coverage.
+    return undefined;
+  }
+
+  const cronPath = getInternalServiceCronPath(service.name, entrypoint, 'cron');
+  return [
+    {
+      path: cronPath,
+      schedule: service.schedule,
+      resolvedHandler: DEFAULT_HANDLER_NAME,
+    },
+  ];
+}

--- a/packages/backends/src/crons.ts
+++ b/packages/backends/src/crons.ts
@@ -7,25 +7,11 @@ import {
 
 const DYNAMIC_SCHEDULE = '<dynamic>';
 
-/** Function name to invoke on the imported user module. */
-const DEFAULT_HANDLER_NAME = 'default';
-
-export interface ServiceCronEntry extends Cron {
-  /**
-   * The function to invoke on the user's module. For v1 this is always
-   * `'default'`; multi-handler / `<dynamic>` support will populate this
-   * from the user's registry.
-   */
-  resolvedHandler: string;
-}
-
 /** Build the JSON route table embedded in `__VC_CRON_ROUTES`. */
-export function buildCronRouteTable(
-  crons: ServiceCronEntry[]
-): Record<string, string> {
+export function buildCronRouteTable(crons: Cron[]): Record<string, string> {
   const table: Record<string, string> = {};
   for (const cron of crons) {
-    table[cron.path] = cron.resolvedHandler;
+    table[cron.path] = 'default';
   }
   return table;
 }
@@ -36,11 +22,16 @@ export function buildCronRouteTable(
  * Mirrors `packages/python/src/crons.ts` for static schedules. Returns
  * `undefined` when the service is not schedule-triggered. Throws on
  * `<dynamic>` schedules — that path is reserved for a follow-up.
+ *
+ * v1 always invokes the user module's default export, so this returns
+ * plain `Cron[]` (no handler-name field). When `handlerFunction` or
+ * `<dynamic>` support lands, this will need to grow a per-path handler
+ * name back.
  */
 export function getServiceCrons(opts: {
   service?: BuildOptions['service'];
   entrypoint?: string;
-}): ServiceCronEntry[] | undefined {
+}): Cron[] | undefined {
   const { service, entrypoint } = opts;
 
   if (!service || !isScheduleTriggeredService(service)) {
@@ -55,19 +46,15 @@ export function getServiceCrons(opts: {
   }
 
   if (service.schedule === DYNAMIC_SCHEDULE) {
-    // Dynamic schedules aren't yet supported for JS/TS services. Return
-    // undefined so the CLI's downstream check (build/index.ts:1235-1260)
-    // fires its existing CRON_SERVICE_NO_CRONS error, preserving the
-    // legacy message and regression coverage.
-    return undefined;
+    throw new Error(
+      'Dynamic cron schedules ("<dynamic>") are not yet supported for JavaScript/TypeScript services. Use a static cron expression in vercel.json.'
+    );
   }
 
-  const cronPath = getInternalServiceCronPath(service.name, entrypoint, 'cron');
   return [
     {
-      path: cronPath,
+      path: getInternalServiceCronPath(service.name, entrypoint, 'cron'),
       schedule: service.schedule,
-      resolvedHandler: DEFAULT_HANDLER_NAME,
     },
   ];
 }

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -87,15 +87,6 @@ export const build: BuildV2 = async args => {
   const buildSpan = span.child('vc.builder.backends.build');
 
   return buildSpan.trace(async () => {
-    // Capture the original (CLI-provided) entrypoint before findEntrypoint
-    // overrides it. The cron URL path is derived from the user-declared
-    // entrypoint so it matches the CLI orchestrator's fallback synthesis.
-    const cronEntries = getServiceCrons({
-      service: args.service,
-      entrypoint: args.entrypoint,
-    });
-    const isCronService = cronEntries !== undefined;
-
     // Use the explicitly-provided entrypoint when provided by CLI/fs-detectors.
     // If sentinel value 'package.json' is passed, fallback to candidate-list discovery.
     const entrypoint =
@@ -104,6 +95,12 @@ export const build: BuildV2 = async args => {
         : await findEntrypointOrThrow(args.workPath);
     debug('Entrypoint', entrypoint);
     args.entrypoint = entrypoint;
+
+    const cronEntries = getServiceCrons({
+      service: args.service,
+      entrypoint,
+    });
+    const isCronService = cronEntries !== undefined;
 
     const userBuildResult = await maybeDoBuildCommand(args, downloadResult);
 
@@ -130,9 +127,8 @@ export const build: BuildV2 = async args => {
       defaultFormat: isCronService ? 'cjs' : undefined,
     });
 
-    // Only hono's introspection is supported for now. Cron services
-    // aren't HTTP-routed (the dispatcher answers a single internal path),
-    // so introspection is skipped regardless of framework.
+    // Only hono's introspection is supported for now.
+    // Cron services should have no public routes, so introspection is skipped.
     const introspectionPromise =
       !isCronService && rolldownResult.framework.slug === 'hono'
         ? introspection({

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -96,7 +96,12 @@ export const build: BuildV2 = async args => {
     });
     const isCronService = cronEntries !== undefined;
 
-    const entrypoint = await findEntrypointOrThrow(args.workPath);
+    // Use the explicitly-provided entrypoint when provided by CLI/fs-detectors.
+    // If sentinel value 'package.json' is passed, fallback to candidate-list discovery.
+    const entrypoint =
+      args.entrypoint && args.entrypoint !== 'package.json'
+        ? args.entrypoint
+        : await findEntrypointOrThrow(args.workPath);
     debug('Entrypoint', entrypoint);
     args.entrypoint = entrypoint;
 

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -16,6 +16,8 @@ import {
 } from '@vercel/build-utils';
 import { findEntrypointOrThrow } from './cervel/index.js';
 import { applyServiceVcInit } from './service-vc-init.js';
+import { applyCronDispatch } from './cron-dispatch.js';
+import { buildCronRouteTable, getServiceCrons } from './crons.js';
 // Re-export cervel functions for use by other packages
 export {
   build as cervelBuild,
@@ -76,6 +78,15 @@ export const build: BuildV2 = async args => {
   const buildSpan = span.child('vc.builder.backends.build');
 
   return buildSpan.trace(async () => {
+    // Capture the original (CLI-provided) entrypoint before findEntrypoint
+    // overrides it. The cron URL path is derived from the user-declared
+    // entrypoint so it matches the CLI orchestrator's fallback synthesis.
+    const cronEntries = getServiceCrons({
+      service: args.service,
+      entrypoint: args.entrypoint,
+    });
+    const isCronService = cronEntries !== undefined;
+
     const entrypoint = await findEntrypointOrThrow(args.workPath);
     debug('Entrypoint', entrypoint);
     args.entrypoint = entrypoint;
@@ -101,9 +112,11 @@ export const build: BuildV2 = async args => {
       span: buildSpan,
     });
 
-    // Only hono's introspection is supported for now
+    // Only hono's introspection is supported for now. Cron services
+    // aren't HTTP-routed (the dispatcher answers a single internal path),
+    // so introspection is skipped regardless of framework.
     const introspectionPromise =
-      rolldownResult.framework.slug === 'hono'
+      !isCronService && rolldownResult.framework.slug === 'hono'
         ? introspection({
             ...args,
             span: buildSpan,
@@ -200,7 +213,16 @@ export const build: BuildV2 = async args => {
 
     let lambdaFiles = files;
     let lambdaHandler = handler;
-    if (shouldStripServiceRoutePrefix) {
+    if (isCronService && cronEntries) {
+      const dispatched = await applyCronDispatch({
+        files,
+        handler,
+        workPath: nftWorkPath,
+        routes: buildCronRouteTable(cronEntries),
+      });
+      lambdaFiles = dispatched.files;
+      lambdaHandler = dispatched.handler;
+    } else if (shouldStripServiceRoutePrefix) {
       const shimmedLambda = await applyServiceVcInit({
         files,
         handler,
@@ -258,17 +280,20 @@ export const build: BuildV2 = async args => {
       };
     };
 
-    // Build routes: filesystem handler, then introspected routes, then catch-all
-    const routes = [
-      {
-        handle: 'filesystem',
-      },
-      ...introspectionResult.routes.map(remapRouteDestination),
-      {
-        src: getServiceCatchallSource(serviceRoutePrefix),
-        dest: internalServiceFunctionPath ?? '/',
-      },
-    ];
+    // Build routes: filesystem handler, then introspected routes, then catch-all.
+    // Cron services only respond at their internal cron path (`_svc/{name}/crons/...`),
+    // which the CLI services pipeline rewrites to `_svc/{name}/index` independently
+    // of this builder.
+    const routes = isCronService
+      ? [{ handle: 'filesystem' }]
+      : [
+          { handle: 'filesystem' },
+          ...introspectionResult.routes.map(remapRouteDestination),
+          {
+            src: getServiceCatchallSource(serviceRoutePrefix),
+            dest: internalServiceFunctionPath ?? '/',
+          },
+        ];
 
     const output: Record<string, Lambda> = internalServiceOutputPath
       ? { [internalServiceOutputPath]: lambda }
@@ -292,6 +317,7 @@ export const build: BuildV2 = async args => {
     return {
       routes,
       output,
+      ...(cronEntries ? { crons: cronEntries } : {}),
     };
   });
 };

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
 import {
@@ -87,11 +89,19 @@ export const build: BuildV2 = async args => {
   const buildSpan = span.child('vc.builder.backends.build');
 
   return buildSpan.trace(async () => {
-    // Use the explicitly-provided entrypoint when provided by CLI/fs-detectors.
-    // If sentinel value 'package.json' is passed, fallback to candidate-list discovery.
-    const entrypoint =
+    // Use an explicit entrypoint when provided by CLI/fs-detectors.
+    // Fall back to candidate-list discovery when:
+    // - The CLI/framework passes the `package.json` sentinel.
+    // - The file doesn't exist (framework-preset placeholders like
+    //   `useRuntime.src: 'index.js'` reach us unreplaced under
+    //   VERCEL_EXPERIMENTAL_BACKENDS).
+    const explicit =
       args.entrypoint && args.entrypoint !== 'package.json'
         ? args.entrypoint
+        : null;
+    const entrypoint =
+      explicit && existsSync(join(args.workPath, explicit))
+        ? explicit
         : await findEntrypointOrThrow(args.workPath);
     debug('Entrypoint', entrypoint);
     args.entrypoint = entrypoint;

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -110,6 +110,10 @@ export const build: BuildV2 = async args => {
     const rolldownResult = await rolldown({
       ...args,
       span: buildSpan,
+      // Cron-service users may have just an entrypoint and a
+      // vercel.json with no package.json. Default `.js` to CJS so the
+      // bundle step can resolve the format like Node would at runtime.
+      defaultFormat: isCronService ? 'cjs' : undefined,
     });
 
     // Only hono's introspection is supported for now. Cron services

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -55,6 +55,15 @@ function hasExplicitBuildCommand(
 }
 
 export const build: BuildV2 = async args => {
+  // Reject `module:function` colon syntax in entrypoints. fs-detectors
+  // parses it into `Service.handlerFunction` regardless of service
+  // type.
+  if (typeof args.config?.handlerFunction === 'string') {
+    throw new Error(
+      `Named-function entrypoints are not supported for JavaScript services (got "${args.entrypoint}:${args.config.handlerFunction}"). Put each handler in its own file with a default export.`
+    );
+  }
+
   const downloadResult = await downloadInstallAndBundle(args);
   const nodeVersion = await getNodeVersion(
     args.workPath,

--- a/packages/backends/src/rolldown/index.ts
+++ b/packages/backends/src/rolldown/index.ts
@@ -20,6 +20,7 @@ export const rolldown = async (
     'entrypoint' | 'workPath' | 'repoRootPath' | 'config'
   > & {
     span?: Span;
+    defaultFormat?: 'esm' | 'cjs';
   }
 ) => {
   const files: Files = {};

--- a/packages/backends/src/rolldown/resolve-format.ts
+++ b/packages/backends/src/rolldown/resolve-format.ts
@@ -4,7 +4,9 @@ import { readFile } from 'node:fs/promises';
 import type { BuildOptions } from '@vercel/build-utils';
 
 export const resolveEntrypointAndFormat = async (
-  args: Pick<BuildOptions, 'entrypoint' | 'workPath'>
+  args: Pick<BuildOptions, 'entrypoint' | 'workPath'> & {
+    defaultFormat?: 'esm' | 'cjs';
+  }
 ) => {
   const extension = extname(args.entrypoint);
   const extensionMap: Record<
@@ -21,7 +23,7 @@ export const resolveEntrypointAndFormat = async (
 
   const extensionInfo = extensionMap[extension] || extensionMap['.js'];
   let resolvedFormat: 'esm' | 'cjs' | undefined =
-    extensionInfo.format === 'auto' ? undefined : extensionInfo.format;
+    extensionInfo.format === 'auto' ? args.defaultFormat : extensionInfo.format;
 
   const packageJsonPath = join(args.workPath, 'package.json');
   let pkg: Record<string, unknown> = {};

--- a/packages/backends/templates/vc_cron_dispatch.cjs
+++ b/packages/backends/templates/vc_cron_dispatch.cjs
@@ -6,17 +6,17 @@
 //
 // `__VC_USER_MODULE_PATH__` is replaced at build time with the relative
 // path to the user's cron entrypoint.
-const { timingSafeEqual: __vc_timingSafeEqual } = require('node:crypto')
-const __vc_user_module = require('__VC_USER_MODULE_PATH__')
+const { timingSafeEqual: __vc_timingSafeEqual } = require('node:crypto');
+const __vc_user_module = require('__VC_USER_MODULE_PATH__');
 
 function jsonResponse(res, status, body) {
-  res.statusCode = status
-  res.setHeader('content-type', 'application/json')
-  res.end(JSON.stringify(body))
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
 }
 
 function unwrapDefault(value) {
-  let current = value
+  let current = value;
   for (let i = 0; i < 5; i++) {
     if (
       current &&
@@ -24,32 +24,32 @@ function unwrapDefault(value) {
       'default' in current &&
       current.default
     ) {
-      current = current.default
+      current = current.default;
     } else {
-      break
+      break;
     }
   }
-  return current
+  return current;
 }
 
 function resolveCronHandler(userModule, name) {
   if (name === 'default') {
-    const unwrapped = unwrapDefault(userModule)
-    if (typeof unwrapped === 'function') return unwrapped
-    if (typeof userModule === 'function') return userModule
-    return undefined
+    const unwrapped = unwrapDefault(userModule);
+    if (typeof unwrapped === 'function') return unwrapped;
+    if (typeof userModule === 'function') return userModule;
+    return undefined;
   }
-  const fn = userModule != null ? userModule[name] : undefined
-  return typeof fn === 'function' ? fn : undefined
+  const fn = userModule != null ? userModule[name] : undefined;
+  return typeof fn === 'function' ? fn : undefined;
 }
 
 function safeBearerEqual(authHeader, secret) {
-  if (typeof authHeader !== 'string') return false
-  const expected = 'Bearer ' + secret
-  const a = Buffer.from(authHeader)
-  const b = Buffer.from(expected)
-  if (a.length !== b.length) return false
-  return __vc_timingSafeEqual(a, b)
+  if (typeof authHeader !== 'string') return false;
+  const expected = 'Bearer ' + secret;
+  const a = Buffer.from(authHeader);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return __vc_timingSafeEqual(a, b);
 }
 
 // Pre-resolve every route at module load. A bad route table fails the
@@ -60,11 +60,11 @@ function safeBearerEqual(authHeader, secret) {
 // Lambda env var names must start with a letter, so `__VC_CRON_ROUTES`
 // would fail at deploy time. The Python builder works around the same
 // constraint by writing the route table into its trampoline source.
-const __vc_routes_parsed = JSON.parse('__VC_ROUTES_JSON__')
-const RESOLVED_HANDLERS = new Map()
+const __vc_routes_parsed = JSON.parse('__VC_ROUTES_JSON__');
+const RESOLVED_HANDLERS = new Map();
 for (const __vc_path in __vc_routes_parsed) {
-  const __vc_name = __vc_routes_parsed[__vc_path]
-  const __vc_fn = resolveCronHandler(__vc_user_module, __vc_name)
+  const __vc_name = __vc_routes_parsed[__vc_path];
+  const __vc_fn = resolveCronHandler(__vc_user_module, __vc_name);
   if (typeof __vc_fn !== 'function') {
     throw new Error(
       'cron handler "' +
@@ -72,9 +72,9 @@ for (const __vc_path in __vc_routes_parsed) {
         '" is not a function in the user module (route: ' +
         __vc_path +
         ')'
-    )
+    );
   }
-  RESOLVED_HANDLERS.set(__vc_path, __vc_fn)
+  RESOLVED_HANDLERS.set(__vc_path, __vc_fn);
 }
 
 async function vcCronDispatch(req, res) {
@@ -82,38 +82,38 @@ async function vcCronDispatch(req, res) {
   // independently of whether the user's cron handler reads it. Cron
   // handlers take no arguments — body bytes are never used. Idempotent
   // and a no-op for non-streaming runtimes.
-  if (typeof req.resume === 'function') req.resume()
+  if (typeof req.resume === 'function') req.resume();
 
-  const method = (req.method || 'GET').toUpperCase()
+  const method = (req.method || 'GET').toUpperCase();
   if (method !== 'GET' && method !== 'POST') {
-    jsonResponse(res, 405, { error: 'method not allowed' })
-    return
+    jsonResponse(res, 405, { error: 'method not allowed' });
+    return;
   }
-  const secret = process.env.CRON_SECRET
+  const secret = process.env.CRON_SECRET;
   if (secret) {
-    const headers = req.headers || {}
-    const authorization = headers.authorization || headers.Authorization
+    const headers = req.headers || {};
+    const authorization = headers.authorization || headers.Authorization;
     if (!safeBearerEqual(authorization, secret)) {
-      jsonResponse(res, 401, { error: 'unauthorized' })
-      return
+      jsonResponse(res, 401, { error: 'unauthorized' });
+      return;
     }
   }
-  const rawUrl = typeof req.url === 'string' ? req.url : '/'
-  const path = rawUrl.split('?')[0]
-  const fn = RESOLVED_HANDLERS.get(path)
+  const rawUrl = typeof req.url === 'string' ? req.url : '/';
+  const path = rawUrl.split('?')[0];
+  const fn = RESOLVED_HANDLERS.get(path);
   if (!fn) {
-    jsonResponse(res, 404, { error: 'no cron handler for path: ' + path })
-    return
+    jsonResponse(res, 404, { error: 'no cron handler for path: ' + path });
+    return;
   }
   try {
-    await fn()
-    jsonResponse(res, 200, { ok: true })
+    await fn();
+    jsonResponse(res, 200, { ok: true });
   } catch (err) {
-    console.error(err)
-    jsonResponse(res, 500, { error: 'internal' })
+    console.error(err);
+    jsonResponse(res, 500, { error: 'internal' });
   }
 }
 
 module.exports = function (req, res) {
-  return vcCronDispatch(req, res)
-}
+  return vcCronDispatch(req, res);
+};

--- a/packages/backends/templates/vc_cron_dispatch.cjs
+++ b/packages/backends/templates/vc_cron_dispatch.cjs
@@ -1,0 +1,119 @@
+// Runtime cron dispatcher (CJS). Generated into a Vercel cron service
+// lambda by `applyCronDispatch` in @vercel/backends. JS analog of
+// vercel-runtime/src/vercel_runtime/crons.py — pre-resolves the route
+// table at module load and dispatches inbound requests to the matching
+// handler on the user's module.
+//
+// `__VC_USER_MODULE_PATH__` is replaced at build time with the relative
+// path to the user's cron entrypoint.
+const { timingSafeEqual: __vc_timingSafeEqual } = require('node:crypto')
+const __vc_user_module = require('__VC_USER_MODULE_PATH__')
+
+function jsonResponse(res, status, body) {
+  res.statusCode = status
+  res.setHeader('content-type', 'application/json')
+  res.end(JSON.stringify(body))
+}
+
+function unwrapDefault(value) {
+  let current = value
+  for (let i = 0; i < 5; i++) {
+    if (
+      current &&
+      typeof current === 'object' &&
+      'default' in current &&
+      current.default
+    ) {
+      current = current.default
+    } else {
+      break
+    }
+  }
+  return current
+}
+
+function resolveCronHandler(userModule, name) {
+  if (name === 'default') {
+    const unwrapped = unwrapDefault(userModule)
+    if (typeof unwrapped === 'function') return unwrapped
+    if (typeof userModule === 'function') return userModule
+    return undefined
+  }
+  const fn = userModule != null ? userModule[name] : undefined
+  return typeof fn === 'function' ? fn : undefined
+}
+
+function safeBearerEqual(authHeader, secret) {
+  if (typeof authHeader !== 'string') return false
+  const expected = 'Bearer ' + secret
+  const a = Buffer.from(authHeader)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return __vc_timingSafeEqual(a, b)
+}
+
+// Pre-resolve every route at module load. A bad route table fails the
+// lambda at boot
+const __vc_routes_raw = process.env.__VC_CRON_ROUTES
+if (!__vc_routes_raw) {
+  throw new Error(
+    'unable to bootstrap cron service: "__VC_CRON_ROUTES" environment variable is not set'
+  )
+}
+const __vc_routes_parsed = JSON.parse(__vc_routes_raw)
+const RESOLVED_HANDLERS = new Map()
+for (const __vc_path in __vc_routes_parsed) {
+  const __vc_name = __vc_routes_parsed[__vc_path]
+  const __vc_fn = resolveCronHandler(__vc_user_module, __vc_name)
+  if (typeof __vc_fn !== 'function') {
+    throw new Error(
+      'cron handler "' +
+        __vc_name +
+        '" is not a function in the user module (route: ' +
+        __vc_path +
+        ')'
+    )
+  }
+  RESOLVED_HANDLERS.set(__vc_path, __vc_fn)
+}
+
+async function vcCronDispatch(req, res) {
+  // Drain any inbound request body so the underlying stream completes
+  // independently of whether the user's cron handler reads it. Cron
+  // handlers take no arguments — body bytes are never used. Idempotent
+  // and a no-op for non-streaming runtimes.
+  if (typeof req.resume === 'function') req.resume()
+
+  const method = (req.method || 'GET').toUpperCase()
+  if (method !== 'GET' && method !== 'POST') {
+    jsonResponse(res, 405, { error: 'method not allowed' })
+    return
+  }
+  const secret = process.env.CRON_SECRET
+  if (secret) {
+    const headers = req.headers || {}
+    const authorization = headers.authorization || headers.Authorization
+    if (!safeBearerEqual(authorization, secret)) {
+      jsonResponse(res, 401, { error: 'unauthorized' })
+      return
+    }
+  }
+  const rawUrl = typeof req.url === 'string' ? req.url : '/'
+  const path = rawUrl.split('?')[0]
+  const fn = RESOLVED_HANDLERS.get(path)
+  if (!fn) {
+    jsonResponse(res, 404, { error: 'no cron handler for path: ' + path })
+    return
+  }
+  try {
+    await fn()
+    jsonResponse(res, 200, { ok: true })
+  } catch (err) {
+    console.error(err)
+    jsonResponse(res, 500, { error: 'internal' })
+  }
+}
+
+module.exports = function (req, res) {
+  return vcCronDispatch(req, res)
+}

--- a/packages/backends/templates/vc_cron_dispatch.cjs
+++ b/packages/backends/templates/vc_cron_dispatch.cjs
@@ -53,14 +53,14 @@ function safeBearerEqual(authHeader, secret) {
 }
 
 // Pre-resolve every route at module load. A bad route table fails the
-// lambda at boot
-const __vc_routes_raw = process.env.__VC_CRON_ROUTES
-if (!__vc_routes_raw) {
-  throw new Error(
-    'unable to bootstrap cron service: "__VC_CRON_ROUTES" environment variable is not set'
-  )
-}
-const __vc_routes_parsed = JSON.parse(__vc_routes_raw)
+// lambda at boot rather than at first request.
+//
+// `__VC_ROUTES_JSON__` is replaced at build time with the JSON route
+// table. Embedded inline here (instead of read from env) because AWS
+// Lambda env var names must start with a letter, so `__VC_CRON_ROUTES`
+// would fail at deploy time. The Python builder works around the same
+// constraint by writing the route table into its trampoline source.
+const __vc_routes_parsed = JSON.parse('__VC_ROUTES_JSON__')
 const RESOLVED_HANDLERS = new Map()
 for (const __vc_path in __vc_routes_parsed) {
   const __vc_name = __vc_routes_parsed[__vc_path]

--- a/packages/backends/templates/vc_cron_dispatch.mjs
+++ b/packages/backends/templates/vc_cron_dispatch.mjs
@@ -53,14 +53,14 @@ function safeBearerEqual(authHeader, secret) {
 }
 
 // Pre-resolve every route at module load. A bad route table fails the
-// lambda at boot
-const __vc_routes_raw = process.env.__VC_CRON_ROUTES
-if (!__vc_routes_raw) {
-  throw new Error(
-    'unable to bootstrap cron service: "__VC_CRON_ROUTES" environment variable is not set'
-  )
-}
-const __vc_routes_parsed = JSON.parse(__vc_routes_raw)
+// lambda at boot rather than at first request.
+//
+// `__VC_ROUTES_JSON__` is replaced at build time with the JSON route
+// table. Embedded inline here (instead of read from env) because AWS
+// Lambda env var names must start with a letter, so `__VC_CRON_ROUTES`
+// would fail at deploy time. The Python builder works around the same
+// constraint by writing the route table into its trampoline source.
+const __vc_routes_parsed = JSON.parse('__VC_ROUTES_JSON__')
 const RESOLVED_HANDLERS = new Map()
 for (const __vc_path in __vc_routes_parsed) {
   const __vc_name = __vc_routes_parsed[__vc_path]

--- a/packages/backends/templates/vc_cron_dispatch.mjs
+++ b/packages/backends/templates/vc_cron_dispatch.mjs
@@ -1,0 +1,119 @@
+// Runtime cron dispatcher (ESM). Generated into a Vercel cron service
+// lambda by `applyCronDispatch` in @vercel/backends. JS analog of
+// vercel-runtime/src/vercel_runtime/crons.py — pre-resolves the route
+// table at module load and dispatches inbound requests to the matching
+// handler on the user's module.
+//
+// `__VC_USER_MODULE_PATH__` is replaced at build time with the relative
+// path to the user's cron entrypoint.
+import { timingSafeEqual as __vc_timingSafeEqual } from 'node:crypto'
+import * as __vc_user_module from '__VC_USER_MODULE_PATH__'
+
+function jsonResponse(res, status, body) {
+  res.statusCode = status
+  res.setHeader('content-type', 'application/json')
+  res.end(JSON.stringify(body))
+}
+
+function unwrapDefault(value) {
+  let current = value
+  for (let i = 0; i < 5; i++) {
+    if (
+      current &&
+      typeof current === 'object' &&
+      'default' in current &&
+      current.default
+    ) {
+      current = current.default
+    } else {
+      break
+    }
+  }
+  return current
+}
+
+function resolveCronHandler(userModule, name) {
+  if (name === 'default') {
+    const unwrapped = unwrapDefault(userModule)
+    if (typeof unwrapped === 'function') return unwrapped
+    if (typeof userModule === 'function') return userModule
+    return undefined
+  }
+  const fn = userModule != null ? userModule[name] : undefined
+  return typeof fn === 'function' ? fn : undefined
+}
+
+function safeBearerEqual(authHeader, secret) {
+  if (typeof authHeader !== 'string') return false
+  const expected = 'Bearer ' + secret
+  const a = Buffer.from(authHeader)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return __vc_timingSafeEqual(a, b)
+}
+
+// Pre-resolve every route at module load. A bad route table fails the
+// lambda at boot
+const __vc_routes_raw = process.env.__VC_CRON_ROUTES
+if (!__vc_routes_raw) {
+  throw new Error(
+    'unable to bootstrap cron service: "__VC_CRON_ROUTES" environment variable is not set'
+  )
+}
+const __vc_routes_parsed = JSON.parse(__vc_routes_raw)
+const RESOLVED_HANDLERS = new Map()
+for (const __vc_path in __vc_routes_parsed) {
+  const __vc_name = __vc_routes_parsed[__vc_path]
+  const __vc_fn = resolveCronHandler(__vc_user_module, __vc_name)
+  if (typeof __vc_fn !== 'function') {
+    throw new Error(
+      'cron handler "' +
+        __vc_name +
+        '" is not a function in the user module (route: ' +
+        __vc_path +
+        ')'
+    )
+  }
+  RESOLVED_HANDLERS.set(__vc_path, __vc_fn)
+}
+
+async function vcCronDispatch(req, res) {
+  // Drain any inbound request body so the underlying stream completes
+  // independently of whether the user's cron handler reads it. Cron
+  // handlers take no arguments — body bytes are never used. Idempotent
+  // and a no-op for non-streaming runtimes.
+  if (typeof req.resume === 'function') req.resume()
+
+  const method = (req.method || 'GET').toUpperCase()
+  if (method !== 'GET' && method !== 'POST') {
+    jsonResponse(res, 405, { error: 'method not allowed' })
+    return
+  }
+  const secret = process.env.CRON_SECRET
+  if (secret) {
+    const headers = req.headers || {}
+    const authorization = headers.authorization || headers.Authorization
+    if (!safeBearerEqual(authorization, secret)) {
+      jsonResponse(res, 401, { error: 'unauthorized' })
+      return
+    }
+  }
+  const rawUrl = typeof req.url === 'string' ? req.url : '/'
+  const path = rawUrl.split('?')[0]
+  const fn = RESOLVED_HANDLERS.get(path)
+  if (!fn) {
+    jsonResponse(res, 404, { error: 'no cron handler for path: ' + path })
+    return
+  }
+  try {
+    await fn()
+    jsonResponse(res, 200, { ok: true })
+  } catch (err) {
+    console.error(err)
+    jsonResponse(res, 500, { error: 'internal' })
+  }
+}
+
+export default function (req, res) {
+  return vcCronDispatch(req, res)
+}

--- a/packages/backends/templates/vc_cron_dispatch.mjs
+++ b/packages/backends/templates/vc_cron_dispatch.mjs
@@ -6,17 +6,17 @@
 //
 // `__VC_USER_MODULE_PATH__` is replaced at build time with the relative
 // path to the user's cron entrypoint.
-import { timingSafeEqual as __vc_timingSafeEqual } from 'node:crypto'
-import * as __vc_user_module from '__VC_USER_MODULE_PATH__'
+import { timingSafeEqual as __vc_timingSafeEqual } from 'node:crypto';
+import * as __vc_user_module from '__VC_USER_MODULE_PATH__';
 
 function jsonResponse(res, status, body) {
-  res.statusCode = status
-  res.setHeader('content-type', 'application/json')
-  res.end(JSON.stringify(body))
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
 }
 
 function unwrapDefault(value) {
-  let current = value
+  let current = value;
   for (let i = 0; i < 5; i++) {
     if (
       current &&
@@ -24,32 +24,32 @@ function unwrapDefault(value) {
       'default' in current &&
       current.default
     ) {
-      current = current.default
+      current = current.default;
     } else {
-      break
+      break;
     }
   }
-  return current
+  return current;
 }
 
 function resolveCronHandler(userModule, name) {
   if (name === 'default') {
-    const unwrapped = unwrapDefault(userModule)
-    if (typeof unwrapped === 'function') return unwrapped
-    if (typeof userModule === 'function') return userModule
-    return undefined
+    const unwrapped = unwrapDefault(userModule);
+    if (typeof unwrapped === 'function') return unwrapped;
+    if (typeof userModule === 'function') return userModule;
+    return undefined;
   }
-  const fn = userModule != null ? userModule[name] : undefined
-  return typeof fn === 'function' ? fn : undefined
+  const fn = userModule != null ? userModule[name] : undefined;
+  return typeof fn === 'function' ? fn : undefined;
 }
 
 function safeBearerEqual(authHeader, secret) {
-  if (typeof authHeader !== 'string') return false
-  const expected = 'Bearer ' + secret
-  const a = Buffer.from(authHeader)
-  const b = Buffer.from(expected)
-  if (a.length !== b.length) return false
-  return __vc_timingSafeEqual(a, b)
+  if (typeof authHeader !== 'string') return false;
+  const expected = 'Bearer ' + secret;
+  const a = Buffer.from(authHeader);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return __vc_timingSafeEqual(a, b);
 }
 
 // Pre-resolve every route at module load. A bad route table fails the
@@ -60,11 +60,11 @@ function safeBearerEqual(authHeader, secret) {
 // Lambda env var names must start with a letter, so `__VC_CRON_ROUTES`
 // would fail at deploy time. The Python builder works around the same
 // constraint by writing the route table into its trampoline source.
-const __vc_routes_parsed = JSON.parse('__VC_ROUTES_JSON__')
-const RESOLVED_HANDLERS = new Map()
+const __vc_routes_parsed = JSON.parse('__VC_ROUTES_JSON__');
+const RESOLVED_HANDLERS = new Map();
 for (const __vc_path in __vc_routes_parsed) {
-  const __vc_name = __vc_routes_parsed[__vc_path]
-  const __vc_fn = resolveCronHandler(__vc_user_module, __vc_name)
+  const __vc_name = __vc_routes_parsed[__vc_path];
+  const __vc_fn = resolveCronHandler(__vc_user_module, __vc_name);
   if (typeof __vc_fn !== 'function') {
     throw new Error(
       'cron handler "' +
@@ -72,9 +72,9 @@ for (const __vc_path in __vc_routes_parsed) {
         '" is not a function in the user module (route: ' +
         __vc_path +
         ')'
-    )
+    );
   }
-  RESOLVED_HANDLERS.set(__vc_path, __vc_fn)
+  RESOLVED_HANDLERS.set(__vc_path, __vc_fn);
 }
 
 async function vcCronDispatch(req, res) {
@@ -82,38 +82,38 @@ async function vcCronDispatch(req, res) {
   // independently of whether the user's cron handler reads it. Cron
   // handlers take no arguments — body bytes are never used. Idempotent
   // and a no-op for non-streaming runtimes.
-  if (typeof req.resume === 'function') req.resume()
+  if (typeof req.resume === 'function') req.resume();
 
-  const method = (req.method || 'GET').toUpperCase()
+  const method = (req.method || 'GET').toUpperCase();
   if (method !== 'GET' && method !== 'POST') {
-    jsonResponse(res, 405, { error: 'method not allowed' })
-    return
+    jsonResponse(res, 405, { error: 'method not allowed' });
+    return;
   }
-  const secret = process.env.CRON_SECRET
+  const secret = process.env.CRON_SECRET;
   if (secret) {
-    const headers = req.headers || {}
-    const authorization = headers.authorization || headers.Authorization
+    const headers = req.headers || {};
+    const authorization = headers.authorization || headers.Authorization;
     if (!safeBearerEqual(authorization, secret)) {
-      jsonResponse(res, 401, { error: 'unauthorized' })
-      return
+      jsonResponse(res, 401, { error: 'unauthorized' });
+      return;
     }
   }
-  const rawUrl = typeof req.url === 'string' ? req.url : '/'
-  const path = rawUrl.split('?')[0]
-  const fn = RESOLVED_HANDLERS.get(path)
+  const rawUrl = typeof req.url === 'string' ? req.url : '/';
+  const path = rawUrl.split('?')[0];
+  const fn = RESOLVED_HANDLERS.get(path);
   if (!fn) {
-    jsonResponse(res, 404, { error: 'no cron handler for path: ' + path })
-    return
+    jsonResponse(res, 404, { error: 'no cron handler for path: ' + path });
+    return;
   }
   try {
-    await fn()
-    jsonResponse(res, 200, { ok: true })
+    await fn();
+    jsonResponse(res, 200, { ok: true });
   } catch (err) {
-    console.error(err)
-    jsonResponse(res, 500, { error: 'internal' })
+    console.error(err);
+    jsonResponse(res, 500, { error: 'internal' });
   }
 }
 
 export default function (req, res) {
-  return vcCronDispatch(req, res)
+  return vcCronDispatch(req, res);
 }

--- a/packages/backends/test/fixtures/20-cron-default-export/index.mjs
+++ b/packages/backends/test/fixtures/20-cron-default-export/index.mjs
@@ -1,0 +1,3 @@
+export default async function () {
+  // no-op cron handler
+}

--- a/packages/backends/test/fixtures/20-cron-default-export/package.json
+++ b/packages/backends/test/fixtures/20-cron-default-export/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "cron-default-export-fixture",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/packages/backends/test/fixtures/20-cron-default-export/routes.json
+++ b/packages/backends/test/fixtures/20-cron-default-export/routes.json
@@ -1,0 +1,9 @@
+[
+  {
+    "handle": "filesystem"
+  },
+  {
+    "src": "/(.*)",
+    "dest": "/"
+  }
+]

--- a/packages/backends/test/unit.cron-dispatch.test.ts
+++ b/packages/backends/test/unit.cron-dispatch.test.ts
@@ -1,0 +1,472 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { applyCronDispatch } from '../src/cron-dispatch';
+
+async function setupWorkPath(packageJson?: object): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'be-cron-dispatch-'));
+  if (packageJson) {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify(packageJson),
+      'utf-8'
+    );
+  }
+  return dir;
+}
+
+function getShimSource(
+  result: Awaited<ReturnType<typeof applyCronDispatch>>
+): string {
+  const blob = result.files[result.handler];
+  // FileBlob.data is the source string we wrote.
+  return (blob as unknown as { data: string }).data;
+}
+
+describe('applyCronDispatch', () => {
+  it('produces an ESM shim for an .mjs handler', async () => {
+    const workPath = await setupWorkPath();
+    try {
+      const result = await applyCronDispatch({
+        files: {},
+        handler: 'index.mjs',
+        workPath,
+      });
+      expect(result.handler).toBe('index.__vc_cron_dispatch.mjs');
+      const src = getShimSource(result);
+      expect(src).toContain('import * as __vc_user_module from "./index.mjs"');
+      expect(src).toContain('export default function');
+      expect(src).toContain('__VC_CRON_ROUTES');
+      expect(src).toContain('CRON_SECRET');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('produces a CJS shim for a .cjs handler', async () => {
+    const workPath = await setupWorkPath();
+    try {
+      const result = await applyCronDispatch({
+        files: {},
+        handler: 'index.cjs',
+        workPath,
+      });
+      expect(result.handler).toBe('index.__vc_cron_dispatch.cjs');
+      const src = getShimSource(result);
+      expect(src).toContain('const __vc_user_module = require("./index.cjs")');
+      expect(src).toContain('module.exports = function');
+      expect(src).toContain('__VC_CRON_ROUTES');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('treats .js as ESM when package.json "type" is "module"', async () => {
+    const workPath = await setupWorkPath({ type: 'module' });
+    try {
+      const result = await applyCronDispatch({
+        files: {},
+        handler: 'index.js',
+        workPath,
+      });
+      expect(result.handler).toBe('index.__vc_cron_dispatch.js');
+      const src = getShimSource(result);
+      expect(src).toContain('import * as __vc_user_module from "./index.js"');
+      expect(src).toContain('export default function');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('treats .js as CJS when package.json has no module type', async () => {
+    const workPath = await setupWorkPath({ name: 'app' });
+    try {
+      const result = await applyCronDispatch({
+        files: {},
+        handler: 'index.js',
+        workPath,
+      });
+      expect(result.handler).toBe('index.__vc_cron_dispatch.js');
+      const src = getShimSource(result);
+      expect(src).toContain('const __vc_user_module = require("./index.js")');
+      expect(src).toContain('module.exports = function');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('places the shim alongside a nested handler', async () => {
+    const workPath = await setupWorkPath({ type: 'module' });
+    try {
+      const result = await applyCronDispatch({
+        files: {},
+        handler: 'jobs/index.mjs',
+        workPath,
+      });
+      expect(result.handler).toBe('jobs/index.__vc_cron_dispatch.mjs');
+      const src = getShimSource(result);
+      expect(src).toContain('import * as __vc_user_module from "./index.mjs"');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves existing files and adds the shim', async () => {
+    const workPath = await setupWorkPath({ type: 'module' });
+    try {
+      const original = { 'index.mjs': 'sentinel' as unknown };
+      const result = await applyCronDispatch({
+        files: original as never,
+        handler: 'index.mjs',
+        workPath,
+      });
+      expect(result.files['index.mjs']).toBe('sentinel');
+      expect(result.files['index.__vc_cron_dispatch.mjs']).toBeDefined();
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+});
+
+interface MockRes {
+  statusCode: number;
+  body: string;
+  setHeader: () => void;
+  end: (body: string) => void;
+}
+
+function makeReq(
+  method: string,
+  url: string,
+  headers: Record<string, string> = {}
+) {
+  return { method, url, headers } as const;
+}
+
+function makeRes(): MockRes {
+  const res = {
+    statusCode: 200,
+    body: '',
+    setHeader() {
+      // no-op
+    },
+    end(body: string) {
+      this.body = body;
+    },
+  } as MockRes;
+  return res;
+}
+
+interface ShimContext {
+  handler: (req: unknown, res: MockRes) => Promise<void>;
+  cleanup: () => Promise<void>;
+}
+
+async function setupShimDir(opts: {
+  /**
+   * Object → JSON-stringified into the env var.
+   * String → used verbatim (for malformed-JSON tests).
+   * `null` → env var deleted (for missing-env tests).
+   */
+  routes: Record<string, string> | string | null;
+  cronSecret?: string;
+  userModuleSource: string;
+}): Promise<{ shimUrl: string; restore: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), 'be-cron-behave-'));
+  await writeFile(
+    join(dir, 'package.json'),
+    JSON.stringify({ type: 'module' }),
+    'utf-8'
+  );
+  await writeFile(join(dir, 'index.mjs'), opts.userModuleSource, 'utf-8');
+  const result = await applyCronDispatch({
+    files: {},
+    handler: 'index.mjs',
+    workPath: dir,
+  });
+  const shimSource = (
+    result.files[result.handler] as unknown as { data: string }
+  ).data;
+  await writeFile(join(dir, result.handler), shimSource, 'utf-8');
+
+  const prevRoutes = process.env.__VC_CRON_ROUTES;
+  const prevSecret = process.env.CRON_SECRET;
+  if (opts.routes === null) {
+    delete process.env.__VC_CRON_ROUTES;
+  } else {
+    process.env.__VC_CRON_ROUTES =
+      typeof opts.routes === 'string'
+        ? opts.routes
+        : JSON.stringify(opts.routes);
+  }
+  if (opts.cronSecret !== undefined) {
+    process.env.CRON_SECRET = opts.cronSecret;
+  } else {
+    delete process.env.CRON_SECRET;
+  }
+
+  return {
+    shimUrl: pathToFileURL(join(dir, result.handler)).toString(),
+    restore: async () => {
+      if (prevRoutes === undefined) delete process.env.__VC_CRON_ROUTES;
+      else process.env.__VC_CRON_ROUTES = prevRoutes;
+      if (prevSecret === undefined) delete process.env.CRON_SECRET;
+      else process.env.CRON_SECRET = prevSecret;
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function loadEsmShim(opts: {
+  routes: Record<string, string>;
+  cronSecret?: string;
+  userModuleSource: string;
+}): Promise<ShimContext> {
+  const setup = await setupShimDir(opts);
+  try {
+    const mod = await import(setup.shimUrl);
+    return { handler: mod.default, cleanup: setup.restore };
+  } catch (err) {
+    await setup.restore();
+    throw err;
+  }
+}
+
+describe('cron dispatcher behavior', () => {
+  it('returns 405 for non-GET/POST methods', async () => {
+    const ctx = await loadEsmShim({
+      routes: { '/_svc/x/crons/index/cron': 'default' },
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      const res = makeRes();
+      await ctx.handler(makeReq('PUT', '/_svc/x/crons/index/cron'), res);
+      expect(res.statusCode).toBe(405);
+      expect(JSON.parse(res.body)).toEqual({ error: 'method not allowed' });
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('checks method before auth (PUT without secret returns 405, not 401)', async () => {
+    const ctx = await loadEsmShim({
+      routes: { '/_svc/x/crons/index/cron': 'default' },
+      cronSecret: 's3cret',
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      const res = makeRes();
+      await ctx.handler(makeReq('PUT', '/_svc/x/crons/index/cron'), res);
+      expect(res.statusCode).toBe(405);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('returns 401 when CRON_SECRET set and Authorization header missing', async () => {
+    const ctx = await loadEsmShim({
+      routes: { '/_svc/x/crons/index/cron': 'default' },
+      cronSecret: 's3cret',
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      const res = makeRes();
+      await ctx.handler(makeReq('POST', '/_svc/x/crons/index/cron'), res);
+      expect(res.statusCode).toBe(401);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('returns 401 when Authorization mismatches (wrong-length too)', async () => {
+    const ctx = await loadEsmShim({
+      routes: { '/_svc/x/crons/index/cron': 'default' },
+      cronSecret: 's3cret',
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      const wrong = makeRes();
+      await ctx.handler(
+        makeReq('POST', '/_svc/x/crons/index/cron', {
+          authorization: 'Bearer wrong',
+        }),
+        wrong
+      );
+      expect(wrong.statusCode).toBe(401);
+
+      // Even at the right length, the wrong content must 401.
+      const wrongSameLen = makeRes();
+      await ctx.handler(
+        makeReq('POST', '/_svc/x/crons/index/cron', {
+          authorization: 'Bearer wrongx',
+        }),
+        wrongSameLen
+      );
+      expect(wrongSameLen.statusCode).toBe(401);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('invokes the default export and returns 200', async () => {
+    const ctx = await loadEsmShim({
+      routes: { '/_svc/x/crons/index/cron': 'default' },
+      userModuleSource: `
+        globalThis.__cron_test_calls = (globalThis.__cron_test_calls || 0)
+        export default async function () {
+          globalThis.__cron_test_calls++
+        }
+      `,
+    });
+    try {
+      (globalThis as Record<string, unknown>).__cron_test_calls = 0;
+      const res = makeRes();
+      await ctx.handler(makeReq('POST', '/_svc/x/crons/index/cron'), res);
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ ok: true });
+      expect((globalThis as Record<string, unknown>).__cron_test_calls).toBe(1);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('returns 200 with valid Bearer secret', async () => {
+    const ctx = await loadEsmShim({
+      routes: { '/_svc/x/crons/index/cron': 'default' },
+      cronSecret: 's3cret',
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      const res = makeRes();
+      await ctx.handler(
+        makeReq('POST', '/_svc/x/crons/index/cron', {
+          authorization: 'Bearer s3cret',
+        }),
+        res
+      );
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('returns 404 when path is not in the route table', async () => {
+    const ctx = await loadEsmShim({
+      routes: { '/_svc/x/crons/index/cron': 'default' },
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      const res = makeRes();
+      await ctx.handler(makeReq('POST', '/something/else'), res);
+      expect(res.statusCode).toBe(404);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('returns 500 when the handler throws', async () => {
+    const ctx = await loadEsmShim({
+      routes: { '/_svc/x/crons/index/cron': 'default' },
+      userModuleSource: `
+        export default async function () {
+          throw new Error('boom')
+        }
+      `,
+    });
+    try {
+      const res = makeRes();
+      await ctx.handler(makeReq('POST', '/_svc/x/crons/index/cron'), res);
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.body)).toEqual({ error: 'internal' });
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('strips query string from the inbound URL', async () => {
+    const ctx = await loadEsmShim({
+      routes: { '/_svc/x/crons/index/cron': 'default' },
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      const res = makeRes();
+      await ctx.handler(
+        makeReq('POST', '/_svc/x/crons/index/cron?foo=bar'),
+        res
+      );
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+});
+
+describe('cron dispatcher boot-time validation', () => {
+  it('throws at module load when a route names a missing handler', async () => {
+    const setup = await setupShimDir({
+      routes: { '/_svc/x/crons/index/cron': 'doesNotExist' },
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      await expect(import(setup.shimUrl)).rejects.toThrow(
+        /not a function in the user module/
+      );
+    } finally {
+      await setup.restore();
+    }
+  });
+
+  it('throws at module load when a named export is not callable', async () => {
+    const setup = await setupShimDir({
+      routes: { '/_svc/x/crons/index/cron': 'cleanup' },
+      userModuleSource: `export const cleanup = 'not-a-function'`,
+    });
+    try {
+      await expect(import(setup.shimUrl)).rejects.toThrow(
+        /not a function in the user module/
+      );
+    } finally {
+      await setup.restore();
+    }
+  });
+
+  it('throws at module load when __VC_CRON_ROUTES is malformed JSON', async () => {
+    const setup = await setupShimDir({
+      routes: 'this-is-not-json',
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      await expect(import(setup.shimUrl)).rejects.toThrow();
+    } finally {
+      await setup.restore();
+    }
+  });
+
+  it('boots successfully with a valid named-export route', async () => {
+    const setup = await setupShimDir({
+      routes: { '/_svc/x/crons/index/hourly': 'hourly' },
+      userModuleSource: `export async function hourly() {}`,
+    });
+    try {
+      await expect(import(setup.shimUrl)).resolves.toBeTruthy();
+    } finally {
+      await setup.restore();
+    }
+  });
+
+  it('throws at module load when __VC_CRON_ROUTES is not set', async () => {
+    const setup = await setupShimDir({
+      routes: null,
+      userModuleSource: 'export default async function () {}',
+    });
+    try {
+      await expect(import(setup.shimUrl)).rejects.toThrow(
+        /__VC_CRON_ROUTES.*environment variable is not set/
+      );
+    } finally {
+      await setup.restore();
+    }
+  });
+});

--- a/packages/backends/test/unit.cron-dispatch.test.ts
+++ b/packages/backends/test/unit.cron-dispatch.test.ts
@@ -33,12 +33,13 @@ describe('applyCronDispatch', () => {
         files: {},
         handler: 'index.mjs',
         workPath,
+        routes: {},
       });
       expect(result.handler).toBe('index.__vc_cron_dispatch.mjs');
       const src = getShimSource(result);
       expect(src).toContain('import * as __vc_user_module from "./index.mjs"');
       expect(src).toContain('export default function');
-      expect(src).toContain('__VC_CRON_ROUTES');
+      expect(src).toContain('vcCronDispatch');
       expect(src).toContain('CRON_SECRET');
     } finally {
       await rm(workPath, { recursive: true, force: true });
@@ -52,12 +53,13 @@ describe('applyCronDispatch', () => {
         files: {},
         handler: 'index.cjs',
         workPath,
+        routes: {},
       });
       expect(result.handler).toBe('index.__vc_cron_dispatch.cjs');
       const src = getShimSource(result);
       expect(src).toContain('const __vc_user_module = require("./index.cjs")');
       expect(src).toContain('module.exports = function');
-      expect(src).toContain('__VC_CRON_ROUTES');
+      expect(src).toContain('vcCronDispatch');
     } finally {
       await rm(workPath, { recursive: true, force: true });
     }
@@ -70,6 +72,7 @@ describe('applyCronDispatch', () => {
         files: {},
         handler: 'index.js',
         workPath,
+        routes: {},
       });
       expect(result.handler).toBe('index.__vc_cron_dispatch.js');
       const src = getShimSource(result);
@@ -87,6 +90,7 @@ describe('applyCronDispatch', () => {
         files: {},
         handler: 'index.js',
         workPath,
+        routes: {},
       });
       expect(result.handler).toBe('index.__vc_cron_dispatch.js');
       const src = getShimSource(result);
@@ -104,6 +108,7 @@ describe('applyCronDispatch', () => {
         files: {},
         handler: 'jobs/index.mjs',
         workPath,
+        routes: {},
       });
       expect(result.handler).toBe('jobs/index.__vc_cron_dispatch.mjs');
       const src = getShimSource(result);
@@ -121,6 +126,7 @@ describe('applyCronDispatch', () => {
         files: original as never,
         handler: 'index.mjs',
         workPath,
+        routes: {},
       });
       expect(result.files['index.mjs']).toBe('sentinel');
       expect(result.files['index.__vc_cron_dispatch.mjs']).toBeDefined();
@@ -165,12 +171,7 @@ interface ShimContext {
 }
 
 async function setupShimDir(opts: {
-  /**
-   * Object → JSON-stringified into the env var.
-   * String → used verbatim (for malformed-JSON tests).
-   * `null` → env var deleted (for missing-env tests).
-   */
-  routes: Record<string, string> | string | null;
+  routes: Record<string, string>;
   cronSecret?: string;
   userModuleSource: string;
 }): Promise<{ shimUrl: string; restore: () => Promise<void> }> {
@@ -185,22 +186,14 @@ async function setupShimDir(opts: {
     files: {},
     handler: 'index.mjs',
     workPath: dir,
+    routes: opts.routes,
   });
   const shimSource = (
     result.files[result.handler] as unknown as { data: string }
   ).data;
   await writeFile(join(dir, result.handler), shimSource, 'utf-8');
 
-  const prevRoutes = process.env.__VC_CRON_ROUTES;
   const prevSecret = process.env.CRON_SECRET;
-  if (opts.routes === null) {
-    delete process.env.__VC_CRON_ROUTES;
-  } else {
-    process.env.__VC_CRON_ROUTES =
-      typeof opts.routes === 'string'
-        ? opts.routes
-        : JSON.stringify(opts.routes);
-  }
   if (opts.cronSecret !== undefined) {
     process.env.CRON_SECRET = opts.cronSecret;
   } else {
@@ -210,8 +203,6 @@ async function setupShimDir(opts: {
   return {
     shimUrl: pathToFileURL(join(dir, result.handler)).toString(),
     restore: async () => {
-      if (prevRoutes === undefined) delete process.env.__VC_CRON_ROUTES;
-      else process.env.__VC_CRON_ROUTES = prevRoutes;
       if (prevSecret === undefined) delete process.env.CRON_SECRET;
       else process.env.CRON_SECRET = prevSecret;
       await rm(dir, { recursive: true, force: true });
@@ -432,18 +423,6 @@ describe('cron dispatcher boot-time validation', () => {
     }
   });
 
-  it('throws at module load when __VC_CRON_ROUTES is malformed JSON', async () => {
-    const setup = await setupShimDir({
-      routes: 'this-is-not-json',
-      userModuleSource: 'export default async function () {}',
-    });
-    try {
-      await expect(import(setup.shimUrl)).rejects.toThrow();
-    } finally {
-      await setup.restore();
-    }
-  });
-
   it('boots successfully with a valid named-export route', async () => {
     const setup = await setupShimDir({
       routes: { '/_svc/x/crons/index/hourly': 'hourly' },
@@ -451,20 +430,6 @@ describe('cron dispatcher boot-time validation', () => {
     });
     try {
       await expect(import(setup.shimUrl)).resolves.toBeTruthy();
-    } finally {
-      await setup.restore();
-    }
-  });
-
-  it('throws at module load when __VC_CRON_ROUTES is not set', async () => {
-    const setup = await setupShimDir({
-      routes: null,
-      userModuleSource: 'export default async function () {}',
-    });
-    try {
-      await expect(import(setup.shimUrl)).rejects.toThrow(
-        /__VC_CRON_ROUTES.*environment variable is not set/
-      );
     } finally {
       await setup.restore();
     }

--- a/packages/backends/test/unit.cron-dispatch.test.ts
+++ b/packages/backends/test/unit.cron-dispatch.test.ts
@@ -225,213 +225,221 @@ async function loadEsmShim(opts: {
   }
 }
 
-describe('cron dispatcher behavior', () => {
-  it('returns 405 for non-GET/POST methods', async () => {
-    const ctx = await loadEsmShim({
-      routes: { '/_svc/x/crons/index/cron': 'default' },
-      userModuleSource: 'export default async function () {}',
+describe.skipIf(process.platform === 'win32')(
+  'cron dispatcher behavior',
+  () => {
+    it('returns 405 for non-GET/POST methods', async () => {
+      const ctx = await loadEsmShim({
+        routes: { '/_svc/x/crons/index/cron': 'default' },
+        userModuleSource: 'export default async function () {}',
+      });
+      try {
+        const res = makeRes();
+        await ctx.handler(makeReq('PUT', '/_svc/x/crons/index/cron'), res);
+        expect(res.statusCode).toBe(405);
+        expect(JSON.parse(res.body)).toEqual({ error: 'method not allowed' });
+      } finally {
+        await ctx.cleanup();
+      }
     });
-    try {
-      const res = makeRes();
-      await ctx.handler(makeReq('PUT', '/_svc/x/crons/index/cron'), res);
-      expect(res.statusCode).toBe(405);
-      expect(JSON.parse(res.body)).toEqual({ error: 'method not allowed' });
-    } finally {
-      await ctx.cleanup();
-    }
-  });
 
-  it('checks method before auth (PUT without secret returns 405, not 401)', async () => {
-    const ctx = await loadEsmShim({
-      routes: { '/_svc/x/crons/index/cron': 'default' },
-      cronSecret: 's3cret',
-      userModuleSource: 'export default async function () {}',
+    it('checks method before auth (PUT without secret returns 405, not 401)', async () => {
+      const ctx = await loadEsmShim({
+        routes: { '/_svc/x/crons/index/cron': 'default' },
+        cronSecret: 's3cret',
+        userModuleSource: 'export default async function () {}',
+      });
+      try {
+        const res = makeRes();
+        await ctx.handler(makeReq('PUT', '/_svc/x/crons/index/cron'), res);
+        expect(res.statusCode).toBe(405);
+      } finally {
+        await ctx.cleanup();
+      }
     });
-    try {
-      const res = makeRes();
-      await ctx.handler(makeReq('PUT', '/_svc/x/crons/index/cron'), res);
-      expect(res.statusCode).toBe(405);
-    } finally {
-      await ctx.cleanup();
-    }
-  });
 
-  it('returns 401 when CRON_SECRET set and Authorization header missing', async () => {
-    const ctx = await loadEsmShim({
-      routes: { '/_svc/x/crons/index/cron': 'default' },
-      cronSecret: 's3cret',
-      userModuleSource: 'export default async function () {}',
+    it('returns 401 when CRON_SECRET set and Authorization header missing', async () => {
+      const ctx = await loadEsmShim({
+        routes: { '/_svc/x/crons/index/cron': 'default' },
+        cronSecret: 's3cret',
+        userModuleSource: 'export default async function () {}',
+      });
+      try {
+        const res = makeRes();
+        await ctx.handler(makeReq('POST', '/_svc/x/crons/index/cron'), res);
+        expect(res.statusCode).toBe(401);
+      } finally {
+        await ctx.cleanup();
+      }
     });
-    try {
-      const res = makeRes();
-      await ctx.handler(makeReq('POST', '/_svc/x/crons/index/cron'), res);
-      expect(res.statusCode).toBe(401);
-    } finally {
-      await ctx.cleanup();
-    }
-  });
 
-  it('returns 401 when Authorization mismatches (wrong-length too)', async () => {
-    const ctx = await loadEsmShim({
-      routes: { '/_svc/x/crons/index/cron': 'default' },
-      cronSecret: 's3cret',
-      userModuleSource: 'export default async function () {}',
+    it('returns 401 when Authorization mismatches (wrong-length too)', async () => {
+      const ctx = await loadEsmShim({
+        routes: { '/_svc/x/crons/index/cron': 'default' },
+        cronSecret: 's3cret',
+        userModuleSource: 'export default async function () {}',
+      });
+      try {
+        const wrong = makeRes();
+        await ctx.handler(
+          makeReq('POST', '/_svc/x/crons/index/cron', {
+            authorization: 'Bearer wrong',
+          }),
+          wrong
+        );
+        expect(wrong.statusCode).toBe(401);
+
+        // Even at the right length, the wrong content must 401.
+        const wrongSameLen = makeRes();
+        await ctx.handler(
+          makeReq('POST', '/_svc/x/crons/index/cron', {
+            authorization: 'Bearer wrongx',
+          }),
+          wrongSameLen
+        );
+        expect(wrongSameLen.statusCode).toBe(401);
+      } finally {
+        await ctx.cleanup();
+      }
     });
-    try {
-      const wrong = makeRes();
-      await ctx.handler(
-        makeReq('POST', '/_svc/x/crons/index/cron', {
-          authorization: 'Bearer wrong',
-        }),
-        wrong
-      );
-      expect(wrong.statusCode).toBe(401);
 
-      // Even at the right length, the wrong content must 401.
-      const wrongSameLen = makeRes();
-      await ctx.handler(
-        makeReq('POST', '/_svc/x/crons/index/cron', {
-          authorization: 'Bearer wrongx',
-        }),
-        wrongSameLen
-      );
-      expect(wrongSameLen.statusCode).toBe(401);
-    } finally {
-      await ctx.cleanup();
-    }
-  });
-
-  it('invokes the default export and returns 200', async () => {
-    const ctx = await loadEsmShim({
-      routes: { '/_svc/x/crons/index/cron': 'default' },
-      userModuleSource: `
+    it('invokes the default export and returns 200', async () => {
+      const ctx = await loadEsmShim({
+        routes: { '/_svc/x/crons/index/cron': 'default' },
+        userModuleSource: `
         globalThis.__cron_test_calls = (globalThis.__cron_test_calls || 0)
         export default async function () {
           globalThis.__cron_test_calls++
         }
       `,
+      });
+      try {
+        (globalThis as Record<string, unknown>).__cron_test_calls = 0;
+        const res = makeRes();
+        await ctx.handler(makeReq('POST', '/_svc/x/crons/index/cron'), res);
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(res.body)).toEqual({ ok: true });
+        expect((globalThis as Record<string, unknown>).__cron_test_calls).toBe(
+          1
+        );
+      } finally {
+        await ctx.cleanup();
+      }
     });
-    try {
-      (globalThis as Record<string, unknown>).__cron_test_calls = 0;
-      const res = makeRes();
-      await ctx.handler(makeReq('POST', '/_svc/x/crons/index/cron'), res);
-      expect(res.statusCode).toBe(200);
-      expect(JSON.parse(res.body)).toEqual({ ok: true });
-      expect((globalThis as Record<string, unknown>).__cron_test_calls).toBe(1);
-    } finally {
-      await ctx.cleanup();
-    }
-  });
 
-  it('returns 200 with valid Bearer secret', async () => {
-    const ctx = await loadEsmShim({
-      routes: { '/_svc/x/crons/index/cron': 'default' },
-      cronSecret: 's3cret',
-      userModuleSource: 'export default async function () {}',
+    it('returns 200 with valid Bearer secret', async () => {
+      const ctx = await loadEsmShim({
+        routes: { '/_svc/x/crons/index/cron': 'default' },
+        cronSecret: 's3cret',
+        userModuleSource: 'export default async function () {}',
+      });
+      try {
+        const res = makeRes();
+        await ctx.handler(
+          makeReq('POST', '/_svc/x/crons/index/cron', {
+            authorization: 'Bearer s3cret',
+          }),
+          res
+        );
+        expect(res.statusCode).toBe(200);
+      } finally {
+        await ctx.cleanup();
+      }
     });
-    try {
-      const res = makeRes();
-      await ctx.handler(
-        makeReq('POST', '/_svc/x/crons/index/cron', {
-          authorization: 'Bearer s3cret',
-        }),
-        res
-      );
-      expect(res.statusCode).toBe(200);
-    } finally {
-      await ctx.cleanup();
-    }
-  });
 
-  it('returns 404 when path is not in the route table', async () => {
-    const ctx = await loadEsmShim({
-      routes: { '/_svc/x/crons/index/cron': 'default' },
-      userModuleSource: 'export default async function () {}',
+    it('returns 404 when path is not in the route table', async () => {
+      const ctx = await loadEsmShim({
+        routes: { '/_svc/x/crons/index/cron': 'default' },
+        userModuleSource: 'export default async function () {}',
+      });
+      try {
+        const res = makeRes();
+        await ctx.handler(makeReq('POST', '/something/else'), res);
+        expect(res.statusCode).toBe(404);
+      } finally {
+        await ctx.cleanup();
+      }
     });
-    try {
-      const res = makeRes();
-      await ctx.handler(makeReq('POST', '/something/else'), res);
-      expect(res.statusCode).toBe(404);
-    } finally {
-      await ctx.cleanup();
-    }
-  });
 
-  it('returns 500 when the handler throws', async () => {
-    const ctx = await loadEsmShim({
-      routes: { '/_svc/x/crons/index/cron': 'default' },
-      userModuleSource: `
+    it('returns 500 when the handler throws', async () => {
+      const ctx = await loadEsmShim({
+        routes: { '/_svc/x/crons/index/cron': 'default' },
+        userModuleSource: `
         export default async function () {
           throw new Error('boom')
         }
       `,
+      });
+      try {
+        const res = makeRes();
+        await ctx.handler(makeReq('POST', '/_svc/x/crons/index/cron'), res);
+        expect(res.statusCode).toBe(500);
+        expect(JSON.parse(res.body)).toEqual({ error: 'internal' });
+      } finally {
+        await ctx.cleanup();
+      }
     });
-    try {
-      const res = makeRes();
-      await ctx.handler(makeReq('POST', '/_svc/x/crons/index/cron'), res);
-      expect(res.statusCode).toBe(500);
-      expect(JSON.parse(res.body)).toEqual({ error: 'internal' });
-    } finally {
-      await ctx.cleanup();
-    }
-  });
 
-  it('strips query string from the inbound URL', async () => {
-    const ctx = await loadEsmShim({
-      routes: { '/_svc/x/crons/index/cron': 'default' },
-      userModuleSource: 'export default async function () {}',
+    it('strips query string from the inbound URL', async () => {
+      const ctx = await loadEsmShim({
+        routes: { '/_svc/x/crons/index/cron': 'default' },
+        userModuleSource: 'export default async function () {}',
+      });
+      try {
+        const res = makeRes();
+        await ctx.handler(
+          makeReq('POST', '/_svc/x/crons/index/cron?foo=bar'),
+          res
+        );
+        expect(res.statusCode).toBe(200);
+      } finally {
+        await ctx.cleanup();
+      }
     });
-    try {
-      const res = makeRes();
-      await ctx.handler(
-        makeReq('POST', '/_svc/x/crons/index/cron?foo=bar'),
-        res
-      );
-      expect(res.statusCode).toBe(200);
-    } finally {
-      await ctx.cleanup();
-    }
-  });
-});
+  }
+);
 
-describe('cron dispatcher boot-time validation', () => {
-  it('throws at module load when a route names a missing handler', async () => {
-    const setup = await setupShimDir({
-      routes: { '/_svc/x/crons/index/cron': 'doesNotExist' },
-      userModuleSource: 'export default async function () {}',
+describe.skipIf(process.platform === 'win32')(
+  'cron dispatcher boot-time validation',
+  () => {
+    it('throws at module load when a route names a missing handler', async () => {
+      const setup = await setupShimDir({
+        routes: { '/_svc/x/crons/index/cron': 'doesNotExist' },
+        userModuleSource: 'export default async function () {}',
+      });
+      try {
+        await expect(import(setup.shimUrl)).rejects.toThrow(
+          /not a function in the user module/
+        );
+      } finally {
+        await setup.restore();
+      }
     });
-    try {
-      await expect(import(setup.shimUrl)).rejects.toThrow(
-        /not a function in the user module/
-      );
-    } finally {
-      await setup.restore();
-    }
-  });
 
-  it('throws at module load when a named export is not callable', async () => {
-    const setup = await setupShimDir({
-      routes: { '/_svc/x/crons/index/cron': 'cleanup' },
-      userModuleSource: `export const cleanup = 'not-a-function'`,
+    it('throws at module load when a named export is not callable', async () => {
+      const setup = await setupShimDir({
+        routes: { '/_svc/x/crons/index/cron': 'cleanup' },
+        userModuleSource: `export const cleanup = 'not-a-function'`,
+      });
+      try {
+        await expect(import(setup.shimUrl)).rejects.toThrow(
+          /not a function in the user module/
+        );
+      } finally {
+        await setup.restore();
+      }
     });
-    try {
-      await expect(import(setup.shimUrl)).rejects.toThrow(
-        /not a function in the user module/
-      );
-    } finally {
-      await setup.restore();
-    }
-  });
 
-  it('boots successfully with a valid named-export route', async () => {
-    const setup = await setupShimDir({
-      routes: { '/_svc/x/crons/index/hourly': 'hourly' },
-      userModuleSource: `export async function hourly() {}`,
+    it('boots successfully with a valid named-export route', async () => {
+      const setup = await setupShimDir({
+        routes: { '/_svc/x/crons/index/hourly': 'hourly' },
+        userModuleSource: `export async function hourly() {}`,
+      });
+      try {
+        await expect(import(setup.shimUrl)).resolves.toBeTruthy();
+      } finally {
+        await setup.restore();
+      }
     });
-    try {
-      await expect(import(setup.shimUrl)).resolves.toBeTruthy();
-    } finally {
-      await setup.restore();
-    }
-  });
-});
+  }
+);

--- a/packages/backends/test/unit.crons.test.ts
+++ b/packages/backends/test/unit.crons.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { buildCronRouteTable, getServiceCrons } from '../src/crons';
+
+describe('getServiceCrons', () => {
+  it('returns undefined for non-schedule-triggered services', () => {
+    expect(
+      getServiceCrons({
+        service: { type: 'web', name: 'web', schedule: '0 0 * * *' },
+        entrypoint: 'server.ts',
+      })
+    ).toBeUndefined();
+    expect(
+      getServiceCrons({
+        service: {
+          type: 'job',
+          trigger: 'queue',
+          name: 'worker',
+          schedule: '0 0 * * *',
+        },
+        entrypoint: 'worker.ts',
+      })
+    ).toBeUndefined();
+    expect(getServiceCrons({ entrypoint: 'cleanup.ts' })).toBeUndefined();
+  });
+
+  it('returns undefined when name or schedule is missing', () => {
+    expect(
+      getServiceCrons({
+        service: { type: 'cron', schedule: '0 0 * * *' },
+        entrypoint: 'cleanup.ts',
+      })
+    ).toBeUndefined();
+    expect(
+      getServiceCrons({
+        service: { type: 'cron', name: 'cleanup' },
+        entrypoint: 'cleanup.ts',
+      })
+    ).toBeUndefined();
+  });
+
+  it('produces a single entry for a static schedule on a cron service', () => {
+    expect(
+      getServiceCrons({
+        service: { type: 'cron', name: 'cleanup', schedule: '0 0 * * *' },
+        entrypoint: 'cleanup.ts',
+      })
+    ).toEqual([
+      {
+        path: '/_svc/cleanup/crons/cleanup/cron',
+        schedule: '0 0 * * *',
+        resolvedHandler: 'default',
+      },
+    ]);
+  });
+
+  it('produces a single entry for a schedule-triggered job', () => {
+    expect(
+      getServiceCrons({
+        service: {
+          type: 'job',
+          trigger: 'schedule',
+          name: 'cleanup',
+          schedule: '*/5 * * * *',
+        },
+        entrypoint: 'jobs/cleanup.ts',
+      })
+    ).toEqual([
+      {
+        path: '/_svc/cleanup/crons/jobs/cleanup/cron',
+        schedule: '*/5 * * * *',
+        resolvedHandler: 'default',
+      },
+    ]);
+  });
+
+  it('throws when entrypoint is missing for a cron service', () => {
+    expect(() =>
+      getServiceCrons({
+        service: { type: 'cron', name: 'cleanup', schedule: '0 0 * * *' },
+      })
+    ).toThrow(/missing an entrypoint/);
+  });
+
+  it('returns undefined on a <dynamic> schedule (defers to CLI legacy check)', () => {
+    // Dynamic schedules aren't yet supported for JS/TS services.
+    // Returning undefined lets the CLI's existing CRON_SERVICE_NO_CRONS
+    // path produce the legacy error message.
+    expect(
+      getServiceCrons({
+        service: { type: 'cron', name: 'cleanup', schedule: '<dynamic>' },
+        entrypoint: 'cleanup.ts',
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe('buildCronRouteTable', () => {
+  it('maps cron paths to handler function names', () => {
+    expect(
+      buildCronRouteTable([
+        {
+          path: '/_svc/cleanup/crons/cleanup/cron',
+          schedule: '0 0 * * *',
+          resolvedHandler: 'default',
+        },
+        {
+          path: '/_svc/tasks/crons/tasks/hourly',
+          schedule: '0 * * * *',
+          resolvedHandler: 'hourly',
+        },
+      ])
+    ).toEqual({
+      '/_svc/cleanup/crons/cleanup/cron': 'default',
+      '/_svc/tasks/crons/tasks/hourly': 'hourly',
+    });
+  });
+
+  it('returns an empty object for an empty input', () => {
+    expect(buildCronRouteTable([])).toEqual({});
+  });
+});

--- a/packages/backends/test/unit.crons.test.ts
+++ b/packages/backends/test/unit.crons.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildCronRouteTable, getServiceCrons } from '../src/crons';
+import { getServiceCrons } from '../src/crons';
 
 describe('getServiceCrons', () => {
   it('returns undefined for non-schedule-triggered services', () => {
@@ -48,7 +48,6 @@ describe('getServiceCrons', () => {
       {
         path: '/_svc/cleanup/crons/cleanup/cron',
         schedule: '0 0 * * *',
-        resolvedHandler: 'default',
       },
     ]);
   });
@@ -68,7 +67,6 @@ describe('getServiceCrons', () => {
       {
         path: '/_svc/cleanup/crons/jobs/cleanup/cron',
         schedule: '*/5 * * * *',
-        resolvedHandler: 'default',
       },
     ]);
   });
@@ -81,41 +79,12 @@ describe('getServiceCrons', () => {
     ).toThrow(/missing an entrypoint/);
   });
 
-  it('returns undefined on a <dynamic> schedule (defers to CLI legacy check)', () => {
-    // Dynamic schedules aren't yet supported for JS/TS services.
-    // Returning undefined lets the CLI's existing CRON_SERVICE_NO_CRONS
-    // path produce the legacy error message.
-    expect(
+  it('throws on a <dynamic> schedule (not yet supported for JS/TS)', () => {
+    expect(() =>
       getServiceCrons({
         service: { type: 'cron', name: 'cleanup', schedule: '<dynamic>' },
         entrypoint: 'cleanup.ts',
       })
-    ).toBeUndefined();
-  });
-});
-
-describe('buildCronRouteTable', () => {
-  it('maps cron paths to handler function names', () => {
-    expect(
-      buildCronRouteTable([
-        {
-          path: '/_svc/cleanup/crons/cleanup/cron',
-          schedule: '0 0 * * *',
-          resolvedHandler: 'default',
-        },
-        {
-          path: '/_svc/tasks/crons/tasks/hourly',
-          schedule: '0 * * * *',
-          resolvedHandler: 'hourly',
-        },
-      ])
-    ).toEqual({
-      '/_svc/cleanup/crons/cleanup/cron': 'default',
-      '/_svc/tasks/crons/tasks/hourly': 'hourly',
-    });
-  });
-
-  it('returns an empty object for an empty input', () => {
-    expect(buildCronRouteTable([])).toEqual({});
+    ).toThrow(/Dynamic cron schedules .* not yet supported/);
   });
 });

--- a/packages/backends/test/unit.test.ts
+++ b/packages/backends/test/unit.test.ts
@@ -493,6 +493,29 @@ it('emits crons[] and a dispatcher shim for a schedule-triggered service', async
   expect(hasCatchall).toBe(false);
 }, 60000);
 
+it('rejects entrypoints with named-function (module:function) syntax', async () => {
+  const fixtureName = '01-express-index-ts-esm';
+  const fixtureSource = join(__dirname, 'fixtures', fixtureName);
+  const { workDir } = await getWorkDir(fixtureName, fixtureSource);
+
+  await expect(
+    build({
+      files: {},
+      workPath: workDir,
+      config: {
+        ...defaultConfig,
+        // fs-detectors sets `handlerFunction` from `entrypoint:
+        // "file.ts:foo"` colon syntax. JS-land has no precedent for
+        // named-function entrypoints — the guard rejects it loudly.
+        handlerFunction: 'someHandler',
+      },
+      meta,
+      entrypoint: 'src/server.ts',
+      repoRootPath: workDir,
+    })
+  ).rejects.toThrow(/Named-function entrypoints are not supported/);
+}, 30000);
+
 it('strips service route prefixes for hono apps at runtime', async () => {
   const fixtureName = '04-hono-index-ts-esm';
   const fixtureSource = join(__dirname, 'fixtures', fixtureName);

--- a/packages/backends/test/unit.test.ts
+++ b/packages/backends/test/unit.test.ts
@@ -428,6 +428,71 @@ it('strips service route prefixes for express apps at runtime', async () => {
   expect(readLambdaResponseBody(response)).toBe('Hello World');
 }, 30000);
 
+it('emits crons[] and a dispatcher shim for a schedule-triggered service', async () => {
+  const fixtureName = '20-cron-default-export';
+  const fixtureSource = join(__dirname, 'fixtures', fixtureName);
+  const { workDir } = await getWorkDir(fixtureName, fixtureSource);
+
+  const result = (await build({
+    files: {},
+    workPath: workDir,
+    config: {
+      ...defaultConfig,
+      serviceName: 'cleanup',
+    },
+    meta,
+    entrypoint: 'index.mjs',
+    repoRootPath: workDir,
+    service: {
+      name: 'cleanup',
+      type: 'job',
+      trigger: 'schedule',
+      schedule: '0 0 * * *',
+    },
+  })) as BuildResultV2Typical;
+
+  // Build result includes the cron entry the CLI/orchestrator consumes.
+  expect(result.crons).toEqual([
+    expect.objectContaining({
+      path: '/_svc/cleanup/crons/index/cron',
+      schedule: '0 0 * * *',
+    }),
+  ]);
+
+  // Lambda is mounted at the internal service path.
+  const lambda = getServiceLambda(result, 'cleanup');
+  expect(lambda).toBeDefined();
+
+  // Lambda handler points at the dispatcher shim, not the user file.
+  expect(lambda.handler).toContain('__vc_cron_dispatch');
+
+  // The dispatcher shim is in the lambda bundle and embeds the route
+  // table inline (not via lambda env, since AWS Lambda rejects env var
+  // names with leading underscores).
+  expect(lambda.files).toBeDefined();
+  const dispatcherFileKey = Object.keys(lambda.files!).find(k =>
+    k.endsWith('__vc_cron_dispatch.mjs')
+  );
+  expect(dispatcherFileKey).toBeDefined();
+  const dispatcherFile = lambda.files![dispatcherFileKey!] as unknown as {
+    data: Buffer | string;
+  };
+  const dispatcherSource =
+    typeof dispatcherFile.data === 'string'
+      ? dispatcherFile.data
+      : dispatcherFile.data.toString('utf-8');
+  expect(dispatcherSource).toContain(
+    `JSON.parse('{"/_svc/cleanup/crons/index/cron":"default"}')`
+  );
+  expect(lambda.environment.__VC_CRON_ROUTES).toBeUndefined();
+
+  // No catchall route — cron services only respond at their internal cron path.
+  const hasCatchall = result.routes?.some(
+    r => typeof r.src === 'string' && r.src.includes('(.*)')
+  );
+  expect(hasCatchall).toBe(false);
+}, 60000);
+
 it('strips service route prefixes for hono apps at runtime', async () => {
   const fixtureName = '04-hono-index-ts-esm';
   const fixtureSource = join(__dirname, 'fixtures', fixtureName);

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-handler/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-handler/.vercel/project.json
@@ -1,0 +1,1 @@
+{"orgId":".","projectId":".","settings":{"framework":null,"installCommand":""}}

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-handler/index.js
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-handler/index.js
@@ -1,0 +1,3 @@
+module.exports = async function () {
+  // cron handler — no-op for the test fixture
+};

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-handler/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-handler/vercel.json
@@ -1,0 +1,10 @@
+{
+  "experimentalServices": {
+    "cleanup": {
+      "type": "job",
+      "trigger": "schedule",
+      "entrypoint": "index.js",
+      "schedule": "0 0 * * *"
+    }
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-nested/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-nested/.vercel/project.json
@@ -1,0 +1,8 @@
+{
+  "orgId": ".",
+  "projectId": ".",
+  "settings": {
+    "framework": null,
+    "installCommand": ""
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-nested/jobs/cleanup.js
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-nested/jobs/cleanup.js
@@ -1,0 +1,3 @@
+module.exports = async function () {
+  // cron handler — declared at jobs/cleanup.js via the explicit entrypoint
+};

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-nested/jobs/report.js
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-nested/jobs/report.js
@@ -1,0 +1,3 @@
+module.exports = async function () {
+  // second cron handler — sibling of jobs/cleanup.js in the same fixture
+};

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-nested/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-nested/vercel.json
@@ -1,0 +1,16 @@
+{
+  "experimentalServices": {
+    "cleanup": {
+      "type": "job",
+      "trigger": "schedule",
+      "entrypoint": "jobs/cleanup.js",
+      "schedule": "0 0 * * *"
+    },
+    "report": {
+      "type": "job",
+      "trigger": "schedule",
+      "entrypoint": "jobs/report.js",
+      "schedule": "0 6 * * *"
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1156,6 +1156,43 @@ describe.skipIf(flakey)('build', () => {
     });
   });
 
+  it('should build multiple JS cron services from nested entrypoints', async () => {
+    // Two cron services in one fixture, each with its own nested
+    // entrypoint under `jobs/`. Verifies the cron URL path includes
+    // the nested directories, that each service builds its own lambda
+    // mounted at `_svc/{name}/index`, and that each lambda's
+    // dispatcher shim ends up alongside the bundled handler.
+    const cwd = fixture('with-services-cron-nested');
+    const output = join(cwd, '.vercel', 'output');
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toBe(0);
+
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config.crons).toEqual(
+      expect.arrayContaining([
+        {
+          path: '/_svc/cleanup/crons/jobs/cleanup/cron',
+          schedule: '0 0 * * *',
+        },
+        {
+          path: '/_svc/report/crons/jobs/report/cron',
+          schedule: '0 6 * * *',
+        },
+      ])
+    );
+
+    const cleanupConfig = await fs.readJSON(
+      join(output, 'functions/_svc/cleanup/index.func/.vc-config.json')
+    );
+    expect(cleanupConfig.handler).toContain('__vc_cron_dispatch');
+
+    const reportConfig = await fs.readJSON(
+      join(output, 'functions/_svc/report/index.func/.vc-config.json')
+    );
+    expect(reportConfig.handler).toContain('__vc_cron_dispatch');
+  });
+
   it('should build a JS cron service through the cron dispatcher', async () => {
     const cwd = fixture('with-services-cron-handler');
     const output = join(cwd, '.vercel', 'output');

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1156,6 +1156,45 @@ describe.skipIf(flakey)('build', () => {
     });
   });
 
+  it('should build a JS cron service through the cron dispatcher', async () => {
+    const cwd = fixture('with-services-cron-handler');
+    const output = join(cwd, '.vercel', 'output');
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toBe(0);
+
+    // Same build-output as the legacy fixture
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config.crons).toEqual([
+      {
+        path: '/_svc/cleanup/crons/index/cron',
+        schedule: '0 0 * * *',
+      },
+    ]);
+    expect(config.routes).toContainEqual({
+      src: '^/_svc/cleanup/crons/.*$',
+      dest: '/_svc/cleanup/index',
+      check: true,
+    });
+
+    // The lambda's handler points at the cron dispatcher shim, not the
+    // user file directly.
+    const funcDir = join(output, 'functions/_svc/cleanup/index.func');
+    const vcConfig = await fs.readJSON(join(funcDir, '.vc-config.json'));
+    expect(vcConfig.handler).toContain('__vc_cron_dispatch');
+
+    // The dispatcher shim file lives in the bundle and embeds the
+    // route table inline.
+    const shimFiles = (await fs.readdir(funcDir)).filter(name =>
+      name.includes('__vc_cron_dispatch')
+    );
+    expect(shimFiles).toHaveLength(1);
+    const shimSource = await fs.readFile(join(funcDir, shimFiles[0]), 'utf-8');
+    expect(shimSource).toContain(
+      `JSON.parse('{"/_svc/cleanup/crons/index/cron":"default"}')`
+    );
+  });
+
   it('should include job service schedules and queue triggers in build output', async () => {
     const cwd = fixture('with-services-job');
     const output = join(cwd, '.vercel', 'output');
@@ -1266,11 +1305,8 @@ createServer((_req, res) => {
       expect(exitCode).toBe(1);
 
       const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds.error).toMatchObject({
-        code: 'CRON_SERVICE_NO_CRONS',
-      });
       expect(builds.error.message).toContain(
-        'Scheduled service "cleanup" did not produce any cron entries.'
+        'Dynamic cron schedules ("<dynamic>") are not yet supported for JavaScript/TypeScript services'
       );
     } finally {
       // Tolerate EBUSY on Windows when the builder still holds file handles.

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -8,6 +8,7 @@ import type {
 } from './types';
 import {
   getServiceQueueTopics,
+  isScheduleTriggeredService,
   JOB_TRIGGERS,
   JobTrigger,
 } from '@vercel/build-utils';
@@ -715,7 +716,11 @@ export async function resolveConfiguredService(
       frameworkDefinition?.useRuntime?.src ||
       'package.json';
   } else if (config.framework) {
-    if (type === 'web' && isNodeBackendFramework(config.framework)) {
+    const isCronService = isScheduleTriggeredService({ type, trigger });
+    if (
+      isNodeBackendFramework(config.framework) &&
+      (type === 'web' || isCronService)
+    ) {
       builderUse = '@vercel/backends';
     } else {
       builderUse =
@@ -733,7 +738,9 @@ export async function resolveConfiguredService(
       );
     }
     if (inferredRuntime === 'node') {
-      builderUse = type === 'web' ? '@vercel/backends' : '@vercel/node';
+      const isCronService = isScheduleTriggeredService({ type, trigger });
+      builderUse =
+        type === 'web' || isCronService ? '@vercel/backends' : '@vercel/node';
     } else {
       builderUse = getBuilderForRuntime(inferredRuntime);
     }

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -1654,6 +1654,69 @@ describe('detectServices', () => {
       });
     });
 
+    it('should route a JS schedule-triggered service to @vercel/backends', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            cleanup: {
+              type: 'job',
+              trigger: 'schedule',
+              entrypoint: 'cleanup.ts',
+              schedule: '0 0 * * *',
+            },
+          },
+        }),
+        'cleanup.ts': 'export default async function () {}',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0].builder.use).toBe('@vercel/backends');
+      expect(result.services[0].builder.config?.serviceName).toBe('cleanup');
+    });
+
+    it('should route a JS legacy cron service to @vercel/backends', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            cleanup: {
+              type: 'cron',
+              entrypoint: 'cleanup.ts',
+              schedule: '0 0 * * *',
+            },
+          },
+        }),
+        'cleanup.ts': 'export default async function () {}',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0].builder.use).toBe('@vercel/backends');
+    });
+
+    it('should still route a JS queue-triggered worker to @vercel/node', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': JSON.stringify({
+          experimentalServices: {
+            worker: {
+              type: 'job',
+              trigger: 'queue',
+              entrypoint: 'worker.ts',
+              topics: ['orders'],
+            },
+          },
+        }),
+        'worker.ts': 'export default async function () {}',
+      });
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0].builder.use).toBe('@vercel/node');
+    });
+
     it('should parse module:function entrypoint for web services', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({


### PR DESCRIPTION
Allows users to define static schedule services like:
```json
    "cleanup": {
      "type": "job",
      "trigger": "schedule",
      "entrypoint": "jobs/cleanup.js",
      "schedule": "* * * * *"
    },
```

The entrypoint must export a default function. Dispatcher will invoke it once per tick.

At build time:
- Route scheduled services (`type: 'cron'` and `type: 'job', trigger: 'schedule'` to backends builder instead of node builder.
- Create cron endpoints at `_svc/{name}/crons/{entrypoint}/cron`.
- Service handlers are wrapped with a dispatcher shim that handles routing and emitted as `crons` in the build result.
- Shims are generated from templates based on module format (ECM/CJS).
- Allows user specified entrypoints in general (not just for cron) but disallow `'module:function'` style entrypoints.

At runtime:
- Reads the route table, verifies `CRON_SECRET`, ensures method is `GET` or `POST`, dispatches to entrypoint
- Entrypoint file must have a default function, lambda fails on boot if none is provided.

Future work:
- dynamic schedules
- `vc dev` for js cron services