### PR TITLE
Add normalized entrypoint detector for runtime builders

### DIFF
--- a/.changeset/old-pots-confess.md
+++ b/.changeset/old-pots-confess.md
@@ -1,0 +1,8 @@
+---
+'@vercel/build-utils': minor
+'@vercel/backends': minor
+'@vercel/python': minor
+'@vercel/go': minor
+---
+
+Add normalized entrypoint detector for runtime builders.

--- a/packages/backends/src/find-entrypoint.ts
+++ b/packages/backends/src/find-entrypoint.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join, relative, resolve, sep } from 'node:path';
+import type { DetectEntrypointFn } from '@vercel/build-utils';
 
 const frameworks = [
   'express',
@@ -111,4 +112,15 @@ export const findEntrypointOrThrow = async (cwd: string): Promise<string> => {
     );
   }
   return entrypoint;
+};
+
+/**
+ * Normalized entrypoint detector for Node services. Wraps {@link findEntrypoint}
+ * and returns the result in the shared {@link DetectedEntrypoint} shape consumed
+ * by services auto-detection.
+ */
+export const detectEntrypoint: DetectEntrypointFn = async ({ workPath }) => {
+  const file = await findEntrypoint(workPath);
+  if (!file) return null;
+  return { kind: 'file', entrypoint: file };
 };

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -31,6 +31,7 @@ export {
   getBuildSummary,
   srvxOptions,
 } from './cervel/index.js';
+export { detectEntrypoint } from './find-entrypoint.js';
 export type {
   CervelBuildOptions,
   CervelServeOptions,

--- a/packages/backends/test/unit.find-entrypoint.test.ts
+++ b/packages/backends/test/unit.find-entrypoint.test.ts
@@ -2,7 +2,11 @@ import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
-import { findEntrypoint, findEntrypointOrThrow } from '../src/find-entrypoint';
+import {
+  detectEntrypoint,
+  findEntrypoint,
+  findEntrypointOrThrow,
+} from '../src/find-entrypoint';
 
 describe('findEntrypoint', () => {
   it('resolves package.json main when the file exists', async () => {
@@ -77,6 +81,39 @@ describe('findEntrypointOrThrow', () => {
       await expect(findEntrypointOrThrow(dir)).rejects.toThrow(
         /package\.json "main"/
       );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('detectEntrypoint (normalized)', () => {
+  it('emits a file-kind result wrapping the discovered entrypoint', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'be-detect-'));
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ name: 'x', dependencies: { hono: '^4' } }),
+        'utf-8'
+      );
+      await writeFile(
+        join(dir, 'index.ts'),
+        `import { Hono } from 'hono'\n`,
+        'utf-8'
+      );
+      await expect(detectEntrypoint({ workPath: dir })).resolves.toEqual({
+        kind: 'file',
+        entrypoint: 'index.ts',
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when no entrypoint is discoverable', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'be-detect-empty-'));
+    try {
+      await expect(detectEntrypoint({ workPath: dir })).resolves.toBeNull();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -999,3 +999,39 @@ export type Services = Record<string, ServiceConfig>;
  * }
  */
 export type ExperimentalServiceGroups = Record<string, string[]>;
+
+/**
+ * Result of a runtime builder's normalized entrypoint detection.
+ *
+ * - `kind: 'file'` — `entrypoint` is a path relative to the scanned `workPath`
+ *   (e.g. `"src/index.ts"`, `"main.go"`, `"main.py"`).
+ * - `kind: 'py-module:attr'` — `entrypoint` is a Python `module:attr` reference
+ *   where the module is dot-separated and resolved relative to the scanned
+ *   `workPath` (e.g. `"main:app"`, `"src.main:app"`).
+ *
+ * @experimental This feature is experimental and may change.
+ */
+export type DetectedEntrypoint =
+  | { kind: 'file'; entrypoint: string }
+  | { kind: 'py-module:attr'; entrypoint: string }
+  | null;
+
+/**
+ * Input to a runtime builder's normalized entrypoint detector.
+ * @experimental This feature is experimental and may change.
+ */
+export interface DetectEntrypointOptions {
+  /** Path to the candidate service directory relative to project root. */
+  workPath: string;
+  /** Framework slug detected for this directory, if any. */
+  framework?: string;
+}
+
+/**
+ * Normalized entrypoint detector signature, implemented by each runtime builder
+ * and consumed by services auto-detection to populate suggested service configs.
+ * @experimental This feature is experimental and may change.
+ */
+export type DetectEntrypointFn = (
+  opts: DetectEntrypointOptions
+) => Promise<DetectedEntrypoint>;

--- a/packages/go/src/entrypoint.ts
+++ b/packages/go/src/entrypoint.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { pathExists } from 'fs-extra';
-import { debug } from '@vercel/build-utils';
+import { debug, type DetectEntrypointFn } from '@vercel/build-utils';
 
 export const GO_CANDIDATE_ENTRYPOINTS = [
   'main.go',
@@ -14,10 +14,13 @@ export const GO_CANDIDATE_ENTRYPOINTS = [
  */
 export async function detectGoEntrypoint(
   workPath: string,
-  configuredEntrypoint: string
+  configuredEntrypoint?: string
 ): Promise<string | null> {
   // If the configured entrypoint exists, use it
-  if (await pathExists(join(workPath, configuredEntrypoint))) {
+  if (
+    configuredEntrypoint &&
+    (await pathExists(join(workPath, configuredEntrypoint)))
+  ) {
     debug(`Using configured Go entrypoint: ${configuredEntrypoint}`);
     return configuredEntrypoint;
   }
@@ -32,3 +35,14 @@ export async function detectGoEntrypoint(
 
   return null;
 }
+
+/**
+ * Normalized entrypoint detector for Go services. Wraps {@link detectGoEntrypoint}
+ * and returns the result in the shared {@link DetectedEntrypoint} shape consumed
+ * by services auto-detection.
+ */
+export const detectEntrypoint: DetectEntrypointFn = async ({ workPath }) => {
+  const file = await detectGoEntrypoint(workPath);
+  if (!file) return null;
+  return { kind: 'file', entrypoint: file };
+};

--- a/packages/go/src/index.ts
+++ b/packages/go/src/index.ts
@@ -47,6 +47,8 @@ import {
 
 import { GO_CANDIDATE_ENTRYPOINTS, detectGoEntrypoint } from './entrypoint';
 
+export { detectEntrypoint, detectGoEntrypoint } from './entrypoint';
+
 import {
   buildStandaloneServer,
   startStandaloneDevServer,

--- a/packages/go/test/detect-entrypoint.test.ts
+++ b/packages/go/test/detect-entrypoint.test.ts
@@ -1,0 +1,51 @@
+import fs from 'fs-extra';
+import { tmpdir } from 'os';
+import path from 'path';
+import { detectEntrypoint } from '../src/entrypoint';
+
+async function makeTmp(name: string): Promise<string> {
+  const dir = path.join(tmpdir(), `vc-go-detect-${name}-${Date.now()}`);
+  await fs.mkdirp(dir);
+  return dir;
+}
+
+describe('detectEntrypoint (normalized)', () => {
+  it('emits a file-kind result for main.go at the workPath root', async () => {
+    const dir = await makeTmp('main');
+    try {
+      await fs.writeFile(path.join(dir, 'main.go'), 'package main\n');
+      await expect(detectEntrypoint({ workPath: dir })).resolves.toEqual({
+        kind: 'file',
+        entrypoint: 'main.go',
+      });
+    } finally {
+      await fs.remove(dir);
+    }
+  });
+
+  it('discovers nested cmd/api/main.go', async () => {
+    const dir = await makeTmp('nested');
+    try {
+      await fs.mkdirp(path.join(dir, 'cmd', 'api'));
+      await fs.writeFile(
+        path.join(dir, 'cmd', 'api', 'main.go'),
+        'package main\n'
+      );
+      await expect(detectEntrypoint({ workPath: dir })).resolves.toEqual({
+        kind: 'file',
+        entrypoint: 'cmd/api/main.go',
+      });
+    } finally {
+      await fs.remove(dir);
+    }
+  });
+
+  it('returns null when no candidate file is present', async () => {
+    const dir = await makeTmp('empty');
+    try {
+      await expect(detectEntrypoint({ workPath: dir })).resolves.toBeNull();
+    } finally {
+      await fs.remove(dir);
+    }
+  });
+});

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -612,9 +612,8 @@ export const detectEntrypoint: DetectEntrypointFn = async ({
   );
   if (!detected?.entrypoint) return null;
   const { entrypoint, variableName } = detected.entrypoint;
-  const modulePath = entrypoint.replace(/\.py$/, '').replace(/\//g, '.');
   return {
     kind: 'py-module:attr',
-    entrypoint: `${modulePath}:${variableName}`,
+    entrypoint: `${entrypointToModule(entrypoint)}:${variableName}`,
   };
 };

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -3,8 +3,10 @@ import { join, relative, posix as pathPosix } from 'path';
 import {
   PythonFramework,
   NowBuildError,
+  isPythonFramework,
   isScheduleTriggeredService,
   isQueueTriggeredService,
+  type DetectEntrypointFn,
   type ServiceType,
   type JobTrigger,
 } from '@vercel/build-utils';
@@ -589,3 +591,30 @@ export async function detectPythonEntrypoint(
     ? { baseDir: djangoManageBaseDir, error }
     : { error };
 }
+
+/**
+ * Normalized entrypoint detector for Python services. Wraps
+ * {@link detectPythonEntrypoint} and converts the result into the shared
+ * {@link DetectedEntrypoint} shape consumed by services auto-detection.
+ *
+ * Returns `null` for non-Python frameworks, when no entrypoint is found,
+ * and for Django when only a `manage.py` baseDir was discovered (the
+ * Django framework hook resolves the WSGI/ASGI entrypoint at build time).
+ */
+export const detectEntrypoint: DetectEntrypointFn = async ({
+  workPath,
+  framework,
+}) => {
+  if (!isPythonFramework(framework)) return null;
+  const detected = await detectPythonEntrypoint(
+    framework as PythonFramework,
+    workPath
+  );
+  if (!detected?.entrypoint) return null;
+  const { entrypoint, variableName } = detected.entrypoint;
+  const modulePath = entrypoint.replace(/\.py$/, '').replace(/\//g, '.');
+  return {
+    kind: 'py-module:attr',
+    entrypoint: `${modulePath}:${variableName}`,
+  };
+};

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -74,6 +74,8 @@ import {
   type PythonEntrypoint,
 } from './entrypoint';
 
+export { detectEntrypoint } from './entrypoint';
+
 export const version = -1;
 
 interface FrameworkHookContext {

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -3772,3 +3772,52 @@ describe('entrypoint diagnostic error messages', () => {
     fs.removeSync(workPath);
   });
 });
+
+describe('detectEntrypoint (normalized)', () => {
+  let detectEntrypoint: typeof import('../src/entrypoint').detectEntrypoint;
+
+  beforeEach(async () => {
+    ({ detectEntrypoint } = await import('../src/entrypoint'));
+  });
+
+  it('encodes nested src/main.py with dot-notation module path', async () => {
+    const workPath = path.join(tmpdir(), `python-detect-nested-${Date.now()}`);
+    fs.mkdirSync(path.join(workPath, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(workPath, 'src', 'main.py'),
+      'from fastapi import FastAPI\napp = FastAPI()\n'
+    );
+
+    const result = await detectEntrypoint({ workPath, framework: 'fastapi' });
+    expect(result).toEqual({
+      kind: 'py-module:attr',
+      entrypoint: 'src.main:app',
+    });
+
+    fs.removeSync(workPath);
+  });
+
+  it('returns null when no entrypoint is discoverable', async () => {
+    const workPath = path.join(tmpdir(), `python-detect-empty-${Date.now()}`);
+    fs.mkdirSync(workPath, { recursive: true });
+
+    const result = await detectEntrypoint({ workPath, framework: 'fastapi' });
+    expect(result).toBeNull();
+
+    fs.removeSync(workPath);
+  });
+
+  it('returns null for non-Python frameworks', async () => {
+    const workPath = path.join(tmpdir(), `python-detect-nonpy-${Date.now()}`);
+    fs.mkdirSync(workPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(workPath, 'main.py'),
+      'from fastapi import FastAPI\napp = FastAPI()\n'
+    );
+
+    const result = await detectEntrypoint({ workPath, framework: 'express' });
+    expect(result).toBeNull();
+
+    fs.removeSync(workPath);
+  });
+});


### PR DESCRIPTION
- Add the `DetectEntrypointFn` contract in `@vercel/build-utils`
  - Enable services auto-detection can ask each runtime for a candidate entrypoint.
  - Implement it in the `Python`, `Node`, and `Go` builders

- Add `DetectedEntrypoint` as a union with:
  - `kind: 'file'` -> a path relative to the service's dir (eg. `src/index.ts`).
  - `kind: 'py-module:attr'` -> a `Python` `module:attr` reference relative to the service's dir (eg. `src.main:app`).

All three types in `@vercel/build-utils` are marked `@experimental`. No consumer is wired up in this PR.

Smaller breakdown of #16241