### PR TITLE
[vercel] Add --filter to `project ls` for name filtering

### DIFF
--- a/.changeset/project-ls-filter.md
+++ b/.changeset/project-ls-filter.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Added `--filter`/`-f <NAME>` flag to `vercel project ls` for filtering projects by name (substring match).

--- a/.changeset/project-ls-filter.md
+++ b/.changeset/project-ls-filter.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Added `--filter`/`-f <NAME>` flag to `vercel project ls` for filtering projects by name (substring match).

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -166,6 +166,14 @@ export const listSubcommand = {
       type: Boolean,
       deprecated: false,
     },
+    {
+      name: 'filter',
+      shorthand: 'f',
+      type: String,
+      argument: 'NAME',
+      description: 'Filter projects by name (substring match)',
+      deprecated: false,
+    },
   ],
   examples: [
     {
@@ -175,6 +183,10 @@ export const listSubcommand = {
     {
       name: 'List projects using a deprecated Node.js version in JSON format',
       value: `${packageName} project ls --update-required --format=json`,
+    },
+    {
+      name: 'Filter projects by name',
+      value: `${packageName} project ls --filter my-app`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -115,9 +115,12 @@ export default async function list(
 function processFlags(
   opts: Record<string, any>,
   telemetryClient: ProjectListTelemetryClient
-): { deprecated: boolean; next?: number; json: boolean } | { error: string } {
+):
+  | { deprecated: boolean; next?: number; json: boolean; filter?: string }
+  | { error: string } {
   const deprecated = opts['--update-required'] || false;
   const next = opts['--next'];
+  const filter = opts['--filter'];
   const formatResult = validateJsonOutput(opts);
   if (!formatResult.valid) {
     return { error: formatResult.error };
@@ -128,12 +131,17 @@ function processFlags(
   telemetryClient.trackCliOptionNext(next);
   telemetryClient.trackCliOptionFormat(opts['--format']);
   telemetryClient.trackCliFlagJson(opts['--json']);
+  telemetryClient.trackCliOptionFilter(filter);
 
-  return { deprecated, next, json };
+  return { deprecated, next, json, filter };
 }
 
 // Helper function to build projects URL
-function buildProjectsUrl(flags: { deprecated: boolean; next?: number }) {
+function buildProjectsUrl(flags: {
+  deprecated: boolean;
+  next?: number;
+  filter?: string;
+}) {
   let url = BASE_PROJECTS_URL;
 
   if (flags.deprecated) {
@@ -141,6 +149,9 @@ function buildProjectsUrl(flags: { deprecated: boolean; next?: number }) {
   }
   if (flags.next) {
     url += `&until=${flags.next}`;
+  }
+  if (flags.filter) {
+    url += `&search=${encodeURIComponent(flags.filter)}`;
   }
 
   return url;

--- a/packages/cli/src/util/telemetry/commands/project/list.ts
+++ b/packages/cli/src/util/telemetry/commands/project/list.ts
@@ -26,4 +26,13 @@ export class ProjectListTelemetryClient
       this.trackCliFlag('json');
     }
   }
+
+  trackCliOptionFilter(filter: string | undefined) {
+    if (filter) {
+      this.trackCliOption({
+        option: 'filter',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5245,6 +5245,7 @@ exports[`help command > project help output snapshots > project list help output
 
   Options:
 
+  -f,  --filter <NAME>    Filter projects by name (substring match)                                                     
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
   -N,  --next <MS>        Show next page of results                                                                     
        --update-required  A list of projects affected by an upcoming deprecation                                        
@@ -5273,6 +5274,10 @@ exports[`help command > project help output snapshots > project list help output
   - List projects using a deprecated Node.js version in JSON format
 
     $ vercel project ls --update-required --format=json
+
+  - Filter projects by name
+
+    $ vercel project ls --filter my-app
 
 "
 `;

--- a/packages/cli/test/unit/commands/project/list.test.ts
+++ b/packages/cli/test/unit/commands/project/list.test.ts
@@ -87,6 +87,54 @@ describe('list', () => {
     });
   });
 
+  describe('--filter', () => {
+    it('should track flag', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+      });
+
+      client.setArgv('project', 'ls', '--filter', 'my-app');
+      await projects(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: `subcommand:list`,
+          value: 'ls',
+        },
+        {
+          key: `option:filter`,
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+
+    it('should pass filter to the API as the search query param', async () => {
+      useUser();
+      useTeams('team_dummy');
+
+      let receivedSearch: string | undefined;
+      client.scenario.get(`/v9/projects`, (req, res) => {
+        receivedSearch = req.query.search as string | undefined;
+        res.json({
+          projects: [defaultProject],
+          pagination: {},
+        });
+      });
+
+      useProject({
+        ...defaultProject,
+      });
+
+      client.setArgv('project', 'ls', '--filter', 'my-app');
+      const exitCode = await projects(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedSearch).toEqual('my-app');
+    });
+  });
+
   describe('--json', () => {
     it('should track flag', async () => {
       useUser();


### PR DESCRIPTION
## Why

Accounts with many projects make finding one in `vercel project ls` painful — output paginates 20 at a time. `--filter`/`-f <NAME>` forwards the value to `/v9/projects` as the `search` query param, returning only matching projects without needing to page through results.

Mirrors the `--filter` pattern already used by `vercel routes` and `vercel metrics`.

## Validation

<details>
<summary>Manual run against a real account</summary>

```
$ pnpm vercel project ls

> vercel@53.0.1 vercel /Users/jsvana/worktrees/vercel/cli-project-ls-filter/packages/cli
> pnpm build && node ./dist/vc.js "project" "ls"


> vercel@53.0.1 build /Users/jsvana/worktrees/vercel/cli-project-ls-filter/packages/cli
> node scripts/build.mjs

Compiling all doT templates...
Compiling error.jst to file
Compiling error_404.jst to file
Compiling error_502.jst to file
Compiling error_base.jst to file
Compiling redirect.jst to file
> Projects found under vercel [2s]

  Project Name                              Latest Production URL                                       Updated   Node Version
  api                                       https://api.vercel.sh                                       1s        22.x
  vercel-alerts                             https://vercel-alerts.vercel.sh                             7s        22.x
  v0chat                                    https://v0chat.vercel.sh                                    52s       24.x
  api-www-avatar                            https://api-www-avatar.vercel.sh                            1m        20.x
  control-plane-default                     https://control-plane-default.vercel.sh                     2m        22.x
  copper-agent                              https://copper-agent.vercel.sh                              2m        22.x
  api-agent                                 https://api-agent.vercel.sh                                 2m        20.x
  internal-engineering-documentation-site   https://internal-engineering-documentation-site.vercel.sh   2m        20.x
  beta-billing-usage-api                    https://beta-billing-usage-api.vercel.sh                    2m        22.x
  copper                                    https://copper.vercel.sh                                    2m        22.x
  ownership                                 https://ownership.vercel.sh                                 2m        24.x
  upkeep-manager                            https://upkeep-manager.vercel.sh                            2m        22.x
  testserver                                https://testserver.vercel.sh                                2m        22.x
  api-support                               https://api-support.vercel.sh                               2m        20.x
  gha-analysis                              https://gha-analysis-prod.vercel.sh                         2m        24.x
  agent-feedback                            https://agent-feedback-prod.vercel.sh                       2m        24.x
  finfra-agent-api                          https://finfra-agent-api.vercel.sh                          2m        24.x
  agent-hub                                 https://agent-hub-prod.vercel.sh                            2m        22.x
  internal-agent-gateway                    https://internal-agent-gateway-prod.vercel.sh               2m        22.x
  blackbox-reconciler                       https://blackbox-reconciler-prod.vercel.sh                  2m        20.x

> To display the next page, run \`vercel project ls --next 1777667330439\`

$ pnpm vercel project ls --filter ownership

> vercel@53.0.1 vercel /Users/jsvana/worktrees/vercel/cli-project-ls-filter/packages/cli
> pnpm build && node ./dist/vc.js "project" "ls" "--filter" "ownership"


> vercel@53.0.1 build /Users/jsvana/worktrees/vercel/cli-project-ls-filter/packages/cli
> node scripts/build.mjs

Compiling all doT templates...
Compiling error.jst to file
Compiling error_404.jst to file
Compiling error_502.jst to file
Compiling error_base.jst to file
Compiling redirect.jst to file
> Projects found under vercel [1s]

  Project Name   Latest Production URL         Updated   Node Version
  ownership      https://ownership.vercel.sh   2m        24.x
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)