### PR TITLE
[CLI] adding auto updating feature

### DIFF
--- a/.changeset/quiet-clouds-upgrade.md
+++ b/.changeset/quiet-clouds-upgrade.md
@@ -1,0 +1,6 @@
+---
+'@vercel/cli-config': patch
+'vercel': patch
+---
+
+Add opt-in automatic CLI updates via `vercel upgrade --enable-auto` and prompt users to enable them after a successful manual upgrade.

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -12,12 +12,14 @@ import {
   globalConfigSchema as generatedGlobalConfigSchema,
   guidanceConfigSchema as generatedGuidanceConfigSchema,
   telemetryConfigSchema as generatedTelemetryConfigSchema,
+  updatesConfigSchema as generatedUpdatesConfigSchema,
 } from './schema.zod';
 import type {
   AuthConfig,
   GlobalConfig,
   GuidanceConfig,
   TelemetryConfig,
+  UpdatesConfig,
 } from './types';
 
 export const telemetryConfigSchema =
@@ -26,10 +28,14 @@ export const telemetryConfigSchema =
 export const guidanceConfigSchema =
   generatedGuidanceConfigSchema.passthrough() as z.ZodType<GuidanceConfig>;
 
+export const updatesConfigSchema =
+  generatedUpdatesConfigSchema.passthrough() as z.ZodType<UpdatesConfig>;
+
 export const globalConfigSchema = generatedGlobalConfigSchema
   .extend({
     telemetry: telemetryConfigSchema.optional(),
     guidance: guidanceConfigSchema.optional(),
+    updates: updatesConfigSchema.optional(),
   })
   .passthrough() as z.ZodType<GlobalConfig>;
 

--- a/packages/cli-config/src/schema.zod.ts
+++ b/packages/cli-config/src/schema.zod.ts
@@ -9,6 +9,10 @@ export const guidanceConfigSchema = z.object({
   enabled: z.boolean().optional(),
 });
 
+export const updatesConfigSchema = z.object({
+  auto: z.boolean().optional(),
+});
+
 export const authConfigSchema = z.object({
   '// Note': z.string().optional(),
   '// Docs': z.string().optional(),
@@ -27,4 +31,5 @@ export const globalConfigSchema = z.object({
   api: z.string().optional(),
   telemetry: telemetryConfigSchema.optional(),
   guidance: guidanceConfigSchema.optional(),
+  updates: updatesConfigSchema.optional(),
 });

--- a/packages/cli-config/src/types.ts
+++ b/packages/cli-config/src/types.ts
@@ -13,6 +13,10 @@ export interface GuidanceConfig {
   enabled?: boolean;
 }
 
+export interface UpdatesConfig {
+  auto?: boolean;
+}
+
 export interface AuthConfig {
   '// Note'?: string;
   '// Docs'?: string;
@@ -31,4 +35,5 @@ export interface GlobalConfig {
   api?: string;
   telemetry?: TelemetryConfig;
   guidance?: GuidanceConfig;
+  updates?: UpdatesConfig;
 }

--- a/packages/cli-config/test/cli-config.test.ts
+++ b/packages/cli-config/test/cli-config.test.ts
@@ -23,6 +23,9 @@ describe('cli-config schema', () => {
         enabled: true,
         sampleRate: 1,
       },
+      updates: {
+        auto: true,
+      },
       authTokenStorage: {
         nested: 'data',
       },
@@ -34,6 +37,9 @@ describe('cli-config schema', () => {
       telemetry: {
         enabled: true,
         sampleRate: 1,
+      },
+      updates: {
+        auto: true,
       },
       authTokenStorage: {
         nested: 'data',

--- a/packages/cli/src/commands/upgrade/command.ts
+++ b/packages/cli/src/commands/upgrade/command.ts
@@ -15,6 +15,20 @@ export const upgradeCommand = {
       description: 'Show the upgrade command without executing it',
     },
     {
+      name: 'enable-auto',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Enable automatic CLI updates for future releases',
+    },
+    {
+      name: 'disable-auto',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Disable automatic CLI updates',
+    },
+    {
       ...formatOption,
       description: 'Specify the output format (json) - implies --dry-run',
     },
@@ -28,6 +42,10 @@ export const upgradeCommand = {
     {
       name: 'Show the upgrade command without running it',
       value: `${packageName} upgrade --dry-run`,
+    },
+    {
+      name: 'Enable automatic CLI updates',
+      value: `${packageName} upgrade --enable-auto`,
     },
     {
       name: 'Get upgrade information as JSON',

--- a/packages/cli/src/commands/upgrade/index.ts
+++ b/packages/cli/src/commands/upgrade/index.ts
@@ -10,6 +10,7 @@ import output from '../../output-manager';
 import pkg from '../../util/pkg';
 import type Client from '../../util/client';
 import { UpgradeTelemetryClient } from '../../util/telemetry/commands/upgrade';
+import { isAutoUpdateEnabled, setAutoUpdate } from '../../util/updates';
 
 export default async function upgrade(client: Client): Promise<number> {
   let parsedArgs = null;
@@ -37,6 +38,8 @@ export default async function upgrade(client: Client): Promise<number> {
   }
 
   const dryRun = parsedArgs.flags['--dry-run'];
+  const enableAuto = parsedArgs.flags['--enable-auto'];
+  const disableAuto = parsedArgs.flags['--disable-auto'];
   const formatResult = validateJsonOutput(parsedArgs.flags);
   if (!formatResult.valid) {
     output.error(formatResult.error);
@@ -45,8 +48,24 @@ export default async function upgrade(client: Client): Promise<number> {
   const asJson = formatResult.jsonOutput;
 
   telemetry.trackCliFlagDryRun(dryRun);
+  telemetry.trackCliFlagEnableAuto(enableAuto);
+  telemetry.trackCliFlagDisableAuto(disableAuto);
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
   telemetry.trackCliFlagJson(parsedArgs.flags['--json']);
+
+  if (enableAuto && disableAuto) {
+    output.error('Cannot use --enable-auto and --disable-auto together');
+    return 1;
+  }
+
+  if (enableAuto || disableAuto) {
+    const enabled = Boolean(enableAuto);
+    setAutoUpdate(client, enabled);
+    output.success(
+      `Automatic CLI updates ${enabled ? 'enabled' : 'disabled'}.`
+    );
+    return 0;
+  }
 
   // --json implies --dry-run behavior
   if (dryRun || asJson) {
@@ -58,12 +77,16 @@ export default async function upgrade(client: Client): Promise<number> {
         currentVersion: pkg.version,
         installationType: global ? 'global' : 'local',
         upgradeCommand: updateCommand,
+        autoUpdatesEnabled: isAutoUpdateEnabled(client.config),
       };
       client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
     } else {
       output.print(`Current version: ${pkg.version}\n`);
       output.print(`Installation type: ${global ? 'global' : 'local'}\n`);
       output.print(`Upgrade command: ${updateCommand}\n`);
+      output.print(
+        `Automatic updates: ${isAutoUpdateEnabled(client.config) ? 'Enabled' : 'Disabled'}\n`
+      );
     }
     return 0;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -116,6 +116,7 @@ function hasProxyConfig(): boolean {
 epipebomb();
 
 let client: Client;
+let resolvedCommandForUpdate: string | undefined;
 
 // Register global error handlers early to catch errors during initialization.
 // Sentry is lazily initialized only when an error actually occurs.
@@ -1183,6 +1184,7 @@ const main = async () => {
         earlyGetUserPromise = getUser(client).catch(() => undefined);
       }
 
+      resolvedCommandForUpdate = targetCommand;
       exitCode = await rootSpan
         .child('vc.cli.command', { command: subcommand || 'deploy' })
         .trace(() => func(client));
@@ -1289,7 +1291,13 @@ main()
         const changelog = `https://github.com/vercel/vercel/releases/tag/vercel%40${latest}`;
         const originalExitCode = typeof exitCode === 'number' ? exitCode : 0;
 
-        if (await canAutoUpdate(client, originalExitCode)) {
+        if (
+          await canAutoUpdate(
+            client,
+            originalExitCode,
+            resolvedCommandForUpdate
+          )
+        ) {
           const upgradeExitCode = await executeUpgrade();
           process.exitCode = originalExitCode;
           if (upgradeExitCode !== 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -61,6 +61,11 @@ import * as ERRORS from './util/errors-ts';
 import { APIError } from './util/errors-ts';
 import getUpdateCommand from './util/get-update-command';
 import { executeUpgrade } from './util/upgrade';
+import {
+  canAutoUpdate,
+  hasAutoUpdatePreference,
+  setAutoUpdate,
+} from './util/updates';
 import { getCommandName, getTitleName } from './util/pkg-name';
 import login from './commands/login';
 import type { AuthConfig, GlobalConfig, User } from '@vercel-internals/types';
@@ -1282,6 +1287,18 @@ main()
       });
       if (latest) {
         const changelog = `https://github.com/vercel/vercel/releases/tag/vercel%40${latest}`;
+        const originalExitCode = typeof exitCode === 'number' ? exitCode : 0;
+
+        if (await canAutoUpdate(client, originalExitCode)) {
+          const upgradeExitCode = await executeUpgrade();
+          process.exitCode = originalExitCode;
+          if (upgradeExitCode !== 0) {
+            output.log(
+              `Automatic update failed. Continuing with original exit code ${originalExitCode}.`
+            );
+          }
+          return;
+        }
 
         if (isTTY) {
           // Interactive mode: prompt user to update now
@@ -1311,6 +1328,16 @@ main()
 
             if (shouldUpgrade) {
               const upgradeExitCode = await executeUpgrade();
+              if (
+                upgradeExitCode === 0 &&
+                !hasAutoUpdatePreference(client.config)
+              ) {
+                const enableAutoUpdates = await client.input.confirm(
+                  'Enable automatic CLI updates for future releases?',
+                  false
+                );
+                setAutoUpdate(client, enableAutoUpdates);
+              }
               process.exitCode = upgradeExitCode;
               return;
             }

--- a/packages/cli/src/util/telemetry/commands/upgrade/index.ts
+++ b/packages/cli/src/util/telemetry/commands/upgrade/index.ts
@@ -12,4 +12,16 @@ export class UpgradeTelemetryClient extends TelemetryClient {
       this.trackCliFlag('json');
     }
   }
+
+  trackCliFlagEnableAuto(enableAuto: boolean | undefined) {
+    if (enableAuto) {
+      this.trackCliFlag('enable-auto');
+    }
+  }
+
+  trackCliFlagDisableAuto(disableAuto: boolean | undefined) {
+    if (disableAuto) {
+      this.trackCliFlag('disable-auto');
+    }
+  }
 }

--- a/packages/cli/src/util/updates.ts
+++ b/packages/cli/src/util/updates.ts
@@ -1,0 +1,49 @@
+import ciInfo from 'ci-info';
+import type { GlobalConfig } from '@vercel-internals/types';
+import type Client from './client';
+import { writeToConfigFile } from './config/files';
+import { isGlobal } from './get-update-command';
+
+export function isAutoUpdateEnabled(config: GlobalConfig): boolean {
+  return config.updates?.auto === true;
+}
+
+export function hasAutoUpdatePreference(config: GlobalConfig): boolean {
+  return typeof config.updates?.auto === 'boolean';
+}
+
+export function setAutoUpdate(client: Client, enabled: boolean): void {
+  client.config = {
+    ...client.config,
+    updates: {
+      ...client.config.updates,
+      auto: enabled,
+    },
+  };
+
+  writeToConfigFile(client.config);
+}
+
+export async function canAutoUpdate(client: Client, exitCode: number) {
+  if (!isAutoUpdateEnabled(client.config)) {
+    return false;
+  }
+
+  if (exitCode !== 0) {
+    return false;
+  }
+
+  if (ciInfo.isCI) {
+    return false;
+  }
+
+  if (client.nonInteractive || client.isAgent) {
+    return false;
+  }
+
+  if (process.argv[2] === 'upgrade') {
+    return false;
+  }
+
+  return isGlobal();
+}

--- a/packages/cli/src/util/updates.ts
+++ b/packages/cli/src/util/updates.ts
@@ -24,7 +24,11 @@ export function setAutoUpdate(client: Client, enabled: boolean): void {
   writeToConfigFile(client.config);
 }
 
-export async function canAutoUpdate(client: Client, exitCode: number) {
+export async function canAutoUpdate(
+  client: Client,
+  exitCode: number,
+  command?: string
+) {
   if (!isAutoUpdateEnabled(client.config)) {
     return false;
   }
@@ -41,7 +45,7 @@ export async function canAutoUpdate(client: Client, exitCode: number) {
     return false;
   }
 
-  if (process.argv[2] === 'upgrade') {
+  if (command === 'upgrade') {
     return false;
   }
 

--- a/packages/cli/test/unit/commands/upgrade/index.test.ts
+++ b/packages/cli/test/unit/commands/upgrade/index.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import upgrade from '../../../../src/commands/upgrade';
+import * as configFilesUtil from '../../../../src/util/config/files';
+
+const writeConfigSpy = vi.spyOn(configFilesUtil, 'writeToConfigFile');
 
 describe('upgrade', () => {
+  afterEach(() => {
+    writeConfigSpy.mockClear();
+  });
+
   describe('--help', () => {
     it('tracks telemetry', async () => {
       const command = 'upgrade';
@@ -42,6 +49,7 @@ describe('upgrade', () => {
       await expect(client.stderr).toOutput('Current version:');
       await expect(client.stderr).toOutput('Installation type:');
       await expect(client.stderr).toOutput('Upgrade command:');
+      await expect(client.stderr).toOutput('Automatic updates: Disabled');
     });
   });
 
@@ -70,6 +78,7 @@ describe('upgrade', () => {
       expect(json).toHaveProperty('currentVersion');
       expect(json).toHaveProperty('installationType');
       expect(json).toHaveProperty('upgradeCommand');
+      expect(json).toHaveProperty('autoUpdatesEnabled', false);
       expect(['global', 'local']).toContain(json.installationType);
     });
   });
@@ -100,7 +109,59 @@ describe('upgrade', () => {
       expect(json).toHaveProperty('currentVersion');
       expect(json).toHaveProperty('installationType');
       expect(json).toHaveProperty('upgradeCommand');
+      expect(json).toHaveProperty('autoUpdatesEnabled', false);
     });
+  });
+
+  describe('--enable-auto', () => {
+    it('enables automatic updates in the global config', async () => {
+      client.setArgv('upgrade', '--enable-auto');
+      const exitCode = await upgrade(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.config.updates?.auto).toBe(true);
+      expect(writeConfigSpy).toHaveBeenCalledWith({
+        updates: { auto: true },
+      });
+      await expect(client.stderr).toOutput('Automatic CLI updates enabled.');
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:enable-auto',
+          value: 'TRUE',
+        },
+      ]);
+    });
+  });
+
+  describe('--disable-auto', () => {
+    it('disables automatic updates in the global config', async () => {
+      client.config = { updates: { auto: true } };
+      client.setArgv('upgrade', '--disable-auto');
+      const exitCode = await upgrade(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.config.updates?.auto).toBe(false);
+      expect(writeConfigSpy).toHaveBeenCalledWith({
+        updates: { auto: false },
+      });
+      await expect(client.stderr).toOutput('Automatic CLI updates disabled.');
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:disable-auto',
+          value: 'TRUE',
+        },
+      ]);
+    });
+  });
+
+  it('rejects mutually exclusive auto-update flags', async () => {
+    client.setArgv('upgrade', '--enable-auto', '--disable-auto');
+    const result = await upgrade(client);
+
+    expect(result).toBe(1);
+    await expect(client.stderr).toOutput(
+      'Cannot use --enable-auto and --disable-auto together'
+    );
   });
 
   it('should reject invalid arguments', async () => {

--- a/packages/cli/test/unit/util/updates.test.ts
+++ b/packages/cli/test/unit/util/updates.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../mocks/client';
+import * as updateCommand from '../../../src/util/get-update-command';
+import * as configFilesUtil from '../../../src/util/config/files';
+import {
+  canAutoUpdate,
+  hasAutoUpdatePreference,
+  isAutoUpdateEnabled,
+  setAutoUpdate,
+} from '../../../src/util/updates';
+
+const isGlobalSpy = vi.spyOn(updateCommand, 'isGlobal');
+const writeConfigSpy = vi.spyOn(configFilesUtil, 'writeToConfigFile');
+
+describe('updates', () => {
+  afterEach(() => {
+    client.reset();
+    isGlobalSpy.mockReset();
+    writeConfigSpy.mockClear();
+  });
+
+  it('reads auto-update state from global config', () => {
+    expect(isAutoUpdateEnabled({})).toBe(false);
+    expect(isAutoUpdateEnabled({ updates: { auto: false } })).toBe(false);
+    expect(isAutoUpdateEnabled({ updates: { auto: true } })).toBe(true);
+  });
+
+  it('detects whether an auto-update preference has been saved', () => {
+    expect(hasAutoUpdatePreference({})).toBe(false);
+    expect(hasAutoUpdatePreference({ updates: { auto: true } })).toBe(true);
+    expect(hasAutoUpdatePreference({ updates: { auto: false } })).toBe(true);
+  });
+
+  it('writes auto-update preference to global config', () => {
+    setAutoUpdate(client, true);
+
+    expect(client.config.updates?.auto).toBe(true);
+    expect(writeConfigSpy).toHaveBeenCalledWith({
+      updates: { auto: true },
+    });
+  });
+
+  it('allows auto-update only for successful global interactive invocations', async () => {
+    client.config = { updates: { auto: true } };
+    isGlobalSpy.mockResolvedValue(true);
+
+    await expect(canAutoUpdate(client, 0)).resolves.toBe(true);
+  });
+
+  it('does not auto-update when disabled', async () => {
+    client.config = { updates: { auto: false } };
+    isGlobalSpy.mockResolvedValue(true);
+
+    await expect(canAutoUpdate(client, 0)).resolves.toBe(false);
+    expect(isGlobalSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-update after failed commands', async () => {
+    client.config = { updates: { auto: true } };
+    isGlobalSpy.mockResolvedValue(true);
+
+    await expect(canAutoUpdate(client, 1)).resolves.toBe(false);
+    expect(isGlobalSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-update local installs', async () => {
+    client.config = { updates: { auto: true } };
+    isGlobalSpy.mockResolvedValue(false);
+
+    await expect(canAutoUpdate(client, 0)).resolves.toBe(false);
+  });
+
+  it('does not auto-update non-interactive invocations', async () => {
+    client.config = { updates: { auto: true } };
+    client.nonInteractive = true;
+    isGlobalSpy.mockResolvedValue(true);
+
+    await expect(canAutoUpdate(client, 0)).resolves.toBe(false);
+    expect(isGlobalSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/unit/util/updates.test.ts
+++ b/packages/cli/test/unit/util/updates.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import ciInfo from 'ci-info';
 import { client } from '../../mocks/client';
 import * as updateCommand from '../../../src/util/get-update-command';
 import * as configFilesUtil from '../../../src/util/config/files';
@@ -9,14 +10,28 @@ import {
   setAutoUpdate,
 } from '../../../src/util/updates';
 
+vi.mock('ci-info', () => ({
+  default: {
+    isCI: false,
+  },
+}));
+
 const isGlobalSpy = vi.spyOn(updateCommand, 'isGlobal');
 const writeConfigSpy = vi.spyOn(configFilesUtil, 'writeToConfigFile');
+
+function setIsCI(value: boolean) {
+  Object.defineProperty(ciInfo, 'isCI', {
+    configurable: true,
+    value,
+  });
+}
 
 describe('updates', () => {
   afterEach(() => {
     client.reset();
     isGlobalSpy.mockReset();
     writeConfigSpy.mockClear();
+    setIsCI(false);
   });
 
   it('reads auto-update state from global config', () => {
@@ -63,6 +78,15 @@ describe('updates', () => {
     expect(isGlobalSpy).not.toHaveBeenCalled();
   });
 
+  it('does not auto-update in CI', async () => {
+    client.config = { updates: { auto: true } };
+    setIsCI(true);
+    isGlobalSpy.mockResolvedValue(true);
+
+    await expect(canAutoUpdate(client, 0)).resolves.toBe(false);
+    expect(isGlobalSpy).not.toHaveBeenCalled();
+  });
+
   it('does not auto-update local installs', async () => {
     client.config = { updates: { auto: true } };
     isGlobalSpy.mockResolvedValue(false);
@@ -76,6 +100,14 @@ describe('updates', () => {
     isGlobalSpy.mockResolvedValue(true);
 
     await expect(canAutoUpdate(client, 0)).resolves.toBe(false);
+    expect(isGlobalSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-update after the resolved upgrade command', async () => {
+    client.config = { updates: { auto: true } };
+    isGlobalSpy.mockResolvedValue(true);
+
+    await expect(canAutoUpdate(client, 0, 'upgrade')).resolves.toBe(false);
     expect(isGlobalSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
 ## Summary

Adds opt-in automatic CLI updates.

- Adds vercel upgrade --enable-auto / --disable-auto
- Persists preference in global config as updates.auto
- Prompts users to enable auto-updates after a successful manual upgrade
- Auto-updates only after successful interactive global CLI runs