### PR TITLE
Add gh-notify-agent: filter GitHub notifications to the ones that matter

### DIFF
--- a/.changeset/gh-notify-agent-5c3b.md
+++ b/.changeset/gh-notify-agent-5c3b.md
@@ -1,0 +1,4 @@
+---
+---
+
+Added `tools/gh-notify-agent`, a standalone Node tool that filters GitHub notifications down to failing CI on the user's PRs, direct @mentions, and real-human comments/reviews on their PRs. Emits to terminal, Slack webhook, and/or desktop.

--- a/tools/gh-notify-agent/README.md
+++ b/tools/gh-notify-agent/README.md
@@ -1,0 +1,167 @@
+# gh-notify-agent
+
+A small Node agent that filters the firehose of GitHub notifications down to
+the signals that actually matter:
+
+- **CI failures** on PRs you authored
+- **@mentions** of you in issue/PR comments (including review comments)
+- **Real-human comments and reviews** on PRs you authored (bots, Dependabot,
+  `github-actions[bot]`, and your own comments are filtered out)
+- *(optional)* **Review requests** where someone asked you to review their PR
+
+It can emit to your **terminal**, a **Slack Incoming Webhook**, and/or native
+**desktop notifications** (macOS / Linux / Windows).
+
+It runs as a one-shot (`once`) for cron/launchd/systemd setups, or as a
+long-lived watcher (`watch`) that polls on an interval.
+
+## Requirements
+
+- Node **20+** (uses global `fetch`, `node:util.parseArgs`, etc. — zero npm deps)
+- A GitHub token exported as `GITHUB_TOKEN` (or `GH_TOKEN`)
+  - Classic PAT: `notifications` + `repo` scopes
+  - Fine-grained: `Notifications: Read`, `Pull requests: Read`, `Contents: Read`,
+    `Checks: Read`, `Metadata: Read`
+
+## Quick start
+
+```bash
+cd tools/gh-notify-agent
+
+export GITHUB_TOKEN=ghp_...
+
+# Run a single poll; prints any matching alerts to stdout
+node src/cli.mjs once --verbose
+
+# Run continuously, polling every 60s, also posting to Slack
+export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/XXX/YYY/ZZZ"
+node src/cli.mjs watch --verbose
+```
+
+Or install globally:
+
+```bash
+cd tools/gh-notify-agent
+npm link      # creates a `gh-notify-agent` binary on PATH
+gh-notify-agent watch
+```
+
+## CLI
+
+```
+gh-notify-agent [command] [options]
+
+Commands:
+  once     Run a single poll and exit (great for cron / launchd / systemd timers)
+  watch    Poll forever on an interval (default)
+
+Options:
+  --poll-seconds <n>      Poll interval for watch mode (default 60)
+  --slack-webhook <url>   Slack Incoming Webhook URL
+  --desktop               Also emit native desktop notifications
+  --no-terminal           Suppress terminal output
+  --state-file <path>     Override state file location
+  --verbose               Log diagnostic info to stderr
+  --help
+```
+
+## Environment variables
+
+| Variable                              | Purpose                                                            |
+| ------------------------------------- | ------------------------------------------------------------------ |
+| `GITHUB_TOKEN` / `GH_TOKEN`           | **Required.** GitHub API token.                                    |
+| `SLACK_WEBHOOK_URL`                   | If set, alerts are also posted to Slack.                           |
+| `GH_NOTIFY_POLL_SECONDS`              | Poll interval (default `60`).                                      |
+| `GH_NOTIFY_DESKTOP=1`                 | Enable native desktop notifications.                               |
+| `GH_NOTIFY_TERMINAL=0`                | Disable terminal output.                                           |
+| `GH_NOTIFY_BOT_LOGINS`                | CSV of extra logins to treat as bots (e.g. `renovate-bot,codecov`).|
+| `GH_NOTIFY_INCLUDE_REVIEW_REQUESTS=0` | Suppress review-request alerts.                                    |
+| `GH_NOTIFY_SINCE_DAYS`                | How far back to look on first run (default `3`).                   |
+| `GH_NOTIFY_STATE_FILE`                | State file path (default `~/.cache/gh-notify-agent/state.json`).   |
+
+## How the filters work
+
+For every unread thread returned by `GET /notifications`, the agent decides
+which category (if any) it belongs to:
+
+- `reason: "ci_activity"` on a PR you authored → look up check runs + combined
+  status on the PR's head SHA; emit `ci_failure` if any are `failure` /
+  `timed_out` / `action_required` / `error`.
+- `reason: "mention"` or `"team_mention"` → fetch issue comments + review
+  comments since last poll and emit `mention` for any that actually contain
+  `@yourlogin` (GitHub's `mention` reason is often false-positive on big
+  threads).
+- `reason: "author"` / `"comment"` / `"subscribed"` on a PR you authored →
+  fetch comments/reviews since last poll; emit `pr_comment` only for ones
+  authored by a non-bot, non-you account.
+- `reason: "review_requested"` → emit `review_request` (toggle off via
+  `GH_NOTIFY_INCLUDE_REVIEW_REQUESTS=0`).
+
+Everything else — releases, stars, watched-repo chatter, Dependabot
+auto-comments on your own PRs, activity on threads you're merely subscribed
+to — is dropped.
+
+Alerts are de-duped across runs via a SHA1 of `(type, repo, pr#, inner-id)`
+stored in a small state file. The state also tracks `lastPollAt` so each
+run only fetches comments/reviews created since the previous run.
+
+## Deploying
+
+### cron (every 2 minutes)
+
+```cron
+*/2 * * * * GITHUB_TOKEN=ghp_... /usr/bin/node /path/to/tools/gh-notify-agent/src/cli.mjs once >>/var/log/gh-notify-agent.log 2>&1
+```
+
+### systemd user service
+
+```ini
+# ~/.config/systemd/user/gh-notify-agent.service
+[Unit]
+Description=GitHub notifications agent
+
+[Service]
+Environment=GITHUB_TOKEN=ghp_...
+Environment=SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXX/YYY/ZZZ
+ExecStart=/usr/bin/node %h/code/tools/gh-notify-agent/src/cli.mjs watch --verbose
+Restart=always
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now gh-notify-agent
+```
+
+### macOS launchd
+
+Create `~/Library/LaunchAgents/dev.gh-notify-agent.plist` with
+`ProgramArguments` pointing at `node src/cli.mjs watch`, then
+`launchctl load` it. Set `GITHUB_TOKEN` via
+`launchctl setenv GITHUB_TOKEN ...` or an `EnvironmentVariables` dict.
+
+## Extending
+
+All filter logic lives in [`src/filters.mjs`](./src/filters.mjs) — it's one
+pure-ish function `buildAlerts({ client, user, notifications, ... })` that
+returns a list of `{ id, type, severity, title, body, url, ... }` alerts.
+
+To add a new sink (email, Discord, ntfy, Pushover, …) drop a new module under
+[`src/notifiers/`](./src/notifiers/) that exposes `{ notify(alert) }`, wire it
+up in [`src/agent.mjs`](./src/agent.mjs)'s `buildSinks()`, and expose a flag
+in [`src/cli.mjs`](./src/cli.mjs).
+
+## Limitations
+
+- Uses GitHub's REST notifications API, which only surfaces *unread* items
+  from the last ~5 days. Anything you already read in the GitHub UI won't
+  re-appear here.
+- The "CI failure" detector hits `check-runs` + combined status for each
+  affected PR head SHA. For repos with huge numbers of checks you may want to
+  raise `GH_NOTIFY_POLL_SECONDS` to stay comfortably inside the 5000 req/hr
+  primary rate limit.
+- Desktop notifications on Linux require `notify-send`; on Windows they
+  require the `BurntToast` PowerShell module. Missing either is a silent
+  no-op.

--- a/tools/gh-notify-agent/package.json
+++ b/tools/gh-notify-agent/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "gh-notify-agent",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Filters GitHub notifications down to the ones that actually matter: failing CI on your PRs, @mentions, and real-human comments on your PRs.",
+  "type": "module",
+  "bin": {
+    "gh-notify-agent": "./src/cli.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "node src/cli.mjs",
+    "once": "node src/cli.mjs once",
+    "watch": "node src/cli.mjs watch",
+    "test": "node --test test/"
+  }
+}

--- a/tools/gh-notify-agent/src/agent.mjs
+++ b/tools/gh-notify-agent/src/agent.mjs
@@ -1,0 +1,136 @@
+import { GitHubClient } from './github.mjs';
+import { buildAlerts } from './filters.mjs';
+import { hasSeen, loadState, markSeen, saveState } from './state.mjs';
+import { createTerminalNotifier } from './notifiers/terminal.mjs';
+import { createSlackNotifier } from './notifiers/slack.mjs';
+import { createDesktopNotifier } from './notifiers/desktop.mjs';
+
+/**
+ * Run a single polling cycle:
+ *   1. Load persisted state.
+ *   2. Fetch unread notifications since last poll (or N days back on first run).
+ *   3. Filter them down to the signals we care about.
+ *   4. Drop anything we've already alerted on.
+ *   5. Emit to configured notifiers and persist state.
+ */
+export async function runOnce(config, { verbose = false } = {}) {
+  const client = new GitHubClient({ token: config.token, apiBase: config.apiBase });
+  const user = await client.getAuthenticatedUser();
+
+  const state = await loadState(config.stateFile);
+  const since = computeSince(state.lastPollAt, config.sinceDays);
+
+  const notifications = await client.listNotifications({
+    since,
+    participating: false,
+    all: false,
+  });
+
+  if (verbose) {
+    process.stderr.write(
+      `[gh-notify-agent] user=${user.login} since=${since} notifications=${notifications.length}\n`
+    );
+  }
+
+  const alerts = await buildAlerts({
+    client,
+    user,
+    notifications,
+    extraBotLogins: config.extraBotLogins,
+    includeReviewRequests: config.includeReviewRequests,
+    since,
+  });
+
+  const fresh = alerts.filter(a => !hasSeen(state, a.id));
+
+  const sinks = buildSinks(config);
+  for (const alert of fresh) {
+    for (const sink of sinks) {
+      try {
+        await sink.notify(alert);
+      } catch (err) {
+        process.stderr.write(
+          `[gh-notify-agent] notifier failed (${sink.name || 'anon'}): ${err.message}\n`
+        );
+      }
+    }
+    markSeen(state, alert.id);
+  }
+
+  state.lastPollAt = new Date().toISOString();
+  await saveState(config.stateFile, state);
+
+  return { user, notificationsCount: notifications.length, alerts: fresh };
+}
+
+/**
+ * Long-running watch loop. Polls every `pollSeconds`, logs errors to stderr
+ * but never exits unless SIGINT/SIGTERM is received.
+ */
+export async function runWatch(config, { verbose = false } = {}) {
+  let running = true;
+  const stop = () => {
+    running = false;
+  };
+  process.on('SIGINT', stop);
+  process.on('SIGTERM', stop);
+
+  while (running) {
+    const start = Date.now();
+    try {
+      const { alerts, notificationsCount } = await runOnce(config, { verbose });
+      if (verbose) {
+        process.stderr.write(
+          `[gh-notify-agent] tick: ${alerts.length} new alert(s) from ${notificationsCount} notifications\n`
+        );
+      }
+    } catch (err) {
+      process.stderr.write(`[gh-notify-agent] poll failed: ${err.message}\n`);
+    }
+    const elapsed = Date.now() - start;
+    const wait = Math.max(5_000, config.pollSeconds * 1000 - elapsed);
+    await sleep(wait, () => !running);
+  }
+}
+
+function buildSinks(config) {
+  const sinks = [];
+  if (config.useTerminal) {
+    const s = createTerminalNotifier();
+    s.name = 'terminal';
+    sinks.push(s);
+  }
+  if (config.slackWebhookUrl) {
+    const s = createSlackNotifier({ webhookUrl: config.slackWebhookUrl });
+    if (s) {
+      s.name = 'slack';
+      sinks.push(s);
+    }
+  }
+  if (config.useDesktop) {
+    const s = createDesktopNotifier();
+    s.name = 'desktop';
+    sinks.push(s);
+  }
+  return sinks;
+}
+
+function computeSince(lastPollAt, sinceDays) {
+  if (lastPollAt) return lastPollAt;
+  const d = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
+  return d.toISOString();
+}
+
+function sleep(ms, shouldAbort) {
+  return new Promise(resolve => {
+    const step = 250;
+    let waited = 0;
+    const timer = setInterval(() => {
+      waited += step;
+      if (waited >= ms || (shouldAbort && shouldAbort())) {
+        clearInterval(timer);
+        resolve();
+      }
+    }, step);
+  });
+}

--- a/tools/gh-notify-agent/src/cli.mjs
+++ b/tools/gh-notify-agent/src/cli.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { loadConfig } from './config.mjs';
+import { runOnce, runWatch } from './agent.mjs';
+
+const USAGE = `gh-notify-agent — filter GitHub notifications to the ones you care about
+
+Usage:
+  gh-notify-agent once            Run a single poll and exit
+  gh-notify-agent watch           Poll continuously (default if no command given)
+  gh-notify-agent --help
+
+Options:
+  --poll-seconds <n>   Polling interval for watch mode (default 60)
+  --slack-webhook <u>  Slack Incoming Webhook URL to post alerts to
+  --desktop            Also emit native desktop notifications
+  --no-terminal        Don't print alerts to the terminal
+  --verbose            Print diagnostic info to stderr
+  --state-file <path>  Override state file location
+
+Environment:
+  GITHUB_TOKEN                 Required. Needs \`notifications\` + \`repo\` scopes.
+  SLACK_WEBHOOK_URL            Same as --slack-webhook.
+  GH_NOTIFY_POLL_SECONDS       Same as --poll-seconds.
+  GH_NOTIFY_DESKTOP=1          Same as --desktop.
+  GH_NOTIFY_BOT_LOGINS         Comma-separated extra bot logins to ignore.
+  GH_NOTIFY_INCLUDE_REVIEW_REQUESTS=0  Suppress review-request alerts.
+  GH_NOTIFY_SINCE_DAYS         How far back to look on first run (default 3).
+  GH_NOTIFY_STATE_FILE         State file path.
+
+Signals emitted:
+  ci_failure      Failing check/CI runs on your PRs.
+  mention         @you in a PR or issue comment.
+  pr_comment      Real humans (not bots, not yourself) commenting or reviewing
+                  on PRs you authored.
+  review_request  Someone requested you as a reviewer (opt-out).
+`;
+
+async function main() {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(2),
+    allowPositionals: true,
+    options: {
+      help: { type: 'boolean', short: 'h' },
+      verbose: { type: 'boolean', short: 'v' },
+      'poll-seconds': { type: 'string' },
+      'slack-webhook': { type: 'string' },
+      desktop: { type: 'boolean' },
+      'no-terminal': { type: 'boolean' },
+      'state-file': { type: 'string' },
+    },
+  });
+
+  if (values.help) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  const command = positionals[0] || 'watch';
+
+  let config;
+  try {
+    config = loadConfig({
+      pollSeconds: values['poll-seconds'],
+      slackWebhookUrl: values['slack-webhook'],
+      useDesktop: values.desktop ? '1' : undefined,
+      useTerminal: values['no-terminal'] ? '0' : undefined,
+      stateFile: values['state-file'],
+    });
+  } catch (err) {
+    process.stderr.write(`Error: ${err.message}\n\n${USAGE}`);
+    process.exit(2);
+  }
+
+  if (command === 'once') {
+    const { alerts } = await runOnce(config, { verbose: values.verbose });
+    if (values.verbose) {
+      process.stderr.write(`[gh-notify-agent] emitted ${alerts.length} alert(s)\n`);
+    }
+    return;
+  }
+
+  if (command === 'watch') {
+    await runWatch(config, { verbose: values.verbose });
+    return;
+  }
+
+  process.stderr.write(`Unknown command: ${command}\n\n${USAGE}`);
+  process.exit(2);
+}
+
+main().catch(err => {
+  process.stderr.write(`[gh-notify-agent] fatal: ${err.stack || err.message || err}\n`);
+  process.exit(1);
+});

--- a/tools/gh-notify-agent/src/config.mjs
+++ b/tools/gh-notify-agent/src/config.mjs
@@ -1,0 +1,61 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+function parseBoolean(value, fallback) {
+  if (value === undefined) return fallback;
+  return /^(1|true|yes|on)$/i.test(value);
+}
+
+function parseCsv(value) {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+export function loadConfig(overrides = {}) {
+  const token = overrides.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (!token) {
+    throw new Error(
+      'Missing GitHub token. Set GITHUB_TOKEN (or GH_TOKEN). ' +
+        'The token needs the `notifications` and `repo` scopes (classic PAT) ' +
+        'or the equivalent fine-grained permissions.'
+    );
+  }
+
+  const pollSeconds = Number(
+    overrides.pollSeconds ?? process.env.GH_NOTIFY_POLL_SECONDS ?? 60
+  );
+
+  return {
+    token,
+    apiBase: process.env.GITHUB_API_URL || 'https://api.github.com',
+    pollSeconds: Number.isFinite(pollSeconds) && pollSeconds > 0 ? pollSeconds : 60,
+    // Output sinks
+    slackWebhookUrl: overrides.slackWebhookUrl ?? process.env.SLACK_WEBHOOK_URL ?? '',
+    useDesktop: parseBoolean(
+      overrides.useDesktop ?? process.env.GH_NOTIFY_DESKTOP,
+      false
+    ),
+    useTerminal: parseBoolean(
+      overrides.useTerminal ?? process.env.GH_NOTIFY_TERMINAL,
+      true
+    ),
+    // Filters
+    // Extra logins to treat as bots (in addition to type==='Bot' and `*[bot]` heuristic).
+    extraBotLogins: parseCsv(process.env.GH_NOTIFY_BOT_LOGINS),
+    // If true, also include review_requested notifications.
+    includeReviewRequests: parseBoolean(
+      process.env.GH_NOTIFY_INCLUDE_REVIEW_REQUESTS,
+      true
+    ),
+    // Only consider notifications within N days (GitHub's default window is ~5).
+    sinceDays: Number(process.env.GH_NOTIFY_SINCE_DAYS ?? 3),
+    // Persistent state file for de-duping.
+    stateFile:
+      overrides.stateFile ??
+      process.env.GH_NOTIFY_STATE_FILE ??
+      join(homedir(), '.cache', 'gh-notify-agent', 'state.json'),
+  };
+}

--- a/tools/gh-notify-agent/src/filters.mjs
+++ b/tools/gh-notify-agent/src/filters.mjs
@@ -1,0 +1,495 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Given the stream of unread notifications + the authed user, produce a list
+ * of alerts corresponding to signals the user actually cares about.
+ *
+ * Signal types:
+ *   - `ci_failure`    : Check/CI failed on a PR authored by the user.
+ *   - `mention`       : The user was @-mentioned in an issue/PR comment.
+ *   - `pr_comment`    : A real human commented/reviewed on a PR authored by the user.
+ *   - `review_request`: Someone requested the user as a reviewer (opt-in).
+ *
+ * Everything else (stars, watched-repo noise, Dependabot chatter, team mentions
+ * on repos the user doesn't own, bot comments on their PRs, etc.) is dropped.
+ */
+
+/** Heuristic for "is this login a bot we should ignore". */
+export function isBotLogin(user, extraBotLogins = []) {
+  if (!user) return false;
+  if (user.type === 'Bot') return true;
+  const login = (user.login || '').toLowerCase();
+  if (!login) return false;
+  if (login.endsWith('[bot]')) return true;
+  if (login === 'github-actions' || login === 'dependabot') return true;
+  return extraBotLogins.map(s => s.toLowerCase()).includes(login);
+}
+
+function parseRepoFullName(fullName) {
+  const [owner, repo] = (fullName || '').split('/');
+  return { owner, repo };
+}
+
+function extractPullNumberFromSubjectUrl(url) {
+  // e.g. https://api.github.com/repos/o/r/pulls/123
+  const m = /\/pulls\/(\d+)(?:$|\/|\?)/.exec(url || '');
+  return m ? Number(m[1]) : null;
+}
+
+function extractIssueNumberFromSubjectUrl(url) {
+  const m = /\/issues\/(\d+)(?:$|\/|\?)/.exec(url || '');
+  return m ? Number(m[1]) : null;
+}
+
+function webUrlFromApiUrl(apiUrl) {
+  if (!apiUrl) return null;
+  // Translate api.github.com/repos/o/r/(pulls|issues)/N -> github.com/o/r/(pull|issues)/N
+  return apiUrl
+    .replace('https://api.github.com/repos/', 'https://github.com/')
+    .replace('/pulls/', '/pull/');
+}
+
+function alertId(parts) {
+  return createHash('sha1').update(parts.join('|')).digest('hex').slice(0, 16);
+}
+
+function containsMention(body, login) {
+  if (!body || !login) return false;
+  const re = new RegExp(`(^|[^A-Za-z0-9_/-])@${login}\\b`, 'i');
+  return re.test(body);
+}
+
+/**
+ * @param {Object} args
+ * @param {GitHubClient} args.client
+ * @param {Object}       args.user           - authenticated user { login, id, ... }
+ * @param {Array}        args.notifications  - GitHub notification threads
+ * @param {string[]}     args.extraBotLogins
+ * @param {boolean}      args.includeReviewRequests
+ * @param {string}       args.since          - ISO timestamp; only consider events at/after
+ * @returns {Promise<Alert[]>}
+ */
+export async function buildAlerts({
+  client,
+  user,
+  notifications,
+  extraBotLogins = [],
+  includeReviewRequests = true,
+  since,
+}) {
+  const alerts = [];
+
+  for (const n of notifications) {
+    try {
+      const perNotification = await alertsForNotification({
+        client,
+        user,
+        notification: n,
+        extraBotLogins,
+        includeReviewRequests,
+        since,
+      });
+      alerts.push(...perNotification);
+    } catch (err) {
+      // Don't let one bad notification poison the stream.
+      // Surface as a low-severity debug alert so we can see it in verbose mode.
+      alerts.push({
+        id: alertId(['error', n.id || '', String(Date.now())]),
+        type: 'debug',
+        severity: 'low',
+        title: `Failed to process notification ${n.id}`,
+        body: String(err && err.message ? err.message : err),
+        url: n.subject?.url || null,
+        threadId: n.id,
+        createdAt: n.updated_at || new Date().toISOString(),
+        repo: n.repository?.full_name || null,
+      });
+    }
+  }
+
+  return dedupeAlerts(alerts);
+}
+
+async function alertsForNotification({
+  client,
+  user,
+  notification,
+  extraBotLogins,
+  includeReviewRequests,
+  since,
+}) {
+  const reason = notification.reason; // mention, team_mention, review_requested, author, comment, ci_activity, ...
+  const subject = notification.subject || {};
+  const subjectType = subject.type; // Issue, PullRequest, CheckSuite, Commit, Release, Discussion
+  const repoFullName = notification.repository?.full_name;
+  const { owner, repo } = parseRepoFullName(repoFullName);
+  if (!owner || !repo) return [];
+
+  const out = [];
+
+  // ─── Review requests (opt-in) ─────────────────────────────────────────────
+  if (reason === 'review_requested' && includeReviewRequests) {
+    if (subjectType === 'PullRequest') {
+      const pr = await client.getSubject(subject.url).catch(() => null);
+      if (pr) {
+        out.push({
+          id: alertId(['review_request', repoFullName, pr.number]),
+          type: 'review_request',
+          severity: 'medium',
+          title: `Review requested: ${repoFullName}#${pr.number} — ${pr.title}`,
+          body: `by @${pr.user?.login || 'unknown'}`,
+          url: pr.html_url,
+          threadId: notification.id,
+          createdAt: notification.updated_at,
+          repo: repoFullName,
+        });
+      }
+    }
+    return out;
+  }
+
+  // ─── PullRequest-subject notifications ────────────────────────────────────
+  if (subjectType === 'PullRequest') {
+    const prNumber = extractPullNumberFromSubjectUrl(subject.url);
+    if (!prNumber) return [];
+
+    const pr = await client.getSubject(subject.url).catch(() => null);
+    if (!pr) return [];
+
+    const isMine = pr.user?.id === user.id;
+
+    // CI failure signal (GitHub surfaces this via reason === 'ci_activity').
+    // We handle CheckSuite subject separately below; here we cover PRs where
+    // GitHub dropped the check info straight onto the PR thread.
+    if (reason === 'ci_activity' && isMine) {
+      const failing = await findFailingChecks(client, { owner, repo, sha: pr.head?.sha });
+      if (failing.length) {
+        out.push(buildCiFailureAlert({ pr, failing, repoFullName, notification }));
+      }
+      return out;
+    }
+
+    // Direct @mention of the user in a PR (comment or body).
+    if (reason === 'mention' || reason === 'team_mention') {
+      const hits = await findMentionHits({
+        client,
+        owner,
+        repo,
+        number: prNumber,
+        user,
+        since,
+      });
+      for (const hit of hits) {
+        out.push({
+          id: alertId(['mention', repoFullName, prNumber, hit.id]),
+          type: 'mention',
+          severity: 'high',
+          title: `@${hit.author} mentioned you in ${repoFullName}#${prNumber}`,
+          body: truncate(hit.body, 500),
+          url: hit.html_url || pr.html_url,
+          threadId: notification.id,
+          createdAt: hit.created_at || notification.updated_at,
+          repo: repoFullName,
+        });
+      }
+      return out;
+    }
+
+    // Comments on PRs authored by the user, from real humans (not the user).
+    if (isMine && (reason === 'author' || reason === 'comment' || reason === 'subscribed')) {
+      const hits = await findHumanPrComments({
+        client,
+        owner,
+        repo,
+        number: prNumber,
+        user,
+        extraBotLogins,
+        since,
+      });
+      for (const hit of hits) {
+        out.push({
+          id: alertId([hit.kind, repoFullName, prNumber, hit.id]),
+          type: 'pr_comment',
+          severity: 'medium',
+          title:
+            hit.kind === 'review'
+              ? `Review from @${hit.author} on ${repoFullName}#${prNumber} (${hit.state})`
+              : `Comment from @${hit.author} on ${repoFullName}#${prNumber}`,
+          body: truncate(hit.body, 500),
+          url: hit.html_url || pr.html_url,
+          threadId: notification.id,
+          createdAt: hit.created_at || notification.updated_at,
+          repo: repoFullName,
+        });
+      }
+      return out;
+    }
+
+    return out;
+  }
+
+  // ─── Issue-subject notifications ──────────────────────────────────────────
+  if (subjectType === 'Issue' && (reason === 'mention' || reason === 'team_mention')) {
+    const issueNumber = extractIssueNumberFromSubjectUrl(subject.url);
+    if (!issueNumber) return [];
+    const hits = await findMentionHits({
+      client,
+      owner,
+      repo,
+      number: issueNumber,
+      user,
+      since,
+      isIssue: true,
+    });
+    for (const hit of hits) {
+      out.push({
+        id: alertId(['mention', repoFullName, issueNumber, hit.id]),
+        type: 'mention',
+        severity: 'high',
+        title: `@${hit.author} mentioned you in ${repoFullName}#${issueNumber}`,
+        body: truncate(hit.body, 500),
+        url: hit.html_url || webUrlFromApiUrl(subject.url),
+        threadId: notification.id,
+        createdAt: hit.created_at || notification.updated_at,
+        repo: repoFullName,
+      });
+    }
+    return out;
+  }
+
+  // ─── CheckSuite / Commit subjects (CI failures) ───────────────────────────
+  if ((subjectType === 'CheckSuite' || subjectType === 'Commit') && reason === 'ci_activity') {
+    // Try to resolve back to a PR owned by the user via the head SHA.
+    const pr = await findOwningPullRequest({
+      client,
+      owner,
+      repo,
+      subject,
+      notification,
+    });
+    if (!pr || pr.user?.id !== user.id) return [];
+
+    const failing = await findFailingChecks(client, {
+      owner,
+      repo,
+      sha: pr.head?.sha,
+    });
+    if (!failing.length) return out;
+    out.push(buildCiFailureAlert({ pr, failing, repoFullName, notification }));
+    return out;
+  }
+
+  return out;
+}
+
+function buildCiFailureAlert({ pr, failing, repoFullName, notification }) {
+  const titleParts = failing
+    .slice(0, 3)
+    .map(c => c.name)
+    .join(', ');
+  const extra = failing.length > 3 ? ` (+${failing.length - 3} more)` : '';
+  return {
+    id: alertId([
+      'ci_failure',
+      repoFullName,
+      pr.number,
+      pr.head?.sha || '',
+      failing.map(c => c.name).join(','),
+    ]),
+    type: 'ci_failure',
+    severity: 'high',
+    title: `CI failing on ${repoFullName}#${pr.number}: ${titleParts}${extra}`,
+    body: failing
+      .slice(0, 10)
+      .map(c => `- ${c.name}${c.details_url ? ` → ${c.details_url}` : ''}`)
+      .join('\n'),
+    url: pr.html_url,
+    threadId: notification.id,
+    createdAt: notification.updated_at,
+    repo: repoFullName,
+  };
+}
+
+async function findFailingChecks(client, { owner, repo, sha }) {
+  if (!sha) return [];
+  const results = [];
+
+  const runs = await client.listCheckRuns({ owner, repo, ref: sha }).catch(() => []);
+  for (const r of runs) {
+    if (r.status === 'completed' && ['failure', 'timed_out', 'action_required'].includes(r.conclusion)) {
+      results.push({
+        name: r.name,
+        details_url: r.html_url || r.details_url,
+        conclusion: r.conclusion,
+      });
+    }
+  }
+
+  // Also include legacy statuses so we don't miss Buildkite, CircleCI, etc.
+  const combined = await client.getCombinedStatus({ owner, repo, ref: sha }).catch(() => null);
+  if (combined?.statuses) {
+    for (const s of combined.statuses) {
+      if (s.state === 'failure' || s.state === 'error') {
+        results.push({
+          name: s.context,
+          details_url: s.target_url,
+          conclusion: s.state,
+        });
+      }
+    }
+  }
+
+  // De-dupe by name (some checks appear in both lists).
+  const seen = new Set();
+  return results.filter(r => (seen.has(r.name) ? false : (seen.add(r.name), true)));
+}
+
+async function findOwningPullRequest({ client, owner, repo, subject, notification }) {
+  // CheckSuite notifications don't link directly to PRs; the subject URL points
+  // at /check-suites/:id which doesn't expose the PR cheaply. Fall back: look
+  // for PRs touched in this thread via the notification's latest_comment_url
+  // or skip. We only care about the user's own PRs; listing open PRs for the
+  // viewer is still cheaper than a check-suite lookup in most cases.
+  if (notification.subject?.latest_comment_url) {
+    const target = await client
+      .getSubject(notification.subject.latest_comment_url)
+      .catch(() => null);
+    if (target?.pull_request) {
+      const pr = await client.getSubject(target.pull_request.url).catch(() => null);
+      if (pr) return pr;
+    }
+  }
+  return null;
+}
+
+async function findMentionHits({
+  client,
+  owner,
+  repo,
+  number,
+  user,
+  since,
+  isIssue = false,
+}) {
+  const hits = [];
+  const issueComments = await client
+    .listIssueComments({ owner, repo, number, since })
+    .catch(() => []);
+  for (const c of issueComments) {
+    if (c.user?.id === user.id) continue;
+    if (containsMention(c.body, user.login)) {
+      hits.push({
+        id: `issue-comment-${c.id}`,
+        author: c.user?.login || 'unknown',
+        body: c.body,
+        html_url: c.html_url,
+        created_at: c.created_at,
+      });
+    }
+  }
+
+  if (!isIssue) {
+    const reviewComments = await client
+      .listPullReviewComments({ owner, repo, number, since })
+      .catch(() => []);
+    for (const c of reviewComments) {
+      if (c.user?.id === user.id) continue;
+      if (containsMention(c.body, user.login)) {
+        hits.push({
+          id: `review-comment-${c.id}`,
+          author: c.user?.login || 'unknown',
+          body: c.body,
+          html_url: c.html_url,
+          created_at: c.created_at,
+        });
+      }
+    }
+  }
+
+  return hits;
+}
+
+async function findHumanPrComments({
+  client,
+  owner,
+  repo,
+  number,
+  user,
+  extraBotLogins,
+  since,
+}) {
+  const hits = [];
+
+  const issueComments = await client
+    .listIssueComments({ owner, repo, number, since })
+    .catch(() => []);
+  for (const c of issueComments) {
+    if (!c.user) continue;
+    if (c.user.id === user.id) continue;
+    if (isBotLogin(c.user, extraBotLogins)) continue;
+    hits.push({
+      kind: 'comment',
+      id: `issue-comment-${c.id}`,
+      author: c.user.login,
+      body: c.body,
+      html_url: c.html_url,
+      created_at: c.created_at,
+    });
+  }
+
+  const reviewComments = await client
+    .listPullReviewComments({ owner, repo, number, since })
+    .catch(() => []);
+  for (const c of reviewComments) {
+    if (!c.user) continue;
+    if (c.user.id === user.id) continue;
+    if (isBotLogin(c.user, extraBotLogins)) continue;
+    hits.push({
+      kind: 'review_comment',
+      id: `review-comment-${c.id}`,
+      author: c.user.login,
+      body: c.body,
+      html_url: c.html_url,
+      created_at: c.created_at,
+    });
+  }
+
+  const reviews = await client
+    .listPullReviews({ owner, repo, number })
+    .catch(() => []);
+  for (const r of reviews) {
+    if (!r.user) continue;
+    if (r.user.id === user.id) continue;
+    if (isBotLogin(r.user, extraBotLogins)) continue;
+    if (!r.submitted_at) continue;
+    if (since && r.submitted_at < since) continue;
+    hits.push({
+      kind: 'review',
+      id: `review-${r.id}`,
+      author: r.user.login,
+      body: r.body || `(${r.state})`,
+      state: r.state,
+      html_url: r.html_url,
+      created_at: r.submitted_at,
+    });
+  }
+
+  return hits;
+}
+
+function dedupeAlerts(alerts) {
+  const seen = new Set();
+  const out = [];
+  for (const a of alerts) {
+    if (seen.has(a.id)) continue;
+    seen.add(a.id);
+    out.push(a);
+  }
+  return out;
+}
+
+function truncate(s, max) {
+  if (!s) return '';
+  const flat = s.replace(/\s+/g, ' ').trim();
+  return flat.length > max ? flat.slice(0, max - 1) + '…' : flat;
+}

--- a/tools/gh-notify-agent/src/github.mjs
+++ b/tools/gh-notify-agent/src/github.mjs
@@ -1,0 +1,144 @@
+/**
+ * Minimal GitHub REST client using global fetch (Node 20+).
+ *
+ * Only the endpoints we need; keeps the tool dependency-free.
+ */
+
+const USER_AGENT = 'gh-notify-agent/0.1';
+
+export class GitHubError extends Error {
+  constructor(message, { status, url, body } = {}) {
+    super(message);
+    this.name = 'GitHubError';
+    this.status = status;
+    this.url = url;
+    this.body = body;
+  }
+}
+
+export class GitHubClient {
+  constructor({ token, apiBase = 'https://api.github.com' }) {
+    if (!token) throw new Error('GitHubClient requires a token');
+    this.token = token;
+    this.apiBase = apiBase.replace(/\/$/, '');
+  }
+
+  async request(path, { method = 'GET', headers = {}, query, body, raw = false } = {}) {
+    const url = new URL(path.startsWith('http') ? path : this.apiBase + path);
+    if (query) {
+      for (const [k, v] of Object.entries(query)) {
+        if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+      }
+    }
+    const res = await fetch(url, {
+      method,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': USER_AGENT,
+        Authorization: `Bearer ${this.token}`,
+        ...headers,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (res.status === 304) return { data: null, res };
+
+    if (!res.ok) {
+      let errBody;
+      try {
+        errBody = await res.text();
+      } catch {
+        errBody = '';
+      }
+      throw new GitHubError(
+        `GitHub ${method} ${url.pathname} -> ${res.status} ${res.statusText}`,
+        { status: res.status, url: url.toString(), body: errBody }
+      );
+    }
+
+    if (raw) return { data: res, res };
+
+    if (res.status === 204) return { data: null, res };
+    const text = await res.text();
+    const data = text ? JSON.parse(text) : null;
+    return { data, res };
+  }
+
+  /** GET /user */
+  async getAuthenticatedUser() {
+    const { data } = await this.request('/user');
+    return data;
+  }
+
+  /**
+   * GET /notifications
+   * Returns unread notifications for the authenticated user.
+   */
+  async listNotifications({ since, participating = false, all = false } = {}) {
+    const { data } = await this.request('/notifications', {
+      query: {
+        participating: participating ? 'true' : 'false',
+        all: all ? 'true' : 'false',
+        since,
+        per_page: 50,
+      },
+    });
+    return data || [];
+  }
+
+  /** PATCH /notifications/threads/:thread_id -> mark a single thread as read. */
+  async markThreadRead(threadId) {
+    await this.request(`/notifications/threads/${threadId}`, { method: 'PATCH' });
+  }
+
+  /** Fetch the subject referenced by a notification (Issue, PR, Commit, etc.). */
+  async getSubject(url) {
+    const { data } = await this.request(url);
+    return data;
+  }
+
+  /** GET /repos/:owner/:repo/commits/:ref/check-runs */
+  async listCheckRuns({ owner, repo, ref }) {
+    const { data } = await this.request(
+      `/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}/check-runs`,
+      { query: { per_page: 100 } }
+    );
+    return data?.check_runs || [];
+  }
+
+  /** GET /repos/:owner/:repo/commits/:ref/status (legacy statuses) */
+  async getCombinedStatus({ owner, repo, ref }) {
+    const { data } = await this.request(
+      `/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}/status`
+    );
+    return data;
+  }
+
+  /** GET /repos/:owner/:repo/issues/:number/comments (issue-level PR comments) */
+  async listIssueComments({ owner, repo, number, since }) {
+    const { data } = await this.request(
+      `/repos/${owner}/${repo}/issues/${number}/comments`,
+      { query: { since, per_page: 100 } }
+    );
+    return data || [];
+  }
+
+  /** GET /repos/:owner/:repo/pulls/:number/comments (review comments) */
+  async listPullReviewComments({ owner, repo, number, since }) {
+    const { data } = await this.request(
+      `/repos/${owner}/${repo}/pulls/${number}/comments`,
+      { query: { since, per_page: 100 } }
+    );
+    return data || [];
+  }
+
+  /** GET /repos/:owner/:repo/pulls/:number/reviews */
+  async listPullReviews({ owner, repo, number }) {
+    const { data } = await this.request(
+      `/repos/${owner}/${repo}/pulls/${number}/reviews`,
+      { query: { per_page: 100 } }
+    );
+    return data || [];
+  }
+}

--- a/tools/gh-notify-agent/src/notifiers/desktop.mjs
+++ b/tools/gh-notify-agent/src/notifiers/desktop.mjs
@@ -1,0 +1,58 @@
+import { spawn } from 'node:child_process';
+import { platform } from 'node:os';
+
+/**
+ * Best-effort native desktop notifications.
+ *
+ *   - macOS: osascript
+ *   - Linux: notify-send (if available)
+ *   - Windows: PowerShell BurntToast (only if installed) — otherwise no-op
+ *
+ * We don't take a dep on node-notifier etc. to keep this tool zero-install.
+ */
+export function createDesktopNotifier() {
+  const os = platform();
+
+  return {
+    async notify(alert) {
+      const title = alert.title || 'GitHub';
+      const body = alert.url ? `${alert.body ? alert.body + '\n' : ''}${alert.url}` : alert.body || '';
+
+      try {
+        if (os === 'darwin') {
+          await run('osascript', [
+            '-e',
+            `display notification ${escapeAppleScript(body)} with title ${escapeAppleScript(title)}`,
+          ]);
+        } else if (os === 'linux') {
+          await run('notify-send', ['--', title, body]).catch(() => {
+            // notify-send not installed; silently no-op.
+          });
+        } else if (os === 'win32') {
+          const ps = `New-BurntToastNotification -Text '${escapeSingleQuotes(title)}','${escapeSingleQuotes(
+            body
+          )}'`;
+          await run('powershell', ['-NoProfile', '-Command', ps]).catch(() => {});
+        }
+      } catch {
+        // Never let a desktop-notification failure break the run.
+      }
+    },
+  };
+}
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(cmd, args, { stdio: 'ignore' });
+    p.on('error', reject);
+    p.on('close', code => (code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`))));
+  });
+}
+
+function escapeAppleScript(s) {
+  return '"' + String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+}
+
+function escapeSingleQuotes(s) {
+  return String(s).replace(/'/g, "''");
+}

--- a/tools/gh-notify-agent/src/notifiers/slack.mjs
+++ b/tools/gh-notify-agent/src/notifiers/slack.mjs
@@ -1,0 +1,68 @@
+const TYPE_EMOJI = {
+  ci_failure: ':x:',
+  mention: ':at:',
+  pr_comment: ':speech_balloon:',
+  review_request: ':eyes:',
+  debug: ':grey_question:',
+};
+
+/**
+ * Slack Incoming Webhook notifier. No deps; just a POST.
+ */
+export function createSlackNotifier({ webhookUrl }) {
+  if (!webhookUrl) return null;
+  return {
+    async notify(alert) {
+      const emoji = TYPE_EMOJI[alert.type] || ':bell:';
+      const text = alert.url
+        ? `${emoji} *<${alert.url}|${escapeMarkdown(alert.title)}>*`
+        : `${emoji} *${escapeMarkdown(alert.title)}*`;
+
+      const blocks = [
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text },
+        },
+      ];
+      if (alert.body) {
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '```' + truncate(alert.body, 2500) + '```',
+          },
+        });
+      }
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `${alert.repo || ''} · ${alert.type} · ${new Date(
+              alert.createdAt || Date.now()
+            ).toISOString()}`,
+          },
+        ],
+      });
+
+      const res = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: alert.title, blocks }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`Slack webhook failed: ${res.status} ${res.statusText} ${body}`);
+      }
+    },
+  };
+}
+
+function escapeMarkdown(s) {
+  return String(s || '').replace(/([*_`])/g, '\\$1');
+}
+
+function truncate(s, max) {
+  const str = String(s);
+  return str.length > max ? str.slice(0, max - 1) + '…' : str;
+}

--- a/tools/gh-notify-agent/src/notifiers/terminal.mjs
+++ b/tools/gh-notify-agent/src/notifiers/terminal.mjs
@@ -1,0 +1,51 @@
+const COLOR = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  green: '\x1b[32m',
+  cyan: '\x1b[36m',
+  magenta: '\x1b[35m',
+};
+
+const ICON = {
+  ci_failure: '✖',
+  mention: '@',
+  pr_comment: '💬',
+  review_request: '👀',
+  debug: '·',
+};
+
+const TYPE_COLOR = {
+  ci_failure: COLOR.red,
+  mention: COLOR.magenta,
+  pr_comment: COLOR.cyan,
+  review_request: COLOR.yellow,
+  debug: COLOR.dim,
+};
+
+export function createTerminalNotifier({ stream = process.stdout, color } = {}) {
+  const useColor = color ?? stream.isTTY ?? false;
+  const paint = (c, s) => (useColor ? `${c}${s}${COLOR.reset}` : s);
+
+  return {
+    async notify(alert) {
+      const tint = TYPE_COLOR[alert.type] || '';
+      const icon = ICON[alert.type] || '•';
+      const header = `${paint(tint + COLOR.bold, `${icon} ${alert.type.toUpperCase()}`)} ${paint(
+        COLOR.dim,
+        new Date(alert.createdAt || Date.now()).toLocaleString()
+      )}`;
+      stream.write(header + '\n');
+      stream.write(paint(COLOR.bold, alert.title) + '\n');
+      if (alert.body) {
+        for (const line of String(alert.body).split('\n')) {
+          stream.write(paint(COLOR.dim, '  ' + line) + '\n');
+        }
+      }
+      if (alert.url) stream.write('  ' + paint(COLOR.cyan, alert.url) + '\n');
+      stream.write('\n');
+    },
+  };
+}

--- a/tools/gh-notify-agent/src/state.mjs
+++ b/tools/gh-notify-agent/src/state.mjs
@@ -1,0 +1,59 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+/**
+ * Persistent state for de-duping notifications across runs.
+ *
+ * Shape:
+ *   {
+ *     seen: { [alertId: string]: isoTimestamp },
+ *     lastPollAt: isoTimestamp
+ *   }
+ *
+ * `alertId` is a stable id we compute for each emitted alert (see filters.mjs).
+ */
+
+const MAX_SEEN = 2000;
+const SEEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export async function loadState(path) {
+  try {
+    const raw = await readFile(path, 'utf8');
+    const parsed = JSON.parse(raw);
+    return {
+      seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
+      lastPollAt: parsed.lastPollAt || null,
+    };
+  } catch (err) {
+    if (err.code === 'ENOENT') return { seen: {}, lastPollAt: null };
+    throw err;
+  }
+}
+
+export async function saveState(path, state) {
+  await mkdir(dirname(path), { recursive: true });
+  const pruned = pruneSeen(state.seen);
+  const payload = {
+    seen: pruned,
+    lastPollAt: state.lastPollAt || null,
+  };
+  await writeFile(path, JSON.stringify(payload, null, 2));
+}
+
+function pruneSeen(seen) {
+  const now = Date.now();
+  const entries = Object.entries(seen).filter(([, ts]) => {
+    const t = Date.parse(ts);
+    return Number.isFinite(t) && now - t < SEEN_TTL_MS;
+  });
+  entries.sort((a, b) => Date.parse(b[1]) - Date.parse(a[1]));
+  return Object.fromEntries(entries.slice(0, MAX_SEEN));
+}
+
+export function markSeen(state, id) {
+  state.seen[id] = new Date().toISOString();
+}
+
+export function hasSeen(state, id) {
+  return Object.prototype.hasOwnProperty.call(state.seen, id);
+}

--- a/tools/gh-notify-agent/test/filters.test.mjs
+++ b/tools/gh-notify-agent/test/filters.test.mjs
@@ -1,0 +1,306 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAlerts, isBotLogin } from '../src/filters.mjs';
+
+const USER = { id: 100, login: 'alice', type: 'User' };
+const BOT = { id: 200, login: 'dependabot[bot]', type: 'Bot' };
+const OTHER = { id: 300, login: 'bob', type: 'User' };
+
+function makeClient(overrides = {}) {
+  return {
+    async getSubject(url) {
+      if (overrides.subjects && overrides.subjects[url]) return overrides.subjects[url];
+      throw new Error(`unexpected getSubject ${url}`);
+    },
+    async listCheckRuns() {
+      return overrides.checkRuns || [];
+    },
+    async getCombinedStatus() {
+      return overrides.combinedStatus || { statuses: [] };
+    },
+    async listIssueComments() {
+      return overrides.issueComments || [];
+    },
+    async listPullReviewComments() {
+      return overrides.reviewComments || [];
+    },
+    async listPullReviews() {
+      return overrides.reviews || [];
+    },
+  };
+}
+
+describe('isBotLogin', () => {
+  it('flags type=Bot', () => {
+    assert.equal(isBotLogin({ type: 'Bot', login: 'x' }), true);
+  });
+  it('flags [bot] suffix', () => {
+    assert.equal(isBotLogin({ type: 'User', login: 'renovate[bot]' }), true);
+  });
+  it('flags known bot logins', () => {
+    assert.equal(isBotLogin({ type: 'User', login: 'dependabot' }), true);
+    assert.equal(isBotLogin({ type: 'User', login: 'github-actions' }), true);
+  });
+  it('honors extraBotLogins', () => {
+    assert.equal(
+      isBotLogin({ type: 'User', login: 'codecov' }, ['codecov']),
+      true
+    );
+  });
+  it('does not flag real users', () => {
+    assert.equal(isBotLogin({ type: 'User', login: 'alice' }), false);
+  });
+});
+
+describe('buildAlerts - mention', () => {
+  it('emits a mention alert when body contains @user', async () => {
+    const notification = {
+      id: 'n1',
+      reason: 'mention',
+      updated_at: '2026-05-01T10:00:00Z',
+      repository: { full_name: 'org/repo' },
+      subject: {
+        type: 'PullRequest',
+        url: 'https://api.github.com/repos/org/repo/pulls/1',
+      },
+    };
+    const pr = {
+      number: 1,
+      title: 'Do thing',
+      user: OTHER,
+      html_url: 'https://github.com/org/repo/pull/1',
+      head: { sha: 'abc' },
+    };
+    const client = makeClient({
+      subjects: { [notification.subject.url]: pr },
+      issueComments: [
+        {
+          id: 9001,
+          user: OTHER,
+          body: 'hey @alice please take a look',
+          html_url: 'https://github.com/org/repo/pull/1#issuecomment-9001',
+          created_at: '2026-05-01T09:59:00Z',
+        },
+        {
+          id: 9002,
+          user: OTHER,
+          body: 'ignore me, no mention here',
+          created_at: '2026-05-01T09:58:00Z',
+        },
+      ],
+    });
+    const alerts = await buildAlerts({
+      client,
+      user: USER,
+      notifications: [notification],
+      since: '2026-04-30T00:00:00Z',
+    });
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0].type, 'mention');
+    assert.match(alerts[0].title, /@bob mentioned you in org\/repo#1/);
+  });
+
+  it('ignores @-substring in email-like or @teamname strings', async () => {
+    const notification = {
+      id: 'n1',
+      reason: 'mention',
+      updated_at: '2026-05-01T10:00:00Z',
+      repository: { full_name: 'org/repo' },
+      subject: {
+        type: 'PullRequest',
+        url: 'https://api.github.com/repos/org/repo/pulls/1',
+      },
+    };
+    const pr = { number: 1, title: 't', user: OTHER, html_url: 'x', head: { sha: 'abc' } };
+    const client = makeClient({
+      subjects: { [notification.subject.url]: pr },
+      issueComments: [
+        { id: 1, user: OTHER, body: 'email alice@example.com', created_at: '2026-05-01' },
+        { id: 2, user: OTHER, body: 'ping @alicefoo', created_at: '2026-05-01' },
+      ],
+    });
+    const alerts = await buildAlerts({ client, user: USER, notifications: [notification] });
+    assert.equal(alerts.length, 0);
+  });
+});
+
+describe('buildAlerts - pr_comment', () => {
+  it('emits pr_comment for human comments on the user\'s PR, skipping bots + self', async () => {
+    const notification = {
+      id: 'n2',
+      reason: 'author',
+      updated_at: '2026-05-01T10:00:00Z',
+      repository: { full_name: 'org/repo' },
+      subject: {
+        type: 'PullRequest',
+        url: 'https://api.github.com/repos/org/repo/pulls/42',
+      },
+    };
+    const pr = {
+      number: 42,
+      title: 'Fix bug',
+      user: USER,
+      html_url: 'https://github.com/org/repo/pull/42',
+      head: { sha: 'head42' },
+    };
+    const client = makeClient({
+      subjects: { [notification.subject.url]: pr },
+      issueComments: [
+        { id: 1, user: OTHER, body: 'nice fix', html_url: 'h1', created_at: '2026-05-01T09:00:00Z' },
+        { id: 2, user: BOT, body: 'beep boop', html_url: 'h2', created_at: '2026-05-01T09:00:00Z' },
+        { id: 3, user: USER, body: 'self reply', html_url: 'h3', created_at: '2026-05-01T09:00:00Z' },
+      ],
+      reviews: [
+        {
+          id: 77,
+          user: OTHER,
+          state: 'CHANGES_REQUESTED',
+          body: 'please fix',
+          html_url: 'h-review',
+          submitted_at: '2026-05-01T09:30:00Z',
+        },
+      ],
+    });
+    const alerts = await buildAlerts({ client, user: USER, notifications: [notification] });
+    const kinds = alerts.map(a => a.type).sort();
+    assert.deepEqual(kinds, ['pr_comment', 'pr_comment']);
+    const titles = alerts.map(a => a.title).join('\n');
+    assert.match(titles, /@bob/);
+    assert.doesNotMatch(titles, /dependabot/);
+    assert.doesNotMatch(titles, /@alice/);
+  });
+
+  it('does not emit pr_comment when the PR is not authored by the user', async () => {
+    const notification = {
+      id: 'n2',
+      reason: 'subscribed',
+      updated_at: '2026-05-01T10:00:00Z',
+      repository: { full_name: 'org/repo' },
+      subject: {
+        type: 'PullRequest',
+        url: 'https://api.github.com/repos/org/repo/pulls/43',
+      },
+    };
+    const pr = { number: 43, title: 't', user: OTHER, html_url: 'x', head: { sha: 'h' } };
+    const client = makeClient({
+      subjects: { [notification.subject.url]: pr },
+      issueComments: [{ id: 1, user: OTHER, body: 'hi', created_at: 'x' }],
+    });
+    const alerts = await buildAlerts({ client, user: USER, notifications: [notification] });
+    assert.equal(alerts.length, 0);
+  });
+});
+
+describe('buildAlerts - ci_failure', () => {
+  it('emits ci_failure when ci_activity fires and check runs have failures', async () => {
+    const notification = {
+      id: 'n3',
+      reason: 'ci_activity',
+      updated_at: '2026-05-01T10:00:00Z',
+      repository: { full_name: 'org/repo' },
+      subject: {
+        type: 'PullRequest',
+        url: 'https://api.github.com/repos/org/repo/pulls/7',
+      },
+    };
+    const pr = {
+      number: 7,
+      title: 'wip',
+      user: USER,
+      html_url: 'https://github.com/org/repo/pull/7',
+      head: { sha: 'deadbeef' },
+    };
+    const client = makeClient({
+      subjects: { [notification.subject.url]: pr },
+      checkRuns: [
+        { name: 'test', status: 'completed', conclusion: 'success' },
+        {
+          name: 'lint',
+          status: 'completed',
+          conclusion: 'failure',
+          html_url: 'https://github.com/org/repo/actions/runs/1',
+        },
+      ],
+      combinedStatus: {
+        statuses: [{ context: 'buildkite', state: 'error', target_url: 'https://bk' }],
+      },
+    });
+    const alerts = await buildAlerts({ client, user: USER, notifications: [notification] });
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0].type, 'ci_failure');
+    assert.match(alerts[0].title, /CI failing on org\/repo#7/);
+    assert.match(alerts[0].body, /lint/);
+    assert.match(alerts[0].body, /buildkite/);
+  });
+
+  it('does not emit ci_failure for PRs not authored by the user', async () => {
+    const notification = {
+      id: 'n3',
+      reason: 'ci_activity',
+      updated_at: '2026-05-01T10:00:00Z',
+      repository: { full_name: 'org/repo' },
+      subject: {
+        type: 'PullRequest',
+        url: 'https://api.github.com/repos/org/repo/pulls/8',
+      },
+    };
+    const pr = { number: 8, title: 't', user: OTHER, html_url: 'x', head: { sha: 'h' } };
+    const client = makeClient({
+      subjects: { [notification.subject.url]: pr },
+      checkRuns: [{ name: 'lint', status: 'completed', conclusion: 'failure' }],
+    });
+    const alerts = await buildAlerts({ client, user: USER, notifications: [notification] });
+    assert.equal(alerts.length, 0);
+  });
+});
+
+describe('buildAlerts - review_request', () => {
+  it('emits review_request when includeReviewRequests is true', async () => {
+    const notification = {
+      id: 'n4',
+      reason: 'review_requested',
+      updated_at: '2026-05-01T10:00:00Z',
+      repository: { full_name: 'org/repo' },
+      subject: {
+        type: 'PullRequest',
+        url: 'https://api.github.com/repos/org/repo/pulls/99',
+      },
+    };
+    const pr = {
+      number: 99,
+      title: 'pls review',
+      user: OTHER,
+      html_url: 'https://github.com/org/repo/pull/99',
+    };
+    const client = makeClient({ subjects: { [notification.subject.url]: pr } });
+    const alerts = await buildAlerts({
+      client,
+      user: USER,
+      notifications: [notification],
+      includeReviewRequests: true,
+    });
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0].type, 'review_request');
+  });
+
+  it('suppresses review_request when includeReviewRequests is false', async () => {
+    const notification = {
+      id: 'n4',
+      reason: 'review_requested',
+      updated_at: '2026-05-01T10:00:00Z',
+      repository: { full_name: 'org/repo' },
+      subject: {
+        type: 'PullRequest',
+        url: 'https://api.github.com/repos/org/repo/pulls/99',
+      },
+    };
+    const client = makeClient();
+    const alerts = await buildAlerts({
+      client,
+      user: USER,
+      notifications: [notification],
+      includeReviewRequests: false,
+    });
+    assert.equal(alerts.length, 0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `tools/gh-notify-agent`, a small standalone Node 20+ tool (zero npm deps) that polls the authenticated user's GitHub notifications and filters them down to the signals most people actually care about:

- **`ci_failure`** — failing check-runs **or** combined-status checks on PRs authored by the user
- **`mention`** — direct `@you` in PR/issue comments, including review comments (verified by re-scanning the thread body so GitHub's noisy `mention` reason doesn't false-positive)
- **`pr_comment`** — real-human comments and reviews on PRs authored by the user (filters out `type: Bot`, `*[bot]`, `dependabot`, `github-actions`, self, plus any extra logins via `GH_NOTIFY_BOT_LOGINS`)
- **`review_request`** *(opt-out via `GH_NOTIFY_INCLUDE_REVIEW_REQUESTS=0`)* — someone requested you as a reviewer

Everything else (stars, watched-repo chatter, release notifications, bot comments, threads you're merely subscribed to, …) is dropped.

## How to use

```bash
cd tools/gh-notify-agent
export GITHUB_TOKEN=ghp_...

node src/cli.mjs once --verbose            # one-shot
node src/cli.mjs watch                     # long-lived poll
```

Sinks: terminal (default), Slack Incoming Webhook (`SLACK_WEBHOOK_URL` / `--slack-webhook`), and/or native desktop (`GH_NOTIFY_DESKTOP=1` / `--desktop`). Supports cron, systemd user service, and launchd — examples in the [README](tools/gh-notify-agent/README.md).

## Implementation notes

- All filter logic is isolated in [`src/filters.mjs`](tools/gh-notify-agent/src/filters.mjs) as one mostly-pure `buildAlerts({ client, user, notifications, ... })` function, easy to unit-test and extend.
- `src/github.mjs` is a thin `fetch`-based GitHub REST client covering just the endpoints we need (notifications, subjects, check-runs, combined status, issue comments, review comments, reviews).
- State (seen alert IDs + `lastPollAt`) is persisted to `~/.cache/gh-notify-agent/state.json` with a 30-day TTL and 2000-entry cap, so alerts are de-duped across runs and each poll only asks GitHub for comments newer than the last run.
- Sinks live under [`src/notifiers/`](tools/gh-notify-agent/src/notifiers/); adding e.g. Discord/ntfy/email is a matter of dropping in a `{ notify(alert) }` module and wiring it into `agent.mjs#buildSinks`.
- The tool intentionally lives outside the pnpm workspace and outside Biome's `includes` — it has no runtime deps and isn't part of anything we publish.

## Tests

Added `node:test` unit suite covering 13 cases across 5 suites:

- `isBotLogin` — `type: Bot`, `[bot]` suffix, known logins, `extraBotLogins`, real users
- `mention` — positive match; rejects `alice@example.com` and `@alicefoo` substring cases
- `pr_comment` — filters out bots and the user themselves; requires PR ownership
- `ci_failure` — surfaces check-run failures **and** legacy combined-status errors (buildkite/circle); suppressed on other users' PRs
- `review_request` — respects the `includeReviewRequests` toggle

```
cd tools/gh-notify-agent
node --test test/
# tests 13 · pass 13 · fail 0
```

## Changeset

Empty-frontmatter changeset at `.changeset/gh-notify-agent-5c3b.md` — no `@vercel/*` packages are affected; this lives under `tools/` which is outside the published surface.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d33f103-4652-4094-8eb8-cb785e7d5c3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d33f103-4652-4094-8eb8-cb785e7d5c3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

