### PR TITLE
[vercel-workers] handle metadata-only callbacks for v2beta

### DIFF
--- a/.changeset/dramatic-queues-resolve.md
+++ b/.changeset/dramatic-queues-resolve.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python-workers": patch
+---
+
+[vercel-workers] Fall back to `receive_message_by_id` for v2beta metadata-only callbacks

--- a/python/vercel-workers/src/vercel/workers/_queue/__init__.py
+++ b/python/vercel-workers/src/vercel/workers/_queue/__init__.py
@@ -32,6 +32,7 @@ from vercel.workers._queue.receive import (
     parse_retry_after,
     receive_message_by_id,
     receive_messages,
+    resolve_v2beta_message,
 )
 from vercel.workers._queue.send import (
     Duration,
@@ -120,6 +121,7 @@ __all__ = [
     "parse_v2beta_callback",
     "receive_message_by_id",
     "receive_messages",
+    "resolve_v2beta_message",
     "select_subscriptions",
     "subscribe",
     "subscriptions",

--- a/python/vercel-workers/src/vercel/workers/_queue/receive.py
+++ b/python/vercel-workers/src/vercel/workers/_queue/receive.py
@@ -25,7 +25,7 @@ from vercel.workers._queue.send import (
     get_queue_base_url,
     get_queue_token,
 )
-from vercel.workers._queue.types import ReceivedMessage
+from vercel.workers._queue.types import ParsedV2BetaCallback, ReceivedMessage
 
 
 def parse_retry_after(response: httpx.Response) -> int | None:
@@ -290,6 +290,46 @@ def receive_message_by_id(
     return payload, delivery_count, timestamp, receipt_handle  # type: ignore[return-value]
 
 
+def resolve_v2beta_message(
+    parsed: ParsedV2BetaCallback,
+    *,
+    visibility_timeout_seconds: int | None = None,
+    timeout: float | None = 10.0,
+) -> ParsedV2BetaCallback:
+    """
+    Ensure a parsed v2beta callback carries a payload and receipt handle.
+
+    Vercel Queues v2beta can delivers messages in 2 modes:
+
+    - Inline: the HTTP body carries the payload and
+      ``ce-vqsreceipthandle`` / ``ce-vqsdeliverycount`` / ``ce-vqscreatedat``
+      headers are present.
+    - Metadata-only: the HTTP body is empty and the payload-related headers
+      are absent. The SDK is expected to call ``receive_message_by_id``
+      to fetch the message body and obtain a receipt handle.
+
+    Returns the input unchanged when the inline mode delivered everything;
+    otherwise returns a new dict augmented with the fetched fields.
+    """
+    if parsed["receiptHandle"]:
+        return parsed
+
+    payload, delivery_count, created_at, receipt_handle = receive_message_by_id(
+        parsed["queueName"],
+        parsed["consumerGroup"],
+        parsed["messageId"],
+        visibility_timeout_seconds=visibility_timeout_seconds,
+        timeout=timeout,
+    )
+    return {
+        **parsed,
+        "receiptHandle": receipt_handle,
+        "deliveryCount": delivery_count,
+        "createdAt": created_at,
+        "payload": payload,
+    }
+
+
 def delete_message(
     queue_name: str,
     consumer_group: str,
@@ -483,4 +523,5 @@ __all__ = [
     "parse_retry_after",
     "receive_message_by_id",
     "receive_messages",
+    "resolve_v2beta_message",
 ]

--- a/python/vercel-workers/src/vercel/workers/callback.py
+++ b/python/vercel-workers/src/vercel/workers/callback.py
@@ -19,6 +19,7 @@ from vercel.workers._queue.receive import (
     parse_retry_after,
     receive_message_by_id,
     receive_messages,
+    resolve_v2beta_message,
 )
 
 __all__ = [
@@ -38,4 +39,5 @@ __all__ = [
     "parse_v2beta_callback",
     "receive_message_by_id",
     "receive_messages",
+    "resolve_v2beta_message",
 ]

--- a/python/vercel-workers/src/vercel/workers/celery/app.py
+++ b/python/vercel-workers/src/vercel/workers/celery/app.py
@@ -69,6 +69,12 @@ def handle_queue_callback(
 
         if is_v2beta:
             v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
+            # fetch the whole message if callback is metadata-only
+            v2 = queue_callback.resolve_v2beta_message(
+                v2,
+                visibility_timeout_seconds=cfg.visibility_timeout_seconds,
+                timeout=cfg.timeout,
+            )
             queue_name = v2["queueName"]
             consumer_group = v2["consumerGroup"]
             message_id = v2["messageId"]

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -219,15 +219,12 @@ def _handle_queue_callback(
         delivery_count = 0
         created_at = ""
 
+        v2: callback.ParsedV2BetaCallback | None = None
         if is_v2beta:
             v2 = callback.parse_v2beta_callback(raw_body, environ or {})
             queue_name = v2["queueName"]
             consumer_group = v2["consumerGroup"]
             message_id = v2["messageId"]
-            receipt_handle = v2["receiptHandle"]
-            delivery_count = v2["deliveryCount"]
-            created_at = v2["createdAt"]
-            payload = v2["payload"]
         else:
             queue_name, consumer_group, message_id = callback.parse_cloudevent(raw_body)
 
@@ -242,7 +239,18 @@ def _handle_queue_callback(
                 },
             )
 
-        if not is_v2beta:
+        if is_v2beta:
+            assert v2 is not None
+            # fetch the whole message if callback is metadata-only
+            v2 = callback.resolve_v2beta_message(
+                v2,
+                visibility_timeout_seconds=visibility_timeout_seconds,
+            )
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload = v2["payload"]
+        else:
             payload, delivery_count, created_at, receipt_handle = callback.receive_message_by_id(
                 queue_name,
                 consumer_group,

--- a/python/vercel-workers/src/vercel/workers/django/app.py
+++ b/python/vercel-workers/src/vercel/workers/django/app.py
@@ -165,15 +165,12 @@ def handle_queue_callback(
     try:
         is_v2beta = queue_callback.is_v2beta_callback(environ or {})
 
+        v2: queue_callback.ParsedV2BetaCallback | None = None
         if is_v2beta:
             v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
             queue_name = v2["queueName"]
             consumer_group = v2["consumerGroup"]
             message_id = v2["messageId"]
-            receipt_handle = v2["receiptHandle"]
-            delivery_count = v2["deliveryCount"]
-            created_at = v2["createdAt"]
-            payload: Any = v2["payload"]
         else:
             queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
 
@@ -188,7 +185,19 @@ def handle_queue_callback(
                 body,
             )
 
-        if not is_v2beta:
+        if is_v2beta:
+            assert v2 is not None
+            # fetch the whole message if callback is metadata-only
+            v2 = queue_callback.resolve_v2beta_message(
+                v2,
+                visibility_timeout_seconds=cfg.visibility_timeout_seconds,
+                timeout=cfg.timeout,
+            )
+            receipt_handle = v2["receiptHandle"]
+            delivery_count = v2["deliveryCount"]
+            created_at = v2["createdAt"]
+            payload: Any = v2["payload"]
+        else:
             (
                 payload,
                 delivery_count,

--- a/python/vercel-workers/src/vercel/workers/dramatiq/app.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/app.py
@@ -154,6 +154,12 @@ def handle_queue_callback(
 
         if is_v2beta:
             v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
+            # fetch the whole message if callback is metadata-only
+            v2 = queue_callback.resolve_v2beta_message(
+                v2,
+                visibility_timeout_seconds=cfg.visibility_timeout_seconds,
+                timeout=cfg.timeout,
+            )
             queue_name = v2["queueName"]
             consumer_group = v2["consumerGroup"]
             message_id = v2["messageId"]


### PR DESCRIPTION
Queues can send a callback without in-lining the message body and in that case it's expected from the client to fetch the message manually