### PR TITLE
[frameworks] detect TanStack Start without nitro

### DIFF
--- a/.changeset/five-snakes-wave.md
+++ b/.changeset/five-snakes-wave.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Detect TanStack Start projects without requiring a top-level `nitro` dependency by matching Start packages directly.

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1920,9 +1920,10 @@ export const frameworks = [
     website: 'https://tanstack.com/start',
     supersedes: ['ionic-react', 'vite'],
     detectors: {
-      every: [
-        { matchPackage: '@tanstack/router-plugin' },
-        { matchPackage: 'nitro' },
+      every: [{ matchPackage: '@tanstack/router-plugin' }],
+      some: [
+        { matchPackage: '@tanstack/react-start' },
+        { matchPackage: '@tanstack/solid-start' },
       ],
     },
     settings: {

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -503,6 +503,33 @@ describe('detectFramework()', () => {
     expect(await detectFramework({ fs, frameworkList })).toBe('remix');
   });
 
+  it('Should detect TanStack Start without `nitro` via `@tanstack/react-start`', async () => {
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({
+        dependencies: {
+          '@tanstack/router-plugin': 'latest',
+          '@tanstack/react-start': 'latest',
+          vite: 'latest',
+        },
+      }),
+    });
+
+    expect(await detectFramework({ fs, frameworkList })).toBe('tanstack-start');
+  });
+
+  it('Should keep TanStack Router apps as `vite` without Start packages', async () => {
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({
+        dependencies: {
+          '@tanstack/router-plugin': 'latest',
+          vite: 'latest',
+        },
+      }),
+    });
+
+    expect(await detectFramework({ fs, frameworkList })).toBe('vite');
+  });
+
   it('Should detect React Router v7 as `react-router` via `vite.config.ts`', async () => {
     const fs = new VirtualFilesystem({
       'vite.config.ts': 'import { reactRouter } from "@react-router/dev/vite"',
@@ -594,6 +621,23 @@ describe('detectFrameworks()', () => {
       f => f.slug
     );
     expect(slugs).toEqual(['remix']);
+  });
+
+  it('Should detect TanStack Start without `nitro` and supersede `vite`', async () => {
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({
+        dependencies: {
+          '@tanstack/router-plugin': 'latest',
+          '@tanstack/react-start': 'latest',
+          vite: 'latest',
+        },
+      }),
+    });
+
+    const slugs = (await detectFrameworks({ fs, frameworkList })).map(
+      f => f.slug
+    );
+    expect(slugs).toEqual(['tanstack-start']);
   });
 
   describe('Hono', () => {


### PR DESCRIPTION
## Summary
- detect `tanstack-start` when `@tanstack/router-plugin` is present with `@tanstack/react-start` or `@tanstack/solid-start`, without requiring `nitro`
- avoid over-detecting TanStack Router-only projects by keeping `vite` when Start packages are absent
- add framework detector tests for positive and negative cases, plus a changeset for `@vercel/frameworks`

## Test plan
- [x] `pre-commit` hook (`lint-staged` -> `biome format` + `biome lint`) on staged files
- [ ] `pnpm test test/unit.framework-detector.test.ts` in `packages/fs-detectors` *(fails in this worktree due `@vercel/frameworks` package entry resolution before tests execute)*

Made with [Cursor](https://cursor.com)