### PR TITLE
cli: Respect .npmrc registry in update notifier

### DIFF
--- a/.changeset/get-latest-respect-npmrc.md
+++ b/.changeset/get-latest-respect-npmrc.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+The CLI's update notifier now respects the `registry` configured in `.npmrc` files (project, user, and global) and the `npm_config_registry` environment variable, instead of always hitting `registry.npmjs.org`. This unblocks update notifications in environments where the public npm registry is firewalled and an internal mirror is configured.

--- a/packages/cli/src/util/get-latest-version/get-latest-worker.cjs
+++ b/packages/cli/src/util/get-latest-version/get-latest-worker.cjs
@@ -15,10 +15,14 @@
  */
 
 const https = require('https');
+const http = require('http');
+const os = require('os');
 const { mkdirSync, writeFileSync } = require('fs');
 const { access, mkdir, readFile, unlink, writeFile } = require('fs/promises');
 const path = require('path');
 const { format, inspect } = require('util');
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
 
 /**
  * An simple output helper which accumulates error and debug log messages in
@@ -71,100 +75,14 @@ class WorkerOutput {
   }
 }
 
-const output = new WorkerOutput({
-  // enable the debug logging if the `--debug` is set or if this worker script
-  // was directly executed
-  debug: process.argv.includes('--debug') || !process.connected,
-});
-
-process.on('unhandledRejection', err => {
-  output.error('Exiting worker due to unhandled rejection:', err);
-  process.exit(1);
-});
-
-// this timer will prevent this worker process from running longer than 10s
-const timer = setTimeout(() => {
-  output.error('Worker timed out after 10 seconds');
-  process.exit(1);
-}, 10000);
-
-// wait for the parent to give us the work payload
-process.once('message', async msg => {
-  output.debug('Received message from parent:', msg);
-
-  output.debug('Disconnecting from parent');
-  process.disconnect();
-
-  const { cacheFile, distTag, name, updateCheckInterval } = msg;
-  const cacheFileParsed = path.parse(cacheFile);
-  await mkdir(cacheFileParsed.dir, { recursive: true });
-
-  output.setLogFile(
-    path.join(cacheFileParsed.dir, `${cacheFileParsed.name}.log`)
-  );
-
-  const lockFile = path.join(
-    cacheFileParsed.dir,
-    `${cacheFileParsed.name}.lock`
-  );
-
-  try {
-    // check for a lock file and either bail if running or write our pid and continue
-    output.debug(`Checking lock file: ${lockFile}`);
-    if (await isRunning(lockFile)) {
-      output.debug('Worker already running, exiting');
-      process.exit(1);
-    }
-    output.debug(`Initializing lock file with pid ${process.pid}`);
-    await writeFile(lockFile, String(process.pid), 'utf-8');
-
-    const tags = await fetchDistTags(name);
-    const version = tags[distTag];
-    const expireAt = Date.now() + updateCheckInterval;
-    const notifyAt = await getNotifyAt(cacheFile, version);
-
-    if (version) {
-      output.debug(`Found dist tag "${distTag}" with version "${version}"`);
-    } else {
-      output.error(`Dist tag "${distTag}" not found`);
-      output.debug('Available dist tags:', Object.keys(tags));
-    }
-
-    output.debug(`Writing cache file: ${cacheFile}`);
-    await writeFile(
-      cacheFile,
-      JSON.stringify({
-        expireAt,
-        notifyAt,
-        version,
-      })
-    );
-  } catch (err) {
-    output.error(`Failed to get package info:`, err);
-  } finally {
-    clearTimeout(timer);
-
-    if (await fileExists(lockFile)) {
-      output.debug(`Releasing lock file: ${lockFile}`);
-      await unlink(lockFile);
-    }
-
-    output.debug(`Worker finished successfully!`);
-
-    // force the worker to exit
-    process.exit(0);
-  }
-});
-
-// signal the parent process we're ready
-if (process.connected) {
-  output.debug("Notifying parent we're ready");
-  process.send({ type: 'ready' });
-} else {
-  // biome-ignore lint/suspicious/noConsole: intentional console usage
-  console.error('No IPC bridge detected, exiting');
-  process.exit(1);
-}
+// Helpers below reference `output` so they can emit debug logs while running
+// inside the worker. When the file is `require()`-d for unit tests, no debug
+// output is needed, so a noop default is used.
+let output = {
+  debug: () => {},
+  error: () => {},
+  setLogFile: () => {},
+};
 
 async function fileExists(file) {
   return access(file)
@@ -218,55 +136,328 @@ async function getNotifyAt(cacheFile, version) {
 }
 
 /**
- * Fetches the dist tags from npm for a given package.
+ * Fetches the dist tags from npm for a given package, using the registry
+ * configured in `.npmrc` files or the `npm_config_registry` environment
+ * variable so that environments with internal mirrors or firewalled
+ * networks work correctly.
  *
  * @param {string} name The package name
  * @returns A map of dist tags to versions
  */
 async function fetchDistTags(name) {
-  // fetch the latest version from npm
-  const agent = new https.Agent({
-    keepAlive: true,
-    maxSockets: 15, // See: `npm config get maxsockets`
-  });
-  const headers = {
-    accept:
-      'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*',
-  };
-  const url = `https://registry.npmjs.org/-/package/${name}/dist-tags`;
+  const config = await loadNpmConfig();
+  const registry = resolveRegistry(config);
+  const url = `${registry}-/package/${name}/dist-tags`;
   output.debug(`Fetching ${url}`);
 
-  return new Promise((resolve, reject) => {
-    const req = https.get(
-      url,
-      {
-        agent,
-        headers,
-      },
-      res => {
-        let buf = '';
-        res.on('data', chunk => {
-          buf += chunk;
-        });
-        res.on('end', () => {
-          try {
-            if (res.statusCode && res.statusCode >= 400) {
-              return reject(
-                new Error(
-                  `Fetch dist-tags failed ${res.statusCode} ${res.statusMessage}`
-                )
-              );
-            }
+  const isHttps = url.startsWith('https://');
+  const requestModule = isHttps ? https : http;
+  const requestOptions = {
+    headers: {
+      accept:
+        'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*',
+    },
+  };
+  if (isHttps) {
+    requestOptions.agent = new https.Agent({
+      keepAlive: true,
+      maxSockets: 15, // See: `npm config get maxsockets`
+    });
+  }
 
-            resolve(JSON.parse(buf));
-          } catch (err) {
-            reject(err);
+  return new Promise((resolve, reject) => {
+    const req = requestModule.get(url, requestOptions, res => {
+      let buf = '';
+      res.on('data', chunk => {
+        buf += chunk;
+      });
+      res.on('end', () => {
+        try {
+          if (res.statusCode && res.statusCode >= 400) {
+            return reject(
+              new Error(
+                `Fetch dist-tags failed ${res.statusCode} ${res.statusMessage}`
+              )
+            );
           }
-        });
-      }
-    );
+
+          resolve(JSON.parse(buf));
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
 
     req.on('error', reject);
     req.end();
   });
+}
+
+/**
+ * Loads and merges the npm-style configuration from `.npmrc` files following
+ * npm's priority order:
+ *
+ *   1. Project `.npmrc` (current cwd, walking up but stopping before the
+ *      user's home directory so we don't read `~/.npmrc` twice)
+ *   2. User `.npmrc` (`$npm_config_userconfig` or `~/.npmrc`)
+ *   3. Global `.npmrc` (`$npm_config_globalconfig`)
+ *
+ * Earlier entries win over later ones, matching npm's behavior.
+ *
+ * @param {string} [cwd] Override for the starting directory (defaults to
+ *   `process.cwd()`). Mostly intended for unit tests.
+ * @returns {Promise<Record<string, string>>}
+ */
+async function loadNpmConfig(cwd = process.cwd()) {
+  const files = [];
+  const home = os.homedir() || null;
+
+  let dir = path.resolve(cwd);
+  while (true) {
+    if (home && samePath(dir, home)) {
+      break;
+    }
+    files.push(path.join(dir, '.npmrc'));
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+
+  const userConfig =
+    process.env.npm_config_userconfig ||
+    (home ? path.join(home, '.npmrc') : null);
+  if (userConfig) {
+    files.push(userConfig);
+  }
+
+  const globalConfig = process.env.npm_config_globalconfig;
+  if (globalConfig) {
+    files.push(globalConfig);
+  }
+
+  const merged = {};
+  for (const file of files) {
+    let content;
+    try {
+      content = await readFile(file, 'utf-8');
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        output.debug(`Failed to read ${file}: ${err.message}`);
+      }
+      continue;
+    }
+
+    output.debug(`Loaded npm config from ${file}`);
+    const parsed = parseNpmrc(content);
+    for (const key of Object.keys(parsed)) {
+      if (!(key in merged)) {
+        merged[key] = parsed[key];
+      }
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Compares two filesystem paths for equality, accounting for case-insensitive
+ * paths on Windows.
+ */
+function samePath(a, b) {
+  return process.platform === 'win32'
+    ? a.toLowerCase() === b.toLowerCase()
+    : a === b;
+}
+
+/**
+ * Parses a minimal subset of the `.npmrc` format into a key/value map.
+ * Comments (`#` and `;`), section headers (`[section]`) and surrounding
+ * quotes are handled — that's enough for the `registry` entry we care about.
+ *
+ * @param {string} content
+ */
+function parseNpmrc(content) {
+  const result = {};
+  for (const raw of content.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (
+      !line ||
+      line.startsWith('#') ||
+      line.startsWith(';') ||
+      line.startsWith('[')
+    ) {
+      continue;
+    }
+
+    const eq = line.indexOf('=');
+    if (eq === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, eq).trim();
+    if (!key) {
+      continue;
+    }
+
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * Resolves the registry URL to use, in priority order:
+ *   1. `npm_config_registry` / `NPM_CONFIG_REGISTRY` environment variable
+ *   2. `registry=` from `.npmrc`
+ *   3. The default `https://registry.npmjs.org/`
+ *
+ * @param {Record<string, string>} config
+ */
+function resolveRegistry(config) {
+  const envRegistry =
+    process.env.npm_config_registry || process.env.NPM_CONFIG_REGISTRY;
+  if (envRegistry) {
+    output.debug(`Using registry from environment: ${envRegistry}`);
+    return normalizeRegistry(envRegistry);
+  }
+
+  if (config.registry) {
+    output.debug(`Using registry from .npmrc: ${config.registry}`);
+    return normalizeRegistry(config.registry);
+  }
+
+  return DEFAULT_REGISTRY;
+}
+
+/**
+ * Normalizes a registry URL by ensuring it has a trailing slash and a valid
+ * `http(s):` protocol. Returns the npmjs.org default if the URL is not a
+ * supported registry URL.
+ *
+ * @param {string} url
+ */
+function normalizeRegistry(url) {
+  const trimmed = (url || '').trim();
+  if (!/^https?:\/\//i.test(trimmed)) {
+    output.debug(`Ignoring invalid registry URL: ${trimmed || '(empty)'}`);
+    return DEFAULT_REGISTRY;
+  }
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+}
+
+module.exports = {
+  parseNpmrc,
+  resolveRegistry,
+  normalizeRegistry,
+  loadNpmConfig,
+};
+
+// The block below is the worker entry point and only runs when this file is
+// executed directly (e.g. via `child_process.spawn`). When the file is loaded
+// via `require()` from a unit test, none of the IPC/timer/exit side effects
+// fire, keeping the helpers above safe to test in isolation.
+if (require.main === module) {
+  output = new WorkerOutput({
+    // enable the debug logging if the `--debug` is set or if this worker
+    // script was directly executed
+    debug: process.argv.includes('--debug') || !process.connected,
+  });
+
+  process.on('unhandledRejection', err => {
+    output.error('Exiting worker due to unhandled rejection:', err);
+    process.exit(1);
+  });
+
+  // this timer will prevent this worker process from running longer than 10s
+  const timer = setTimeout(() => {
+    output.error('Worker timed out after 10 seconds');
+    process.exit(1);
+  }, 10000);
+
+  // wait for the parent to give us the work payload
+  process.once('message', async msg => {
+    output.debug('Received message from parent:', msg);
+
+    output.debug('Disconnecting from parent');
+    process.disconnect();
+
+    const { cacheFile, distTag, name, updateCheckInterval } = msg;
+    const cacheFileParsed = path.parse(cacheFile);
+    await mkdir(cacheFileParsed.dir, { recursive: true });
+
+    output.setLogFile(
+      path.join(cacheFileParsed.dir, `${cacheFileParsed.name}.log`)
+    );
+
+    const lockFile = path.join(
+      cacheFileParsed.dir,
+      `${cacheFileParsed.name}.lock`
+    );
+
+    try {
+      // check for a lock file and either bail if running or write our pid and continue
+      output.debug(`Checking lock file: ${lockFile}`);
+      if (await isRunning(lockFile)) {
+        output.debug('Worker already running, exiting');
+        process.exit(1);
+      }
+      output.debug(`Initializing lock file with pid ${process.pid}`);
+      await writeFile(lockFile, String(process.pid), 'utf-8');
+
+      const tags = await fetchDistTags(name);
+      const version = tags[distTag];
+      const expireAt = Date.now() + updateCheckInterval;
+      const notifyAt = await getNotifyAt(cacheFile, version);
+
+      if (version) {
+        output.debug(`Found dist tag "${distTag}" with version "${version}"`);
+      } else {
+        output.error(`Dist tag "${distTag}" not found`);
+        output.debug('Available dist tags:', Object.keys(tags));
+      }
+
+      output.debug(`Writing cache file: ${cacheFile}`);
+      await writeFile(
+        cacheFile,
+        JSON.stringify({
+          expireAt,
+          notifyAt,
+          version,
+        })
+      );
+    } catch (err) {
+      output.error(`Failed to get package info:`, err);
+    } finally {
+      clearTimeout(timer);
+
+      if (await fileExists(lockFile)) {
+        output.debug(`Releasing lock file: ${lockFile}`);
+        await unlink(lockFile);
+      }
+
+      output.debug(`Worker finished successfully!`);
+
+      // force the worker to exit
+      process.exit(0);
+    }
+  });
+
+  // signal the parent process we're ready
+  if (process.connected) {
+    output.debug("Notifying parent we're ready");
+    process.send({ type: 'ready' });
+  } else {
+    // biome-ignore lint/suspicious/noConsole: intentional console usage
+    console.error('No IPC bridge detected, exiting');
+    process.exit(1);
+  }
 }

--- a/packages/cli/test/unit/util/get-latest-worker.test.ts
+++ b/packages/cli/test/unit/util/get-latest-worker.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const require = createRequire(import.meta.url);
+
+const workerPath = join(
+  __dirname,
+  '../../../src/util/get-latest-version/get-latest-worker.cjs'
+);
+
+const { parseNpmrc, resolveRegistry, normalizeRegistry, loadNpmConfig } =
+  require(workerPath);
+
+describe('get-latest-worker helpers', () => {
+  describe('parseNpmrc', () => {
+    it('parses key=value pairs', () => {
+      expect(parseNpmrc('registry=https://example.com/')).toEqual({
+        registry: 'https://example.com/',
+      });
+    });
+
+    it('ignores blank lines, comments, and section headers', () => {
+      const content = [
+        '',
+        '# a hash comment',
+        '; a semicolon comment',
+        '[some-section]',
+        'registry=https://example.com/',
+        '',
+      ].join('\n');
+      expect(parseNpmrc(content)).toEqual({
+        registry: 'https://example.com/',
+      });
+    });
+
+    it('strips surrounding quotes from values', () => {
+      const content = 'registry="https://example.com/"';
+      expect(parseNpmrc(content)).toEqual({
+        registry: 'https://example.com/',
+      });
+    });
+
+    it('returns an empty object for an empty file', () => {
+      expect(parseNpmrc('')).toEqual({});
+    });
+  });
+
+  describe('normalizeRegistry', () => {
+    it('appends a trailing slash if missing', () => {
+      expect(normalizeRegistry('https://example.com')).toBe(
+        'https://example.com/'
+      );
+    });
+
+    it('keeps an existing trailing slash', () => {
+      expect(normalizeRegistry('https://example.com/')).toBe(
+        'https://example.com/'
+      );
+    });
+
+    it('preserves a path component', () => {
+      expect(normalizeRegistry('https://example.com/repo/npm/')).toBe(
+        'https://example.com/repo/npm/'
+      );
+    });
+
+    it('accepts http:// urls', () => {
+      expect(normalizeRegistry('http://example.com')).toBe(
+        'http://example.com/'
+      );
+    });
+
+    it('falls back to the npmjs.org default for invalid urls', () => {
+      expect(normalizeRegistry('not-a-url')).toBe(
+        'https://registry.npmjs.org/'
+      );
+      expect(normalizeRegistry('')).toBe('https://registry.npmjs.org/');
+      expect(normalizeRegistry('ftp://example.com/')).toBe(
+        'https://registry.npmjs.org/'
+      );
+    });
+  });
+
+  describe('resolveRegistry', () => {
+    afterEach(() => {
+      delete process.env.npm_config_registry;
+      delete process.env.NPM_CONFIG_REGISTRY;
+    });
+
+    it('falls back to the npmjs.org default when nothing is configured', () => {
+      expect(resolveRegistry({})).toBe('https://registry.npmjs.org/');
+    });
+
+    it('honors npm_config_registry from the environment', () => {
+      process.env.npm_config_registry = 'https://npm.internal.example.com/';
+      expect(resolveRegistry({})).toBe('https://npm.internal.example.com/');
+    });
+
+    it('uses the registry= entry from .npmrc when no env override is set', () => {
+      expect(
+        resolveRegistry({
+          registry: 'https://npm.internal.example.com/',
+        })
+      ).toBe('https://npm.internal.example.com/');
+    });
+
+    it('environment registry beats .npmrc entries', () => {
+      process.env.npm_config_registry = 'https://env.example.com/';
+      expect(
+        resolveRegistry({
+          registry: 'https://npmrc.example.com/',
+        })
+      ).toBe('https://env.example.com/');
+    });
+  });
+
+  describe('loadNpmConfig', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'vercel-get-latest-worker-'));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+      delete process.env.npm_config_userconfig;
+      delete process.env.npm_config_globalconfig;
+    });
+
+    it('reads a .npmrc from the provided cwd', async () => {
+      writeFileSync(
+        join(tmpDir, '.npmrc'),
+        'registry=https://internal.example.com/'
+      );
+      // Point user/global configs at empty so they don't leak from the host
+      // machine and pollute the test.
+      const emptyConfig = join(tmpDir, 'empty.npmrc');
+      writeFileSync(emptyConfig, '');
+      process.env.npm_config_userconfig = emptyConfig;
+      process.env.npm_config_globalconfig = emptyConfig;
+
+      const config = await loadNpmConfig(tmpDir);
+      expect(config.registry).toBe('https://internal.example.com/');
+    });
+
+    it('walks parent directories looking for .npmrc files', async () => {
+      const project = join(tmpDir, 'parent', 'child');
+      mkdirSync(project, { recursive: true });
+      writeFileSync(
+        join(tmpDir, 'parent', '.npmrc'),
+        'registry=https://parent.example.com/'
+      );
+
+      const emptyConfig = join(tmpDir, 'empty.npmrc');
+      writeFileSync(emptyConfig, '');
+      process.env.npm_config_userconfig = emptyConfig;
+      process.env.npm_config_globalconfig = emptyConfig;
+
+      const config = await loadNpmConfig(project);
+      expect(config.registry).toBe('https://parent.example.com/');
+    });
+
+    it('lets project .npmrc override user .npmrc', async () => {
+      const projectDir = join(tmpDir, 'project');
+      mkdirSync(projectDir);
+      writeFileSync(
+        join(projectDir, '.npmrc'),
+        'registry=https://project.example.com/'
+      );
+
+      const userConfig = join(tmpDir, 'user.npmrc');
+      writeFileSync(userConfig, 'registry=https://user.example.com/');
+      process.env.npm_config_userconfig = userConfig;
+
+      const emptyConfig = join(tmpDir, 'empty.npmrc');
+      writeFileSync(emptyConfig, '');
+      process.env.npm_config_globalconfig = emptyConfig;
+
+      const config = await loadNpmConfig(projectDir);
+      expect(config.registry).toBe('https://project.example.com/');
+    });
+
+    it('falls back to user .npmrc when no project file is found', async () => {
+      const projectDir = join(tmpDir, 'project');
+      mkdirSync(projectDir);
+
+      const userConfig = join(tmpDir, 'user.npmrc');
+      writeFileSync(userConfig, 'registry=https://user.example.com/');
+      process.env.npm_config_userconfig = userConfig;
+
+      const emptyConfig = join(tmpDir, 'empty.npmrc');
+      writeFileSync(emptyConfig, '');
+      process.env.npm_config_globalconfig = emptyConfig;
+
+      const config = await loadNpmConfig(projectDir);
+      expect(config.registry).toBe('https://user.example.com/');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The CLI's background update notifier (`get-latest-worker.cjs`) hard-coded `https://registry.npmjs.org/` when checking for newer versions. In environments where the public npm registry is firewalled and an internal mirror is configured via `.npmrc` (or `npm_config_registry`), the check would silently fail and users never saw "newer version available" notifications.

This change resolves the registry the same way npm does, then uses it for the dist-tags request:

1. `npm_config_registry` / `NPM_CONFIG_REGISTRY` environment variable (highest)
2. `registry=` from project / user / global `.npmrc` files
3. Fallback to `https://registry.npmjs.org/`

## What it does

- `loadNpmConfig(cwd)` walks from `cwd` up to (but not including) the home directory collecting project `.npmrc` files, then appends the user (`$npm_config_userconfig` or `~/.npmrc`) and global (`$npm_config_globalconfig`) configs. Earlier entries win, matching npm's precedence.
- `parseNpmrc(content)` parses the minimal subset of `.npmrc` we need: `key=value` pairs with comments (`#`/`;`), `[section]` headers, and surrounding quotes handled.
- `resolveRegistry(config)` applies the env > `.npmrc` > default priority above and `normalizeRegistry(url)` enforces a trailing `/` and a valid `http(s):` protocol (falling back to npmjs.org for malformed values).
- `fetchDistTags(name)` uses the resolved registry and switches between `https` and `http` so plain-HTTP internal mirrors also work.

The worker entry point (IPC, timer, exit handlers) is wrapped in `if (require.main === module)` so the helpers can be unit-tested via `require()` without spawning a worker.

## Scope

Intentionally minimal — the worker only needs the `registry` value:

- No auth header support (`_authToken`, `_auth`, `username`/`_password`). The update check is a non-critical background notifier; if a user's mirror requires auth they can fall back to the existing default behavior or set `npm_config_registry` to a token-less proxy. Easy to layer on later if needed.
- No scoped registry (`@scope:registry`) handling. The package being checked is always `vercel`, which isn't scoped.
- No `${VAR}` expansion in `.npmrc` parsing. That's only useful with auth tokens.

The constraint that this file must not depend on any 3rd-party packages (it isn't bundled by esbuild) is preserved — only `node:` built-ins are used.

## Test plan

- [x] Unit tests for `parseNpmrc`, `normalizeRegistry`, `resolveRegistry`, and `loadNpmConfig` (covers env override, `.npmrc` resolution, project-over-user precedence, parent-directory walking).
- [ ] CI: `pnpm test-unit` for `packages/cli`.
- [ ] Manual: drop a project `.npmrc` with `registry=http://internal.example.com/`, run `vc --debug` and confirm the worker logs `Using registry from .npmrc: ...` and fetches from that URL.
