### PR TITLE
Update Next.js adapter version

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -29,7 +29,7 @@
     "@vercel/nft": "1.5.0"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.21",
+    "@next-community/adapter-vercel": "0.0.1-beta.22",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1643,8 +1643,8 @@ importers:
         version: 1.5.0
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.21
-        version: 0.0.1-beta.21(next@16.1.6)
+        specifier: 0.0.1-beta.22
+        version: 0.0.1-beta.22(next@16.1.6)
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -6361,8 +6361,8 @@ packages:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  /@next-community/adapter-vercel@0.0.1-beta.21(next@16.1.6):
-    resolution: {integrity: sha512-MDD2iui9TecZdmWPCek2wCMyAZ6H96X/DHA3MUkLkfghQ39R6qAgMaMSuV2+L+pJzwwxEg32m9Myk0mq0A7jLQ==}
+  /@next-community/adapter-vercel@0.0.1-beta.22(next@16.1.6):
+    resolution: {integrity: sha512-ZlRIi8MUWBLPxsFLzA2kxw1HOf5ius5kjyhHk7oVg1mhFy7QCCuhC35BrBXm1FN+7jWF4ST+jwxZ9u2lQt0MXQ==}
     engines: {node: '>= 20.6.0'}
     peerDependencies:
       next: '>= 16.1.1-canary.18'


### PR DESCRIPTION
### Related Issues

Fixes #16406.

### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests, or tests are not required because this only bumps the packaged Next.js adapter dependency.

#### Documentation

- [x] Documentation is not needed

### 📝 Description

Updates `@next-community/adapter-vercel` from `0.0.1-beta.21` to `0.0.1-beta.22` for `@vercel/next`.

The newer adapter guards preview-comments toolbar injection when Next.js does not pass `ctx.projectDir` to `modifyConfig`, avoiding the `TypeError: The "path" argument must be of type string. Received undefined` failure reported in #16406.

### 🧪 Verification

- `pnpm --filter @vercel/routing-utils build`
- `pnpm --filter @vercel/next build`
- Confirmed the built adapter contains the `typeof ctx.projectDir !== "undefined"` guard around `VERCEL_PREVIEW_COMMENTS_ENABLED` toolbar injection.
