### PR TITLE
[cli] Add `vercel connect detach` and `--triggers` flag on attach

### DIFF
--- a/.changeset/cli-connect-detach.md
+++ b/.changeset/cli-connect-detach.md
@@ -1,0 +1,9 @@
+---
+'vercel': minor
+---
+
+Add `vercel connect detach` to detach a Vercel project from a connector via `DELETE /v1/connect/connectors/:id/projects/:projectId`. Mirrors `vercel connect attach` and matches the project-scope "Disconnect" button in the dashboard.
+
+Add `--triggers`, `--trigger-branch`, and `--trigger-path` flags to `vercel connect attach`. When `--triggers` is set, the project is also registered as a trigger destination on the connector via `PATCH /v1/connect/connectors/:id/trigger-destinations` so verified webhooks get forwarded to it. Requires the connector to support triggers; warns if the connector was created without `triggers.enabled`.
+
+Both features gated behind the existing `FF_CONNEX_ENABLED` flag.

--- a/packages/cli/src/commands/connex/attach.ts
+++ b/packages/cli/src/commands/connex/attach.ts
@@ -10,20 +10,20 @@ import { ProjectNotFound } from '../../util/errors-ts';
 import { envTargetChoices, isValidEnvTarget } from '../../util/env/env-target';
 import { normalizeRepeatableStringFilters } from '../../util/command-validation';
 import { packageName } from '../../util/pkg-name';
+import {
+  MAX_TRIGGER_DESTINATIONS,
+  buildTriggerDestination,
+  findMatchingDestination,
+  formatDestination,
+  patchTriggerDestinations,
+} from '../../util/connex/trigger-destinations';
+import type {
+  ConnexClientIdentity,
+  ConnexClientProject,
+  ConnexTriggerDestination,
+} from './types';
 
 const ALL_ENVS = ['production', 'preview', 'development'] as const;
-
-interface ConnexClientIdentity {
-  id: string;
-  uid: string;
-  name?: string;
-}
-
-interface ConnexClientProject {
-  clientId: string;
-  projectId: string;
-  environments: string[];
-}
 
 function envSetsEqual(a: readonly string[], b: readonly string[]): boolean {
   if (a.length !== b.length) {
@@ -39,6 +39,9 @@ export async function attach(
   flags: {
     '--environment'?: string[];
     '--project'?: string;
+    '--triggers'?: boolean;
+    '--trigger-branch'?: string;
+    '--trigger-path'?: string;
     '--yes'?: boolean;
     '--format'?: string;
     '--json'?: boolean;
@@ -51,9 +54,19 @@ export async function attach(
   }
   const asJson = formatResult.jsonOutput;
   const skipConfirmation = !!flags['--yes'];
+  const withTriggers = !!flags['--triggers'];
+  const triggerBranch = flags['--trigger-branch'];
+  const triggerPath = flags['--trigger-path'];
 
   if (asJson && !skipConfirmation) {
     output.error('--format=json requires --yes to skip confirmation prompts');
+    return 1;
+  }
+
+  if (!withTriggers && (triggerBranch || triggerPath)) {
+    output.error(
+      '--trigger-branch and --trigger-path require --triggers to also be set.'
+    );
     return 1;
   }
 
@@ -131,7 +144,9 @@ export async function attach(
     projectName = linked.project.name;
   }
 
-  // Resolve client identity → canonical id + display name.
+  // Resolve client identity → canonical id + display name. The base GET
+  // response also carries supportsTriggers / triggers / triggerDestinations,
+  // which we need for the --triggers path.
   output.spinner('Retrieving connector…');
   let target: ConnexClientIdentity;
   try {
@@ -152,6 +167,41 @@ export async function attach(
 
   const displayName = target.uid || target.name || target.id;
 
+  // Pre-flight: trigger-destination planning.
+  let desiredDestination: ConnexTriggerDestination | undefined;
+  let triggerAlreadyRegistered = false;
+  let triggersEnabledOnConnector = true;
+  if (withTriggers) {
+    if (target.supportsTriggers === false) {
+      output.error(
+        `Connector ${chalk.bold(displayName)} does not support triggers (only Slack supports incoming webhooks today).`
+      );
+      return 1;
+    }
+
+    triggersEnabledOnConnector = target.triggers?.enabled === true;
+    desiredDestination = buildTriggerDestination({
+      projectId,
+      branch: triggerBranch,
+      path: triggerPath,
+    });
+
+    const currentDestinations = target.triggerDestinations ?? [];
+    triggerAlreadyRegistered =
+      findMatchingDestination(currentDestinations, desiredDestination) !==
+      undefined;
+
+    if (
+      !triggerAlreadyRegistered &&
+      currentDestinations.length >= MAX_TRIGGER_DESTINATIONS
+    ) {
+      output.error(
+        `Connector ${chalk.bold(displayName)} already has ${MAX_TRIGGER_DESTINATIONS} trigger destinations. Remove one in the dashboard before adding a new one.`
+      );
+      return 1;
+    }
+  }
+
   // Pre-fetch existing attachment for the diff prompt and the no-op check.
   let existingAttachment: ConnexClientProject | undefined;
   try {
@@ -166,11 +216,14 @@ export async function attach(
     }
   }
 
-  // No-op: already attached with the same environments. Skip the prompt and the POST.
-  if (
-    existingAttachment &&
-    envSetsEqual(existingAttachment.environments ?? [], environments)
-  ) {
+  const attachmentMatches =
+    existingAttachment !== undefined &&
+    envSetsEqual(existingAttachment.environments ?? [], environments);
+  const shouldAttach = !attachmentMatches;
+  const shouldRegisterTrigger = withTriggers && !triggerAlreadyRegistered;
+
+  // Total no-op: nothing to do.
+  if (!shouldAttach && !shouldRegisterTrigger) {
     if (asJson) {
       client.stdout.write(
         `${JSON.stringify(
@@ -179,6 +232,7 @@ export async function attach(
             uid: target.uid,
             projectId,
             environments,
+            triggerDestination: withTriggers ? desiredDestination : undefined,
             unchanged: true,
           },
           null,
@@ -187,10 +241,13 @@ export async function attach(
       );
       return 0;
     }
+    const triggerPart = withTriggers
+      ? ` (trigger destination already registered)`
+      : '';
     output.log(
       `Connector ${chalk.bold(displayName)} is already attached to ${chalk.bold(
         projectName
-      )} for environments: ${environments.join(', ')}. Nothing to do.`
+      )} for environments: ${environments.join(', ')}${triggerPart}. Nothing to do.`
     );
     return 0;
   }
@@ -204,22 +261,36 @@ export async function attach(
   }
 
   if (!skipConfirmation) {
-    if (existingAttachment) {
-      const current = (existingAttachment.environments ?? []).join(', ') || '—';
-      const next = environments.join(', ');
+    if (shouldAttach) {
+      if (existingAttachment) {
+        const current =
+          (existingAttachment.environments ?? []).join(', ') || '—';
+        const next = environments.join(', ');
+        output.log(
+          `Connector ${chalk.bold(displayName)} is already attached to ${chalk.bold(
+            projectName
+          )}.`
+        );
+        output.log(`  Current:  ${current}`);
+        output.log(`  Will set: ${next}`);
+      } else {
+        output.log(
+          `Connector ${chalk.bold(displayName)} will be attached to ${chalk.bold(
+            projectName
+          )} for environments: ${environments.join(', ')}.`
+        );
+      }
+    }
+
+    if (shouldRegisterTrigger && desiredDestination) {
       output.log(
-        `Connector ${chalk.bold(displayName)} is already attached to ${chalk.bold(
-          projectName
-        )}.`
+        `Will register as trigger destination: ${formatDestination(desiredDestination)}.`
       );
-      output.log(`  Current:  ${current}`);
-      output.log(`  Will set: ${next}`);
-    } else {
-      output.log(
-        `Connector ${chalk.bold(displayName)} will be attached to ${chalk.bold(
-          projectName
-        )} for environments: ${environments.join(', ')}.`
-      );
+      if (!triggersEnabledOnConnector) {
+        output.warn(
+          `Triggers are not enabled on this connector. The destination will be registered, but no events will flow until the connector is recreated with triggers enabled.`
+        );
+      }
     }
 
     const confirmed = await client.input.confirm('Continue?', false);
@@ -230,34 +301,66 @@ export async function attach(
   }
 
   // Upsert the attachment.
-  output.spinner('Attaching project…');
-  try {
-    await client.fetch<unknown>(
-      `/v1/connect/connectors/${encodeURIComponent(target.id)}/projects/${encodeURIComponent(projectId)}`,
-      {
-        method: 'POST',
-        body: { environments },
+  if (shouldAttach) {
+    output.spinner('Attaching project…');
+    try {
+      await client.fetch<unknown>(
+        `/v1/connect/connectors/${encodeURIComponent(target.id)}/projects/${encodeURIComponent(projectId)}`,
+        {
+          method: 'POST',
+          body: { environments },
+        }
+      );
+    } catch (err: unknown) {
+      output.stopSpinner();
+      const status = (err as { status?: number }).status;
+      if (status === 403) {
+        output.error(
+          `You don't have permission to attach projects on this team. Owner or Member role required.`
+        );
+        return 1;
       }
-    );
-  } catch (err: unknown) {
+      if (status === 404) {
+        output.error(
+          `No connector found for ${chalk.bold(displayName)}, or project ${chalk.bold(projectName)} is no longer accessible.`
+        );
+        return 1;
+      }
+      printError(err);
+      return 1;
+    }
     output.stopSpinner();
-    const status = (err as { status?: number }).status;
-    if (status === 403) {
-      output.error(
-        `You don't have permission to attach projects on this team. Owner or Member role required.`
-      );
-      return 1;
-    }
-    if (status === 404) {
-      output.error(
-        `No connector found for ${chalk.bold(displayName)}, or project ${chalk.bold(projectName)} is no longer accessible.`
-      );
-      return 1;
-    }
-    printError(err);
-    return 1;
   }
-  output.stopSpinner();
+
+  // Register the trigger destination (PATCH replaces the full list, so merge first).
+  if (shouldRegisterTrigger && desiredDestination) {
+    const merged: ConnexTriggerDestination[] = [
+      ...(target.triggerDestinations ?? []),
+      desiredDestination,
+    ];
+    output.spinner('Registering trigger destination…');
+    try {
+      await patchTriggerDestinations(client, target.id, merged);
+    } catch (err: unknown) {
+      output.stopSpinner();
+      const status = (err as { status?: number }).status;
+      if (status === 403) {
+        output.error(
+          `You don't have permission to update trigger destinations on this team. Owner or Member role required.`
+        );
+        return 1;
+      }
+      if (status === 404) {
+        output.error(
+          `Trigger destinations are not available for this team (the connex-triggers feature is not enabled).`
+        );
+        return 1;
+      }
+      printError(err);
+      return 1;
+    }
+    output.stopSpinner();
+  }
 
   if (asJson) {
     client.stdout.write(
@@ -267,6 +370,7 @@ export async function attach(
           uid: target.uid,
           projectId,
           environments,
+          triggerDestination: withTriggers ? desiredDestination : undefined,
         },
         null,
         2
@@ -275,8 +379,15 @@ export async function attach(
     return 0;
   }
 
-  output.success(
-    `Attached connector ${chalk.bold(displayName)} to ${chalk.bold(projectName)} for environments: ${environments.join(', ')}.`
-  );
+  if (shouldAttach) {
+    output.success(
+      `Attached connector ${chalk.bold(displayName)} to ${chalk.bold(projectName)} for environments: ${environments.join(', ')}.`
+    );
+  }
+  if (shouldRegisterTrigger && desiredDestination) {
+    output.success(
+      `Registered ${chalk.bold(projectName)} as a trigger destination (${formatDestination(desiredDestination)}).`
+    );
+  }
   return 0;
 }

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -284,6 +284,32 @@ export const attachSubcommand = {
       description: 'Project name or ID (default: current linked project)',
     },
     {
+      name: 'triggers',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Also register this project as a trigger destination so the connector forwards verified webhooks to it (max 3 destinations per connector)',
+    },
+    {
+      name: 'trigger-branch',
+      shorthand: null,
+      type: String,
+      argument: 'BRANCH',
+      deprecated: false,
+      description:
+        'Target a specific git branch for the trigger destination (default: production). Only valid with --triggers.',
+    },
+    {
+      name: 'trigger-path',
+      shorthand: null,
+      type: String,
+      argument: 'PATH',
+      deprecated: false,
+      description:
+        'Path on the destination project that receives the forwarded webhook (default: /{service}). Only valid with --triggers.',
+    },
+    {
       ...yesOption,
       description: 'Skip the confirmation prompt',
     },
@@ -303,8 +329,57 @@ export const attachSubcommand = {
       value: `${packageName} connect attach slack/my-bot --project my-app`,
     },
     {
+      name: 'Attach and register the project as a trigger destination',
+      value: `${packageName} connect attach scl_abc123 --triggers`,
+    },
+    {
+      name: 'Attach and register a preview-branch trigger destination',
+      value: `${packageName} connect attach scl_abc123 --triggers --trigger-branch staging --trigger-path /slack`,
+    },
+    {
       name: 'Non-interactive output as JSON',
       value: `${packageName} connect attach scl_abc123 --yes --format=json`,
+    },
+  ],
+} as const;
+
+export const detachSubcommand = {
+  name: 'detach',
+  aliases: [],
+  description: 'Detach a Vercel project from a connector',
+  arguments: [
+    {
+      name: 'client',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'project',
+      shorthand: 'p',
+      type: String,
+      argument: 'NAME_OR_ID',
+      deprecated: false,
+      description: 'Project name or ID (default: current linked project)',
+    },
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt',
+    },
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Detach the current project from a connector',
+      value: `${packageName} connect detach scl_abc123`,
+    },
+    {
+      name: 'Detach a different project by name',
+      value: `${packageName} connect detach slack/my-bot --project my-app`,
+    },
+    {
+      name: 'Non-interactive output as JSON',
+      value: `${packageName} connect detach scl_abc123 --yes --format=json`,
     },
   ],
 } as const;
@@ -320,6 +395,7 @@ export const connexCommand = {
     listSubcommand,
     tokenSubcommand,
     attachSubcommand,
+    detachSubcommand,
     removeSubcommand,
     openSubcommand,
   ],

--- a/packages/cli/src/commands/connex/detach.ts
+++ b/packages/cli/src/commands/connex/detach.ts
@@ -1,0 +1,241 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { validateJsonOutput } from '../../util/output-format';
+import { printError } from '../../util/error';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import { getLinkedProject } from '../../util/projects/link';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
+import { packageName } from '../../util/pkg-name';
+import type { ConnexClientIdentity, ConnexClientProject } from './types';
+
+export async function detach(
+  client: Client,
+  args: string[],
+  flags: {
+    '--project'?: string;
+    '--yes'?: boolean;
+    '--format'?: string;
+    '--json'?: boolean;
+  }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+  const skipConfirmation = !!flags['--yes'];
+
+  if (asJson && !skipConfirmation) {
+    output.error('--format=json requires --yes to skip confirmation prompts');
+    return 1;
+  }
+
+  const clientIdOrUid = args[0];
+  if (!clientIdOrUid) {
+    output.error(
+      'Missing connector ID or UID. Usage: vercel connect detach <client>'
+    );
+    return 1;
+  }
+
+  // Resolve project — explicit --project takes priority over the linked one.
+  let projectId: string;
+  let projectName: string;
+
+  const projectFlag = flags['--project'];
+  if (projectFlag) {
+    await selectConnexTeam(client, 'Select the team that owns this project');
+    const team = client.config.currentTeam;
+
+    output.spinner('Looking up project…');
+    let resolvedProject;
+    try {
+      resolvedProject = await getProjectByNameOrId(client, projectFlag, team);
+    } catch (err: unknown) {
+      output.stopSpinner();
+      printError(err);
+      return 1;
+    }
+    output.stopSpinner();
+
+    if (resolvedProject instanceof ProjectNotFound) {
+      output.error(
+        `Project ${chalk.bold(projectFlag)} was not found. Check the name/ID and try again.`
+      );
+      return 1;
+    }
+
+    projectId = resolvedProject.id;
+    projectName = resolvedProject.name;
+  } else {
+    const linked = await getLinkedProject(client);
+    if (linked.status === 'error') {
+      return linked.exitCode;
+    }
+    if (linked.status === 'not_linked') {
+      output.error(
+        `No linked project found. Run \`${packageName} link\` first or pass --project=<name_or_id>.`
+      );
+      return 1;
+    }
+    if (linked.org.type === 'team') {
+      client.config.currentTeam = linked.org.id;
+    } else {
+      client.config.currentTeam = undefined;
+    }
+    projectId = linked.project.id;
+    projectName = linked.project.name;
+  }
+
+  // Resolve client identity → canonical id + display name.
+  output.spinner('Retrieving connector…');
+  let target: ConnexClientIdentity;
+  try {
+    target = await client.fetch<ConnexClientIdentity>(
+      `/v1/connect/connectors/${encodeURIComponent(clientIdOrUid)}`
+    );
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 404) {
+      output.error(`No connector found for ${chalk.bold(clientIdOrUid)}.`);
+      return 1;
+    }
+    printError(err);
+    return 1;
+  }
+  output.stopSpinner();
+
+  const displayName = target.uid || target.name || target.id;
+
+  // Pre-fetch existing attachment. If absent, treat as a no-op success.
+  let existingAttachment: ConnexClientProject | undefined;
+  try {
+    existingAttachment = await client.fetch<ConnexClientProject>(
+      `/v1/connect/connectors/${encodeURIComponent(target.id)}/projects/${encodeURIComponent(projectId)}`
+    );
+  } catch (err: unknown) {
+    const status = (err as { status?: number }).status;
+    if (status !== 404) {
+      printError(err);
+      return 1;
+    }
+  }
+
+  if (!existingAttachment) {
+    if (asJson) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            clientId: target.id,
+            uid: target.uid,
+            projectId,
+            unchanged: true,
+          },
+          null,
+          2
+        )}\n`
+      );
+      return 0;
+    }
+    output.log(
+      `Connector ${chalk.bold(displayName)} is not attached to ${chalk.bold(
+        projectName
+      )}. Nothing to do.`
+    );
+    return 0;
+  }
+
+  // Confirmation.
+  if (!skipConfirmation && !client.stdin.isTTY) {
+    output.error(
+      'Confirmation required. Use `--yes` to skip the confirmation prompt.'
+    );
+    return 1;
+  }
+
+  if (!skipConfirmation) {
+    const envs = (existingAttachment.environments ?? []).join(', ') || '—';
+    output.log(
+      `Connector ${chalk.bold(displayName)} will be detached from ${chalk.bold(
+        projectName
+      )}.`
+    );
+    output.log(`  Environments: ${envs}`);
+
+    const confirmed = await client.input.confirm('Continue?', false);
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  // Detach.
+  output.spinner('Detaching project…');
+  try {
+    await client.fetch<unknown>(
+      `/v1/connect/connectors/${encodeURIComponent(target.id)}/projects/${encodeURIComponent(projectId)}`,
+      { method: 'DELETE' }
+    );
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 403) {
+      output.error(
+        `You don't have permission to detach projects on this team. Owner or Member role required.`
+      );
+      return 1;
+    }
+    if (status === 404) {
+      // Race: the attachment disappeared between pre-fetch and DELETE. Treat as success.
+      if (asJson) {
+        client.stdout.write(
+          `${JSON.stringify(
+            {
+              clientId: target.id,
+              uid: target.uid,
+              projectId,
+              unchanged: true,
+            },
+            null,
+            2
+          )}\n`
+        );
+        return 0;
+      }
+      output.log(
+        `Connector ${chalk.bold(displayName)} is not attached to ${chalk.bold(
+          projectName
+        )}. Nothing to do.`
+      );
+      return 0;
+    }
+    printError(err);
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          clientId: target.id,
+          uid: target.uid,
+          projectId,
+          detached: true,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  output.success(
+    `Detached connector ${chalk.bold(displayName)} from ${chalk.bold(projectName)}.`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -12,6 +12,7 @@ import {
   listSubcommand,
   tokenSubcommand,
   attachSubcommand,
+  detachSubcommand,
   removeSubcommand,
   openSubcommand,
   connexCommand,
@@ -20,6 +21,7 @@ import { create } from './create';
 import { list } from './list';
 import { token } from './token';
 import { attach } from './attach';
+import { detach } from './detach';
 import { remove } from './remove';
 import { openClient } from './open';
 import {
@@ -34,6 +36,7 @@ const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
   token: getCommandAliases(tokenSubcommand),
   attach: getCommandAliases(attachSubcommand),
+  detach: getCommandAliases(detachSubcommand),
   remove: getCommandAliases(removeSubcommand),
   open: getCommandAliases(openSubcommand),
 };
@@ -141,12 +144,39 @@ export default async function connex(client: Client): Promise<number> {
           attachParsedArgs.flags['--environment']
         );
         telemetry.trackCliOptionProject(attachParsedArgs.flags['--project']);
+        telemetry.trackCliFlagTriggers(attachParsedArgs.flags['--triggers']);
+        telemetry.trackCliOptionTriggerBranch(
+          attachParsedArgs.flags['--trigger-branch']
+        );
+        telemetry.trackCliOptionTriggerPath(
+          attachParsedArgs.flags['--trigger-path']
+        );
         telemetry.trackCliFlagYes(attachParsedArgs.flags['--yes']);
         telemetry.trackCliOptionFormat(attachParsedArgs.flags['--format']);
         return await attach(
           client,
           attachParsedArgs.args,
           attachParsedArgs.flags
+        );
+      }
+      case 'detach': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex', subcommandOriginal);
+          printHelp(detachSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandDetach(subcommandOriginal);
+
+        const detachFlagsSpec = getFlagsSpecification(detachSubcommand.options);
+        const detachParsedArgs = parseArguments(subArgs, detachFlagsSpec);
+        telemetry.trackCliArgumentClient(detachParsedArgs.args[0]);
+        telemetry.trackCliOptionProject(detachParsedArgs.flags['--project']);
+        telemetry.trackCliFlagYes(detachParsedArgs.flags['--yes']);
+        telemetry.trackCliOptionFormat(detachParsedArgs.flags['--format']);
+        return await detach(
+          client,
+          detachParsedArgs.args,
+          detachParsedArgs.flags
         );
       }
       case 'remove': {

--- a/packages/cli/src/commands/connex/remove.ts
+++ b/packages/cli/src/commands/connex/remove.ts
@@ -3,23 +3,11 @@ import output from '../../output-manager';
 import type Client from '../../util/client';
 import { validateJsonOutput } from '../../util/output-format';
 import { selectConnexTeam } from '../../util/connex/select-team';
-
-interface ConnexClientIdentity {
-  id: string;
-  uid: string;
-  name?: string;
-}
-
-interface ConnexClientProject {
-  clientId: string;
-  projectId: string;
-  project?: { id: string; name: string };
-}
-
-interface ListProjectsResponse {
-  projects: ConnexClientProject[];
-  cursor?: string;
-}
+import type {
+  ConnexClientIdentity,
+  ConnexClientProject,
+  ConnexClientProjectListResponse,
+} from './types';
 
 export async function remove(
   client: Client,
@@ -81,7 +69,7 @@ export async function remove(
   let projectLinks: ConnexClientProject[];
   try {
     output.spinner('Checking connected projects…');
-    const res = await client.fetch<ListProjectsResponse>(
+    const res = await client.fetch<ConnexClientProjectListResponse>(
       `/v1/connect/connectors/${encodeURIComponent(target.id)}/projects`
     );
     projectLinks = res.projects ?? [];

--- a/packages/cli/src/commands/connex/types.ts
+++ b/packages/cli/src/commands/connex/types.ts
@@ -17,3 +17,30 @@ export interface ConnexClient {
   supportedSubjectTypes: Array<'user' | 'app'>;
   supportsInstallation: boolean;
 }
+
+export interface ConnexClientIdentity {
+  id: string;
+  uid: string;
+  name?: string;
+  supportsTriggers?: boolean;
+  triggers?: { enabled: boolean };
+  triggerDestinations?: ConnexTriggerDestination[];
+}
+
+export interface ConnexTriggerDestination {
+  projectId: string;
+  branch?: string;
+  path?: string;
+}
+
+export interface ConnexClientProject {
+  clientId: string;
+  projectId: string;
+  environments?: string[];
+  project?: { id: string; name: string };
+}
+
+export interface ConnexClientProjectListResponse {
+  projects: ConnexClientProject[];
+  cursor?: string;
+}

--- a/packages/cli/src/util/connex/trigger-destinations.ts
+++ b/packages/cli/src/util/connex/trigger-destinations.ts
@@ -1,0 +1,78 @@
+import chalk from 'chalk';
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../client';
+import type { ConnexTriggerDestination } from '../../commands/connex/types';
+
+export const MAX_TRIGGER_DESTINATIONS = 3;
+
+export function destinationsMatch(
+  a: ConnexTriggerDestination,
+  b: ConnexTriggerDestination
+): boolean {
+  return (
+    a.projectId === b.projectId &&
+    (a.branch ?? null) === (b.branch ?? null) &&
+    (a.path ?? null) === (b.path ?? null)
+  );
+}
+
+export function findMatchingDestination(
+  destinations: readonly ConnexTriggerDestination[],
+  desired: ConnexTriggerDestination
+): ConnexTriggerDestination | undefined {
+  return destinations.find(d => destinationsMatch(d, desired));
+}
+
+export function buildTriggerDestination(input: {
+  projectId: string;
+  branch?: string;
+  path?: string;
+}): ConnexTriggerDestination {
+  const dest: ConnexTriggerDestination = { projectId: input.projectId };
+  if (input.branch !== undefined) {
+    dest.branch = input.branch;
+  }
+  if (input.path !== undefined) {
+    dest.path = input.path;
+  }
+  return dest;
+}
+
+export function formatDestination(d: ConnexTriggerDestination): string {
+  return [
+    `project ${chalk.bold(d.projectId)}`,
+    `branch ${chalk.bold(d.branch ?? 'production')}`,
+    `path ${chalk.bold(d.path ?? '<default>')}`,
+  ].join(', ');
+}
+
+function toJsonDestination(d: ConnexTriggerDestination): JSONObject {
+  const entry: JSONObject = { projectId: d.projectId };
+  if (d.branch !== undefined) {
+    entry.branch = d.branch;
+  }
+  if (d.path !== undefined) {
+    entry.path = d.path;
+  }
+  return entry;
+}
+
+/**
+ * Replaces the full trigger-destinations list on a connector. The PATCH
+ * endpoint is replace-not-append, so callers compute the desired final list
+ * (existing + additions) before calling.
+ */
+export async function patchTriggerDestinations(
+  client: Client,
+  connectorId: string,
+  destinations: readonly ConnexTriggerDestination[]
+): Promise<void> {
+  const body = destinations.map(toJsonDestination);
+  await client.fetch<unknown>(
+    `/v1/connect/connectors/${encodeURIComponent(connectorId)}/trigger-destinations`,
+    {
+      method: 'PATCH',
+      body: { destinations: body },
+    }
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -48,6 +48,13 @@ export class ConnexTelemetryClient
     });
   }
 
+  trackCliSubcommandDetach(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'detach',
+      value: actual,
+    });
+  }
+
   trackCliArgumentClient(v: string | undefined) {
     if (v) {
       this.trackCliArgument({
@@ -66,6 +73,30 @@ export class ConnexTelemetryClient
   trackCliFlagDisconnectAll(v: boolean | undefined) {
     if (v) {
       this.trackCliFlag('disconnect-all');
+    }
+  }
+
+  trackCliFlagTriggers(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('triggers');
+    }
+  }
+
+  trackCliOptionTriggerBranch(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'trigger-branch',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionTriggerPath(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'trigger-path',
+        value: this.redactedValue,
+      });
     }
   }
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -759,11 +759,17 @@ exports[`help command > connex help output snapshots > connex attach subcommand 
 
   Options:
 
-  -e,  --environment <ENV>     Environments to enable. Repeatable and comma-separated (e.g. -e production -e preview, or
-                               -e production,preview). Defaults to all environments.                                    
-  -F,  --format <FORMAT>       Specify the output format (json)                                                         
-  -p,  --project <NAME_OR_ID>  Project name or ID (default: current linked project)                                     
-  -y,  --yes                   Skip the confirmation prompt                                                             
+  -e,  --environment <ENV>        Environments to enable. Repeatable and comma-separated (e.g. -e production -e preview, or
+                                  -e production,preview). Defaults to all environments.                                    
+  -F,  --format <FORMAT>          Specify the output format (json)                                                         
+  -p,  --project <NAME_OR_ID>     Project name or ID (default: current linked project)                                     
+       --trigger-branch <BRANCH>  Target a specific git branch for the trigger destination (default: production). Only     
+                                  valid with --triggers.                                                                   
+       --trigger-path <PATH>      Path on the destination project that receives the forwarded webhook (default:            
+                                  /{service}). Only valid with --triggers.                                                 
+       --triggers                 Also register this project as a trigger destination so the connector forwards verified   
+                                  webhooks to it (max 3 destinations per connector)                                        
+  -y,  --yes                      Skip the confirmation prompt                                                             
 
 
   Global Options:
@@ -793,6 +799,14 @@ exports[`help command > connex help output snapshots > connex attach subcommand 
   - Attach a different project by name
 
     $ vercel connect attach slack/my-bot --project my-app
+
+  - Attach and register the project as a trigger destination
+
+    $ vercel connect attach scl_abc123 --triggers
+
+  - Attach and register a preview-branch trigger destination
+
+    $ vercel connect attach scl_abc123 --triggers --trigger-branch staging --trigger-path /slack
 
   - Non-interactive output as JSON
 
@@ -849,6 +863,50 @@ exports[`help command > connex help output snapshots > connex create subcommand 
 "
 `;
 
+exports[`help command > connex help output snapshots > connex detach subcommand > connex detach subcommand help column width 120 1`] = `
+"
+  ▲ vercel connect detach client [options]
+
+  Detach a Vercel project from a connector                                                                              
+
+  Options:
+
+  -F,  --format <FORMAT>       Specify the output format (json)                                                         
+  -p,  --project <NAME_OR_ID>  Project name or ID (default: current linked project)                                     
+  -y,  --yes                   Skip the confirmation prompt                                                             
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Detach the current project from a connector
+
+    $ vercel connect detach scl_abc123
+
+  - Detach a different project by name
+
+    $ vercel connect detach slack/my-bot --project my-app
+
+  - Non-interactive output as JSON
+
+    $ vercel connect detach scl_abc123 --yes --format=json
+
+"
+`;
+
 exports[`help command > connex help output snapshots > connex help column width 80 1`] = `
 "
   ▲ vercel connect command
@@ -865,6 +923,7 @@ exports[`help command > connex help output snapshots > connex help column width 
                   like scl_abc or a UID like slack/my-bot)              
   attach  client  Attach a Vercel project to a connector for one or more
                   environments                                          
+  detach  client  Detach a Vercel project from a connector              
   remove  client  Delete a connector                                    
   open    id      Open a connector in the Vercel dashboard              
 

--- a/packages/cli/test/unit/commands/connex/attach.test.ts
+++ b/packages/cli/test/unit/commands/connex/attach.test.ts
@@ -451,4 +451,383 @@ describe('connex attach', () => {
       "don't have permission to attach"
     );
   });
+
+  describe('--triggers', () => {
+    it('rejects --trigger-branch without --triggers', async () => {
+      await setupLinkedProject(team);
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--trigger-branch',
+        'main',
+        '--yes'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        '--trigger-branch and --trigger-path require --triggers'
+      );
+    });
+
+    it('errors when the connector does not support triggers', async () => {
+      await setupLinkedProject(team);
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'github/my-app',
+          supportsTriggers: false,
+        });
+      });
+
+      client.setArgv('connect', 'attach', 'scl_abc123', '--triggers', '--yes');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'does not support triggers'
+      );
+    });
+
+    it('attaches and registers a default trigger destination', async () => {
+      await setupLinkedProject(team);
+      let patchBody: { destinations: Array<{ projectId: string }> } | undefined;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.statusCode = 404;
+          res.json({});
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.statusCode = 200;
+          res.json({});
+        }
+      );
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (req, res) => {
+          patchBody = req.body;
+          res.statusCode = 200;
+          res.json({});
+        }
+      );
+
+      client.setArgv('connect', 'attach', 'scl_abc123', '--triggers', '--yes');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody?.destinations).toEqual([{ projectId: PROJECT_ID }]);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Attached connector');
+      expect(stderr).toContain('Registered');
+      expect(stderr).toContain('trigger destination');
+    });
+
+    it('passes branch and path through to the PATCH', async () => {
+      await setupLinkedProject(team);
+      let patchBody:
+        | {
+            destinations: Array<{
+              projectId: string;
+              branch?: string;
+              path?: string;
+            }>;
+          }
+        | undefined;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.statusCode = 404;
+          res.json({});
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({});
+        }
+      );
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (req, res) => {
+          patchBody = req.body;
+          res.json({});
+        }
+      );
+
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--triggers',
+        '--trigger-branch',
+        'staging',
+        '--trigger-path',
+        '/slack-events',
+        '--yes'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody?.destinations).toEqual([
+        { projectId: PROJECT_ID, branch: 'staging', path: '/slack-events' },
+      ]);
+    });
+
+    it('merges with existing trigger destinations', async () => {
+      await setupLinkedProject(team);
+      let patchBody:
+        | { destinations: Array<{ projectId: string; branch?: string }> }
+        | undefined;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [{ projectId: 'prj_existing' }],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.statusCode = 404;
+          res.json({});
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({});
+        }
+      );
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (req, res) => {
+          patchBody = req.body;
+          res.json({});
+        }
+      );
+
+      client.setArgv('connect', 'attach', 'scl_abc123', '--triggers', '--yes');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody?.destinations).toEqual([
+        { projectId: 'prj_existing' },
+        { projectId: PROJECT_ID },
+      ]);
+    });
+
+    it('warns but proceeds when triggers.enabled is false on the connector', async () => {
+      await setupLinkedProject(team);
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: false },
+          triggerDestinations: [],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.statusCode = 404;
+          res.json({});
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({});
+        }
+      );
+      let patchCalled = false;
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (_req, res) => {
+          patchCalled = true;
+          res.json({});
+        }
+      );
+
+      // Interactive flow so we see the warning text before the prompt.
+      client.setArgv('connect', 'attach', 'scl_abc123', '--triggers');
+
+      const exitCodePromise = connect(client);
+      await expect(client.stderr).toOutput('Triggers are not enabled');
+      await expect(client.stderr).toOutput('Continue?');
+      client.stdin.write('y\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toBe(0);
+      expect(patchCalled).toBe(true);
+    });
+
+    it('errors when the connector already has 3 trigger destinations', async () => {
+      await setupLinkedProject(team);
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [
+            { projectId: 'prj_1' },
+            { projectId: 'prj_2' },
+            { projectId: 'prj_3' },
+          ],
+        });
+      });
+
+      client.setArgv('connect', 'attach', 'scl_abc123', '--triggers', '--yes');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'already has 3 trigger destinations'
+      );
+    });
+
+    it('no-ops the trigger PATCH when the destination is already registered', async () => {
+      await setupLinkedProject(team);
+      let patchCalled = false;
+      let postCalled = false;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [{ projectId: PROJECT_ID }],
+        });
+      });
+      // Attachment already exists with matching envs.
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({
+            clientId: 'scl_abc123',
+            projectId: PROJECT_ID,
+            environments: ['production', 'preview', 'development'],
+          });
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          postCalled = true;
+          res.json({});
+        }
+      );
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (_req, res) => {
+          patchCalled = true;
+          res.json({});
+        }
+      );
+
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--triggers',
+        '--yes',
+        '--format=json'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(postCalled).toBe(false);
+      expect(patchCalled).toBe(false);
+      const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(parsed.unchanged).toBe(true);
+      expect(parsed.triggerDestination).toEqual({ projectId: PROJECT_ID });
+    });
+
+    it('still PATCHes the trigger destination when attachment is unchanged but destination is new', async () => {
+      await setupLinkedProject(team);
+      let patchCalled = false;
+      let postCalled = false;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({
+            clientId: 'scl_abc123',
+            projectId: PROJECT_ID,
+            environments: ['production', 'preview', 'development'],
+          });
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          postCalled = true;
+          res.json({});
+        }
+      );
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (_req, res) => {
+          patchCalled = true;
+          res.json({});
+        }
+      );
+
+      client.setArgv('connect', 'attach', 'scl_abc123', '--triggers', '--yes');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(postCalled).toBe(false);
+      expect(patchCalled).toBe(true);
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/connex/detach.test.ts
+++ b/packages/cli/test/unit/commands/connex/detach.test.ts
@@ -1,0 +1,367 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { join } from 'path';
+import { mkdirp, writeJSON } from 'fs-extra';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import connect from '../../../../src/commands/connex';
+
+const PROJECT_ID = 'prj_linked_test';
+const PROJECT_NAME = 'my-app';
+
+async function setupLinkedProject(team: { id: string }): Promise<void> {
+  const cwd = setupTmpDir();
+  await mkdirp(join(cwd, '.vercel'));
+  await writeJSON(join(cwd, '.vercel', 'project.json'), {
+    orgId: team.id,
+    projectId: PROJECT_ID,
+    projectName: PROJECT_NAME,
+  });
+  client.cwd = cwd;
+}
+
+describe('connex detach', () => {
+  let team: { id: string; slug: string };
+
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    team = useTeam('team_test');
+    client.config.currentTeam = team.id;
+    useProject({ ...defaultProject, id: PROJECT_ID, name: PROJECT_NAME });
+  });
+
+  it('errors when no client argument is provided', async () => {
+    await setupLinkedProject(team);
+    client.setArgv('connect', 'detach');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing connector ID or UID'
+    );
+  });
+
+  it('rejects --format=json without --yes', async () => {
+    await setupLinkedProject(team);
+    client.setArgv('connect', 'detach', 'scl_abc123', '--format=json');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '--format=json requires --yes'
+    );
+  });
+
+  it('errors when no project is linked and --project is not provided', async () => {
+    client.cwd = setupTmpDir();
+    client.setArgv('connect', 'detach', 'scl_abc123', '--yes');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('No linked project found');
+  });
+
+  it('errors with a friendly message when the client is not found', async () => {
+    await setupLinkedProject(team);
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv('connect', 'detach', 'scl_missing', '--yes');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('No connector found for');
+  });
+
+  it('exits as a no-op when the project is not attached', async () => {
+    await setupLinkedProject(team);
+    let deleteCalled = false;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.statusCode = 404;
+        res.json({ error: { code: 'not_found' } });
+      }
+    );
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        deleteCalled = true;
+        res.statusCode = 200;
+        res.json({});
+      }
+    );
+
+    client.setArgv('connect', 'detach', 'scl_abc123');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(deleteCalled).toBe(false);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('not attached');
+    expect(stderr).toContain('Nothing to do');
+    expect(stderr).not.toContain('Continue?');
+  });
+
+  it('emits unchanged:true JSON receipt on no-op with --yes --format=json', async () => {
+    await setupLinkedProject(team);
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.statusCode = 404;
+        res.json({});
+      }
+    );
+
+    client.setArgv('connect', 'detach', 'scl_abc123', '--yes', '--format=json');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(parsed).toEqual({
+      clientId: 'scl_abc123',
+      uid: 'slack/my-bot',
+      projectId: PROJECT_ID,
+      unchanged: true,
+    });
+  });
+
+  it('detaches with --yes and DELETEs the resolved scl_ id', async () => {
+    await setupLinkedProject(team);
+    let deletedClientId = '';
+    let deletedProjectId = '';
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot', name: 'My Bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.json({
+          clientId: 'scl_abc123',
+          projectId: PROJECT_ID,
+          environments: ['production', 'preview'],
+        });
+      }
+    );
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (req, res) => {
+        deletedClientId = req.params.clientId;
+        deletedProjectId = req.params.projectId;
+        res.statusCode = 200;
+        res.json({});
+      }
+    );
+
+    client.setArgv('connect', 'detach', 'slack/my-bot', '--yes');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(deletedClientId).toBe('scl_abc123');
+    expect(deletedProjectId).toBe(PROJECT_ID);
+    expect(client.stderr.getFullOutput()).toContain('Detached connector');
+  });
+
+  it('shows the prompt with current environments and proceeds on confirm', async () => {
+    await setupLinkedProject(team);
+    let deleteCalled = false;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.json({
+          clientId: 'scl_abc123',
+          projectId: PROJECT_ID,
+          environments: ['production'],
+        });
+      }
+    );
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        deleteCalled = true;
+        res.statusCode = 200;
+        res.json({});
+      }
+    );
+
+    client.setArgv('connect', 'detach', 'scl_abc123');
+
+    const exitCodePromise = connect(client);
+
+    await expect(client.stderr).toOutput('will be detached');
+    await expect(client.stderr).toOutput('Environments: production');
+    await expect(client.stderr).toOutput('Continue?');
+    client.stdin.write('y\n');
+
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(deleteCalled).toBe(true);
+  });
+
+  it('cancels cleanly when the user declines the prompt', async () => {
+    await setupLinkedProject(team);
+    let deleteCalled = false;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.json({
+          clientId: 'scl_abc123',
+          projectId: PROJECT_ID,
+          environments: ['production'],
+        });
+      }
+    );
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        deleteCalled = true;
+        res.statusCode = 200;
+        res.json({});
+      }
+    );
+
+    client.setArgv('connect', 'detach', 'scl_abc123');
+
+    const exitCodePromise = connect(client);
+
+    await expect(client.stderr).toOutput('Continue?');
+    client.stdin.write('n\n');
+
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(deleteCalled).toBe(false);
+    expect(client.stderr.getFullOutput()).toContain('Canceled');
+  });
+
+  it('requires --yes when stdin is not a TTY', async () => {
+    await setupLinkedProject(team);
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.json({
+          clientId: 'scl_abc123',
+          projectId: PROJECT_ID,
+          environments: ['production'],
+        });
+      }
+    );
+
+    client.setArgv('connect', 'detach', 'scl_abc123');
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Confirmation required');
+  });
+
+  it('emits a JSON receipt on --yes --format=json', async () => {
+    await setupLinkedProject(team);
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.json({
+          clientId: 'scl_abc123',
+          projectId: PROJECT_ID,
+          environments: ['production'],
+        });
+      }
+    );
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.statusCode = 200;
+        res.json({});
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'detach',
+      'slack/my-bot',
+      '--yes',
+      '--format=json'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(parsed).toEqual({
+      clientId: 'scl_abc123',
+      uid: 'slack/my-bot',
+      projectId: PROJECT_ID,
+      detached: true,
+    });
+  });
+
+  it('surfaces a friendly error on 403 from the DELETE endpoint', async () => {
+    await setupLinkedProject(team);
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.json({
+          clientId: 'scl_abc123',
+          projectId: PROJECT_ID,
+          environments: ['production'],
+        });
+      }
+    );
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.statusCode = 403;
+        res.json({ error: { code: 'forbidden', message: 'Forbidden' } });
+      }
+    );
+
+    client.setArgv('connect', 'detach', 'scl_abc123', '--yes');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      "don't have permission to detach"
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -480,6 +480,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('connex detach subcommand', () => {
+      it('connex detach subcommand help column width 120', () => {
+        expect(
+          help(connex.detachSubcommand, {
+            columns: 120,
+            parent: connex.connexCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('integration help output snapshots', () => {


### PR DESCRIPTION
## Summary

- Adds `vercel connect detach <client>`. Calls `DELETE /v1/connect/connectors/:id/projects/:projectId`. Mirrors `vercel connect attach`.
- Adds `--triggers`, `--trigger-branch`, `--trigger-path` to `vercel connect attach`. When `--triggers` is set, registers the project as a trigger destination via `PATCH /v1/connect/connectors/:id/trigger-destinations`.
- Extracts shared connex types into `commands/connex/types.ts`.
- Extracts trigger-destination helpers into `util/connex/trigger-destinations.ts` for reuse by future `connect triggers` subcommands.

(Everything still gated behind `FF_CONNEX_ENABLED`)

## Behavior notes

- `--triggers` on `attach` is a convenience only — bundles attach + register-destination for the Slack bootstrap case. The two are independent resources.
- `detach` removes token access only. Trigger destinations stay; they're managed separately

## Test plan

- [x] `npx vitest run test/unit/commands/connex test/unit/commands/help.test.ts` — 237/237 passing
- [x] `npx tsc --noEmit` clean
- [x] Help snapshot regenerated
- [x] Changeset added
- [x] Manual: `connect detach <id>` against a real connector
- [x] Manual: `connect attach <id> --triggers` on a Slack connector with the `connex-triggers` flag
- [x] Manual: `connect attach <id> --triggers --trigger-branch staging --trigger-path /slack-events`
- [ ] Manual: error path — `--triggers` on a non-Slack connector
- [ ] Manual: re-run `attach --triggers` (expect no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)