### PR TITLE
fix(ls): display BLOCKED deployment status instead of UNKNOWN

### DIFF
--- a/.changeset/fix-blocked-state-display.md
+++ b/.changeset/fix-blocked-state-display.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+fix(ls): display `BLOCKED` deployment status instead of `UNKNOWN`

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -124,6 +124,7 @@ export default async function list(client: Client) {
       'QUEUED',
       'READY',
       'CANCELED',
+      'BLOCKED',
     ];
     const statusValues = statusFlag.split(',').map(s => s.trim().toUpperCase());
     const invalidStatuses = statusValues.filter(
@@ -439,6 +440,8 @@ export function stateString(s: string) {
       return chalk.white(CIRCLE) + sTitle;
     case 'CANCELED':
       return chalk.gray(sTitle);
+    case 'BLOCKED':
+      return chalk.gray(CIRCLE) + sTitle;
     default:
       return chalk.gray('UNKNOWN');
   }

--- a/packages/cli/test/unit/commands/list/index.test.ts
+++ b/packages/cli/test/unit/commands/list/index.test.ts
@@ -566,7 +566,7 @@ describe('list', () => {
 
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput(
-        'Invalid status values: INVALID. Valid values are: BUILDING, ERROR, INITIALIZING, QUEUED, READY, CANCELED'
+        'Invalid status values: INVALID. Valid values are: BUILDING, ERROR, INITIALIZING, QUEUED, READY, CANCELED, BLOCKED'
       );
     });
 


### PR DESCRIPTION
## Summary

`vercel ls` shows `UNKNOWN` for deployments in `BLOCKED` state because `stateString()` has no `BLOCKED` case and falls through to the default.

## Changes

- Added `case 'BLOCKED'` to `stateString()` returning `chalk.gray(CIRCLE) + sTitle` (consistent with `QUEUED` style)
- Added `'BLOCKED'` to the valid `--status` filter values so users can use `vercel ls --status BLOCKED`
- Updated the test assertion for the error message listing valid filter statuses

## Fixes

Fixes #16379