### PR TITLE
cli/logs: Resolve deployment targets without linked projects

### DIFF
--- a/.changeset/bright-logs-resolve-deployments.md
+++ b/.changeset/bright-logs-resolve-deployments.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow `vc logs <deployment-url>` to resolve the project from the deployment instead of requiring a linked local project, and include the current scope in related lookup errors.

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -33,6 +33,22 @@ interface BranchDeployment {
   url: string;
 }
 
+interface LogsTarget {
+  projectId: string;
+  projectSlug: string;
+  orgSlug: string;
+  ownerId: string;
+  deploymentId?: string;
+}
+
+interface ResolveLogsTargetOptions {
+  contextName: string;
+  deploymentOption?: string;
+  projectOption?: string;
+}
+
+type ResolveLogsTargetResult = LogsTarget | { exitCode: number };
+
 async function getLatestDeploymentByBranch(
   client: Client,
   projectId: string,
@@ -203,6 +219,130 @@ function parseSources(sources?: string | string[]): string[] {
   return sources;
 }
 
+async function resolveLogsTarget(
+  client: Client,
+  { contextName, deploymentOption, projectOption }: ResolveLogsTargetOptions
+): Promise<ResolveLogsTargetResult> {
+  if (deploymentOption) {
+    output.spinner(`Resolving deployment "${deploymentOption}"`, 1000);
+    let deployment: Awaited<ReturnType<typeof getDeployment>>;
+    try {
+      deployment = await getDeployment(client, contextName, deploymentOption);
+    } catch (err) {
+      if (err instanceof DeploymentNotFound) {
+        output.error(
+          `Deployment not found: ${deploymentOption} under ${chalk.bold(
+            contextName
+          )}`
+        );
+        return { exitCode: 1 };
+      }
+      if (err instanceof InvalidDeploymentId) {
+        output.error(`Invalid deployment ID: ${deploymentOption}`);
+        return { exitCode: 1 };
+      }
+      throw err;
+    } finally {
+      output.stopSpinner();
+    }
+
+    if (!deployment.projectId) {
+      output.error('Deployment is not associated with a project.');
+      return { exitCode: 1 };
+    }
+
+    output.spinner(`Fetching project "${deployment.projectId}"`, 1000);
+    const project = await getProjectByIdOrName(client, deployment.projectId);
+    output.stopSpinner();
+
+    if (project instanceof ProjectNotFound) {
+      output.error(
+        `Project not found: ${deployment.projectId} under ${chalk.bold(
+          contextName
+        )}`
+      );
+      return { exitCode: 1 };
+    }
+
+    if (projectOption) {
+      output.spinner(`Fetching project "${projectOption}"`, 1000);
+      const explicitProject = await getProjectByIdOrName(client, projectOption);
+      output.stopSpinner();
+
+      if (explicitProject instanceof ProjectNotFound) {
+        output.error(
+          `Project not found: ${projectOption} under ${chalk.bold(contextName)}`
+        );
+        return { exitCode: 1 };
+      }
+
+      if (explicitProject.id !== project.id) {
+        output.error(
+          `The deployment "${deploymentOption}" does not belong to "${projectOption}". Remove either the deployment selection or the ${chalk.bold(
+            '--project'
+          )} option.`
+        );
+        return { exitCode: 1 };
+      }
+    }
+
+    return {
+      projectId: project.id,
+      projectSlug: project.name,
+      orgSlug: contextName,
+      ownerId: project.accountId,
+      deploymentId: deployment.id,
+    };
+  }
+
+  if (projectOption) {
+    output.spinner(`Fetching project "${projectOption}"`, 1000);
+    const project = await getProjectByIdOrName(
+      client,
+      projectOption,
+      client.config.currentTeam
+    );
+    output.stopSpinner();
+
+    if (project instanceof ProjectNotFound) {
+      output.error(
+        `Project not found: ${projectOption} under ${chalk.bold(contextName)}`
+      );
+      return { exitCode: 1 };
+    }
+
+    return {
+      projectId: project.id,
+      projectSlug: project.name,
+      orgSlug: contextName,
+      ownerId: project.accountId,
+    };
+  }
+
+  const link = await getLinkedProject(client);
+  if (link.status === 'error') {
+    return { exitCode: link.exitCode };
+  }
+  if (link.status === 'not_linked') {
+    output.error(
+      `Your codebase isn't linked to a project on Vercel. Run ${getCommandName(
+        'link'
+      )} to begin, or specify a project with ${chalk.bold('--project')}.`
+    );
+    return { exitCode: 1 };
+  }
+
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+
+  return {
+    projectId: link.project.id,
+    projectSlug: link.project.name,
+    orgSlug: link.org.slug,
+    ownerId: link.org.id,
+  };
+}
+
 export default async function logs(client: Client) {
   let parsedArguments;
   const flagsSpecification = getFlagsSpecification(logsCommand.options);
@@ -306,7 +446,7 @@ export default async function logs(client: Client) {
     }
   }
 
-  let contextName: string | null = null;
+  let contextName: string;
 
   try {
     ({ contextName } = await getScope(client));
@@ -321,72 +461,17 @@ export default async function logs(client: Client) {
     throw err;
   }
 
-  let projectId: string;
-  let projectSlug: string;
-  let orgSlug: string;
-  let ownerId: string;
-
-  if (projectOption) {
-    output.spinner(`Fetching project "${projectOption}"`, 1000);
-    const project = await getProjectByIdOrName(
-      client,
-      projectOption,
-      client.config.currentTeam
-    );
-    output.stopSpinner();
-
-    if (project instanceof ProjectNotFound) {
-      output.error(`Project not found: ${projectOption}`);
-      return 1;
-    }
-    projectId = project.id;
-    projectSlug = project.name;
-    orgSlug = contextName!;
-    ownerId = project.accountId;
-  } else {
-    const link = await getLinkedProject(client);
-    if (link.status === 'error') {
-      return link.exitCode;
-    } else if (link.status === 'not_linked') {
-      output.error(
-        `Your codebase isn't linked to a project on Vercel. Run ${getCommandName(
-          'link'
-        )} to begin, or specify a project with ${chalk.bold('--project')}.`
-      );
-      return 1;
-    }
-    client.config.currentTeam =
-      link.org.type === 'team' ? link.org.id : undefined;
-    projectId = link.project.id;
-    projectSlug = link.project.name;
-    orgSlug = link.org.slug;
-    ownerId = link.org.id;
+  const logsTarget = await resolveLogsTarget(client, {
+    contextName,
+    deploymentOption,
+    projectOption,
+  });
+  if ('exitCode' in logsTarget) {
+    return logsTarget.exitCode;
   }
 
-  let deploymentId: string | undefined;
-  if (deploymentOption) {
-    output.spinner(`Resolving deployment "${deploymentOption}"`, 1000);
-    try {
-      const deployment = await getDeployment(
-        client,
-        contextName!,
-        deploymentOption
-      );
-      deploymentId = deployment.id;
-      output.stopSpinner();
-    } catch (err) {
-      output.stopSpinner();
-      if (err instanceof DeploymentNotFound) {
-        output.error(`Deployment not found: ${deploymentOption}`);
-        return 1;
-      }
-      if (err instanceof InvalidDeploymentId) {
-        output.error(`Invalid deployment ID: ${deploymentOption}`);
-        return 1;
-      }
-      throw err;
-    }
-  }
+  const { projectId, projectSlug, orgSlug, ownerId } = logsTarget;
+  let { deploymentId } = logsTarget;
 
   // Determine branch filter:
   // - If --branch is explicitly set (string), use it

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -251,6 +251,8 @@ async function resolveLogsTarget(
       return { exitCode: 1 };
     }
 
+    // `getDeployment()` already resolved under `client.config.currentTeam` via
+    // `client.fetch()`, and project/log lookups should stay in that same scope.
     output.spinner(`Fetching project "${deployment.projectId}"`, 1000);
     const project = await getProjectByIdOrName(client, deployment.projectId);
     output.stopSpinner();
@@ -297,11 +299,7 @@ async function resolveLogsTarget(
 
   if (projectOption) {
     output.spinner(`Fetching project "${projectOption}"`, 1000);
-    const project = await getProjectByIdOrName(
-      client,
-      projectOption,
-      client.config.currentTeam
-    );
+    const project = await getProjectByIdOrName(client, projectOption);
     output.stopSpinner();
 
     if (project instanceof ProjectNotFound) {

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -280,7 +280,7 @@ async function resolveLogsTarget(
 
       if (explicitProject.id !== project.id) {
         output.error(
-          `The deployment "${deploymentOption}" does not belong to "${projectOption}". Remove either the deployment selection or the ${chalk.bold(
+          `The deployment "${deploymentOption}" does not belong to "${projectOption}" project. Remove either the deployment selection or the ${chalk.bold(
             '--project'
           )} option.`
         );

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -780,7 +780,7 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput(
-        `The deployment "${deployment.id}" does not belong to "other-project". Remove either the deployment selection or the --project option.`
+        `The deployment "${deployment.id}" does not belong to "other-project" project. Remove either the deployment selection or the --project option.`
       );
     });
   });

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -1,14 +1,40 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
-import { useTeams } from '../../../mocks/team';
+import { useTeam, useTeams } from '../../../mocks/team';
 import { defaultProject, useProject } from '../../../mocks/project';
 import { useDeployment } from '../../../mocks/deployment';
 import logs from '../../../../src/commands/logs';
 import { join } from 'path';
 
-const fixture = (name: string) =>
-  join(__dirname, '../../../fixtures/unit/commands/logs', name);
+const logsFixturesDir = join(__dirname, '../../../fixtures/unit/commands/logs');
+
+const fixture = (name: string) => join(logsFixturesDir, name);
+
+const logsProject = {
+  ...defaultProject,
+  id: 'prj_logstest',
+  name: 'logs-test-project',
+  accountId: 'team_dummy',
+};
+
+function useLogsDeployment(creator: ReturnType<typeof useUser>) {
+  const deployment = useDeployment({
+    creator: {
+      id: logsProject.accountId,
+      email: creator.email,
+      name: 'Vercel',
+      username: 'vercel',
+    },
+    project: logsProject,
+  });
+  deployment.team = {
+    id: logsProject.accountId,
+    name: 'Vercel',
+    slug: 'vercel',
+  };
+  return deployment;
+}
 
 // API response format (what the server returns)
 interface ApiLogEntry {
@@ -678,16 +704,12 @@ describe('logs', () => {
     beforeEach(() => {
       useUser();
       useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        id: 'prj_logstest',
-        name: 'logs-test-project',
-      });
+      useProject(logsProject);
     });
 
     it('should filter by deployment ID with --no-follow', async () => {
       const user = useUser();
-      const deployment = useDeployment({ creator: user });
+      const deployment = useLogsDeployment(user);
 
       let receivedDeploymentId: string | undefined;
       client.scenario.get('/api/logs/request-logs', (req, res) => {
@@ -708,7 +730,7 @@ describe('logs', () => {
 
     it('should track telemetry for --deployment option', async () => {
       const user = useUser();
-      const deployment = useDeployment({ creator: user });
+      const deployment = useLogsDeployment(user);
 
       client.scenario.get(
         `/v1/projects/prj_logstest/deployments/${deployment.id}/runtime-logs`,
@@ -734,22 +756,47 @@ describe('logs', () => {
         },
       ]);
     });
+
+    it('should error when --project does not match the deployment project', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+      useProject({
+        ...defaultProject,
+        id: 'prj_other',
+        name: 'other-project',
+        accountId: logsProject.accountId,
+      });
+
+      client.cwd = logsFixturesDir;
+      client.setArgv(
+        'logs',
+        '--deployment',
+        deployment.id,
+        '--project',
+        'other-project',
+        '--no-follow'
+      );
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        `The deployment "${deployment.id}" does not belong to "other-project". Remove either the deployment selection or the --project option.`
+      );
+    });
   });
 
   describe('positional deployment argument (implicit --follow)', () => {
+    let logsTeam: ReturnType<typeof useTeam>;
+
     beforeEach(() => {
       useUser();
-      useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        id: 'prj_logstest',
-        name: 'logs-test-project',
-      });
+      logsTeam = useTeam(logsProject.accountId);
+      useProject(logsProject);
     });
 
     it('should enable --follow implicitly when deployment ID is specified', async () => {
       const user = useUser();
-      const deployment = useDeployment({ creator: user });
+      const deployment = useLogsDeployment(user);
 
       client.scenario.get(
         `/v1/projects/prj_logstest/deployments/${deployment.id}/runtime-logs`,
@@ -768,7 +815,7 @@ describe('logs', () => {
 
     it('should allow --no-follow to disable implicit follow', async () => {
       const user = useUser();
-      const deployment = useDeployment({ creator: user });
+      const deployment = useLogsDeployment(user);
 
       let receivedDeploymentId: string | undefined;
       client.scenario.get('/api/logs/request-logs', (req, res) => {
@@ -789,7 +836,7 @@ describe('logs', () => {
 
     it('should extract hostname from URL positional argument', async () => {
       const user = useUser();
-      const deployment = useDeployment({ creator: user });
+      const deployment = useLogsDeployment(user);
 
       client.scenario.get(`/v13/deployments/${deployment.url}`, (_req, res) => {
         res.json(deployment);
@@ -810,9 +857,116 @@ describe('logs', () => {
       expect(exitCode).toEqual(0);
     });
 
+    it('should stream logs for a deployment URL without a linked project', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+
+      let receivedTeamId: string | undefined;
+      client.scenario.get(
+        `/v1/projects/prj_logstest/deployments/${deployment.id}/runtime-logs`,
+        (req, res) => {
+          receivedTeamId = req.query.teamId as string;
+          res.status(200);
+          res.end();
+        }
+      );
+
+      client.config.currentTeam = logsTeam.id;
+      client.cwd = logsFixturesDir;
+      client.setArgv('logs', `https://${deployment.url}`);
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedTeamId).toEqual(logsProject.accountId);
+    });
+
+    it('should fetch historical logs for a deployment URL without a linked project', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+      let receivedQuery:
+        | {
+            projectId?: string;
+            ownerId?: string;
+            deploymentId?: string;
+            teamId?: string;
+          }
+        | undefined;
+
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedQuery = {
+          projectId: req.query.projectId as string,
+          ownerId: req.query.ownerId as string,
+          deploymentId: req.query.deploymentId as string,
+          teamId: req.query.teamId as string,
+        };
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.config.currentTeam = logsTeam.id;
+      client.cwd = logsFixturesDir;
+      client.setArgv('logs', `https://${deployment.url}`, '--no-follow');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedQuery).toEqual({
+        projectId: logsProject.id,
+        ownerId: logsProject.accountId,
+        deploymentId: deployment.id,
+        teamId: logsProject.accountId,
+      });
+    });
+
+    it('should use the current scope when the deployment project cannot be found', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+      deployment.projectId = 'prj_missing_logs';
+
+      client.scenario.get('/v9/projects/prj_missing_logs', (_req, res) => {
+        res.status(404).json({ error: { code: 'not_found' } });
+      });
+
+      client.config.currentTeam = logsTeam.id;
+      client.cwd = logsFixturesDir;
+      client.setArgv('logs', deployment.id, '--no-follow');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        `Project not found: prj_missing_logs under ${logsTeam.slug}`
+      );
+    });
+
+    it('should use the current scope when an explicit project cannot be found', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+
+      client.scenario.get('/v9/projects/missing-project', (_req, res) => {
+        res.status(404).json({ error: { code: 'not_found' } });
+      });
+
+      client.config.currentTeam = logsTeam.id;
+      client.cwd = logsFixturesDir;
+      client.setArgv(
+        'logs',
+        deployment.id,
+        '--project',
+        'missing-project',
+        '--no-follow'
+      );
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        `Project not found: missing-project under ${logsTeam.slug}`
+      );
+    });
+
     it('should prioritize positional argument over --deployment flag', async () => {
       const user = useUser();
-      const deployment = useDeployment({ creator: user });
+      const deployment = useLogsDeployment(user);
 
       client.scenario.get(
         `/v1/projects/prj_logstest/deployments/${deployment.id}/runtime-logs`,
@@ -884,6 +1038,22 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput("isn't linked to a project");
+    });
+
+    it('should include the current scope when a deployment is not found', async () => {
+      const user = useUser();
+      const team = useTeam(logsProject.accountId);
+      useLogsDeployment(user);
+
+      client.config.currentTeam = team.id;
+      client.cwd = logsFixturesDir;
+      client.setArgv('logs', 'dpl_missing');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        `Deployment not found: dpl_missing under ${team.slug}`
+      );
     });
   });
 

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -919,7 +919,7 @@ describe('logs', () => {
       });
     });
 
-    it('should use the current scope when the deployment project cannot be found', async () => {
+    it('should include the searched scope in error message when the deployment project cannot be found', async () => {
       const user = useUser();
       const deployment = useLogsDeployment(user);
       deployment.projectId = 'prj_missing_logs';
@@ -939,7 +939,7 @@ describe('logs', () => {
       );
     });
 
-    it('should use the current scope when an explicit project cannot be found', async () => {
+    it('should include the searched scope in error message when an explicit project cannot be found', async () => {
       const user = useUser();
       const deployment = useLogsDeployment(user);
 


### PR DESCRIPTION
Resolve logs targets from deployment IDs and URLs before falling back to explicit projects or linked projects, allowing deployment-scoped logs outside linked directories.

Validate --project against the resolved deployment project, preserve the selected scope for downstream lookups, and include that scope in related errors.