### PR TITLE
[build-utils] Cleanup getLambdaSupportsStreaming

### DIFF
--- a/.changeset/thin-yaks-study.md
+++ b/.changeset/thin-yaks-study.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Cleanup getLambdaSupportsStreaming

--- a/packages/build-utils/src/finalize-lambda.ts
+++ b/packages/build-utils/src/finalize-lambda.ts
@@ -1,7 +1,6 @@
 import type { Lambda } from './lambda';
 import type { NodejsLambda } from './nodejs-lambda';
 import type { BytecodeCachingOptions } from './process-serverless/get-lambda-preload-scripts';
-import type { SupportsStreamingResult } from './process-serverless/get-lambda-supports-streaming';
 import { getEncryptedEnv } from './process-serverless/get-encrypted-env-file';
 import { getLambdaEnvironment } from './process-serverless/get-lambda-environment';
 import { getLambdaSupportsStreaming } from './process-serverless/get-lambda-supports-streaming';
@@ -77,8 +76,6 @@ export interface FinalizeLambdaResult {
   /** Compressed size in bytes. */
   size: number;
   uncompressedBytes: number;
-  /** Non-fatal streaming detection error, if any. Caller decides how to log. */
-  streamingError?: SupportsStreamingResult['error'];
 }
 
 /**
@@ -186,11 +183,11 @@ export async function finalizeLambda(
   };
 
   // 7. Streaming detection
-  const streamingResult = await getLambdaSupportsStreaming(
+  const streamingResult = getLambdaSupportsStreaming(
     lambda,
     forceStreamingRuntime
   );
-  lambda.supportsResponseStreaming = streamingResult.supportsStreaming;
+  lambda.supportsResponseStreaming = streamingResult;
 
   return {
     buffer: zipResult.buffer,
@@ -198,6 +195,5 @@ export async function finalizeLambda(
     digest: zipResult.digest,
     size: zipResult.size,
     uncompressedBytes,
-    streamingError: streamingResult.error,
   };
 }

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -180,10 +180,7 @@ export {
   getLambdaPreloadScripts,
   type BytecodeCachingOptions,
 } from './process-serverless/get-lambda-preload-scripts';
-export {
-  getLambdaSupportsStreaming,
-  type SupportsStreamingResult,
-} from './process-serverless/get-lambda-supports-streaming';
+export { getLambdaSupportsStreaming } from './process-serverless/get-lambda-supports-streaming';
 
 export {
   streamToDigestAsync,

--- a/packages/build-utils/src/process-serverless/get-lambda-supports-streaming.ts
+++ b/packages/build-utils/src/process-serverless/get-lambda-supports-streaming.ts
@@ -6,11 +6,6 @@ interface LambdaLike {
   supportsResponseStreaming?: boolean;
 }
 
-export interface SupportsStreamingResult {
-  supportsStreaming: boolean | undefined;
-  error?: { handler: string; message: string };
-}
-
 /**
  * Determines if a Lambda should have streaming enabled.
  *
@@ -24,25 +19,25 @@ export interface SupportsStreamingResult {
  * enabled. If the setting is defined it will be honored. Enabled by
  * default for Node.js.
  */
-export async function getLambdaSupportsStreaming(
+export function getLambdaSupportsStreaming(
   lambda: LambdaLike,
   forceStreamingRuntime: boolean
-): Promise<SupportsStreamingResult> {
+): boolean | undefined {
   if (lambda.awsLambdaHandler) {
-    return { supportsStreaming: false };
+    return false;
   }
 
   if (forceStreamingRuntime) {
-    return { supportsStreaming: true };
+    return true;
   }
 
   if (typeof lambda.supportsResponseStreaming === 'boolean') {
-    return { supportsStreaming: lambda.supportsResponseStreaming };
+    return lambda.supportsResponseStreaming;
   }
 
   if ('launcherType' in lambda && lambda.launcherType === 'Nodejs') {
-    return { supportsStreaming: true };
+    return true;
   }
 
-  return { supportsStreaming: undefined };
+  return undefined;
 }

--- a/packages/build-utils/test/unit.finalize-lambda.test.ts
+++ b/packages/build-utils/test/unit.finalize-lambda.test.ts
@@ -46,7 +46,7 @@ describe('finalizeLambda()', () => {
     });
 
     expect(result.buffer).toBeInstanceOf(Buffer);
-    expect(result.buffer.length).toBeGreaterThan(0);
+    expect(result.buffer?.length).toBeGreaterThan(0);
     expect(result.zipPath).toBeNull();
     expect(result.digest).toEqual(sha256(result.buffer));
     expect(result.uncompressedBytes).toEqual(0);
@@ -131,13 +131,12 @@ describe('finalizeLambda()', () => {
     });
     (lambda as any).launcherType = 'Nodejs';
 
-    const result = await finalizeLambda({
+    await finalizeLambda({
       lambda,
       bytecodeCachingOptions: NO_BYTECODE,
       forceStreamingRuntime: false,
     });
 
-    expect(result.streamingError).toBeUndefined();
     expect(lambda.supportsResponseStreaming).toEqual(true);
   });
 
@@ -156,13 +155,12 @@ describe('finalizeLambda()', () => {
       awsLambdaHandler: 'index.handler',
     });
 
-    const result = await finalizeLambda({
+    await finalizeLambda({
       lambda,
       bytecodeCachingOptions: NO_BYTECODE,
       forceStreamingRuntime: false,
     });
 
-    expect(result.streamingError).toBeUndefined();
     expect(lambda.supportsResponseStreaming).toEqual(false);
   });
 

--- a/packages/build-utils/test/unit.get-lambda-supports-streaming.test.ts
+++ b/packages/build-utils/test/unit.get-lambda-supports-streaming.test.ts
@@ -3,19 +3,18 @@ import { getLambdaSupportsStreaming } from '../src/process-serverless/get-lambda
 
 describe('getLambdaSupportsStreaming()', () => {
   it('returns true when forceStreamingRuntime is true', async () => {
-    const result = await getLambdaSupportsStreaming(
+    const result = getLambdaSupportsStreaming(
       {
         handler: 'handler.py',
         runtime: 'python3.8',
       },
       true
     );
-    expect(result.supportsStreaming).toEqual(true);
-    expect(result.error).toBeUndefined();
+    expect(result).toEqual(true);
   });
 
   it('honors `supportsResponseStreaming` from the lambda', async () => {
-    const result = await getLambdaSupportsStreaming(
+    const result = getLambdaSupportsStreaming(
       {
         supportsResponseStreaming: false,
         launcherType: 'Nodejs',
@@ -24,12 +23,11 @@ describe('getLambdaSupportsStreaming()', () => {
       },
       false
     );
-    expect(result.supportsStreaming).toEqual(false);
-    expect(result.error).toBeUndefined();
+    expect(result).toEqual(false);
   });
 
   it('returns true when launcherType is Nodejs', async () => {
-    const result = await getLambdaSupportsStreaming(
+    const result = getLambdaSupportsStreaming(
       {
         launcherType: 'Nodejs',
         handler: 'handler.js',
@@ -37,24 +35,22 @@ describe('getLambdaSupportsStreaming()', () => {
       },
       false
     );
-    expect(result.supportsStreaming).toEqual(true);
-    expect(result.error).toBeUndefined();
+    expect(result).toEqual(true);
   });
 
   it('returns undefined when launcherType is not Nodejs', async () => {
-    const result = await getLambdaSupportsStreaming(
+    const result = getLambdaSupportsStreaming(
       {
         handler: 'handler.py',
         runtime: 'python3.8',
       },
       false
     );
-    expect(result.supportsStreaming).toEqual(undefined);
-    expect(result.error).toBeUndefined();
+    expect(result).toEqual(undefined);
   });
 
   it('honors supportsResponseStreaming for non-Nodejs runtimes', async () => {
-    const result = await getLambdaSupportsStreaming(
+    const result = getLambdaSupportsStreaming(
       {
         handler: 'handler.py',
         runtime: 'python3.8',
@@ -62,12 +58,11 @@ describe('getLambdaSupportsStreaming()', () => {
       },
       false
     );
-    expect(result.supportsStreaming).toEqual(true);
-    expect(result.error).toBeUndefined();
+    expect(result).toEqual(true);
   });
 
   it('returns false when awsLambdaHandler is set on a Nodejs lambda', async () => {
-    const result = await getLambdaSupportsStreaming(
+    const result = getLambdaSupportsStreaming(
       {
         awsLambdaHandler: 'index.handler',
         launcherType: 'Nodejs',
@@ -76,12 +71,11 @@ describe('getLambdaSupportsStreaming()', () => {
       },
       false
     );
-    expect(result.supportsStreaming).toEqual(false);
-    expect(result.error).toBeUndefined();
+    expect(result).toEqual(false);
   });
 
   it('returns false for awsLambdaHandler even when forceStreamingRuntime is true', async () => {
-    const result = await getLambdaSupportsStreaming(
+    const result = getLambdaSupportsStreaming(
       {
         awsLambdaHandler: 'index.handler',
         launcherType: 'Nodejs',
@@ -90,12 +84,11 @@ describe('getLambdaSupportsStreaming()', () => {
       },
       true
     );
-    expect(result.supportsStreaming).toEqual(false);
-    expect(result.error).toBeUndefined();
+    expect(result).toEqual(false);
   });
 
   it('returns false for awsLambdaHandler even when supportsResponseStreaming is true', async () => {
-    const result = await getLambdaSupportsStreaming(
+    const result = getLambdaSupportsStreaming(
       {
         awsLambdaHandler: 'index.handler',
         supportsResponseStreaming: true,
@@ -105,12 +98,11 @@ describe('getLambdaSupportsStreaming()', () => {
       },
       false
     );
-    expect(result.supportsStreaming).toEqual(false);
-    expect(result.error).toBeUndefined();
+    expect(result).toEqual(false);
   });
 
   it('treats empty awsLambdaHandler as not-an-AWS-handler', async () => {
-    const result = await getLambdaSupportsStreaming(
+    const result = getLambdaSupportsStreaming(
       {
         awsLambdaHandler: '',
         launcherType: 'Nodejs',
@@ -119,7 +111,6 @@ describe('getLambdaSupportsStreaming()', () => {
       },
       false
     );
-    expect(result.supportsStreaming).toEqual(true);
-    expect(result.error).toBeUndefined();
+    expect(result).toEqual(true);
   });
 });


### PR DESCRIPTION
After https://github.com/vercel/vercel/pull/15795,
- It doesn't have to be async anymore.
- It never throws any errors anymore.