### PR TITLE
test(cli): avoid README in cwd deploy fixture

### DIFF
--- a/.changeset/fresh-content-cwd.md
+++ b/.changeset/fresh-content-cwd.md
@@ -1,0 +1,4 @@
+---
+---
+
+Updated a CLI integration fixture to avoid relying on root README.md being served by zero-config static deployments.

--- a/.changeset/fresh-content-cwd.md
+++ b/.changeset/fresh-content-cwd.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Updated a CLI integration fixture to avoid relying on root README.md being served by zero-config static deployments.
+Updated CLI integration fixtures for default and conflicting sub-directory deployments to avoid relying on root README.md being served by zero-config static deployments.

--- a/packages/cli/test/helpers/prepare.js
+++ b/packages/cli/test/helpers/prepare.js
@@ -149,9 +149,9 @@ module.exports = async function prepare(session, binaryPath, tmpFixturesDir) {
         redirects: [{ source: `/(.*)`, destination: 'https://example.com/$1' }],
       }),
     },
-    'deploy-with-only-readme-vercel-json': {
+    'deploy-with-only-content-vercel-json': {
       'vercel.json': JSON.stringify({ version: 2 }),
-      'README.md': 'readme contents',
+      'content.txt': 'content file contents',
     },
     'deploy-default-with-sub-directory': {
       'vercel.json': JSON.stringify({ version: 2 }),

--- a/packages/cli/test/helpers/prepare.js
+++ b/packages/cli/test/helpers/prepare.js
@@ -160,9 +160,10 @@ module.exports = async function prepare(session, binaryPath, tmpFixturesDir) {
     },
     'deploy-default-with-conflicting-sub-directory': {
       'list/vercel.json': JSON.stringify({ version: 2 }),
-      'list/list/README.md': 'nested nested readme contents',
-      'list/README.md':
-        'readme contents for deploy-default-with-conflicting-sub-directory',
+      'list/list/content.txt':
+        'nested contents for deploy-default-with-conflicting-sub-directory',
+      'list/content.txt':
+        'root contents for deploy-default-with-conflicting-sub-directory',
     },
     'deploy-default-with-prebuilt-preview': {
       'vercel.json': JSON.stringify({ version: 2 }),

--- a/packages/cli/test/helpers/prepare.js
+++ b/packages/cli/test/helpers/prepare.js
@@ -149,7 +149,7 @@ module.exports = async function prepare(session, binaryPath, tmpFixturesDir) {
         redirects: [{ source: `/(.*)`, destination: 'https://example.com/$1' }],
       }),
     },
-    'deploy-with-only-content-vercel-json': {
+    'deploy-with-only-readme-vercel-json': {
       'vercel.json': JSON.stringify({ version: 2 }),
       'content.txt': 'content file contents',
     },

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -184,10 +184,11 @@ test('default command should work with --cwd option', async () => {
 
   const url = stdout;
 
-  const deploymentResult = await nodeFetch(`${url}/README.md`);
+  // Root README.md is intentionally excluded from zero-config static deployments.
+  const deploymentResult = await nodeFetch(`${url}/content.txt`);
   const body = await deploymentResult.text();
   expect(body).toEqual(
-    'readme contents for deploy-default-with-conflicting-sub-directory'
+    'root contents for deploy-default-with-conflicting-sub-directory'
   );
 });
 

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -788,9 +788,9 @@ describe('telemetry submits data', () => {
   });
 });
 
-test('deploys with only vercel.json and README.md', async () => {
+test('deploys with only vercel.json and a static file', async () => {
   const directory = await setupE2EFixture(
-    'deploy-with-only-readme-vercel-json'
+    'deploy-with-only-content-vercel-json'
   );
 
   const { exitCode, stdout, stderr } = await execCli(
@@ -810,9 +810,9 @@ test('deploys with only vercel.json and README.md', async () => {
   );
 
   const { host } = new URL(stdout);
-  const res = await nodeFetch(`https://${host}/README.md`);
+  const res = await nodeFetch(`https://${host}/content.txt`);
   const text = await res.text();
-  expect(text).toMatch(/readme contents/);
+  expect(text).toMatch(/content file contents/);
 });
 
 test('reject deprecated `now.json` files', async () => {

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -790,7 +790,7 @@ describe('telemetry submits data', () => {
 
 test('deploys with only vercel.json and a static file', async () => {
   const directory = await setupE2EFixture(
-    'deploy-with-only-content-vercel-json'
+    'deploy-with-only-readme-vercel-json'
   );
 
   const { exitCode, stdout, stderr } = await execCli(


### PR DESCRIPTION
## Summary

Fixes the `default command should work with --cwd option` CLI integration fixture so it no longer relies on root `README.md` being served by zero-config static deployments.

Root `README.md` is now intentionally excluded from zero-config `@vercel/static` output by vercel/vercel#16056. The test started failing once API/build-container picked up a newer bundled CLI via vercel/api#71235.

## Changes

- Replaced the fixture’s root/nested `README.md` files with `content.txt`.
- Updated the `--cwd` integration test to fetch `/content.txt`.
- Added a changeset for the test fixture update.