### PR TITLE
fix(build): inline userland punycode to eliminate Node.js DEP0040 warning

### DIFF
--- a/.changeset/fix-dep0040-punycode-1778928360.md
+++ b/.changeset/fix-dep0040-punycode-1778928360.md
@@ -1,0 +1,21 @@
+---
+"vercel": patch
+"@vercel/build-utils": patch
+"@vercel/go": patch
+"@vercel/static-build": patch
+---
+
+fix(build): inline userland punycode to eliminate Node.js DEP0040 DeprecationWarning
+
+Adds an esbuild plugin to `utils/build.mjs` that redirects `require("punycode")`
+to the userland npm `punycode@2.x` package when bundling. This prevents the
+`[DEP0040] DeprecationWarning: The 'punycode' module is deprecated` from firing
+in Node 22+ hosted build environments where `NODE_NO_WARNINGS` cannot reach the
+Vercel CLI launcher process.
+
+The warning was emitted at CLI startup because `node-fetch@2.x` bundles
+`whatwg-url@5.x` and `tr46@0.0.3`, both of which call `require("punycode")`
+(the deprecated Node built-in) at module-initialization time. By inlining the
+userland package instead, the Node built-in is never reached.
+
+Fixes #16344.

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -1,9 +1,55 @@
 import execa from 'execa';
 import ts from 'typescript';
 import path from 'node:path';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { build } from 'esbuild';
 import { fileURLToPath } from 'node:url';
+
+// Resolve the userland punycode npm package path from the pnpm store.
+// This is used to avoid the Node.js DEP0040 deprecation warning that fires
+// when old packages (tr46@0.0.3, whatwg-url@5.x) use require("punycode")
+// — the deprecated built-in — which gets bundled by esbuild.
+// By redirecting to the userland npm package, the code is inlined and no
+// runtime require("punycode") call reaches Node.js.
+function findUserlandPunycode() {
+  const pnpmDir = fileURLToPath(
+    new URL('../node_modules/.pnpm', import.meta.url)
+  );
+  if (!existsSync(pnpmDir)) return null;
+  let dirs;
+  try {
+    dirs = readdirSync(pnpmDir).filter(d => /^punycode@\d/.test(d));
+  } catch {
+    return null;
+  }
+  // Sort descending by version to prefer the highest version
+  dirs.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+  for (const dir of dirs) {
+    const main = `${pnpmDir}/${dir}/node_modules/punycode/punycode.js`;
+    if (existsSync(main)) return main;
+  }
+  return null;
+}
+
+/** @type {string | null} */
+const _userlandPunycodePath = findUserlandPunycode();
+
+/**
+ * esbuild plugin: resolve require("punycode") to the userland npm package
+ * (punycode@2.x) to avoid Node.js DEP0040 DeprecationWarning in Node 22+.
+ * Only active when bundling (bundle: true) and the package is found.
+ *
+ * @type {import('esbuild').Plugin}
+ */
+const punycodeUserlandPlugin = {
+  name: 'punycode-userland',
+  setup(build) {
+    if (!_userlandPunycodePath) return;
+    build.onResolve({ filter: /^punycode$/ }, () => ({
+      path: _userlandPunycodePath,
+    }));
+  },
+};
 
 export function getDependencies(cwd = process.cwd()) {
   const pkgPath = path.join(cwd, 'package.json');
@@ -56,6 +102,12 @@ export async function esbuild(
 
   let outdir = opts.outfile ? undefined : tsconfig.options.outDir;
 
+  // Merge the punycode plugin only when bundling to avoid DEP0040 warnings
+  const plugins = [
+    ...(opts.bundle ? [punycodeUserlandPlugin] : []),
+    ...(opts.plugins ?? []),
+  ];
+
   await build({
     entryPoints,
     format: 'cjs',
@@ -64,6 +116,7 @@ export async function esbuild(
     target: ts.ScriptTarget[tsconfig.options.target],
     sourcemap: tsconfig.options.sourceMap,
     ...opts,
+    plugins,
   });
 }
 


### PR DESCRIPTION
## Summary

Adds an esbuild plugin to `utils/build.mjs` that resolves `require("punycode")` to the userland npm `punycode@2.x` package when bundling, eliminating the `[DEP0040] DeprecationWarning: The 'punycode' module is deprecated` in Node 22+ hosted build environments.

Fixes #16344.

## Root cause

`node-fetch@2.x` (in `devDependencies` of several packages) gets bundled by esbuild. Its transitive dependencies `whatwg-url@5.0.0` and `tr46@0.0.3` both call `require("punycode")` at module-initialization time, which resolves to the deprecated Node.js built-in in Node 22+, triggering `DEP0040`.

Because the warning fires during CLI bootstrap — before any user subprocess starts — it cannot be suppressed with `NODE_NO_WARNINGS` in `vercel.json` build env or dashboard environment variables.

## Fix

The `esbuild()` utility in `utils/build.mjs` now includes a plugin (`punycodeUserlandPlugin`) that, when `bundle: true`, intercepts any `require("punycode")` and resolves it to the userland `punycode@2.x` npm package already present in the pnpm store. esbuild then inlines the package code, so no `require("punycode")` call reaches Node.js at runtime.

The plugin:
- Dynamically finds the highest-version `punycode@*` package in the pnpm store (no hardcoded version)
- Falls back gracefully to the default (Node built-in) if the package is not found
- Only activates when `bundle: true` — transpile-only builds are unaffected
- Preserves any `plugins` option passed by the caller (e.g. `jsoncParserPlugin` in CLI build)

## Packages affected

All four packages that bundle `node-fetch` (and its transitive deps) with esbuild:
- `vercel` (CLI)
- `@vercel/build-utils`
- `@vercel/go`
- `@vercel/static-build`