### PR TITLE
Fix CLI punycode warning during launcher bootstrap

### DIFF
--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -1,5 +1,26 @@
 #!/usr/bin/env node
 /* biome-ignore-all lint/suspicious/noConsole: CLI entry point */
+{
+  // Install this before importing `index.js`; ESM dependencies can emit this
+  // warning during bootstrap, before the CLI module body runs.
+  const PUNYCODE_DEPRECATION_WARNING =
+    'DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.';
+  const originalError = console.error;
+
+  console.error = (...args) => {
+    const isPunycodeDeprecation = args.some(
+      arg =>
+        typeof arg === 'string' && arg.includes(PUNYCODE_DEPRECATION_WARNING)
+    );
+
+    if (isPunycodeDeprecation) {
+      return;
+    }
+
+    originalError(...args);
+  };
+}
+
 // This shim defers loading the real module until the compile cache is enabled.
 // https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
 // enableCompileCache was added in Node.js 22.8.0, so we need to handle older versions.

--- a/packages/cli/test/unit/esm/punycode-warning.test.ts
+++ b/packages/cli/test/unit/esm/punycode-warning.test.ts
@@ -1,0 +1,58 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+describe('vc.js punycode warnings', () => {
+  let fixtureDir: string | undefined;
+
+  afterEach(async () => {
+    if (fixtureDir) {
+      await rm(fixtureDir, { recursive: true, force: true });
+      fixtureDir = undefined;
+    }
+  });
+
+  it('silences DEP0040 warnings emitted while loading the CLI', async () => {
+    fixtureDir = await mkdtemp(join(tmpdir(), 'vercel-cli-punycode-'));
+    const vcSource = await readFile(
+      join(__dirname, '../../../src/vc.js'),
+      'utf8'
+    );
+
+    await writeFile(
+      join(fixtureDir, 'package.json'),
+      JSON.stringify({ type: 'module' })
+    );
+    await writeFile(join(fixtureDir, 'vc.js'), vcSource);
+    await writeFile(
+      join(fixtureDir, 'index.js'),
+      [
+        "process.emitWarning('The `punycode` module is deprecated. Please use a userland alternative instead.', {",
+        "  type: 'DeprecationWarning',",
+        "  code: 'DEP0040',",
+        '});',
+        "process.emitWarning('keep this warning', {",
+        "  type: 'Warning',",
+        "  code: 'KEEP',",
+        '});',
+        'await new Promise(resolve => setImmediate(resolve));',
+      ].join('\n')
+    );
+
+    const { stderr } = await execFileAsync(
+      process.execPath,
+      [join(fixtureDir, 'vc.js'), 'build'],
+      { cwd: fixtureDir }
+    );
+
+    expect(stderr).not.toContain('[DEP0040]');
+    expect(stderr).not.toContain('punycode');
+    expect(stderr).toContain('[KEEP]');
+    expect(stderr).toContain('keep this warning');
+  });
+});

--- a/packages/cli/test/unit/esm/punycode-warning.test.ts
+++ b/packages/cli/test/unit/esm/punycode-warning.test.ts
@@ -1,10 +1,13 @@
 import { execFile } from 'node:child_process';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { afterEach, describe, expect, it } from 'vitest';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const execFileAsync = promisify(execFile);
 
 describe('vc.js punycode warnings', () => {


### PR DESCRIPTION
Description

Fixes #16344.

Summary
Moves the DEP0040 punycode warning filter into the CLI launcher so it is installed before index.js and its ESM dependencies are imported. This prevents Node 22 hosted builds from printing the deprecated punycode warning during CLI bootstrap.

Adds a regression test that verifies DEP0040 is silenced while unrelated warnings still pass through.

Validation
corepack pnpm --filter vercel test test/unit/esm/punycode-warning.test.ts
corepack pnpm --filter vercel test test/unit/esm
corepack pnpm --filter vercel exec biome lint src/vc.js test/unit/esm/punycode-warning.test.ts
corepack pnpm --filter vercel exec biome format src/vc.js test/unit/esm/punycode-warning.test.ts