### PR TITLE
Experiment: auto-link Git repo projects

### DIFF
--- a/.changeset/repo-aware-link.md
+++ b/.changeset/repo-aware-link.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Use Git repository and root directory matches before folder-name matches when linking projects.

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -141,7 +141,6 @@ export default async function link(client: Client) {
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
       searchAcrossTeams: !explicitScopeProvided,
-      skipSetupConfirmation: true,
     });
 
     if (typeof link === 'number') {

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -141,6 +141,7 @@ export default async function link(client: Client) {
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
       searchAcrossTeams: !explicitScopeProvided,
+      skipSetupConfirmation: true,
     });
 
     if (typeof link === 'number') {

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -10,7 +10,7 @@ import toHumanPath from '../humanize-path';
 import { VERCEL_DIR, VERCEL_DIR_REPO, writeReadme } from '../projects/link';
 import { getRemoteUrls } from '../create-git-meta';
 import link from '../output/link';
-import { emoji, prependEmoji } from '../emoji';
+import { emoji, prependEmoji, type EmojiLabel } from '../emoji';
 import selectOrg from '../input/select-org';
 import { addToGitIgnore } from './add-to-gitignore';
 import type Client from '../client';
@@ -48,6 +48,12 @@ export interface RepoLink {
   repoConfig?: RepoProjectsConfig;
 }
 
+export interface ResolvedGitRemote {
+  rootPath: string;
+  remoteName: string;
+  repoUrl: string;
+}
+
 export interface EnsureRepoLinkOptions {
   yes: boolean;
   overwrite: boolean;
@@ -82,6 +88,139 @@ export async function getRepoLink(
   );
 
   return { rootPath, repoConfig, repoConfigPath };
+}
+
+export async function resolveGitRemote(
+  client: Client,
+  rootPath: string,
+  {
+    yes,
+    existingRemoteName,
+  }: {
+    yes: boolean;
+    /** When set, skip remote selection and use this remote. */
+    existingRemoteName?: string;
+  }
+): Promise<ResolvedGitRemote | undefined> {
+  // Use getGitConfigPath to correctly resolve the config path for
+  // regular repos, worktrees, and submodules. Falls back to the
+  // traditional path if git commands fail.
+  const gitConfigPath =
+    getGitConfigPath({ cwd: rootPath }) ?? join(rootPath, '.git/config');
+  const remoteUrls = await getRemoteUrls(gitConfigPath);
+  if (!remoteUrls) {
+    return undefined;
+  }
+
+  let remoteName: string;
+  if (existingRemoteName) {
+    // Re-use the remote from the existing repo.json
+    remoteName = existingRemoteName;
+    if (!remoteUrls[remoteName]) {
+      throw new Error(
+        `Git remote "${remoteName}" from repo.json no longer exists`
+      );
+    }
+  } else {
+    const remoteNames = Object.keys(remoteUrls).sort();
+    if (remoteNames.length === 1) {
+      remoteName = remoteNames[0];
+    } else {
+      const defaultRemote = remoteNames.includes('origin')
+        ? 'origin'
+        : remoteNames[0];
+      if (yes) {
+        remoteName = defaultRemote;
+      } else {
+        remoteName = await client.input.select({
+          message: 'Which Git remote should be used?',
+          choices: remoteNames.map(name => {
+            return { name: name, value: name };
+          }),
+          default: defaultRemote,
+        });
+      }
+    }
+  }
+
+  return { rootPath, remoteName, repoUrl: remoteUrls[remoteName] };
+}
+
+export async function fetchProjectsForRepoUrl(
+  client: Client,
+  repoUrl: string,
+  orgId: string
+): Promise<Project[]> {
+  const query = new URLSearchParams({ repoUrl });
+  const projectsIterator = client.fetchPaginated<{
+    projects: Project[];
+  }>(`/v9/projects?${query}`, { accountId: orgId });
+
+  let projects: Project[] = [];
+  for await (const chunk of projectsIterator) {
+    projects = projects.concat(chunk.projects);
+  }
+  return projects;
+}
+
+export async function linkRepoProject(
+  client: Client,
+  cwd: string,
+  {
+    project,
+    orgId,
+    orgSlug,
+    remoteName,
+    successEmoji = 'link',
+  }: {
+    project: Project;
+    orgId: string;
+    orgSlug: string;
+    remoteName: string;
+    successEmoji?: EmojiLabel;
+  }
+): Promise<RepoLink> {
+  const repoLink = await getRepoLink(client, cwd);
+  if (!repoLink) {
+    throw new Error('Could not determine Git repository root directory');
+  }
+
+  const directory = normalizePath(project.rootDirectory || '.');
+  const projectConfig: RepoProjectConfig = {
+    id: project.id,
+    name: project.name,
+    directory,
+    orgId,
+  };
+  const existingProjects = repoLink.repoConfig?.projects ?? [];
+  const filteredProjects = existingProjects.filter(
+    p => p.id !== project.id && normalizePath(p.directory) !== directory
+  );
+  const repoConfig: RepoProjectsConfig = {
+    remoteName,
+    projects: [...filteredProjects, projectConfig],
+  };
+
+  await outputJSON(repoLink.repoConfigPath, repoConfig, { spaces: 2 });
+  await writeReadme(repoLink.rootPath);
+  const isGitIgnoreUpdated = await addToGitIgnore(repoLink.rootPath);
+
+  output.print(
+    prependEmoji(
+      `Linked to ${chalk.bold(
+        `${orgSlug}/${project.name}`
+      )} (created ${VERCEL_DIR}${
+        isGitIgnoreUpdated ? ' and added it to .gitignore' : ''
+      })`,
+      emoji(successEmoji)
+    ) + '\n'
+  );
+
+  return {
+    repoConfig,
+    repoConfigPath: repoLink.repoConfigPath,
+    rootPath: repoLink.rootPath,
+  };
 }
 
 /**
@@ -145,48 +284,14 @@ async function discoverRepoProjects(
   );
   client.config.currentTeam = org.type === 'team' ? org.id : undefined;
 
-  // Use getGitConfigPath to correctly resolve the config path for
-  // regular repos, worktrees, and submodules. Falls back to the
-  // traditional path if git commands fail.
-  const gitConfigPath =
-    getGitConfigPath({ cwd: rootPath }) ?? join(rootPath, '.git/config');
-  const remoteUrls = await getRemoteUrls(gitConfigPath);
-  if (!remoteUrls) {
+  const remote = await resolveGitRemote(client, rootPath, {
+    yes,
+    existingRemoteName,
+  });
+  if (!remote) {
     throw new Error('Could not determine Git remote URLs');
   }
-
-  let remoteName: string;
-  if (existingRemoteName) {
-    // Re-use the remote from the existing repo.json
-    remoteName = existingRemoteName;
-    if (!remoteUrls[remoteName]) {
-      throw new Error(
-        `Git remote "${remoteName}" from repo.json no longer exists`
-      );
-    }
-  } else {
-    const remoteNames = Object.keys(remoteUrls).sort();
-    if (remoteNames.length === 1) {
-      remoteName = remoteNames[0];
-    } else {
-      // Prompt user to select which remote to use
-      const defaultRemote = remoteNames.includes('origin')
-        ? 'origin'
-        : remoteNames[0];
-      if (yes) {
-        remoteName = defaultRemote;
-      } else {
-        remoteName = await client.input.select({
-          message: 'Which Git remote should be used?',
-          choices: remoteNames.map(name => {
-            return { name: name, value: name };
-          }),
-          default: defaultRemote,
-        });
-      }
-    }
-  }
-  const repoUrl = remoteUrls[remoteName];
+  const { remoteName, repoUrl } = remote;
   const parsedRepoUrl = parseRepoUrl(repoUrl);
   if (!parsedRepoUrl) {
     throw new Error(`Failed to parse Git URL: ${repoUrl}`);
@@ -197,18 +302,8 @@ async function discoverRepoProjects(
   output.spinner(
     `Fetching Projects for ${repoUrlLink} under ${chalk.bold(org.slug)}…`
   );
-  let projects: Project[] = [];
-  const query = new URLSearchParams({ repoUrl });
-  const projectsIterator = client.fetchPaginated<{
-    projects: Project[];
-  }>(`/v9/projects?${query}`);
   const detectedProjects = await detectedProjectsPromise;
-  for await (const chunk of projectsIterator) {
-    projects = projects.concat(chunk.projects);
-    if (chunk.pagination.next) {
-      output.spinner(`Found ${chalk.bold(projects.length)} Projects…`, 0);
-    }
-  }
+  let projects = await fetchProjectsForRepoUrl(client, repoUrl, org.id);
 
   // Filter out projects that are already linked in repo.json (by ID or directory)
   if (existingProjectIds || existingDirectories) {
@@ -595,5 +690,8 @@ export function findProjectsFromPath(
   // selections (with the deepest directory depth), so pick the first
   // one and filter on those matches.
   const firstMatch = matches[0];
+  if (!firstMatch) {
+    return [];
+  }
   return matches.filter(match => match.directory === firstMatch.directory);
 }

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -223,6 +223,84 @@ export async function linkRepoProject(
   };
 }
 
+export async function linkRepoProjects(
+  client: Client,
+  cwd: string,
+  {
+    projects,
+    remoteName,
+    successEmoji = 'link',
+  }: {
+    projects: Array<{
+      project: Project;
+      orgId: string;
+      orgSlug: string;
+    }>;
+    remoteName: string;
+    successEmoji?: EmojiLabel;
+  }
+): Promise<RepoLink> {
+  const repoLink = await getRepoLink(client, cwd);
+  if (!repoLink) {
+    throw new Error('Could not determine Git repository root directory');
+  }
+
+  const projectConfigs: RepoProjectConfig[] = projects.map(
+    ({ project, orgId }) => ({
+      id: project.id,
+      name: project.name,
+      directory: normalizePath(project.rootDirectory || '.'),
+      orgId,
+    })
+  );
+  const projectIds = new Set(projectConfigs.map(project => project.id));
+  const existingProjects = repoLink.repoConfig?.projects ?? [];
+  const filteredProjects = existingProjects.filter(
+    project => !projectIds.has(project.id)
+  );
+  const repoConfig: RepoProjectsConfig = {
+    ...repoLink.repoConfig,
+    remoteName,
+    projects: [...filteredProjects, ...projectConfigs],
+  };
+
+  await outputJSON(repoLink.repoConfigPath, repoConfig, { spaces: 2 });
+  await writeReadme(repoLink.rootPath);
+  const isGitIgnoreUpdated = await addToGitIgnore(repoLink.rootPath);
+
+  output.print(
+    prependEmoji(
+      `Linked ${pluralize(
+        'Project',
+        projectConfigs.length,
+        true
+      )} from Git repository (created ${VERCEL_DIR}${
+        isGitIgnoreUpdated ? ' and added it to .gitignore' : ''
+      })`,
+      emoji(successEmoji)
+    ) + '\n'
+  );
+  for (const [orgSlug, count] of countProjectsByOrgSlug(projects)) {
+    output.print(`  ${pluralize('Project', count, true)} from ${orgSlug}\n`);
+  }
+
+  return {
+    repoConfig,
+    repoConfigPath: repoLink.repoConfigPath,
+    rootPath: repoLink.rootPath,
+  };
+}
+
+function countProjectsByOrgSlug(
+  projects: Array<{ orgSlug: string }>
+): Array<[string, number]> {
+  const counts = new Map<string, number>();
+  for (const project of projects) {
+    counts.set(project.orgSlug, (counts.get(project.orgSlug) ?? 0) + 1);
+  }
+  return Array.from(counts.entries());
+}
+
 /**
  * Runs the project discovery flow: selects org, discovers/creates projects,
  * and returns the selected projects as `RepoProjectConfig[]`.

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -14,7 +14,7 @@ import {
   VERCEL_DIR_README,
   VERCEL_DIR_PROJECT,
 } from '../projects/link';
-import { linkRepoProject } from './repo';
+import { linkRepoProject, linkRepoProjects } from './repo';
 import createProject from '../projects/create-project';
 import type Client from '../client';
 import { printError } from '../error';
@@ -56,6 +56,7 @@ import {
 } from './services-setup';
 import searchProjectAcrossTeams from '../projects/search-project-across-teams';
 import type { CrossTeamMatch } from '../projects/search-project-across-teams';
+import getTeams from '../teams/get-teams';
 
 export interface SetupAndLinkOptions {
   autoConfirm?: boolean;
@@ -71,6 +72,8 @@ export interface SetupAndLinkOptions {
   v0?: boolean;
   /** When true, search matching projects across teams before standard linking flow */
   searchAcrossTeams?: boolean;
+  /** When true, start setup immediately without asking "Set up <path>?" */
+  skipSetupConfirmation?: boolean;
 }
 
 function formatMatchReason(match: CrossTeamMatch): string {
@@ -201,59 +204,26 @@ async function linkCrossTeamMatch({
   return { status: 'linked', org: match.org, project: match.project };
 }
 
-async function promptForLimitedTeams(
-  client: Client,
-  teams: Team[]
-): Promise<Team[]> {
+async function promptForTeamsToSearch(client: Client): Promise<Team[]> {
+  const teams = await getTeams(client);
   if (teams.length === 0) {
     return [];
   }
+  if (teams.length === 1) {
+    return teams;
+  }
 
   return await client.input.checkbox<Team>({
-    message: 'Which SSO-protected teams should be searched?',
+    message: 'Which teams should be searched?',
+    pageSize: Math.min(20, teams.length),
     choices: teams.map(team => ({
-      name: team.name ? `${team.name} (${team.slug})` : team.slug,
+      name: `${team.name ? `${team.name} (${team.slug})` : team.slug}${
+        team.limited ? ' (SSO-protected)' : ''
+      }`,
       value: team,
+      checked: !team.limited,
     })),
   });
-}
-
-async function searchSelectedLimitedTeams({
-  client,
-  path,
-  projectName,
-  gitProjectName,
-  teams,
-}: {
-  client: Client;
-  path: string;
-  projectName: string;
-  gitProjectName?: string;
-  teams: Team[];
-}): Promise<CrossTeamMatch[]> {
-  const selectedTeams = await promptForLimitedTeams(client, teams);
-  if (selectedTeams.length === 0) {
-    return [];
-  }
-
-  output.spinner('Searching selected SSO-protected teams…', 1000);
-  try {
-    const result = await searchProjectAcrossTeams(client, projectName, path, {
-      teams: selectedTeams,
-      skipLimited: false,
-      gitProjectName,
-    });
-    printCrossTeamSearchScope({
-      searchedTeamSlugs: result.searchedTeamSlugs,
-      skippedLimitedTeamSlugs: [],
-    });
-    return result.matches;
-  } catch (err) {
-    output.debug(`Selected SSO-protected team search failed: ${err}`);
-    return [];
-  } finally {
-    output.stopSpinner();
-  }
 }
 
 async function linkCrossTeamMatches({
@@ -357,6 +327,44 @@ async function linkCrossTeamMatches({
   });
 }
 
+async function linkAllRepoRootMatches({
+  client,
+  path,
+  matches,
+  successEmoji,
+}: {
+  client: Client;
+  path: string;
+  matches: CrossTeamMatch[];
+  successEmoji: EmojiLabel;
+}): Promise<ProjectLinkResult | null> {
+  const repoRootMatches = matches.filter(
+    match => match.reason === 'repo-root' && match.repo
+  );
+  if (repoRootMatches.length === 0) {
+    return null;
+  }
+
+  const firstMatch = repoRootMatches[0];
+  const remoteName = firstMatch.repo!.remoteName;
+  await linkRepoProjects(client, path, {
+    projects: repoRootMatches.map(match => ({
+      project: match.project,
+      orgId: match.org.id,
+      orgSlug: match.org.slug,
+    })),
+    remoteName,
+    successEmoji,
+  });
+
+  return {
+    status: 'linked',
+    org: firstMatch.org,
+    project: firstMatch.project,
+    repoRoot: firstMatch.repo!.rootPath,
+  };
+}
+
 export default async function setupAndLink(
   client: Client,
   path: string,
@@ -371,6 +379,7 @@ export default async function setupAndLink(
     pullEnv = true,
     v0,
     searchAcrossTeams = false,
+    skipSetupConfirmation = false,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
   const { config } = client;
@@ -406,6 +415,7 @@ export default async function setupAndLink(
   const shouldStartSetup =
     autoConfirm ||
     nonInteractive ||
+    skipSetupConfirmation ||
     (await client.input.confirm(
       `${setupMsg} ${chalk.cyan(`“${toHumanPath(path)}”`)}?`,
       true
@@ -422,7 +432,10 @@ export default async function setupAndLink(
     let crossTeamMatches: CrossTeamMatch[] = [];
     let searchedTeamSlugs: string[] = [];
     let skippedLimitedTeamSlugs: string[] = [];
-    let skippedLimitedTeams: Team[] = [];
+    const selectedTeams =
+      autoConfirm || nonInteractive
+        ? undefined
+        : await promptForTeamsToSearch(client);
     output.spinner('Searching for existing projects…', 1000);
     try {
       const searchResult = await searchProjectAcrossTeams(
@@ -433,12 +446,13 @@ export default async function setupAndLink(
           autoConfirm,
           nonInteractive,
           gitProjectName,
+          teams: selectedTeams,
+          skipLimited: selectedTeams ? false : undefined,
         }
       );
       crossTeamMatches = searchResult.matches;
       searchedTeamSlugs = searchResult.searchedTeamSlugs;
       skippedLimitedTeamSlugs = searchResult.skippedLimitedTeamSlugs;
-      skippedLimitedTeams = searchResult.skippedLimitedTeams;
     } catch (err) {
       output.debug(`Cross-team search failed: ${err}`);
     } finally {
@@ -450,6 +464,16 @@ export default async function setupAndLink(
         searchedTeamSlugs,
         skippedLimitedTeamSlugs,
       });
+    }
+
+    const linkedRepoMatches = await linkAllRepoRootMatches({
+      client,
+      path,
+      matches: crossTeamMatches,
+      successEmoji,
+    });
+    if (linkedRepoMatches) {
+      return linkedRepoMatches;
     }
 
     const linkedMatch = await linkCrossTeamMatches({
@@ -465,41 +489,7 @@ export default async function setupAndLink(
       return linkedMatch;
     }
 
-    if (!autoConfirm && !nonInteractive && skippedLimitedTeams.length > 0) {
-      if (crossTeamMatches.length === 0) {
-        output.log(
-          `No matching projects found in the ${searchedTeamSlugs.length} ${searchedTeamSlugs.length === 1 ? 'team' : 'teams'} available in your current session.`
-        );
-      }
-      const limitedTeamMatches = await searchSelectedLimitedTeams({
-        client,
-        path,
-        projectName,
-        gitProjectName,
-        teams: skippedLimitedTeams,
-      });
-      const linkedLimitedMatch = await linkCrossTeamMatches({
-        client,
-        path,
-        matches: limitedTeamMatches,
-        successEmoji,
-        autoConfirm,
-        nonInteractive,
-        pullEnv,
-      });
-      if (linkedLimitedMatch) {
-        return linkedLimitedMatch;
-      }
-      if (limitedTeamMatches.length === 0) {
-        output.log(
-          'No matching projects found in the selected SSO-protected teams.'
-        );
-      }
-      skipAutoDetect =
-        skipAutoDetect ||
-        crossTeamMatches.length > 0 ||
-        limitedTeamMatches.length > 0;
-    } else if (crossTeamMatches.length > 0) {
+    if (crossTeamMatches.length > 0) {
       skipAutoDetect = true;
     }
   }

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -71,8 +71,6 @@ export interface SetupAndLinkOptions {
   v0?: boolean;
   /** When true, search matching projects across teams before standard linking flow */
   searchAcrossTeams?: boolean;
-  /** When true, start setup immediately without asking "Set up <path>?" */
-  skipSetupConfirmation?: boolean;
 }
 
 function formatMatchReason(match: CrossTeamMatch): string {
@@ -370,7 +368,6 @@ export default async function setupAndLink(
     pullEnv = true,
     v0,
     searchAcrossTeams = false,
-    skipSetupConfirmation = false,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
   const { config } = client;
@@ -404,7 +401,6 @@ export default async function setupAndLink(
   const shouldStartSetup =
     autoConfirm ||
     nonInteractive ||
-    skipSetupConfirmation ||
     (await client.input.confirm(
       `${setupMsg} ${chalk.cyan(`“${toHumanPath(path)}”`)}?`,
       true

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -468,7 +468,7 @@ export default async function setupAndLink(
     if (!autoConfirm && !nonInteractive && skippedLimitedTeams.length > 0) {
       if (crossTeamMatches.length === 0) {
         output.log(
-          'No matching projects found in teams available to your current session.'
+          `No matching projects found in the ${searchedTeamSlugs.length} ${searchedTeamSlugs.length === 1 ? 'team' : 'teams'} available in your current session.`
         );
       }
       const limitedTeamMatches = await searchSelectedLimitedTeams({

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -5,6 +5,7 @@ import type {
   ProjectLinkResult,
   ProjectSettings,
   Org,
+  Team,
 } from '@vercel-internals/types';
 import {
   getLinkedProject,
@@ -13,9 +14,11 @@ import {
   VERCEL_DIR_README,
   VERCEL_DIR_PROJECT,
 } from '../projects/link';
+import { linkRepoProject } from './repo';
 import createProject from '../projects/create-project';
 import type Client from '../client';
 import { printError } from '../error';
+import pull from '../../commands/env/pull';
 import { parseGitConfig, pluckRemoteUrls } from '../create-git-meta';
 import {
   selectAndParseRemoteUrl,
@@ -68,6 +71,289 @@ export interface SetupAndLinkOptions {
   v0?: boolean;
   /** When true, search matching projects across teams before standard linking flow */
   searchAcrossTeams?: boolean;
+  /** When true, start setup immediately without asking "Set up <path>?" */
+  skipSetupConfirmation?: boolean;
+}
+
+function formatMatchReason(match: CrossTeamMatch): string {
+  if (match.reason === 'repo-root') {
+    return chalk.gray('(linked by git)');
+  }
+  return chalk.gray('(folder name)');
+}
+
+function formatCrossTeamMatch(match: CrossTeamMatch): string {
+  return `${chalk.blue(match.org.slug)}/${match.project.name} ${formatMatchReason(
+    match
+  )}`;
+}
+
+function formatTeamList(slugs: string[]): string {
+  const shown = slugs.slice(0, 5);
+  const suffix =
+    slugs.length > shown.length
+      ? `, and ${slugs.length - shown.length} more`
+      : '';
+  return `${shown.join(', ')}${suffix}`;
+}
+
+function printCrossTeamSearchScope({
+  searchedTeamSlugs,
+  skippedLimitedTeamSlugs,
+}: {
+  searchedTeamSlugs: string[];
+  skippedLimitedTeamSlugs: string[];
+}): void {
+  if (searchedTeamSlugs.length > 0) {
+    output.log(`Searched teams: ${formatTeamList(searchedTeamSlugs)}`);
+  }
+  if (skippedLimitedTeamSlugs.length > 0) {
+    output.log(
+      `Skipped ${skippedLimitedTeamSlugs.length} SSO-protected ${skippedLimitedTeamSlugs.length === 1 ? 'team' : 'teams'}`
+    );
+  }
+}
+
+async function maybePullEnvAfterLink(
+  client: Client,
+  path: string,
+  autoConfirm: boolean,
+  pullEnv: boolean
+): Promise<void> {
+  if (!pullEnv || !client.stdin.isTTY || client.nonInteractive) {
+    return;
+  }
+
+  const pullEnvConfirmed =
+    autoConfirm ||
+    (await client.input.confirm(
+      'Would you like to pull environment variables now?',
+      true
+    ));
+
+  if (!pullEnvConfirmed) {
+    return;
+  }
+
+  const originalCwd = client.cwd;
+  try {
+    client.cwd = path;
+    const args = autoConfirm ? ['--yes'] : [];
+    const exitCode = await pull(client, args, 'vercel-cli:link');
+
+    if (exitCode !== 0) {
+      output.error(
+        'Failed to pull environment variables. You can run `vc env pull` manually.'
+      );
+    }
+  } catch (_error) {
+    output.error(
+      'Failed to pull environment variables. You can run `vc env pull` manually.'
+    );
+  } finally {
+    client.cwd = originalCwd;
+  }
+}
+
+async function linkCrossTeamMatch({
+  client,
+  path,
+  match,
+  successEmoji,
+  autoConfirm,
+  pullEnv,
+}: {
+  client: Client;
+  path: string;
+  match: CrossTeamMatch;
+  successEmoji: EmojiLabel;
+  autoConfirm: boolean;
+  pullEnv: boolean;
+}): Promise<ProjectLinkResult> {
+  client.config.currentTeam =
+    match.org.type === 'team' ? match.org.id : undefined;
+
+  if (match.reason === 'repo-root' && match.repo) {
+    await linkRepoProject(client, path, {
+      project: match.project,
+      orgId: match.org.id,
+      orgSlug: match.org.slug,
+      remoteName: match.repo.remoteName,
+      successEmoji,
+    });
+    await maybePullEnvAfterLink(client, path, autoConfirm, pullEnv);
+    return {
+      status: 'linked',
+      org: match.org,
+      project: match.project,
+      repoRoot: match.repo.rootPath,
+    };
+  }
+
+  await linkFolderToProject(
+    client,
+    path,
+    { projectId: match.project.id, orgId: match.org.id },
+    match.project.name,
+    match.org.slug,
+    successEmoji,
+    autoConfirm,
+    pullEnv
+  );
+  return { status: 'linked', org: match.org, project: match.project };
+}
+
+async function promptForLimitedTeams(
+  client: Client,
+  teams: Team[]
+): Promise<Team[]> {
+  if (teams.length === 0) {
+    return [];
+  }
+
+  return await client.input.checkbox<Team>({
+    message: 'Which SSO-protected teams should be searched?',
+    choices: teams.map(team => ({
+      name: team.name ? `${team.name} (${team.slug})` : team.slug,
+      value: team,
+    })),
+  });
+}
+
+async function searchSelectedLimitedTeams({
+  client,
+  path,
+  projectName,
+  teams,
+}: {
+  client: Client;
+  path: string;
+  projectName: string;
+  teams: Team[];
+}): Promise<CrossTeamMatch[]> {
+  const selectedTeams = await promptForLimitedTeams(client, teams);
+  if (selectedTeams.length === 0) {
+    return [];
+  }
+
+  output.spinner('Searching selected SSO-protected teams…', 1000);
+  try {
+    const result = await searchProjectAcrossTeams(client, projectName, path, {
+      teams: selectedTeams,
+      skipLimited: false,
+    });
+    printCrossTeamSearchScope({
+      searchedTeamSlugs: result.searchedTeamSlugs,
+      skippedLimitedTeamSlugs: [],
+    });
+    return result.matches;
+  } catch (err) {
+    output.debug(`Selected SSO-protected team search failed: ${err}`);
+    return [];
+  } finally {
+    output.stopSpinner();
+  }
+}
+
+async function linkCrossTeamMatches({
+  client,
+  path,
+  matches,
+  successEmoji,
+  autoConfirm,
+  nonInteractive,
+  pullEnv,
+}: {
+  client: Client;
+  path: string;
+  matches: CrossTeamMatch[];
+  successEmoji: EmojiLabel;
+  autoConfirm: boolean;
+  nonInteractive: boolean;
+  pullEnv: boolean;
+}): Promise<ProjectLinkResult | null> {
+  if (matches.length === 0) {
+    return null;
+  }
+
+  if (matches.length === 1) {
+    const match = matches[0];
+
+    if (autoConfirm || nonInteractive) {
+      return await linkCrossTeamMatch({
+        client,
+        path,
+        match,
+        successEmoji,
+        autoConfirm,
+        pullEnv,
+      });
+    }
+
+    const confirmed = await client.input.confirm(
+      `Found project ${formatCrossTeamMatch(match)}. Link to it?`,
+      true
+    );
+    if (confirmed) {
+      return await linkCrossTeamMatch({
+        client,
+        path,
+        match,
+        successEmoji,
+        autoConfirm,
+        pullEnv,
+      });
+    }
+    return null;
+  }
+
+  const currentTeamMatch = matches.find(
+    match => match.org.id === client.config.currentTeam
+  );
+
+  if (autoConfirm && currentTeamMatch) {
+    return await linkCrossTeamMatch({
+      client,
+      path,
+      match: currentTeamMatch,
+      successEmoji,
+      autoConfirm,
+      pullEnv,
+    });
+  }
+
+  if (nonInteractive) {
+    return null;
+  }
+
+  const choices = matches.map(match => ({
+    name: formatCrossTeamMatch(match),
+    value: match as CrossTeamMatch | null,
+  }));
+  choices.push({
+    name: 'Not one of these projects',
+    value: null,
+  });
+
+  const selected = await client.input.select<CrossTeamMatch | null>({
+    message:
+      'Found matching projects across teams. Which one do you want to link?',
+    choices,
+    default: currentTeamMatch ?? undefined,
+  });
+
+  if (!selected) {
+    return null;
+  }
+
+  return await linkCrossTeamMatch({
+    client,
+    path,
+    match: selected,
+    successEmoji,
+    autoConfirm,
+    pullEnv,
+  });
 }
 
 export default async function setupAndLink(
@@ -84,6 +370,7 @@ export default async function setupAndLink(
     pullEnv = true,
     v0,
     searchAcrossTeams = false,
+    skipSetupConfirmation = false,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
   const { config } = client;
@@ -117,6 +404,7 @@ export default async function setupAndLink(
   const shouldStartSetup =
     autoConfirm ||
     nonInteractive ||
+    skipSetupConfirmation ||
     (await client.input.confirm(
       `${setupMsg} ${chalk.cyan(`“${toHumanPath(path)}”`)}?`,
       true
@@ -131,124 +419,80 @@ export default async function setupAndLink(
   if (searchAcrossTeams) {
     // Search for existing projects across all teams
     let crossTeamMatches: CrossTeamMatch[] = [];
+    let searchedTeamSlugs: string[] = [];
+    let skippedLimitedTeamSlugs: string[] = [];
+    let skippedLimitedTeams: Team[] = [];
     output.spinner('Searching for existing projects…', 1000);
     try {
-      crossTeamMatches = await searchProjectAcrossTeams(client, projectName);
+      const searchResult = await searchProjectAcrossTeams(
+        client,
+        projectName,
+        path,
+        {
+          autoConfirm,
+          nonInteractive,
+        }
+      );
+      crossTeamMatches = searchResult.matches;
+      searchedTeamSlugs = searchResult.searchedTeamSlugs;
+      skippedLimitedTeamSlugs = searchResult.skippedLimitedTeamSlugs;
+      skippedLimitedTeams = searchResult.skippedLimitedTeams;
     } catch (err) {
       output.debug(`Cross-team search failed: ${err}`);
     } finally {
       output.stopSpinner();
     }
 
-    if (crossTeamMatches.length === 1) {
-      const match = crossTeamMatches[0];
+    if (crossTeamMatches.length > 0 && !autoConfirm && !nonInteractive) {
+      printCrossTeamSearchScope({
+        searchedTeamSlugs,
+        skippedLimitedTeamSlugs,
+      });
+    }
 
-      if (autoConfirm || nonInteractive) {
-        config.currentTeam =
-          match.org.type === 'team' ? match.org.id : undefined;
-        await linkFolderToProject(
-          client,
-          path,
-          { projectId: match.project.id, orgId: match.org.id },
-          match.project.name,
-          match.org.slug,
-          successEmoji,
-          autoConfirm,
-          pullEnv
-        );
-        return { status: 'linked', org: match.org, project: match.project };
-      }
+    const linkedMatch = await linkCrossTeamMatches({
+      client,
+      path,
+      matches: crossTeamMatches,
+      successEmoji,
+      autoConfirm,
+      nonInteractive,
+      pullEnv,
+    });
+    if (linkedMatch) {
+      return linkedMatch;
+    }
 
-      const confirmed = await client.input.confirm(
-        `Found project ${chalk.blue(match.org.slug)}/${match.project.name}. Link to it?`,
-        true
-      );
-      if (confirmed) {
-        config.currentTeam =
-          match.org.type === 'team' ? match.org.id : undefined;
-        await linkFolderToProject(
-          client,
-          path,
-          { projectId: match.project.id, orgId: match.org.id },
-          match.project.name,
-          match.org.slug,
-          successEmoji,
-          autoConfirm,
-          pullEnv
-        );
-        return { status: 'linked', org: match.org, project: match.project };
+    if (!autoConfirm && !nonInteractive && skippedLimitedTeams.length > 0) {
+      const limitedTeamMatches = await searchSelectedLimitedTeams({
+        client,
+        path,
+        projectName,
+        teams: skippedLimitedTeams,
+      });
+      const linkedLimitedMatch = await linkCrossTeamMatches({
+        client,
+        path,
+        matches: limitedTeamMatches,
+        successEmoji,
+        autoConfirm,
+        nonInteractive,
+        pullEnv,
+      });
+      if (linkedLimitedMatch) {
+        return linkedLimitedMatch;
       }
+      if (limitedTeamMatches.length === 0) {
+        output.log(
+          'No matching projects found in the selected SSO-protected teams.'
+        );
+      }
+      skipAutoDetect =
+        skipAutoDetect ||
+        crossTeamMatches.length > 0 ||
+        limitedTeamMatches.length > 0;
+    } else if (crossTeamMatches.length > 0) {
       skipAutoDetect = true;
-    } else if (crossTeamMatches.length > 1) {
-      // Auto-link only when there's an unambiguous match on the current team
-      const currentTeamMatch = autoConfirm
-        ? crossTeamMatches.find(m => m.org.id === config.currentTeam)
-        : undefined;
-
-      if (currentTeamMatch) {
-        config.currentTeam =
-          currentTeamMatch.org.type === 'team'
-            ? currentTeamMatch.org.id
-            : undefined;
-        await linkFolderToProject(
-          client,
-          path,
-          {
-            projectId: currentTeamMatch.project.id,
-            orgId: currentTeamMatch.org.id,
-          },
-          currentTeamMatch.project.name,
-          currentTeamMatch.org.slug,
-          successEmoji,
-          autoConfirm,
-          pullEnv
-        );
-        return {
-          status: 'linked',
-          org: currentTeamMatch.org,
-          project: currentTeamMatch.project,
-        };
-      }
-
-      if (!nonInteractive) {
-        // Multiple matches and no unambiguous current-team match: prompt user to select
-        const choices = crossTeamMatches.map(m => ({
-          name: `${chalk.blue(m.org.slug)}/${m.project.name}`,
-          value: m as CrossTeamMatch | null,
-        }));
-        choices.push({
-          name: "Don't link to an existing project",
-          value: null,
-        });
-
-        const selected = await client.input.select<CrossTeamMatch | null>({
-          message:
-            'Found matching projects across teams. Which one do you want to link?',
-          choices,
-        });
-
-        if (selected) {
-          config.currentTeam =
-            selected.org.type === 'team' ? selected.org.id : undefined;
-          await linkFolderToProject(
-            client,
-            path,
-            { projectId: selected.project.id, orgId: selected.org.id },
-            selected.project.name,
-            selected.org.slug,
-            successEmoji,
-            autoConfirm,
-            pullEnv
-          );
-          return {
-            status: 'linked',
-            org: selected.org,
-            project: selected.project,
-          };
-        }
-        skipAutoDetect = true;
-      }
-      // nonInteractive with multiple matches: fall through to selectOrg
     }
   }
 

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -222,11 +222,13 @@ async function searchSelectedLimitedTeams({
   client,
   path,
   projectName,
+  gitProjectName,
   teams,
 }: {
   client: Client;
   path: string;
   projectName: string;
+  gitProjectName?: string;
   teams: Team[];
 }): Promise<CrossTeamMatch[]> {
   const selectedTeams = await promptForLimitedTeams(client, teams);
@@ -239,6 +241,7 @@ async function searchSelectedLimitedTeams({
     const result = await searchProjectAcrossTeams(client, projectName, path, {
       teams: selectedTeams,
       skipLimited: false,
+      gitProjectName,
     });
     printCrossTeamSearchScope({
       searchedTeamSlugs: result.searchedTeamSlugs,
@@ -363,7 +366,7 @@ export default async function setupAndLink(
     link,
     successEmoji = 'link',
     setupMsg = 'Set up',
-    projectName = basename(path),
+    projectName,
     nonInteractive = false,
     pullEnv = true,
     v0,
@@ -371,6 +374,8 @@ export default async function setupAndLink(
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
   const { config } = client;
+  const gitProjectName = projectName;
+  projectName = projectName ?? basename(path);
 
   if (!isDirectory(path)) {
     output.error(`Expected directory but found file: ${path}`);
@@ -427,6 +432,7 @@ export default async function setupAndLink(
         {
           autoConfirm,
           nonInteractive,
+          gitProjectName,
         }
       );
       crossTeamMatches = searchResult.matches;
@@ -464,6 +470,7 @@ export default async function setupAndLink(
         client,
         path,
         projectName,
+        gitProjectName,
         teams: skippedLimitedTeams,
       });
       const linkedLimitedMatch = await linkCrossTeamMatches({

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -466,6 +466,11 @@ export default async function setupAndLink(
     }
 
     if (!autoConfirm && !nonInteractive && skippedLimitedTeams.length > 0) {
+      if (crossTeamMatches.length === 0) {
+        output.log(
+          'No matching projects found in teams available to your current session.'
+        );
+      }
       const limitedTeamMatches = await searchSelectedLimitedTeams({
         client,
         path,

--- a/packages/cli/src/util/projects/search-project-across-teams.ts
+++ b/packages/cli/src/util/projects/search-project-across-teams.ts
@@ -39,11 +39,13 @@ export default async function searchProjectAcrossTeams(
     nonInteractive = false,
     teams,
     skipLimited,
+    gitProjectName,
   }: {
     autoConfirm?: boolean;
     nonInteractive?: boolean;
     teams?: Team[];
     skipLimited?: boolean;
+    gitProjectName?: string;
   } = {}
 ): Promise<CrossTeamSearchResult> {
   const teamsToSearch = teams ?? (await getTeams(client));
@@ -80,6 +82,7 @@ export default async function searchProjectAcrossTeams(
   const repoMatchesPromise = searchProjectsByRepoRoot({
     client,
     cwd,
+    gitProjectName,
     orgs,
     autoConfirm,
     nonInteractive,
@@ -130,12 +133,14 @@ export default async function searchProjectAcrossTeams(
 async function searchProjectsByRepoRoot({
   client,
   cwd,
+  gitProjectName,
   orgs,
   autoConfirm,
   nonInteractive,
 }: {
   client: Client;
   cwd: string;
+  gitProjectName?: string;
   orgs: Org[];
   autoConfirm: boolean;
   nonInteractive: boolean;
@@ -170,12 +175,19 @@ async function searchProjectsByRepoRoot({
           remote.repoUrl,
           org.id
         );
-        const repoProjectConfigs = projects.map(project => ({
-          id: project.id,
-          name: project.name,
-          directory: project.rootDirectory || '.',
-          orgId: org.id,
-        }));
+        const repoProjectConfigs = projects
+          .filter(
+            project =>
+              !gitProjectName ||
+              project.id === gitProjectName ||
+              project.name === gitProjectName
+          )
+          .map(project => ({
+            id: project.id,
+            name: project.name,
+            directory: project.rootDirectory || '.',
+            orgId: org.id,
+          }));
         const matchingProjects = findProjectsFromPath(
           repoProjectConfigs,
           relativePath

--- a/packages/cli/src/util/projects/search-project-across-teams.ts
+++ b/packages/cli/src/util/projects/search-project-across-teams.ts
@@ -5,10 +5,8 @@ import getProjectByIdOrName from './get-project-by-id-or-name';
 import { ProjectNotFound } from '../errors-ts';
 import slugify from '@sindresorhus/slugify';
 import output from '../../output-manager';
-import { relative } from 'path';
 import {
   fetchProjectsForRepoUrl,
-  findProjectsFromPath,
   findRepoRoot,
   resolveGitRemote,
   type ResolvedGitRemote,
@@ -166,7 +164,6 @@ async function searchProjectsByRepoRoot({
     return [];
   }
 
-  const relativePath = relative(rootPath, cwd);
   const results = await Promise.all(
     orgs.map(async org => {
       try {
@@ -188,11 +185,7 @@ async function searchProjectsByRepoRoot({
             directory: project.rootDirectory || '.',
             orgId: org.id,
           }));
-        const matchingProjects = findProjectsFromPath(
-          repoProjectConfigs,
-          relativePath
-        );
-        return matchingProjects
+        return repoProjectConfigs
           .map(match => {
             const project = projects.find(p => p.id === match.id);
             if (!project) {

--- a/packages/cli/src/util/projects/search-project-across-teams.ts
+++ b/packages/cli/src/util/projects/search-project-across-teams.ts
@@ -1,29 +1,63 @@
 import type Client from '../client';
-import type { Project, Org } from '@vercel-internals/types';
+import type { Project, Org, Team } from '@vercel-internals/types';
 import getTeams from '../teams/get-teams';
 import getProjectByIdOrName from './get-project-by-id-or-name';
 import { ProjectNotFound } from '../errors-ts';
 import slugify from '@sindresorhus/slugify';
 import output from '../../output-manager';
+import { relative } from 'path';
+import {
+  fetchProjectsForRepoUrl,
+  findProjectsFromPath,
+  findRepoRoot,
+  resolveGitRemote,
+  type ResolvedGitRemote,
+} from '../link/repo';
 
 export interface CrossTeamMatch {
   project: Project;
   org: Org;
+  reason: 'repo-root' | 'folder-name';
+  repo?: ResolvedGitRemote & {
+    directory: string;
+  };
+}
+
+export interface CrossTeamSearchResult {
+  matches: CrossTeamMatch[];
+  searchedTeamSlugs: string[];
+  skippedLimitedTeamSlugs: string[];
+  skippedLimitedTeams: Team[];
 }
 
 export default async function searchProjectAcrossTeams(
   client: Client,
-  projectName: string
-): Promise<CrossTeamMatch[]> {
-  const teams = await getTeams(client);
+  projectName: string,
+  cwd: string,
+  {
+    autoConfirm = false,
+    nonInteractive = false,
+    teams,
+    skipLimited,
+  }: {
+    autoConfirm?: boolean;
+    nonInteractive?: boolean;
+    teams?: Team[];
+    skipLimited?: boolean;
+  } = {}
+): Promise<CrossTeamSearchResult> {
+  const teamsToSearch = teams ?? (await getTeams(client));
+  const shouldSkipLimited = skipLimited ?? true;
 
   // Skip "limited" (SAML-enforced) teams here to avoid forcing re-auth
   // during auto-detect. If nothing matches, `setupAndLink` falls through to
   // `selectOrg`, where picking a limited team triggers re-auth deliberately.
-  const accessibleTeams: typeof teams = [];
+  const accessibleTeams: typeof teamsToSearch = [];
+  const skippedTeams: Team[] = [];
   const skippedSlugs: string[] = [];
-  for (const t of teams) {
-    if (t.limited) {
+  for (const t of teamsToSearch) {
+    if (shouldSkipLimited && t.limited) {
+      skippedTeams.push(t);
       skippedSlugs.push(t.slug);
     } else {
       accessibleTeams.push(t);
@@ -36,11 +70,20 @@ export default async function searchProjectAcrossTeams(
     );
   }
 
+  const searchedTeamSlugs = accessibleTeams.map(team => team.slug);
   const orgs: Org[] = accessibleTeams.map(t => ({
     type: 'team' as const,
     id: t.id,
     slug: t.slug,
   }));
+
+  const repoMatchesPromise = searchProjectsByRepoRoot({
+    client,
+    cwd,
+    orgs,
+    autoConfirm,
+    nonInteractive,
+  });
 
   const slugifiedName = slugify(projectName);
   const searchNames = [projectName];
@@ -48,17 +91,24 @@ export default async function searchProjectAcrossTeams(
     searchNames.push(slugifiedName);
   }
 
-  const searchPromises = orgs.flatMap(org =>
+  const folderNameSearchPromises = orgs.flatMap(org =>
     searchNames.map(name =>
       getProjectByIdOrName(client, name, org.id)
         .then(result =>
-          result instanceof ProjectNotFound ? null : { project: result, org }
+          result instanceof ProjectNotFound
+            ? null
+            : { project: result, org, reason: 'folder-name' as const }
         )
         .catch(() => null)
     )
   );
 
-  const results = await Promise.all(searchPromises);
+  const [repoMatches, folderNameMatches] = await Promise.all([
+    repoMatchesPromise,
+    Promise.all(folderNameSearchPromises),
+  ]);
+
+  const results = [...repoMatches, ...folderNameMatches];
 
   const seen = new Set<string>();
   const matches: CrossTeamMatch[] = [];
@@ -69,5 +119,92 @@ export default async function searchProjectAcrossTeams(
     }
   }
 
-  return matches;
+  return {
+    matches,
+    searchedTeamSlugs,
+    skippedLimitedTeamSlugs: skippedSlugs,
+    skippedLimitedTeams: skippedTeams,
+  };
+}
+
+async function searchProjectsByRepoRoot({
+  client,
+  cwd,
+  orgs,
+  autoConfirm,
+  nonInteractive,
+}: {
+  client: Client;
+  cwd: string;
+  orgs: Org[];
+  autoConfirm: boolean;
+  nonInteractive: boolean;
+}): Promise<CrossTeamMatch[]> {
+  const rootPath = await findRepoRoot(cwd);
+  if (!rootPath) {
+    return [];
+  }
+
+  let remote: ResolvedGitRemote | undefined;
+  try {
+    remote = await resolveGitRemote(client, rootPath, {
+      yes: autoConfirm || nonInteractive,
+    });
+  } catch (error) {
+    output.debug(
+      `Failed to resolve Git remote for cross-team search: ${error}`
+    );
+    return [];
+  }
+
+  if (!remote) {
+    return [];
+  }
+
+  const relativePath = relative(rootPath, cwd);
+  const results = await Promise.all(
+    orgs.map(async org => {
+      try {
+        const projects = await fetchProjectsForRepoUrl(
+          client,
+          remote.repoUrl,
+          org.id
+        );
+        const repoProjectConfigs = projects.map(project => ({
+          id: project.id,
+          name: project.name,
+          directory: project.rootDirectory || '.',
+          orgId: org.id,
+        }));
+        const matchingProjects = findProjectsFromPath(
+          repoProjectConfigs,
+          relativePath
+        );
+        return matchingProjects
+          .map(match => {
+            const project = projects.find(p => p.id === match.id);
+            if (!project) {
+              return null;
+            }
+            return {
+              project,
+              org,
+              reason: 'repo-root' as const,
+              repo: {
+                ...remote,
+                directory: match.directory,
+              },
+            };
+          })
+          .filter(Boolean) as CrossTeamMatch[];
+      } catch (error) {
+        output.debug(
+          `Failed to search Git-linked projects under ${org.slug}: ${error}`
+        );
+        return [];
+      }
+    })
+  );
+
+  return results.flat();
 }

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -860,9 +860,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput('Link to it?');
     client.stdin.write('y\n');
 
@@ -893,9 +890,6 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
-
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -952,9 +946,6 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
-
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -1031,9 +1022,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1100,9 +1088,6 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
-
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -1190,9 +1175,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1277,9 +1259,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1344,9 +1323,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1403,9 +1379,6 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
-
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -1572,9 +1545,6 @@ describe('link', () => {
 
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Found project');
       client.stdin.write('y\n');
 
@@ -1614,9 +1584,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1654,9 +1621,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1693,9 +1657,6 @@ describe('link', () => {
       client.cwd = cwd;
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
-
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
@@ -1741,9 +1702,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1785,9 +1743,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1827,9 +1782,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1868,9 +1820,6 @@ describe('link', () => {
       const originalCwd = client.cwd;
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
-
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
@@ -1934,9 +1883,6 @@ describe('link', () => {
       client.cwd = cwd;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1972,9 +1918,6 @@ describe('link', () => {
       client.cwd = cwd;
       client.setArgv();
       const exitCodePromise = link(client);
-
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
 
       // Decline cross-team match
       await expect(client.stderr).toOutput('Link to it?');
@@ -2017,9 +1960,6 @@ describe('link', () => {
 
       client.cwd = cwd;
       const exitCodePromise = link(client);
-
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
 
       // No match found during cross-team search, should go to selectOrg
       await expect(client.stderr).toOutput(
@@ -2253,21 +2193,13 @@ describe('link', () => {
       client.cwd = projectDir;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput('Which teams should be searched?');
+      client.stdin.write('\n');
 
       await expect(client.stderr).toOutput('Searched teams:');
-      await expect(client.stderr).toOutput('Skipped 1 SSO-protected team');
-      await expect(client.stderr).toOutput('Found project');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput(
-        `Linked to ${teamA.slug}/${projectA.name}`
+        'Linked 1 Project from Git repository'
       );
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
-      client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -2393,19 +2325,9 @@ describe('link', () => {
       client.setArgv('--project', expectedProject.name);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput('Found project');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput(
-        `Linked to ${teamA.slug}/${expectedProject.name}`
+        'Linked 1 Project from Git repository'
       );
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
-      client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -2421,7 +2343,7 @@ describe('link', () => {
       ]);
     });
 
-    it('should show repo-root and folder-name matches together', async () => {
+    it('should auto-link all Git-linked projects before folder-name matches', async () => {
       useUser({ version: 'northstar' });
       const repoRoot = setupTmpDir();
       const projectDir = join(repoRoot, 'apps/web');
@@ -2442,6 +2364,12 @@ describe('link', () => {
         name: 'dashboard',
         rootDirectory: 'apps/web',
       };
+      const secondRepoProject = {
+        ...defaultProject,
+        id: 'proj-repo-team-b',
+        name: 'dashboard-team-b',
+        rootDirectory: 'apps/api',
+      };
       const folderProject = {
         ...defaultProject,
         id: 'proj-folder',
@@ -2451,6 +2379,9 @@ describe('link', () => {
       client.scenario.get('/v9/projects', (req, res) => {
         if (req.query.teamId === teamA.id && req.query.repoUrl === repoUrl) {
           return res.json({ projects: [repoProject], pagination: {} });
+        }
+        if (req.query.teamId === teamB.id && req.query.repoUrl === repoUrl) {
+          return res.json({ projects: [secondRepoProject], pagination: {} });
         }
         return res.json({ projects: [], pagination: {} });
       });
@@ -2465,22 +2396,31 @@ describe('link', () => {
       client.cwd = projectDir;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput('Not one of these projects');
+      await expect(client.stderr).toOutput('Which teams should be searched?');
       client.stdin.write('\n');
 
       await expect(client.stderr).toOutput(
-        `Linked to ${teamA.slug}/${repoProject.name}`
+        'Linked 2 Projects from Git repository'
       );
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
-      client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+
+      const repoJson = await readJSON(join(repoRoot, '.vercel/repo.json'));
+      expect(repoJson.projects).toEqual([
+        {
+          directory: 'apps/web',
+          id: repoProject.id,
+          name: repoProject.name,
+          orgId: teamA.id,
+        },
+        {
+          directory: 'apps/api',
+          id: secondRepoProject.id,
+          name: secondRepoProject.name,
+          orgId: teamB.id,
+        },
+      ]);
     });
 
     it('should search selected SSO-protected teams after no first-pass matches', async () => {
@@ -2512,13 +2452,8 @@ describe('link', () => {
       client.cwd = cwd;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput(
-        'Which SSO-protected teams should be searched?'
-      );
-      client.stdin.write(' \n');
+      await expect(client.stderr).toOutput('Which teams should be searched?');
+      client.stdin.write('a\n');
 
       await expect(client.stderr).toOutput('Found project');
       client.stdin.write('y\n');
@@ -2664,8 +2599,8 @@ describe('link', () => {
         client.cwd = cwd;
         const exitCodePromise = link(client);
 
-        await expect(client.stderr).toOutput('Set up');
-        client.stdin.write('y\n');
+        await expect(client.stderr).toOutput('Which teams should be searched?');
+        client.stdin.write('\n');
 
         await expect(client.stderr).toOutput(
           'Found matching projects across teams'
@@ -2721,8 +2656,8 @@ describe('link', () => {
         client.cwd = cwd;
         const exitCodePromise = link(client);
 
-        await expect(client.stderr).toOutput('Set up');
-        client.stdin.write('y\n');
+        await expect(client.stderr).toOutput('Which teams should be searched?');
+        client.stdin.write('\n');
 
         await expect(client.stderr).toOutput(
           'Found matching projects across teams'

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -860,6 +860,9 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
+
     await expect(client.stderr).toOutput('Link to it?');
     client.stdin.write('y\n');
 
@@ -890,6 +893,9 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
+
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -946,6 +952,9 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
+
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -1022,6 +1031,9 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
+
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1088,6 +1100,9 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
+
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -1175,6 +1190,9 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
+
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1259,6 +1277,9 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
+
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1323,6 +1344,9 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
+
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1379,6 +1403,9 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
+
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -1545,6 +1572,9 @@ describe('link', () => {
 
       const exitCodePromise = link(client);
 
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Found project');
       client.stdin.write('y\n');
 
@@ -1584,6 +1614,9 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1621,6 +1654,9 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1657,6 +1693,9 @@ describe('link', () => {
       client.cwd = cwd;
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
@@ -1702,6 +1741,9 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1743,6 +1785,9 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1782,6 +1827,9 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1820,6 +1868,9 @@ describe('link', () => {
       const originalCwd = client.cwd;
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
@@ -1883,6 +1934,9 @@ describe('link', () => {
       client.cwd = cwd;
       const exitCodePromise = link(client);
 
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1918,6 +1972,9 @@ describe('link', () => {
       client.cwd = cwd;
       client.setArgv();
       const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
 
       // Decline cross-team match
       await expect(client.stderr).toOutput('Link to it?');
@@ -1960,6 +2017,9 @@ describe('link', () => {
 
       client.cwd = cwd;
       const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
 
       // No match found during cross-team search, should go to selectOrg
       await expect(client.stderr).toOutput(
@@ -2193,6 +2253,9 @@ describe('link', () => {
       client.cwd = projectDir;
       const exitCodePromise = link(client);
 
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Searched teams:');
       await expect(client.stderr).toOutput('Skipped 1 SSO-protected team');
       await expect(client.stderr).toOutput('Found project');
@@ -2333,6 +2396,9 @@ describe('link', () => {
       client.cwd = projectDir;
       const exitCodePromise = link(client);
 
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
       await expect(client.stderr).toOutput('Not one of these projects');
       client.stdin.write('\n');
 
@@ -2376,6 +2442,9 @@ describe('link', () => {
 
       client.cwd = cwd;
       const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         'Which SSO-protected teams should be searched?'
@@ -2526,6 +2595,9 @@ describe('link', () => {
         client.cwd = cwd;
         const exitCodePromise = link(client);
 
+        await expect(client.stderr).toOutput('Set up');
+        client.stdin.write('y\n');
+
         await expect(client.stderr).toOutput(
           'Found matching projects across teams'
         );
@@ -2579,6 +2651,9 @@ describe('link', () => {
         client.config.currentTeam = 'team_b';
         client.cwd = cwd;
         const exitCodePromise = link(client);
+
+        await expect(client.stderr).toOutput('Set up');
+        client.stdin.write('y\n');
 
         await expect(client.stderr).toOutput(
           'Found matching projects across teams'

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -2352,6 +2352,75 @@ describe('link', () => {
       ]);
     });
 
+    it('should respect --project when matching Git-linked projects', async () => {
+      useUser({ version: 'northstar' });
+      const repoRoot = setupTmpDir();
+      const projectDir = join(repoRoot, 'apps/web');
+      const repoUrl = 'https://github.com/user/repo.git';
+      await mkdirp(join(repoRoot, '.git'));
+      await mkdirp(projectDir);
+      await writeFile(
+        join(repoRoot, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+
+      const [teamA] = useTeams('team_a') as Team[];
+      const wrongProject = {
+        ...defaultProject,
+        id: 'proj-wrong',
+        name: 'wrong-app',
+        rootDirectory: 'apps/web',
+      };
+      const expectedProject = {
+        ...defaultProject,
+        id: 'proj-expected',
+        name: 'expected-app',
+        rootDirectory: 'apps/web',
+      };
+
+      client.scenario.get('/v9/projects', (req, res) => {
+        if (req.query.teamId === teamA.id && req.query.repoUrl === repoUrl) {
+          return res.json({
+            projects: [wrongProject, expectedProject],
+            pagination: {},
+          });
+        }
+        return res.json({ projects: [], pagination: {} });
+      });
+      useUnknownProject();
+
+      client.cwd = projectDir;
+      client.setArgv('--project', expectedProject.name);
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Found project');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${teamA.slug}/${expectedProject.name}`
+      );
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('n\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      const repoJson = await readJSON(join(repoRoot, '.vercel/repo.json'));
+      expect(repoJson.projects).toEqual([
+        {
+          directory: 'apps/web',
+          id: expectedProject.id,
+          name: expectedProject.name,
+          orgId: teamA.id,
+        },
+      ]);
+    });
+
     it('should show repo-root and folder-name matches together', async () => {
       useUser({ version: 'northstar' });
       const repoRoot = setupTmpDir();

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -860,9 +860,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput('Link to it?');
     client.stdin.write('y\n');
 
@@ -893,9 +890,6 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
-
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -952,9 +946,6 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
-
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -1031,9 +1022,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1100,9 +1088,6 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
-
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -1190,9 +1175,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1277,9 +1259,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1344,9 +1323,6 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
-
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
     );
@@ -1403,9 +1379,6 @@ describe('link', () => {
 
     client.cwd = cwd;
     const exitCodePromise = link(client);
-
-    await expect(client.stderr).toOutput('Set up');
-    client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       'Which scope should contain your project?'
@@ -1572,9 +1545,6 @@ describe('link', () => {
 
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Found project');
       client.stdin.write('y\n');
 
@@ -1614,9 +1584,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1654,9 +1621,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1693,9 +1657,6 @@ describe('link', () => {
       client.cwd = cwd;
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
-
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
@@ -1741,9 +1702,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1785,9 +1743,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1827,9 +1782,6 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1868,9 +1820,6 @@ describe('link', () => {
       const originalCwd = client.cwd;
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
-
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
@@ -1934,9 +1883,6 @@ describe('link', () => {
       client.cwd = cwd;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
-
       await expect(client.stderr).toOutput('Link to it?');
       client.stdin.write('y\n');
 
@@ -1972,9 +1918,6 @@ describe('link', () => {
       client.cwd = cwd;
       client.setArgv();
       const exitCodePromise = link(client);
-
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
 
       // Decline cross-team match
       await expect(client.stderr).toOutput('Link to it?');
@@ -2017,9 +1960,6 @@ describe('link', () => {
 
       client.cwd = cwd;
       const exitCodePromise = link(client);
-
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
 
       // No match found during cross-team search, should go to selectOrg
       await expect(client.stderr).toOutput(
@@ -2216,6 +2156,251 @@ describe('link', () => {
       reauthSpy.mockRestore();
     });
 
+    it('should link repo root matches using repo.json', async () => {
+      useUser({ version: 'northstar' });
+      const repoRoot = setupTmpDir();
+      const projectDir = join(repoRoot, 'apps/web');
+      const repoUrl = 'https://github.com/user/repo.git';
+      await mkdirp(join(repoRoot, '.git'));
+      await mkdirp(projectDir);
+      await writeFile(
+        join(repoRoot, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+
+      const [teamA] = useTeams('team_a') as Team[];
+      const limitedTeam = createTeam(
+        'team_limited',
+        'team-limited',
+        'Team Limited'
+      );
+      (limitedTeam as Team & { limited?: boolean }).limited = true;
+      const projectA = {
+        ...defaultProject,
+        id: 'proj-on-a',
+        name: 'dashboard',
+        rootDirectory: 'apps/web',
+      };
+
+      client.scenario.get('/v9/projects', (req, res) => {
+        if (req.query.teamId === teamA.id && req.query.repoUrl === repoUrl) {
+          return res.json({ projects: [projectA], pagination: {} });
+        }
+        return res.json({ projects: [], pagination: {} });
+      });
+      useUnknownProject();
+
+      client.cwd = projectDir;
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Searched teams:');
+      await expect(client.stderr).toOutput('Skipped 1 SSO-protected team');
+      await expect(client.stderr).toOutput('Found project');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${teamA.slug}/${projectA.name}`
+      );
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('n\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      const repoJson = await readJSON(join(repoRoot, '.vercel/repo.json'));
+      expect(repoJson).toEqual({
+        remoteName: 'origin',
+        projects: [
+          {
+            directory: 'apps/web',
+            id: projectA.id,
+            name: projectA.name,
+            orgId: teamA.id,
+          },
+        ],
+      });
+      expect(await pathExists(join(projectDir, '.vercel/project.json'))).toBe(
+        false
+      );
+    });
+
+    it('should preserve repo.json entries when adding a repo root match', async () => {
+      useUser({ version: 'northstar' });
+      const repoRoot = setupTmpDir();
+      const projectDir = join(repoRoot, 'apps/web');
+      const repoUrl = 'https://github.com/user/repo.git';
+      await mkdirp(join(repoRoot, '.git'));
+      await mkdirp(join(repoRoot, '.vercel'));
+      await mkdirp(projectDir);
+      await writeFile(
+        join(repoRoot, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+      await writeJSON(join(repoRoot, '.vercel/repo.json'), {
+        remoteName: 'origin',
+        projects: [
+          {
+            directory: 'apps/api',
+            id: 'proj-api',
+            name: 'api',
+            orgId: 'team_a',
+          },
+        ],
+      });
+
+      const [teamA] = useTeams('team_a') as Team[];
+      const projectA = {
+        ...defaultProject,
+        id: 'proj-web',
+        name: 'web',
+        rootDirectory: 'apps/web',
+      };
+
+      client.scenario.get('/v9/projects', (req, res) => {
+        if (req.query.teamId === teamA.id && req.query.repoUrl === repoUrl) {
+          return res.json({ projects: [projectA], pagination: {} });
+        }
+        return res.json({ projects: [], pagination: {} });
+      });
+      useUnknownProject();
+
+      client.cwd = projectDir;
+      client.setArgv('--yes');
+      const exitCode = await link(client);
+
+      expect(exitCode).toEqual(0);
+
+      const repoJson = await readJSON(join(repoRoot, '.vercel/repo.json'));
+      expect(repoJson.projects).toEqual([
+        {
+          directory: 'apps/api',
+          id: 'proj-api',
+          name: 'api',
+          orgId: 'team_a',
+        },
+        {
+          directory: 'apps/web',
+          id: projectA.id,
+          name: projectA.name,
+          orgId: teamA.id,
+        },
+      ]);
+    });
+
+    it('should show repo-root and folder-name matches together', async () => {
+      useUser({ version: 'northstar' });
+      const repoRoot = setupTmpDir();
+      const projectDir = join(repoRoot, 'apps/web');
+      const repoUrl = 'https://github.com/user/repo.git';
+      const folderName = basename(projectDir);
+      await mkdirp(join(repoRoot, '.git'));
+      await mkdirp(projectDir);
+      await writeFile(
+        join(repoRoot, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+
+      const [teamA] = useTeams('team_a') as Team[];
+      const teamB = createTeam('team_b', 'team-b', 'Team B');
+      const repoProject = {
+        ...defaultProject,
+        id: 'proj-repo',
+        name: 'dashboard',
+        rootDirectory: 'apps/web',
+      };
+      const folderProject = {
+        ...defaultProject,
+        id: 'proj-folder',
+        name: folderName,
+      };
+
+      client.scenario.get('/v9/projects', (req, res) => {
+        if (req.query.teamId === teamA.id && req.query.repoUrl === repoUrl) {
+          return res.json({ projects: [repoProject], pagination: {} });
+        }
+        return res.json({ projects: [], pagination: {} });
+      });
+      client.scenario.get(`/v9/projects/${folderName}`, (req, res) => {
+        if (req.query.teamId === teamB.id) {
+          return res.json(folderProject);
+        }
+        return res.status(404).json({ error: { code: 'not_found' } });
+      });
+      useUnknownProject();
+
+      client.cwd = projectDir;
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Not one of these projects');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${teamA.slug}/${repoProject.name}`
+      );
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('n\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should search selected SSO-protected teams after no first-pass matches', async () => {
+      useUser({ version: 'northstar' });
+      const cwd = setupTmpDir();
+      const projectName = basename(cwd);
+
+      useTeams('team_a');
+      const limitedTeam = createTeam(
+        'team_limited',
+        'team-limited',
+        'Team Limited'
+      );
+      (limitedTeam as Team & { limited?: boolean }).limited = true;
+      const limitedProject = {
+        ...defaultProject,
+        id: 'proj-limited',
+        name: projectName,
+      };
+
+      client.scenario.get(`/v9/projects/${projectName}`, (req, res) => {
+        if (req.query.teamId === limitedTeam.id) {
+          return res.json(limitedProject);
+        }
+        return res.status(404).json({ error: { code: 'not_found' } });
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput(
+        'Which SSO-protected teams should be searched?'
+      );
+      client.stdin.write(' \n');
+
+      await expect(client.stderr).toOutput('Found project');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${limitedTeam.slug}/${limitedProject.name}`
+      );
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('n\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+      expect(projectJson.projectId).toEqual(limitedProject.id);
+      expect(projectJson.orgId).toEqual(limitedTeam.id);
+    });
+
     describe('multiple matches', () => {
       it('should auto-link to current team match with --yes', async () => {
         useUser();
@@ -2341,9 +2526,6 @@ describe('link', () => {
         client.cwd = cwd;
         const exitCodePromise = link(client);
 
-        await expect(client.stderr).toOutput('Set up');
-        client.stdin.write('y\n');
-
         await expect(client.stderr).toOutput(
           'Found matching projects across teams'
         );
@@ -2362,6 +2544,60 @@ describe('link', () => {
 
         const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
         expect(projectJson.projectId).toEqual('proj-on-a');
+      });
+
+      it('should default to the current team match when prompting interactively', async () => {
+        useUser();
+        const cwd = setupTmpDir();
+        const projectName = basename(cwd);
+
+        useTeams('team_a');
+        createTeam('team_b', 'team-b', 'Team B');
+
+        const projectA = {
+          ...defaultProject,
+          id: 'proj-on-a',
+          name: projectName,
+        };
+        const projectB = {
+          ...defaultProject,
+          id: 'proj-on-b',
+          name: projectName,
+        };
+
+        client.scenario.get(`/v9/projects/${projectName}`, (req, res) => {
+          if (req.query.teamId === 'team_a') {
+            return res.json(projectA);
+          }
+          if (req.query.teamId === 'team_b') {
+            return res.json(projectB);
+          }
+          res.status(404).json({ error: { code: 'not_found' } });
+        });
+        useUnknownProject();
+
+        client.config.currentTeam = 'team_b';
+        client.cwd = cwd;
+        const exitCodePromise = link(client);
+
+        await expect(client.stderr).toOutput(
+          'Found matching projects across teams'
+        );
+        client.stdin.write('\n');
+
+        await expect(client.stderr).toOutput('Linked to');
+
+        await expect(client.stderr).toOutput(
+          'Would you like to pull environment variables now?'
+        );
+        client.stdin.write('n\n');
+
+        const exitCode = await exitCodePromise;
+        expect(exitCode).toEqual(0);
+
+        const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+        expect(projectJson.projectId).toEqual('proj-on-b');
+        expect(projectJson.orgId).toEqual('team_b');
       });
 
       it('should fall through to selectOrg when non-interactive with multiple matches', async () => {


### PR DESCRIPTION
## Summary
- Experiment with plain `vc link` auto-writing all selected Git-linked projects into `.vercel/repo.json`.
- Ask up front which teams should be searched, including SSO-protected teams in the same multiselect.
- Only fall back to folder-name matching when no Git-linked projects are found.

## Behavior
This builds on the repo-aware link work and explores making `vc link --repo` less necessary for existing Git-linked projects.

Unlike the prior behavior, this experiment does not ask the user to select a single Git-linked match. After team selection, it fetches every project connected to the current Git remote in the selected teams and writes them all to `.vercel/repo.json`.

```bash
$ vc link
? Which teams should be searched?
❯◉ team-alpha (team-alpha)
 ◉ team-beta (team-beta)
 ◯ enterprise-apps (enterprise-apps) (SSO-protected)
```

If Git-linked projects are found, they are written immediately:

```bash
✅  Linked 35 Projects from Git repository (created .vercel)
  28 Projects from team-alpha
  7 Projects from team-beta
```

The `repo.json` update is additive by project id: existing entries are preserved unless a newly matched project has the same id. It intentionally allows directory collisions across projects or teams, so later commands can use the existing repo-link project selector when a cwd matches more than one entry.

If no Git-linked projects are found, the flow falls back to folder-name matching.

## Test plan
- `pnpm exec vitest run packages/cli/test/unit/commands/link/index.test.ts`
- `pnpm --filter vercel type-check`
- `pnpm exec biome lint \"packages/cli/src/util/projects/search-project-across-teams.ts\" \"packages/cli/src/util/link/repo.ts\" \"packages/cli/src/util/link/setup-and-link.ts\" \"packages/cli/src/commands/link/index.ts\" \"packages/cli/test/unit/commands/link/index.test.ts\"`


Made with [Cursor](https://cursor.com)