### PR TITLE
[python/vercel-workers] register queue client subscriptions

### DIFF
--- a/.changeset/queue-client-entrypoint.md
+++ b/.changeset/queue-client-entrypoint.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Support Python queue-triggered job services that target a named `QueueClient` entrypoint such as `worker:queue`.

--- a/packages/cli/test/dev/fixtures/services-worker/vercel.json
+++ b/packages/cli/test/dev/fixtures/services-worker/vercel.json
@@ -11,6 +11,13 @@
       "entrypoint": "worker/worker.py",
       "topics": ["tasks-topic"]
     },
+    "worker-client": {
+      "type": "job",
+      "trigger": "queue",
+      "runtime": "python",
+      "entrypoint": "worker/worker:queue",
+      "topics": ["client-topic"]
+    },
     "worker-wildcard": {
       "type": "worker",
       "runtime": "python",

--- a/packages/cli/test/dev/fixtures/services-worker/web/server.py
+++ b/packages/cli/test/dev/fixtures/services-worker/web/server.py
@@ -22,3 +22,9 @@ def enqueue():
     with open(os.path.join(RESULT_DIR, "send_result.json"), "w") as f:
         json.dump({"messageId": message_id}, f)
     return {"messageId": message_id}
+
+
+@app.post("/enqueue-client")
+def enqueue_client():
+    result = send("client-topic", {"action": "client-test", "value": 7})
+    return {"messageId": result.get("messageId", "")}

--- a/packages/cli/test/dev/fixtures/services-worker/worker/worker.py
+++ b/packages/cli/test/dev/fixtures/services-worker/worker/worker.py
@@ -1,15 +1,30 @@
 import json
 import os
 
-from vercel.workers import subscribe
+from vercel.workers import QueueClient, subscribe
 
 RESULT_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".results")
+queue = QueueClient()
 
 
 @subscribe(topic="tasks-topic")
 def handle_task(message, metadata):
     os.makedirs(RESULT_DIR, exist_ok=True)
     with open(os.path.join(RESULT_DIR, "worker_exact_result.json"), "w") as f:
+        json.dump(
+            {
+                "received": True,
+                "message": message,
+                "messageId": metadata.get("messageId", ""),
+            },
+            f,
+        )
+
+
+@queue.subscribe(topic="client-topic")
+def handle_client_task(message, metadata):
+    os.makedirs(RESULT_DIR, exist_ok=True)
+    with open(os.path.join(RESULT_DIR, "worker_client_result.json"), "w") as f:
         json.dump(
             {
                 "received": True,

--- a/packages/cli/test/dev/integration-5.test.ts
+++ b/packages/cli/test/dev/integration-5.test.ts
@@ -900,7 +900,7 @@ describe('[vercel dev] Worker service', () => {
     await fs.remove(resultsDir);
   });
 
-  test('[vercel dev] web send() triggers exact and wildcard worker execution', async () => {
+  test('[vercel dev] web send() triggers exact, wildcard, and named client worker execution', async () => {
     const dir = fixture('services-worker');
     const { dev, port, readyResolver } = await testFixture(
       dir,
@@ -952,6 +952,31 @@ describe('[vercel dev] Worker service', () => {
       expect(wildcardResult).toHaveProperty('received', true);
       expect(wildcardResult.message).toHaveProperty('action', 'test');
       expect(wildcardResult.message).toHaveProperty('value', 42);
+
+      const clientEnqueueRes = await nodeFetch(
+        `http://localhost:${port}/enqueue-client`,
+        {
+          method: 'POST',
+        }
+      );
+      expect(clientEnqueueRes.status).toBe(200);
+      const clientEnqueueJson = await clientEnqueueRes.json();
+      expect(clientEnqueueJson).toHaveProperty('messageId');
+
+      const clientResultPath = join(resultsDir, 'worker_client_result.json');
+      let clientResult: any = null;
+      for (let i = 0; i < 30; i++) {
+        await sleep(500);
+        if (await fs.pathExists(clientResultPath)) {
+          clientResult = await fs.readJson(clientResultPath);
+          break;
+        }
+      }
+
+      expect(clientResult).not.toBeNull();
+      expect(clientResult).toHaveProperty('received', true);
+      expect(clientResult.message).toHaveProperty('action', 'client-test');
+      expect(clientResult.message).toHaveProperty('value', 7);
     } finally {
       await dev.kill();
     }

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -16,6 +16,7 @@ import {
   execCommand,
   scanParentDirs,
   getEnvForPackageManager,
+  isQueueTriggeredService,
   isPythonFramework,
   Span,
   BUILDER_INSTALLER_STEP,
@@ -623,7 +624,7 @@ export const build: BuildVX = async ({
   debug('Entrypoint is', entrypoint);
   const moduleName = entrypoint.replace(/\//g, '.').replace(/\.py$/i, '');
 
-  if (handlerFunction) {
+  if (handlerFunction && !(service && isQueueTriggeredService(service))) {
     const entrypointPath = join(workPath, entrypoint);
     const source = await fs.promises.readFile(entrypointPath, 'utf-8');
     const found = await containsTopLevelCallable(source, handlerFunction);

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -2092,6 +2092,35 @@ describe('handlerFunction validation', () => {
     ).rejects.toThrow(/Handler function "cleanup" not found/);
   });
 
+  it('allows queue-triggered job handlerFunction to name a QueueClient', async () => {
+    const files = {
+      'worker.py': new FileBlob({
+        data: 'from vercel.workers import QueueClient\nqueue = QueueClient()\n',
+      }),
+      'pyproject.toml': new FileBlob({
+        data: '[project]\nname = "x"\nversion = "0.0.1"\n',
+      }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath: mockWorkPath,
+      files,
+      entrypoint: 'worker.py',
+      meta: { isDev: false },
+      config: { handlerFunction: 'queue' },
+      repoRootPath: mockWorkPath,
+      service: { type: 'job', trigger: 'queue' },
+    });
+
+    const handler = getBuildOutputV3(result).files?.['vc__handler__python.py'];
+    if (!handler || !('data' in handler)) {
+      throw new Error('handler bootstrap not found');
+    }
+    expect(handler.data.toString()).toContain(
+      '"__VC_HANDLER_VARIABLE_NAME": "queue"'
+    );
+  });
+
   it('uses handlerFunction as variable name for web services', async () => {
     const files = {
       'app.py': new FileBlob({

--- a/python/vercel-runtime/src/vercel_runtime/dev.py
+++ b/python/vercel-runtime/src/vercel_runtime/dev.py
@@ -406,7 +406,7 @@ def _setup_apps() -> None:
         return
 
     if is_worker_service():
-        worker_app = maybe_bootstrap_worker_service_app(mod)
+        worker_app = maybe_bootstrap_worker_service_app(mod, variable_name)
         if worker_app is not None:
             _asgi_user_app = cast("ASGI", worker_app)
             return

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -474,9 +474,13 @@ except Exception:
 
 if is_worker_service():
     try:
-        worker_app = maybe_bootstrap_worker_service_app(__vc_module)
+        worker_app = maybe_bootstrap_worker_service_app(
+            __vc_module,
+            _entrypoint_varname,
+        )
         if worker_app is not None:
             __vc_module.__dict__["app"] = worker_app
+            _entrypoint_varname = "app"
             __vc_variables = dir(__vc_module)
     except Exception:
         _stderr("Error bootstrapping worker service app:")

--- a/python/vercel-runtime/src/vercel_runtime/workers.py
+++ b/python/vercel-runtime/src/vercel_runtime/workers.py
@@ -36,7 +36,10 @@ def prepare_worker_environment() -> None:
     workers_runtime.prepare_environment(os.environ)
 
 
-def maybe_bootstrap_worker_service_app(module: object) -> object | None:
+def maybe_bootstrap_worker_service_app(
+    module: object,
+    variable_name: str | None = None,
+) -> object | None:
     workers_runtime = _load_workers_runtime()
     if workers_runtime is None:
         raise RuntimeError(
@@ -46,5 +49,8 @@ def maybe_bootstrap_worker_service_app(module: object) -> object | None:
         )
     return cast(
         "object | None",
-        workers_runtime.maybe_bootstrap_worker_service_app(module),
+        workers_runtime.maybe_bootstrap_worker_service_app(
+            module,
+            variable_name,
+        ),
     )

--- a/python/vercel-runtime/tests/test_workers.py
+++ b/python/vercel-runtime/tests/test_workers.py
@@ -64,7 +64,24 @@ class TestMaybeBootstrapWorkerServiceApp(unittest.TestCase):
 
         self.assertIs(app, expected_app)
         bridge.maybe_bootstrap_worker_service_app.assert_called_once_with(
-            module
+            module,
+            None,
+        )
+
+    def test_delegates_variable_name_to_workers_runtime(self) -> None:
+        module = types.SimpleNamespace()
+        expected_app = object()
+        bridge = types.SimpleNamespace(
+            maybe_bootstrap_worker_service_app=Mock(return_value=expected_app)
+        )
+
+        with patch.object(vrw, "_load_workers_runtime", return_value=bridge):
+            app = vrw.maybe_bootstrap_worker_service_app(module, "queue")
+
+        self.assertIs(app, expected_app)
+        bridge.maybe_bootstrap_worker_service_app.assert_called_once_with(
+            module,
+            "queue",
         )
 
     def test_raises_when_workers_runtime_is_missing(self) -> None:

--- a/python/vercel-workers/src/vercel/workers/_queue/client.py
+++ b/python/vercel-workers/src/vercel/workers/_queue/client.py
@@ -86,6 +86,10 @@ class _BaseQueueClient:
     def has_subscriptions(self) -> bool:
         return bool(self._subscriptions)
 
+    @property
+    def subscriptions(self) -> list[Subscription]:
+        return self._subscriptions
+
 
 class QueueClient(_BaseQueueClient):
     """Configured synchronous client for publishing Vercel Queue messages."""

--- a/python/vercel-workers/src/vercel/workers/_runtime.py
+++ b/python/vercel-workers/src/vercel/workers/_runtime.py
@@ -5,6 +5,11 @@ from collections.abc import MutableMapping
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, TypeGuard
 
+from ._queue.client import (
+    AsyncQueueClient,
+    QueueClient,
+)
+from .callback import build_asgi_app_for_subscriptions
 from .client import (
     get_asgi_app as get_generic_asgi_app,
     has_subscriptions,
@@ -81,6 +86,10 @@ def is_vercel_dramatiq_broker(
     return isinstance(candidate, VercelQueuesBroker)
 
 
+def is_queue_client(candidate: object) -> TypeGuard[QueueClient | AsyncQueueClient]:
+    return isinstance(candidate, QueueClient | AsyncQueueClient)
+
+
 def _find_celery_app(module: object) -> CeleryAppType | None:
     candidates = [
         getattr(module, "app", None),
@@ -155,7 +164,35 @@ def _bootstrap_generic_worker_app() -> object | None:
     return get_generic_asgi_app()
 
 
-def _resolve_worker_service_app(module: object) -> object | None:
+def _bootstrap_queue_client_worker_app(
+    module: object,
+    variable_name: str | None,
+) -> object | None:
+    if not variable_name:
+        return None
+
+    client = getattr(module, variable_name, None)
+    if not is_queue_client(client):
+        return None
+
+    subscriptions = client.subscriptions
+    if not subscriptions:
+        raise RuntimeError(
+            f'queue client "{variable_name}" did not register any subscriptions: '
+            + "ensure your worker entrypoint imports task modules before startup"
+        )
+
+    return build_asgi_app_for_subscriptions(subscriptions)
+
+
+def _resolve_worker_service_app(
+    module: object,
+    variable_name: str | None = None,
+) -> object | None:
+    queue_client_app = _bootstrap_queue_client_worker_app(module, variable_name)
+    if queue_client_app is not None:
+        return queue_client_app
+
     bootstrappers = (
         ("Celery", lambda: _bootstrap_celery_worker_app(module)),
         ("Dramatiq", lambda: _bootstrap_dramatiq_worker_app(module)),
@@ -173,9 +210,12 @@ def _resolve_worker_service_app(module: object) -> object | None:
     return _bootstrap_generic_worker_app()
 
 
-def maybe_bootstrap_worker_service_app(module: object) -> object | None:
+def maybe_bootstrap_worker_service_app(
+    module: object,
+    variable_name: str | None = None,
+) -> object | None:
     exported_names = dir(module)
-    app = _resolve_worker_service_app(module)
+    app = _resolve_worker_service_app(module, variable_name)
     if app is not None:
         return app
 

--- a/python/vercel-workers/tests/test_runtime_bridge.py
+++ b/python/vercel-workers/tests/test_runtime_bridge.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import patch
 
 import vercel.workers._runtime as vwr
+from vercel.workers import QueueClient
 
 
 class TestPrepareEnvironment(unittest.TestCase):
@@ -81,6 +82,26 @@ class TestWorkerBootstrapBridge(unittest.TestCase):
             app = vwr._resolve_worker_service_app(types.SimpleNamespace())
 
         self.assertIs(app, expected_app)
+
+    def test_resolve_worker_service_app_uses_named_queue_client(self) -> None:
+        expected_app = object()
+        queue = QueueClient()
+
+        @queue.subscribe(topic="orders")
+        def handle(payload: object) -> None:
+            _ = payload
+
+        module = types.SimpleNamespace(queue=queue)
+
+        with patch.object(
+            vwr,
+            "build_asgi_app_for_subscriptions",
+            return_value=expected_app,
+        ) as build_app:
+            app = vwr._resolve_worker_service_app(module, "queue")
+
+        self.assertIs(app, expected_app)
+        build_app.assert_called_once_with(queue.subscriptions)
 
     def test_bootstrap_worker_service_app_wraps_framework_errors(self) -> None:
         with (


### PR DESCRIPTION
Implements bootstrapping worker apps for queue-triggered services that declare a queue client, e.g. 

```python
from vercel.workers import QueueClient, subscribe

queue = QueueClient()

@queue.subscribe(topic="client-topic")
def handle(message, metadata):
   ...
```
