### PR TITLE
[static-build] Support Vite Environments API for SSR projects

### DIFF
--- a/.changeset/three-rocks-try.md
+++ b/.changeset/three-rocks-try.md
@@ -1,0 +1,5 @@
+---
+"@vercel/static-build": patch
+---
+
+[static-build] Add vite-environments path for TanStack Start

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@vercel/gatsby-plugin-vercel-analytics": "workspace:*",
     "@vercel/gatsby-plugin-vercel-builder": "workspace:*",
+    "@vercel/nft": "1.5.0",
     "@vercel/static-config": "workspace:*",
     "ts-morph": "12.0.0"
   },

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -27,6 +27,7 @@
     "@vercel/gatsby-plugin-vercel-builder": "workspace:*",
     "@vercel/nft": "1.5.0",
     "@vercel/static-config": "workspace:*",
+    "nitro": "npm:nitro-nightly@latest",
     "ts-morph": "12.0.0"
   },
   "devDependencies": {

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -46,7 +46,7 @@ import * as GatsbyUtils from './utils/gatsby';
 import * as NuxtUtils from './utils/nuxt';
 import {
   buildViteEnvironments,
-  shouldUseViteEnvironments,
+  detectViteServerEnvironments,
 } from './utils/vite-environments';
 import type { ImagesConfig, BuildConfig } from './utils/_shared';
 import treeKill from 'tree-kill';
@@ -813,20 +813,23 @@ export const build: BuildV2 = async ({
         return await BuildOutputV2.createBuildOutput(workPath);
       }
 
-      // Temporary: when a Vite-powered meta-framework (currently scoped to
-      // TanStack Start without Nitro) declares server "environments" in its
-      // vite config, take over the post-build mapping so the server entry
-      // becomes a Vercel Function instead of being shipped as a static .js.
-      // Move this out of `static-build` once `@vercel/vite` (or the
-      // framework detector) is wired up properly.
-      if (shouldUseViteEnvironments(pkg)) {
+      // If this is a vite project whose vite config declares a server
+      // environment that actually produced output on disk, take over the
+      // post-build mapping so the server bundle becomes a Vercel Function
+      // instead of being shipped as a static .js. Falls through silently
+      // for plain vite SPAs, vitepress, non-vite projects, etc.
+      const viteDetection = await detectViteServerEnvironments(entrypointDir);
+      if (viteDetection) {
         debug(
-          'Vite environments path triggered (TanStack Start without Nitro)'
+          `Vite environments path triggered (${viteDetection.environments
+            .map(e => `${e.name}:${e.consumer}`)
+            .join(', ')})`
         );
         return await buildViteEnvironments({
           workPath: entrypointDir,
           repoRootPath,
           nodeVersion,
+          detection: viteDetection,
         });
       }
 

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -48,6 +48,10 @@ import {
   buildViteEnvironments,
   detectViteServerEnvironments,
 } from './utils/vite-environments';
+import {
+  getNitroInjectionBuildCommand,
+  shouldInjectNitro,
+} from './utils/inject-nitro';
 import type { ImagesConfig, BuildConfig } from './utils/_shared';
 import treeKill from 'tree-kill';
 import {
@@ -384,8 +388,19 @@ export const build: BuildV2 = async ({
       frameworkList: frameworks,
     })) ?? {};
   const devCommand = getCommand('dev', pkg, config, framework);
-  const buildCommand = getCommand('build', pkg, config, framework);
+  let buildCommand = getCommand('build', pkg, config, framework);
   const installCommand = getCommand('install', pkg, config, framework);
+
+  // For Vite projects on the default `vite build` script with no `nitro`
+  // dep declared, hand the build off to Nitro (`nitro build --builder vite`).
+  // Nitro emits BOA v3 to `.vercel/output/` and the v3 check below
+  // short-circuits the rest of this builder. See `utils/inject-nitro.ts`.
+  if (!meta.isDev && shouldInjectNitro({ pkg, config, buildCommand })) {
+    buildCommand = getNitroInjectionBuildCommand();
+    console.log(
+      `Detected \`vite build\` without a \`nitro\` dependency. Replacing the build command with \`nitro build --builder vite\` for SSR support.`
+    );
+  }
 
   if (pkg || buildCommand) {
     const gemfilePath = path.join(workPath, 'Gemfile');

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -44,6 +44,10 @@ import * as BuildOutputV2 from './utils/build-output-v2';
 import * as BuildOutputV3 from './utils/build-output-v3';
 import * as GatsbyUtils from './utils/gatsby';
 import * as NuxtUtils from './utils/nuxt';
+import {
+  buildViteEnvironments,
+  shouldUseViteEnvironments,
+} from './utils/vite-environments';
 import type { ImagesConfig, BuildConfig } from './utils/_shared';
 import treeKill from 'tree-kill';
 import {
@@ -807,6 +811,23 @@ export const build: BuildV2 = async ({
         await BuildOutputV2.getBuildOutputDirectory(outputDirPrefix);
       if (buildOutputPathV2) {
         return await BuildOutputV2.createBuildOutput(workPath);
+      }
+
+      // Temporary: when a Vite-powered meta-framework (currently scoped to
+      // TanStack Start without Nitro) declares server "environments" in its
+      // vite config, take over the post-build mapping so the server entry
+      // becomes a Vercel Function instead of being shipped as a static .js.
+      // Move this out of `static-build` once `@vercel/vite` (or the
+      // framework detector) is wired up properly.
+      if (shouldUseViteEnvironments(pkg)) {
+        debug(
+          'Vite environments path triggered (TanStack Start without Nitro)'
+        );
+        return await buildViteEnvironments({
+          workPath: entrypointDir,
+          repoRootPath,
+          nodeVersion,
+        });
       }
 
       const extraOutputs = await BuildOutputV1.readBuildOutputDirectory({

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -47,6 +47,7 @@ import * as NuxtUtils from './utils/nuxt';
 import {
   buildViteEnvironments,
   detectViteServerEnvironments,
+  projectDeclaresViteServerEnvironment,
 } from './utils/vite-environments';
 import {
   getNitroInjectionBuildCommand,
@@ -391,16 +392,13 @@ export const build: BuildV2 = async ({
   let buildCommand = getCommand('build', pkg, config, framework);
   const installCommand = getCommand('install', pkg, config, framework);
 
-  // For Vite projects on the default `vite build` script with no `nitro`
-  // dep declared, hand the build off to Nitro (`nitro build --builder vite`).
-  // Nitro emits BOA v3 to `.vercel/output/` and the v3 check below
-  // short-circuits the rest of this builder. See `utils/inject-nitro.ts`.
-  if (!meta.isDev && shouldInjectNitro({ pkg, config, buildCommand })) {
-    buildCommand = getNitroInjectionBuildCommand();
-    console.log(
-      `Detected \`vite build\` without a \`nitro\` dependency. Replacing the build command with \`nitro build --builder vite\` for SSR support.`
-    );
-  }
+  // Cheap pre-install gate. We still need to confirm the project actually
+  // declares an SSR-shaped vite environment before swapping the command,
+  // which requires running `vite.resolveConfig` and therefore depends on
+  // `vite` being installed — that check happens after the install step
+  // below (see the `nitroInjectionEligible` block).
+  const nitroInjectionEligible =
+    !meta.isDev && shouldInjectNitro({ pkg, config, buildCommand });
 
   if (pkg || buildCommand) {
     const gemfilePath = path.join(workPath, 'Gemfile');
@@ -758,6 +756,28 @@ export const build: BuildV2 = async ({
     } else {
       if (meta.isDev) {
         debug(`WARN: A dev script is missing`);
+      }
+
+      // Confirm Nitro injection is actually wanted now that `vite` is on
+      // disk. `projectDeclaresViteServerEnvironment` runs vite.resolveConfig
+      // and asks "does this project actually declare a server environment
+      // with output distinct from its client?". Plain Vite SPAs, plain
+      // Svelte SPAs, and SvelteKit (which has its own Vercel adapter) all
+      // return `false` here — the broad package-level gate would otherwise
+      // misfire and hand them to Nitro, which can't build them.
+      if (nitroInjectionEligible) {
+        const hasServerEnv =
+          await projectDeclaresViteServerEnvironment(entrypointDir);
+        if (hasServerEnv) {
+          buildCommand = getNitroInjectionBuildCommand();
+          console.log(
+            `Detected \`vite build\` with a server environment but no \`nitro\` dependency. Replacing the build command with \`nitro build --builder vite\` for SSR support.`
+          );
+        } else {
+          debug(
+            'Skipping nitro injection: no SSR-shaped vite environment declared'
+          );
+        }
       }
 
       if (buildCommand) {

--- a/packages/static-build/src/utils/inject-nitro.ts
+++ b/packages/static-build/src/utils/inject-nitro.ts
@@ -1,0 +1,105 @@
+/**
+ * Vite + Nitro injection.
+ *
+ * For Vite-powered projects that use the default `vite build` script and
+ * don't declare a `nitro` dependency, we swap the build command from
+ * `vite build` to `nitro build --builder vite`. Nitro then takes over the
+ * server build, applies its `vercel` preset, and emits BOA v3 to
+ * `.vercel/output/` directly — the existing v3 check in
+ * `@vercel/static-build` then short-circuits the rest of this builder.
+ *
+ * Nitro is shipped as a direct dependency of `@vercel/static-build`, so
+ * we don't need to `npm install` it at user-build time. We resolve the
+ * CLI binary from this package's own `node_modules` and invoke it via
+ * `node <path-to-cli>`.
+ *
+ * Detection mirrors PR #16338's heuristics minus the env-flag gate and
+ * the framework-slug allowlist:
+ *   - The user hasn't overridden `buildCommand` (in project settings or
+ *     vercel.json) — that signals they're driving their own pipeline.
+ *   - The package's `build` script is exactly `vite build` — anything
+ *     customized (`svelte-kit sync && vite build`, `vitepress build`,
+ *     `react-router build`, etc.) is left alone.
+ *   - The project doesn't already declare a `nitro` dep — if it does,
+ *     they're managing Nitro themselves.
+ */
+import { createRequire } from 'module';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import type { Config, PackageJson } from '@vercel/build-utils';
+
+const require_ = createRequire(__filename);
+
+interface ShouldInjectNitroOptions {
+  pkg?: PackageJson | null;
+  config: Config;
+  buildCommand: string | null;
+}
+
+export function shouldInjectNitro({
+  pkg,
+  config,
+  buildCommand,
+}: ShouldInjectNitroOptions): boolean {
+  // User has their own build pipeline configured.
+  if (config.projectSettings?.buildCommand != null) return false;
+  if (typeof buildCommand === 'string') return false;
+
+  // Only swap when the package's build script is literally `vite build`.
+  // Anything custom is left alone — that's the user's intent and we don't
+  // want to break SvelteKit (`svelte-kit sync && vite build`), Astro, etc.
+  const buildScript = pkg?.scripts?.build;
+  if (typeof buildScript !== 'string' || buildScript.trim() !== 'vite build') {
+    return false;
+  }
+
+  // User-declared nitro means they're driving it themselves.
+  const deps = { ...pkg?.dependencies, ...pkg?.devDependencies };
+  if (deps.nitro) return false;
+
+  return true;
+}
+
+let cachedNitroBinPath: string | undefined;
+
+/**
+ * Resolve the absolute path to the Nitro CLI script from this package's
+ * own node_modules. Cached because resolution is stable for the process
+ * lifetime.
+ */
+export function resolveNitroBin(): string {
+  if (cachedNitroBinPath) return cachedNitroBinPath;
+
+  const pkgPath = require_.resolve('nitro/package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+    bin?: string | Record<string, string>;
+  };
+
+  let binRelative: string | undefined;
+  if (typeof pkg.bin === 'string') {
+    binRelative = pkg.bin;
+  } else if (pkg.bin && typeof pkg.bin === 'object') {
+    binRelative = pkg.bin.nitro ?? Object.values(pkg.bin)[0];
+  }
+
+  if (!binRelative) {
+    throw new Error(
+      'Could not resolve the Nitro CLI binary from the installed `nitro` package.'
+    );
+  }
+
+  cachedNitroBinPath = join(dirname(pkgPath), binRelative);
+  return cachedNitroBinPath;
+}
+
+/**
+ * Build the shell command that invokes the bundled Nitro CLI.
+ * `node <abs-path-to-cli> build --builder vite` works cross-platform and
+ * doesn't depend on a `.bin` symlink existing in the user's project.
+ */
+export function getNitroInjectionBuildCommand(): string {
+  const bin = resolveNitroBin();
+  // JSON.stringify gives us a properly-quoted absolute path that survives
+  // spaces in directory names on all platforms.
+  return `node ${JSON.stringify(bin)} build --builder vite`;
+}

--- a/packages/static-build/src/utils/vite-environments.ts
+++ b/packages/static-build/src/utils/vite-environments.ts
@@ -1,0 +1,315 @@
+/**
+ * Temporary integration point for the Vite "environments" API.
+ *
+ * The framework detector currently routes TanStack Start (and other Vite-
+ * powered meta-frameworks) through `@vercel/static-build`. That works for the
+ * client output, but the per-environment `dist/server/server.js` web-fetch
+ * handler produced by frameworks built on Vite's Environments API is ignored
+ * — the SSR / server-fn surface effectively breaks.
+ *
+ * This module fills the gap from inside `static-build`:
+ *
+ *   1. Detect projects that opt into the path (today: TanStack Start without
+ *      a Nitro adapter).
+ *   2. Use the project's own `vite` to call `resolveConfig` and learn each
+ *      declared environment's `consumer` ('client' | 'server') and `outDir`.
+ *   3. Map client envs → static assets; map server envs → a `NodejsLambda`
+ *      with `useWebApi: true` (the runtime invokes `default.fetch`, matching
+ *      the Web-standard handler shape these bundles emit).
+ *
+ * Once `@vercel/vite` (or the framework detector) is wired up properly this
+ * file can move out unchanged.
+ */
+import { existsSync, promises as fs } from 'fs';
+import { basename, isAbsolute, join, relative, resolve } from 'path';
+import { createRequire } from 'module';
+import { nodeFileTrace } from '@vercel/nft';
+import {
+  type BuildResultV2Typical,
+  type Files,
+  type NodeVersion,
+  type PackageJson,
+  debug,
+  FileFsRef,
+  glob,
+  NodejsLambda,
+} from '@vercel/build-utils';
+
+const SERVER_ENTRY_CANDIDATES = ['server.js', 'index.js', 'entry-server.js'];
+
+interface ViteEnvironmentConfig {
+  consumer?: 'client' | 'server';
+  build?: {
+    outDir?: string;
+    rollupOptions?: {
+      input?: string | string[] | Record<string, string>;
+    };
+  };
+  resolve?: {
+    conditions?: string[];
+  };
+}
+
+interface ResolvedViteConfig {
+  root: string;
+  environments?: Record<string, ViteEnvironmentConfig>;
+  build?: {
+    outDir?: string;
+  };
+}
+
+interface ResolvedEnvironment {
+  name: string;
+  consumer: 'client' | 'server';
+  outDir: string;
+  inputNames: string[];
+  conditions: string[];
+}
+
+/**
+ * Returns true when this project should be handled by the vite-environments
+ * path. Today: TanStack Start present and no Nitro opt-in. Keep the trigger
+ * narrow until the detector is updated.
+ */
+export function shouldUseViteEnvironments(
+  pkg: PackageJson | null | undefined
+): boolean {
+  if (!pkg) return false;
+  if (!hasTanstackStart(pkg)) return false;
+  if (hasNitro(pkg)) return false;
+  return true;
+}
+
+export async function buildViteEnvironments({
+  workPath,
+  repoRootPath,
+  nodeVersion,
+}: {
+  workPath: string;
+  repoRootPath: string;
+  nodeVersion: NodeVersion;
+}): Promise<BuildResultV2Typical> {
+  const environments = await resolveViteEnvironments(workPath);
+
+  const clientEnvironments = environments.filter(e => e.consumer === 'client');
+  const serverEnvironments = environments.filter(e => e.consumer === 'server');
+
+  let staticFiles: Files = {};
+  for (const env of clientEnvironments) {
+    if (!existsSync(env.outDir)) {
+      debug(
+        `Skipping client environment "${env.name}": outDir ${env.outDir} does not exist`
+      );
+      continue;
+    }
+    const found = await glob('**', env.outDir);
+    staticFiles = { ...staticFiles, ...found };
+  }
+
+  const output: BuildResultV2Typical['output'] = { ...staticFiles };
+  let primaryServerFunctionPath: string | undefined;
+
+  for (const env of serverEnvironments) {
+    if (!existsSync(env.outDir)) {
+      throw new Error(
+        `Server environment "${env.name}" declared outDir "${env.outDir}" but it does not exist after build`
+      );
+    }
+
+    const entryFile = await findServerEntry(env);
+    if (!entryFile) {
+      throw new Error(
+        `Could not locate the server entry file inside "${env.outDir}" for environment "${env.name}". Expected a top-level .js entry (e.g. server.js, index.js).`
+      );
+    }
+
+    const fn = await createServerFunction({
+      entryAbsolutePath: entryFile,
+      rootDir: repoRootPath,
+      entrypointDir: workPath,
+      nodeVersion,
+      conditions: env.conditions,
+      environmentName: env.name,
+    });
+
+    const outputPath =
+      serverEnvironments.length === 1 || env.name === 'server'
+        ? 'index'
+        : `__vite/${env.name}`;
+    output[outputPath] = fn;
+    if (!primaryServerFunctionPath) {
+      primaryServerFunctionPath = outputPath;
+    }
+  }
+
+  const routes: BuildResultV2Typical['routes'] = [{ handle: 'filesystem' }];
+  if (primaryServerFunctionPath) {
+    routes.push({ src: '/(.*)', dest: `/${primaryServerFunctionPath}` });
+  }
+  routes.push({ handle: 'hit' });
+  routes.push({
+    src: '^/assets/(.*)$',
+    headers: { 'cache-control': 'public, max-age=31536000, immutable' },
+    continue: true,
+  });
+
+  return { routes, output };
+}
+
+async function resolveViteEnvironments(
+  workPath: string
+): Promise<ResolvedEnvironment[]> {
+  const projectRequire = createRequire(join(workPath, 'index.js'));
+  let vite: typeof import('vite');
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    vite = projectRequire('vite');
+  } catch (err) {
+    throw new Error(
+      `The vite-environments path requires "vite" to be installed in the project. ` +
+        `(${(err as Error).message})`
+    );
+  }
+
+  // `resolveConfig` runs each plugin's `config`/`configResolved` hook, so
+  // plugin-contributed environments (e.g. tanstackStart()) are visible.
+  const resolved = (await vite.resolveConfig(
+    { root: workPath },
+    'build'
+  )) as ResolvedViteConfig;
+
+  const envs: ResolvedEnvironment[] = [];
+  const envMap = resolved.environments ?? {};
+  for (const [name, env] of Object.entries(envMap)) {
+    const consumer = env.consumer;
+    if (consumer !== 'client' && consumer !== 'server') continue;
+
+    const outDirRel = env.build?.outDir ?? resolved.build?.outDir ?? 'dist';
+    const outDir = isAbsolute(outDirRel)
+      ? outDirRel
+      : resolve(resolved.root || workPath, outDirRel);
+
+    envs.push({
+      name,
+      consumer,
+      outDir,
+      inputNames: collectInputNames(env.build?.rollupOptions?.input),
+      conditions: env.resolve?.conditions ?? [],
+    });
+  }
+
+  if (envs.length === 0) {
+    throw new Error(
+      'No vite environments with a "client" or "server" consumer were resolved. ' +
+        'Ensure the project uses Vite 6+ and a framework plugin that declares environments.'
+    );
+  }
+
+  return envs;
+}
+
+function collectInputNames(
+  input: string | string[] | Record<string, string> | undefined
+): string[] {
+  if (!input) return [];
+  if (typeof input === 'string') return [stripExt(basename(input))];
+  if (Array.isArray(input)) return input.map(i => stripExt(basename(i)));
+  return Object.keys(input);
+}
+
+function stripExt(filename: string) {
+  return filename.replace(/\.[^.]+$/, '');
+}
+
+async function findServerEntry(
+  env: ResolvedEnvironment
+): Promise<string | null> {
+  // 1) Prefer a name matching the rollup input (e.g. "server" → "server.js").
+  for (const name of env.inputNames) {
+    const candidate = join(env.outDir, `${name}.js`);
+    if (existsSync(candidate)) return candidate;
+  }
+  // 2) Well-known names.
+  for (const name of SERVER_ENTRY_CANDIDATES) {
+    const candidate = join(env.outDir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  // 3) Lone top-level .js file in the env's outDir.
+  const entries = await fs.readdir(env.outDir, { withFileTypes: true });
+  const topLevelJs = entries.filter(e => e.isFile() && e.name.endsWith('.js'));
+  if (topLevelJs.length === 1) {
+    return join(env.outDir, topLevelJs[0].name);
+  }
+  return null;
+}
+
+async function createServerFunction({
+  entryAbsolutePath,
+  rootDir,
+  entrypointDir,
+  nodeVersion,
+  conditions,
+  environmentName,
+}: {
+  entryAbsolutePath: string;
+  rootDir: string;
+  entrypointDir: string;
+  nodeVersion: NodeVersion;
+  conditions: string[];
+  environmentName: string;
+}) {
+  const traceConditions = conditions.length
+    ? conditions
+    : ['node', 'import', 'require', 'default'];
+
+  const trace = await nodeFileTrace([entryAbsolutePath], {
+    base: rootDir,
+    processCwd: entrypointDir,
+    conditions: traceConditions,
+  });
+
+  for (const warning of trace.warnings) {
+    debug(`nft warning (vite/${environmentName}): ${warning.message}`);
+  }
+
+  const files: Files = {};
+  for (const file of trace.fileList) {
+    files[file] = await FileFsRef.fromFsPath({ fsPath: join(rootDir, file) });
+  }
+
+  const handler = relative(rootDir, entryAbsolutePath);
+
+  return new NodejsLambda({
+    files,
+    handler,
+    runtime: nodeVersion.runtime,
+    shouldAddHelpers: false,
+    shouldAddSourcemapSupport: false,
+    operationType: 'SSR',
+    supportsResponseStreaming: true,
+    useWebApi: true,
+  });
+}
+
+function hasTanstackStart(pkg: PackageJson): boolean {
+  return (
+    hasDependency(pkg, '@tanstack/react-start') ||
+    hasDependency(pkg, '@tanstack/solid-start')
+  );
+}
+
+function hasNitro(pkg: PackageJson): boolean {
+  return (
+    hasDependency(pkg, 'nitropack') ||
+    hasDependency(pkg, 'nitro') ||
+    hasDependency(pkg, '@tanstack/start-server-nitro')
+  );
+}
+
+function hasDependency(pkg: PackageJson, name: string): boolean {
+  return Boolean(
+    pkg.dependencies?.[name] ||
+      pkg.devDependencies?.[name] ||
+      pkg.peerDependencies?.[name]
+  );
+}

--- a/packages/static-build/src/utils/vite-environments.ts
+++ b/packages/static-build/src/utils/vite-environments.ts
@@ -70,19 +70,48 @@ export interface ViteEnvironmentsDetection {
   environments: ResolvedEnvironment[];
 }
 
+// Resolved environments are cached per workPath. `resolveConfig` runs every
+// plugin's `config`/`configResolved` hook, which for some frameworks is
+// non-trivial (route-tree codegen, content-collections scans). Pre-build
+// and post-build paths both want the same answer; memoize so we don't pay
+// twice.
+const envCache = new Map<string, Promise<ResolvedEnvironment[] | null>>();
+
 /**
- * Cheaply attempts to discover vite environments with server output on disk.
- * Returns `null` when there's nothing to do — caller should fall through to
- * the normal static-build path. Never throws on the "not a vite project"
- * cases; only throws if vite *is* present and resolveConfig blows up in a
- * way we can't recover from.
+ * Test helper. The cache lives at module scope so it survives across
+ * vitest cases in the same worker; call this in `beforeEach` to keep
+ * tests independent.
  */
-export async function detectViteServerEnvironments(
+export function _resetViteEnvironmentsCacheForTests(): void {
+  envCache.clear();
+}
+
+/**
+ * Resolve the vite environments declared by the project (after pruning
+ * phantom server envs that share their outDir with a client env). Returns
+ * `null` when this isn't a vite project or resolveConfig fails. Does NOT
+ * check that the outDirs exist on disk — that's the caller's job for the
+ * post-build path. Memoized.
+ */
+export async function getViteEnvironments(
   workPath: string
-): Promise<ViteEnvironmentsDetection | null> {
+): Promise<ResolvedEnvironment[] | null> {
+  const cached = envCache.get(workPath);
+  if (cached) return cached;
+  const promise = loadViteEnvironments(workPath);
+  envCache.set(workPath, promise);
+  return promise;
+}
+
+async function loadViteEnvironments(
+  workPath: string
+): Promise<ResolvedEnvironment[] | null> {
   // Pre-check: is vite resolvable from this project at all? If not, this
   // isn't a vite build and we shouldn't pay the cost of resolveConfig.
-  const projectRequire = createRequire(join(workPath, 'index.js'));
+  // `createRequire` uses the path only as a resolution anchor — Node walks
+  // up its dirname looking for `node_modules`. The file is never opened,
+  // so the basename here is arbitrary.
+  const projectRequire = createRequire(join(workPath, '__vite_detect__'));
   let vite: typeof import('vite');
   try {
     vite = projectRequire('vite');
@@ -127,20 +156,49 @@ export async function detectViteServerEnvironments(
     });
   }
 
-  // Prune phantom server environments before deciding whether to take over.
-  // Some Vite plugins (e.g. @sveltejs/vite-plugin-svelte) register a default
-  // `ssr` environment even when the user is shipping a plain client SPA.
-  // Its outDir defaults to `dist`, which is also where the client built,
-  // so a naive existsSync check would fire for every Vite project. Real
-  // SSR frameworks (TanStack Start, RR v7, Hydrogen) always use a distinct
-  // outDir for the server bundle, and even if they didn't, we couldn't pick
-  // apart a server entry from client SPA files in a shared directory.
+  // Prune phantom server environments. Some Vite plugins (e.g.
+  // @sveltejs/vite-plugin-svelte, and Vite itself) register a default `ssr`
+  // environment even when the user is shipping a plain client SPA. Its
+  // outDir defaults to `dist`, which is also where the client built — so
+  // anything that shares an outDir with a client env isn't a real SSR
+  // setup we should be wrapping or handing to Nitro.
   const clientOutDirs = new Set(
     environments.filter(e => e.consumer === 'client').map(e => e.outDir)
   );
-  const filtered = environments.filter(env => {
+  return environments.filter(env => {
     if (env.consumer !== 'server') return true;
-    if (clientOutDirs.has(env.outDir)) return false;
+    return !clientOutDirs.has(env.outDir);
+  });
+}
+
+/**
+ * Pre-build check: does this vite project declare at least one real
+ * (non-phantom) server environment? Used by the Nitro-injection path to
+ * decide whether replacing `vite build` with `nitro build --builder vite`
+ * is safe — plain Vite/Svelte SPAs return `false` because their only
+ * server-shaped env is the phantom one that shares the client outDir.
+ */
+export async function projectDeclaresViteServerEnvironment(
+  workPath: string
+): Promise<boolean> {
+  const envs = await getViteEnvironments(workPath);
+  if (!envs) return false;
+  return envs.some(e => e.consumer === 'server');
+}
+
+/**
+ * Post-build check: cheaply discovers vite environments with built server
+ * output on disk. Returns `null` when there's nothing to do — caller
+ * should fall through to the normal static-build path.
+ */
+export async function detectViteServerEnvironments(
+  workPath: string
+): Promise<ViteEnvironmentsDetection | null> {
+  const envs = await getViteEnvironments(workPath);
+  if (!envs) return null;
+
+  const filtered = envs.filter(env => {
+    if (env.consumer !== 'server') return true;
     return existsSync(env.outDir);
   });
 

--- a/packages/static-build/src/utils/vite-environments.ts
+++ b/packages/static-build/src/utils/vite-environments.ts
@@ -127,15 +127,27 @@ export async function detectViteServerEnvironments(
     });
   }
 
-  // Only take over if at least one server environment actually produced
-  // output on disk. Vanilla Vite SPAs, vitepress, etc. either have no
-  // server env or have one that wasn't built — those should fall through.
-  const hasBuiltServer = environments.some(
-    e => e.consumer === 'server' && existsSync(e.outDir)
+  // Prune phantom server environments before deciding whether to take over.
+  // Some Vite plugins (e.g. @sveltejs/vite-plugin-svelte) register a default
+  // `ssr` environment even when the user is shipping a plain client SPA.
+  // Its outDir defaults to `dist`, which is also where the client built,
+  // so a naive existsSync check would fire for every Vite project. Real
+  // SSR frameworks (TanStack Start, RR v7, Hydrogen) always use a distinct
+  // outDir for the server bundle, and even if they didn't, we couldn't pick
+  // apart a server entry from client SPA files in a shared directory.
+  const clientOutDirs = new Set(
+    environments.filter(e => e.consumer === 'client').map(e => e.outDir)
   );
+  const filtered = environments.filter(env => {
+    if (env.consumer !== 'server') return true;
+    if (clientOutDirs.has(env.outDir)) return false;
+    return existsSync(env.outDir);
+  });
+
+  const hasBuiltServer = filtered.some(e => e.consumer === 'server');
   if (!hasBuiltServer) return null;
 
-  return { environments };
+  return { environments: filtered };
 }
 
 export async function buildViteEnvironments({

--- a/packages/static-build/src/utils/vite-environments.ts
+++ b/packages/static-build/src/utils/vite-environments.ts
@@ -1,34 +1,34 @@
 /**
- * Temporary integration point for the Vite "environments" API.
+ * Integration point for Vite's "environments" API.
  *
- * The framework detector currently routes TanStack Start (and other Vite-
- * powered meta-frameworks) through `@vercel/static-build`. That works for the
- * client output, but the per-environment `dist/server/server.js` web-fetch
- * handler produced by frameworks built on Vite's Environments API is ignored
- * — the SSR / server-fn surface effectively breaks.
+ * When a project's vite config declares one or more `environments` with
+ * `consumer: 'server'` (TanStack Start, React Router v7, future Hydrogen,
+ * custom SSR setups), the per-environment server bundle would otherwise be
+ * shipped as a static `.js` and the SSR / server-fn surface would silently
+ * break. This module fills that gap from inside `static-build`:
  *
- * This module fills the gap from inside `static-build`:
+ *   1. After the user's build, call the project's own `vite.resolveConfig`
+ *      to learn each declared environment's `consumer` and `outDir`.
+ *   2. If at least one server environment has produced output, map every
+ *      client `outDir` into static assets and every server `outDir` into
+ *      a `NodejsLambda` with `useWebApi: true` — the runtime invokes
+ *      `default.fetch`, matching the Web-standard handler these bundles
+ *      emit.
+ *   3. Otherwise (vite missing, plain SPA, build failed), return `null`
+ *      and let `static-build` fall through to its normal path.
  *
- *   1. Detect projects that opt into the path (today: TanStack Start without
- *      a Nitro adapter).
- *   2. Use the project's own `vite` to call `resolveConfig` and learn each
- *      declared environment's `consumer` ('client' | 'server') and `outDir`.
- *   3. Map client envs → static assets; map server envs → a `NodejsLambda`
- *      with `useWebApi: true` (the runtime invokes `default.fetch`, matching
- *      the Web-standard handler shape these bundles emit).
- *
- * Once `@vercel/vite` (or the framework detector) is wired up properly this
- * file can move out unchanged.
+ * Lives in `static-build` as a stopgap; once `@vercel/vite` (or the
+ * framework detector) is wired up, the module can move out unchanged.
  */
 import { existsSync, promises as fs } from 'fs';
 import { basename, isAbsolute, join, relative, resolve } from 'path';
 import { createRequire } from 'module';
 import { nodeFileTrace } from '@vercel/nft';
+import { errorToString } from '@vercel/error-utils';
 import {
   type BuildResultV2Typical,
   type Files,
   type NodeVersion,
-  type PackageJson,
   debug,
   FileFsRef,
   glob,
@@ -58,7 +58,7 @@ interface ResolvedViteConfig {
   };
 }
 
-interface ResolvedEnvironment {
+export interface ResolvedEnvironment {
   name: string;
   consumer: 'client' | 'server';
   outDir: string;
@@ -66,33 +66,95 @@ interface ResolvedEnvironment {
   conditions: string[];
 }
 
+export interface ViteEnvironmentsDetection {
+  environments: ResolvedEnvironment[];
+}
+
 /**
- * Returns true when this project should be handled by the vite-environments
- * path. Today: TanStack Start present and no Nitro opt-in. Keep the trigger
- * narrow until the detector is updated.
+ * Cheaply attempts to discover vite environments with server output on disk.
+ * Returns `null` when there's nothing to do — caller should fall through to
+ * the normal static-build path. Never throws on the "not a vite project"
+ * cases; only throws if vite *is* present and resolveConfig blows up in a
+ * way we can't recover from.
  */
-export function shouldUseViteEnvironments(
-  pkg: PackageJson | null | undefined
-): boolean {
-  if (!pkg) return false;
-  if (!hasTanstackStart(pkg)) return false;
-  if (hasNitro(pkg)) return false;
-  return true;
+export async function detectViteServerEnvironments(
+  workPath: string
+): Promise<ViteEnvironmentsDetection | null> {
+  // Pre-check: is vite resolvable from this project at all? If not, this
+  // isn't a vite build and we shouldn't pay the cost of resolveConfig.
+  const projectRequire = createRequire(join(workPath, 'index.js'));
+  let vite: typeof import('vite');
+  try {
+    vite = projectRequire('vite');
+  } catch {
+    return null;
+  }
+
+  if (typeof vite.resolveConfig !== 'function') {
+    debug('Detected vite, but `resolveConfig` is missing — skipping');
+    return null;
+  }
+
+  // `resolveConfig` runs each plugin's `config`/`configResolved` hook, so
+  // plugin-contributed environments (e.g. tanstackStart()) become visible.
+  let resolved: ResolvedViteConfig;
+  try {
+    resolved = (await vite.resolveConfig(
+      { root: workPath },
+      'build'
+    )) as ResolvedViteConfig;
+  } catch (err) {
+    debug(`vite.resolveConfig failed: ${errorToString(err)}`);
+    return null;
+  }
+
+  const environments: ResolvedEnvironment[] = [];
+  for (const [name, env] of Object.entries(resolved.environments ?? {})) {
+    const consumer = env.consumer;
+    if (consumer !== 'client' && consumer !== 'server') continue;
+
+    const outDirRel = env.build?.outDir ?? resolved.build?.outDir ?? 'dist';
+    const outDir = isAbsolute(outDirRel)
+      ? outDirRel
+      : resolve(resolved.root || workPath, outDirRel);
+
+    environments.push({
+      name,
+      consumer,
+      outDir,
+      inputNames: collectInputNames(env.build?.rollupOptions?.input),
+      conditions: env.resolve?.conditions ?? [],
+    });
+  }
+
+  // Only take over if at least one server environment actually produced
+  // output on disk. Vanilla Vite SPAs, vitepress, etc. either have no
+  // server env or have one that wasn't built — those should fall through.
+  const hasBuiltServer = environments.some(
+    e => e.consumer === 'server' && existsSync(e.outDir)
+  );
+  if (!hasBuiltServer) return null;
+
+  return { environments };
 }
 
 export async function buildViteEnvironments({
   workPath,
   repoRootPath,
   nodeVersion,
+  detection,
 }: {
   workPath: string;
   repoRootPath: string;
   nodeVersion: NodeVersion;
+  detection: ViteEnvironmentsDetection;
 }): Promise<BuildResultV2Typical> {
-  const environments = await resolveViteEnvironments(workPath);
-
-  const clientEnvironments = environments.filter(e => e.consumer === 'client');
-  const serverEnvironments = environments.filter(e => e.consumer === 'server');
+  const clientEnvironments = detection.environments.filter(
+    e => e.consumer === 'client'
+  );
+  const serverEnvironments = detection.environments.filter(
+    e => e.consumer === 'server'
+  );
 
   let staticFiles: Files = {};
   for (const env of clientEnvironments) {
@@ -111,9 +173,13 @@ export async function buildViteEnvironments({
 
   for (const env of serverEnvironments) {
     if (!existsSync(env.outDir)) {
-      throw new Error(
-        `Server environment "${env.name}" declared outDir "${env.outDir}" but it does not exist after build`
+      // Server env declared but not built — skip rather than fail, since
+      // `detectViteServerEnvironments` already confirmed at least one
+      // server env did produce output.
+      debug(
+        `Skipping server environment "${env.name}": outDir ${env.outDir} does not exist`
       );
+      continue;
     }
 
     const entryFile = await findServerEntry(env);
@@ -154,58 +220,6 @@ export async function buildViteEnvironments({
   });
 
   return { routes, output };
-}
-
-async function resolveViteEnvironments(
-  workPath: string
-): Promise<ResolvedEnvironment[]> {
-  const projectRequire = createRequire(join(workPath, 'index.js'));
-  let vite: typeof import('vite');
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    vite = projectRequire('vite');
-  } catch (err) {
-    throw new Error(
-      `The vite-environments path requires "vite" to be installed in the project. ` +
-        `(${(err as Error).message})`
-    );
-  }
-
-  // `resolveConfig` runs each plugin's `config`/`configResolved` hook, so
-  // plugin-contributed environments (e.g. tanstackStart()) are visible.
-  const resolved = (await vite.resolveConfig(
-    { root: workPath },
-    'build'
-  )) as ResolvedViteConfig;
-
-  const envs: ResolvedEnvironment[] = [];
-  const envMap = resolved.environments ?? {};
-  for (const [name, env] of Object.entries(envMap)) {
-    const consumer = env.consumer;
-    if (consumer !== 'client' && consumer !== 'server') continue;
-
-    const outDirRel = env.build?.outDir ?? resolved.build?.outDir ?? 'dist';
-    const outDir = isAbsolute(outDirRel)
-      ? outDirRel
-      : resolve(resolved.root || workPath, outDirRel);
-
-    envs.push({
-      name,
-      consumer,
-      outDir,
-      inputNames: collectInputNames(env.build?.rollupOptions?.input),
-      conditions: env.resolve?.conditions ?? [],
-    });
-  }
-
-  if (envs.length === 0) {
-    throw new Error(
-      'No vite environments with a "client" or "server" consumer were resolved. ' +
-        'Ensure the project uses Vite 6+ and a framework plugin that declares environments.'
-    );
-  }
-
-  return envs;
 }
 
 function collectInputNames(
@@ -289,27 +303,4 @@ async function createServerFunction({
     supportsResponseStreaming: true,
     useWebApi: true,
   });
-}
-
-function hasTanstackStart(pkg: PackageJson): boolean {
-  return (
-    hasDependency(pkg, '@tanstack/react-start') ||
-    hasDependency(pkg, '@tanstack/solid-start')
-  );
-}
-
-function hasNitro(pkg: PackageJson): boolean {
-  return (
-    hasDependency(pkg, 'nitropack') ||
-    hasDependency(pkg, 'nitro') ||
-    hasDependency(pkg, '@tanstack/start-server-nitro')
-  );
-}
-
-function hasDependency(pkg: PackageJson, name: string): boolean {
-  return Boolean(
-    pkg.dependencies?.[name] ||
-      pkg.devDependencies?.[name] ||
-      pkg.peerDependencies?.[name]
-  );
 }

--- a/packages/static-build/src/utils/vite-environments.ts
+++ b/packages/static-build/src/utils/vite-environments.ts
@@ -168,6 +168,12 @@ export async function buildViteEnvironments({
     e => e.consumer === 'server'
   );
 
+  console.log(
+    `Detected Vite environments: ${detection.environments
+      .map(e => `${e.name} (${e.consumer}) → ${relative(workPath, e.outDir)}`)
+      .join(', ')}`
+  );
+
   let staticFiles: Files = {};
   for (const env of clientEnvironments) {
     if (!existsSync(env.outDir)) {
@@ -177,6 +183,11 @@ export async function buildViteEnvironments({
       continue;
     }
     const found = await glob('**', env.outDir);
+    console.log(
+      `Collected ${Object.keys(found).length} static asset(s) from "${
+        env.name
+      }" (${relative(workPath, env.outDir)})`
+    );
     staticFiles = { ...staticFiles, ...found };
   }
 
@@ -200,6 +211,13 @@ export async function buildViteEnvironments({
         `Could not locate the server entry file inside "${env.outDir}" for environment "${env.name}". Expected a top-level .js entry (e.g. server.js, index.js).`
       );
     }
+
+    console.log(
+      `Creating server function from "${env.name}" → ${relative(
+        workPath,
+        entryFile
+      )}`
+    );
 
     const fn = await createServerFunction({
       entryAbsolutePath: entryFile,

--- a/packages/static-build/test/build-fixtures/17-vite-environments/.gitignore
+++ b/packages/static-build/test/build-fixtures/17-vite-environments/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+yarn.lock

--- a/packages/static-build/test/build-fixtures/17-vite-environments/build.js
+++ b/packages/static-build/test/build-fixtures/17-vite-environments/build.js
@@ -1,0 +1,29 @@
+// Synthesizes the post-build layout produced by a vite project that uses
+// the Environments API with one `client` and one `server` environment.
+// Mirrors what TanStack Start / React Router v7 / Hydrogen leave on disk:
+// distinct dist/client and dist/server directories, with the server entry
+// at the root of its outDir.
+const fs = require('fs');
+const path = require('path');
+
+const clientDir = path.join(__dirname, 'dist', 'client');
+const serverDir = path.join(__dirname, 'dist', 'server');
+
+fs.mkdirSync(path.join(clientDir, 'assets'), { recursive: true });
+fs.mkdirSync(serverDir, { recursive: true });
+
+fs.writeFileSync(path.join(clientDir, 'index.html'), '<h1>Client SPA</h1>\n');
+fs.writeFileSync(
+  path.join(clientDir, 'assets', 'main.js'),
+  'console.log("client")\n'
+);
+fs.writeFileSync(
+  path.join(serverDir, 'server.js'),
+  `// Minimal web-fetch handler, same shape vite SSR builds emit.
+export default {
+  async fetch() {
+    return new Response('ok');
+  },
+};
+`
+);

--- a/packages/static-build/test/build-fixtures/17-vite-environments/package.json
+++ b/packages/static-build/test/build-fixtures/17-vite-environments/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "17-vite-environments",
+  "private": true,
+  "scripts": {
+    "build": "node build.js"
+  }
+}

--- a/packages/static-build/test/build.test.ts
+++ b/packages/static-build/test/build.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { remove } from 'fs-extra';
+import { remove, outputFile } from 'fs-extra';
 import { build } from '../src';
 
 vi.setConfig({ testTimeout: 2 * 60 * 1000, hookTimeout: 2 * 60 * 1000 });
@@ -175,6 +175,176 @@ describe('build()', () => {
       expect(err.message).toEqual(
         `Detected Build Output v3 from the "build" script, but it is not supported for \`vercel dev\`. Please set the Development Command in your Project Settings.`
       );
+    });
+  });
+
+  describe('Vite Environments API', () => {
+    // The fixture's `build` script produces a realistic post-build layout:
+    //   dist/client/{index.html,assets/main.js}   ← client env outDir
+    //   dist/server/server.js                     ← server env outDir
+    // We stub `vite` in the fixture's node_modules at test time so
+    // `detectViteServerEnvironments` can resolve it and read a deterministic
+    // environments map without pulling real vite + a framework plugin into
+    // the test dependency graph. The stub reads its environments map from a
+    // sibling JSON file each call, so tests can swap behaviour without
+    // fighting Node's require cache.
+    const workPath = path.join(
+      __dirname,
+      'build-fixtures',
+      '17-vite-environments'
+    );
+    const viteStubDir = path.join(workPath, 'node_modules', 'vite');
+    const viteStubConfigPath = path.join(viteStubDir, 'resolved.json');
+
+    async function writeViteStub() {
+      await outputFile(
+        path.join(viteStubDir, 'package.json'),
+        JSON.stringify({
+          name: 'vite',
+          version: '0.0.0-stub',
+          main: 'index.js',
+        })
+      );
+      await outputFile(
+        path.join(viteStubDir, 'index.js'),
+        `const fs = require('fs');
+const path = require('path');
+exports.resolveConfig = async function resolveConfig(inlineConfig) {
+  const cfg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'resolved.json'), 'utf8')
+  );
+  return Object.assign({ root: inlineConfig && inlineConfig.root }, cfg);
+};
+`
+      );
+    }
+
+    async function writeStubConfig(config: unknown) {
+      await outputFile(viteStubConfigPath, JSON.stringify(config));
+    }
+
+    async function cleanup() {
+      await Promise.all([
+        remove(path.join(workPath, 'dist')),
+        remove(path.join(workPath, 'node_modules')),
+      ]);
+    }
+
+    beforeEach(writeViteStub);
+    afterEach(cleanup);
+
+    it('wraps the server env entry as a function and ships the client env as static', async () => {
+      await writeStubConfig({
+        build: { outDir: 'dist' },
+        environments: {
+          client: {
+            consumer: 'client',
+            build: { outDir: 'dist/client' },
+            resolve: { conditions: ['browser', 'import'] },
+          },
+          server: {
+            consumer: 'server',
+            build: {
+              outDir: 'dist/server',
+              rollupOptions: { input: { server: 'src/server.ts' } },
+            },
+            resolve: { conditions: ['node', 'import', 'require'] },
+          },
+        },
+      });
+
+      const buildResult = await build({
+        files: {},
+        entrypoint: 'package.json',
+        repoRootPath: workPath,
+        workPath,
+        config: {},
+        meta: {
+          skipDownload: true,
+          cliVersion: '0.0.0',
+        },
+      });
+
+      if ('buildOutputVersion' in buildResult) {
+        throw new Error('Unexpected `buildOutputVersion` in build result');
+      }
+
+      // Client env's outDir → static files at the root of the output.
+      expect(buildResult.output['index.html']).toBeTruthy();
+      expect(buildResult.output['assets/main.js']).toBeTruthy();
+
+      // Server env's entry → a Vercel Function at `index`. The handler is
+      // relative to `repoRootPath`, which equals `workPath` here.
+      const fn = buildResult.output['index'] as any;
+      expect(fn).toBeTruthy();
+      expect(fn.type).toBe('Lambda');
+      expect(fn.useWebApi).toBe(true);
+      expect(fn.handler).toBe(path.join('dist', 'server', 'server.js'));
+
+      // Routes: filesystem first, then catch-all to the server function.
+      const routes = buildResult.routes ?? [];
+      expect(routes[0]).toEqual({ handle: 'filesystem' });
+      expect(routes[1]).toEqual({ src: '/(.*)', dest: '/index' });
+    });
+
+    it('falls through when no server environment is declared', async () => {
+      await writeStubConfig({
+        build: { outDir: 'dist' },
+        environments: {
+          client: { consumer: 'client', build: { outDir: 'dist/client' } },
+        },
+      });
+
+      const buildResult = await build({
+        files: {},
+        entrypoint: 'package.json',
+        repoRootPath: workPath,
+        workPath,
+        config: { outputDirectory: 'dist/client' },
+        meta: {
+          skipDownload: true,
+          cliVersion: '0.0.0',
+        },
+      });
+
+      if ('buildOutputVersion' in buildResult) {
+        throw new Error('Unexpected `buildOutputVersion` in build result');
+      }
+
+      // Static-build's normal path was used: no server function.
+      expect(buildResult.output['index']).toBeFalsy();
+      expect(buildResult.output['index.html']).toBeTruthy();
+    });
+
+    it('falls through when the server env shares the client env outDir', async () => {
+      // @sveltejs/vite-plugin-svelte registers a phantom `ssr` env with
+      // outDir defaulting to `dist`. Make sure we don't try to take over.
+      await writeStubConfig({
+        build: { outDir: 'dist' },
+        environments: {
+          client: { consumer: 'client', build: { outDir: 'dist/client' } },
+          ssr: { consumer: 'server', build: { outDir: 'dist/client' } },
+        },
+      });
+
+      const buildResult = await build({
+        files: {},
+        entrypoint: 'package.json',
+        repoRootPath: workPath,
+        workPath,
+        config: { outputDirectory: 'dist/client' },
+        meta: {
+          skipDownload: true,
+          cliVersion: '0.0.0',
+        },
+      });
+
+      if ('buildOutputVersion' in buildResult) {
+        throw new Error('Unexpected `buildOutputVersion` in build result');
+      }
+
+      expect(buildResult.output['index']).toBeFalsy();
+      expect(buildResult.output['index.html']).toBeTruthy();
     });
   });
 });

--- a/packages/static-build/test/build.test.ts
+++ b/packages/static-build/test/build.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { remove, outputFile } from 'fs-extra';
 import { build } from '../src';
+import { _resetViteEnvironmentsCacheForTests } from '../src/utils/vite-environments';
 
 vi.setConfig({ testTimeout: 2 * 60 * 1000, hookTimeout: 2 * 60 * 1000 });
 
@@ -230,7 +231,10 @@ exports.resolveConfig = async function resolveConfig(inlineConfig) {
       ]);
     }
 
-    beforeEach(writeViteStub);
+    beforeEach(async () => {
+      _resetViteEnvironmentsCacheForTests();
+      await writeViteStub();
+    });
     afterEach(cleanup);
 
     it('wraps the server env entry as a function and ships the client env as static', async () => {

--- a/packages/static-build/test/inject-nitro.test.ts
+++ b/packages/static-build/test/inject-nitro.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import type { Config, PackageJson } from '@vercel/build-utils';
+import {
+  getNitroInjectionBuildCommand,
+  resolveNitroBin,
+  shouldInjectNitro,
+} from '../src/utils/inject-nitro';
+
+function vitePkg(overrides: Partial<PackageJson> = {}): PackageJson {
+  return {
+    name: 'fixture',
+    version: '0.0.0',
+    scripts: { build: 'vite build' },
+    dependencies: { vite: '6.0.0' },
+    ...overrides,
+  };
+}
+
+function emptyConfig(overrides: Partial<Config> = {}): Config {
+  return { zeroConfig: true, projectSettings: {}, ...overrides };
+}
+
+describe('shouldInjectNitro()', () => {
+  it('fires for any project using the default `vite build` script with no nitro dep', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg(),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(true);
+  });
+
+  it('fires regardless of framework slug — no allowlist', () => {
+    // Project that looks nothing like TanStack should still get injected
+    // as long as it matches the gates.
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({
+          dependencies: {
+            vite: '6.0.0',
+            '@solidjs/start': '1.0.0',
+          },
+        }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(true);
+  });
+
+  it('skips when projectSettings.buildCommand is set', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg(),
+        config: emptyConfig({
+          projectSettings: { buildCommand: 'custom build' },
+        }),
+        buildCommand: null,
+      })
+    ).toBe(false);
+  });
+
+  it('skips when a config-level buildCommand is provided', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg(),
+        config: emptyConfig(),
+        buildCommand: 'pnpm run custom-build',
+      })
+    ).toBe(false);
+  });
+
+  it('skips when the build script is anything other than literal `vite build`', () => {
+    // SvelteKit
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({ scripts: { build: 'svelte-kit sync && vite build' } }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+
+    // VitePress
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({ scripts: { build: 'vitepress build docs' } }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+
+    // React Router
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({ scripts: { build: 'react-router build' } }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+  });
+
+  it('skips when nitro dep is declared (user manages it themselves)', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({
+          dependencies: { vite: '6.0.0', nitro: 'latest' },
+        }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({
+          devDependencies: { nitro: 'latest' },
+        }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+  });
+
+  it('skips when no package.json is found', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: null,
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+  });
+
+  it('tolerates whitespace around the build script', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({ scripts: { build: '  vite build  ' } }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('resolveNitroBin()', () => {
+  it('resolves to an absolute path inside the installed nitro package', () => {
+    const bin = resolveNitroBin();
+    // pnpm stores the package under its real name (`nitro-nightly`), so we
+    // accept either spelling.
+    expect(bin).toMatch(/[/\\]nitro(-nightly)?[/\\]/);
+    expect(bin).toMatch(/\.(m?js|cjs)$/);
+  });
+});
+
+describe('getNitroInjectionBuildCommand()', () => {
+  it('invokes node against the resolved nitro CLI with --builder vite', () => {
+    const cmd = getNitroInjectionBuildCommand();
+    expect(cmd.startsWith('node ')).toBe(true);
+    expect(cmd.endsWith(' build --builder vite')).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2286,6 +2286,9 @@ importers:
       '@vercel/gatsby-plugin-vercel-builder':
         specifier: workspace:*
         version: link:../gatsby-plugin-vercel-builder
+      '@vercel/nft':
+        specifier: 1.5.0
+        version: 1.5.0
       '@vercel/static-config':
         specifier: workspace:*
         version: link:../static-config
@@ -15735,12 +15738,6 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /magic-string@0.30.17:
-    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-    dev: true
-
   /magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
     dependencies:
@@ -20276,9 +20273,9 @@ packages:
       '@vitest/spy': 2.0.1
       '@vitest/utils': 2.0.1
       chai: 5.2.0
-      debug: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
       execa: 8.0.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 1.1.2
       picocolors: 1.1.1
       std-env: 3.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2292,6 +2292,9 @@ importers:
       '@vercel/static-config':
         specifier: workspace:*
         version: link:../static-config
+      nitro:
+        specifier: npm:nitro-nightly@latest
+        version: /nitro-nightly@3.0.1-20260108-220050-08740398(vite@5.1.8)
       ts-morph:
         specifier: 12.0.0
         version: 12.0.0
@@ -6562,6 +6565,187 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: true
 
+  /@oxc-minify/binding-android-arm-eabi@0.107.0:
+    resolution: {integrity: sha512-c8OTma/AnIdYxWUsubX6qSb5/EYpGymbkdpdjL5GKmtHWjUHpfzBWjzrNqnVm3KEPHcmbnJF4hJRi/Ti1mftJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-android-arm64@0.107.0:
+    resolution: {integrity: sha512-NHoJpyugWtCbKNjvtHUgXHoj7Bhkf1/VVyK4c6W6Xbz+w6Wtm8X5mfymL9XnbS99BOeN/LwYD5Mj6DO7NvHsCw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-darwin-arm64@0.107.0:
+    resolution: {integrity: sha512-bTV2VXUSDN/i83wozKe56hfM3vMrPGSyCa+N/Nnmd94DTLXoHPk73P+JYJNbHl6/sH6nxYyFdLh7SYDn/HETdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-darwin-x64@0.107.0:
+    resolution: {integrity: sha512-HZTH0tZSeS3z0Woe4PLKOUMYxOp5ejHHju45XyAHooglEQR3w6VlZ1HQ3Kw4MCJqf4Z06z0nb7YhxpdS4getVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-freebsd-x64@0.107.0:
+    resolution: {integrity: sha512-jj7Q+8ktkGnQmhqOKpy34BkfkohUhGLSMrrBtISaKT0WN09RSkpxVBpoXCsifDZDiNk+JD9rPnWWAnLV+vEfFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-arm-gnueabihf@0.107.0:
+    resolution: {integrity: sha512-ID771jAKIAHPuaZUB4ljYBtBi98Z7P1PoPRPIyO3pYCaQjIXlxXYRCiovu0e8AGRFu65vq+uifEVFlwQgzbldg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-arm-musleabihf@0.107.0:
+    resolution: {integrity: sha512-FsUoHmWTy1fwXo8fiGpkk9/CPaTXoUgkVILsuTbZE+jHTO1xsoKpSNvm9UKJMNxSELSgt0iGnnww9q9tj5imBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-arm64-gnu@0.107.0:
+    resolution: {integrity: sha512-97HCc3oxU1I06EOdbNSna6FFGVOb6aR93ucSNtkekJjfOfsKYJOZV/SF80DGWRYR2uDX5ChRj1d3fUBR1uWCiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-arm64-musl@0.107.0:
+    resolution: {integrity: sha512-/qsts0t/i2r+nQdYxhyg4usLPPJJZMW4QFWq4yHa7AIpbYpMggm3KMEMS+WsDO09mMJrEMe3FafcXx81QQRixA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-ppc64-gnu@0.107.0:
+    resolution: {integrity: sha512-wyq/KLE1FaffORx7wZYxUaIwNv9dPPpdJUF6SuN0YKufkAabMqeq4XsXOXo4BBiVEEy2wYz68xUVh0k5SnIoNA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-riscv64-gnu@0.107.0:
+    resolution: {integrity: sha512-+X4XArSQpiAPwooojKxXmci/WSXnwmRT4uc1C6+sf73JIYeIqhxHpgACBeuIQiwPIONMOBJ3L4EA5VXBU4ADmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-riscv64-musl@0.107.0:
+    resolution: {integrity: sha512-j9h77oDyJkilYY59k/Ing+k1Fy9wjonKl7S8GhqHmr3K5L2T/5bgoetPUtmanZkiaKX3ZDE/Yxgk6QxqymyNIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-s390x-gnu@0.107.0:
+    resolution: {integrity: sha512-id71v100CWrORuy9W93bmVVDLRz6yck/DlD12cMtZFrN5ed2NpMn8ekhkTcSdqAhikcdNRfxIhYVWqOd7qzO5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-x64-gnu@0.107.0:
+    resolution: {integrity: sha512-g0KexSyD+kUFfr4TUFceh9Zoi7mh/eqzCFl/tUP78bSegs/hRTzJzKeBH6qliJtb++lcvFwtacl7ertyf+dmTQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-linux-x64-musl@0.107.0:
+    resolution: {integrity: sha512-NLyrEEav8EexP7JDt2Lvn4p27PcoiDHt7AhsSSd0yNgNsrLcq8/jgM5RnZ+3XXXXfJiw2rQOGCifwmmjmMYdow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-openharmony-arm64@0.107.0:
+    resolution: {integrity: sha512-fDnVUgVT/FRNaek4uqXsldfl/m+f048A3IXQxtXSt8cb1nsiTYTa+L9wSWGcv8ohQ0xkT7MYRmHwLJ0q9PhYpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-wasm32-wasi@0.107.0:
+    resolution: {integrity: sha512-C2BzPWXB+yysl8FYwv1/BfoIrSFA+D93/aZ/e3ZumNh4zef1H/u+biI6IGIrclHFOA5P4I6QAmYHSm+eC42dHg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    requiresBuild: true
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-win32-arm64-msvc@0.107.0:
+    resolution: {integrity: sha512-7QYS2Kz6iEuJIZs8XhZ/saTXSjG9l9rXU5p35u9kZUq1HZhDOETGHItf/4WxqMFjpRc1j1cJUzeadP4ilniwog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-win32-ia32-msvc@0.107.0:
+    resolution: {integrity: sha512-I72JSHIEgegQvFMaRVewnEN/n8d6nwxYDwWsjgJbjrhPDw7oZOI18zw14RyyYVo4eRqPHKQFYtmmT6hINXvUhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-minify/binding-win32-x64-msvc@0.107.0:
+    resolution: {integrity: sha512-BQ0vmZWxIdllKjmaXfoyECOVogoL4UKUc6dbwcCKBsmiwTDhTeQRkX+XK017HsmvCoh/8gpsr8lBUlIh18mj4g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-parser/binding-android-arm-eabi@0.121.0:
     resolution: {integrity: sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6766,10 +6950,28 @@ packages:
     resolution: {integrity: sha512-lxmZK4xFrdvU0yZiDwgVQTCvh2gHWBJCBk5ALsrtsBWhs0uDIi+FTOnXRQeQfs304imdvTdaakT/lqwQ8hkOXQ==}
     dev: true
 
+  /@oxc-transform/binding-android-arm-eabi@0.107.0:
+    resolution: {integrity: sha512-YFAKgq4NuyAEf1goTaFO+Bd8KBJO6Q4nhYqV/BTZxw4gKI18AGyfZbgbdTxP8ezgGYOjlVLoHsCUaHCXMyLTyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-android-arm-eabi@0.111.0:
     resolution: {integrity: sha512-NdFLicvorfHYu0g2ftjVJaH7+Dz27AQUNJOq8t/ofRUoWmczOodgUCHx8C1M1htCN4ZmhS/FzfSy6yd/UngJGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-transform/binding-android-arm64@0.107.0:
+    resolution: {integrity: sha512-5dlfce4fLp8yaGOpKG8xQ2GaovyqbEc4cKysajNeh+4zWh5QukY+xZgSRqGky0dJAdljf1u2G+aHFKpFSJZROg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: false
@@ -6784,10 +6986,28 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-darwin-arm64@0.107.0:
+    resolution: {integrity: sha512-/sYLVFQdwBZy+OOUwEC3Z54EcUKhZclkORkPLSKTqid9u7kV8shjIzRlYvmvkjSiXcAfrjTnKQQW7JdP7b4pgA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-darwin-arm64@0.111.0:
     resolution: {integrity: sha512-2UYmExxpXzmiHTldhNlosWqG9Nc4US51K0GB9RLcGlTE23WO33vVo1NVAKwxPE+KYuhffwDnRYTovTMUjzwvZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-transform/binding-darwin-x64@0.107.0:
+    resolution: {integrity: sha512-l+p38Dn7x3QkMEL8nMN3qcrWihe0738fKCuOdP8Ol+U9eUxqmCubBr/tT7eTkYomI7wmKt0mmUNAnBtEMsP8Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
@@ -6802,6 +7022,15 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-freebsd-x64@0.107.0:
+    resolution: {integrity: sha512-Jf6j/+IhBWzJ+S0VkBF6ORS+CcedYdcpNJNkNUZZmKHPKWH0koygA7uzvBAk4aCOOHrWJ9SvtMNMpX+eXJl0rQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-freebsd-x64@0.111.0:
     resolution: {integrity: sha512-prvf32IcEuLnLZbNVomFosBu0CaZpyj3YsZ6epbOgJy8iJjfLsXBb+PrkO/NBKzjuJoJa2+u7jFKRE0KT7gSOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6811,8 +7040,26 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-linux-arm-gnueabihf@0.107.0:
+    resolution: {integrity: sha512-Sj5c+tNANJ5dXeaw1OoYM7uak6QrOrHXDvCsmgTzpKulkInTRjt0Fox244jXHoI1mI7oy2Ql6BGxVUPSgjKdBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-linux-arm-gnueabihf@0.111.0:
     resolution: {integrity: sha512-+se3579Wp7VOk8TnTZCpT+obTAyzOw2b/UuoM0+51LtbzCSfjKxd4A+o7zRl7GyPrPZvx57KdbMOC9rWB1xNrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-transform/binding-linux-arm-musleabihf@0.107.0:
+    resolution: {integrity: sha512-8QL0Z6oY6/WyMBigD2lxHDd0QZ1l4BScwbbbIgd9TCHYIU30yKebG1lhZjjYGCDwHMIRZGIkWe3QkMqekrQcog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -6829,8 +7076,26 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-linux-arm64-gnu@0.107.0:
+    resolution: {integrity: sha512-4JO63MC0GFvRKWCr/HOuYJiC3his5Def1rQHKlvsnoso4hWoFMFe8ovlZwbQGyInOGoh+AzneWTrPHxWZPL8cA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-linux-arm64-gnu@0.111.0:
     resolution: {integrity: sha512-HtfQv8j796gzI5WR/RaP6IMwFpiL0vYeDrUA1hYhlPzTHKYan/B+NlhJkKOI1v24yAl/yEnFmb0pxIxLNqBqBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-transform/binding-linux-arm64-musl@0.107.0:
+    resolution: {integrity: sha512-BEhpjsw2itpJFvBoGWbuyqe7yIroOhPrpjXkYXmLG4ITXyfh6DxOGddpwD5YiIbGcJwct6CAufb6SKrym7wA4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -6847,6 +7112,15 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-linux-ppc64-gnu@0.107.0:
+    resolution: {integrity: sha512-Ksqr9UcoURU3ZrNUQrkZUlsQ9pta+X0E2Sspt7PY7GXFRUU8jqde/pabdega1EyxbG26KtEmQWITZC7uMnNMKQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-linux-ppc64-gnu@0.111.0:
     resolution: {integrity: sha512-PKpVRrSvBNK3tv9vwxn7Fay+QWZmprPGlEqJcseBJllQc5mFMD4Q/w44chu5iR9ZLsDeSHzmNWrgMLo4J0sP2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6856,8 +7130,26 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-linux-riscv64-gnu@0.107.0:
+    resolution: {integrity: sha512-abM06UUQc5BLs1LQj6+o+UZr3GR815gMnh82aI0ij+TuPuan355rNJyewySic+IjLi35DzwzTNl6ooDYDMKSJw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-linux-riscv64-gnu@0.111.0:
     resolution: {integrity: sha512-9bUml6rMgk+8GF5rvNMweFspkzSiCjqpV6HduwiUyexqfGKrmjq9IZOxxvnzkE2RGdQzP507NNDoVNYIoGQYuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-transform/binding-linux-riscv64-musl@0.107.0:
+    resolution: {integrity: sha512-Ien3+97MmPMoOv0AMO6dE5rPwxRFBWzLIADZQf+aBLkSoPwuh7lduFsKZRIdRqhwwUbOrTzMezl9nxpiXlJxPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -6874,6 +7166,15 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-linux-s390x-gnu@0.107.0:
+    resolution: {integrity: sha512-hYIDp9tX2gqOPxHZQAUCnYdSLzyJFD4S0bDQi0nHktxWvDeThK4W2He0sA480F9hDzebtfPORcMekJadIkgX2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-linux-s390x-gnu@0.111.0:
     resolution: {integrity: sha512-sRG1KIfZ0ML9ToEygm5aM/5GJeBA05uHlgW3M0Rx/DNWMJhuahLmqWuB02aWSmijndLfEKXLLXIWhvWupRG8lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6883,8 +7184,26 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-linux-x64-gnu@0.107.0:
+    resolution: {integrity: sha512-Pjx7vE0Eg7XjVWNPZ7NYRKE7IKWiC2JX4rxNnjFsVy9zmMzC2PWFVDve5Aqbir6V5xEQP0AT65mmrSpCvxoZyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-linux-x64-gnu@0.111.0:
     resolution: {integrity: sha512-T0Kmvk+OdlUdABdXlDIf3MQReMzFfC75NEI9x8jxy5pKooACEFg0k0V8gyR3gq4DzbDCfucqFQDWNvSgIopAbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-transform/binding-linux-x64-musl@0.107.0:
+    resolution: {integrity: sha512-ae4jiBdaCcXVLUA7sF438QasbK4SsuJ0LrXEojjWzssnqSvVHAE77Ljm/UMkb/TaUpzVN6cc0rOZyblHu9WJtw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -6901,12 +7220,31 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-openharmony-arm64@0.107.0:
+    resolution: {integrity: sha512-C5LOVOMZIzXQqfkBrYsJSZoP8XshdYiS+fZFY89pqhxN5Gur9P9ohMEmI4HHTyGHLTHr0NpgNNy9gczmFNjifg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-openharmony-arm64@0.111.0:
     resolution: {integrity: sha512-d8J+ejc0j5WODbVwR/QxFaI65YMwvG0W53vcVCHwa6ja1QI5lpe7sislrefG2EFYgnY47voMRzlXab5d4gEcDw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-transform/binding-wasm32-wasi@0.107.0:
+    resolution: {integrity: sha512-8mvH8OBy1XRaz64Rv5oRqneQBS+OnJft8RdfUu7cMvY6egbRs6fmgR7eK09v8I1IOd2NjNZh4ceDVzTJY8RoRQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    requiresBuild: true
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
     dev: false
     optional: true
 
@@ -6920,6 +7258,15 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-win32-arm64-msvc@0.107.0:
+    resolution: {integrity: sha512-QkNUn164eM+ZFhcqwEWEa1fdDu0bMMouUc7sOge9Tz1Rrtdh9pyRY/Py6ueXNahgKfdl+OSAdvx2R5Ovs/TXCA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-win32-arm64-msvc@0.111.0:
     resolution: {integrity: sha512-YeP80Riptc0MkVVBnzbmoFuHVLUq278+MbwNo9sTLALmzTIJxJqN029xRZbG+Bun7aLsoZhmRnm3J5JZ1NcP5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6929,10 +7276,28 @@ packages:
     dev: false
     optional: true
 
+  /@oxc-transform/binding-win32-ia32-msvc@0.107.0:
+    resolution: {integrity: sha512-moocSOxVOhyGJ/aMEsnu/5m42igKzS1WW0xfO11XYhpT39Jy965s92u4c3F8ExtutJQSYwrZRPG0tXqIImFHpw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@oxc-transform/binding-win32-ia32-msvc@0.111.0:
     resolution: {integrity: sha512-A6ztCXpoSHt6PbvGAFqB0MLOcGG7ZJrrPXY1iB0zfOB1atLgI8oNePGxPl03XSbwpiTsFJ1oo8rj9DXcBzgT9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oxc-transform/binding-win32-x64-msvc@0.107.0:
+    resolution: {integrity: sha512-dz/yY+c4832akxvhoBIfHP6RddERWZatQ5nXPBip79kioIHgwYWCm3To7PgAcbT+cMbuVm4TZCgWlvdSZs4C1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: false
@@ -11989,6 +12354,17 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  /crossws@0.4.5(srvx@0.10.1):
+    resolution: {integrity: sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
+    dependencies:
+      srvx: 0.10.1
+    dev: false
+
   /css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
     dependencies:
@@ -12055,6 +12431,30 @@ packages:
   /date-fns@1.29.0:
     resolution: {integrity: sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==}
     dev: true
+
+  /db0@0.3.4:
+    resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
+    peerDependencies:
+      '@electric-sql/pglite': '*'
+      '@libsql/client': '*'
+      better-sqlite3: '*'
+      drizzle-orm: '*'
+      mysql2: '*'
+      sqlite3: '*'
+    peerDependenciesMeta:
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mysql2:
+        optional: true
+      sqlite3:
+        optional: true
+    dev: false
 
   /dc-polyfill@0.1.10:
     resolution: {integrity: sha512-9iSbB8XZ7aIrhUtWI5ulEOJ+IyUN+axquodHK+bZO4r7HfY/xwmo6I4fYYf+aiDom+WMcN/wnzCz+pKvHDDCug==}
@@ -14274,6 +14674,21 @@ packages:
       through2: 2.0.5
     dev: true
 
+  /h3@2.0.1-rc.22(crossws@0.4.5):
+    resolution: {integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+    dependencies:
+      crossws: 0.4.5(srvx@0.10.1)
+      rou3: 0.8.1
+      srvx: 0.11.15
+    dev: false
+
   /has-ansi@2.0.0:
     resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
     engines: {node: '>=0.10.0'}
@@ -15236,7 +15651,6 @@ packages:
   /jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-    dev: true
 
   /jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
@@ -16270,9 +16684,77 @@ packages:
       - babel-plugin-macros
     dev: true
 
+  /nf3@0.3.17:
+    resolution: {integrity: sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ==}
+    dev: false
+
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
+
+  /nitro-nightly@3.0.1-20260108-220050-08740398(vite@5.1.8):
+    resolution: {integrity: sha512-kWRnNRfxQRbjQz8YlQTnPW111kQYDFLI6PZhB6cMxTF9RCABw+UtA9+bYWsb27FkkpV8/Osky23xYauXiBjsGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      rolldown: '*'
+      rollup: ^4.55.1
+      vite: '>=7.3.0'
+      xml2js: ^0.6.2
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      xml2js:
+        optional: true
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.5(srvx@0.10.1)
+      db0: 0.3.4
+      h3: 2.0.1-rc.22(crossws@0.4.5)
+      jiti: 2.6.1
+      nf3: 0.3.17
+      ofetch: 2.0.0-alpha.3
+      ohash: 2.0.11
+      oxc-minify: 0.107.0
+      oxc-transform: 0.107.0
+      srvx: 0.10.1
+      undici: 7.24.0
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.7(db0@0.3.4)(ofetch@2.0.0-alpha.3)
+      vite: 5.1.8(@types/node@20.11.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - lru-cache
+      - mongodb
+      - mysql2
+      - sqlite3
+      - uploadthing
+    dev: false
 
   /node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
@@ -16540,6 +17022,14 @@ packages:
         optional: true
     dev: true
 
+  /ofetch@2.0.0-alpha.3:
+    resolution: {integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==}
+    dev: false
+
+  /ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+    dev: false
+
   /ohm-js@17.2.1:
     resolution: {integrity: sha512-4cXF0G09fAYU9z61kTfkNbKK1Kz/sGEZ5NbVWHoe9Qi7VB7y+Spwk051CpUTfUENdlIr+vt8tMV4/LosTE2cDQ==}
     engines: {node: '>=0.12.1'}
@@ -16687,6 +17177,32 @@ packages:
       safe-push-apply: 1.0.0
     dev: true
 
+  /oxc-minify@0.107.0:
+    resolution: {integrity: sha512-XNUrQWpMXAqSh8PLAkNIzoDmD7aTy6HBnCSlL/HBEAQq0xN2QE9Bs9hjYIoYAQAW8PlKV0B4fMzQr1u2B+o3JA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    optionalDependencies:
+      '@oxc-minify/binding-android-arm-eabi': 0.107.0
+      '@oxc-minify/binding-android-arm64': 0.107.0
+      '@oxc-minify/binding-darwin-arm64': 0.107.0
+      '@oxc-minify/binding-darwin-x64': 0.107.0
+      '@oxc-minify/binding-freebsd-x64': 0.107.0
+      '@oxc-minify/binding-linux-arm-gnueabihf': 0.107.0
+      '@oxc-minify/binding-linux-arm-musleabihf': 0.107.0
+      '@oxc-minify/binding-linux-arm64-gnu': 0.107.0
+      '@oxc-minify/binding-linux-arm64-musl': 0.107.0
+      '@oxc-minify/binding-linux-ppc64-gnu': 0.107.0
+      '@oxc-minify/binding-linux-riscv64-gnu': 0.107.0
+      '@oxc-minify/binding-linux-riscv64-musl': 0.107.0
+      '@oxc-minify/binding-linux-s390x-gnu': 0.107.0
+      '@oxc-minify/binding-linux-x64-gnu': 0.107.0
+      '@oxc-minify/binding-linux-x64-musl': 0.107.0
+      '@oxc-minify/binding-openharmony-arm64': 0.107.0
+      '@oxc-minify/binding-wasm32-wasi': 0.107.0
+      '@oxc-minify/binding-win32-arm64-msvc': 0.107.0
+      '@oxc-minify/binding-win32-ia32-msvc': 0.107.0
+      '@oxc-minify/binding-win32-x64-msvc': 0.107.0
+    dev: false
+
   /oxc-parser@0.121.0:
     resolution: {integrity: sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -16716,6 +17232,32 @@ packages:
       '@oxc-parser/binding-win32-x64-msvc': 0.121.0
     dev: true
     optional: true
+
+  /oxc-transform@0.107.0:
+    resolution: {integrity: sha512-vAjfqpgIIndkXjDChfvScPcRytpYkOcARhaqi6n85Op+dMRqa3ZvavMFQSZejG1Oc0nht0P8bZFZlCFKQqNIqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.107.0
+      '@oxc-transform/binding-android-arm64': 0.107.0
+      '@oxc-transform/binding-darwin-arm64': 0.107.0
+      '@oxc-transform/binding-darwin-x64': 0.107.0
+      '@oxc-transform/binding-freebsd-x64': 0.107.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.107.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.107.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.107.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.107.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.107.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.107.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.107.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.107.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.107.0
+      '@oxc-transform/binding-linux-x64-musl': 0.107.0
+      '@oxc-transform/binding-openharmony-arm64': 0.107.0
+      '@oxc-transform/binding-wasm32-wasi': 0.107.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.107.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.107.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.107.0
+    dev: false
 
   /oxc-transform@0.111.0:
     resolution: {integrity: sha512-oa5KKSDNLHZGaiqIGAbCWXeN9IJUAz9MElWcQX90epDxdKc9Hrt/BsLj3K4gDqfAYa5dwdH+ZCFJG9hR74fiGg==}
@@ -17005,7 +17547,6 @@ packages:
 
   /pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-    dev: true
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
@@ -17975,6 +18516,10 @@ packages:
       '@rollup/rollup-win32-x64-msvc': 4.52.5
       fsevents: 2.3.3
 
+  /rou3@0.8.1:
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
+    dev: false
+
   /router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -18562,6 +19107,18 @@ packages:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
     dev: true
+
+  /srvx@0.10.1:
+    resolution: {integrity: sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+    dev: false
+
+  /srvx@0.11.15:
+    resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+    dev: false
 
   /srvx@0.8.9:
     resolution: {integrity: sha512-wYc3VLZHRzwYrWJhkEqkhLb31TI0SOkfYZDkUhXdp3NoCnNS0FqajiQszZZjfow/VYEuc6Q5sZh9nM6kPy2NBQ==}
@@ -19912,6 +20469,12 @@ packages:
     resolution: {integrity: sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==}
     engines: {node: '>=20.18.1'}
 
+  /unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+    dependencies:
+      pathe: 2.0.3
+    dev: false
+
   /unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -19967,6 +20530,84 @@ packages:
       '@oxc-project/runtime': 0.97.0
       rolldown: 1.0.0-beta.50
     dev: true
+
+  /unstorage@2.0.0-alpha.7(db0@0.3.4)(ofetch@2.0.0-alpha.3):
+    resolution: {integrity: sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.11.0
+      '@azure/cosmos': ^4.9.1
+      '@azure/data-tables': ^13.3.2
+      '@azure/identity': ^4.13.0
+      '@azure/keyvault-secrets': ^4.10.0
+      '@azure/storage-blob': ^12.31.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.13.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.36.2
+      '@vercel/blob': '>=0.27.3'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      chokidar: ^4 || ^5
+      db0: '>=0.3.4'
+      idb-keyval: ^6.2.2
+      ioredis: ^5.9.3
+      lru-cache: ^11.2.6
+      mongodb: ^6 || ^7
+      ofetch: '*'
+      uploadthing: ^7.7.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      chokidar:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      lru-cache:
+        optional: true
+      mongodb:
+        optional: true
+      ofetch:
+        optional: true
+      uploadthing:
+        optional: true
+    dependencies:
+      db0: 0.3.4
+      ofetch: 2.0.0-alpha.3
+    dev: false
 
   /unzipper@0.12.3:
     resolution: {integrity: sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==}


### PR DESCRIPTION
## Summary

- Adds a post-build mapping inside `@vercel/static-build` that handles any Vite project whose vite config declares one or more `environments` with `consumer: 'server'` (TanStack Start, React Router v7, future Hydrogen, custom SSR setups).
- New module `packages/static-build/src/utils/vite-environments.ts` resolves the project's own vite (`vite.resolveConfig`), walks `resolved.environments`, copies each `consumer: 'client'` env's `outDir` into static output, and wraps each `consumer: 'server'` env's entry as a `NodejsLambda` with `useWebApi: true` — the runtime invokes `default.fetch`, matching the Web-standard handler shape these bundles emit.
- Hook lives in `static-build`'s `build()` immediately after the BOA v3/v2 checks, so projects that already emit `.vercel/output/` are still respected. Non-vite projects, vite SPAs, and vitepress fall through silently (vite not resolvable, or no server env with built output).
- Adds `@vercel/nft@1.5.0` to `static-build` dependencies for tracing the server entry (same version the remix builder uses).

## Trigger

Purely behavioral — no package-name allowlist:

1. Is `vite` resolvable from the project? If not → fall through.
2. Does `vite.resolveConfig({ root }, 'build')` succeed? If it throws → debug-log and fall through.
3. Does at least one environment have `consumer: 'server'` with an `outDir` that exists on disk? If not → fall through.
4. Otherwise take over and map every env to its appropriate output.

## Why this lives in `static-build`

The framework detector (run from the API) currently routes vite-powered meta-frameworks like TanStack Start through `@vercel/static-build`. That works for the client output, but per-env `dist/server/*.js` web-fetch handlers were being shipped as static `.js` files and SSR / server functions silently broke. This fixes it without touching the detector or shipping a new builder package. Once `@vercel/vite` (or the detector) is wired up properly, the module can move out unchanged.

## Test plan

- [ ] Local smoke against a built TanStack Start project: expect 1 `NodejsLambda` at `index` wrapping `dist/server/server.js` (`useWebApi: true`), plus static assets from `dist/client/`. (Smoke runner not included in this PR — happy to add a fixtures-based vitest if reviewers want one.)
- [ ] Local smoke against a built React Router v7 project (single server env emitting `build/server/index.js`) — expect equivalent shape.
- [ ] Deploy a real TanStack Start project via `vercel build` + `vercel deploy --prebuilt` and confirm SSR + `server.handlers` + `createServerFn` all work end-to-end.
- [ ] Verify a vanilla Vite SPA still goes through the original `BuildOutputV1` path unchanged (no server env → fall through).
- [ ] Verify a vitepress project still goes through the original path (no server env).
- [ ] Verify a non-vite `static-build` project (e.g. Gatsby, Hugo) is untouched (vite not resolvable → fall through).

## Known caveats

- `resolveConfig` re-runs each plugin's `config`/`configResolved` hook. For projects with content-collections / route-tree codegen this fires those plugins a second time after the user's build. Idempotent in practice but worth a release note when we ship.
- Multi-server-env apps (e.g. RSC + SSR) currently map to a single catch-all server function. Fine for TanStack Start and React Router v7 today; will need finer routing when more shapes appear.
- Server entry discovery falls back to "lone top-level `.js` in the env's `outDir`" when neither the rollup input name nor a well-known name matches. Errors loudly if no entry can be found rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)