### PR TITLE
[build-utils] Fix config.framework in deserializeBuildOutput

### DIFF
--- a/.changeset/tough-ants-design.md
+++ b/.changeset/tough-ants-design.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Fix config.framework in deserializeBuildOutput

--- a/packages/build-utils/src/deserialize/deserialize-build-output-types.ts
+++ b/packages/build-utils/src/deserialize/deserialize-build-output-types.ts
@@ -67,7 +67,7 @@ export type InspectSerializedLambda = (
 ) => Promise<boolean>;
 
 export interface DeserializeBuildOutputOptions<
-  TResult extends DeserializeBuildOutputResult = DeserializeBuildOutputResult,
+  TMeta = unknown,
   TLambda extends Lambda = Lambda,
 > {
   outputDir: string;
@@ -81,9 +81,7 @@ export interface DeserializeBuildOutputOptions<
   inspectSerializedLambda?: InspectSerializedLambda;
   warn?: (message: string) => void;
   includeDeploymentId?: boolean;
-  getMeta?: (
-    hasServerActions: boolean
-  ) => TResult extends { meta?: infer TMeta } ? TMeta : never;
+  getMeta?: (hasServerActions: boolean) => TMeta;
 }
 
 export type DeserializeBuildOutputFiles = BuildResultV2Typical['output'];

--- a/packages/build-utils/src/deserialize/deserialize-build-output.ts
+++ b/packages/build-utils/src/deserialize/deserialize-build-output.ts
@@ -188,10 +188,12 @@ function applyGroupedLambdas<TLambda extends Lambda>(
 }
 
 export async function deserializeBuildOutput<
-  TConfig extends DeserializeBuildOutputConfig = DeserializeBuildOutputConfig,
-  TResult extends DeserializeBuildOutputResult = DeserializeBuildOutputResult,
+  TFlags = unknown,
+  TMeta = unknown,
   TLambda extends Lambda = Lambda,
->(options: DeserializeBuildOutputOptions<TResult, TLambda>): Promise<TResult> {
+>(
+  options: DeserializeBuildOutputOptions<TMeta, TLambda>
+): Promise<DeserializeBuildOutputResult<TFlags, TMeta>> {
   const {
     outputDir,
     repoRootPath,
@@ -208,7 +210,8 @@ export async function deserializeBuildOutput<
   } = options;
   let hasServerActions = false;
   const configPath = join(outputDir, 'config.json');
-  const config = await maybeReadJSON<TConfig>(configPath);
+  const config =
+    await maybeReadJSON<DeserializeBuildOutputConfig<TFlags>>(configPath);
 
   if (!config) {
     throw new Error(`Config file was not found at "${configPath}"`);
@@ -222,9 +225,7 @@ export async function deserializeBuildOutput<
 
   validateDeploymentId(config.deploymentId);
 
-  const flags = await maybeReadJSON<TResult['flags']>(
-    join(outputDir, 'flags.json')
-  );
+  const flags = await maybeReadJSON<TFlags>(join(outputDir, 'flags.json'));
 
   const staticDir = join(outputDir, 'static');
   const output: BuildResultV2Typical['output'] = await glob('**', {
@@ -352,5 +353,5 @@ export async function deserializeBuildOutput<
     framework,
     ...(includeDeploymentId ? { deploymentId: config.deploymentId } : {}),
     ...(meta !== undefined ? { meta } : {}),
-  } as TResult;
+  };
 }

--- a/packages/build-utils/src/deserialize/deserialize-build-output.ts
+++ b/packages/build-utils/src/deserialize/deserialize-build-output.ts
@@ -340,7 +340,7 @@ export async function deserializeBuildOutput<
   );
   applyGroupedLambdas(output, groupedLambdas);
 
-  const framework = validateFrameworkVersion(config?.framework?.version);
+  const framework = validateFrameworkVersion(config?.framework);
   const meta = getMeta?.(hasServerActions);
   return {
     wildcard: config.wildcard,

--- a/packages/build-utils/src/deserialize/validate-framework-version.ts
+++ b/packages/build-utils/src/deserialize/validate-framework-version.ts
@@ -1,37 +1,47 @@
 import { NowBuildError } from '../errors';
 
 type FrameworkMeta = {
+  slug: string;
   version: string;
 };
 
+const MAX_SLUG_LENGTH = 50;
 const MAX_FRAMEWORK_VERSION_LENGTH = 50;
 
 export function validateFrameworkVersion(
-  frameworkVersion: string | undefined
+  framework: FrameworkMeta | undefined
 ): FrameworkMeta | undefined {
-  if (!frameworkVersion) {
+  if (!framework) {
     return undefined;
   }
 
-  if (typeof frameworkVersion !== 'string') {
+  const { slug, version } = framework;
+
+  if (typeof version !== 'string') {
     throw new NowBuildError({
-      message: `Invalid config.json: "framework.version" type "${typeof frameworkVersion}" should be "string"`,
+      message: `Invalid config.json: "version" type "${typeof version}" should be "string"`,
       code: 'VC_BUILD_INVALID_CONFIG_JSON_FRAMEWORK_VERSION_TYPE',
     });
   }
 
-  if (frameworkVersion.length > MAX_FRAMEWORK_VERSION_LENGTH) {
-    const trimmedFrameworkVersion = frameworkVersion.slice(
+  if (slug.length > MAX_SLUG_LENGTH) {
+    const trimmedFrameworkSlug = slug.slice(0, MAX_SLUG_LENGTH);
+    throw new NowBuildError({
+      message: `Invalid config.json: "framework.slug" length ${slug.length} > ${MAX_SLUG_LENGTH}. "${trimmedFrameworkSlug}..."`,
+      code: 'VC_BUILD_INVALID_CONFIG_JSON_FRAMEWORK_SLUG_LENGTH',
+    });
+  }
+
+  if (version.length > MAX_FRAMEWORK_VERSION_LENGTH) {
+    const trimmedFrameworkVersion = version.slice(
       0,
       MAX_FRAMEWORK_VERSION_LENGTH
     );
     throw new NowBuildError({
-      message: `Invalid config.json: "framework.version" length ${frameworkVersion.length} > ${MAX_FRAMEWORK_VERSION_LENGTH}. "${trimmedFrameworkVersion}..."`,
+      message: `Invalid config.json: "framework.version" length ${version.length} > ${MAX_FRAMEWORK_VERSION_LENGTH}. "${trimmedFrameworkVersion}..."`,
       code: 'VC_BUILD_INVALID_CONFIG_JSON_FRAMEWORK_VERSION_LENGTH',
     });
   }
 
-  return {
-    version: frameworkVersion,
-  };
+  return framework;
 }

--- a/packages/build-utils/src/deserialize/validate-framework-version.ts
+++ b/packages/build-utils/src/deserialize/validate-framework-version.ts
@@ -17,6 +17,12 @@ export function validateFrameworkVersion(
 
   const { slug, version } = framework;
 
+  if (typeof slug !== 'string') {
+    // Ideally this would throw, but slug is a new field and there might be some users that don't
+    // emit it yet.
+    return undefined;
+  }
+
   if (typeof version !== 'string') {
     throw new NowBuildError({
       message: `Invalid config.json: "version" type "${typeof version}" should be "string"`,


### PR DESCRIPTION
Correctly return `framework.slug` in deseralizebuildoutput

This was broken beceause of an unsafe `as`