### PR TITLE
Add exportName to js crons.

### DIFF
--- a/.changeset/tall-bees-attack.md
+++ b/.changeset/tall-bees-attack.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': minor
+---
+
+Add exportName to js crons.

--- a/packages/backends/src/crons.ts
+++ b/packages/backends/src/crons.ts
@@ -7,11 +7,22 @@ import {
 
 const DYNAMIC_SCHEDULE = '<dynamic>';
 
-/** Build the JSON route table embedded in `__VC_CRON_ROUTES`. */
-export function buildCronRouteTable(crons: Cron[]): Record<string, string> {
+export interface BackendsCron extends Cron {
+  /**
+   * Name of the export on the user's bundled module that the dispatcher
+   * should invoke for this entry. `'default'` for static schedules; for
+   * `<dynamic>` schedules each entry names a different named export.
+   */
+  exportName: string;
+}
+
+/** Build the JSON route table embedded in the dispatcher shim. */
+export function buildCronRouteTable(
+  crons: BackendsCron[]
+): Record<string, string> {
   const table: Record<string, string> = {};
   for (const cron of crons) {
-    table[cron.path] = 'default';
+    table[cron.path] = cron.exportName;
   }
   return table;
 }
@@ -22,16 +33,11 @@ export function buildCronRouteTable(crons: Cron[]): Record<string, string> {
  * Mirrors `packages/python/src/crons.ts` for static schedules. Returns
  * `undefined` when the service is not schedule-triggered. Throws on
  * `<dynamic>` schedules — that path is reserved for a follow-up.
- *
- * v1 always invokes the user module's default export, so this returns
- * plain `Cron[]` (no handler-name field). When `handlerFunction` or
- * `<dynamic>` support lands, this will need to grow a per-path handler
- * name back.
  */
 export function getServiceCrons(opts: {
   service?: BuildOptions['service'];
   entrypoint?: string;
-}): Cron[] | undefined {
+}): BackendsCron[] | undefined {
   const { service, entrypoint } = opts;
 
   if (!service || !isScheduleTriggeredService(service)) {
@@ -55,6 +61,7 @@ export function getServiceCrons(opts: {
     {
       path: getInternalServiceCronPath(service.name, entrypoint, 'cron'),
       schedule: service.schedule,
+      exportName: 'default',
     },
   ];
 }

--- a/packages/backends/src/crons.ts
+++ b/packages/backends/src/crons.ts
@@ -7,7 +7,7 @@ import {
 
 const DYNAMIC_SCHEDULE = '<dynamic>';
 
-export interface BackendsCron extends Cron {
+export interface BackendsCronEntry extends Cron {
   /**
    * Name of the export on the user's bundled module that the dispatcher
    * should invoke for this entry. `'default'` for static schedules; for
@@ -18,7 +18,7 @@ export interface BackendsCron extends Cron {
 
 /** Build the JSON route table embedded in the dispatcher shim. */
 export function buildCronRouteTable(
-  crons: BackendsCron[]
+  crons: BackendsCronEntry[]
 ): Record<string, string> {
   const table: Record<string, string> = {};
   for (const cron of crons) {
@@ -37,7 +37,7 @@ export function buildCronRouteTable(
 export function getServiceCrons(opts: {
   service?: BuildOptions['service'];
   entrypoint?: string;
-}): BackendsCron[] | undefined {
+}): BackendsCronEntry[] | undefined {
   const { service, entrypoint } = opts;
 
   if (!service || !isScheduleTriggeredService(service)) {

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -345,7 +345,17 @@ export const build: BuildV2 = async args => {
     return {
       routes,
       output,
-      ...(cronEntries ? { crons: cronEntries } : {}),
+      // Emit only the public {path, schedule} shape; `exportName` is an
+      // internal plumbing field consumed by `buildCronRouteTable` and
+      // doesn't belong in the build artifact.
+      ...(cronEntries
+        ? {
+            crons: cronEntries.map(({ path, schedule }) => ({
+              path,
+              schedule,
+            })),
+          }
+        : {}),
     };
   });
 };

--- a/packages/backends/test/unit.crons.test.ts
+++ b/packages/backends/test/unit.crons.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getServiceCrons } from '../src/crons';
+import { buildCronRouteTable, getServiceCrons } from '../src/crons';
 
 describe('getServiceCrons', () => {
   it('returns undefined for non-schedule-triggered services', () => {
@@ -48,6 +48,7 @@ describe('getServiceCrons', () => {
       {
         path: '/_svc/cleanup/crons/cleanup/cron',
         schedule: '0 0 * * *',
+        exportName: 'default',
       },
     ]);
   });
@@ -67,6 +68,7 @@ describe('getServiceCrons', () => {
       {
         path: '/_svc/cleanup/crons/jobs/cleanup/cron',
         schedule: '*/5 * * * *',
+        exportName: 'default',
       },
     ]);
   });
@@ -86,5 +88,27 @@ describe('getServiceCrons', () => {
         entrypoint: 'cleanup.ts',
       })
     ).toThrow(/Dynamic cron schedules .* not yet supported/);
+  });
+});
+
+describe('buildCronRouteTable', () => {
+  it('maps each entry path to its handler', () => {
+    expect(
+      buildCronRouteTable([
+        {
+          path: '/_svc/cleanup/crons/cleanup/cron',
+          schedule: '0 0 * * *',
+          exportName: 'default',
+        },
+        {
+          path: '/_svc/jobs/crons/jobs/hourly',
+          schedule: '0 * * * *',
+          exportName: 'hourly',
+        },
+      ])
+    ).toEqual({
+      '/_svc/cleanup/crons/cleanup/cron': 'default',
+      '/_svc/jobs/crons/jobs/hourly': 'hourly',
+    });
   });
 });


### PR DESCRIPTION
- Add `exportName` field to a new `BackendsCron` interface extending the public Cron type.
- Each cron entry can declare which named export of the user module the dispatcher should invoke
  - Static schedules emit 'default'
  - `<dynamic>` schedules will emit a different export per entry (follow-up PR)
  
  
Smaller breakdown of #16201