### PR TITLE
[vercel] connect list: add --type, --service, --search filter flags

### DIFF
--- a/.changeset/connect-list-filters.md
+++ b/.changeset/connect-list-filters.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `--type`, `--service`, and `--search` filter flags to `vercel connect list`.

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -163,6 +163,32 @@ export const listSubcommand = {
       deprecated: false,
       description: 'Cursor for the next page of results',
     },
+    {
+      name: 'search',
+      shorthand: null,
+      type: String,
+      argument: 'TEXT',
+      deprecated: false,
+      description: 'Search connectors by name or UID',
+    },
+    {
+      name: 'service',
+      shorthand: null,
+      type: [String],
+      argument: 'NAME',
+      deprecated: false,
+      description:
+        'Filter by service name (e.g. slack, mcp.linear.app). Repeatable.',
+    },
+    {
+      name: 'type',
+      shorthand: null,
+      type: [String],
+      argument: 'TYPE',
+      deprecated: false,
+      description:
+        'Filter by connector type (slack, github, oauth, custom). Repeatable.',
+    },
     formatOption,
   ],
   examples: [
@@ -173,6 +199,26 @@ export const listSubcommand = {
     {
       name: 'List every connector in the team',
       value: `${packageName} connect list --all-projects`,
+    },
+    {
+      name: 'Filter by connector type',
+      value: `${packageName} connect list --type slack`,
+    },
+    {
+      name: 'Filter by multiple types',
+      value: `${packageName} connect list --type oauth --type github`,
+    },
+    {
+      name: 'Filter by service name',
+      value: `${packageName} connect list --service mcp.linear.app`,
+    },
+    {
+      name: 'Search by text',
+      value: `${packageName} connect list --search linear`,
+    },
+    {
+      name: 'Combine filters',
+      value: `${packageName} connect list --type oauth --search prod`,
     },
     {
       name: 'Limit the number of results',

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -149,6 +149,9 @@ export default async function connex(client: Client): Promise<number> {
         );
         telemetry.trackCliOptionLimit(listParsedArgs.flags['--limit']);
         telemetry.trackCliOptionNext(listParsedArgs.flags['--next']);
+        telemetry.trackCliOptionSearch(listParsedArgs.flags['--search']);
+        telemetry.trackCliOptionService(listParsedArgs.flags['--service']);
+        telemetry.trackCliOptionType(listParsedArgs.flags['--type']);
         telemetry.trackCliOptionFormat(listParsedArgs.flags['--format']);
         return await list(client, listParsedArgs.flags);
       }

--- a/packages/cli/src/commands/connex/list.ts
+++ b/packages/cli/src/commands/connex/list.ts
@@ -48,6 +48,9 @@ export async function list(
     '--all-projects'?: boolean;
     '--limit'?: number;
     '--next'?: string;
+    '--search'?: string;
+    '--service'?: string[];
+    '--type'?: string[];
     '--format'?: string;
     '--json'?: boolean;
   }
@@ -59,6 +62,13 @@ export async function list(
   }
   const asJson = formatResult.jsonOutput;
   const allProjects = flags['--all-projects'] === true;
+  const types = (flags['--type'] ?? [])
+    .flatMap(v => v.split(',').map(s => s.trim().toLowerCase()))
+    .filter(Boolean);
+  const services = (flags['--service'] ?? [])
+    .flatMap(v => v.split(',').map(s => s.trim().toLowerCase()))
+    .filter(Boolean);
+  const searchQuery = flags['--search'];
 
   let projectId: string | undefined;
   let projectName: string | undefined;
@@ -101,6 +111,15 @@ export async function list(
     params.set('include', 'projects');
   } else if (projectId) {
     params.set('projectId', projectId);
+  }
+  if (types.length > 0) {
+    params.set('type', types.join(','));
+  }
+  if (services.length > 0) {
+    params.set('service', services.join(','));
+  }
+  if (searchQuery) {
+    params.set('search', searchQuery);
   }
   const query = params.toString();
   const url = `/v1/connect/connectors${query ? `?${query}` : ''}`;
@@ -220,10 +239,13 @@ export async function list(
   );
 
   if (response.cursor) {
-    const nextCommand = allProjects
-      ? `${packageName} connect list --all-projects --next ${response.cursor}`
-      : `${packageName} connect list --next ${response.cursor}`;
-    output.log(`To see more, run \`${nextCommand}\``);
+    const parts = [`${packageName} connect list`];
+    if (allProjects) parts.push('--all-projects');
+    for (const t of types) parts.push(`--type ${t}`);
+    for (const s of services) parts.push(`--service ${s}`);
+    if (searchQuery) parts.push(`--search "${searchQuery}"`);
+    parts.push(`--next ${response.cursor}`);
+    output.log(`To see more, run \`${parts.join(' ')}\``);
   }
 
   return 0;

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -172,6 +172,51 @@ export class ConnexTelemetryClient
     }
   }
 
+  trackCliOptionSearch(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'search',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionService(v: string[] | undefined) {
+    if (!v || v.length === 0) {
+      return;
+    }
+    for (const raw of v) {
+      for (const svc of raw.split(',')) {
+        const trimmed = svc.trim();
+        if (!trimmed) {
+          continue;
+        }
+        this.trackCliOption({
+          option: 'service',
+          value: this.redactedValue,
+        });
+      }
+    }
+  }
+
+  trackCliOptionType(v: string[] | undefined) {
+    if (!v || v.length === 0) {
+      return;
+    }
+    for (const raw of v) {
+      for (const t of raw.split(',')) {
+        const trimmed = t.trim();
+        if (!trimmed) {
+          continue;
+        }
+        this.trackCliOption({
+          option: 'type',
+          value: trimmed,
+        });
+      }
+    }
+  }
+
   trackCliOptionFormat(v: string | undefined) {
     if (v) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -992,6 +992,9 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
        --limit <COUNT>    Number of connectors to return per page                                                       
        --next <CURSOR>    Cursor for the next page of results                                                           
+       --search <TEXT>    Search connectors by name or UID                                                              
+       --service <NAME>   Filter by service name (e.g. slack, mcp.linear.app). Repeatable.                              
+       --type <TYPE>      Filter by connector type (slack, github, oauth, custom). Repeatable.                          
 
 
   Global Options:
@@ -1017,6 +1020,26 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
   - List every connector in the team
 
     $ vercel connect list --all-projects
+
+  - Filter by connector type
+
+    $ vercel connect list --type slack
+
+  - Filter by multiple types
+
+    $ vercel connect list --type oauth --type github
+
+  - Filter by service name
+
+    $ vercel connect list --service mcp.linear.app
+
+  - Search by text
+
+    $ vercel connect list --search linear
+
+  - Combine filters
+
+    $ vercel connect list --type oauth --search prod
 
   - Limit the number of results
 

--- a/packages/cli/test/unit/commands/connex/list.test.ts
+++ b/packages/cli/test/unit/commands/connex/list.test.ts
@@ -397,6 +397,121 @@ describe('connex list', () => {
     });
   });
 
+  describe('filter flags (--type, --service, --search)', () => {
+    it('should forward --type as a query param', async () => {
+      let requestUrl = '';
+      client.scenario.get('/v1/connect/connectors', (req, res) => {
+        requestUrl = req.url ?? '';
+        res.json({ clients: [] });
+      });
+
+      client.setArgv('connect', 'list', '--all-projects', '--type', 'slack');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestUrl).toContain('type=slack');
+    });
+
+    it('should join multiple --type values as comma-separated', async () => {
+      let requestUrl = '';
+      client.scenario.get('/v1/connect/connectors', (req, res) => {
+        requestUrl = req.url ?? '';
+        res.json({ clients: [] });
+      });
+
+      client.setArgv(
+        'connect',
+        'list',
+        '--all-projects',
+        '--type',
+        'slack',
+        '--type',
+        'github'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestUrl).toContain('type=slack%2Cgithub');
+    });
+
+    it('should forward --service as a query param', async () => {
+      let requestUrl = '';
+      client.scenario.get('/v1/connect/connectors', (req, res) => {
+        requestUrl = req.url ?? '';
+        res.json({ clients: [] });
+      });
+
+      client.setArgv(
+        'connect',
+        'list',
+        '--all-projects',
+        '--service',
+        'mcp.linear.app'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestUrl).toContain('service=mcp.linear.app');
+    });
+
+    it('should forward --search as a query param', async () => {
+      let requestUrl = '';
+      client.scenario.get('/v1/connect/connectors', (req, res) => {
+        requestUrl = req.url ?? '';
+        res.json({ clients: [] });
+      });
+
+      client.setArgv('connect', 'list', '--all-projects', '--search', 'linear');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(requestUrl).toContain('search=linear');
+    });
+
+    it('should include active filter flags in the next-page hint', async () => {
+      client.scenario.get('/v1/connect/connectors', (_req, res) => {
+        res.json({
+          clients: [
+            {
+              id: 'scl_1',
+              uid: 'slack/a',
+              name: 'A',
+              type: 'slack',
+              typeName: 'Slack',
+              createdAt: Date.now(),
+              includes: {
+                projects: { items: [], hasMore: false, cursor: null },
+              },
+            },
+          ],
+          cursor: 'cursor-xyz',
+        });
+      });
+
+      client.setArgv(
+        'connect',
+        'list',
+        '--all-projects',
+        '--type',
+        'slack',
+        '--search',
+        'linear'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('--type slack');
+      expect(stderr).toContain('--search "linear"');
+      expect(stderr).toContain('--next cursor-xyz');
+    });
+  });
+
   it('should output JSON for project-scoped list without projects field', async () => {
     const project = { ...defaultProject, id: 'proj_json_1', name: 'json-app' };
     useProject(project);


### PR DESCRIPTION
## Why

Extending `vercel connect list` command to support search and filter.

- `--type` / `--service`: Eg `vercel connect list --type slack`. API uses the AOSS `terms` filter (exact match), so values are normalized to lowercase at the CLI layer to match stored data.
- `--search` is passed as-is; the backend handles case-insensitivity on both the AOSS and DDB-fallback paths.
- The pagination hint (`To see more, run ...`) now includes any active filter flags so the next-page command preserves the filter context.

Fixes [MKT-3829](https://linear.app/vercel/issue/MKT-3829/find-filter-connectors)

## Validation

```
vercel connect list --type slack
vercel connect list --type oauth --type github
vercel connect list --service mcp.linear.app
vercel connect list --search linear
vercel connect list --type oauth --search prod --all-projects
```