### PR TITLE
[cli] Add --open and --view flags to `vc traces get`

### DIFF
--- a/.changeset/traces-get-open-view.md
+++ b/.changeset/traces-get-open-view.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Added `--open` and `--view` flags to `vercel traces get`. `--open` opens the trace in the Vercel Dashboard instead of printing the markdown summary. `--view <timeline|tree|gantt>` selects the dashboard view and is only valid with `--open`.

--- a/packages/cli/src/commands/traces/command.ts
+++ b/packages/cli/src/commands/traces/command.ts
@@ -24,6 +24,23 @@ export const getSubcommand = {
       description:
         'Project name or id to fetch the trace from (overrides the linked project).',
     },
+    {
+      name: 'open',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Open the trace in the Vercel Dashboard instead of printing it.',
+    },
+    {
+      name: 'view',
+      shorthand: null,
+      type: String,
+      argument: 'timeline|tree|gantt',
+      deprecated: false,
+      description:
+        'Dashboard view to open. Only valid with --open. Defaults to timeline.',
+    },
   ],
   examples: [
     {
@@ -41,6 +58,14 @@ export const getSubcommand = {
     {
       name: 'Fetch a trace from a specific team and project',
       value: `${packageName} traces get req_1234567890 --scope my-team --project my-app`,
+    },
+    {
+      name: 'Open the trace in the Vercel Dashboard',
+      value: `${packageName} traces get req_1234567890 --open`,
+    },
+    {
+      name: 'Open the trace in the Vercel Dashboard with the gantt view',
+      value: `${packageName} traces get req_1234567890 --open --view gantt`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/traces/get.ts
+++ b/packages/cli/src/commands/traces/get.ts
@@ -1,15 +1,90 @@
+import open from 'open';
 import type Client from '../../util/client';
 import output from '../../output-manager';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { getLinkedProject } from '../../util/projects/link';
+import type { ProjectLinkResult } from '@vercel-internals/types';
+import getTeamById from '../../util/teams/get-team-by-id';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
 import { help } from '../help';
 import { getSubcommand, tracesCommand } from './command';
 import { fetchTrace } from './fetch-trace';
 import { renderMarkdown } from './render-markdown';
 import { resolveScope } from './scope-resolver';
 import type { TracesTelemetryClient } from '../../util/telemetry/commands/traces';
+
+const VIEW_OPTIONS = ['timeline', 'tree', 'gantt'] as const;
+type View = (typeof VIEW_OPTIONS)[number];
+
+function isView(value: string): value is View {
+  return (VIEW_OPTIONS as readonly string[]).includes(value);
+}
+
+function buildDashboardUrl({
+  teamSlug,
+  projectName,
+  traceId,
+  view,
+}: {
+  teamSlug: string;
+  projectName: string;
+  traceId: string;
+  view: View | undefined;
+}): string {
+  const base = `https://vercel.com/${encodeURIComponent(teamSlug)}/${encodeURIComponent(projectName)}/logs/traces/${encodeURIComponent(traceId)}`;
+  // Omit `?view=` for the dashboard default to let the dashboard own it.
+  if (view && view !== 'timeline') {
+    return `${base}?view=${encodeURIComponent(view)}`;
+  }
+  return base;
+}
+
+async function resolveDashboardScope({
+  client,
+  scopeFlag,
+  projectFlag,
+  teamId,
+  linkedProject,
+}: {
+  client: Client;
+  scopeFlag: string | undefined;
+  projectFlag: string | undefined;
+  teamId: string;
+  linkedProject: ProjectLinkResult;
+}): Promise<{ teamSlug: string; projectName: string } | { error: string }> {
+  let teamSlug: string;
+  if (scopeFlag) {
+    // Team ids start with `team_`; anything else is already a slug.
+    if (scopeFlag.startsWith('team_')) {
+      const team = await getTeamById(client, scopeFlag);
+      teamSlug = team.slug;
+    } else {
+      teamSlug = scopeFlag;
+    }
+  } else if (linkedProject.status === 'linked') {
+    teamSlug = linkedProject.org.slug;
+  } else {
+    return { error: 'Unable to resolve team slug for the dashboard URL.' };
+  }
+
+  let projectName: string;
+  if (projectFlag) {
+    const project = await getProjectByNameOrId(client, projectFlag, teamId);
+    if (project instanceof ProjectNotFound) {
+      return { error: `Project not found: ${projectFlag}` };
+    }
+    projectName = project.name;
+  } else if (linkedProject.status === 'linked') {
+    projectName = linkedProject.project.name;
+  } else {
+    return { error: 'Unable to resolve project name for the dashboard URL.' };
+  }
+
+  return { teamSlug, projectName };
+}
 
 export default async function get(
   client: Client,
@@ -30,10 +105,35 @@ export default async function get(
   const json = parsedArgs.flags['--json'];
   const scopeFlag = parsedArgs.flags['--scope'];
   const projectFlag = parsedArgs.flags['--project'];
+  const openFlag = parsedArgs.flags['--open'];
+  const viewFlag = parsedArgs.flags['--view'];
 
   telemetry.trackCliArgumentRequestId(requestId);
   telemetry.trackCliFlagJson(json);
   telemetry.trackCliOptionProject(projectFlag);
+  telemetry.trackCliFlagOpen(openFlag);
+  telemetry.trackCliOptionView(viewFlag);
+
+  if (json && openFlag) {
+    output.error('`--json` and `--open` cannot be used together.');
+    return 1;
+  }
+
+  if (viewFlag && !openFlag) {
+    output.error('`--view` can only be used with `--open`.');
+    return 1;
+  }
+
+  let view: View | undefined;
+  if (viewFlag !== undefined) {
+    if (!isView(viewFlag)) {
+      output.error(
+        `\`--view\` must be one of: ${VIEW_OPTIONS.join(', ')}. Received: ${viewFlag}`
+      );
+      return 1;
+    }
+    view = viewFlag;
+  }
 
   if (!requestId) {
     output.print(
@@ -47,11 +147,12 @@ export default async function get(
 
   let teamId: string;
   let projectId: string;
-  if (scopeFlag && projectFlag) {
+  let linkedProject: ProjectLinkResult | undefined;
+  if (scopeFlag && projectFlag && !openFlag) {
     teamId = scopeFlag;
     projectId = projectFlag;
   } else {
-    const linkedProject = await getLinkedProject(client);
+    linkedProject = await getLinkedProject(client);
     if (linkedProject.status === 'error') {
       return linkedProject.exitCode;
     }
@@ -82,6 +183,34 @@ export default async function get(
     return 1;
   }
   output.stopSpinner();
+
+  if (openFlag) {
+    if (!linkedProject) {
+      // Should be unreachable: the open path forces linkedProject resolution above.
+      output.error('Unable to resolve project link for the dashboard URL.');
+      return 1;
+    }
+    const resolved = await resolveDashboardScope({
+      client,
+      scopeFlag,
+      projectFlag,
+      teamId,
+      linkedProject,
+    });
+    if ('error' in resolved) {
+      output.error(resolved.error);
+      return 1;
+    }
+    const url = buildDashboardUrl({
+      teamSlug: resolved.teamSlug,
+      projectName: resolved.projectName,
+      traceId: trace.traceId,
+      view,
+    });
+    output.log(`Opening ${url} in your browser...`);
+    await open(url);
+    return 0;
+  }
 
   if (json) {
     client.stdout.write(`${JSON.stringify(trace, null, 2)}\n`);

--- a/packages/cli/src/commands/traces/get.ts
+++ b/packages/cli/src/commands/traces/get.ts
@@ -154,7 +154,12 @@ export default async function get(
   } else {
     linkedProject = await getLinkedProject(client);
     if (linkedProject.status === 'error') {
-      return linkedProject.exitCode;
+      if (scopeFlag && projectFlag) {
+        // Both flags were provided so we can proceed without a linked project.
+        linkedProject = { status: 'not_linked', org: null, project: null };
+      } else {
+        return linkedProject.exitCode;
+      }
     }
     const scope = resolveScope({
       flags: { scope: scopeFlag, project: projectFlag },

--- a/packages/cli/src/commands/traces/get.ts
+++ b/packages/cli/src/commands/traces/get.ts
@@ -9,6 +9,8 @@ import type { ProjectLinkResult } from '@vercel-internals/types';
 import getTeamById from '../../util/teams/get-team-by-id';
 import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
 import { ProjectNotFound } from '../../util/errors-ts';
+import { outputAgentError } from '../../util/agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
 import { help } from '../help';
 import { getSubcommand, tracesCommand } from './command';
 import { fetchTrace } from './fetch-trace';
@@ -54,7 +56,9 @@ async function resolveDashboardScope({
   projectFlag: string | undefined;
   teamId: string;
   linkedProject: ProjectLinkResult;
-}): Promise<{ teamSlug: string; projectName: string } | { error: string }> {
+}): Promise<
+  { teamSlug: string; projectName: string } | { error: string; reason: string }
+> {
   let teamSlug: string;
   if (scopeFlag) {
     // Team ids start with `team_`; anything else is already a slug.
@@ -67,20 +71,29 @@ async function resolveDashboardScope({
   } else if (linkedProject.status === 'linked') {
     teamSlug = linkedProject.org.slug;
   } else {
-    return { error: 'Unable to resolve team slug for the dashboard URL.' };
+    return {
+      error: 'Unable to resolve team slug for the dashboard URL.',
+      reason: AGENT_REASON.NOT_LINKED,
+    };
   }
 
   let projectName: string;
   if (projectFlag) {
     const project = await getProjectByNameOrId(client, projectFlag, teamId);
     if (project instanceof ProjectNotFound) {
-      return { error: `Project not found: ${projectFlag}` };
+      return {
+        error: `Project not found: ${projectFlag}`,
+        reason: AGENT_REASON.NOT_FOUND,
+      };
     }
     projectName = project.name;
   } else if (linkedProject.status === 'linked') {
     projectName = linkedProject.project.name;
   } else {
-    return { error: 'Unable to resolve project name for the dashboard URL.' };
+    return {
+      error: 'Unable to resolve project name for the dashboard URL.',
+      reason: AGENT_REASON.NOT_LINKED,
+    };
   }
 
   return { teamSlug, projectName };
@@ -115,21 +128,43 @@ export default async function get(
   telemetry.trackCliOptionView(viewFlag);
 
   if (json && openFlag) {
-    output.error('`--json` and `--open` cannot be used together.');
+    const msg = '`--json` and `--open` cannot be used together.';
+    if (client.nonInteractive) {
+      outputAgentError(client, {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: msg,
+      });
+    }
+    output.error(msg);
     return 1;
   }
 
   if (viewFlag && !openFlag) {
-    output.error('`--view` can only be used with `--open`.');
+    const msg = '`--view` can only be used with `--open`.';
+    if (client.nonInteractive) {
+      outputAgentError(client, {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: msg,
+      });
+    }
+    output.error(msg);
     return 1;
   }
 
   let view: View | undefined;
   if (viewFlag !== undefined) {
     if (!isView(viewFlag)) {
-      output.error(
-        `\`--view\` must be one of: ${VIEW_OPTIONS.join(', ')}. Received: ${viewFlag}`
-      );
+      const msg = `\`--view\` must be one of: ${VIEW_OPTIONS.join(', ')}. Received: ${viewFlag}`;
+      if (client.nonInteractive) {
+        outputAgentError(client, {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: msg,
+        });
+      }
+      output.error(msg);
       return 1;
     }
     view = viewFlag;
@@ -192,7 +227,15 @@ export default async function get(
   if (openFlag) {
     if (!linkedProject) {
       // Should be unreachable: the open path forces linkedProject resolution above.
-      output.error('Unable to resolve project link for the dashboard URL.');
+      const msg = 'Unable to resolve project link for the dashboard URL.';
+      if (client.nonInteractive) {
+        outputAgentError(client, {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.NOT_LINKED,
+          message: msg,
+        });
+      }
+      output.error(msg);
       return 1;
     }
     const resolved = await resolveDashboardScope({
@@ -203,6 +246,13 @@ export default async function get(
       linkedProject,
     });
     if ('error' in resolved) {
+      if (client.nonInteractive) {
+        outputAgentError(client, {
+          status: AGENT_STATUS.ERROR,
+          reason: resolved.reason,
+          message: resolved.error,
+        });
+      }
       output.error(resolved.error);
       return 1;
     }

--- a/packages/cli/src/util/telemetry/commands/traces/index.ts
+++ b/packages/cli/src/util/telemetry/commands/traces/index.ts
@@ -29,4 +29,19 @@ export class TracesTelemetryClient
       });
     }
   }
+
+  trackCliFlagOpen(open: boolean | undefined) {
+    if (open) {
+      this.trackCliFlag('open');
+    }
+  }
+
+  trackCliOptionView(view: string | undefined) {
+    if (view) {
+      this.trackCliOption({
+        option: 'view',
+        value: view,
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/traces/get.test.ts
+++ b/packages/cli/test/unit/commands/traces/get.test.ts
@@ -1,5 +1,5 @@
 import open from 'open';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import traces from '../../../../src/commands/traces';
 import * as linkModule from '../../../../src/util/projects/link';
@@ -446,6 +446,111 @@ describe('vercel traces get', () => {
       expect(mockedOpen).toHaveBeenCalledWith(
         'https://vercel.com/team-alpha/project-from-flag/logs/traces/trace_001'
       );
+    });
+  });
+
+  describe('non-interactive mode', () => {
+    afterEach(() => {
+      client.nonInteractive = false;
+    });
+
+    function readAgentPayload(): Record<string, unknown> {
+      const stdout = client.stdout.getFullOutput().trim();
+      return JSON.parse(stdout);
+    }
+
+    function spyExit() {
+      return vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+    }
+
+    it('emits invalid_arguments JSON when --json and --open are combined', async () => {
+      const exitSpy = spyExit();
+      client.nonInteractive = true;
+      client.setArgv('traces', 'get', 'req_x', '--open', '--json');
+
+      await expect(traces(client)).rejects.toThrow('exit');
+
+      const payload = readAgentPayload();
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('invalid_arguments');
+      expect(payload.message).toBe(
+        '`--json` and `--open` cannot be used together.'
+      );
+
+      exitSpy.mockRestore();
+    });
+
+    it('emits invalid_arguments JSON when --view is used without --open', async () => {
+      const exitSpy = spyExit();
+      client.nonInteractive = true;
+      client.setArgv('traces', 'get', 'req_x', '--view', 'tree');
+
+      await expect(traces(client)).rejects.toThrow('exit');
+
+      const payload = readAgentPayload();
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('invalid_arguments');
+      expect(payload.message).toBe('`--view` can only be used with `--open`.');
+
+      exitSpy.mockRestore();
+    });
+
+    it('emits invalid_arguments JSON on an invalid --view value', async () => {
+      const exitSpy = spyExit();
+      client.nonInteractive = true;
+      client.setArgv(
+        'traces',
+        'get',
+        'req_x',
+        '--open',
+        '--view',
+        'flamegraph'
+      );
+
+      await expect(traces(client)).rejects.toThrow('exit');
+
+      const payload = readAgentPayload();
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('invalid_arguments');
+      expect(payload.message).toBe(
+        '`--view` must be one of: timeline, tree, gantt. Received: flamegraph'
+      );
+
+      exitSpy.mockRestore();
+    });
+
+    it('emits not_found JSON when --open --project resolves to an unknown project', async () => {
+      const exitSpy = spyExit();
+      mockNotLinked();
+      client.scenario.get('/v1/projects/traces', (_req, res) => {
+        res.json({ trace: sampleTrace });
+      });
+      client.scenario.get('/v9/projects/missing-project', (_req, res) => {
+        res.status(404).json({ error: { code: 'not_found' } });
+      });
+
+      client.nonInteractive = true;
+      client.setArgv(
+        'traces',
+        'get',
+        'req_missing_project',
+        '--open',
+        '--scope',
+        'team-alpha',
+        '--project',
+        'missing-project'
+      );
+
+      await expect(traces(client)).rejects.toThrow('exit');
+
+      const payload = readAgentPayload();
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('not_found');
+      expect(payload.message).toBe('Project not found: missing-project');
+
+      exitSpy.mockRestore();
     });
   });
 });

--- a/packages/cli/test/unit/commands/traces/get.test.ts
+++ b/packages/cli/test/unit/commands/traces/get.test.ts
@@ -1,3 +1,4 @@
+import open from 'open';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import traces from '../../../../src/commands/traces';
@@ -6,7 +7,12 @@ import type { Trace } from '../../../../src/commands/traces/types';
 
 vi.mock('../../../../src/util/projects/link');
 
+vi.mock('open', () => ({
+  default: vi.fn(),
+}));
+
 const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedOpen = vi.mocked(open);
 
 function mockLinkedProject() {
   mockedGetLinkedProject.mockResolvedValue({
@@ -62,6 +68,7 @@ describe('vercel traces get', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     client.reset();
+    mockedOpen.mockResolvedValue(undefined as never);
   });
 
   it('prints the markdown summary to stdout for a 200 response', async () => {
@@ -253,5 +260,192 @@ describe('vercel traces get', () => {
 
     expect(calls).toBe(1);
     expect(exitCode).toBe(1);
+  });
+
+  describe('--open', () => {
+    it('opens the dashboard URL using the linked project slug/name', async () => {
+      mockLinkedProject();
+      client.scenario.get('/v1/projects/traces', (_req, res) => {
+        res.json({ trace: sampleTrace });
+      });
+
+      client.setArgv('traces', 'get', 'req_open', '--open');
+      const exitCode = await traces(client);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOpen).toHaveBeenCalledWith(
+        'https://vercel.com/my-team/traces-project/logs/traces/trace_001'
+      );
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain(
+        'Opening https://vercel.com/my-team/traces-project/logs/traces/trace_001 in your browser...'
+      );
+      expect(client.stdout.getFullOutput()).toBe('');
+    });
+
+    it('omits ?view= when --view is timeline', async () => {
+      mockLinkedProject();
+      client.scenario.get('/v1/projects/traces', (_req, res) => {
+        res.json({ trace: sampleTrace });
+      });
+
+      client.setArgv(
+        'traces',
+        'get',
+        'req_timeline',
+        '--open',
+        '--view',
+        'timeline'
+      );
+      const exitCode = await traces(client);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOpen).toHaveBeenCalledWith(
+        'https://vercel.com/my-team/traces-project/logs/traces/trace_001'
+      );
+    });
+
+    it('appends ?view=tree when --view=tree', async () => {
+      mockLinkedProject();
+      client.scenario.get('/v1/projects/traces', (_req, res) => {
+        res.json({ trace: sampleTrace });
+      });
+
+      client.setArgv('traces', 'get', 'req_tree', '--open', '--view', 'tree');
+      const exitCode = await traces(client);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOpen).toHaveBeenCalledWith(
+        'https://vercel.com/my-team/traces-project/logs/traces/trace_001?view=tree'
+      );
+    });
+
+    it('appends ?view=gantt when --view=gantt', async () => {
+      mockLinkedProject();
+      client.scenario.get('/v1/projects/traces', (_req, res) => {
+        res.json({ trace: sampleTrace });
+      });
+
+      client.setArgv('traces', 'get', 'req_gantt', '--open', '--view', 'gantt');
+      const exitCode = await traces(client);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOpen).toHaveBeenCalledWith(
+        'https://vercel.com/my-team/traces-project/logs/traces/trace_001?view=gantt'
+      );
+    });
+
+    it('errors when --open and --json are combined', async () => {
+      client.setArgv('traces', 'get', 'req_x', '--open', '--json');
+      const exitCode = await traces(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        '`--json` and `--open` cannot be used together.'
+      );
+      expect(mockedOpen).not.toHaveBeenCalled();
+    });
+
+    it('errors when --view is used without --open', async () => {
+      client.setArgv('traces', 'get', 'req_x', '--view', 'tree');
+      const exitCode = await traces(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        '`--view` can only be used with `--open`.'
+      );
+      expect(mockedOpen).not.toHaveBeenCalled();
+    });
+
+    it('errors on an invalid --view value', async () => {
+      client.setArgv(
+        'traces',
+        'get',
+        'req_x',
+        '--open',
+        '--view',
+        'flamegraph'
+      );
+      const exitCode = await traces(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        '`--view` must be one of: timeline, tree, gantt. Received: flamegraph'
+      );
+      expect(mockedOpen).not.toHaveBeenCalled();
+    });
+
+    it('resolves --scope=team_id via /teams/:id to get the slug', async () => {
+      mockNotLinked();
+      client.scenario.get('/teams/team_abc', (_req, res) => {
+        res.json({
+          id: 'team_abc',
+          slug: 'team-alpha',
+          name: 'Team Alpha',
+        });
+      });
+      client.scenario.get('/v9/projects/project-from-flag', (_req, res) => {
+        res.json({
+          id: 'prj_xyz',
+          name: 'project-from-flag',
+          accountId: 'team_abc',
+          updatedAt: Date.now(),
+          createdAt: Date.now(),
+        });
+      });
+      client.scenario.get('/v1/projects/traces', (_req, res) => {
+        res.json({ trace: sampleTrace });
+      });
+
+      client.setArgv(
+        'traces',
+        'get',
+        'req_scope',
+        '--open',
+        '--scope',
+        'team_abc',
+        '--project',
+        'project-from-flag'
+      );
+      const exitCode = await traces(client);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOpen).toHaveBeenCalledWith(
+        'https://vercel.com/team-alpha/project-from-flag/logs/traces/trace_001'
+      );
+    });
+
+    it('uses --scope verbatim when it is already a slug', async () => {
+      mockNotLinked();
+      client.scenario.get('/v9/projects/project-from-flag', (_req, res) => {
+        res.json({
+          id: 'prj_xyz',
+          name: 'project-from-flag',
+          accountId: 'team_abc',
+          updatedAt: Date.now(),
+          createdAt: Date.now(),
+        });
+      });
+      client.scenario.get('/v1/projects/traces', (_req, res) => {
+        res.json({ trace: sampleTrace });
+      });
+
+      client.setArgv(
+        'traces',
+        'get',
+        'req_slug',
+        '--open',
+        '--scope',
+        'team-alpha',
+        '--project',
+        'project-from-flag'
+      );
+      const exitCode = await traces(client);
+
+      expect(exitCode).toBe(0);
+      expect(mockedOpen).toHaveBeenCalledWith(
+        'https://vercel.com/team-alpha/project-from-flag/logs/traces/trace_001'
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `--open` opens the trace in the Vercel Dashboard (`/<teamSlug>/<projectName>/logs/traces/<traceId>`) instead of printing markdown/JSON to stdout
- `--view=<timeline|tree|gantt>` selects the dashboard view; omitted from the URL when default (`timeline`) so the dashboard owns the default
- Flag rules: `--open` is mutually exclusive with `--json`; `--view` requires `--open`; `--view` value is validated against the allowlist

## Implementation notes

When a linked project is present, the URL uses `linkedProject.org.slug` and `linkedProject.project.name` directly — no extra API calls. With `--scope`/`--project` overrides, the team slug is resolved via `getTeamById` when the value is a `team_*` id (otherwise treated as a slug verbatim), and the project name is resolved via `getProjectByNameOrId`. All URL path segments are encoded with `encodeURIComponent`.

## Test plan

- [x] `npx vitest run packages/cli/test/unit/commands/traces/` — 53/53 passing (19 in `get.test.ts`, including 8 new cases for `--open`/`--view`)
- [x] `tsc --noEmit` clean
- [x] Manual: `vc traces get <requestId> --open` from a linked dir opens the correct dashboard URL
- [x] Manual: `vc traces get <requestId> --open --view=tree` appends `?view=tree`
- [x] Manual: `vc traces get <requestId> --open --view=timeline` omits the query string
- [x] Manual: `--open --json` errors; `--view tree` without `--open` errors; `--view flamegraph` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)