### PR TITLE
Publish npm packages in dependency order

### DIFF
--- a/.changeset/topological-npm-publish.md
+++ b/.changeset/topological-npm-publish.md
@@ -1,0 +1,4 @@
+---
+---
+
+Publish npm packages in dependency order.

--- a/utils/npm-publish.sh
+++ b/utils/npm-publish.sh
@@ -15,9 +15,25 @@ NPM_TAG=${1:-}
 TARBALL_DIR=$(mktemp -d)
 trap 'rm -rf "$TARBALL_DIR"' EXIT
 
-# Get all public (non-private) workspace packages as JSON from pnpm
+# Get all public (non-private) workspace packages as JSON from pnpm,
+# then order them by pnpm's recursive execution order. This publishes
+# workspace dependencies before their dependents while preserving npm publish
+# for OIDC trusted publishing.
 # Each line: <package-name>\t<path>
-packages=$(pnpm ls -r --depth -1 --json | jq -r '.[] | select(.private != true) | "\(.name)\t\(.path)"')
+package_metadata=$(pnpm ls -r --depth -1 --json)
+topological_paths=$(
+  pnpm --workspace-concurrency=1 recursive exec pwd |
+    jq -R -s 'split("\n") | map(select(length > 0))'
+)
+packages=$(
+  jq -r --argjson topological_paths "$topological_paths" '
+    map(select(.private != true)) as $packages |
+    $topological_paths[] as $path |
+    $packages[] |
+    select(.path == $path) |
+    "\(.name)\t\(.path)"
+  ' <<< "$package_metadata"
+)
 
 if [ -z "$packages" ]; then
   echo "No publishable packages found."


### PR DESCRIPTION
## Summary
- Order `utils/npm-publish.sh` publish attempts using pnpm recursive execution order, which sorts workspace dependencies before dependents. As I understand it, `pnpm ls -r` is not a guarantee of sort order https://github.com/pnpm/pnpm/issues/7716
- Keep the existing `pnpm pack` + `npm publish --provenance` flow so trusted publishing behavior stays unchanged.
- Preserve stop-on-first-failure behavior so downstream packages are not published after an upstream workspace dependency fails.

## Test plan
- `bash -n utils/npm-publish.sh`
- Previewed publish order with `pnpm --workspace-concurrency=1 recursive exec pwd` joined against `pnpm ls -r --depth -1 --json`
- `git diff --check -- utils/npm-publish.sh`


Made with [Cursor](https://cursor.com)