### PR TITLE
fix(cli): tighten SdkKey type to keep plaintext off list responses

### DIFF
--- a/.changeset/flags-sdk-keys-drop-plaintext-from-list-json.md
+++ b/.changeset/flags-sdk-keys-drop-plaintext-from-list-json.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Tighten the `SdkKey` type so plaintext `keyValue`, `tokenValue`, and `connectionString` can no longer appear on list responses. `flags sdk-keys ls --json` already omitted these via an explicit allowlist; the type split makes the guarantee static. Create-time output from `flags sdk-keys add` is unaffected.

--- a/packages/cli/src/util/flags/sdk-keys.ts
+++ b/packages/cli/src/util/flags/sdk-keys.ts
@@ -1,6 +1,11 @@
 import type { JSONObject } from '@vercel-internals/types';
 import type Client from '../client';
-import type { SdkKey, SdkKeysListResponse, CreateSdkKeyRequest } from './types';
+import type {
+  SdkKey,
+  SdkKeysListResponse,
+  CreateSdkKeyRequest,
+  CreatedSdkKey,
+} from './types';
 import output from '../../output-manager';
 
 export async function getSdkKeys(
@@ -19,11 +24,11 @@ export async function createSdkKey(
   client: Client,
   projectId: string,
   request: CreateSdkKeyRequest
-): Promise<SdkKey> {
+): Promise<CreatedSdkKey> {
   output.debug(`Creating SDK key for project ${projectId}`);
 
   const url = `/v1/projects/${encodeURIComponent(projectId)}/feature-flags/sdk-keys`;
-  const response = await client.fetch<SdkKey>(url, {
+  const response = await client.fetch<CreatedSdkKey>(url, {
     method: 'PUT',
     body: request as unknown as JSONObject,
   });

--- a/packages/cli/src/util/flags/types.ts
+++ b/packages/cli/src/util/flags/types.ts
@@ -132,12 +132,18 @@ export interface SdkKey {
   updatedAt: number;
   label?: string;
   deletedAt?: number;
-  keyValue?: string;
-  tokenValue?: string;
-  connectionString?: string;
   // Server-masked preview of the key value, e.g. `vf_server_abc********`.
   // Safe to display; never contains the full secret.
   partialKeyValue?: string;
+}
+
+// Returned only from the create endpoint, where the API reveals the
+// plaintext key once. The list endpoint never returns these fields, and the
+// CLI must never emit them in `flags sdk-keys ls` output (table or JSON).
+export interface CreatedSdkKey extends SdkKey {
+  keyValue?: string;
+  tokenValue?: string;
+  connectionString?: string;
 }
 
 export interface SdkKeysListResponse {

--- a/packages/cli/test/mocks/flags.ts
+++ b/packages/cli/test/mocks/flags.ts
@@ -1,5 +1,10 @@
 import { client } from './client';
-import type { Flag, SdkKey, FlagSettings } from '../../src/util/flags/types';
+import type {
+  Flag,
+  SdkKey,
+  CreatedSdkKey,
+  FlagSettings,
+} from '../../src/util/flags/types';
 
 export const defaultFlagSettings: FlagSettings = {
   typeName: 'settings',
@@ -296,7 +301,7 @@ export function useFlags(
   client.scenario.put(
     '/v1/projects/:projectId/feature-flags/sdk-keys',
     (req, res) => {
-      const newKey: SdkKey = {
+      const newKey: CreatedSdkKey = {
         hashKey: `sdk_key_${Date.now()}`,
         projectId: req.params.projectId,
         type: req.body.sdkKeyType,
@@ -308,7 +313,21 @@ export function useFlags(
         keyValue: `vercel_flags_${Date.now()}_secret`,
         connectionString: `https://flags.vercel.com/v1/flags/${req.params.projectId}`,
       };
-      sdkKeysList.push(newKey);
+      // Only the non-secret subset is persisted in the in-memory list, so
+      // subsequent LIST calls never replay the cleartext fields the API
+      // returned on creation.
+      const listRow: SdkKey = {
+        hashKey: newKey.hashKey,
+        projectId: newKey.projectId,
+        type: newKey.type,
+        environment: newKey.environment,
+        createdBy: newKey.createdBy,
+        createdAt: newKey.createdAt,
+        updatedAt: newKey.updatedAt,
+        label: newKey.label,
+        partialKeyValue: newKey.partialKeyValue,
+      };
+      sdkKeysList.push(listRow);
       res.json(newKey);
     }
   );

--- a/packages/cli/test/unit/commands/flags/sdk-keys.test.ts
+++ b/packages/cli/test/unit/commands/flags/sdk-keys.test.ts
@@ -86,7 +86,14 @@ describe('flags sdk-keys', () => {
     });
 
     it('never leaks cleartext secrets in the default table output', async () => {
-      const sdkKeysWithSecrets: SdkKey[] = [
+      // Simulate a mixed-version window where the API still returns
+      // plaintext `keyValue` / `tokenValue` / `connectionString` on LIST.
+      // The CLI must strip these fields regardless of what the API returns.
+      // Cast through `unknown` because we are deliberately simulating a
+      // non-conformant API payload: `SdkKey` no longer declares the
+      // plaintext fields, but we want to prove the CLI strips them even
+      // if a stale API deploy sneaks them onto the LIST response.
+      const sdkKeysWithSecrets = [
         {
           ...defaultSdkKeys[0],
           keyValue: 'vf_server_fullsecretvalue_should_not_leak',
@@ -94,7 +101,7 @@ describe('flags sdk-keys', () => {
           connectionString:
             'https://flags.vercel.com/v1/flags/secret_should_not_leak',
         },
-      ];
+      ] as unknown as SdkKey[];
       client.reset();
       useUser();
       useTeams('team_dummy');
@@ -121,6 +128,61 @@ describe('flags sdk-keys', () => {
       );
       expect(combined).not.toContain('tok_fullsecrettoken_should_not_leak');
       expect(combined).not.toContain('secret_should_not_leak');
+    });
+
+    it('never leaks cleartext secrets in --json output', async () => {
+      // Same mixed-version simulation as the table-output test, but asserts
+      // the JSON contract exposed to scripts. Even if a stale API deploy
+      // still returns plaintext on LIST, `flags sdk-keys ls --json` must
+      // never surface `keyValue`, `tokenValue`, or `connectionString` to
+      // stdout.
+      // Cast through `unknown` because we are deliberately simulating a
+      // non-conformant API payload: `SdkKey` no longer declares the
+      // plaintext fields, but we want to prove the CLI strips them even
+      // if a stale API deploy sneaks them onto the LIST response.
+      const sdkKeysWithSecrets = [
+        {
+          ...defaultSdkKeys[0],
+          keyValue: 'vf_server_fullsecretvalue_should_not_leak_json',
+          tokenValue: 'tok_fullsecrettoken_should_not_leak_json',
+          connectionString:
+            'https://flags.vercel.com/v1/flags/secret_should_not_leak_json',
+        },
+        {
+          ...defaultSdkKeys[1],
+          keyValue: 'vf_client_fullsecretvalue_should_not_leak_json',
+        },
+      ] as unknown as SdkKey[];
+      client.reset();
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'vercel-flags-test',
+        name: 'vercel-flags-test',
+      });
+      useFlags(undefined, sdkKeysWithSecrets);
+      const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+      client.cwd = cwd;
+      client.stdin.isTTY = false;
+
+      client.setArgv('flags', 'sdk-keys', 'ls', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const raw = client.stdout.getFullOutput();
+      expect(raw).not.toContain('vf_server_fullsecretvalue_should_not_leak');
+      expect(raw).not.toContain('vf_client_fullsecretvalue_should_not_leak');
+      expect(raw).not.toContain('tok_fullsecrettoken_should_not_leak');
+      expect(raw).not.toContain('secret_should_not_leak');
+
+      const parsed = JSON.parse(raw);
+      expect(parsed.sdkKeys).toHaveLength(2);
+      for (const row of parsed.sdkKeys) {
+        expect(row).not.toHaveProperty('keyValue');
+        expect(row).not.toHaveProperty('tokenValue');
+        expect(row).not.toHaveProperty('connectionString');
+      }
     });
 
     describe('--json', () => {


### PR DESCRIPTION
## Summary

- Split the shared `SdkKey` type into a list-safe shape and a create-only `CreatedSdkKey` that extends it with the plaintext `keyValue` / `tokenValue` / `connectionString`. `flags sdk-keys add` still reveals the secret once on creation; the LIST code path can no longer touch it at the type level.
- `vercel flags sdk-keys ls --json` already omitted these fields via an explicit allowlist — this change locks the contract at the type layer and adds a regression test.
- Updates the `useFlags` mock so the in-memory list it backs only persists the non-secret subset after a create, closer to real API behavior.

No user-observable change to `ls --json` output: the fields it emits (`hashKey`, `type`, `environment`, `label`, `partialKeyValue`, `createdAt`, `updatedAt`) are unchanged. Create-time output from `flags sdk-keys add` is unaffected.

## Test plan

- [x] New unit test pumps plaintext `keyValue` / `tokenValue` / `connectionString` through the LIST mock and asserts neither the raw stdout nor the parsed JSON contains them.
- [x] Existing table-output leak test still passes against the same mixed-version mock.
- [x] \`npx vitest run packages/cli/test/unit/commands/flags/sdk-keys.test.ts\` — 18/18 pass.
- [x] \`pnpm lint\` clean on touched files; prettier clean.

Made with [Cursor](https://cursor.com)