### PR TITLE
[cli] Add `--project` flag to `build`, `deploy`, `pull`, and `dev`

### DIFF
--- a/.changeset/project-flag-build-deploy-pull-dev.md
+++ b/.changeset/project-flag-build-deploy-pull-dev.md
@@ -9,6 +9,7 @@ When `--project` is provided, the CLI will:
 - Disambiguate monorepo `.vercel/repo.json` linked projects without prompting (matches by name **or** ID)
 - Resolve the project via the API when no local link is present
 - Fail fast with a clean "Project ... was not found" error if the value cannot be resolved (never silently creates a new project)
+- In non-interactive contexts (CI, agents) the same failure also emits a structured JSON payload with a `next` array of suggested follow-up commands.
 
 This is particularly important for agents (which run non-interactively by default): they can now target a specific project in monorepos and unlinked directories without relying on interactive setup prompts or the project picker.
 

--- a/.changeset/project-flag-build-deploy-pull-dev.md
+++ b/.changeset/project-flag-build-deploy-pull-dev.md
@@ -1,0 +1,17 @@
+---
+'vercel': minor
+---
+
+Add `--project <NAME_OR_ID>` flag to `build`, `deploy`, `pull`, and `dev` for non-interactive CI/CD and agent-driven use.
+
+When `--project` is provided, the CLI will:
+
+- Disambiguate monorepo `.vercel/repo.json` linked projects without prompting (matches by name **or** ID)
+- Resolve the project via the API when no local link is present
+- Fail fast with a clean "Project ... was not found" error if the value cannot be resolved (never silently creates a new project)
+
+This is particularly important for agents (which run non-interactively by default): they can now target a specific project in monorepos and unlinked directories without relying on interactive setup prompts or the project picker.
+
+The flag is also accepted on `vercel deploy init` (excluded on `vercel deploy continue` because `--id` already identifies the deployment).
+
+The new API-based resolution is opt-in via the explicit `--project` flag, so commands like `vercel deploy` in an unlinked directory keep their existing behavior of falling back to interactive setup.

--- a/packages/cli/src/commands/activity/command.ts
+++ b/packages/cli/src/commands/activity/command.ts
@@ -1,5 +1,10 @@
 import { packageName } from '../../util/pkg-name';
-import { formatOption, limitOption, nextOption } from '../../util/arg-common';
+import {
+  formatOption,
+  limitOption,
+  nextOption,
+  projectOption,
+} from '../../util/arg-common';
 
 export const typesSubcommand = {
   name: 'types',
@@ -67,11 +72,8 @@ export const activityCommand = {
       description: 'Show events before this date (ISO 8601 or relative).',
     },
     {
-      name: 'project',
+      ...projectOption,
       shorthand: 'p',
-      type: String,
-      argument: 'NAME_OR_ID',
-      deprecated: false,
       description:
         'Filter by project (overrides auto-detected linked project).',
     },

--- a/packages/cli/src/commands/alerts/command.ts
+++ b/packages/cli/src/commands/alerts/command.ts
@@ -1,4 +1,8 @@
-import { formatOption, limitOption } from '../../util/arg-common';
+import {
+  formatOption,
+  limitOption,
+  projectOption,
+} from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
 import { rulesAggregateCommand } from './rules/command';
 
@@ -26,11 +30,8 @@ export const inspectSubcommand = {
   options: [
     formatOption,
     {
-      name: 'project',
+      ...projectOption,
       shorthand: 'p',
-      type: String,
-      argument: 'NAME_OR_ID',
-      deprecated: false,
       description:
         'Filter by project (overrides auto-detected linked project).',
     },
@@ -72,11 +73,8 @@ export const alertsCommand = {
         'Filter by alert type. Repeatable and comma-separated (for example --type usage_anomaly,error_anomaly).',
     },
     {
-      name: 'project',
+      ...projectOption,
       shorthand: 'p',
-      type: String,
-      argument: 'NAME_OR_ID',
-      deprecated: false,
       description:
         'Filter by project (overrides auto-detected linked project).',
     },

--- a/packages/cli/src/commands/alerts/rules/command.ts
+++ b/packages/cli/src/commands/alerts/rules/command.ts
@@ -1,13 +1,14 @@
-import { formatOption, yesOption } from '../../../util/arg-common';
+import {
+  formatOption,
+  projectOption,
+  yesOption,
+} from '../../../util/arg-common';
 import { packageName } from '../../../util/pkg-name';
 
 const scopeOptions = [
   {
-    name: 'project',
+    ...projectOption,
     shorthand: 'p',
-    type: String,
-    argument: 'NAME_OR_ID',
-    deprecated: false,
     description:
       'Project scope (overrides linked project). Requires team context.',
   },

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 
 export const buildCommand = {
   name: 'build',
@@ -52,6 +52,7 @@ export const buildCommand = {
       argument: 'ID',
       deprecated: false,
     },
+    projectOption,
   ],
   examples: [
     {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -267,7 +267,7 @@ export default async function main(client: Client): Promise<number> {
   // If repo linked, update `cwd` to the repo root
   let link = await rootSpan
     .child('vc.getProjectLink')
-    .trace(() => getProjectLink(client, cwd, projectNameOrId));
+    .trace(() => getProjectLink(client, cwd, projectNameOrId, true));
 
   // No local link matched `--project`; resolve via API before the
   // settings-pull prompt would silently re-link to the wrong project.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -93,7 +93,11 @@ import stamp from '../../util/output/stamp';
 import parseTarget from '../../util/parse-target';
 import cliPkg from '../../util/pkg';
 import * as cli from '../../util/pkg-name';
-import { getProjectLink, VERCEL_DIR } from '../../util/projects/link';
+import {
+  getLinkedProject,
+  getProjectLink,
+  VERCEL_DIR,
+} from '../../util/projects/link';
 import { resolveProjectCwd } from '../../util/projects/find-project-root';
 import {
   pickOverrides,
@@ -215,6 +219,7 @@ export default async function main(client: Client): Promise<number> {
     telemetryClient.trackCliFlagYes(parsedArgs.flags['--yes']);
     telemetryClient.trackCliFlagStandalone(parsedArgs.flags['--standalone']);
     telemetryClient.trackCliOptionId(parsedArgs.flags['--id']);
+    telemetryClient.trackCliOptionProject(parsedArgs.flags['--project']);
   } catch (error) {
     printError(error);
     return 1;
@@ -256,10 +261,38 @@ export default async function main(client: Client): Promise<number> {
     return 1;
   }
 
+  const projectNameOrId = parsedArgs.flags['--project'];
+
   // If repo linked, update `cwd` to the repo root
-  const link = await rootSpan
+  let link = await rootSpan
     .child('vc.getProjectLink')
-    .trace(() => getProjectLink(client, cwd));
+    .trace(() => getProjectLink(client, cwd, projectNameOrId));
+
+  // No local link matched `--project`; resolve via API before the
+  // settings-pull prompt would silently re-link to the wrong project.
+  if (projectNameOrId && !link) {
+    const linkedFromApi = await getLinkedProject(
+      client,
+      cwd,
+      projectNameOrId,
+      true
+    );
+    if (linkedFromApi.status === 'linked') {
+      link = {
+        projectId: linkedFromApi.project.id,
+        orgId: linkedFromApi.org.id,
+        repoRoot: linkedFromApi.repoRoot,
+      };
+    } else if (linkedFromApi.status === 'error') {
+      return linkedFromApi.exitCode;
+    } else {
+      output.error(
+        `Project "${projectNameOrId}" was not found. Verify the name or ID and your team scope.`
+      );
+      return 1;
+    }
+  }
+
   const projectRootDirectory = link?.projectRootDirectory ?? '';
   if (link?.repoRoot) {
     cwd = client.cwd = link.repoRoot;
@@ -339,7 +372,8 @@ export default async function main(client: Client): Promise<number> {
       client.cwd,
       Boolean(parsedArgs.flags['--yes']),
       target,
-      parsedArgs.flags
+      parsedArgs.flags,
+      projectNameOrId
     );
     if (result !== 0) {
       return result;

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -98,6 +98,7 @@ import {
   getProjectLink,
   VERCEL_DIR,
 } from '../../util/projects/link';
+import { printProjectNotFoundError } from '../../util/projects/project-not-found-error';
 import { resolveProjectCwd } from '../../util/projects/find-project-root';
 import {
   pickOverrides,
@@ -286,9 +287,7 @@ export default async function main(client: Client): Promise<number> {
     } else if (linkedFromApi.status === 'error') {
       return linkedFromApi.exitCode;
     } else {
-      output.error(
-        `Project "${projectNameOrId}" was not found. Verify the name or ID and your team scope.`
-      );
+      await printProjectNotFoundError(client, projectNameOrId, 'build');
       return 1;
     }
   }

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -1,4 +1,4 @@
-import { formatOption, yesOption } from '../../util/arg-common';
+import { formatOption, projectOption, yesOption } from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
 
 export const createSubcommand = {
@@ -359,11 +359,8 @@ export const attachSubcommand = {
         'Environments to enable. Repeatable and comma-separated (e.g. -e production -e preview, or -e production,preview). Defaults to all environments.',
     },
     {
-      name: 'project',
+      ...projectOption,
       shorthand: 'p',
-      type: String,
-      argument: 'NAME_OR_ID',
-      deprecated: false,
       description: 'Project name or ID (default: current linked project)',
     },
     {
@@ -438,11 +435,8 @@ export const detachSubcommand = {
   ],
   options: [
     {
-      name: 'project',
+      ...projectOption,
       shorthand: 'p',
-      type: String,
-      argument: 'NAME_OR_ID',
-      deprecated: false,
       description: 'Project name or ID (default: current linked project)',
     },
     {

--- a/packages/cli/src/commands/deploy-hooks/command.ts
+++ b/packages/cli/src/commands/deploy-hooks/command.ts
@@ -1,13 +1,13 @@
 import { packageName } from '../../util/pkg-name';
-import { formatOption, yesOption } from '../../util/arg-common';
+import {
+  formatOption,
+  projectOption as sharedProjectOption,
+  yesOption,
+} from '../../util/arg-common';
 
 const projectOption = {
-  name: 'project',
+  ...sharedProjectOption,
   shorthand: 'p',
-  type: String,
-  argument: 'PROJECT',
-  description: 'Project name or ID (defaults to the linked project)',
-  deprecated: false,
 } as const;
 
 export const listSubcommand = {

--- a/packages/cli/src/commands/deploy/command.ts
+++ b/packages/cli/src/commands/deploy/command.ts
@@ -3,6 +3,7 @@ import {
   forceOption,
   formatOption,
   jsonOption,
+  projectOption,
   yesOption,
 } from '../../util/arg-common';
 
@@ -108,6 +109,7 @@ export const initSubcommand = {
     formatOption,
     jsonOption,
     confirmOption,
+    projectOption,
     {
       name: 'functions-beta',
       shorthand: null,
@@ -330,6 +332,7 @@ export const deployCommand = {
     formatOption,
     jsonOption,
     confirmOption,
+    projectOption,
     {
       name: 'functions-beta',
       shorthand: null,

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -183,6 +183,7 @@ async function handleInitDeployment(
 
   telemetryClient.trackCliFlagJson(parsedArguments.flags['--json']);
   telemetryClient.trackCliOptionFormat(parsedArguments.flags['--format']);
+  telemetryClient.trackCliOptionProject(parsedArguments.flags['--project']);
   telemetryClient.trackCliFlagFunctionsBeta(
     parsedArguments.flags['--functions-beta']
   );
@@ -190,6 +191,7 @@ async function handleInitDeployment(
     parsedArguments.flags['--no-functions-beta']
   );
 
+  const projectNameOrId = parsedArguments.flags['--project'];
   const functionsBeta = parsedArguments.flags['--functions-beta'];
   const noFunctionsBeta = parsedArguments.flags['--no-functions-beta'];
 
@@ -295,11 +297,14 @@ async function handleInitDeployment(
   const link = await ensureLink('deploy', client, cwd, {
     autoConfirm,
     setupMsg: 'Set up',
-    projectName: getProjectName({
-      nameParam: undefined,
-      nowConfig: localConfig,
-      paths,
-    }),
+    projectName:
+      projectNameOrId ??
+      getProjectName({
+        nameParam: undefined,
+        nowConfig: localConfig,
+        paths,
+      }),
+    failIfNotFound: !!projectNameOrId,
     v0: isV0,
   });
   if (typeof link === 'number') {
@@ -1007,6 +1012,7 @@ async function handleDefaultDeploy(
   telemetryClient.trackCliFlagWithCache(parsedArguments.flags['--with-cache']);
   telemetryClient.trackCliFlagJson(parsedArguments.flags['--json']);
   telemetryClient.trackCliOptionFormat(parsedArguments.flags['--format']);
+  telemetryClient.trackCliOptionProject(parsedArguments.flags['--project']);
   telemetryClient.trackCliFlagFunctionsBeta(
     parsedArguments.flags['--functions-beta']
   );
@@ -1014,6 +1020,7 @@ async function handleDefaultDeploy(
     parsedArguments.flags['--no-functions-beta']
   );
 
+  const projectNameOrId = parsedArguments.flags['--project'];
   const functionsBeta = parsedArguments.flags['--functions-beta'];
   const noFunctionsBeta = parsedArguments.flags['--no-functions-beta'];
 
@@ -1183,11 +1190,14 @@ async function handleDefaultDeploy(
   const link = await ensureLink('deploy', client, cwd, {
     autoConfirm,
     setupMsg: 'Set up',
-    projectName: getProjectName({
-      nameParam: parsedArguments.flags['--name'],
-      nowConfig: localConfig,
-      paths,
-    }),
+    projectName:
+      projectNameOrId ??
+      getProjectName({
+        nameParam: parsedArguments.flags['--name'],
+        nowConfig: localConfig,
+        paths,
+      }),
+    failIfNotFound: !!projectNameOrId,
     v0: isV0,
   });
   if (typeof link === 'number') {

--- a/packages/cli/src/commands/dev/command.ts
+++ b/packages/cli/src/commands/dev/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { confirmOption, yesOption } from '../../util/arg-common';
+import { confirmOption, projectOption, yesOption } from '../../util/arg-common';
 
 export const devCommand = {
   name: 'dev',
@@ -30,6 +30,7 @@ export const devCommand = {
     yesOption,
     { name: 'port', shorthand: 'p', type: String, deprecated: true },
     confirmOption,
+    projectOption,
   ],
   examples: [
     {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -8,6 +8,7 @@ import DevServer, { DevCommandExitError } from '../../util/dev/server';
 import { parseListen } from '../../util/dev/parse-listen';
 import type Client from '../../util/client';
 import { getLinkedProject } from '../../util/projects/link';
+import { printProjectNotFoundError } from '../../util/projects/project-not-found-error';
 import type { ProjectSettings } from '@vercel-internals/types';
 import setupAndLink from '../../util/link/setup-and-link';
 import { findRepoRoot } from '../../util/link/repo';
@@ -67,9 +68,7 @@ export default async function dev(
           `To link your project, run ${getCommandName('dev')} without \`-L\` or \`--local\` or ${getCommandName('link')}.`
       );
     } else if (projectNameOrId) {
-      output.error(
-        `Project "${projectNameOrId}" was not found. Verify the name or ID and your team scope.`
-      );
+      await printProjectNotFoundError(client, projectNameOrId, 'dev');
       return 1;
     } else {
       link = await setupAndLink(client, cwd, {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -33,6 +33,7 @@ type Options = {
   '--listen': string;
   '--local': boolean;
   '--yes': boolean;
+  '--project': string;
 };
 
 export default async function dev(
@@ -47,8 +48,15 @@ export default async function dev(
 
   cwd = await resolveProjectCwd(cwd);
 
+  const projectNameOrId = opts['--project'];
+
   // retrieve dev command
-  let link = await getLinkedProject(client, cwd);
+  let link = await getLinkedProject(
+    client,
+    cwd,
+    projectNameOrId,
+    !!projectNameOrId
+  );
 
   if (link.status === 'not_linked' && !process.env.__VERCEL_SKIP_DEV_CMD) {
     if (opts['--local']) {
@@ -58,6 +66,11 @@ export default async function dev(
           '  - Project settings are defined by local configuration\n\n' +
           `To link your project, run ${getCommandName('dev')} without \`-L\` or \`--local\` or ${getCommandName('link')}.`
       );
+    } else if (projectNameOrId) {
+      output.error(
+        `Project "${projectNameOrId}" was not found. Verify the name or ID and your team scope.`
+      );
+      return 1;
     } else {
       link = await setupAndLink(client, cwd, {
         autoConfirm: opts['--yes'],

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -68,6 +68,7 @@ export default async function main(client: Client) {
   telemetry.trackCliFlagYes(parsedArgs.flags['--yes']);
   telemetry.trackCliOptionPort(parsedArgs.flags['--port']);
   telemetry.trackCliOptionListen(parsedArgs.flags['--listen']);
+  telemetry.trackCliOptionProject(parsedArgs.flags['--project']);
 
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('dev');

--- a/packages/cli/src/commands/link/command.ts
+++ b/packages/cli/src/commands/link/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { confirmOption, yesOption } from '../../util/arg-common';
+import { confirmOption, projectOption, yesOption } from '../../util/arg-common';
 
 export const addSubcommand = {
   name: 'add',
@@ -37,13 +37,10 @@ export const linkCommand = {
       deprecated: false,
     },
     {
-      name: 'project',
+      ...projectOption,
+      shorthand: 'p',
       description:
         'Project name or ID to link to (required for non-interactive)',
-      shorthand: 'p',
-      argument: 'NAME_OR_ID',
-      type: String,
-      deprecated: false,
     },
     {
       name: 'team',

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -1,4 +1,5 @@
 import { packageName } from '../../util/pkg-name';
+import { projectOption } from '../../util/arg-common';
 
 // has to be ms compliant
 // https://github.com/vercel/ms/blob/fe5338229cfdac6822891dcb9c24660b4d2e612b/src/index.ts#L95
@@ -17,13 +18,7 @@ export const logsCommand = {
     },
   ],
   options: [
-    {
-      name: 'project',
-      shorthand: 'p',
-      type: String,
-      deprecated: false,
-      description: 'Project ID or name (defaults to linked project)',
-    },
+    { ...projectOption, shorthand: 'p' },
     {
       name: 'deployment',
       shorthand: 'd',

--- a/packages/cli/src/commands/metrics/command.ts
+++ b/packages/cli/src/commands/metrics/command.ts
@@ -1,4 +1,4 @@
-import { formatOption } from '../../util/arg-common';
+import { formatOption, projectOption } from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
 
 export const schemaSubcommand = {
@@ -103,12 +103,8 @@ export const metricsCommand = {
       argument: 'SIZE',
     },
     {
-      name: 'project',
+      ...projectOption,
       shorthand: 'p',
-      type: String,
-      deprecated: false,
-      description: 'Project name or ID (default: linked project)',
-      argument: 'NAME_OR_ID',
     },
     {
       name: 'all',

--- a/packages/cli/src/commands/pull/command.ts
+++ b/packages/cli/src/commands/pull/command.ts
@@ -1,6 +1,6 @@
 import { packageName } from '../../util/pkg-name';
 import { getEnvTargetPlaceholder } from '../../util/env/env-target';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 import type { getFlagsSpecification } from '../../util/get-flags-specification';
 import type { parseArguments } from '../../util/get-args';
 
@@ -44,6 +44,7 @@ export const pullCommand = {
       description:
         'Skip questions when setting up new project using default scope and settings',
     },
+    projectOption,
   ],
   examples: [
     {

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -97,13 +97,15 @@ export default async function main(client: Client) {
   telemetryClient.trackCliFlagProd(isProduction);
   telemetryClient.trackCliOptionGitBranch(parsedArgs.flags['--git-branch']);
   telemetryClient.trackCliOptionEnvironment(parsedArgs.flags['--environment']);
+  telemetryClient.trackCliOptionProject(parsedArgs.flags['--project']);
 
   const returnCode = await pullCommandLogic(
     client,
     cwd,
     autoConfirm,
     environment,
-    parsedArgs.flags
+    parsedArgs.flags,
+    parsedArgs.flags['--project']
   );
 
   if (returnCode === 0 && !autoConfirm) {
@@ -118,11 +120,14 @@ export async function pullCommandLogic(
   cwd: string,
   autoConfirm: boolean,
   environment: string,
-  flags: PullCommandFlags
+  flags: PullCommandFlags,
+  projectNameOrId?: string
 ): Promise<number> {
   const link = await ensureLink('pull', client, cwd, {
     autoConfirm,
     pullEnv: false,
+    projectName: projectNameOrId,
+    failIfNotFound: !!projectNameOrId,
   });
   if (typeof link === 'number') {
     return link;

--- a/packages/cli/src/commands/tokens/command.ts
+++ b/packages/cli/src/commands/tokens/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { formatOption } from '../../util/arg-common';
+import { formatOption, projectOption } from '../../util/arg-common';
 
 export const listSubcommand = {
   name: 'list',
@@ -38,11 +38,8 @@ export const addSubcommand = {
   options: [
     formatOption,
     {
-      name: 'project',
-      shorthand: null,
-      type: String,
+      ...projectOption,
       description: 'Optional project ID to scope the token to',
-      deprecated: false,
     },
   ],
   examples: [

--- a/packages/cli/src/util/agent-output-constants.ts
+++ b/packages/cli/src/util/agent-output-constants.ts
@@ -24,6 +24,7 @@ export const AGENT_REASON = {
   PROJECT_SETTINGS_REQUIRED: 'project_settings_required',
   NOT_LINKED: 'not_linked',
   NOT_FOUND: 'not_found',
+  PROJECT_NOT_FOUND: 'project_not_found',
   MISSING_SCOPE: 'missing_scope',
   API_ERROR: 'api_error',
   // Env

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -77,6 +77,8 @@ export interface AgentErrorPayload {
   action?: string;
   /** ACL resource the permission applies to (e.g. "project", "deployment"). Present on 403 when the API provides it. */
   resource?: string;
+  /** Team slug or username/email that was searched. Present on `project_not_found`. */
+  scope?: string;
 }
 
 /**

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -243,6 +243,15 @@ export const allOption = {
   description: 'List resources across all projects',
 } as const;
 
+export const projectOption = {
+  name: 'project',
+  shorthand: null,
+  type: String,
+  argument: 'NAME_OR_ID',
+  description: 'Project name or ID (defaults to the linked project)',
+  deprecated: false,
+} as const;
+
 type GlobalOpt = (typeof globalCommandOptions)[number];
 
 const GLOBAL_LONG_TO_OPT = new Map<string, GlobalOpt>();

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -45,7 +45,15 @@ export async function ensureLink(
       // and the repo-linked project is ambiguous).
       link = { status: 'not_linked', org: null, project: null };
     } else {
-      link = await getLinkedProject(client, cwd, opts.projectName);
+      // `failIfNotFound` doubles as the opt-in for API-based name/ID
+      // resolution: both behaviors only apply when `projectName` came from
+      // an explicit user flag.
+      link = await getLinkedProject(
+        client,
+        cwd,
+        opts.projectName,
+        opts.failIfNotFound
+      );
     }
     opts.link = link;
   }
@@ -54,6 +62,19 @@ export async function ensureLink(
     (link.status === 'linked' && opts.forceDelete) ||
     link.status === 'not_linked'
   ) {
+    // Explicit `--project` was provided but could not be resolved; bail out
+    // before `setupAndLink` would offer to create a new project for a typo.
+    if (
+      link.status === 'not_linked' &&
+      opts.failIfNotFound &&
+      opts.projectName
+    ) {
+      output.error(
+        `Project "${opts.projectName}" was not found. Verify the name or ID and your team scope.`
+      );
+      return 1;
+    }
+
     link = await setupAndLink(client, cwd, opts);
 
     if (link.status === 'not_linked') {

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -8,6 +8,7 @@ import type { SetupAndLinkOptions } from '../link/setup-and-link';
 import type { ProjectLinked } from '@vercel-internals/types';
 import output from '../../output-manager';
 import { outputActionRequired, buildCommandWithYes } from '../agent-output';
+import { printProjectNotFoundError } from '../projects/project-not-found-error';
 
 /**
  * Checks if a project is already linked and if not, links the project and
@@ -69,9 +70,7 @@ export async function ensureLink(
       opts.failIfNotFound &&
       opts.projectName
     ) {
-      output.error(
-        `Project "${opts.projectName}" was not found. Verify the name or ID and your team scope.`
-      );
+      await printProjectNotFoundError(client, opts.projectName, commandName);
       return 1;
     }
 

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -72,6 +72,12 @@ export interface SetupAndLinkOptions {
   v0?: boolean;
   /** When true, search matching projects across teams before standard linking flow */
   searchAcrossTeams?: boolean;
+  /**
+   * When true with an explicit `projectName`, bail out instead of running
+   * `setupAndLink`. Use for user-supplied `--project <NAME_OR_ID>` so typos
+   * fail fast rather than creating a new project.
+   */
+  failIfNotFound?: boolean;
 }
 
 function formatMatchReason(match: CrossTeamMatch): string {

--- a/packages/cli/src/util/projects/get-org-by-id.ts
+++ b/packages/cli/src/util/projects/get-org-by-id.ts
@@ -1,0 +1,38 @@
+import type Client from '../client';
+import type { Org } from '@vercel-internals/types';
+import { isAPIError } from '../errors-ts';
+import getUser from '../get-user';
+import getTeamById from '../teams/get-team-by-id';
+
+/**
+ * Resolves a `team_*` ID to a team `Org`, or a user ID to a user `Org`.
+ * Returns `null` if the org could not be resolved.
+ */
+export default async function getOrgById(
+  client: Client,
+  orgId: string
+): Promise<Org | null> {
+  if (orgId.startsWith('team_')) {
+    try {
+      const team = await getTeamById(client, orgId);
+      if (!team) return null;
+      return { type: 'team', id: team.id, slug: team.slug };
+    } catch (err) {
+      // If the linked team no longer exists (or test mocks intentionally omit
+      // this endpoint), treat it as "not linked" instead of hard-failing.
+      if (
+        isAPIError(err) &&
+        (err.status === 404 ||
+          err.code === 'not_found' ||
+          err.code === 'mock_unimplemented')
+      ) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  const user = await getUser(client);
+  if (user.id !== orgId) return null;
+  return { type: 'user', id: orgId, slug: user.username };
+}

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -5,10 +5,9 @@ import { ensureDir } from 'fs-extra';
 import { promisify } from 'util';
 
 import getProjectByIdOrName from '../projects/get-project-by-id-or-name';
+import getOrgById from './get-org-by-id';
 import type Client from '../client';
 import { InvalidToken, isAPIError, ProjectNotFound } from '../errors-ts';
-import getUser from '../get-user';
-import getTeamById from '../teams/get-team-by-id';
 import type {
   Project,
   ProjectLinkResult,
@@ -112,9 +111,11 @@ async function getProjectLinkFromRepoLink(
     const selectableProjects =
       projects.length > 0 ? projects : repoLink.repoConfig.projects;
 
-    // If --project flag was provided, try to find a matching project by name
+    // If --project flag was provided, match by ID or name
     if (projectName) {
-      project = selectableProjects.find(p => p.name === projectName);
+      project = selectableProjects.find(
+        p => p.id === projectName || p.name === projectName
+      );
     }
 
     // Fall back to interactive selection if no project was found
@@ -212,32 +213,6 @@ export async function getLinkFromDir<T = ProjectLink>(
   }
 }
 
-async function getOrgById(client: Client, orgId: string): Promise<Org | null> {
-  if (orgId.startsWith('team_')) {
-    try {
-      const team = await getTeamById(client, orgId);
-      if (!team) return null;
-      return { type: 'team', id: team.id, slug: team.slug };
-    } catch (err) {
-      // If the linked team no longer exists (or test mocks intentionally omit
-      // this endpoint), treat it as "not linked" instead of hard-failing.
-      if (
-        isAPIError(err) &&
-        (err.status === 404 ||
-          err.code === 'not_found' ||
-          err.code === 'mock_unimplemented')
-      ) {
-        return null;
-      }
-      throw err;
-    }
-  }
-
-  const user = await getUser(client);
-  if (user.id !== orgId) return null;
-  return { type: 'user', id: orgId, slug: user.username };
-}
-
 async function hasProjectLink(
   client: Client,
   projectLink: ProjectLink,
@@ -289,7 +264,14 @@ async function hasProjectLink(
 export async function getLinkedProject(
   client: Client,
   path = client.cwd,
-  projectName?: string
+  projectName?: string,
+  /**
+   * When `true`, resolve `projectName` via the API if no local link matches.
+   * Only enable for explicit user-supplied names (e.g. `--project`) so that
+   * implicit `projectName` defaults (like a directory basename) keep their
+   * existing `not_linked` → `setupAndLink` flow.
+   */
+  apiFallback?: boolean
 ): Promise<ProjectLinkResult> {
   path = await resolveProjectCwd(path);
 
@@ -308,10 +290,26 @@ export async function getLinkedProject(
     return { status: 'error', exitCode: 1 };
   }
 
-  const link =
+  let link =
     VERCEL_ORG_ID && VERCEL_PROJECT_ID
       ? { orgId: VERCEL_ORG_ID, projectId: VERCEL_PROJECT_ID }
       : await getProjectLink(client, path, projectName);
+
+  // Resolve `projectName` via the API when no local link matches. Enables
+  // non-interactive CI use (e.g. `vercel deploy --project my-app`).
+  if (!link && projectName && apiFallback) {
+    try {
+      const apiProject = await getProjectByIdOrName(client, projectName);
+      if (!(apiProject instanceof ProjectNotFound)) {
+        link = {
+          projectId: apiProject.id,
+          orgId: apiProject.accountId,
+        };
+      }
+    } catch {
+      // Swallow; caller handles `not_linked` below.
+    }
+  }
 
   if (!link) {
     return { status: 'not_linked', org: null, project: null };

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -78,23 +78,41 @@ export function getVercelDirectory(cwd: string): string {
 export async function getProjectLink(
   client: Client,
   path: string,
-  projectName?: string
+  projectName?: string,
+  projectNameIsExplicit?: boolean
 ): Promise<ProjectLink | null> {
   // Prefer an explicit per-directory link (`.vercel/project.json`) over a
   // repository-level link (`.vercel/repo.json`). This prevents scenarios where
   // a freshly-created local link (e.g. after `vc link`) is ignored and the
   // user is re-prompted to select a repo-linked project again.
+  // When `projectNameIsExplicit` is true, the caller is resolving a user-
+  // supplied `--project` value, so mismatched local links must not win.
   const dirLink = await getLinkFromDir(getVercelDirectory(path));
   if (dirLink) {
-    return dirLink;
+    if (!projectNameIsExplicit || !projectName) {
+      return dirLink;
+    }
+
+    if (
+      dirLink.projectId === projectName ||
+      dirLink.projectName === projectName
+    ) {
+      return dirLink;
+    }
   }
-  return await getProjectLinkFromRepoLink(client, path, projectName);
+  return await getProjectLinkFromRepoLink(
+    client,
+    path,
+    projectName,
+    projectNameIsExplicit
+  );
 }
 
 async function getProjectLinkFromRepoLink(
   client: Client,
   path: string,
-  projectName?: string
+  projectName?: string,
+  projectNameIsExplicit?: boolean
 ): Promise<ProjectLink | null> {
   const repoLink = await getRepoLink(client, path);
   if (!repoLink?.repoConfig) {
@@ -105,7 +123,12 @@ async function getProjectLinkFromRepoLink(
     relative(repoLink.rootPath, path)
   );
   let project: RepoProjectConfig | undefined;
-  if (projects.length === 1) {
+
+  if (projectName && projectNameIsExplicit) {
+    project = repoLink.repoConfig.projects.find(
+      p => p.id === projectName || p.name === projectName
+    );
+  } else if (projects.length === 1) {
     project = projects[0];
   } else {
     const selectableProjects =
@@ -293,7 +316,7 @@ export async function getLinkedProject(
   let link =
     VERCEL_ORG_ID && VERCEL_PROJECT_ID
       ? { orgId: VERCEL_ORG_ID, projectId: VERCEL_PROJECT_ID }
-      : await getProjectLink(client, path, projectName);
+      : await getProjectLink(client, path, projectName, apiFallback);
 
   // Resolve `projectName` via the API when no local link matches. Enables
   // non-interactive CI use (e.g. `vercel deploy --project my-app`).

--- a/packages/cli/src/util/projects/project-not-found-error.ts
+++ b/packages/cli/src/util/projects/project-not-found-error.ts
@@ -1,0 +1,68 @@
+import type Client from '../client';
+import getScope from '../get-scope';
+import output from '../../output-manager';
+import {
+  buildCommandWithGlobalFlags,
+  outputAgentError,
+  shouldEmitNonInteractiveCommandError,
+} from '../agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../agent-output-constants';
+
+/**
+ * Emits a consistent "Project <x> was not found" error that names the scope
+ * that was searched and points users to `--scope`, `vercel switch`, and
+ * `vercel teams ls`. In non-interactive contexts (CI, agents) it also emits a
+ * structured JSON payload via `outputAgentError`.
+ */
+export async function printProjectNotFoundError(
+  client: Client,
+  projectNameOrId: string,
+  commandName: string
+): Promise<void> {
+  let contextName: string | undefined;
+  try {
+    const scope = await getScope(client);
+    contextName = scope.contextName;
+  } catch (err) {
+    output.debug(`getScope failed during error reporting: ${err}`);
+  }
+
+  const scopeClause = contextName ? ` (${contextName})` : '';
+  const headline = `Project "${projectNameOrId}" was not found in the current scope${scopeClause}.`;
+
+  output.error(
+    `${headline}\n\n` +
+      `If it lives in a different team or account:\n` +
+      `  • Retry with \`--scope <team-slug|your-username>\`, or\n` +
+      `  • Run \`vercel switch <team-slug|your-username>\` to change scope.\n\n` +
+      `List accessible teams with \`vercel teams ls\`.`
+  );
+
+  if (!shouldEmitNonInteractiveCommandError(client)) {
+    return;
+  }
+
+  const retryWithScope = buildCommandWithGlobalFlags(
+    client.argv,
+    `${commandName} --project ${projectNameOrId} --scope <team-slug>`
+  );
+
+  outputAgentError(
+    client,
+    {
+      status: AGENT_STATUS.ERROR,
+      reason: AGENT_REASON.PROJECT_NOT_FOUND,
+      message: `${headline} If it lives in a different team or account, retry with --scope <team-slug|your-username> or run \`vercel switch <team-slug|your-username>\` to change scope.`,
+      ...(contextName ? { scope: contextName } : {}),
+      next: [
+        { command: 'vercel teams ls', when: 'list accessible teams' },
+        { command: retryWithScope, when: 'retry with a specific team' },
+        {
+          command: 'vercel switch <team-slug>',
+          when: 'change the default scope',
+        },
+      ],
+    },
+    1
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/activity/index.ts
+++ b/packages/cli/src/util/telemetry/commands/activity/index.ts
@@ -51,15 +51,6 @@ export class ActivityTelemetryClient
     }
   }
 
-  trackCliOptionProject(v: string | undefined) {
-    if (v) {
-      this.trackCliOption({
-        option: 'project',
-        value: this.redactedValue,
-      });
-    }
-  }
-
   trackCliFlagAll(v: boolean | undefined) {
     if (v) {
       this.trackCliFlag('all');

--- a/packages/cli/src/util/telemetry/commands/alerts/index.ts
+++ b/packages/cli/src/util/telemetry/commands/alerts/index.ts
@@ -56,15 +56,6 @@ export class AlertsTelemetryClient
     }
   }
 
-  trackCliOptionProject(v: string | undefined) {
-    if (v) {
-      this.trackCliOption({
-        option: 'project',
-        value: this.redactedValue,
-      });
-    }
-  }
-
   trackCliFlagAll(v: boolean | undefined) {
     if (v) {
       this.trackCliFlag('all');

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -198,13 +198,4 @@ export class ConnexTelemetryClient
       }
     }
   }
-
-  trackCliOptionProject(v: string | undefined) {
-    if (v) {
-      this.trackCliOption({
-        option: 'project',
-        value: this.redactedValue,
-      });
-    }
-  }
 }

--- a/packages/cli/src/util/telemetry/commands/deploy-hooks/create.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy-hooks/create.ts
@@ -23,13 +23,4 @@ export class DeployHooksCreateTelemetryClient
       });
     }
   }
-
-  trackCliOptionProject(project: string | undefined) {
-    if (project) {
-      this.trackCliOption({
-        option: 'project',
-        value: project,
-      });
-    }
-  }
 }

--- a/packages/cli/src/util/telemetry/commands/deploy-hooks/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy-hooks/ls.ts
@@ -14,13 +14,4 @@ export class DeployHooksLsTelemetryClient
       });
     }
   }
-
-  trackCliOptionProject(project: string | undefined) {
-    if (project) {
-      this.trackCliOption({
-        option: 'project',
-        value: project,
-      });
-    }
-  }
 }

--- a/packages/cli/src/util/telemetry/commands/deploy-hooks/rm.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy-hooks/rm.ts
@@ -15,15 +15,6 @@ export class DeployHooksRmTelemetryClient
     }
   }
 
-  trackCliOptionProject(project: string | undefined) {
-    if (project) {
-      this.trackCliOption({
-        option: 'project',
-        value: project,
-      });
-    }
-  }
-
   trackCliFlagYes(yes: boolean | undefined) {
     if (yes) {
       this.trackCliFlag('yes');

--- a/packages/cli/src/util/telemetry/commands/link/index.ts
+++ b/packages/cli/src/util/telemetry/commands/link/index.ts
@@ -31,15 +31,6 @@ export class LinkTelemetryClient
     }
   }
 
-  trackCliOptionProject(project: string | undefined) {
-    if (project) {
-      this.trackCliOption({
-        option: 'project',
-        value: this.redactedValue,
-      });
-    }
-  }
-
   trackCliOptionTeam(value: string | undefined) {
     if (value) {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/logs/index.ts
+++ b/packages/cli/src/util/telemetry/commands/logs/index.ts
@@ -15,15 +15,6 @@ export class LogsTelemetryClient
     }
   }
 
-  trackCliOptionProject(v: string | undefined) {
-    if (v) {
-      this.trackCliOption({
-        option: 'project',
-        value: this.redactedValue,
-      });
-    }
-  }
-
   trackCliOptionDeployment(v: string | undefined) {
     if (v) {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/metrics/index.ts
+++ b/packages/cli/src/util/telemetry/commands/metrics/index.ts
@@ -96,15 +96,6 @@ export class MetricsTelemetryClient
     }
   }
 
-  trackCliOptionProject(v: string | undefined) {
-    if (v) {
-      this.trackCliOption({
-        option: 'project',
-        value: this.redactedValue,
-      });
-    }
-  }
-
   trackCliFlagAll(v: boolean | undefined) {
     if (v) {
       this.trackCliFlag('all');

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -344,6 +344,21 @@ export class TelemetryClient {
       });
     }
   }
+
+  /**
+   * Tracks the --project option. Value is redacted because project names/IDs
+   * may be sensitive. Accepts `string | string[]` so commands with a repeatable
+   * `--project` can override. Not all commands support repeated `--project` flags
+   */
+  trackCliOptionProject(value: string | string[] | undefined) {
+    if (!value) return;
+    if (Array.isArray(value) && value.length === 0) return;
+
+    this.trackCliOption({
+      option: 'project',
+      value: this.redactedValue,
+    });
+  }
 }
 
 export class TelemetryEventStore {

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1228,6 +1228,13 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 (shorth…
                                 for     
                                 \`--targ…
+       --project <NAME_OR_ID>   Project 
+                                name or 
+                                ID      
+                                (defaul…
+                                to the  
+                                linked  
+                                project)
   -p,  --public                 Deploym…
                                 is      
                                 public  
@@ -1384,6 +1391,8 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 existing build                                  
        --prod                   Create a production deployment (shorthand for   
                                 \`--target=production\`)                          
+       --project <NAME_OR_ID>   Project name or ID (defaults to the linked      
+                                project)                                        
   -p,  --public                 Deployment is public (\`/_src\`) is exposed)      
        --regions <REGION>       Set default regions to enable the deployment on 
        --skip-domain            Disable the automatic promotion (aliasing) of   
@@ -1457,6 +1466,7 @@ exports[`help command > deploy help output snapshots > deploy help column width 
        --no-wait                Don't wait for the deployment to finish                                                 
        --prebuilt               Use in combination with \`vc build\`. Deploy an existing build                            
        --prod                   Create a production deployment (shorthand for \`--target=production\`)                    
+       --project <NAME_OR_ID>   Project name or ID (defaults to the linked project)                                     
   -p,  --public                 Deployment is public (\`/_src\`) is exposed)                                              
        --regions <REGION>       Set default regions to enable the deployment on                                         
        --skip-domain            Disable the automatic promotion (aliasing) of the relevant domains to a new production  
@@ -1514,9 +1524,12 @@ exports[`help command > dev help output snapshots > dev --help > outputs help 1`
 
   Options:
 
-  -l,  --listen <URI>  Specify a URI endpoint on which to listen [0.0.0.0:3000] 
-  -L,  --local         Start the dev server without linking to a Vercel project 
-  -y,  --yes           Accept default value for all prompts                     
+  -l,  --listen <URI>          Specify a URI endpoint on which to listen             
+                               [0.0.0.0:3000]                                        
+  -L,  --local                 Start the dev server without linking to a Vercel      
+                               project                                               
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)   
+  -y,  --yes                   Accept default value for all prompts                  
 
 
   Global Options:
@@ -5685,6 +5698,11 @@ exports[`help command > pull help output snapshots > pull help column width 40 1
                                pull specific 
                                Environment   
                                Variables for 
+       --project <NAME_OR_ID>  Project name  
+                               or ID         
+                               (defaults to  
+                               the linked    
+                               project)      
   -y,  --yes                   Skip questions
                                when setting  
                                up new project
@@ -5777,6 +5795,7 @@ exports[`help command > pull help output snapshots > pull help column width 80 1
        --environment <TARGET>  Deployment environment [development]                  
        --git-branch <NAME>     Specify the Git branch to pull specific Environment   
                                Variables for                                         
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)   
   -y,  --yes                   Skip questions when setting up new project using      
                                default scope and settings                            
 
@@ -5832,6 +5851,7 @@ exports[`help command > pull help output snapshots > pull help column width 120 
 
        --environment <TARGET>  Deployment environment [development]                                                          
        --git-branch <NAME>     Specify the Git branch to pull specific Environment Variables for                             
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)                                           
   -y,  --yes                   Skip questions when setting up new project using default scope and settings                   
 
 

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -2636,7 +2636,7 @@ fs.writeFileSync(
       const exitCodePromise = build(client);
 
       await expect(client.stderr).toOutput(
-        'Project "does-not-exist" was not found.'
+        'Project "does-not-exist" was not found'
       );
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "build"').toEqual(1);

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -2619,4 +2619,51 @@ fs.writeFileSync(
       ])
     );
   });
+
+  describe('--project', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('fails fast with a clean error when the project does not exist anywhere', async () => {
+      const cwd = await getWriteableDirectory();
+      useUser();
+      useTeams('team_dummy');
+      // No useProject() — every API lookup will 404.
+
+      client.cwd = cwd;
+      client.setArgv('build', '--project=does-not-exist');
+      const exitCodePromise = build(client);
+
+      await expect(client.stderr).toOutput(
+        'Project "does-not-exist" was not found.'
+      );
+      const exitCode = await exitCodePromise;
+      expect(exitCode, 'exit code for "build"').toEqual(1);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:project',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+
+    it('tracks --project telemetry as [REDACTED]', async () => {
+      const cwd = await getWriteableDirectory();
+      useUser();
+      useTeams('team_dummy');
+
+      client.cwd = cwd;
+      client.setArgv('build', '--project=my-app');
+      await build(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:project',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -2747,7 +2747,7 @@ describe('deploy', () => {
       const exitCodePromise = deploy(client);
 
       await expect(client.stderr).toOutput(
-        'Project "does-not-exist" was not found.'
+        'Project "does-not-exist" was not found'
       );
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "deploy"').toEqual(1);

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1,5 +1,5 @@
 import type { MockInstance } from 'vitest';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import bytes from 'bytes';
 import fs from 'fs-extra';
 import { join } from 'path';
@@ -2728,6 +2728,29 @@ describe('deploy', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+    });
+  });
+
+  describe('--project', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('fails fast with a clean error when --project does not resolve', async () => {
+      const cwd = setupTmpDir();
+      useUser();
+      useTeams('team_dummy');
+      // Intentionally no useProject() — every API lookup will 404.
+
+      client.cwd = cwd;
+      client.setArgv('deploy', '--yes', '--project=does-not-exist');
+      const exitCodePromise = deploy(client);
+
+      await expect(client.stderr).toOutput(
+        'Project "does-not-exist" was not found.'
+      );
+      const exitCode = await exitCodePromise;
+      expect(exitCode, 'exit code for "deploy"').toEqual(1);
     });
   });
 });

--- a/packages/cli/test/unit/commands/dev/index.test.ts
+++ b/packages/cli/test/unit/commands/dev/index.test.ts
@@ -432,4 +432,23 @@ describe('dev', () => {
       });
     });
   });
+
+  describe('--project', () => {
+    it('tracks --project telemetry as [REDACTED]', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue(projectPath);
+
+      client.setArgv('dev', '--project=my-app');
+      const exitCodePromise = dev(client);
+
+      // dev normally only exits on SIGTERM; here it boots the mocked server.
+      await expect(exitCodePromise).resolves.toEqual(undefined);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:project',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/dev/index.test.ts
+++ b/packages/cli/test/unit/commands/dev/index.test.ts
@@ -437,7 +437,7 @@ describe('dev', () => {
     it('tracks --project telemetry as [REDACTED]', async () => {
       vi.spyOn(process, 'cwd').mockReturnValue(projectPath);
 
-      client.setArgv('dev', '--project=my-app');
+      client.setArgv('dev', `--project=${projectId}`);
       const exitCodePromise = dev(client);
 
       // dev normally only exits on SIGTERM; here it boots the mocked server.

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -481,7 +481,7 @@ describe('pull', () => {
       const exitCodePromise = pull(client);
 
       await expect(client.stderr).toOutput(
-        'Project "does-not-exist" was not found.'
+        'Project "does-not-exist" was not found'
       );
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "pull"').toEqual(1);

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -422,4 +422,69 @@ describe('pull', () => {
       },
     ]);
   });
+
+  describe('--project', () => {
+    it('resolves the project via API in an unlinked directory', async () => {
+      const cwd = setupUnitFixture('vercel-pull-unlinked');
+      useUser();
+      const teams = useTeams('team_dummy');
+      assert(Array.isArray(teams));
+      useProject({
+        ...defaultProject,
+        id: 'prj_via_flag',
+        name: 'project-via-flag',
+        accountId: 'team_dummy',
+      });
+
+      client.setArgv(
+        'pull',
+        '--yes',
+        '--project=project-via-flag',
+        '--environment=production',
+        cwd
+      );
+      const exitCodePromise = pull(client);
+
+      await expect(client.stderr).toOutput(
+        `Downloading \`production\` Environment Variables for ${teams[0].slug}/project-via-flag`
+      );
+      const exitCode = await exitCodePromise;
+      expect(exitCode, 'exit code for "pull"').toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:projectPath',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'flag:yes',
+          value: 'TRUE',
+        },
+        {
+          key: 'option:environment',
+          value: 'production',
+        },
+        {
+          key: 'option:project',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+
+    it('fails fast with a clean error when --project does not resolve', async () => {
+      const cwd = setupUnitFixture('vercel-pull-unlinked');
+      useUser();
+      useTeams('team_dummy');
+      // No useProject() — every GET /v9/projects/* will 404.
+
+      client.setArgv('pull', '--yes', '--project=does-not-exist', cwd);
+      const exitCodePromise = pull(client);
+
+      await expect(client.stderr).toOutput(
+        'Project "does-not-exist" was not found.'
+      );
+      const exitCode = await exitCodePromise;
+      expect(exitCode, 'exit code for "pull"').toEqual(1);
+    });
+  });
 });

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -388,4 +388,98 @@ describe('getLinkedProject', () => {
     expect(link.project.id).toEqual('QmScb7GPQt6gsS');
     expect(link.repoRoot).toEqual(cwd);
   });
+
+  it('should auto-select project in `repo.json` when projectName matches by ID', async () => {
+    const cwd = fixture('monorepo-link');
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'QmX6P93ChNDoZP',
+      name: 'monorepo-marketing',
+    });
+
+    const selectSpy = vi.spyOn(client.input, 'select');
+    const link = await getLinkedProject(client, cwd, 'QmX6P93ChNDoZP');
+    expect(selectSpy).not.toHaveBeenCalled();
+    selectSpy.mockRestore();
+
+    if (link.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.project.id).toEqual('QmX6P93ChNDoZP');
+    expect(link.repoRoot).toEqual(cwd);
+  });
+
+  it('should resolve project via API when projectName is provided, apiFallback is true, and no local link exists', async () => {
+    const cwd = setupTmpDir('no-local-link');
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'prj_api_fallback',
+      name: 'api-fallback-project',
+      accountId: 'team_dummy',
+    });
+
+    const link = await getLinkedProject(
+      client,
+      cwd,
+      'api-fallback-project',
+      true
+    );
+    if (link.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.org.id).toEqual('team_dummy');
+    expect(link.org.type).toEqual('team');
+    expect(link.project.id).toEqual('prj_api_fallback');
+    expect(link.repoRoot).toBeUndefined();
+  });
+
+  it('should return not_linked when projectName is provided, apiFallback is true, and the project does not exist anywhere', async () => {
+    const cwd = setupTmpDir('no-local-link-not-found');
+
+    useUser();
+    useTeams('team_dummy');
+    // Intentionally no useProject — every API lookup 404s.
+
+    const link = await getLinkedProject(
+      client,
+      cwd,
+      'definitely-missing',
+      true
+    );
+    expect(link.status).toEqual('not_linked');
+  });
+
+  it('should not call API fallback when no projectName is provided', async () => {
+    const cwd = setupTmpDir('no-link-no-flag');
+
+    useUser();
+    useTeams('team_dummy');
+
+    const link = await getLinkedProject(client, cwd);
+    expect(link.status).toEqual('not_linked');
+  });
+
+  it('should not call API fallback when projectName is provided but apiFallback is not enabled', async () => {
+    const cwd = setupTmpDir('no-link-implicit-name');
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'prj_should_not_match',
+      name: 'no-link-implicit-name',
+      accountId: 'team_dummy',
+    });
+
+    // Protects callers like `vercel deploy` that pass a directory-derived
+    // `projectName` and rely on `setupAndLink` running interactively.
+    const link = await getLinkedProject(client, cwd, 'no-link-implicit-name');
+    expect(link.status).toEqual('not_linked');
+  });
 });

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -294,6 +294,57 @@ describe('getLinkedProject', () => {
     expect(link.repoRoot).toBeUndefined();
   });
 
+  it('should let explicit projectName override `project.json`', async () => {
+    const cwd = setupTmpDir('project-name-over-project-json');
+    const vercelDir = join(cwd, '.vercel');
+    await mkdirp(vercelDir);
+    await writeJSON(join(vercelDir, 'project.json'), {
+      orgId: 'team_dummy',
+      projectId: 'linked-project',
+      projectName: 'linked-project',
+    });
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'explicit-project',
+      name: 'explicit-project',
+      accountId: 'team_dummy',
+    });
+
+    const link = await getLinkedProject(client, cwd, 'explicit-project', true);
+    if (link.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.project.id).toEqual('explicit-project');
+    expect(link.repoRoot).toBeUndefined();
+  });
+
+  it('should let explicit projectName override repo path auto-selection', async () => {
+    const cwd = fixture('monorepo-link');
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'QmX6P93ChNDoZP',
+      name: 'monorepo-marketing',
+    });
+
+    const link = await getLinkedProject(
+      client,
+      join(cwd, 'dashboard'),
+      'monorepo-marketing',
+      true
+    );
+    if (link.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.project.id).toEqual('QmX6P93ChNDoZP');
+    expect(link.repoRoot).toEqual(cwd);
+  });
+
   it('should return link with legacy `repo.json` (top-level orgId)', async () => {
     const cwd = fixture('monorepo-link-legacy');
 

--- a/packages/cli/test/unit/util/projects/project-not-found-error.test.ts
+++ b/packages/cli/test/unit/util/projects/project-not-found-error.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+import { printProjectNotFoundError } from '../../../../src/util/projects/project-not-found-error';
+import * as getScopeModule from '../../../../src/util/get-scope';
+
+describe('printProjectNotFoundError', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client.reset();
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {}) as () => never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    vi.restoreAllMocks();
+    (client as { nonInteractive: boolean }).nonInteractive = false;
+  });
+
+  describe('interactive mode', () => {
+    it('emits a multi-line error naming the current scope and recovery hints', async () => {
+      useUser();
+      const teams = useTeams('team_dummy');
+      const teamSlug = Array.isArray(teams)
+        ? teams[0].slug
+        : teams.teams[0].slug;
+      client.config.currentTeam = 'team_dummy';
+
+      await printProjectNotFoundError(client, 'foo', 'deploy');
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain(
+        `Project "foo" was not found in the current scope (${teamSlug}).`
+      );
+      expect(stderr).toContain('--scope <team-slug|your-username>');
+      expect(stderr).toContain('vercel switch <team-slug|your-username>');
+      expect(stderr).toContain('vercel teams ls');
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a scope-agnostic message when getScope fails', async () => {
+      vi.spyOn(getScopeModule, 'default').mockRejectedValue(
+        new Error('network down')
+      );
+
+      await printProjectNotFoundError(client, 'foo', 'deploy');
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain(
+        'Project "foo" was not found in the current scope.'
+      );
+      expect(stderr).toContain('vercel teams ls');
+      // No parenthetical scope name when scope lookup fails.
+      expect(stderr).not.toMatch(
+        /Project "foo" was not found in the current scope \(/
+      );
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('non-interactive mode', () => {
+    it('emits structured JSON with reason, scope, and a next array', async () => {
+      useUser();
+      const teams = useTeams('team_dummy');
+      const teamSlug = Array.isArray(teams)
+        ? teams[0].slug
+        : teams.teams[0].slug;
+      client.config.currentTeam = 'team_dummy';
+      (client as { nonInteractive: boolean }).nonInteractive = true;
+      client.setArgv('deploy', '--project=foo');
+
+      await printProjectNotFoundError(client, 'foo', 'deploy');
+
+      const stdout = client.stdout.getFullOutput();
+      const payload = JSON.parse(stdout);
+
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'project_not_found',
+        scope: teamSlug,
+        message: expect.stringContaining('Project "foo" was not found'),
+      });
+
+      expect(Array.isArray(payload.next)).toBe(true);
+      expect(payload.next).toHaveLength(3);
+      expect(payload.next[0]).toEqual({
+        command: 'vercel teams ls',
+        when: 'list accessible teams',
+      });
+      expect(payload.next[1].command).toContain('--scope <team-slug>');
+      expect(payload.next[1].command).toContain('--project foo');
+      expect(payload.next[2].command).toBe('vercel switch <team-slug>');
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('omits the scope field when getScope fails', async () => {
+      vi.spyOn(getScopeModule, 'default').mockRejectedValue(
+        new Error('network down')
+      );
+      (client as { nonInteractive: boolean }).nonInteractive = true;
+      client.setArgv('deploy', '--project=foo');
+
+      await printProjectNotFoundError(client, 'foo', 'deploy');
+
+      const stdout = client.stdout.getFullOutput();
+      const payload = JSON.parse(stdout);
+
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('project_not_found');
+      expect(payload.scope).toBeUndefined();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/packages/cli/test/unit/util/projects/project-not-found-error.test.ts
+++ b/packages/cli/test/unit/util/projects/project-not-found-error.test.ts
@@ -6,13 +6,15 @@ import { printProjectNotFoundError } from '../../../../src/util/projects/project
 import * as getScopeModule from '../../../../src/util/get-scope';
 
 describe('printProjectNotFoundError', () => {
-  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: { mockRestore: () => void };
 
   beforeEach(() => {
     client.reset();
     exitSpy = vi
       .spyOn(process, 'exit')
-      .mockImplementation((() => {}) as () => never);
+      .mockImplementation((() => {}) as () => never) as unknown as {
+      mockRestore: () => void;
+    };
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Adds `--project <NAME_OR_ID>` flag to `vercel build`, `vercel deploy`, `vercel pull`, and `vercel dev` for non-interactive CI/CD and agent-driven use.

When `--project` is provided, the CLI will:

- Disambiguate monorepo `.vercel/repo.json` linked projects without prompting (matches by name **or** ID)
- Resolve the project via the API when no local link is present
- Fail fast with a clean `Project "<x>" was not found` error if the value cannot be resolved (never silently creates a new project)

This is particularly important for agents (which run non-interactively by default): they can now target a specific project in monorepos and unlinked directories without relying on interactive setup prompts or the project picker.

The flag is also accepted on `vercel deploy init` (excluded on `vercel deploy continue` because `--id` already identifies the deployment).

## Examples

```bash
# Monorepo disambiguation (matches by name or ID via repo.json)
vercel build --project my-app
vercel build --project prj_abc123

# Unlinked CI dir — resolves via API
vercel deploy --project my-app --prebuilt
vercel pull --project my-app --environment production
vercel dev --project my-app

# Errors fail fast:
vercel deploy --project nonexistent
# Error: Project "nonexistent" was not found. Verify the name or ID and your team scope.
# exit 1
```

## Implementation notes

Project name/ID resolution is now centralized in `getLinkedProject`, so every command that funnels through it (including `vercel link`, `vercel logs`, `vercel alerts`, `vercel deploy-hooks`, etc.) inherits the same matching rules. Existing inline `--project` flag definitions have been refactored to use a shared `projectOption` primitive in `arg-common.ts`, and the duplicated `trackCliOptionProject` telemetry method has been moved to the base `TelemetryClient` class — which also fixes a missing-redaction inconsistency in `vercel deploy-hooks` telemetry where raw project names were being logged.

API-based resolution only fires when `--project` is explicitly passed. Commands like `vercel deploy` that internally derive a default project name from the directory basename are unaffected and still fall back to the existing interactive setup flow.

## Tested

- 738+ affected unit tests pass (`packages/cli/test/unit/{util/projects,util/link,commands/{build,deploy,pull,dev,link,logs,alerts,activity,metrics,deploy-hooks,connex}}`)
- New tests cover: repo.json ID match, API fallback opt-in gating, fail-fast on unresolved name, telemetry redaction
- `pnpm lint` clean, no new `src/` type errors, help snapshots regenerated
