### PR TITLE
cli/project/token: Skip extra network on success

### DIFF
--- a/.changeset/bright-trees-retire.md
+++ b/.changeset/bright-trees-retire.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Avoid extra network if token fetch works

--- a/packages/cli/src/commands/project/token.ts
+++ b/packages/cli/src/commands/project/token.ts
@@ -7,6 +7,7 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
+import { getRawProjectLink } from '../../util/projects/link';
 import { validateJsonOutput } from '../../util/output-format';
 import { tokenSubcommand } from './command';
 
@@ -39,6 +40,28 @@ export default async function getOidcToken(client: Client, argv: string[]) {
     return 1;
   }
   const [name] = args;
+  let token: string | null = null;
+
+  // Fast path: when no explicit project name is given, try the token endpoint
+  // directly from the link without validating it first. This avoids two API
+  // calls in the common case. If it fails, fall back to the validation flow.
+  if (!name) {
+    const link = await getRawProjectLink(client, client.cwd);
+    if (link) {
+      try {
+        token = await fetchProjectToken(client, link.projectId, link.orgId);
+      } catch (_err) {
+        // Fall through to the validation flow for a better error message.
+      }
+    }
+  }
+
+  if (token) {
+    writeTokenOutput(token, asJson, client);
+    return 0;
+  }
+
+  // Slow path: validate the project/link first, then get token.
   const project = await getProjectByCwdOrLink({
     autoConfirm: Boolean(flags['--yes']),
     nonInteractive: true,
@@ -46,29 +69,8 @@ export default async function getOidcToken(client: Client, argv: string[]) {
     commandName: 'project token',
     projectNameOrId: name,
   });
-
   try {
-    const res = await client.fetch<{ token: string }>(
-      `/projects/${project.id}/token`,
-      {
-        method: 'POST',
-        accountId: project.accountId,
-        body: JSON.stringify({
-          source: 'vercel-cli',
-        }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    );
-
-    if (asJson) {
-      client.stdout.write(`${JSON.stringify({ token: res.token }, null, 2)}\n`);
-    } else {
-      client.stdout.write(`${res.token}\n`);
-    }
-
-    return 0;
+    token = await fetchProjectToken(client, project.id, project.accountId);
   } catch (err: unknown) {
     if (isAPIError(err) && err.status === 404) {
       output.error('No such project exists');
@@ -80,5 +82,37 @@ export default async function getOidcToken(client: Client, argv: string[]) {
     }
     output.error(`An unexpected error occurred!\n${err as string}`);
     return 1;
+  }
+
+  writeTokenOutput(token, asJson, client);
+  return 0;
+}
+
+async function fetchProjectToken(
+  client: Client,
+  projectId: string,
+  teamId: string
+): Promise<string> {
+  const res = await client.fetch<{ token: string }>(
+    `/projects/${projectId}/token`,
+    {
+      method: 'POST',
+      accountId: teamId,
+      body: JSON.stringify({
+        source: 'vercel-cli',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+  return res.token;
+}
+
+function writeTokenOutput(token: string, asJson: boolean, client: Client) {
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify({ token }, null, 2)}\n`);
+  } else {
+    client.stdout.write(`${token}\n`);
   }
 }

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -286,13 +286,28 @@ async function hasProjectLink(
   return false;
 }
 
+export async function getRawProjectLink(
+  client: Client,
+  path: string,
+  projectName?: string
+): Promise<ProjectLink | null> {
+  const VERCEL_ORG_ID = getPlatformEnv('ORG_ID');
+  const VERCEL_PROJECT_ID = getPlatformEnv('PROJECT_ID');
+
+  if (VERCEL_ORG_ID && VERCEL_PROJECT_ID) {
+    return { orgId: VERCEL_ORG_ID, projectId: VERCEL_PROJECT_ID };
+  }
+
+  path = await resolveProjectCwd(path);
+
+  return getProjectLink(client, path, projectName);
+}
+
 export async function getLinkedProject(
   client: Client,
   path = client.cwd,
   projectName?: string
 ): Promise<ProjectLinkResult> {
-  path = await resolveProjectCwd(path);
-
   const VERCEL_ORG_ID = getPlatformEnv('ORG_ID');
   const VERCEL_PROJECT_ID = getPlatformEnv('PROJECT_ID');
   const shouldUseEnv = Boolean(VERCEL_ORG_ID && VERCEL_PROJECT_ID);
@@ -308,11 +323,7 @@ export async function getLinkedProject(
     return { status: 'error', exitCode: 1 };
   }
 
-  const link =
-    VERCEL_ORG_ID && VERCEL_PROJECT_ID
-      ? { orgId: VERCEL_ORG_ID, projectId: VERCEL_PROJECT_ID }
-      : await getProjectLink(client, path, projectName);
-
+  const link = await getRawProjectLink(client, path, projectName);
   if (!link) {
     return { status: 'not_linked', org: null, project: null };
   }

--- a/packages/cli/test/unit/commands/project/token.test.ts
+++ b/packages/cli/test/unit/commands/project/token.test.ts
@@ -103,4 +103,67 @@ describe('project token', () => {
 
     fetchSpy.mockRestore();
   });
+
+  it('uses fast path when linked and skips project validation', async () => {
+    const team = useTeam('team_fast');
+
+    // Set up the link file
+    const cwd = setupTmpDir();
+    await outputFile(
+      join(cwd, '.vercel', 'project.json'),
+      JSON.stringify({ orgId: team.id, projectId: 'prj_fast' })
+    );
+    client.cwd = cwd;
+
+    // Only mock the token endpoint - no useUser/useProject needed
+    let requestBody: unknown;
+    client.scenario.post('/projects/:projectId/token', (req, res) => {
+      requestBody = req.body;
+      res.json({ token: 'fast-token' });
+    });
+
+    client.setArgv('project', 'token');
+
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe('fast-token\n');
+    expect(requestBody).toEqual({ source: 'vercel-cli' });
+  });
+
+  it('falls back to validation when fast path fails', async () => {
+    const team = useTeam('team_fallback');
+    useUser();
+    useProject({
+      ...defaultProject,
+      id: 'prj_fallback',
+      name: 'fallback-project',
+      accountId: team.id,
+    });
+
+    const cwd = setupTmpDir();
+    await outputFile(
+      join(cwd, '.vercel', 'project.json'),
+      JSON.stringify({ orgId: team.id, projectId: 'prj_fallback' })
+    );
+    client.cwd = cwd;
+
+    let attempts = 0;
+    client.scenario.post('/projects/:projectId/token', (_req, res) => {
+      attempts++;
+      if (attempts === 1) {
+        res.status(404).json({ error: { message: 'Not found' } });
+      } else {
+        res.json({ token: 'fallback-token' });
+      }
+    });
+
+    client.setArgv('project', 'token');
+
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe('fallback-token\n');
+    expect(attempts).toBe(2);
+  });
 });


### PR DESCRIPTION
Previously we were unconditionally calling the following three endpoints:

1. GET  /teams/{team_id}
2. GET  /v9/projects/{project_id}?teamId={team_id}
3. POST /projects/{project_id}/token?teamId={team_id}

The main reason for the first two requests was to get better errors if you were removed from the team, or the project moved from one team to another. But that only matters if you cannot successfully get the token, so now we just try to get the token first and retry if the first request fails which will give the better error messages.