### PR TITLE
[python] cold start improvements

### DIFF
--- a/.changeset/itchy-snails-share.md
+++ b/.changeset/itchy-snails-share.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python-runtime': patch
+'@vercel/python': patch
+---
+
+minor performance improvements

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -32,6 +32,32 @@ import { detectTargetPlatform } from './platform-info';
 
 const readFile = promisify(fs.readFile);
 
+/**
+ * Files that are never needed at runtime and can be safely stripped from the
+ * vendor directory to reduce bundle size:
+ *
+ * - `*.pyi`          – type stubs for static type checkers
+ * - `py.typed`       – PEP 561 marker for typed packages
+ * - `WHEEL`          – wheel format metadata (installer use only)
+ * - `INSTALLER`      – records which tool installed the package
+ * - `direct_url.json`– PEP 610 install provenance
+ */
+const STRIP_BASENAMES = new Set([
+  'py.typed',
+  'WHEEL',
+  'INSTALLER',
+  'direct_url.json',
+]);
+
+function shouldStripVendorFile(filePath: string): boolean {
+  const segments = filePath.split(sep);
+  if (segments.includes('__pycache__')) return true;
+  const name = segments[segments.length - 1] ?? '';
+  if (name.endsWith('.pyc') || name.endsWith('.pyi')) return true;
+  if (STRIP_BASENAMES.has(name)) return true;
+  return false;
+}
+
 // AWS Lambda uncompressed size limit is 250MB, but we use 245MB to leave room for Lambda layers
 export const LAMBDA_SIZE_THRESHOLD_BYTES = 245 * 1024 * 1024;
 
@@ -744,10 +770,7 @@ export class PythonDependencyExternalizer {
           if (!resolve(resolvedDir, filePath).startsWith(dirPrefix)) {
             continue;
           }
-          if (
-            filePath.endsWith('.pyc') ||
-            filePath.split(sep).includes('__pycache__')
-          ) {
+          if (shouldStripVendorFile(filePath)) {
             continue;
           }
           const srcFsPath = join(dir, filePath);
@@ -831,11 +854,7 @@ export class PythonDependencyExternalizer {
           if (!resolve(resolvedDir, filePath).startsWith(dirPrefix)) {
             continue;
           }
-          // Skip .pyc and __pycache__
-          if (
-            filePath.endsWith('.pyc') ||
-            filePath.split(sep).includes('__pycache__')
-          ) {
+          if (shouldStripVendorFile(filePath)) {
             continue;
           }
 

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -802,6 +802,9 @@ from vercel_runtime.vc_init import vc_handler
 
   const lambdaEnv = {} as Record<string, string>;
   lambdaEnv.PYTHONPATH = vendorDir;
+  // Lambda uses a read-only filesystem; skip .pyc generation to avoid
+  // wasted syscalls on every import.
+  lambdaEnv.PYTHONDONTWRITEBYTECODE = '1';
   Object.assign(lambdaEnv, quirksResult.env);
   if (shouldInstallVercelWorkers) {
     lambdaEnv.VERCEL_HAS_WORKER_SERVICES = '1';

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -438,6 +438,9 @@ if os.path.exists(_runtime_config_path):
                     "PATH": os.environ.get("PATH", ""),
                     "VIRTUAL_ENV": _deps_dir,
                     "UV_PYTHON_DOWNLOADS": "never",
+                    # Skip writing INSTALLER, REQUESTED, and
+                    # direct_url.json — they are never read at runtime.
+                    "UV_NO_INSTALLER_METADATA": "1",
                 },
             )
             _install_duration = time.time() - _install_start


### PR DESCRIPTION
Some minor improvements for bundle efficiency and cold start times:

- new func `shouldStripVendorFile` to prevent unused files from being shipped in the function bundle
- `PYTHONDONTWRITEBYTECODE=1` - deployment env is a read only filesystem
- `UV_NO_INSTALLER_METADATA=1` - skip writing uv installer metadata files to site-packages