### PR TITLE
fix(cli): warn that `--sensitive` variables cannot be retrieved via `env pull`

### DIFF
--- a/.changeset/fix-sensitive-env-pull-warning.md
+++ b/.changeset/fix-sensitive-env-pull-warning.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): warn when `--sensitive` flag is used that the variable cannot be retrieved via `vercel env pull`

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -753,7 +753,7 @@ export default async function add(client: Client, argv: string[]) {
     !skipConfirm;
   if (canPromptForType) {
     output.log(
-      `Sensitive values cannot be retrieved later from the dashboard or CLI.`
+      `Sensitive values cannot be retrieved later from the dashboard or CLI, including via ${getCommandName('env pull')}.`
     );
     const keepSensitive = await client.input.confirm(
       `Make it sensitive?`,
@@ -778,6 +778,20 @@ export default async function add(client: Client, argv: string[]) {
         `Your team requires sensitive Environment Variables for Production and Preview.`
       );
     }
+  }
+
+  // When --sensitive is explicitly set (not via interactive prompt), remind the
+  // user that sensitive values cannot be pulled. The interactive prompt already
+  // surfaces this note, but non-interactive / --yes invocations skip that flow.
+  if (
+    finalType === 'sensitive' &&
+    hasSensitiveCapable &&
+    !canPromptForType &&
+    forceSensitive
+  ) {
+    output.log(
+      `Sensitive values cannot be retrieved later from the dashboard or CLI, including via ${getCommandName('env pull')}.`
+    );
   }
 
   const upsert = opts['--force'] ? 'true' : '';

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -354,6 +354,50 @@ describe('env add', () => {
       });
     });
 
+    describe('--sensitive warns about env pull', () => {
+      it('shows a retrieval warning when --sensitive is passed explicitly with --yes', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'SENSITIVE_WITH_YES',
+          'production',
+          '--sensitive',
+          '--value',
+          'supersecret',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        // Should warn that sensitive values cannot be retrieved via env pull
+        await expect(client.stderr).toOutput(
+          'Sensitive values cannot be retrieved later from the dashboard or CLI'
+        );
+
+        expect(spy).toHaveBeenCalled();
+        const [, , , type, , value] = spy.mock.calls[0] as unknown as [
+          unknown,
+          unknown,
+          unknown,
+          string,
+          unknown,
+          string,
+        ];
+        expect(type).toBe('sensitive');
+        // Verify the value is correctly stored (not empty)
+        expect(value).toBe('supersecret');
+
+        spy.mockRestore();
+      });
+    });
+
     describe('mixed Development + other Environments', () => {
       it('errors when the interactive checkbox picks Development alongside Production/Preview', async () => {
         client.setArgv('env', 'add', 'MIXED_TARGETS');


### PR DESCRIPTION
## Summary

When `--sensitive` is passed explicitly (e.g. `--sensitive --value V --yes` in CI), no warning was shown about the retrieval limitation of sensitive Environment Variables. The interactive "Make it sensitive?" prompt already included this note, but non-interactive / `--yes` invocations skipped that flow entirely.

This left users without any indication that `vercel env pull` would return an empty value for the variable — causing confusion where the variable appears to have been saved with an empty value (see #16160).

## Changes

- `packages/cli/src/commands/env/add.ts`: When `--sensitive` is explicitly set and targets Production/Preview, emit the retrieval-limitation log message even when the interactive prompt is skipped. Also mention `vercel env pull` by name in the existing interactive-prompt message for clarity.
- `packages/cli/test/unit/commands/env/add.test.ts`: Add a test verifying that the retrieval warning is shown when `--sensitive --value V --yes` is used, and that the value is correctly stored (not empty).
- `.changeset/fix-sensitive-env-pull-warning.md`: Patch changeset for `vercel` package.

## Reproduction (from #16160)

```bash
# Before this fix: no warning shown, user discovers empty value only after pull
vercel env add TEST_VAR production --sensitive --yes --value 'postgresql://...'
# → "Added Environment Variable TEST_VAR..." (no mention of pull limitation)
# → vercel env pull → TEST_VAR=""  ← user confused

# After this fix:
# → Added Environment Variable TEST_VAR...
# → Sensitive values cannot be retrieved later from the dashboard or CLI,
#    including via vercel env pull.
```

Closes #16160