### PR TITLE
[services] Change getServiceCrons to async.

### DIFF
--- a/.changeset/mighty-llamas-reflect.md
+++ b/.changeset/mighty-llamas-reflect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': minor
+---
+
+Change getServiceCrons to async.

--- a/packages/backends/src/crons.ts
+++ b/packages/backends/src/crons.ts
@@ -34,10 +34,10 @@ export function buildCronRouteTable(
  * `undefined` when the service is not schedule-triggered. Throws on
  * `<dynamic>` schedules — that path is reserved for a follow-up.
  */
-export function getServiceCrons(opts: {
+export async function getServiceCrons(opts: {
   service?: BuildOptions['service'];
   entrypoint?: string;
-}): BackendsCronEntry[] | undefined {
+}): Promise<BackendsCronEntry[] | undefined> {
   const { service, entrypoint } = opts;
 
   if (!service || !isScheduleTriggeredService(service)) {

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -107,7 +107,7 @@ export const build: BuildV2 = async args => {
     debug('Entrypoint', entrypoint);
     args.entrypoint = entrypoint;
 
-    const cronEntries = getServiceCrons({
+    const cronEntries = await getServiceCrons({
       service: args.service,
       entrypoint,
     });

--- a/packages/backends/test/unit.crons.test.ts
+++ b/packages/backends/test/unit.crons.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { buildCronRouteTable, getServiceCrons } from '../src/crons';
 
 describe('getServiceCrons', () => {
-  it('returns undefined for non-schedule-triggered services', () => {
+  it('returns undefined for non-schedule-triggered services', async () => {
     expect(
-      getServiceCrons({
+      await getServiceCrons({
         service: { type: 'web', name: 'web', schedule: '0 0 * * *' },
         entrypoint: 'server.ts',
       })
     ).toBeUndefined();
     expect(
-      getServiceCrons({
+      await getServiceCrons({
         service: {
           type: 'job',
           trigger: 'queue',
@@ -20,27 +20,27 @@ describe('getServiceCrons', () => {
         entrypoint: 'worker.ts',
       })
     ).toBeUndefined();
-    expect(getServiceCrons({ entrypoint: 'cleanup.ts' })).toBeUndefined();
+    expect(await getServiceCrons({ entrypoint: 'cleanup.ts' })).toBeUndefined();
   });
 
-  it('returns undefined when name or schedule is missing', () => {
+  it('returns undefined when name or schedule is missing', async () => {
     expect(
-      getServiceCrons({
+      await getServiceCrons({
         service: { type: 'cron', schedule: '0 0 * * *' },
         entrypoint: 'cleanup.ts',
       })
     ).toBeUndefined();
     expect(
-      getServiceCrons({
+      await getServiceCrons({
         service: { type: 'cron', name: 'cleanup' },
         entrypoint: 'cleanup.ts',
       })
     ).toBeUndefined();
   });
 
-  it('produces a single entry for a static schedule on a cron service', () => {
+  it('produces a single entry for a static schedule on a cron service', async () => {
     expect(
-      getServiceCrons({
+      await getServiceCrons({
         service: { type: 'cron', name: 'cleanup', schedule: '0 0 * * *' },
         entrypoint: 'cleanup.ts',
       })
@@ -53,9 +53,9 @@ describe('getServiceCrons', () => {
     ]);
   });
 
-  it('produces a single entry for a schedule-triggered job', () => {
+  it('produces a single entry for a schedule-triggered job', async () => {
     expect(
-      getServiceCrons({
+      await getServiceCrons({
         service: {
           type: 'job',
           trigger: 'schedule',
@@ -73,21 +73,21 @@ describe('getServiceCrons', () => {
     ]);
   });
 
-  it('throws when entrypoint is missing for a cron service', () => {
-    expect(() =>
+  it('throws when entrypoint is missing for a cron service', async () => {
+    await expect(
       getServiceCrons({
         service: { type: 'cron', name: 'cleanup', schedule: '0 0 * * *' },
       })
-    ).toThrow(/missing an entrypoint/);
+    ).rejects.toThrow(/missing an entrypoint/);
   });
 
-  it('throws on a <dynamic> schedule (not yet supported for JS/TS)', () => {
-    expect(() =>
+  it('throws on a <dynamic> schedule (not yet supported for JS/TS)', async () => {
+    await expect(
       getServiceCrons({
         service: { type: 'cron', name: 'cleanup', schedule: '<dynamic>' },
         entrypoint: 'cleanup.ts',
       })
-    ).toThrow(/Dynamic cron schedules .* not yet supported/);
+    ).rejects.toThrow(/Dynamic cron schedules .* not yet supported/);
   });
 });
 


### PR DESCRIPTION
Switches `getServiceCrons` from sync to async, returning `Promise<BackendsCronEntry[] | undefined>`.

This is signature-only prep so that `<dynamic>` schedule detection can `import()` the bundled entrypoint and create the appropriate cron entries.

Followup to #16302. Part of a breakdown of #16201.