### PR TITLE
fix(cli): clarify bisect target mismatch guidance 

### DIFF
--- a/.changeset/clear-bisect-targets.md
+++ b/.changeset/clear-bisect-targets.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve the `vercel bisect` error shown when the known good and known bad deployments come from different targets.

--- a/packages/cli/src/commands/bisect/index.ts
+++ b/packages/cli/src/commands/bisect/index.ts
@@ -183,12 +183,16 @@ export default async function bisect(client: Client): Promise<number> {
   }
 
   if (badDeployment.target !== goodDeployment.target) {
+    const badTargetName = getDeploymentTargetName(badDeployment);
+    const goodTargetName = getDeploymentTargetName(goodDeployment);
+    const badTarget = formatDeploymentTarget(badTargetName);
+    const goodTarget = formatDeploymentTarget(goodTargetName);
+
     output.error(
-      `Bad deployment target "${
-        badDeployment.target || 'preview'
-      }" does not match good deployment target "${
-        goodDeployment.target || 'preview'
-      }"`
+      `Cannot bisect deployments from different targets.\n\n` +
+        `Known bad:  ${link(`https://${badDeployment.url}`)} (${badTarget})\n` +
+        `Known good: ${link(`https://${goodDeployment.url}`)} (${goodTarget})\n\n` +
+        `${capitalize(badTargetName)} and ${goodTargetName} deployments have separate histories. Use a known good URL from ${badTarget}, or use a known bad URL from ${goodTarget}.`
     );
     return 1;
   }
@@ -359,4 +363,16 @@ function getCommit(deployment: Deployment) {
     deployment.meta?.gitlabCommitMessage ||
     deployment.meta?.bitbucketCommitMessage;
   return { sha, message };
+}
+
+function getDeploymentTargetName(deployment: Deployment) {
+  return deployment.target || 'preview';
+}
+
+function formatDeploymentTarget(target: string) {
+  return `target: ${target}`;
+}
+
+function capitalize(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
 }

--- a/packages/cli/src/commands/bisect/index.ts
+++ b/packages/cli/src/commands/bisect/index.ts
@@ -183,16 +183,14 @@ export default async function bisect(client: Client): Promise<number> {
   }
 
   if (badDeployment.target !== goodDeployment.target) {
-    const badTargetName = getDeploymentTargetName(badDeployment);
-    const goodTargetName = getDeploymentTargetName(goodDeployment);
-    const badTarget = formatDeploymentTarget(badTargetName);
-    const goodTarget = formatDeploymentTarget(goodTargetName);
+    const badTarget = badDeployment.target || 'preview';
+    const goodTarget = goodDeployment.target || 'preview';
 
     output.error(
       `Cannot bisect deployments from different targets.\n\n` +
         `Known bad:  ${link(`https://${badDeployment.url}`)} (${badTarget})\n` +
         `Known good: ${link(`https://${goodDeployment.url}`)} (${goodTarget})\n\n` +
-        `${capitalize(badTargetName)} and ${goodTargetName} deployments have separate histories. Use a known good URL from ${badTarget}, or use a known bad URL from ${goodTarget}.`
+        `Use a known good URL from ${badTarget}, or use a known bad URL from ${goodTarget}.`
     );
     return 1;
   }
@@ -363,16 +361,4 @@ function getCommit(deployment: Deployment) {
     deployment.meta?.gitlabCommitMessage ||
     deployment.meta?.bitbucketCommitMessage;
   return { sha, message };
-}
-
-function getDeploymentTargetName(deployment: Deployment) {
-  return deployment.target || 'preview';
-}
-
-function formatDeploymentTarget(target: string) {
-  return `target: ${target}`;
-}
-
-function capitalize(value: string) {
-  return value.charAt(0).toUpperCase() + value.slice(1);
 }

--- a/packages/cli/test/unit/commands/bisect/index.test.ts
+++ b/packages/cli/test/unit/commands/bisect/index.test.ts
@@ -466,9 +466,9 @@ describe('bisect', () => {
 
       await expect(client.stderr).toOutput(
         `Error: Cannot bisect deployments from different targets.\n\n` +
-          `Known bad:  https://${badDeployment.url} (target: production)\n` +
-          `Known good: https://${goodDeployment.url} (target: staging)\n\n` +
-          `Production and staging deployments have separate histories.`
+          `Known bad:  https://${badDeployment.url} (production)\n` +
+          `Known good: https://${goodDeployment.url} (staging)\n\n` +
+          `Use a known good URL from production, or use a known bad URL from staging.`
       );
 
       await expect(bisectPromise).resolves.toEqual(1);

--- a/packages/cli/test/unit/commands/bisect/index.test.ts
+++ b/packages/cli/test/unit/commands/bisect/index.test.ts
@@ -438,5 +438,40 @@ describe('bisect', () => {
 
       await expect(bisectPromise).resolves.toEqual(1);
     });
+
+    it('should explain which deployments have mismatched targets', async () => {
+      const user = useUser();
+      const now = Date.now();
+      const goodDeployment = useDeployment({
+        creator: user,
+        createdAt: now,
+        target: 'staging',
+      });
+      const badDeployment = useDeployment({
+        creator: user,
+        createdAt: now + 10000,
+        target: 'production',
+      });
+
+      client.setArgv(
+        'bisect',
+        '--good',
+        `https://${goodDeployment.url}`,
+        '--bad',
+        `https://${badDeployment.url}`,
+        '--path',
+        '/docs'
+      );
+      const bisectPromise = bisect(client);
+
+      await expect(client.stderr).toOutput(
+        `Error: Cannot bisect deployments from different targets.\n\n` +
+          `Known bad:  https://${badDeployment.url} (target: production)\n` +
+          `Known good: https://${goodDeployment.url} (target: staging)\n\n` +
+          `Production and staging deployments have separate histories.`
+      );
+
+      await expect(bisectPromise).resolves.toEqual(1);
+    });
   });
 });


### PR DESCRIPTION
Show both deployment targets in the bisect mismatch error and make the history warning reflect the actual targets involved. This gives users clearer guidance about which good or bad URLs to use when target histories are separate.

I was using this command, and didn't understand what exactly I did wrong when I received this error in the first place.