### PR TITLE
[FIX] Fixing a single deployment error

### DIFF
--- a/.changeset/fix-cli-binary-worker.md
+++ b/.changeset/fix-cli-binary-worker.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix standalone CLI binary latest-version worker startup.

--- a/packages/cli/pkg.js
+++ b/packages/cli/pkg.js
@@ -1,3 +1,10 @@
 #!/usr/bin/env node
 
-await import('./dist/vc.js');
+const [, , script] = process.argv;
+
+if (script && script.endsWith('dist/get-latest-worker.cjs')) {
+  process.argv.splice(2, 1);
+  await import('./dist/get-latest-worker.cjs');
+} else {
+  await import('./dist/vc.js');
+}

--- a/packages/cli/pkg.js
+++ b/packages/cli/pkg.js
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 
+import { basename } from 'node:path';
+
 const [, , script] = process.argv;
 
-if (script && script.endsWith('dist/get-latest-worker.cjs')) {
+// In the standalone binary, process.execPath points back to this binary.
+// Route internal worker invocations here so script paths are not parsed as CLI args.
+if (script && basename(script) === 'get-latest-worker.cjs') {
   process.argv.splice(2, 1);
   await import('./dist/get-latest-worker.cjs');
 } else {


### PR DESCRIPTION
• ## Summary

Fix standalone CLI binary update checks by routing the internal latest-version worker through the binary entrypoint instead of treating the worker script path as a CLI argument.