### PR TITLE
[services] Implement dynamic JS/TS cron service detection

### DIFF
--- a/.changeset/tall-comics-destroy.md
+++ b/.changeset/tall-comics-destroy.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': minor
+---
+
+Implement dynamic JS/TS cron service detection.

--- a/packages/backends/src/crons.ts
+++ b/packages/backends/src/crons.ts
@@ -4,8 +4,11 @@ import {
   getInternalServiceCronPath,
   isScheduleTriggeredService,
 } from '@vercel/build-utils';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const DYNAMIC_SCHEDULE = '<dynamic>';
+const HANDLER_RE = /^[a-zA-Z0-9_-]+$/;
 
 export interface BackendsCronEntry extends Cron {
   /**
@@ -64,4 +67,142 @@ export async function getServiceCrons(opts: {
       exportName: 'default',
     },
   ];
+}
+interface DetectedEntry {
+  handler: string;
+  schedule: string;
+}
+
+export async function getServiceCronsDynamic(opts: {
+  serviceName: string;
+  entrypoint: string;
+  bundle: { dir: string; handler: string };
+}): Promise<BackendsCronEntry[]> {
+  const detected = await detectDynamicCrons(opts.bundle);
+
+  if (detected.length === 0) {
+    throw new Error(
+      'Dynamic cron detection returned no entries; the registry must yield at least one {handler, schedule} entry.'
+    );
+  }
+
+  return detected.map(entry => ({
+    path: getInternalServiceCronPath(
+      opts.serviceName,
+      opts.entrypoint,
+      entry.handler
+    ),
+    schedule: entry.schedule,
+    exportName: entry.handler,
+  }));
+}
+
+/**
+ * Dynamically import the bundled entry, call its default export, and
+ * validate the returned entries. Runs in-process: the user module's
+ * top-level side effects persist for the rest of the build (same
+ * constraint the lambda has at cold-start, so any well-formed cron
+ * entrypoint is teardown-clean).
+ */
+async function detectDynamicCrons(bundle: {
+  dir: string;
+  handler: string;
+}): Promise<DetectedEntry[]> {
+  const entryAbs = join(bundle.dir, bundle.handler);
+  let userModule: unknown;
+  try {
+    userModule = await import(pathToFileURL(entryAbs).toString());
+  } catch (err) {
+    throw new Error(
+      `could not import cron entrypoint: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`
+    );
+  }
+
+  const defaultExport = unwrapDefault(userModule);
+  if (typeof defaultExport !== 'function') {
+    throw new Error(
+      'cron entrypoint must default-export a function that returns an array of cron entries'
+    );
+  }
+
+  let result: unknown;
+  try {
+    result = await (defaultExport as () => unknown)();
+  } catch (err) {
+    throw new Error(
+      `error calling default export: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`
+    );
+  }
+
+  return validateEntries(result, userModule);
+}
+
+function unwrapDefault(value: unknown): unknown {
+  let current = value;
+  for (let i = 0; i < 5; i++) {
+    if (
+      current &&
+      typeof current === 'object' &&
+      'default' in (current as object) &&
+      (current as { default: unknown }).default
+    ) {
+      current = (current as { default: unknown }).default;
+    } else {
+      break;
+    }
+  }
+  return current;
+}
+
+function validateEntries(
+  result: unknown,
+  userModule: unknown
+): DetectedEntry[] {
+  if (!Array.isArray(result)) {
+    throw new Error(
+      `default export must return an array, got: ${Object.prototype.toString.call(result)}`
+    );
+  }
+
+  const entries: DetectedEntry[] = [];
+  const seen = new Set<string>();
+  for (const item of result) {
+    if (item === null || typeof item !== 'object') {
+      throw new Error(
+        `each cron entry must be an object with {handler, schedule}, got: ${JSON.stringify(item)}`
+      );
+    }
+    const handler = (item as { handler?: unknown }).handler;
+    const schedule = (item as { schedule?: unknown }).schedule;
+    if (typeof handler !== 'string' || handler === '') {
+      throw new Error(
+        `cron entry "handler" must be a non-empty string, got: ${JSON.stringify(item)}`
+      );
+    }
+    if (!HANDLER_RE.test(handler)) {
+      throw new Error(
+        `cron entry handler "${handler}" contains invalid characters; allowed: [a-zA-Z0-9_-]`
+      );
+    }
+    if (seen.has(handler)) {
+      throw new Error(`duplicate cron entry handler: "${handler}"`);
+    }
+    if (typeof schedule !== 'string' || schedule === '') {
+      throw new Error(
+        `cron entry "schedule" must be a non-empty string, got: ${JSON.stringify(item)}`
+      );
+    }
+    const exported =
+      userModule && typeof userModule === 'object'
+        ? (userModule as Record<string, unknown>)[handler]
+        : undefined;
+    if (typeof exported !== 'function') {
+      throw new Error(
+        `cron entry handler "${handler}" does not match a function export on the cron entrypoint`
+      );
+    }
+    seen.add(handler);
+    entries.push({ handler, schedule });
+  }
+  return entries;
 }

--- a/packages/backends/src/rolldown/index.ts
+++ b/packages/backends/src/rolldown/index.ts
@@ -6,7 +6,7 @@ import { build as rolldownBuild } from 'rolldown';
 import { builtinModules } from 'node:module';
 import { join, dirname, relative, extname } from 'node:path';
 import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { type Files, FileBlob, isBackendFramework } from '@vercel/build-utils';
 import { nft } from './nft.js';
 import { exports as resolveExports } from 'resolve.exports';
@@ -340,3 +340,44 @@ module.exports = requireFromContext('${pkgName}');
   );
   return { files, handler, framework, localBuildFiles };
 };
+
+/**
+ * Materialize an in-memory `Files` map (typically rolldown's `write:
+ * false` output) onto disk under `workPath`. The directory is placed
+ * inside `workPath` so externalized npm imports walk up to the project's
+ * `node_modules`. Caller owns cleanup of the returned path.
+ */
+export async function stageBundleOnDisk(opts: {
+  files: Files;
+  workPath: string;
+  /** Prefix for the mkdtemp suffix; defaults to `.vc-bundle-`. */
+  prefix?: string;
+}): Promise<string> {
+  const dir = await mkdtemp(join(opts.workPath, opts.prefix ?? '.vc-bundle-'));
+  for (const [relPath, file] of Object.entries(opts.files)) {
+    const data = await readFileData(file);
+    if (data === undefined) continue;
+    const absPath = join(dir, relPath);
+    await mkdir(dirname(absPath), { recursive: true });
+    await writeFile(absPath, data);
+  }
+  return dir;
+}
+
+async function readFileData(
+  file: unknown
+): Promise<Buffer | string | undefined> {
+  if (file && typeof file === 'object') {
+    if ('data' in file) {
+      const data = (file as { data: unknown }).data;
+      if (typeof data === 'string' || Buffer.isBuffer(data)) return data;
+    }
+    if (
+      'fsPath' in file &&
+      typeof (file as { fsPath: unknown }).fsPath === 'string'
+    ) {
+      return readFile((file as { fsPath: string }).fsPath);
+    }
+  }
+  return undefined;
+}

--- a/packages/backends/src/rolldown/index.ts
+++ b/packages/backends/src/rolldown/index.ts
@@ -359,7 +359,7 @@ export async function stageBundleOnDisk(opts: {
     if (data === undefined) continue;
     const absPath = join(dir, relPath);
     await mkdir(dirname(absPath), { recursive: true });
-    await writeFile(absPath, data);
+    await writeFile(absPath, data as string | NodeJS.ArrayBufferView);
   }
   return dir;
 }


### PR DESCRIPTION
Followup to https://github.com/vercel/vercel/pull/16302 and #16310. Part of a breakdown of https://github.com/vercel/vercel/pull/16201.

Detects dynamic crons during the build step:
- Stage the rolldown bundle in a temporary dir via `stageBundleOnDisk`
- Import the bundled entrypoint
- Call the default export
- Validate the resulting `{handler, schedule}` entries
- The `handler` field must name a valid function export
  
Note: this PR does not actually connect the detection to the build system yet.