### PR TITLE
[cli] expose VERCEL_PROJECT_ID and VERCEL_ORG_ID to `vercel dev` process

### DIFF
--- a/.changeset/dev-expose-project-org-ids.md
+++ b/.changeset/dev-expose-project-org-ids.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+`vercel dev` now exposes `VERCEL_PROJECT_ID` and `VERCEL_ORG_ID` from the linked `.vercel/project.json` to the dev process, mirroring how the platform sets them in prod and preview. Existing values in `process.env` or `.env` files take precedence and are not overridden.

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -106,6 +106,8 @@ export default async function dev(
   let projectSettings: ProjectSettings | undefined;
   let envValues: Record<string, string> = {};
   let repoRoot: string | undefined;
+  let projectId: string | undefined;
+  let orgId: string | undefined;
   if (link.status === 'linked') {
     const { project, org } = link;
 
@@ -127,6 +129,8 @@ export default async function dev(
     client.config.currentTeam = org.type === 'team' ? org.id : undefined;
 
     projectSettings = project;
+    projectId = project.id;
+    orgId = org.id;
 
     if (project.rootDirectory) {
       cwd = join(cwd, project.rootDirectory);
@@ -176,6 +180,8 @@ export default async function dev(
     envValues,
     repoRoot,
     services,
+    projectId,
+    orgId,
   });
 
   const controller = new AbortController();

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -181,6 +181,8 @@ export default class DevServer {
   private startPromise: Promise<void> | null;
 
   private envValues: Record<string, string>;
+  private projectId?: string;
+  private orgId?: string;
 
   private shouldUseServicesOrchestrator(): boolean {
     if (!this.services || this.services.length === 0) {
@@ -194,6 +196,8 @@ export default class DevServer {
     this.repoRoot = options.repoRoot ?? cwd;
     this.envConfigs = { buildEnv: {}, runEnv: {}, allEnv: {} };
     this.envValues = options.envValues || {};
+    this.projectId = options.projectId;
+    this.orgId = options.orgId;
     this.files = {};
     this.originalProjectSettings = options.projectSettings;
     this.projectSettings = options.projectSettings;
@@ -738,6 +742,26 @@ export default class DevServer {
     // simulate parts of the platform for local environment
     allEnv['VERCEL_ENV'] = 'development';
     allEnv['VERCEL'] = '1';
+
+    // Expose the linked project's IDs the same way the platform does in
+    // prod/preview. Don't override a value the user explicitly set in their
+    // shell or `.env` files.
+    if (this.projectId && !process.env.VERCEL_PROJECT_ID) {
+      if (!('VERCEL_PROJECT_ID' in allEnv)) {
+        allEnv['VERCEL_PROJECT_ID'] = this.projectId;
+      }
+      if (!('VERCEL_PROJECT_ID' in runEnv)) {
+        runEnv['VERCEL_PROJECT_ID'] = this.projectId;
+      }
+    }
+    if (this.orgId && !process.env.VERCEL_ORG_ID) {
+      if (!('VERCEL_ORG_ID' in allEnv)) {
+        allEnv['VERCEL_ORG_ID'] = this.orgId;
+      }
+      if (!('VERCEL_ORG_ID' in runEnv)) {
+        runEnv['VERCEL_ORG_ID'] = this.orgId;
+      }
+    }
 
     // mirror how VERCEL_REGION is injected in prod/preview
     // only inject in `runEnvs`, because `allEnvs` is exposed to dev command

--- a/packages/cli/src/util/dev/types.ts
+++ b/packages/cli/src/util/dev/types.ts
@@ -26,6 +26,8 @@ export interface DevServerOptions {
   envValues?: Record<string, string>;
   repoRoot?: string;
   services?: ResolvedService[];
+  projectId?: string;
+  orgId?: string;
 }
 
 export interface EnvConfigs {

--- a/packages/cli/test/unit/commands/dev/index.test.ts
+++ b/packages/cli/test/unit/commands/dev/index.test.ts
@@ -7,15 +7,23 @@ import { useTeams } from '../../../mocks/team';
 import { useProject } from '../../../mocks/project';
 
 const { devServerInstances, mockedRepoRoots } = vi.hoisted(() => ({
-  devServerInstances: [] as { cwd: string }[],
+  devServerInstances: [] as {
+    cwd: string;
+    projectId?: string;
+    orgId?: string;
+  }[],
   mockedRepoRoots: new Map<string, string>(),
 }));
 
 vi.mock('../../../../src/util/dev/server', () => {
   class DevServer {
     devCommand = 'framework dev';
-    constructor(cwd: string) {
-      devServerInstances.push({ cwd });
+    constructor(cwd: string, options: { projectId?: string; orgId?: string }) {
+      devServerInstances.push({
+        cwd,
+        projectId: options.projectId,
+        orgId: options.orgId,
+      });
     }
     feed() {}
     stop() {
@@ -325,6 +333,32 @@ describe('dev', () => {
       // Normalize separators so the assertion holds on Windows, where
       // `path.join` produces backslashes.
       expect(devServerInstances[0].cwd.replace(/\\/g, '/')).toBe(projectDir);
+    });
+  });
+
+  describe('project/org IDs', () => {
+    it('passes the linked project and org IDs to DevServer', async () => {
+      client.setArgv('dev', projectPath);
+      const exitCodePromise = dev(client);
+
+      await expect(exitCodePromise).resolves.toEqual(undefined);
+      expect(devServerInstances).toHaveLength(1);
+      expect(devServerInstances[0]).toEqual({ projectId, orgId });
+    });
+
+    it('omits the IDs for unlinked projects in --local mode', async () => {
+      const unlinkedPath = '/user/name/code/unlinked-project';
+      vol.fromJSON({}, unlinkedPath);
+
+      client.setArgv('dev', '--local', unlinkedPath);
+      const exitCodePromise = dev(client);
+
+      await expect(exitCodePromise).resolves.toEqual(undefined);
+      expect(devServerInstances).toHaveLength(1);
+      expect(devServerInstances[0]).toEqual({
+        projectId: undefined,
+        orgId: undefined,
+      });
     });
   });
 });

--- a/packages/cli/test/unit/commands/dev/index.test.ts
+++ b/packages/cli/test/unit/commands/dev/index.test.ts
@@ -343,7 +343,7 @@ describe('dev', () => {
 
       await expect(exitCodePromise).resolves.toEqual(undefined);
       expect(devServerInstances).toHaveLength(1);
-      expect(devServerInstances[0]).toEqual({ projectId, orgId });
+      expect(devServerInstances[0]).toMatchObject({ projectId, orgId });
     });
 
     it('omits the IDs for unlinked projects in --local mode', async () => {
@@ -355,7 +355,7 @@ describe('dev', () => {
 
       await expect(exitCodePromise).resolves.toEqual(undefined);
       expect(devServerInstances).toHaveLength(1);
-      expect(devServerInstances[0]).toEqual({
+      expect(devServerInstances[0]).toMatchObject({
         projectId: undefined,
         orgId: undefined,
       });


### PR DESCRIPTION
## Summary

When a project is linked, `vercel dev` now exposes `VERCEL_PROJECT_ID` and `VERCEL_ORG_ID` to the spawned dev process, matching how the platform sets them in prod and preview. Without this, code that reads those env vars (SDKs, scripts, telemetry) works in deployed environments but is silently `undefined` locally.

### Precedence
The injection only fills in values that aren't already set, so user overrides win:
1. Shell (`VERCEL_PROJECT_ID=xxx vercel dev`)
2. Local `.env` / `.env.build` files
3. Linked `.vercel/project.json` (new)

Each variable is checked independently — setting only one in the shell still gets the other injected from the link.

### Implementation
- `DevServerOptions` gains optional `projectId` / `orgId` (`util/dev/types.ts`).
- `dev.ts` passes them when a project is linked.
- `server.ts` injects into both `allEnv` and `runEnv` after the existing `VERCEL_ENV` / `VERCEL` block, gated by `process.env.<name>` and `<name> in <envObj>`.

## Test plan

- [x] New unit test: `passes the linked project and org IDs to DevServer` asserts they reach the DevServer constructor for a linked project.
- [x] New unit test: `omits the IDs for unlinked projects in --local mode` asserts no IDs are passed when there's no link.
- [x] All 11 `test/unit/commands/dev/index.test.ts` tests pass.
- [ ] Manual: link a project, run `vercel dev`, confirm `process.env.VERCEL_PROJECT_ID` / `VERCEL_ORG_ID` are visible to the framework and to user code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)