### PR TITLE
chore: bump `@vercel/cli-config` & `@vercel/cli-exec`

### DIFF
--- a/.changeset/green-scissors-serve.md
+++ b/.changeset/green-scissors-serve.md
@@ -1,0 +1,6 @@
+---
+'@vercel/cli-config': patch
+'@vercel/cli-exec': patch
+---
+
+Bump only


### PR DESCRIPTION
Bumping those two packages' versions only for trusted publishing.