### PR TITLE
[ci] Fix cargo git fetch hangs in the unit-test step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -357,6 +357,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           TURBO_BASE_SHA: ${{ needs.setup.outputs.baseSha }}
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
           FORCE_COLOR: '1'
           VITEST_TEST_FILES: ${{ matrix.useEnvPaths == true && join(matrix.testPaths, ' ') || '' }}
           # Datadog Test Optimization: emit per-test spans correlated to the


### PR DESCRIPTION
When the `@vercel/python-analysis` unit test runs `build:wasm`, `cargo build --target wasm32-wasip2 --release` occasionally hangs on updating git until the workflow's timeout-minutes fires.
  
This happens because `cargo`'s default `libgit2` backend has no timeout for stalled fetches and will block indefinitely. The retry loop in the (`Test ${{matrix.packageName}}`) step retries on non-zero exit, but a hang never exits, so only the workflow timeout ever ends the job.
  
Fixed by setting `CARGO_NET_GIT_FETCH_WITH_CLI=true` on the test step so cargo uses the system `git`. 
`git` will properly handle HTTP timeouts and TCP keepalive allowing the retry loop to catch them.