### PR TITLE
Use small-ICU Node for CLI release binaries

### DIFF
--- a/.changeset/lazy-cli-bundle-loading.md
+++ b/.changeset/lazy-cli-bundle-loading.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+---
+
+Reduce the CLI startup bundle by lazy-loading error reporting and extension execution paths.
+Use a Brotli-compressed small-ICU Node runtime for the macOS arm64 release binary.

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -60,7 +60,7 @@ jobs:
             custom_node_path: .node-runtime/node-v22.22.2-linux-arm64-small-icu/bin/node
             custom_node_platform: linux
             custom_node_arch: arm64
-          - runner: ubuntu-latest-32-core
+          - runner: ubuntu-latest
             target: node22.22.2-linux-x64
             asset: vercel-linux-x64
             ext: ''
@@ -69,7 +69,7 @@ jobs:
             custom_node_path: .node-runtime/node-v22.22.2-linux-x64-small-icu/bin/node
             custom_node_platform: linux
             custom_node_arch: x64
-          - runner: windows-latest-8-core
+          - runner: windows-latest
             target: node22.22.2-win-x64
             asset: vercel-windows-x64
             ext: '.exe'

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -60,7 +60,7 @@ jobs:
             custom_node_path: .node-runtime/node-v22.22.2-linux-arm64-small-icu/bin/node
             custom_node_platform: linux
             custom_node_arch: arm64
-          - runner: ubuntu-latest
+          - runner: ubuntu-latest-32-core
             target: node22.22.2-linux-x64
             asset: vercel-linux-x64
             ext: ''

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'melkey/bun-working-branch'
+      - 'ijjk-small-icu-release-binary'
     tags:
       - 'vercel@*'
   workflow_dispatch:

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
+          - runner: macos-15-xlarge
             target: node22.22.2-macos-arm64
             asset: vercel-darwin-arm64
             ext: ''
@@ -42,7 +42,7 @@ jobs:
             custom_node_path: .node-runtime/node-v22.22.2-darwin-arm64-small-icu/bin/node
             custom_node_platform: darwin
             custom_node_arch: arm64
-          - runner: macos-15-intel
+          - runner: macos-15-large
             target: node22.22.2-macos-x64
             asset: vercel-darwin-x64
             ext: ''

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -16,6 +16,11 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  TURBO_REMOTE_ONLY: 'true'
+  TURBO_TEAM: 'vercel'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
 concurrency:
   group: release-binary-${{ github.ref }}
   cancel-in-progress: false
@@ -28,35 +33,50 @@ jobs:
       matrix:
         include:
           - runner: macos-14
-            target: node22-macos-arm64
+            target: node22.22.2-macos-arm64
             asset: vercel-darwin-arm64
             ext: ''
             sign: true
             smoke: true
+            custom_node_path: .node-runtime/node-v22.22.2-darwin-arm64-small-icu/bin/node
+            custom_node_platform: darwin
+            custom_node_arch: arm64
           - runner: macos-15-intel
-            target: node22-macos-x64
+            target: node22.22.2-macos-x64
             asset: vercel-darwin-x64
             ext: ''
             sign: true
             smoke: true
-          - runner: ubuntu-latest
-            target: node22-linux-arm64
+            custom_node_path: .node-runtime/node-v22.22.2-darwin-x64-small-icu/bin/node
+            custom_node_platform: darwin
+            custom_node_arch: x64
+          - runner: ubuntu-24.04-arm
+            target: node22.22.2-linux-arm64
             asset: vercel-linux-arm64
             ext: ''
             sign: false
             smoke: false
+            custom_node_path: .node-runtime/node-v22.22.2-linux-arm64-small-icu/bin/node
+            custom_node_platform: linux
+            custom_node_arch: arm64
           - runner: ubuntu-latest
-            target: node22-linux-x64
+            target: node22.22.2-linux-x64
             asset: vercel-linux-x64
             ext: ''
             sign: false
             smoke: true
+            custom_node_path: .node-runtime/node-v22.22.2-linux-x64-small-icu/bin/node
+            custom_node_platform: linux
+            custom_node_arch: x64
           - runner: windows-latest
-            target: node22-win-x64
+            target: node22.22.2-win-x64
             asset: vercel-windows-x64
             ext: '.exe'
             sign: false
             smoke: true
+            custom_node_path: .node-runtime/node-v22.22.2-win-x64-small-icu/node.exe
+            custom_node_platform: win
+            custom_node_arch: x64
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -97,11 +117,20 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
+      - name: Build custom Node runtime
+        if: ${{ matrix.custom_node_path != '' }}
+        env:
+          VERCEL_CLI_NODE_VERSION: 22.22.2
+          VERCEL_CLI_NODE_PLATFORM: ${{ matrix.custom_node_platform }}
+          VERCEL_CLI_NODE_ARCH: ${{ matrix.custom_node_arch }}
+        run: pnpm turbo --no-update-notifier run build-binary-node --filter vercel --output-logs=new-only
+
       - name: Build binary
         working-directory: packages/cli
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        run: node scripts/build-binary.mjs --target ${{ matrix.target }} --output ./dist-bin/${{ matrix.asset }}${{ matrix.ext }}
+          VERCEL_CLI_BINARY_NODE_PATH: ${{ matrix.custom_node_path }}
+        run: node scripts/build-binary.mjs --target ${{ matrix.target }} --compress Brotli --output ./dist-bin/${{ matrix.asset }}${{ matrix.ext }}
 
       - name: Install rcodesign
         if: ${{ matrix.sign }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -69,7 +69,7 @@ jobs:
             custom_node_path: .node-runtime/node-v22.22.2-linux-x64-small-icu/bin/node
             custom_node_platform: linux
             custom_node_arch: x64
-          - runner: windows-latest
+          - runner: windows-latest-8-core
             target: node22.22.2-win-x64
             asset: vercel-windows-x64
             ext: '.exe'

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -48,9 +48,9 @@ jobs:
             ext: ''
             sign: true
             smoke: true
-            custom_node_path: .node-runtime/node-v22.22.2-darwin-x64-small-icu/bin/node
-            custom_node_platform: darwin
-            custom_node_arch: x64
+            custom_node_path: ''
+            custom_node_platform: ''
+            custom_node_arch: ''
           - runner: ubuntu-24.04-arm
             target: node22.22.2-linux-arm64
             asset: vercel-linux-arm64

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -133,6 +133,17 @@ jobs:
           VERCEL_CLI_BINARY_NODE_PATH: ${{ matrix.custom_node_path }}
         run: node scripts/build-binary.mjs --target ${{ matrix.target }} --compress Brotli --output ./dist-bin/${{ matrix.asset }}${{ matrix.ext }}
 
+      - name: Smoke test binary before signing
+        shell: bash
+        working-directory: packages/cli
+        run: |
+          set -euo pipefail
+          bin="dist-bin/${{ matrix.asset }}${{ matrix.ext }}"
+          chmod +x "$bin" || true
+          out=$(./"$bin" --version)
+          echo "$out"
+          test -n "$out"
+
       - name: Install rcodesign
         if: ${{ matrix.sign }}
         run: cargo install apple-codesign --locked

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 dist
 dist-bin
 .pkg-staging
+.node-runtime
 .vscode
 .zed
 npm-debug.log

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "build": "node scripts/build.mjs",
     "build-binary": "pnpm --filter vercel... build && node scripts/build-binary.mjs",
     "build-binary:host": "pnpm --filter vercel... build && node scripts/build-binary.mjs --target host --output ./dist-bin/vercel",
+    "build-binary-node": "node scripts/build-binary-node.mjs",
     "dev": "echo \"'pnpm dev [command]' has been removed. Use 'pnpm vercel [command]' instead.\" && exit 1",
     "vercel": "pnpm build && node ./dist/vc.js",
     "vc": "pnpm vercel",

--- a/packages/cli/scripts/build-binary-node.mjs
+++ b/packages/cli/scripts/build-binary-node.mjs
@@ -52,7 +52,7 @@ try {
   await fs.mkdir(dirname(outputNode), { recursive: true });
   await fs.copyFile(builtNode, outputNode);
   await fs.chmod(outputNode, 0o755);
-  await stripAndSignNode();
+  const stripped = await stripAndSignNode();
 
   if (!(await isExpectedNode(outputNode, nodePlatform, nodeArch))) {
     throw new Error(
@@ -69,6 +69,7 @@ try {
         arch: nodeArch,
         intl: 'small-icu',
         locales: ['en'],
+        stripped,
         configure: configureFlags(),
       },
       null,
@@ -118,14 +119,20 @@ async function buildNode(sourceDir) {
 
 async function stripAndSignNode() {
   if (nodePlatform === 'win') {
-    return;
+    return false;
   }
 
-  await run('strip', [outputNode], packageRoot);
+  const shouldStrip = !(nodePlatform === 'darwin' && nodeArch === 'x64');
+
+  if (shouldStrip) {
+    await run('strip', [outputNode], packageRoot);
+  }
 
   if (nodePlatform === 'darwin') {
     await run('codesign', ['-f', '--sign', '-', outputNode], packageRoot);
   }
+
+  return shouldStrip;
 }
 
 function configureFlags() {

--- a/packages/cli/scripts/build-binary-node.mjs
+++ b/packages/cli/scripts/build-binary-node.mjs
@@ -1,0 +1,276 @@
+import { execFile, spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { availableParallelism, platform, arch, tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { pipeline } from 'node:stream/promises';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const nodeVersion = process.env.VERCEL_CLI_NODE_VERSION ?? '22.22.2';
+const nodeTag = `v${nodeVersion}`;
+const nodePlatform =
+  process.env.VERCEL_CLI_NODE_PLATFORM ?? nodePlatformForHost(platform());
+const nodeArch = process.env.VERCEL_CLI_NODE_ARCH ?? nodeArchForHost(arch());
+const runtimeName = `node-${nodeTag}-${nodePlatform}-${nodeArch}-small-icu`;
+const outputNode = join(
+  packageRoot,
+  '.node-runtime',
+  runtimeName,
+  nodeBinPath()
+);
+const buildJobs =
+  process.env.VERCEL_CLI_NODE_BUILD_JOBS ?? String(availableParallelism());
+
+if (
+  platform() !== hostPlatformForNodePlatform(nodePlatform) ||
+  nodeArchForHost(arch()) !== nodeArch
+) {
+  throw new Error(
+    `Custom CLI Node runtime build must run on the target architecture; requested ${nodePlatform}-${nodeArch}, got ${platform()}-${arch()}`
+  );
+}
+
+if (await isExpectedNode(outputNode, nodePlatform, nodeArch)) {
+  console.log(`Custom CLI Node runtime already exists: ${outputNode}`);
+  process.exit(0);
+}
+
+const buildRoot = await fs.mkdtemp(join(tmpdir(), 'vercel-cli-node-'));
+const sourceArchive = join(buildRoot, `node-${nodeTag}.tar.gz`);
+const sourceDir = join(buildRoot, `node-${nodeTag}`);
+
+try {
+  await downloadAndVerifySource(sourceArchive);
+  await run('tar', ['-xzf', sourceArchive], buildRoot);
+
+  const builtNode = await buildNode(sourceDir);
+  await fs.mkdir(dirname(outputNode), { recursive: true });
+  await fs.copyFile(builtNode, outputNode);
+  await fs.chmod(outputNode, 0o755);
+  await stripAndSignNode();
+
+  if (!(await isExpectedNode(outputNode, nodePlatform, nodeArch))) {
+    throw new Error(
+      `Built runtime does not report ${nodeTag} ${nodePlatform}-${nodeArch}: ${outputNode}`
+    );
+  }
+
+  await fs.writeFile(
+    join(dirname(outputNode), 'metadata.json'),
+    JSON.stringify(
+      {
+        nodeVersion: nodeTag,
+        platform: nodePlatform,
+        arch: nodeArch,
+        intl: 'small-icu',
+        locales: ['en'],
+        configure: configureFlags(),
+      },
+      null,
+      2
+    ) + '\n'
+  );
+
+  console.log(`Built custom CLI Node runtime: ${outputNode}`);
+} finally {
+  await fs.rm(buildRoot, { recursive: true, force: true });
+}
+
+async function buildNode(sourceDir) {
+  if (nodePlatform === 'win') {
+    const configFlags = configureFlags()
+      .filter(flag => !flag.startsWith('--dest-cpu='))
+      .join(' ');
+
+    await run(
+      'vcbuild.bat',
+      [
+        'release',
+        nodeArch,
+        'small-icu',
+        'nonpm',
+        'nocorepack',
+        'openssl-no-asm',
+      ],
+      sourceDir,
+      {
+        shell: true,
+        env: {
+          ...process.env,
+          config_flags: configFlags,
+        },
+      }
+    );
+
+    return join(sourceDir, 'Release', 'node.exe');
+  }
+
+  await run('./configure', configureFlags(), sourceDir);
+  await run('make', [`-j${buildJobs}`], sourceDir);
+
+  return join(sourceDir, 'out', 'Release', 'node');
+}
+
+async function stripAndSignNode() {
+  if (nodePlatform === 'win') {
+    return;
+  }
+
+  await run('strip', [outputNode], packageRoot);
+
+  if (nodePlatform === 'darwin') {
+    await run('codesign', ['-f', '--sign', '-', outputNode], packageRoot);
+  }
+}
+
+function configureFlags() {
+  return [
+    `--dest-cpu=${nodeArch}`,
+    `--dest-os=${configureOsForNodePlatform(nodePlatform)}`,
+    '--with-intl=small-icu',
+    '--with-icu-locales=en',
+    '--without-inspector',
+    '--without-npm',
+    '--without-corepack',
+    '--without-sqlite',
+  ];
+}
+
+async function downloadAndVerifySource(destination) {
+  const sourceUrl = `https://nodejs.org/dist/${nodeTag}/node-${nodeTag}.tar.gz`;
+  const checksumUrl = `https://nodejs.org/dist/${nodeTag}/SHASUMS256.txt`;
+
+  console.log(`Downloading ${sourceUrl}`);
+  await download(sourceUrl, destination);
+
+  const checksums = await fetchText(checksumUrl);
+  const checksumLine = checksums
+    .split('\n')
+    .find(line => line.includes(` node-${nodeTag}.tar.gz`));
+  const expectedHash = checksumLine?.split(/\s+/)[0];
+
+  if (!expectedHash) {
+    throw new Error(`Could not find checksum for node-${nodeTag}.tar.gz`);
+  }
+
+  const actualHash = createHash('sha256')
+    .update(await fs.readFile(destination))
+    .digest('hex');
+
+  if (actualHash !== expectedHash) {
+    throw new Error(
+      `Checksum mismatch for node-${nodeTag}.tar.gz: expected ${expectedHash}, got ${actualHash}`
+    );
+  }
+}
+
+async function download(url, destination) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download ${url}: ${response.status}`);
+  }
+  await pipeline(response.body, createWriteStream(destination));
+}
+
+async function fetchText(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: ${response.status}`);
+  }
+  return response.text();
+}
+
+async function run(command, args, cwd, options = {}) {
+  console.log(`$ ${command} ${args.join(' ')}`);
+  const child = spawn(command, args, {
+    cwd,
+    env: options.env ?? process.env,
+    shell: options.shell ?? false,
+    stdio: 'inherit',
+  });
+
+  const exitCode = await new Promise((resolveExit, reject) => {
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`${command} exited with signal ${signal}`));
+        return;
+      }
+      resolveExit(code ?? 1);
+    });
+  });
+
+  if (exitCode !== 0) {
+    throw new Error(`${command} exited with code ${exitCode}`);
+  }
+}
+
+function nodePlatformForHost(hostPlatform) {
+  if (hostPlatform === 'darwin' || hostPlatform === 'linux') {
+    return hostPlatform;
+  }
+
+  if (hostPlatform === 'win32') {
+    return 'win';
+  }
+
+  throw new Error(`Unsupported host platform: ${hostPlatform}`);
+}
+
+function hostPlatformForNodePlatform(targetPlatform) {
+  if (targetPlatform === 'darwin' || targetPlatform === 'linux') {
+    return targetPlatform;
+  }
+
+  if (targetPlatform === 'win') {
+    return 'win32';
+  }
+
+  throw new Error(`Unsupported target platform: ${targetPlatform}`);
+}
+
+function nodeArchForHost(hostArch) {
+  if (hostArch === 'arm64' || hostArch === 'x64') {
+    return hostArch;
+  }
+
+  throw new Error(`Unsupported host architecture: ${hostArch}`);
+}
+
+function configureOsForNodePlatform(targetPlatform) {
+  if (targetPlatform === 'darwin') {
+    return 'mac';
+  }
+
+  if (targetPlatform === 'linux' || targetPlatform === 'win') {
+    return targetPlatform;
+  }
+
+  throw new Error(`Unsupported Node configure platform: ${targetPlatform}`);
+}
+
+function nodeBinPath() {
+  return nodePlatform === 'win' ? 'node.exe' : join('bin', 'node');
+}
+
+async function isExpectedNode(nodePath, expectedPlatform, expectedArch) {
+  try {
+    const { stdout } = await execFileAsync(nodePath, [
+      '-p',
+      'JSON.stringify({version: process.version, platform: process.platform, arch: process.arch})',
+    ]);
+    const metadata = JSON.parse(stdout);
+    return (
+      metadata.version === nodeTag &&
+      metadata.platform === hostPlatformForNodePlatform(expectedPlatform) &&
+      metadata.arch === expectedArch
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/scripts/build-binary.mjs
+++ b/packages/cli/scripts/build-binary.mjs
@@ -1,10 +1,12 @@
-import { spawn } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs/promises';
+import { promisify } from 'node:util';
 
 const require = createRequire(import.meta.url);
+const execFileAsync = promisify(execFile);
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const stagingRoot = join(packageRoot, '.pkg-staging');
@@ -97,6 +99,7 @@ for (const dependency of directDependencies) {
 }
 
 const args = normalizeOutputArgs(process.argv.slice(2));
+const customNodeRuntimeEnv = await seedCustomNodeRuntime(args);
 const child = spawn(
   process.execPath,
   [pkgBin, './pkg.js', '--config', './pkg.config.mjs', ...args],
@@ -104,6 +107,7 @@ const child = spawn(
     cwd: stagingRoot,
     env: {
       ...process.env,
+      ...customNodeRuntimeEnv,
       VERCEL_CLI_BINARY_OUTPUT_DIR: join(packageRoot, 'dist-bin'),
     },
     stdio: 'inherit',
@@ -295,4 +299,99 @@ function normalizeFromPackageRoot(path) {
     return path;
   }
   return resolve(packageRoot, path);
+}
+
+async function seedCustomNodeRuntime(args) {
+  const customNodePath = process.env.VERCEL_CLI_BINARY_NODE_PATH;
+
+  if (!customNodePath) {
+    return {};
+  }
+
+  const target = getSingleTarget(args);
+  if (!target) {
+    throw new Error(
+      'VERCEL_CLI_BINARY_NODE_PATH requires a single explicit --target value'
+    );
+  }
+
+  const parsedTarget = parseExactNodeTarget(target);
+  if (!parsedTarget) {
+    throw new Error(
+      `VERCEL_CLI_BINARY_NODE_PATH requires an exact Node patch target, got "${target}"`
+    );
+  }
+
+  const resolvedNodePath = normalizeFromPackageRoot(customNodePath);
+  const { stdout } = await execFileAsync(resolvedNodePath, ['--version']);
+  const nodeVersion = stdout.trim();
+  const expectedVersion = `v${parsedTarget.version}`;
+
+  if (nodeVersion !== expectedVersion) {
+    throw new Error(
+      `Custom Node runtime version mismatch: expected ${expectedVersion}, got ${nodeVersion}`
+    );
+  }
+
+  const nodeOs = nodeOsForTargetPlatform(parsedTarget.platform);
+  const cacheHome = process.env.VERCEL_CLI_BINARY_NODE_CACHE_HOME
+    ? normalizeFromPackageRoot(process.env.VERCEL_CLI_BINARY_NODE_CACHE_HOME)
+    : join(packageRoot, '.node-runtime', 'pkg-home');
+  const cacheDir = join(cacheHome, '.pkg-cache', 'sea');
+  const nodeDirName = `node-${expectedVersion}-${nodeOs}-${parsedTarget.arch}`;
+  const cacheNodePath =
+    nodeOs === 'win'
+      ? join(cacheDir, `${nodeDirName}.exe`)
+      : join(cacheDir, nodeDirName, 'bin', 'node');
+  const archivePath = join(
+    cacheDir,
+    `${nodeDirName}.${nodeOs === 'win' ? 'zip' : 'tar.gz'}`
+  );
+
+  await fs.mkdir(dirname(cacheNodePath), { recursive: true });
+  await fs.copyFile(resolvedNodePath, cacheNodePath);
+  await fs.chmod(cacheNodePath, 0o755);
+  await fs.writeFile(`${cacheNodePath}.ok`, '');
+  await fs.writeFile(archivePath, '');
+  await fs.writeFile(`${archivePath}.ok`, '');
+
+  console.log(
+    `Seeded yao-pkg SEA cache with custom Node runtime for ${target}: ${resolvedNodePath}`
+  );
+
+  return { HOME: cacheHome, USERPROFILE: cacheHome };
+}
+
+function getSingleTarget(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--target' || arg === '-t') {
+      return args[index + 1];
+    }
+
+    if (arg.startsWith('--target=')) {
+      return arg.slice('--target='.length);
+    }
+  }
+}
+
+function parseExactNodeTarget(target) {
+  const match = target.match(
+    /^node(?<version>\d+\.\d+\.\d+)-(?<platform>[^-]+)-(?<arch>[^-]+)$/
+  );
+
+  return match?.groups;
+}
+
+function nodeOsForTargetPlatform(targetPlatform) {
+  if (targetPlatform === 'macos') {
+    return 'darwin';
+  }
+
+  if (targetPlatform === 'linux' || targetPlatform === 'win') {
+    return targetPlatform;
+  }
+
+  throw new Error(`Unsupported custom Node target platform: ${targetPlatform}`);
 }

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -1,7 +1,7 @@
 import { isErrnoException } from '@vercel/error-utils';
 import type { Deployment } from '@vercel-internals/types';
 import chalk from 'chalk';
-import { format } from 'date-fns';
+import format from 'date-fns/format';
 import type Client from '../../util/client';
 import { createGitMeta } from '../../util/create-git-meta';
 import { printError } from '../../util/error';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -67,7 +67,6 @@ import type { AuthConfig, GlobalConfig, User } from '@vercel-internals/types';
 import type { VercelConfig } from '@vercel/client';
 import { Agent as HttpsAgent } from 'https';
 import box from './util/output/box';
-import { execExtension } from './util/extension/exec';
 import { TelemetryEventStore } from './util/telemetry';
 import { RootTelemetryClient } from './util/telemetry/root';
 import { help } from './args';
@@ -121,7 +120,7 @@ const handleRejection = async (err: any) => {
       await handleUnexpected(err);
     } else {
       output.error(`An unexpected rejection occurred\n  ${err}`);
-      await reportError(getSentry(), client, err);
+      await reportError(await getSentry(), client, err);
     }
   } else {
     output.error('An unexpected empty rejection occurred');
@@ -140,7 +139,7 @@ const handleUnexpected = async (err: Error) => {
   }
 
   output.error(`An unexpected error occurred!\n${err.stack}`);
-  await reportError(getSentry(), client, err);
+  await reportError(await getSentry(), client, err);
 
   process.exit(1);
 };
@@ -859,6 +858,7 @@ const main = async () => {
 
       // Try to execute as an extension
       try {
+        const { execExtension } = await import('./util/extension/exec');
         exitCode = await execExtension(
           client,
           targetCommand,
@@ -1247,7 +1247,7 @@ const main = async () => {
       }
       output.prettyError(err);
     } else {
-      await reportError(getSentry(), client, err);
+      await reportError(await getSentry(), client, err);
 
       // Otherwise it is an unexpected error and we should show the trace
       // and an unexpected error message

--- a/packages/cli/src/util/blob/format-store.ts
+++ b/packages/cli/src/util/blob/format-store.ts
@@ -1,6 +1,6 @@
 import bytes from 'bytes';
 import chalk from 'chalk';
-import { format } from 'date-fns';
+import format from 'date-fns/format';
 import output from '../../output-manager';
 
 export interface StoreDetails {

--- a/packages/cli/src/util/get-sentry.ts
+++ b/packages/cli/src/util/get-sentry.ts
@@ -8,12 +8,19 @@ let sentry: typeof SentryType | undefined;
  * which improves CLI startup performance for the common case
  * where no errors occur.
  */
-export function getSentry(): typeof SentryType {
+export async function getSentry(): Promise<typeof SentryType> {
   if (!sentry) {
-    // Dynamic require to avoid loading Sentry at startup
-    const Sentry = require('@sentry/node') as typeof SentryType;
-    const { SENTRY_DSN } = require('./constants');
-    const pkg = require('./pkg').default;
+    // Dynamic import to keep Sentry out of the startup bundle.
+    const [SentryModule, { SENTRY_DSN }, { default: pkg }] = await Promise.all([
+      import('@sentry/node'),
+      import('./constants'),
+      import('./pkg'),
+    ]);
+    const Sentry = (
+      'init' in SentryModule
+        ? SentryModule
+        : (SentryModule as unknown as { default: typeof SentryType }).default
+    ) as typeof SentryType;
 
     Sentry.init({
       dsn: SENTRY_DSN,

--- a/packages/cli/src/util/logs.ts
+++ b/packages/cli/src/util/logs.ts
@@ -1,6 +1,6 @@
 import type { Deployment } from '@vercel-internals/types';
 import chalk from 'chalk';
-import { format } from 'date-fns';
+import format from 'date-fns/format';
 import ms from 'ms';
 import jsonlines from 'jsonlines';
 import split from 'split2';

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -10,7 +10,10 @@
       ]
     },
     "build-binary-node": {
-      "inputs": ["package.json", "scripts/build-binary-node.mjs"],
+      "inputs": [
+        "$TURBO_ROOT$/.github/workflows/release-binary.yml",
+        "scripts/build-binary-node.mjs"
+      ],
       "outputs": [".node-runtime/**"],
       "env": [
         "VERCEL_CLI_NODE_ARCH",

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -8,6 +8,15 @@
         "src/util/constants.ts",
         "src/util/dev/templates/*.ts"
       ]
+    },
+    "build-binary-node": {
+      "inputs": ["package.json", "scripts/build-binary-node.mjs"],
+      "outputs": [".node-runtime/**"],
+      "env": [
+        "VERCEL_CLI_NODE_ARCH",
+        "VERCEL_CLI_NODE_PLATFORM",
+        "VERCEL_CLI_NODE_VERSION"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- build a custom Node 22.22.2 runtime for every release-binary target with small-ICU and without npm/corepack/inspector/sqlite
- run the custom Node compilation through a cacheable Turbo task keyed by platform, arch, and Node version
- seed yao-pkg's SEA cache from that runtime and package release binaries with Brotli compression
- use an arm64 Linux runner for the linux-arm64 binary so the custom runtime is built for the target architecture

## Why
The default yao-pkg macOS arm64 binary was about 132 MiB uncompressed. The small-ICU + Brotli path keeps the CLI's Intl/Luxon usage working while reducing the tested macOS arm64 binary to about 58.6 MiB, and applying the same custom Node path to all release targets keeps binary construction consistent across platforms.

## Validation
- pnpm type-check in packages/cli
- node --check for build-binary scripts
- Turbo dry runs for darwin/linux/win platform hashes
- rebuilt macOS arm64 small-ICU Brotli binary and verified --version / --help