### PR TITLE
Add canary prerelease experiment

### DIFF
--- a/.changeset/canary-prerelease-experiment.md
+++ b/.changeset/canary-prerelease-experiment.md
@@ -1,0 +1,4 @@
+---
+---
+
+Added an experimental manual canary prerelease workflow.

--- a/.github/workflows/canary-prerelease.yml
+++ b/.github/workflows/canary-prerelease.yml
@@ -1,0 +1,104 @@
+name: Canary Prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      forcePackage:
+        description: Optional package to force-bump when there are no pending canary changesets
+        required: false
+        type: string
+
+env:
+  TURBO_REMOTE_ONLY: 'true'
+  TURBO_TEAM: 'vercel'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  canary-prerelease:
+    name: Canary Prerelease
+    runs-on: ubuntu-latest
+    environment: release # Required for trusted publishing if this run publishes PyPI packages
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Validate Branch
+        run: |
+          if [ "$GITHUB_REF_NAME" != "canary" ]; then
+            echo "Run this workflow from the canary branch, not $GITHUB_REF_NAME."
+            exit 1
+          fi
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Necessary for the publish step to work since it uses HEAD^ to determine if the version has changed
+          fetch-depth: 2
+
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: wasm32-wasip2
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: 'pyproject.toml'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.10.11'
+
+      - name: install npm@11
+        run: npm i -g npm@11
+
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Packages
+        run: pnpm build
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Create Canary Prerelease Pull Request or Publish
+        id: changesets
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf
+        with:
+          version: pnpm ci:version:canary-prerelease
+          publish: pnpm ci:publish:canary-prerelease
+          title: Version Packages (canary)
+          commit: Version Packages (canary)
+          commitMode: 'github-api'
+          createGithubReleases: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
+          CANARY_PRERELEASE_PACKAGE: ${{ github.event.inputs.forcePackage }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+  summary:
+    name: Summary (canary prerelease)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - canary-prerelease
+    steps:
+      - name: Check All
+        run: echo OK

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "ci:publish": "node utils/publish-runtimes.mjs && bash utils/npm-publish.sh && changeset tag",
     "ci:version:canary": "node utils/changeset-version-canary.js && pnpm install --no-frozen-lockfile",
     "ci:publish:canary": "bash utils/npm-publish.sh canary",
+    "ci:version:canary-prerelease": "node utils/changeset-prerelease-canary.js",
+    "ci:publish:canary-prerelease": "node utils/publish-runtimes.mjs && bash utils/npm-publish.sh canary && changeset tag",
     "type-check": "turbo type-check --concurrency=12 --output-logs=errors-only --summarize --continue"
   },
   "lint-staged": {

--- a/utils/changeset-prerelease-canary.js
+++ b/utils/changeset-prerelease-canary.js
@@ -1,0 +1,65 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const preStatePath = path.join(root, '.changeset', 'pre.json');
+const forcePackage = process.env.CANARY_PRERELEASE_PACKAGE;
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} exited with ${result.status}`
+    );
+  }
+}
+
+function ensureCanaryPreState() {
+  if (!fs.existsSync(preStatePath)) {
+    run('pnpm', ['changeset', 'pre', 'enter', 'canary']);
+    return;
+  }
+
+  const preState = JSON.parse(fs.readFileSync(preStatePath, 'utf8'));
+
+  if (preState.mode !== 'pre' || preState.tag !== 'canary') {
+    throw new Error(
+      `.changeset/pre.json is already configured for ${preState.mode}:${preState.tag}; expected pre:canary`
+    );
+  }
+}
+
+function createForcedChangeset() {
+  if (!forcePackage) {
+    return;
+  }
+
+  const fileName = `canary-prerelease-${Date.now()}.md`;
+  const changesetPath = path.join(root, '.changeset', fileName);
+  const contents = `---\n'${forcePackage}': patch\n---\n\nForced canary prerelease for ${forcePackage}.\n`;
+
+  fs.writeFileSync(changesetPath, contents);
+  console.log(`Created ${path.relative(root, changesetPath)}`);
+}
+
+function main() {
+  ensureCanaryPreState();
+  createForcedChangeset();
+
+  run('pnpm', ['changeset', 'version']);
+  run('node', ['utils/sync-python-version.js', '--pep440-prerelease']);
+  run('uv', ['lock']);
+  run('pnpm', ['install', '--no-frozen-lockfile']);
+}
+
+main();

--- a/utils/sync-python-version.js
+++ b/utils/sync-python-version.js
@@ -13,6 +13,7 @@ const fs = require('fs');
 const path = require('path');
 
 const VERSION_TS_PATH = 'packages/python/src/package-versions.ts';
+const SHOULD_MAP_PRERELEASE = process.argv.includes('--pep440-prerelease');
 
 const PYTHON_PACKAGES = [
   {
@@ -29,6 +30,47 @@ const PYTHON_PACKAGES = [
   },
 ];
 
+function toPep440Version(version) {
+  if (!SHOULD_MAP_PRERELEASE) {
+    return version;
+  }
+
+  const match = version.match(/^(\d+\.\d+\.\d+)(?:-([a-zA-Z]+)\.?(\d+))?$/);
+
+  if (!match) {
+    return version;
+  }
+
+  const [, baseVersion, prereleaseLabel, prereleaseNumber] = match;
+
+  if (!prereleaseLabel) {
+    return version;
+  }
+
+  const number = prereleaseNumber ?? '0';
+  const normalizedLabel = prereleaseLabel.toLowerCase();
+
+  if (normalizedLabel === 'canary' || normalizedLabel === 'dev') {
+    return `${baseVersion}.dev${number}`;
+  }
+
+  if (normalizedLabel === 'alpha' || normalizedLabel === 'a') {
+    return `${baseVersion}a${number}`;
+  }
+
+  if (normalizedLabel === 'beta' || normalizedLabel === 'b') {
+    return `${baseVersion}b${number}`;
+  }
+
+  if (normalizedLabel === 'rc') {
+    return `${baseVersion}rc${number}`;
+  }
+
+  throw new Error(
+    `Cannot map npm prerelease version "${version}" to a PEP 440 version`
+  );
+}
+
 function syncVersion(packageConfig) {
   const { name, packageJsonPath, pyprojectPath } = packageConfig;
 
@@ -44,11 +86,17 @@ function syncVersion(packageConfig) {
   }
 
   const packageJson = JSON.parse(fs.readFileSync(packageJsonFullPath, 'utf8'));
-  const version = packageJson.version;
+  const packageVersion = packageJson.version;
 
-  if (!version) {
+  if (!packageVersion) {
     console.log(`Skipping ${name}: no version found in package.json`);
     return { updated: false, version: null };
+  }
+
+  const version = toPep440Version(packageVersion);
+
+  if (packageVersion !== version) {
+    console.log(`${name}: mapped npm ${packageVersion} -> Python ${version}`);
   }
 
   // Read pyproject.toml


### PR DESCRIPTION
## Summary
- Add a manual-only `Canary Prerelease` workflow that must be run from a long-lived `canary` branch.
- Add canary prerelease scripts that enter/validate Changesets `pre:canary`, run `changeset version`, and publish npm packages under the `canary` dist-tag.
- Teach the Python version sync step to map npm prerelease versions to PEP 440 when explicitly requested, e.g. `0.13.2-canary.3` -> `0.13.2.dev3`.

## How to try it
1. Create or update a `canary` branch from `main`.
2. Run the manual `Canary Prerelease` workflow from the `canary` branch.
3. Inspect the generated `Version Packages (canary)` PR against `canary`.
4. Merge it manually if the prerelease state looks right.
5. Run the workflow again from `canary` to publish the prerelease versions to npm `canary`.

The workflow also accepts an optional `forcePackage` input, intended for testing a Next.js-style always-moving canary such as `vercel@canary` when no pending changeset would otherwise bump that package.

## Guardrails
- No schedule and no auto-merge yet.
- Workflow exits unless it is run from the `canary` branch.
- Stable `release.yml` on `main` is unchanged.
- Python prerelease mapping is opt-in via `--pep440-prerelease`.

## Test plan
- `node --check utils/changeset-prerelease-canary.js`
- `node --check utils/sync-python-version.js`
- `node -e "JSON.parse(require('fs').readFileSync('package.json', 'utf8'))"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/canary-prerelease.yml')"`
- `pnpm exec biome lint utils/changeset-prerelease-canary.js utils/sync-python-version.js`
- `pnpm exec prettier --check package.json utils/changeset-prerelease-canary.js utils/sync-python-version.js .github/workflows/canary-prerelease.yml .changeset/canary-prerelease-experiment.md`
- `git diff --check`
- Smoke-tested Python mapping: `0.13.2-canary.3` -> `0.13.2.dev3`, then restored generated files.


Made with [Cursor](https://cursor.com)