### PR TITLE
[static-build] Codemod to add Nitro as a Vite plugin for TanStack Start builds 

### DIFF
--- a/.changeset/tall-apples-start.md
+++ b/.changeset/tall-apples-start.md
@@ -1,0 +1,5 @@
+---
+'@vercel/static-build': patch
+---
+
+Add Nitro dependency and Vite plugin injection for TanStack Start builds.

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -15,11 +15,11 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "test": "vitest run --config ../../vitest.config.mts",
-    "test-unit": "pnpm test test/build.test.ts test/hugo.test.ts test/gatsby.test.ts test/prepare-cache.test.ts",
+    "test-unit": "pnpm test test/build.test.ts test/hugo.test.ts test/gatsby.test.ts test/prepare-cache.test.ts test/tanstack-start.test.ts",
     "test-e2e": "pnpm test test/integration-*.test.js",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/build.test.ts' 'test/hugo.test.ts' 'test/gatsby.test.ts' 'test/prepare-cache.test.ts'",
+    "vitest-unit": "glob --absolute 'test/build.test.ts' 'test/hugo.test.ts' 'test/gatsby.test.ts' 'test/prepare-cache.test.ts' 'test/tanstack-start.test.ts'",
     "vitest-e2e": "glob --absolute 'test/integration-*.test.js'"
   },
   "dependencies": {

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -44,6 +44,7 @@ import * as BuildOutputV2 from './utils/build-output-v2';
 import * as BuildOutputV3 from './utils/build-output-v3';
 import * as GatsbyUtils from './utils/gatsby';
 import * as NuxtUtils from './utils/nuxt';
+import * as TanStackStartUtils from './utils/tanstack-start';
 import type { ImagesConfig, BuildConfig } from './utils/_shared';
 import treeKill from 'tree-kill';
 import {
@@ -374,13 +375,13 @@ export const build: BuildV2 = async ({
   const devScript = pkg ? getScriptName(pkg, 'dev', config) : null;
   const framework = getFramework(config, pkg);
   const localFileSystemDetector = new LocalFileSystemDetector(workPath);
-  const { detectedVersion = null } =
-    (await detectFrameworkRecord({
-      fs: localFileSystemDetector,
-      frameworkList: frameworks,
-    })) ?? {};
+  const detectedFrameworkRecord = await detectFrameworkRecord({
+    fs: localFileSystemDetector,
+    frameworkList: frameworks,
+  });
+  const { detectedVersion = null } = detectedFrameworkRecord ?? {};
   const devCommand = getCommand('dev', pkg, config, framework);
-  const buildCommand = getCommand('build', pkg, config, framework);
+  let buildCommand = getCommand('build', pkg, config, framework);
   const installCommand = getCommand('install', pkg, config, framework);
 
   if (pkg || buildCommand) {
@@ -483,6 +484,19 @@ export const build: BuildV2 = async ({
             break;
         }
       }
+    }
+
+    if (
+      !meta.isDev &&
+      (framework?.slug === 'tanstack-start' ||
+        detectedFrameworkRecord?.slug === 'tanstack-start')
+    ) {
+      buildCommand = await TanStackStartUtils.prepareTanStackStartBuildCommand({
+        buildCommand,
+        dir: entrypointDir,
+        meta,
+        packageBuildScript: pkg?.scripts?.build,
+      });
     }
 
     const nodeVersion = await getNodeVersion(

--- a/packages/static-build/src/utils/tanstack-start.ts
+++ b/packages/static-build/src/utils/tanstack-start.ts
@@ -1,0 +1,262 @@
+import path from 'path';
+import { constants, promises as fs } from 'fs';
+import {
+  Node,
+  Project,
+  SyntaxKind,
+  type ArrayLiteralExpression,
+  type ObjectLiteralExpression,
+  type SourceFile,
+} from 'ts-morph';
+import { runNpmInstall, type Meta } from '@vercel/build-utils';
+
+const NITRO_PACKAGE = 'nitro';
+const NITRO_VITE_IMPORT = 'nitro/vite';
+const VITE_CONFIG_FILES = [
+  'vite.config.ts',
+  'vite.config.mts',
+  'vite.config.cts',
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.cjs',
+];
+
+async function fileExists(filePath: string): Promise<boolean> {
+  return fs.access(filePath, constants.F_OK).then(
+    () => true,
+    () => false
+  );
+}
+
+async function findViteConfigPath(dir: string): Promise<string | undefined> {
+  for (const file of VITE_CONFIG_FILES) {
+    const configPath = path.join(dir, file);
+    if (await fileExists(configPath)) {
+      return configPath;
+    }
+  }
+
+  return undefined;
+}
+
+function toImportPath(fromDir: string, toFile: string) {
+  let importPath = path.relative(fromDir, toFile).split(path.sep).join('/');
+
+  if (!importPath.startsWith('.')) {
+    importPath = `./${importPath}`;
+  }
+
+  return importPath;
+}
+
+function quoteShellArg(value: string) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function isSimpleViteBuildCommand(command: string) {
+  return /^\s*vite\s+build(?:\s|$)/.test(command) && !/[;&|]/.test(command);
+}
+
+function getObjectLiteralFromInitializer(
+  node: Node
+): ObjectLiteralExpression | undefined {
+  if (Node.isObjectLiteralExpression(node)) {
+    return node;
+  }
+
+  if (Node.isCallExpression(node)) {
+    const [firstArg] = node.getArguments();
+    if (firstArg && Node.isObjectLiteralExpression(firstArg)) {
+      return firstArg;
+    }
+  }
+
+  return undefined;
+}
+
+function getExportedConfigObject(
+  sourceFile: SourceFile
+): ObjectLiteralExpression | undefined {
+  const exportAssignment = sourceFile
+    .getExportAssignments()
+    .find(assignment => !assignment.isExportEquals());
+
+  if (!exportAssignment) {
+    return;
+  }
+
+  const expression = exportAssignment.getExpression();
+  const objectLiteral = getObjectLiteralFromInitializer(expression);
+  if (objectLiteral) {
+    return objectLiteral;
+  }
+
+  if (!Node.isIdentifier(expression)) {
+    return;
+  }
+
+  const declaration = sourceFile.getVariableDeclaration(expression.getText());
+  const initializer = declaration?.getInitializer();
+  return initializer ? getObjectLiteralFromInitializer(initializer) : undefined;
+}
+
+function findViteConfigObject(
+  sourceFile: SourceFile
+): ObjectLiteralExpression | undefined {
+  for (const callExpression of sourceFile.getDescendantsOfKind(
+    SyntaxKind.CallExpression
+  )) {
+    if (callExpression.getExpression().getText() !== 'defineConfig') {
+      continue;
+    }
+
+    const [firstArg] = callExpression.getArguments();
+    if (firstArg && Node.isObjectLiteralExpression(firstArg)) {
+      return firstArg;
+    }
+  }
+
+  return getExportedConfigObject(sourceFile);
+}
+
+function hasNitroPlugin(plugins: ArrayLiteralExpression) {
+  return plugins
+    .getElements()
+    .some(element => /\bnitro\s*\(/.test(element.getText()));
+}
+
+function configAlreadyUsesNitro(configPath: string) {
+  const project = new Project();
+  const sourceFile = project.addSourceFileAtPath(configPath);
+
+  if (
+    sourceFile
+      .getImportDeclarations()
+      .some(
+        declaration =>
+          declaration.getModuleSpecifierValue() === NITRO_VITE_IMPORT
+      )
+  ) {
+    const configObject = findViteConfigObject(sourceFile);
+    const pluginsProperty = configObject?.getProperty('plugins');
+    if (pluginsProperty && Node.isPropertyAssignment(pluginsProperty)) {
+      const initializer = pluginsProperty.getInitializer();
+      return Boolean(
+        initializer &&
+          Node.isArrayLiteralExpression(initializer) &&
+          hasNitroPlugin(initializer)
+      );
+    }
+  }
+
+  return false;
+}
+
+function canResolveNitro(projectDir: string) {
+  try {
+    require.resolve(NITRO_VITE_IMPORT, {
+      paths: [projectDir],
+    });
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+async function ensureHelperNitroDependency(helperDir: string, meta: Meta) {
+  await fs.mkdir(helperDir, { recursive: true });
+
+  const packageJsonPath = path.join(helperDir, 'package.json');
+  if (!(await fileExists(packageJsonPath))) {
+    await fs.writeFile(
+      packageJsonPath,
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: {
+            [NITRO_PACKAGE]: 'latest',
+          },
+        },
+        null,
+        2
+      )}\n`
+    );
+  }
+
+  console.log(
+    `Installing "${NITRO_PACKAGE}" for TanStack Start build configuration`
+  );
+  await runNpmInstall(helperDir, [], { env: process.env }, meta);
+}
+
+async function writeWrapperConfig({
+  helperDir,
+  userConfigPath,
+}: {
+  helperDir: string;
+  userConfigPath: string;
+}) {
+  await fs.mkdir(helperDir, { recursive: true });
+
+  const wrapperConfigPath = path.join(helperDir, 'vite.config.mjs');
+  const userConfigImportPath = toImportPath(helperDir, userConfigPath);
+  const contents = `import { mergeConfig } from 'vite';
+import { nitro } from 'nitro/vite';
+import userConfig from '${userConfigImportPath}';
+
+export default async function tanStackStartVercelConfig(configEnv) {
+  const resolvedUserConfig =
+    typeof userConfig === 'function' ? await userConfig(configEnv) : await userConfig;
+
+  return mergeConfig(resolvedUserConfig, {
+    plugins: [nitro()],
+  });
+}
+`;
+
+  await fs.writeFile(wrapperConfigPath, contents);
+  return wrapperConfigPath;
+}
+
+export async function prepareTanStackStartBuildCommand({
+  buildCommand,
+  dir,
+  meta,
+  packageBuildScript,
+}: {
+  buildCommand: string | null;
+  dir: string;
+  meta: Meta;
+  packageBuildScript?: string;
+}) {
+  const userConfigPath = await findViteConfigPath(dir);
+  if (!userConfigPath || configAlreadyUsesNitro(userConfigPath)) {
+    return buildCommand;
+  }
+
+  const helperDir = path.join(dir, '.vercel', 'tanstack-start');
+  const wrapperConfigPath = await writeWrapperConfig({
+    helperDir,
+    userConfigPath,
+  });
+
+  if (!canResolveNitro(dir)) {
+    await ensureHelperNitroDependency(helperDir, meta);
+  }
+
+  const relativeWrapperConfigPath = toImportPath(dir, wrapperConfigPath);
+  const baseBuildCommand =
+    buildCommand ||
+    (packageBuildScript && isSimpleViteBuildCommand(packageBuildScript)
+      ? packageBuildScript
+      : 'vite build');
+  const command = `${baseBuildCommand} --config ${quoteShellArg(
+    relativeWrapperConfigPath
+  )}`;
+
+  console.log(
+    `Using generated TanStack Start Vite config \`${wrapperConfigPath}\``
+  );
+
+  return command;
+}

--- a/packages/static-build/test/tanstack-start.test.ts
+++ b/packages/static-build/test/tanstack-start.test.ts
@@ -1,0 +1,176 @@
+import os from 'os';
+import path from 'path';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+
+const mocks = vi.hoisted(() => ({
+  runNpmInstall: vi.fn(async () => true),
+}));
+
+vi.mock('@vercel/build-utils', () => ({
+  runNpmInstall: mocks.runNpmInstall,
+}));
+
+import { prepareTanStackStartBuildCommand } from '../src/utils/tanstack-start';
+
+async function createFixture(files: Record<string, string>) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'tanstack-start-'));
+
+  for (const [file, contents] of Object.entries(files)) {
+    const filePath = path.join(dir, file);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, contents);
+  }
+
+  return dir;
+}
+
+describe('prepareTanStackStartBuildCommand()', () => {
+  beforeEach(() => {
+    mocks.runNpmInstall.mockClear();
+  });
+
+  test('generates a wrapper Vite config and leaves user files unchanged', async () => {
+    const packageJson = JSON.stringify({
+      dependencies: {
+        '@tanstack/react-start': 'latest',
+      },
+    });
+    const viteConfig = [
+      "import { defineConfig } from 'vite';",
+      "import { tanstackStart } from '@tanstack/react-start/plugin/vite';",
+      "import viteReact from '@vitejs/plugin-react';",
+      '',
+      'export default defineConfig({',
+      '  plugins: [tanstackStart(), viteReact()],',
+      '});',
+      '',
+    ].join('\n');
+    const dir = await createFixture({
+      'package.json': packageJson,
+      'vite.config.ts': viteConfig,
+    });
+
+    try {
+      const buildCommand = await prepareTanStackStartBuildCommand({
+        buildCommand: null,
+        dir,
+        meta: {},
+      });
+
+      expect(buildCommand).toBe(
+        "vite build --config '.vercel/tanstack-start/vite.config.mjs'"
+      );
+      expect(await readFile(path.join(dir, 'package.json'), 'utf8')).toBe(
+        packageJson
+      );
+      expect(await readFile(path.join(dir, 'vite.config.ts'), 'utf8')).toBe(
+        viteConfig
+      );
+
+      const wrapperConfig = await readFile(
+        path.join(dir, '.vercel/tanstack-start/vite.config.mjs'),
+        'utf8'
+      );
+      expect(wrapperConfig).toContain("import { nitro } from 'nitro/vite';");
+      expect(wrapperConfig).toContain(
+        "import userConfig from '../../vite.config.ts';"
+      );
+      expect(wrapperConfig).toContain('plugins: [nitro()]');
+
+      const helperPackageJson = await readFile(
+        path.join(dir, '.vercel/tanstack-start/package.json'),
+        'utf8'
+      );
+      expect(JSON.parse(helperPackageJson).dependencies.nitro).toBe('latest');
+      expect(mocks.runNpmInstall).toHaveBeenCalledWith(
+        path.join(dir, '.vercel/tanstack-start'),
+        [],
+        { env: process.env },
+        {}
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('preserves an explicit Vite build command', async () => {
+    const dir = await createFixture({
+      'package.json': JSON.stringify({}),
+      'vite.config.ts': 'export default { plugins: [] };\n',
+      'node_modules/nitro/vite/index.js': 'export function nitro() {}\n',
+    });
+
+    try {
+      const buildCommand = await prepareTanStackStartBuildCommand({
+        buildCommand: 'vite build --mode production',
+        dir,
+        meta: {},
+      });
+
+      expect(buildCommand).toBe(
+        "vite build --mode production --config '.vercel/tanstack-start/vite.config.mjs'"
+      );
+      expect(mocks.runNpmInstall).not.toHaveBeenCalled();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('preserves a simple package build script', async () => {
+    const dir = await createFixture({
+      'package.json': JSON.stringify({}),
+      'vite.config.ts': 'export default { plugins: [] };\n',
+      'node_modules/nitro/vite/index.js': 'export function nitro() {}\n',
+    });
+
+    try {
+      const buildCommand = await prepareTanStackStartBuildCommand({
+        buildCommand: null,
+        dir,
+        meta: {},
+        packageBuildScript: 'vite build --mode production',
+      });
+
+      expect(buildCommand).toBe(
+        "vite build --mode production --config '.vercel/tanstack-start/vite.config.mjs'"
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('does not generate a wrapper when the user config already uses nitro', async () => {
+    const dir = await createFixture({
+      'package.json': JSON.stringify({
+        dependencies: {
+          nitro: '3.0.1-alpha.0',
+        },
+      }),
+      'vite.config.ts': [
+        "import { defineConfig } from 'vite';",
+        "import { nitro } from 'nitro/vite';",
+        '',
+        'export default defineConfig({',
+        '  plugins: [nitro()],',
+        '});',
+        '',
+      ].join('\n'),
+    });
+
+    try {
+      const buildCommand = await prepareTanStackStartBuildCommand({
+        buildCommand: null,
+        dir,
+        meta: {},
+      });
+
+      expect(buildCommand).toBeNull();
+      await expect(
+        readFile(path.join(dir, '.vercel/tanstack-start/vite.config.mjs'))
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(mocks.runNpmInstall).not.toHaveBeenCalled();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Detects TanStack Start projects during build and wraps the user's Vite config with one that adds the `nitro()` plugin, so builds work on Vercel without requiring the user to configure nitro themselves.
- Installs `nitro` into a helper `.vercel/tanstack-start` directory when it cannot be resolved from the project, and rewrites the build command to point at the generated wrapper config.
- Skips wrapping when the user's Vite config already imports `nitro/vite` and registers the plugin.

## Test plan
- [ ] `pnpm test test/tanstack-start.test.ts` in `packages/static-build`
- [ ] Verify a TanStack Start app builds end-to-end on Vercel without manual nitro setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)