### PR TITLE
Update env pull gitignore pattern

### DIFF
--- a/.changeset/silver-envs-pull.md
+++ b/.changeset/silver-envs-pull.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update `vercel env pull` to add `.env*` to `.gitignore` for default `.env.local` pulls.

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -282,11 +282,11 @@ export async function envPullCommandLogic(
   if (filename === '.env.local') {
     // When the file is `.env.local`, we also add it to `.gitignore`
     // to avoid accidentally committing it to git.
-    // We use '.env*.local' to match the default .gitignore from
+    // We use '.env*' to match the default .gitignore from
     // create-next-app template. See:
-    // https://github.com/vercel/next.js/blob/06abd634899095b6cc28e6e8315b1e8b9c8df939/packages/create-next-app/templates/app/js/gitignore#L28
+    // https://github.com/vercel/next.js/commit/09a385669b3757ef59065138901eb3084d35d418
     const rootPath = link.repoRoot ?? cwd;
-    isGitIgnoreUpdated = await addToGitIgnore(rootPath, '.env*.local');
+    isGitIgnoreUpdated = await addToGitIgnore(rootPath, '.env*');
   }
 
   output.print(

--- a/packages/cli/test/fixtures/unit/vercel-env-pull-with-gitignore/.gitignore
+++ b/packages/cli/test/fixtures/unit/vercel-env-pull-with-gitignore/.gitignore
@@ -1,4 +1,4 @@
 .next
 yarn.lock
 !.vercel
-.env*.local
+.env*

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -1020,9 +1020,9 @@ test('[vc link] should not duplicate paths in .gitignore', async () => {
   // Ensure the message is correct pattern
   expect(stderr).toMatch(/Linked to /m);
 
-  // Ensure .gitignore contains .vercel and .env*.local (from env pull)
+  // Ensure .gitignore contains .vercel and .env* (from env pull)
   const gitignore = await readFile(path.join(dir, '.gitignore'), 'utf8');
-  expect(gitignore).toBe('.vercel\n.env*.local\n');
+  expect(gitignore).toBe('.vercel\n.env*\n');
 });
 
 test('[vc dev] should show prompts to set up project', async () => {

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -50,10 +50,12 @@ describe('env pull', () => {
     expect(exitCode, 'exit code for "env"').toEqual(0);
 
     const rawDevEnv = await fs.readFile(path.join(cwd, '.env.local'));
+    const gitignore = await fs.readFile(path.join(cwd, '.gitignore'), 'utf8');
 
     // check for development env value
     const devFileHasDevEnv = rawDevEnv.toString().includes('SPECIAL_FLAG');
     expect(devFileHasDevEnv).toBeTruthy();
+    expect(gitignore).toBe('.next\nyarn.lock\n!.vercel\n.env*\n');
 
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       {


### PR DESCRIPTION
## Summary
- Update default `vercel env pull` behavior to add `.env*` to `.gitignore` instead of `.env*.local`
- Align the comment with the newer create-next-app default from vercel/next.js@09a385669b3757ef59065138901eb3084d35d418
- Update unit/integration expectations and add a changeset

## Tests
- `pnpm test test/unit/commands/env/pull.test.ts`

Note: I also attempted `pnpm --filter vercel... build`; it built the needed CLI dependencies but stopped at `@vercel/python-analysis` because rustup is not installed in this environment.