### PR TITLE
cli-exec: New package to locate and run the CLI from libraries

### DIFF
--- a/.changeset/cool-apes-jog.md
+++ b/.changeset/cool-apes-jog.md
@@ -1,0 +1,5 @@
+---
+'@vercel/cli-exec': minor
+---
+
+Add a reusable CLI wrapper package for resolving and executing the local Vercel CLI.

--- a/packages/cli-exec/README.md
+++ b/packages/cli-exec/README.md
@@ -1,0 +1,52 @@
+# `@vercel/cli-exec`
+
+Helpers for locating and executing the Vercel CLI from other Node packages.
+
+## API
+
+### `findVercelCli(options?)`
+
+Resolves the Vercel CLI executable without running it.
+
+- Prefers the nearest `node_modules/.bin/vercel`
+- Falls back to the provided `PATH`
+- Returns `null` when no usable CLI installation is found
+
+### `execVercelCli(args, options?)`
+
+Resolves and runs the Vercel CLI, returning:
+
+- `stdout`
+- `stderr`
+- `invocation`
+
+It preserves access to local `node_modules/.bin` entries and Node itself even
+when the caller passes a sanitized `PATH`.
+
+### `clearVercelCliCache()`
+
+Clears cached CLI lookups. Use this when a long-lived process needs to pick up
+an install or uninstall that happened after an earlier resolution attempt.
+
+### `VercelCliError`
+
+Thrown when resolution or execution fails. The `code` field is one of:
+
+- `VERCEL_CLI_INVALID_CWD`
+- `VERCEL_CLI_NOT_FOUND`
+- `VERCEL_CLI_PERMISSION_DENIED`
+- `VERCEL_CLI_ERRORED`
+- `VERCEL_CLI_TIMED_OUT`
+- `VERCEL_CLI_CANCELED`
+- `VERCEL_CLI_SIGNALED`
+- `VERCEL_CLI_EXEC_FAILED`
+
+Available fields:
+
+- `message`: human-readable error message
+- `code`: stable machine-readable error code
+- `invocation`: resolved CLI command metadata when a command was selected
+- `stdout`: captured standard output when the child process produced output
+- `stderr`: captured standard error when the child process produced output
+- `exitCode`: numeric exit code for non-zero process exits
+- `cause`: original underlying error when available

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@vercel/cli-exec",
+  "description": "Helpers for locating and executing the Vercel CLI",
+  "homepage": "https://vercel.com",
+  "files": [
+    "dist"
+  ],
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "version": "0.0.1",
+  "repository": {
+    "directory": "packages/cli-exec",
+    "type": "git",
+    "url": "git+https://github.com/vercel/vercel.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/vercel/issues"
+  },
+  "engines": {
+    "node": ">= 18"
+  },
+  "scripts": {
+    "build": "node ../../utils/build.mjs",
+    "test": "vitest run -c ../../vitest.config.mts",
+    "vitest-run": "vitest run -c ../../vitest.config.mts",
+    "vitest-unit": "glob --absolute 'tests/*.test.ts'",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "execa": "5.1.1"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.0",
+    "vitest": "2.1.4"
+  }
+}

--- a/packages/cli-exec/src/index.ts
+++ b/packages/cli-exec/src/index.ts
@@ -1,0 +1,541 @@
+import { accessSync, constants, realpathSync, statSync } from 'node:fs';
+import path from 'node:path';
+import execa from 'execa';
+
+/**
+ * The resolved executable and arguments needed to invoke the Vercel CLI.
+ */
+export interface VercelCliInvocation {
+  command: string;
+  commandArgs: string[];
+  source: 'local-bin' | 'path';
+}
+
+/**
+ * Options for executing the resolved Vercel CLI.
+ */
+export interface ExecVercelCliOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+}
+
+/**
+ * Captured output and invocation details from a successful CLI execution.
+ */
+export interface ExecVercelCliResult {
+  stdout: string;
+  stderr: string;
+  invocation: VercelCliInvocation;
+}
+
+/**
+ * Options for resolving the Vercel CLI without executing it.
+ */
+export interface FindVercelCliOptions {
+  cwd?: string;
+  path?: string;
+}
+
+/**
+ * Stable error codes produced by {@link VercelCliError}.
+ */
+export type VercelCliErrorCode =
+  | 'VERCEL_CLI_INVALID_CWD'
+  | 'VERCEL_CLI_NOT_FOUND'
+  | 'VERCEL_CLI_PERMISSION_DENIED'
+  | 'VERCEL_CLI_ERRORED'
+  | 'VERCEL_CLI_TIMED_OUT'
+  | 'VERCEL_CLI_CANCELED'
+  | 'VERCEL_CLI_SIGNALED'
+  | 'VERCEL_CLI_EXEC_FAILED';
+
+/**
+ * Error returned when CLI resolution or execution fails.
+ *
+ * `code` is always set. The remaining fields are populated when the failure
+ * happened after a CLI invocation was resolved or started.
+ */
+export class VercelCliError extends Error {
+  /**
+   * Stable machine-readable error code.
+   */
+  code: VercelCliErrorCode;
+
+  /**
+   * Resolved CLI command and arguments, when available.
+   */
+  invocation?: VercelCliInvocation;
+
+  /**
+   * Captured standard output from the failed process, when available.
+   */
+  stdout?: string;
+
+  /**
+   * Captured standard error from the failed process, when available.
+   */
+  stderr?: string;
+
+  /**
+   * Process exit code for non-zero exits, when available.
+   */
+  exitCode?: number;
+
+  constructor(options: {
+    code: VercelCliErrorCode;
+    message: string;
+    invocation?: VercelCliInvocation;
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number;
+    cause?: unknown;
+  }) {
+    super(options.message);
+    this.name = 'VercelCliError';
+    this.code = options.code;
+    this.invocation = options.invocation;
+    this.stdout = options.stdout;
+    this.stderr = options.stderr;
+    this.exitCode = options.exitCode;
+    if (options.cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+/**
+ * Resolves the Vercel CLI from the nearest `node_modules/.bin` directories
+ * first, then falls back to the provided `PATH`.
+ *
+ * Returns `null` when no usable CLI executable can be found.
+ */
+export function findVercelCli(
+  options: FindVercelCliOptions = {}
+): VercelCliInvocation | null {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const pathValue = options.path ?? getEnvPath(process.env);
+  const cacheKey = getCliInvocationCacheKey(cwd, pathValue);
+
+  if (cliInvocationCache.has(cacheKey)) {
+    return cliInvocationCache.get(cacheKey) ?? null;
+  }
+
+  const invocation = resolveCliInvocation(cwd, pathValue);
+
+  cliInvocationCache.set(cacheKey, invocation);
+  return invocation;
+}
+
+/**
+ * Clears cached positive and negative CLI resolutions.
+ *
+ * Call this after installing or removing the CLI in a long-lived process that
+ * needs to re-resolve the executable from disk.
+ */
+export function clearVercelCliCache() {
+  cliInvocationCache.clear();
+}
+
+/**
+ * Resolves and executes the Vercel CLI with the provided arguments.
+ *
+ * The execution environment is adjusted so local `node_modules/.bin`
+ * directories and the current Node executable remain available even when a
+ * caller passes a sanitized `PATH`.
+ */
+export async function execVercelCli(
+  args: string[],
+  options: ExecVercelCliOptions = {}
+): Promise<ExecVercelCliResult> {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  assertValidCwd(cwd);
+  const env = mergeExecEnv(options.env);
+  const pathValue = getEnvPath(env);
+  const cacheKey = getCliInvocationCacheKey(cwd, pathValue);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const invocation = findVercelCli({ cwd, path: pathValue });
+    if (!invocation) {
+      throw new VercelCliError({
+        code: 'VERCEL_CLI_NOT_FOUND',
+        message: 'Unable to find a usable Vercel CLI installation.',
+      });
+    }
+
+    try {
+      const execaOptions: ExecaOptions = {
+        cwd,
+        env: prependLocalBinsToEnvPath(cwd, env),
+        windowsHide: true,
+      };
+
+      if (options.signal) {
+        execaOptions.signal = options.signal;
+      }
+
+      const { stdout, stderr } = await execa(
+        invocation.command,
+        [...invocation.commandArgs, ...args],
+        execaOptions
+      );
+
+      return { stdout, stderr, invocation };
+    } catch (error) {
+      const wrappedError = toVercelCliError(invocation, error);
+      if (wrappedError.code === 'VERCEL_CLI_NOT_FOUND' && attempt === 0) {
+        cliInvocationCache.delete(cacheKey);
+        continue;
+      }
+
+      throw wrappedError;
+    }
+  }
+
+  throw new VercelCliError({
+    code: 'VERCEL_CLI_NOT_FOUND',
+    message: 'Unable to find a usable Vercel CLI installation.',
+  });
+}
+
+interface ResolvedCommand {
+  path: string;
+  realPath: string;
+}
+
+type ExecaOptions = execa.Options & {
+  signal?: AbortSignal;
+  windowsHide?: boolean;
+};
+
+// Cache misses too so repeated calls do not keep rescanning PATH in long-lived
+// processes. Callers can clear the cache to force re-resolution after installs.
+const cliInvocationCache = new Map<string, VercelCliInvocation | null>();
+
+function getVercelCommandNames(): string[] {
+  // Intentionally resolve only the canonical `vercel` binary. `vc` is a
+  // convenience alias for interactive use, but callers should not depend on it
+  // being present in every installation layout.
+  const commandBases = ['vercel'];
+
+  if (process.platform !== 'win32') {
+    return commandBases;
+  }
+
+  const extensions = ['.cmd', '.exe', ''];
+  return commandBases.flatMap(command =>
+    extensions.map(extension => `${command}${extension}`)
+  );
+}
+
+function getAncestorDirectories(cwd: string): string[] {
+  const directories = [];
+  let current = path.resolve(cwd);
+
+  while (true) {
+    directories.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return directories;
+    }
+    current = parent;
+  }
+}
+
+function getCanonicalPath(filePath: string): string {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return filePath;
+  }
+}
+
+function getLocalBinDirectories(cwd: string): string[] {
+  const searchRoot = getCanonicalPath(path.resolve(cwd));
+
+  return getAncestorDirectories(searchRoot).map(directory =>
+    path.join(directory, 'node_modules', '.bin')
+  );
+}
+
+function isNodeScript(filePath: string): boolean {
+  return ['.js', '.cjs', '.mjs'].includes(path.extname(filePath));
+}
+
+function splitPath(pathValue: string): string[] {
+  return pathValue.split(path.delimiter).filter(Boolean);
+}
+
+function getEnvPath(env: NodeJS.ProcessEnv = process.env): string {
+  if (process.platform !== 'win32') {
+    return env.PATH ?? '';
+  }
+
+  const pathKeys = Object.keys(env).filter(key => key.toLowerCase() === 'path');
+
+  for (let index = pathKeys.length - 1; index >= 0; index--) {
+    const value = env[pathKeys[index]];
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return '';
+}
+
+function setEnvPath(
+  env: NodeJS.ProcessEnv = process.env,
+  pathValue: string
+): NodeJS.ProcessEnv {
+  if (process.platform !== 'win32') {
+    return {
+      ...env,
+      PATH: pathValue,
+    };
+  }
+
+  const normalizedEnv = { ...env };
+
+  for (const key of Object.keys(normalizedEnv)) {
+    if (key !== 'PATH' && key.toLowerCase() === 'path') {
+      delete normalizedEnv[key];
+    }
+  }
+
+  normalizedEnv.PATH = pathValue;
+  return normalizedEnv;
+}
+
+function mergeExecEnv(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  if (!env) {
+    return process.env;
+  }
+
+  return { ...process.env, ...env };
+}
+
+function findCommandInPath(
+  command: string,
+  pathValue: string,
+  cwd: string
+): ResolvedCommand | null {
+  for (const directory of splitPath(pathValue)) {
+    const candidateDirectory = path.isAbsolute(directory)
+      ? directory
+      : path.resolve(cwd, directory);
+    const candidate = path.join(candidateDirectory, command);
+    try {
+      accessSync(
+        candidate,
+        process.platform === 'win32'
+          ? constants.F_OK
+          : constants.F_OK | constants.X_OK
+      );
+
+      if (!statSync(candidate).isFile()) {
+        continue;
+      }
+
+      return { path: candidate, realPath: realpathSync(candidate) };
+    } catch {}
+  }
+
+  return null;
+}
+
+function getCliInvocationCacheKey(cwd: string, pathValue: string): string {
+  return `${cwd}\0${pathValue}`;
+}
+
+function isLocalBinPath(cwd: string, filePath: string): boolean {
+  const resolvedFilePath = path.resolve(filePath);
+  let canonicalFilePath = resolvedFilePath;
+
+  try {
+    canonicalFilePath = path.join(
+      realpathSync(path.dirname(resolvedFilePath)),
+      path.basename(resolvedFilePath)
+    );
+  } catch {}
+
+  return getLocalBinDirectories(cwd).some(localBinDirectory => {
+    try {
+      localBinDirectory = realpathSync(localBinDirectory);
+    } catch {}
+    return canonicalFilePath.startsWith(`${localBinDirectory}${path.sep}`);
+  });
+}
+
+function prependLocalBinsToPath(cwd: string, pathValue = ''): string {
+  return prependPathEntries(pathValue, getLocalBinDirectories(cwd));
+}
+
+function prependPathEntries(pathValue: string, directories: string[]): string {
+  const pathParts = pathValue.split(path.delimiter).filter(Boolean);
+  const prepended: string[] = [];
+
+  for (const directory of directories) {
+    if (!pathParts.includes(directory) && !prepended.includes(directory)) {
+      prepended.push(directory);
+    }
+  }
+
+  if (prepended.length === 0) {
+    return pathValue;
+  }
+
+  return pathValue === '' || pathValue === path.delimiter
+    ? `${prepended.join(path.delimiter)}${pathValue}`
+    : [...prepended, pathValue].join(path.delimiter);
+}
+
+function prependLocalBinsToEnvPath(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  const localPath = prependLocalBinsToPath(cwd, getEnvPath(env));
+
+  return setEnvPath(
+    env,
+    prependPathEntries(localPath, [path.dirname(process.execPath)])
+  );
+}
+
+function resolveCliInvocation(
+  cwd: string,
+  pathValue: string
+): VercelCliInvocation | null {
+  const resolvedPath = prependLocalBinsToPath(cwd, pathValue);
+
+  for (const command of getVercelCommandNames()) {
+    const resolvedCommand = findCommandInPath(command, resolvedPath, cwd);
+    if (!resolvedCommand) {
+      continue;
+    }
+
+    const source = isLocalBinPath(cwd, resolvedCommand.path)
+      ? 'local-bin'
+      : 'path';
+
+    if (isNodeScript(resolvedCommand.realPath)) {
+      return {
+        command: process.execPath,
+        commandArgs: [resolvedCommand.realPath],
+        source,
+      };
+    }
+
+    return {
+      command: resolvedCommand.realPath,
+      commandArgs: [],
+      source,
+    };
+  }
+
+  return null;
+}
+
+function assertValidCwd(cwd: string) {
+  try {
+    if (!statSync(cwd).isDirectory()) {
+      throw new Error('not a directory');
+    }
+  } catch {
+    throw new VercelCliError({
+      code: 'VERCEL_CLI_INVALID_CWD',
+      message: `Working directory ${JSON.stringify(cwd)} does not exist or is not a directory.`,
+    });
+  }
+}
+
+function toVercelCliError(
+  invocation: VercelCliInvocation,
+  error: unknown
+): VercelCliError {
+  if (typeof error === 'object' && error !== null) {
+    const execaError = error as {
+      code?: string;
+      exitCode?: number;
+      timedOut?: boolean;
+      isCanceled?: boolean;
+      signal?: string | null;
+      stdout?: string;
+      stderr?: string;
+      shortMessage?: string;
+      message?: string;
+    };
+
+    if (execaError.code === 'ENOENT') {
+      return new VercelCliError({
+        code: 'VERCEL_CLI_NOT_FOUND',
+        message: `Unable to find Vercel CLI command ${JSON.stringify(invocation.command)}.`,
+        invocation,
+        cause: error,
+      });
+    }
+
+    if (execaError.code === 'EACCES' || execaError.code === 'EPERM') {
+      return new VercelCliError({
+        code: 'VERCEL_CLI_PERMISSION_DENIED',
+        message: `Permission denied while executing Vercel CLI command ${JSON.stringify(invocation.command)}.`,
+        invocation,
+        cause: error,
+      });
+    }
+
+    if (execaError.timedOut) {
+      return new VercelCliError({
+        code: 'VERCEL_CLI_TIMED_OUT',
+        message: `Timed out while executing Vercel CLI command ${JSON.stringify(invocation.command)}.`,
+        invocation,
+        stdout: execaError.stdout,
+        stderr: execaError.stderr,
+        cause: error,
+      });
+    }
+
+    if (execaError.isCanceled) {
+      return new VercelCliError({
+        code: 'VERCEL_CLI_CANCELED',
+        message: `Canceled while executing Vercel CLI command ${JSON.stringify(invocation.command)}.`,
+        invocation,
+        stdout: execaError.stdout,
+        stderr: execaError.stderr,
+        cause: error,
+      });
+    }
+
+    if (execaError.signal) {
+      return new VercelCliError({
+        code: 'VERCEL_CLI_SIGNALED',
+        message: `Vercel CLI command ${JSON.stringify(invocation.command)} exited due to signal ${execaError.signal}.`,
+        invocation,
+        stdout: execaError.stdout,
+        stderr: execaError.stderr,
+        cause: error,
+      });
+    }
+
+    if (typeof execaError.exitCode === 'number') {
+      return new VercelCliError({
+        code: 'VERCEL_CLI_ERRORED',
+        message:
+          execaError.shortMessage ??
+          execaError.message ??
+          `Vercel CLI command ${JSON.stringify(invocation.command)} exited with code ${execaError.exitCode}.`,
+        invocation,
+        stdout: execaError.stdout,
+        stderr: execaError.stderr,
+        exitCode: execaError.exitCode,
+        cause: error,
+      });
+    }
+  }
+
+  return new VercelCliError({
+    code: 'VERCEL_CLI_EXEC_FAILED',
+    message: `Could not execute Vercel CLI command ${JSON.stringify(invocation.command)}.`,
+    invocation,
+    cause: error,
+  });
+}

--- a/packages/cli-exec/src/index.ts
+++ b/packages/cli-exec/src/index.ts
@@ -14,9 +14,18 @@ export interface VercelCliInvocation {
 /**
  * Options for executing the resolved Vercel CLI.
  */
-export interface ExecVercelCliOptions {
-  cwd?: string;
-  env?: NodeJS.ProcessEnv;
+export interface ExecVercelCliOptions
+  extends Pick<
+    execa.Options,
+    | 'cwd'
+    | 'env'
+    | 'input'
+    | 'stdio'
+    | 'stdin'
+    | 'stdout'
+    | 'stderr'
+    | 'timeout'
+  > {
   signal?: AbortSignal;
 }
 
@@ -24,8 +33,8 @@ export interface ExecVercelCliOptions {
  * Captured output and invocation details from a successful CLI execution.
  */
 export interface ExecVercelCliResult {
-  stdout: string;
-  stderr: string;
+  stdout?: string;
+  stderr?: string;
   invocation: VercelCliInvocation;
 }
 
@@ -165,6 +174,12 @@ export async function execVercelCli(
 
     try {
       const execaOptions: ExecaOptions = {
+        input: options.input,
+        stdio: options.stdio,
+        stdin: options.stdin,
+        stdout: options.stdout,
+        stderr: options.stderr,
+        timeout: options.timeout,
         cwd,
         env: prependLocalBinsToEnvPath(cwd, env),
         windowsHide: true,

--- a/packages/cli-exec/tests/index.test.ts
+++ b/packages/cli-exec/tests/index.test.ts
@@ -1,0 +1,662 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  clearVercelCliCache,
+  execVercelCli,
+  findVercelCli,
+  VercelCliError,
+} from '../src/index';
+
+const directories: string[] = [];
+
+afterEach(() => {
+  clearVercelCliCache();
+  vi.unstubAllEnvs();
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function createDirectory(): string {
+  const directory = mkdtempSync(path.join(tmpdir(), 'cli-exec-'));
+  directories.push(directory);
+  return directory;
+}
+
+function writeExecutable(
+  filePath: string,
+  contents: { posix: string; win32: string }
+) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    process.platform === 'win32' ? contents.win32 : contents.posix
+  );
+
+  if (process.platform !== 'win32') {
+    chmodSync(filePath, 0o755);
+  }
+}
+
+const windowsOnlyTest = process.platform === 'win32' ? test : test.skip;
+
+test('finds a local node_modules bin via the prepended PATH', () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  mkdirSync(path.dirname(binPath), { recursive: true });
+  writeFileSync(
+    binPath,
+    process.platform === 'win32'
+      ? '@echo off\r\nnode -e "process.stdout.write(JSON.stringify({args:process.argv.slice(1)}))" %*\r\n'
+      : '#!/bin/sh\nnode -e "process.stdout.write(JSON.stringify({args:process.argv.slice(1)}))" "$@"\n'
+  );
+  if (process.platform !== 'win32') {
+    chmodSync(binPath, 0o755);
+  }
+
+  expect(findVercelCli({ cwd })).toEqual({
+    command: realpathSync(binPath),
+    commandArgs: [],
+    source: 'local-bin',
+  });
+
+  const invocation = findVercelCli({ cwd });
+
+  expect(invocation).toEqual({
+    command: realpathSync(binPath),
+    commandArgs: [],
+    source: 'local-bin',
+  });
+
+  return expect(
+    execVercelCli(['project', 'token', 'my-project'], { cwd })
+  ).resolves.toMatchObject({
+    invocation: {
+      command: realpathSync(binPath),
+      source: 'local-bin',
+    },
+    stdout: JSON.stringify({ args: ['project', 'token', 'my-project'] }),
+  });
+});
+
+test('prefers the installed package bin over node_modules/.bin shims', () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const shimPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  mkdirSync(path.dirname(shimPath), { recursive: true });
+  writeFileSync(
+    shimPath,
+    process.platform === 'win32'
+      ? '@echo off\r\nnode -e "process.stdout.write("ok")"\r\n'
+      : '#!/bin/sh\necho ok\n'
+  );
+  if (process.platform !== 'win32') {
+    chmodSync(shimPath, 0o755);
+  }
+
+  const invocation = findVercelCli({ cwd });
+
+  expect(invocation).toEqual({
+    command: realpathSync(shimPath),
+    commandArgs: [],
+    source: 'local-bin',
+  });
+});
+
+test('falls back to PATH when no local binary exists', () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const globalBinDir = createDirectory();
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(globalBinDir, binName);
+
+  mkdirSync(cwd, { recursive: true });
+  writeExecutable(binPath, {
+    win32: '@echo off\r\n',
+    posix: '#!/bin/sh\n',
+  });
+  vi.stubEnv('PATH', globalBinDir);
+
+  expect(findVercelCli({ cwd })).toEqual({
+    command: realpathSync(binPath),
+    commandArgs: [],
+    source: 'path',
+  });
+});
+
+windowsOnlyTest('falls back to Path when PATH is unset', () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const globalBinDir = createDirectory();
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(globalBinDir, binName);
+  const originalPath = process.env.PATH;
+  const originalPathKey = process.env.Path;
+
+  mkdirSync(cwd, { recursive: true });
+  writeExecutable(binPath, {
+    win32: '@echo off\r\n',
+    posix: '#!/bin/sh\n',
+  });
+
+  try {
+    delete process.env.PATH;
+    process.env.Path = globalBinDir;
+
+    expect(findVercelCli({ cwd })).toEqual({
+      command: realpathSync(binPath),
+      commandArgs: [],
+      source: 'path',
+    });
+  } finally {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+
+    if (originalPathKey === undefined) {
+      delete process.env.Path;
+    } else {
+      process.env.Path = originalPathKey;
+    }
+  }
+});
+
+test('uses the provided PATH for resolution and caching', async () => {
+  const cwd = createDirectory();
+  const firstBinDir = createDirectory();
+  const secondBinDir = createDirectory();
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const firstBinPath = path.join(firstBinDir, binName);
+  const secondBinPath = path.join(secondBinDir, binName);
+
+  writeFileSync(
+    firstBinPath,
+    process.platform === 'win32'
+      ? '@echo off\r\nnode -e "process.stdout.write(\'first\')"\r\n'
+      : '#!/bin/sh\nnode -e "process.stdout.write(\'first\')"\n'
+  );
+  writeFileSync(
+    secondBinPath,
+    process.platform === 'win32'
+      ? '@echo off\r\nnode -e "process.stdout.write(\'second\')"\r\n'
+      : '#!/bin/sh\nnode -e "process.stdout.write(\'second\')"\n'
+  );
+  if (process.platform !== 'win32') {
+    chmodSync(firstBinPath, 0o755);
+    chmodSync(secondBinPath, 0o755);
+  }
+
+  const firstEnv = { PATH: firstBinDir };
+  const secondEnv = { PATH: secondBinDir };
+
+  expect(findVercelCli({ cwd, path: firstEnv.PATH })).toEqual({
+    command: realpathSync(firstBinPath),
+    commandArgs: [],
+    source: 'path',
+  });
+  expect(findVercelCli({ cwd, path: secondEnv.PATH })).toEqual({
+    command: realpathSync(secondBinPath),
+    commandArgs: [],
+    source: 'path',
+  });
+
+  await expect(
+    execVercelCli([], { cwd, env: firstEnv })
+  ).resolves.toMatchObject({
+    stdout: 'first',
+    invocation: {
+      command: realpathSync(firstBinPath),
+      source: 'path',
+    },
+  });
+  await expect(
+    execVercelCli([], { cwd, env: secondEnv })
+  ).resolves.toMatchObject({
+    stdout: 'second',
+    invocation: {
+      command: realpathSync(secondBinPath),
+      source: 'path',
+    },
+  });
+});
+
+test('inherits process PATH when the provided env omits it', async () => {
+  const cwd = createDirectory();
+  const globalBinDir = createDirectory();
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(globalBinDir, binName);
+
+  writeExecutable(binPath, {
+    win32:
+      '@echo off\r\nnode -e "process.stdout.write(process.env.TEST_VALUE || \'\')"\r\n',
+    posix:
+      '#!/bin/sh\nnode -e "process.stdout.write(process.env.TEST_VALUE || \'\')"\n',
+  });
+  vi.stubEnv('PATH', globalBinDir);
+
+  await expect(
+    execVercelCli([], {
+      cwd,
+      env: { TEST_VALUE: 'inherited-path' },
+    })
+  ).resolves.toMatchObject({
+    stdout: 'inherited-path',
+    invocation: {
+      command: realpathSync(binPath),
+      source: 'path',
+    },
+  });
+});
+
+windowsOnlyTest('uses the provided Path when env casing differs', async () => {
+  const cwd = createDirectory();
+  const globalBinDir = createDirectory();
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(globalBinDir, binName);
+
+  writeExecutable(binPath, {
+    win32:
+      '@echo off\r\nnode -e "process.stdout.write(process.env.TEST_VALUE || \'\')"\r\n',
+    posix:
+      '#!/bin/sh\nnode -e "process.stdout.write(process.env.TEST_VALUE || \'\')"\n',
+  });
+  vi.stubEnv('PATH', '');
+
+  await expect(
+    execVercelCli([], {
+      cwd,
+      env: {
+        Path: globalBinDir,
+        TEST_VALUE: 'case-insensitive-path',
+      },
+    })
+  ).resolves.toMatchObject({
+    stdout: 'case-insensitive-path',
+    invocation: {
+      command: realpathSync(binPath),
+      source: 'path',
+    },
+  });
+});
+
+test('caches the resolved CLI lookup', () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  mkdirSync(path.dirname(binPath), { recursive: true });
+  writeFileSync(
+    binPath,
+    process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n'
+  );
+  if (process.platform !== 'win32') {
+    chmodSync(binPath, 0o755);
+  }
+
+  const first = findVercelCli({ cwd });
+  rmSync(path.join(root, 'node_modules'), { recursive: true, force: true });
+  const second = findVercelCli({ cwd });
+
+  expect(second).toEqual(first);
+});
+
+test('skips directory entries while resolving the CLI', () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const blockedBinPath = path.join(
+    root,
+    'apps',
+    'web',
+    'node_modules',
+    '.bin',
+    binName
+  );
+  const fallbackBinPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  mkdirSync(blockedBinPath, { recursive: true });
+  writeExecutable(fallbackBinPath, {
+    win32: '@echo off\r\n',
+    posix: '#!/bin/sh\n',
+  });
+
+  expect(findVercelCli({ cwd, path: '' })).toEqual({
+    command: realpathSync(fallbackBinPath),
+    commandArgs: [],
+    source: 'local-bin',
+  });
+});
+
+test('caches negative CLI lookups until the cache is cleared', () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+
+  expect(findVercelCli({ cwd, path: '' })).toBeNull();
+
+  writeExecutable(binPath, {
+    win32: '@echo off\r\n',
+    posix: '#!/bin/sh\n',
+  });
+
+  expect(findVercelCli({ cwd, path: '' })).toBeNull();
+
+  clearVercelCliCache();
+
+  expect(findVercelCli({ cwd, path: '' })).toEqual({
+    command: realpathSync(binPath),
+    commandArgs: [],
+    source: 'local-bin',
+  });
+});
+
+test('can execute the locally installed vercel package bin', async () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  mkdirSync(path.dirname(binPath), { recursive: true });
+  writeFileSync(
+    binPath,
+    process.platform === 'win32'
+      ? '@echo off\r\nnode -e "process.stdout.write(JSON.stringify({args:process.argv.slice(1)}))" %*\r\n'
+      : '#!/bin/sh\nnode -e "process.stdout.write(JSON.stringify({args:process.argv.slice(1)}))" "$@"\n'
+  );
+  if (process.platform !== 'win32') {
+    chmodSync(binPath, 0o755);
+  }
+
+  const result = await execVercelCli(['project', 'token', 'my-project'], {
+    cwd,
+  });
+
+  expect(result?.invocation.source).toBe('local-bin');
+  expect(JSON.parse(result?.stdout ?? '{}')).toEqual({
+    args: ['project', 'token', 'my-project'],
+  });
+});
+
+test('adds node to PATH when executing a local bin with a sanitized env', async () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  writeExecutable(binPath, {
+    win32: '@echo off\r\nnode -e "process.stdout.write(\'ok\')"\r\n',
+    posix: '#!/bin/sh\nnode -e "process.stdout.write(\'ok\')"\n',
+  });
+
+  await expect(
+    execVercelCli([], { cwd, env: { PATH: '' } })
+  ).resolves.toMatchObject({
+    stdout: 'ok',
+    invocation: {
+      command: realpathSync(binPath),
+      source: 'local-bin',
+    },
+  });
+});
+
+test('does not resolve a global CLI next to node when PATH is empty', async () => {
+  const cwd = createDirectory();
+  const fakeNodeDir = createDirectory();
+  const originalExecPath = process.execPath;
+
+  writeExecutable(
+    path.join(
+      fakeNodeDir,
+      process.platform === 'win32' ? 'vercel.cmd' : 'vercel'
+    ),
+    {
+      win32: '@echo off\r\nexit /b 0\r\n',
+      posix: '#!/bin/sh\nexit 0\n',
+    }
+  );
+
+  try {
+    Object.defineProperty(process, 'execPath', {
+      value: path.join(
+        fakeNodeDir,
+        process.platform === 'win32' ? 'node.exe' : 'node'
+      ),
+      configurable: true,
+      writable: true,
+    });
+
+    expect(findVercelCli({ cwd, path: '' })).toBeNull();
+
+    await expect(
+      execVercelCli([], { cwd, env: { PATH: '' } })
+    ).rejects.toMatchObject({
+      code: 'VERCEL_CLI_NOT_FOUND',
+    });
+  } finally {
+    Object.defineProperty(process, 'execPath', {
+      value: originalExecPath,
+      configurable: true,
+      writable: true,
+    });
+  }
+});
+
+test('resolves relative PATH entries from the provided cwd', () => {
+  const cwd = createDirectory();
+  const relativeBinDir = path.join(cwd, 'tools');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(relativeBinDir, binName);
+
+  writeExecutable(binPath, {
+    win32: '@echo off\r\n',
+    posix: '#!/bin/sh\n',
+  });
+
+  expect(findVercelCli({ cwd, path: path.join('.', 'tools') })).toEqual({
+    command: realpathSync(binPath),
+    commandArgs: [],
+    source: 'path',
+  });
+});
+
+const posixOnlyTest = process.platform === 'win32' ? test.skip : test;
+
+posixOnlyTest('finds a local bin from a symlinked cwd', async () => {
+  const root = createDirectory();
+  const linkRoot = createDirectory();
+  const realCwd = path.join(root, 'apps', 'web');
+  const symlinkedCwd = path.join(linkRoot, 'apps', 'web');
+  const binPath = path.join(root, 'node_modules', '.bin', 'vercel');
+
+  mkdirSync(realCwd, { recursive: true });
+  mkdirSync(path.dirname(symlinkedCwd), { recursive: true });
+  writeExecutable(binPath, {
+    win32: '@echo off\r\nnode -e "process.stdout.write(\'ok\')"\r\n',
+    posix: '#!/bin/sh\nnode -e "process.stdout.write(\'ok\')"\n',
+  });
+  symlinkSync(realCwd, symlinkedCwd, 'dir');
+
+  expect(findVercelCli({ cwd: symlinkedCwd, path: '' })).toEqual({
+    command: realpathSync(binPath),
+    commandArgs: [],
+    source: 'local-bin',
+  });
+
+  await expect(
+    execVercelCli([], { cwd: symlinkedCwd, env: { PATH: '' } })
+  ).resolves.toMatchObject({
+    stdout: 'ok',
+    invocation: {
+      command: realpathSync(binPath),
+      source: 'local-bin',
+    },
+  });
+});
+
+posixOnlyTest(
+  'prefers the real project local bin over a symlink parent bin',
+  async () => {
+    const root = createDirectory();
+    const linkRoot = createDirectory();
+    const realCwd = path.join(root, 'apps', 'web');
+    const symlinkedCwd = path.join(linkRoot, 'apps', 'web');
+    const realBinPath = path.join(root, 'node_modules', '.bin', 'vercel');
+    const symlinkBinPath = path.join(
+      linkRoot,
+      'node_modules',
+      '.bin',
+      'vercel'
+    );
+
+    mkdirSync(realCwd, { recursive: true });
+    mkdirSync(path.dirname(symlinkedCwd), { recursive: true });
+    writeExecutable(realBinPath, {
+      win32: '@echo off\r\nnode -e "process.stdout.write(\'real\')"\r\n',
+      posix: '#!/bin/sh\nnode -e "process.stdout.write(\'real\')"\n',
+    });
+    writeExecutable(symlinkBinPath, {
+      win32: '@echo off\r\nnode -e "process.stdout.write(\'fake\')"\r\n',
+      posix: '#!/bin/sh\nnode -e "process.stdout.write(\'fake\')"\n',
+    });
+    symlinkSync(realCwd, symlinkedCwd, 'dir');
+
+    expect(findVercelCli({ cwd: symlinkedCwd, path: '' })).toEqual({
+      command: realpathSync(realBinPath),
+      commandArgs: [],
+      source: 'local-bin',
+    });
+
+    await expect(
+      execVercelCli([], { cwd: symlinkedCwd, env: { PATH: '' } })
+    ).resolves.toMatchObject({
+      stdout: 'real',
+      invocation: {
+        command: realpathSync(realBinPath),
+        source: 'local-bin',
+      },
+    });
+  }
+);
+
+posixOnlyTest(
+  'treats a symlinked local bin as a local node script',
+  async () => {
+    const root = createDirectory();
+    const cwd = path.join(root, 'apps', 'web');
+    const binPath = path.join(root, 'node_modules', '.bin', 'vercel');
+    const cliPath = path.join(
+      root,
+      'node_modules',
+      'vercel',
+      'dist',
+      'index.js'
+    );
+
+    mkdirSync(cwd, { recursive: true });
+    mkdirSync(path.dirname(binPath), { recursive: true });
+    mkdirSync(path.dirname(cliPath), { recursive: true });
+    writeFileSync(
+      cliPath,
+      'process.stdout.write(JSON.stringify({args:process.argv.slice(2)}));\n'
+    );
+    chmodSync(cliPath, 0o755);
+    symlinkSync(cliPath, binPath);
+
+    expect(findVercelCli({ cwd })).toEqual({
+      command: process.execPath,
+      commandArgs: [realpathSync(binPath)],
+      source: 'local-bin',
+    });
+
+    await expect(
+      execVercelCli(['project', 'token', 'my-project'], { cwd })
+    ).resolves.toMatchObject({
+      stdout: JSON.stringify({ args: ['project', 'token', 'my-project'] }),
+      invocation: {
+        command: process.execPath,
+        commandArgs: [realpathSync(binPath)],
+        source: 'local-bin',
+      },
+    });
+  }
+);
+
+test('throws a not-found error when no CLI can be resolved', async () => {
+  const cwd = createDirectory();
+  vi.stubEnv('PATH', '');
+
+  await expect(
+    execVercelCli(['project', 'token'], { cwd })
+  ).rejects.toMatchObject({
+    code: 'VERCEL_CLI_NOT_FOUND',
+  });
+});
+
+test('throws an invalid-cwd error when cwd does not exist', async () => {
+  const cwd = path.join(createDirectory(), 'missing');
+
+  await expect(execVercelCli(['project', 'token'], { cwd })).rejects.toEqual(
+    expect.objectContaining<VercelCliError>({
+      code: 'VERCEL_CLI_INVALID_CWD',
+      message: `Working directory ${JSON.stringify(cwd)} does not exist or is not a directory.`,
+    })
+  );
+});
+
+test('throws an exit-code error when the CLI exits non-zero', async () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  mkdirSync(path.dirname(binPath), { recursive: true });
+  writeFileSync(
+    binPath,
+    process.platform === 'win32'
+      ? '@echo off\r\nexit /b 7\r\n'
+      : '#!/bin/sh\nexit 7\n'
+  );
+  if (process.platform !== 'win32') {
+    chmodSync(binPath, 0o755);
+  }
+
+  await expect(execVercelCli(['project', 'token'], { cwd })).rejects.toEqual(
+    expect.objectContaining<VercelCliError>({
+      code: 'VERCEL_CLI_ERRORED',
+      exitCode: 7,
+      invocation: {
+        command: realpathSync(binPath),
+        commandArgs: [],
+        source: 'local-bin',
+      },
+    })
+  );
+});

--- a/packages/cli-exec/tests/index.test.ts
+++ b/packages/cli-exec/tests/index.test.ts
@@ -403,6 +403,110 @@ test('can execute the locally installed vercel package bin', async () => {
   });
 });
 
+test('passes input through to execa', async () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  writeExecutable(binPath, {
+    win32:
+      "@echo off\r\nnode -e \"let data='';process.stdin.on('data',chunk=>data+=chunk);process.stdin.on('end',()=>process.stdout.write(data.toUpperCase()))\"\r\n",
+    posix:
+      "#!/bin/sh\nnode -e \"let data='';process.stdin.on('data',chunk=>data+=chunk);process.stdin.on('end',()=>process.stdout.write(data.toUpperCase()))\"\n",
+  });
+
+  await expect(
+    execVercelCli([], { cwd, input: 'hello', stdin: 'pipe' })
+  ).resolves.toMatchObject({
+    stdout: 'HELLO',
+    invocation: {
+      command: realpathSync(binPath),
+      source: 'local-bin',
+    },
+  });
+});
+
+test('passes stdout and stderr options through to execa', async () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  writeExecutable(binPath, {
+    win32:
+      "@echo off\r\nnode -e \"process.stdout.write('out');process.stderr.write('err')\"\r\n",
+    posix:
+      "#!/bin/sh\nnode -e \"process.stdout.write('out');process.stderr.write('err')\"\n",
+  });
+
+  await expect(
+    execVercelCli([], {
+      cwd,
+      stdout: 'ignore',
+      stderr: 'pipe',
+    })
+  ).resolves.toMatchObject({
+    stdout: undefined,
+    stderr: 'err',
+    invocation: {
+      command: realpathSync(binPath),
+      source: 'local-bin',
+    },
+  });
+});
+
+test('passes stdio through to execa', async () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  writeExecutable(binPath, {
+    win32:
+      "@echo off\r\nnode -e \"process.stdout.write('out');process.stderr.write('err')\"\r\n",
+    posix:
+      "#!/bin/sh\nnode -e \"process.stdout.write('out');process.stderr.write('err')\"\n",
+  });
+
+  await expect(execVercelCli([], { cwd, stdio: 'ignore' })).resolves.toEqual({
+    stdout: undefined,
+    stderr: undefined,
+    invocation: {
+      command: realpathSync(binPath),
+      commandArgs: [],
+      source: 'local-bin',
+    },
+  });
+});
+
+test('passes timeout through to execa', async () => {
+  const root = createDirectory();
+  const cwd = path.join(root, 'apps', 'web');
+  const binName = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+  const binPath = path.join(root, 'node_modules', '.bin', binName);
+
+  mkdirSync(cwd, { recursive: true });
+  writeExecutable(binPath, {
+    win32: '@echo off\r\nnode -e "setTimeout(() => {}, 1000)"\r\n',
+    posix: '#!/bin/sh\nnode -e "setTimeout(() => {}, 1000)"\n',
+  });
+
+  await expect(execVercelCli([], { cwd, timeout: 10 })).rejects.toEqual(
+    expect.objectContaining<VercelCliError>({
+      code: 'VERCEL_CLI_TIMED_OUT',
+      invocation: {
+        command: realpathSync(binPath),
+        commandArgs: [],
+        source: 'local-bin',
+      },
+    })
+  );
+});
+
 test('adds node to PATH when executing a local bin with a sanitized env', async () => {
   const root = createDirectory();
   const cwd = path.join(root, 'apps', 'web');

--- a/packages/cli-exec/tsconfig.json
+++ b/packages/cli-exec/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "sourceMap": true,
+    "types": ["node"],
+    "lib": ["ES2021"]
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,6 +955,19 @@ importers:
         specifier: 2.1.4
         version: 2.1.4(@edge-runtime/vm@3.2.0)(@types/node@20.11.0)
 
+  packages/cli-exec:
+    dependencies:
+      execa:
+        specifier: 5.1.1
+        version: 5.1.1
+    devDependencies:
+      '@types/node':
+        specifier: 20.11.0
+        version: 20.11.0
+      vitest:
+        specifier: 2.1.4
+        version: 2.1.4(@edge-runtime/vm@3.2.0)(@types/node@20.11.0)
+
   packages/client:
     dependencies:
       '@vercel/build-utils':


### PR DESCRIPTION
`@vercel/cli-exec` is a small helper library that locates and runs
the Vercel CLI.  Its main purpose is so that we can use the CLI as a
trusted helper in cases where we need to read sensitive data that only
the CLI binary is authorized to do (e.g keychain access for tokens).
