### PR TITLE
[vercel-cli] Rename dashboard URL in vc connex open: /connex → /connect

### DIFF
--- a/.changeset/connex-open-connect-url.md
+++ b/.changeset/connex-open-connect-url.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): point `vc connect open` and registration error URLs at the renamed `/connect` dashboard route

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -154,7 +154,7 @@ describe('connex create', () => {
         error: {
           code: 'registration_required',
           message: 'Registration required',
-          registerUrl: 'https://vercel.com/test/~/connex/register?type=slack',
+          registerUrl: 'https://vercel.com/test/~/connect/register?type=slack',
         },
       });
     });
@@ -194,7 +194,7 @@ describe('connex create', () => {
       res.json({
         error: {
           message: 'Registration required',
-          registerUrl: 'https://vercel.com/test/~/connex/register',
+          registerUrl: 'https://vercel.com/test/~/connect/register',
         },
       });
     });
@@ -246,7 +246,7 @@ describe('connex create', () => {
       res.json({
         error: {
           message: 'Registration required',
-          registerUrl: 'https://vercel.com/test/~/connex/register',
+          registerUrl: 'https://vercel.com/test/~/connect/register',
         },
       });
     });
@@ -396,7 +396,7 @@ describe('connex create', () => {
       res.json({
         error: {
           message: 'Registration required',
-          registerUrl: 'https://vercel.com/test/~/connex/register',
+          registerUrl: 'https://vercel.com/test/~/connect/register',
         },
       });
     });


### PR DESCRIPTION
## Summary

`vc connex open <clientId>` opens the Vercel dashboard URL for a Connex client. Updates the hardcoded path from `~/connex/{id}` to `~/connect/{id}` to match the dashboard rename.

- `packages/cli/src/commands/connex/open.ts` — opened URL
- Tests updated to assert new URL

Backend API endpoints under `/v1/connex/*` (used by `vc connex token/list/create/remove`) are unchanged.

## Coordinated with
- vercel/api PR for the api-side URL builders (managed-create-client redirect, GitHub App manifest url)
- vercel/front PR for the dashboard rename (ships with permanent `/connex` → `/connect` redirect for legacy URLs already stored externally)

## Validation
- `vc connex open` opens the new URL
- All connex unit tests pass with new URLs