### PR TITLE
[node] Disable response streaming for AWS custom handler lambdas

### DIFF
--- a/.changeset/slimy-ducks-drum.md
+++ b/.changeset/slimy-ducks-drum.md
@@ -1,0 +1,5 @@
+---
+'@vercel/node': patch
+---
+
+Disable response streaming for AWS custom handler lambdas

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -601,9 +601,10 @@ export const build = async ({
       config.helpers === false || process.env.NODEJS_HELPERS === '0'
     );
 
-    const supportsResponseStreaming =
-      (staticConfig?.supportsResponseStreaming ??
-        staticConfig?.experimentalResponseStreaming) === true
+    const supportsResponseStreaming = awsLambdaHandler
+      ? false
+      : (staticConfig?.supportsResponseStreaming ??
+            staticConfig?.experimentalResponseStreaming) === true
         ? true
         : undefined;
 

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -601,12 +601,15 @@ export const build = async ({
       config.helpers === false || process.env.NODEJS_HELPERS === '0'
     );
 
-    const supportsResponseStreaming = awsLambdaHandler
-      ? false
-      : (staticConfig?.supportsResponseStreaming ??
-            staticConfig?.experimentalResponseStreaming) === true
-        ? true
-        : undefined;
+    let supportsResponseStreaming: boolean | undefined;
+    if (awsLambdaHandler) {
+      supportsResponseStreaming = false;
+    } else if (
+      (staticConfig?.supportsResponseStreaming ??
+        staticConfig?.experimentalResponseStreaming) === true
+    ) {
+      supportsResponseStreaming = true;
+    }
 
     const enableBundling =
       process.env.VERCEL_API_FUNCTION_BUNDLING === '1' &&

--- a/packages/node/test/unit/aws-custom-handler.test.ts
+++ b/packages/node/test/unit/aws-custom-handler.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { prepareFilesystem } from './test-utils';
+import { build } from '../../src';
+import type { NodejsLambda } from '@vercel/build-utils';
+
+describe('AWS custom handler', () => {
+  afterEach(() => {
+    delete process.env.NODEJS_AWS_HANDLER_NAME;
+  });
+
+  it('should disable response streaming when NODEJS_AWS_HANDLER_NAME is set', async () => {
+    process.env.NODEJS_AWS_HANDLER_NAME = 'myCustomHandler';
+
+    const filesystem = await prepareFilesystem({
+      'index.js': `
+        exports.myCustomHandler = async function() {
+          return {
+            statusCode: 200,
+            headers: {},
+            body: 'custom handler',
+          };
+        };
+      `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'index.js',
+      config: {},
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+    const lambda = buildResult.output as NodejsLambda;
+    expect(lambda.supportsResponseStreaming).toBe(false);
+    expect(lambda.awsLambdaHandler).toBe('index.myCustomHandler');
+  });
+
+  it('should not disable response streaming for regular handlers', async () => {
+    const filesystem = await prepareFilesystem({
+      'api/hello.js': `
+        export default (req, res) => res.send('hello');
+      `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'api/hello.js',
+      config: {},
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+    const lambda = buildResult.output as NodejsLambda;
+    expect(lambda.supportsResponseStreaming).toBeUndefined();
+    expect(lambda.awsLambdaHandler).toBe('');
+  });
+});


### PR DESCRIPTION
I started seeing a test for custom AWS handlers hang and fail on [my rusty PR](https://github.com/vercel/functions/pull/3127). I tracked it down to this PR https://github.com/vercel/vercel/pull/15795 which enables response streaming by default for all functions. This breaks custom AWS handlers which don't stream their bodies though, like this one.

This behavior is legacy so I'm not sure if we still want to support it. If we do, this PR disables streaming for custom handlers.