### PR TITLE
[python] configure runtime cache for Python functions

### DIFF
--- a/.changeset/sixty-carrots-obey.md
+++ b/.changeset/sixty-carrots-obey.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-runtime': minor
+---
+
+Configure runtime cache for Python functions

--- a/python/vercel-runtime/src/vercel_runtime/cache.py
+++ b/python/vercel-runtime/src/vercel_runtime/cache.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from vercel_runtime.headers import decode_header_bytes
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+
+# Needed to type HTTP-handler/WSGI paths
+class _HeadersLike(Protocol):
+    def items(self) -> Iterable[tuple[object, object]]: ...
+
+
+_SC_HEADERS_NAME = "x-vercel-sc-headers"
+_SC_HOST_NAME = "x-vercel-sc-host"
+_SC_BASEPATH_NAME = "x-vercel-sc-basepath"
+_SC_PROTOCOL_NAME = "x-vercel-sc-protocol"
+_SC_RUNTIME_CACHE_NAME = "x-vercel-sc-runtime-cache"
+
+# If this header is set, then we should strip some extra headers
+# before passing them to the client code
+SC_NO_HEADER_LEAK_HEADER: str = "x-vercel-sc-no-header-leak"
+
+# Special cache headers that determine which cache should be used,
+# in this case to tell the API to use the runtime cache
+_SC_CLIENT_ORIGIN_NAME = "x-vercel-internal-sc-client-origin"
+_SC_CLIENT_NAME_NAME = "x-vercel-internal-sc-client-name"
+_SC_CLIENT_VALUE = "RUNTIME_CACHE"
+
+# Headers always stripped
+SC_HEADERS_ALWAYS_STRIP: frozenset[str] = frozenset({_SC_RUNTIME_CACHE_NAME})
+
+# Headers stripped only when x-vercel-sc-no-header-leak is set
+SC_HEADERS_STRIP_ON_NO_LEAK: frozenset[str] = frozenset(
+    {
+        _SC_HEADERS_NAME,
+        _SC_HOST_NAME,
+        _SC_BASEPATH_NAME,
+        _SC_PROTOCOL_NAME,
+        SC_NO_HEADER_LEAK_HEADER,
+    }
+)
+
+
+def set_runtime_cache_from_asgi_pairs(
+    headers_list: list[tuple[bytes, bytes]],
+) -> None:
+    _set_runtime_cache_from_pairs(
+        (decode_header_bytes(k).lower(), decode_header_bytes(v))
+        for k, v in headers_list
+    )
+
+
+def set_runtime_cache_from_http_headers(headers: _HeadersLike | None) -> None:
+    if headers is None:
+        return
+    _set_runtime_cache_from_pairs(
+        (str(k).lower(), str(v))
+        for k, v in headers.items()
+        if k is not None and v is not None
+    )
+
+
+def _set_runtime_cache_from_pairs(
+    pairs: Iterable[tuple[str, str]],
+) -> None:
+    sc_headers_raw: str | None = None
+    sc_host: str | None = None
+    sc_basepath: str | None = None
+    sc_protocol: str | None = None
+
+    for key, value in pairs:
+        if not key:
+            continue
+        if key == _SC_HEADERS_NAME:
+            sc_headers_raw = value
+        elif key == _SC_HOST_NAME:
+            sc_host = value
+        elif key == _SC_BASEPATH_NAME:
+            sc_basepath = value
+        elif key == _SC_PROTOCOL_NAME:
+            sc_protocol = value
+
+    _apply_cache_context(
+        sc_headers_raw=sc_headers_raw,
+        sc_host=sc_host,
+        sc_basepath=sc_basepath,
+        sc_protocol=sc_protocol,
+    )
+
+
+def _apply_cache_context(
+    *,
+    sc_headers_raw: str | None,
+    sc_host: str | None,
+    sc_basepath: str | None,
+    sc_protocol: str | None,
+) -> None:
+    if not sc_headers_raw or not sc_host:
+        return
+
+    modules = _load_vercel_cache_modules()
+    if modules is None:
+        return
+    cache_build, context = modules
+
+    try:
+        parsed = json.loads(sc_headers_raw)
+    except (TypeError, ValueError):
+        return
+    if not isinstance(parsed, dict):
+        return
+
+    parsed_mapping = cast("Mapping[object, object]", parsed)
+    headers: dict[str, str] = {
+        str(k): str(v) for k, v in parsed_mapping.items()
+    }
+    headers[_SC_CLIENT_ORIGIN_NAME] = _SC_CLIENT_VALUE
+    headers[_SC_CLIENT_NAME_NAME] = _SC_CLIENT_VALUE
+
+    endpoint = _build_endpoint(
+        host=sc_host,
+        basepath=sc_basepath,
+        protocol=sc_protocol,
+    )
+
+    # Build and try to inject both caches into the context,
+    # so any request handler can use a cache
+    sync_cache = cache_build.BuildCache(endpoint=endpoint, headers=headers)
+    async_cache = cache_build.AsyncBuildCache(
+        endpoint=endpoint,
+        headers=headers,
+    )
+
+    try:
+        context.set_context(cache=sync_cache, async_cache=async_cache)
+    except TypeError:
+        # For older `vercel` release (before 0.5.9) set only sync cache
+        context.set_context(cache=sync_cache)
+
+
+# We don't depend on `vercel` package directly, so
+# use an optional import here. If we can import the modules -
+# we'll configure caches, otherwise we skip the behaviour
+def _load_vercel_cache_modules() -> Any | None:
+    with contextlib.suppress(ImportError):
+        import vercel.cache.cache_build as cache_build  # type: ignore[import-not-found]  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        import vercel.cache.context as context  # type: ignore[import-not-found]  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+
+        return cache_build, context
+    return None
+
+
+def _build_endpoint(
+    *,
+    host: str,
+    basepath: str | None,
+    protocol: str | None,
+) -> str:
+    proto = protocol or "https"
+    return f"{proto}://{host}{basepath or ''}/v1/suspense-cache/"

--- a/python/vercel-runtime/src/vercel_runtime/cache.py
+++ b/python/vercel-runtime/src/vercel_runtime/cache.py
@@ -143,6 +143,19 @@ def _apply_cache_context(
         context.set_context(cache=sync_cache)
 
 
+def clear_runtime_cache_context() -> None:
+    modules = _load_vercel_cache_modules()
+    if modules is None:
+        return
+
+    _, context = modules
+    try:
+        context.set_context(cache=None, async_cache=None)
+    except TypeError:
+        # Older `vercel` SDK without the async_cache kwarg.
+        context.set_context(cache=None)
+
+
 # We don't depend on `vercel` package directly, so
 # use an optional import here. If we can import the modules -
 # we'll configure caches, otherwise we skip the behaviour

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -18,6 +18,13 @@ import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import TYPE_CHECKING, Any, Literal, Never, TextIO
 
+from vercel_runtime.cache import (
+    SC_HEADERS_ALWAYS_STRIP,
+    SC_HEADERS_STRIP_ON_NO_LEAK,
+    SC_NO_HEADER_LEAK_HEADER,
+    set_runtime_cache_from_asgi_pairs,
+    set_runtime_cache_from_http_headers,
+)
 from vercel_runtime.crons import (
     bootstrap_cron_service_app,
     is_cron_service,
@@ -563,6 +570,8 @@ class ASGIMiddleware:
         invocation_id = "0"
         request_id = 0
         internal_oidc_token: str | None = None
+        sc_pairs: list[tuple[bytes, bytes]] = []
+        sc_no_header_leak = False
 
         for raw_k, raw_v in headers_list:
             key_bytes = raw_k if isinstance(raw_k, bytes) else raw_k.encode()
@@ -583,12 +592,24 @@ class ASGIMiddleware:
             if key == INTERNAL_OIDC_HEADER_NAME:
                 internal_oidc_token = val
                 continue
+            if key in SC_HEADERS_ALWAYS_STRIP:
+                continue
+            if key in SC_HEADERS_STRIP_ON_NO_LEAK:
+                # Hold these aside until we know whether the proxy asked us to
+                # hide them from client code
+                sc_pairs.append((key_bytes, val_bytes))
+                if key == SC_NO_HEADER_LEAK_HEADER:
+                    sc_no_header_leak = bool(val)
+                continue
             new_headers.append((key_bytes, val_bytes))
 
         append_oidc_header_if_missing(
             new_headers,
             internal_oidc_token=internal_oidc_token,
         )
+        if not sc_no_header_leak:
+            # Proxy didn't ask for header hiding, so extend the normal headers
+            new_headers.extend(sc_pairs)
 
         new_scope = dict(scope)
         new_scope["headers"] = new_headers
@@ -615,6 +636,7 @@ class ASGIMiddleware:
             }
         )
         set_vercel_headers_from_asgi_pairs(new_headers)
+        set_runtime_cache_from_asgi_pairs(sc_pairs)
 
         try:
             await self.app(new_scope, receive, send)
@@ -753,6 +775,18 @@ if "VERCEL_IPC_PATH" in os.environ:
                 self.headers[OIDC_HEADER_NAME] = oidc_token
             with contextlib.suppress(Exception):
                 del self.headers[INTERNAL_OIDC_HEADER_NAME]
+
+            sc_no_header_leak = bool(
+                self.headers.get(SC_NO_HEADER_LEAK_HEADER),
+            )
+            set_runtime_cache_from_http_headers(self.headers)
+            for sc_header in SC_HEADERS_ALWAYS_STRIP:
+                with contextlib.suppress(Exception):
+                    del self.headers[sc_header]
+            if sc_no_header_leak:
+                for sc_header in SC_HEADERS_STRIP_ON_NO_LEAK:
+                    with contextlib.suppress(Exception):
+                        del self.headers[sc_header]
 
             send_message(
                 {
@@ -982,14 +1016,27 @@ if (
     port = server.server_address[1]  # type: ignore[attr-defined]
 
     def vc_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
-        _thread.start_new_thread(server.handle_request, ())  # type: ignore[attr-defined]
-
         payload = json.loads(event["body"])
         path, _ = apply_service_route_prefix_to_target(payload["path"])
         headers = normalize_event_headers(payload.get("headers", {}))
         method = payload["method"]
         encoding = payload.get("encoding")
         body = payload.get("body")
+
+        sc_no_header_leak = bool(headers.get(SC_NO_HEADER_LEAK_HEADER))
+        set_runtime_cache_from_http_headers(headers)
+        for sc_header in SC_HEADERS_ALWAYS_STRIP:
+            headers.pop(sc_header, None)
+        if sc_no_header_leak:
+            for sc_header in SC_HEADERS_STRIP_ON_NO_LEAK:
+                headers.pop(sc_header, None)
+
+        # `_thread.start_new_thread` does not propagate contextvars
+        captured_ctx = contextvars.copy_context()
+        _thread.start_new_thread(
+            captured_ctx.run,
+            (server.handle_request,),  # type: ignore[attr-defined]
+        )
 
         if (body is not None and len(body) > 0) and (
             encoding is not None and encoding == "base64"
@@ -1066,6 +1113,15 @@ else:
             payload = json.loads(event["body"])
 
             raw_headers = normalize_event_headers(payload.get("headers", {}))
+
+            sc_no_header_leak = bool(raw_headers.get(SC_NO_HEADER_LEAK_HEADER))
+            set_runtime_cache_from_http_headers(raw_headers)
+            for sc_header in SC_HEADERS_ALWAYS_STRIP:
+                raw_headers.pop(sc_header, None)
+            if sc_no_header_leak:
+                for sc_header in SC_HEADERS_STRIP_ON_NO_LEAK:
+                    raw_headers.pop(sc_header, None)
+
             headers = Headers(raw_headers)
 
             body: Any = payload.get("body", "")
@@ -1347,11 +1403,30 @@ else:
             header_pairs = normalize_event_header_pairs(
                 payload.get("headers", {})
             )
+
+            sc_pairs: list[tuple[str, str]] = []
+            sc_no_header_leak = False
             headers: dict[str, str] = {}
             headers_encoded: list[tuple[bytes, bytes]] = []
             for key, value in header_pairs:
+                key_lower = key.lower()
+                if key_lower in SC_HEADERS_ALWAYS_STRIP:
+                    continue
+                if key_lower in SC_HEADERS_STRIP_ON_NO_LEAK:
+                    sc_pairs.append((key_lower, value))
+                    if key_lower == SC_NO_HEADER_LEAK_HEADER:
+                        sc_no_header_leak = bool(value)
+                    continue
                 headers[key] = value
-                headers_encoded.append((key.lower().encode(), value.encode()))
+                headers_encoded.append((key_lower.encode(), value.encode()))
+
+            set_runtime_cache_from_http_headers(dict(sc_pairs))
+            if not sc_no_header_leak:
+                for sc_key, sc_value in sc_pairs:
+                    headers[sc_key] = sc_value
+                    headers_encoded.append(
+                        (sc_key.encode(), sc_value.encode()),
+                    )
 
             body = payload.get("body", b"")
             if payload.get("encoding") == "base64":

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -22,6 +22,7 @@ from vercel_runtime.cache import (
     SC_HEADERS_ALWAYS_STRIP,
     SC_HEADERS_STRIP_ON_NO_LEAK,
     SC_NO_HEADER_LEAK_HEADER,
+    clear_runtime_cache_context,
     set_runtime_cache_from_asgi_pairs,
     set_runtime_cache_from_http_headers,
 )
@@ -641,6 +642,7 @@ class ASGIMiddleware:
         try:
             await self.app(new_scope, receive, send)
         finally:
+            clear_runtime_cache_context()
             clear_vercel_headers_context()
             storage.reset(token)
             send_message(
@@ -812,6 +814,7 @@ if "VERCEL_IPC_PATH" in os.environ:
             try:
                 self.handle_request()  # type: ignore[attr-defined]
             finally:
+                clear_runtime_cache_context()
                 clear_vercel_headers_context()
                 storage.reset(token)
                 send_message(
@@ -1037,6 +1040,7 @@ if (
             captured_ctx.run,
             (server.handle_request,),  # type: ignore[attr-defined]
         )
+        clear_runtime_cache_context()
 
         if (body is not None and len(body) > 0) and (
             encoding is not None and encoding == "base64"
@@ -1174,6 +1178,7 @@ else:
             try:
                 response = Response.from_app(wsgi_user_app, environ)
             finally:
+                clear_runtime_cache_context()
                 clear_vercel_headers_context()
 
             return_dict: dict[str, Any] = {
@@ -1472,4 +1477,5 @@ else:
                 response = asgi_cycle(asgi_user_app, body)
                 return response
             finally:
+                clear_runtime_cache_context()
                 clear_vercel_headers_context()

--- a/python/vercel-runtime/tests/fixtures/asgi_app.py
+++ b/python/vercel-runtime/tests/fixtures/asgi_app.py
@@ -1,5 +1,7 @@
 """A basic ASGI application for testing."""
 
+import json
+
 
 async def app(scope, receive, send):
     if scope["type"] != "http":
@@ -7,20 +9,30 @@ async def app(scope, receive, send):
 
     path = scope.get("path", "/")
     method = scope.get("method", "GET")
-    body = f"{method} {path}".encode()
-    if path == "/oidc":
+    content_type = b"text/plain"
+
+    if path == "/headers":
+        payload = {
+            key.decode().lower(): value.decode()
+            for key, value in scope.get("headers", [])
+        }
+        body = json.dumps(payload).encode()
+        content_type = b"application/json"
+    elif path == "/oidc":
         headers = {
             key.decode(): value.decode()
             for key, value in scope.get("headers", [])
         }
         body = headers.get("x-vercel-oidc-token", "").encode()
+    else:
+        body = f"{method} {path}".encode()
 
     await send(
         {
             "type": "http.response.start",
             "status": 200,
             "headers": [
-                (b"content-type", b"text/plain"),
+                (b"content-type", content_type),
             ],
         }
     )

--- a/python/vercel-runtime/tests/fixtures/http_handler.py
+++ b/python/vercel-runtime/tests/fixtures/http_handler.py
@@ -1,5 +1,6 @@
 """A basic BaseHTTPRequestHandler for testing."""
 
+import json
 from http.server import BaseHTTPRequestHandler
 
 
@@ -11,6 +12,15 @@ class handler(BaseHTTPRequestHandler):
             self.end_headers()
             token = self.headers.get("x-vercel-oidc-token", "")
             self.wfile.write(token.encode())
+            return
+
+        if self.path == "/headers":
+            payload = {k.lower(): v for k, v in self.headers.items()}
+            body = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
             return
 
         self.send_response(200)

--- a/python/vercel-runtime/tests/fixtures/wsgi_app.py
+++ b/python/vercel-runtime/tests/fixtures/wsgi_app.py
@@ -1,10 +1,22 @@
 """A basic WSGI application for testing."""
 
+import json
+
 
 def app(environ, start_response):
     method = environ.get("REQUEST_METHOD", "GET")
     path = environ.get("PATH_INFO", "/")
     query = environ.get("QUERY_STRING", "")
+
+    if path == "/headers":
+        payload = {
+            key[5:].lower().replace("_", "-"): value
+            for key, value in environ.items()
+            if key.startswith("HTTP_")
+        }
+        body = json.dumps(payload)
+        start_response("200 OK", [("Content-Type", "application/json")])
+        return [body.encode()]
 
     body = f"{method} {path}"
     if query:

--- a/python/vercel-runtime/tests/test_cache_context.py
+++ b/python/vercel-runtime/tests/test_cache_context.py
@@ -238,5 +238,51 @@ class TestSetRuntimeCacheFromHTTP(unittest.TestCase):
         cache_ns.context.set_context.assert_called_once()
 
 
+class TestClearRuntimeCacheContext(unittest.TestCase):
+    def test_calls_set_context_with_none_for_both_slots(self) -> None:
+        cache_ns = _mock_cache_namespace()
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc.clear_runtime_cache_context()
+
+        cache_ns.context.set_context.assert_called_once_with(
+            cache=None,
+            async_cache=None,
+        )
+
+    def test_falls_back_when_async_cache_kwarg_unsupported(self) -> None:
+        def reject_async_cache(**kwargs: object) -> None:
+            if "async_cache" in kwargs:
+                raise TypeError("unexpected keyword 'async_cache'")
+
+        cache_ns = _mock_cache_namespace(
+            set_context_side_effect=reject_async_cache,
+        )
+
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc.clear_runtime_cache_context()
+
+        calls = cache_ns.context.set_context.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertIn("async_cache", calls[0].kwargs)
+        self.assertNotIn("async_cache", calls[1].kwargs)
+        self.assertIsNone(calls[1].kwargs["cache"])
+
+    def test_noop_when_vercel_cache_unavailable(self) -> None:
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=None,
+        ):
+            vrc.clear_runtime_cache_context()  # should not raise
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/python/vercel-runtime/tests/test_cache_context.py
+++ b/python/vercel-runtime/tests/test_cache_context.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+import types
+import unittest
+from typing import Any
+from unittest.mock import Mock, patch
+
+import vercel_runtime.cache as vrc
+
+
+def _mock_cache_namespace(
+    set_context_side_effect: Any = None,
+) -> types.SimpleNamespace:
+    sync_instance = object()
+    async_instance = object()
+    cache_build = types.SimpleNamespace(
+        BuildCache=Mock(return_value=sync_instance),
+        AsyncBuildCache=Mock(return_value=async_instance),
+    )
+    cv_cache = types.SimpleNamespace(set=Mock())
+    cv_async_cache = types.SimpleNamespace(set=Mock())
+    context = types.SimpleNamespace(
+        set_context=Mock(side_effect=set_context_side_effect),
+        _cv_cache=cv_cache,
+        _cv_async_cache=cv_async_cache,
+    )
+    return types.SimpleNamespace(
+        cache_build=cache_build,
+        context=context,
+        sync_instance=sync_instance,
+        async_instance=async_instance,
+    )
+
+
+def _sc_headers_payload() -> dict[str, str]:
+    return {"authorization": "Bearer fake-jwt", "x-vercel-extra": "1"}
+
+
+def _sc_asgi_pairs(
+    *,
+    no_header_leak: bool = False,
+    extra: list[tuple[bytes, bytes]] | None = None,
+) -> list[tuple[bytes, bytes]]:
+    pairs: list[tuple[bytes, bytes]] = [
+        (b"x-vercel-sc-headers", json.dumps(_sc_headers_payload()).encode()),
+        (b"x-vercel-sc-host", b"cache.example.com"),
+        (b"x-vercel-sc-basepath", b"/iad1"),
+        (b"x-vercel-sc-protocol", b"https"),
+    ]
+    if no_header_leak:
+        pairs.append((b"x-vercel-sc-no-header-leak", b"1"))
+    if extra:
+        pairs.extend(extra)
+    return pairs
+
+
+def _sc_http_headers(*, no_header_leak: bool = False) -> dict[str, str]:
+    headers: dict[str, str] = {
+        "x-vercel-sc-headers": json.dumps(_sc_headers_payload()),
+        "x-vercel-sc-host": "cache.example.com",
+        "x-vercel-sc-basepath": "/iad1",
+        "x-vercel-sc-protocol": "https",
+    }
+    if no_header_leak:
+        headers["x-vercel-sc-no-header-leak"] = "1"
+    return headers
+
+
+class TestLoadVercelCache(unittest.TestCase):
+    def test_returns_none_when_vercel_cache_missing(self) -> None:
+        with patch.object(vrc, "_load_vercel_cache_modules", return_value=None):
+            self.assertIsNone(vrc._load_vercel_cache_modules())
+
+
+class TestApplyCacheContext(unittest.TestCase):
+    def test_constructs_clients_and_installs_into_context(self) -> None:
+        cache_ns = _mock_cache_namespace()
+
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc._apply_cache_context(
+                sc_headers_raw=json.dumps(_sc_headers_payload()),
+                sc_host="cache.example.com",
+                sc_basepath="/iad1",
+                sc_protocol="https",
+            )
+
+        sync_call = cache_ns.cache_build.BuildCache.call_args
+        self.assertEqual(
+            sync_call.kwargs["endpoint"],
+            "https://cache.example.com/iad1/v1/suspense-cache/",
+        )
+        headers_sent = sync_call.kwargs["headers"]
+        self.assertEqual(headers_sent["authorization"], "Bearer fake-jwt")
+        self.assertEqual(
+            headers_sent["x-vercel-internal-sc-client-origin"],
+            "RUNTIME_CACHE",
+        )
+        self.assertEqual(
+            headers_sent["x-vercel-internal-sc-client-name"],
+            "RUNTIME_CACHE",
+        )
+
+        cache_ns.context.set_context.assert_called_once_with(
+            cache=cache_ns.sync_instance,
+            async_cache=cache_ns.async_instance,
+        )
+
+    def test_falls_back_when_async_cache_kwarg_unsupported(self) -> None:
+        def reject_async_cache(**kwargs: object) -> None:
+            if "async_cache" in kwargs:
+                raise TypeError("unexpected keyword 'async_cache'")
+
+        cache_ns = _mock_cache_namespace(
+            set_context_side_effect=reject_async_cache,
+        )
+
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc._apply_cache_context(
+                sc_headers_raw=json.dumps(_sc_headers_payload()),
+                sc_host="cache.example.com",
+                sc_basepath="/iad1",
+                sc_protocol="https",
+            )
+
+        calls = cache_ns.context.set_context.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertIn("async_cache", calls[0].kwargs)
+        self.assertNotIn("async_cache", calls[1].kwargs)
+        self.assertIs(calls[1].kwargs["cache"], cache_ns.sync_instance)
+
+    def test_noop_when_sc_headers_missing(self) -> None:
+        cache_ns = _mock_cache_namespace()
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc._apply_cache_context(
+                sc_headers_raw=None,
+                sc_host="cache.example.com",
+                sc_basepath="/iad1",
+                sc_protocol="https",
+            )
+
+        cache_ns.context.set_context.assert_not_called()
+        cache_ns.cache_build.BuildCache.assert_not_called()
+
+    def test_noop_when_sc_host_missing(self) -> None:
+        cache_ns = _mock_cache_namespace()
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc._apply_cache_context(
+                sc_headers_raw=json.dumps(_sc_headers_payload()),
+                sc_host=None,
+                sc_basepath="/iad1",
+                sc_protocol="https",
+            )
+
+        cache_ns.context.set_context.assert_not_called()
+
+    def test_noop_when_vercel_cache_unavailable(self) -> None:
+        with patch.object(vrc, "_load_vercel_cache_modules", return_value=None):
+            vrc._apply_cache_context(
+                sc_headers_raw=json.dumps(_sc_headers_payload()),
+                sc_host="cache.example.com",
+                sc_basepath="/iad1",
+                sc_protocol="https",
+            )
+
+    def test_noop_when_sc_headers_invalid_json(self) -> None:
+        cache_ns = _mock_cache_namespace()
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc._apply_cache_context(
+                sc_headers_raw="{not json",
+                sc_host="suspense-cache.example.com",
+                sc_basepath="/iad1",
+                sc_protocol="https",
+            )
+
+        cache_ns.context.set_context.assert_not_called()
+
+    def test_noop_when_sc_headers_not_dict(self) -> None:
+        cache_ns = _mock_cache_namespace()
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc._apply_cache_context(
+                sc_headers_raw=json.dumps(["not", "a", "dict"]),
+                sc_host="cache.example.com",
+                sc_basepath="/iad1",
+                sc_protocol="https",
+            )
+
+        cache_ns.context.set_context.assert_not_called()
+
+
+class TestSetRuntimeCacheFromASGI(unittest.TestCase):
+    def test_installs_cache_when_sc_headers_present(self) -> None:
+        cache_ns = _mock_cache_namespace()
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc.set_runtime_cache_from_asgi_pairs(_sc_asgi_pairs())
+
+        cache_ns.context.set_context.assert_called_once()
+
+
+class TestSetRuntimeCacheFromHTTP(unittest.TestCase):
+    def test_dict_input(self) -> None:
+        cache_ns = _mock_cache_namespace()
+        with patch.object(
+            vrc,
+            "_load_vercel_cache_modules",
+            return_value=(cache_ns.cache_build, cache_ns.context),
+        ):
+            vrc.set_runtime_cache_from_http_headers(_sc_http_headers())
+
+        cache_ns.context.set_context.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -378,6 +378,65 @@ class TestHTTPHandler(_RuntimeTestCase):
             sock.close()
             self.assertIn(b"400", data)
 
+    async def test_sc_headers_stripped_per_no_leak_flag(self) -> None:
+        ep_abs, ep_rel, mod = _make_entrypoint("http_handler.py", self.tmp_path)
+        async with _run_runtime(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            ipc_socket_path=self.n1.socket_path,
+            variable_name="handler",
+        ):
+            ss = await self.n1.wait_for_message(
+                ServerStartedMessage, timeout=10.0
+            )
+            port = ss.payload.http_port
+
+            # Without x-vercel-sc-no-header-leak most headers are passed down
+            resp = await _http_get(
+                port,
+                "/headers",
+                headers={
+                    "x-vercel-sc-headers": '{"authorization": "Bearer x"}',
+                    "x-vercel-sc-host": "cache.example.com",
+                    "x-vercel-sc-basepath": "/iad1",
+                    "x-vercel-sc-protocol": "https",
+                    "x-vercel-sc-runtime-cache": "1",
+                },
+            )
+            self.assertEqual(resp.status, 200)
+            seen = json.loads(resp.read())
+            self.assertNotIn("x-vercel-sc-runtime-cache", seen)
+            self.assertIn("x-vercel-sc-headers", seen)
+            self.assertIn("x-vercel-sc-host", seen)
+            self.assertIn("x-vercel-sc-basepath", seen)
+            self.assertIn("x-vercel-sc-protocol", seen)
+
+            # With x-vercel-sc-no-header-leak every header is stripped
+            resp = await _http_get(
+                port,
+                "/headers",
+                headers={
+                    "x-vercel-sc-headers": '{"authorization": "Bearer x"}',
+                    "x-vercel-sc-host": "cache.example.com",
+                    "x-vercel-sc-basepath": "/iad1",
+                    "x-vercel-sc-protocol": "https",
+                    "x-vercel-sc-no-header-leak": "1",
+                    "x-vercel-sc-runtime-cache": "1",
+                },
+            )
+            self.assertEqual(resp.status, 200)
+            seen = json.loads(resp.read())
+            for sc_header in (
+                "x-vercel-sc-headers",
+                "x-vercel-sc-host",
+                "x-vercel-sc-basepath",
+                "x-vercel-sc-protocol",
+                "x-vercel-sc-no-header-leak",
+                "x-vercel-sc-runtime-cache",
+            ):
+                self.assertNotIn(sc_header, seen)
+
 
 class TestWSGIApp(_RuntimeTestCase):
     """Tests for WSGI app entrypoints."""
@@ -447,6 +506,60 @@ class TestWSGIApp(_RuntimeTestCase):
             resp = await _http_get(port, "/oidc")
             self.assertEqual(resp.status, 200)
             self.assertEqual(resp.read().decode(), "env-token")
+
+    async def test_sc_headers_stripped_per_no_leak_flag(self) -> None:
+        ep_abs, ep_rel, mod = _make_entrypoint("wsgi_app.py", self.tmp_path)
+        async with _run_runtime(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            ipc_socket_path=self.n1.socket_path,
+        ):
+            ss = await self.n1.wait_for_message(
+                ServerStartedMessage, timeout=10.0
+            )
+            port = ss.payload.http_port
+
+            resp = await _http_get(
+                port,
+                "/headers",
+                headers={
+                    "x-vercel-sc-headers": '{"authorization": "Bearer x"}',
+                    "x-vercel-sc-host": "cache.example.com",
+                    "x-vercel-sc-basepath": "/iad1",
+                    "x-vercel-sc-protocol": "https",
+                    "x-vercel-sc-runtime-cache": "1",
+                },
+            )
+            self.assertEqual(resp.status, 200)
+            seen = json.loads(resp.read())
+            self.assertNotIn("x-vercel-sc-runtime-cache", seen)
+            self.assertIn("x-vercel-sc-headers", seen)
+            self.assertIn("x-vercel-sc-host", seen)
+
+            resp = await _http_get(
+                port,
+                "/headers",
+                headers={
+                    "x-vercel-sc-headers": '{"authorization": "Bearer x"}',
+                    "x-vercel-sc-host": "cache.example.com",
+                    "x-vercel-sc-basepath": "/iad1",
+                    "x-vercel-sc-protocol": "https",
+                    "x-vercel-sc-no-header-leak": "1",
+                    "x-vercel-sc-runtime-cache": "1",
+                },
+            )
+            self.assertEqual(resp.status, 200)
+            seen = json.loads(resp.read())
+            for sc_header in (
+                "x-vercel-sc-headers",
+                "x-vercel-sc-host",
+                "x-vercel-sc-basepath",
+                "x-vercel-sc-protocol",
+                "x-vercel-sc-no-header-leak",
+                "x-vercel-sc-runtime-cache",
+            ):
+                self.assertNotIn(sc_header, seen)
 
 
 class TestASGIApp(_RuntimeTestCase):
@@ -532,6 +645,60 @@ class TestASGIApp(_RuntimeTestCase):
             resp = await _http_get(port, "/oidc")
             self.assertEqual(resp.status, 200)
             self.assertEqual(resp.read().decode(), "env-token")
+
+    async def test_sc_headers_stripped_per_no_leak_flag(self) -> None:
+        ep_abs, ep_rel, mod = _make_entrypoint("asgi_app.py", self.tmp_path)
+        async with _run_runtime(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            ipc_socket_path=self.n1.socket_path,
+        ):
+            ss = await self.n1.wait_for_message(
+                ServerStartedMessage, timeout=10.0
+            )
+            port = ss.payload.http_port
+
+            resp = await _http_get(
+                port,
+                "/headers",
+                headers={
+                    "x-vercel-sc-headers": '{"authorization": "Bearer x"}',
+                    "x-vercel-sc-host": "cache.example.com",
+                    "x-vercel-sc-basepath": "/iad1",
+                    "x-vercel-sc-protocol": "https",
+                    "x-vercel-sc-runtime-cache": "1",
+                },
+            )
+            self.assertEqual(resp.status, 200)
+            seen = json.loads(resp.read())
+            self.assertNotIn("x-vercel-sc-runtime-cache", seen)
+            self.assertIn("x-vercel-sc-headers", seen)
+            self.assertIn("x-vercel-sc-host", seen)
+
+            resp = await _http_get(
+                port,
+                "/headers",
+                headers={
+                    "x-vercel-sc-headers": '{"authorization": "Bearer x"}',
+                    "x-vercel-sc-host": "cache.example.com",
+                    "x-vercel-sc-basepath": "/iad1",
+                    "x-vercel-sc-protocol": "https",
+                    "x-vercel-sc-no-header-leak": "1",
+                    "x-vercel-sc-runtime-cache": "1",
+                },
+            )
+            self.assertEqual(resp.status, 200)
+            seen = json.loads(resp.read())
+            for sc_header in (
+                "x-vercel-sc-headers",
+                "x-vercel-sc-host",
+                "x-vercel-sc-basepath",
+                "x-vercel-sc-protocol",
+                "x-vercel-sc-no-header-leak",
+                "x-vercel-sc-runtime-cache",
+            ):
+                self.assertNotIn(sc_header, seen)
 
 
 class TestCronService(_RuntimeTestCase):


### PR DESCRIPTION
Use request headers to configure runtime cache and set instances of it in the context