### PR TITLE
cli/logs: Handle non-live deployments

### DIFF
--- a/.changeset/quiet-logs-fail.md
+++ b/.changeset/quiet-logs-fail.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Show deployment failure details instead of querying logs for deployments that never reached Ready.

--- a/.changeset/quiet-logs-fail.md
+++ b/.changeset/quiet-logs-fail.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Show deployment failure details instead of querying logs for deployments that never reached Ready.
+Show a clearer error instead of querying logs for deployments that never reached Ready.

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -1,4 +1,5 @@
 import { isErrnoException } from '@vercel/error-utils';
+import type { Deployment } from '@vercel-internals/types';
 import chalk from 'chalk';
 import { format } from 'date-fns';
 import type Client from '../../util/client';
@@ -6,7 +7,7 @@ import { createGitMeta } from '../../util/create-git-meta';
 import { printError } from '../../util/error';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import getScope from '../../util/get-scope';
+import getScope, { detectExplicitScope } from '../../util/get-scope';
 import { formatProject } from '../../util/projects/format-project';
 import getProjectByIdOrName from '../../util/projects/get-project-by-id-or-name';
 import { getLinkedProject } from '../../util/projects/link';
@@ -38,7 +39,7 @@ interface LogsTarget {
   projectSlug: string;
   orgSlug: string;
   ownerId: string;
-  deploymentId?: string;
+  deployment?: Deployment;
 }
 
 interface ResolveLogsTargetOptions {
@@ -219,6 +220,37 @@ function parseSources(sources?: string | string[]): string[] {
   return sources;
 }
 
+function isNonLiveTerminalDeployment(deployment: Deployment): boolean {
+  return (
+    deployment.readyState === 'ERROR' || deployment.readyState === 'CANCELED'
+  );
+}
+
+function getInspectCommand(
+  deployment: Deployment,
+  contextName?: string
+): string {
+  const scopeOption = contextName ? ` --scope ${contextName}` : '';
+  return `vc inspect https://${deployment.url}${scopeOption}`;
+}
+
+function printNonLiveDeploymentError(
+  deployment: Deployment,
+  contextName?: string
+): void {
+  const inspectCommand = getInspectCommand(deployment, contextName);
+  const message = [
+    `Logs are unavailable because deployment ${chalk.bold(
+      deployment.id
+    )} never reached ${chalk.bold('READY')} (${deployment.readyState}).`,
+    `Run ${chalk.cyan(inspectCommand)} for deployment details.`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  output.error(message);
+}
+
 async function resolveLogsTarget(
   client: Client,
   { contextName, deploymentOption, projectOption }: ResolveLogsTargetOptions
@@ -293,7 +325,7 @@ async function resolveLogsTarget(
       projectSlug: project.name,
       orgSlug: contextName,
       ownerId: project.accountId,
-      deploymentId: deployment.id,
+      deployment,
     };
   }
 
@@ -468,8 +500,27 @@ export default async function logs(client: Client) {
     return logsTarget.exitCode;
   }
 
-  const { projectId, projectSlug, orgSlug, ownerId } = logsTarget;
-  let { deploymentId } = logsTarget;
+  const { projectId, projectSlug, orgSlug, ownerId, deployment } = logsTarget;
+  let deploymentId = deployment?.id;
+
+  if (deployment && isNonLiveTerminalDeployment(deployment)) {
+    const inspectContextName = detectExplicitScope(client)
+      ? contextName
+      : undefined;
+    const inspectCommand = getInspectCommand(deployment, inspectContextName);
+
+    if (jsonOption) {
+      client.stdout.write(
+        `${JSON.stringify({
+          type: 'deployment_error',
+          message: `Logs are unavailable because deployment ${deployment.id} never reached READY (${deployment.readyState}). Run ${inspectCommand} for deployment details.`,
+        })}\n`
+      );
+    } else {
+      printNonLiveDeploymentError(deployment, inspectContextName);
+    }
+    return 1;
+  }
 
   // Determine branch filter:
   // - If --branch is explicitly set (string), use it

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -23,7 +23,7 @@ import {
   type RequestLogMessage,
 } from '../../util/logs-v2';
 import getDeployment from '../../util/get-deployment';
-import { getCommandName } from '../../util/pkg-name';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import { LogsTelemetryClient } from '../../util/telemetry/commands/logs';
 import { help } from '../help';
 import { logsCommand } from './command';
@@ -226,12 +226,19 @@ function isNonLiveTerminalDeployment(deployment: Deployment): boolean {
   );
 }
 
+// Both forms wrap the command in backticks. `plain: true` uses literal
+// backticks with no color (suitable for embedding in JSON output); the default
+// uses gray backticks and cyan text for terminal display.
 function getInspectCommand(
   deployment: Deployment,
-  contextName?: string
+  contextName?: string,
+  { plain = false }: { plain?: boolean } = {}
 ): string {
   const scopeOption = contextName ? ` --scope ${contextName}` : '';
-  return `vc inspect https://${deployment.url}${scopeOption}`;
+  const command = `inspect https://${deployment.url}${scopeOption}`;
+  return plain
+    ? `\`${getCommandNamePlain(command)}\``
+    : getCommandName(command);
 }
 
 function printNonLiveDeploymentError(
@@ -239,16 +246,12 @@ function printNonLiveDeploymentError(
   contextName?: string
 ): void {
   const inspectCommand = getInspectCommand(deployment, contextName);
-  const message = [
+  output.error(
     `Logs are unavailable because deployment ${chalk.bold(
       deployment.id
-    )} never reached ${chalk.bold('READY')} (${deployment.readyState}).`,
-    `Run ${chalk.cyan(inspectCommand)} for deployment details.`,
-  ]
-    .filter(Boolean)
-    .join('\n');
-
-  output.error(message);
+    )} never reached READY and ended in ${deployment.readyState}.\n` +
+      `Run ${inspectCommand} for deployment details.`
+  );
 }
 
 async function resolveLogsTarget(
@@ -507,13 +510,15 @@ export default async function logs(client: Client) {
     const inspectContextName = detectExplicitScope(client)
       ? contextName
       : undefined;
-    const inspectCommand = getInspectCommand(deployment, inspectContextName);
+    const inspectCommand = getInspectCommand(deployment, inspectContextName, {
+      plain: true,
+    });
 
     if (jsonOption) {
       client.stdout.write(
         `${JSON.stringify({
           type: 'deployment_error',
-          message: `Logs are unavailable because deployment ${deployment.id} never reached READY (${deployment.readyState}). Run ${inspectCommand} for deployment details.`,
+          message: `Logs are unavailable because deployment ${deployment.id} never reached READY and ended in ${deployment.readyState}. Run ${inspectCommand} for deployment details.`,
         })}\n`
       );
     } else {

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useTeam, useTeams } from '../../../mocks/team';
@@ -91,6 +91,15 @@ function useRequestLogs(logs: ApiLogEntry[] = []) {
       hasMoreRows: false,
     });
   });
+}
+
+function addDeploymentErrorDetails(
+  deployment: ReturnType<typeof useDeployment>
+) {
+  deployment.errorCode = 'BUILD_FAILED';
+  deployment.errorMessage = 'Build failed during deployment';
+  deployment.errorStep = 'build';
+  deployment.errorLink = 'https://vercel.com/docs/deployments/troubleshoot';
 }
 
 describe('logs', () => {
@@ -783,6 +792,42 @@ describe('logs', () => {
         `The deployment "${deployment.id}" does not belong to "other-project" project. Remove either the deployment selection or the --project option.`
       );
     });
+
+    it('should show deployment error for errored deployment with --deployment', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+      deployment.readyState = 'ERROR';
+      deployment.status = 'ERROR';
+      addDeploymentErrorDetails(deployment);
+      const runtimeLogsSpy = vi.fn();
+
+      client.scenario.get(
+        `/v1/projects/prj_logstest/deployments/${deployment.id}/runtime-logs`,
+        (_req, res) => {
+          runtimeLogsSpy();
+          res.end();
+        }
+      );
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--deployment', deployment.id);
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      expect(runtimeLogsSpy).not.toHaveBeenCalled();
+      const output = client.getFullOutput();
+      expect(output).toContain('Logs are unavailable');
+      expect(output).toContain(
+        `deployment ${deployment.id} never reached READY (ERROR)`
+      );
+      expect(output).not.toContain('Reason:');
+      expect(output).not.toContain('Code:');
+      expect(output).not.toContain('Step:');
+      expect(output).not.toContain('Details:');
+      expect(output).toContain(
+        `Run vc inspect https://${deployment.url} for deployment details.`
+      );
+    });
   });
 
   describe('positional deployment argument (implicit --follow)', () => {
@@ -811,6 +856,129 @@ describe('logs', () => {
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);
+    });
+
+    it('should show deployment error and skip runtime logs for errored deployment', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+      deployment.readyState = 'ERROR';
+      deployment.status = 'ERROR';
+      addDeploymentErrorDetails(deployment);
+      const runtimeLogsSpy = vi.fn();
+
+      client.scenario.get(
+        `/v1/projects/prj_logstest/deployments/${deployment.id}/runtime-logs`,
+        (_req, res) => {
+          runtimeLogsSpy();
+          res.end();
+        }
+      );
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', deployment.id);
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      expect(runtimeLogsSpy).not.toHaveBeenCalled();
+      expect(client.getFullOutput()).toContain(
+        `deployment ${deployment.id} never reached READY (ERROR)`
+      );
+    });
+
+    it('should include explicit scope in the inspect command for errored deployment', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+      deployment.readyState = 'ERROR';
+      deployment.status = 'ERROR';
+      addDeploymentErrorDetails(deployment);
+
+      client.config.currentTeam = logsTeam.id;
+      client.cwd = logsFixturesDir;
+      client.setArgv('logs', deployment.id, '--scope', logsTeam.slug);
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      expect(client.getFullOutput()).toContain(
+        `Run vc inspect https://${deployment.url} --scope ${logsTeam.slug} for deployment details.`
+      );
+    });
+
+    it('should show deployment error and skip request logs for errored deployment with --no-follow', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+      deployment.readyState = 'ERROR';
+      deployment.status = 'ERROR';
+      addDeploymentErrorDetails(deployment);
+      const requestLogsSpy = vi.fn();
+
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        requestLogsSpy();
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', deployment.id, '--no-follow');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      expect(requestLogsSpy).not.toHaveBeenCalled();
+      expect(client.getFullOutput()).toContain(
+        `deployment ${deployment.id} never reached READY (ERROR)`
+      );
+    });
+
+    it('should show deployment error for canceled deployment', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+      deployment.readyState = 'CANCELED';
+      deployment.status = 'CANCELED';
+      const requestLogsSpy = vi.fn();
+
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        requestLogsSpy();
+        res.json({ rows: [], hasMoreRows: false });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', deployment.id, '--no-follow');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      expect(requestLogsSpy).not.toHaveBeenCalled();
+      expect(client.getFullOutput()).toContain(
+        `deployment ${deployment.id} never reached READY (CANCELED)`
+      );
+    });
+
+    it('should output structured JSON for errored deployment', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+      deployment.readyState = 'ERROR';
+      deployment.status = 'ERROR';
+      addDeploymentErrorDetails(deployment);
+      const runtimeLogsSpy = vi.fn();
+
+      client.scenario.get(
+        `/v1/projects/prj_logstest/deployments/${deployment.id}/runtime-logs`,
+        (_req, res) => {
+          runtimeLogsSpy();
+          res.end();
+        }
+      );
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', deployment.id, '--json');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      expect(runtimeLogsSpy).not.toHaveBeenCalled();
+      expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+        type: 'deployment_error',
+        message: `Logs are unavailable because deployment ${deployment.id} never reached READY (ERROR). Run vc inspect https://${deployment.url} for deployment details.`,
+      });
     });
 
     it('should allow --no-follow to disable implicit follow', async () => {

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -18,7 +18,10 @@ const logsProject = {
   accountId: 'team_dummy',
 };
 
-function useLogsDeployment(creator: ReturnType<typeof useUser>) {
+function useLogsDeployment(
+  creator: ReturnType<typeof useUser>,
+  state?: Parameters<typeof useDeployment>[0]['state']
+) {
   const deployment = useDeployment({
     creator: {
       id: logsProject.accountId,
@@ -27,6 +30,7 @@ function useLogsDeployment(creator: ReturnType<typeof useUser>) {
       username: 'vercel',
     },
     project: logsProject,
+    state,
   });
   deployment.team = {
     id: logsProject.accountId,
@@ -91,15 +95,6 @@ function useRequestLogs(logs: ApiLogEntry[] = []) {
       hasMoreRows: false,
     });
   });
-}
-
-function addDeploymentErrorDetails(
-  deployment: ReturnType<typeof useDeployment>
-) {
-  deployment.errorCode = 'BUILD_FAILED';
-  deployment.errorMessage = 'Build failed during deployment';
-  deployment.errorStep = 'build';
-  deployment.errorLink = 'https://vercel.com/docs/deployments/troubleshoot';
 }
 
 describe('logs', () => {
@@ -795,10 +790,7 @@ describe('logs', () => {
 
     it('should show deployment error for errored deployment with --deployment', async () => {
       const user = useUser();
-      const deployment = useLogsDeployment(user);
-      deployment.readyState = 'ERROR';
-      deployment.status = 'ERROR';
-      addDeploymentErrorDetails(deployment);
+      const deployment = useLogsDeployment(user, 'ERROR');
       const runtimeLogsSpy = vi.fn();
 
       client.scenario.get(
@@ -818,14 +810,10 @@ describe('logs', () => {
       const output = client.getFullOutput();
       expect(output).toContain('Logs are unavailable');
       expect(output).toContain(
-        `deployment ${deployment.id} never reached READY (ERROR)`
+        `deployment ${deployment.id} never reached READY and ended in ERROR`
       );
-      expect(output).not.toContain('Reason:');
-      expect(output).not.toContain('Code:');
-      expect(output).not.toContain('Step:');
-      expect(output).not.toContain('Details:');
       expect(output).toContain(
-        `Run vc inspect https://${deployment.url} for deployment details.`
+        `Run \`vercel inspect https://${deployment.url}\` for deployment details.`
       );
     });
   });
@@ -860,10 +848,7 @@ describe('logs', () => {
 
     it('should show deployment error and skip runtime logs for errored deployment', async () => {
       const user = useUser();
-      const deployment = useLogsDeployment(user);
-      deployment.readyState = 'ERROR';
-      deployment.status = 'ERROR';
-      addDeploymentErrorDetails(deployment);
+      const deployment = useLogsDeployment(user, 'ERROR');
       const runtimeLogsSpy = vi.fn();
 
       client.scenario.get(
@@ -881,16 +866,13 @@ describe('logs', () => {
       expect(exitCode).toEqual(1);
       expect(runtimeLogsSpy).not.toHaveBeenCalled();
       expect(client.getFullOutput()).toContain(
-        `deployment ${deployment.id} never reached READY (ERROR)`
+        `deployment ${deployment.id} never reached READY and ended in ERROR`
       );
     });
 
     it('should include explicit scope in the inspect command for errored deployment', async () => {
       const user = useUser();
-      const deployment = useLogsDeployment(user);
-      deployment.readyState = 'ERROR';
-      deployment.status = 'ERROR';
-      addDeploymentErrorDetails(deployment);
+      const deployment = useLogsDeployment(user, 'ERROR');
 
       client.config.currentTeam = logsTeam.id;
       client.cwd = logsFixturesDir;
@@ -899,16 +881,13 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(1);
       expect(client.getFullOutput()).toContain(
-        `Run vc inspect https://${deployment.url} --scope ${logsTeam.slug} for deployment details.`
+        `Run \`vercel inspect https://${deployment.url} --scope ${logsTeam.slug}\` for deployment details.`
       );
     });
 
     it('should show deployment error and skip request logs for errored deployment with --no-follow', async () => {
       const user = useUser();
-      const deployment = useLogsDeployment(user);
-      deployment.readyState = 'ERROR';
-      deployment.status = 'ERROR';
-      addDeploymentErrorDetails(deployment);
+      const deployment = useLogsDeployment(user, 'ERROR');
       const requestLogsSpy = vi.fn();
 
       client.scenario.get('/api/logs/request-logs', (_req, res) => {
@@ -926,15 +905,13 @@ describe('logs', () => {
       expect(exitCode).toEqual(1);
       expect(requestLogsSpy).not.toHaveBeenCalled();
       expect(client.getFullOutput()).toContain(
-        `deployment ${deployment.id} never reached READY (ERROR)`
+        `deployment ${deployment.id} never reached READY and ended in ERROR`
       );
     });
 
     it('should show deployment error for canceled deployment', async () => {
       const user = useUser();
-      const deployment = useLogsDeployment(user);
-      deployment.readyState = 'CANCELED';
-      deployment.status = 'CANCELED';
+      const deployment = useLogsDeployment(user, 'CANCELED');
       const requestLogsSpy = vi.fn();
 
       client.scenario.get('/api/logs/request-logs', (_req, res) => {
@@ -949,16 +926,13 @@ describe('logs', () => {
       expect(exitCode).toEqual(1);
       expect(requestLogsSpy).not.toHaveBeenCalled();
       expect(client.getFullOutput()).toContain(
-        `deployment ${deployment.id} never reached READY (CANCELED)`
+        `deployment ${deployment.id} never reached READY and ended in CANCELED`
       );
     });
 
     it('should output structured JSON for errored deployment', async () => {
       const user = useUser();
-      const deployment = useLogsDeployment(user);
-      deployment.readyState = 'ERROR';
-      deployment.status = 'ERROR';
-      addDeploymentErrorDetails(deployment);
+      const deployment = useLogsDeployment(user, 'ERROR');
       const runtimeLogsSpy = vi.fn();
 
       client.scenario.get(
@@ -977,7 +951,7 @@ describe('logs', () => {
       expect(runtimeLogsSpy).not.toHaveBeenCalled();
       expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
         type: 'deployment_error',
-        message: `Logs are unavailable because deployment ${deployment.id} never reached READY (ERROR). Run vc inspect https://${deployment.url} for deployment details.`,
+        message: `Logs are unavailable because deployment ${deployment.id} never reached READY and ended in ERROR. Run \`vercel inspect https://${deployment.url}\` for deployment details.`,
       });
     });
 


### PR DESCRIPTION
## Summary

- Return a deployment-level error when `vercel logs` targets an ERROR or CANCELED deployment.
- Avoid runtime-log streaming and request-log queries for deployments that never reached READY.
- Point users and JSON consumers to `vc inspect <deployment>` for deployment details.

## Validation

- `npx vitest run packages/cli/test/unit/commands/logs/index.test.ts`
- `./node_modules/.bin/turbo type-check --filter=vercel`