### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/cli-evals.yml
+++ b/.github/workflows/cli-evals.yml
@@ -10,6 +10,9 @@ on:
     # Run weekly on Tuesday at 9:00 AM UTC.
     - cron: '0 9 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   evals:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-evals.yml
+++ b/.github/workflows/cli-evals.yml
@@ -7,6 +7,9 @@ on:
     # Run weekly on Tuesday at 9:00 AM UTC.
     - cron: '0 9 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   evals:
     runs-on: ubuntu-latest

--- a/.github/workflows/faster-template-prebuild-nextjs.yml
+++ b/.github/workflows/faster-template-prebuild-nextjs.yml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
     inputs:
 
+permissions:
+  contents: read
+
 jobs:
   clone-build-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-python-packages.yml
+++ b/.github/workflows/test-python-packages.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Discover Python Packages


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `cron-update-gatsby-fixtures.yml`, `cron-update-next-canary.yml`, `cron-update-next-latest.yml`, `cron-update-turbo.yml`, `discussions-auto-close.yml`, `test-lint.yml`, `update-remix-run-dev.yml`, `update-sandbox.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.