### PR TITLE
fix(cli): exempt middleware routes from scopeRoutesToServiceOwnership

### DIFF
--- a/.changeset/fix-middleware-service-route-ownership.md
+++ b/.changeset/fix-middleware-service-route-ownership.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+fix(cli): exempt middleware routes from scopeRoutesToServiceOwnership to prevent broken services-mode deployments

--- a/packages/cli/src/util/build/service-route-ownership.ts
+++ b/packages/cli/src/util/build/service-route-ownership.ts
@@ -37,7 +37,11 @@ export function scopeRoutesToServiceOwnership({
     return routes;
   }
   return routes.map(route => {
-    if ('handle' in route || typeof route.src !== 'string') {
+    if (
+      'handle' in route ||
+      'middlewarePath' in route ||
+      typeof route.src !== 'string'
+    ) {
       return route;
     }
     return {

--- a/packages/cli/test/unit/util/build/service-route-ownership.test.ts
+++ b/packages/cli/test/unit/util/build/service-route-ownership.test.ts
@@ -94,4 +94,23 @@ describe('scopeRoutesToServiceOwnership()', () => {
     expect(match).toBeTruthy();
     expect(match?.[1]).toBe('about/team');
   });
+
+  test('preserves middleware routes without modifying their src', () => {
+    const owner = createWebService('web', '/');
+    const middlewareRoute: Route = {
+      src: '^/(.*)$',
+      middlewarePath: 'middleware',
+      continue: true,
+    };
+    const routes: Route[] = [middlewareRoute];
+    const scoped = scopeRoutesToServiceOwnership({
+      routes,
+      owner,
+      allServices: [owner, createWebService('dashboard', '/dashboard')],
+    });
+
+    // Middleware routes must be returned unchanged — scoping their src
+    // corrupts the ownership lookaheads and breaks deployments.
+    expect(scoped[0]).toBe(middlewareRoute);
+  });
 });


### PR DESCRIPTION
## What

Middleware routes (those carrying a `middlewarePath` key) were not exempted from the ownership-scoping pass in `scopeRoutesToServiceOwnership()`. The function wraps every web-service route's `src` regex with prefix-exclusion lookaheads, but when applied to middleware routes the rewritten `src` is syntactically invalid and causes silent deploy failures in services-mode projects that include a `middleware.ts`.

## Fix

Add `'middlewarePath' in route` to the existing guard condition alongside `'handle' in route`:

```ts
// before
if ('handle' in route || typeof route.src !== 'string') {

// after
if ('handle' in route || 'middlewarePath' in route || typeof route.src !== 'string') {
```

The reporter also identified the `isRouteMiddleware()` helper in `@vercel/build-utils` as a reference for what constitutes a middleware route.

## Testing

Added a vitest unit test to `service-route-ownership.test.ts` that passes a middleware route (with `middlewarePath` key) through `scopeRoutesToServiceOwnership()` and asserts the route object is returned unchanged.

All 5 tests pass ✅

Fixes #16296