### PR TITLE
fix(cli): avoid default scope lookup during link

### DIFF
--- a/.changeset/quiet-crabs-link.md
+++ b/.changeset/quiet-crabs-link.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Avoid resolving the configured default team before unscoped `vercel link --yes --project` cross-team search, so team-scoped tokens can still link projects they can access.

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -12,7 +12,7 @@ import output from '../../output-manager';
 import { LinkTelemetryClient } from '../../util/telemetry/commands/link';
 import { getCommandAliases } from '..';
 import { autoInstallVercelPlugin } from '../../util/agent/auto-install-agentic';
-import getScope from '../../util/get-scope';
+import getScope, { detectExplicitScope } from '../../util/get-scope';
 
 const COMMAND_CONFIG = {
   add: getCommandAliases(addSubcommand),
@@ -125,7 +125,10 @@ export default async function link(client: Client) {
       return 1;
     }
   } else {
-    const scopeContext = await getScope(client, { resolveLocalScope: true });
+    const explicitScopeProvided = detectExplicitScope(client);
+    if (explicitScopeProvided) {
+      await getScope(client, { resolveLocalScope: true });
+    }
 
     // Non-interactive when flag is passed or when agent (e.g. no TTY) so JSON is output when confirmation needed
     const linkNonInteractive =
@@ -137,7 +140,7 @@ export default async function link(client: Client) {
       projectName: parsedArgs.flags['--project'],
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
-      searchAcrossTeams: !scopeContext.explicitScopeProvided,
+      searchAcrossTeams: !explicitScopeProvided,
     });
 
     if (typeof link === 'number') {

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -212,7 +212,7 @@ export function applyScopeFromLink(client: Client, link: { org: Org }): void {
     : undefined;
 }
 
-function detectExplicitScope(client: Client): boolean {
+export function detectExplicitScope(client: Client): boolean {
   const argv = client.argv;
   for (const arg of argv) {
     if (

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -2108,6 +2108,48 @@ describe('link', () => {
       reauthSpy.mockRestore();
     });
 
+    it('should not resolve the default team before unscoped cross-team search', async () => {
+      const defaultTeamId = 'team_default';
+      useUser({ version: 'northstar', defaultTeamId });
+      const cwd = setupTmpDir();
+      const projectName = 'project-x';
+
+      const [teamA] = useTeams('team_a') as Team[];
+      const projectA = {
+        ...defaultProject,
+        id: 'proj-on-a',
+        name: projectName,
+      };
+
+      client.scenario.get(`/teams/${defaultTeamId}`, (_req, res) => {
+        res.status(403).json({
+          error: {
+            code: 'team_unauthorized',
+            message:
+              'Not authorized: Trying to access resource under scope "default-team".',
+          },
+        });
+      });
+      client.scenario.get(`/v9/projects/${projectName}`, (req, res) => {
+        if (req.query.teamId === teamA.id) {
+          return res.json(projectA);
+        }
+
+        res.status(404).json({ error: { code: 'not_found' } });
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('--project', projectName, '--yes');
+
+      const exitCode = await link(client);
+
+      expect(exitCode).toEqual(0);
+      const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+      expect(projectJson.orgId).toEqual(teamA.id);
+      expect(projectJson.projectId).toEqual(projectA.id);
+    });
+
     it('should skip SAML-limited teams during cross-team search', async () => {
       useUser({ version: 'northstar' });
       const cwd = setupTmpDir();


### PR DESCRIPTION
## Summary
- Avoid resolving full scope context before unscoped `vercel link --yes --project` cross-team search.
- Preserve explicit `--scope` / `--team` behavior so lookup stays limited to the requested scope.
- Add a regression test for a token that cannot access the configured default team but can access the target project team.

## Test plan
- `npx vitest run packages/cli/test/unit/commands/link/index.test.ts`


Made with [Cursor](https://cursor.com)