### PR TITLE
[build-utils] Further improve validateFrameworkVersion

### DIFF
--- a/.changeset/dull-tools-wink.md
+++ b/.changeset/dull-tools-wink.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Further improve validateFrameworkVersion

--- a/packages/build-utils/src/deserialize/validate-framework-version.ts
+++ b/packages/build-utils/src/deserialize/validate-framework-version.ts
@@ -11,21 +11,22 @@ const MAX_FRAMEWORK_VERSION_LENGTH = 50;
 export function validateFrameworkVersion(
   framework: FrameworkMeta | undefined
 ): FrameworkMeta | undefined {
-  if (!framework) {
+  if (!framework || !framework.slug || !framework.version) {
     return undefined;
   }
 
   const { slug, version } = framework;
 
   if (typeof slug !== 'string') {
-    // Ideally this would throw, but slug is a new field and there might be some users that don't
-    // emit it yet.
-    return undefined;
+    throw new NowBuildError({
+      message: `Invalid config.json: "framework.slug" type "${typeof slug}" should be "string"`,
+      code: 'VC_BUILD_INVALID_CONFIG_JSON_FRAMEWORK_SLUG_TYPE',
+    });
   }
 
   if (typeof version !== 'string') {
     throw new NowBuildError({
-      message: `Invalid config.json: "version" type "${typeof version}" should be "string"`,
+      message: `Invalid config.json: "framework.version" type "${typeof version}" should be "string"`,
       code: 'VC_BUILD_INVALID_CONFIG_JSON_FRAMEWORK_VERSION_TYPE',
     });
   }

--- a/packages/build-utils/test/unit.validate-framework-version.test.ts
+++ b/packages/build-utils/test/unit.validate-framework-version.test.ts
@@ -1,0 +1,79 @@
+import assert from 'assert';
+import { validateFrameworkVersion } from '../src';
+import { describe, it } from 'vitest';
+
+describe('validateFrameworkVersion', () => {
+  it('returns undefined if empty', () => {
+    const framework = validateFrameworkVersion(undefined);
+    assert.strictEqual(framework, undefined);
+  });
+
+  it('returns undefined if missing slug', () => {
+    // @ts-expect-error - deliberately testing invalid value
+    const frameworkRaw: { slug: string; version: string } = {};
+    const framework = validateFrameworkVersion(frameworkRaw);
+    assert.strictEqual(framework, undefined);
+  });
+
+  it('returns undefined if missing version', () => {
+    // @ts-expect-error - deliberately testing invalid value
+    const frameworkRaw: { slug: string; version: string } = {
+      slug: 'foo',
+    };
+    const framework = validateFrameworkVersion(frameworkRaw);
+    assert.strictEqual(framework, undefined);
+  });
+
+  it('throws error if "slug" is not a string', () => {
+    const frameworkVersionRaw: { slug: string; version: string } = {
+      slug: 123 as any,
+      version: '1.0.0',
+    };
+    assert.throws(() => {
+      validateFrameworkVersion(frameworkVersionRaw);
+    }, /Invalid config.json: "framework.slug" type/);
+  });
+
+  it('throws if "slug" is too long', () => {
+    const frameworkVersionRaw = {
+      // too long
+      version: 'foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo',
+      slug: '123',
+    };
+
+    assert.throws(() => {
+      validateFrameworkVersion(frameworkVersionRaw);
+    }, /Invalid config.json: "framework.version" length/);
+  });
+
+  it('throws error if "version" is not a string', () => {
+    const frameworkVersionRaw: { slug: string; version: string } = {
+      slug: 'foo',
+      version: 123 as any,
+    };
+    assert.throws(() => {
+      validateFrameworkVersion(frameworkVersionRaw);
+    }, /Invalid config.json: "framework.version" type/);
+  });
+
+  it('throws if "version" is too long', () => {
+    const frameworkVersionRaw = {
+      slug: 'foo',
+      // too long
+      version: '123456789 123456789 123456789 123456789 123456789 123',
+    };
+
+    assert.throws(() => {
+      validateFrameworkVersion(frameworkVersionRaw);
+    }, /Invalid config.json: "framework.version" length/);
+  });
+
+  it('returns populated "framework"', () => {
+    const frameworkVersionRaw = {
+      slug: 'foo',
+      version: '123',
+    };
+    const framework = validateFrameworkVersion(frameworkVersionRaw);
+    assert.strictEqual(framework, frameworkVersionRaw);
+  });
+});

--- a/packages/build-utils/test/unit.validate-framework-version.test.ts
+++ b/packages/build-utils/test/unit.validate-framework-version.test.ts
@@ -37,13 +37,13 @@ describe('validateFrameworkVersion', () => {
   it('throws if "slug" is too long', () => {
     const frameworkVersionRaw = {
       // too long
-      version: 'foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo',
-      slug: '123',
+      slug: 'foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo',
+      version: '123',
     };
 
     assert.throws(() => {
       validateFrameworkVersion(frameworkVersionRaw);
-    }, /Invalid config.json: "framework.version" length/);
+    }, /Invalid config.json: "framework.slug" length/);
   });
 
   it('throws error if "version" is not a string', () => {


### PR DESCRIPTION
Followup to https://github.com/vercel/vercel/pull/16397

Moves some tests over