### PR TITLE
[cli] Add `vercel connect revoke-tokens` subcommand

### DIFF
--- a/.changeset/cli-connect-revoke-tokens.md
+++ b/.changeset/cli-connect-revoke-tokens.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel connect revoke-tokens` subcommand to revoke tokens issued from a connector.

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -310,6 +310,62 @@ export const tokenSubcommand = {
   ],
 } as const;
 
+export const revokeTokensSubcommand = {
+  name: 'revoke-tokens',
+  aliases: [],
+  description: 'Revoke tokens issued from a connector',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'my-tokens',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Revoke only your own tokens for this connector',
+    },
+    {
+      name: 'all-tokens',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Revoke every token for all users and installations. Requires team owner or member permissions.',
+    },
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt',
+    },
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Interactively select which tokens to revoke',
+      value: `${packageName} connect revoke-tokens scl_abc123`,
+    },
+    {
+      name: 'Revoke only your own tokens',
+      value: `${packageName} connect revoke-tokens scl_abc123 --my-tokens`,
+    },
+    {
+      name: 'Revoke all tokens for all users',
+      value: `${packageName} connect revoke-tokens scl_abc123 --all-tokens`,
+    },
+    {
+      name: 'Skip the confirmation prompt',
+      value: `${packageName} connect revoke-tokens scl_abc123 --my-tokens --yes`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} connect revoke-tokens scl_abc123 --my-tokens --yes --format=json`,
+    },
+  ],
+} as const;
+
 export const openSubcommand = {
   name: 'open',
   aliases: [],
@@ -476,6 +532,7 @@ export const connexCommand = {
     attachSubcommand,
     detachSubcommand,
     removeSubcommand,
+    revokeTokensSubcommand,
     openSubcommand,
   ],
   examples: [

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -316,7 +316,7 @@ export const revokeTokensSubcommand = {
   description: 'Revoke tokens issued from a connector',
   arguments: [
     {
-      name: 'id',
+      name: 'connector',
       required: true,
     },
   ],

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -15,6 +15,7 @@ import {
   attachSubcommand,
   detachSubcommand,
   removeSubcommand,
+  revokeTokensSubcommand,
   openSubcommand,
   connexCommand,
 } from './command';
@@ -25,6 +26,7 @@ import { token } from './token';
 import { attach } from './attach';
 import { detach } from './detach';
 import { remove } from './remove';
+import { revokeTokens } from './revoke-tokens';
 import { openClient } from './open';
 import {
   buildCommandWithGlobalFlags,
@@ -41,6 +43,7 @@ const COMMAND_CONFIG = {
   attach: getCommandAliases(attachSubcommand),
   detach: getCommandAliases(detachSubcommand),
   remove: getCommandAliases(removeSubcommand),
+  'revoke-tokens': getCommandAliases(revokeTokensSubcommand),
   open: getCommandAliases(openSubcommand),
 };
 
@@ -234,6 +237,38 @@ export default async function connex(client: Client): Promise<number> {
           client,
           removeParsedArgs.args,
           removeParsedArgs.flags
+        );
+      }
+      case 'revoke-tokens': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex', subcommandOriginal);
+          printHelp(revokeTokensSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandRevokeTokens(subcommandOriginal);
+
+        const revokeTokensFlagsSpec = getFlagsSpecification(
+          revokeTokensSubcommand.options
+        );
+        const revokeTokensParsedArgs = parseArguments(
+          subArgs,
+          revokeTokensFlagsSpec
+        );
+        telemetry.trackCliArgumentId(revokeTokensParsedArgs.args[0]);
+        telemetry.trackCliFlagMyTokens(
+          revokeTokensParsedArgs.flags['--my-tokens']
+        );
+        telemetry.trackCliFlagAllTokens(
+          revokeTokensParsedArgs.flags['--all-tokens']
+        );
+        telemetry.trackCliFlagYes(revokeTokensParsedArgs.flags['--yes']);
+        telemetry.trackCliOptionFormat(
+          revokeTokensParsedArgs.flags['--format']
+        );
+        return await revokeTokens(
+          client,
+          revokeTokensParsedArgs.args,
+          revokeTokensParsedArgs.flags
         );
       }
       case 'open': {

--- a/packages/cli/src/commands/connex/revoke-tokens.ts
+++ b/packages/cli/src/commands/connex/revoke-tokens.ts
@@ -1,0 +1,213 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { validateJsonOutput } from '../../util/output-format';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import type { ConnexClientIdentity } from './types';
+
+interface RevokeTokensResult {
+  tokensFound: number;
+  deleted: number;
+  providerRevoked: number;
+  providerSkipped: number;
+  providerFailed: number;
+}
+
+export async function revokeTokens(
+  client: Client,
+  args: string[],
+  flags: {
+    '--my-tokens'?: boolean;
+    '--all-tokens'?: boolean;
+    '--yes'?: boolean;
+    '--format'?: string;
+    '--json'?: boolean;
+  }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  if (asJson && !flags['--yes']) {
+    output.error('--format=json requires --yes to skip confirmation prompts');
+    return 1;
+  }
+
+  const clientIdOrUid = args[0];
+  if (!clientIdOrUid) {
+    output.error(
+      'Missing connector ID or UID. Usage: vercel connect revoke-tokens <id>'
+    );
+    return 1;
+  }
+
+  const myTokens = !!flags['--my-tokens'];
+  const allTokens = !!flags['--all-tokens'];
+
+  if (myTokens && allTokens) {
+    output.error('--my-tokens and --all-tokens are mutually exclusive.');
+    return 1;
+  }
+
+  if (flags['--yes'] && !myTokens && !allTokens) {
+    output.error(
+      '--yes requires a scope flag. Use --yes --my-tokens or --yes --all-tokens.'
+    );
+    return 1;
+  }
+
+  await selectConnexTeam(client, 'Select the team for this connector');
+
+  output.spinner('Retrieving connector…');
+  let target: ConnexClientIdentity;
+  try {
+    target = await client.fetch<ConnexClientIdentity>(
+      `/v1/connect/connectors/${encodeURIComponent(clientIdOrUid)}`
+    );
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 404) {
+      output.error(`No connector found for ${chalk.bold(clientIdOrUid)}.`);
+      return 1;
+    }
+    output.error(
+      `Failed to look up ${chalk.bold(clientIdOrUid)}: ${(err as Error).message}`
+    );
+    return 1;
+  }
+  output.stopSpinner();
+
+  const displayName = target.name || target.uid || target.id;
+
+  // Resolve scope: flag → interactive TTY → error
+  let scope: 'mine' | 'all';
+  if (myTokens) {
+    scope = 'mine';
+  } else if (allTokens) {
+    scope = 'all';
+  } else if (client.stdin.isTTY) {
+    const choice = await client.input.select({
+      message: 'Which tokens do you want to revoke?',
+      choices: [
+        {
+          name: `My tokens — revoke only your own tokens for ${displayName}`,
+          value: 'mine',
+        },
+        {
+          name: 'All tokens — revoke every token for all users and installations',
+          value: 'all',
+        },
+      ],
+    });
+    scope = choice as 'mine' | 'all';
+  } else {
+    output.error(
+      'Scope required. Use --my-tokens to revoke your tokens or --all-tokens to revoke all tokens.'
+    );
+    return 1;
+  }
+
+  // Confirmation
+  if (!flags['--yes']) {
+    if (!client.stdin.isTTY) {
+      output.error(
+        'Confirmation required. Use `--yes` to skip the confirmation prompt.'
+      );
+      return 1;
+    }
+
+    if (scope === 'mine') {
+      output.log(
+        `Tokens issued from ${chalk.bold(displayName)} for your account will stop working. You'll need to re-authorize to use this connector again.`
+      );
+    } else {
+      output.log(
+        `Every token issued from ${chalk.bold(displayName)} will stop working. Anyone using this connector will need to re-authorize.`
+      );
+    }
+
+    const confirmed = await client.input.confirm(
+      `${chalk.red('Are you sure?')}`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  const body: Record<string, unknown> =
+    scope === 'mine'
+      ? { subject: { type: 'user', id: client.authConfig.userId } }
+      : {};
+
+  output.spinner('Revoking tokens…');
+  let result: RevokeTokensResult;
+  try {
+    result = await client.fetch<RevokeTokensResult>(
+      `/v1/connect/connectors/${encodeURIComponent(target.id)}/tokens`,
+      {
+        method: 'DELETE',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 403) {
+      output.error(
+        `You don't have permission to revoke tokens for ${chalk.bold(displayName)}.`
+      );
+      return 1;
+    }
+    output.error(
+      `Failed to revoke tokens for ${chalk.bold(displayName)}: ${(err as Error).message}`
+    );
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          id: target.id,
+          uid: target.uid,
+          scope,
+          tokensFound: result.tokensFound,
+          deleted: result.deleted,
+          providerRevoked: result.providerRevoked,
+          providerSkipped: result.providerSkipped,
+          providerFailed: result.providerFailed,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  const plural = result.deleted === 1 ? 'token' : 'tokens';
+  if (scope === 'mine') {
+    output.success(
+      `Revoked your ${plural} from ${chalk.bold(displayName)} (${result.deleted} ${plural} deleted).`
+    );
+  } else {
+    output.success(
+      `Revoked all ${plural} from ${chalk.bold(displayName)} (${result.deleted} ${plural} deleted).`
+    );
+  }
+
+  if (result.providerFailed > 0) {
+    output.warn(
+      `${result.providerFailed} token(s) could not be revoked from the provider. They have been removed from Vercel Connect.`
+    );
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/connex/revoke-tokens.ts
+++ b/packages/cli/src/commands/connex/revoke-tokens.ts
@@ -39,7 +39,7 @@ export async function revokeTokens(
   const clientIdOrUid = args[0];
   if (!clientIdOrUid) {
     output.error(
-      'Missing connector ID or UID. Usage: vercel connect revoke-tokens <id>'
+      'Missing connector ID or UID. Usage: vercel connect revoke-tokens <connector>'
     );
     return 1;
   }
@@ -82,13 +82,14 @@ export async function revokeTokens(
   output.stopSpinner();
 
   const displayName = target.name || target.uid || target.id;
+  const supportsRevocation = target.supportsRevocation !== false;
 
-  // Resolve scope: flag → interactive TTY → error
-  let scope: 'mine' | 'all';
+  // Resolve subjectScope: flag → interactive TTY → error
+  let subjectScope: 'mine' | 'all';
   if (myTokens) {
-    scope = 'mine';
+    subjectScope = 'mine';
   } else if (allTokens) {
-    scope = 'all';
+    subjectScope = 'all';
   } else if (client.stdin.isTTY) {
     const choice = await client.input.select({
       message: 'Which tokens do you want to revoke?',
@@ -103,7 +104,7 @@ export async function revokeTokens(
         },
       ],
     });
-    scope = choice as 'mine' | 'all';
+    subjectScope = choice as 'mine' | 'all';
   } else {
     output.error(
       'Scope required. Use --my-tokens to revoke your tokens or --all-tokens to revoke all tokens.'
@@ -120,13 +121,19 @@ export async function revokeTokens(
       return 1;
     }
 
-    if (scope === 'mine') {
+    if (subjectScope === 'mine') {
       output.log(
         `Tokens issued from ${chalk.bold(displayName)} for your account will stop working. You'll need to re-authorize to use this connector again.`
       );
     } else {
       output.log(
         `Every token issued from ${chalk.bold(displayName)} will stop working. Anyone using this connector will need to re-authorize.`
+      );
+    }
+
+    if (!supportsRevocation) {
+      output.warn(
+        `${chalk.bold(displayName)} does not support provider-side token revocation. Tokens will be removed from Vercel Connect but may remain valid at the provider until they expire.`
       );
     }
 
@@ -141,7 +148,7 @@ export async function revokeTokens(
   }
 
   const body: Record<string, unknown> =
-    scope === 'mine'
+    subjectScope === 'mine'
       ? { subject: { type: 'user', id: client.authConfig.userId } }
       : {};
 
@@ -178,7 +185,8 @@ export async function revokeTokens(
         {
           id: target.id,
           uid: target.uid,
-          scope,
+          scope: subjectScope,
+          supportsRevocation,
           tokensFound: result.tokensFound,
           deleted: result.deleted,
           providerRevoked: result.providerRevoked,
@@ -193,7 +201,7 @@ export async function revokeTokens(
   }
 
   const plural = result.deleted === 1 ? 'token' : 'tokens';
-  if (scope === 'mine') {
+  if (subjectScope === 'mine') {
     output.success(
       `Revoked your ${plural} from ${chalk.bold(displayName)} (${result.deleted} ${plural} deleted).`
     );
@@ -203,7 +211,11 @@ export async function revokeTokens(
     );
   }
 
-  if (result.providerFailed > 0) {
+  if (!supportsRevocation) {
+    output.warn(
+      `${chalk.bold(displayName)} does not support provider-side token revocation. Tokens were removed from Vercel Connect but may remain valid at the provider until they expire.`
+    );
+  } else if (result.providerFailed > 0) {
     output.warn(
       `${result.providerFailed} token(s) could not be revoked from the provider. They have been removed from Vercel Connect.`
     );

--- a/packages/cli/src/commands/connex/types.ts
+++ b/packages/cli/src/commands/connex/types.ts
@@ -24,6 +24,7 @@ export interface ConnexClientIdentity {
   id: string;
   uid: string;
   name?: string;
+  supportsRevocation?: boolean;
   supportsTriggers?: boolean;
   triggers?: { enabled: boolean };
   triggerDestinations?: ConnexTriggerDestination[];

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -63,6 +63,13 @@ export class ConnexTelemetryClient
     });
   }
 
+  trackCliSubcommandRevokeTokens(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'revoke-tokens',
+      value: actual,
+    });
+  }
+
   trackCliArgumentClient(v: string | undefined) {
     if (v) {
       this.trackCliArgument({
@@ -145,6 +152,18 @@ export class ConnexTelemetryClient
         option: 'trigger-path',
         value: this.redactedValue,
       });
+    }
+  }
+
+  trackCliFlagMyTokens(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('my-tokens');
+    }
+  }
+
+  trackCliFlagAllTokens(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('all-tokens');
     }
   }
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -924,19 +924,21 @@ exports[`help command > connex help output snapshots > connex help column width 
 
   Commands:
 
-  create         type    Create a new connector                             
-  update         id      Update connector branding (icon and colors)        
-  list                   List connectors linked to the current project      
-                         (falls back to every connector in the team when no 
-                         project is linked or when --all-projects is set)   
-  token          id      Get a token for a connector (accepts a connector ID
-                         like scl_abc or a UID like slack/my-bot)           
-  attach         client  Attach a Vercel project to a connector for one or  
-                         more environments                                  
-  detach         client  Detach a Vercel project from a connector           
-  remove         client  Delete a connector                                 
-  revoke-tokens  id      Revoke tokens issued from a connector              
-  open           id      Open a connector in the Vercel dashboard           
+  create         type       Create a new connector                      
+  update         id         Update connector branding (icon and colors) 
+  list                      List connectors linked to the current       
+                            project (falls back to every connector in   
+                            the team when no project is linked or when  
+                            --all-projects is set)                      
+  token          id         Get a token for a connector (accepts a      
+                            connector ID like scl_abc or a UID like     
+                            slack/my-bot)                               
+  attach         client     Attach a Vercel project to a connector for  
+                            one or more environments                    
+  detach         client     Detach a Vercel project from a connector    
+  remove         client     Delete a connector                          
+  revoke-tokens  connector  Revoke tokens issued from a connector       
+  open           id         Open a connector in the Vercel dashboard    
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -924,18 +924,19 @@ exports[`help command > connex help output snapshots > connex help column width 
 
   Commands:
 
-  create  type    Create a new connector                                
-  update  id      Update connector branding (icon and colors)           
-  list            List connectors linked to the current project (falls  
-                  back to every connector in the team when no project is
-                  linked or when --all-projects is set)                 
-  token   id      Get a token for a connector (accepts a connector ID   
-                  like scl_abc or a UID like slack/my-bot)              
-  attach  client  Attach a Vercel project to a connector for one or more
-                  environments                                          
-  detach  client  Detach a Vercel project from a connector              
-  remove  client  Delete a connector                                    
-  open    id      Open a connector in the Vercel dashboard              
+  create         type    Create a new connector                             
+  update         id      Update connector branding (icon and colors)        
+  list                   List connectors linked to the current project      
+                         (falls back to every connector in the team when no 
+                         project is linked or when --all-projects is set)   
+  token          id      Get a token for a connector (accepts a connector ID
+                         like scl_abc or a UID like slack/my-bot)           
+  attach         client  Attach a Vercel project to a connector for one or  
+                         more environments                                  
+  detach         client  Detach a Vercel project from a connector           
+  remove         client  Delete a connector                                 
+  revoke-tokens  id      Revoke tokens issued from a connector              
+  open           id      Open a connector in the Vercel dashboard           
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/connex/revoke-tokens.test.ts
+++ b/packages/cli/test/unit/commands/connex/revoke-tokens.test.ts
@@ -1,0 +1,373 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import connect from '../../../../src/commands/connex';
+
+const CONNECTOR_ID = 'scl_abc123';
+const CONNECTOR_UID = 'slack/my-bot';
+const CONNECTOR_NAME = 'My Bot';
+
+const DEFAULT_REVOKE_RESULT = {
+  tokensFound: 2,
+  deleted: 2,
+  providerRevoked: 2,
+  providerSkipped: 0,
+  providerFailed: 0,
+};
+
+describe('connex revoke-tokens', () => {
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    const team = useTeam('team_test');
+    client.config.currentTeam = team.id;
+  });
+
+  it('errors when no connector argument is provided', async () => {
+    client.setArgv('connect', 'revoke-tokens');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing connector ID or UID'
+    );
+  });
+
+  it('errors when both --my-tokens and --all-tokens are provided', async () => {
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_ID,
+      '--my-tokens',
+      '--all-tokens',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '--my-tokens and --all-tokens are mutually exclusive'
+    );
+  });
+
+  it('errors when --yes is passed without a scope flag', async () => {
+    client.setArgv('connect', 'revoke-tokens', CONNECTOR_ID, '--yes');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '--yes requires a scope flag'
+    );
+    expect(client.stderr.getFullOutput()).toContain('--my-tokens');
+    expect(client.stderr.getFullOutput()).toContain('--all-tokens');
+  });
+
+  it('rejects --format=json without --yes', async () => {
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_ID,
+      '--my-tokens',
+      '--format=json'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '--format=json requires --yes'
+    );
+  });
+
+  it('errors with a friendly message when the connector is not found', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      'scl_missing',
+      '--my-tokens',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('No connector found for');
+  });
+
+  it('errors in non-TTY when no scope flag is provided', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+
+    client.setArgv('connect', 'revoke-tokens', CONNECTOR_ID);
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Scope required');
+    expect(client.stderr.getFullOutput()).toContain('--my-tokens');
+    expect(client.stderr.getFullOutput()).toContain('--all-tokens');
+  });
+
+  it('requires --yes when stdin is not a TTY', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+
+    client.setArgv('connect', 'revoke-tokens', CONNECTOR_ID, '--my-tokens');
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Confirmation required');
+  });
+
+  it('revokes my tokens with --my-tokens --yes and sends the correct body', async () => {
+    let requestBody: unknown;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (req, res) => {
+        requestBody = req.body;
+        res.json(DEFAULT_REVOKE_RESULT);
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_UID,
+      '--my-tokens',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain('Revoked your');
+    expect(client.stderr.getFullOutput()).toContain(CONNECTOR_NAME);
+    const body = requestBody as { subject?: { type: string; id: string } };
+    expect(body.subject?.type).toBe('user');
+    expect(body.subject?.id).toBeTruthy();
+  });
+
+  it('revokes all tokens with --all-tokens --yes and sends an empty body', async () => {
+    let requestBody: unknown;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (req, res) => {
+        requestBody = req.body;
+        res.json(DEFAULT_REVOKE_RESULT);
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_ID,
+      '--all-tokens',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain('Revoked all');
+    expect(client.stderr.getFullOutput()).toContain(CONNECTOR_NAME);
+    expect(requestBody).toEqual({});
+  });
+
+  it('shows confirmation prompt and proceeds on confirm (--my-tokens)', async () => {
+    let deleteCalled = false;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (_req, res) => {
+        deleteCalled = true;
+        res.json(DEFAULT_REVOKE_RESULT);
+      }
+    );
+
+    client.setArgv('connect', 'revoke-tokens', CONNECTOR_ID, '--my-tokens');
+
+    const exitCodePromise = connect(client);
+
+    await expect(client.stderr).toOutput(
+      'Tokens issued from My Bot for your account will stop working'
+    );
+    await expect(client.stderr).toOutput('Are you sure?');
+    client.stdin.write('y\n');
+
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(deleteCalled).toBe(true);
+  });
+
+  it('cancels cleanly when the user declines the prompt', async () => {
+    let deleteCalled = false;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (_req, res) => {
+        deleteCalled = true;
+        res.json(DEFAULT_REVOKE_RESULT);
+      }
+    );
+
+    client.setArgv('connect', 'revoke-tokens', CONNECTOR_ID, '--my-tokens');
+
+    const exitCodePromise = connect(client);
+
+    await expect(client.stderr).toOutput('Are you sure?');
+    client.stdin.write('n\n');
+
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(deleteCalled).toBe(false);
+    expect(client.stderr.getFullOutput()).toContain('Canceled');
+  });
+
+  it('emits a JSON receipt on --yes --format=json', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (_req, res) => {
+        res.json(DEFAULT_REVOKE_RESULT);
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_ID,
+      '--my-tokens',
+      '--yes',
+      '--format=json'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(parsed).toMatchObject({
+      id: CONNECTOR_ID,
+      uid: CONNECTOR_UID,
+      scope: 'mine',
+      tokensFound: 2,
+      deleted: 2,
+      providerRevoked: 2,
+      providerSkipped: 0,
+      providerFailed: 0,
+    });
+  });
+
+  it('emits scope:all in JSON receipt for --all-tokens', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (_req, res) => {
+        res.json(DEFAULT_REVOKE_RESULT);
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_ID,
+      '--all-tokens',
+      '--yes',
+      '--format=json'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(parsed.scope).toBe('all');
+  });
+
+  it('surfaces a friendly error on 403 from the DELETE endpoint', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (_req, res) => {
+        res.statusCode = 403;
+        res.json({ error: { code: 'forbidden', message: 'Forbidden' } });
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_ID,
+      '--my-tokens',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      "don't have permission to revoke tokens"
+    );
+  });
+
+  it('warns when providerFailed is non-zero', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (_req, res) => {
+        res.json({ ...DEFAULT_REVOKE_RESULT, providerFailed: 1 });
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_ID,
+      '--my-tokens',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain(
+      'could not be revoked from the provider'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/connex/revoke-tokens.test.ts
+++ b/packages/cli/test/unit/commands/connex/revoke-tokens.test.ts
@@ -255,7 +255,12 @@ describe('connex revoke-tokens', () => {
 
   it('emits a JSON receipt on --yes --format=json', async () => {
     client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
-      res.json({ id: CONNECTOR_ID, uid: CONNECTOR_UID, name: CONNECTOR_NAME });
+      res.json({
+        id: CONNECTOR_ID,
+        uid: CONNECTOR_UID,
+        name: CONNECTOR_NAME,
+        supportsRevocation: true,
+      });
     });
     client.scenario.delete(
       '/v1/connect/connectors/:clientId/tokens',
@@ -281,6 +286,7 @@ describe('connex revoke-tokens', () => {
       id: CONNECTOR_ID,
       uid: CONNECTOR_UID,
       scope: 'mine',
+      supportsRevocation: true,
       tokensFound: 2,
       deleted: 2,
       providerRevoked: 2,
@@ -368,6 +374,72 @@ describe('connex revoke-tokens', () => {
     expect(exitCode).toBe(0);
     expect(client.stderr.getFullOutput()).toContain(
       'could not be revoked from the provider'
+    );
+  });
+
+  it('warns before confirmation when connector does not support provider revocation', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({
+        id: CONNECTOR_ID,
+        uid: CONNECTOR_UID,
+        name: CONNECTOR_NAME,
+        supportsRevocation: false,
+      });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (_req, res) => {
+        res.json(DEFAULT_REVOKE_RESULT);
+      }
+    );
+
+    client.setArgv('connect', 'revoke-tokens', CONNECTOR_ID, '--my-tokens');
+
+    const exitCodePromise = connect(client);
+
+    await expect(client.stderr).toOutput(
+      'does not support provider-side token revocation'
+    );
+    await expect(client.stderr).toOutput('Are you sure?');
+    client.stdin.write('y\n');
+
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('warns after success when connector does not support provider revocation', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({
+        id: CONNECTOR_ID,
+        uid: CONNECTOR_UID,
+        name: CONNECTOR_NAME,
+        supportsRevocation: false,
+      });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (_req, res) => {
+        res.json(DEFAULT_REVOKE_RESULT);
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_ID,
+      '--my-tokens',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain(
+      'does not support provider-side token revocation'
+    );
+    expect(client.stderr.getFullOutput()).toContain(
+      'may remain valid at the provider'
     );
   });
 });


### PR DESCRIPTION
## Summary

- Adds `vercel connect revoke-tokens <id>` subcommand
- `--my-tokens` revokes personal tokens for the caller's account only (`subject: { type: 'user', id: <userId> }`)
  - It will revoke all tokens for the user regardless of issuer. Per-issuer filtering can be added via an `--issuer` option if needed.
- `--all-tokens` revokes every token for all users and installations (empty body; server enforces `ConnexClient.Delete` permission)
- Interactive scope selection (TTY only) when neither flag is given
- Comes with a `--yes` flag

## API

`DELETE /v1/connect/connectors/:clientId/tokens`

| Flag | Request body |
|---|---|
| `--my-tokens` | `{ subject: { type: "user", id: "<userId>" } }` |
| `--all-tokens` | `{}` |

Server-side two-tier ACL is unchanged — callers without `ConnexClient.Delete` are silently scoped to their own tokens by the API.

## Test plan

- [x] `vercel connect revoke-tokens <id>` → interactive scope prompt
- [x] `vercel connect revoke-tokens <id> --my-tokens --yes` → revokes own tokens
- [x] `vercel connect revoke-tokens <id> --all-tokens --yes` → revokes all tokens
- [x] `vercel connect revoke-tokens <id> --yes` → errors, requires scope flag
- [x] `vercel connect revoke-tokens --help` → permission note visible on `--all-tokens`
- [x] All 15 unit tests pass: `npx vitest run packages/cli/test/unit/commands/connex/revoke-tokens.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)