### PR TITLE
[services] Use builder entrypoint detection in service auto-detection.

### DIFF
--- a/.changeset/lucky-papayas-taste.md
+++ b/.changeset/lucky-papayas-taste.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': minor
+---
+
+Use builder entrypoint detection in service auto-detection.

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -989,7 +989,7 @@ describe('link', () => {
           routePrefix: '/',
         },
         api: {
-          entrypoint: 'services/api',
+          root: 'services/api',
           routePrefix: '/_/api',
         },
       },
@@ -1214,7 +1214,7 @@ describe('link', () => {
           routePrefix: '/',
         },
         api: {
-          entrypoint: 'services/api',
+          root: 'services/api',
           routePrefix: '/_/api',
         },
       },
@@ -1296,7 +1296,7 @@ describe('link', () => {
           routePrefix: '/',
         },
         api: {
-          entrypoint: 'services/api',
+          root: 'services/api',
           routePrefix: '/_/api',
         },
       },

--- a/packages/fs-detectors/src/services/auto-detect.ts
+++ b/packages/fs-detectors/src/services/auto-detect.ts
@@ -1,11 +1,18 @@
 import type { Framework } from '@vercel/frameworks';
+import type { DetectEntrypointFn } from '@vercel/build-utils';
 import { detectFrameworks } from '../detect-framework';
 import { frameworkList } from '@vercel/frameworks';
 import type { DetectorFilesystem } from '../detectors/filesystem';
 import type { ExperimentalServices, ServiceDetectionError } from './types';
+import { isFrontendFramework } from './utils';
 
 export interface AutoDetectOptions {
   fs: DetectorFilesystem;
+  /**
+   * Optional callback used to enrich runtime services with a normalized
+   * entrypoint (file path or `module:attr` reference).
+   */
+  detectEntrypoint?: DetectEntrypointFn;
 }
 
 export interface AutoDetectResult {
@@ -58,7 +65,7 @@ const DETECTION_FRAMEWORKS = frameworkList.filter(
 export async function autoDetectServices(
   options: AutoDetectOptions
 ): Promise<AutoDetectResult> {
-  const { fs } = options;
+  const { fs, detectEntrypoint } = options;
 
   const rootFrameworks = await detectFrameworks({
     fs,
@@ -79,7 +86,7 @@ export async function autoDetectServices(
   }
 
   if (rootFrameworks.length === 1) {
-    return detectServicesAtRoot(fs, rootFrameworks[0]);
+    return detectServicesAtRoot(fs, rootFrameworks[0], detectEntrypoint);
   }
 
   for (const frontendLocation of FRONTEND_LOCATIONS) {
@@ -111,7 +118,8 @@ export async function autoDetectServices(
       return detectServicesFrontendSubdir(
         fs,
         frontendFrameworks[0],
-        frontendLocation
+        frontendLocation,
+        detectEntrypoint
       );
     }
   }
@@ -130,7 +138,8 @@ export async function autoDetectServices(
 
 async function detectServicesAtRoot(
   fs: DetectorFilesystem,
-  rootFramework: Framework
+  rootFramework: Framework,
+  detectEntrypoint: DetectEntrypointFn | undefined
 ): Promise<AutoDetectResult> {
   const services: ExperimentalServices = {};
 
@@ -139,7 +148,7 @@ async function detectServicesAtRoot(
     routePrefix: '/',
   };
 
-  const backendResult = await detectBackendServices(fs);
+  const backendResult = await detectBackendServices(fs, detectEntrypoint);
   if (backendResult.error) {
     return {
       services: null,
@@ -163,7 +172,8 @@ async function detectServicesAtRoot(
 async function detectServicesFrontendSubdir(
   fs: DetectorFilesystem,
   frontendFramework: Framework,
-  frontendLocation: string
+  frontendLocation: string,
+  detectEntrypoint: DetectEntrypointFn | undefined
 ): Promise<AutoDetectResult> {
   const services: ExperimentalServices = {};
 
@@ -172,11 +182,11 @@ async function detectServicesFrontendSubdir(
 
   services[serviceName] = {
     framework: frontendFramework.slug ?? undefined,
-    entrypoint: frontendLocation,
+    root: frontendLocation,
     routePrefix: '/',
   };
 
-  const backendResult = await detectBackendServices(fs);
+  const backendResult = await detectBackendServices(fs, detectEntrypoint);
   if (backendResult.error) {
     return {
       services: null,
@@ -205,13 +215,21 @@ async function detectServicesFrontendSubdir(
   };
 }
 
-async function detectBackendServices(fs: DetectorFilesystem): Promise<{
+async function detectBackendServices(
+  fs: DetectorFilesystem,
+  detectEntrypoint: DetectEntrypointFn | undefined
+): Promise<{
   services: ExperimentalServices;
   error?: ServiceDetectionError;
 }> {
   const services: ExperimentalServices = {};
 
-  const backendResult = await detectServiceInDir(fs, BACKEND_DIR, 'backend');
+  const backendResult = await detectServiceInDir(
+    fs,
+    BACKEND_DIR,
+    'backend',
+    detectEntrypoint
+  );
   if (backendResult.error) {
     return { services: {}, error: backendResult.error };
   }
@@ -219,7 +237,10 @@ async function detectBackendServices(fs: DetectorFilesystem): Promise<{
     services.backend = backendResult.service;
   }
 
-  const multiServicesResult = await detectServicesDirectory(fs);
+  const multiServicesResult = await detectServicesDirectory(
+    fs,
+    detectEntrypoint
+  );
   if (multiServicesResult.error) {
     return { services: {}, error: multiServicesResult.error };
   }
@@ -242,7 +263,10 @@ async function detectBackendServices(fs: DetectorFilesystem): Promise<{
   return { services };
 }
 
-async function detectServicesDirectory(fs: DetectorFilesystem): Promise<{
+async function detectServicesDirectory(
+  fs: DetectorFilesystem,
+  detectEntrypoint: DetectEntrypointFn | undefined
+): Promise<{
   services: ExperimentalServices;
   error?: ServiceDetectionError;
 }> {
@@ -264,7 +288,12 @@ async function detectServicesDirectory(fs: DetectorFilesystem): Promise<{
     const serviceName = entry.name;
     const serviceDir = `${SERVICES_DIR}/${serviceName}`;
 
-    const result = await detectServiceInDir(fs, serviceDir, serviceName);
+    const result = await detectServiceInDir(
+      fs,
+      serviceDir,
+      serviceName,
+      detectEntrypoint
+    );
     if (result.error) {
       return { services: {}, error: result.error };
     }
@@ -279,7 +308,8 @@ async function detectServicesDirectory(fs: DetectorFilesystem): Promise<{
 async function detectServiceInDir(
   fs: DetectorFilesystem,
   dirPath: string,
-  serviceName: string
+  serviceName: string,
+  detectEntrypoint: DetectEntrypointFn | undefined
 ): Promise<{
   service?: ExperimentalServices[string];
   error?: ServiceDetectionError;
@@ -307,17 +337,24 @@ async function detectServiceInDir(
     };
   }
 
-  if (frameworks.length === 1) {
-    const framework = frameworks[0];
-
-    return {
-      service: {
-        framework: framework.slug ?? undefined,
-        entrypoint: dirPath,
-        routePrefix: `/_/${serviceName}`,
-      },
-    };
+  if (frameworks.length !== 1) {
+    return {};
   }
 
-  return {};
+  const framework = frameworks[0];
+  const slug = framework.slug ?? undefined;
+  const routePrefix = `/_/${serviceName}`;
+
+  const detected =
+    detectEntrypoint && !isFrontendFramework(slug)
+      ? await detectEntrypoint({ workPath: dirPath, framework: slug })
+      : null;
+  return {
+    service: {
+      framework: slug,
+      root: dirPath,
+      ...(detected ? { entrypoint: detected.entrypoint } : {}),
+      routePrefix,
+    },
+  };
 }

--- a/packages/fs-detectors/src/services/auto-detect.ts
+++ b/packages/fs-detectors/src/services/auto-detect.ts
@@ -1,4 +1,5 @@
 import type { Framework } from '@vercel/frameworks';
+import type { DetectEntrypointFn } from '@vercel/build-utils';
 import { detectFrameworks } from '../detect-framework';
 import { frameworkList } from '@vercel/frameworks';
 import type { DetectorFilesystem } from '../detectors/filesystem';
@@ -7,10 +8,15 @@ import type {
   ServiceDetectionError,
   ServiceDetectionWarning,
 } from './types';
-import { DETECTION_FRAMEWORKS } from './utils';
+import { isFrontendFramework, DETECTION_FRAMEWORKS } from './utils';
 
 export interface AutoDetectOptions {
   fs: DetectorFilesystem;
+  /**
+   * Optional callback used to enrich runtime services with a normalized
+   * entrypoint (file path or `module:attr` reference).
+   */
+  detectEntrypoint?: DetectEntrypointFn;
 }
 
 export interface AutoDetectResult {
@@ -58,7 +64,7 @@ const FRONTEND_LOCATIONS = [FRONTEND_DIR, APPS_WEB_DIR];
 export async function autoDetectServices(
   options: AutoDetectOptions
 ): Promise<AutoDetectResult> {
-  const { fs } = options;
+  const { fs, detectEntrypoint } = options;
 
   const rootFrameworks = await detectFrameworks({
     fs,
@@ -80,7 +86,7 @@ export async function autoDetectServices(
   }
 
   if (rootFrameworks.length === 1) {
-    return detectServicesAtRoot(fs, rootFrameworks[0]);
+    return detectServicesAtRoot(fs, rootFrameworks[0], detectEntrypoint);
   }
 
   for (const frontendLocation of FRONTEND_LOCATIONS) {
@@ -113,7 +119,8 @@ export async function autoDetectServices(
       return detectServicesFrontendSubdir(
         fs,
         frontendFrameworks[0],
-        frontendLocation
+        frontendLocation,
+        detectEntrypoint
       );
     }
   }
@@ -133,7 +140,8 @@ export async function autoDetectServices(
 
 async function detectServicesAtRoot(
   fs: DetectorFilesystem,
-  rootFramework: Framework
+  rootFramework: Framework,
+  detectEntrypoint: DetectEntrypointFn | undefined
 ): Promise<AutoDetectResult> {
   const services: ExperimentalServices = {};
 
@@ -142,7 +150,7 @@ async function detectServicesAtRoot(
     routePrefix: '/',
   };
 
-  const backendResult = await detectBackendServices(fs);
+  const backendResult = await detectBackendServices(fs, detectEntrypoint);
   if (backendResult.error) {
     return {
       services: null,
@@ -169,7 +177,8 @@ async function detectServicesAtRoot(
 async function detectServicesFrontendSubdir(
   fs: DetectorFilesystem,
   frontendFramework: Framework,
-  frontendLocation: string
+  frontendLocation: string,
+  detectEntrypoint: DetectEntrypointFn | undefined
 ): Promise<AutoDetectResult> {
   const services: ExperimentalServices = {};
 
@@ -178,11 +187,11 @@ async function detectServicesFrontendSubdir(
 
   services[serviceName] = {
     framework: frontendFramework.slug ?? undefined,
-    entrypoint: frontendLocation,
+    root: frontendLocation,
     routePrefix: '/',
   };
 
-  const backendResult = await detectBackendServices(fs);
+  const backendResult = await detectBackendServices(fs, detectEntrypoint);
   if (backendResult.error) {
     return {
       services: null,
@@ -214,13 +223,21 @@ async function detectServicesFrontendSubdir(
   };
 }
 
-async function detectBackendServices(fs: DetectorFilesystem): Promise<{
+async function detectBackendServices(
+  fs: DetectorFilesystem,
+  detectEntrypoint: DetectEntrypointFn | undefined
+): Promise<{
   services: ExperimentalServices;
   error?: ServiceDetectionError;
 }> {
   const services: ExperimentalServices = {};
 
-  const backendResult = await detectServiceInDir(fs, BACKEND_DIR, 'backend');
+  const backendResult = await detectServiceInDir(
+    fs,
+    BACKEND_DIR,
+    'backend',
+    detectEntrypoint
+  );
   if (backendResult.error) {
     return { services: {}, error: backendResult.error };
   }
@@ -228,7 +245,10 @@ async function detectBackendServices(fs: DetectorFilesystem): Promise<{
     services.backend = backendResult.service;
   }
 
-  const multiServicesResult = await detectServicesDirectory(fs);
+  const multiServicesResult = await detectServicesDirectory(
+    fs,
+    detectEntrypoint
+  );
   if (multiServicesResult.error) {
     return { services: {}, error: multiServicesResult.error };
   }
@@ -251,7 +271,10 @@ async function detectBackendServices(fs: DetectorFilesystem): Promise<{
   return { services };
 }
 
-async function detectServicesDirectory(fs: DetectorFilesystem): Promise<{
+async function detectServicesDirectory(
+  fs: DetectorFilesystem,
+  detectEntrypoint: DetectEntrypointFn | undefined
+): Promise<{
   services: ExperimentalServices;
   error?: ServiceDetectionError;
 }> {
@@ -273,7 +296,12 @@ async function detectServicesDirectory(fs: DetectorFilesystem): Promise<{
     const serviceName = entry.name;
     const serviceDir = `${SERVICES_DIR}/${serviceName}`;
 
-    const result = await detectServiceInDir(fs, serviceDir, serviceName);
+    const result = await detectServiceInDir(
+      fs,
+      serviceDir,
+      serviceName,
+      detectEntrypoint
+    );
     if (result.error) {
       return { services: {}, error: result.error };
     }
@@ -288,7 +316,8 @@ async function detectServicesDirectory(fs: DetectorFilesystem): Promise<{
 async function detectServiceInDir(
   fs: DetectorFilesystem,
   dirPath: string,
-  serviceName: string
+  serviceName: string,
+  detectEntrypoint: DetectEntrypointFn | undefined
 ): Promise<{
   service?: ExperimentalServices[string];
   error?: ServiceDetectionError;
@@ -316,17 +345,24 @@ async function detectServiceInDir(
     };
   }
 
-  if (frameworks.length === 1) {
-    const framework = frameworks[0];
-
-    return {
-      service: {
-        framework: framework.slug ?? undefined,
-        entrypoint: dirPath,
-        routePrefix: `/_/${serviceName}`,
-      },
-    };
+  if (frameworks.length !== 1) {
+    return {};
   }
 
-  return {};
+  const framework = frameworks[0];
+  const slug = framework.slug ?? undefined;
+  const routePrefix = `/_/${serviceName}`;
+
+  const detected =
+    detectEntrypoint && !isFrontendFramework(slug)
+      ? await detectEntrypoint({ workPath: dirPath, framework: slug })
+      : null;
+  return {
+    service: {
+      framework: slug,
+      root: dirPath,
+      ...(detected ? { entrypoint: detected.entrypoint } : {}),
+      routePrefix,
+    },
+  };
 }

--- a/packages/fs-detectors/src/services/detect-railway.ts
+++ b/packages/fs-detectors/src/services/detect-railway.ts
@@ -1,6 +1,7 @@
 import { posix as posixPath } from 'path';
 import toml from 'smol-toml';
 import type { Framework } from '@vercel/frameworks';
+import type { DetectEntrypointFn } from '@vercel/build-utils';
 import { frameworkList } from '@vercel/frameworks';
 import { detectFrameworks } from '../detect-framework';
 import type { DetectorFilesystem } from '../detectors/filesystem';
@@ -84,8 +85,9 @@ const DETECTION_FRAMEWORKS = frameworkList.filter(
  */
 export async function detectRailwayServices(options: {
   fs: DetectorFilesystem;
+  detectEntrypoint?: DetectEntrypointFn;
 }): Promise<RailwayDetectResult> {
-  const { fs } = options;
+  const { fs, detectEntrypoint } = options;
 
   const { configs, warnings } = await findRailwayConfigs(fs);
   if (configs.length === 0) {
@@ -169,11 +171,22 @@ export async function detectRailwayServices(options: {
     }
 
     const framework = frameworks[0];
+    const slug = framework.slug ?? undefined;
 
     let serviceConfig: ExperimentalServiceConfig = {};
-    serviceConfig.framework = framework.slug ?? undefined;
+    serviceConfig.framework = slug;
+
     if (cf.dirPath !== '.') {
-      serviceConfig.entrypoint = cf.dirPath;
+      serviceConfig.root = cf.dirPath;
+      if (detectEntrypoint && !isFrontendFramework(slug)) {
+        const detected = await detectEntrypoint({
+          workPath: cf.dirPath,
+          framework: slug,
+        });
+        if (detected) {
+          serviceConfig.entrypoint = detected.entrypoint;
+        }
+      }
     }
 
     const buildCommand = combineBuildCommand(

--- a/packages/fs-detectors/src/services/detect-railway.ts
+++ b/packages/fs-detectors/src/services/detect-railway.ts
@@ -1,5 +1,6 @@
 import { posix as posixPath } from 'path';
 import toml from 'smol-toml';
+import type { DetectEntrypointFn } from '@vercel/build-utils';
 import { detectFrameworks } from '../detect-framework';
 import type { DetectorFilesystem } from '../detectors/filesystem';
 import type {
@@ -12,6 +13,7 @@ import {
   assignRoutePrefixes,
   DETECTION_FRAMEWORKS,
   inferRuntimeFromFramework,
+  isFrontendFramework,
 } from './utils';
 
 export interface RailwayDetectResult {
@@ -81,8 +83,9 @@ const SKIP_DIRS = new Set([
  */
 export async function detectRailwayServices(options: {
   fs: DetectorFilesystem;
+  detectEntrypoint?: DetectEntrypointFn;
 }): Promise<RailwayDetectResult> {
-  const { fs } = options;
+  const { fs, detectEntrypoint } = options;
 
   const { configs, warnings } = await findRailwayConfigs(fs);
   if (configs.length === 0) {
@@ -168,11 +171,22 @@ export async function detectRailwayServices(options: {
     }
 
     const framework = frameworks[0];
+    const slug = framework.slug ?? undefined;
 
     let serviceConfig: ExperimentalServiceConfig = {};
-    serviceConfig.framework = framework.slug ?? undefined;
+    serviceConfig.framework = slug;
+
     if (cf.dirPath !== '.') {
-      serviceConfig.entrypoint = cf.dirPath;
+      serviceConfig.root = cf.dirPath;
+      if (detectEntrypoint && !isFrontendFramework(slug)) {
+        const detected = await detectEntrypoint({
+          workPath: cf.dirPath,
+          framework: slug,
+        });
+        if (detected) {
+          serviceConfig.entrypoint = detected.entrypoint;
+        }
+      }
     }
 
     if (cf.config.build?.buildCommand) {

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -80,6 +80,10 @@ function toInferredLayoutConfig(
   for (const [name, service] of Object.entries(services)) {
     const serviceConfig: InferredServicesConfig[string] = {};
 
+    if (typeof service.root === 'string') {
+      serviceConfig.root = service.root;
+    }
+
     if (typeof service.entrypoint === 'string') {
       serviceConfig.entrypoint = service.entrypoint;
     }
@@ -112,7 +116,7 @@ function toInferredLayoutConfig(
 export async function detectServices(
   options: DetectServicesOptions
 ): Promise<DetectServicesResult> {
-  const { fs, workPath } = options;
+  const { fs, workPath, detectEntrypoint } = options;
 
   // Scope filesystem to workPath if provided
   const scopedFs = workPath ? fs.chdir(workPath) : fs;
@@ -143,7 +147,10 @@ export async function detectServices(
   // Try auto-detection
   if (!hasConfiguredServices) {
     // Try Railway config detection first
-    const railwayResult = await detectRailwayServices({ fs: scopedFs });
+    const railwayResult = await detectRailwayServices({
+      fs: scopedFs,
+      detectEntrypoint,
+    });
     if (railwayResult.errors.length > 0) {
       return withResolvedResult({
         services: [],
@@ -187,7 +194,10 @@ export async function detectServices(
     }
 
     // Fall back to layout-based auto-detection
-    const autoResult = await autoDetectServices({ fs: scopedFs });
+    const autoResult = await autoDetectServices({
+      fs: scopedFs,
+      detectEntrypoint,
+    });
     if (autoResult.services && autoResult.errors.length === 0) {
       const result = await resolveAllConfiguredServices(
         autoResult.services,

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -6,6 +6,7 @@ import {
   scopeRouteSourceToOwnership,
 } from '@vercel/routing-utils';
 import type {
+  DetectEntrypointFn,
   DetectServicesOptions,
   DetectServicesResult,
   EnvVars,
@@ -90,6 +91,10 @@ function toInferredLayoutConfig(
       serviceConfig.type = service.type;
     }
 
+    if (typeof service.root === 'string') {
+      serviceConfig.root = service.root;
+    }
+
     if (typeof service.entrypoint === 'string') {
       serviceConfig.entrypoint = service.entrypoint;
     }
@@ -132,7 +137,7 @@ interface PlatformDetectResult {
 export async function detectServices(
   options: DetectServicesOptions
 ): Promise<DetectServicesResult> {
-  const { fs, workPath } = options;
+  const { fs, workPath, detectEntrypoint } = options;
 
   // Scope filesystem to workPath if provided
   const scopedFs = workPath ? fs.chdir(workPath) : fs;
@@ -169,6 +174,7 @@ export async function detectServices(
     const detectors: Array<{
       detect: (options: {
         fs: DetectorFilesystem;
+        detectEntrypoint?: DetectEntrypointFn;
       }) => Promise<PlatformDetectResult>;
       source: InferredServicesResult['source'];
     }> = [
@@ -179,7 +185,7 @@ export async function detectServices(
     ];
 
     for (const { detect, source } of detectors) {
-      const detectResult = await detect({ fs: scopedFs });
+      const detectResult = await detect({ fs: scopedFs, detectEntrypoint });
       const match = await tryResolveInferred(detectResult, source, scopedFs);
       if (match) return match;
     }

--- a/packages/fs-detectors/src/services/types.ts
+++ b/packages/fs-detectors/src/services/types.ts
@@ -1,5 +1,6 @@
 import type { Route } from '@vercel/routing-utils';
 import type {
+  DetectEntrypointFn,
   EnvVar,
   EnvVars,
   ExperimentalServiceConfig,
@@ -16,6 +17,7 @@ import type {
 import type { DetectorFilesystem } from '../detectors/filesystem';
 
 export type {
+  DetectEntrypointFn,
   EnvVar,
   EnvVars,
   ExperimentalServiceConfig,
@@ -42,6 +44,12 @@ export interface DetectServicesOptions {
    * If provided, vercel.json is read from this path.
    */
   workPath?: string;
+  /**
+   * Optional callback that, given a candidate service directory and its
+   * detected framework, returns a normalized entrypoint (file path or
+   * `module:attr` reference). Used to suggested service configs.
+   */
+  detectEntrypoint?: DetectEntrypointFn;
 }
 
 export interface ServicesRoutes {

--- a/packages/fs-detectors/test/unit.auto-detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.auto-detect-services.test.ts
@@ -1,4 +1,5 @@
 import { detectServices, autoDetectServices } from '../src';
+import type { DetectEntrypointFn } from '@vercel/build-utils';
 import VirtualFilesystem from './virtual-file-system';
 
 describe('autoDetectServices', () => {
@@ -25,7 +26,7 @@ describe('autoDetectServices', () => {
       expect(result.services!.frontend!.entrypoint).toBeUndefined();
       expect(result.services!.backend).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'backend',
+        root: 'backend',
         routePrefix: '/_/backend',
       });
     });
@@ -80,12 +81,12 @@ describe('autoDetectServices', () => {
       expect(result.services).not.toBeNull();
       expect(result.services!.frontend).toMatchObject({
         framework: 'nextjs',
-        entrypoint: 'frontend',
+        root: 'frontend',
         routePrefix: '/',
       });
       expect(result.services!.backend).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'backend',
+        root: 'backend',
         routePrefix: '/_/backend',
       });
     });
@@ -149,17 +150,17 @@ describe('autoDetectServices', () => {
 
       expect(result.services!.frontend).toMatchObject({
         framework: 'nextjs',
-        entrypoint: 'frontend',
+        root: 'frontend',
         routePrefix: '/',
       });
       expect(result.services!['service-a']).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'services/service-a',
+        root: 'services/service-a',
         routePrefix: '/_/service-a',
       });
       expect(result.services!['service-b']).toMatchObject({
         framework: 'flask',
-        entrypoint: 'services/service-b',
+        root: 'services/service-b',
         routePrefix: '/_/service-b',
       });
     });
@@ -188,7 +189,7 @@ describe('autoDetectServices', () => {
       expect(result.services!.frontend!.entrypoint).toBeUndefined();
       expect(result.services!.api).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'services/api',
+        root: 'services/api',
         routePrefix: '/_/api',
       });
     });
@@ -257,22 +258,22 @@ describe('autoDetectServices', () => {
 
       expect(result.services!.web).toMatchObject({
         framework: 'nextjs',
-        entrypoint: 'apps/web',
+        root: 'apps/web',
         routePrefix: '/',
       });
       expect(result.services!.auth).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'services/auth',
+        root: 'services/auth',
         routePrefix: '/_/auth',
       });
       expect(result.services!.payments).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'services/payments',
+        root: 'services/payments',
         routePrefix: '/_/payments',
       });
       expect(result.services!.notifications).toMatchObject({
         framework: 'flask',
-        entrypoint: 'services/notifications',
+        root: 'services/notifications',
         routePrefix: '/_/notifications',
       });
     });
@@ -409,12 +410,12 @@ describe('detectServices with auto-detection', () => {
       expect(result.services).not.toBeNull();
       expect(result.services!.frontend).toMatchObject({
         framework: 'sveltekit-1',
-        entrypoint: 'frontend',
+        root: 'frontend',
         routePrefix: '/',
       });
       expect(result.services!.backend).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'backend',
+        root: 'backend',
         routePrefix: '/_/backend',
       });
     });
@@ -444,7 +445,7 @@ describe('detectServices with auto-detection', () => {
       });
       expect(result.services!.backend).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'backend',
+        root: 'backend',
         routePrefix: '/_/backend',
       });
     });
@@ -520,5 +521,90 @@ describe('detectServices with auto-detection', () => {
       expect(backend?.routePrefix).toBe('/_/backend');
       expect(backend?.routePrefixSource).toBe('generated');
     });
+  });
+});
+
+describe('autoDetectServices with detectEntrypoint callback', () => {
+  it('emits root + entrypoint for runtime services and root-only for frontend services', async () => {
+    const fs = new VirtualFilesystem({
+      'frontend/package.json': JSON.stringify({
+        dependencies: { next: '14.0.0' },
+      }),
+      'backend/pyproject.toml': '[project]\ndependencies = ["fastapi"]',
+      'backend/main.py': 'from fastapi import FastAPI\napp = FastAPI()',
+    });
+
+    const detectEntrypoint: DetectEntrypointFn = async ({
+      workPath,
+      framework,
+    }) => {
+      // Mock the per-runtime helper: assert the auto-detect plumbing
+      // forwards both the directory and the framework slug, and respond
+      // with a Python-style module:attr reference.
+      expect(workPath).toBe('backend');
+      expect(framework).toBe('fastapi');
+      return { kind: 'py-module:attr', entrypoint: 'main:app' };
+    };
+
+    const result = await autoDetectServices({ fs, detectEntrypoint });
+
+    expect(result.errors).toEqual([]);
+    expect(result.services).not.toBeNull();
+    expect(result.services!.frontend).toEqual({
+      framework: 'nextjs',
+      root: 'frontend',
+      routePrefix: '/',
+    });
+    expect(result.services!.frontend!.entrypoint).toBeUndefined();
+    expect(result.services!.backend).toEqual({
+      framework: 'fastapi',
+      root: 'backend',
+      entrypoint: 'main:app',
+      routePrefix: '/_/backend',
+    });
+  });
+
+  it('emits root only (no entrypoint) when the callback returns null for a runtime service', async () => {
+    const fs = new VirtualFilesystem({
+      'frontend/package.json': JSON.stringify({
+        dependencies: { next: '14.0.0' },
+      }),
+      'backend/pyproject.toml': '[project]\ndependencies = ["fastapi"]',
+      // No main.py — the callback below returns null, mimicking a
+      // detector that couldn't find a concrete entrypoint. The framework
+      // hook resolves the actual file at build time.
+    });
+
+    const detectEntrypoint: DetectEntrypointFn = async () => null;
+
+    const result = await autoDetectServices({ fs, detectEntrypoint });
+
+    expect(result.errors).toEqual([]);
+    expect(result.services!.backend).toEqual({
+      framework: 'fastapi',
+      root: 'backend',
+      routePrefix: '/_/backend',
+    });
+    expect(result.services!.backend!.entrypoint).toBeUndefined();
+  });
+
+  it('does not invoke the callback for frontend-only services', async () => {
+    const fs = new VirtualFilesystem({
+      'frontend/package.json': JSON.stringify({
+        dependencies: { next: '14.0.0' },
+      }),
+      'backend/pyproject.toml': '[project]\ndependencies = ["fastapi"]',
+      'backend/main.py': 'from fastapi import FastAPI\napp = FastAPI()',
+    });
+
+    const calls: Array<{ workPath: string; framework?: string }> = [];
+    const detectEntrypoint: DetectEntrypointFn = async opts => {
+      calls.push(opts);
+      return { kind: 'py-module:attr', entrypoint: 'main:app' };
+    };
+
+    await autoDetectServices({ fs, detectEntrypoint });
+
+    expect(calls).toEqual([{ workPath: 'backend', framework: 'fastapi' }]);
   });
 });

--- a/packages/fs-detectors/test/unit.auto-detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.auto-detect-services.test.ts
@@ -1,4 +1,5 @@
 import { detectServices, autoDetectServices } from '../src';
+import type { DetectEntrypointFn } from '@vercel/build-utils';
 import VirtualFilesystem from './virtual-file-system';
 
 describe('autoDetectServices', () => {
@@ -25,7 +26,7 @@ describe('autoDetectServices', () => {
       expect(result.services!.frontend!.entrypoint).toBeUndefined();
       expect(result.services!.backend).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'backend',
+        root: 'backend',
         routePrefix: '/_/backend',
       });
     });
@@ -80,12 +81,12 @@ describe('autoDetectServices', () => {
       expect(result.services).not.toBeNull();
       expect(result.services!.frontend).toMatchObject({
         framework: 'nextjs',
-        entrypoint: 'frontend',
+        root: 'frontend',
         routePrefix: '/',
       });
       expect(result.services!.backend).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'backend',
+        root: 'backend',
         routePrefix: '/_/backend',
       });
     });
@@ -149,17 +150,17 @@ describe('autoDetectServices', () => {
 
       expect(result.services!.frontend).toMatchObject({
         framework: 'nextjs',
-        entrypoint: 'frontend',
+        root: 'frontend',
         routePrefix: '/',
       });
       expect(result.services!['service-a']).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'services/service-a',
+        root: 'services/service-a',
         routePrefix: '/_/service-a',
       });
       expect(result.services!['service-b']).toMatchObject({
         framework: 'flask',
-        entrypoint: 'services/service-b',
+        root: 'services/service-b',
         routePrefix: '/_/service-b',
       });
     });
@@ -188,7 +189,7 @@ describe('autoDetectServices', () => {
       expect(result.services!.frontend!.entrypoint).toBeUndefined();
       expect(result.services!.api).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'services/api',
+        root: 'services/api',
         routePrefix: '/_/api',
       });
     });
@@ -257,22 +258,22 @@ describe('autoDetectServices', () => {
 
       expect(result.services!.web).toMatchObject({
         framework: 'nextjs',
-        entrypoint: 'apps/web',
+        root: 'apps/web',
         routePrefix: '/',
       });
       expect(result.services!.auth).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'services/auth',
+        root: 'services/auth',
         routePrefix: '/_/auth',
       });
       expect(result.services!.payments).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'services/payments',
+        root: 'services/payments',
         routePrefix: '/_/payments',
       });
       expect(result.services!.notifications).toMatchObject({
         framework: 'flask',
-        entrypoint: 'services/notifications',
+        root: 'services/notifications',
         routePrefix: '/_/notifications',
       });
     });
@@ -409,12 +410,12 @@ describe('detectServices with auto-detection', () => {
       expect(result.services).not.toBeNull();
       expect(result.services!.frontend).toMatchObject({
         framework: 'sveltekit-1',
-        entrypoint: 'frontend',
+        root: 'frontend',
         routePrefix: '/',
       });
       expect(result.services!.backend).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'backend',
+        root: 'backend',
         routePrefix: '/_/backend',
       });
     });
@@ -444,7 +445,7 @@ describe('detectServices with auto-detection', () => {
       });
       expect(result.services!.backend).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'backend',
+        root: 'backend',
         routePrefix: '/_/backend',
       });
     });
@@ -521,5 +522,90 @@ describe('detectServices with auto-detection', () => {
       expect(backend?.routePrefix).toBe('/_/backend');
       expect(backend?.routePrefixSource).toBe('generated');
     });
+  });
+});
+
+describe('autoDetectServices with detectEntrypoint callback', () => {
+  it('emits root + entrypoint for runtime services and root-only for frontend services', async () => {
+    const fs = new VirtualFilesystem({
+      'frontend/package.json': JSON.stringify({
+        dependencies: { next: '14.0.0' },
+      }),
+      'backend/pyproject.toml': '[project]\ndependencies = ["fastapi"]',
+      'backend/main.py': 'from fastapi import FastAPI\napp = FastAPI()',
+    });
+
+    const detectEntrypoint: DetectEntrypointFn = async ({
+      workPath,
+      framework,
+    }) => {
+      // Mock the per-runtime helper: assert the auto-detect plumbing
+      // forwards both the directory and the framework slug, and respond
+      // with a Python-style module:attr reference.
+      expect(workPath).toBe('backend');
+      expect(framework).toBe('fastapi');
+      return { kind: 'py-module:attr', entrypoint: 'main:app' };
+    };
+
+    const result = await autoDetectServices({ fs, detectEntrypoint });
+
+    expect(result.errors).toEqual([]);
+    expect(result.services).not.toBeNull();
+    expect(result.services!.frontend).toEqual({
+      framework: 'nextjs',
+      root: 'frontend',
+      routePrefix: '/',
+    });
+    expect(result.services!.frontend!.entrypoint).toBeUndefined();
+    expect(result.services!.backend).toEqual({
+      framework: 'fastapi',
+      root: 'backend',
+      entrypoint: 'main:app',
+      routePrefix: '/_/backend',
+    });
+  });
+
+  it('emits root only (no entrypoint) when the callback returns null for a runtime service', async () => {
+    const fs = new VirtualFilesystem({
+      'frontend/package.json': JSON.stringify({
+        dependencies: { next: '14.0.0' },
+      }),
+      'backend/pyproject.toml': '[project]\ndependencies = ["fastapi"]',
+      // No main.py — the callback below returns null, mimicking a
+      // detector that couldn't find a concrete entrypoint. The framework
+      // hook resolves the actual file at build time.
+    });
+
+    const detectEntrypoint: DetectEntrypointFn = async () => null;
+
+    const result = await autoDetectServices({ fs, detectEntrypoint });
+
+    expect(result.errors).toEqual([]);
+    expect(result.services!.backend).toEqual({
+      framework: 'fastapi',
+      root: 'backend',
+      routePrefix: '/_/backend',
+    });
+    expect(result.services!.backend!.entrypoint).toBeUndefined();
+  });
+
+  it('does not invoke the callback for frontend-only services', async () => {
+    const fs = new VirtualFilesystem({
+      'frontend/package.json': JSON.stringify({
+        dependencies: { next: '14.0.0' },
+      }),
+      'backend/pyproject.toml': '[project]\ndependencies = ["fastapi"]',
+      'backend/main.py': 'from fastapi import FastAPI\napp = FastAPI()',
+    });
+
+    const calls: Array<{ workPath: string; framework?: string }> = [];
+    const detectEntrypoint: DetectEntrypointFn = async opts => {
+      calls.push(opts);
+      return { kind: 'py-module:attr', entrypoint: 'main:app' };
+    };
+
+    await autoDetectServices({ fs, detectEntrypoint });
+
+    expect(calls).toEqual([{ workPath: 'backend', framework: 'fastapi' }]);
   });
 });

--- a/packages/fs-detectors/test/unit.detect-railway-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-railway-services.test.ts
@@ -1,5 +1,6 @@
 import { detectServices } from '../src';
 import { detectRailwayServices } from '../src/services/detect-railway';
+import type { DetectEntrypointFn } from '@vercel/build-utils';
 import VirtualFilesystem from './virtual-file-system';
 
 describe('detectRailwayServices', () => {
@@ -93,12 +94,12 @@ describe('detectRailwayServices', () => {
       expect(Object.keys(result.services!)).toHaveLength(2);
       expect(result.services!.web).toMatchObject({
         framework: 'nextjs',
-        entrypoint: 'web',
+        root: 'web',
         routePrefix: '/',
       });
       expect(result.services!.api).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'api',
+        root: 'api',
         routePrefix: '/_/api',
         buildCommand: "echo 'test'",
       });
@@ -130,7 +131,7 @@ describe('detectRailwayServices', () => {
 
       // "web" is preferred to be at /
       expect(result.services!.web).toMatchObject({
-        entrypoint: 'web',
+        root: 'web',
         routePrefix: '/',
       });
       expect(result.services!.dashboard.routePrefix).toBe('/_/dashboard');
@@ -652,5 +653,69 @@ describe('detectServices with Railway detection', () => {
 
     expect(result.source).toBe('configured');
     expect(result.inferred).toBeNull();
+  });
+
+  describe('with detectEntrypoint callback', () => {
+    it('emits root + entrypoint for runtime services', async () => {
+      const fs = new VirtualFilesystem({
+        'railway.json': JSON.stringify({
+          build: { buildCommand: 'npm run build' },
+        }),
+        'package.json': JSON.stringify({
+          dependencies: { next: '14.0.0' },
+        }),
+        'api/railway.json': JSON.stringify({}),
+        'api/pyproject.toml': '[project]\ndependencies = ["fastapi"]',
+        'api/main.py': 'from fastapi import FastAPI\napp = FastAPI()',
+      });
+
+      const detectEntrypoint: DetectEntrypointFn = async ({
+        workPath,
+        framework,
+      }) => {
+        expect(workPath).toBe('api');
+        expect(framework).toBe('fastapi');
+        return { kind: 'py-module:attr', entrypoint: 'main:app' };
+      };
+
+      const result = await detectRailwayServices({ fs, detectEntrypoint });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).not.toBeNull();
+      // root service stays as today (no dirPath, so no root/entrypoint).
+      expect(result.services!.web).toMatchObject({ framework: 'nextjs' });
+      expect(result.services!.web.entrypoint).toBeUndefined();
+      // Subdirectory service gets root + entrypoint instead of directory-as-entrypoint.
+      expect(result.services!.api).toEqual({
+        framework: 'fastapi',
+        root: 'api',
+        entrypoint: 'main:app',
+        routePrefix: '/_/api',
+      });
+    });
+
+    it('omits entrypoint for frontend frameworks even with the callback', async () => {
+      const fs = new VirtualFilesystem({
+        'web/railway.json': JSON.stringify({}),
+        'web/package.json': JSON.stringify({
+          dependencies: { next: '14.0.0' },
+        }),
+      });
+
+      let invoked = false;
+      const detectEntrypoint: DetectEntrypointFn = async () => {
+        invoked = true;
+        return { kind: 'file', entrypoint: 'should-not-be-emitted.ts' };
+      };
+
+      const result = await detectRailwayServices({ fs, detectEntrypoint });
+
+      expect(invoked).toBe(false);
+      expect(result.services!.web).toMatchObject({
+        framework: 'nextjs',
+        root: 'web',
+      });
+      expect(result.services!.web.entrypoint).toBeUndefined();
+    });
   });
 });

--- a/packages/fs-detectors/test/unit.detect-railway-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-railway-services.test.ts
@@ -1,5 +1,6 @@
 import { detectServices } from '../src';
 import { detectRailwayServices } from '../src/services/detect-railway';
+import type { DetectEntrypointFn } from '@vercel/build-utils';
 import VirtualFilesystem from './virtual-file-system';
 
 describe('detectRailwayServices', () => {
@@ -93,12 +94,12 @@ describe('detectRailwayServices', () => {
       expect(Object.keys(result.services!)).toHaveLength(2);
       expect(result.services!.web).toMatchObject({
         framework: 'nextjs',
-        entrypoint: 'web',
+        root: 'web',
         routePrefix: '/',
       });
       expect(result.services!.api).toMatchObject({
         framework: 'fastapi',
-        entrypoint: 'api',
+        root: 'api',
         routePrefix: '/_/api',
         buildCommand: "echo 'test'",
       });
@@ -130,7 +131,7 @@ describe('detectRailwayServices', () => {
 
       // "web" is preferred to be at /
       expect(result.services!.web).toMatchObject({
-        entrypoint: 'web',
+        root: 'web',
         routePrefix: '/',
       });
       expect(result.services!.dashboard.routePrefix).toBe('/_/dashboard');
@@ -635,5 +636,69 @@ describe('detectServices with Railway detection', () => {
 
     expect(result.source).toBe('configured');
     expect(result.inferred).toBeNull();
+  });
+
+  describe('with detectEntrypoint callback', () => {
+    it('emits root + entrypoint for runtime services', async () => {
+      const fs = new VirtualFilesystem({
+        'railway.json': JSON.stringify({
+          build: { buildCommand: 'npm run build' },
+        }),
+        'package.json': JSON.stringify({
+          dependencies: { next: '14.0.0' },
+        }),
+        'api/railway.json': JSON.stringify({}),
+        'api/pyproject.toml': '[project]\ndependencies = ["fastapi"]',
+        'api/main.py': 'from fastapi import FastAPI\napp = FastAPI()',
+      });
+
+      const detectEntrypoint: DetectEntrypointFn = async ({
+        workPath,
+        framework,
+      }) => {
+        expect(workPath).toBe('api');
+        expect(framework).toBe('fastapi');
+        return { kind: 'py-module:attr', entrypoint: 'main:app' };
+      };
+
+      const result = await detectRailwayServices({ fs, detectEntrypoint });
+
+      expect(result.errors).toEqual([]);
+      expect(result.services).not.toBeNull();
+      // root service stays as today (no dirPath, so no root/entrypoint).
+      expect(result.services!.web).toMatchObject({ framework: 'nextjs' });
+      expect(result.services!.web.entrypoint).toBeUndefined();
+      // Subdirectory service gets root + entrypoint instead of directory-as-entrypoint.
+      expect(result.services!.api).toEqual({
+        framework: 'fastapi',
+        root: 'api',
+        entrypoint: 'main:app',
+        routePrefix: '/_/api',
+      });
+    });
+
+    it('omits entrypoint for frontend frameworks even with the callback', async () => {
+      const fs = new VirtualFilesystem({
+        'web/railway.json': JSON.stringify({}),
+        'web/package.json': JSON.stringify({
+          dependencies: { next: '14.0.0' },
+        }),
+      });
+
+      let invoked = false;
+      const detectEntrypoint: DetectEntrypointFn = async () => {
+        invoked = true;
+        return { kind: 'file', entrypoint: 'should-not-be-emitted.ts' };
+      };
+
+      const result = await detectRailwayServices({ fs, detectEntrypoint });
+
+      expect(invoked).toBe(false);
+      expect(result.services!.web).toMatchObject({
+        framework: 'nextjs',
+        root: 'web',
+      });
+      expect(result.services!.web.entrypoint).toBeUndefined();
+    });
   });
 });

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -80,7 +80,7 @@ describe('detectServices', () => {
         config: {
           frontend: { framework: 'nextjs', routePrefix: '/' },
           backend: {
-            entrypoint: 'backend',
+            root: 'backend',
             routePrefix: '/_/backend',
           },
         },

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -75,7 +75,7 @@ describe('detectServices', () => {
         config: {
           frontend: { framework: 'nextjs', routePrefix: '/' },
           backend: {
-            entrypoint: 'backend',
+            root: 'backend',
             routePrefix: '/_/backend',
           },
         },


### PR DESCRIPTION
Breakdown of #16241. Followup to #16300.

Use builders' `DetectEntrypointFn` in services auto-detection so suggested service configs include a concrete `entrypoint` file instead of a directory.

