### PR TITLE
[services] Allow builder V2 to expose startDevServer.

### DIFF
--- a/.changeset/loud-crews-cry.md
+++ b/.changeset/loud-crews-cry.md
@@ -1,0 +1,6 @@
+---
+'@vercel/build-utils': minor
+'vercel': minor
+---
+
+Allow builder V2 to expose startDevServer.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -477,6 +477,7 @@ export interface BuilderV2 {
   diagnostics?: Diagnostics;
   prepareCache?: PrepareCache;
   shouldServe?: ShouldServe;
+  startDevServer?: StartDevServer;
 }
 
 export interface BuilderV3 {

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -23,6 +23,7 @@ import {
   runNpmInstall,
   getServiceUrlEnvVars,
   getExperimentalServiceUrlEnvVars,
+  type BuilderV2,
   type BuilderV3,
   type BuilderVX,
   type Config,
@@ -612,14 +613,16 @@ export class ServicesOrchestrator {
       const builders = await importBuilders(new Set([builderSpec]), this.cwd);
       const builderWithPkg = builders.get(builderSpec);
       const builder = builderWithPkg?.builder as
+        | BuilderV2
         | BuilderV3
         | BuilderVX
         | undefined;
 
-      if (
-        (builder?.version !== 3 && builder?.version !== -1) ||
-        !builder?.startDevServer
-      ) {
+      const versionAccepted =
+        builder?.version === 3 ||
+        builder?.version === -1 ||
+        builder?.version === 2;
+      if (!versionAccepted || !builder?.startDevServer) {
         return null;
       }
 

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -618,11 +618,7 @@ export class ServicesOrchestrator {
         | BuilderVX
         | undefined;
 
-      const versionAccepted =
-        builder?.version === 3 ||
-        builder?.version === -1 ||
-        builder?.version === 2;
-      if (!versionAccepted || !builder?.startDevServer) {
+      if (!builder?.startDevServer) {
         return null;
       }
 


### PR DESCRIPTION
Add optional `startDevServer` to the `BuilderV2` interface and expands the ServicesOrchestrator version check to accept `version === 2`.