### PR TITLE
Add Vercel OIDC token validation helpers

### DIFF
--- a/.changeset/oidc-validate-helpers.md
+++ b/.changeset/oidc-validate-helpers.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': minor
+---
+
+Add `isValidVercelOidcToken` and `assertValidVercelOidcToken` helpers for verifying the signature, expiration, and claims of a Vercel OIDC token against one or more matchers. The matchers support every claim in the OIDC token (e.g. `team`, `project`, `environment`, `teamId`, `projectId`). When `assertValidVercelOidcToken` rejects a token it throws a new `UnacceptableVercelOidcTokenError`.

--- a/.changeset/oidc-validate-helpers.md
+++ b/.changeset/oidc-validate-helpers.md
@@ -2,4 +2,4 @@
 '@vercel/oidc': minor
 ---
 
-Add `isValidVercelOidcToken` and `assertValidVercelOidcToken` helpers for verifying the signature, expiration, and claims of a Vercel OIDC token against one or more matchers. The matchers support every claim in the OIDC token (e.g. `team`, `project`, `environment`, `teamId`, `projectId`). When `assertValidVercelOidcToken` rejects a token it throws a new `UnacceptableVercelOidcTokenError`.
+Add `isValidVercelOidcToken` and `assertValidVercelOidcToken` helpers for verifying the signature, expiration, and claims of a Vercel OIDC token against one or more matchers. The matchers support every claim in the OIDC token (e.g. `team`, `project`, `environment`, `teamId`, `projectId`). When `assertValidVercelOidcToken` rejects a token it throws a new `UnacceptableVercelOidcTokenError`. The implementation has no runtime dependencies; it uses the platform `SubtleCrypto` and `fetch` APIs and works in Node and browser environments.

--- a/packages/oidc/README.md
+++ b/packages/oidc/README.md
@@ -39,3 +39,59 @@ Gets the current OIDC token from the request context or environment variable. Wi
 ### `getVercelOidcTokenSync()`
 
 Synchronously gets the current OIDC token without refreshing. Use `getVercelOidcToken()` if you need automatic refresh in development.
+
+### Validating an OIDC Token
+
+```typescript
+import {
+  isValidVercelOidcToken,
+  assertValidVercelOidcToken,
+  UnacceptableVercelOidcTokenError,
+} from '@vercel/oidc';
+
+// Returns true/false
+const ok = await isValidVercelOidcToken(
+  [
+    { team: 'vercel', project: 'vercel-alerts', environment: 'production' },
+    { team: 'vercel-labs', project: 'oidc-trigger', environment: 'preview' },
+  ],
+  token
+);
+
+// Throws UnacceptableVercelOidcTokenError if the token is not valid or no
+// matcher applies. Verifies the JWT signature, expiration, and standard claims.
+try {
+  await assertValidVercelOidcToken(
+    { team: 'vercel', project: 'vercel-alerts', environment: 'production' },
+    token
+  );
+} catch (err) {
+  if (err instanceof UnacceptableVercelOidcTokenError) {
+    // reject the request
+  }
+  throw err;
+}
+```
+
+### `isValidVercelOidcToken(matchers, token)`
+
+Returns `true` if the given Vercel OIDC token has a valid signature, has not
+expired, and matches at least one of the provided matchers; otherwise `false`.
+
+Each matcher is matched as a logical AND of its non-`undefined` properties, and
+the array of matchers is treated as a logical OR. Supported matcher properties:
+
+- `iss`, `aud`, `sub` &mdash; standard JWT claims
+- `team` / `owner` &mdash; team slug
+- `teamId` / `owner_id` &mdash; team ID (`team_*`)
+- `project` &mdash; project name
+- `projectId` / `project_id` &mdash; project ID (`prj_*`)
+- `environment` &mdash; `production`, `preview`, or `development`
+- `userId` / `user_id` &mdash; user ID (only set in `development`)
+
+A single matcher object (not wrapped in an array) is also accepted.
+
+### `assertValidVercelOidcToken(matchers, token)`
+
+Same as `isValidVercelOidcToken`, but throws `UnacceptableVercelOidcTokenError`
+when no matcher applies or the token cannot be verified.

--- a/packages/oidc/docs/README.md
+++ b/packages/oidc/docs/README.md
@@ -8,10 +8,18 @@
 
 - [AccessTokenMissingError](classes/AccessTokenMissingError.md)
 - [RefreshAccessTokenFailedError](classes/RefreshAccessTokenFailedError.md)
+- [UnacceptableVercelOidcTokenError](classes/UnacceptableVercelOidcTokenError.md)
+
+## Interfaces
+
+- [VercelOidcTokenClaims](interfaces/VercelOidcTokenClaims.md)
+- [VercelOidcTokenMatcher](interfaces/VercelOidcTokenMatcher.md)
 
 ## Functions
 
+- [assertValidVercelOidcToken](functions/assertValidVercelOidcToken.md)
 - [getContext](functions/getContext.md)
 - [getVercelOidcToken](functions/getVercelOidcToken.md)
 - [getVercelOidcTokenSync](functions/getVercelOidcTokenSync.md)
 - [getVercelToken](functions/getVercelToken.md)
+- [isValidVercelOidcToken](functions/isValidVercelOidcToken.md)

--- a/packages/oidc/docs/classes/UnacceptableVercelOidcTokenError.md
+++ b/packages/oidc/docs/classes/UnacceptableVercelOidcTokenError.md
@@ -4,7 +4,7 @@
 
 # Class: UnacceptableVercelOidcTokenError
 
-Defined in: packages/oidc/src/validate.ts:85
+Defined in: [packages/oidc/src/validate.ts:91](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L91)
 
 Thrown by [assertValidVercelOidcToken](../functions/assertValidVercelOidcToken.md) when a token cannot be accepted.
 
@@ -18,7 +18,7 @@ Thrown by [assertValidVercelOidcToken](../functions/assertValidVercelOidcToken.m
 
 > **new UnacceptableVercelOidcTokenError**(`message`, `cause?`): `UnacceptableVercelOidcTokenError`
 
-Defined in: packages/oidc/src/validate.ts:88
+Defined in: [packages/oidc/src/validate.ts:94](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L94)
 
 #### Parameters
 
@@ -44,7 +44,7 @@ Defined in: packages/oidc/src/validate.ts:88
 
 > `optional` **cause?**: `unknown`
 
-Defined in: packages/oidc/src/validate.ts:86
+Defined in: [packages/oidc/src/validate.ts:92](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L92)
 
 ---
 
@@ -132,7 +132,7 @@ Defined in: node_modules/.pnpm/@types+node@20.11.0/node_modules/@types/node/glob
 
 > **toString**(): `string`
 
-Defined in: packages/oidc/src/validate.ts:94
+Defined in: [packages/oidc/src/validate.ts:100](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L100)
 
 Returns a string representation of an object.
 

--- a/packages/oidc/docs/classes/UnacceptableVercelOidcTokenError.md
+++ b/packages/oidc/docs/classes/UnacceptableVercelOidcTokenError.md
@@ -1,0 +1,169 @@
+[**@vercel/oidc**](../README.md)
+
+---
+
+# Class: UnacceptableVercelOidcTokenError
+
+Defined in: packages/oidc/src/validate.ts:85
+
+Thrown by [assertValidVercelOidcToken](../functions/assertValidVercelOidcToken.md) when a token cannot be accepted.
+
+## Extends
+
+- [`Error`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error)
+
+## Constructors
+
+### Constructor
+
+> **new UnacceptableVercelOidcTokenError**(`message`, `cause?`): `UnacceptableVercelOidcTokenError`
+
+Defined in: packages/oidc/src/validate.ts:88
+
+#### Parameters
+
+##### message
+
+`string`
+
+##### cause?
+
+`unknown`
+
+#### Returns
+
+`UnacceptableVercelOidcTokenError`
+
+#### Overrides
+
+`Error.constructor`
+
+## Properties
+
+### cause?
+
+> `optional` **cause?**: `unknown`
+
+Defined in: packages/oidc/src/validate.ts:86
+
+---
+
+### message
+
+> **message**: `string`
+
+Defined in: node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es5.d.ts:1077
+
+#### Inherited from
+
+`Error.message`
+
+---
+
+### name
+
+> **name**: `string`
+
+Defined in: node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es5.d.ts:1076
+
+#### Inherited from
+
+`Error.name`
+
+---
+
+### stack?
+
+> `optional` **stack?**: `string`
+
+Defined in: node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es5.d.ts:1078
+
+#### Inherited from
+
+`Error.stack`
+
+---
+
+### prepareStackTrace?
+
+> `static` `optional` **prepareStackTrace?**: (`err`, `stackTraces`) => `any`
+
+Defined in: node_modules/.pnpm/@types+node@20.11.0/node_modules/@types/node/globals.d.ts:28
+
+Optional override for formatting stack traces
+
+#### Parameters
+
+##### err
+
+[`Error`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error)
+
+##### stackTraces
+
+`CallSite`[]
+
+#### Returns
+
+`any`
+
+#### See
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+#### Inherited from
+
+`Error.prepareStackTrace`
+
+---
+
+### stackTraceLimit
+
+> `static` **stackTraceLimit**: `number`
+
+Defined in: node_modules/.pnpm/@types+node@20.11.0/node_modules/@types/node/globals.d.ts:30
+
+#### Inherited from
+
+`Error.stackTraceLimit`
+
+## Methods
+
+### toString()
+
+> **toString**(): `string`
+
+Defined in: packages/oidc/src/validate.ts:94
+
+Returns a string representation of an object.
+
+#### Returns
+
+`string`
+
+---
+
+### captureStackTrace()
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Defined in: node_modules/.pnpm/@types+node@20.11.0/node_modules/@types/node/globals.d.ts:21
+
+Create .stack property on a target object
+
+#### Parameters
+
+##### targetObject
+
+`object`
+
+##### constructorOpt?
+
+[`Function`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function)
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+`Error.captureStackTrace`

--- a/packages/oidc/docs/classes/UnacceptableVercelOidcTokenError.md
+++ b/packages/oidc/docs/classes/UnacceptableVercelOidcTokenError.md
@@ -4,7 +4,7 @@
 
 # Class: UnacceptableVercelOidcTokenError
 
-Defined in: [packages/oidc/src/validate.ts:91](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L91)
+Defined in: [packages/oidc/src/validate.ts:96](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L96)
 
 Thrown by [assertValidVercelOidcToken](../functions/assertValidVercelOidcToken.md) when a token cannot be accepted.
 
@@ -18,7 +18,7 @@ Thrown by [assertValidVercelOidcToken](../functions/assertValidVercelOidcToken.m
 
 > **new UnacceptableVercelOidcTokenError**(`message`, `cause?`): `UnacceptableVercelOidcTokenError`
 
-Defined in: [packages/oidc/src/validate.ts:94](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L94)
+Defined in: [packages/oidc/src/validate.ts:99](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L99)
 
 #### Parameters
 
@@ -44,7 +44,7 @@ Defined in: [packages/oidc/src/validate.ts:94](https://github.com/vercel/vercel/
 
 > `optional` **cause?**: `unknown`
 
-Defined in: [packages/oidc/src/validate.ts:92](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L92)
+Defined in: [packages/oidc/src/validate.ts:97](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L97)
 
 ---
 
@@ -132,7 +132,7 @@ Defined in: node_modules/.pnpm/@types+node@20.11.0/node_modules/@types/node/glob
 
 > **toString**(): `string`
 
-Defined in: [packages/oidc/src/validate.ts:100](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L100)
+Defined in: [packages/oidc/src/validate.ts:105](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L105)
 
 Returns a string representation of an object.
 

--- a/packages/oidc/docs/functions/assertValidVercelOidcToken.md
+++ b/packages/oidc/docs/functions/assertValidVercelOidcToken.md
@@ -6,7 +6,7 @@
 
 > **assertValidVercelOidcToken**(`matchers`, `token`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`\>
 
-Defined in: [packages/oidc/src/validate.ts:553](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L553)
+Defined in: [packages/oidc/src/validate.ts:363](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L363)
 
 Verifies the signature and claims of a Vercel OIDC token and asserts that it
 matches at least one of the provided matchers. Throws

--- a/packages/oidc/docs/functions/assertValidVercelOidcToken.md
+++ b/packages/oidc/docs/functions/assertValidVercelOidcToken.md
@@ -6,7 +6,7 @@
 
 > **assertValidVercelOidcToken**(`matchers`, `token`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`\>
 
-Defined in: packages/oidc/src/validate.ts:328
+Defined in: [packages/oidc/src/validate.ts:553](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L553)
 
 Verifies the signature and claims of a Vercel OIDC token and asserts that it
 matches at least one of the provided matchers. Throws

--- a/packages/oidc/docs/functions/assertValidVercelOidcToken.md
+++ b/packages/oidc/docs/functions/assertValidVercelOidcToken.md
@@ -1,0 +1,47 @@
+[**@vercel/oidc**](../README.md)
+
+---
+
+# Function: assertValidVercelOidcToken()
+
+> **assertValidVercelOidcToken**(`matchers`, `token`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`\>
+
+Defined in: packages/oidc/src/validate.ts:328
+
+Verifies the signature and claims of a Vercel OIDC token and asserts that it
+matches at least one of the provided matchers. Throws
+[UnacceptableVercelOidcTokenError](../classes/UnacceptableVercelOidcTokenError.md) if the token cannot be verified or
+does not match any of the matchers.
+
+## Parameters
+
+### matchers
+
+[`VercelOidcTokenMatcher`](../interfaces/VercelOidcTokenMatcher.md) \| readonly [`VercelOidcTokenMatcher`](../interfaces/VercelOidcTokenMatcher.md)[]
+
+### token
+
+`string`
+
+### options?
+
+`ValidateVercelOidcTokenOptions`
+
+## Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`\>
+
+## Example
+
+```ts
+import { assertValidVercelOidcToken } from '@vercel/oidc';
+
+await assertValidVercelOidcToken(
+  [{ team: 'vercel', project: 'vercel-alerts', environment: 'production' }],
+  token
+);
+```
+
+## Throws
+
+If the token is not valid.

--- a/packages/oidc/docs/functions/isValidVercelOidcToken.md
+++ b/packages/oidc/docs/functions/isValidVercelOidcToken.md
@@ -1,0 +1,48 @@
+[**@vercel/oidc**](../README.md)
+
+---
+
+# Function: isValidVercelOidcToken()
+
+> **isValidVercelOidcToken**(`matchers`, `token`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`boolean`\>
+
+Defined in: packages/oidc/src/validate.ts:299
+
+Returns `true` if the given Vercel OIDC token has a valid signature, has not
+expired, and matches at least one of the provided matchers; otherwise
+`false`.
+
+The token's signature is verified against the JSON Web Key Set served by the
+issuer (either `https://oidc.vercel.com` or `https://oidc.vercel.com/[TEAM_SLUG]`).
+
+## Parameters
+
+### matchers
+
+[`VercelOidcTokenMatcher`](../interfaces/VercelOidcTokenMatcher.md) \| readonly [`VercelOidcTokenMatcher`](../interfaces/VercelOidcTokenMatcher.md)[]
+
+### token
+
+`string`
+
+### options?
+
+`ValidateVercelOidcTokenOptions`
+
+## Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`boolean`\>
+
+## Example
+
+```ts
+import { isValidVercelOidcToken } from '@vercel/oidc';
+
+const ok = await isValidVercelOidcToken(
+  [
+    { team: 'vercel', project: 'vercel-alerts', environment: 'production' },
+    { team: 'vercel-labs', project: 'oidc-trigger', environment: 'preview' },
+  ],
+  token
+);
+```

--- a/packages/oidc/docs/functions/isValidVercelOidcToken.md
+++ b/packages/oidc/docs/functions/isValidVercelOidcToken.md
@@ -6,7 +6,7 @@
 
 > **isValidVercelOidcToken**(`matchers`, `token`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`boolean`\>
 
-Defined in: packages/oidc/src/validate.ts:299
+Defined in: [packages/oidc/src/validate.ts:524](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L524)
 
 Returns `true` if the given Vercel OIDC token has a valid signature, has not
 expired, and matches at least one of the provided matchers; otherwise

--- a/packages/oidc/docs/functions/isValidVercelOidcToken.md
+++ b/packages/oidc/docs/functions/isValidVercelOidcToken.md
@@ -6,7 +6,7 @@
 
 > **isValidVercelOidcToken**(`matchers`, `token`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`boolean`\>
 
-Defined in: [packages/oidc/src/validate.ts:524](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L524)
+Defined in: [packages/oidc/src/validate.ts:334](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L334)
 
 Returns `true` if the given Vercel OIDC token has a valid signature, has not
 expired, and matches at least one of the provided matchers; otherwise

--- a/packages/oidc/docs/interfaces/VercelOidcTokenClaims.md
+++ b/packages/oidc/docs/interfaces/VercelOidcTokenClaims.md
@@ -4,7 +4,7 @@
 
 # Interface: VercelOidcTokenClaims
 
-Defined in: [packages/oidc/src/validate.ts:19](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L19)
+Defined in: [packages/oidc/src/validate.ts:24](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L24)
 
 Claims emitted in a Vercel OIDC token.
 
@@ -24,7 +24,7 @@ Other claims that may be present.
 
 > `optional` **aud?**: `string` \| `string`[]
 
-Defined in: [packages/oidc/src/validate.ts:23](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L23)
+Defined in: [packages/oidc/src/validate.ts:28](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L28)
 
 Audience. `https://vercel.com/[TEAM_SLUG]`.
 
@@ -34,7 +34,7 @@ Audience. `https://vercel.com/[TEAM_SLUG]`.
 
 > `optional` **environment?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:41](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L41)
+Defined in: [packages/oidc/src/validate.ts:46](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L46)
 
 Environment: `production`, `preview`, or `development`.
 
@@ -44,7 +44,7 @@ Environment: `production`, `preview`, or `development`.
 
 > `optional` **exp?**: `number`
 
-Defined in: [packages/oidc/src/validate.ts:27](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L27)
+Defined in: [packages/oidc/src/validate.ts:32](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L32)
 
 Expiration time (seconds since epoch).
 
@@ -54,7 +54,7 @@ Expiration time (seconds since epoch).
 
 > `optional` **iat?**: `number`
 
-Defined in: [packages/oidc/src/validate.ts:31](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L31)
+Defined in: [packages/oidc/src/validate.ts:36](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L36)
 
 Issued-at time (seconds since epoch).
 
@@ -64,7 +64,7 @@ Issued-at time (seconds since epoch).
 
 > `optional` **iss?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:21](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L21)
+Defined in: [packages/oidc/src/validate.ts:26](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L26)
 
 Issuer. `https://oidc.vercel.com` (global) or `https://oidc.vercel.com/[TEAM_SLUG]` (team).
 
@@ -74,7 +74,7 @@ Issuer. `https://oidc.vercel.com` (global) or `https://oidc.vercel.com/[TEAM_SLU
 
 > `optional` **nbf?**: `number`
 
-Defined in: [packages/oidc/src/validate.ts:29](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L29)
+Defined in: [packages/oidc/src/validate.ts:34](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L34)
 
 Not-before time (seconds since epoch).
 
@@ -84,7 +84,7 @@ Not-before time (seconds since epoch).
 
 > `optional` **owner?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:33](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L33)
+Defined in: [packages/oidc/src/validate.ts:38](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L38)
 
 Team slug (e.g. `acme`).
 
@@ -94,7 +94,7 @@ Team slug (e.g. `acme`).
 
 > `optional` **owner_id?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:35](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L35)
+Defined in: [packages/oidc/src/validate.ts:40](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L40)
 
 Team ID (e.g. `team_7Gw5...`).
 
@@ -104,7 +104,7 @@ Team ID (e.g. `team_7Gw5...`).
 
 > `optional` **project?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:37](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L37)
+Defined in: [packages/oidc/src/validate.ts:42](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L42)
 
 Project name (e.g. `acme_website`).
 
@@ -114,7 +114,7 @@ Project name (e.g. `acme_website`).
 
 > `optional` **project_id?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:39](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L39)
+Defined in: [packages/oidc/src/validate.ts:44](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L44)
 
 Project ID (e.g. `prj_7Gw5...`).
 
@@ -124,7 +124,7 @@ Project ID (e.g. `prj_7Gw5...`).
 
 > `optional` **sub?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:25](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L25)
+Defined in: [packages/oidc/src/validate.ts:30](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L30)
 
 Subject. `owner:[TEAM_SLUG]:project:[PROJECT_NAME]:environment:[ENVIRONMENT]`.
 
@@ -134,6 +134,6 @@ Subject. `owner:[TEAM_SLUG]:project:[PROJECT_NAME]:environment:[ENVIRONMENT]`.
 
 > `optional` **user_id?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:43](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L43)
+Defined in: [packages/oidc/src/validate.ts:48](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L48)
 
 User ID. Only present when environment is `development`.

--- a/packages/oidc/docs/interfaces/VercelOidcTokenClaims.md
+++ b/packages/oidc/docs/interfaces/VercelOidcTokenClaims.md
@@ -1,0 +1,197 @@
+[**@vercel/oidc**](../README.md)
+
+---
+
+# Interface: VercelOidcTokenClaims
+
+Defined in: packages/oidc/src/validate.ts:21
+
+Claims emitted in a Vercel OIDC token.
+
+## See
+
+https://vercel.com/docs/oidc/reference#oidc-token-anatomy
+
+## Extends
+
+- `JWTPayload`
+
+## Indexable
+
+> \[`propName`: `string`\]: `unknown`
+
+Any other JWT Claim Set member.
+
+## Properties
+
+### aud?
+
+> `optional` **aud?**: `string` \| `string`[]
+
+Defined in: packages/oidc/src/validate.ts:25
+
+Audience. `https://vercel.com/[TEAM_SLUG]`.
+
+#### Overrides
+
+`JWTPayload.aud`
+
+---
+
+### environment?
+
+> `optional` **environment?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:37
+
+Environment: `production`, `preview`, or `development`.
+
+---
+
+### exp?
+
+> `optional` **exp?**: `number`
+
+Defined in: node_modules/.pnpm/jose@5.9.6/node_modules/jose/dist/types/types.d.ts:612
+
+JWT Expiration Time
+
+#### See
+
+[RFC7519#section-4.1.4](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4)
+
+#### Inherited from
+
+`JWTPayload.exp`
+
+---
+
+### iat?
+
+> `optional` **iat?**: `number`
+
+Defined in: node_modules/.pnpm/jose@5.9.6/node_modules/jose/dist/types/types.d.ts:619
+
+JWT Issued At
+
+#### See
+
+[RFC7519#section-4.1.6](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.6)
+
+#### Inherited from
+
+`JWTPayload.iat`
+
+---
+
+### iss?
+
+> `optional` **iss?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:23
+
+Issuer. `https://oidc.vercel.com` (global) or `https://oidc.vercel.com/[TEAM_SLUG]` (team).
+
+#### Overrides
+
+`JWTPayload.iss`
+
+---
+
+### jti?
+
+> `optional` **jti?**: `string`
+
+Defined in: node_modules/.pnpm/jose@5.9.6/node_modules/jose/dist/types/types.d.ts:598
+
+JWT ID
+
+#### See
+
+[RFC7519#section-4.1.7](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.7)
+
+#### Inherited from
+
+`JWTPayload.jti`
+
+---
+
+### nbf?
+
+> `optional` **nbf?**: `number`
+
+Defined in: node_modules/.pnpm/jose@5.9.6/node_modules/jose/dist/types/types.d.ts:605
+
+JWT Not Before
+
+#### See
+
+[RFC7519#section-4.1.5](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.5)
+
+#### Inherited from
+
+`JWTPayload.nbf`
+
+---
+
+### owner?
+
+> `optional` **owner?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:29
+
+Team slug (e.g. `acme`).
+
+---
+
+### owner_id?
+
+> `optional` **owner_id?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:31
+
+Team ID (e.g. `team_7Gw5...`).
+
+---
+
+### project?
+
+> `optional` **project?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:33
+
+Project name (e.g. `acme_website`).
+
+---
+
+### project_id?
+
+> `optional` **project_id?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:35
+
+Project ID (e.g. `prj_7Gw5...`).
+
+---
+
+### sub?
+
+> `optional` **sub?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:27
+
+Subject. `owner:[TEAM_SLUG]:project:[PROJECT_NAME]:environment:[ENVIRONMENT]`.
+
+#### Overrides
+
+`JWTPayload.sub`
+
+---
+
+### user_id?
+
+> `optional` **user_id?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:39
+
+User ID. Only present when environment is `development`.

--- a/packages/oidc/docs/interfaces/VercelOidcTokenClaims.md
+++ b/packages/oidc/docs/interfaces/VercelOidcTokenClaims.md
@@ -4,7 +4,7 @@
 
 # Interface: VercelOidcTokenClaims
 
-Defined in: packages/oidc/src/validate.ts:21
+Defined in: [packages/oidc/src/validate.ts:19](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L19)
 
 Claims emitted in a Vercel OIDC token.
 
@@ -12,15 +12,11 @@ Claims emitted in a Vercel OIDC token.
 
 https://vercel.com/docs/oidc/reference#oidc-token-anatomy
 
-## Extends
-
-- `JWTPayload`
-
 ## Indexable
 
-> \[`propName`: `string`\]: `unknown`
+> \[`claim`: `string`\]: `unknown`
 
-Any other JWT Claim Set member.
+Other claims that may be present.
 
 ## Properties
 
@@ -28,13 +24,9 @@ Any other JWT Claim Set member.
 
 > `optional` **aud?**: `string` \| `string`[]
 
-Defined in: packages/oidc/src/validate.ts:25
+Defined in: [packages/oidc/src/validate.ts:23](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L23)
 
 Audience. `https://vercel.com/[TEAM_SLUG]`.
-
-#### Overrides
-
-`JWTPayload.aud`
 
 ---
 
@@ -42,7 +34,7 @@ Audience. `https://vercel.com/[TEAM_SLUG]`.
 
 > `optional` **environment?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:37
+Defined in: [packages/oidc/src/validate.ts:41](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L41)
 
 Environment: `production`, `preview`, or `development`.
 
@@ -52,17 +44,9 @@ Environment: `production`, `preview`, or `development`.
 
 > `optional` **exp?**: `number`
 
-Defined in: node_modules/.pnpm/jose@5.9.6/node_modules/jose/dist/types/types.d.ts:612
+Defined in: [packages/oidc/src/validate.ts:27](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L27)
 
-JWT Expiration Time
-
-#### See
-
-[RFC7519#section-4.1.4](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4)
-
-#### Inherited from
-
-`JWTPayload.exp`
+Expiration time (seconds since epoch).
 
 ---
 
@@ -70,17 +54,9 @@ JWT Expiration Time
 
 > `optional` **iat?**: `number`
 
-Defined in: node_modules/.pnpm/jose@5.9.6/node_modules/jose/dist/types/types.d.ts:619
+Defined in: [packages/oidc/src/validate.ts:31](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L31)
 
-JWT Issued At
-
-#### See
-
-[RFC7519#section-4.1.6](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.6)
-
-#### Inherited from
-
-`JWTPayload.iat`
+Issued-at time (seconds since epoch).
 
 ---
 
@@ -88,31 +64,9 @@ JWT Issued At
 
 > `optional` **iss?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:23
+Defined in: [packages/oidc/src/validate.ts:21](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L21)
 
 Issuer. `https://oidc.vercel.com` (global) or `https://oidc.vercel.com/[TEAM_SLUG]` (team).
-
-#### Overrides
-
-`JWTPayload.iss`
-
----
-
-### jti?
-
-> `optional` **jti?**: `string`
-
-Defined in: node_modules/.pnpm/jose@5.9.6/node_modules/jose/dist/types/types.d.ts:598
-
-JWT ID
-
-#### See
-
-[RFC7519#section-4.1.7](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.7)
-
-#### Inherited from
-
-`JWTPayload.jti`
 
 ---
 
@@ -120,17 +74,9 @@ JWT ID
 
 > `optional` **nbf?**: `number`
 
-Defined in: node_modules/.pnpm/jose@5.9.6/node_modules/jose/dist/types/types.d.ts:605
+Defined in: [packages/oidc/src/validate.ts:29](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L29)
 
-JWT Not Before
-
-#### See
-
-[RFC7519#section-4.1.5](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.5)
-
-#### Inherited from
-
-`JWTPayload.nbf`
+Not-before time (seconds since epoch).
 
 ---
 
@@ -138,7 +84,7 @@ JWT Not Before
 
 > `optional` **owner?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:29
+Defined in: [packages/oidc/src/validate.ts:33](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L33)
 
 Team slug (e.g. `acme`).
 
@@ -148,7 +94,7 @@ Team slug (e.g. `acme`).
 
 > `optional` **owner_id?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:31
+Defined in: [packages/oidc/src/validate.ts:35](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L35)
 
 Team ID (e.g. `team_7Gw5...`).
 
@@ -158,7 +104,7 @@ Team ID (e.g. `team_7Gw5...`).
 
 > `optional` **project?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:33
+Defined in: [packages/oidc/src/validate.ts:37](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L37)
 
 Project name (e.g. `acme_website`).
 
@@ -168,7 +114,7 @@ Project name (e.g. `acme_website`).
 
 > `optional` **project_id?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:35
+Defined in: [packages/oidc/src/validate.ts:39](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L39)
 
 Project ID (e.g. `prj_7Gw5...`).
 
@@ -178,13 +124,9 @@ Project ID (e.g. `prj_7Gw5...`).
 
 > `optional` **sub?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:27
+Defined in: [packages/oidc/src/validate.ts:25](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L25)
 
 Subject. `owner:[TEAM_SLUG]:project:[PROJECT_NAME]:environment:[ENVIRONMENT]`.
-
-#### Overrides
-
-`JWTPayload.sub`
 
 ---
 
@@ -192,6 +134,6 @@ Subject. `owner:[TEAM_SLUG]:project:[PROJECT_NAME]:environment:[ENVIRONMENT]`.
 
 > `optional` **user_id?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:39
+Defined in: [packages/oidc/src/validate.ts:43](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L43)
 
 User ID. Only present when environment is `development`.

--- a/packages/oidc/docs/interfaces/VercelOidcTokenMatcher.md
+++ b/packages/oidc/docs/interfaces/VercelOidcTokenMatcher.md
@@ -4,7 +4,7 @@
 
 # Interface: VercelOidcTokenMatcher
 
-Defined in: [packages/oidc/src/validate.ts:59](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L59)
+Defined in: [packages/oidc/src/validate.ts:64](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L64)
 
 A matcher used to validate the claims of a Vercel OIDC token.
 
@@ -22,7 +22,7 @@ supported. When both are provided on the same matcher, both must match.
 
 > `optional` **aud?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:63](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L63)
+Defined in: [packages/oidc/src/validate.ts:68](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L68)
 
 Matches the `aud` claim.
 
@@ -32,7 +32,7 @@ Matches the `aud` claim.
 
 > `optional` **environment?**: `string` & `object` \| `"production"` \| `"preview"` \| `"development"`
 
-Defined in: [packages/oidc/src/validate.ts:81](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L81)
+Defined in: [packages/oidc/src/validate.ts:86](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L86)
 
 Matches the `environment` claim.
 
@@ -42,7 +42,7 @@ Matches the `environment` claim.
 
 > `optional` **iss?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:61](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L61)
+Defined in: [packages/oidc/src/validate.ts:66](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L66)
 
 Matches the `iss` claim.
 
@@ -52,7 +52,7 @@ Matches the `iss` claim.
 
 > `optional` **owner?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:69](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L69)
+Defined in: [packages/oidc/src/validate.ts:74](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L74)
 
 Matches the `owner` claim (the team slug).
 
@@ -62,7 +62,7 @@ Matches the `owner` claim (the team slug).
 
 > `optional` **owner_id?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:73](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L73)
+Defined in: [packages/oidc/src/validate.ts:78](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L78)
 
 Matches the `owner_id` claim (the team ID).
 
@@ -72,7 +72,7 @@ Matches the `owner_id` claim (the team ID).
 
 > `optional` **project?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:75](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L75)
+Defined in: [packages/oidc/src/validate.ts:80](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L80)
 
 Matches the `project` claim (the project name).
 
@@ -82,7 +82,7 @@ Matches the `project` claim (the project name).
 
 > `optional` **project_id?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:79](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L79)
+Defined in: [packages/oidc/src/validate.ts:84](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L84)
 
 Matches the `project_id` claim (the project ID).
 
@@ -92,7 +92,7 @@ Matches the `project_id` claim (the project ID).
 
 > `optional` **projectId?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:77](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L77)
+Defined in: [packages/oidc/src/validate.ts:82](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L82)
 
 Matches the `project_id` claim (the project ID). Alias for `project_id`.
 
@@ -102,7 +102,7 @@ Matches the `project_id` claim (the project ID). Alias for `project_id`.
 
 > `optional` **sub?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:65](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L65)
+Defined in: [packages/oidc/src/validate.ts:70](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L70)
 
 Matches the `sub` claim.
 
@@ -112,7 +112,7 @@ Matches the `sub` claim.
 
 > `optional` **team?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:67](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L67)
+Defined in: [packages/oidc/src/validate.ts:72](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L72)
 
 Matches the `owner` claim (the team slug). Alias for `owner`.
 
@@ -122,7 +122,7 @@ Matches the `owner` claim (the team slug). Alias for `owner`.
 
 > `optional` **teamId?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:71](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L71)
+Defined in: [packages/oidc/src/validate.ts:76](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L76)
 
 Matches the `owner_id` claim (the team ID). Alias for `owner_id`.
 
@@ -132,7 +132,7 @@ Matches the `owner_id` claim (the team ID). Alias for `owner_id`.
 
 > `optional` **user_id?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:85](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L85)
+Defined in: [packages/oidc/src/validate.ts:90](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L90)
 
 Matches the `user_id` claim.
 
@@ -142,6 +142,6 @@ Matches the `user_id` claim.
 
 > `optional` **userId?**: `string`
 
-Defined in: [packages/oidc/src/validate.ts:83](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L83)
+Defined in: [packages/oidc/src/validate.ts:88](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L88)
 
 Matches the `user_id` claim. Alias for `user_id`.

--- a/packages/oidc/docs/interfaces/VercelOidcTokenMatcher.md
+++ b/packages/oidc/docs/interfaces/VercelOidcTokenMatcher.md
@@ -1,0 +1,147 @@
+[**@vercel/oidc**](../README.md)
+
+---
+
+# Interface: VercelOidcTokenMatcher
+
+Defined in: packages/oidc/src/validate.ts:53
+
+A matcher used to validate the claims of a Vercel OIDC token.
+
+All non-`undefined` properties on a matcher must equal the corresponding claim
+on the token for the matcher to be considered a match. A token is accepted if
+it matches at least one of the provided matchers.
+
+Both friendly aliases (e.g. `team`, `teamId`, `projectId`, `userId`) and the
+raw OIDC claim names (e.g. `owner`, `owner_id`, `project_id`, `user_id`) are
+supported. When both are provided on the same matcher, both must match.
+
+## Properties
+
+### aud?
+
+> `optional` **aud?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:57
+
+Matches the `aud` claim.
+
+---
+
+### environment?
+
+> `optional` **environment?**: `string` & `object` \| `"production"` \| `"preview"` \| `"development"`
+
+Defined in: packages/oidc/src/validate.ts:75
+
+Matches the `environment` claim.
+
+---
+
+### iss?
+
+> `optional` **iss?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:55
+
+Matches the `iss` claim.
+
+---
+
+### owner?
+
+> `optional` **owner?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:63
+
+Matches the `owner` claim (the team slug).
+
+---
+
+### owner_id?
+
+> `optional` **owner_id?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:67
+
+Matches the `owner_id` claim (the team ID).
+
+---
+
+### project?
+
+> `optional` **project?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:69
+
+Matches the `project` claim (the project name).
+
+---
+
+### project_id?
+
+> `optional` **project_id?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:73
+
+Matches the `project_id` claim (the project ID).
+
+---
+
+### projectId?
+
+> `optional` **projectId?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:71
+
+Matches the `project_id` claim (the project ID). Alias for `project_id`.
+
+---
+
+### sub?
+
+> `optional` **sub?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:59
+
+Matches the `sub` claim.
+
+---
+
+### team?
+
+> `optional` **team?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:61
+
+Matches the `owner` claim (the team slug). Alias for `owner`.
+
+---
+
+### teamId?
+
+> `optional` **teamId?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:65
+
+Matches the `owner_id` claim (the team ID). Alias for `owner_id`.
+
+---
+
+### user_id?
+
+> `optional` **user_id?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:79
+
+Matches the `user_id` claim.
+
+---
+
+### userId?
+
+> `optional` **userId?**: `string`
+
+Defined in: packages/oidc/src/validate.ts:77
+
+Matches the `user_id` claim. Alias for `user_id`.

--- a/packages/oidc/docs/interfaces/VercelOidcTokenMatcher.md
+++ b/packages/oidc/docs/interfaces/VercelOidcTokenMatcher.md
@@ -4,7 +4,7 @@
 
 # Interface: VercelOidcTokenMatcher
 
-Defined in: packages/oidc/src/validate.ts:53
+Defined in: [packages/oidc/src/validate.ts:59](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L59)
 
 A matcher used to validate the claims of a Vercel OIDC token.
 
@@ -22,7 +22,7 @@ supported. When both are provided on the same matcher, both must match.
 
 > `optional` **aud?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:57
+Defined in: [packages/oidc/src/validate.ts:63](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L63)
 
 Matches the `aud` claim.
 
@@ -32,7 +32,7 @@ Matches the `aud` claim.
 
 > `optional` **environment?**: `string` & `object` \| `"production"` \| `"preview"` \| `"development"`
 
-Defined in: packages/oidc/src/validate.ts:75
+Defined in: [packages/oidc/src/validate.ts:81](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L81)
 
 Matches the `environment` claim.
 
@@ -42,7 +42,7 @@ Matches the `environment` claim.
 
 > `optional` **iss?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:55
+Defined in: [packages/oidc/src/validate.ts:61](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L61)
 
 Matches the `iss` claim.
 
@@ -52,7 +52,7 @@ Matches the `iss` claim.
 
 > `optional` **owner?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:63
+Defined in: [packages/oidc/src/validate.ts:69](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L69)
 
 Matches the `owner` claim (the team slug).
 
@@ -62,7 +62,7 @@ Matches the `owner` claim (the team slug).
 
 > `optional` **owner_id?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:67
+Defined in: [packages/oidc/src/validate.ts:73](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L73)
 
 Matches the `owner_id` claim (the team ID).
 
@@ -72,7 +72,7 @@ Matches the `owner_id` claim (the team ID).
 
 > `optional` **project?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:69
+Defined in: [packages/oidc/src/validate.ts:75](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L75)
 
 Matches the `project` claim (the project name).
 
@@ -82,7 +82,7 @@ Matches the `project` claim (the project name).
 
 > `optional` **project_id?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:73
+Defined in: [packages/oidc/src/validate.ts:79](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L79)
 
 Matches the `project_id` claim (the project ID).
 
@@ -92,7 +92,7 @@ Matches the `project_id` claim (the project ID).
 
 > `optional` **projectId?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:71
+Defined in: [packages/oidc/src/validate.ts:77](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L77)
 
 Matches the `project_id` claim (the project ID). Alias for `project_id`.
 
@@ -102,7 +102,7 @@ Matches the `project_id` claim (the project ID). Alias for `project_id`.
 
 > `optional` **sub?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:59
+Defined in: [packages/oidc/src/validate.ts:65](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L65)
 
 Matches the `sub` claim.
 
@@ -112,7 +112,7 @@ Matches the `sub` claim.
 
 > `optional` **team?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:61
+Defined in: [packages/oidc/src/validate.ts:67](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L67)
 
 Matches the `owner` claim (the team slug). Alias for `owner`.
 
@@ -122,7 +122,7 @@ Matches the `owner` claim (the team slug). Alias for `owner`.
 
 > `optional` **teamId?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:65
+Defined in: [packages/oidc/src/validate.ts:71](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L71)
 
 Matches the `owner_id` claim (the team ID). Alias for `owner_id`.
 
@@ -132,7 +132,7 @@ Matches the `owner_id` claim (the team ID). Alias for `owner_id`.
 
 > `optional` **user_id?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:79
+Defined in: [packages/oidc/src/validate.ts:85](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L85)
 
 Matches the `user_id` claim.
 
@@ -142,6 +142,6 @@ Matches the `user_id` claim.
 
 > `optional` **userId?**: `string`
 
-Defined in: packages/oidc/src/validate.ts:77
+Defined in: [packages/oidc/src/validate.ts:83](https://github.com/vercel/vercel/blob/main/packages/oidc/src/validate.ts#L83)
 
 Matches the `user_id` claim. Alias for `user_id`.

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -26,10 +26,8 @@
   "bugs": {
     "url": "https://github.com/vercel/vercel/issues"
   },
-  "dependencies": {
-    "jose": "5.9.6"
-  },
   "devDependencies": {
+    "jose": "5.9.6",
     "prettier": "3.8.3",
     "tinyspawn": "1.3.1",
     "typedoc": "0.28.19",

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -26,6 +26,9 @@
   "bugs": {
     "url": "https://github.com/vercel/vercel/issues"
   },
+  "dependencies": {
+    "jose": "5.9.6"
+  },
   "devDependencies": {
     "prettier": "3.8.3",
     "tinyspawn": "1.3.1",

--- a/packages/oidc/src/index-browser.ts
+++ b/packages/oidc/src/index-browser.ts
@@ -3,6 +3,12 @@ export {
   AccessTokenMissingError,
   RefreshAccessTokenFailedError,
 } from './auth-errors';
+export {
+  isValidVercelOidcToken,
+  assertValidVercelOidcToken,
+  UnacceptableVercelOidcTokenError,
+} from './validate';
+export type { VercelOidcTokenMatcher, VercelOidcTokenClaims } from './validate';
 
 export async function getVercelOidcToken(): Promise<string> {
   return '';

--- a/packages/oidc/src/index.ts
+++ b/packages/oidc/src/index.ts
@@ -8,3 +8,9 @@ export {
   RefreshAccessTokenFailedError,
 } from './auth-errors';
 export { getVercelToken } from './token-util';
+export {
+  isValidVercelOidcToken,
+  assertValidVercelOidcToken,
+  UnacceptableVercelOidcTokenError,
+} from './validate';
+export type { VercelOidcTokenMatcher, VercelOidcTokenClaims } from './validate';

--- a/packages/oidc/src/jwt.test.ts
+++ b/packages/oidc/src/jwt.test.ts
@@ -1,0 +1,210 @@
+import { describe, test, expect, beforeEach, beforeAll } from 'vitest';
+import {
+  SignJWT,
+  generateKeyPair,
+  exportJWK,
+  type JWK,
+  type KeyLike,
+} from 'jose';
+import {
+  decodeJwt,
+  findJwksKey,
+  verifyRs256Signature,
+  _resetJwksCacheForTesting,
+  type Jwks,
+  type JwksFetcher,
+  type PublicJsonWebKey,
+} from './jwt';
+
+const ISSUER = 'https://oidc.example.test/jwt-test';
+const KID_A = 'key-a';
+const KID_B = 'key-b';
+
+function toJwk(jwk: JWK, kid: string): PublicJsonWebKey {
+  return { ...jwk, kid, alg: 'RS256', use: 'sig' } as PublicJsonWebKey;
+}
+
+describe('decodeJwt', () => {
+  let privateKey: KeyLike;
+
+  beforeAll(async () => {
+    const kp = await generateKeyPair('RS256', { extractable: true });
+    privateKey = kp.privateKey;
+  });
+
+  test('decodes a well-formed JWT', async () => {
+    const token = await new SignJWT({ foo: 'bar' })
+      .setProtectedHeader({ alg: 'RS256', kid: KID_A, typ: 'JWT' })
+      .setIssuer('https://example.test')
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 60)
+      .sign(privateKey);
+
+    const decoded = decodeJwt(token);
+    expect(decoded.header.alg).toBe('RS256');
+    expect(decoded.header.kid).toBe(KID_A);
+    expect(decoded.payload.foo).toBe('bar');
+    expect(decoded.payload.iss).toBe('https://example.test');
+    expect(decoded.signature.byteLength).toBeGreaterThan(0);
+    expect(decoded.signedData.byteLength).toBeGreaterThan(0);
+  });
+
+  test('throws on a token with the wrong number of segments', () => {
+    expect(() => decodeJwt('a.b')).toThrow(/three dot-separated/);
+    expect(() => decodeJwt('a.b.c.d')).toThrow(/three dot-separated/);
+  });
+
+  test('throws when header or payload is not valid base64url JSON', () => {
+    const bad = 'aGVsbG8.aGVsbG8.aGVsbG8';
+    expect(() => decodeJwt(bad)).toThrow(/base64url JSON/);
+  });
+});
+
+describe('verifyRs256Signature', () => {
+  let privateKey: KeyLike;
+  let publicJwk: PublicJsonWebKey;
+  let otherPublicJwk: PublicJsonWebKey;
+
+  beforeAll(async () => {
+    const kp = await generateKeyPair('RS256', { extractable: true });
+    privateKey = kp.privateKey;
+    publicJwk = toJwk(await exportJWK(kp.publicKey), KID_A);
+    const other = await generateKeyPair('RS256', { extractable: true });
+    otherPublicJwk = toJwk(await exportJWK(other.publicKey), 'other');
+  });
+
+  test('returns true for a valid signature', async () => {
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: 'RS256', kid: KID_A, typ: 'JWT' })
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 60)
+      .sign(privateKey);
+    const decoded = decodeJwt(token);
+    expect(
+      await verifyRs256Signature(
+        publicJwk,
+        decoded.signedData,
+        decoded.signature
+      )
+    ).toBe(true);
+  });
+
+  test('returns false for a signature signed with a different key', async () => {
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: 'RS256', kid: KID_A, typ: 'JWT' })
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 60)
+      .sign(privateKey);
+    const decoded = decodeJwt(token);
+    expect(
+      await verifyRs256Signature(
+        otherPublicJwk,
+        decoded.signedData,
+        decoded.signature
+      )
+    ).toBe(false);
+  });
+
+  test('throws for a non-RSA JWK', async () => {
+    const ecJwk: PublicJsonWebKey = {
+      kty: 'EC',
+      crv: 'P-256',
+      x: 'AAA',
+      y: 'AAA',
+    };
+    await expect(
+      verifyRs256Signature(ecJwk, new Uint8Array(), new Uint8Array())
+    ).rejects.toThrow(/expected "RSA"/);
+  });
+
+  test('throws for a JWK with a non-RS256 alg', async () => {
+    const badJwk: PublicJsonWebKey = { ...publicJwk, alg: 'RS512' };
+    await expect(
+      verifyRs256Signature(badJwk, new Uint8Array(), new Uint8Array())
+    ).rejects.toThrow(/expected "RS256"/);
+  });
+});
+
+describe('findJwksKey', () => {
+  let publicJwkA: PublicJsonWebKey;
+  let publicJwkB: PublicJsonWebKey;
+
+  beforeAll(async () => {
+    const kp1 = await generateKeyPair('RS256', { extractable: true });
+    publicJwkA = toJwk(await exportJWK(kp1.publicKey), KID_A);
+    const kp2 = await generateKeyPair('RS256', { extractable: true });
+    publicJwkB = toJwk(await exportJWK(kp2.publicKey), KID_B);
+  });
+
+  beforeEach(() => {
+    _resetJwksCacheForTesting();
+  });
+
+  test('returns the matching key', async () => {
+    const fetcher: JwksFetcher = async () => ({ keys: [publicJwkA] });
+    expect(await findJwksKey(ISSUER, KID_A, fetcher)).toMatchObject({
+      kid: KID_A,
+    });
+  });
+
+  test('returns null when no key matches the kid even after a refresh', async () => {
+    let calls = 0;
+    const fetcher: JwksFetcher = async () => {
+      calls++;
+      return { keys: [publicJwkA] };
+    };
+    expect(await findJwksKey(ISSUER, 'missing', fetcher)).toBeNull();
+    expect(calls).toBe(2); // initial fetch + one forced refresh
+  });
+
+  test('caches successful fetches across calls within the TTL', async () => {
+    let calls = 0;
+    const fetcher: JwksFetcher = async () => {
+      calls++;
+      return { keys: [publicJwkA] };
+    };
+    await findJwksKey(ISSUER, KID_A, fetcher);
+    await findJwksKey(ISSUER, KID_A, fetcher);
+    await findJwksKey(ISSUER, KID_A, fetcher);
+    expect(calls).toBe(1);
+  });
+
+  test('forces a refresh when the cached set does not contain the kid', async () => {
+    let callCount = 0;
+    const responses: Jwks[] = [
+      { keys: [publicJwkA] },
+      { keys: [publicJwkA, publicJwkB] },
+    ];
+    const fetcher: JwksFetcher = async () => responses[callCount++]!;
+
+    expect(await findJwksKey(ISSUER, KID_A, fetcher)).toMatchObject({
+      kid: KID_A,
+    });
+    expect(callCount).toBe(1);
+
+    expect(await findJwksKey(ISSUER, KID_B, fetcher)).toMatchObject({
+      kid: KID_B,
+    });
+    expect(callCount).toBe(2);
+  });
+
+  test('rate-limits forced refreshes', async () => {
+    let callCount = 0;
+    const fetcher: JwksFetcher = async () => {
+      callCount++;
+      return { keys: [publicJwkA] };
+    };
+    await findJwksKey(ISSUER, 'missing-1', fetcher);
+    expect(callCount).toBe(2);
+    await findJwksKey(ISSUER, 'missing-2', fetcher);
+    // Second lookup of an unknown kid should not trigger another forced fetch
+    // because the rate-limit window has not elapsed.
+    expect(callCount).toBe(2);
+  });
+
+  test('propagates fetcher errors', async () => {
+    const fetcher: JwksFetcher = async () => {
+      throw new Error('network down');
+    };
+    await expect(findJwksKey(ISSUER, KID_A, fetcher)).rejects.toThrow(
+      /network down/
+    );
+  });
+});

--- a/packages/oidc/src/jwt.ts
+++ b/packages/oidc/src/jwt.ts
@@ -1,0 +1,244 @@
+/**
+ * Minimal JWT + JWKS helpers used by {@link ./validate.ts}.
+ *
+ * This module is intentionally generic: it knows nothing about Vercel-specific
+ * issuers, claims, or matchers. It only deals in JWTs and JSON Web Key Sets.
+ *
+ * It uses the platform `SubtleCrypto` and `fetch` APIs, both of which are
+ * global in Node 20+ and in browsers, so this module has no runtime
+ * dependencies.
+ */
+
+/** Default time-to-live for cached JWKS responses. */
+const JWKS_DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+/** Minimum delay between forced JWKS refreshes when an unknown `kid` is encountered. */
+const JWKS_MIN_REFRESH_INTERVAL_MS = 30 * 1000;
+
+/**
+ * A JSON Web Key.
+ *
+ * Only the fields used during signature verification are listed here; other
+ * fields described by RFC 7517 are accepted but ignored.
+ */
+export interface PublicJsonWebKey {
+  kty: string;
+  kid?: string;
+  alg?: string;
+  use?: string;
+  n?: string;
+  e?: string;
+  [key: string]: unknown;
+}
+
+/** A JSON Web Key Set as returned by `${issuer}/.well-known/jwks`. */
+export interface Jwks {
+  keys: PublicJsonWebKey[];
+}
+
+/**
+ * A function that fetches the JSON Web Key Set for a given issuer. Useful for
+ * tests and for applications that want to provide their own caching, retry, or
+ * proxying layer.
+ */
+export type JwksFetcher = (issuer: string) => Promise<Jwks>;
+
+/** A decoded but as-yet-unverified JWT. */
+export interface DecodedJwt {
+  header: { alg?: unknown; kid?: unknown; typ?: unknown };
+  payload: Record<string, unknown>;
+  signature: Uint8Array;
+  /** The signed input (`${header}.${payload}` as UTF-8 bytes). */
+  signedData: Uint8Array;
+}
+
+interface JwksCacheEntry {
+  jwks: Jwks;
+  fetchedAt: number;
+  refreshedAt: number;
+}
+
+const jwksCache = new Map<string, JwksCacheEntry>();
+
+/**
+ * The default JWKS fetcher. Fetches `${issuer}/.well-known/jwks` and validates
+ * the response shape.
+ */
+export const defaultFetchJwks: JwksFetcher = async issuer => {
+  const url = `${issuer}/.well-known/jwks`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch JWKS from ${url}: HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as unknown;
+  if (
+    !json ||
+    typeof json !== 'object' ||
+    !Array.isArray((json as Jwks).keys)
+  ) {
+    throw new Error(`Invalid JWKS response from ${url}`);
+  }
+  return json as Jwks;
+};
+
+async function loadJwks(
+  issuer: string,
+  fetchJwks: JwksFetcher,
+  options: { force?: boolean } = {}
+): Promise<Jwks> {
+  const cached = jwksCache.get(issuer);
+  const now = Date.now();
+  if (
+    cached &&
+    !options.force &&
+    now - cached.fetchedAt < JWKS_DEFAULT_TTL_MS
+  ) {
+    return cached.jwks;
+  }
+  if (
+    cached &&
+    options.force &&
+    now - cached.refreshedAt < JWKS_MIN_REFRESH_INTERVAL_MS
+  ) {
+    return cached.jwks;
+  }
+  const jwks = await fetchJwks(issuer);
+  const fetchedAt = Date.now();
+  // Only update `refreshedAt` when this fetch was a forced refresh, so the
+  // rate-limit window only restricts back-to-back forced refreshes (and not
+  // a forced refresh that happens right after the initial unforced fetch).
+  const refreshedAt = options.force ? fetchedAt : (cached?.refreshedAt ?? 0);
+  jwksCache.set(issuer, { jwks, fetchedAt, refreshedAt });
+  return jwks;
+}
+
+/**
+ * Returns the JWK matching the given `kid` from the issuer's JWKS, or `null`
+ * if no such key exists. If the cached JWKS does not contain the requested
+ * `kid`, a single rate-limited refresh is attempted in case keys have rotated.
+ */
+export async function findJwksKey(
+  issuer: string,
+  kid: string,
+  fetchJwks: JwksFetcher = defaultFetchJwks
+): Promise<PublicJsonWebKey | null> {
+  let jwks = await loadJwks(issuer, fetchJwks);
+  let key = jwks.keys.find(k => k.kid === kid);
+  if (key) return key;
+  jwks = await loadJwks(issuer, fetchJwks, { force: true });
+  key = jwks.keys.find(k => k.kid === kid);
+  return key ?? null;
+}
+
+/** @internal Used by tests to reset the per-issuer JWKS cache. */
+export function _resetJwksCacheForTesting(): void {
+  jwksCache.clear();
+}
+
+function getSubtle(): SubtleCrypto {
+  const subtle = (globalThis as { crypto?: { subtle?: SubtleCrypto } }).crypto
+    ?.subtle;
+  if (!subtle) {
+    throw new Error(
+      'WebCrypto SubtleCrypto API is not available in this environment'
+    );
+  }
+  return subtle;
+}
+
+function base64UrlDecode(input: string): Uint8Array {
+  const b64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=');
+  if (typeof atob === 'function') {
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  return new Uint8Array(
+    (
+      globalThis as { Buffer?: { from(s: string, e: string): Uint8Array } }
+    ).Buffer!.from(padded, 'base64')
+  );
+}
+
+function utf8Decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+function utf8Encode(input: string): Uint8Array {
+  return new TextEncoder().encode(input);
+}
+
+/**
+ * Splits a JWT into its three parts and decodes the header and payload as
+ * JSON. Does **not** verify the signature.
+ *
+ * @throws {Error} If the input is not a syntactically valid JWT.
+ */
+export function decodeJwt(token: string): DecodedJwt {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('JWT must contain exactly three dot-separated segments');
+  }
+  const [headerB64, payloadB64, signatureB64] = parts;
+  let header: unknown;
+  let payload: unknown;
+  try {
+    header = JSON.parse(utf8Decode(base64UrlDecode(headerB64)));
+    payload = JSON.parse(utf8Decode(base64UrlDecode(payloadB64)));
+  } catch (error) {
+    const wrapped = new Error(
+      'JWT header or payload is not valid base64url JSON'
+    );
+    (wrapped as { cause?: unknown }).cause = error;
+    throw wrapped;
+  }
+  if (!header || typeof header !== 'object') {
+    throw new Error('JWT header is not an object');
+  }
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('JWT payload is not an object');
+  }
+  return {
+    header: header as DecodedJwt['header'],
+    payload: payload as Record<string, unknown>,
+    signature: base64UrlDecode(signatureB64),
+    signedData: utf8Encode(`${headerB64}.${payloadB64}`),
+  };
+}
+
+/**
+ * Verifies an `RS256` signature using a JSON Web Key.
+ *
+ * @throws {Error} If the JWK's `kty` is not `RSA` or its `alg` is not `RS256`.
+ */
+export async function verifyRs256Signature(
+  jwk: PublicJsonWebKey,
+  signedData: Uint8Array,
+  signature: Uint8Array
+): Promise<boolean> {
+  if (jwk.kty !== 'RSA') {
+    throw new Error(`Unsupported JWK key type "${jwk.kty}"; expected "RSA"`);
+  }
+  if (jwk.alg !== undefined && jwk.alg !== 'RS256') {
+    throw new Error(`Unsupported JWK algorithm "${jwk.alg}"; expected "RS256"`);
+  }
+  const subtle = getSubtle();
+  const algorithm = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' };
+  const cryptoKey = await subtle.importKey(
+    'jwk',
+    { ...jwk, alg: 'RS256', ext: true },
+    algorithm,
+    false,
+    ['verify']
+  );
+  return subtle.verify(
+    algorithm.name,
+    cryptoKey,
+    signature as BufferSource,
+    signedData as BufferSource
+  );
+}

--- a/packages/oidc/src/validate.test.ts
+++ b/packages/oidc/src/validate.test.ts
@@ -406,4 +406,258 @@ describe('validate vercel oidc token', () => {
       'UnacceptableVercelOidcTokenError'
     );
   });
+
+  /*
+   * Exhaustive per-property coverage. Each row defines a single matcher
+   * property, the underlying claim it should match, the value to put on the
+   * token, and a different value used to verify that the matcher rejects a
+   * mismatch. This is the source of truth that every property in
+   * VercelOidcTokenMatcher behaves correctly in isolation.
+   */
+  const TEAM_ISSUER = 'https://oidc.vercel.com/acme';
+  const matcherCases: ReadonlyArray<{
+    name: string;
+    matcherProp: keyof VercelOidcTokenMatcher;
+    claimProp: keyof TokenClaims;
+    matchingValue: string;
+    nonMatchingValue: string;
+    /** Optional override applied to the signing options/claims. */
+    extraClaims?: Partial<TokenClaims>;
+    issuer?: string;
+  }> = [
+    {
+      name: 'iss (global issuer)',
+      matcherProp: 'iss',
+      claimProp: 'iss',
+      matchingValue: 'https://oidc.vercel.com',
+      nonMatchingValue: 'https://oidc.vercel.com/acme',
+      issuer: 'https://oidc.vercel.com',
+    },
+    {
+      name: 'iss (team issuer)',
+      matcherProp: 'iss',
+      claimProp: 'iss',
+      matchingValue: TEAM_ISSUER,
+      nonMatchingValue: 'https://oidc.vercel.com',
+      issuer: TEAM_ISSUER,
+    },
+    {
+      name: 'aud',
+      matcherProp: 'aud',
+      claimProp: 'aud',
+      matchingValue: 'https://vercel.com/acme',
+      nonMatchingValue: 'https://vercel.com/other',
+    },
+    {
+      name: 'sub',
+      matcherProp: 'sub',
+      claimProp: 'sub',
+      matchingValue: 'owner:acme:project:acme_website:environment:production',
+      nonMatchingValue: 'owner:acme:project:other:environment:production',
+    },
+    {
+      name: 'team (alias for owner)',
+      matcherProp: 'team',
+      claimProp: 'owner',
+      matchingValue: 'acme',
+      nonMatchingValue: 'vercel',
+    },
+    {
+      name: 'owner',
+      matcherProp: 'owner',
+      claimProp: 'owner',
+      matchingValue: 'acme',
+      nonMatchingValue: 'vercel',
+    },
+    {
+      name: 'teamId (alias for owner_id)',
+      matcherProp: 'teamId',
+      claimProp: 'owner_id',
+      matchingValue: 'team_abc123',
+      nonMatchingValue: 'team_xyz789',
+    },
+    {
+      name: 'owner_id',
+      matcherProp: 'owner_id',
+      claimProp: 'owner_id',
+      matchingValue: 'team_abc123',
+      nonMatchingValue: 'team_xyz789',
+    },
+    {
+      name: 'project',
+      matcherProp: 'project',
+      claimProp: 'project',
+      matchingValue: 'acme_website',
+      nonMatchingValue: 'acme_other',
+    },
+    {
+      name: 'projectId (alias for project_id)',
+      matcherProp: 'projectId',
+      claimProp: 'project_id',
+      matchingValue: 'prj_abc123',
+      nonMatchingValue: 'prj_xyz789',
+    },
+    {
+      name: 'project_id',
+      matcherProp: 'project_id',
+      claimProp: 'project_id',
+      matchingValue: 'prj_abc123',
+      nonMatchingValue: 'prj_xyz789',
+    },
+    {
+      name: 'environment',
+      matcherProp: 'environment',
+      claimProp: 'environment',
+      matchingValue: 'production',
+      nonMatchingValue: 'preview',
+    },
+    {
+      name: 'userId (alias for user_id)',
+      matcherProp: 'userId',
+      claimProp: 'user_id',
+      matchingValue: 'usr_42',
+      nonMatchingValue: 'usr_99',
+      extraClaims: { user_id: 'usr_42' },
+    },
+    {
+      name: 'user_id',
+      matcherProp: 'user_id',
+      claimProp: 'user_id',
+      matchingValue: 'usr_42',
+      nonMatchingValue: 'usr_99',
+      extraClaims: { user_id: 'usr_42' },
+    },
+  ];
+
+  describe('every matcher property', () => {
+    test.each(
+      matcherCases
+    )('$name accepts when the claim equals the matcher value', async ({
+      matcherProp,
+      claimProp,
+      matchingValue,
+      extraClaims,
+      issuer,
+    }) => {
+      const claims: TokenClaims = {
+        ...validClaims,
+        ...extraClaims,
+        [claimProp]: matchingValue,
+      };
+      const token = await signToken(claims, { privateKey, issuer });
+      const matcher: VercelOidcTokenMatcher = {
+        [matcherProp]: matchingValue,
+      } as VercelOidcTokenMatcher;
+      expect(await isValidVercelOidcToken(matcher, token, { fetchJwks })).toBe(
+        true
+      );
+    });
+
+    test.each(
+      matcherCases
+    )('$name rejects when the claim differs from the matcher value', async ({
+      matcherProp,
+      claimProp,
+      matchingValue,
+      nonMatchingValue,
+      extraClaims,
+      issuer,
+    }) => {
+      const claims: TokenClaims = {
+        ...validClaims,
+        ...extraClaims,
+        [claimProp]: matchingValue,
+      };
+      const token = await signToken(claims, { privateKey, issuer });
+      const matcher: VercelOidcTokenMatcher = {
+        [matcherProp]: nonMatchingValue,
+      } as VercelOidcTokenMatcher;
+      expect(await isValidVercelOidcToken(matcher, token, { fetchJwks })).toBe(
+        false
+      );
+    });
+
+    // `iss` is structurally required by the verifier itself (we reject any
+    // token whose issuer is not a Vercel OIDC issuer before matchers even
+    // run), so an "absent iss" case has no meaningful behaviour to test on
+    // the matcher level.
+    test.each(
+      matcherCases.filter(c => c.claimProp !== 'iss')
+    )('$name rejects when the claim is absent from the token', async ({
+      matcherProp,
+      claimProp,
+      matchingValue,
+    }) => {
+      // Build a token that intentionally omits the claim under test.
+      const { [claimProp]: _omitted, ...claimsWithoutThisOne } = validClaims;
+      const token = await signToken(claimsWithoutThisOne, { privateKey });
+      const matcher: VercelOidcTokenMatcher = {
+        [matcherProp]: matchingValue,
+      } as VercelOidcTokenMatcher;
+      expect(await isValidVercelOidcToken(matcher, token, { fetchJwks })).toBe(
+        false
+      );
+    });
+  });
+
+  test('all properties on a single matcher must AND together', async () => {
+    const claims: TokenClaims = { ...validClaims, user_id: 'usr_42' };
+    const token = await signToken(claims, { privateKey });
+
+    // Every property correct.
+    expect(
+      await isValidVercelOidcToken(
+        {
+          team: 'acme',
+          teamId: 'team_abc123',
+          project: 'acme_website',
+          projectId: 'prj_abc123',
+          environment: 'production',
+          userId: 'usr_42',
+          aud: 'https://vercel.com/acme',
+          sub: 'owner:acme:project:acme_website:environment:production',
+          iss: 'https://oidc.vercel.com',
+        },
+        token,
+        { fetchJwks }
+      )
+    ).toBe(true);
+
+    // A single property wrong, everything else correct → reject.
+    expect(
+      await isValidVercelOidcToken(
+        {
+          team: 'acme',
+          teamId: 'team_abc123',
+          project: 'acme_website',
+          projectId: 'prj_abc123',
+          environment: 'preview', // <- wrong
+          userId: 'usr_42',
+          aud: 'https://vercel.com/acme',
+          sub: 'owner:acme:project:acme_website:environment:production',
+          iss: 'https://oidc.vercel.com',
+        },
+        token,
+        { fetchJwks }
+      )
+    ).toBe(false);
+  });
+
+  test('matcher with both an alias and its raw claim must agree', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    // team and owner agree -> matches.
+    expect(
+      await isValidVercelOidcToken({ team: 'acme', owner: 'acme' }, token, {
+        fetchJwks,
+      })
+    ).toBe(true);
+    // team and owner disagree -> rejects (one of the two will fail).
+    expect(
+      await isValidVercelOidcToken(
+        { team: 'acme', owner: 'someone-else' },
+        token,
+        { fetchJwks }
+      )
+    ).toBe(false);
+  });
 });

--- a/packages/oidc/src/validate.test.ts
+++ b/packages/oidc/src/validate.test.ts
@@ -5,13 +5,13 @@ import {
   exportJWK,
   type JWK,
   type KeyLike,
-  createLocalJWKSet,
 } from 'jose';
 import {
   assertValidVercelOidcToken,
   isValidVercelOidcToken,
   UnacceptableVercelOidcTokenError,
-  type JwksResolver,
+  type Jwks,
+  type JwksFetcher,
   type VercelOidcTokenMatcher,
 } from './validate';
 
@@ -59,21 +59,21 @@ describe('validate vercel oidc token', () => {
   let privateKey: KeyLike;
   let publicJwk: JWK;
   let otherPrivateKey: KeyLike;
-  let jwksResolver: JwksResolver;
+  let fetchJwks: JwksFetcher;
 
   beforeAll(async () => {
-    const kp = await generateKeyPair('RS256');
+    const kp = await generateKeyPair('RS256', { extractable: true });
     privateKey = kp.privateKey;
     publicJwk = await exportJWK(kp.publicKey);
     publicJwk.kid = KID;
     publicJwk.alg = 'RS256';
     publicJwk.use = 'sig';
 
-    const otherKp = await generateKeyPair('RS256');
+    const otherKp = await generateKeyPair('RS256', { extractable: true });
     otherPrivateKey = otherKp.privateKey;
 
-    const localJwks = createLocalJWKSet({ keys: [publicJwk] });
-    jwksResolver = () => localJwks;
+    const jwks: Jwks = { keys: [publicJwk as Jwks['keys'][number]] };
+    fetchJwks = async () => jwks;
   });
 
   const validClaims: TokenClaims = {
@@ -91,11 +91,11 @@ describe('validate vercel oidc token', () => {
     const matchers: VercelOidcTokenMatcher[] = [
       { team: 'acme', project: 'acme_website', environment: 'production' },
     ];
-    expect(
-      await isValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
-    ).toBe(true);
+    expect(await isValidVercelOidcToken(matchers, token, { fetchJwks })).toBe(
+      true
+    );
     await expect(
-      assertValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
+      assertValidVercelOidcToken(matchers, token, { fetchJwks })
     ).resolves.toBeUndefined();
   });
 
@@ -105,9 +105,9 @@ describe('validate vercel oidc token', () => {
       { team: 'vercel', project: 'vercel-alerts', environment: 'production' },
       { team: 'acme', project: 'acme_website', environment: 'production' },
     ];
-    expect(
-      await isValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
-    ).toBe(true);
+    expect(await isValidVercelOidcToken(matchers, token, { fetchJwks })).toBe(
+      true
+    );
   });
 
   test('accepts a single matcher object (not wrapped in an array)', async () => {
@@ -117,9 +117,9 @@ describe('validate vercel oidc token', () => {
       project: 'acme_website',
       environment: 'production',
     };
-    expect(
-      await isValidVercelOidcToken(matcher, token, { jwks: jwksResolver })
-    ).toBe(true);
+    expect(await isValidVercelOidcToken(matcher, token, { fetchJwks })).toBe(
+      true
+    );
   });
 
   test('rejects a token whose claims do not match any matcher', async () => {
@@ -127,11 +127,11 @@ describe('validate vercel oidc token', () => {
     const matchers: VercelOidcTokenMatcher[] = [
       { team: 'vercel', project: 'vercel-alerts', environment: 'production' },
     ];
-    expect(
-      await isValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
-    ).toBe(false);
+    expect(await isValidVercelOidcToken(matchers, token, { fetchJwks })).toBe(
+      false
+    );
     await expect(
-      assertValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
+      assertValidVercelOidcToken(matchers, token, { fetchJwks })
     ).rejects.toBeInstanceOf(UnacceptableVercelOidcTokenError);
   });
 
@@ -140,9 +140,9 @@ describe('validate vercel oidc token', () => {
     const matchers: VercelOidcTokenMatcher[] = [
       { team: 'acme', project: 'acme_website', environment: 'preview' },
     ];
-    expect(
-      await isValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
-    ).toBe(false);
+    expect(await isValidVercelOidcToken(matchers, token, { fetchJwks })).toBe(
+      false
+    );
   });
 
   test('matches by team ID and project ID', async () => {
@@ -151,14 +151,14 @@ describe('validate vercel oidc token', () => {
       await isValidVercelOidcToken(
         { teamId: 'team_abc123', projectId: 'prj_abc123' },
         token,
-        { jwks: jwksResolver }
+        { fetchJwks }
       )
     ).toBe(true);
     expect(
       await isValidVercelOidcToken(
         { teamId: 'team_other', projectId: 'prj_abc123' },
         token,
-        { jwks: jwksResolver }
+        { fetchJwks }
       )
     ).toBe(false);
   });
@@ -175,7 +175,7 @@ describe('validate vercel oidc token', () => {
           user_id: 'usr_42',
         },
         token,
-        { jwks: jwksResolver }
+        { fetchJwks }
       )
     ).toBe(true);
   });
@@ -184,12 +184,12 @@ describe('validate vercel oidc token', () => {
     const token = await signToken(validClaims, { privateKey });
     expect(
       await isValidVercelOidcToken({ aud: 'https://vercel.com/acme' }, token, {
-        jwks: jwksResolver,
+        fetchJwks,
       })
     ).toBe(true);
     expect(
       await isValidVercelOidcToken({ aud: 'https://vercel.com/other' }, token, {
-        jwks: jwksResolver,
+        fetchJwks,
       })
     ).toBe(false);
   });
@@ -206,7 +206,7 @@ describe('validate vercel oidc token', () => {
       await isValidVercelOidcToken(
         { aud: 'https://vercel.com/acme-staging' },
         token,
-        { jwks: jwksResolver }
+        { fetchJwks }
       )
     ).toBe(true);
   });
@@ -220,14 +220,14 @@ describe('validate vercel oidc token', () => {
       await isValidVercelOidcToken(
         { team: 'acme', project: 'acme_website', environment: 'production' },
         token,
-        { jwks: jwksResolver }
+        { fetchJwks }
       )
     ).toBe(false);
     await expect(
       assertValidVercelOidcToken(
         { team: 'acme', project: 'acme_website', environment: 'production' },
         token,
-        { jwks: jwksResolver }
+        { fetchJwks }
       )
     ).rejects.toBeInstanceOf(UnacceptableVercelOidcTokenError);
   });
@@ -238,16 +238,80 @@ describe('validate vercel oidc token', () => {
       await isValidVercelOidcToken(
         { team: 'acme', project: 'acme_website', environment: 'production' },
         token,
-        { jwks: jwksResolver }
+        { fetchJwks }
+      )
+    ).toBe(false);
+  });
+
+  test('rejects a token with a tampered payload', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    const [headerB64, payloadB64, signatureB64] = token.split('.');
+    const decoded = JSON.parse(
+      Buffer.from(payloadB64, 'base64url').toString('utf8')
+    );
+    decoded.environment = 'production';
+    decoded.owner = 'attacker';
+    const tamperedPayload = Buffer.from(JSON.stringify(decoded)).toString(
+      'base64url'
+    );
+    const tampered = `${headerB64}.${tamperedPayload}.${signatureB64}`;
+    expect(
+      await isValidVercelOidcToken(
+        { team: 'attacker', environment: 'production' },
+        tampered,
+        { fetchJwks }
+      )
+    ).toBe(false);
+  });
+
+  test('rejects a token with alg=none', async () => {
+    const header = Buffer.from(
+      JSON.stringify({ alg: 'none', typ: 'JWT', kid: KID })
+    ).toString('base64url');
+    const payload = Buffer.from(
+      JSON.stringify({
+        ...validClaims,
+        iss: 'https://oidc.vercel.com',
+        exp: Math.floor(Date.now() / 1000) + 60,
+        iat: Math.floor(Date.now() / 1000),
+      })
+    ).toString('base64url');
+    const unsigned = `${header}.${payload}.`;
+    expect(
+      await isValidVercelOidcToken(
+        { team: 'acme', project: 'acme_website', environment: 'production' },
+        unsigned,
+        { fetchJwks }
+      )
+    ).toBe(false);
+  });
+
+  test('rejects a token with a non-RS256 algorithm', async () => {
+    const header = Buffer.from(
+      JSON.stringify({ alg: 'HS256', typ: 'JWT', kid: KID })
+    ).toString('base64url');
+    const payload = Buffer.from(
+      JSON.stringify({
+        ...validClaims,
+        iss: 'https://oidc.vercel.com',
+        exp: Math.floor(Date.now() / 1000) + 60,
+      })
+    ).toString('base64url');
+    const fake = `${header}.${payload}.AAAA`;
+    expect(
+      await isValidVercelOidcToken(
+        { team: 'acme', project: 'acme_website', environment: 'production' },
+        fake,
+        { fetchJwks }
       )
     ).toBe(false);
   });
 
   test('rejects a token from a non-Vercel issuer without fetching JWKS', async () => {
     let resolverCalled = false;
-    const detectingResolver: JwksResolver = issuer => {
+    const detectingFetcher: JwksFetcher = async issuer => {
       resolverCalled = true;
-      return jwksResolver(issuer);
+      return fetchJwks(issuer);
     };
     const token = await signToken(validClaims, {
       privateKey,
@@ -257,7 +321,7 @@ describe('validate vercel oidc token', () => {
       await isValidVercelOidcToken(
         { team: 'acme', project: 'acme_website', environment: 'production' },
         token,
-        { jwks: detectingResolver }
+        { fetchJwks: detectingFetcher }
       )
     ).toBe(false);
     expect(resolverCalled).toBe(false);
@@ -272,7 +336,7 @@ describe('validate vercel oidc token', () => {
       await isValidVercelOidcToken(
         { team: 'acme', project: 'acme_website', environment: 'production' },
         token,
-        { jwks: jwksResolver }
+        { fetchJwks }
       )
     ).toBe(false);
   });
@@ -286,34 +350,44 @@ describe('validate vercel oidc token', () => {
       await isValidVercelOidcToken(
         { team: 'acme', project: 'acme_website', environment: 'production' },
         token,
-        { jwks: jwksResolver }
+        { fetchJwks }
       )
     ).toBe(true);
   });
 
   test('rejects an empty token string', async () => {
     expect(
-      await isValidVercelOidcToken({ team: 'acme' }, '', {
-        jwks: jwksResolver,
-      })
+      await isValidVercelOidcToken({ team: 'acme' }, '', { fetchJwks })
     ).toBe(false);
     await expect(
-      assertValidVercelOidcToken({ team: 'acme' }, '', { jwks: jwksResolver })
+      assertValidVercelOidcToken({ team: 'acme' }, '', { fetchJwks })
     ).rejects.toBeInstanceOf(UnacceptableVercelOidcTokenError);
   });
 
   test('rejects a malformed token', async () => {
     expect(
       await isValidVercelOidcToken({ team: 'acme' }, 'not-a-jwt', {
-        jwks: jwksResolver,
+        fetchJwks,
       })
     ).toBe(false);
   });
 
   test('rejects when no matchers are provided', async () => {
     const token = await signToken(validClaims, { privateKey });
+    expect(await isValidVercelOidcToken([], token, { fetchJwks })).toBe(false);
+  });
+
+  test('rejects when the kid is not found in the JWKS', async () => {
+    const token = await signToken(validClaims, {
+      privateKey,
+      keyId: 'unknown-kid',
+    });
     expect(
-      await isValidVercelOidcToken([], token, { jwks: jwksResolver })
+      await isValidVercelOidcToken(
+        { team: 'acme', project: 'acme_website', environment: 'production' },
+        token,
+        { fetchJwks }
+      )
     ).toBe(false);
   });
 
@@ -322,7 +396,7 @@ describe('validate vercel oidc token', () => {
     let error: unknown;
     try {
       await assertValidVercelOidcToken({ team: 'vercel' }, token, {
-        jwks: jwksResolver,
+        fetchJwks,
       });
     } catch (e) {
       error = e;

--- a/packages/oidc/src/validate.test.ts
+++ b/packages/oidc/src/validate.test.ts
@@ -1,0 +1,335 @@
+import { describe, test, expect, beforeAll } from 'vitest';
+import {
+  SignJWT,
+  generateKeyPair,
+  exportJWK,
+  type JWK,
+  type KeyLike,
+  createLocalJWKSet,
+} from 'jose';
+import {
+  assertValidVercelOidcToken,
+  isValidVercelOidcToken,
+  UnacceptableVercelOidcTokenError,
+  type JwksResolver,
+  type VercelOidcTokenMatcher,
+} from './validate';
+
+const KID = 'test-key-id';
+
+interface TokenClaims {
+  iss?: string;
+  aud?: string | string[];
+  sub?: string;
+  owner?: string;
+  owner_id?: string;
+  project?: string;
+  project_id?: string;
+  environment?: string;
+  user_id?: string;
+}
+
+interface SignOptions {
+  issuer?: string;
+  expiresAt?: Date;
+  algorithm?: string;
+  keyId?: string;
+  privateKey: KeyLike;
+}
+
+async function signToken(
+  claims: TokenClaims,
+  opts: SignOptions
+): Promise<string> {
+  const issuer = opts.issuer ?? claims.iss ?? 'https://oidc.vercel.com';
+  const exp = opts.expiresAt ?? new Date(Date.now() + 60_000);
+  return new SignJWT({ ...claims })
+    .setProtectedHeader({
+      alg: opts.algorithm ?? 'RS256',
+      kid: opts.keyId ?? KID,
+      typ: 'JWT',
+    })
+    .setIssuedAt()
+    .setIssuer(issuer)
+    .setExpirationTime(Math.floor(exp.getTime() / 1000))
+    .sign(opts.privateKey);
+}
+
+describe('validate vercel oidc token', () => {
+  let privateKey: KeyLike;
+  let publicJwk: JWK;
+  let otherPrivateKey: KeyLike;
+  let jwksResolver: JwksResolver;
+
+  beforeAll(async () => {
+    const kp = await generateKeyPair('RS256');
+    privateKey = kp.privateKey;
+    publicJwk = await exportJWK(kp.publicKey);
+    publicJwk.kid = KID;
+    publicJwk.alg = 'RS256';
+    publicJwk.use = 'sig';
+
+    const otherKp = await generateKeyPair('RS256');
+    otherPrivateKey = otherKp.privateKey;
+
+    const localJwks = createLocalJWKSet({ keys: [publicJwk] });
+    jwksResolver = () => localJwks;
+  });
+
+  const validClaims: TokenClaims = {
+    aud: 'https://vercel.com/acme',
+    sub: 'owner:acme:project:acme_website:environment:production',
+    owner: 'acme',
+    owner_id: 'team_abc123',
+    project: 'acme_website',
+    project_id: 'prj_abc123',
+    environment: 'production',
+  };
+
+  test('accepts a token with matching team/project/environment', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    const matchers: VercelOidcTokenMatcher[] = [
+      { team: 'acme', project: 'acme_website', environment: 'production' },
+    ];
+    expect(
+      await isValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
+    ).toBe(true);
+    await expect(
+      assertValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
+    ).resolves.toBeUndefined();
+  });
+
+  test('accepts a token matching any matcher in an array', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    const matchers: VercelOidcTokenMatcher[] = [
+      { team: 'vercel', project: 'vercel-alerts', environment: 'production' },
+      { team: 'acme', project: 'acme_website', environment: 'production' },
+    ];
+    expect(
+      await isValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
+    ).toBe(true);
+  });
+
+  test('accepts a single matcher object (not wrapped in an array)', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    const matcher: VercelOidcTokenMatcher = {
+      team: 'acme',
+      project: 'acme_website',
+      environment: 'production',
+    };
+    expect(
+      await isValidVercelOidcToken(matcher, token, { jwks: jwksResolver })
+    ).toBe(true);
+  });
+
+  test('rejects a token whose claims do not match any matcher', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    const matchers: VercelOidcTokenMatcher[] = [
+      { team: 'vercel', project: 'vercel-alerts', environment: 'production' },
+    ];
+    expect(
+      await isValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
+    ).toBe(false);
+    await expect(
+      assertValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
+    ).rejects.toBeInstanceOf(UnacceptableVercelOidcTokenError);
+  });
+
+  test('rejects a matcher with a wrong environment even when team/project match', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    const matchers: VercelOidcTokenMatcher[] = [
+      { team: 'acme', project: 'acme_website', environment: 'preview' },
+    ];
+    expect(
+      await isValidVercelOidcToken(matchers, token, { jwks: jwksResolver })
+    ).toBe(false);
+  });
+
+  test('matches by team ID and project ID', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    expect(
+      await isValidVercelOidcToken(
+        { teamId: 'team_abc123', projectId: 'prj_abc123' },
+        token,
+        { jwks: jwksResolver }
+      )
+    ).toBe(true);
+    expect(
+      await isValidVercelOidcToken(
+        { teamId: 'team_other', projectId: 'prj_abc123' },
+        token,
+        { jwks: jwksResolver }
+      )
+    ).toBe(false);
+  });
+
+  test('supports raw OIDC claim names (owner, owner_id, project_id, user_id)', async () => {
+    const claims: TokenClaims = { ...validClaims, user_id: 'usr_42' };
+    const token = await signToken(claims, { privateKey });
+    expect(
+      await isValidVercelOidcToken(
+        {
+          owner: 'acme',
+          owner_id: 'team_abc123',
+          project_id: 'prj_abc123',
+          user_id: 'usr_42',
+        },
+        token,
+        { jwks: jwksResolver }
+      )
+    ).toBe(true);
+  });
+
+  test('matches the aud claim', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    expect(
+      await isValidVercelOidcToken({ aud: 'https://vercel.com/acme' }, token, {
+        jwks: jwksResolver,
+      })
+    ).toBe(true);
+    expect(
+      await isValidVercelOidcToken({ aud: 'https://vercel.com/other' }, token, {
+        jwks: jwksResolver,
+      })
+    ).toBe(false);
+  });
+
+  test('matches when the aud claim is an array', async () => {
+    const token = await signToken(
+      {
+        ...validClaims,
+        aud: ['https://vercel.com/acme', 'https://vercel.com/acme-staging'],
+      },
+      { privateKey }
+    );
+    expect(
+      await isValidVercelOidcToken(
+        { aud: 'https://vercel.com/acme-staging' },
+        token,
+        { jwks: jwksResolver }
+      )
+    ).toBe(true);
+  });
+
+  test('rejects an expired token', async () => {
+    const token = await signToken(validClaims, {
+      privateKey,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    expect(
+      await isValidVercelOidcToken(
+        { team: 'acme', project: 'acme_website', environment: 'production' },
+        token,
+        { jwks: jwksResolver }
+      )
+    ).toBe(false);
+    await expect(
+      assertValidVercelOidcToken(
+        { team: 'acme', project: 'acme_website', environment: 'production' },
+        token,
+        { jwks: jwksResolver }
+      )
+    ).rejects.toBeInstanceOf(UnacceptableVercelOidcTokenError);
+  });
+
+  test('rejects a token signed with a different key', async () => {
+    const token = await signToken(validClaims, { privateKey: otherPrivateKey });
+    expect(
+      await isValidVercelOidcToken(
+        { team: 'acme', project: 'acme_website', environment: 'production' },
+        token,
+        { jwks: jwksResolver }
+      )
+    ).toBe(false);
+  });
+
+  test('rejects a token from a non-Vercel issuer without fetching JWKS', async () => {
+    let resolverCalled = false;
+    const detectingResolver: JwksResolver = issuer => {
+      resolverCalled = true;
+      return jwksResolver(issuer);
+    };
+    const token = await signToken(validClaims, {
+      privateKey,
+      issuer: 'https://attacker.example.com',
+    });
+    expect(
+      await isValidVercelOidcToken(
+        { team: 'acme', project: 'acme_website', environment: 'production' },
+        token,
+        { jwks: detectingResolver }
+      )
+    ).toBe(false);
+    expect(resolverCalled).toBe(false);
+  });
+
+  test('rejects a Vercel-issuer-like URL with an invalid path', async () => {
+    const token = await signToken(validClaims, {
+      privateKey,
+      issuer: 'https://oidc.vercel.com.evil.com',
+    });
+    expect(
+      await isValidVercelOidcToken(
+        { team: 'acme', project: 'acme_website', environment: 'production' },
+        token,
+        { jwks: jwksResolver }
+      )
+    ).toBe(false);
+  });
+
+  test('accepts the team-mode issuer', async () => {
+    const token = await signToken(validClaims, {
+      privateKey,
+      issuer: 'https://oidc.vercel.com/acme',
+    });
+    expect(
+      await isValidVercelOidcToken(
+        { team: 'acme', project: 'acme_website', environment: 'production' },
+        token,
+        { jwks: jwksResolver }
+      )
+    ).toBe(true);
+  });
+
+  test('rejects an empty token string', async () => {
+    expect(
+      await isValidVercelOidcToken({ team: 'acme' }, '', {
+        jwks: jwksResolver,
+      })
+    ).toBe(false);
+    await expect(
+      assertValidVercelOidcToken({ team: 'acme' }, '', { jwks: jwksResolver })
+    ).rejects.toBeInstanceOf(UnacceptableVercelOidcTokenError);
+  });
+
+  test('rejects a malformed token', async () => {
+    expect(
+      await isValidVercelOidcToken({ team: 'acme' }, 'not-a-jwt', {
+        jwks: jwksResolver,
+      })
+    ).toBe(false);
+  });
+
+  test('rejects when no matchers are provided', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    expect(
+      await isValidVercelOidcToken([], token, { jwks: jwksResolver })
+    ).toBe(false);
+  });
+
+  test('UnacceptableVercelOidcTokenError preserves cause', async () => {
+    const token = await signToken(validClaims, { privateKey });
+    let error: unknown;
+    try {
+      await assertValidVercelOidcToken({ team: 'vercel' }, token, {
+        jwks: jwksResolver,
+      });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(UnacceptableVercelOidcTokenError);
+    expect((error as UnacceptableVercelOidcTokenError).name).toBe(
+      'UnacceptableVercelOidcTokenError'
+    );
+  });
+});

--- a/packages/oidc/src/validate.ts
+++ b/packages/oidc/src/validate.ts
@@ -1,11 +1,3 @@
-import {
-  createRemoteJWKSet,
-  jwtVerify,
-  decodeJwt,
-  type JWTVerifyGetKey,
-  type JWTPayload,
-} from 'jose';
-
 /**
  * The base issuer URL for Vercel OIDC tokens.
  *
@@ -13,18 +5,30 @@ import {
  */
 const VERCEL_OIDC_ISSUER_BASE = 'https://oidc.vercel.com';
 
+/** Default time-to-live for cached JWKS responses. */
+const JWKS_DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+/** Minimum delay between forced JWKS refreshes when an unknown `kid` is encountered. */
+const JWKS_MIN_REFRESH_INTERVAL_MS = 30 * 1000;
+
 /**
  * Claims emitted in a Vercel OIDC token.
  *
  * @see https://vercel.com/docs/oidc/reference#oidc-token-anatomy
  */
-export interface VercelOidcTokenClaims extends JWTPayload {
+export interface VercelOidcTokenClaims {
   /** Issuer. `https://oidc.vercel.com` (global) or `https://oidc.vercel.com/[TEAM_SLUG]` (team). */
   iss?: string;
   /** Audience. `https://vercel.com/[TEAM_SLUG]`. */
   aud?: string | string[];
   /** Subject. `owner:[TEAM_SLUG]:project:[PROJECT_NAME]:environment:[ENVIRONMENT]`. */
   sub?: string;
+  /** Expiration time (seconds since epoch). */
+  exp?: number;
+  /** Not-before time (seconds since epoch). */
+  nbf?: number;
+  /** Issued-at time (seconds since epoch). */
+  iat?: number;
   /** Team slug (e.g. `acme`). */
   owner?: string;
   /** Team ID (e.g. `team_7Gw5...`). */
@@ -37,6 +41,8 @@ export interface VercelOidcTokenClaims extends JWTPayload {
   environment?: string;
   /** User ID. Only present when environment is `development`. */
   user_id?: string;
+  /** Other claims that may be present. */
+  [claim: string]: unknown;
 }
 
 /**
@@ -100,37 +106,217 @@ export class UnacceptableVercelOidcTokenError extends Error {
 }
 
 /**
- * The signature of a function used to fetch the JSON Web Key Set for a given
- * issuer. Useful for testing or when you want to provide your own caching layer.
+ * A JSON Web Key.
+ *
+ * Only the fields used during signature verification are listed here; other
+ * fields described by RFC 7517 are accepted but ignored.
+ */
+interface PublicJsonWebKey {
+  kty: string;
+  kid?: string;
+  alg?: string;
+  use?: string;
+  n?: string;
+  e?: string;
+  [key: string]: unknown;
+}
+
+/** A JSON Web Key Set as returned by `${issuer}/.well-known/jwks`. */
+export interface Jwks {
+  keys: PublicJsonWebKey[];
+}
+
+/**
+ * A function that fetches the JSON Web Key Set for a given issuer. Useful for
+ * tests and for applications that want to provide their own caching, retry, or
+ * proxying layer.
  *
  * @internal
  */
-export type JwksResolver = (issuer: string) => JWTVerifyGetKey;
-
-const defaultJwksCache = new Map<string, JWTVerifyGetKey>();
-
-const defaultJwksResolver: JwksResolver = issuer => {
-  let jwks = defaultJwksCache.get(issuer);
-  if (!jwks) {
-    jwks = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks`));
-    defaultJwksCache.set(issuer, jwks);
-  }
-  return jwks;
-};
+export type JwksFetcher = (issuer: string) => Promise<Jwks>;
 
 /**
  * @internal
  */
 export interface ValidateVercelOidcTokenOptions {
   /**
-   * Function used to resolve the JWKS for a given issuer. Defaults to a
-   * function that fetches the JWKS from `${issuer}/.well-known/jwks`.
-   *
-   * Mainly useful for testing.
+   * Function used to fetch the JWKS for a given issuer. Defaults to a function
+   * that fetches `${issuer}/.well-known/jwks` and caches the response in memory.
    *
    * @internal
    */
-  jwks?: JwksResolver;
+  fetchJwks?: JwksFetcher;
+}
+
+interface JwksCacheEntry {
+  jwks: Jwks;
+  fetchedAt: number;
+  refreshedAt: number;
+}
+
+const jwksCache = new Map<string, JwksCacheEntry>();
+
+const defaultFetchJwks: JwksFetcher = async issuer => {
+  const url = `${issuer}/.well-known/jwks`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch JWKS from ${url}: HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as unknown;
+  if (
+    !json ||
+    typeof json !== 'object' ||
+    !Array.isArray((json as Jwks).keys)
+  ) {
+    throw new Error(`Invalid JWKS response from ${url}`);
+  }
+  return json as Jwks;
+};
+
+async function loadJwks(
+  issuer: string,
+  fetchJwks: JwksFetcher,
+  options: { force?: boolean } = {}
+): Promise<Jwks> {
+  const cached = jwksCache.get(issuer);
+  const now = Date.now();
+  if (
+    cached &&
+    !options.force &&
+    now - cached.fetchedAt < JWKS_DEFAULT_TTL_MS
+  ) {
+    return cached.jwks;
+  }
+  if (
+    cached &&
+    options.force &&
+    now - cached.refreshedAt < JWKS_MIN_REFRESH_INTERVAL_MS
+  ) {
+    return cached.jwks;
+  }
+  const jwks = await fetchJwks(issuer);
+  const fetchedAt = Date.now();
+  jwksCache.set(issuer, { jwks, fetchedAt, refreshedAt: fetchedAt });
+  return jwks;
+}
+
+async function findKey(
+  issuer: string,
+  kid: string,
+  fetchJwks: JwksFetcher
+): Promise<PublicJsonWebKey | null> {
+  let jwks = await loadJwks(issuer, fetchJwks);
+  let key = jwks.keys.find(k => k.kid === kid);
+  if (key) return key;
+  // Key not found: assume keys may have rotated and force a refresh.
+  jwks = await loadJwks(issuer, fetchJwks, { force: true });
+  key = jwks.keys.find(k => k.kid === kid);
+  return key ?? null;
+}
+
+function getSubtle(): SubtleCrypto {
+  const subtle = (globalThis as { crypto?: { subtle?: SubtleCrypto } }).crypto
+    ?.subtle;
+  if (!subtle) {
+    throw new Error(
+      'WebCrypto SubtleCrypto API is not available in this environment'
+    );
+  }
+  return subtle;
+}
+
+function base64UrlDecode(input: string): Uint8Array {
+  const b64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=');
+  if (typeof atob === 'function') {
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  // Node fallback (Node 16+ has atob globally, but be defensive).
+  return new Uint8Array(
+    (
+      globalThis as { Buffer?: { from(s: string, e: string): Uint8Array } }
+    ).Buffer!.from(padded, 'base64')
+  );
+}
+
+function utf8Decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+function utf8Encode(input: string): Uint8Array {
+  return new TextEncoder().encode(input);
+}
+
+interface DecodedJwt {
+  header: { alg?: unknown; kid?: unknown; typ?: unknown };
+  payload: VercelOidcTokenClaims;
+  signature: Uint8Array;
+  signedData: Uint8Array;
+}
+
+function decodeJwt(token: string): DecodedJwt {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('JWT must contain exactly three dot-separated segments');
+  }
+  const [headerB64, payloadB64, signatureB64] = parts;
+  let header: unknown;
+  let payload: unknown;
+  try {
+    header = JSON.parse(utf8Decode(base64UrlDecode(headerB64)));
+    payload = JSON.parse(utf8Decode(base64UrlDecode(payloadB64)));
+  } catch (error) {
+    const wrapped = new Error(
+      'JWT header or payload is not valid base64url JSON'
+    );
+    (wrapped as { cause?: unknown }).cause = error;
+    throw wrapped;
+  }
+  if (!header || typeof header !== 'object') {
+    throw new Error('JWT header is not an object');
+  }
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('JWT payload is not an object');
+  }
+  return {
+    header: header as DecodedJwt['header'],
+    payload: payload as VercelOidcTokenClaims,
+    signature: base64UrlDecode(signatureB64),
+    signedData: utf8Encode(`${headerB64}.${payloadB64}`),
+  };
+}
+
+async function verifyRs256Signature(
+  jwk: PublicJsonWebKey,
+  signedData: Uint8Array,
+  signature: Uint8Array
+): Promise<boolean> {
+  if (jwk.kty !== 'RSA') {
+    throw new Error(`Unsupported JWK key type "${jwk.kty}"; expected "RSA"`);
+  }
+  if (jwk.alg !== undefined && jwk.alg !== 'RS256') {
+    throw new Error(`Unsupported JWK algorithm "${jwk.alg}"; expected "RS256"`);
+  }
+  const subtle = getSubtle();
+  const algorithm = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' };
+  const cryptoKey = await subtle.importKey(
+    'jwk',
+    { ...jwk, alg: 'RS256', ext: true },
+    algorithm,
+    false,
+    ['verify']
+  );
+  return subtle.verify(
+    algorithm.name,
+    cryptoKey,
+    signature as BufferSource,
+    signedData as BufferSource
+  );
 }
 
 function isVercelIssuer(iss: string | undefined): iss is string {
@@ -193,20 +379,15 @@ function normalizeMatchers(
     : [matchers as VercelOidcTokenMatcher];
 }
 
-/**
- * Verifies the signature, expiration, and standard claims of a Vercel OIDC
- * token, then matches its claims against the provided matchers.
- *
- * @internal
- */
+type VerificationResult =
+  | { ok: true; claims: VercelOidcTokenClaims }
+  | { ok: false; reason: string; cause?: unknown };
+
 async function verifyAndMatch(
   matchers: VercelOidcTokenMatcher | ReadonlyArray<VercelOidcTokenMatcher>,
   token: string,
   options?: ValidateVercelOidcTokenOptions
-): Promise<
-  | { ok: true; claims: VercelOidcTokenClaims }
-  | { ok: false; reason: string; cause?: unknown }
-> {
+): Promise<VerificationResult> {
   if (typeof token !== 'string' || token.length === 0) {
     return { ok: false, reason: 'Token must be a non-empty string' };
   }
@@ -216,44 +397,88 @@ async function verifyAndMatch(
     return { ok: false, reason: 'At least one matcher is required' };
   }
 
-  let unverifiedClaims: VercelOidcTokenClaims;
+  let decoded: DecodedJwt;
   try {
-    unverifiedClaims = decodeJwt(token) as VercelOidcTokenClaims;
+    decoded = decodeJwt(token);
   } catch (error) {
     return { ok: false, reason: 'Token is not a valid JWT', cause: error };
   }
 
-  if (!isVercelIssuer(unverifiedClaims.iss)) {
+  const { header, payload, signature, signedData } = decoded;
+
+  if (header.alg !== 'RS256') {
     return {
       ok: false,
-      reason: `Token issuer "${unverifiedClaims.iss}" is not a valid Vercel OIDC issuer`,
+      reason: `Unsupported JWT algorithm "${String(header.alg)}"; expected "RS256"`,
     };
   }
+  if (typeof header.kid !== 'string' || header.kid.length === 0) {
+    return { ok: false, reason: 'JWT header is missing a "kid" property' };
+  }
 
-  const issuer = unverifiedClaims.iss;
-  const jwks = (options?.jwks ?? defaultJwksResolver)(issuer);
+  if (!isVercelIssuer(payload.iss)) {
+    return {
+      ok: false,
+      reason: `Token issuer "${String(payload.iss)}" is not a valid Vercel OIDC issuer`,
+    };
+  }
+  const issuer = payload.iss;
+  const fetchJwks = options?.fetchJwks ?? defaultFetchJwks;
 
-  let verified: VercelOidcTokenClaims;
+  let jwk: PublicJsonWebKey | null;
   try {
-    const result = await jwtVerify(token, jwks, {
-      issuer,
-      algorithms: ['RS256'],
-    });
-    verified = result.payload as VercelOidcTokenClaims;
+    jwk = await findKey(issuer, header.kid, fetchJwks);
   } catch (error) {
     return {
       ok: false,
       reason:
         error instanceof Error
-          ? `Token signature or claims could not be verified: ${error.message}`
-          : 'Token signature or claims could not be verified',
+          ? `Failed to load JWKS for ${issuer}: ${error.message}`
+          : `Failed to load JWKS for ${issuer}`,
       cause: error,
+    };
+  }
+  if (!jwk) {
+    return {
+      ok: false,
+      reason: `No key matching kid "${header.kid}" was found in JWKS for ${issuer}`,
+    };
+  }
+
+  let signatureValid: boolean;
+  try {
+    signatureValid = await verifyRs256Signature(jwk, signedData, signature);
+  } catch (error) {
+    return {
+      ok: false,
+      reason:
+        error instanceof Error
+          ? `Token signature could not be verified: ${error.message}`
+          : 'Token signature could not be verified',
+      cause: error,
+    };
+  }
+  if (!signatureValid) {
+    return { ok: false, reason: 'Token signature is invalid' };
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (typeof payload.exp !== 'number') {
+    return { ok: false, reason: 'Token is missing an "exp" claim' };
+  }
+  if (payload.exp <= nowSeconds) {
+    return { ok: false, reason: 'Token is expired' };
+  }
+  if (typeof payload.nbf === 'number' && payload.nbf > nowSeconds) {
+    return {
+      ok: false,
+      reason: 'Token is not yet valid (nbf is in the future)',
     };
   }
 
   for (const matcher of normalized) {
-    if (matcherMatches(matcher, verified)) {
-      return { ok: true, claims: verified };
+    if (matcherMatches(matcher, payload)) {
+      return { ok: true, claims: payload };
     }
   }
 
@@ -262,15 +487,15 @@ async function verifyAndMatch(
     reason:
       'Token claims did not match any of the provided matchers. ' +
       `Matched against claims: ${JSON.stringify({
-        iss: verified.iss,
-        aud: verified.aud,
-        sub: verified.sub,
-        owner: verified.owner,
-        owner_id: verified.owner_id,
-        project: verified.project,
-        project_id: verified.project_id,
-        environment: verified.environment,
-        user_id: verified.user_id,
+        iss: payload.iss,
+        aud: payload.aud,
+        sub: payload.sub,
+        owner: payload.owner,
+        owner_id: payload.owner_id,
+        project: payload.project,
+        project_id: payload.project_id,
+        environment: payload.environment,
+        user_id: payload.user_id,
       })}`,
   };
 }

--- a/packages/oidc/src/validate.ts
+++ b/packages/oidc/src/validate.ts
@@ -1,0 +1,337 @@
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  decodeJwt,
+  type JWTVerifyGetKey,
+  type JWTPayload,
+} from 'jose';
+
+/**
+ * The base issuer URL for Vercel OIDC tokens.
+ *
+ * In team issuer mode, the actual issuer is `https://oidc.vercel.com/[TEAM_SLUG]`.
+ */
+const VERCEL_OIDC_ISSUER_BASE = 'https://oidc.vercel.com';
+
+/**
+ * Claims emitted in a Vercel OIDC token.
+ *
+ * @see https://vercel.com/docs/oidc/reference#oidc-token-anatomy
+ */
+export interface VercelOidcTokenClaims extends JWTPayload {
+  /** Issuer. `https://oidc.vercel.com` (global) or `https://oidc.vercel.com/[TEAM_SLUG]` (team). */
+  iss?: string;
+  /** Audience. `https://vercel.com/[TEAM_SLUG]`. */
+  aud?: string | string[];
+  /** Subject. `owner:[TEAM_SLUG]:project:[PROJECT_NAME]:environment:[ENVIRONMENT]`. */
+  sub?: string;
+  /** Team slug (e.g. `acme`). */
+  owner?: string;
+  /** Team ID (e.g. `team_7Gw5...`). */
+  owner_id?: string;
+  /** Project name (e.g. `acme_website`). */
+  project?: string;
+  /** Project ID (e.g. `prj_7Gw5...`). */
+  project_id?: string;
+  /** Environment: `production`, `preview`, or `development`. */
+  environment?: string;
+  /** User ID. Only present when environment is `development`. */
+  user_id?: string;
+}
+
+/**
+ * A matcher used to validate the claims of a Vercel OIDC token.
+ *
+ * All non-`undefined` properties on a matcher must equal the corresponding claim
+ * on the token for the matcher to be considered a match. A token is accepted if
+ * it matches at least one of the provided matchers.
+ *
+ * Both friendly aliases (e.g. `team`, `teamId`, `projectId`, `userId`) and the
+ * raw OIDC claim names (e.g. `owner`, `owner_id`, `project_id`, `user_id`) are
+ * supported. When both are provided on the same matcher, both must match.
+ */
+export interface VercelOidcTokenMatcher {
+  /** Matches the `iss` claim. */
+  iss?: string;
+  /** Matches the `aud` claim. */
+  aud?: string;
+  /** Matches the `sub` claim. */
+  sub?: string;
+  /** Matches the `owner` claim (the team slug). Alias for `owner`. */
+  team?: string;
+  /** Matches the `owner` claim (the team slug). */
+  owner?: string;
+  /** Matches the `owner_id` claim (the team ID). Alias for `owner_id`. */
+  teamId?: string;
+  /** Matches the `owner_id` claim (the team ID). */
+  owner_id?: string;
+  /** Matches the `project` claim (the project name). */
+  project?: string;
+  /** Matches the `project_id` claim (the project ID). Alias for `project_id`. */
+  projectId?: string;
+  /** Matches the `project_id` claim (the project ID). */
+  project_id?: string;
+  /** Matches the `environment` claim. */
+  environment?: 'production' | 'preview' | 'development' | (string & {});
+  /** Matches the `user_id` claim. Alias for `user_id`. */
+  userId?: string;
+  /** Matches the `user_id` claim. */
+  user_id?: string;
+}
+
+/**
+ * Thrown by {@link assertValidVercelOidcToken} when a token cannot be accepted.
+ */
+export class UnacceptableVercelOidcTokenError extends Error {
+  cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'UnacceptableVercelOidcTokenError';
+    this.cause = cause;
+  }
+
+  override toString() {
+    if (this.cause) {
+      return `${this.name}: ${this.message}: ${this.cause}`;
+    }
+    return `${this.name}: ${this.message}`;
+  }
+}
+
+/**
+ * The signature of a function used to fetch the JSON Web Key Set for a given
+ * issuer. Useful for testing or when you want to provide your own caching layer.
+ *
+ * @internal
+ */
+export type JwksResolver = (issuer: string) => JWTVerifyGetKey;
+
+const defaultJwksCache = new Map<string, JWTVerifyGetKey>();
+
+const defaultJwksResolver: JwksResolver = issuer => {
+  let jwks = defaultJwksCache.get(issuer);
+  if (!jwks) {
+    jwks = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks`));
+    defaultJwksCache.set(issuer, jwks);
+  }
+  return jwks;
+};
+
+/**
+ * @internal
+ */
+export interface ValidateVercelOidcTokenOptions {
+  /**
+   * Function used to resolve the JWKS for a given issuer. Defaults to a
+   * function that fetches the JWKS from `${issuer}/.well-known/jwks`.
+   *
+   * Mainly useful for testing.
+   *
+   * @internal
+   */
+  jwks?: JwksResolver;
+}
+
+function isVercelIssuer(iss: string | undefined): iss is string {
+  if (typeof iss !== 'string') return false;
+  if (iss === VERCEL_OIDC_ISSUER_BASE) return true;
+  if (!iss.startsWith(`${VERCEL_OIDC_ISSUER_BASE}/`)) return false;
+  // Make sure the path component looks like a team slug and not e.g. a path
+  // traversal attack: `https://oidc.vercel.com/../evil.com`.
+  const remainder = iss.slice(`${VERCEL_OIDC_ISSUER_BASE}/`.length);
+  return /^[A-Za-z0-9_-]+$/.test(remainder);
+}
+
+const matcherClaimMap: ReadonlyArray<
+  [keyof VercelOidcTokenMatcher, keyof VercelOidcTokenClaims]
+> = [
+  ['iss', 'iss'],
+  ['aud', 'aud'],
+  ['sub', 'sub'],
+  ['team', 'owner'],
+  ['owner', 'owner'],
+  ['teamId', 'owner_id'],
+  ['owner_id', 'owner_id'],
+  ['project', 'project'],
+  ['projectId', 'project_id'],
+  ['project_id', 'project_id'],
+  ['environment', 'environment'],
+  ['userId', 'user_id'],
+  ['user_id', 'user_id'],
+];
+
+function claimMatchesValue(claim: unknown, expected: string): boolean {
+  if (typeof claim === 'string') {
+    return claim === expected;
+  }
+  if (Array.isArray(claim)) {
+    return claim.some(v => v === expected);
+  }
+  return false;
+}
+
+function matcherMatches(
+  matcher: VercelOidcTokenMatcher,
+  claims: VercelOidcTokenClaims
+): boolean {
+  for (const [matcherKey, claimKey] of matcherClaimMap) {
+    const expected = matcher[matcherKey];
+    if (expected === undefined) continue;
+    if (!claimMatchesValue(claims[claimKey], expected)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function normalizeMatchers(
+  matchers: VercelOidcTokenMatcher | ReadonlyArray<VercelOidcTokenMatcher>
+): ReadonlyArray<VercelOidcTokenMatcher> {
+  return Array.isArray(matchers)
+    ? matchers
+    : [matchers as VercelOidcTokenMatcher];
+}
+
+/**
+ * Verifies the signature, expiration, and standard claims of a Vercel OIDC
+ * token, then matches its claims against the provided matchers.
+ *
+ * @internal
+ */
+async function verifyAndMatch(
+  matchers: VercelOidcTokenMatcher | ReadonlyArray<VercelOidcTokenMatcher>,
+  token: string,
+  options?: ValidateVercelOidcTokenOptions
+): Promise<
+  | { ok: true; claims: VercelOidcTokenClaims }
+  | { ok: false; reason: string; cause?: unknown }
+> {
+  if (typeof token !== 'string' || token.length === 0) {
+    return { ok: false, reason: 'Token must be a non-empty string' };
+  }
+
+  const normalized = normalizeMatchers(matchers);
+  if (normalized.length === 0) {
+    return { ok: false, reason: 'At least one matcher is required' };
+  }
+
+  let unverifiedClaims: VercelOidcTokenClaims;
+  try {
+    unverifiedClaims = decodeJwt(token) as VercelOidcTokenClaims;
+  } catch (error) {
+    return { ok: false, reason: 'Token is not a valid JWT', cause: error };
+  }
+
+  if (!isVercelIssuer(unverifiedClaims.iss)) {
+    return {
+      ok: false,
+      reason: `Token issuer "${unverifiedClaims.iss}" is not a valid Vercel OIDC issuer`,
+    };
+  }
+
+  const issuer = unverifiedClaims.iss;
+  const jwks = (options?.jwks ?? defaultJwksResolver)(issuer);
+
+  let verified: VercelOidcTokenClaims;
+  try {
+    const result = await jwtVerify(token, jwks, {
+      issuer,
+      algorithms: ['RS256'],
+    });
+    verified = result.payload as VercelOidcTokenClaims;
+  } catch (error) {
+    return {
+      ok: false,
+      reason:
+        error instanceof Error
+          ? `Token signature or claims could not be verified: ${error.message}`
+          : 'Token signature or claims could not be verified',
+      cause: error,
+    };
+  }
+
+  for (const matcher of normalized) {
+    if (matcherMatches(matcher, verified)) {
+      return { ok: true, claims: verified };
+    }
+  }
+
+  return {
+    ok: false,
+    reason:
+      'Token claims did not match any of the provided matchers. ' +
+      `Matched against claims: ${JSON.stringify({
+        iss: verified.iss,
+        aud: verified.aud,
+        sub: verified.sub,
+        owner: verified.owner,
+        owner_id: verified.owner_id,
+        project: verified.project,
+        project_id: verified.project_id,
+        environment: verified.environment,
+        user_id: verified.user_id,
+      })}`,
+  };
+}
+
+/**
+ * Returns `true` if the given Vercel OIDC token has a valid signature, has not
+ * expired, and matches at least one of the provided matchers; otherwise
+ * `false`.
+ *
+ * The token's signature is verified against the JSON Web Key Set served by the
+ * issuer (either `https://oidc.vercel.com` or `https://oidc.vercel.com/[TEAM_SLUG]`).
+ *
+ * @example
+ * ```ts
+ * import { isValidVercelOidcToken } from '@vercel/oidc';
+ *
+ * const ok = await isValidVercelOidcToken(
+ *   [
+ *     { team: 'vercel', project: 'vercel-alerts', environment: 'production' },
+ *     { team: 'vercel-labs', project: 'oidc-trigger', environment: 'preview' },
+ *   ],
+ *   token
+ * );
+ * ```
+ */
+export async function isValidVercelOidcToken(
+  matchers: VercelOidcTokenMatcher | ReadonlyArray<VercelOidcTokenMatcher>,
+  token: string,
+  options?: ValidateVercelOidcTokenOptions
+): Promise<boolean> {
+  const result = await verifyAndMatch(matchers, token, options);
+  return result.ok;
+}
+
+/**
+ * Verifies the signature and claims of a Vercel OIDC token and asserts that it
+ * matches at least one of the provided matchers. Throws
+ * {@link UnacceptableVercelOidcTokenError} if the token cannot be verified or
+ * does not match any of the matchers.
+ *
+ * @example
+ * ```ts
+ * import { assertValidVercelOidcToken } from '@vercel/oidc';
+ *
+ * await assertValidVercelOidcToken(
+ *   [
+ *     { team: 'vercel', project: 'vercel-alerts', environment: 'production' },
+ *   ],
+ *   token
+ * );
+ * ```
+ *
+ * @throws {UnacceptableVercelOidcTokenError} If the token is not valid.
+ */
+export async function assertValidVercelOidcToken(
+  matchers: VercelOidcTokenMatcher | ReadonlyArray<VercelOidcTokenMatcher>,
+  token: string,
+  options?: ValidateVercelOidcTokenOptions
+): Promise<void> {
+  const result = await verifyAndMatch(matchers, token, options);
+  if (!result.ok) {
+    throw new UnacceptableVercelOidcTokenError(result.reason, result.cause);
+  }
+}

--- a/packages/oidc/src/validate.ts
+++ b/packages/oidc/src/validate.ts
@@ -1,15 +1,20 @@
+import {
+  decodeJwt,
+  defaultFetchJwks,
+  findJwksKey,
+  verifyRs256Signature,
+  type DecodedJwt,
+  type Jwks,
+  type JwksFetcher,
+  type PublicJsonWebKey,
+} from './jwt';
+
 /**
  * The base issuer URL for Vercel OIDC tokens.
  *
  * In team issuer mode, the actual issuer is `https://oidc.vercel.com/[TEAM_SLUG]`.
  */
 const VERCEL_OIDC_ISSUER_BASE = 'https://oidc.vercel.com';
-
-/** Default time-to-live for cached JWKS responses. */
-const JWKS_DEFAULT_TTL_MS = 10 * 60 * 1000;
-
-/** Minimum delay between forced JWKS refreshes when an unknown `kid` is encountered. */
-const JWKS_MIN_REFRESH_INTERVAL_MS = 30 * 1000;
 
 /**
  * Claims emitted in a Vercel OIDC token.
@@ -106,34 +111,9 @@ export class UnacceptableVercelOidcTokenError extends Error {
 }
 
 /**
- * A JSON Web Key.
- *
- * Only the fields used during signature verification are listed here; other
- * fields described by RFC 7517 are accepted but ignored.
+ * Re-exported from `./jwt` for convenience.
  */
-interface PublicJsonWebKey {
-  kty: string;
-  kid?: string;
-  alg?: string;
-  use?: string;
-  n?: string;
-  e?: string;
-  [key: string]: unknown;
-}
-
-/** A JSON Web Key Set as returned by `${issuer}/.well-known/jwks`. */
-export interface Jwks {
-  keys: PublicJsonWebKey[];
-}
-
-/**
- * A function that fetches the JSON Web Key Set for a given issuer. Useful for
- * tests and for applications that want to provide their own caching, retry, or
- * proxying layer.
- *
- * @internal
- */
-export type JwksFetcher = (issuer: string) => Promise<Jwks>;
+export type { Jwks, JwksFetcher };
 
 /**
  * @internal
@@ -148,178 +128,7 @@ export interface ValidateVercelOidcTokenOptions {
   fetchJwks?: JwksFetcher;
 }
 
-interface JwksCacheEntry {
-  jwks: Jwks;
-  fetchedAt: number;
-  refreshedAt: number;
-}
-
-const jwksCache = new Map<string, JwksCacheEntry>();
-
-const defaultFetchJwks: JwksFetcher = async issuer => {
-  const url = `${issuer}/.well-known/jwks`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`Failed to fetch JWKS from ${url}: HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as unknown;
-  if (
-    !json ||
-    typeof json !== 'object' ||
-    !Array.isArray((json as Jwks).keys)
-  ) {
-    throw new Error(`Invalid JWKS response from ${url}`);
-  }
-  return json as Jwks;
-};
-
-async function loadJwks(
-  issuer: string,
-  fetchJwks: JwksFetcher,
-  options: { force?: boolean } = {}
-): Promise<Jwks> {
-  const cached = jwksCache.get(issuer);
-  const now = Date.now();
-  if (
-    cached &&
-    !options.force &&
-    now - cached.fetchedAt < JWKS_DEFAULT_TTL_MS
-  ) {
-    return cached.jwks;
-  }
-  if (
-    cached &&
-    options.force &&
-    now - cached.refreshedAt < JWKS_MIN_REFRESH_INTERVAL_MS
-  ) {
-    return cached.jwks;
-  }
-  const jwks = await fetchJwks(issuer);
-  const fetchedAt = Date.now();
-  jwksCache.set(issuer, { jwks, fetchedAt, refreshedAt: fetchedAt });
-  return jwks;
-}
-
-async function findKey(
-  issuer: string,
-  kid: string,
-  fetchJwks: JwksFetcher
-): Promise<PublicJsonWebKey | null> {
-  let jwks = await loadJwks(issuer, fetchJwks);
-  let key = jwks.keys.find(k => k.kid === kid);
-  if (key) return key;
-  // Key not found: assume keys may have rotated and force a refresh.
-  jwks = await loadJwks(issuer, fetchJwks, { force: true });
-  key = jwks.keys.find(k => k.kid === kid);
-  return key ?? null;
-}
-
-function getSubtle(): SubtleCrypto {
-  const subtle = (globalThis as { crypto?: { subtle?: SubtleCrypto } }).crypto
-    ?.subtle;
-  if (!subtle) {
-    throw new Error(
-      'WebCrypto SubtleCrypto API is not available in this environment'
-    );
-  }
-  return subtle;
-}
-
-function base64UrlDecode(input: string): Uint8Array {
-  const b64 = input.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=');
-  if (typeof atob === 'function') {
-    const binary = atob(padded);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-      bytes[i] = binary.charCodeAt(i);
-    }
-    return bytes;
-  }
-  // Node fallback (Node 16+ has atob globally, but be defensive).
-  return new Uint8Array(
-    (
-      globalThis as { Buffer?: { from(s: string, e: string): Uint8Array } }
-    ).Buffer!.from(padded, 'base64')
-  );
-}
-
-function utf8Decode(bytes: Uint8Array): string {
-  return new TextDecoder().decode(bytes);
-}
-
-function utf8Encode(input: string): Uint8Array {
-  return new TextEncoder().encode(input);
-}
-
-interface DecodedJwt {
-  header: { alg?: unknown; kid?: unknown; typ?: unknown };
-  payload: VercelOidcTokenClaims;
-  signature: Uint8Array;
-  signedData: Uint8Array;
-}
-
-function decodeJwt(token: string): DecodedJwt {
-  const parts = token.split('.');
-  if (parts.length !== 3) {
-    throw new Error('JWT must contain exactly three dot-separated segments');
-  }
-  const [headerB64, payloadB64, signatureB64] = parts;
-  let header: unknown;
-  let payload: unknown;
-  try {
-    header = JSON.parse(utf8Decode(base64UrlDecode(headerB64)));
-    payload = JSON.parse(utf8Decode(base64UrlDecode(payloadB64)));
-  } catch (error) {
-    const wrapped = new Error(
-      'JWT header or payload is not valid base64url JSON'
-    );
-    (wrapped as { cause?: unknown }).cause = error;
-    throw wrapped;
-  }
-  if (!header || typeof header !== 'object') {
-    throw new Error('JWT header is not an object');
-  }
-  if (!payload || typeof payload !== 'object') {
-    throw new Error('JWT payload is not an object');
-  }
-  return {
-    header: header as DecodedJwt['header'],
-    payload: payload as VercelOidcTokenClaims,
-    signature: base64UrlDecode(signatureB64),
-    signedData: utf8Encode(`${headerB64}.${payloadB64}`),
-  };
-}
-
-async function verifyRs256Signature(
-  jwk: PublicJsonWebKey,
-  signedData: Uint8Array,
-  signature: Uint8Array
-): Promise<boolean> {
-  if (jwk.kty !== 'RSA') {
-    throw new Error(`Unsupported JWK key type "${jwk.kty}"; expected "RSA"`);
-  }
-  if (jwk.alg !== undefined && jwk.alg !== 'RS256') {
-    throw new Error(`Unsupported JWK algorithm "${jwk.alg}"; expected "RS256"`);
-  }
-  const subtle = getSubtle();
-  const algorithm = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' };
-  const cryptoKey = await subtle.importKey(
-    'jwk',
-    { ...jwk, alg: 'RS256', ext: true },
-    algorithm,
-    false,
-    ['verify']
-  );
-  return subtle.verify(
-    algorithm.name,
-    cryptoKey,
-    signature as BufferSource,
-    signedData as BufferSource
-  );
-}
-
-function isVercelIssuer(iss: string | undefined): iss is string {
+function isVercelIssuer(iss: unknown): iss is string {
   if (typeof iss !== 'string') return false;
   if (iss === VERCEL_OIDC_ISSUER_BASE) return true;
   if (!iss.startsWith(`${VERCEL_OIDC_ISSUER_BASE}/`)) return false;
@@ -405,6 +214,7 @@ async function verifyAndMatch(
   }
 
   const { header, payload, signature, signedData } = decoded;
+  const claims = payload as VercelOidcTokenClaims;
 
   if (header.alg !== 'RS256') {
     return {
@@ -416,18 +226,18 @@ async function verifyAndMatch(
     return { ok: false, reason: 'JWT header is missing a "kid" property' };
   }
 
-  if (!isVercelIssuer(payload.iss)) {
+  if (!isVercelIssuer(claims.iss)) {
     return {
       ok: false,
-      reason: `Token issuer "${String(payload.iss)}" is not a valid Vercel OIDC issuer`,
+      reason: `Token issuer "${String(claims.iss)}" is not a valid Vercel OIDC issuer`,
     };
   }
-  const issuer = payload.iss;
+  const issuer = claims.iss;
   const fetchJwks = options?.fetchJwks ?? defaultFetchJwks;
 
   let jwk: PublicJsonWebKey | null;
   try {
-    jwk = await findKey(issuer, header.kid, fetchJwks);
+    jwk = await findJwksKey(issuer, header.kid, fetchJwks);
   } catch (error) {
     return {
       ok: false,
@@ -463,13 +273,13 @@ async function verifyAndMatch(
   }
 
   const nowSeconds = Math.floor(Date.now() / 1000);
-  if (typeof payload.exp !== 'number') {
+  if (typeof claims.exp !== 'number') {
     return { ok: false, reason: 'Token is missing an "exp" claim' };
   }
-  if (payload.exp <= nowSeconds) {
+  if (claims.exp <= nowSeconds) {
     return { ok: false, reason: 'Token is expired' };
   }
-  if (typeof payload.nbf === 'number' && payload.nbf > nowSeconds) {
+  if (typeof claims.nbf === 'number' && claims.nbf > nowSeconds) {
     return {
       ok: false,
       reason: 'Token is not yet valid (nbf is in the future)',
@@ -477,8 +287,8 @@ async function verifyAndMatch(
   }
 
   for (const matcher of normalized) {
-    if (matcherMatches(matcher, payload)) {
-      return { ok: true, claims: payload };
+    if (matcherMatches(matcher, claims)) {
+      return { ok: true, claims };
     }
   }
 
@@ -487,15 +297,15 @@ async function verifyAndMatch(
     reason:
       'Token claims did not match any of the provided matchers. ' +
       `Matched against claims: ${JSON.stringify({
-        iss: payload.iss,
-        aud: payload.aud,
-        sub: payload.sub,
-        owner: payload.owner,
-        owner_id: payload.owner_id,
-        project: payload.project,
-        project_id: payload.project_id,
-        environment: payload.environment,
-        user_id: payload.user_id,
+        iss: claims.iss,
+        aud: claims.aud,
+        sub: claims.sub,
+        owner: claims.owner,
+        owner_id: claims.owner_id,
+        project: claims.project,
+        project_id: claims.project_id,
+        environment: claims.environment,
+        user_id: claims.user_id,
       })}`,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1894,6 +1894,10 @@ importers:
         version: 2.1.4(@edge-runtime/vm@3.2.0)(@types/node@20.11.0)
 
   packages/oidc:
+    dependencies:
+      jose:
+        specifier: 5.9.6
+        version: 5.9.6
     devDependencies:
       prettier:
         specifier: 3.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1894,11 +1894,10 @@ importers:
         version: 2.1.4(@edge-runtime/vm@3.2.0)(@types/node@20.11.0)
 
   packages/oidc:
-    dependencies:
+    devDependencies:
       jose:
         specifier: 5.9.6
         version: 5.9.6
-    devDependencies:
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -15245,7 +15244,6 @@ packages:
 
   /jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
-    dev: false
 
   /jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `isValidVercelOidcToken` and `assertValidVercelOidcToken` helpers to `@vercel/oidc` for verifying the signature, expiration, and claims of a Vercel OIDC token against one or more matchers. Closes IAM-6886.

```ts
import { isValidVercelOidcToken, assertValidVercelOidcToken } from '@vercel/oidc';

await assertValidVercelOidcToken(
  [
    { team: 'vercel',       project: 'vercel-alerts', environment: 'production' },
    { team: 'vercel-labs',  project: 'oidc-trigger',  environment: 'preview'    },
  ],
  token,
);
```

## What's added

- **`isValidVercelOidcToken(matchers, token): Promise<boolean>`** &mdash; returns `true` if the token has a valid signature (verified against the issuer's JWKS), has not expired, and matches at least one matcher; otherwise `false`.
- **`assertValidVercelOidcToken(matchers, token): Promise<void>`** &mdash; same as above but throws `UnacceptableVercelOidcTokenError` when the token cannot be accepted.
- **`UnacceptableVercelOidcTokenError`** &mdash; thrown by `assertValidVercelOidcToken` when no matcher applies or the token cannot be verified.
- **`VercelOidcTokenMatcher`** &mdash; supports every claim documented at https://vercel.com/docs/oidc/reference#oidc-token-anatomy:
  - `iss`, `aud`, `sub`
  - `team` / `owner` (team slug)
  - `teamId` / `owner_id` (team ID, `team_*`)
  - `project` (project name)
  - `projectId` / `project_id` (project ID, `prj_*`)
  - `environment` (`production`, `preview`, `development`)
  - `userId` / `user_id` (only set in `development`)
- A single matcher may also be passed without wrapping it in an array.

## Files

- `packages/oidc/src/jwt.ts` &mdash; generic JWT/JWKS helpers (no Vercel knowledge): `decodeJwt`, `verifyRs256Signature`, `findJwksKey`, `defaultFetchJwks`, plus the per-issuer JWKS cache.
- `packages/oidc/src/validate.ts` &mdash; Vercel-specific layer: issuer check, matcher type, error class, and the two public functions.
- `packages/oidc/src/jwt.test.ts` &mdash; 13 unit tests for the generic helpers.
- `packages/oidc/src/validate.test.ts` &mdash; 64 tests for the public API, including exhaustive per-property matcher coverage.

## Implementation notes

- **No runtime dependencies.** Uses the platform `SubtleCrypto` and `fetch` APIs, both of which are global in Node 20+ (the package's minimum) and in browsers (the package's existing browser export).
- JWT decode does base64url decode + JSON parse; signature verification calls `subtle.importKey('jwk', ...)` followed by `subtle.verify('RSASSA-PKCS1-v1_5', ...)`.
- The JWT header's `alg` is required to be exactly `RS256`. `alg: none`, `HS*`, or any other algorithm is rejected before any further processing &mdash; this prevents algorithm-confusion attacks.
- The `iss` claim is required to be `https://oidc.vercel.com` or `https://oidc.vercel.com/[TEAM_SLUG]` (with a strict `[A-Za-z0-9_-]+` slug regex) **before** any JWKS network request is made, so a malicious token cannot trick the verifier into fetching keys from an arbitrary URL.
- JWKS is fetched from `${iss}/.well-known/jwks` and cached per issuer with a 10-minute TTL. If the requested `kid` is not in the cached set, the JWKS is force-refreshed once (rate-limited to one forced refresh per 30 seconds) to handle key rotation.
- `jose` is kept only as a `devDependency` because it makes generating fixture keypairs and signing test tokens much easier than rolling that ourselves.
- Exported from both the Node and browser entry points.

## Tests

77 new tests across two files, 112 total in the package, all passing:

- **`validate.test.ts` (64)** &mdash; happy path, expired tokens, wrong signing key, **tampered payloads**, **`alg: none`**, **non-RS256 algorithms**, **unknown kid**, untrusted issuer (no JWKS fetch attempted), team-mode issuer, malformed/empty tokens, single-matcher input, the new error class, **plus a parameterized "every matcher property" sweep** that for each of the 14 supported matcher properties (`iss`, `aud`, `sub`, `team`, `owner`, `teamId`, `owner_id`, `project`, `projectId`, `project_id`, `environment`, `userId`, `user_id`) asserts: accepts when the claim matches, rejects when the claim differs, and rejects when the claim is absent. Also includes a "single property wrong, rest correct → reject" test that fills in every supported property and an "alias + raw claim must agree on the same matcher" test.
- **`jwt.test.ts` (13)** &mdash; JWT decode happy path + malformed input, RS256 verify happy path + wrong key + non-RSA JWK + non-RS256 alg, key lookup happy path + missing kid + cache hit + key rotation forces refresh + forced-refresh rate limit + fetcher error propagation.

I also smoke-tested the live JWKS endpoint by hand: building the package and calling `assertValidVercelOidcToken` with a forged `kid` against `https://oidc.vercel.com` returns the expected `No key matching kid "..." was found in JWKS for ...` error, confirming the JWKS fetch and parse path works against the real issuer.

## Changeset

Included as `@vercel/oidc: minor`.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IAM-6886](https://linear.app/vercel/issue/IAM-6886/request-for-vercel-oidc-token-validation-helpers)

<div><a href="https://cursor.com/agents/bc-8300ba33-260c-449a-9c01-e6f410cd2c2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8300ba33-260c-449a-9c01-e6f410cd2c2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

