### PR TITLE
fix(cli): harden env pull file permissions

### DIFF
--- a/.changeset/rare-snakes-prove.md
+++ b/.changeset/rare-snakes-prove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Harden file permissions for env files written by `vercel env pull`.

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
-import { outputFile } from 'fs-extra';
 import { closeSync, openSync, readSync } from 'fs';
+import * as fsPromises from 'fs/promises';
+import fs from 'fs-extra';
 import { resolve } from 'path';
 import type Client from '../../util/client';
 import { emoji, prependEmoji } from '../../util/emoji';
@@ -36,6 +37,7 @@ import {
 } from '../../util/agent-output';
 
 const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
+const ENV_FILE_MODE = 0o600;
 
 function readHeadSync(path: string, length: number) {
   const buffer = Buffer.alloc(length);
@@ -61,6 +63,17 @@ function tryReadHeadSync(path: string, length: number) {
     if (!isErrnoException(err) || err.code !== 'ENOENT') {
       throw err;
     }
+  }
+}
+
+async function writeManagedEnvFile(path: string, contents: string) {
+  await fs.outputFile(path, contents, {
+    encoding: 'utf8',
+    mode: ENV_FILE_MODE,
+  });
+
+  if (process.platform !== 'win32') {
+    await fsPromises.chmod(path, ENV_FILE_MODE);
   }
 }
 
@@ -270,7 +283,7 @@ export async function envPullCommandLogic(
       .join('\n') +
     '\n';
 
-  await outputFile(fullPath, contents, 'utf8');
+  await writeManagedEnvFile(fullPath, contents);
 
   if (deltaString) {
     output.print('\n' + deltaString);

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import fs from 'fs-extra';
+import * as fsPromises from 'fs/promises';
 import path from 'path';
 import { parse } from 'dotenv';
 import env from '../../../../src/commands/env';
@@ -205,6 +206,61 @@ describe('env pull', () => {
         value: 'TRUE',
       },
     ]);
+  });
+
+  it('should create managed env files with restricted permissions', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+    });
+    const cwd = setupUnitFixture('vercel-env-pull');
+    const outputFileSpy = vi.spyOn(fs, 'outputFile');
+    const platformSpy = vi
+      .spyOn(process, 'platform', 'get')
+      .mockReturnValue('win32');
+
+    client.cwd = cwd;
+    client.setArgv('env', 'pull', 'other.env', '--yes');
+
+    await expect(env(client)).resolves.toEqual(0);
+    expect(outputFileSpy).toHaveBeenCalledWith(
+      path.join(cwd, 'other.env'),
+      expect.any(String),
+      expect.objectContaining({
+        encoding: 'utf8',
+        mode: 0o600,
+      })
+    );
+
+    platformSpy.mockRestore();
+    outputFileSpy.mockRestore();
+  });
+
+  it('should harden permissions for managed env files on posix', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+    });
+    const cwd = setupUnitFixture('vercel-env-pull');
+    const chmodSpy = vi.spyOn(fsPromises, 'chmod').mockResolvedValue();
+    const platformSpy = vi
+      .spyOn(process, 'platform', 'get')
+      .mockReturnValue('linux');
+
+    client.cwd = cwd;
+    client.setArgv('env', 'pull', 'other.env', '--yes');
+
+    await expect(env(client)).resolves.toEqual(0);
+    expect(chmodSpy).toHaveBeenCalledWith(path.join(cwd, 'other.env'), 0o600);
+
+    platformSpy.mockRestore();
+    chmodSpy.mockRestore();
   });
 
   it('should use given environment', async () => {


### PR DESCRIPTION
﻿## Problem

`vercel env pull` writes managed `.env*` files without explicitly restricting file permissions. On POSIX systems that commonly lands as group/world-readable depending on umask, which is not a great default for secrets downloaded by the CLI.

## Root cause

The command writes env files with `outputFile(fullPath, contents, 'utf8')` and never reapplies a restricted mode after writing.

## Fix

- add a small helper that writes managed env files with `mode: 0o600`
- on POSIX, follow the write with `chmod(0o600)` so already-existing CLI-managed files are hardened too
- add focused unit tests covering the restricted write options and the POSIX chmod path
- add a changeset for `vercel`

## Solution sketch

```mermaid
flowchart TD
    A[env pull downloads secrets] --> B[write managed env file]
    B --> C[set mode 0o600 on create]
    C --> D{POSIX platform?}
    D -- no --> E[finish]
    D -- yes --> F[chmod file to 0o600]
    F --> E
```

## Duplicate check

- checked adjacent open work like `#16312` and `#16136`; they touch nearby CLI surface but not this permission hardening behavior
- did not find an open issue/PR specifically for restricting `env pull` output file mode to `0600`

## Tests

Attempted:

- `corepack pnpm test test/unit/commands/env/pull.test.ts`

Environment note:

- the local workspace does not have `node_modules`, so `vitest` is not available in this environment and the test command could not complete here

Added focused test coverage in:

- `packages/cli/test/unit/commands/env/pull.test.ts`

## Risk

Low. The change only affects files created or rewritten by `env pull`, and the intent matches existing secure defaults already used elsewhere for sensitive CLI material.
