### PR TITLE
docs(vercel-cli skill): add Speed Insights to skill keywords and routing

### DIFF
--- a/.changeset/skill-speed-insights-keywords.md
+++ b/.changeset/skill-speed-insights-keywords.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Speed Insights and Core Web Vitals to the `vercel-cli` skill description and decision tree so agents are routed to `references/monitoring-and-debugging.md` when users ask about Speed Insights metrics.

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vercel-cli
-description: Deploy, manage, inspect, and troubleshoot Vercel projects from the command line. Use for Vercel deployments, projects and teams, environment variables, domains and DNS, logs, metrics, usage, activity, alerts, firewall rules, cache, cron jobs, deploy hooks, Edge Config, feature flags, integrations, connectors, Blob storage, microfrontends, rolling releases, custom environments, Sandbox, agent/MCP setup, preview access, local development, or `vercel api` fallback.
+description: Deploy, manage, inspect, and troubleshoot Vercel projects from the command line. Use for Vercel deployments, projects and teams, environment variables, domains and DNS, logs, metrics, Speed Insights, Core Web Vitals, usage, activity, alerts, firewall rules, cache, cron jobs, deploy hooks, Edge Config, feature flags, integrations, connectors, Blob storage, microfrontends, rolling releases, custom environments, Sandbox, agent/MCP setup, preview access, local development, or `vercel api` fallback.
 ---
 
 # Vercel CLI Skill
@@ -45,7 +45,7 @@ Use this to route to the correct reference file:
 - **CI/CD automation** → `references/ci-automation.md`
 - **Domains or DNS** → `references/domains-and-dns.md`
 - **Projects or teams** → `references/projects-and-teams.md`
-- **Logs, metrics, activity, performance, preview access, or production debugging** → `references/monitoring-and-debugging.md`
+- **Logs, metrics, Speed Insights, Core Web Vitals, activity, performance, preview access, or production debugging** → `references/monitoring-and-debugging.md`
 - **Alerts, usage, contracts, billing purchases, tokens, telemetry, or CLI upgrades** → `references/platform-ops.md`
 - **Blob storage** → `references/storage.md`
 - **Integrations (databases, storage, etc.)** → `references/integrations.md`


### PR DESCRIPTION
Adds "Speed Insights" and "Core Web Vitals" to the vercel-cli skill's frontmatter description and the monitoring-and-debugging decision-tree bullet so agents load the skill and route to the metrics docs when users ask about Speed Insights. No new content section — agents are expected to use `vercel metrics schema` to discover the underlying metric IDs.