### PR TITLE
[backends] Unify NFT traces into a single pass

### DIFF
--- a/.changeset/backends-nft-cjs-trace-roots.md
+++ b/.changeset/backends-nft-cjs-trace-roots.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Trace runtime dependencies from rolldown's output chunks rather than TypeScript source files. NFT picks the `require` vs `import` exports condition based on the parent file's parse result, so source-driven tracing miscategorises packages whose conditional exports point at different files (e.g. `@planetscale/database` -> `dist/index.js` for `import`, `dist/cjs/index.js` for `require`). A CJS bundle that did `require('@planetscale/database')` at runtime would fail with `Cannot find module` because the CJS variant was never traced or uploaded.

--- a/.changeset/backends-unify-nft-traces.md
+++ b/.changeset/backends-unify-nft-traces.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Collapse the two NFT traces (one inside `rolldown()` for adjacent assets, one at the top level for node_modules) into a single trace from the rolldown output chunks. `preserveModules: true` keeps the output directory parallel to source, so `__dirname`-relative asset detection still works from the chunks. Drops the now-unused `localBuildFiles` tracking and the `ignoreNodeModules` branch in `nft.ts`.

--- a/packages/backends/src/build.ts
+++ b/packages/backends/src/build.ts
@@ -56,13 +56,9 @@ export const maybeDoBuildCommand = async (
       }
     }
   }
-  const localBuildFiles = new Set<string>();
   let files: Files | undefined;
   if (outputDir && entrypoint) {
     files = await glob('**', outputDir);
-    for (const file of Object.keys(files)) {
-      localBuildFiles.add(join(outputDir, file));
-    }
   }
-  return { localBuildFiles, files, handler: entrypoint, outputDir };
+  return { files, handler: entrypoint, outputDir };
 };

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
-import { delimiter, join } from 'node:path';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { delimiter, dirname, join } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
 import {
@@ -199,25 +200,50 @@ export const build: BuildV2 = async args => {
       });
     }
 
-    const localBuildFiles =
-      userBuildResult?.localBuildFiles.size > 0
-        ? userBuildResult?.localBuildFiles
-        : rolldownResult.localBuildFiles;
-
     const files = userBuildResult?.files || rolldownResult.files;
     const handler = userBuildResult?.handler || rolldownResult.handler;
     const nftWorkPath = userBuildResult?.outputDir || args.workPath;
 
-    await nft({
-      ...args,
-      workPath: nftWorkPath,
-      localBuildFiles,
-      files,
-      ignoreNodeModules: false,
-      ignore: args.config.excludeFiles,
-      conditions: isBun ? ['bun'] : undefined,
-      span: buildSpan,
-    });
+    // Trace from the *runtime* file shape (rolldown's CJS/ESM output) rather
+    // than the TS sources. NFT picks the `require` vs `import` condition based
+    // on how the parent file parses, so source-driven tracing miscategorises
+    // packages whose conditional exports point at different files
+    // (e.g. @planetscale/database -> dist/index.js vs dist/cjs/index.js).
+    // FileBlob chunks live in memory, so materialize them next to the source
+    // tree (where pnpm's `packages/*/node_modules` symlinks are reachable from
+    // node_modules resolution) and remove them when tracing finishes.
+    const repoBase = args.repoRootPath || args.workPath;
+    const materialized: string[] = [];
+    const traceRoots = new Set<string>();
+    for (const [relPath, file] of Object.entries(files)) {
+      if (!isJsLikeExtension(relPath)) continue;
+      if (file.type === 'FileBlob') {
+        const abs = join(repoBase, relPath);
+        if (!existsSync(abs)) {
+          await mkdir(dirname(abs), { recursive: true });
+          await writeFile(abs, file.data);
+          materialized.push(abs);
+        }
+        traceRoots.add(abs);
+      } else if (file.type === 'FileFsRef') {
+        traceRoots.add(file.fsPath);
+      }
+    }
+
+    try {
+      await nft({
+        ...args,
+        workPath: nftWorkPath,
+        localBuildFiles: traceRoots,
+        files,
+        ignoreNodeModules: false,
+        ignore: args.config.excludeFiles,
+        conditions: isBun ? ['bun'] : undefined,
+        span: buildSpan,
+      });
+    } finally {
+      await Promise.all(materialized.map(p => rm(p, { force: true })));
+    }
 
     try {
       await generateProjectManifest({
@@ -387,6 +413,25 @@ export const build: BuildV2 = async args => {
 
 export const prepareCache: PrepareCache = ({ repoRootPath, workPath }) => {
   return glob(defaultCachePathGlob, repoRootPath || workPath);
+};
+
+const JS_LIKE_EXTENSIONS = new Set([
+  '.js',
+  '.cjs',
+  '.mjs',
+  '.ts',
+  '.cts',
+  '.mts',
+  '.tsx',
+  '.jsx',
+  '.json',
+  '.node',
+]);
+
+const isJsLikeExtension = (path: string) => {
+  const dot = path.lastIndexOf('.');
+  if (dot === -1) return false;
+  return JS_LIKE_EXTENSIONS.has(path.slice(dot).toLowerCase());
 };
 
 const normalizeArray = (value: any) =>

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -234,9 +234,8 @@ export const build: BuildV2 = async args => {
       await nft({
         ...args,
         workPath: nftWorkPath,
-        localBuildFiles: traceRoots,
+        traceRoots,
         files,
-        ignoreNodeModules: false,
         ignore: args.config.excludeFiles,
         conditions: isBun ? ['bun'] : undefined,
         span: buildSpan,

--- a/packages/backends/src/rolldown/index.ts
+++ b/packages/backends/src/rolldown/index.ts
@@ -5,10 +5,8 @@ import { resolveEntrypointAndFormat } from './resolve-format.js';
 import { build as rolldownBuild } from 'rolldown';
 import { builtinModules } from 'node:module';
 import { join, dirname, relative, extname } from 'node:path';
-import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { type Files, FileBlob, isBackendFramework } from '@vercel/build-utils';
-import { nft } from './nft.js';
 import { exports as resolveExports } from 'resolve.exports';
 
 const PLUGIN_NAME = 'vercel:backends';
@@ -25,7 +23,6 @@ export const rolldown = async (
 ) => {
   const files: Files = {};
   const { format, extension } = await resolveEntrypointAndFormat(args);
-  const localBuildFiles = new Set<string>();
   let handler: string | null = null;
 
   // Cache for package.json contents
@@ -134,10 +131,6 @@ export const rolldown = async (
     return id === 'bun' || id.startsWith('bun:');
   };
 
-  const isLocalImport = (id: string) => {
-    return !id.startsWith('node:') && !id.includes('node_modules');
-  };
-
   const plugin = (): Plugin => {
     return {
       name: PLUGIN_NAME,
@@ -162,21 +155,6 @@ export const rolldown = async (
           // Handle bun builtins (e.g. `bun`, `bun:sqlite`, `bun:ffi`)
           if (isBunBuiltin(id)) {
             return { id, external: true };
-          }
-
-          // Track local files for NFT (skip resolver artifacts that point at missing paths,
-          // e.g. optional workspace packages or broken pnpm links).
-          if (resolved?.id && isLocalImport(resolved.id)) {
-            if (existsSync(resolved.id)) {
-              localBuildFiles.add(resolved.id);
-            }
-          } else if (!resolved && !(isBareImport(id) && importer)) {
-            // Entry point (no importer) or unresolved local file
-            // Skip bare imports from importers (e.g. @repo/pkg that failed to resolve)
-            const candidate = join(args.workPath, id);
-            if (existsSync(candidate)) {
-              localBuildFiles.add(candidate);
-            }
           }
 
           // If the importer is a shim, let bare imports be external (don't shim again)
@@ -319,15 +297,6 @@ module.exports = requireFromContext('${pkgName}');
     }
   }
 
-  await nft({
-    ...args,
-    localBuildFiles,
-    files,
-    span: rolldownSpan ?? new Span({ name: 'vc.builder.backends.nft' }),
-    ignoreNodeModules: true,
-    ignore: args.config.excludeFiles,
-  });
-
   if (!handler) {
     throw new Error(
       `Unable to resolve build handler for entrypoint: ${args.entrypoint}`
@@ -338,5 +307,5 @@ module.exports = requireFromContext('${pkgName}');
       `${c.bold(c.cyan('✓'))} Build complete — Using ${c.bold(args.entrypoint)} as the root entrypoint.`
     )
   );
-  return { files, handler, framework, localBuildFiles };
+  return { files, handler, framework };
 };

--- a/packages/backends/src/rolldown/nft.ts
+++ b/packages/backends/src/rolldown/nft.ts
@@ -1,17 +1,16 @@
 import type { BuildOptions, Files } from '@vercel/build-utils';
 import { nodeFileTrace } from '@vercel/nft';
 import { existsSync } from 'node:fs';
-import { readFile, lstat, stat } from 'node:fs/promises';
+import { readFile, lstat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { isNativeError } from 'node:util/types';
-import { FileFsRef, FileBlob, type Span } from '@vercel/build-utils';
+import { FileFsRef, type Span } from '@vercel/build-utils';
 import { transform } from 'oxc-transform';
 
 export const nft = async (
   args: Pick<BuildOptions, 'workPath' | 'repoRootPath'> & {
-    ignoreNodeModules: boolean;
     ignore?: string | string[] | undefined;
-    localBuildFiles: Set<string>;
+    traceRoots: Set<string>;
     files: Files;
     span: Span;
     conditions?: string[];
@@ -20,17 +19,12 @@ export const nft = async (
   const nftSpan = args.span.child('vc.builder.backends.nft');
 
   const runNft = async () => {
-    const ignorePatterns = [
-      ...(args.ignoreNodeModules ? ['**/node_modules/**'] : []),
-      ...(args.ignore
-        ? Array.isArray(args.ignore)
-          ? args.ignore
-          : [args.ignore]
-        : []),
-    ];
-    const traceRoots = Array.from(args.localBuildFiles).filter(p =>
-      existsSync(p)
-    );
+    const ignorePatterns = args.ignore
+      ? Array.isArray(args.ignore)
+        ? args.ignore
+        : [args.ignore]
+      : [];
+    const traceRoots = Array.from(args.traceRoots).filter(p => existsSync(p));
     const nftResult = await nodeFileTrace(traceRoots, {
       base: args.repoRootPath,
       processCwd: args.workPath,
@@ -76,38 +70,23 @@ export const nft = async (
         }
         throw error;
       }
-      const outputPath = file;
 
-      if (args.localBuildFiles.has(join(args.repoRootPath, outputPath))) {
+      if (args.traceRoots.has(absolutePath)) {
         continue;
       }
 
       if (stats.isSymbolicLink() || stats.isFile()) {
-        if (args.ignoreNodeModules) {
-          // Symlinks may point to directories — only read actual files
-          const targetStats = stats.isSymbolicLink()
-            ? await stat(absolutePath)
-            : stats;
-          if (targetStats.isFile()) {
-            // Use FileBlob so introspection can include these files
-            const content = await readFile(absolutePath, 'utf-8');
-            args.files[outputPath] = new FileBlob({
-              data: content,
-              mode: stats.mode,
-            });
-          }
-        } else {
-          args.files[outputPath] = new FileFsRef({
-            fsPath: absolutePath,
-            mode: stats.mode,
-          });
-        }
+        args.files[file] = new FileFsRef({
+          fsPath: absolutePath,
+          mode: stats.mode,
+        });
       }
     }
   };
 
   await nftSpan.trace(runNft);
 };
+
 const isTypeScriptFile = (fsPath: string) => {
   if (
     fsPath.endsWith('.d.ts') ||


### PR DESCRIPTION
## Summary

Follow-up to #16361 — collapses the two NFT traces into one.

Before this stack there were two NFT calls:
1. Inside `rolldown/index.ts` (`ignoreNodeModules: true`) — traced from TS sources to pick up adjacent assets (`.md`, `.txt`, etc.) next to source files. Discovered files were added as `FileBlob`s so introspection could read them.
2. In `build()` (`ignoreNodeModules: false`) — traced node_modules dependencies. Discovered files were added as `FileFsRef`s for upload via filePathMap.

The first PR (#16361) switched call #2 to trace from rolldown's output chunks instead of TS sources, fixing the ESM/CJS exports-condition mismatch.

This PR drops call #1 entirely. `preserveModules: true` keeps each output chunk at the same relative path as its source file, so `__dirname`-relative asset detection still works when tracing from the output. Both responsibilities are now covered by the single top-level trace.

## Behavior changes

- Adjacent assets (e.g. `.md`/`.txt`/`.json` next to source files) are now added to the function as `FileFsRef` rather than `FileBlob`. They're uploaded via filePathMap instead of being bundled into the function. This is fine for non-code resources, and is consistent with how every other traced file already behaves.
- The introspection step (which writes `FileBlob`s to a tmp dir before loading) still has all rolldown chunks (those remain `FileBlob`s, created by rolldown's own loop). It just skips adjacent assets, which weren't code anyway.

## Cleanups

- Removed `localBuildFiles` tracking from `rolldown()` and `maybeDoBuildCommand()` — no consumers left.
- Simplified `nft.ts`: renamed `localBuildFiles` → `traceRoots`, dropped the `ignoreNodeModules` parameter and the `FileBlob` branch since there's only one caller now.

## Test plan

- [ ] CI tests pass
- [ ] Manual re-deploy of the customer repro from #16361 still works
- [ ] Spot-check a fixture that exercises adjacent-asset detection (a route file that does `fs.readFileSync(__dirname + '/foo.txt')`) — the asset should still land in the lambda

🤖 Generated with [Claude Code](https://claude.com/claude-code)