### PR TITLE
[services] Add project manifest to node frontend builders.

### DIFF
--- a/.changeset/healthy-swans-explode.md
+++ b/.changeset/healthy-swans-explode.md
@@ -1,0 +1,9 @@
+---
+'@vercel/static-build': minor
+'@vercel/hydrogen': minor
+'@vercel/redwood': minor
+'@vercel/remix-builder': minor
+'@vercel/next': minor
+---
+
+Add project manifest to node frontend builders.

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1663,7 +1663,12 @@ createServer((_req, res) => {
 
       const files = await fs.readdir(output);
       // we should NOT see `functions` because that means `middleware.ts` was processed
-      expect(files.sort()).toEqual(['builds.json', 'config.json', 'static']);
+      expect(files.sort()).toEqual([
+        'builds.json',
+        'config.json',
+        'diagnostics',
+        'static',
+      ]);
     } finally {
       delete process.env.STORYBOOK_DISABLE_TELEMETRY;
     }

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -25,3 +25,6 @@ export const startDevServer: StartDevServer = async opts => {
     entrypoint,
   });
 };
+
+import { createDiagnostics } from '@vercel/build-utils';
+export const diagnostics = createDiagnostics('node');

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -34,3 +34,6 @@ export const startDevServer: StartDevServer = async opts => {
     publicDir: 'public',
   });
 };
+
+import { createDiagnostics } from '@vercel/build-utils';
+export const diagnostics = createDiagnostics('node');

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -31,3 +31,6 @@ export const startDevServer: StartDevServer = async opts => {
     entrypoint,
   });
 };
+
+import { createDiagnostics } from '@vercel/build-utils';
+export const diagnostics = createDiagnostics('node');

--- a/packages/h3/src/index.ts
+++ b/packages/h3/src/index.ts
@@ -31,3 +31,6 @@ export const startDevServer: StartDevServer = async opts => {
     entrypoint,
   });
 };
+
+import { createDiagnostics } from '@vercel/build-utils';
+export const diagnostics = createDiagnostics('node');

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -26,3 +26,6 @@ export const startDevServer: StartDevServer = async opts => {
     publicDir: 'public',
   });
 };
+
+import { createDiagnostics } from '@vercel/build-utils';
+export const diagnostics = createDiagnostics('node');

--- a/packages/hydrogen/src/build.ts
+++ b/packages/hydrogen/src/build.ts
@@ -5,7 +5,9 @@ import {
   download,
   EdgeFunction,
   execCommand,
+  generateProjectManifest,
   getEnvForPackageManager,
+  getNodeVersion,
   getPrefixedEnvVars,
   glob,
   readConfigFile,
@@ -23,6 +25,7 @@ export const build: BuildV2 = async ({
   workPath,
   config,
   meta = {},
+  service,
 }) => {
   const { installCommand, buildCommand } = config;
 
@@ -40,8 +43,16 @@ export const build: BuildV2 = async ({
   const mountpoint = dirname(entrypoint);
   const entrypointDir = join(workPath, mountpoint);
 
+  const nodeVersion = await getNodeVersion(
+    entrypointDir,
+    undefined,
+    config,
+    meta
+  );
+
   const {
     cliType,
+    lockfilePath,
     lockfileVersion,
     packageJsonPackageManager,
     turboSupportsCorepackHome,
@@ -73,6 +84,22 @@ export const build: BuildV2 = async ({
       { env: spawnEnv },
       meta,
       config.projectSettings?.createdAt
+    );
+  }
+
+  try {
+    await generateProjectManifest({
+      workPath: entrypointDir,
+      nodeVersion,
+      cliType,
+      lockfilePath,
+      lockfileVersion,
+      framework: 'hydrogen',
+      serviceType: service?.type,
+    });
+  } catch (err) {
+    debug(
+      `Failed to write hydrogen manifest: ${err instanceof Error ? err.message : String(err)}`
     );
   }
 

--- a/packages/hydrogen/src/build.ts
+++ b/packages/hydrogen/src/build.ts
@@ -8,6 +8,7 @@ import {
   generateProjectManifest,
   getEnvForPackageManager,
   getNodeVersion,
+  getReportedServiceType,
   getPrefixedEnvVars,
   glob,
   readConfigFile,
@@ -94,8 +95,8 @@ export const build: BuildV2 = async ({
       cliType,
       lockfilePath,
       lockfileVersion,
-      framework: 'hydrogen',
-      serviceType: service?.type,
+      framework: config.framework ?? undefined,
+      serviceType: service ? getReportedServiceType(service) : undefined,
     });
   } catch (err) {
     debug(

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -1,3 +1,6 @@
+import { createDiagnostics } from '@vercel/build-utils';
+
 export const version = 2;
 export * from './build';
 export * from './prepare-cache';
+export const diagnostics = createDiagnostics('node');

--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -31,3 +31,6 @@ export const startDevServer: StartDevServer = async opts => {
     entrypoint,
   });
 };
+
+import { createDiagnostics } from '@vercel/build-utils';
+export const diagnostics = createDiagnostics('node');

--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -31,3 +31,6 @@ export const startDevServer: StartDevServer = async opts => {
     entrypoint,
   });
 };
+
+import { createDiagnostics } from '@vercel/build-utils';
+export const diagnostics = createDiagnostics('node');

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -30,6 +30,8 @@ import {
   detectPackageManager,
   BUILDER_INSTALLER_STEP,
   BUILDER_COMPILE_STEP,
+  createDiagnostics,
+  generateProjectManifest,
   type TriggerEvent,
 } from '@vercel/build-utils';
 import { Route, RouteWithHandle, RouteWithSrc } from '@vercel/routing-utils';
@@ -275,6 +277,7 @@ export const build: BuildV2 = async buildOptions => {
   const nodeVersion = await getNodeVersion(entryPath, undefined, config, meta);
   const {
     cliType,
+    lockfilePath,
     lockfileVersion,
     packageJsonPackageManager,
     turboSupportsCorepackHome,
@@ -576,6 +579,22 @@ export const build: BuildV2 = async buildOptions => {
 
   if (buildCallback) {
     await buildCallback(buildOptions);
+  }
+
+  try {
+    await generateProjectManifest({
+      workPath,
+      nodeVersion,
+      cliType,
+      lockfilePath,
+      lockfileVersion,
+      framework: 'nextjs',
+      serviceType: buildOptions.service?.type,
+    });
+  } catch (err) {
+    debug(
+      `Failed to write next manifest: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
 
   let buildOutputVersion: undefined | number;
@@ -2983,11 +3002,14 @@ export const build: BuildV2 = async buildOptions => {
   };
 };
 
+const packageManifestDiagnostics = createDiagnostics('node');
+
 export const diagnostics: Diagnostics = async ({
   config,
   entrypoint,
   workPath,
   repoRootPath,
+  ...rest
 }) => {
   const entryDirectory = path.dirname(entrypoint);
   const entryPath = path.join(workPath, entryDirectory);
@@ -3000,6 +3022,13 @@ export const diagnostics: Diagnostics = async ({
   );
 
   return {
+    ...(await packageManifestDiagnostics({
+      config,
+      entrypoint,
+      workPath,
+      repoRootPath,
+      ...rest,
+    })),
     // Collect output in `.next/diagnostics`
     ...(await glob(
       '*',

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -32,6 +32,7 @@ import {
   BUILDER_COMPILE_STEP,
   createDiagnostics,
   generateProjectManifest,
+  getReportedServiceType,
   type TriggerEvent,
 } from '@vercel/build-utils';
 import { Route, RouteWithHandle, RouteWithSrc } from '@vercel/routing-utils';
@@ -588,8 +589,10 @@ export const build: BuildV2 = async buildOptions => {
       cliType,
       lockfilePath,
       lockfileVersion,
-      framework: 'nextjs',
-      serviceType: buildOptions.service?.type,
+      framework: config.framework ?? undefined,
+      serviceType: buildOptions.service
+        ? getReportedServiceType(buildOptions.service)
+        : undefined,
     });
   } catch (err) {
     debug(

--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -16,6 +16,8 @@ import {
   download,
   glob,
   debug,
+  createDiagnostics,
+  generateProjectManifest,
   getNodeVersion,
   getPrefixedEnvVars,
   runNpmInstall,
@@ -53,6 +55,7 @@ export const build: BuildV2 = async ({
   entrypoint,
   meta = {},
   config = {},
+  service,
 }) => {
   await download(files, workPath, meta);
 
@@ -77,6 +80,7 @@ export const build: BuildV2 = async ({
 
   const {
     cliType,
+    lockfilePath,
     lockfileVersion,
     packageJsonPackageManager,
     turboSupportsCorepackHome,
@@ -109,6 +113,22 @@ export const build: BuildV2 = async ({
       { env: spawnEnv },
       meta,
       config.projectSettings?.createdAt
+    );
+  }
+
+  try {
+    await generateProjectManifest({
+      workPath: entrypointFsDirname,
+      nodeVersion,
+      cliType,
+      lockfilePath,
+      lockfileVersion,
+      framework: 'redwood',
+      serviceType: service?.type,
+    });
+  } catch (err) {
+    debug(
+      `Failed to write redwood manifest: ${err instanceof Error ? err.message : String(err)}`
     );
   }
 
@@ -338,3 +358,5 @@ function hasScript(scriptName: string, pkg: PackageJson | null) {
 export const prepareCache: PrepareCache = ({ repoRootPath, workPath }) => {
   return glob(defaultCachePathGlob, repoRootPath || workPath);
 };
+
+export const diagnostics = createDiagnostics('node');

--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -18,6 +18,7 @@ import {
   debug,
   createDiagnostics,
   generateProjectManifest,
+  getReportedServiceType,
   getNodeVersion,
   getPrefixedEnvVars,
   runNpmInstall,
@@ -123,8 +124,8 @@ export const build: BuildV2 = async ({
       cliType,
       lockfilePath,
       lockfileVersion,
-      framework: 'redwood',
-      serviceType: service?.type,
+      framework: config.framework ?? undefined,
+      serviceType: service ? getReportedServiceType(service) : undefined,
     });
   } catch (err) {
     debug(

--- a/packages/remix/src/build-legacy.ts
+++ b/packages/remix/src/build-legacy.ts
@@ -9,6 +9,7 @@ import {
   FileFsRef,
   generateProjectManifest,
   getEnvForPackageManager,
+  getReportedServiceType,
   getNodeVersion,
   glob,
   EdgeFunction,
@@ -154,8 +155,8 @@ export const build: BuildV2 = async ({
       cliType,
       lockfilePath,
       lockfileVersion,
-      framework: 'remix',
-      serviceType: service?.type,
+      framework: config.framework ?? undefined,
+      serviceType: service ? getReportedServiceType(service) : undefined,
     });
   } catch (err) {
     debug(

--- a/packages/remix/src/build-legacy.ts
+++ b/packages/remix/src/build-legacy.ts
@@ -7,6 +7,7 @@ import {
   execCommand,
   FileBlob,
   FileFsRef,
+  generateProjectManifest,
   getEnvForPackageManager,
   getNodeVersion,
   glob,
@@ -81,6 +82,7 @@ export const build: BuildV2 = async ({
   repoRootPath,
   config,
   meta = {},
+  service,
 }) => {
   const { installCommand, buildCommand } = config;
 
@@ -142,6 +144,22 @@ export const build: BuildV2 = async ({
       { env: spawnEnv },
       meta,
       config.projectSettings?.createdAt
+    );
+  }
+
+  try {
+    await generateProjectManifest({
+      workPath: entrypointFsDirname,
+      nodeVersion,
+      cliType,
+      lockfilePath,
+      lockfileVersion,
+      framework: 'remix',
+      serviceType: service?.type,
+    });
+  } catch (err) {
+    debug(
+      `Failed to write remix manifest: ${err instanceof Error ? err.message : String(err)}`
     );
   }
 

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -6,6 +6,7 @@ import {
   BuildResultV2Typical,
   debug,
   execCommand,
+  generateProjectManifest,
   getEnvForPackageManager,
   getNodeVersion,
   glob,
@@ -288,6 +289,7 @@ export const build: BuildV2 = async ({
   repoRootPath,
   config,
   meta = {},
+  service,
 }) => {
   const { installCommand, buildCommand } = config;
   const mountpoint = dirname(entrypoint);
@@ -308,6 +310,7 @@ export const build: BuildV2 = async ({
 
   const {
     cliType,
+    lockfilePath,
     lockfileVersion,
     packageJson,
     packageJsonPackageManager,
@@ -340,6 +343,22 @@ export const build: BuildV2 = async ({
       { env: spawnEnv },
       meta,
       config.projectSettings?.createdAt
+    );
+  }
+
+  try {
+    await generateProjectManifest({
+      workPath: entrypointFsDirname,
+      nodeVersion,
+      cliType,
+      lockfilePath,
+      lockfileVersion,
+      framework: frameworkSettings.slug,
+      serviceType: service?.type,
+    });
+  } catch (err) {
+    debug(
+      `Failed to write remix manifest: ${err instanceof Error ? err.message : String(err)}`
     );
   }
 

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -8,6 +8,7 @@ import {
   execCommand,
   generateProjectManifest,
   getEnvForPackageManager,
+  getReportedServiceType,
   getNodeVersion,
   glob,
   runNpmInstall,
@@ -353,8 +354,8 @@ export const build: BuildV2 = async ({
       cliType,
       lockfilePath,
       lockfileVersion,
-      framework: frameworkSettings.slug,
-      serviceType: service?.type,
+      framework: config.framework ?? undefined,
+      serviceType: service ? getReportedServiceType(service) : undefined,
     });
   } catch (err) {
     debug(

--- a/packages/remix/src/index.ts
+++ b/packages/remix/src/index.ts
@@ -1,3 +1,6 @@
+import { createDiagnostics } from '@vercel/build-utils';
+
 export const version = 2;
 export * from './build';
 export * from './prepare-cache';
+export const diagnostics = createDiagnostics('node');

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -30,6 +30,8 @@ import {
   runPipInstall,
   runPackageJsonScript,
   runShellScript,
+  createDiagnostics,
+  generateProjectManifest,
   getNodeVersion,
   debug,
   NowBuildError,
@@ -352,6 +354,7 @@ export const build: BuildV2 = async ({
   repoRootPath,
   config,
   meta = {},
+  service,
 }) => {
   await download(files, workPath, meta);
 
@@ -494,6 +497,7 @@ export const build: BuildV2 = async ({
 
     const {
       cliType,
+      lockfilePath,
       lockfileVersion,
       packageJsonPackageManager,
       turboSupportsCorepackHome,
@@ -600,6 +604,24 @@ export const build: BuildV2 = async ({
           );
           isNpmInstall = true;
         }
+      }
+    }
+
+    if (framework?.slug) {
+      try {
+        await generateProjectManifest({
+          workPath: entrypointDir,
+          nodeVersion,
+          cliType,
+          lockfilePath,
+          lockfileVersion,
+          framework: framework.slug,
+          serviceType: service?.type,
+        });
+      } catch (err) {
+        debug(
+          `Failed to write static-build manifest: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     }
 
@@ -936,3 +958,5 @@ export const prepareCache: PrepareCache = async ({
 
   return cacheFiles;
 };
+
+export const diagnostics = createDiagnostics('node');

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -32,6 +32,7 @@ import {
   runShellScript,
   createDiagnostics,
   generateProjectManifest,
+  getReportedServiceType,
   getNodeVersion,
   debug,
   NowBuildError,
@@ -616,7 +617,7 @@ export const build: BuildV2 = async ({
           lockfilePath,
           lockfileVersion,
           framework: framework.slug,
-          serviceType: service?.type,
+          serviceType: service ? getReportedServiceType(service) : undefined,
         });
       } catch (err) {
         debug(


### PR DESCRIPTION
Re-use existing manifest generation functionality and apply it to the `next`, `remix`, `redwood`, `hydrogen`, and `static-build` builders.

Tested it manually.