### PR TITLE
fix(cli): warn when env add --value V --yes defaults to sensitive (Production/Preview)

### DIFF
--- a/.changeset/fix-env-add-sensitive-default-warning.md
+++ b/.changeset/fix-env-add-sensitive-default-warning.md
@@ -1,0 +1,23 @@
+---
+'vercel': patch
+---
+
+fix(cli): warn when `env add --value V --yes` defaults to sensitive (Production/Preview)
+
+Since CLI 53.x, `vercel env add NAME production --value V --yes` stores
+variables as sensitive by default. Sensitive values are encrypted at rest
+and cannot be retrieved later via the dashboard or `vercel env pull`.
+
+Previously, this retrieval limitation was only surfaced through an
+interactive "Make it sensitive?" prompt that was skipped when `--yes` or
+`--value` bypassed the confirm flow. Users would only discover the issue
+after running `vercel env pull` and seeing an empty value.
+
+This change shows the retrieval-limitation notice whenever a variable is
+stored as sensitive and the interactive prompt was not displayed — whether
+the default sensitive behaviour applies (Production/Preview without
+`--no-sensitive`), the team policy enforces it, or `--sensitive` is set
+explicitly with `--yes`. Encrypted variables (`--no-sensitive`) are
+unaffected and still silently succeed.
+
+Closes #16232

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -753,7 +753,7 @@ export default async function add(client: Client, argv: string[]) {
     !skipConfirm;
   if (canPromptForType) {
     output.log(
-      `Sensitive values cannot be retrieved later from the dashboard or CLI.`
+      `Sensitive values cannot be retrieved later from the dashboard or CLI, including via ${getCommandName('env pull')}.`
     );
     const keepSensitive = await client.input.confirm(
       `Make it sensitive?`,
@@ -778,6 +778,20 @@ export default async function add(client: Client, argv: string[]) {
         `Your team requires sensitive Environment Variables for Production and Preview.`
       );
     }
+  }
+
+  // When finalType defaults to sensitive (53.x: Production/Preview default) or is
+  // forced sensitive and the interactive prompt was not shown, warn the user that
+  // the value cannot be retrieved later via env pull. This covers:
+  //   • --value V --yes  (skipConfirm=true, canPromptForType=false, sensitive by default)
+  //   • --sensitive --yes  (userWasExplicit=true → canPromptForType=false)
+  //   • client.nonInteractive=true  (canPromptForType=false)
+  // The policy-on branch above shows its own message but does not mention env pull,
+  // so we supplement it here too when applicable.
+  if (finalType === 'sensitive' && hasSensitiveCapable && !canPromptForType) {
+    output.log(
+      `Sensitive values cannot be retrieved later from the dashboard or CLI, including via ${getCommandName('env pull')}.`
+    );
   }
 
   const upsert = opts['--force'] ? 'true' : '';

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -247,6 +247,81 @@ describe('env add', () => {
       });
     });
 
+    describe('default-sensitive with --value --yes (53.x regression, #16232)', () => {
+      it('shows retrieval-limitation warning when --value --yes defaults to sensitive on Production', async () => {
+        // Reproduces #16232 Bug 1: CLI 53.x made Production/Preview sensitive by default.
+        // When --value V --yes is used without --sensitive, the variable is stored as
+        // sensitive and env pull returns an empty value. The user should be warned.
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'DEFAULT_SENSITIVE_VALUE_YES',
+          'production',
+          '--value',
+          'secret123',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+
+        // The warning should appear even though --sensitive was not passed explicitly.
+        await expect(client.stderr).toOutput(
+          'Sensitive values cannot be retrieved later from the dashboard or CLI'
+        );
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        // The value must actually be stored (not empty).
+        expect(spy).toHaveBeenCalled();
+        const [, , , type, , value] = spy.mock.calls[0] as unknown as [
+          unknown,
+          unknown,
+          unknown,
+          string,
+          unknown,
+          string,
+        ];
+        expect(type).toBe('sensitive');
+        expect(value).toBe('secret123');
+
+        spy.mockRestore();
+      });
+
+      it('does NOT show retrieval-limitation warning when --no-sensitive is set (encrypted, pullable)', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv(
+          'env',
+          'add',
+          'ENCRYPTED_VALUE_YES',
+          'production',
+          '--no-sensitive',
+          '--value',
+          'secret123',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        // No warning for encrypted (pullable) vars.
+        expect(spy).toHaveBeenCalled();
+        const type = spy.mock.calls[0][3];
+        expect(type).toBe('encrypted');
+
+        spy.mockRestore();
+      });
+    });
+
     describe('--sensitive + Development', () => {
       it('errors when --sensitive is passed and the target is Development', async () => {
         client.setArgv(


### PR DESCRIPTION
## Summary

Since CLI 53.x (`feat #16041`), `vercel env add NAME production --value V --yes` stores variables as **sensitive** by default for Production and Preview. Sensitive values are encrypted at rest and **cannot be retrieved later** via the dashboard or `vercel env pull` — which returns an empty string for sensitive variables.

Previously, the retrieval limitation was surfaced only through an interactive `Make it sensitive?` prompt that was skipped when `--yes` or `--value` bypassed the confirm flow. Non-interactive CI scripts discovered the issue only after running `env pull` and seeing `NAME=""`, assuming the value was not stored.

## Fix

Show the retrieval-limitation notice whenever a variable is stored as sensitive and the interactive prompt was not displayed:

- **`--value V --yes` without `--sensitive`** → defaults to sensitive in 53.x (the reported regression)
- **`--sensitive --yes`** → explicitly sensitive, partially covered by #16223 which targets the same issue but only when `forceSensitive=true`
- **`client.nonInteractive=true`** → no prompt shown
- **Team policy enforces sensitive** → supplemental note alongside the existing policy message

Encrypted variables (`--no-sensitive`) are unaffected and silently succeed.

Also extends the interactive prompt message to mention `vercel env pull` by name for clarity.

## Regression repro

```bash
# Before this fix: no warning shown, user discovers empty value only after pull
vercel env add MY_SECRET production --value "postgresql://..." --yes
# → "Added Environment Variable MY_SECRET..." (no mention of pull limitation)
# → vercel env pull → MY_SECRET=""  ← confused: value stored as empty?

# After this fix:
# → Added Environment Variable MY_SECRET...
# → Sensitive values cannot be retrieved later from the dashboard or CLI,
#    including via vercel env pull.
```

## Tests

Added two new tests:
1. Verifies the warning is shown when `--value V --yes` is used (default sensitive, no explicit flag) and the correct value is passed to the API (not empty)
2. Verifies no warning is shown when `--no-sensitive` is used (encrypted, pullable)

Closes #16232