### PR TITLE
Harden OIDC token cache handling

### DIFF
--- a/.changeset/oidc-token-cache-hardening.md
+++ b/.changeset/oidc-token-cache-hardening.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+Harden OIDC token refresh URL construction and cache file naming.

--- a/packages/oidc/src/token-cache.test.ts
+++ b/packages/oidc/src/token-cache.test.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from 'crypto';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+vi.mock('./token-io');
+
+import { getUserDataDir } from './token-io';
+import { getVercelOidcToken, loadToken, saveToken } from './token-util';
+
+describe('token cache hardening', () => {
+  let rootDir: string;
+  let userDataDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+
+    rootDir = path.join(os.tmpdir(), `token-cache-${randomUUID()}`);
+    userDataDir = path.join(rootDir, 'data');
+    fs.mkdirSync(userDataDir, { recursive: true });
+    vi.mocked(getUserDataDir).mockReturnValue(userDataDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  test('encodes project and team values in the refresh URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 'oidc-token' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getVercelOidcToken(
+      'auth-token',
+      'project/with spaces',
+      'team&role=owner'
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.vercel.com/v1/projects/project%2Fwith%20spaces/token?source=vercel-oidc-refresh&teamId=team%26role%3Downer',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer auth-token',
+        },
+      }
+    );
+  });
+
+  test('stores project token cache entries using encoded file names', () => {
+    const projectId = '../com.vercel.cli/auth';
+    const token = { token: 'cached-token' };
+
+    saveToken(token, projectId);
+
+    const tokenDir = path.join(userDataDir, 'com.vercel.token');
+    const escapedAuthPath = path.join(
+      userDataDir,
+      'com.vercel.cli',
+      'auth.json'
+    );
+    const tokenPath = path.join(
+      tokenDir,
+      `${encodeURIComponent(projectId)}.json`
+    );
+
+    expect(fs.existsSync(escapedAuthPath)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(tokenPath, 'utf8'))).toEqual(token);
+    expect(loadToken(projectId)).toEqual(token);
+
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/packages/oidc/src/token-util.ts
+++ b/packages/oidc/src/token-util.ts
@@ -98,8 +98,16 @@ export async function getVercelOidcToken(
   projectId: string,
   teamId?: string
 ): Promise<VercelTokenResponse | null> {
-  const url = `https://api.vercel.com/v1/projects/${projectId}/token?source=vercel-oidc-refresh${teamId ? `&teamId=${teamId}` : ''}`;
-  const res = await fetch(url, {
+  const url = new URL(
+    `/v1/projects/${encodeURIComponent(projectId)}/token`,
+    'https://api.vercel.com'
+  );
+  url.searchParams.set('source', 'vercel-oidc-refresh');
+  if (teamId) {
+    url.searchParams.set('teamId', teamId);
+  }
+
+  const res = await fetch(url.toString(), {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${authToken}`,
@@ -153,34 +161,36 @@ export function findProjectInfo(): { projectId: string; teamId: string } {
 }
 
 export function saveToken(token: VercelTokenResponse, projectId: string): void {
-  const dir = getUserDataDir();
-  if (!dir) {
-    throw new VercelOidcTokenError(
-      'Unable to find user data directory. Please reach out to Vercel support.'
-    );
-  }
-  const tokenPath = path.join(dir, 'com.vercel.token', `${projectId}.json`);
+  const tokenPath = getTokenPath(projectId);
   const tokenJson = JSON.stringify(token);
-  fs.mkdirSync(path.dirname(tokenPath), { mode: 0o770, recursive: true }); // read/write/exec perms for owner/group only, x required for dir ops
-  fs.writeFileSync(tokenPath, tokenJson);
-  fs.chmodSync(tokenPath, 0o660); // read/write perms for owner only
+  fs.mkdirSync(path.dirname(tokenPath), { mode: 0o700, recursive: true });
+  fs.writeFileSync(tokenPath, tokenJson, { mode: 0o600 });
+  fs.chmodSync(tokenPath, 0o600);
   return;
 }
 
 export function loadToken(projectId: string): VercelTokenResponse | null {
-  const dir = getUserDataDir();
-  if (!dir) {
-    throw new VercelOidcTokenError(
-      'Unable to find user data directory. Please reach out to Vercel support.'
-    );
-  }
-  const tokenPath = path.join(dir, 'com.vercel.token', `${projectId}.json`);
+  const tokenPath = getTokenPath(projectId);
   if (!fs.existsSync(tokenPath)) {
     return null;
   }
   const token = JSON.parse(fs.readFileSync(tokenPath, 'utf8'));
   assertVercelOidcTokenResponse(token);
   return token;
+}
+
+function getTokenPath(projectId: string): string {
+  const dir = getUserDataDir();
+  if (!dir) {
+    throw new VercelOidcTokenError(
+      'Unable to find user data directory. Please reach out to Vercel support.'
+    );
+  }
+  return path.join(
+    dir,
+    'com.vercel.token',
+    `${encodeURIComponent(projectId)}.json`
+  );
 }
 
 interface TokenPayload {


### PR DESCRIPTION
## What changed

This hardens the `@vercel/oidc` development token refresh path in two small ways:

- Build the OIDC refresh URL with `URL` and `URLSearchParams`, encoding project and team values before they cross the network boundary.
- Store cached project OIDC tokens under encoded filenames instead of using the raw project value in the cache path.
- Tighten cached token directory/file permissions from group-readable/group-writable to owner-only.

## Why

The project/team values can come from local project configuration or explicit refresh options. Treating those values as structured URL/path components makes the helper more robust when project identifiers or slugs contain reserved URL or filesystem characters, and keeps cached token files inside the intended `com.vercel.token` directory.

## Validation

- `pnpm --dir packages/oidc test -- --run`
- `pnpm --dir packages/oidc build:code`
- Pre-commit hook ran successfully for the commit.
