### PR TITLE
ci: allow test strategy PR comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ permissions:
   checks: read
   deployments: read
   issues: write
-  pull-requests: read
+  pull-requests: write
   statuses: write
 
 env:
@@ -132,6 +132,7 @@ jobs:
   comment-test-strategy:
     name: Comment Test Strategy
     runs-on: ubuntu-latest
+    continue-on-error: true
     needs:
       - setup
     steps:


### PR DESCRIPTION
Grant pull request write permission for the test strategy comment and keep the comment job from failing the test workflow if commenting is unavailable.

Made-with: Cursor