### PR TITLE
cli/whoami: fall back when linked team scope is inaccessible

### DIFF
--- a/.changeset/fair-walls-sin.md
+++ b/.changeset/fair-walls-sin.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vc whoami` to fall back to the global scope when a linked project's team is inaccessible.

--- a/packages/cli/src/commands/whoami/index.ts
+++ b/packages/cli/src/commands/whoami/index.ts
@@ -11,6 +11,29 @@ import output from '../../output-manager';
 import { WhoamiTelemetryClient } from '../../util/telemetry/commands/whoami';
 import { validateJsonOutput } from '../../util/output-format';
 
+function isAuthorizationError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const maybeError = error as { code?: unknown; message?: unknown };
+  if (typeof maybeError.code === 'string') {
+    const normalizedCode = maybeError.code.toLowerCase();
+    if (
+      normalizedCode === 'not_authorized' ||
+      normalizedCode === 'forbidden' ||
+      normalizedCode === 'team_unauthorized'
+    ) {
+      return true;
+    }
+  }
+
+  return (
+    typeof maybeError.message === 'string' &&
+    maybeError.message.toLowerCase().includes('not authorized')
+  );
+}
+
 export default async function whoami(client: Client): Promise<number> {
   let parsedArgs = null;
 
@@ -43,7 +66,21 @@ export default async function whoami(client: Client): Promise<number> {
   const asJson = formatResult.jsonOutput;
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
 
-  const scope = await getScope(client, { resolveLocalScope: true });
+  const scope = await getScope(client, { resolveLocalScope: true }).catch(
+    async error => {
+      if (!isAuthorizationError(error)) {
+        throw error;
+      }
+
+      const fallbackScope = await getScope(client);
+      return {
+        ...fallbackScope,
+        globalTeam: fallbackScope.team,
+        explicitScopeProvided: false,
+        scopeMismatch: false,
+      };
+    }
+  );
   const { user, team, globalTeam } = scope;
 
   // A local override exists when the effective team (from the linked project)

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -48,29 +48,6 @@ interface GetScopeWithoutLocalScopeOptions extends GetScopeOptions {
   resolveLocalScope?: false;
 }
 
-function isAuthorizationError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) {
-    return false;
-  }
-
-  const maybeError = error as { code?: unknown; message?: unknown };
-  if (typeof maybeError.code === 'string') {
-    const normalizedCode = maybeError.code.toLowerCase();
-    if (
-      normalizedCode === 'not_authorized' ||
-      normalizedCode === 'forbidden' ||
-      normalizedCode === 'team_unauthorized'
-    ) {
-      return true;
-    }
-  }
-
-  return (
-    typeof maybeError.message === 'string' &&
-    maybeError.message.toLowerCase().includes('not authorized')
-  );
-}
-
 export default function getScope(
   client: Client,
   opts: GetScopeWithLocalScopeOptions
@@ -173,37 +150,25 @@ export default async function getScope(
       ? { type: 'team', id: team.id, slug: team.slug }
       : { type: 'user', id: user.id, slug: user.username };
   } else if (localOrgId) {
-    const localTeamId = localOrgId.startsWith('team_') ? localOrgId : undefined;
-    client.config.currentTeam = localTeamId;
+    client.config.currentTeam = localOrgId.startsWith('team_')
+      ? localOrgId
+      : undefined;
 
-    try {
-      const correctedTeam = localTeamId
-        ? await getTeamById(client, localTeamId)
-        : null;
-      const correctedUser = await getUser(client);
-      resolvedOrg = correctedTeam
-        ? { type: 'team', id: correctedTeam.id, slug: correctedTeam.slug }
-        : {
-            type: 'user',
-            id: correctedUser.id,
-            slug: correctedUser.username,
-          };
-      resolvedContextName = correctedTeam
-        ? correctedTeam.slug
-        : correctedUser.username || correctedUser.email;
-      resolvedTeam = correctedTeam;
-    } catch (error) {
-      if (!isAuthorizationError(error)) {
-        throw error;
-      }
-
-      client.config.currentTeam = globalTeamId;
-      resolvedOrg = team
-        ? { type: 'team', id: team.id, slug: team.slug }
-        : { type: 'user', id: user.id, slug: user.username };
-      resolvedContextName = team ? team.slug : user.username || user.email;
-      resolvedTeam = team;
-    }
+    const correctedTeam = client.config.currentTeam
+      ? await getTeamById(client, client.config.currentTeam)
+      : null;
+    const correctedUser = await getUser(client);
+    resolvedOrg = correctedTeam
+      ? { type: 'team', id: correctedTeam.id, slug: correctedTeam.slug }
+      : {
+          type: 'user',
+          id: correctedUser.id,
+          slug: correctedUser.username,
+        };
+    resolvedContextName = correctedTeam
+      ? correctedTeam.slug
+      : correctedUser.username || correctedUser.email;
+    resolvedTeam = correctedTeam;
   } else {
     if (isCrossTeamRepo) {
       output.warn(

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -48,6 +48,29 @@ interface GetScopeWithoutLocalScopeOptions extends GetScopeOptions {
   resolveLocalScope?: false;
 }
 
+function isAuthorizationError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const maybeError = error as { code?: unknown; message?: unknown };
+  if (typeof maybeError.code === 'string') {
+    const normalizedCode = maybeError.code.toLowerCase();
+    if (
+      normalizedCode === 'not_authorized' ||
+      normalizedCode === 'forbidden' ||
+      normalizedCode === 'team_unauthorized'
+    ) {
+      return true;
+    }
+  }
+
+  return (
+    typeof maybeError.message === 'string' &&
+    maybeError.message.toLowerCase().includes('not authorized')
+  );
+}
+
 export default function getScope(
   client: Client,
   opts: GetScopeWithLocalScopeOptions
@@ -150,25 +173,37 @@ export default async function getScope(
       ? { type: 'team', id: team.id, slug: team.slug }
       : { type: 'user', id: user.id, slug: user.username };
   } else if (localOrgId) {
-    client.config.currentTeam = localOrgId.startsWith('team_')
-      ? localOrgId
-      : undefined;
+    const localTeamId = localOrgId.startsWith('team_') ? localOrgId : undefined;
+    client.config.currentTeam = localTeamId;
 
-    const correctedTeam = client.config.currentTeam
-      ? await getTeamById(client, client.config.currentTeam)
-      : null;
-    const correctedUser = await getUser(client);
-    resolvedOrg = correctedTeam
-      ? { type: 'team', id: correctedTeam.id, slug: correctedTeam.slug }
-      : {
-          type: 'user',
-          id: correctedUser.id,
-          slug: correctedUser.username,
-        };
-    resolvedContextName = correctedTeam
-      ? correctedTeam.slug
-      : correctedUser.username || correctedUser.email;
-    resolvedTeam = correctedTeam;
+    try {
+      const correctedTeam = localTeamId
+        ? await getTeamById(client, localTeamId)
+        : null;
+      const correctedUser = await getUser(client);
+      resolvedOrg = correctedTeam
+        ? { type: 'team', id: correctedTeam.id, slug: correctedTeam.slug }
+        : {
+            type: 'user',
+            id: correctedUser.id,
+            slug: correctedUser.username,
+          };
+      resolvedContextName = correctedTeam
+        ? correctedTeam.slug
+        : correctedUser.username || correctedUser.email;
+      resolvedTeam = correctedTeam;
+    } catch (error) {
+      if (!isAuthorizationError(error)) {
+        throw error;
+      }
+
+      client.config.currentTeam = globalTeamId;
+      resolvedOrg = team
+        ? { type: 'team', id: team.id, slug: team.slug }
+        : { type: 'user', id: user.id, slug: user.username };
+      resolvedContextName = team ? team.slug : user.username || user.email;
+      resolvedTeam = team;
+    }
   } else {
     if (isCrossTeamRepo) {
       output.warn(

--- a/packages/cli/test/unit/commands/whoami/index.test.ts
+++ b/packages/cli/test/unit/commands/whoami/index.test.ts
@@ -82,6 +82,32 @@ describe('whoami', () => {
     expect(stderr).toContain(`globally selected: ${globalTeam.slug}`);
   });
 
+  it('should fall back to the global team when local linked scope is inaccessible', async () => {
+    useUser();
+    const globalTeam = useTeam();
+    const forbiddenTeamId = 'team_forbidden';
+    client.config.currentTeam = globalTeam.id;
+    client.scenario.get(`/teams/${forbiddenTeamId}`, (_req, res) => {
+      res.status(403).json({
+        code: 'team_unauthorized',
+        message: 'Not authorized',
+      });
+    });
+
+    const cwd = setupTmpDir();
+    client.cwd = cwd;
+    await outputFile(
+      join(cwd, '.vercel', 'project.json'),
+      JSON.stringify({ orgId: forbiddenTeamId, projectId: 'prj_1' })
+    );
+
+    const exitCode = await whoami(client);
+    expect(exitCode).toEqual(0);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain(`Active team: ${globalTeam.slug}`);
+    expect(stderr).not.toContain('Local override:');
+  });
+
   it('should print only the Vercel username when output is not a TTY', async () => {
     const user = useUser();
     client.stdout.isTTY = false;


### PR DESCRIPTION
## Summary
- prevent `vc whoami` from failing when a linked local project points to a team the current token cannot access
- catch authorization errors while resolving local linked scope and gracefully fall back to the global selected scope
- add a unit test that reproduces this case and verifies fallback behavior, plus a changeset entry

## Test plan
- [ ] `pnpm vitest run test/unit/commands/whoami/index.test.ts` *(currently fails in this worktree with Vite package resolution error for `@vercel/error-utils`)*


Made with [Cursor](https://cursor.com)