### PR TITLE
[python] Pass link-mode=copy when installing vercel-workers.

### DIFF
--- a/.changeset/python-uv-pip-copy.md
+++ b/.changeset/python-uv-pip-copy.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Use copy link mode for injected uv pip installs to avoid cross-device cache clone failures.

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -598,7 +598,7 @@ export const build: BuildVX = async ({
   await uv.pip({
     venvPath,
     projectDir: join(workPath, entryDirectory),
-    args: ['install', runtimeDep],
+    args: ['install', '--link-mode', 'copy', runtimeDep],
   });
 
   if (shouldInstallVercelWorkers) {
@@ -610,7 +610,7 @@ export const build: BuildVX = async ({
     await uv.pip({
       venvPath,
       projectDir: join(workPath, entryDirectory),
-      args: ['install', workersDep],
+      args: ['install', '--link-mode', 'copy', workersDep],
     });
   }
 

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -3496,6 +3496,18 @@ describe('worker services dependency installation', () => {
     expect(pipCalls.some(args => args.includes(workersDep))).toBe(true);
   });
 
+  it('uses copy link mode for injected pip installs', async () => {
+    const { pipCalls } = await buildWithPipSpy({ hasWorkerServices: true });
+    expect(pipCalls).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining(['install', '--link-mode', 'copy']),
+      ])
+    );
+    for (const args of pipCalls) {
+      expect(args.slice(0, 3)).toEqual(['install', '--link-mode', 'copy']);
+    }
+  });
+
   it('does not install vercel-workers when worker services are not enabled', async () => {
     const { pipCalls } = await buildWithPipSpy();
     expect(


### PR DESCRIPTION
Fixes issue with installing vercel-workers with a restored `venv` that was cached from a previous build:

```
Error: Failed to run "uv pip install vercel-workers==0.0.22": Command failed: /usr/local/bin/uv pip install vercel-workers==0.0.22
Using Python 3.14.3 environment at: /vercel/path0/server/.vercel/python/services/worker/.venv
Resolved 16 packages in 34ms
Uninstalled 1 package in 0.95ms
error: Failed to install: vercel_workers-0.0.22-py3-none-any.whl (vercel-workers==0.0.22)
  Caused by: Failed to clone `/vercel/path0/server/.vercel/python/cache/uv/archive-v0/8BAwjdioJ3YaAIHYKU2gg/vercel_workers-0.0.22.dist-info/RECORD` to `/vercel/path0/server/.vercel/python/services/worker/.venv/lib/python3.14/site-packages/vercel_workers-0.0.22.dist-info/RECORD`
  Caused by: Invalid cross-device link (os error 18)
```