### PR TITLE
[remix] Cover root index single-fetch path and add unit test

### DIFF
--- a/.changeset/react-router-data-suffix-routing.md
+++ b/.changeset/react-router-data-suffix-routing.md
@@ -2,4 +2,4 @@
 '@vercel/remix-builder': patch
 ---
 
-Emit `.data` function entries for React Router single-fetch routes so per-route function config is preserved.
+Emit `.data` function entries for React Router single-fetch routes so per-route function config is preserved. Also emits a `_root.data` entry for the root index route, which uses that URL (not `/index.data`) for its single-fetch document loader.

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -18,6 +18,7 @@ import {
 } from '@vercel/build-utils';
 import {
   getPathFromRoute,
+  getReactRouterDataPaths,
   getRegExpFromPath,
   getPackageVersion,
   hasScript,
@@ -534,9 +535,12 @@ export const build: BuildV2 = async ({
 
     output[path] = func;
     if (isReactRouter) {
-      // Emit a parallel entry so the filesystem handle resolves `<path>.data`
-      // to the same bundle. `writeFunctionSymlink` dedupes this to a symlink.
-      output[`${path}.data`] = func;
+      // Emit parallel entries so the filesystem handle resolves the
+      // single-fetch URL(s) for this route to the same bundle. Note that
+      // the root index route uses `/_root.data` rather than `/index.data`.
+      for (const dataPath of getReactRouterDataPaths(path)) {
+        output[dataPath] = func;
+      }
     }
 
     // If this is a dynamic route then add a Vercel route

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -282,6 +282,30 @@ export function getRegExpFromPath(rePath: string): RegExp | false {
 }
 
 /**
+ * React Router v7 single-fetch rewrites loader/action requests from
+ * `<path>` to `<path>.data` for client-side navigations. For most routes
+ * the `.data` URL mirrors the document path, but the root index route is
+ * special: its single-fetch URL is `/_root.data`, not `/index.data`.
+ *
+ * Returns the list of `output` keys (relative to the Build Output `output`
+ * map) that should resolve to the same function as the given `path`, so
+ * that single-fetch requests hit the dedicated route bundle and preserve
+ * any per-route `runtime` / `memory` / `regions` overrides instead of
+ * falling through to the SSR catch-all.
+ */
+export function getReactRouterDataPaths(path: string): string[] {
+  const paths = [`${path}.data`];
+  // `getPathFromRoute()` resolves the root index route (and any
+  // layout-nested index without an intermediate path segment) to
+  // `path === 'index'`. React Router uses `/_root.data` for that route's
+  // single-fetch URL, so register that variant as well.
+  if (path === 'index') {
+    paths.push('_root.data');
+  }
+  return paths;
+}
+
+/**
  * Updates the `dest` process.env object to match the `source` one.
  * A function is returned to restore the `dest` env back to how
  * it was originally.

--- a/packages/remix/test/unit.get-react-router-data-paths.test.ts
+++ b/packages/remix/test/unit.get-react-router-data-paths.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { getReactRouterDataPaths } from '../src/utils';
+
+describe('getReactRouterDataPaths()', () => {
+  it.each([
+    {
+      path: 'about',
+      expected: ['about.data'],
+    },
+    {
+      path: 'api/hello',
+      expected: ['api/hello.data'],
+    },
+    {
+      path: 'projects/create',
+      expected: ['projects/create.data'],
+    },
+    {
+      path: 'projects/*',
+      expected: ['projects/*.data'],
+    },
+    {
+      path: ':foo/:bar/:baz',
+      expected: [':foo/:bar/:baz.data'],
+    },
+    {
+      path: '(:lang)',
+      expected: ['(:lang).data'],
+    },
+  ])('should return only `<path>.data` for non-root path "$path"', ({
+    path,
+    expected,
+  }) => {
+    expect(getReactRouterDataPaths(path)).toEqual(expected);
+  });
+
+  it('should also return `_root.data` for the root index path', () => {
+    // `getPathFromRoute()` resolves the root index route to `path === 'index'`.
+    // React Router single-fetch uses `/_root.data` for that route's
+    // single-fetch URL, not `/index.data`, so both must be registered.
+    expect(getReactRouterDataPaths('index')).toEqual([
+      'index.data',
+      '_root.data',
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the React Router single-fetch fix on this branch. The original change emitted `output[`${path}.data`]` entries for every React Router route so that single-fetch requests resolve to the dedicated route bundle instead of falling through to the SSR catch-all.

That fix is correct for non-root routes. The root index route is a special case: React Router's single-fetch URL for it is `/_root.data`, not `/.data` or `/index.data`. Because `getPathFromRoute()` resolves the root index to `path === 'index'`, the original change only registered `output['index.data']`, so `/_root.data` still missed the filesystem handle and fell through to `routes.push({ src: '/(.*)', dest: '/' })`. That rewrites the URL to `/`, strips the `.data` suffix before the function runs, and reproduces the same per-route function-config bypass the parent PR is fixing.

## What changed

- `packages/remix/src/utils.ts` — add `getReactRouterDataPaths(path)` which returns the list of `output` keys that should be registered for a given route path. For non-root paths it returns `['<path>.data']`. For the root index path (`'index'`) it also returns `'_root.data'`.
- `packages/remix/src/build-vite.ts` — replace the inline `output[`${path}.data`] = func` with a loop over `getReactRouterDataPaths(path)` so the root index also gets a `_root.data` entry pointing at the same function.
- `packages/remix/test/unit.get-react-router-data-paths.test.ts` — focused unit test asserting the helper returns just `<path>.data` for normal paths and additionally `_root.data` for the root index, so this branch is covered without requiring a deployment.
- Updated the changeset description to mention the `_root.data` case.

The dynamic-route handling and the `isReactRouter` gate are unchanged, so nothing about the Remix path is affected.

## Validation

- `pnpm vitest-run run test/unit.*.test.ts` (in `packages/remix`) — 123 passed, 4 skipped.
- `pnpm type-check` (in `packages/remix`) — clean.
- `pnpm lint` — no new findings.
- `pnpm prettier --check` on the touched files — clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a1e4242-b189-4cfa-b14f-938f8cecb988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a1e4242-b189-4cfa-b14f-938f8cecb988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

