### PR TITLE
[cli] Rename "Connex client" to "Connex connector" in user-visible strings

### DIFF
--- a/.changeset/connex-rename-client-to-connector.md
+++ b/.changeset/connex-rename-client-to-connector.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Rename "Connex client" to "Connex connector" in user-visible `vc connex` strings (help text, spinners, error/success messages) to match the dashboard rename. Flag names, command names, positional argument names, types, file paths, and API endpoints are unchanged.

--- a/packages/cli/src/commands/connex/attach.ts
+++ b/packages/cli/src/commands/connex/attach.ts
@@ -60,7 +60,7 @@ export async function attach(
   const clientIdOrUid = args[0];
   if (!clientIdOrUid) {
     output.error(
-      'Missing client ID or UID. Usage: vercel connex attach <client>'
+      'Missing connector ID or UID. Usage: vercel connex attach <client>'
     );
     return 1;
   }
@@ -132,7 +132,7 @@ export async function attach(
   }
 
   // Resolve client identity → canonical id + display name.
-  output.spinner('Retrieving Connex client…');
+  output.spinner('Retrieving Connex connector…');
   let target: ConnexClientIdentity;
   try {
     target = await client.fetch<ConnexClientIdentity>(
@@ -142,7 +142,9 @@ export async function attach(
     output.stopSpinner();
     const status = (err as { status?: number }).status;
     if (status === 404) {
-      output.error(`No Connex client found for ${chalk.bold(clientIdOrUid)}.`);
+      output.error(
+        `No Connex connector found for ${chalk.bold(clientIdOrUid)}.`
+      );
       return 1;
     }
     printError(err);
@@ -188,7 +190,7 @@ export async function attach(
       return 0;
     }
     output.log(
-      `Connex client ${chalk.bold(displayName)} is already attached to ${chalk.bold(
+      `Connex connector ${chalk.bold(displayName)} is already attached to ${chalk.bold(
         projectName
       )} for environments: ${environments.join(', ')}. Nothing to do.`
     );
@@ -208,7 +210,7 @@ export async function attach(
       const current = (existingAttachment.environments ?? []).join(', ') || '—';
       const next = environments.join(', ');
       output.log(
-        `Connex client ${chalk.bold(displayName)} is already attached to ${chalk.bold(
+        `Connex connector ${chalk.bold(displayName)} is already attached to ${chalk.bold(
           projectName
         )}.`
       );
@@ -216,7 +218,7 @@ export async function attach(
       output.log(`  Will set: ${next}`);
     } else {
       output.log(
-        `Connex client ${chalk.bold(displayName)} will be attached to ${chalk.bold(
+        `Connex connector ${chalk.bold(displayName)} will be attached to ${chalk.bold(
           projectName
         )} for environments: ${environments.join(', ')}.`
       );
@@ -250,7 +252,7 @@ export async function attach(
     }
     if (status === 404) {
       output.error(
-        `No Connex client found for ${chalk.bold(displayName)}, or project ${chalk.bold(projectName)} is no longer accessible.`
+        `No Connex connector found for ${chalk.bold(displayName)}, or project ${chalk.bold(projectName)} is no longer accessible.`
       );
       return 1;
     }
@@ -276,7 +278,7 @@ export async function attach(
   }
 
   output.success(
-    `Attached Connex client ${chalk.bold(displayName)} to ${chalk.bold(projectName)} for environments: ${environments.join(', ')}.`
+    `Attached Connex connector ${chalk.bold(displayName)} to ${chalk.bold(projectName)} for environments: ${environments.join(', ')}.`
   );
   return 0;
 }

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -4,7 +4,7 @@ import { packageName } from '../../util/pkg-name';
 export const createSubcommand = {
   name: 'create',
   aliases: [],
-  description: 'Create a new Connex client',
+  description: 'Create a new Connex connector',
   arguments: [
     {
       name: 'type',
@@ -18,14 +18,14 @@ export const createSubcommand = {
       type: String,
       argument: 'NAME',
       deprecated: false,
-      description: 'Name of the Connex client',
+      description: 'Name of the Connex connector',
     },
     {
       name: 'triggers',
       shorthand: null,
       type: Boolean,
       deprecated: false,
-      description: 'Enable webhook triggers for this client',
+      description: 'Enable webhook triggers for this connector',
     },
     formatOption,
   ],
@@ -53,7 +53,7 @@ export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
   description:
-    'List Connex clients linked to the current project (falls back to every client in the team when no project is linked or when --all-projects is set)',
+    'List Connex connectors linked to the current project (falls back to every connector in the team when no project is linked or when --all-projects is set)',
   arguments: [],
   options: [
     {
@@ -62,7 +62,7 @@ export const listSubcommand = {
       type: Boolean,
       deprecated: false,
       description:
-        'List every Connex client in the team, regardless of project link',
+        'List every Connex connector in the team, regardless of project link',
     },
     {
       name: 'limit',
@@ -70,7 +70,7 @@ export const listSubcommand = {
       type: Number,
       argument: 'COUNT',
       deprecated: false,
-      description: 'Number of clients to return per page',
+      description: 'Number of connectors to return per page',
     },
     {
       name: 'next',
@@ -84,11 +84,11 @@ export const listSubcommand = {
   ],
   examples: [
     {
-      name: 'List Connex clients linked to the current project',
+      name: 'List Connex connectors linked to the current project',
       value: `${packageName} connex list`,
     },
     {
-      name: 'List every Connex client in the team',
+      name: 'List every Connex connector in the team',
       value: `${packageName} connex list --all-projects`,
     },
     {
@@ -109,7 +109,7 @@ export const listSubcommand = {
 export const removeSubcommand = {
   name: 'remove',
   aliases: ['rm'],
-  description: 'Delete a Connex client',
+  description: 'Delete a Connex connector',
   arguments: [
     {
       name: 'client',
@@ -119,28 +119,29 @@ export const removeSubcommand = {
   options: [
     {
       name: 'disconnect-all',
-      description: 'Disconnects all projects from the client before deletion',
+      description:
+        'Disconnects all projects from the connector before deletion',
       shorthand: 'a',
       type: Boolean,
       deprecated: false,
     },
     {
       ...yesOption,
-      description: 'Skip the confirmation prompt when deleting a client',
+      description: 'Skip the confirmation prompt when deleting a connector',
     },
     formatOption,
   ],
   examples: [
     {
-      name: 'Delete a Connex client by ID',
+      name: 'Delete a Connex connector by ID',
       value: `${packageName} connex remove scl_abc123`,
     },
     {
-      name: 'Delete a Connex client by UID',
+      name: 'Delete a Connex connector by UID',
       value: `${packageName} connex remove slack/my-bot`,
     },
     {
-      name: 'Disconnect all projects from a client, then delete it',
+      name: 'Disconnect all projects from a connector, then delete it',
       value: [
         `${packageName} connex remove scl_abc123 --disconnect-all`,
         `${packageName} connex remove slack/my-bot -a`,
@@ -161,7 +162,7 @@ export const tokenSubcommand = {
   name: 'token',
   aliases: [],
   description:
-    'Get a token for a Connex client (accepts a client ID like scl_abc or a UID like slack/my-bot)',
+    'Get a token for a Connex connector (accepts a connector ID like scl_abc or a UID like slack/my-bot)',
   arguments: [
     {
       name: 'id',
@@ -176,7 +177,7 @@ export const tokenSubcommand = {
       argument: 'TYPE',
       deprecated: false,
       description:
-        'Subject type: "user" (default, acts on behalf of you) or "app" (uses the client\'s default installation)',
+        'Subject type: "user" (default, acts on behalf of you) or "app" (uses the connector\'s default installation)',
     },
     {
       name: 'installation-id',
@@ -185,7 +186,7 @@ export const tokenSubcommand = {
       argument: 'ID',
       deprecated: false,
       description:
-        "Target a specific installation (only useful with --subject app; defaults to the client's default installation)",
+        "Target a specific installation (only useful with --subject app; defaults to the connector's default installation)",
     },
     {
       name: 'scopes',
@@ -200,11 +201,11 @@ export const tokenSubcommand = {
   ],
   examples: [
     {
-      name: 'Get a user token by client ID',
+      name: 'Get a user token by connector ID',
       value: `${packageName} connex token scl_abc123`,
     },
     {
-      name: 'Get a token by client UID',
+      name: 'Get a token by connector UID',
       value: `${packageName} connex token slack/my-bot`,
     },
     {
@@ -229,7 +230,7 @@ export const tokenSubcommand = {
 export const openSubcommand = {
   name: 'open',
   aliases: [],
-  description: 'Open a Connex client in the Vercel dashboard',
+  description: 'Open a Connex connector in the Vercel dashboard',
   arguments: [
     {
       name: 'id',
@@ -239,11 +240,11 @@ export const openSubcommand = {
   options: [formatOption],
   examples: [
     {
-      name: 'Open a client by ID',
+      name: 'Open a connector by ID',
       value: `${packageName} connex open scl_abc123`,
     },
     {
-      name: 'Open a client by UID',
+      name: 'Open a connector by UID',
       value: `${packageName} connex open slack/my-bot`,
     },
     {
@@ -257,7 +258,7 @@ export const attachSubcommand = {
   name: 'attach',
   aliases: [],
   description:
-    'Attach a Vercel project to a Connex client for one or more environments',
+    'Attach a Vercel project to a Connex connector for one or more environments',
   arguments: [
     {
       name: 'client',
@@ -290,7 +291,7 @@ export const attachSubcommand = {
   ],
   examples: [
     {
-      name: 'Attach the current project to a client for all environments',
+      name: 'Attach the current project to a connector for all environments',
       value: `${packageName} connex attach scl_abc123`,
     },
     {
@@ -311,7 +312,7 @@ export const attachSubcommand = {
 export const connexCommand = {
   name: 'connex',
   aliases: [],
-  description: 'Manage Vercel Connect clients',
+  description: 'Manage Vercel Connect connectors',
   arguments: [],
   options: [],
   subcommands: [
@@ -328,7 +329,7 @@ export const connexCommand = {
       value: `${packageName} connex create slack`,
     },
     {
-      name: 'List Connex clients on the current team',
+      name: 'List Connex connectors on the current team',
       value: `${packageName} connex list`,
     },
     {
@@ -336,11 +337,11 @@ export const connexCommand = {
       value: `${packageName} connex token scl_abc123`,
     },
     {
-      name: 'Attach the current project to a client',
+      name: 'Attach the current project to a connector',
       value: `${packageName} connex attach scl_abc123`,
     },
     {
-      name: 'Open a client in the dashboard',
+      name: 'Open a connector in the dashboard',
       value: `${packageName} connex open scl_abc123`,
     },
   ],

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -38,7 +38,7 @@ export async function create(
   // Resolve team
   await selectConnexTeam(
     client,
-    'Select the team where you want to create this client'
+    'Select the team where you want to create this connector'
   );
 
   // Get app name from flag or interactive prompt
@@ -46,7 +46,7 @@ export async function create(
   if (!name) {
     if (!client.stdin.isTTY) {
       output.error(
-        'Missing required flag --name. In non-interactive mode, provide --name for the client.'
+        'Missing required flag --name. In non-interactive mode, provide --name for the connector.'
       );
       return 1;
     }
@@ -149,11 +149,11 @@ export async function create(
     );
   } else if (hasBeenInstalled) {
     output.success(
-      `${serviceType} client created and installed: ${createdClient.id} (UID ${createdClient.uid})`
+      `${serviceType} connector created and installed: ${createdClient.id} (UID ${createdClient.uid})`
     );
   } else {
     output.success(
-      `${serviceType} client created: ${createdClient.id} (UID ${createdClient.uid})`
+      `${serviceType} connector created: ${createdClient.id} (UID ${createdClient.uid})`
     );
   }
   return 0;

--- a/packages/cli/src/commands/connex/list.ts
+++ b/packages/cli/src/commands/connex/list.ts
@@ -83,7 +83,7 @@ export async function list(
   if (unscoped) {
     await selectConnexTeam(
       client,
-      'Select the team whose Connex clients you want to list'
+      'Select the team whose Connex connectors you want to list'
     );
   }
 
@@ -102,7 +102,7 @@ export async function list(
   const query = params.toString();
   const url = `/v1/connex/clients${query ? `?${query}` : ''}`;
 
-  output.spinner('Fetching Connex clients…');
+  output.spinner('Fetching Connex connectors…');
   let response: ListClientsResponse;
   try {
     response = await client.fetch<ListClientsResponse>(url);
@@ -159,18 +159,18 @@ export async function list(
   if (clients.length === 0) {
     if (unscoped) {
       output.log(
-        `No Connex clients found. Create one with \`${packageName} connex create <type>\`.`
+        `No Connex connectors found. Create one with \`${packageName} connex create <type>\`.`
       );
     } else {
       output.log(
-        `No Connex clients linked to ${chalk.bold(projectName ?? 'this project')}. Run \`${packageName} connex list --all-projects\` to see every client in the team.`
+        `No Connex connectors linked to ${chalk.bold(projectName ?? 'this project')}. Run \`${packageName} connex list --all-projects\` to see every connector in the team.`
       );
     }
     return 0;
   }
 
   if (!unscoped && projectName) {
-    output.log(`Connex clients linked to ${chalk.bold(projectName)}:`);
+    output.log(`Connex connectors linked to ${chalk.bold(projectName)}:`);
   }
 
   const headers = ['UID', 'ID', 'Name', 'Type'];

--- a/packages/cli/src/commands/connex/open.ts
+++ b/packages/cli/src/commands/connex/open.ts
@@ -24,11 +24,14 @@ export async function openClient(
 
   const clientIdOrUid = args[0];
   if (!clientIdOrUid) {
-    output.error('Missing client ID or UID. Usage: vercel connex open <id>');
+    output.error('Missing connector ID or UID. Usage: vercel connex open <id>');
     return 1;
   }
 
-  await selectConnexTeam(client, 'Select the team whose Connex client to open');
+  await selectConnexTeam(
+    client,
+    'Select the team whose Connex connector to open'
+  );
 
   const { team } = await getScope(client);
   if (!team) {
@@ -36,7 +39,7 @@ export async function openClient(
     return 1;
   }
 
-  output.spinner('Looking up Connex client…');
+  output.spinner('Looking up Connex connector…');
   let resolvedId: string;
   try {
     // Resolve to the scl_ id even if the caller passed a UID. The dashboard
@@ -51,7 +54,7 @@ export async function openClient(
     const status = (err as { status?: number }).status;
     if (status === 404) {
       output.error(
-        `Connex client ${chalk.bold(`"${clientIdOrUid}"`)} not found on team ${chalk.bold(team.slug)}, or Connex is not enabled for this team.`
+        `Connex connector ${chalk.bold(`"${clientIdOrUid}"`)} not found on team ${chalk.bold(team.slug)}, or Connex is not enabled for this team.`
       );
       return 1;
     }
@@ -69,7 +72,7 @@ export async function openClient(
 
   if (client.stdout.isTTY) {
     output.print(
-      `Opening Connex client ${chalk.bold(clientIdOrUid)} in the dashboard…\n`
+      `Opening Connex connector ${chalk.bold(clientIdOrUid)} in the dashboard…\n`
     );
     open(url);
     return 0;

--- a/packages/cli/src/commands/connex/remove.ts
+++ b/packages/cli/src/commands/connex/remove.ts
@@ -49,14 +49,14 @@ export async function remove(
   const clientIdOrUid = args[0];
   if (!clientIdOrUid) {
     output.error(
-      'Missing client ID or UID. Usage: vercel connex remove <client>'
+      'Missing connector ID or UID. Usage: vercel connex remove <client>'
     );
     return 1;
   }
 
-  await selectConnexTeam(client, 'Select the team for this Connex client');
+  await selectConnexTeam(client, 'Select the team for this Connex connector');
 
-  output.spinner('Retrieving Connex client…');
+  output.spinner('Retrieving Connex connector…');
   let target: ConnexClientIdentity;
   try {
     target = await client.fetch<ConnexClientIdentity>(
@@ -66,7 +66,9 @@ export async function remove(
     output.stopSpinner();
     const status = (err as { status?: number }).status;
     if (status === 404) {
-      output.error(`No Connex client found for ${chalk.bold(clientIdOrUid)}.`);
+      output.error(
+        `No Connex connector found for ${chalk.bold(clientIdOrUid)}.`
+      );
       return 1;
     }
     output.error(
@@ -98,7 +100,7 @@ export async function remove(
     const count = projectLinks.length;
     const plural = count === 1 ? 'project' : 'projects';
     output.error(
-      `Cannot delete Connex client ${chalk.bold(displayName)} while it has ${count} connected ${plural}. Please disconnect any projects using this client first or use the \`--disconnect-all\` flag.`
+      `Cannot delete Connex connector ${chalk.bold(displayName)} while it has ${count} connected ${plural}. Please disconnect any projects using this connector first or use the \`--disconnect-all\` flag.`
     );
     return 1;
   }
@@ -116,7 +118,7 @@ export async function remove(
         ? ` ${projectLinks.length} connected ${projectLinks.length === 1 ? 'project' : 'projects'} will be disconnected.`
         : '';
     output.log(
-      `Connex client ${chalk.bold(displayName)} will be deleted permanently.${cascadeNote}`
+      `Connex connector ${chalk.bold(displayName)} will be deleted permanently.${cascadeNote}`
     );
     const confirmed = await client.input.confirm(
       `${chalk.red('Are you sure?')}`,
@@ -129,7 +131,7 @@ export async function remove(
   }
 
   try {
-    output.spinner('Deleting Connex client…');
+    output.spinner('Deleting Connex connector…');
     await client.fetch<unknown>(
       `/v1/connex/clients/${encodeURIComponent(target.id)}`,
       { method: 'DELETE' }
@@ -151,7 +153,7 @@ export async function remove(
   }
 
   output.success(
-    `Connex client ${chalk.bold(displayName)} successfully removed.`
+    `Connex connector ${chalk.bold(displayName)} successfully removed.`
   );
   return 0;
 }

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -43,7 +43,9 @@ export async function token(
 
   const clientId = args[0];
   if (!clientId) {
-    output.error('Missing client ID or UID. Usage: vercel connex token <id>');
+    output.error(
+      'Missing connector ID or UID. Usage: vercel connex token <id>'
+    );
     return 1;
   }
 
@@ -82,13 +84,13 @@ export async function token(
   const errorMessage = result.errorMessage ?? 'Failed to get token';
 
   if (errorCode === 'not_found') {
-    output.error('Client not found or Connex is not enabled for this team.');
+    output.error('Connector not found or Connex is not enabled for this team.');
     return 1;
   }
 
   if (errorCode === 'unresolved_token') {
     output.error(
-      `${errorMessage} This client does not support getting a token for the requested subject.`
+      `${errorMessage} This connector does not support getting a token for the requested subject.`
     );
     return 1;
   }

--- a/packages/cli/src/util/connex/request-code.ts
+++ b/packages/cli/src/util/connex/request-code.ts
@@ -60,7 +60,7 @@ export async function awaitConnexResult(
           output.stopSpinner();
           const clientId = result.data.clientId as string | undefined;
           if (clientId) {
-            output.log(`Client created: ${clientId}`);
+            output.log(`Connector created: ${clientId}`);
           }
           output.spinner(`${result.progress}...`);
         }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -757,7 +757,7 @@ exports[`help command > connex help output snapshots > connex attach subcommand 
 "
   ▲ vercel connex attach client [options]
 
-  Attach a Vercel project to a Connex client for one or more environments                                               
+  Attach a Vercel project to a Connex connector for one or more environments                                            
 
   Options:
 
@@ -784,7 +784,7 @@ exports[`help command > connex help output snapshots > connex attach subcommand 
 
   Examples:
 
-  - Attach the current project to a client for all environments
+  - Attach the current project to a connector for all environments
 
     $ vercel connex attach scl_abc123
 
@@ -807,13 +807,13 @@ exports[`help command > connex help output snapshots > connex create subcommand 
 "
   ▲ vercel connex create type [options]
 
-  Create a new Connex client                                                                                            
+  Create a new Connex connector                                                                                         
 
   Options:
 
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
-  -n,  --name <NAME>      Name of the Connex client                                                                     
-       --triggers         Enable webhook triggers for this client                                                       
+  -n,  --name <NAME>      Name of the Connex connector                                                                  
+       --triggers         Enable webhook triggers for this connector                                                    
 
 
   Global Options:
@@ -855,20 +855,20 @@ exports[`help command > connex help output snapshots > connex help column width 
 "
   ▲ vercel connex command
 
-  Manage Vercel Connect clients                                                 
+  Manage Vercel Connect connectors                                              
 
   Commands:
 
-  create  type    Create a new Connex client                            
-  list            List Connex clients linked to the current project     
-                  (falls back to every client in the team when no       
+  create  type    Create a new Connex connector                         
+  list            List Connex connectors linked to the current project  
+                  (falls back to every connector in the team when no    
                   project is linked or when --all-projects is set)      
-  token   id      Get a token for a Connex client (accepts a client ID  
-                  like scl_abc or a UID like slack/my-bot)              
-  attach  client  Attach a Vercel project to a Connex client for one or 
-                  more environments                                     
-  remove  client  Delete a Connex client                                
-  open    id      Open a Connex client in the Vercel dashboard          
+  token   id      Get a token for a Connex connector (accepts a         
+                  connector ID like scl_abc or a UID like slack/my-bot) 
+  attach  client  Attach a Vercel project to a Connex connector for one 
+                  or more environments                                  
+  remove  client  Delete a Connex connector                             
+  open    id      Open a Connex connector in the Vercel dashboard       
 
 
   Global Options:
@@ -893,7 +893,7 @@ exports[`help command > connex help output snapshots > connex help column width 
 
     $ vercel connex create slack
 
-  - List Connex clients on the current team
+  - List Connex connectors on the current team
 
     $ vercel connex list
 
@@ -901,11 +901,11 @@ exports[`help command > connex help output snapshots > connex help column width 
 
     $ vercel connex token scl_abc123
 
-  - Attach the current project to a client
+  - Attach the current project to a connector
 
     $ vercel connex attach scl_abc123
 
-  - Open a client in the dashboard
+  - Open a connector in the dashboard
 
     $ vercel connex open scl_abc123
 
@@ -916,14 +916,14 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
 "
   ▲ vercel connex list [options]
 
-  List Connex clients linked to the current project (falls back to every client in the team when no project is linked   
-  or when --all-projects is set)                                                                                        
+  List Connex connectors linked to the current project (falls back to every connector in the team when no project is    
+  linked or when --all-projects is set)                                                                                 
 
   Options:
 
-       --all-projects     List every Connex client in the team, regardless of project link                              
+       --all-projects     List every Connex connector in the team, regardless of project link                           
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
-       --limit <COUNT>    Number of clients to return per page                                                          
+       --limit <COUNT>    Number of connectors to return per page                                                       
        --next <CURSOR>    Cursor for the next page of results                                                           
 
 
@@ -943,11 +943,11 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
 
   Examples:
 
-  - List Connex clients linked to the current project
+  - List Connex connectors linked to the current project
 
     $ vercel connex list
 
-  - List every Connex client in the team
+  - List every Connex connector in the team
 
     $ vercel connex list --all-projects
 
@@ -970,7 +970,7 @@ exports[`help command > connex help output snapshots > connex open subcommand > 
 "
   ▲ vercel connex open id [options]
 
-  Open a Connex client in the Vercel dashboard                                                                          
+  Open a Connex connector in the Vercel dashboard                                                                       
 
   Options:
 
@@ -993,11 +993,11 @@ exports[`help command > connex help output snapshots > connex open subcommand > 
 
   Examples:
 
-  - Open a client by ID
+  - Open a connector by ID
 
     $ vercel connex open scl_abc123
 
-  - Open a client by UID
+  - Open a connector by UID
 
     $ vercel connex open slack/my-bot
 
@@ -1012,15 +1012,15 @@ exports[`help command > connex help output snapshots > connex token subcommand >
 "
   ▲ vercel connex token id [options]
 
-  Get a token for a Connex client (accepts a client ID like scl_abc or a UID like slack/my-bot)                         
+  Get a token for a Connex connector (accepts a connector ID like scl_abc or a UID like slack/my-bot)                   
 
   Options:
 
   -F,  --format <FORMAT>       Specify the output format (json)                                                              
-       --installation-id <ID>  Target a specific installation (only useful with --subject app; defaults to the client's      
+       --installation-id <ID>  Target a specific installation (only useful with --subject app; defaults to the connector's   
                                default installation)                                                                         
        --scopes <SCOPES>       Scopes (comma- or space-separated)                                                            
-  -s,  --subject <TYPE>        Subject type: "user" (default, acts on behalf of you) or "app" (uses the client's default     
+  -s,  --subject <TYPE>        Subject type: "user" (default, acts on behalf of you) or "app" (uses the connector's default  
                                installation)                                                                                 
   -y,  --yes                   Accept default value for all prompts                                                          
 
@@ -1041,11 +1041,11 @@ exports[`help command > connex help output snapshots > connex token subcommand >
 
   Examples:
 
-  - Get a user token by client ID
+  - Get a user token by connector ID
 
     $ vercel connex token scl_abc123
 
-  - Get a token by client UID
+  - Get a token by connector UID
 
     $ vercel connex token slack/my-bot
 

--- a/packages/cli/test/unit/commands/connex/attach.test.ts
+++ b/packages/cli/test/unit/commands/connex/attach.test.ts
@@ -40,7 +40,9 @@ describe('connex attach', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(1);
-    expect(client.stderr.getFullOutput()).toContain('Missing client ID or UID');
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing connector ID or UID'
+    );
   });
 
   it('rejects --format=json without --yes', async () => {
@@ -92,7 +94,7 @@ describe('connex attach', () => {
 
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain(
-      'No Connex client found for'
+      'No Connex connector found for'
     );
   });
 
@@ -135,7 +137,9 @@ describe('connex attach', () => {
       'preview',
       'development',
     ]);
-    expect(client.stderr.getFullOutput()).toContain('Attached Connex client');
+    expect(client.stderr.getFullOutput()).toContain(
+      'Attached Connex connector'
+    );
   });
 
   it('parses comma-separated environments', async () => {

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -277,7 +277,7 @@ describe('connex create', () => {
     const exitCodePromise = connex(client);
 
     await expect(client.stderr).toOutput(
-      'Select the team where you want to create this client'
+      'Select the team where you want to create this connector'
     );
     // Arrow down past the personal account to select the team.
     client.stdin.write('[B\n');
@@ -323,7 +323,7 @@ describe('connex create', () => {
     const exitCodePromise = connex(client);
 
     await expect(client.stderr).toOutput(
-      'Select the team where you want to create this client'
+      'Select the team where you want to create this connector'
     );
     // Accept the default (personal account for non-northstar users).
     client.stdin.write('\n');

--- a/packages/cli/test/unit/commands/connex/list.test.ts
+++ b/packages/cli/test/unit/commands/connex/list.test.ts
@@ -68,7 +68,7 @@ describe('connex list', () => {
       expect(requestUrl).toContain(`projectId=${project.id}`);
       expect(requestUrl).not.toContain('include=projects');
       const stderr = client.stderr.getFullOutput();
-      expect(stderr).toContain('Connex clients linked to');
+      expect(stderr).toContain('Connex connectors linked to');
       expect(stderr).toContain(project.name);
       expect(stderr).toContain('slack/my-bot');
     });
@@ -92,7 +92,7 @@ describe('connex list', () => {
 
       expect(exitCode).toBe(0);
       const stderr = client.stderr.getFullOutput();
-      expect(stderr).toContain('No Connex clients linked to');
+      expect(stderr).toContain('No Connex connectors linked to');
       expect(stderr).toContain(project.name);
       expect(stderr).toContain('--all-projects');
     });
@@ -137,7 +137,7 @@ describe('connex list', () => {
       const stderr = client.stderr.getFullOutput();
       expect(stderr).toContain('Projects');
       expect(stderr).toContain('web');
-      expect(stderr).not.toContain('Connex clients linked to');
+      expect(stderr).not.toContain('Connex connectors linked to');
     });
   });
 
@@ -278,7 +278,7 @@ describe('connex list', () => {
 
       expect(exitCode).toBe(0);
       expect(client.stderr.getFullOutput()).toContain(
-        'No Connex clients found'
+        'No Connex connectors found'
       );
     });
 

--- a/packages/cli/test/unit/commands/connex/open.test.ts
+++ b/packages/cli/test/unit/commands/connex/open.test.ts
@@ -40,7 +40,7 @@ describe('connex open', () => {
       `https://vercel.com/${encodeURIComponent(team.slug)}/~/connex/${clientId}`
     );
     expect(client.stderr.getFullOutput()).toContain(
-      'Opening Connex client scl_abc123'
+      'Opening Connex connector scl_abc123'
     );
   });
 
@@ -85,7 +85,9 @@ describe('connex open', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(1);
-    expect(client.stderr.getFullOutput()).toContain('Missing client ID or UID');
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing connector ID or UID'
+    );
     expect(openMock).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/test/unit/commands/connex/remove.test.ts
+++ b/packages/cli/test/unit/commands/connex/remove.test.ts
@@ -20,7 +20,9 @@ describe('connex remove', () => {
     const exitCode = await connex(client);
 
     expect(exitCode).toBe(1);
-    expect(client.stderr.getFullOutput()).toContain('Missing client ID or UID');
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing connector ID or UID'
+    );
   });
 
   it('should error with a friendly message when the client is not found', async () => {
@@ -35,7 +37,7 @@ describe('connex remove', () => {
 
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain(
-      'No Connex client found for'
+      'No Connex connector found for'
     );
   });
 

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -22,7 +22,7 @@ describe('connex token', () => {
 
     const exitCode = await connex(client);
 
-    await expect(client.stderr).toOutput('Missing client ID or UID');
+    await expect(client.stderr).toOutput('Missing connector ID or UID');
     expect(exitCode).toBe(1);
   });
 
@@ -179,7 +179,7 @@ describe('connex token', () => {
 
     const exitCode = await connex(client);
 
-    await expect(client.stderr).toOutput('Client not found');
+    await expect(client.stderr).toOutput('Connector not found');
     expect(exitCode).toBe(1);
   });
 


### PR DESCRIPTION
## Summary

Sibling rename to https://github.com/vercel/front/pull/69902 ([vercel-site] Rename Client to Connector for Connect feature). Updates user-visible strings in the `vc connex` command surface from "Connex client" / "client" to "Connex connector" / "connector" so the CLI matches the dashboard's renamed terminology.

## Scope

**Renamed:** help descriptions, example names, spinner text, error messages, and success messages across:
- `packages/cli/src/commands/connex/command.ts` — subcommand descriptions, option descriptions, example titles
- `packages/cli/src/commands/connex/{attach,create,list,open,remove,token}.ts` — runtime messages
- `packages/cli/src/util/connex/request-code.ts` — partial-result log line
- Snapshot in `packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap`
- Test assertions in `packages/cli/test/unit/commands/connex/*.test.ts`

**Intentionally untouched:**
- Flag names (`--disconnect-all`, `--client`, `--uid`, `--name`, etc.) — public CLI contract
- Command names (`vc connex create / remove / attach / ls / open / token`)
- Positional argument names (e.g. `name: 'client'`) — surfaces as `<client>` placeholder in usage hints, which are kept consistent
- Type/interface names (`ConnexClient`, `ConnexClientIdentity`, `ConnexClientProject`, etc.)
- File paths and module names
- API endpoints (`/v1/connex/clients/...`)
- Telemetry argument names (`trackCliArgumentClient`) — wire values that would break analytics if renamed
- OAuth protocol terms and error codes (`client_installation_required`, `user_authorization_required`, etc.)

The top-level `connex` description "Manage Vercel Connect clients" → "Manage Vercel Connect connectors" matches the dashboard product copy ("Connect" / "Connector").

## Test plan

- [x] Connex unit tests pass: `t packages/cli/test/unit/commands/connex/`
- [x] Help snapshot regenerated via the actual `help()` function so the rewrapped column-80 / column-120 padding is correct
- [ ] Local CI (deploy preview) — `vc connex --help` output matches the new snapshot