### PR TITLE
[cli] connex: Scope list clients to current project by default; add --all

### DIFF
--- a/.changeset/connex-list-project-scoped.md
+++ b/.changeset/connex-list-project-scoped.md
@@ -2,4 +2,4 @@
 'vercel': minor
 ---
 
-`vercel connex list` now defaults to clients linked to the current project. Use `--all` to list every Connex client in the team; the table also shows a `Projects` column with the linked project names per client (with a `+ more` suffix when truncated).
+`vercel connex list` now defaults to clients linked to the current project. When no project is linked, it falls back to listing every Connex client in the team (same as `--all-projects`). Use `--all-projects` to force the team-wide view; the table includes a `Projects` column with the linked project names per client (with a `+ more` suffix when truncated).

--- a/.changeset/connex-list-project-scoped.md
+++ b/.changeset/connex-list-project-scoped.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+`vercel connex list` now defaults to clients linked to the current project. Use `--all` to list every Connex client in the team; the table also shows a `Projects` column with the linked project names per client (with a `+ more` suffix when truncated).

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -53,11 +53,11 @@ export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
   description:
-    'List Connex clients linked to the current project (use --all for every client in the team)',
+    'List Connex clients linked to the current project (falls back to every client in the team when no project is linked or when --all-projects is set)',
   arguments: [],
   options: [
     {
-      name: 'all',
+      name: 'all-projects',
       shorthand: null,
       type: Boolean,
       deprecated: false,
@@ -89,7 +89,7 @@ export const listSubcommand = {
     },
     {
       name: 'List every Connex client in the team',
-      value: `${packageName} connex list --all`,
+      value: `${packageName} connex list --all-projects`,
     },
     {
       name: 'Limit the number of results',

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -52,9 +52,18 @@ export const createSubcommand = {
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
-  description: 'List Connex clients for the current team',
+  description:
+    'List Connex clients linked to the current project (use --all for every client in the team)',
   arguments: [],
   options: [
+    {
+      name: 'all',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'List every Connex client in the team, regardless of project link',
+    },
     {
       name: 'limit',
       shorthand: null,
@@ -75,8 +84,12 @@ export const listSubcommand = {
   ],
   examples: [
     {
-      name: 'List Connex clients for the current team',
+      name: 'List Connex clients linked to the current project',
       value: `${packageName} connex list`,
+    },
+    {
+      name: 'List every Connex client in the team',
+      value: `${packageName} connex list --all`,
     },
     {
       name: 'Limit the number of results',

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -103,6 +103,7 @@ export default async function connex(client: Client): Promise<number> {
 
         const listFlagsSpec = getFlagsSpecification(listSubcommand.options);
         const listParsedArgs = parseArguments(subArgs, listFlagsSpec);
+        telemetry.trackCliFlagAll(listParsedArgs.flags['--all']);
         telemetry.trackCliOptionLimit(listParsedArgs.flags['--limit']);
         telemetry.trackCliOptionNext(listParsedArgs.flags['--next']);
         telemetry.trackCliOptionFormat(listParsedArgs.flags['--format']);

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -103,7 +103,9 @@ export default async function connex(client: Client): Promise<number> {
 
         const listFlagsSpec = getFlagsSpecification(listSubcommand.options);
         const listParsedArgs = parseArguments(subArgs, listFlagsSpec);
-        telemetry.trackCliFlagAll(listParsedArgs.flags['--all']);
+        telemetry.trackCliFlagAllProjects(
+          listParsedArgs.flags['--all-projects']
+        );
         telemetry.trackCliOptionLimit(listParsedArgs.flags['--limit']);
         telemetry.trackCliOptionNext(listParsedArgs.flags['--next']);
         telemetry.trackCliOptionFormat(listParsedArgs.flags['--format']);

--- a/packages/cli/src/commands/connex/list.ts
+++ b/packages/cli/src/commands/connex/list.ts
@@ -8,9 +8,14 @@ import { getLinkedProject } from '../../util/projects/link';
 import table from '../../util/output/table';
 import { packageName } from '../../util/pkg-name';
 
-interface ConnexClientProject {
+interface LinkedProject {
   id: string;
   name: string;
+}
+
+interface ConnexClientProjectLink {
+  projectId: string;
+  project?: LinkedProject;
 }
 
 interface ConnexClient {
@@ -20,7 +25,10 @@ interface ConnexClient {
   type: string;
   typeName?: string;
   createdAt: number;
-  projects?: ConnexClientProject[];
+  includes?: {
+    projects?: ConnexClientProjectLink[];
+    hasMoreProjects?: boolean;
+  };
 }
 
 interface ListClientsResponse {
@@ -118,7 +126,8 @@ export async function list(
         type: string;
         typeName?: string;
         createdAt: number;
-        projects?: ConnexClientProject[];
+        projects?: LinkedProject[];
+        hasMoreProjects?: boolean;
       } = {
         uid: c.uid,
         id: c.id,
@@ -128,7 +137,10 @@ export async function list(
         createdAt: c.createdAt,
       };
       if (all) {
-        item.projects = c.projects ?? [];
+        item.projects = (c.includes?.projects ?? [])
+          .map(p => p.project)
+          .filter((p): p is LinkedProject => Boolean(p));
+        item.hasMoreProjects = c.includes?.hasMoreProjects === true;
       }
       return item;
     });
@@ -167,8 +179,20 @@ export async function list(
       c.typeName || c.type,
     ];
     if (all) {
-      const names = (c.projects ?? []).map(p => p.name).filter(Boolean);
-      row.push(names.length ? names.join(', ') : chalk.gray('–'));
+      const names = (c.includes?.projects ?? [])
+        .map(p => p.project?.name)
+        .filter((n): n is string => Boolean(n));
+      const more = c.includes?.hasMoreProjects === true;
+      let cell: string;
+      if (names.length === 0 && !more) {
+        cell = chalk.gray('–');
+      } else {
+        const parts: string[] = [];
+        if (names.length) parts.push(names.join(', '));
+        if (more) parts.push(chalk.gray('+ more'));
+        cell = parts.join(' ');
+      }
+      row.push(cell);
     }
     return row;
   });

--- a/packages/cli/src/commands/connex/list.ts
+++ b/packages/cli/src/commands/connex/list.ts
@@ -26,8 +26,11 @@ interface ConnexClient {
   typeName?: string;
   createdAt: number;
   includes?: {
-    projects?: ConnexClientProjectLink[];
-    hasMoreProjects?: boolean;
+    projects?: {
+      items: ConnexClientProjectLink[];
+      hasMore: boolean;
+      cursor?: string | null;
+    };
   };
 }
 
@@ -39,7 +42,7 @@ interface ListClientsResponse {
 export async function list(
   client: Client,
   flags: {
-    '--all'?: boolean;
+    '--all-projects'?: boolean;
     '--limit'?: number;
     '--next'?: string;
     '--format'?: string;
@@ -52,34 +55,36 @@ export async function list(
     return 1;
   }
   const asJson = formatResult.jsonOutput;
-  const all = flags['--all'] === true;
+  const allProjects = flags['--all-projects'] === true;
 
   let projectId: string | undefined;
   let projectName: string | undefined;
 
-  if (all) {
-    await selectConnexTeam(
-      client,
-      'Select the team whose Connex clients you want to list'
-    );
-  } else {
+  if (!allProjects) {
     const linked = await getLinkedProject(client);
     if (linked.status === 'error') {
       return linked.exitCode;
     }
-    if (linked.status === 'not_linked') {
-      output.error(
-        `No project linked. Either use \`${packageName} link\` to link a project, or the \`--all\` flag to list all clients.`
-      );
-      return 1;
+    if (linked.status === 'linked') {
+      if (linked.org.type === 'team') {
+        client.config.currentTeam = linked.org.id;
+      } else {
+        client.config.currentTeam = undefined;
+      }
+      projectId = linked.project.id;
+      projectName = linked.project.name;
     }
-    if (linked.org.type === 'team') {
-      client.config.currentTeam = linked.org.id;
-    } else {
-      client.config.currentTeam = undefined;
-    }
-    projectId = linked.project.id;
-    projectName = linked.project.name;
+    // status === 'not_linked' → fall through to unscoped mode
+  }
+
+  // Unscoped mode: no project link in scope, or `--all-projects` was passed.
+  // Resolve a team explicitly so we have one for the API call.
+  const unscoped = !projectId;
+  if (unscoped) {
+    await selectConnexTeam(
+      client,
+      'Select the team whose Connex clients you want to list'
+    );
   }
 
   const params = new URLSearchParams();
@@ -89,7 +94,7 @@ export async function list(
   if (flags['--next']) {
     params.set('cursor', flags['--next']);
   }
-  if (all) {
+  if (unscoped) {
     params.set('include', 'projects');
   } else if (projectId) {
     params.set('projectId', projectId);
@@ -136,11 +141,12 @@ export async function list(
         typeName: c.typeName,
         createdAt: c.createdAt,
       };
-      if (all) {
-        item.projects = (c.includes?.projects ?? [])
+      if (unscoped) {
+        const projectsInclude = c.includes?.projects;
+        item.projects = (projectsInclude?.items ?? [])
           .map(p => p.project)
           .filter((p): p is LinkedProject => Boolean(p));
-        item.hasMoreProjects = c.includes?.hasMoreProjects === true;
+        item.hasMoreProjects = projectsInclude?.hasMore === true;
       }
       return item;
     });
@@ -151,24 +157,24 @@ export async function list(
   }
 
   if (clients.length === 0) {
-    if (all) {
+    if (unscoped) {
       output.log(
         `No Connex clients found. Create one with \`${packageName} connex create <type>\`.`
       );
     } else {
       output.log(
-        `No Connex clients linked to ${chalk.bold(projectName ?? 'this project')}. Run \`${packageName} connex list --all\` to see every client in the team.`
+        `No Connex clients linked to ${chalk.bold(projectName ?? 'this project')}. Run \`${packageName} connex list --all-projects\` to see every client in the team.`
       );
     }
     return 0;
   }
 
-  if (!all && projectName) {
+  if (!unscoped && projectName) {
     output.log(`Connex clients linked to ${chalk.bold(projectName)}:`);
   }
 
   const headers = ['UID', 'ID', 'Name', 'Type'];
-  if (all) {
+  if (unscoped) {
     headers.push('Projects');
   }
   const rows = clients.map(c => {
@@ -178,11 +184,12 @@ export async function list(
       c.name || chalk.gray('–'),
       c.typeName || c.type,
     ];
-    if (all) {
-      const names = (c.includes?.projects ?? [])
+    if (unscoped) {
+      const projectsInclude = c.includes?.projects;
+      const names = (projectsInclude?.items ?? [])
         .map(p => p.project?.name)
         .filter((n): n is string => Boolean(n));
-      const more = c.includes?.hasMoreProjects === true;
+      const more = projectsInclude?.hasMore === true;
       let cell: string;
       if (names.length === 0 && !more) {
         cell = chalk.gray('–');
@@ -204,8 +211,8 @@ export async function list(
   );
 
   if (response.cursor) {
-    const nextCommand = all
-      ? `${packageName} connex list --all --next ${response.cursor}`
+    const nextCommand = allProjects
+      ? `${packageName} connex list --all-projects --next ${response.cursor}`
       : `${packageName} connex list --next ${response.cursor}`;
     output.log(`To see more, run \`${nextCommand}\``);
   }

--- a/packages/cli/src/commands/connex/list.ts
+++ b/packages/cli/src/commands/connex/list.ts
@@ -1,12 +1,17 @@
 import chalk from 'chalk';
-import ms from 'ms';
 import output from '../../output-manager';
 import type Client from '../../util/client';
 import { validateJsonOutput } from '../../util/output-format';
 import { printError } from '../../util/error';
 import { selectConnexTeam } from '../../util/connex/select-team';
+import { getLinkedProject } from '../../util/projects/link';
 import table from '../../util/output/table';
 import { packageName } from '../../util/pkg-name';
+
+interface ConnexClientProject {
+  id: string;
+  name: string;
+}
 
 interface ConnexClient {
   id: string;
@@ -15,6 +20,7 @@ interface ConnexClient {
   type: string;
   typeName?: string;
   createdAt: number;
+  projects?: ConnexClientProject[];
 }
 
 interface ListClientsResponse {
@@ -25,6 +31,7 @@ interface ListClientsResponse {
 export async function list(
   client: Client,
   flags: {
+    '--all'?: boolean;
     '--limit'?: number;
     '--next'?: string;
     '--format'?: string;
@@ -37,11 +44,35 @@ export async function list(
     return 1;
   }
   const asJson = formatResult.jsonOutput;
+  const all = flags['--all'] === true;
 
-  await selectConnexTeam(
-    client,
-    'Select the team whose Connex clients you want to list'
-  );
+  let projectId: string | undefined;
+  let projectName: string | undefined;
+
+  if (all) {
+    await selectConnexTeam(
+      client,
+      'Select the team whose Connex clients you want to list'
+    );
+  } else {
+    const linked = await getLinkedProject(client);
+    if (linked.status === 'error') {
+      return linked.exitCode;
+    }
+    if (linked.status === 'not_linked') {
+      output.error(
+        `No project linked. Either use \`${packageName} link\` to link a project, or the \`--all\` flag to list all clients.`
+      );
+      return 1;
+    }
+    if (linked.org.type === 'team') {
+      client.config.currentTeam = linked.org.id;
+    } else {
+      client.config.currentTeam = undefined;
+    }
+    projectId = linked.project.id;
+    projectName = linked.project.name;
+  }
 
   const params = new URLSearchParams();
   if (flags['--limit'] !== undefined) {
@@ -49,6 +80,11 @@ export async function list(
   }
   if (flags['--next']) {
     params.set('cursor', flags['--next']);
+  }
+  if (all) {
+    params.set('include', 'projects');
+  } else if (projectId) {
+    params.set('projectId', projectId);
   }
   const query = params.toString();
   const url = `/v1/connex/clients${query ? `?${query}` : ''}`;
@@ -74,14 +110,28 @@ export async function list(
   const clients = response.clients ?? [];
 
   if (asJson) {
-    const jsonClients = clients.map(c => ({
-      uid: c.uid,
-      id: c.id,
-      name: c.name,
-      type: c.type,
-      typeName: c.typeName,
-      createdAt: c.createdAt,
-    }));
+    const jsonClients = clients.map(c => {
+      const item: {
+        uid: string;
+        id: string;
+        name: string;
+        type: string;
+        typeName?: string;
+        createdAt: number;
+        projects?: ConnexClientProject[];
+      } = {
+        uid: c.uid,
+        id: c.id,
+        name: c.name,
+        type: c.type,
+        typeName: c.typeName,
+        createdAt: c.createdAt,
+      };
+      if (all) {
+        item.projects = c.projects ?? [];
+      }
+      return item;
+    });
     client.stdout.write(
       `${JSON.stringify({ clients: jsonClients, cursor: response.cursor }, null, 2)}\n`
     );
@@ -89,39 +139,51 @@ export async function list(
   }
 
   if (clients.length === 0) {
-    output.log(
-      `No Connex clients found. Create one with \`${packageName} connex create <type>\`.`
-    );
+    if (all) {
+      output.log(
+        `No Connex clients found. Create one with \`${packageName} connex create <type>\`.`
+      );
+    } else {
+      output.log(
+        `No Connex clients linked to ${chalk.bold(projectName ?? 'this project')}. Run \`${packageName} connex list --all\` to see every client in the team.`
+      );
+    }
     return 0;
   }
 
-  const now = Date.now();
-  const rows = clients.map(c => [
-    c.uid || chalk.gray('–'),
-    c.id,
-    c.name || chalk.gray('–'),
-    c.typeName || c.type,
-    c.createdAt
-      ? chalk.gray(`${ms(Math.max(0, now - c.createdAt))} ago`)
-      : chalk.gray('–'),
-  ]);
+  if (!all && projectName) {
+    output.log(`Connex clients linked to ${chalk.bold(projectName)}:`);
+  }
+
+  const headers = ['UID', 'ID', 'Name', 'Type'];
+  if (all) {
+    headers.push('Projects');
+  }
+  const rows = clients.map(c => {
+    const row = [
+      c.uid || chalk.gray('–'),
+      c.id,
+      c.name || chalk.gray('–'),
+      c.typeName || c.type,
+    ];
+    if (all) {
+      const names = (c.projects ?? []).map(p => p.name).filter(Boolean);
+      row.push(names.length ? names.join(', ') : chalk.gray('–'));
+    }
+    return row;
+  });
 
   output.print(
-    `${table(
-      [
-        ['UID', 'ID', 'Name', 'Type', 'Created'].map(h =>
-          chalk.bold(chalk.cyan(h))
-        ),
-        ...rows,
-      ],
-      { hsep: 4 }
-    )}\n`
+    `${table([headers.map(h => chalk.bold(chalk.cyan(h))), ...rows], {
+      hsep: 4,
+    })}\n`
   );
 
   if (response.cursor) {
-    output.log(
-      `To see more, run \`${packageName} connex list --next ${response.cursor}\``
-    );
+    const nextCommand = all
+      ? `${packageName} connex list --all --next ${response.cursor}`
+      : `${packageName} connex list --next ${response.cursor}`;
+    output.log(`To see more, run \`${nextCommand}\``);
   }
 
   return 0;

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -62,9 +62,9 @@ export class ConnexTelemetryClient
     }
   }
 
-  trackCliFlagAll(v: boolean | undefined) {
+  trackCliFlagAllProjects(v: boolean | undefined) {
     if (v) {
-      this.trackCliFlag('all');
+      this.trackCliFlag('all-projects');
     }
   }
 

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -62,6 +62,12 @@ export class ConnexTelemetryClient
     }
   }
 
+  trackCliFlagAll(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('all');
+    }
+  }
+
   trackCliOptionLimit(v: number | undefined) {
     if (v !== undefined) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -810,7 +810,8 @@ exports[`help command > connex help output snapshots > connex help column width 
   Commands:
 
   create  type    Create a new Connex client                            
-  list            List Connex clients for the current team              
+  list            List Connex clients linked to the current project (use
+                  --all for every client in the team)                   
   token   id      Get a token for a Connex client (accepts a client ID  
                   like scl_abc or a UID like slack/my-bot)              
   remove  client  Delete a Connex client                                
@@ -858,10 +859,11 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
 "
   ▲ vercel connex list [options]
 
-  List Connex clients for the current team                                                                              
+  List Connex clients linked to the current project (use --all for every client in the team)                            
 
   Options:
 
+       --all              List every Connex client in the team, regardless of project link                              
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
        --limit <COUNT>    Number of clients to return per page                                                          
        --next <CURSOR>    Cursor for the next page of results                                                           
@@ -883,9 +885,13 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
 
   Examples:
 
-  - List Connex clients for the current team
+  - List Connex clients linked to the current project
 
     $ vercel connex list
+
+  - List every Connex client in the team
+
+    $ vercel connex list --all
 
   - Limit the number of results
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -810,8 +810,9 @@ exports[`help command > connex help output snapshots > connex help column width 
   Commands:
 
   create  type    Create a new Connex client                            
-  list            List Connex clients linked to the current project (use
-                  --all for every client in the team)                   
+  list            List Connex clients linked to the current project     
+                  (falls back to every client in the team when no       
+                  project is linked or when --all-projects is set)      
   token   id      Get a token for a Connex client (accepts a client ID  
                   like scl_abc or a UID like slack/my-bot)              
   remove  client  Delete a Connex client                                
@@ -859,11 +860,12 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
 "
   ▲ vercel connex list [options]
 
-  List Connex clients linked to the current project (use --all for every client in the team)                            
+  List Connex clients linked to the current project (falls back to every client in the team when no project is linked   
+  or when --all-projects is set)                                                                                        
 
   Options:
 
-       --all              List every Connex client in the team, regardless of project link                              
+       --all-projects     List every Connex client in the team, regardless of project link                              
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
        --limit <COUNT>    Number of clients to return per page                                                          
        --next <CURSOR>    Cursor for the next page of results                                                           
@@ -891,7 +893,7 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
 
   - List every Connex client in the team
 
-    $ vercel connex list --all
+    $ vercel connex list --all-projects
 
   - Limit the number of results
 

--- a/packages/cli/test/unit/commands/connex/list.test.ts
+++ b/packages/cli/test/unit/commands/connex/list.test.ts
@@ -33,16 +33,7 @@ describe('connex list', () => {
     client.config.currentTeam = team.id;
   });
 
-  describe('without --all (project-scoped)', () => {
-    it('should error when no project is linked', async () => {
-      client.setArgv('connex', 'list');
-
-      const exitCode = await connex(client);
-
-      expect(exitCode).toBe(1);
-      expect(client.stderr.getFullOutput()).toContain('No project linked');
-    });
-
+  describe('default (project-scoped when linked)', () => {
     it('should request clients filtered by the linked projectId', async () => {
       const project = {
         ...defaultProject,
@@ -103,11 +94,54 @@ describe('connex list', () => {
       const stderr = client.stderr.getFullOutput();
       expect(stderr).toContain('No Connex clients linked to');
       expect(stderr).toContain(project.name);
-      expect(stderr).toContain('--all');
+      expect(stderr).toContain('--all-projects');
+    });
+
+    it('should fall back to unscoped list when no project is linked', async () => {
+      let requestUrl = '';
+      client.scenario.get('/v1/connex/clients', (req, res) => {
+        requestUrl = req.url ?? '';
+        res.json({
+          clients: [
+            {
+              id: 'scl_abc123',
+              uid: 'slack/my-bot',
+              name: 'My Bot',
+              type: 'slack',
+              typeName: 'Slack',
+              createdAt: Date.now() - 60_000,
+              includes: {
+                projects: {
+                  items: [
+                    {
+                      projectId: 'proj_1',
+                      project: { id: 'proj_1', name: 'web' },
+                    },
+                  ],
+                  hasMore: false,
+                  cursor: null,
+                },
+              },
+            },
+          ],
+        });
+      });
+
+      client.setArgv('connex', 'list');
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestUrl).toContain('include=projects');
+      expect(requestUrl).not.toContain('projectId=');
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Projects');
+      expect(stderr).toContain('web');
+      expect(stderr).not.toContain('Connex clients linked to');
     });
   });
 
-  describe('with --all', () => {
+  describe('with --all-projects', () => {
     it('should request clients with include=projects', async () => {
       let requestUrl = '';
       client.scenario.get('/v1/connex/clients', (req, res) => {
@@ -122,23 +156,27 @@ describe('connex list', () => {
               typeName: 'Slack',
               createdAt: Date.now() - 60_000,
               includes: {
-                projects: [
-                  {
-                    projectId: 'proj_1',
-                    project: { id: 'proj_1', name: 'web' },
-                  },
-                  {
-                    projectId: 'proj_2',
-                    project: { id: 'proj_2', name: 'docs' },
-                  },
-                ],
+                projects: {
+                  items: [
+                    {
+                      projectId: 'proj_1',
+                      project: { id: 'proj_1', name: 'web' },
+                    },
+                    {
+                      projectId: 'proj_2',
+                      project: { id: 'proj_2', name: 'docs' },
+                    },
+                  ],
+                  hasMore: false,
+                  cursor: null,
+                },
               },
             },
           ],
         });
       });
 
-      client.setArgv('connex', 'list', '--all');
+      client.setArgv('connex', 'list', '--all-projects');
 
       const exitCode = await connex(client);
 
@@ -151,7 +189,7 @@ describe('connex list', () => {
       expect(stderr).not.toContain('+ more');
     });
 
-    it('should append "+ more" when hasMoreProjects is true', async () => {
+    it('should append "+ more" when includes.projects.hasMore is true', async () => {
       client.scenario.get('/v1/connex/clients', (_req, res) => {
         res.json({
           clients: [
@@ -163,20 +201,23 @@ describe('connex list', () => {
               typeName: 'Slack',
               createdAt: Date.now() - 60_000,
               includes: {
-                projects: [
-                  {
-                    projectId: 'proj_1',
-                    project: { id: 'proj_1', name: 'web' },
-                  },
-                ],
-                hasMoreProjects: true,
+                projects: {
+                  items: [
+                    {
+                      projectId: 'proj_1',
+                      project: { id: 'proj_1', name: 'web' },
+                    },
+                  ],
+                  hasMore: true,
+                  cursor: 'p_cursor',
+                },
               },
             },
           ],
         });
       });
 
-      client.setArgv('connex', 'list', '--all');
+      client.setArgv('connex', 'list', '--all-projects');
 
       const exitCode = await connex(client);
 
@@ -198,21 +239,25 @@ describe('connex list', () => {
               typeName: 'Slack',
               createdAt: Date.now() - 60_000,
               includes: {
-                projects: [
-                  {
-                    projectId: 'proj_live',
-                    project: { id: 'proj_live', name: 'live-app' },
-                  },
-                  // deleted project — no `project` field
-                  { projectId: 'proj_gone' },
-                ],
+                projects: {
+                  items: [
+                    {
+                      projectId: 'proj_live',
+                      project: { id: 'proj_live', name: 'live-app' },
+                    },
+                    // deleted project — no `project` field
+                    { projectId: 'proj_gone' },
+                  ],
+                  hasMore: false,
+                  cursor: null,
+                },
               },
             },
           ],
         });
       });
 
-      client.setArgv('connex', 'list', '--all');
+      client.setArgv('connex', 'list', '--all-projects');
 
       const exitCode = await connex(client);
 
@@ -227,7 +272,7 @@ describe('connex list', () => {
         res.json({ clients: [] });
       });
 
-      client.setArgv('connex', 'list', '--all');
+      client.setArgv('connex', 'list', '--all-projects');
 
       const exitCode = await connex(client);
 
@@ -243,7 +288,7 @@ describe('connex list', () => {
         res.json({ error: { code: 'not_found', message: 'Not Found' } });
       });
 
-      client.setArgv('connex', 'list', '--all');
+      client.setArgv('connex', 'list', '--all-projects');
 
       const exitCode = await connex(client);
 
@@ -263,15 +308,18 @@ describe('connex list', () => {
               typeName: 'OAuth',
               createdAt: 1_700_000_000_000,
               includes: {
-                projects: [
-                  {
-                    projectId: 'proj_1',
-                    project: { id: 'proj_1', name: 'web' },
-                  },
-                  // deleted — gets dropped from json projects
-                  { projectId: 'proj_gone' },
-                ],
-                hasMoreProjects: true,
+                projects: {
+                  items: [
+                    {
+                      projectId: 'proj_1',
+                      project: { id: 'proj_1', name: 'web' },
+                    },
+                    // deleted — gets dropped from json projects
+                    { projectId: 'proj_gone' },
+                  ],
+                  hasMore: true,
+                  cursor: 'p_cursor',
+                },
               },
             },
           ],
@@ -279,7 +327,7 @@ describe('connex list', () => {
         });
       });
 
-      client.setArgv('connex', 'list', '--all', '--format=json');
+      client.setArgv('connex', 'list', '--all-projects', '--format=json');
 
       const exitCode = await connex(client);
 
@@ -295,7 +343,7 @@ describe('connex list', () => {
       expect(first.hasMoreProjects).toBe(true);
     });
 
-    it('should print --all in next-page hint when the response has a cursor', async () => {
+    it('should print --all-projects in next-page hint when the response has a cursor', async () => {
       client.scenario.get('/v1/connex/clients', (_req, res) => {
         res.json({
           clients: [
@@ -306,20 +354,22 @@ describe('connex list', () => {
               type: 'slack',
               typeName: 'Slack',
               createdAt: Date.now(),
-              includes: { projects: [] },
+              includes: {
+                projects: { items: [], hasMore: false, cursor: null },
+              },
             },
           ],
           cursor: 'cursor-abc',
         });
       });
 
-      client.setArgv('connex', 'list', '--all');
+      client.setArgv('connex', 'list', '--all-projects');
 
       const exitCode = await connex(client);
 
       expect(exitCode).toBe(0);
       expect(client.stderr.getFullOutput()).toContain(
-        'connex list --all --next cursor-abc'
+        'connex list --all-projects --next cursor-abc'
       );
     });
 
@@ -333,7 +383,7 @@ describe('connex list', () => {
       client.setArgv(
         'connex',
         'list',
-        '--all',
+        '--all-projects',
         '--limit',
         '5',
         '--next',

--- a/packages/cli/test/unit/commands/connex/list.test.ts
+++ b/packages/cli/test/unit/commands/connex/list.test.ts
@@ -121,10 +121,18 @@ describe('connex list', () => {
               type: 'slack',
               typeName: 'Slack',
               createdAt: Date.now() - 60_000,
-              projects: [
-                { id: 'proj_1', name: 'web' },
-                { id: 'proj_2', name: 'docs' },
-              ],
+              includes: {
+                projects: [
+                  {
+                    projectId: 'proj_1',
+                    project: { id: 'proj_1', name: 'web' },
+                  },
+                  {
+                    projectId: 'proj_2',
+                    project: { id: 'proj_2', name: 'docs' },
+                  },
+                ],
+              },
             },
           ],
         });
@@ -140,6 +148,78 @@ describe('connex list', () => {
       const stderr = client.stderr.getFullOutput();
       expect(stderr).toContain('Projects');
       expect(stderr).toContain('web, docs');
+      expect(stderr).not.toContain('+ more');
+    });
+
+    it('should append "+ more" when hasMoreProjects is true', async () => {
+      client.scenario.get('/v1/connex/clients', (_req, res) => {
+        res.json({
+          clients: [
+            {
+              id: 'scl_abc123',
+              uid: 'slack/my-bot',
+              name: 'My Bot',
+              type: 'slack',
+              typeName: 'Slack',
+              createdAt: Date.now() - 60_000,
+              includes: {
+                projects: [
+                  {
+                    projectId: 'proj_1',
+                    project: { id: 'proj_1', name: 'web' },
+                  },
+                ],
+                hasMoreProjects: true,
+              },
+            },
+          ],
+        });
+      });
+
+      client.setArgv('connex', 'list', '--all');
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(0);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('web');
+      expect(stderr).toContain('+ more');
+    });
+
+    it('should skip deleted projects when rendering names', async () => {
+      client.scenario.get('/v1/connex/clients', (_req, res) => {
+        res.json({
+          clients: [
+            {
+              id: 'scl_abc123',
+              uid: 'slack/my-bot',
+              name: 'My Bot',
+              type: 'slack',
+              typeName: 'Slack',
+              createdAt: Date.now() - 60_000,
+              includes: {
+                projects: [
+                  {
+                    projectId: 'proj_live',
+                    project: { id: 'proj_live', name: 'live-app' },
+                  },
+                  // deleted project — no `project` field
+                  { projectId: 'proj_gone' },
+                ],
+              },
+            },
+          ],
+        });
+      });
+
+      client.setArgv('connex', 'list', '--all');
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(0);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('live-app');
+      expect(stderr).not.toContain('proj_gone');
     });
 
     it('should render empty-state without project context', async () => {
@@ -171,7 +251,7 @@ describe('connex list', () => {
       expect(client.stderr.getFullOutput()).toContain('Connex is not enabled');
     });
 
-    it('should output JSON with projects when --format=json is used', async () => {
+    it('should output JSON with projects and hasMoreProjects when --format=json is used', async () => {
       client.scenario.get('/v1/connex/clients', (_req, res) => {
         res.json({
           clients: [
@@ -182,7 +262,17 @@ describe('connex list', () => {
               type: 'oauth',
               typeName: 'OAuth',
               createdAt: 1_700_000_000_000,
-              projects: [{ id: 'proj_1', name: 'web' }],
+              includes: {
+                projects: [
+                  {
+                    projectId: 'proj_1',
+                    project: { id: 'proj_1', name: 'web' },
+                  },
+                  // deleted — gets dropped from json projects
+                  { projectId: 'proj_gone' },
+                ],
+                hasMoreProjects: true,
+              },
             },
           ],
           cursor: 'next-page',
@@ -202,6 +292,7 @@ describe('connex list', () => {
       expect(Object.keys(first)[0]).toBe('uid');
       expect(first.uid).toBe('oauth/my-client');
       expect(first.projects).toEqual([{ id: 'proj_1', name: 'web' }]);
+      expect(first.hasMoreProjects).toBe(true);
     });
 
     it('should print --all in next-page hint when the response has a cursor', async () => {
@@ -215,7 +306,7 @@ describe('connex list', () => {
               type: 'slack',
               typeName: 'Slack',
               createdAt: Date.now(),
-              projects: [],
+              includes: { projects: [] },
             },
           ],
           cursor: 'cursor-abc',
@@ -289,5 +380,6 @@ describe('connex list', () => {
     const [first] = parsed.clients;
     expect(first.uid).toBe('oauth/my-client');
     expect(first).not.toHaveProperty('projects');
+    expect(first).not.toHaveProperty('hasMoreProjects');
   });
 });

--- a/packages/cli/test/unit/commands/connex/list.test.ts
+++ b/packages/cli/test/unit/commands/connex/list.test.ts
@@ -1,8 +1,27 @@
 import { describe, beforeEach, expect, it } from 'vitest';
+import { join } from 'path';
+import { mkdirp, writeJSON } from 'fs-extra';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useTeam } from '../../../mocks/team';
+import { useProject, defaultProject } from '../../../mocks/project';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
 import connex from '../../../../src/commands/connex';
+
+async function linkProjectInCwd(
+  team: { id: string },
+  project: { id: string; name: string }
+): Promise<string> {
+  const cwd = setupTmpDir();
+  await mkdirp(join(cwd, '.vercel'));
+  await writeJSON(join(cwd, '.vercel', 'project.json'), {
+    orgId: team.id,
+    projectId: project.id,
+    projectName: project.name,
+  });
+  client.cwd = cwd;
+  return cwd;
+}
 
 describe('connex list', () => {
   let team: { id: string; slug: string };
@@ -10,66 +29,240 @@ describe('connex list', () => {
   beforeEach(() => {
     client.reset();
     useUser();
-    team = useTeam();
+    team = useTeam('team_test');
     client.config.currentTeam = team.id;
   });
 
-  it('should render a table of clients on success', async () => {
-    client.scenario.get('/v1/connex/clients', (_req, res) => {
-      res.json({
-        clients: [
-          {
-            id: 'scl_abc123',
-            uid: 'slack/my-bot',
-            name: 'My Bot',
-            type: 'slack',
-            typeName: 'Slack',
-            createdAt: Date.now() - 60_000,
-          },
-        ],
+  describe('without --all (project-scoped)', () => {
+    it('should error when no project is linked', async () => {
+      client.setArgv('connex', 'list');
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain('No project linked');
+    });
+
+    it('should request clients filtered by the linked projectId', async () => {
+      const project = {
+        ...defaultProject,
+        id: 'proj_linked_1',
+        name: 'my-app',
+      };
+      useProject(project);
+      await linkProjectInCwd(team, project);
+
+      let requestUrl = '';
+      client.scenario.get('/v1/connex/clients', (req, res) => {
+        requestUrl = req.url ?? '';
+        res.json({
+          clients: [
+            {
+              id: 'scl_abc123',
+              uid: 'slack/my-bot',
+              name: 'My Bot',
+              type: 'slack',
+              typeName: 'Slack',
+              createdAt: Date.now() - 60_000,
+            },
+          ],
+        });
       });
+
+      client.setArgv('connex', 'list');
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestUrl).toContain(`projectId=${project.id}`);
+      expect(requestUrl).not.toContain('include=projects');
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Connex clients linked to');
+      expect(stderr).toContain(project.name);
+      expect(stderr).toContain('slack/my-bot');
     });
 
-    client.setArgv('connex', 'list');
+    it('should show empty-state with project name when no clients are linked', async () => {
+      const project = {
+        ...defaultProject,
+        id: 'proj_linked_2',
+        name: 'empty-app',
+      };
+      useProject(project);
+      await linkProjectInCwd(team, project);
 
-    const exitCode = await connex(client);
+      client.scenario.get('/v1/connex/clients', (_req, res) => {
+        res.json({ clients: [] });
+      });
 
-    expect(exitCode).toBe(0);
-    const stderr = client.stderr.getFullOutput();
-    expect(stderr).toContain('slack/my-bot');
-    expect(stderr).toContain('scl_abc123');
-    expect(stderr).toContain('My Bot');
-    expect(stderr).toContain('Slack');
+      client.setArgv('connex', 'list');
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(0);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('No Connex clients linked to');
+      expect(stderr).toContain(project.name);
+      expect(stderr).toContain('--all');
+    });
   });
 
-  it('should show empty-state message when no clients exist', async () => {
-    client.scenario.get('/v1/connex/clients', (_req, res) => {
-      res.json({ clients: [] });
+  describe('with --all', () => {
+    it('should request clients with include=projects', async () => {
+      let requestUrl = '';
+      client.scenario.get('/v1/connex/clients', (req, res) => {
+        requestUrl = req.url ?? '';
+        res.json({
+          clients: [
+            {
+              id: 'scl_abc123',
+              uid: 'slack/my-bot',
+              name: 'My Bot',
+              type: 'slack',
+              typeName: 'Slack',
+              createdAt: Date.now() - 60_000,
+              projects: [
+                { id: 'proj_1', name: 'web' },
+                { id: 'proj_2', name: 'docs' },
+              ],
+            },
+          ],
+        });
+      });
+
+      client.setArgv('connex', 'list', '--all');
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestUrl).toContain('include=projects');
+      expect(requestUrl).not.toContain('projectId=');
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Projects');
+      expect(stderr).toContain('web, docs');
     });
 
-    client.setArgv('connex', 'list');
+    it('should render empty-state without project context', async () => {
+      client.scenario.get('/v1/connex/clients', (_req, res) => {
+        res.json({ clients: [] });
+      });
 
-    const exitCode = await connex(client);
+      client.setArgv('connex', 'list', '--all');
 
-    expect(exitCode).toBe(0);
-    expect(client.stderr.getFullOutput()).toContain('No Connex clients found');
-  });
+      const exitCode = await connex(client);
 
-  it('should show friendly error when connex feature flag is off (404)', async () => {
-    client.scenario.get('/v1/connex/clients', (_req, res) => {
-      res.statusCode = 404;
-      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+      expect(exitCode).toBe(0);
+      expect(client.stderr.getFullOutput()).toContain(
+        'No Connex clients found'
+      );
     });
 
-    client.setArgv('connex', 'list');
+    it('should show friendly error when connex feature flag is off (404)', async () => {
+      client.scenario.get('/v1/connex/clients', (_req, res) => {
+        res.statusCode = 404;
+        res.json({ error: { code: 'not_found', message: 'Not Found' } });
+      });
 
-    const exitCode = await connex(client);
+      client.setArgv('connex', 'list', '--all');
 
-    expect(exitCode).toBe(1);
-    expect(client.stderr.getFullOutput()).toContain('Connex is not enabled');
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain('Connex is not enabled');
+    });
+
+    it('should output JSON with projects when --format=json is used', async () => {
+      client.scenario.get('/v1/connex/clients', (_req, res) => {
+        res.json({
+          clients: [
+            {
+              id: 'scl_xyz',
+              uid: 'oauth/my-client',
+              name: 'My OAuth',
+              type: 'oauth',
+              typeName: 'OAuth',
+              createdAt: 1_700_000_000_000,
+              projects: [{ id: 'proj_1', name: 'web' }],
+            },
+          ],
+          cursor: 'next-page',
+        });
+      });
+
+      client.setArgv('connex', 'list', '--all', '--format=json');
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(0);
+      const stdout = client.stdout.getFullOutput();
+      const parsed = JSON.parse(stdout.trim());
+      expect(parsed.cursor).toBe('next-page');
+      expect(parsed.clients).toHaveLength(1);
+      const [first] = parsed.clients;
+      expect(Object.keys(first)[0]).toBe('uid');
+      expect(first.uid).toBe('oauth/my-client');
+      expect(first.projects).toEqual([{ id: 'proj_1', name: 'web' }]);
+    });
+
+    it('should print --all in next-page hint when the response has a cursor', async () => {
+      client.scenario.get('/v1/connex/clients', (_req, res) => {
+        res.json({
+          clients: [
+            {
+              id: 'scl_1',
+              uid: 'slack/a',
+              name: 'A',
+              type: 'slack',
+              typeName: 'Slack',
+              createdAt: Date.now(),
+              projects: [],
+            },
+          ],
+          cursor: 'cursor-abc',
+        });
+      });
+
+      client.setArgv('connex', 'list', '--all');
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.stderr.getFullOutput()).toContain(
+        'connex list --all --next cursor-abc'
+      );
+    });
+
+    it('should forward --limit and --next as query params', async () => {
+      let requestUrl = '';
+      client.scenario.get('/v1/connex/clients', (req, res) => {
+        requestUrl = req.url ?? '';
+        res.json({ clients: [] });
+      });
+
+      client.setArgv(
+        'connex',
+        'list',
+        '--all',
+        '--limit',
+        '5',
+        '--next',
+        'prev-cursor'
+      );
+
+      const exitCode = await connex(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestUrl).toContain('limit=5');
+      expect(requestUrl).toContain('cursor=prev-cursor');
+      expect(requestUrl).toContain('include=projects');
+    });
   });
 
-  it('should output JSON when --format=json is used', async () => {
+  it('should output JSON for project-scoped list without projects field', async () => {
+    const project = { ...defaultProject, id: 'proj_json_1', name: 'json-app' };
+    useProject(project);
+    await linkProjectInCwd(team, project);
+
     client.scenario.get('/v1/connex/clients', (_req, res) => {
       res.json({
         clients: [
@@ -82,7 +275,6 @@ describe('connex list', () => {
             createdAt: 1_700_000_000_000,
           },
         ],
-        cursor: 'next-page',
       });
     });
 
@@ -93,55 +285,9 @@ describe('connex list', () => {
     expect(exitCode).toBe(0);
     const stdout = client.stdout.getFullOutput();
     const parsed = JSON.parse(stdout.trim());
-    expect(parsed.cursor).toBe('next-page');
     expect(parsed.clients).toHaveLength(1);
     const [first] = parsed.clients;
-    // UID should be first field in each client object
-    expect(Object.keys(first)[0]).toBe('uid');
     expect(first.uid).toBe('oauth/my-client');
-    expect(first.id).toBe('scl_xyz');
-  });
-
-  it('should print next-page hint when the response has a cursor', async () => {
-    client.scenario.get('/v1/connex/clients', (_req, res) => {
-      res.json({
-        clients: [
-          {
-            id: 'scl_1',
-            uid: 'slack/a',
-            name: 'A',
-            type: 'slack',
-            typeName: 'Slack',
-            createdAt: Date.now(),
-          },
-        ],
-        cursor: 'cursor-abc',
-      });
-    });
-
-    client.setArgv('connex', 'list');
-
-    const exitCode = await connex(client);
-
-    expect(exitCode).toBe(0);
-    expect(client.stderr.getFullOutput()).toContain(
-      'connex list --next cursor-abc'
-    );
-  });
-
-  it('should forward --limit and --next as query params', async () => {
-    let requestUrl = '';
-    client.scenario.get('/v1/connex/clients', (req, res) => {
-      requestUrl = req.url ?? '';
-      res.json({ clients: [] });
-    });
-
-    client.setArgv('connex', 'list', '--limit', '5', '--next', 'prev-cursor');
-
-    const exitCode = await connex(client);
-
-    expect(exitCode).toBe(0);
-    expect(requestUrl).toContain('limit=5');
-    expect(requestUrl).toContain('cursor=prev-cursor');
+    expect(first).not.toHaveProperty('projects');
   });
 });


### PR DESCRIPTION
## Summary

- Default `vc connex list` now lists Connex clients linked to the project in scope, using the new `projectId` query param ([api#71389](https://github.com/vercel/api/pull/71389)).
- Add `--all` to list every client in the team. With `--all`, requests pass `include=projects` ([api#71586](https://github.com/vercel/api/pull/71586)) and the table shows a `Projects` column with the linked project names per client.
- When no project is linked and `--all` isn't passed, the command errors with: `No project linked. Either use 'vercel link' to link a project, or the '--all' flag to list all clients.`
- The non-JSON table no longer shows a `Created` column. JSON output is unchanged for the project-scoped case; with `--all` it includes a `projects` array per client.

## Test plan
- [x] `vc connex list` in a linked project shows only that project's clients with a header
- [x] `vc connex list` with no link errors with the link/--all hint
- [x] `vc connex list --all` shows every team client and a `Projects` column
- [x] `vc connex list --all --format=json` includes `projects` per client
- [x] `vc connex list --format=json` (project-scoped) omits `projects`
- [ ] Pagination hint preserves `--all` in the next-page command

🤖 Generated with [Claude Code](https://claude.com/claude-code)