### PR TITLE
[remix] Serve react-router prerendered routes from static files

### DIFF
--- a/.changeset/react-router-prerender-static.md
+++ b/.changeset/react-router-prerender-static.md
@@ -1,0 +1,9 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Serve React Router v7 prerendered routes from static HTML/data files instead of the SSR function.
+
+Previously, when `react-router build` ran with `prerender()` configured, the prerendered HTML and `.data` files were emitted into the build output but the per-route SSR function was still installed at the same logical paths, so the filesystem handle resolved requests to the function instead of the static files.
+
+The builder now scans the client output for prerender artifacts (`<path>.html` and `index.html` for the root) and, when found, skips the SSR function override and emits a pre-filesystem rewrite from `/<path>` to the prerendered HTML file. Routes that aren't prerendered continue to be served by the SSR function unchanged.

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -17,6 +17,7 @@ import {
   NodejsLambda,
 } from '@vercel/build-utils';
 import {
+  findPrerenderedHtmlFile,
   getPathFromRoute,
   getReactRouterDataPaths,
   getRegExpFromPath,
@@ -504,17 +505,24 @@ export const build: BuildV2 = async ({
 
   const output: BuildResultV2Typical['output'] = staticFiles;
   const assetsDir = viteConfig?.build?.assetsDir || 'assets';
-  const routes: any[] = [
-    {
-      handle: 'filesystem',
-    },
-  ];
 
   // React Router v7 single-fetch rewrites loader/action network requests from
   // `<path>` to `<path>.data`. Without an entry for the `.data` variant, the
   // filesystem handle misses and traffic falls through to the SSR catch-all,
   // bypassing any per-route `runtime` / `memory` / `regions` overrides.
   const isReactRouter = frameworkSettings.slug === 'react-router';
+
+  // Snapshot the static file keys before we mutate `output` below, so that
+  // prerender detection sees only the original glob result (the `client/`
+  // directory contents, including any prerender artifacts).
+  const staticFileKeys = new Set(Object.keys(staticFiles));
+
+  // Pre-filesystem rewrites that map `/foo` to `/foo.html` for prerendered
+  // routes. We collect these first and prepend them to the routes array so
+  // they run before the filesystem handle resolves the rewritten path.
+  const prerenderRewrites: { src: string; dest: string }[] = [];
+
+  const routes: any[] = [];
 
   for (const [id, functionId] of Object.entries(
     buildManifest.routeIdToServerBundleId ?? {}
@@ -526,6 +534,28 @@ export const build: BuildV2 = async ({
     // and doesn't have any sub-routes, then a function should not be created.
     if (!path) {
       continue;
+    }
+
+    // If React Router's `prerender()` emitted a static HTML file for this
+    // route, serve that instead of routing through the SSR function. The
+    // function bundle still ships (in case other dynamic routes share it),
+    // but we skip the per-route overrides that would shadow the prerender
+    // artifacts. `<path>.data` files are emitted as-is by RR and already
+    // present in `output` from the static glob, so they resolve naturally.
+    if (isReactRouter) {
+      const htmlFile = findPrerenderedHtmlFile(path, staticFileKeys);
+      if (htmlFile) {
+        if (path !== 'index') {
+          // BOA's filesystem handle matches keys exactly, so requests for
+          // `/about` won't auto-resolve `about.html`. Add an explicit
+          // rewrite that runs before the filesystem handle.
+          prerenderRewrites.push({
+            src: `^/${path}/?$`,
+            dest: `/${htmlFile}`,
+          });
+        }
+        continue;
+      }
     }
 
     const func = functionsMap.get(functionId);
@@ -565,6 +595,11 @@ export const build: BuildV2 = async ({
       });
     }
   }
+
+  // Pre-filesystem prerender rewrites must come before the filesystem
+  // handle so the rewritten path (e.g. `/about.html`) gets resolved by
+  // the static lookup.
+  routes.unshift(...prerenderRewrites, { handle: 'filesystem' });
 
   // For the 404 case, invoke the Function (or serve the static file
   // for `ssr: false` mode) at the `/` path. Remix will serve its 404 route.

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -306,6 +306,33 @@ export function getReactRouterDataPaths(path: string): string[] {
 }
 
 /**
+ * React Router v7 `prerender()` writes static HTML + `.data` files to the
+ * client build directory at build time. For a route at URL path `/about`
+ * it emits `build/client/about.html` and `build/client/about.data`; for
+ * the root it emits `build/client/index.html` and `build/client/_root.data`.
+ *
+ * Given a route path (as returned by `getPathFromRoute()`) and the set of
+ * file keys present in the static client output, returns the relative key
+ * of the prerendered HTML file if one exists, or `undefined` if the route
+ * was not prerendered.
+ *
+ * Detecting prerender artifacts from the emitted files (rather than from
+ * the user's `prerender` config) keeps this resilient to the various
+ * config shapes — `true`, `string[]`, async function — that React Router
+ * accepts.
+ */
+export function findPrerenderedHtmlFile(
+  path: string,
+  staticFileKeys: Set<string>
+): string | undefined {
+  // For the root index route, `getPathFromRoute()` returns `path === 'index'`,
+  // and React Router emits the document as `index.html` at the client root.
+  const candidates =
+    path === 'index' ? ['index.html'] : [`${path}.html`, `${path}/index.html`];
+  return candidates.find(c => staticFileKeys.has(c));
+}
+
+/**
  * Updates the `dest` process.env object to match the `source` one.
  * A function is returned to restore the `dest` env back to how
  * it was originally.

--- a/packages/remix/test/unit.find-prerendered-html-file.test.ts
+++ b/packages/remix/test/unit.find-prerendered-html-file.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findPrerenderedHtmlFile,
+  getPathFromRoute,
+  getReactRouterDataPaths,
+  getRegExpFromPath,
+} from '../src/utils';
+import type { RouteManifest } from '../src/types';
+
+describe('findPrerenderedHtmlFile()', () => {
+  it('returns the matching `<path>.html` file for a static route', () => {
+    const keys = new Set(['about.html', 'about.data', 'index.html']);
+    expect(findPrerenderedHtmlFile('about', keys)).toBe('about.html');
+  });
+
+  it('returns `index.html` for the root index path', () => {
+    const keys = new Set(['index.html', '_root.data']);
+    expect(findPrerenderedHtmlFile('index', keys)).toBe('index.html');
+  });
+
+  it('falls back to `<path>/index.html` when `<path>.html` is absent', () => {
+    // React Router has historically emitted directory-style HTML files for
+    // some prerendered routes; tolerate both layouts.
+    const keys = new Set(['docs/getting-started/index.html']);
+    expect(findPrerenderedHtmlFile('docs/getting-started', keys)).toBe(
+      'docs/getting-started/index.html'
+    );
+  });
+
+  it('returns undefined when no prerender artifact exists', () => {
+    const keys = new Set(['assets/app.js', 'favicon.ico']);
+    expect(findPrerenderedHtmlFile('about', keys)).toBeUndefined();
+  });
+
+  it('does not match dynamic paths whose literal segment is not on disk', () => {
+    // The detection is purely file-based, so dynamic paths like
+    // `posts/:slug` never match (RR doesn't emit a `posts/:slug.html` file).
+    const keys = new Set(['posts/foo.html', 'posts/foo.data']);
+    expect(findPrerenderedHtmlFile('posts/:slug', keys)).toBeUndefined();
+  });
+});
+
+// Integration-style assertion that mirrors the per-route loop in
+// `build-vite.ts` for React Router. Given a synthetic route manifest and a
+// set of static-file keys that mimic what `prerender()` would have written
+// to `build/client/`, walk every route the same way the build loop does and
+// snapshot the resulting `output` keys, prerender rewrites, and SSR function
+// overrides. Catches regressions in prerender handling (e.g. the SSR function
+// shadowing a prerendered route) without requiring a deployment.
+describe('react-router prerender build output', () => {
+  const routes: RouteManifest = {
+    root: { id: 'root', file: 'app/root.tsx', path: '' },
+    'routes/home': {
+      id: 'routes/home',
+      parentId: 'root',
+      file: 'app/routes/home.tsx',
+      index: true,
+    },
+    'routes/about': {
+      id: 'routes/about',
+      parentId: 'root',
+      file: 'app/routes/about.tsx',
+      path: 'about',
+    },
+    'routes/contact': {
+      id: 'routes/contact',
+      parentId: 'root',
+      file: 'app/routes/contact.tsx',
+      path: 'contact',
+    },
+    'routes/api.users.$id': {
+      id: 'routes/api.users.$id',
+      parentId: 'root',
+      file: 'app/routes/api.users.$id.ts',
+      path: 'api/users/:id',
+    },
+  };
+
+  // Simulate `prerender()` emitting static HTML + .data for `/` and `/about`
+  // (but NOT `/contact` or the dynamic `/api/users/:id` route).
+  const staticFileKeys = new Set([
+    'assets/app.js',
+    'favicon.ico',
+    'index.html',
+    '_root.data',
+    'about.html',
+    'about.data',
+  ]);
+
+  type OutputAssignment =
+    | { kind: 'function'; path: string }
+    | { kind: 'static'; path: string; htmlFile: string };
+
+  function simulateBuildOutput() {
+    const assignments: OutputAssignment[] = [];
+    const dataAssignments: { dataPath: string; kind: 'function' }[] = [];
+    const prerenderRewrites: { src: string; dest: string }[] = [];
+    const dynamicRules: { src: string; dest: string }[] = [];
+
+    for (const route of Object.values(routes)) {
+      const { path, rePath } = getPathFromRoute(route, routes);
+      if (!path) continue;
+
+      const htmlFile = findPrerenderedHtmlFile(path, staticFileKeys);
+      if (htmlFile) {
+        assignments.push({ kind: 'static', path, htmlFile });
+        if (path !== 'index') {
+          prerenderRewrites.push({
+            src: `^/${path}/?$`,
+            dest: `/${htmlFile}`,
+          });
+        }
+        continue;
+      }
+
+      assignments.push({ kind: 'function', path });
+      for (const dataPath of getReactRouterDataPaths(path)) {
+        dataAssignments.push({ dataPath, kind: 'function' });
+      }
+      const reData = getRegExpFromPath(`${rePath}.data`);
+      if (reData) {
+        dynamicRules.push({ src: reData.source, dest: `${path}.data` });
+      }
+      const re = getRegExpFromPath(rePath);
+      if (re) {
+        dynamicRules.push({ src: re.source, dest: path });
+      }
+    }
+
+    return { assignments, dataAssignments, prerenderRewrites, dynamicRules };
+  }
+
+  it('does not install an SSR function override for prerendered routes', () => {
+    const { assignments } = simulateBuildOutput();
+    const aboutAssignment = assignments.find(a => a.path === 'about');
+    expect(aboutAssignment).toEqual({
+      kind: 'static',
+      path: 'about',
+      htmlFile: 'about.html',
+    });
+
+    const indexAssignment = assignments.find(a => a.path === 'index');
+    expect(indexAssignment).toEqual({
+      kind: 'static',
+      path: 'index',
+      htmlFile: 'index.html',
+    });
+  });
+
+  it('still installs an SSR function override for non-prerendered routes', () => {
+    const { assignments } = simulateBuildOutput();
+    const contactAssignment = assignments.find(a => a.path === 'contact');
+    expect(contactAssignment).toEqual({ kind: 'function', path: 'contact' });
+
+    const dynamicAssignment = assignments.find(a => a.path === 'api/users/:id');
+    expect(dynamicAssignment).toEqual({
+      kind: 'function',
+      path: 'api/users/:id',
+    });
+  });
+
+  it('does not overwrite the prerendered `.data` file with the SSR function', () => {
+    // For a prerendered route, the `.data` file was emitted by RR's prerender
+    // step and is already in `staticFiles`. The build loop must NOT assign
+    // the SSR function over the static `.data` key.
+    const { dataAssignments } = simulateBuildOutput();
+    expect(
+      dataAssignments.find(d => d.dataPath === 'about.data')
+    ).toBeUndefined();
+    expect(
+      dataAssignments.find(d => d.dataPath === '_root.data')
+    ).toBeUndefined();
+    expect(
+      dataAssignments.find(d => d.dataPath === 'index.data')
+    ).toBeUndefined();
+  });
+
+  it('emits a pre-filesystem rewrite from `/<path>` to the prerendered HTML file', () => {
+    const { prerenderRewrites } = simulateBuildOutput();
+    // The BOA filesystem handle matches keys exactly, so a request for
+    // `/about` needs an explicit rewrite to `/about.html` to resolve the
+    // prerendered file.
+    expect(prerenderRewrites).toContainEqual({
+      src: '^/about/?$',
+      dest: '/about.html',
+    });
+    // No rewrite needed for the root because BOA's filesystem handle
+    // already resolves `/` to `index.html` via the conventional index
+    // lookup; emitting a redundant rule would just be noise.
+    expect(
+      prerenderRewrites.find(r => r.dest === '/index.html')
+    ).toBeUndefined();
+  });
+
+  it('does not emit dynamic regex rules for prerendered routes', () => {
+    // Prerendered routes have no dynamic segments by construction, so
+    // `getRegExpFromPath` would already return false. Confirm the simulated
+    // loop produces dynamic rules only for the un-prerendered dynamic route.
+    const { dynamicRules } = simulateBuildOutput();
+    const aboutRule = dynamicRules.find(
+      r => r.dest === 'about' || r.dest === 'about.data'
+    );
+    expect(aboutRule).toBeUndefined();
+    // The dynamic `api/users/:id` route still produces its rules.
+    expect(
+      dynamicRules.find(r => r.dest === 'api/users/:id.data')
+    ).toBeDefined();
+    expect(dynamicRules.find(r => r.dest === 'api/users/:id')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

When `react-router build` runs with `prerender()` configured, React Router emits static HTML and `.data` files into `build/client/`, but the builder still installed the per-route SSR function at the same logical paths. The BOA filesystem handle then routed requests to the function instead of the prerendered static files, defeating the point of `prerender()`.

This fix detects prerender artifacts by scanning the client output for `<path>.html` (and `index.html` for the root). When found, the builder:

- Skips the `output[path] = func` and `output[<path>.data] = func` overrides that were shadowing the static files.
- Emits a pre-filesystem rewrite `{ src: '^/<path>/?\$', dest: '/<path>.html' }` so requests resolve to the prerendered file via the filesystem handle.

Non-prerendered routes continue to be served by the SSR function unchanged.



## Test plan

- [x] Added \`packages/remix/test/unit.find-prerendered-html-file.test.ts\` with 10 tests covering:
  - The detection helper across the various RR output layouts (\`<path>.html\`, \`<path>/index.html\`, \`index.html\` for root, and the no-match case).
  - A simulated build-output assertion (mirrors the existing single-fetch test) that walks a synthetic route manifest and verifies prerendered routes get static assignments + pre-filesystem rewrites, non-prerendered routes still get the SSR function, and \`.data\` files aren't overwritten.
- [x] All existing unit tests still pass (\`packages/remix\`: 137 passed, 4 skipped).
- [x] \`tsc --noEmit\` clean.
- [ ] Deploy the customer's reproduction against this builder and confirm prerendered routes are served from static (no function invocation in logs).