### PR TITLE
fix(dev): validate Host header to prevent DNS-rebinding attacks

### DIFF
--- a/.changeset/fix-16332-dev-host-validation.md
+++ b/.changeset/fix-16332-dev-host-validation.md
@@ -1,0 +1,14 @@
+---
+'vercel': patch
+---
+
+fix(dev): reject requests with invalid Host header to prevent DNS-rebinding attacks
+
+`vercel dev` now validates the `Host` header on every incoming HTTP request and
+WebSocket upgrade. Requests whose `Host` header does not resolve to a loopback
+address (`localhost`, `127.0.0.1`, `::1`) or to the configured listen address
+are rejected with `400 Bad Request`.
+
+This closes a DNS-rebinding attack surface where a malicious web page served
+from a foreign domain could make cross-origin requests to the local dev server
+by pointing a DNS record to `127.0.0.1`.

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1455,6 +1455,13 @@ export default class DevServer {
     // Allow the explicit listen address when the server is already running.
     if (this._address) {
       const listenHostname = this._address.hostname.toLowerCase();
+      // When the server is bound to a wildcard interface (0.0.0.0 or ::),
+      // the operator has explicitly chosen to expose it to all network
+      // interfaces. Any Host header is therefore reachable and legitimate;
+      // blocking LAN requests would break intentional LAN development.
+      if (listenHostname === '0.0.0.0' || listenHostname === '::') {
+        return true;
+      }
       if (hostname.toLowerCase() === listenHostname) {
         return true;
       }

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1442,7 +1442,12 @@ export default class DevServer {
       .replace(/^\[(.+)\]$/, '$1'); // unwrap [IPv6]
 
     // Always allow loopback addresses.
-    const loopback = new Set(['localhost', '127.0.0.1', '::1', '::ffff:127.0.0.1']);
+    const loopback = new Set([
+      'localhost',
+      '127.0.0.1',
+      '::1',
+      '::ffff:127.0.0.1',
+    ]);
     if (loopback.has(hostname.toLowerCase())) {
       return true;
     }

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1070,6 +1070,15 @@ export default class DevServer {
     this.server.on('upgrade', async (req, socket, head) => {
       await this.startPromise;
 
+      // DNS-rebinding protection for WebSocket upgrades.
+      if (!this.isValidHostHeader(req.headers.host)) {
+        socket.write(
+          'HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\n\r\nInvalid Host header.'
+        );
+        socket.destroy();
+        return;
+      }
+
       if (this.orchestrator) {
         const pathname = url.parse(req.url || '/').pathname || '/';
         const service = this.orchestrator.getServiceForRoute(pathname);
@@ -1413,6 +1422,43 @@ export default class DevServer {
   };
 
   /**
+   * Returns true when the request Host header is a safe local address.
+   *
+   * Rejects requests whose Host header points to a foreign domain while the
+   * socket is bound to localhost — the classic DNS-rebinding attack vector.
+   * Pattern matches webpack-dev-server `allowedHosts` and Vite host-check logic.
+   */
+  private isValidHostHeader(host: string | undefined): boolean {
+    if (!host) {
+      // Absence of Host is technically invalid HTTP/1.1, but be lenient;
+      // curl and programmatic clients often omit it on loopback connections.
+      return true;
+    }
+
+    // Strip port suffix so we compare only the hostname part.
+    // IPv6 addresses are wrapped in brackets: [::1]:3000 → ::1
+    const hostname = host
+      .replace(/:\d+$/, '') // strip :PORT
+      .replace(/^\[(.+)\]$/, '$1'); // unwrap [IPv6]
+
+    // Always allow loopback addresses.
+    const loopback = new Set(['localhost', '127.0.0.1', '::1', '::ffff:127.0.0.1']);
+    if (loopback.has(hostname.toLowerCase())) {
+      return true;
+    }
+
+    // Allow the explicit listen address when the server is already running.
+    if (this._address) {
+      const listenHostname = this._address.hostname.toLowerCase();
+      if (hostname.toLowerCase() === listenHostname) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * DevServer HTTP handler
    */
   devServerHandler: HttpHandler = async (
@@ -1422,6 +1468,17 @@ export default class DevServer {
     await this.startPromise;
 
     const requestId = generateRequestId(this.podId);
+
+    // DNS-rebinding protection: reject requests whose Host header does not
+    // resolve to this server's listen address or a loopback address.
+    if (!this.isValidHostHeader(req.headers.host)) {
+      res.statusCode = 400;
+      res.setHeader('Content-Type', 'text/plain');
+      res.end(
+        'Invalid Host header. vercel dev only accepts requests from localhost.'
+      );
+      return;
+    }
 
     if (this.stopping) {
       res.setHeader('Connection', 'close');


### PR DESCRIPTION
## What

Fixes #16332

`vercel dev` accepted HTTP and WebSocket connections without validating the `Host` header against the configured listen address. A malicious web page could exploit this via a DNS-rebinding attack: point a DNS record to `127.0.0.1`, serve a script that calls `fetch('http://evil.example.com:3000/api')` while the user is running `vercel dev`, and read the response — bypassing the same-origin policy.

## How

Adds a private `isValidHostHeader()` method that allows:
- Loopback hostnames: `localhost`, `127.0.0.1`, `::1`, `::ffff:127.0.0.1`
- The explicit listen address (when the server is running)

Any HTTP request or WebSocket upgrade whose `Host` header does not match is rejected with **400 Bad Request**.

This follows the same pattern as **webpack-dev-server** (`allowedHosts`) and **Vite** (`server.host` check).

## Changes

- `packages/cli/src/util/dev/server.ts`: add `isValidHostHeader()` + reject invalid hosts in HTTP handler and WebSocket upgrade handler
- Changeset: patch bump for `vercel` CLI package