### PR TITLE
Add <dynamic> schedule cron services for js/ts.

### DIFF
--- a/.changeset/tall-bobcats-argue.md
+++ b/.changeset/tall-bobcats-argue.md
@@ -1,0 +1,6 @@
+---
+'@vercel/backends': minor
+'vercel': minor
+---
+
+Add support for dynamic scheduled jobs for JS/TS.

--- a/packages/backends/src/crons.ts
+++ b/packages/backends/src/crons.ts
@@ -4,8 +4,11 @@ import {
   getInternalServiceCronPath,
   isScheduleTriggeredService,
 } from '@vercel/build-utils';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const DYNAMIC_SCHEDULE = '<dynamic>';
+export const DYNAMIC_SCHEDULE = '<dynamic>';
+const HANDLER_RE = /^[a-zA-Z0-9_-]+$/;
 
 export interface BackendsCronEntry extends Cron {
   /**
@@ -30,15 +33,20 @@ export function buildCronRouteTable(
 /**
  * Compute cron entries for a JS/TS cron service build.
  *
- * Mirrors `packages/python/src/crons.ts` for static schedules. Returns
- * `undefined` when the service is not schedule-triggered. Throws on
- * `<dynamic>` schedules — that path is reserved for a follow-up.
+ * Static schedules produce a single entry that routes the service's
+ * schedule to the user module's default export.
+ *
+ * For `<dynamic>` schedules, callers must pass `bundle` — a directory on
+ * disk containing the bundled handler — so this function can `import()`
+ * the entry and call its default export to discover entries. The caller
+ * owns the directory's lifecycle (creation and cleanup).
  */
 export async function getServiceCrons(opts: {
   service?: BuildOptions['service'];
   entrypoint?: string;
+  bundle?: { dir: string; handler: string };
 }): Promise<BackendsCronEntry[] | undefined> {
-  const { service, entrypoint } = opts;
+  const { service, entrypoint, bundle } = opts;
 
   if (!service || !isScheduleTriggeredService(service)) {
     return undefined;
@@ -52,9 +60,16 @@ export async function getServiceCrons(opts: {
   }
 
   if (service.schedule === DYNAMIC_SCHEDULE) {
-    throw new Error(
-      'Dynamic cron schedules ("<dynamic>") are not yet supported for JavaScript/TypeScript services. Use a static cron expression in vercel.json.'
-    );
+    if (!bundle) {
+      throw new Error(
+        'Dynamic cron detection requires the bundled output on disk.'
+      );
+    }
+    return getServiceCronsDynamic({
+      serviceName: service.name,
+      entrypoint,
+      bundle,
+    });
   }
 
   return [
@@ -64,4 +79,143 @@ export async function getServiceCrons(opts: {
       exportName: 'default',
     },
   ];
+}
+
+interface DetectedEntry {
+  handler: string;
+  schedule: string;
+}
+
+async function getServiceCronsDynamic(opts: {
+  serviceName: string;
+  entrypoint: string;
+  bundle: { dir: string; handler: string };
+}): Promise<BackendsCronEntry[]> {
+  const detected = await detectDynamicCrons(opts.bundle);
+
+  if (detected.length === 0) {
+    throw new Error(
+      'Dynamic cron detection returned no entries; the registry must yield at least one {handler, schedule} entry.'
+    );
+  }
+
+  return detected.map(entry => ({
+    path: getInternalServiceCronPath(
+      opts.serviceName,
+      opts.entrypoint,
+      entry.handler
+    ),
+    schedule: entry.schedule,
+    exportName: entry.handler,
+  }));
+}
+
+/**
+ * Dynamically import the bundled entry, call its default export, and
+ * validate the returned entries. Runs in-process: the user module's
+ * top-level side effects persist for the rest of the build (same
+ * constraint the lambda has at cold-start, so any well-formed cron
+ * entrypoint is teardown-clean).
+ */
+async function detectDynamicCrons(bundle: {
+  dir: string;
+  handler: string;
+}): Promise<DetectedEntry[]> {
+  const entryAbs = join(bundle.dir, bundle.handler);
+  let userModule: unknown;
+  try {
+    userModule = await import(pathToFileURL(entryAbs).toString());
+  } catch (err) {
+    throw new Error(
+      `could not import cron entrypoint: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`
+    );
+  }
+
+  const defaultExport = unwrapDefault(userModule);
+  if (typeof defaultExport !== 'function') {
+    throw new Error(
+      'cron entrypoint must default-export a function that returns an array of cron entries'
+    );
+  }
+
+  let result: unknown;
+  try {
+    result = await (defaultExport as () => unknown)();
+  } catch (err) {
+    throw new Error(
+      `error calling default export: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`
+    );
+  }
+
+  return validateEntries(result, userModule);
+}
+
+function unwrapDefault(value: unknown): unknown {
+  let current = value;
+  for (let i = 0; i < 5; i++) {
+    if (
+      current &&
+      typeof current === 'object' &&
+      'default' in (current as object) &&
+      (current as { default: unknown }).default
+    ) {
+      current = (current as { default: unknown }).default;
+    } else {
+      break;
+    }
+  }
+  return current;
+}
+
+function validateEntries(
+  result: unknown,
+  userModule: unknown
+): DetectedEntry[] {
+  if (!Array.isArray(result)) {
+    throw new Error(
+      `default export must return an array, got: ${Object.prototype.toString.call(result)}`
+    );
+  }
+
+  const entries: DetectedEntry[] = [];
+  const seen = new Set<string>();
+  for (const item of result) {
+    if (item === null || typeof item !== 'object') {
+      throw new Error(
+        `each cron entry must be an object with {handler, schedule}, got: ${JSON.stringify(item)}`
+      );
+    }
+    const handler = (item as { handler?: unknown }).handler;
+    const schedule = (item as { schedule?: unknown }).schedule;
+    if (typeof handler !== 'string' || handler === '') {
+      throw new Error(
+        `cron entry "handler" must be a non-empty string, got: ${JSON.stringify(item)}`
+      );
+    }
+    if (!HANDLER_RE.test(handler)) {
+      throw new Error(
+        `cron entry handler "${handler}" contains invalid characters; allowed: [a-zA-Z0-9_-]`
+      );
+    }
+    if (seen.has(handler)) {
+      throw new Error(`duplicate cron entry handler: "${handler}"`);
+    }
+    if (typeof schedule !== 'string' || schedule === '') {
+      throw new Error(
+        `cron entry "schedule" must be a non-empty string, got: ${JSON.stringify(item)}`
+      );
+    }
+    const exported =
+      userModule && typeof userModule === 'object'
+        ? (userModule as Record<string, unknown>)[handler]
+        : undefined;
+    if (typeof exported !== 'function') {
+      throw new Error(
+        `cron entry handler "${handler}" does not match a function export on the cron entrypoint`
+      );
+    }
+    seen.add(handler);
+    entries.push({ handler, schedule });
+  }
+  return entries;
 }

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
@@ -10,6 +11,7 @@ import {
   debug,
   getNodeVersion,
   getLambdaOptionsFromFunction,
+  isScheduleTriggeredService,
   Span,
   type PrepareCache,
   type BuildV2,
@@ -20,7 +22,11 @@ import {
 import { findEntrypointOrThrow } from './cervel/index.js';
 import { applyServiceVcInit } from './service-vc-init.js';
 import { applyCronDispatch } from './cron-dispatch.js';
-import { buildCronRouteTable, getServiceCrons } from './crons.js';
+import {
+  buildCronRouteTable,
+  getServiceCrons,
+  DYNAMIC_SCHEDULE,
+} from './crons.js';
 // Re-export cervel functions for use by other packages
 export {
   build as cervelBuild,
@@ -36,7 +42,7 @@ export type {
   CervelServeOptions,
   PathOptions,
 } from './cervel/index.js';
-import { rolldown } from './rolldown/index.js';
+import { rolldown, stageBundleOnDisk } from './rolldown/index.js';
 import { introspection } from './rolldown/introspection.js';
 import { nft } from './rolldown/nft.js';
 import { maybeDoBuildCommand } from './build.js';
@@ -107,11 +113,10 @@ export const build: BuildV2 = async args => {
     debug('Entrypoint', entrypoint);
     args.entrypoint = entrypoint;
 
-    const cronEntries = await getServiceCrons({
-      service: args.service,
-      entrypoint,
-    });
-    const isCronService = cronEntries !== undefined;
+    const isCronService =
+      !!args.service && isScheduleTriggeredService(args.service);
+    const isDynamicCron =
+      isCronService && args.service?.schedule === DYNAMIC_SCHEDULE;
 
     const userBuildResult = await maybeDoBuildCommand(args, downloadResult);
 
@@ -182,6 +187,42 @@ export const build: BuildV2 = async args => {
     const files = userBuildResult?.files || rolldownResult.files;
     const handler = userBuildResult?.handler || rolldownResult.handler;
     const nftWorkPath = userBuildResult?.outputDir || args.workPath;
+
+    // For `<dynamic>` schedules, we need to actually execute the cron service
+    // to discover its entries. We do this by staging the bundle on disk
+    // and then `import()`ing the entrypoint to call its default export.
+    let stagedBundleDir: string | undefined;
+    let dynamicBundle: { dir: string; handler: string } | undefined;
+    if (isDynamicCron) {
+      if (userBuildResult?.outputDir && userBuildResult.handler) {
+        dynamicBundle = {
+          dir: userBuildResult.outputDir,
+          handler: userBuildResult.handler,
+        };
+      } else {
+        stagedBundleDir = await stageBundleOnDisk({
+          files,
+          workPath: nftWorkPath,
+          prefix: '.vc-cron-bundle-',
+        });
+        dynamicBundle = { dir: stagedBundleDir, handler };
+      }
+    }
+    let cronEntries: Awaited<ReturnType<typeof getServiceCrons>>;
+    try {
+      cronEntries = await getServiceCrons({
+        service: args.service,
+        entrypoint,
+        bundle: dynamicBundle,
+      });
+    } finally {
+      if (stagedBundleDir) {
+        await rm(stagedBundleDir, {
+          recursive: true,
+          force: true,
+        }).catch(() => {});
+      }
+    }
 
     await nft({
       ...args,

--- a/packages/backends/src/rolldown/index.ts
+++ b/packages/backends/src/rolldown/index.ts
@@ -6,7 +6,7 @@ import { build as rolldownBuild } from 'rolldown';
 import { builtinModules } from 'node:module';
 import { join, dirname, relative, extname } from 'node:path';
 import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { type Files, FileBlob, isBackendFramework } from '@vercel/build-utils';
 import { nft } from './nft.js';
 import { exports as resolveExports } from 'resolve.exports';
@@ -340,3 +340,44 @@ module.exports = requireFromContext('${pkgName}');
   );
   return { files, handler, framework, localBuildFiles };
 };
+
+/**
+ * Materialize an in-memory `Files` map (typically rolldown's `write:
+ * false` output) onto disk under `workPath`. The directory is placed
+ * inside `workPath` so externalized npm imports walk up to the project's
+ * `node_modules`. Caller owns cleanup of the returned path.
+ */
+export async function stageBundleOnDisk(opts: {
+  files: Files;
+  workPath: string;
+  /** Prefix for the mkdtemp suffix; defaults to `.vc-bundle-`. */
+  prefix?: string;
+}): Promise<string> {
+  const dir = await mkdtemp(join(opts.workPath, opts.prefix ?? '.vc-bundle-'));
+  for (const [relPath, file] of Object.entries(opts.files)) {
+    const data = await readFileData(file);
+    if (data === undefined) continue;
+    const absPath = join(dir, relPath);
+    await mkdir(dirname(absPath), { recursive: true });
+    await writeFile(absPath, data);
+  }
+  return dir;
+}
+
+async function readFileData(
+  file: unknown
+): Promise<Buffer | string | undefined> {
+  if (file && typeof file === 'object') {
+    if ('data' in file) {
+      const data = (file as { data: unknown }).data;
+      if (typeof data === 'string' || Buffer.isBuffer(data)) return data;
+    }
+    if (
+      'fsPath' in file &&
+      typeof (file as { fsPath: unknown }).fsPath === 'string'
+    ) {
+      return readFile((file as { fsPath: string }).fsPath);
+    }
+  }
+  return undefined;
+}

--- a/packages/backends/src/rolldown/index.ts
+++ b/packages/backends/src/rolldown/index.ts
@@ -359,7 +359,7 @@ export async function stageBundleOnDisk(opts: {
     if (data === undefined) continue;
     const absPath = join(dir, relPath);
     await mkdir(dirname(absPath), { recursive: true });
-    await writeFile(absPath, data);
+    await writeFile(absPath, data as string | NodeJS.ArrayBufferView);
   }
   return dir;
 }

--- a/packages/backends/test/unit.crons.test.ts
+++ b/packages/backends/test/unit.crons.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { buildCronRouteTable, getServiceCrons } from '../src/crons';
 
 describe('getServiceCrons', () => {
@@ -81,13 +84,171 @@ describe('getServiceCrons', () => {
     ).rejects.toThrow(/missing an entrypoint/);
   });
 
-  it('throws on a <dynamic> schedule (not yet supported for JS/TS)', async () => {
+  it('throws on a <dynamic> schedule when no bundle is provided', async () => {
     await expect(
       getServiceCrons({
         service: { type: 'cron', name: 'cleanup', schedule: '<dynamic>' },
         entrypoint: 'cleanup.ts',
       })
-    ).rejects.toThrow(/Dynamic cron schedules .* not yet supported/);
+    ).rejects.toThrow(/Dynamic cron detection requires the bundled output/);
+  });
+});
+
+describe('getServiceCrons (<dynamic>)', () => {
+  let bundleDir: string;
+
+  beforeEach(async () => {
+    bundleDir = await mkdtemp(join(tmpdir(), 'be-cron-dynamic-'));
+    // Mark the dir as ESM so `.mjs`-via-extension already implies ESM,
+    // and a hypothetical `.js` would also be treated as ESM.
+    await writeFile(
+      join(bundleDir, 'package.json'),
+      JSON.stringify({ type: 'module' }),
+      'utf-8'
+    );
+  });
+
+  afterEach(async () => {
+    await rm(bundleDir, { recursive: true, force: true });
+  });
+
+  async function detect(handler: string, source: string) {
+    await writeFile(join(bundleDir, handler), source, 'utf-8');
+    return getServiceCrons({
+      service: { type: 'cron', name: 'tasks', schedule: '<dynamic>' },
+      entrypoint: handler,
+      bundle: { dir: bundleDir, handler },
+    });
+  }
+
+  it('detects a single sync entry', async () => {
+    const result = await detect(
+      'index.mjs',
+      `
+export default () => [{ handler: 'hourly', schedule: '0 * * * *' }];
+export function hourly() {}
+`
+    );
+    expect(result).toEqual([
+      {
+        path: '/_svc/tasks/crons/index/hourly',
+        schedule: '0 * * * *',
+        exportName: 'hourly',
+      },
+    ]);
+  });
+
+  it('detects multiple async entries', async () => {
+    const result = await detect(
+      'index.mjs',
+      `
+export default async () => [
+  { handler: 'hourly', schedule: '0 * * * *' },
+  { handler: 'daily',  schedule: '0 0 * * *' },
+];
+export async function hourly() {}
+export async function daily()  {}
+`
+    );
+    expect(result).toEqual([
+      {
+        path: '/_svc/tasks/crons/index/hourly',
+        schedule: '0 * * * *',
+        exportName: 'hourly',
+      },
+      {
+        path: '/_svc/tasks/crons/index/daily',
+        schedule: '0 0 * * *',
+        exportName: 'daily',
+      },
+    ]);
+  });
+
+  it('errors when default export is missing', async () => {
+    await expect(
+      detect('index.mjs', `export const notDefault = () => [];`)
+    ).rejects.toThrow(/must default-export a function/);
+  });
+
+  it('errors when default export is not callable', async () => {
+    await expect(
+      detect('index.mjs', `export default 'not a function';`)
+    ).rejects.toThrow(/must default-export a function/);
+  });
+
+  it('surfaces errors thrown by the registry', async () => {
+    await expect(
+      detect('index.mjs', `export default () => { throw new Error('boom'); };`)
+    ).rejects.toThrow(/error calling default export[\s\S]*boom/);
+  });
+
+  it('errors when the registry returns a non-array', async () => {
+    await expect(
+      detect(
+        'index.mjs',
+        `export default () => ({ handler: 'h', schedule: '* * * * *' });`
+      )
+    ).rejects.toThrow(/must return an array/);
+  });
+
+  it('errors when the registry returns no entries', async () => {
+    await expect(
+      detect('index.mjs', `export default () => [];`)
+    ).rejects.toThrow(/returned no entries/);
+  });
+
+  it('errors when an entry is missing handler', async () => {
+    await expect(
+      detect('index.mjs', `export default () => [{ schedule: '* * * * *' }];`)
+    ).rejects.toThrow(/"handler" must be a non-empty string/);
+  });
+
+  it('errors when an entry is missing schedule', async () => {
+    await expect(
+      detect(
+        'index.mjs',
+        `
+export default () => [{ handler: 'hourly' }];
+export function hourly() {}
+`
+      )
+    ).rejects.toThrow(/"schedule" must be a non-empty string/);
+  });
+
+  it('errors when handler contains invalid characters', async () => {
+    await expect(
+      detect(
+        'index.mjs',
+        `
+export default () => [{ handler: 'bad/name', schedule: '* * * * *' }];
+export function badName() {}
+`
+      )
+    ).rejects.toThrow(/contains invalid characters/);
+  });
+
+  it('errors when handler does not match a function export', async () => {
+    await expect(
+      detect(
+        'index.mjs',
+        `export default () => [{ handler: 'missing', schedule: '* * * * *' }];`
+      )
+    ).rejects.toThrow(/does not match a function export/);
+  });
+
+  it('errors on duplicate handlers', async () => {
+    await expect(
+      detect(
+        'index.mjs',
+        `
+export default () => [
+  { handler: 'hourly', schedule: '0 * * * *' },
+  { handler: 'hourly', schedule: '0 0 * * *' },
+];
+export function hourly() {}
+`
+      )
+    ).rejects.toThrow(/duplicate cron entry handler/);
   });
 });
 

--- a/packages/backends/test/unit.crons.test.ts
+++ b/packages/backends/test/unit.crons.test.ts
@@ -94,54 +94,56 @@ describe('getServiceCrons', () => {
   });
 });
 
-describe('getServiceCrons (<dynamic>)', () => {
-  let bundleDir: string;
+describe.skipIf(process.platform === 'win32')(
+  'getServiceCrons (<dynamic>)',
+  () => {
+    let bundleDir: string;
 
-  beforeEach(async () => {
-    bundleDir = await mkdtemp(join(tmpdir(), 'be-cron-dynamic-'));
-    // Mark the dir as ESM so `.mjs`-via-extension already implies ESM,
-    // and a hypothetical `.js` would also be treated as ESM.
-    await writeFile(
-      join(bundleDir, 'package.json'),
-      JSON.stringify({ type: 'module' }),
-      'utf-8'
-    );
-  });
-
-  afterEach(async () => {
-    await rm(bundleDir, { recursive: true, force: true });
-  });
-
-  async function detect(handler: string, source: string) {
-    await writeFile(join(bundleDir, handler), source, 'utf-8');
-    return getServiceCrons({
-      service: { type: 'cron', name: 'tasks', schedule: '<dynamic>' },
-      entrypoint: handler,
-      bundle: { dir: bundleDir, handler },
+    beforeEach(async () => {
+      bundleDir = await mkdtemp(join(tmpdir(), 'be-cron-dynamic-'));
+      // Mark the dir as ESM so `.mjs`-via-extension already implies ESM,
+      // and a hypothetical `.js` would also be treated as ESM.
+      await writeFile(
+        join(bundleDir, 'package.json'),
+        JSON.stringify({ type: 'module' }),
+        'utf-8'
+      );
     });
-  }
 
-  it('detects a single sync entry', async () => {
-    const result = await detect(
-      'index.mjs',
-      `
+    afterEach(async () => {
+      await rm(bundleDir, { recursive: true, force: true });
+    });
+
+    async function detect(handler: string, source: string) {
+      await writeFile(join(bundleDir, handler), source, 'utf-8');
+      return getServiceCrons({
+        service: { type: 'cron', name: 'tasks', schedule: '<dynamic>' },
+        entrypoint: handler,
+        bundle: { dir: bundleDir, handler },
+      });
+    }
+
+    it('detects a single sync entry', async () => {
+      const result = await detect(
+        'index.mjs',
+        `
 export default () => [{ handler: 'hourly', schedule: '0 * * * *' }];
 export function hourly() {}
 `
-    );
-    expect(result).toEqual([
-      {
-        path: '/_svc/tasks/crons/index/hourly',
-        schedule: '0 * * * *',
-        exportName: 'hourly',
-      },
-    ]);
-  });
+      );
+      expect(result).toEqual([
+        {
+          path: '/_svc/tasks/crons/index/hourly',
+          schedule: '0 * * * *',
+          exportName: 'hourly',
+        },
+      ]);
+    });
 
-  it('detects multiple async entries', async () => {
-    const result = await detect(
-      'index.mjs',
-      `
+    it('detects multiple async entries', async () => {
+      const result = await detect(
+        'index.mjs',
+        `
 export default async () => [
   { handler: 'hourly', schedule: '0 * * * *' },
   { handler: 'daily',  schedule: '0 0 * * *' },
@@ -149,108 +151,112 @@ export default async () => [
 export async function hourly() {}
 export async function daily()  {}
 `
-    );
-    expect(result).toEqual([
-      {
-        path: '/_svc/tasks/crons/index/hourly',
-        schedule: '0 * * * *',
-        exportName: 'hourly',
-      },
-      {
-        path: '/_svc/tasks/crons/index/daily',
-        schedule: '0 0 * * *',
-        exportName: 'daily',
-      },
-    ]);
-  });
+      );
+      expect(result).toEqual([
+        {
+          path: '/_svc/tasks/crons/index/hourly',
+          schedule: '0 * * * *',
+          exportName: 'hourly',
+        },
+        {
+          path: '/_svc/tasks/crons/index/daily',
+          schedule: '0 0 * * *',
+          exportName: 'daily',
+        },
+      ]);
+    });
 
-  it('errors when default export is missing', async () => {
-    await expect(
-      detect('index.mjs', `export const notDefault = () => [];`)
-    ).rejects.toThrow(/must default-export a function/);
-  });
+    it('errors when default export is missing', async () => {
+      await expect(
+        detect('index.mjs', `export const notDefault = () => [];`)
+      ).rejects.toThrow(/must default-export a function/);
+    });
 
-  it('errors when default export is not callable', async () => {
-    await expect(
-      detect('index.mjs', `export default 'not a function';`)
-    ).rejects.toThrow(/must default-export a function/);
-  });
+    it('errors when default export is not callable', async () => {
+      await expect(
+        detect('index.mjs', `export default 'not a function';`)
+      ).rejects.toThrow(/must default-export a function/);
+    });
 
-  it('surfaces errors thrown by the registry', async () => {
-    await expect(
-      detect('index.mjs', `export default () => { throw new Error('boom'); };`)
-    ).rejects.toThrow(/error calling default export[\s\S]*boom/);
-  });
+    it('surfaces errors thrown by the registry', async () => {
+      await expect(
+        detect(
+          'index.mjs',
+          `export default () => { throw new Error('boom'); };`
+        )
+      ).rejects.toThrow(/error calling default export[\s\S]*boom/);
+    });
 
-  it('errors when the registry returns a non-array', async () => {
-    await expect(
-      detect(
-        'index.mjs',
-        `export default () => ({ handler: 'h', schedule: '* * * * *' });`
-      )
-    ).rejects.toThrow(/must return an array/);
-  });
+    it('errors when the registry returns a non-array', async () => {
+      await expect(
+        detect(
+          'index.mjs',
+          `export default () => ({ handler: 'h', schedule: '* * * * *' });`
+        )
+      ).rejects.toThrow(/must return an array/);
+    });
 
-  it('errors when the registry returns no entries', async () => {
-    await expect(
-      detect('index.mjs', `export default () => [];`)
-    ).rejects.toThrow(/returned no entries/);
-  });
+    it('errors when the registry returns no entries', async () => {
+      await expect(
+        detect('index.mjs', `export default () => [];`)
+      ).rejects.toThrow(/returned no entries/);
+    });
 
-  it('errors when an entry is missing handler', async () => {
-    await expect(
-      detect('index.mjs', `export default () => [{ schedule: '* * * * *' }];`)
-    ).rejects.toThrow(/"handler" must be a non-empty string/);
-  });
+    it('errors when an entry is missing handler', async () => {
+      await expect(
+        detect('index.mjs', `export default () => [{ schedule: '* * * * *' }];`)
+      ).rejects.toThrow(/"handler" must be a non-empty string/);
+    });
 
-  it('errors when an entry is missing schedule', async () => {
-    await expect(
-      detect(
-        'index.mjs',
-        `
+    it('errors when an entry is missing schedule', async () => {
+      await expect(
+        detect(
+          'index.mjs',
+          `
 export default () => [{ handler: 'hourly' }];
 export function hourly() {}
 `
-      )
-    ).rejects.toThrow(/"schedule" must be a non-empty string/);
-  });
+        )
+      ).rejects.toThrow(/"schedule" must be a non-empty string/);
+    });
 
-  it('errors when handler contains invalid characters', async () => {
-    await expect(
-      detect(
-        'index.mjs',
-        `
+    it('errors when handler contains invalid characters', async () => {
+      await expect(
+        detect(
+          'index.mjs',
+          `
 export default () => [{ handler: 'bad/name', schedule: '* * * * *' }];
 export function badName() {}
 `
-      )
-    ).rejects.toThrow(/contains invalid characters/);
-  });
+        )
+      ).rejects.toThrow(/contains invalid characters/);
+    });
 
-  it('errors when handler does not match a function export', async () => {
-    await expect(
-      detect(
-        'index.mjs',
-        `export default () => [{ handler: 'missing', schedule: '* * * * *' }];`
-      )
-    ).rejects.toThrow(/does not match a function export/);
-  });
+    it('errors when handler does not match a function export', async () => {
+      await expect(
+        detect(
+          'index.mjs',
+          `export default () => [{ handler: 'missing', schedule: '* * * * *' }];`
+        )
+      ).rejects.toThrow(/does not match a function export/);
+    });
 
-  it('errors on duplicate handlers', async () => {
-    await expect(
-      detect(
-        'index.mjs',
-        `
+    it('errors on duplicate handlers', async () => {
+      await expect(
+        detect(
+          'index.mjs',
+          `
 export default () => [
   { handler: 'hourly', schedule: '0 * * * *' },
   { handler: 'hourly', schedule: '0 0 * * *' },
 ];
 export function hourly() {}
 `
-      )
-    ).rejects.toThrow(/duplicate cron entry handler/);
-  });
-});
+        )
+      ).rejects.toThrow(/duplicate cron entry handler/);
+    });
+  }
+);
 
 describe('buildCronRouteTable', () => {
   it('maps each entry path to its handler', () => {

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-dynamic/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-dynamic/.vercel/project.json
@@ -1,0 +1,8 @@
+{
+  "orgId": ".",
+  "projectId": ".",
+  "settings": {
+    "framework": null,
+    "installCommand": ""
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-dynamic/index.mjs
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-dynamic/index.mjs
@@ -1,0 +1,18 @@
+// A cron service whose schedule list is computed at build time. The
+// default export is awaited by `getServiceCrons` to discover entries;
+// each entry's `handler` names a function export on this module that
+// the dispatcher invokes at runtime.
+export default async function getCrons() {
+  return [
+    { handler: 'hourly', schedule: '0 * * * *' },
+    { handler: 'daily', schedule: '0 0 * * *' },
+  ];
+}
+
+export async function hourly() {
+  // hourly job
+}
+
+export async function daily() {
+  // daily job
+}

--- a/packages/cli/test/fixtures/unit/commands/build/with-services-cron-dynamic/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/with-services-cron-dynamic/vercel.json
@@ -1,0 +1,10 @@
+{
+  "experimentalServices": {
+    "tasks": {
+      "type": "job",
+      "trigger": "schedule",
+      "entrypoint": "index.mjs",
+      "schedule": "<dynamic>"
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1193,6 +1193,50 @@ describe.skipIf(flakey)('build', () => {
     expect(reportConfig.handler).toContain('__vc_cron_dispatch');
   });
 
+  it('should build a JS cron service with a dynamic schedule', async () => {
+    // The default export's getCrons() is run at build time to enumerate
+    // entries; each entry's `handler` names a function export that the
+    // dispatcher routes to at runtime.
+    const cwd = fixture('with-services-cron-dynamic');
+    const output = join(cwd, '.vercel', 'output');
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toBe(0);
+
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config.crons).toEqual(
+      expect.arrayContaining([
+        {
+          path: '/_svc/tasks/crons/index/hourly',
+          schedule: '0 * * * *',
+        },
+        {
+          path: '/_svc/tasks/crons/index/daily',
+          schedule: '0 0 * * *',
+        },
+      ])
+    );
+    expect(config.routes).toContainEqual({
+      src: '^/_svc/tasks/crons/.*$',
+      dest: '/_svc/tasks/index',
+      check: true,
+    });
+
+    // The lambda's handler is the dispatcher shim, and the shim source
+    // embeds the route table mapping each cron path to its export name.
+    const funcDir = join(output, 'functions/_svc/tasks/index.func');
+    const vcConfig = await fs.readJSON(join(funcDir, '.vc-config.json'));
+    expect(vcConfig.handler).toContain('__vc_cron_dispatch');
+
+    const shimFiles = (await fs.readdir(funcDir)).filter(name =>
+      name.includes('__vc_cron_dispatch')
+    );
+    expect(shimFiles).toHaveLength(1);
+    const shimSource = await fs.readFile(join(funcDir, shimFiles[0]), 'utf-8');
+    expect(shimSource).toContain('"/_svc/tasks/crons/index/hourly":"hourly"');
+    expect(shimSource).toContain('"/_svc/tasks/crons/index/daily":"daily"');
+  });
+
   it('should build a JS cron service through the cron dispatcher', async () => {
     const cwd = fixture('with-services-cron-handler');
     const output = join(cwd, '.vercel', 'output');

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1314,7 +1314,10 @@ describe.skipIf(flakey)('build', () => {
     expect(serverRouteIndex).toBeLessThan(fallbackRouteIndex);
   });
 
-  it('should fail build when schedule-triggered job uses a dynamic schedule without builder crons', async () => {
+  it('should fail build when a dynamic-schedule entrypoint is not a cron registry', async () => {
+    // `<dynamic>` requires the entrypoint's default export to be a
+    // function returning {handler, schedule}[]. A bare HTTP server has
+    // no default export at all, so detection fails.
     const cwd = await createTempServicesProject({
       experimentalServices: {
         cleanup: {
@@ -1343,7 +1346,7 @@ createServer((_req, res) => {
 
       const builds = await fs.readJSON(join(output, 'builds.json'));
       expect(builds.error.message).toContain(
-        'Dynamic cron schedules ("<dynamic>") are not yet supported for JavaScript/TypeScript services'
+        'cron entrypoint must default-export a function'
       );
     } finally {
       // Tolerate EBUSY on Windows when the builder still holds file handles.

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1372,13 +1372,7 @@ describe.skipIf(flakey)('build', () => {
         },
       },
       files: {
-        'index.js': `const { createServer } = require('node:http');
-
-createServer((_req, res) => {
-  res.statusCode = 200;
-  res.end('ok');
-}).listen(3000);
-`,
+        'index.js': `module.exports.handler = function () {};\n`,
       },
     });
     const output = join(cwd, '.vercel', 'output');


### PR DESCRIPTION
Add support for JS/TS cron services via `"schedule": "<dynamic>"` in `vercel.json`.

The `entrypoint` must default export function a `getCrons()` function returning `[{ handler, schedule }]`, where `handler` names another export on the same module.

Example:
```json
{
  "experimentalServices": {
    "ping": {
      "type": "job",
      "trigger": "schedule",
      "entrypoint": "index.mjs",
      "schedule": "<dynamic>"
    }
  }
}

```
```js
export default async function getCrons() {
  return [
    { handler: 'oneMinute', schedule: '* * * * *' },
    { handler: 'twoMinute', schedule: '*/2 * * * *' },
  ];
}
export async function oneMinute() {}
export async function twoMinute() {}
```

The endpoint is `/_svc/<service-name>/crons/<entrypoint>/<handler>`. The above example will generate the endpoints:
- `/_svc/ping/crons/index/oneMinute`
- `/_svc/ping/crons/index/twoMinute`

Changes to build process for dynamic schedules:
- After rolldown, stage a copy of the bundle into a temporary dir
  - Use user build dir if a custom build command was provided
- `getServiceCrons` loads the entrypoint, awaits its default export, validates, and generates cron entries

