### PR TITLE
@vercel/oidc: rename `getVercelOidcTokenSync` to `getVercelOidcTokenFromContext` for clarity

### DIFF
--- a/.changeset/oidc-rename-sync-to-from-context.md
+++ b/.changeset/oidc-rename-sync-to-from-context.md
@@ -1,0 +1,7 @@
+---
+'@vercel/oidc': minor
+'@vercel/oidc-aws-credentials-provider': patch
+'@vercel/functions': patch
+---
+
+Add `getVercelOidcTokenFromContext()` and deprecate `getVercelOidcTokenSync()`. The old name implied a sync/async pair with `getVercelOidcToken()`, but the async variant additionally refreshes expired tokens — the difference is what they do, not how. The deprecated alias is preserved.

--- a/packages/functions/src/oidc/aws-credentials-provider.ts
+++ b/packages/functions/src/oidc/aws-credentials-provider.ts
@@ -1,6 +1,6 @@
 import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import type { FromWebTokenInit } from '@aws-sdk/credential-provider-web-identity';
-import { getVercelOidcTokenSync } from '@vercel/oidc';
+import { getVercelOidcTokenFromContext } from '@vercel/oidc';
 
 /**
  * The init object for the `awsCredentialsProvider` function.
@@ -74,7 +74,7 @@ export function awsCredentialsProvider(
     const { fromWebToken } = await loadAwsCredentialProviderWebIdentity();
     return fromWebToken({
       ...init,
-      webIdentityToken: getVercelOidcTokenSync(),
+      webIdentityToken: getVercelOidcTokenFromContext(),
     })();
   };
 }

--- a/packages/functions/src/oidc/index.ts
+++ b/packages/functions/src/oidc/index.ts
@@ -14,4 +14,8 @@ export { awsCredentialsProvider } from './aws-credentials-provider';
  * @deprecated Use @vercel/oidc instead
  * OIDC authentication for Vercel Functions
  */
-export { getVercelOidcToken, getVercelOidcTokenSync } from '@vercel/oidc';
+export {
+  getVercelOidcToken,
+  getVercelOidcTokenFromContext,
+  getVercelOidcTokenSync,
+} from '@vercel/oidc';

--- a/packages/functions/test/unit/index.test.ts
+++ b/packages/functions/test/unit/index.test.ts
@@ -38,6 +38,7 @@ describe('@vercel/functions/oidc', () => {
   const EXPECTED_METHODS = [
     'awsCredentialsProvider',
     'getVercelOidcToken',
+    'getVercelOidcTokenFromContext',
     'getVercelOidcTokenSync',
   ];
 

--- a/packages/oidc-aws-credentials-provider/src/aws-credentials-provider.ts
+++ b/packages/oidc-aws-credentials-provider/src/aws-credentials-provider.ts
@@ -1,7 +1,7 @@
 import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import type { FromWebTokenInit } from '@aws-sdk/credential-provider-web-identity';
 import { fromWebToken } from '@aws-sdk/credential-provider-web-identity';
-import { getVercelOidcTokenSync } from '@vercel/oidc';
+import { getVercelOidcTokenFromContext } from '@vercel/oidc';
 
 /**
  * The init object for the `awsCredentialsProvider` function.
@@ -64,7 +64,7 @@ export function awsCredentialsProvider(
   return async () => {
     return fromWebToken({
       ...init,
-      webIdentityToken: getVercelOidcTokenSync(),
+      webIdentityToken: getVercelOidcTokenFromContext(),
     })();
   };
 }

--- a/packages/oidc/README.md
+++ b/packages/oidc/README.md
@@ -36,6 +36,13 @@ Gets the current OIDC token from the request context or environment variable. Wi
 - `team?: string` - Team ID (team\_\*) or slug
 - `expirationBufferMs?: number` - Buffer time in ms before expiry to trigger refresh (default: 0)
 
+### `getVercelOidcTokenFromContext()`
+
+Synchronously reads the current OIDC token from the request context (`x-vercel-oidc-token` header) or the `VERCEL_OIDC_TOKEN` environment variable. Does not refresh the token. Use `getVercelOidcToken()` if you need automatic refresh in development.
+
 ### `getVercelOidcTokenSync()`
 
-Synchronously gets the current OIDC token without refreshing. Use `getVercelOidcToken()` if you need automatic refresh in development.
+> [!WARNING]
+> Deprecated — use [`getVercelOidcTokenFromContext()`](#getverceloidctokenfromcontext) instead. The `Sync` suffix was misleading because `getVercelOidcToken()` is not a sync/async pair with this function — it additionally refreshes the token when expired.
+
+Alias for `getVercelOidcTokenFromContext()`.

--- a/packages/oidc/src/get-vercel-oidc-token.test.ts
+++ b/packages/oidc/src/get-vercel-oidc-token.test.ts
@@ -6,11 +6,16 @@ import * as fs from 'fs';
 
 vi.mock('./token-io');
 vi.mock('./get-context', () => ({
-  getContext: () => ({ headers: {} }),
+  getContext: vi.fn(() => ({ headers: {} })),
 }));
 
 import { findRootDir, getUserDataDir } from './token-io';
-import { getVercelOidcToken } from './get-vercel-oidc-token';
+import {
+  getVercelOidcToken,
+  getVercelOidcTokenFromContext,
+  getVercelOidcTokenSync,
+} from './get-vercel-oidc-token';
+import { getContext } from './get-context';
 import * as tokenUtil from './token-util';
 
 describe('getVercelOidcToken - Error Scenarios', () => {
@@ -400,6 +405,63 @@ describe('getVercelOidcToken - Error Scenarios', () => {
 
     expect(token).toBe(validToken);
     expect(getVercelOidcTokenSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('getVercelOidcTokenFromContext', () => {
+  beforeEach(() => {
+    vi.mocked(getContext).mockReturnValue({ headers: {} });
+    delete process.env.VERCEL_OIDC_TOKEN;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_OIDC_TOKEN;
+  });
+
+  test('returns the token from the x-vercel-oidc-token request header', () => {
+    vi.mocked(getContext).mockReturnValue({
+      headers: { 'x-vercel-oidc-token': 'header-token' },
+    });
+
+    expect(getVercelOidcTokenFromContext()).toBe('header-token');
+  });
+
+  test('falls back to the VERCEL_OIDC_TOKEN env var when the header is absent', () => {
+    process.env.VERCEL_OIDC_TOKEN = 'env-token';
+
+    expect(getVercelOidcTokenFromContext()).toBe('env-token');
+  });
+
+  test('prefers the request header over the env var', () => {
+    vi.mocked(getContext).mockReturnValue({
+      headers: { 'x-vercel-oidc-token': 'header-token' },
+    });
+    process.env.VERCEL_OIDC_TOKEN = 'env-token';
+
+    expect(getVercelOidcTokenFromContext()).toBe('header-token');
+  });
+
+  test('throws a helpful error when neither the header nor the env var is set', () => {
+    expect(() => getVercelOidcTokenFromContext()).toThrow(
+      /'x-vercel-oidc-token' header is missing/
+    );
+  });
+});
+
+describe('getVercelOidcTokenSync (deprecated alias)', () => {
+  beforeEach(() => {
+    vi.mocked(getContext).mockReturnValue({ headers: {} });
+    delete process.env.VERCEL_OIDC_TOKEN;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_OIDC_TOKEN;
+  });
+
+  test('delegates to getVercelOidcTokenFromContext', () => {
+    process.env.VERCEL_OIDC_TOKEN = 'env-token';
+
+    expect(getVercelOidcTokenSync()).toBe(getVercelOidcTokenFromContext());
   });
 });
 

--- a/packages/oidc/src/get-vercel-oidc-token.ts
+++ b/packages/oidc/src/get-vercel-oidc-token.ts
@@ -31,7 +31,7 @@ export interface GetVercelOidcTokenOptions {
  * This function is used to retrieve the OIDC token from the request context or the environment variable.
  * It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
  *
- * Unlike the `getVercelOidcTokenSync` function, this function will refresh the token if it is expired in a development environment.
+ * Unlike the `getVercelOidcTokenFromContext` function, this function will refresh the token if it is expired in a development environment.
  *
  * @param {GetVercelOidcTokenOptions} [options] - Optional configuration for token retrieval.
  * @returns {Promise<string>} A promise that resolves to the OIDC token.
@@ -68,7 +68,7 @@ export async function getVercelOidcToken(
   let err: any;
 
   try {
-    token = getVercelOidcTokenSync();
+    token = getVercelOidcTokenFromContext();
   } catch (error) {
     err = error;
   }
@@ -85,7 +85,7 @@ export async function getVercelOidcToken(
       isExpired(getTokenPayload(token), options?.expirationBufferMs)
     ) {
       await refreshToken(options);
-      token = getVercelOidcTokenSync();
+      token = getVercelOidcTokenFromContext();
     }
   } catch (error) {
     let message = err instanceof Error ? err.message : '';
@@ -101,14 +101,14 @@ export async function getVercelOidcToken(
 }
 
 /**
- * Gets the current OIDC token from the request context or the environment variable.
+ * Reads the current OIDC token from the request context or the environment variable.
  *
  * Do not cache this value, as it is subject to change in production!
  *
  * This function is used to retrieve the OIDC token from the request context or the environment variable.
  * It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
  *
- * This function will not refresh the token if it is expired. For refreshing the token, use the @{link getVercelOidcToken} function.
+ * This function will not refresh the token if it is expired. For refreshing the token, use the {@link getVercelOidcToken} function.
  *
  * @returns {string} The OIDC token.
  * @throws {Error} If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set.
@@ -117,11 +117,11 @@ export async function getVercelOidcToken(
  *
  * ```js
  * // Using the OIDC token
- * const token = getVercelOidcTokenSync();
+ * const token = getVercelOidcTokenFromContext();
  * console.log('OIDC Token:', token);
  * ```
  */
-export function getVercelOidcTokenSync(): string {
+export function getVercelOidcTokenFromContext(): string {
   const token =
     getContext().headers?.['x-vercel-oidc-token'] ??
     process.env.VERCEL_OIDC_TOKEN;
@@ -133,4 +133,13 @@ export function getVercelOidcTokenSync(): string {
   }
 
   return token;
+}
+
+/**
+ * @deprecated Use {@link getVercelOidcTokenFromContext} instead. The `Sync` suffix
+ * was misleading because the async {@link getVercelOidcToken} is not a sync/async pair
+ * with this function — it additionally refreshes the token when expired.
+ */
+export function getVercelOidcTokenSync(): string {
+  return getVercelOidcTokenFromContext();
 }

--- a/packages/oidc/src/index-browser.ts
+++ b/packages/oidc/src/index-browser.ts
@@ -8,6 +8,13 @@ export async function getVercelOidcToken(): Promise<string> {
   return '';
 }
 
+export function getVercelOidcTokenFromContext(): string {
+  return '';
+}
+
+/**
+ * @deprecated Use {@link getVercelOidcTokenFromContext} instead.
+ */
 export function getVercelOidcTokenSync(): string {
   return '';
 }

--- a/packages/oidc/src/index.ts
+++ b/packages/oidc/src/index.ts
@@ -1,5 +1,6 @@
 export {
   getVercelOidcToken,
+  getVercelOidcTokenFromContext,
   getVercelOidcTokenSync,
 } from './get-vercel-oidc-token';
 export { getContext } from './get-context';


### PR DESCRIPTION
Also deprecate getVercelOidcTokenSync