### PR TITLE
Support --scope & --project for env commands

### DIFF
--- a/.changeset/env-project-option.md
+++ b/.changeset/env-project-option.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add support for the global `--project` option in `vc env` commands.

--- a/.changeset/env-project-option.md
+++ b/.changeset/env-project-option.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Add support for the global `--project` option in `vc env` commands.
+Add support for explicit `--project` and `--scope` selection in `vc env` commands.

--- a/packages/cli/src/commands/deploy-hooks/index.ts
+++ b/packages/cli/src/commands/deploy-hooks/index.ts
@@ -44,6 +44,11 @@ export default async function main(client: Client) {
     parsedArgs.args.slice(1),
     COMMAND_CONFIG
   );
+  const project = parsedArgs.flags['--project'];
+  const forwardedArgs = [...args];
+  if (typeof project === 'string') {
+    forwardedArgs.push('--project', project);
+  }
 
   const needHelp = parsedArgs.flags['--help'];
 
@@ -70,20 +75,20 @@ export default async function main(client: Client) {
         return printHelp(createSubcommand);
       }
       telemetry.trackCliSubcommandCreate(subcommandOriginal);
-      return create(client, args);
+      return create(client, forwardedArgs);
     case 'rm':
       if (needHelp) {
         telemetry.trackCliFlagHelp('deploy-hooks', subcommandOriginal);
         return printHelp(removeSubcommand);
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
-      return rm(client, args);
+      return rm(client, forwardedArgs);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('deploy-hooks', subcommandOriginal);
         return printHelp(listSubcommand);
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
-      return ls(client, args);
+      return ls(client, forwardedArgs);
   }
 }

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -26,7 +26,6 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { addSubcommand } from './command';
-import { getLinkedProject } from '../../util/projects/link';
 import { determineAgent } from '@vercel/detect-agent';
 import { suggestNextCommands } from '../../util/suggest-next-commands';
 import getTeamById from '../../util/teams/get-team-by-id';
@@ -37,6 +36,7 @@ import {
   buildEnvAddCommandWithPreservedArgs,
   getPreservedArgsForEnvAdd,
 } from '../../util/agent-output';
+import { getEnvLinkedProject } from './project';
 
 type EnvType = 'encrypted' | 'sensitive';
 
@@ -163,7 +163,7 @@ export default async function add(client: Client, argv: string[]) {
 
   // Non-interactive: resolve link and choices once, then report all missing requirements in a single JSON (no iteration)
   if (client.nonInteractive) {
-    const link = await getLinkedProject(client);
+    const link = await getEnvLinkedProject(client, opts['--project']);
     if (link.status === 'error') {
       return link.exitCode;
     }
@@ -433,7 +433,7 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  const link = await getLinkedProject(client);
+  const link = await getEnvLinkedProject(client, opts['--project']);
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -137,6 +137,7 @@ export default async function add(client: Client, argv: string[]) {
   telemetryClient.trackCliFlagForce(opts['--force']);
   telemetryClient.trackCliFlagGuidance(opts['--guidance']);
   telemetryClient.trackCliFlagYes(opts['--yes']);
+  telemetryClient.trackCliOptionScope(opts['--scope']);
 
   if (args.length > 3) {
     output.error(
@@ -163,7 +164,11 @@ export default async function add(client: Client, argv: string[]) {
 
   // Non-interactive: resolve link and choices once, then report all missing requirements in a single JSON (no iteration)
   if (client.nonInteractive) {
-    const link = await getEnvLinkedProject(client, opts['--project']);
+    const link = await getEnvLinkedProject(
+      client,
+      opts['--project'],
+      opts['--scope']
+    );
     if (link.status === 'error') {
       return link.exitCode;
     }
@@ -433,7 +438,11 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  const link = await getEnvLinkedProject(client, opts['--project']);
+  const link = await getEnvLinkedProject(
+    client,
+    opts['--project'],
+    opts['--scope']
+  );
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -4,6 +4,14 @@ import { forceOption, formatOption, yesOption } from '../../util/arg-common';
 
 const targetPlaceholder = getEnvTargetPlaceholder();
 
+const scopeOption = {
+  name: 'scope',
+  shorthand: 's',
+  type: String,
+  argument: 'SCOPE',
+  deprecated: false,
+} as const;
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -20,6 +28,7 @@ export const listSubcommand = {
   ],
   options: [
     formatOption,
+    scopeOption,
     {
       name: 'guidance',
       description: 'Receive command suggestions once command is complete',
@@ -76,6 +85,7 @@ export const addSubcommand = {
       description:
         'Skip the confirmation prompt when adding an Environment Variable',
     },
+    scopeOption,
     {
       name: 'guidance',
       description: 'Receive command suggestions once command is complete',
@@ -153,6 +163,7 @@ export const removeSubcommand = {
     },
   ],
   options: [
+    scopeOption,
     {
       ...yesOption,
       description:
@@ -227,6 +238,7 @@ export const pullSubcommand = {
       description:
         'Skip the confirmation prompt when removing an environment variable',
     },
+    scopeOption,
   ],
   examples: [
     {
@@ -274,6 +286,7 @@ export const runSubcommand = {
       argument: 'NAME',
       deprecated: false,
     },
+    scopeOption,
   ],
   examples: [
     {
@@ -315,6 +328,7 @@ export const updateSubcommand = {
       description:
         'Skip the confirmation prompt when updating an Environment Variable',
     },
+    scopeOption,
     {
       name: 'value',
       description:

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -59,6 +59,9 @@ export default async function main(client: Client) {
   );
 
   const needHelp = parsedArgs.flags['--help'];
+  const project = parsedArgs.flags['--project'];
+  const forwardedArgs =
+    typeof project === 'string' ? [...args, '--project', project] : args;
 
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('env', subcommand);
@@ -82,7 +85,7 @@ export default async function main(client: Client) {
         return 2;
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
-      exitCode = await ls(client, args);
+      exitCode = await ls(client, forwardedArgs);
       break;
     case 'add':
       if (needHelp) {
@@ -91,7 +94,7 @@ export default async function main(client: Client) {
         return 2;
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
-      exitCode = await add(client, args);
+      exitCode = await add(client, forwardedArgs);
       break;
     case 'rm':
       if (needHelp) {
@@ -100,7 +103,7 @@ export default async function main(client: Client) {
         return 2;
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
-      exitCode = await rm(client, args);
+      exitCode = await rm(client, forwardedArgs);
       break;
     case 'pull':
       if (needHelp) {
@@ -109,7 +112,7 @@ export default async function main(client: Client) {
         return 2;
       }
       telemetry.trackCliSubcommandPull(subcommandOriginal);
-      exitCode = await pull(client, args);
+      exitCode = await pull(client, forwardedArgs);
       break;
     case 'run':
       /**
@@ -134,7 +137,7 @@ export default async function main(client: Client) {
         return 2;
       }
       telemetry.trackCliSubcommandUpdate(subcommandOriginal);
-      exitCode = await update(client, args);
+      exitCode = await update(client, forwardedArgs);
       break;
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -60,8 +60,14 @@ export default async function main(client: Client) {
 
   const needHelp = parsedArgs.flags['--help'];
   const project = parsedArgs.flags['--project'];
-  const forwardedArgs =
-    typeof project === 'string' ? [...args, '--project', project] : args;
+  const scope = parsedArgs.flags['--scope'];
+  const forwardedArgs = [...args];
+  if (typeof scope === 'string') {
+    forwardedArgs.push('--scope', scope);
+  }
+  if (typeof project === 'string') {
+    forwardedArgs.push('--project', project);
+  }
 
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('env', subcommand);

--- a/packages/cli/src/commands/env/ls.ts
+++ b/packages/cli/src/commands/env/ls.ts
@@ -69,8 +69,13 @@ export default async function ls(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliFlagGuidance(flags['--guidance']);
   telemetryClient.trackCliOptionFormat(flags['--format']);
+  telemetryClient.trackCliOptionScope(flags['--scope']);
 
-  const link = await getEnvLinkedProject(client, flags['--project']);
+  const link = await getEnvLinkedProject(
+    client,
+    flags['--project'],
+    flags['--scope']
+  );
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/ls.ts
+++ b/packages/cli/src/commands/env/ls.ts
@@ -22,10 +22,10 @@ import { listSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { getLinkedProject } from '../../util/projects/link';
 import { determineAgent } from '@vercel/detect-agent';
 import { suggestNextCommands } from '../../util/suggest-next-commands';
 import { validateLsArgs } from '../../util/validate-ls-args';
+import { getEnvLinkedProject } from './project';
 
 export default async function ls(client: Client, argv: string[]) {
   const telemetryClient = new EnvLsTelemetryClient({
@@ -70,7 +70,7 @@ export default async function ls(client: Client, argv: string[]) {
   telemetryClient.trackCliFlagGuidance(flags['--guidance']);
   telemetryClient.trackCliOptionFormat(flags['--format']);
 
-  const link = await getLinkedProject(client);
+  const link = await getEnvLinkedProject(client, flags['--project']);
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/project.ts
+++ b/packages/cli/src/commands/env/project.ts
@@ -1,0 +1,36 @@
+import type { Org, ProjectLinkResult } from '@vercel-internals/types';
+import type Client from '../../util/client';
+import { ProjectNotFound } from '../../util/errors-ts';
+import getUser from '../../util/get-user';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { getLinkedProject } from '../../util/projects/link';
+import getTeamById from '../../util/teams/get-team-by-id';
+import output from '../../output-manager';
+
+export async function getEnvLinkedProject(
+  client: Client,
+  projectNameOrId?: string
+): Promise<ProjectLinkResult> {
+  if (!projectNameOrId) {
+    return getLinkedProject(client);
+  }
+
+  const project = await getProjectByNameOrId(client, projectNameOrId);
+  if (project instanceof ProjectNotFound) {
+    output.error(project.message);
+    return { status: 'error', exitCode: 1 };
+  }
+
+  const org = await getProjectOrg(client, project.accountId);
+  return { status: 'linked', org, project };
+}
+
+async function getProjectOrg(client: Client, accountId: string): Promise<Org> {
+  if (accountId.startsWith('team_')) {
+    const team = await getTeamById(client, accountId);
+    return { type: 'team', id: team.id, slug: team.slug };
+  }
+
+  const user = await getUser(client);
+  return { type: 'user', id: user.id, slug: user.username };
+}

--- a/packages/cli/src/commands/env/project.ts
+++ b/packages/cli/src/commands/env/project.ts
@@ -5,12 +5,21 @@ import getUser from '../../util/get-user';
 import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
 import { getLinkedProject } from '../../util/projects/link';
 import getTeamById from '../../util/teams/get-team-by-id';
+import getTeams from '../../util/teams/get-teams';
 import output from '../../output-manager';
 
 export async function getEnvLinkedProject(
   client: Client,
-  projectNameOrId?: string
+  projectNameOrId?: string,
+  scope?: string
 ): Promise<ProjectLinkResult> {
+  if (scope) {
+    const scopeResult = await applyEnvScope(client, scope);
+    if (scopeResult.status === 'error') {
+      return scopeResult;
+    }
+  }
+
   if (!projectNameOrId) {
     return getLinkedProject(client);
   }
@@ -33,4 +42,25 @@ async function getProjectOrg(client: Client, accountId: string): Promise<Org> {
 
   const user = await getUser(client);
   return { type: 'user', id: user.id, slug: user.username };
+}
+
+async function applyEnvScope(
+  client: Client,
+  scope: string
+): Promise<{ status: 'ok' } | { status: 'error'; exitCode: number }> {
+  const user = await getUser(client);
+  if (user.id === scope || user.email === scope || user.username === scope) {
+    delete client.config.currentTeam;
+    return { status: 'ok' };
+  }
+
+  const teams = await getTeams(client);
+  const team = teams.find(team => team.id === scope || team.slug === scope);
+  if (!team) {
+    output.error('The specified scope does not exist');
+    return { status: 'error', exitCode: 1 };
+  }
+
+  client.config.currentTeam = team.id;
+  return { status: 'ok' };
 }

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -27,13 +27,13 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import parseTarget from '../../util/parse-target';
-import { getLinkedProject } from '../../util/projects/link';
 import {
   buildCommandWithYes,
   getPreservedArgsForEnvPull,
   outputActionRequired,
   outputAgentError,
 } from '../../util/agent-output';
+import { getEnvLinkedProject } from './project';
 
 const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
 
@@ -111,7 +111,7 @@ export default async function pull(
   telemetryClient.trackCliOptionEnvironment(opts['--environment']);
   telemetryClient.trackCliOptionId(opts['--id']);
 
-  const link = await getLinkedProject(client);
+  const link = await getEnvLinkedProject(client, opts['--project']);
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -110,8 +110,13 @@ export default async function pull(
   telemetryClient.trackCliOptionGitBranch(gitBranch);
   telemetryClient.trackCliOptionEnvironment(opts['--environment']);
   telemetryClient.trackCliOptionId(opts['--id']);
+  telemetryClient.trackCliOptionScope(opts['--scope']);
 
-  const link = await getEnvLinkedProject(client, opts['--project']);
+  const link = await getEnvLinkedProject(
+    client,
+    opts['--project'],
+    opts['--scope']
+  );
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -81,8 +81,13 @@ export default async function rm(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentEnvironment(envTarget);
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliFlagYes(opts['--yes']);
+  telemetryClient.trackCliOptionScope(opts['--scope']);
 
-  const link = await getEnvLinkedProject(client, opts['--project']);
+  const link = await getEnvLinkedProject(
+    client,
+    opts['--project'],
+    opts['--scope']
+  );
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -17,7 +17,6 @@ import { removeSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { getLinkedProject } from '../../util/projects/link';
 import {
   outputActionRequired,
   outputAgentError,
@@ -25,6 +24,7 @@ import {
   buildEnvRmCommandWithPreservedArgs,
   getPreservedArgsForEnvRm,
 } from '../../util/agent-output';
+import { getEnvLinkedProject } from './project';
 
 export default async function rm(client: Client, argv: string[]) {
   const telemetryClient = new EnvRmTelemetryClient({
@@ -82,7 +82,7 @@ export default async function rm(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliFlagYes(opts['--yes']);
 
-  const link = await getLinkedProject(client);
+  const link = await getEnvLinkedProject(client, opts['--project']);
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/run.ts
+++ b/packages/cli/src/commands/env/run.ts
@@ -6,10 +6,10 @@ import { printError } from '../../util/error';
 import { runSubcommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
-import { getLinkedProject } from '../../util/projects/link';
 import { pullEnvRecords } from '../../util/env/get-env-records';
 import parseTarget from '../../util/parse-target';
 import { getCommandName } from '../../util/pkg-name';
+import { getEnvLinkedProject } from './project';
 
 /**
  * Parses argv for the run subcommand, splitting on `--` to separate
@@ -65,7 +65,7 @@ export default async function run(client: Client): Promise<number> {
   }
 
   // Get the linked project
-  const link = await getLinkedProject(client);
+  const link = await getEnvLinkedProject(client, parsedArgs.flags['--project']);
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/run.ts
+++ b/packages/cli/src/commands/env/run.ts
@@ -65,7 +65,11 @@ export default async function run(client: Client): Promise<number> {
   }
 
   // Get the linked project
-  const link = await getEnvLinkedProject(client, parsedArgs.flags['--project']);
+  const link = await getEnvLinkedProject(
+    client,
+    parsedArgs.flags['--project'],
+    parsedArgs.flags['--scope']
+  );
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -22,7 +22,6 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { updateSubcommand } from './command';
-import { getLinkedProject } from '../../util/projects/link';
 import getTeamById from '../../util/teams/get-team-by-id';
 import type { ProjectEnvVariable } from '@vercel-internals/types';
 
@@ -38,6 +37,7 @@ import {
   buildEnvUpdateCommandWithPreservedArgs,
   getPreservedArgsForEnvUpdate,
 } from '../../util/agent-output';
+import { getEnvLinkedProject } from './project';
 
 export default async function update(client: Client, argv: string[]) {
   let parsedArgs;
@@ -180,7 +180,7 @@ export default async function update(client: Client, argv: string[]) {
     }
   }
 
-  const link = await getLinkedProject(client);
+  const link = await getEnvLinkedProject(client, opts['--project']);
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -78,6 +78,7 @@ export default async function update(client: Client, argv: string[]) {
   telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
   telemetryClient.trackCliFlagYes(opts['--yes']);
   telemetryClient.trackCliOptionValue(valueFromFlag);
+  telemetryClient.trackCliOptionScope(opts['--scope']);
 
   if (args.length > 3) {
     if (client.nonInteractive) {
@@ -180,7 +181,11 @@ export default async function update(client: Client, argv: string[]) {
     }
   }
 
-  const link = await getEnvLinkedProject(client, opts['--project']);
+  const link = await getEnvLinkedProject(
+    client,
+    opts['--project'],
+    opts['--scope']
+  );
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -379,6 +379,7 @@ const main = async () => {
   telemetry.trackCliFlagDebug(parsedArgs.flags['--debug']);
   telemetry.trackCliFlagNoColor(parsedArgs.flags['--no-color']);
   telemetry.trackCliOptionScope(parsedArgs.flags['--scope']);
+  telemetry.trackCliOptionProject(parsedArgs.flags['--project']);
   telemetry.trackCliOptionToken(parsedArgs.flags['--token']);
   telemetry.trackCliOptionTeam(parsedArgs.flags['--team']);
   telemetry.trackCliOptionApi(parsedArgs.flags['--api']);

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -102,6 +102,7 @@ const GLOBAL_FLAG_NAMES = new Set([
   '--non-interactive',
   '--scope',
   '--team',
+  '--project',
   '-S',
   '-T',
   // --token/-t are intentionally excluded and stripped via stripSensitiveAuthArgs.

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -72,6 +72,14 @@ export const globalCommandOptions = [
     deprecated: false,
   },
   {
+    name: 'project',
+    shorthand: null,
+    type: String,
+    argument: 'PROJECT',
+    description: 'Set a custom project',
+    deprecated: false,
+  },
+  {
     name: 'token',
     shorthand: 't',
     type: String,

--- a/packages/cli/src/util/telemetry/commands/env/add.ts
+++ b/packages/cli/src/util/telemetry/commands/env/add.ts
@@ -48,6 +48,15 @@ export class EnvAddTelemetryClient
     }
   }
 
+  trackCliOptionScope(scope: string | undefined) {
+    if (scope) {
+      this.trackCliOption({
+        option: 'scope',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagSensitive(sensitive: boolean | undefined) {
     if (sensitive) {
       this.trackCliFlag('sensitive');

--- a/packages/cli/src/util/telemetry/commands/env/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/env/ls.ts
@@ -35,4 +35,13 @@ export class EnvLsTelemetryClient
       this.trackCliFlag('guidance');
     }
   }
+
+  trackCliOptionScope(scope: string | undefined) {
+    if (scope) {
+      this.trackCliOption({
+        option: 'scope',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/env/pull.ts
+++ b/packages/cli/src/util/telemetry/commands/env/pull.ts
@@ -39,6 +39,15 @@ export class EnvPullTelemetryClient
     }
   }
 
+  trackCliOptionScope(scope: string | undefined) {
+    if (scope) {
+      this.trackCliOption({
+        option: 'scope',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagYes(yes: boolean | undefined) {
     if (yes) {
       this.trackCliFlag('yes');

--- a/packages/cli/src/util/telemetry/commands/env/rm.ts
+++ b/packages/cli/src/util/telemetry/commands/env/rm.ts
@@ -39,6 +39,15 @@ export class EnvRmTelemetryClient
     }
   }
 
+  trackCliOptionScope(scope: string | undefined) {
+    if (scope) {
+      this.trackCliOption({
+        option: 'scope',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagYes(yes: boolean | undefined) {
     if (yes) {
       this.trackCliFlag('yes');

--- a/packages/cli/src/util/telemetry/commands/env/update.ts
+++ b/packages/cli/src/util/telemetry/commands/env/update.ts
@@ -51,6 +51,15 @@ export class EnvUpdateTelemetryClient
     }
   }
 
+  trackCliOptionScope(scope: string | undefined) {
+    if (scope) {
+      this.trackCliOption({
+        option: 'scope',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliOptionValue(value: string | undefined) {
     if (value) {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -539,6 +539,15 @@ export class RootTelemetryClient extends TelemetryClient {
     }
   }
 
+  trackCliOptionProject(project: string | undefined) {
+    if (project) {
+      this.trackCliOption({
+        option: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliOptionToken(token: string | undefined) {
     if (token) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -61,6 +61,9 @@ exports[`help command > alias help output snapshots > alias help column width 40
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -112,6 +115,7 @@ exports[`help command > alias help output snapshots > alias help column width 80
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -156,6 +160,7 @@ exports[`help command > alias help output snapshots > alias help column width 12
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -200,6 +205,7 @@ exports[`help command > alias help output snapshots > alias list subcommand > al
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -228,6 +234,7 @@ exports[`help command > alias help output snapshots > alias remove subcommand > 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -251,6 +258,7 @@ exports[`help command > alias help output snapshots > alias set subcommand > ali
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -320,6 +328,9 @@ exports[`help command > bisect help output snapshots > bisect help column width 
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -373,6 +384,7 @@ exports[`help command > bisect help output snapshots > bisect help column width 
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -419,6 +431,7 @@ exports[`help command > bisect help output snapshots > bisect help column width 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -463,6 +476,7 @@ exports[`help command > certs help output snapshots > certs add help output snap
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -531,6 +545,9 @@ exports[`help command > certs help output snapshots > certs help column width 40
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -584,6 +601,7 @@ exports[`help command > certs help output snapshots > certs help column width 80
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -630,6 +648,7 @@ exports[`help command > certs help output snapshots > certs help column width 12
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -675,6 +694,7 @@ exports[`help command > certs help output snapshots > certs issue help output sn
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -710,6 +730,7 @@ exports[`help command > certs help output snapshots > certs list help output sna
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -739,6 +760,7 @@ exports[`help command > certs help output snapshots > certs remove help output s
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -775,6 +797,7 @@ exports[`help command > connex help output snapshots > connex create subcommand 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -830,6 +853,7 @@ exports[`help command > connex help output snapshots > connex help column width 
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -880,6 +904,7 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -930,6 +955,7 @@ exports[`help command > connex help output snapshots > connex open subcommand > 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -978,6 +1004,7 @@ exports[`help command > connex help output snapshots > connex token subcommand >
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -1196,6 +1223,9 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -1283,6 +1313,7 @@ exports[`help command > deploy help output snapshots > deploy help column width 
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -1352,6 +1383,7 @@ exports[`help command > deploy help output snapshots > deploy help column width 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -1407,6 +1439,7 @@ exports[`help command > dev help output snapshots > dev --help > outputs help 1`
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -1440,6 +1473,7 @@ exports[`help command > dns help output snapshots > dns add help output snapshot
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -1526,6 +1560,9 @@ exports[`help command > dns help output snapshots > dns help column width 40 1`]
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -1597,6 +1634,7 @@ exports[`help command > dns help output snapshots > dns help column width 80 1`]
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -1660,6 +1698,7 @@ exports[`help command > dns help output snapshots > dns help column width 120 1`
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -1715,6 +1754,7 @@ exports[`help command > dns help output snapshots > dns import help output snaps
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -1744,6 +1784,7 @@ exports[`help command > dns help output snapshots > dns list help output snapsho
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -1772,6 +1813,7 @@ exports[`help command > dns help output snapshots > dns remove help output snaps
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -1800,6 +1842,7 @@ exports[`help command > domains help output snapshots > domains add help output 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -1831,6 +1874,7 @@ exports[`help command > domains help output snapshots > domains buy help output 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -1945,6 +1989,9 @@ exports[`help command > domains help output snapshots > domains help column widt
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -1990,6 +2037,7 @@ exports[`help command > domains help output snapshots > domains help column widt
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -2025,6 +2073,7 @@ exports[`help command > domains help output snapshots > domains help column widt
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2048,6 +2097,7 @@ exports[`help command > domains help output snapshots > domains inspect help out
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2078,6 +2128,7 @@ exports[`help command > domains help output snapshots > domains list help output
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2112,6 +2163,7 @@ exports[`help command > domains help output snapshots > domains move help output
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2140,6 +2192,7 @@ exports[`help command > domains help output snapshots > domains price help outpu
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2178,6 +2231,7 @@ exports[`help command > domains help output snapshots > domains remove help outp
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2201,6 +2255,7 @@ exports[`help command > domains help output snapshots > domains transfer-in help
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2235,6 +2290,7 @@ exports[`help command > env help output snapshots > env add help output snapshot
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2384,6 +2440,9 @@ exports[`help command > env help output snapshots > env help column width 40 1`]
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -2439,6 +2498,7 @@ exports[`help command > env help output snapshots > env help column width 80 1`]
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -2480,6 +2540,7 @@ exports[`help command > env help output snapshots > env help column width 120 1`
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2515,6 +2576,7 @@ exports[`help command > env help output snapshots > env list help output snapsho
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2546,6 +2608,7 @@ exports[`help command > env help output snapshots > env pull help output snapsho
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2585,6 +2648,7 @@ exports[`help command > env help output snapshots > env remove help output snaps
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2630,6 +2694,7 @@ exports[`help command > git help output snapshots > git connect help output snap
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2668,6 +2733,7 @@ exports[`help command > git help output snapshots > git disconnect help output s
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2748,6 +2814,9 @@ exports[`help command > git help output snapshots > git help column width 40 1`]
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -2786,6 +2855,7 @@ exports[`help command > git help output snapshots > git help column width 80 1`]
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -2816,6 +2886,7 @@ exports[`help command > git help output snapshots > git help column width 120 1`
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2875,6 +2946,9 @@ exports[`help command > init help output snapshots > init help column width 40 1
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -2928,6 +3002,7 @@ exports[`help command > init help output snapshots > init help column width 80 1
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -2974,6 +3049,7 @@ exports[`help command > init help output snapshots > init help column width 120 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3063,6 +3139,9 @@ exports[`help command > inspect help output snapshots > inspect help column widt
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -3128,6 +3207,7 @@ exports[`help command > inspect help output snapshots > inspect help column widt
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -3185,6 +3265,7 @@ exports[`help command > inspect help output snapshots > inspect help column widt
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3242,6 +3323,7 @@ exports[`help command > integration help output snapshots > integration accept-t
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3285,6 +3367,7 @@ exports[`help command > integration help output snapshots > integration balance 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3324,6 +3407,7 @@ exports[`help command > integration help output snapshots > integration discover
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3368,6 +3452,7 @@ exports[`help command > integration help output snapshots > integration guide su
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3639,6 +3724,9 @@ exports[`help command > integration help output snapshots > integration help col
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -3717,6 +3805,7 @@ exports[`help command > integration help output snapshots > integration help col
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -3770,6 +3859,7 @@ exports[`help command > integration help output snapshots > integration help col
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3805,6 +3895,7 @@ exports[`help command > integration help output snapshots > integration installa
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3849,6 +3940,7 @@ exports[`help command > integration help output snapshots > integration list sub
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3899,6 +3991,7 @@ exports[`help command > integration help output snapshots > integration remove s
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -3951,6 +4044,7 @@ exports[`help command > integration help output snapshots > integration update s
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -4006,6 +4100,7 @@ exports[`help command > integration-resource help output snapshots > integration
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -4044,6 +4139,7 @@ exports[`help command > integration-resource help output snapshots > integration
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -4151,6 +4247,9 @@ exports[`help command > integration-resource help output snapshots > integration
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -4196,6 +4295,7 @@ exports[`help command > integration-resource help output snapshots > integration
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -4227,6 +4327,7 @@ exports[`help command > integration-resource help output snapshots > integration
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -4257,6 +4358,7 @@ exports[`help command > integration-resource help output snapshots > integration
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -4372,6 +4474,9 @@ exports[`help command > link help output snapshots > link help column width 40 1
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -4446,6 +4551,7 @@ exports[`help command > link help output snapshots > link help column width 80 1
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -4509,6 +4615,7 @@ exports[`help command > link help output snapshots > link help column width 120 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -4637,6 +4744,9 @@ exports[`help command > list help output snapshots > list help column width 40 1
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -4714,6 +4824,7 @@ exports[`help command > list help output snapshots > list help column width 80 1
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -4781,6 +4892,7 @@ exports[`help command > list help output snapshots > list help column width 120 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -4863,6 +4975,9 @@ exports[`help command > login help output snapshots > login help column width 40
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -4897,6 +5012,7 @@ exports[`help command > login help output snapshots > login help column width 80
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -v,  --version              Output the version number                         
 
@@ -4925,6 +5041,7 @@ exports[`help command > login help output snapshots > login help column width 12
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -v,  --version              Output the version number                                                                 
 
@@ -4953,6 +5070,7 @@ exports[`help command > project help output snapshots > project add help output 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5104,6 +5222,9 @@ exports[`help command > project help output snapshots > project help column widt
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -5158,6 +5279,7 @@ exports[`help command > project help output snapshots > project help column widt
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -5200,6 +5322,7 @@ exports[`help command > project help output snapshots > project help column widt
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5228,6 +5351,7 @@ exports[`help command > project help output snapshots > project inspect help out
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5269,6 +5393,7 @@ exports[`help command > project help output snapshots > project list help output
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5306,6 +5431,7 @@ exports[`help command > project help output snapshots > project remove help outp
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5329,6 +5455,7 @@ exports[`help command > project help output snapshots > project rename help outp
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5408,6 +5535,9 @@ exports[`help command > promote help output snapshots > promote help column widt
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -5455,6 +5585,7 @@ exports[`help command > promote help output snapshots > promote help column widt
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -5495,6 +5626,7 @@ exports[`help command > promote help output snapshots > promote help column widt
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5529,6 +5661,7 @@ exports[`help command > promote help output snapshots > promote status help outp
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5608,6 +5741,9 @@ exports[`help command > pull help output snapshots > pull help column width 40 1
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -5669,6 +5805,7 @@ exports[`help command > pull help output snapshots > pull help column width 80 1
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -5721,6 +5858,7 @@ exports[`help command > pull help output snapshots > pull help column width 120 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5805,6 +5943,9 @@ exports[`help command > redeploy help output snapshots > redeploy help column wi
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -5855,6 +5996,7 @@ exports[`help command > redeploy help output snapshots > redeploy help column wi
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -5898,6 +6040,7 @@ exports[`help command > redeploy help output snapshots > redeploy help column wi
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -5972,6 +6115,9 @@ exports[`help command > remove help output snapshots > remove help column width 
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -6022,6 +6168,7 @@ exports[`help command > remove help output snapshots > remove help column width 
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -6065,6 +6212,7 @@ exports[`help command > remove help output snapshots > remove help column width 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6150,6 +6298,9 @@ exports[`help command > rollback help output snapshots > rollback help column wi
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -6197,6 +6348,7 @@ exports[`help command > rollback help output snapshots > rollback help column wi
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -6237,6 +6389,7 @@ exports[`help command > rollback help output snapshots > rollback help column wi
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6277,6 +6430,7 @@ exports[`help command > rollback help output snapshots > rollback status help ou
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6343,6 +6497,9 @@ exports[`help command > target help output snapshots > target help column width 
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -6378,6 +6535,7 @@ exports[`help command > target help output snapshots > target help column width 
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -6406,6 +6564,7 @@ exports[`help command > target help output snapshots > target help column width 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6435,6 +6594,7 @@ exports[`help command > target help output snapshots > target list help output s
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6470,6 +6630,7 @@ exports[`help command > teams help output snapshots > teams add help output snap
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6569,6 +6730,9 @@ exports[`help command > teams help output snapshots > teams help column width 40
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -6611,6 +6775,7 @@ exports[`help command > teams help output snapshots > teams help column width 80
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -6645,6 +6810,7 @@ exports[`help command > teams help output snapshots > teams help column width 12
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6668,6 +6834,7 @@ exports[`help command > teams help output snapshots > teams invite help output s
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6707,6 +6874,7 @@ exports[`help command > teams help output snapshots > teams list help output sna
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6736,6 +6904,7 @@ exports[`help command > teams help output snapshots > teams switch help output s
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -v,  --version              Output the version number                                                                 
 
@@ -6764,6 +6933,7 @@ exports[`help command > telemetry help output snapshots > telemetry disable help
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6787,6 +6957,7 @@ exports[`help command > telemetry help output snapshots > telemetry enable help 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6852,6 +7023,9 @@ exports[`help command > telemetry help output snapshots > telemetry help column 
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -6889,6 +7063,7 @@ exports[`help command > telemetry help output snapshots > telemetry help column 
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -6919,6 +7094,7 @@ exports[`help command > telemetry help output snapshots > telemetry help column 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -6942,6 +7118,7 @@ exports[`help command > telemetry help output snapshots > telemetry status help 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -7002,6 +7179,9 @@ exports[`help command > whoami help output snapshots > whoami help column width 
                               this is   
                               the       
                               default   
+       --project <PROJECT>    Set a     
+                              custom    
+                              project   
   -S,  --scope                Set a     
                               custom    
                               scope     
@@ -7043,6 +7223,7 @@ exports[`help command > whoami help output snapshots > whoami help column width 
        --no-color             No color mode (default off)                       
        --non-interactive      Run without interactive prompts; when an agent is 
                               detected this is the default                      
+       --project <PROJECT>    Set a custom project                              
   -S,  --scope                Set a custom scope                                
   -t,  --token <TOKEN>        Login token                                       
   -v,  --version              Output the version number                         
@@ -7077,6 +7258,7 @@ exports[`help command > whoami help output snapshots > whoami help column width 
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
        --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+       --project <PROJECT>    Set a custom project                                                                      
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 

--- a/packages/cli/test/unit/commands/env/ls.test.ts
+++ b/packages/cli/test/unit/commands/env/ls.test.ts
@@ -81,6 +81,36 @@ describe('env ls', () => {
     });
   });
 
+  describe('--project', () => {
+    beforeEach(() => {
+      useProject(
+        {
+          ...defaultProject,
+          id: 'explicit-env-project',
+          name: 'explicit-env-project',
+          accountId: 'team_dummy',
+        },
+        []
+      );
+    });
+
+    it('uses a global --project before the env command', async () => {
+      client.setArgv('--project', 'explicit-env-project', 'env', 'ls');
+      const exitCode = await env(client);
+
+      expect(exitCode).toEqual(0);
+      expect(client.stderr.getFullOutput()).toContain('explicit-env-project');
+    });
+
+    it('uses --project after the env subcommand', async () => {
+      client.setArgv('env', 'ls', '--project', 'explicit-env-project');
+      const exitCode = await env(client);
+
+      expect(exitCode).toEqual(0);
+      expect(client.stderr.getFullOutput()).toContain('explicit-env-project');
+    });
+  });
+
   describe('[environment]', () => {
     it('tracks `environment` argument', async () => {
       client.setArgv('env', 'ls', 'production');

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -6,7 +6,7 @@ import env from '../../../../src/commands/env';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
 import { defaultProject, envs, useProject } from '../../../mocks/project';
-import { useTeams } from '../../../mocks/team';
+import { type Team, useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 
 describe('env pull', () => {
@@ -65,6 +65,48 @@ describe('env pull', () => {
         value: 'TRUE',
       },
     ]);
+  });
+
+  it('should pull with -s scope and --project without a local link', async () => {
+    useUser();
+    const teams = useTeams('team_env_scope') as Team[];
+    const team = teams[0];
+    team.slug = 'foo';
+    useProject(
+      {
+        ...defaultProject,
+        id: 'explicit-env-pull',
+        name: 'bar',
+        accountId: team.id,
+      },
+      [
+        {
+          type: 'encrypted',
+          id: 'explicit-env-pull-var',
+          key: 'SCOPED_PROJECT_VAR',
+          value: 'from-scoped-project',
+          target: ['development'],
+          gitBranch: undefined,
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    const cwd = setupUnitFixture('vercel-pull-unlinked');
+    client.cwd = cwd;
+    client.setArgv('env', 'pull', '-s', 'foo', '--project', 'bar', '--yes');
+
+    const exitCodePromise = env(client);
+    await expect(client.stderr).toOutput(
+      'Downloading `development` Environment Variables for'
+    );
+    await expect(client.stderr).toOutput('Created .env.local file');
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "env pull"').toEqual(0);
+
+    const rawDevEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(rawDevEnv).toContain('SCOPED_PROJECT_VAR="from-scoped-project"');
   });
 
   it('should handle pulling from Preview env vars', async () => {

--- a/packages/cli/test/unit/commands/env/run.test.ts
+++ b/packages/cli/test/unit/commands/env/run.test.ts
@@ -165,6 +165,60 @@ describe('env run', () => {
       ]);
     });
 
+    it('should run command with an explicit project', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject(
+        {
+          ...defaultProject,
+          id: 'explicit-env-run',
+          name: 'explicit-env-run',
+          accountId: 'team_dummy',
+        },
+        [
+          {
+            type: 'encrypted',
+            id: 'explicit-env-run-var',
+            key: 'EXPLICIT_RUN_VAR',
+            value: 'from-explicit-project',
+            target: ['development'],
+            gitBranch: undefined,
+            configurationId: null,
+            updatedAt: 1557241361455,
+            createdAt: 1557241361455,
+          },
+        ]
+      );
+      const cwd = setupUnitFixture('vercel-pull-unlinked');
+      client.cwd = cwd;
+
+      client.setArgv(
+        'env',
+        'run',
+        '--project',
+        'explicit-env-run',
+        '--',
+        'echo',
+        'hello'
+      );
+      const exitCodePromise = env(client);
+
+      await expect(client.stderr).toOutput(
+        'Downloading `development` Environment Variables'
+      );
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      expect(execa).toHaveBeenCalledWith('echo', ['hello'], {
+        cwd,
+        stdio: 'inherit',
+        reject: false,
+        env: expect.objectContaining({
+          EXPLICIT_RUN_VAR: 'from-explicit-project',
+        }),
+      });
+    });
+
     it('should run command with specified environment', async () => {
       useUser();
       useTeams('team_dummy');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `--project` as a recognized global CLI option.
- Resolve explicit projects for `vc env` subcommands and forward global `--project`/`--scope` through env subcommand routing.
- Add env-local `-s` support for scope selection so `vc env pull -s <scope> --project <project>` works without a local link.
- Add env unit coverage for explicit project and scope selection, including `env run`.

## Tests
- `pnpm exec vitest run packages/cli/test/unit/commands/env`
- `pnpm --filter vercel type-check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f3a2172-3c64-429e-b2e4-1c9b6331760d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f3a2172-3c64-429e-b2e4-1c9b6331760d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

