### PR TITLE
test: intentionally break emoji test to verify CI

### DIFF
--- a/.changeset/intentional-test-failure.md
+++ b/.changeset/intentional-test-failure.md
@@ -1,0 +1,4 @@
+---
+---
+
+Intentionally failing CLI test to verify CI behavior.

--- a/packages/cli/test/unit/util/emoji.test.ts
+++ b/packages/cli/test/unit/util/emoji.test.ts
@@ -3,7 +3,7 @@ import { removeEmoji } from '../../../src/util/emoji';
 
 describe('removeEmoji', () => {
   it('trims leading whitespace after removing a leading emoji', () => {
-    expect(removeEmoji('💡  hello')).toBe('hello');
+    expect(removeEmoji('💡  hello')).toBe('goodbye');
   });
 
   it('preserves a leading newline for multiline messages', () => {


### PR DESCRIPTION
## Summary

Intentionally modifies a CLI unit test (`packages/cli/test/unit/util/emoji.test.ts`) to fail in order to verify CI behavior. **Do not merge.**

The change updates the expected value in `removeEmoji` test from `'hello'` to `'goodbye'`, which will cause the test to fail.

## Test plan

- [ ] Confirm CI runs and reports the failing test
- [ ] Close PR without merging

Made with [Cursor](https://cursor.com)