### PR TITLE
refactor: update indexOf to includes

### DIFF
--- a/.changeset/refactor-indexof.md
+++ b/.changeset/refactor-indexof.md
@@ -1,0 +1,7 @@
+---
+'@vercel/node': patch
+'vercel': patch
+'@vercel/next': patch
+---
+
+Refactor: update indexOf to includes for better efficiency and readability.

--- a/packages/cli/src/commands/alias/set.ts
+++ b/packages/cli/src/commands/alias/set.ts
@@ -364,7 +364,7 @@ function handleCreateAliasError<T>(
 function getTargetsForAlias(args: string[], { alias }: VercelConfig = {}) {
   if (args.length) {
     return [args[args.length - 1]]
-      .map(target => (target.indexOf('.') !== -1 ? toHost(target) : target))
+      .map(target => (target.includes('.') ? toHost(target) : target))
       .filter((x): x is string => !!x && typeof x === 'string');
   }
 

--- a/packages/cli/src/util/alias/assign-alias.ts
+++ b/packages/cli/src/util/alias/assign-alias.ts
@@ -15,7 +15,7 @@ export default async function assignAlias(
   // Check if the alias is a custom domain, because then
   // we have to configure the DNS records and certificate
   if (
-    alias.indexOf('.') !== -1 &&
+    alias.includes('.') &&
     !alias.endsWith('.now.sh') &&
     !alias.endsWith('.vercel.app')
   ) {

--- a/packages/cli/src/util/get-subcommand.ts
+++ b/packages/cli/src/util/get-subcommand.ts
@@ -14,7 +14,7 @@ export default function getSubcommand(
 ): SubcommandParsed {
   const [subcommand, ...rest] = cliArgs;
   for (const k of Object.keys(config)) {
-    if (k !== 'default' && config[k].indexOf(subcommand) !== -1) {
+    if (k !== 'default' && config[k].includes(subcommand)) {
       return {
         subcommand: k,
         subcommandOriginal: subcommand,

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -195,7 +195,7 @@ function isLegacyNext(nextVersion: string) {
   }
 
   // If the version is an exact match with the legacy versions
-  if (nextLegacyVersions.indexOf(nextVersion) !== -1) {
+  if (nextLegacyVersions.includes(nextVersion)) {
     return true;
   }
 

--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -524,5 +524,5 @@ type SourceOutput = { code: string; map: string };
  * Filter diagnostics.
  */
 function filterDiagnostics(diagnostics: _ts.Diagnostic[], ignore: number[]) {
-  return diagnostics.filter(x => ignore.indexOf(x.code) === -1);
+  return diagnostics.filter(x => !ignore.includes(x.code));
 }


### PR DESCRIPTION
Went through the codebase and swapped out the remaining `indexOf(...) !== -1` / `=== -1` patterns for `.includes()`. Just a readability thing - `includes()` returns a boolean directly which is what all these call sites actually want.

### What changed

- `packages/node/src/typescript.ts` - filter check on diagnostic ignore list
- `packages/cli/src/commands/alias/set.ts` - domain format check
- `packages/cli/src/util/get-subcommand.ts` - subcommand lookup
- `packages/cli/src/util/alias/assign-alias.ts` - domain format check
- `packages/next/src/index.ts` - legacy version check

All one-liners. No logic changes, just the method swap. `includes()` has been around since ES2016 and is already used in other parts of the codebase so this just brings these spots in line.

Also noticed a handful of `TODO`/`FIXME` comments scattered around (e.g. `server.ts` re: `x-forwarded-for`, `builder.ts` cleanup) happy to tackle those separately if useful.