### PR TITLE
[frameworks] move import screenshots from Cloudinary to Vercel Blob

### DIFF
--- a/.changeset/migrate-import-screenshots-to-blob.md
+++ b/.changeset/migrate-import-screenshots-to-blob.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Move framework import screenshots from Cloudinary (`assets.vercel.com`) to Vercel Blob. The four affected entries (Next.js, Nuxt, SvelteKit, SvelteKit legacy) now point at `https://py8fhxnkzwtsqdo9.public.blob.vercel-storage.com/front/import/*.png`. Same images, different host — consumers see no behavior change.

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -66,7 +66,7 @@ export const frameworks = [
     darkModeLogo:
       'https://api-frameworks.vercel.sh/framework-logos/next-dark.svg',
     screenshot:
-      'https://assets.vercel.com/image/upload/v1701461207/front/import/nextjs.png',
+      'https://py8fhxnkzwtsqdo9.public.blob.vercel-storage.com/front/import/nextjs.png',
     tagline:
       'Next.js makes you productive with React instantly — whether you want to build static or dynamic sites.',
     description: 'A Next.js app and a Serverless Function API.',
@@ -1093,7 +1093,7 @@ export const frameworks = [
     demo: 'https://sveltekit-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/svelte.svg',
     screenshot:
-      'https://assets.vercel.com/image/upload/v1647366075/front/import/sveltekit.png',
+      'https://py8fhxnkzwtsqdo9.public.blob.vercel-storage.com/front/import/sveltekit.png',
     tagline:
       'SvelteKit is a framework for building web applications of all sizes.',
     description: 'A SvelteKit legacy app optimized Edge-first.',
@@ -1135,7 +1135,7 @@ export const frameworks = [
     demo: 'https://sveltekit-1-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/svelte.svg',
     screenshot:
-      'https://assets.vercel.com/image/upload/v1647366075/front/import/sveltekit.png',
+      'https://py8fhxnkzwtsqdo9.public.blob.vercel-storage.com/front/import/sveltekit.png',
     tagline:
       'SvelteKit is a framework for building web applications of all sizes.',
     description: 'A SvelteKit app optimized Edge-first.',
@@ -1525,7 +1525,7 @@ export const frameworks = [
     demo: 'https://nuxtjs-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/nuxt.svg',
     screenshot:
-      'https://assets.vercel.com/image/upload/v1647366075/front/import/nuxtjs.png',
+      'https://py8fhxnkzwtsqdo9.public.blob.vercel-storage.com/front/import/nuxtjs.png',
     tagline:
       'Nuxt is the open source framework that makes full-stack development with Vue.js intuitive.',
     description: 'A Nuxt app, bootstrapped with create-nuxt-app.',

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -85,7 +85,7 @@ export interface Framework {
   darkModeLogo?: string;
   /**
    * A URL to a screenshot of the demo
-   * @example "https://assets.vercel.com/image/upload/v1647366075/front/import/nextjs.png"
+   * @example "https://py8fhxnkzwtsqdo9.public.blob.vercel-storage.com/front/import/nextjs.png"
    */
   screenshot?: string;
   /**


### PR DESCRIPTION
## Summary

- Move the four import screenshot URLs (Next.js, Nuxt, SvelteKit, SvelteKit legacy) from `assets.vercel.com/image/upload/.../front/import/*.png` to `py8fhxnkzwtsqdo9.public.blob.vercel-storage.com/front/import/*.png`
- Update the matching `screenshot` JSDoc `@example` in `types.ts`
- Includes a `@vercel/frameworks` patch changeset

## Context

vercel.com is removing Cloudinary as a CDN for vercel.com-owned assets. The framework `screenshot` field returned by `api-frameworks.vercel.sh/api/v1/frameworks` is one of the last places this domain leaks through to consumers. Same images, different host — already mirrored in the destination bucket.

## Test plan

- [ ] After deploy, `curl https://api-frameworks.vercel.sh/api/v1/frameworks` returns `*.public.blob.vercel-storage.com` URLs for `nextjs` / `nuxtjs` / `sveltekit` / `sveltekit-1`
- [ ] Existing image URLs still resolve (verified 200 OK on the destination bucket for all three unique PNGs)