### PR TITLE
[CLI] Handling stale cached plugin installs + removing nontty install suggestions

### DIFF
--- a/.changeset/stale-claude-plugin-registry.md
+++ b/.changeset/stale-claude-plugin-registry.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Handle stale Claude Code Vercel plugin registry entries during plugin migration.

--- a/packages/cli/src/util/agent/auto-install-agentic.ts
+++ b/packages/cli/src/util/agent/auto-install-agentic.ts
@@ -8,7 +8,6 @@ import { KNOWN_AGENTS } from '@vercel/detect-agent';
 import type Client from '../client';
 import output from '../../output-manager';
 import getGlobalPathConfig from '../config/global-path';
-import { AGENT_ACTION } from '../agent-output-constants';
 
 const PREFS_FILE = 'agent-preferences.json';
 const CLAUDE_LEGACY_PLUGIN_ID = 'vercel-plugin@vercel';
@@ -27,6 +26,15 @@ export function getPluginTargetForAgent(
   if (!agentName) {
     return undefined;
   }
+
+  if (
+    agentName === KNOWN_AGENTS.CLAUDE ||
+    agentName.startsWith('claude-code') ||
+    agentName === KNOWN_AGENTS.COWORK
+  ) {
+    return 'claude-code';
+  }
+
   return AGENT_TO_TARGET[agentName];
 }
 
@@ -42,9 +50,15 @@ interface ClaudeListedPlugin {
   scope?: string;
   enabled?: boolean;
   installPath?: string;
+  stale?: boolean;
   installedAt?: string;
   lastUpdated?: string;
   mcpServers?: Record<string, unknown>;
+}
+
+interface ClaudeInstalledPluginsRegistry {
+  plugins?: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 export type ClaudePluginInstallState =
@@ -130,7 +144,7 @@ async function readClaudeInstalledPluginsFromRegistry(): Promise<
 > {
   try {
     const raw = await readFile(
-      join(homedir(), '.claude', 'plugins', 'installed_plugins.json'),
+      getClaudeInstalledPluginsRegistryPath(),
       'utf-8'
     );
     const data = JSON.parse(raw);
@@ -152,6 +166,48 @@ async function readClaudeInstalledPluginsFromRegistry(): Promise<
     return entries;
   } catch {
     return [];
+  }
+}
+
+function getClaudeInstalledPluginsRegistryPath(): string {
+  return join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
+}
+
+async function markStaleClaudePluginInstalls(
+  plugins: ClaudeListedPlugin[]
+): Promise<ClaudeListedPlugin[]> {
+  return Promise.all(
+    plugins.map(async plugin => {
+      if (plugin.installPath && !(await fileExists(plugin.installPath))) {
+        return { ...plugin, stale: true };
+      }
+      return plugin;
+    })
+  );
+}
+
+async function removeClaudePluginFromRegistry(
+  pluginId: string
+): Promise<boolean> {
+  try {
+    const registryPath = getClaudeInstalledPluginsRegistryPath();
+    const raw = await readFile(registryPath, 'utf-8');
+    const data = JSON.parse(raw) as ClaudeInstalledPluginsRegistry;
+
+    if (!data.plugins || !(pluginId in data.plugins)) {
+      return false;
+    }
+
+    delete data.plugins[pluginId];
+    await writeFile(
+      registryPath,
+      `${JSON.stringify(data, null, 2)}\n`,
+      'utf-8'
+    );
+    return true;
+  } catch (err) {
+    output.debug(`Failed to remove Claude plugin registry entry: ${err}`);
+    return false;
   }
 }
 
@@ -213,7 +269,7 @@ async function getClaudeInstalledPlugins(): Promise<ClaudeListedPlugin[]> {
     try {
       const parsed = JSON.parse(result.stdout);
       if (Array.isArray(parsed)) {
-        return parsed as ClaudeListedPlugin[];
+        return markStaleClaudePluginInstalls(parsed as ClaudeListedPlugin[]);
       }
     } catch (err) {
       output.debug(`Failed to parse Claude plugin list JSON: ${err}`);
@@ -224,7 +280,9 @@ async function getClaudeInstalledPlugins(): Promise<ClaudeListedPlugin[]> {
     );
   }
 
-  return readClaudeInstalledPluginsFromRegistry();
+  return markStaleClaudePluginInstalls(
+    await readClaudeInstalledPluginsFromRegistry()
+  );
 }
 
 async function fetchLatestVercelPluginVersion(): Promise<string | undefined> {
@@ -381,81 +439,6 @@ export function buildClaudePromptCopy(
   };
 }
 
-export function buildClaudeActionRequiredMessage(
-  status: ClaudePluginStatus,
-  plan: ClaudePluginMigrationPlan
-): string {
-  if (status.state === 'legacy-only') {
-    return `Working with Vercel is easier with the latest Vercel Plugin for Claude Code. It will run:\n1. claude plugins install ${CLAUDE_OFFICIAL_PLUGIN_ID}\n2. claude plugins uninstall ${CLAUDE_LEGACY_PLUGIN_ID}\nWould you like me to update it?`;
-  }
-
-  if (status.state === 'both' || plan.removeLegacy) {
-    return `Working with Vercel is easier with the latest Vercel Plugin for Claude Code. It will run:\n1. claude plugins uninstall ${CLAUDE_LEGACY_PLUGIN_ID}\nWould you like me to update it?`;
-  }
-
-  if (plan.updateOfficial) {
-    return `Working with Vercel is easier with the latest Vercel Plugin for Claude Code. It will run:\n1. claude plugins update ${CLAUDE_OFFICIAL_PLUGIN_ID}\nWould you like me to update it?`;
-  }
-
-  return `Working with Vercel is easier with the Vercel Plugin for Claude Code. It will run:\n1. claude plugins install ${CLAUDE_OFFICIAL_PLUGIN_ID}\nWould you like me to install it?`;
-}
-
-function buildClaudeActionRequiredLabel(
-  status: ClaudePluginStatus,
-  plan: ClaudePluginMigrationPlan
-): string {
-  if (
-    status.state === 'legacy-only' ||
-    status.state === 'both' ||
-    plan.removeLegacy ||
-    plan.updateOfficial
-  ) {
-    return 'Update it';
-  }
-
-  return 'Install it';
-}
-
-function getClaudeActionRequiredCommand(
-  status: ClaudePluginStatus,
-  plan: ClaudePluginMigrationPlan
-): string {
-  if (plan.installOfficial && status.state === 'none') {
-    return `claude plugins install ${CLAUDE_OFFICIAL_PLUGIN_ID}`;
-  }
-
-  if (status.state === 'both' && plan.removeLegacy) {
-    return `claude plugins uninstall ${CLAUDE_LEGACY_PLUGIN_ID}`;
-  }
-
-  if (plan.updateOfficial && status.state === 'official-only') {
-    return `claude plugins update ${CLAUDE_OFFICIAL_PLUGIN_ID}`;
-  }
-
-  return `claude plugins install ${CLAUDE_OFFICIAL_PLUGIN_ID}`;
-}
-
-function getClaudeActionRequiredNextSteps(
-  status: ClaudePluginStatus,
-  plan: ClaudePluginMigrationPlan
-): Array<{ command: string; when?: string }> {
-  const next: Array<{ command: string; when?: string }> = [
-    {
-      command: getClaudeActionRequiredCommand(status, plan),
-      when: buildClaudeActionRequiredLabel(status, plan),
-    },
-  ];
-
-  if (status.state === 'legacy-only' && plan.removeLegacy) {
-    next.push({
-      command: `claude plugins uninstall ${CLAUDE_LEGACY_PLUGIN_ID}`,
-      when: 'Remove the old plugin after the update',
-    });
-  }
-
-  return next;
-}
-
 async function runClaudeCommand(
   spinnerMessage: string,
   successMessage: string,
@@ -481,9 +464,54 @@ async function runClaudeCommand(
   return false;
 }
 
+async function removeStaleLegacyClaudePlugin(
+  removeMarketplace: boolean
+): Promise<boolean> {
+  output.spinner('Removing the stale legacy Vercel Claude plugin...');
+  const removedRegistryEntry = await removeClaudePluginFromRegistry(
+    CLAUDE_LEGACY_PLUGIN_ID
+  );
+  output.stopSpinner();
+
+  if (!removedRegistryEntry) {
+    output.warn(
+      'Could not remove the stale legacy Vercel Claude plugin registry entry.'
+    );
+    return false;
+  }
+
+  output.success('Removed the stale legacy Vercel Claude plugin');
+
+  if (removeMarketplace) {
+    const removedMarketplace = await runClaudeCommand(
+      'Removing the legacy Vercel marketplace...',
+      'Removed the legacy Vercel marketplace',
+      'Removed the stale legacy Vercel plugin, but could not remove the legacy marketplace.',
+      ['plugins', 'marketplace', 'remove', 'vercel'],
+      { quietSuccess: true }
+    );
+    if (!removedMarketplace) {
+      output.log('Cleanup command: claude plugins marketplace remove vercel');
+    }
+  }
+
+  return true;
+}
+
 async function runClaudeMigration(
   plan: ClaudePluginMigrationPlan
 ): Promise<void> {
+  let removedStaleLegacy = false;
+
+  if (plan.removeLegacy) {
+    const statusBeforeInstall = await getClaudePluginStatus();
+    if (statusBeforeInstall.legacy?.stale) {
+      removedStaleLegacy = await removeStaleLegacyClaudePlugin(
+        plan.removeLegacyMarketplace
+      );
+    }
+  }
+
   if (plan.installOfficial) {
     const installed = await runClaudeCommand(
       'Installing the official Vercel Claude plugin...',
@@ -527,7 +555,7 @@ async function runClaudeMigration(
     }
   }
 
-  if (plan.removeLegacyMarketplace) {
+  if (plan.removeLegacyMarketplace && !removedStaleLegacy) {
     const finalStatus = await getClaudePluginStatus();
     if (!finalStatus.legacy) {
       const removedMarketplace = await runClaudeCommand(
@@ -620,39 +648,9 @@ export async function autoInstallVercelPlugin(
           confirmMessage = claudePrompt.confirm;
         }
 
-        // Agents in non-TTY: output structured JSON so agent prompts the user
+        // Agent command output is often interpreted as tool data. Keep plugin
+        // install prompts to TTY flows so non-TTY agent output stays clean.
         if (client.isAgent && !client.stdin.isTTY) {
-          const actionRequiredMessage =
-            uninstalledTargets.includes('claude-code') &&
-            claudeStatus &&
-            claudePlan
-              ? buildClaudeActionRequiredMessage(claudeStatus, claudePlan)
-              : promptMessages.join(' ');
-          const next =
-            uninstalledTargets.includes('claude-code') &&
-            claudeStatus &&
-            claudePlan
-              ? getClaudeActionRequiredNextSteps(claudeStatus, claudePlan)
-              : [
-                  {
-                    command: `claude plugins install ${CLAUDE_OFFICIAL_PLUGIN_ID}`,
-                    when: 'Install it',
-                  },
-                ];
-          client.stdout.write(
-            `${JSON.stringify(
-              {
-                status: 'action_required',
-                reason: 'plugin_install',
-                action: AGENT_ACTION.CONFIRMATION_REQUIRED,
-                message: actionRequiredMessage,
-                userActionRequired: true,
-                next,
-              },
-              null,
-              2
-            )}\n`
-          );
           await markPromptedToday(prefs);
           return;
         }

--- a/packages/cli/test/unit/util/auto-install-agentic.test.ts
+++ b/packages/cli/test/unit/util/auto-install-agentic.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { KNOWN_AGENTS } from '@vercel/detect-agent';
 import {
-  buildClaudeActionRequiredMessage,
   buildClaudePromptCopy,
   buildClaudePluginMigrationPlan,
   buildClaudePluginStatus,
@@ -22,6 +21,9 @@ describe('getPluginTargetForAgent', () => {
   it('maps Claude Code agents to the Claude plugin target', () => {
     expect(getPluginTargetForAgent(KNOWN_AGENTS.CLAUDE)).toBe('claude-code');
     expect(getPluginTargetForAgent(KNOWN_AGENTS.COWORK)).toBe('claude-code');
+    expect(getPluginTargetForAgent('claude-code/2.1.126/agent')).toBe(
+      'claude-code'
+    );
   });
 
   it('does not map Codex to a Claude plugin target', () => {
@@ -61,6 +63,23 @@ describe('buildClaudePluginStatus', () => {
     expect(status.state).toBe('both');
     expect(status.legacy?.version).toBe('0.32.6');
     expect(status.official?.version).toBe('0.32.7');
+  });
+
+  it('preserves stale legacy install metadata', () => {
+    const status = buildClaudePluginStatus(
+      [
+        {
+          id: 'vercel-plugin@vercel',
+          version: '0.22.0',
+          installPath: '/missing/vercel-plugin',
+          stale: true,
+        },
+      ],
+      '0.32.7'
+    );
+
+    expect(status.state).toBe('legacy-only');
+    expect(status.legacy?.stale).toBe(true);
   });
 });
 
@@ -210,31 +229,5 @@ describe('buildClaudePromptCopy', () => {
       'Working with Vercel is easier with the latest Vercel Plugin for Claude Code'
     );
     expect(copy.confirm).toContain('0.32.6 to 0.32.7');
-  });
-});
-
-describe('buildClaudeActionRequiredMessage', () => {
-  it('uses marketplace upgrade wording for legacy Claude installs', () => {
-    const message = buildClaudeActionRequiredMessage(
-      {
-        state: 'legacy-only',
-        legacy: { id: 'vercel-plugin@vercel', version: '0.22.0' },
-        latestVersion: '0.32.7',
-      },
-      {
-        installOfficial: true,
-        updateOfficial: false,
-        removeLegacy: true,
-        removeLegacyMarketplace: true,
-      }
-    );
-
-    expect(message).toContain(
-      'Working with Vercel is easier with the latest Vercel Plugin for Claude Code'
-    );
-    expect(message).toContain(
-      'claude plugins install vercel@claude-plugins-official'
-    );
-    expect(message).toContain('claude plugins uninstall vercel-plugin@vercel');
   });
 });


### PR DESCRIPTION
Fixes Claude Code Vercel plugin migration in the CLI.
  - Maps versioned Claude agent names like claude-code/… to the Claude plugin target.
  - Handles stale legacy vercel-plugin@vercel registry entries whose cache directory no
    longer exists.
  - Suppresses plugin install prompts in agent/non-TTY command output; interactive TTY
    prompts still work.