### PR TITLE
ci: display 'CLI' instead of 'vercel' in test chunk job names

### DIFF
--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -286,6 +286,28 @@ function getRunnerOptions(scriptName, packageName) {
   return runnerOptions;
 }
 
+function getRunnerShort(runner) {
+  switch (runner) {
+    case 'ubuntu-latest':
+      return 'linux';
+    case 'macos-14':
+      return 'mac';
+    case 'windows-latest':
+      return 'win';
+    default:
+      return runner;
+  }
+}
+
+function getPackageDisplayName(packageName) {
+  switch (packageName) {
+    case 'vercel':
+      return 'CLI';
+    default:
+      return packageName;
+  }
+}
+
 async function getChunkedTests() {
   let scripts = [...runnersMap.keys()];
   const rootPath = path.resolve(__dirname, '..');
@@ -384,15 +406,13 @@ async function getChunkedTests() {
           (chunk, chunkNumber, allChunks) => {
             return nodeVersions.flatMap(nodeVersion => {
               return runners.map(runner => {
-                const runnerShort = runner
-                  .replace('ubuntu-latest', 'linux')
-                  .replace('macos-14', 'mac')
-                  .replace('windows-latest', 'win');
+                const runnerShort = getRunnerShort(runner);
+                const packageDisplayName = getPackageDisplayName(packageName);
                 const chunkSuffix =
                   allChunks.length > 1
                     ? ` [${chunkNumber + 1}/${allChunks.length}]`
                     : '';
-                const label = `${packageName} (${runnerShort}/node${nodeVersion})${chunkSuffix}`;
+                const label = `${packageDisplayName} (${runnerShort}/node${nodeVersion})${chunkSuffix}`;
                 return {
                   runner,
                   packagePath,


### PR DESCRIPTION
## Summary

- Test chunk job names now show `CLI (linux/node22) [4/4]` instead of `vercel (linux/node22) [4/4]`
- Refactors inline chained `.replace()` calls for runner names into a `getRunnerShort()` switch function
- Adds a parallel `getPackageDisplayName()` switch function for package display name overrides — both follow the same pattern, making future additions straightforward

## Test plan

- [ ] Verify CI job names in a PR show `CLI` instead of `vercel` for the CLI package shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)