### PR TITLE
Update vercel-cli skill guidance for agents

### DIFF
--- a/.changeset/vercel-cli-agent-sandbox.md
+++ b/.changeset/vercel-cli-agent-sandbox.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update Vercel CLI skill guidance for agent sandbox usage.

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vercel-cli
-description: Deploy, manage, and develop projects on Vercel from the command line
+description: Deploy, manage, inspect, and troubleshoot Vercel projects from the command line. Use for Vercel deployments, projects and teams, environment variables, domains and DNS, logs, metrics, usage, activity, firewall rules, preview access, local development, integrations, or `vercel api` fallback.
 ---
 
 # Vercel CLI Skill
@@ -42,13 +42,13 @@ Use this to route to the correct reference file:
 - **CI/CD automation** → `references/ci-automation.md`
 - **Domains or DNS** → `references/domains-and-dns.md`
 - **Projects or teams** → `references/projects-and-teams.md`
-- **Logs, debugging, or accessing preview deploys** → `references/monitoring-and-debugging.md`
+- **Logs, metrics, usage, activity, performance, or production debugging** → `references/monitoring-and-debugging.md`
 - **Blob storage** → `references/storage.md`
 - **Integrations (databases, storage, etc.)** → `references/integrations.md`
 - **Routing rules** → `references/routing.md`
 - **Firewall (WAF rules, IP blocks, rate limiting)** → `references/firewall.md`
 - **Access a preview deployment** → use `vercel curl` (see `references/monitoring-and-debugging.md`)
-- **CLI doesn't have a command for it** → use `vercel api` as a fallback (see `references/advanced.md`)
+- **CLI command is unavailable or output is missing required fields** → use `vercel api` after first-class CLI paths are unavailable or insufficient (see `references/advanced.md`)
 - **Node.js backends (Express, Hono, etc.)** → `references/node-backends.md`
 - **Monorepos (Turborepo, Nx, workspaces)** → `references/monorepos.md`
 - **Bun runtime** → `references/bun.md`

--- a/skills/vercel-cli/command/vercel.md
+++ b/skills/vercel-cli/command/vercel.md
@@ -1,8 +1,8 @@
 ---
-description: Load the Vercel CLI skill for deploying, managing, and developing projects on the Vercel platform. Use when users ask to "deploy a project", "set up environment variables", "configure a domain", "start local development", manage Vercel infrastructure, "add a database", "install an integration", "connect a third-party service", or manage Marketplace integrations.
+description: Load the Vercel CLI skill for deploying, managing, inspecting, and troubleshooting projects on the Vercel platform. Use when users ask to deploy a project, inspect deployments, debug logs or metrics, check activity or usage, set up environment variables, configure domains or DNS, start local development, manage Vercel infrastructure, add databases or integrations, connect third-party services, or use Vercel API fallback.
 ---
 
-Load the Vercel CLI skill and help with project deployment and management.
+Load the Vercel CLI skill and help with Vercel project deployment, management, inspection, and troubleshooting.
 
 ## Workflow
 

--- a/skills/vercel-cli/references/advanced.md
+++ b/skills/vercel-cli/references/advanced.md
@@ -4,15 +4,29 @@
 
 **Use `vercel api` when a CLI command doesn't exist for what you need.** Full access to the Vercel REST API with automatic authentication.
 
+Use first-class CLI commands before `vercel api` whenever they expose the data or mutation you need.
+
+Use `vercel api` when:
+
+- The first-class CLI command does not exist.
+- The first-class command omits fields needed for the answer.
+- JSON output is needed for filtering or aggregation.
+- Endpoint discovery is needed through `vercel api list`.
+
+Keep calls narrow and shape large responses before presenting them. Use `--raw-field` instead of typed `--field` when the API expects a string value that looks like a boolean or number.
+
 ```bash
 vercel api /v2/user                                    # GET current user
 vercel api /v9/projects --scope my-team                # list projects
 vercel api /v10/projects -X POST -F name=my-project    # create project
 vercel api /v6/deployments --paginate                  # paginate all results
-vercel api ls                                          # list available endpoints
+vercel api list                                        # list available endpoints
+vercel api list --format json                          # list endpoints as JSON
+vercel api "/v6/deployments?projectId=<project-id>&limit=10" --scope <team>
+vercel api /v9/projects/<project>/env/<env-id> -X PATCH --raw-field value=false --scope <team>
 ```
 
-Use `vercel api ls` to discover available endpoints.
+Use `vercel api list` to discover available endpoints. `vercel api ls` is also accepted as an alias.
 
 ## Other Commands
 

--- a/skills/vercel-cli/references/environment-variables.md
+++ b/skills/vercel-cli/references/environment-variables.md
@@ -6,6 +6,20 @@ Env vars are scoped to **environments**: production, preview (can be branch-spec
 
 Variables can be plain text or sensitive (encrypted, not readable after creation).
 
+## Inspecting Env Vars
+
+`vercel env ls` shows configured variable names, targets, and metadata. Plain values may appear in JSON output; sensitive values are not readable after creation.
+
+For metadata-oriented investigations, start with:
+
+```bash
+# Run from a linked project directory
+vercel env ls --format json
+vercel env ls production --format json
+```
+
+If CLI output does not include required metadata, use `vercel api` after checking available endpoints with `vercel api list`. Do not invent unsupported `env ls` scope/project flags; link or switch scope first when the command requires project context.
+
 ## Managing Env Vars
 
 ```bash

--- a/skills/vercel-cli/references/firewall.md
+++ b/skills/vercel-cli/references/firewall.md
@@ -8,6 +8,18 @@
 - **Attack mode** — emergency mode that challenges unverified visitors during an active attack (verified bots and crawlers are exempt)
 - **System mitigations** — automatic DDoS protection that can be temporarily paused for debugging
 
+## Contents
+
+- [Overview](#overview)
+- [Custom Rules](#custom-rules)
+- [IP Blocks](#ip-blocks)
+- [System Bypass](#system-bypass)
+- [Attack Mode](#attack-mode)
+- [System Mitigations](#system-mitigations)
+- [Publishing](#publishing)
+- [Agent Usage](#agent-usage)
+- [Anti-Patterns](#anti-patterns)
+
 ## Overview
 
 ```bash

--- a/skills/vercel-cli/references/monitoring-and-debugging.md
+++ b/skills/vercel-cli/references/monitoring-and-debugging.md
@@ -1,5 +1,28 @@
 # Monitoring & Debugging
 
+## Diagnostic Ladder
+
+For production issues, start broad and narrow with bounded commands:
+
+1. Identify project and scope.
+2. List recent deployments: `vercel list <project> --scope <team> --status READY --format json`.
+3. Inspect the relevant deployment: `vercel inspect <deployment-url>`.
+4. Check logs for a bounded window: `vercel logs <deployment-url> --no-follow --since 1h --limit 100 --json`.
+5. If metrics are available, inspect schema first, then query a relevant metric with a bounded time window and group-by.
+6. If logs or metrics are unavailable, report the permission, subscription, retention, or no-data limitation and use deployments, activity, or inspect output as fallback evidence.
+
+Useful discovery commands:
+
+```bash
+vercel logs --help
+vercel metrics --help
+vercel metrics schema --format=json
+vercel metrics schema <metric-or-prefix> --format=json
+vercel activity --help
+vercel activity types --format json --scope <team>
+vercel usage --help
+```
+
 ## Logs
 
 ```bash
@@ -9,6 +32,19 @@ vercel logs --level error --level warn         # filter by severity
 vercel logs --source lambda                    # filter by source (lambda, edge, static)
 vercel logs --since 2024-01-01                 # filter by time
 vercel logs --query "timeout"                  # search
+```
+
+## Metrics
+
+Inspect schema before querying unfamiliar metrics. Use bounded time windows and group limits when grouping results.
+
+```bash
+vercel metrics schema                                                    # list available metrics
+vercel metrics schema vercel.function_invocation                         # inspect a metric prefix
+vercel metrics vercel.function_invocation.count --since 1h               # query linked project
+vercel metrics vercel.function_invocation.count -f "http_status ge 500" --group-by error_code --since 1h --format=json
+vercel metrics vercel.function_invocation.request_duration_ms -a avg --group-by route --since 1h
+vercel metrics --all vercel.function_invocation.count --group-by project_id --since 24h
 ```
 
 ## Inspecting Deployments

--- a/skills/vercel-cli/references/projects-and-teams.md
+++ b/skills/vercel-cli/references/projects-and-teams.md
@@ -30,6 +30,26 @@ vercel teams switch my-team          # switch by slug
 vercel teams invite user@example.com # invite member
 ```
 
+## Discovering Scope
+
+Use these commands when the user has not specified a team or project and the task is read-only:
+
+```bash
+vercel whoami
+vercel teams ls --format json
+vercel project ls --scope <team-slug> --format json
+vercel list <project-name> --scope <team-slug> --status READY --format json
+```
+
+Use explicit scope after selecting or inferring the team:
+
+```bash
+vercel project inspect <project-name> --scope <team-slug>
+vercel list <project-name> --scope <team-slug> --status READY --format json
+```
+
+Do not conclude that no projects or deployments exist after checking only one relevant scope. If several plausible targets remain, ask the user to choose from the candidates found. Avoid broad enumeration across unrelated teams unless the user asked for account-wide investigation.
+
 ## Scoping
 
 Use `--scope` or `--team` on any command to target a specific team:


### PR DESCRIPTION
## Summary

Updates the vercel-cli skill for agent-driven Vercel operations, especially Vercel Agent-style sandboxes where auth is managed and injected by the agent and the CLI skill is available as local guidance.

- expand skill and command triggers for operational inspection and troubleshooting
- add bounded discovery guidance for projects, teams, logs, metrics, env vars, and API fallback
- add a TOC to the long firewall reference
