### PR TITLE
Use repo links for Git-backed project setup

### DIFF
--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -448,6 +448,7 @@ export type ProjectLinked = {
   org: Org;
   project: Project;
   repoRoot?: string;
+  projectRootDirectory?: string;
 };
 
 export type ProjectNotLinked = {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -93,6 +93,7 @@ import parseTarget from '../../util/parse-target';
 import cliPkg from '../../util/pkg';
 import * as cli from '../../util/pkg-name';
 import { getProjectLink, VERCEL_DIR } from '../../util/projects/link';
+import { getEffectiveRootDirectory } from '../../util/projects/effective-root-directory';
 import { resolveProjectCwd } from '../../util/projects/find-project-root';
 import {
   pickOverrides,
@@ -456,7 +457,16 @@ export default async function main(client: Client): Promise<number> {
       await rootSpan
         .child('vc.doBuild')
         .trace(span =>
-          doBuild(client, project, buildsJson, cwd, outputDir, span, standalone)
+          doBuild(
+            client,
+            project,
+            projectRootDirectory,
+            buildsJson,
+            cwd,
+            outputDir,
+            span,
+            standalone
+          )
         );
     } finally {
       await rootSpan.stop();
@@ -548,6 +558,7 @@ export default async function main(client: Client): Promise<number> {
 async function doBuild(
   client: Client,
   project: ProjectLinkAndSettings,
+  repoProjectDirectory: string | undefined,
   buildsJson: BuildsManifest,
   cwd: string,
   outputDir: string,
@@ -559,7 +570,11 @@ async function doBuild(
   // Regex pattern for validating deploymentId characters: alphanumeric, hyphen, underscore
   const VALID_DEPLOYMENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
-  const workPath = join(cwd, project.settings.rootDirectory || '.');
+  const effectiveRootDirectory = getEffectiveRootDirectory({
+    projectRootDirectory: project.settings.rootDirectory,
+    repoProjectDirectory,
+  });
+  const workPath = join(cwd, effectiveRootDirectory || '.');
 
   const sourceConfigFile = await findSourceVercelConfigFile(workPath);
   let corepackShimDir: string | null | undefined;
@@ -651,8 +666,7 @@ async function doBuild(
   if (
     process.env.VERCEL_BUILD_MONOREPO_SUPPORT === '1' &&
     pkg?.scripts?.['vercel-build'] === undefined &&
-    projectSettings.rootDirectory !== null &&
-    projectSettings.rootDirectory !== '.'
+    effectiveRootDirectory !== ''
   ) {
     await setMonorepoDefaultSettings(cwd, workPath, projectSettings);
   }

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -70,6 +70,7 @@ import { getCommandNameWithGlobalFlags } from '../../util/arg-common';
 import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 import { AGENT_STATUS } from '../../util/agent-output-constants';
+import { getEffectiveRootDirectory } from '../../util/projects/effective-root-directory';
 import { pickOverrides } from '../../util/projects/project-settings';
 import validatePaths, {
   validateRootDirectory,
@@ -306,7 +307,10 @@ async function handleInitDeployment(
   }
 
   const { org, project } = link;
-  const rootDirectory = project.rootDirectory;
+  const rootDirectory = getEffectiveRootDirectory({
+    projectRootDirectory: project.rootDirectory,
+    repoProjectDirectory: link.projectRootDirectory,
+  });
   const sourceFilesOutsideRootDirectory =
     project.sourceFilesOutsideRootDirectory ?? true;
 
@@ -915,8 +919,12 @@ async function handleContinueSubcommand(
 
   // Resolve vercelOutputDir - prebuilt is implicit for continue
   let vercelOutputDir: string = join(cwd, '.vercel/output');
-  if (link.repoRoot && link.project.rootDirectory) {
-    vercelOutputDir = join(cwd, link.project.rootDirectory, '.vercel/output');
+  const effectiveRootDirectory = getEffectiveRootDirectory({
+    projectRootDirectory: link.project.rootDirectory,
+    repoProjectDirectory: link.projectRootDirectory,
+  });
+  if (link.repoRoot && effectiveRootDirectory) {
+    vercelOutputDir = join(cwd, effectiveRootDirectory, '.vercel/output');
   }
 
   const prebuiltExists = await fs.pathExists(vercelOutputDir);
@@ -1193,7 +1201,10 @@ async function handleDefaultDeploy(
   }
 
   const { org, project } = link;
-  const rootDirectory = project.rootDirectory;
+  const rootDirectory = getEffectiveRootDirectory({
+    projectRootDirectory: project.rootDirectory,
+    repoProjectDirectory: link.projectRootDirectory,
+  });
   const sourceFilesOutsideRootDirectory =
     project.sourceFilesOutsideRootDirectory ?? true;
 
@@ -1206,8 +1217,8 @@ async function handleDefaultDeploy(
   if (parsedArguments.flags['--prebuilt']) {
     vercelOutputDir = join(cwd, '.vercel/output');
 
-    if (link.repoRoot && link.project.rootDirectory) {
-      vercelOutputDir = join(cwd, link.project.rootDirectory, '.vercel/output');
+    if (link.repoRoot && rootDirectory) {
+      vercelOutputDir = join(cwd, rootDirectory, '.vercel/output');
     }
 
     const prebuiltExists = await fs.pathExists(vercelOutputDir);

--- a/packages/cli/src/commands/git/connect.ts
+++ b/packages/cli/src/commands/git/connect.ts
@@ -20,6 +20,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { connectSubcommand } from './command';
 import { ensureLink } from '../../util/link/ensure-link';
+import { linkRepoProject } from '../../util/link/repo';
 
 interface ConnectArgParams {
   client: Client;
@@ -162,6 +163,15 @@ export default async function connect(client: Client, argv: string[]) {
   if (typeof result === 'number') {
     return result;
   }
+  const remoteName = getRemoteNameForRepo(remoteUrls, repoInfo);
+  if (remoteName) {
+    await linkRepoProject(client, cwd, {
+      project,
+      orgId: org.id,
+      orgSlug: org.slug,
+      remoteName,
+    });
+  }
 
   return 0;
 }
@@ -232,10 +242,37 @@ async function connectArgWithLocalGit({
       if (typeof result === 'number') {
         return result;
       }
+      const remoteName = getRemoteNameForRepo(remoteUrls, repoInfo);
+      if (remoteName) {
+        await linkRepoProject(client, client.cwd, {
+          project,
+          orgId: org.id,
+          orgSlug: org.slug,
+          remoteName,
+        });
+      }
     }
     return 0;
   }
   return await connectArg({ client, confirm, org, project, repoInfo });
+}
+
+function getRemoteNameForRepo(
+  remoteUrls: Dictionary<string>,
+  repoInfo: RepoInfo
+): string | null {
+  for (const [name, url] of Object.entries(remoteUrls)) {
+    const parsed = parseRepoUrl(url);
+    if (
+      parsed &&
+      parsed.provider === repoInfo.provider &&
+      parsed.org === repoInfo.org &&
+      parsed.repo === repoInfo.repo
+    ) {
+      return name;
+    }
+  }
+  return null;
 }
 
 async function promptConnectArg({

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -7,6 +7,7 @@ import { parseArguments } from '../../util/get-args';
 import stamp from '../../util/output/stamp';
 import { VERCEL_DIR, VERCEL_DIR_PROJECT } from '../../util/projects/link';
 import { writeProjectSettings } from '../../util/projects/project-settings';
+import { getEffectiveRootDirectory } from '../../util/projects/effective-root-directory';
 import { envPullCommandLogic } from '../env/pull';
 import {
   isValidEnvTarget,
@@ -132,7 +133,11 @@ export async function pullCommandLogic(
 
   let currentDirectory: string;
   if (repoRoot) {
-    currentDirectory = join(repoRoot, project.rootDirectory || '');
+    const effectiveRootDirectory = getEffectiveRootDirectory({
+      projectRootDirectory: project.rootDirectory,
+      repoProjectDirectory: link.projectRootDirectory,
+    });
+    currentDirectory = join(repoRoot, effectiveRootDirectory);
   } else {
     currentDirectory = cwd;
   }

--- a/packages/cli/src/util/input/input-root-directory.ts
+++ b/packages/cli/src/util/input/input-root-directory.ts
@@ -7,7 +7,8 @@ import type Client from '../client';
 export async function inputRootDirectory(
   client: Client,
   cwd: string,
-  autoConfirm = false
+  autoConfirm = false,
+  defaultRootDirectory?: string | null
 ) {
   if (autoConfirm) {
     return null;
@@ -16,6 +17,7 @@ export async function inputRootDirectory(
   while (true) {
     const rootDirectory = await client.input.text({
       message: `In which directory is your code located?`,
+      default: defaultRootDirectory ?? undefined,
       transformer: (input: string) => {
         return `${chalk.dim(`./`)}${input}`;
       },

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -5,9 +5,15 @@ import { homedir } from 'os';
 import slugify from '@sindresorhus/slugify';
 import { basename, join } from 'path';
 import { normalizePath, traverseUpDirectories } from '@vercel/build-utils';
-import { lstat, readJSON, outputJSON } from 'fs-extra';
+import { lstat, readJSON, outputJSON, remove } from 'fs-extra';
 import toHumanPath from '../humanize-path';
-import { VERCEL_DIR, VERCEL_DIR_REPO, writeReadme } from '../projects/link';
+import {
+  getVercelDirectory,
+  VERCEL_DIR,
+  VERCEL_DIR_PROJECT,
+  VERCEL_DIR_REPO,
+  writeReadme,
+} from '../projects/link';
 import { getRemoteUrls } from '../create-git-meta';
 import link from '../output/link';
 import { emoji, prependEmoji, type EmojiLabel } from '../emoji';
@@ -202,6 +208,7 @@ export async function linkRepoProject(
   };
 
   await outputJSON(repoLink.repoConfigPath, repoConfig, { spaces: 2 });
+  await remove(join(getVercelDirectory(cwd), VERCEL_DIR_PROJECT));
   await writeReadme(repoLink.rootPath);
   const isGitIgnoreUpdated = await addToGitIgnore(repoLink.rootPath);
 

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -14,13 +14,15 @@ import {
   VERCEL_DIR_README,
   VERCEL_DIR_PROJECT,
 } from '../projects/link';
-import { linkRepoProject } from './repo';
+import { findRepoRoot, linkRepoProject, resolveGitRemote } from './repo';
 import createProject from '../projects/create-project';
 import type Client from '../client';
 import { printError } from '../error';
 import pull from '../../commands/env/pull';
 import { parseGitConfig, pluckRemoteUrls } from '../create-git-meta';
 import {
+  type RepoInfo,
+  parseRepoUrl,
   selectAndParseRemoteUrl,
   checkExistsAndConnect,
 } from '../git/connect-git-provider';
@@ -56,6 +58,12 @@ import {
 } from './services-setup';
 import searchProjectAcrossTeams from '../projects/search-project-across-teams';
 import type { CrossTeamMatch } from '../projects/search-project-across-teams';
+
+interface GitConnectionChoice {
+  repoInfo: RepoInfo;
+  repoRoot: string;
+  remoteName: string;
+}
 
 export interface SetupAndLinkOptions {
   autoConfirm?: boolean;
@@ -199,6 +207,41 @@ async function linkCrossTeamMatch({
     pullEnv
   );
   return { status: 'linked', org: match.org, project: match.project };
+}
+
+async function promptForGitConnection(
+  client: Client,
+  repoRoot: string,
+  autoConfirm: boolean
+): Promise<GitConnectionChoice | null> {
+  const shouldConnect =
+    autoConfirm ||
+    (await client.input.confirm(
+      `Detected a repository. Connect it to this project?`,
+      true
+    ));
+  if (!shouldConnect) {
+    return null;
+  }
+
+  const remote = await resolveGitRemote(client, repoRoot, {
+    yes: autoConfirm,
+  });
+  if (!remote) {
+    return null;
+  }
+
+  const repoInfo = parseRepoUrl(remote.repoUrl);
+  if (!repoInfo) {
+    output.log(`Failed to parse Git repo data from ${remote.repoUrl}`);
+    return null;
+  }
+
+  return {
+    repoInfo,
+    repoRoot,
+    remoteName: remote.remoteName,
+  };
 }
 
 async function promptForLimitedTeams(
@@ -575,6 +618,14 @@ export default async function setupAndLink(
     let settings: ProjectSettings = {};
     let pathWithRootDirectory = path;
     let rootInferredServicesChoice: InferredServicesChoice | null = null;
+    const detectedRepoRoot = await findRepoRoot(path);
+    const gitConnection = detectedRepoRoot
+      ? await promptForGitConnection(client, detectedRepoRoot, autoConfirm)
+      : null;
+    const rootDirectoryBasePath = detectedRepoRoot ?? path;
+    const defaultRootDirectory = detectedRepoRoot
+      ? toProjectRootDirectory(detectedRepoRoot, path)
+      : null;
 
     if (!rootServicesSetup.hasConfiguredServices) {
       rootInferredServicesChoice = await promptForInferredServicesSetup({
@@ -609,14 +660,22 @@ export default async function setupAndLink(
 
       if (rootInferredServicesChoice?.type === 'single-app') {
         rootDirectory = toProjectRootDirectory(
-          path,
+          rootDirectoryBasePath,
           rootInferredServicesChoice.selectedPath
         );
       } else {
-        rootDirectory = await inputRootDirectory(client, path, autoConfirm);
+        rootDirectory = await inputRootDirectory(
+          client,
+          rootDirectoryBasePath,
+          autoConfirm,
+          defaultRootDirectory
+        );
         if (
           rootDirectory &&
-          !(await validateRootDirectory(path, join(path, rootDirectory)))
+          !(await validateRootDirectory(
+            rootDirectoryBasePath,
+            join(rootDirectoryBasePath, rootDirectory)
+          ))
         ) {
           return {
             status: 'error',
@@ -626,7 +685,9 @@ export default async function setupAndLink(
         }
       }
 
-      pathWithRootDirectory = rootDirectory ? join(path, rootDirectory) : path;
+      pathWithRootDirectory = rootDirectory
+        ? join(rootDirectoryBasePath, rootDirectory)
+        : path;
       const selectedRootServicesSetup =
         pathWithRootDirectory === path
           ? null
@@ -657,11 +718,11 @@ export default async function setupAndLink(
       } else {
         if (selectedRootInferredServicesChoice?.type === 'single-app') {
           rootDirectory = toProjectRootDirectory(
-            path,
+            rootDirectoryBasePath,
             selectedRootInferredServicesChoice.selectedPath
           );
           pathWithRootDirectory = rootDirectory
-            ? join(path, rootDirectory)
+            ? join(rootDirectoryBasePath, rootDirectory)
             : path;
         }
 
@@ -737,21 +798,45 @@ export default async function setupAndLink(
       v0,
     });
 
-    await linkFolderToProject(
-      client,
-      path,
-      {
-        projectId: project.id,
-        orgId: org.id,
-      },
-      project.name,
-      org.slug,
-      successEmoji,
-      autoConfirm,
-      false // don't prompt to pull env for newly created projects
-    );
-
-    await connectGitRepository(client, path, project, autoConfirm, org);
+    if (gitConnection) {
+      const connected = await connectGitRepository(
+        client,
+        path,
+        project,
+        autoConfirm,
+        org,
+        gitConnection
+      );
+      if (!connected) {
+        await linkFolderToProject(
+          client,
+          path,
+          {
+            projectId: project.id,
+            orgId: org.id,
+          },
+          project.name,
+          org.slug,
+          successEmoji,
+          autoConfirm,
+          false // don't prompt to pull env for newly created projects
+        );
+      }
+    } else {
+      await linkFolderToProject(
+        client,
+        path,
+        {
+          projectId: project.id,
+          orgId: org.id,
+        },
+        project.name,
+        org.slug,
+        successEmoji,
+        autoConfirm,
+        false // don't prompt to pull env for newly created projects
+      );
+    }
 
     return { status: 'linked', org, project };
   } catch (err) {
@@ -776,18 +861,43 @@ export async function connectGitRepository(
   path: string,
   project: { id: string; link?: any },
   autoConfirm: boolean,
-  org: Org
-): Promise<void> {
+  org: Org,
+  gitConnection?: GitConnectionChoice
+): Promise<boolean> {
   try {
+    if (gitConnection) {
+      const result = await checkExistsAndConnect({
+        client,
+        confirm: autoConfirm,
+        gitProviderLink: project.link,
+        org,
+        gitOrg: gitConnection.repoInfo.org,
+        project: project as any,
+        provider: gitConnection.repoInfo.provider,
+        repo: gitConnection.repoInfo.repo,
+        repoPath: `${gitConnection.repoInfo.org}/${gitConnection.repoInfo.repo}`,
+      });
+      if (typeof result === 'number') {
+        return false;
+      }
+      await linkRepoProject(client, path, {
+        project: project as any,
+        orgId: org.id,
+        orgSlug: org.slug,
+        remoteName: gitConnection.remoteName,
+      });
+      return true;
+    }
+
     const gitConfig = await parseGitConfig(join(path, '.git/config'));
 
     if (!gitConfig) {
-      return;
+      return false;
     }
 
     const remoteUrls = pluckRemoteUrls(gitConfig);
     if (!remoteUrls || Object.keys(remoteUrls).length === 0) {
-      return;
+      return false;
     }
 
     const shouldConnect =
@@ -798,12 +908,12 @@ export async function connectGitRepository(
       ));
 
     if (!shouldConnect) {
-      return;
+      return false;
     }
 
     const repoInfo = await selectAndParseRemoteUrl(client, remoteUrls);
     if (!repoInfo) {
-      return;
+      return false;
     }
 
     await checkExistsAndConnect({
@@ -817,8 +927,10 @@ export async function connectGitRepository(
       repo: repoInfo.repo,
       repoPath: `${repoInfo.org}/${repoInfo.repo}`,
     });
+    return true;
   } catch (error) {
     // Silently ignore git connection errors to not disrupt the main flow
     output.debug(`Failed to connect git repository: ${error}`);
+    return false;
   }
 }

--- a/packages/cli/src/util/projects/effective-root-directory.ts
+++ b/packages/cli/src/util/projects/effective-root-directory.ts
@@ -1,0 +1,22 @@
+import { normalizePath } from '@vercel/build-utils';
+
+function normalizeRootDirectory(value?: string | null): string {
+  if (!value || value === '.') {
+    return '';
+  }
+  return normalizePath(value);
+}
+
+export function getEffectiveRootDirectory({
+  projectRootDirectory,
+  repoProjectDirectory,
+}: {
+  projectRootDirectory?: string | null;
+  repoProjectDirectory?: string | null;
+}): string {
+  const remoteRootDirectory = normalizeRootDirectory(projectRootDirectory);
+  if (remoteRootDirectory) {
+    return remoteRootDirectory;
+  }
+  return normalizeRootDirectory(repoProjectDirectory);
+}

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -394,7 +394,13 @@ export async function getLinkedProject(
     return { status: 'not_linked', org: null, project: null };
   }
 
-  return { status: 'linked', org, project, repoRoot: link.repoRoot };
+  return {
+    status: 'linked',
+    org,
+    project,
+    repoRoot: link.repoRoot,
+    projectRootDirectory: link.projectRootDirectory,
+  };
 }
 
 const VERCEL_DIR_README_CONTENT = `> Why do I have a folder named ".vercel" in my project?

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1707,7 +1707,7 @@ createServer((_req, res) => {
       ...defaultProject,
       id: 'QmbKpqpiUqbcke',
       name: 'monorepo-dashboard',
-      rootDirectory: 'dashboard',
+      rootDirectory: null,
       outputDirectory: 'dist',
       framework: null,
     });

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1707,7 +1707,7 @@ createServer((_req, res) => {
       ...defaultProject,
       id: 'QmbKpqpiUqbcke',
       name: 'monorepo-dashboard',
-      rootDirectory: null,
+      rootDirectory: 'dashboard',
       outputDirectory: 'dist',
       framework: null,
     });
@@ -1745,6 +1745,35 @@ createServer((_req, res) => {
     expect(
       (await fs.readFile(join(output, 'static/index.txt'), 'utf8')).trim()
     ).toEqual('marketing');
+  });
+
+  it('should build with local repo.json directory when project rootDirectory is empty', async () => {
+    const cwd = fixture('../../monorepo-link');
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'QmbKpqpiUqbcke',
+      name: 'monorepo-dashboard',
+      rootDirectory: null,
+      outputDirectory: 'dist',
+      framework: null,
+    });
+
+    const output = join(cwd, 'dashboard/.vercel/output');
+    client.cwd = join(cwd, 'dashboard');
+    client.setArgv('build', '--yes');
+
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
+    delete process.env.__VERCEL_BUILD_RUNNING;
+
+    const files = await fs.readdir(join(output, 'static'));
+    expect(files.sort()).toEqual(['index.txt']);
+    expect(
+      (await fs.readFile(join(output, 'static/index.txt'), 'utf8')).trim()
+    ).toEqual('dashboard');
   });
 
   it('should write to flags.json', async () => {

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -7,11 +7,14 @@ import { defaultProject, useProject } from '../../../mocks/project';
 import { client } from '../../../mocks/client';
 import git from '../../../../src/commands/git';
 import type { Project } from '@vercel-internals/types';
-import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('git connect', () => {
   const fixture = (name: string) =>
-    join(__dirname, '../../../fixtures/unit/commands/git/connect', name);
+    setupUnitFixture(join('commands/git/connect', name));
 
   describe('--non-interactive', () => {
     it('outputs action_required JSON and exits when not linked and multiple teams (no --scope)', async () => {
@@ -196,44 +199,49 @@ describe('git connect', () => {
     it('connects an unlinked project', async () => {
       const cwd = fixture('unlinked');
       client.cwd = cwd;
-      client.setArgv('git', 'connect');
-      const gitPromise = git(client);
+      try {
+        await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
+        client.setArgv('git', 'connect');
+        const gitPromise = git(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
+        await expect(client.stderr).toOutput('Set up');
+        client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput(
-        'Which scope should contain your project?'
-      );
-      client.stdin.write('\r');
+        await expect(client.stderr).toOutput(
+          'Which scope should contain your project?'
+        );
+        client.stdin.write('\r');
 
-      await expect(client.stderr).toOutput('Found project');
-      client.stdin.write('y\n');
+        await expect(client.stderr).toOutput('Found project');
+        client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
-      client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          'Would you like to pull environment variables now?'
+        );
+        client.stdin.write('n\n');
 
-      await expect(client.stderr).toOutput(
-        `Connecting GitHub repository: https://github.com/user/repo`
-      );
+        await expect(client.stderr).toOutput(
+          `Connecting GitHub repository: https://github.com/user/repo`
+        );
 
-      const exitCode = await gitPromise;
-      await expect(client.stderr).toOutput('Connected');
+        const exitCode = await gitPromise;
+        await expect(client.stderr).toOutput('Connected');
 
-      expect(exitCode).toEqual(0);
+        expect(exitCode).toEqual(0);
 
-      const project: Project = await client.fetch(`/v8/projects/unlinked`);
-      expect(project.link).toMatchObject({
-        type: 'github',
-        repo: 'user/repo',
-        repoId: 1010,
-        gitCredentialId: '',
-        sourceless: true,
-        createdAt: 1656109539791,
-        updatedAt: 1656109539791,
-      });
+        const project: Project = await client.fetch(`/v8/projects/unlinked`);
+        expect(project.link).toMatchObject({
+          type: 'github',
+          repo: 'user/repo',
+          repoId: 1010,
+          gitCredentialId: '',
+          sourceless: true,
+          createdAt: 1656109539791,
+          updatedAt: 1656109539791,
+        });
+      } finally {
+        await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
+      }
     });
   });
 
@@ -677,7 +685,13 @@ describe('git connect', () => {
       const gitPromise = git(client);
 
       await expect(client.stderr).toOutput(
-        `Found multiple Git repositories in your local Git config:\n  • origin: https://github.com/user/repo.git\n  • secondary: https://github.com/user/repo2.git`
+        `Found multiple Git repositories in your local Git config:`
+      );
+      await expect(client.stderr).toOutput(
+        `origin: https://github.com/user/repo.git`
+      );
+      await expect(client.stderr).toOutput(
+        `secondary: https://github.com/user/repo2.git`
       );
       await expect(client.stderr).toOutput(
         `Do you still want to connect https://github.com/user3/repo3? (y/N)`


### PR DESCRIPTION
## Summary
- Write `.vercel/repo.json` when a newly linked project is connected to a local Git repo, and remove the local `project.json` in that path.
- Fall back to `.vercel/project.json` if Git provider connection fails or the user declines connecting the repo.
- Use the local repo mapping as the effective root for build/deploy/pull when the remote project `rootDirectory` is empty.

## Behavior
This treats `.vercel/repo.json` as the local repo routing table, not as proof that the Vercel project is currently Git-linked. Git connection is used when available, but a repo entry can also represent local knowledge of where a project lives inside a repo.

### Creating a project from inside an app directory
```bash
$ cd apps/web
$ vc link
? Set up "~/repo/apps/web"? yes
? Which scope should contain your project? acme
? Link to existing project? no
? What's your project's name? web
? Detected a repository. Connect it to this project? yes
? In which directory is your code located? ./apps/web
> Connecting GitHub repository: https://github.com/acme/repo
> Connected
Linked to acme/web (created .vercel)
```

When Git connection succeeds, the local link is written at the repo root:

```json
{
  "remoteName": "origin",
  "projects": [
    {
      "id": "prj_123",
      "name": "web",
      "directory": "apps/web",
      "orgId": "team_123"
    }
  ]
}
```

If the Git provider connection fails, the command still links locally with the existing project-link behavior:

```bash
> Connecting GitHub repository: https://github.com/acme/repo
Error: Failed to connect acme/repo to project. Make sure there aren't any typos and that you have access to the repository if it's private.
Linked to acme/web (created .vercel)
```

### Effective local root
For repo-linked projects, commands now distinguish:

- `repo.json.directory`: local routing directory for this repo checkout
- `project.rootDirectory`: remote project setting used for Git deployments

If the remote project root is set, it stays authoritative. If the remote root is empty, local commands can use the repo mapping as the effective local root:

```bash
# repo.json says web lives at apps/web
# project.rootDirectory is empty
$ cd apps/web
$ vc build
# builds apps/web instead of repo root
```

This fixes the case where a non-Git-connected project is locally known to live under `apps/web`, while the remote root setting remains empty.

## Test plan
- `pnpm exec vitest run packages/cli/test/unit/commands/build/index.test.ts packages/cli/test/unit/commands/link/index.test.ts packages/cli/test/unit/commands/git/connect.test.ts`
- `pnpm --filter vercel type-check`
- `pnpm exec biome lint \"packages/cli/src/commands/build/index.ts\" \"packages/cli/src/commands/deploy/index.ts\" \"packages/cli/src/commands/pull/index.ts\" \"packages/cli/src/commands/git/connect.ts\" \"packages/cli/src/util/projects/effective-root-directory.ts\" \"packages/cli/src/util/projects/link.ts\" \"packages/cli/src/util/link/repo.ts\" \"packages/cli/src/util/link/setup-and-link.ts\" \"packages/cli/src/util/input/input-root-directory.ts\" \"packages/cli/test/unit/commands/build/index.test.ts\" \"packages/cli/test/unit/commands/git/connect.test.ts\"`


Made with [Cursor](https://cursor.com)