### PR TITLE
[vercel/functions] cache api get defaults options.name to the provided key

### DIFF
--- a/.changeset/wet-rats-cry.md
+++ b/.changeset/wet-rats-cry.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': minor
+---
+
+`getCache().get()` now defaults `options.name` to the provided `key` when omitted, so GET requests show a human-readable label in o11y instead of the raw hashed `itemId`. Pass `name: ''` to suppress this behavior and use the hashed key.

--- a/packages/functions/docs/index/interfaces/RuntimeCache.md
+++ b/packages/functions/docs/index/interfaces/RuntimeCache.md
@@ -38,7 +38,7 @@ A promise that resolves when the value is deleted.
 
 > **expireTag**: (`tag`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`\>
 
-Defined in: [packages/functions/src/cache/types.ts:44](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L44)
+Defined in: [packages/functions/src/cache/types.ts:49](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L49)
 
 Expires cache entries by tag.
 
@@ -60,9 +60,9 @@ A promise that resolves when the cache entries expiration request is received.
 
 ### get
 
-> **get**: (`key`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`unknown`\>
+> **get**: (`key`, `options?`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`unknown`\>
 
-Defined in: [packages/functions/src/cache/types.ts:19](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L19)
+Defined in: [packages/functions/src/cache/types.ts:21](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L21)
 
 Retrieves a value from the cache.
 
@@ -73,6 +73,16 @@ Retrieves a value from the cache.
 `string`
 
 The key of the value to retrieve.
+
+##### options?
+
+Optional settings for the cache read.
+
+###### name?
+
+`string`
+
+Optional user-friendly name for the cache entry used for o11y. Defaults to the provided `key` when omitted; pass `''` to suppress sending a name.
 
 #### Returns
 
@@ -86,7 +96,7 @@ A promise that resolves to the value, or null if not found.
 
 > **set**: (`key`, `value`, `options?`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`\>
 
-Defined in: [packages/functions/src/cache/types.ts:32](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L32)
+Defined in: [packages/functions/src/cache/types.ts:37](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L37)
 
 Sets a value in the cache.
 

--- a/packages/functions/src/cache/build-client.ts
+++ b/packages/functions/src/cache/build-client.ts
@@ -29,12 +29,19 @@ export class BuildCache {
     this.timeout = timeout;
   }
 
-  public get = async (key: string) => {
+  public get = async (key: string, options?: { name?: string }) => {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.timeout);
     try {
+      const optionalHeaders: Record<string, string> = {};
+      if (options?.name) {
+        optionalHeaders[HEADERS_VERCEL_CACHE_ITEM_NAME] = options.name;
+      }
       const res = await fetch(`${this.endpoint}${key}`, {
-        headers: this.headers,
+        headers: {
+          ...this.headers,
+          ...optionalHeaders,
+        },
         method: 'GET',
         signal: controller.signal,
       });

--- a/packages/functions/src/cache/in-memory-cache.ts
+++ b/packages/functions/src/cache/in-memory-cache.ts
@@ -10,7 +10,11 @@ interface CacheEntry {
 export class InMemoryCache implements RuntimeCache {
   private cache: Record<string, CacheEntry> = {};
 
-  async get(key: string): Promise<unknown | null> {
+  async get(
+    key: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options?: { name?: string }
+  ): Promise<unknown | null> {
     const entry = this.cache[key];
     if (entry) {
       if (entry.ttl && entry.lastModified + entry.ttl * 1000 < Date.now()) {

--- a/packages/functions/src/cache/in-memory-cache.ts
+++ b/packages/functions/src/cache/in-memory-cache.ts
@@ -10,11 +10,7 @@ interface CacheEntry {
 export class InMemoryCache implements RuntimeCache {
   private cache: Record<string, CacheEntry> = {};
 
-  async get(
-    key: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _options?: { name?: string }
-  ): Promise<unknown | null> {
+  async get(key: string, options?: { name?: string }): Promise<unknown | null> {
     const entry = this.cache[key];
     if (entry) {
       if (entry.ttl && entry.lastModified + entry.ttl * 1000 < Date.now()) {

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -67,8 +67,11 @@ function wrapWithKeyTransformation(
   makeKey: (key: string) => string
 ): RuntimeCache {
   return {
-    get: (key: string) => {
-      return resolveCache().get(makeKey(key));
+    get: (key: string, options?: { name?: string }) => {
+      return resolveCache().get(makeKey(key), {
+        ...options,
+        name: options?.name ?? key,
+      });
     },
     set: (
       key: string,

--- a/packages/functions/src/cache/types.ts
+++ b/packages/functions/src/cache/types.ts
@@ -14,9 +14,11 @@ export interface RuntimeCache {
    * Retrieves a value from the cache.
    *
    * @param {string} key - The key of the value to retrieve.
+   * @param {Object} [options] - Optional settings for the cache read.
+   * @param {string} [options.name] - Optional user-friendly name for the cache entry used for o11y. Defaults to the provided `key` when omitted; pass `''` to suppress sending a name.
    * @returns {Promise<unknown | null>} A promise that resolves to the value, or null if not found.
    */
-  get: (key: string) => Promise<unknown | null>;
+  get: (key: string, options?: { name?: string }) => Promise<unknown | null>;
 
   /**
    * Sets a value in the cache.

--- a/packages/functions/test/unit/cache/build-client.test.ts
+++ b/packages/functions/test/unit/cache/build-client.test.ts
@@ -40,6 +40,46 @@ describe('BuildCache', () => {
     expect(result).toEqual(value);
   });
 
+  it('should send x-vercel-cache-item-name header on get when name is provided', async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'fresh' },
+      json: async () => value,
+    });
+    await cache.get(key, { name: 'human-name' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(key),
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'x-vercel-cache-item-name': 'human-name',
+        }),
+      })
+    );
+  });
+
+  it('should not send x-vercel-cache-item-name header on get when name is omitted', async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'fresh' },
+      json: async () => value,
+    });
+    await cache.get(key);
+    const callHeaders = fetchMock.mock.calls[0][1].headers;
+    expect(callHeaders).not.toHaveProperty('x-vercel-cache-item-name');
+  });
+
+  it('should not send x-vercel-cache-item-name header on get when name is an empty string', async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'fresh' },
+      json: async () => value,
+    });
+    await cache.get(key, { name: '' });
+    const callHeaders = fetchMock.mock.calls[0][1].headers;
+    expect(callHeaders).not.toHaveProperty('x-vercel-cache-item-name');
+  });
+
   it('should return null when status is 404', async () => {
     fetchMock.mockResolvedValueOnce({ status: 404 });
     const result = await cache.get(key);

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -38,7 +38,7 @@ describe('getCache', () => {
     expect(mockCache.set).toHaveBeenCalledWith('b876d32', 'value', {
       name: 'key',
     });
-    expect(mockCache.get).toHaveBeenCalledWith('b876d32', undefined);
+    expect(mockCache.get).toHaveBeenCalledWith('b876d32', { name: 'key' });
   });
 
   test('should return the same cache instance for multiple calls to getCache when no context cache is available', async () => {
@@ -89,7 +89,7 @@ describe('getCache', () => {
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
-    expect(mockCache.get).toHaveBeenCalledWith('b876d32', undefined);
+    expect(mockCache.get).toHaveBeenCalledWith('b876d32', { name: 'key' });
   });
 
   test('should use the provided namespace and separator', async () => {
@@ -103,7 +103,9 @@ describe('getCache', () => {
     expect(mockCache.set).toHaveBeenCalledWith('test:b876d32', 'value', {
       name: 'key',
     });
-    expect(mockCache.get).toHaveBeenCalledWith('test:b876d32', undefined);
+    expect(mockCache.get).toHaveBeenCalledWith('test:b876d32', {
+      name: 'key',
+    });
   });
 
   test('should use the default namespace separator if none is provided', async () => {
@@ -119,10 +121,9 @@ describe('getCache', () => {
         name: 'key',
       }
     );
-    expect(mockCache.get).toHaveBeenCalledWith(
-      `${namespace}$b876d32`,
-      undefined
-    );
+    expect(mockCache.get).toHaveBeenCalledWith(`${namespace}$b876d32`, {
+      name: 'key',
+    });
   });
 
   test('should default options.name to the original key when not provided', async () => {
@@ -152,6 +153,30 @@ describe('getCache', () => {
       name: 'explicit-name',
       tags: ['t1'],
       ttl: 60,
+    });
+  });
+
+  test('should default get options.name to the original key when not provided', async () => {
+    const cache = getCache();
+    await cache.get('my-key');
+    expect(mockCache.get).toHaveBeenCalledWith('57f938ab', {
+      name: 'my-key',
+    });
+  });
+
+  test('should preserve an explicit empty string options.name on get as a suppression sentinel', async () => {
+    const cache = getCache();
+    await cache.get('my-key', { name: '' });
+    expect(mockCache.get).toHaveBeenCalledWith('57f938ab', {
+      name: '',
+    });
+  });
+
+  test('should preserve explicit options.name on get when provided', async () => {
+    const cache = getCache();
+    await cache.get('my-key', { name: 'explicit-name' });
+    expect(mockCache.get).toHaveBeenCalledWith('57f938ab', {
+      name: 'explicit-name',
     });
   });
 });


### PR DESCRIPTION
## Problem

The `get` method on the Runtime Cache api never sent the `x-vercel-cache-item-name` header, so even when a value was stored with a user-friendly `options.name` on `set`, the corresponding GET request showed up in o11y tooling labeled with the raw hashed `itemId` instead of the human-readable name. This is the asymmetric counterpart to the [recently-fixed `set`](https://github.com/vercel/vercel/pull/16293) default — `set` was correctly naming entries, but `get` wasn't. 

## Solution

Default `options.name` on `get` to the original `key` when the caller omits it, mirroring the existing `set` behavior. An explicit empty string (`name: ''`) is preserved and acts as a suppression sentinel so passing `''` is an option for callers who don't want the raw key in the o11y. The wrapper passes the option through, and `BuildCache.get` sends the `x-vercel-cache-item-name` header when the name is a non-empty string.

## Changes

- `packages/functions/src/cache/types.ts` — widened `RuntimeCache.get` to accept an optional `{ name?: string }`

- `packages/functions/src/cache/index.ts` — in the `get` wrapper, spread `options` and fall back to `key` for `name` via `??` (preserves `''` as a sentinel), mirroring `set`.

- `packages/functions/src/cache/build-client.ts` — `BuildCache.get` accepts the new option and sets `x-vercel-cache-item-name` when `name` is non-empty.

- `packages/functions/src/cache/in-memory-cache.ts` — `InMemoryCache.get` accepts the new option for type alignment with `RuntimeCache` (ignored at runtime).

- `packages/functions/docs/index/interfaces/RuntimeCache.md` — regenerated docs to match the updated JSDoc.

- `packages/functions/test/unit/cache/index.test.ts` — existing `get` assertions updated to expect the new default; three new tests cover (a) the default-when-omitted path, (b) `{ name: '' }` preserved as a suppression sentinel, and (c) explicit `name` preserved.

- `packages/functions/test/unit/cache/build-client.test.ts` — three new tests covering the header behavior on GET (sent when name provided, omitted when name is `undefined`, omitted when name is `''`).

