### PR TITLE
Include framework slug in output/config.json

### DIFF
--- a/.changeset/lemon-needles-joke.md
+++ b/.changeset/lemon-needles-joke.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': patch
+'@vercel/next': patch
+'vercel': patch
+---
+
+Include framework slug in output/config.json

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -715,7 +715,7 @@ export interface BuildResultV2Typical {
     value: string;
   }>;
   framework?: {
-    slug?: string;
+    slug: string;
     version: string;
   };
   flags?: { definitions: FlagDefinitions };

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -715,6 +715,7 @@ export interface BuildResultV2Typical {
     value: string;
   }>;
   framework?: {
+    slug?: string;
     version: string;
   };
   flags?: { definitions: FlagDefinitions };

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -148,7 +148,7 @@ interface BuildOutputConfig {
   routes?: BuildResultV2Typical['routes'];
   overrides?: Record<string, PathOverride>;
   framework?: {
-    slug?: string;
+    slug: string;
     version: string;
   };
   crons?: Cron[];
@@ -1883,7 +1883,7 @@ function getDirectorySizeInMB(dir: string): {
 async function getFramework(
   cwd: string,
   buildResults: Map<Builder, BuildResult | BuildOutputConfig>
-): Promise<{ slug: string | undefined; version: string } | undefined> {
+): Promise<{ slug: string; version: string } | undefined> {
   const detectedFramework = await detectFrameworkRecord({
     fs: new LocalFileSystemDetector(cwd),
     frameworkList,
@@ -1911,23 +1911,26 @@ async function getFramework(
   }
 
   // determine framework version from listed package.json version
-  if (detectedFramework.detectedVersion) {
+  if (detectedFramework.slug) {
     // check for a valid, explicit version, not a range
-    if (semver.valid(detectedFramework.detectedVersion)) {
+    if (
+      detectedFramework.detectedVersion &&
+      semver.valid(detectedFramework.detectedVersion)
+    ) {
       return {
-        slug: detectedFramework.slug ?? undefined,
+        slug: detectedFramework.slug,
         version: detectedFramework.detectedVersion,
       };
     }
-  }
 
-  // determine framework version with runtime lookup
-  const frameworkVersion = detectFrameworkVersion(detectedFramework);
-  if (frameworkVersion) {
-    return {
-      slug: detectedFramework.slug ?? undefined,
-      version: frameworkVersion,
-    };
+    // determine framework version with runtime lookup
+    const frameworkVersion = detectFrameworkVersion(detectedFramework);
+    if (frameworkVersion) {
+      return {
+        slug: detectedFramework.slug,
+        version: frameworkVersion,
+      };
+    }
   }
 }
 

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -148,6 +148,7 @@ interface BuildOutputConfig {
   routes?: BuildResultV2Typical['routes'];
   overrides?: Record<string, PathOverride>;
   framework?: {
+    slug?: string;
     version: string;
   };
   crons?: Cron[];
@@ -1882,7 +1883,7 @@ function getDirectorySizeInMB(dir: string): {
 async function getFramework(
   cwd: string,
   buildResults: Map<Builder, BuildResult | BuildOutputConfig>
-): Promise<{ version: string } | undefined> {
+): Promise<{ slug: string | undefined; version: string } | undefined> {
   const detectedFramework = await detectFrameworkRecord({
     fs: new LocalFileSystemDetector(cwd),
     frameworkList,
@@ -1899,7 +1900,12 @@ async function getFramework(
         'framework' in buildResult &&
         build.use === detectedFramework.useRuntime.use
       ) {
-        return buildResult.framework;
+        return buildResult.framework
+          ? {
+              slug: buildResult.framework.slug,
+              version: buildResult.framework.version,
+            }
+          : undefined;
       }
     }
   }
@@ -1909,6 +1915,7 @@ async function getFramework(
     // check for a valid, explicit version, not a range
     if (semver.valid(detectedFramework.detectedVersion)) {
       return {
+        slug: detectedFramework.slug ?? undefined,
         version: detectedFramework.detectedVersion,
       };
     }
@@ -1918,6 +1925,7 @@ async function getFramework(
   const frameworkVersion = detectFrameworkVersion(detectedFramework);
   if (frameworkVersion) {
     return {
+      slug: detectedFramework.slug ?? undefined,
       version: frameworkVersion,
     };
   }

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1155,7 +1155,7 @@ export const build: BuildV2 = async buildOptions => {
             ]
           : []),
       ],
-      framework: { version: nextVersion },
+      framework: { slug: 'nextjs', version: nextVersion },
       ...(deploymentId && { deploymentId }),
     };
   }
@@ -2977,7 +2977,7 @@ export const build: BuildV2 = async buildOptions => {
                   ]),
           ]),
     ],
-    framework: { version: nextVersion },
+    framework: { slug: 'nextjs', version: nextVersion },
     ...(deploymentId && { deploymentId }),
   };
 };

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2982,7 +2982,7 @@ export async function serverBuild({
             },
           ]),
     ],
-    framework: { version: nextVersion },
+    framework: { slug: 'nextjs', version: nextVersion },
     flags: variantsManifest || undefined,
   };
 }

--- a/packages/remix/src/build-legacy.ts
+++ b/packages/remix/src/build-legacy.ts
@@ -616,7 +616,11 @@ module.exports = config;`;
     continue: true,
   });
 
-  return { routes, output, framework: { version: remixVersion } };
+  return {
+    routes,
+    output,
+    framework: { slug: 'remix', version: remixVersion },
+  };
 };
 
 function hasScript(scriptName: string, pkg: PackageJson | null) {

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -585,7 +585,11 @@ export const build: BuildV2 = async ({
     continue: true,
   });
 
-  return { routes, output, framework: { version: frameworkVersion } };
+  return {
+    routes,
+    output,
+    framework: { slug: 'remix', version: frameworkVersion },
+  };
 };
 
 async function traceEdgeFiles({


### PR DESCRIPTION
So that
```
.vercel/output/config.json
```
contains this:
```
  },
  "framework": {
    "slug": "nextjs",
    "version": "16.3.0-canary.22"
  },
```