### PR TITLE
[ci] Support VITEST_TEST_FILES env var and print test manifest per chunk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,6 +293,40 @@ jobs:
         run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...
         env:
           FORCE_COLOR: '1'
+
+      - name: "Print test manifest (chunk ${{matrix.chunkNumber}}/${{matrix.allChunksLength}})"
+        shell: bash
+        env:
+          VITEST_TEST_FILES: ${{ matrix.useEnvPaths == true && join(matrix.testPaths, ' ') || '' }}
+        run: |
+          # Resolve the file list the same way the test step does
+          if [ -n "$VITEST_TEST_FILES" ]; then
+            files="$VITEST_TEST_FILES"
+            source="VITEST_TEST_FILES env var"
+          else
+            files="${{ join(matrix.testPaths, ' ') }}"
+            source="CLI args"
+          fi
+
+          count=$(echo "$files" | tr ' ' '\n' | grep -c .)
+          echo "Chunk ${{matrix.chunkNumber}} of ${{matrix.allChunksLength}} — $count files via $source"
+          echo "$files" | tr ' ' '\n' | grep . | sort | sed 's/^/  /'
+
+          {
+            echo "## Chunk ${{matrix.chunkNumber}}/${{matrix.allChunksLength}} — \`${{matrix.packageName}}\`"
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Runner | \`${{matrix.runner}}\` / Node v\`${{matrix.nodeVersion}}\` |"
+            echo "| Files | $count (via $source) |"
+            echo ""
+            echo "<details><summary>File list</summary>"
+            echo ""
+            echo '```'
+            echo "$files" | tr ' ' '\n' | grep . | sort
+            echo '```'
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Test ${{matrix.packageName}}
         run: |
           attempt=1
@@ -302,7 +336,15 @@ jobs:
           while [ "$attempt" -le "$max_attempts" ]; do
             echo "Running tests (attempt $attempt/$max_attempts): ${{matrix.testScript}} ${{matrix.packageName}}"
 
-            if node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}; then
+            # When VITEST_TEST_FILES is set, the test script reads paths from that env var
+            # instead of CLI args, avoiding the Windows cmd.exe ~8191 char arg limit.
+            if [ -n "$VITEST_TEST_FILES" ]; then
+              run_cmd="node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir='.turbo' --log-order=stream --filter=${{matrix.packageName}}"
+            else
+              run_cmd="node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir='.turbo' --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}"
+            fi
+
+            if eval "$run_cmd"; then
               exit 0
             fi
 
@@ -320,6 +362,7 @@ jobs:
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           TURBO_BASE_SHA: ${{ needs.setup.outputs.baseSha }}
           FORCE_COLOR: '1'
+          VITEST_TEST_FILES: ${{ matrix.useEnvPaths == true && join(matrix.testPaths, ' ') || '' }}
           # Datadog Test Optimization: emit per-test spans correlated to the
           # GitHub Actions job span, replacing the previous post-hoc JUnit
           # upload. See test/lib/deployment/metrics.js for the legacy


### PR DESCRIPTION
## Summary

- Adds `VITEST_TEST_FILES` env var support to the unit-test step: when a matrix entry has `useEnvPaths: true`, paths are passed via env var instead of CLI args, bypassing the Windows `cmd.exe` ~8191 char arg limit that `turbo` hits when spawning `package.json` scripts
- Adds a **"Print test manifest"** step (runs after build, before tests) that logs chunk number, file count, and sorted file list to both the step log and `GITHUB_STEP_SUMMARY`
- No packages use `useEnvPaths` yet — this PR is inert on its own and safe to merge immediately

## Why two PRs?

GitHub Actions runs the workflow from the **base branch** (`main`), not the PR branch. So `chunk-tests.js` changes that emit `useEnvPaths: true` must only land after this workflow change is already on `main`. A follow-up PR will bump the CLI to `max: 7` chunks and add the `vitest-run.mjs` wrapper.

## Test plan

- [ ] Verify existing unit-test jobs still pass (no behavior change — `VITEST_TEST_FILES` is empty for all packages until the follow-up lands)
- [ ] Check one job's Step Summary tab shows the manifest table

🤖 Generated with [Claude Code](https://claude.com/claude-code)