### PR TITLE
[cli] Suppress metrics JSON status output

### DIFF
--- a/.changeset/quiet-json-metrics.md
+++ b/.changeset/quiet-json-metrics.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Suppress metrics query status output when using `--format=json`.

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -241,7 +241,7 @@ export default async function query(
   // too fine for the time range (granResult.adjusted will be true in that case).
   const rangeMs = endTime.getTime() - startTime.getTime();
   const granResult = computeGranularity(rangeMs, granularity);
-  if (granResult.adjusted && granResult.notice) {
+  if (!jsonOutput && granResult.adjusted && granResult.notice) {
     output.log(`Notice: ${granResult.notice}`);
   }
 
@@ -266,7 +266,9 @@ export default async function query(
     limit: limit ?? 10,
   };
 
-  output.spinner('Querying metrics...');
+  if (!jsonOutput) {
+    output.spinner('Querying metrics...');
+  }
   let response: MetricsQueryResponse;
   try {
     response = await client.fetch<MetricsQueryResponse>(
@@ -291,7 +293,9 @@ export default async function query(
     }
     return 1;
   } finally {
-    output.stopSpinner();
+    if (!jsonOutput) {
+      output.stopSpinner();
+    }
   }
 
   // Format and output

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -609,6 +609,31 @@ describe('metrics query v2', () => {
       expect(parsed.data).toHaveLength(1);
       expect(parsed.summary).toHaveLength(1);
       expect(parsed.statistics).toBeDefined();
+      expect(client.stderr.getFullOutput()).toBe('');
+    });
+
+    it('should stay quiet on stderr when JSON output adjusts granularity', async () => {
+      mockMetricDetail();
+      mockApiSuccess();
+      client.setArgv(
+        'metrics',
+        'vercel.request.count',
+        '--format=json',
+        '--since',
+        '2025-01-01T00:00:00Z',
+        '--until',
+        '2025-01-10T00:00:00Z',
+        '--granularity',
+        '1m'
+      );
+
+      const exitCode = await query(client, new MockTelemetry());
+
+      expect(exitCode).toBe(0);
+      const output = client.stdout.getFullOutput();
+      const parsed = JSON.parse(output);
+      expect(parsed.query.granularity).toEqual({ hours: 4 });
+      expect(client.stderr.getFullOutput()).toBe('');
     });
   });
 


### PR DESCRIPTION
## Summary
- suppress human-readable metrics query status output when using `--format=json`
- keep text-mode spinner and granularity notices unchanged
- add JSON-mode coverage that stderr remains empty, including adjusted granularity

## Validation
- `npx vitest run packages/cli/test/unit/commands/metrics/*.test.ts`