### PR TITLE
[cli] Skip redundant CLI deploy fetches

### DIFF
--- a/.changeset/cuddly-buckets-design.md
+++ b/.changeset/cuddly-buckets-design.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Skip redundant deploy project and final deployment fetches in the CLI success path.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -494,6 +494,7 @@ async function handleInitDeployment(
       manual: true,
       jsonOutput: asJson,
       functionsBeta: functionsBeta || undefined,
+      linkedProject: project,
     };
 
     if (!localConfig.builds || localConfig.builds.length === 0) {
@@ -1445,6 +1446,7 @@ async function handleDefaultDeploy(
       agentName: client.agentName,
       jsonOutput: asJson,
       functionsBeta: functionsBeta || undefined,
+      linkedProject: project,
     };
 
     if (!localConfig.builds || localConfig.builds.length === 0) {
@@ -1631,7 +1633,9 @@ async function handleDefaultDeploy(
       return 1;
     }
 
-    if (!noWait) {
+    // The deploy status loop already returns the final payload for the normal
+    // READY + alias-assigned path, so skip the old no-op success refetch.
+    if (!noWait && shouldReconcileFinalDeployment(deployment)) {
       await getDeployment(client, contextName, deployment.id);
     }
 
@@ -2258,6 +2262,46 @@ function getDeploymentOutputJson(
     deploymentApiUrl: `${apiUrl}/v13/deployments/${deployment.id}`,
     ...(error ? { error } : {}),
   };
+}
+
+// Keep one reconciliation fetch for ambiguous terminal states where alias/check
+// details may have changed after the payload we are holding was produced.
+function shouldReconcileFinalDeployment(
+  deployment:
+    | {
+        readyState?: string;
+        aliasAssigned?: boolean | number | null;
+        aliasError?: unknown;
+        checksConclusion?: string;
+        checks?: {
+          'deployment-alias'?: {
+            state?: string;
+          };
+        };
+      }
+    | null
+    | undefined
+): boolean {
+  if (!deployment) {
+    return false;
+  }
+
+  if (deployment.readyState !== 'READY') {
+    return true;
+  }
+
+  if (deployment.aliasError || !deployment.aliasAssigned) {
+    return true;
+  }
+
+  if (
+    deployment.checksConclusion === 'failed' ||
+    deployment.checks?.['deployment-alias']?.state === 'failed'
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 // v2 checks: fetch check runs and print failures

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -53,6 +53,7 @@ export default async function processDeployment({
   manual,
   jsonOutput,
   functionsBeta,
+  linkedProject,
   ...args
 }: {
   now: Now;
@@ -78,6 +79,7 @@ export default async function processDeployment({
   manual?: boolean;
   jsonOutput?: boolean;
   functionsBeta?: boolean;
+  linkedProject?: Project;
 }) {
   const {
     now,
@@ -137,8 +139,9 @@ export default async function processDeployment({
     output.stopSpinner();
   }
 
-  let rollingRelease: ProjectRollingRelease | undefined;
-  let project: Project | ProjectNotFound | undefined;
+  let rollingRelease: ProjectRollingRelease | undefined =
+    linkedProject?.rollingRelease;
+  let project: Project | ProjectNotFound | undefined = linkedProject;
   let latestLogMessage = '';
 
   try {

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -11,7 +11,7 @@ import { responseError } from './error';
 import stamp from './output/stamp';
 import { APIError, BuildError } from './errors-ts';
 import printIndications from './print-indications';
-import type { GitMetadata, Org } from '@vercel-internals/types';
+import type { GitMetadata, Org, Project } from '@vercel-internals/types';
 import type { VercelConfig } from './dev/types';
 import type Client from './client';
 import { type FetchOptions, isJSONObject } from './client';
@@ -57,6 +57,7 @@ export interface CreateOptions {
   manual?: boolean;
   jsonOutput?: boolean;
   functionsBeta?: boolean;
+  linkedProject?: Project;
 }
 
 export interface RemoveOptions {
@@ -136,6 +137,7 @@ export default class Now {
       manual,
       jsonOutput = false,
       functionsBeta,
+      linkedProject,
     }: CreateOptions,
     org: Org,
     isSettingUpProject: boolean,
@@ -189,6 +191,7 @@ export default class Now {
       manual,
       jsonOutput,
       functionsBeta,
+      linkedProject,
     });
 
     if (deployment && deployment.warnings) {

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1715,6 +1715,15 @@ describe('deploy', () => {
     it('should display the primary production domain when aliased', async () => {
       const user = useUser();
       useTeams('team_dummy');
+      let projectFetchCount = 0;
+      client.scenario.get(`/v9/projects/static`, (_req, res) => {
+        projectFetchCount++;
+        res.json({
+          ...defaultProject,
+          name: 'static',
+          id: 'static',
+        });
+      });
       useProject({
         ...defaultProject,
         name: 'static',
@@ -1795,6 +1804,8 @@ describe('deploy', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+      expect(projectFetchCount).toEqual(1);
+      expect(callCount).toEqual(2);
     });
 
     it('should not display aliased domain for preview deployments', async () => {


### PR DESCRIPTION
Remove two redundant API fetches from the normal CLI deploy success path:

- Reuse the project already loaded during link resolution instead of refetching it in `processDeployment()` for rolling release checks.
- Skips the final `GET /v13/deployments/:id` when the deploy status loop already returned a `READY` + alias-assigned deployment payload.

A reconciliation fetch is still kept for ambiguous states where alias/check details may need to be refreshed.

<br>

This removes two success-path API calls every time which means faster by ~0.8s per deploy on average from my laptop in `lhr1` (30 run median).