### PR TITLE
[cli] Wire builder entrypoint detection into service setup.

### DIFF
--- a/.changeset/perfect-zoos-destroy.md
+++ b/.changeset/perfect-zoos-destroy.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Wire builder entrypoint detection into service setup.

--- a/packages/cli/src/util/link/services-setup.ts
+++ b/packages/cli/src/util/link/services-setup.ts
@@ -18,6 +18,7 @@ import {
   type ServicesConfigWriteBlocker,
   writeServicesConfig,
 } from '../projects/detect-services';
+import { createDetectEntrypoint } from '../projects/detect-entrypoint';
 
 const SERVICES_DOCS_URL = 'https://vercel.com/docs/services';
 const INFERRED_SERVICES_PROMPT =
@@ -40,6 +41,7 @@ export async function getServicesSetupState(
 ): Promise<ServicesSetupState> {
   const detectServicesResult = await detectServices({
     fs: new LocalFileSystemDetector(workPath),
+    detectEntrypoint: createDetectEntrypoint(workPath),
   });
   // `resolved` is undefined when no services are detected at all (common for
   // empty or simple fixtures). Defensive optional chain avoids crashing the

--- a/packages/cli/src/util/projects/detect-entrypoint.ts
+++ b/packages/cli/src/util/projects/detect-entrypoint.ts
@@ -1,0 +1,49 @@
+import { join } from 'path';
+import {
+  isPythonFramework,
+  isNodeBackendFramework,
+  normalizePath,
+  type DetectEntrypointFn,
+  type DetectedEntrypoint,
+} from '@vercel/build-utils';
+import { detectEntrypoint as detectNodeEntrypoint } from '@vercel/backends';
+import { detectEntrypoint as detectPythonEntrypoint } from '@vercel/python';
+import { detectEntrypoint as detectGoEntrypoint } from '@vercel/go';
+
+/**
+ * Build a {@link DetectEntrypointFn} that dispatches to the per-runtime
+ * builder helpers based on the framework slug. The resulting callback is
+ * suitable for passing into `detectServices`.
+ *
+ * `projectRoot` is the project root. The fs-detectors callback passes
+ * `workPath` relative to project root, which we resolve here so the
+ * per-builder helpers can read files directly.
+ */
+export function createDetectEntrypoint(
+  projectRoot: string
+): DetectEntrypointFn {
+  return ({ workPath, framework }): Promise<DetectedEntrypoint> => {
+    // Normalize to forward slashes so the path is platform-consistent;
+    // Node's `fs` accepts either separator on Windows.
+    const absWorkPath = normalizePath(join(projectRoot, workPath));
+    // Builder packages ship without `.d.ts`; casts re-narrow the
+    // `allowJs`-inferred return type back to `DetectedEntrypoint`.
+    if (isPythonFramework(framework)) {
+      return detectPythonEntrypoint({
+        workPath: absWorkPath,
+        framework,
+      }) as Promise<DetectedEntrypoint>;
+    }
+    if (isNodeBackendFramework(framework)) {
+      return detectNodeEntrypoint({
+        workPath: absWorkPath,
+      }) as Promise<DetectedEntrypoint>;
+    }
+    if (framework === 'go') {
+      return detectGoEntrypoint({
+        workPath: absWorkPath,
+      }) as Promise<DetectedEntrypoint>;
+    }
+    return Promise.resolve(null);
+  };
+}

--- a/packages/cli/src/util/projects/detect-entrypoint.ts
+++ b/packages/cli/src/util/projects/detect-entrypoint.ts
@@ -6,9 +6,6 @@ import {
   type DetectEntrypointFn,
   type DetectedEntrypoint,
 } from '@vercel/build-utils';
-import { detectEntrypoint as detectNodeEntrypoint } from '@vercel/backends';
-import { detectEntrypoint as detectPythonEntrypoint } from '@vercel/python';
-import { detectEntrypoint as detectGoEntrypoint } from '@vercel/go';
 
 /**
  * Build a {@link DetectEntrypointFn} that dispatches to the per-runtime
@@ -18,32 +15,39 @@ import { detectEntrypoint as detectGoEntrypoint } from '@vercel/go';
  * `projectRoot` is the project root. The fs-detectors callback passes
  * `workPath` relative to project root, which we resolve here so the
  * per-builder helpers can read files directly.
+ *
+ * Builder modules are loaded lazily so importers don't pay their startup
+ * cost (and don't trip over eager `readFileSync` calls in mocked-fs test
+ * environments) until a runtime framework is actually detected.
  */
 export function createDetectEntrypoint(
   projectRoot: string
 ): DetectEntrypointFn {
-  return ({ workPath, framework }): Promise<DetectedEntrypoint> => {
+  return async ({ workPath, framework }): Promise<DetectedEntrypoint> => {
     // Normalize to forward slashes so the path is platform-consistent;
     // Node's `fs` accepts either separator on Windows.
     const absWorkPath = normalizePath(join(projectRoot, workPath));
     // Builder packages ship without `.d.ts`; casts re-narrow the
     // `allowJs`-inferred return type back to `DetectedEntrypoint`.
     if (isPythonFramework(framework)) {
-      return detectPythonEntrypoint({
+      const { detectEntrypoint } = await import('@vercel/python');
+      return detectEntrypoint({
         workPath: absWorkPath,
         framework,
       }) as Promise<DetectedEntrypoint>;
     }
     if (isNodeBackendFramework(framework)) {
-      return detectNodeEntrypoint({
+      const { detectEntrypoint } = await import('@vercel/backends');
+      return detectEntrypoint({
         workPath: absWorkPath,
       }) as Promise<DetectedEntrypoint>;
     }
     if (framework === 'go') {
-      return detectGoEntrypoint({
+      const { detectEntrypoint } = await import('@vercel/go');
+      return detectEntrypoint({
         workPath: absWorkPath,
       }) as Promise<DetectedEntrypoint>;
     }
-    return Promise.resolve(null);
+    return null;
   };
 }

--- a/packages/cli/src/util/projects/detect-services.ts
+++ b/packages/cli/src/util/projects/detect-services.ts
@@ -13,6 +13,7 @@ import { isVercelTomlEnabled } from '../is-vercel-toml-enabled';
 import { CantParseJSONFile } from '../errors-ts';
 import readJSONFile from '../read-json-file';
 import { validateConfig } from '../validate-config';
+import { createDetectEntrypoint } from './detect-entrypoint';
 
 export type ServicesConfigWriteBlocker = 'builds' | 'functions';
 
@@ -67,7 +68,10 @@ export async function tryDetectServices(
   }
 
   const fs = new LocalFileSystemDetector(cwd);
-  const result = await detectServices({ fs });
+  const result = await detectServices({
+    fs,
+    detectEntrypoint: createDetectEntrypoint(cwd),
+  });
 
   // No services configured
   const hasNoServicesError = result.errors.some(

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -989,7 +989,6 @@ describe('link', () => {
           routePrefix: '/',
         },
         api: {
-          framework: 'fastapi',
           root: 'services/api',
           entrypoint: 'index:app',
           routePrefix: '/_/api',
@@ -1216,7 +1215,6 @@ describe('link', () => {
           routePrefix: '/',
         },
         api: {
-          framework: 'fastapi',
           root: 'services/api',
           entrypoint: 'index:app',
           routePrefix: '/_/api',
@@ -1300,7 +1298,6 @@ describe('link', () => {
           routePrefix: '/',
         },
         api: {
-          framework: 'fastapi',
           root: 'services/api',
           entrypoint: 'index:app',
           routePrefix: '/_/api',

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -989,7 +989,9 @@ describe('link', () => {
           routePrefix: '/',
         },
         api: {
+          framework: 'fastapi',
           root: 'services/api',
+          entrypoint: 'index:app',
           routePrefix: '/_/api',
         },
       },
@@ -1214,7 +1216,9 @@ describe('link', () => {
           routePrefix: '/',
         },
         api: {
+          framework: 'fastapi',
           root: 'services/api',
+          entrypoint: 'index:app',
           routePrefix: '/_/api',
         },
       },
@@ -1296,7 +1300,9 @@ describe('link', () => {
           routePrefix: '/',
         },
         api: {
+          framework: 'fastapi',
           root: 'services/api',
+          entrypoint: 'index:app',
           routePrefix: '/_/api',
         },
       },

--- a/packages/cli/test/unit/util/projects/detect-entrypoint.test.ts
+++ b/packages/cli/test/unit/util/projects/detect-entrypoint.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const detectPython = vi.fn();
+const detectNode = vi.fn();
+const detectGo = vi.fn();
+
+vi.mock('@vercel/python', () => ({ detectEntrypoint: detectPython }));
+vi.mock('@vercel/backends', () => ({ detectEntrypoint: detectNode }));
+vi.mock('@vercel/go', () => ({ detectEntrypoint: detectGo }));
+
+const { createDetectEntrypoint } = await import(
+  '../../../../src/util/projects/detect-entrypoint'
+);
+
+describe('createDetectEntrypoint', () => {
+  beforeEach(() => {
+    detectPython.mockReset();
+    detectNode.mockReset();
+    detectGo.mockReset();
+    detectPython.mockResolvedValue({
+      kind: 'py-module:attr',
+      entrypoint: 'main:app',
+    });
+    detectNode.mockResolvedValue({ kind: 'file', entrypoint: 'index.ts' });
+    detectGo.mockResolvedValue({ kind: 'file', entrypoint: 'main.go' });
+  });
+
+  it('routes Python frameworks to @vercel/python and joins workPath against project root', async () => {
+    const dispatch = createDetectEntrypoint('/abs/project');
+    const result = await dispatch({
+      workPath: 'services/api',
+      framework: 'fastapi',
+    });
+
+    expect(detectPython).toHaveBeenCalledWith({
+      workPath: '/abs/project/services/api',
+      framework: 'fastapi',
+    });
+    expect(detectNode).not.toHaveBeenCalled();
+    expect(detectGo).not.toHaveBeenCalled();
+    expect(result).toEqual({ kind: 'py-module:attr', entrypoint: 'main:app' });
+  });
+
+  it('routes Node backend frameworks to @vercel/backends', async () => {
+    const dispatch = createDetectEntrypoint('/abs/project');
+    const result = await dispatch({
+      workPath: 'backend',
+      framework: 'hono',
+    });
+
+    expect(detectNode).toHaveBeenCalledWith({
+      workPath: '/abs/project/backend',
+    });
+    expect(detectPython).not.toHaveBeenCalled();
+    expect(detectGo).not.toHaveBeenCalled();
+    expect(result).toEqual({ kind: 'file', entrypoint: 'index.ts' });
+  });
+
+  it('routes the go runtime framework to @vercel/go', async () => {
+    const dispatch = createDetectEntrypoint('/abs/project');
+    const result = await dispatch({
+      workPath: 'services/svc',
+      framework: 'go',
+    });
+
+    expect(detectGo).toHaveBeenCalledWith({
+      workPath: '/abs/project/services/svc',
+    });
+    expect(detectPython).not.toHaveBeenCalled();
+    expect(detectNode).not.toHaveBeenCalled();
+    expect(result).toEqual({ kind: 'file', entrypoint: 'main.go' });
+  });
+
+  it('returns null for frontend frameworks (no per-runtime detector)', async () => {
+    const dispatch = createDetectEntrypoint('/abs/project');
+    const result = await dispatch({
+      workPath: 'apps/web',
+      framework: 'nextjs',
+    });
+
+    expect(detectPython).not.toHaveBeenCalled();
+    expect(detectNode).not.toHaveBeenCalled();
+    expect(detectGo).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no framework slug is supplied', async () => {
+    const dispatch = createDetectEntrypoint('/abs/project');
+    const result = await dispatch({ workPath: 'whatever' });
+
+    expect(detectPython).not.toHaveBeenCalled();
+    expect(detectNode).not.toHaveBeenCalled();
+    expect(detectGo).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -22,7 +22,6 @@ import type {
 import {
   getInternalServiceCronPathPrefix,
   getInternalServiceFunctionPath,
-  isFrontendFramework,
   isRouteOwningBuilder,
   isStaticBuild,
   readVercelConfig,
@@ -103,8 +102,9 @@ function toInferredLayoutConfig(
       serviceConfig.routePrefix = service.routePrefix;
     }
 
-    // Keep the framework setting only for frontend services
-    if (isFrontendFramework(service.framework)) {
+    // Persist the framework slug so the resolver doesn't have to
+    // re-detect it from the workspace later.
+    if (typeof service.framework === 'string') {
       serviceConfig.framework = service.framework;
     }
 

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -22,6 +22,7 @@ import type {
 import {
   getInternalServiceCronPathPrefix,
   getInternalServiceFunctionPath,
+  isFrontendFramework,
   isRouteOwningBuilder,
   isStaticBuild,
   readVercelConfig,
@@ -102,9 +103,8 @@ function toInferredLayoutConfig(
       serviceConfig.routePrefix = service.routePrefix;
     }
 
-    // Persist the framework slug so the resolver doesn't have to
-    // re-detect it from the workspace later.
-    if (typeof service.framework === 'string') {
+    // Keep the framework setting only for frontend services
+    if (isFrontendFramework(service.framework)) {
       serviceConfig.framework = service.framework;
     }
 


### PR DESCRIPTION
Breakdown of https://github.com/vercel/vercel/pull/16241. Followup to https://github.com/vercel/vercel/pull/16300 and https://github.com/vercel/vercel/pull/16335

Add `createDetectEntrypoint` which dispatches entrypoint detection to the appropriate builder's `DetectEntrypointFn`. 

Note: `ruby` and `rust` builders are not covered, as they do not have an entrypoint detection mechanism.