### PR TITLE
[CLI] Adding telemetry matching with active plugin sessions

### DIFF
--- a/.changeset/fresh-plugin-markers.md
+++ b/.changeset/fresh-plugin-markers.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Track Vercel plugin active-session markers in CLI telemetry.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -69,6 +69,7 @@ import { Agent as HttpsAgent } from 'https';
 import box from './util/output/box';
 import { TelemetryEventStore } from './util/telemetry';
 import { RootTelemetryClient } from './util/telemetry/root';
+import { readVercelPluginActiveSessionMarker } from './util/telemetry/vercel-plugin';
 import { help } from './args';
 import { checkTelemetryStatus } from './util/telemetry/check-status';
 import output from './output-manager';
@@ -365,6 +366,11 @@ const main = async () => {
   const { isAgent, agent: detectedAgent } = await determineAgent();
   telemetry.trackInvocationId(telemetryEventStore.currentInvocationId);
   telemetry.trackDeviceId(telemetryEventStore.currentDeviceId);
+  const vercelPluginMarker = readVercelPluginActiveSessionMarker();
+  if (vercelPluginMarker) {
+    telemetry.trackVercelPluginActiveSession();
+    telemetry.trackVercelPluginVersion(vercelPluginMarker.pluginVersion);
+  }
   telemetry.trackAgenticUse(detectedAgent?.name);
   telemetry.trackCPUs();
   telemetry.trackPlatform();

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -234,6 +234,22 @@ export class TelemetryClient {
     }
   }
 
+  protected trackVercelPluginActiveSession() {
+    this.track({
+      key: 'vercel_plugin_active_session',
+      value: 'TRUE',
+    });
+  }
+
+  protected trackVercelPluginVersion(version: string | undefined) {
+    if (version) {
+      this.track({
+        key: 'vercel_plugin_version',
+        value: version,
+      });
+    }
+  }
+
   protected trackErrorStatus(status: number | string | undefined) {
     if (typeof status !== 'undefined') {
       this.track({

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -486,6 +486,14 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackDeviceId(deviceId);
   }
 
+  trackVercelPluginActiveSession() {
+    super.trackVercelPluginActiveSession();
+  }
+
+  trackVercelPluginVersion(version: string | undefined) {
+    super.trackVercelPluginVersion(version);
+  }
+
   trackErrorStatus(status: number | string | undefined) {
     super.trackErrorStatus(status);
   }

--- a/packages/cli/src/util/telemetry/vercel-plugin.ts
+++ b/packages/cli/src/util/telemetry/vercel-plugin.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const ACTIVE_SESSION_MARKER_PATH = join(
+  homedir(),
+  '.config',
+  'vercel-plugin',
+  'active-session.json'
+);
+const SEMVERISH_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+export interface VercelPluginActiveSessionMarker {
+  pluginVersion: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function readVercelPluginActiveSessionMarker(
+  opts: { filePath?: string; now?: () => number } = {}
+): VercelPluginActiveSessionMarker | null {
+  const filePath = opts.filePath ?? ACTIVE_SESSION_MARKER_PATH;
+  const now = opts.now?.() ?? Date.now();
+
+  try {
+    const marker = JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
+
+    if (!isRecord(marker)) {
+      return null;
+    }
+
+    if (marker.schema !== 1 || marker.active !== true) {
+      return null;
+    }
+
+    if (typeof marker.expiresAt !== 'number' || marker.expiresAt <= now) {
+      return null;
+    }
+
+    if (
+      typeof marker.pluginVersion !== 'string' ||
+      !SEMVERISH_RE.test(marker.pluginVersion)
+    ) {
+      return null;
+    }
+
+    return {
+      pluginVersion: marker.pluginVersion,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/test/unit/telemetry/vercel-plugin.test.ts
+++ b/packages/cli/test/unit/telemetry/vercel-plugin.test.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+import { readVercelPluginActiveSessionMarker } from '../../../src/util/telemetry/vercel-plugin';
+
+describe('vercel plugin active-session marker', () => {
+  let markerFilePath: string;
+
+  beforeEach(() => {
+    markerFilePath = join(
+      tmpdir(),
+      `vercel-plugin-active-session-${randomUUID()}.json`
+    );
+    rmSync(markerFilePath, { force: true });
+  });
+
+  function writeMarker(marker: unknown) {
+    mkdirSync(dirname(markerFilePath), { recursive: true });
+    writeFileSync(markerFilePath, JSON.stringify(marker));
+  }
+
+  it('reads a fresh marker', () => {
+    writeMarker({
+      schema: 1,
+      active: true,
+      pluginVersion: '0.42.1',
+      updatedAt: 1000,
+      expiresAt: 2000,
+    });
+
+    expect(
+      readVercelPluginActiveSessionMarker({
+        filePath: markerFilePath,
+        now: () => 1500,
+      })
+    ).toEqual({ pluginVersion: '0.42.1' });
+  });
+
+  it('ignores a missing, expired, or malformed marker', () => {
+    expect(
+      readVercelPluginActiveSessionMarker({ filePath: markerFilePath })
+    ).toBeNull();
+
+    writeMarker({
+      schema: 1,
+      active: true,
+      pluginVersion: '0.42.1',
+      updatedAt: 1000,
+      expiresAt: 1500,
+    });
+    expect(
+      readVercelPluginActiveSessionMarker({
+        filePath: markerFilePath,
+        now: () => 1500,
+      })
+    ).toBeNull();
+
+    writeMarker({ schema: 1, active: true, pluginVersion: '../secret' });
+    expect(
+      readVercelPluginActiveSessionMarker({
+        filePath: markerFilePath,
+        now: () => 1000,
+      })
+    ).toBeNull();
+  });
+
+  it('tracks the marker as root telemetry', () => {
+    const telemetryEventStore = new TelemetryEventStore({
+      isDebug: true,
+      config: { enabled: true },
+    });
+    const telemetry = new RootTelemetryClient({
+      opts: { store: telemetryEventStore },
+    });
+
+    telemetry.trackVercelPluginActiveSession();
+    telemetry.trackVercelPluginVersion('0.42.1');
+
+    expect(telemetryEventStore.readonlyEvents).toMatchObject([
+      {
+        key: 'vercel_plugin_active_session',
+        value: 'TRUE',
+      },
+      {
+        key: 'vercel_plugin_version',
+        value: '0.42.1',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
• ## Summary

  Adds CLI telemetry support for detecting recent Vercel Plugin active sessions.

  ## Changes

  - Reads ~/.config/vercel-plugin/active-session.json during CLI startup
  - Defensively validates marker schema, expiry, and plugin version
  - Emits plugin cohort telemetry only when a fresh marker is present
  - Adds focused unit coverage and a changeset

  ## Tests

  - pnpm test test/unit/telemetry/vercel-plugin.test.ts