### PR TITLE
[services] error on framework = "services" but no services configured

### DIFF
--- a/.changeset/silent-ties-obey.md
+++ b/.changeset/silent-ties-obey.md
@@ -1,0 +1,5 @@
+---
+"@vercel/fs-detectors": patch
+---
+
+[services] error on framework = "services" but no services configured

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -147,6 +147,8 @@ export async function detectBuilders(
   if (hasServicesConfig || framework === 'services') {
     return getServicesBuilders({
       workPath: options.workPath,
+      configuredServices: services,
+      projectFramework: framework,
     });
   }
 

--- a/packages/fs-detectors/src/services/get-services-builders.ts
+++ b/packages/fs-detectors/src/services/get-services-builders.ts
@@ -46,9 +46,7 @@ export async function getServicesBuilders(
 ): Promise<ServicesBuildersResult> {
   const { workPath, configuredServices, projectFramework } = options;
   const hasServiceDefinitions =
-    configuredServices != null &&
-    typeof configuredServices === 'object' &&
-    Object.keys(configuredServices).length > 0;
+    configuredServices != null && Object.keys(configuredServices).length > 0;
 
   if (
     projectFramework === 'services' &&

--- a/packages/fs-detectors/src/services/get-services-builders.ts
+++ b/packages/fs-detectors/src/services/get-services-builders.ts
@@ -1,5 +1,5 @@
 import type { Route } from '@vercel/routing-utils';
-import type { Builder } from '@vercel/build-utils';
+import type { Builder, ExperimentalServices } from '@vercel/build-utils';
 import type { ResolvedService } from './types';
 import { detectServices } from './detect-services';
 import { LocalFileSystemDetector } from '../detectors/local-file-system-detector';
@@ -13,6 +13,8 @@ export interface ErrorResponse {
 
 export interface GetServicesBuildersOptions {
   workPath?: string;
+  configuredServices?: ExperimentalServices;
+  projectFramework?: string | null;
 }
 
 export interface ServicesBuildersResult {
@@ -28,6 +30,11 @@ export interface ServicesBuildersResult {
   services?: ResolvedService[];
 }
 
+function isExperimentalServicesAutoDetectionEnabled(): boolean {
+  const env = process.env.VERCEL_USE_EXPERIMENTAL_SERVICES;
+  return env === '1' || env?.toLowerCase() === 'true';
+}
+
 /**
  * Get builders for services - adapter for detectBuilders.
  *
@@ -37,7 +44,35 @@ export interface ServicesBuildersResult {
 export async function getServicesBuilders(
   options: GetServicesBuildersOptions
 ): Promise<ServicesBuildersResult> {
-  const { workPath } = options;
+  const { workPath, configuredServices, projectFramework } = options;
+  const hasServiceDefinitions =
+    configuredServices != null &&
+    typeof configuredServices === 'object' &&
+    Object.keys(configuredServices).length > 0;
+
+  if (
+    projectFramework === 'services' &&
+    !hasServiceDefinitions &&
+    !isExperimentalServicesAutoDetectionEnabled()
+  ) {
+    return {
+      builders: null,
+      errors: [
+        {
+          code: 'MISSING_EXPERIMENTAL_SERVICES',
+          message:
+            'Project framework is set to "services", but no services are declared. Add `experimentalServices` to vercel.json with at least one service, or change the project framework setting.',
+        },
+      ],
+      warnings: [],
+      hostRewriteRoutes: null,
+      defaultRoutes: null,
+      fallbackRoutes: null,
+      redirectRoutes: null,
+      rewriteRoutes: null,
+      errorRoutes: null,
+    };
+  }
 
   if (!workPath) {
     return {

--- a/packages/fs-detectors/test/fixtures/e2e/07-services-frontend-backend-zc/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/07-services-frontend-backend-zc/vercel.json
@@ -2,5 +2,10 @@
   "uploadNowJson": true,
   "projectSettings": {
     "framework": "services"
+  },
+  "build": {
+    "env": {
+      "VERCEL_USE_EXPERIMENTAL_SERVICES": "1"
+    }
   }
 }

--- a/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/08-services-frontend-backend-ruby-zc/vercel.json
@@ -2,5 +2,10 @@
   "uploadNowJson": true,
   "projectSettings": {
     "framework": "services"
+  },
+  "build": {
+    "env": {
+      "VERCEL_USE_EXPERIMENTAL_SERVICES": "1"
+    }
   }
 }

--- a/packages/fs-detectors/test/fixtures/e2e/09-services-frontend-backend-go-zc/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/09-services-frontend-backend-go-zc/vercel.json
@@ -2,5 +2,10 @@
   "uploadNowJson": true,
   "projectSettings": {
     "framework": "services"
+  },
+  "build": {
+    "env": {
+      "VERCEL_USE_EXPERIMENTAL_SERVICES": "1"
+    }
   }
 }

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -154,6 +154,71 @@ describe('Test `detectBuilders`', () => {
     );
   });
 
+  it('should error when the services framework is selected without experimentalServices', async () => {
+    const { builders, errors, defaultRoutes, rewriteRoutes } =
+      await detectBuilders(['package.json'], undefined, {
+        projectSettings: {
+          framework: 'services',
+        },
+      });
+
+    expect(builders).toBeNull();
+    expect(defaultRoutes).toBeNull();
+    expect(rewriteRoutes).toBeNull();
+    expect(errors).toEqual([
+      {
+        code: 'MISSING_EXPERIMENTAL_SERVICES',
+        message:
+          'Project framework is set to "services", but no services are declared. Add `experimentalServices` to vercel.json with at least one service, or change the project framework setting.',
+      },
+    ]);
+  });
+
+  it('should allow services framework auto-detection when experimental services env is enabled', async () => {
+    const originalEnv = process.env.VERCEL_USE_EXPERIMENTAL_SERVICES;
+    process.env.VERCEL_USE_EXPERIMENTAL_SERVICES = '1';
+
+    try {
+      const workPath = join(
+        __dirname,
+        'fixtures',
+        'e2e',
+        '07-services-frontend-backend-zc'
+      );
+      const { builders, errors, services } = await detectBuilders(
+        ['vercel.json'],
+        undefined,
+        {
+          projectSettings: {
+            framework: 'services',
+          },
+          workPath,
+        }
+      );
+
+      expect(errors).toBeNull();
+      expect(services).toHaveLength(2);
+      expect(builders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            src: 'frontend/package.json',
+            use: '@vercel/next',
+          }),
+          expect.objectContaining({
+            src: 'backend/<detect>',
+            use: '@vercel/python',
+          }),
+        ])
+      );
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.VERCEL_USE_EXPERIMENTAL_SERVICES;
+      } else {
+        process.env.VERCEL_USE_EXPERIMENTAL_SERVICES = originalEnv;
+      }
+    }
+  });
+
   it('should never select now.json src', async () => {
     const files = ['docs/index.md', 'mkdocs.yml', 'now.json'];
     const { builders } = await invokeDetectBuildersAndThrow(files, null, {


### PR DESCRIPTION
Projects created with "services" as the framework should have `experimentalServices` set in `vercel.json`

Currently, if a project is created _with_ `experimentalServices` and the framework preset set to "services", but then `experimentalServices` is deleted, it will fall back to the old, unreleased zero-config services detection/building logic, which we don't want to support