### PR TITLE
[frameworks] add Ash framework preset

### DIFF
--- a/.changeset/add-ash-framework.md
+++ b/.changeset/add-ash-framework.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': minor
+---
+
+Add Ash framework preset

--- a/packages/frameworks/logos/ash-dark.svg
+++ b/packages/frameworks/logos/ash-dark.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Ash">
+  <title>Ash</title>
+  <rect width="48" height="48" rx="8" fill="#fff"/>
+  <text x="24" y="24" fill="#000"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-size="14" font-weight="700" letter-spacing="1"
+        text-anchor="middle" dominant-baseline="central">ASH</text>
+</svg>

--- a/packages/frameworks/logos/ash.svg
+++ b/packages/frameworks/logos/ash.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Ash">
+  <title>Ash</title>
+  <rect width="48" height="48" rx="8" fill="#000"/>
+  <text x="24" y="24" fill="#fff"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-size="14" font-weight="700" letter-spacing="1"
+        text-anchor="middle" dominant-baseline="central">ASH</text>
+</svg>

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2274,6 +2274,41 @@ export const frameworks = [
     ],
   },
   {
+    name: 'Ash',
+    slug: 'ash',
+    logo: 'https://api-frameworks.vercel.sh/framework-logos/ash.svg',
+    tagline:
+      'A filesystem-first framework for durable backend agents on Vercel.',
+    description:
+      'An Ash app: agents authored as a directory of files, compiled and served on Vercel.',
+    detectors: {
+      every: [
+        {
+          path: 'package.json',
+          matchContent:
+            '"(dev)?(d|D)ependencies":\\s*{[^}]*"experimental-ash":\\s*".+?"[^}]*}',
+        },
+      ],
+    },
+    settings: {
+      installCommand: {
+        placeholder: '`pnpm install`, `yarn install`, or `npm install`',
+      },
+      buildCommand: {
+        value: 'ash build',
+        placeholder: '`npm run build` or `ash build`',
+      },
+      devCommand: {
+        value: 'ash dev',
+        placeholder: 'ash dev',
+      },
+      outputDirectory: {
+        value: '.output',
+      },
+    },
+    getOutputDirName: async () => '.output',
+  },
+  {
     name: 'Sanity (v3)',
     slug: 'sanity-v3',
     demo: 'https://sanity-studio-template.vercel.app',

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2309,6 +2309,7 @@ export const frameworks = [
       },
     },
     getOutputDirName: async () => '.output',
+    experimental: true,
   },
   {
     name: 'Sanity (v3)',

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2277,6 +2277,8 @@ export const frameworks = [
     name: 'Ash',
     slug: 'ash',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/ash.svg',
+    darkModeLogo:
+      'https://api-frameworks.vercel.sh/framework-logos/ash-dark.svg',
     tagline:
       'A filesystem-first framework for durable backend agents on Vercel.',
     description:


### PR DESCRIPTION
## Summary

Adds **Ash** (`experimental-ash`) as a framework preset so it can be referenced from `experimentalServices` in `vercel.json` / `vercel.ts` and used with `vercel dev`.

- `slug: 'ash'` — what users put in `experimentalServices.<svc>.framework`.
- `devCommand: 'ash dev'` — Ash's CLI reads `$PORT` from env, which the services orchestrator auto-allocates and injects, so no `--port` flag is needed.
- `buildCommand: 'ash build'`, `outputDirectory: '.output'`.
- Detector: `every` match on `experimental-ash` in `package.json` `dependencies`/`devDependencies`.
- No `useRuntime` is set on purpose — the orchestrator falls through to `devCommand`, which is the experimentalServices flow for frameworks that ship their own dev server.

## Known gap (why this is a draft)

`packages/frameworks/logos/ash.svg` does not exist yet — Ash has no finalized logo (the docs site uses a text wordmark "Agent Framework", and favicons are stock `create-next-app` boilerplate). The `ensure logo file exists in ./packages/frameworks/logos/` test in `packages/frameworks/test/frameworks.unit.test.ts` will fail until a logo file is added. Once design produces one (and it's uploaded to `api-frameworks.vercel.sh/framework-logos/ash.svg`), drop the SVG in `packages/frameworks/logos/` and this PR can be flipped out of draft.

## Test plan

- [ ] Add `packages/frameworks/logos/ash.svg`
- [ ] `pnpm --filter @vercel/frameworks test` passes (logo, unique slug, snapshot)
- [ ] Smoke test: create a `vercel.json` with `experimentalServices.ash-svc.framework = "ash"` in an Ash project; run `vercel dev`; confirm the orchestrator spawns `ash dev`, sets `PORT`, and proxies requests through the configured `mount`.
- [ ] Smoke test: detection works in a project that has `experimental-ash` in `package.json` dependencies but doesn't explicitly set `framework`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)