### PR TITLE
[services] Pass service type and framework to node builder's project manifest.

### DIFF
--- a/.changeset/slow-ladybugs-brake.md
+++ b/.changeset/slow-ladybugs-brake.md
@@ -1,0 +1,5 @@
+---
+'@vercel/node': patch
+---
+
+Pass service type and framework to node manifest.

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -31,6 +31,7 @@ import {
   getEnvForPackageManager,
   scanParentDirs,
   isBunVersion,
+  getReportedServiceType,
 } from '@vercel/build-utils';
 import type {
   File,
@@ -432,6 +433,7 @@ export const build = async ({
   repoRootPath,
   config = {},
   meta = {},
+  service,
   considerBuildCommand = false,
   entrypointCallback,
   checks = () => {},
@@ -719,6 +721,8 @@ export const build = async ({
       cliType,
       lockfilePath,
       lockfileVersion,
+      framework: config.framework ?? undefined,
+      serviceType: service ? getReportedServiceType(service) : undefined,
     });
   } catch (err) {
     debug(


### PR DESCRIPTION
Fixes missing framework + service type for worker and queue jobs.