### PR TITLE
[services] Add project manifest to go builder.

### DIFF
--- a/.changeset/slimy-pots-yell.md
+++ b/.changeset/slimy-pots-yell.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': minor
+---
+
+Add project manifest to go builder.

--- a/packages/go/src/diagnostics.ts
+++ b/packages/go/src/diagnostics.ts
@@ -1,0 +1,188 @@
+import fs from 'fs';
+import {
+  writeProjectManifest,
+  createDiagnostics,
+  MANIFEST_VERSION,
+  type PackageManifest,
+  type PackageManifestDependency,
+} from '@vercel/build-utils';
+
+interface GoModModule {
+  name: string;
+  version: string;
+  indirect: boolean;
+}
+
+const stripComment = (s: string) => s.replace(/\/\/.*$/, '').trim();
+
+// `// indirect` may appear with or without a leading space. Match Go's
+// modfile parser by allowing either form, but only as the trailing comment.
+const isIndirectComment = (s: string) => /\/\/\s*indirect\s*$/.test(s);
+
+// Parses a require entry — text after the `require` keyword (single-line)
+// or a single line inside a `require ( ... )` block.
+function parseRequireEntry(
+  text: string,
+  rawWithComment: string
+): GoModModule | null {
+  const m = stripComment(text).match(/^(\S+)\s+(\S+)/);
+  if (!m) return null;
+  return {
+    name: m[1],
+    version: m[2],
+    indirect: isIndirectComment(rawWithComment),
+  };
+}
+
+// Parses a replace entry — text after the `replace` keyword (single-line)
+// or a single line inside a `replace ( ... )` block. Returns the LHS module
+// name iff the entry replaces it with a local file path (RHS has no version,
+// per the Go spec); returns null for module-path replacements and for
+// unparseable lines.
+function getDependencyReplacedByLocal(text: string): string | null {
+  const m = stripComment(text).match(
+    /^(\S+)(?:\s+\S+)?\s+=>\s+\S+(?:\s+(\S+))?\s*$/
+  );
+  if (!m) return null;
+  return m[2] ? null : m[1];
+}
+
+export function parseGoMod(content: string): {
+  goVersion: string;
+  modules: GoModModule[];
+} {
+  const lines = content.split(/\r?\n/);
+  let goVersion = '';
+  const allModules: GoModModule[] = [];
+  const localReplaces = new Set<string>();
+
+  let i = 0;
+  while (i < lines.length) {
+    const raw = lines[i].trim();
+
+    if (!raw || raw.startsWith('//')) {
+      i++;
+      continue;
+    }
+
+    // Read the go version
+    const goMatch = raw.match(/^go\s+(\d+\.\d+(?:\.\d+)?)/);
+    if (goMatch) {
+      goVersion = goMatch[1];
+      i++;
+      continue;
+    }
+
+    // Read a require block
+    if (/^require\s*\(/.test(raw)) {
+      i++;
+      while (i < lines.length) {
+        const innerRaw = lines[i].trim();
+        if (innerRaw === ')') {
+          i++;
+          break;
+        }
+        const entry = parseRequireEntry(innerRaw, innerRaw);
+        if (entry) allModules.push(entry);
+        i++;
+      }
+      continue;
+    }
+
+    // Read a replace block
+    if (/^replace\s*\(/.test(raw)) {
+      i++;
+      while (i < lines.length) {
+        const innerRaw = lines[i].trim();
+        if (innerRaw === ')') {
+          i++;
+          break;
+        }
+        const local = getDependencyReplacedByLocal(innerRaw);
+        if (local) localReplaces.add(local);
+        i++;
+      }
+      continue;
+    }
+
+    // Read a single-line require
+    const reqHead = stripComment(raw).match(/^require\s+(.*)$/);
+    if (reqHead) {
+      const entry = parseRequireEntry(reqHead[1], raw);
+      if (entry) allModules.push(entry);
+      i++;
+      continue;
+    }
+
+    // Read a single-line replace
+    const replHead = stripComment(raw).match(/^replace\s+(.*)$/);
+    if (replHead) {
+      const local = getDependencyReplacedByLocal(replHead[1]);
+      if (local) localReplaces.add(local);
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  const modules = allModules.filter(m => !localReplaces.has(m.name));
+  return { goVersion, modules };
+}
+
+export async function generateProjectManifest({
+  workPath,
+  goModPath,
+  goVersion,
+}: {
+  workPath: string;
+  goModPath: string | undefined;
+  goVersion: string;
+}): Promise<void> {
+  try {
+    if (!goModPath) return;
+
+    const content = await fs.promises.readFile(goModPath, 'utf-8');
+    const { goVersion: parsedGoVersion, modules } = parseGoMod(content);
+
+    const resolved = parsedGoVersion || goVersion;
+
+    const directDeps: PackageManifestDependency[] = [];
+    const transitiveDeps: PackageManifestDependency[] = [];
+
+    for (const mod of modules) {
+      const dep: PackageManifestDependency = {
+        name: mod.name,
+        type: mod.indirect ? 'transitive' : 'direct',
+        scopes: ['prod'],
+        requested: mod.version,
+        resolved: mod.version,
+        source: 'registry',
+        sourceUrl: 'https://proxy.golang.org',
+      };
+      if (mod.indirect) {
+        transitiveDeps.push(dep);
+      } else {
+        directDeps.push(dep);
+      }
+    }
+
+    const manifest: PackageManifest = {
+      version: MANIFEST_VERSION,
+      runtime: 'go',
+      runtimeVersion: {
+        resolved,
+      },
+      dependencies: [
+        ...directDeps.sort((a, b) => a.name.localeCompare(b.name)),
+        ...transitiveDeps.sort((a, b) => a.name.localeCompare(b.name)),
+      ],
+    };
+
+    await writeProjectManifest(manifest, workPath, 'go');
+  } catch {
+    // Never throw — build must succeed
+  }
+}
+
+export const diagnostics = createDiagnostics('go');

--- a/packages/go/src/diagnostics.ts
+++ b/packages/go/src/diagnostics.ts
@@ -34,17 +34,28 @@ function parseRequireEntry(
   };
 }
 
+// A parsed replace directive.
+// `from.version` undefined → matches all versions of `from.name`.
+// `to` null → local file-path replacement (drop the module).
+// `to` object → module-path replacement (substitute name + version).
+interface ReplaceRule {
+  from: { name: string; version: string | undefined };
+  to: { name: string; version: string } | null;
+}
+
 // Parses a replace entry — text after the `replace` keyword (single-line)
-// or a single line inside a `replace ( ... )` block. Returns the LHS module
-// name iff the entry replaces it with a local file path (RHS has no version,
-// per the Go spec); returns null for module-path replacements and for
+// or a single line inside a `replace ( ... )` block. Returns null for
 // unparseable lines.
-function getDependencyReplacedByLocal(text: string): string | null {
+function parseReplaceEntry(text: string): ReplaceRule | null {
   const m = stripComment(text).match(
-    /^(\S+)(?:\s+\S+)?\s+=>\s+\S+(?:\s+(\S+))?\s*$/
+    /^(\S+)(?:\s+(\S+))?\s+=>\s+(\S+)(?:\s+(\S+))?\s*$/
   );
   if (!m) return null;
-  return m[2] ? null : m[1];
+  const from = { name: m[1], version: m[2] };
+  // RHS has a version → module-path replacement; otherwise → local file path
+  return m[4]
+    ? { from, to: { name: m[3], version: m[4] } }
+    : { from, to: null };
 }
 
 export function parseGoMod(content: string): {
@@ -54,7 +65,7 @@ export function parseGoMod(content: string): {
   const lines = content.split(/\r?\n/);
   let goVersion = '';
   const allModules: GoModModule[] = [];
-  const localReplaces = new Set<string>();
+  const replaceRules: ReplaceRule[] = [];
 
   let i = 0;
   while (i < lines.length) {
@@ -98,8 +109,8 @@ export function parseGoMod(content: string): {
           i++;
           break;
         }
-        const local = getDependencyReplacedByLocal(innerRaw);
-        if (local) localReplaces.add(local);
+        const rule = parseReplaceEntry(innerRaw);
+        if (rule) replaceRules.push(rule);
         i++;
       }
       continue;
@@ -117,8 +128,8 @@ export function parseGoMod(content: string): {
     // Read a single-line replace
     const replHead = stripComment(raw).match(/^replace\s+(.*)$/);
     if (replHead) {
-      const local = getDependencyReplacedByLocal(replHead[1]);
-      if (local) localReplaces.add(local);
+      const rule = parseReplaceEntry(replHead[1]);
+      if (rule) replaceRules.push(rule);
       i++;
       continue;
     }
@@ -126,7 +137,30 @@ export function parseGoMod(content: string): {
     i++;
   }
 
-  const modules = allModules.filter(m => !localReplaces.has(m.name));
+  // Apply replace rules to each required module. A version-specific rule
+  // (`replace foo v1.2.3 => ...`) only applies when versions match; a
+  // versionless rule (`replace foo => ...`) applies to any version. When
+  // both exist for the same module, the specific match takes precedence.
+  const modules: GoModModule[] = [];
+  for (const m of allModules) {
+    const specific = replaceRules.find(
+      r => r.from.name === m.name && r.from.version === m.version
+    );
+    const wildcard = replaceRules.find(
+      r => r.from.name === m.name && r.from.version === undefined
+    );
+    const rule = specific ?? wildcard;
+    if (!rule) {
+      modules.push(m);
+      continue;
+    }
+    if (rule.to === null) continue; // local replace → drop
+    modules.push({
+      name: rule.to.name,
+      version: rule.to.version,
+      indirect: m.indirect,
+    });
+  }
   return { goVersion, modules };
 }
 

--- a/packages/go/src/diagnostics.ts
+++ b/packages/go/src/diagnostics.ts
@@ -167,19 +167,21 @@ export function parseGoMod(content: string): {
 export async function generateProjectManifest({
   workPath,
   goModPath,
-  goVersion,
+  resolvedGoVersion,
+  framework,
+  serviceType,
 }: {
   workPath: string;
   goModPath: string | undefined;
-  goVersion: string;
+  resolvedGoVersion: string;
+  framework?: string | null;
+  serviceType?: string | null;
 }): Promise<void> {
   try {
     if (!goModPath) return;
 
     const content = await fs.promises.readFile(goModPath, 'utf-8');
-    const { goVersion: parsedGoVersion, modules } = parseGoMod(content);
-
-    const resolved = parsedGoVersion || goVersion;
+    const { goVersion: requested, modules } = parseGoMod(content);
 
     const directDeps: PackageManifestDependency[] = [];
     const transitiveDeps: PackageManifestDependency[] = [];
@@ -204,8 +206,11 @@ export async function generateProjectManifest({
     const manifest: PackageManifest = {
       version: MANIFEST_VERSION,
       runtime: 'go',
+      ...(framework ? { framework } : {}),
+      ...(serviceType ? { serviceType } : {}),
       runtimeVersion: {
-        resolved,
+        ...(requested ? { requested } : {}),
+        resolved: resolvedGoVersion,
       },
       dependencies: [
         ...directDeps.sort((a, b) => a.name.localeCompare(b.name)),

--- a/packages/go/src/diagnostics.ts
+++ b/packages/go/src/diagnostics.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import {
   writeProjectManifest,
   createDiagnostics,
@@ -7,181 +6,81 @@ import {
   type PackageManifestDependency,
 } from '@vercel/build-utils';
 
-interface GoModModule {
+import type { GoModJson } from './go-helpers';
+
+interface NormalizedModule {
   name: string;
   version: string;
   indirect: boolean;
 }
 
-const stripComment = (s: string) => s.replace(/\/\/.*$/, '').trim();
+/**
+ * Applies a `go.mod`'s Replace[] rules to its Require[] list.
+ *
+ * Version-specific rules (`replace foo v1.2.3 => ...`) only fire when versions match.
+ * Version-less rules (`replace foo => ...`) fire for any version of the same module.
+ *
+ * Local-path replacements (`replace foo => ../local`) drop the module entirely.
+ * Module-path replacements (`replace foo => github.com/fork/bar`) substitute name + version.
+ *
+ * Indirect status is preserved.
+ */
+export function applyReplaces(goMod: GoModJson): NormalizedModule[] {
+  const requires = goMod.Require ?? [];
+  const replaces = goMod.Replace ?? [];
+  const result: NormalizedModule[] = [];
 
-// `// indirect` may appear with or without a leading space. Match Go's
-// modfile parser by allowing either form, but only as the trailing comment.
-const isIndirectComment = (s: string) => /\/\/\s*indirect\s*$/.test(s);
-
-// Parses a require entry — text after the `require` keyword (single-line)
-// or a single line inside a `require ( ... )` block.
-function parseRequireEntry(
-  text: string,
-  rawWithComment: string
-): GoModModule | null {
-  const m = stripComment(text).match(/^(\S+)\s+(\S+)/);
-  if (!m) return null;
-  return {
-    name: m[1],
-    version: m[2],
-    indirect: isIndirectComment(rawWithComment),
-  };
-}
-
-// A parsed replace directive.
-// `from.version` undefined → matches all versions of `from.name`.
-// `to` null → local file-path replacement (drop the module).
-// `to` object → module-path replacement (substitute name + version).
-interface ReplaceRule {
-  from: { name: string; version: string | undefined };
-  to: { name: string; version: string } | null;
-}
-
-// Parses a replace entry — text after the `replace` keyword (single-line)
-// or a single line inside a `replace ( ... )` block. Returns null for
-// unparseable lines.
-function parseReplaceEntry(text: string): ReplaceRule | null {
-  const m = stripComment(text).match(
-    /^(\S+)(?:\s+(\S+))?\s+=>\s+(\S+)(?:\s+(\S+))?\s*$/
-  );
-  if (!m) return null;
-  const from = { name: m[1], version: m[2] };
-  // RHS has a version → module-path replacement; otherwise → local file path
-  return m[4]
-    ? { from, to: { name: m[3], version: m[4] } }
-    : { from, to: null };
-}
-
-export function parseGoMod(content: string): {
-  goVersion: string;
-  modules: GoModModule[];
-} {
-  const lines = content.split(/\r?\n/);
-  let goVersion = '';
-  const allModules: GoModModule[] = [];
-  const replaceRules: ReplaceRule[] = [];
-
-  let i = 0;
-  while (i < lines.length) {
-    const raw = lines[i].trim();
-
-    if (!raw || raw.startsWith('//')) {
-      i++;
-      continue;
-    }
-
-    // Read the go version
-    const goMatch = raw.match(/^go\s+(\d+\.\d+(?:\.\d+)?)/);
-    if (goMatch) {
-      goVersion = goMatch[1];
-      i++;
-      continue;
-    }
-
-    // Read a require block
-    if (/^require\s*\(/.test(raw)) {
-      i++;
-      while (i < lines.length) {
-        const innerRaw = lines[i].trim();
-        if (innerRaw === ')') {
-          i++;
-          break;
-        }
-        const entry = parseRequireEntry(innerRaw, innerRaw);
-        if (entry) allModules.push(entry);
-        i++;
-      }
-      continue;
-    }
-
-    // Read a replace block
-    if (/^replace\s*\(/.test(raw)) {
-      i++;
-      while (i < lines.length) {
-        const innerRaw = lines[i].trim();
-        if (innerRaw === ')') {
-          i++;
-          break;
-        }
-        const rule = parseReplaceEntry(innerRaw);
-        if (rule) replaceRules.push(rule);
-        i++;
-      }
-      continue;
-    }
-
-    // Read a single-line require
-    const reqHead = stripComment(raw).match(/^require\s+(.*)$/);
-    if (reqHead) {
-      const entry = parseRequireEntry(reqHead[1], raw);
-      if (entry) allModules.push(entry);
-      i++;
-      continue;
-    }
-
-    // Read a single-line replace
-    const replHead = stripComment(raw).match(/^replace\s+(.*)$/);
-    if (replHead) {
-      const rule = parseReplaceEntry(replHead[1]);
-      if (rule) replaceRules.push(rule);
-      i++;
-      continue;
-    }
-
-    i++;
-  }
-
-  // Apply replace rules to each required module. A version-specific rule
-  // (`replace foo v1.2.3 => ...`) only applies when versions match; a
-  // versionless rule (`replace foo => ...`) applies to any version. When
-  // both exist for the same module, the specific match takes precedence.
-  const modules: GoModModule[] = [];
-  for (const m of allModules) {
-    const specific = replaceRules.find(
-      r => r.from.name === m.name && r.from.version === m.version
+  for (const req of requires) {
+    const specific = replaces.find(
+      r => r.Old.Path === req.Path && r.Old.Version === req.Version
     );
-    const wildcard = replaceRules.find(
-      r => r.from.name === m.name && r.from.version === undefined
+    const wildcard = replaces.find(
+      r => r.Old.Path === req.Path && r.Old.Version === undefined
     );
     const rule = specific ?? wildcard;
+
+    const indirect = req.Indirect === true;
+
     if (!rule) {
-      modules.push(m);
+      result.push({ name: req.Path, version: req.Version, indirect });
       continue;
     }
-    if (rule.to === null) continue; // local replace → drop
-    modules.push({
-      name: rule.to.name,
-      version: rule.to.version,
-      indirect: m.indirect,
+
+    if (rule.New.Version === undefined) {
+      continue;
+    }
+
+    result.push({
+      name: rule.New.Path,
+      version: rule.New.Version,
+      indirect,
     });
   }
-  return { goVersion, modules };
+
+  return result;
 }
 
 export async function generateProjectManifest({
   workPath,
-  goModPath,
+  goModJson,
   resolvedGoVersion,
   framework,
   serviceType,
 }: {
   workPath: string;
-  goModPath: string | undefined;
+  goModJson: GoModJson | null;
   resolvedGoVersion: string;
   framework?: string | null;
   serviceType?: string | null;
 }): Promise<void> {
   try {
-    if (!goModPath) return;
+    if (!goModJson) return;
 
-    const content = await fs.promises.readFile(goModPath, 'utf-8');
-    const { goVersion: requested, modules } = parseGoMod(content);
+    const projectModule = goModJson.Module?.Path;
+    const modules = applyReplaces(goModJson).filter(
+      m => m.name !== projectModule
+    );
+    const requested = goModJson.Go;
 
     const directDeps: PackageManifestDependency[] = [];
     const transitiveDeps: PackageManifestDependency[] = [];

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -205,13 +205,15 @@ Learn more: https://vercel.com/docs/functions/serverless-functions/runtimes/go
 export class GoWrapper {
   private env: Env;
   private opts: execa.Options;
+  readonly resolvedVersion: string;
 
-  constructor(env: Env, opts: execa.Options = {}) {
+  constructor(env: Env, opts: execa.Options = {}, resolvedVersion: string) {
     if (!opts.cwd) {
       opts.cwd = process.cwd();
     }
     this.env = env;
     this.opts = opts;
+    this.resolvedVersion = resolvedVersion;
   }
 
   private async execute(...args: string[]) {
@@ -437,7 +439,7 @@ export async function createGo({
         debug(`Selected go ${version} (from ${label})`);
 
         await setGoEnv(goDir);
-        return new GoWrapper(env, opts);
+        return new GoWrapper(env, opts, version);
       } else {
         debug(`Found go ${version} in ${label}, but need ${goSelectedVersion}`);
       }
@@ -453,7 +455,7 @@ export async function createGo({
   });
 
   await setGoEnv(goGlobalCacheDir);
-  return new GoWrapper(env, opts);
+  return new GoWrapper(env, opts, goSelectedVersion);
 }
 
 /**

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -202,6 +202,16 @@ Learn more: https://vercel.com/docs/functions/serverless-functions/runtimes/go
   return JSON.parse(analyzed) as Analyzed;
 }
 
+export interface GoModJson {
+  Module?: { Path: string };
+  Go?: string;
+  Require?: Array<{ Path: string; Version: string; Indirect?: boolean }>;
+  Replace?: Array<{
+    Old: { Path: string; Version?: string };
+    New: { Path: string; Version?: string };
+  }>;
+}
+
 export class GoWrapper {
   private env: Env;
   private opts: execa.Options;
@@ -252,6 +262,26 @@ export class GoWrapper {
       args.push('-e');
     }
     return this.execute(...args);
+  }
+
+  /**
+   * Runs `go mod edit -json <path>` and returns the parsed structure.
+   */
+  async modEditJson(goModPath: string): Promise<GoModJson | null> {
+    try {
+      debug(`Exec: go mod edit -json ${goModPath}`);
+      const result = await execa('go', ['mod', 'edit', '-json', goModPath], {
+        ...this.opts,
+        env: this.env,
+        extendEnv: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      return JSON.parse(result.stdout) as GoModJson;
+    } catch (err) {
+      debug(`Failed to read go.mod for manifest: ${err}`);
+      return null;
+    }
   }
 
   vendor() {

--- a/packages/go/src/index.ts
+++ b/packages/go/src/index.ts
@@ -263,9 +263,10 @@ export async function build(options: BuildOptions) {
 
     // Emit the manifest after resolving the Go version but before building the handler
     // injects the @vercel/go-bridge.
+    const goModJson = goModPath ? await go.modEditJson(goModPath) : null;
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson,
       resolvedGoVersion: go.resolvedVersion,
       framework: config.framework ?? undefined,
       serviceType: service ? getReportedServiceType(service) : undefined,

--- a/packages/go/src/index.ts
+++ b/packages/go/src/index.ts
@@ -55,7 +55,9 @@ import {
   startStandaloneDevServer,
 } from './standalone-server';
 
-export { shouldServe };
+import { generateProjectManifest, diagnostics } from './diagnostics';
+
+export { shouldServe, diagnostics };
 
 // in order to allow the user to have `main.go`,
 // we need our `main.go` to be called something else
@@ -294,6 +296,8 @@ export async function build(options: BuildOptions) {
         });
       });
     }
+
+    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
 
     return {
       output: lambda,

--- a/packages/go/src/index.ts
+++ b/packages/go/src/index.ts
@@ -34,6 +34,7 @@ import {
   cloneEnv,
   getProvidedRuntime,
   execCommand,
+  getReportedServiceType,
 } from '@vercel/build-utils';
 
 const TMP = tmpdir();
@@ -122,7 +123,14 @@ type UndoActions = {
 export const version = 3;
 
 export async function build(options: BuildOptions) {
-  const { files, config, workPath, meta = {}, registerPreDeploy } = options;
+  const {
+    files,
+    config,
+    workPath,
+    meta = {},
+    service,
+    registerPreDeploy,
+  } = options;
   let { entrypoint } = options;
 
   const goPath = await getWriteableDirectory();
@@ -253,6 +261,16 @@ export async function build(options: BuildOptions) {
       workPath,
     });
 
+    // Emit the manifest after resolving the Go version but before building the handler
+    // injects the @vercel/go-bridge.
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: go.resolvedVersion,
+      framework: config.framework ?? undefined,
+      serviceType: service ? getReportedServiceType(service) : undefined,
+    });
+
     const outDir = await getWriteableDirectory();
     const buildOptions: BuildHandlerOptions = {
       downloadPath,
@@ -296,8 +314,6 @@ export async function build(options: BuildOptions) {
         });
       });
     }
-
-    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
 
     return {
       output: lambda,

--- a/packages/go/src/standalone-server.ts
+++ b/packages/go/src/standalone-server.ts
@@ -15,6 +15,7 @@ import {
   cloneEnv,
   getLambdaOptionsFromFunction,
   execCommand,
+  getReportedServiceType,
 } from '@vercel/build-utils';
 
 import { createGo, findGoBinary } from './go-helpers';
@@ -57,6 +58,7 @@ export async function buildStandaloneServer({
   workPath,
   meta = {},
   registerPreDeploy,
+  service,
 }: BuildOptions): Promise<{ output: Lambda }> {
   debug(`Building standalone Go server: ${entrypoint}`);
 
@@ -226,7 +228,13 @@ export async function buildStandaloneServer({
     });
   }
 
-  await generateProjectManifest({ workPath, goModPath, goVersion: '' });
+  await generateProjectManifest({
+    workPath,
+    goModPath,
+    resolvedGoVersion: go.resolvedVersion,
+    framework: config.framework ?? undefined,
+    serviceType: service ? getReportedServiceType(service) : undefined,
+  });
 
   return { output: lambda };
 }

--- a/packages/go/src/standalone-server.ts
+++ b/packages/go/src/standalone-server.ts
@@ -228,9 +228,10 @@ export async function buildStandaloneServer({
     });
   }
 
+  const goModJson = goModPath ? await go.modEditJson(goModPath) : null;
   await generateProjectManifest({
     workPath,
-    goModPath,
+    goModJson,
     resolvedGoVersion: go.resolvedVersion,
     framework: config.framework ?? undefined,
     serviceType: service ? getReportedServiceType(service) : undefined,

--- a/packages/go/src/standalone-server.ts
+++ b/packages/go/src/standalone-server.ts
@@ -18,6 +18,7 @@ import {
 } from '@vercel/build-utils';
 
 import { createGo, findGoBinary } from './go-helpers';
+import { generateProjectManifest } from './diagnostics';
 
 /**
  * Find the go.mod file starting from a directory and scanning up.
@@ -224,6 +225,8 @@ export async function buildStandaloneServer({
       });
     });
   }
+
+  await generateProjectManifest({ workPath, goModPath, goVersion: '' });
 
   return { output: lambda };
 }

--- a/packages/go/test/diagnostics.test.ts
+++ b/packages/go/test/diagnostics.test.ts
@@ -9,9 +9,10 @@ import {
 } from '@vercel/build-utils';
 import {
   generateProjectManifest,
-  parseGoMod,
+  applyReplaces,
   diagnostics,
 } from '../src/diagnostics';
+import type { GoModJson } from '../src/go-helpers';
 
 const DIAGNOSTICS_PATH = manifestPath('go');
 
@@ -19,456 +20,12 @@ function makeTempDir(): string {
   return fs.mkdtempSync(path.join(tmpdir(), 'vc-go-diag-test-'));
 }
 
-function writeGoMod(dir: string, content: string): string {
-  const goModPath = path.join(dir, 'go.mod');
-  fs.writeFileSync(goModPath, content);
-  return goModPath;
-}
-
-describe('parseGoMod', () => {
-  it('extracts go version from go directive', () => {
-    const { goVersion } = parseGoMod('module example.com/app\n\ngo 1.21\n');
-    expect(goVersion).toBe('1.21');
-  });
-
-  it('extracts go version with patch', () => {
-    const { goVersion } = parseGoMod('module example.com/app\n\ngo 1.21.3\n');
-    expect(goVersion).toBe('1.21.3');
-  });
-
-  it('returns empty string when no go directive', () => {
-    const { goVersion } = parseGoMod('module example.com/app\n');
-    expect(goVersion).toBe('');
-  });
-
-  it('parses direct deps from require block', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/gin-gonic/gin v1.9.1
-    github.com/stretchr/testify v1.8.4
-)
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(2);
-    expect(modules[0]).toMatchObject({
-      name: 'github.com/gin-gonic/gin',
-      version: 'v1.9.1',
-      indirect: false,
-    });
-    expect(modules[1]).toMatchObject({
-      name: 'github.com/stretchr/testify',
-      version: 'v1.8.4',
-      indirect: false,
-    });
-  });
-
-  it('parses indirect deps', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/gin-gonic/gin v1.9.1
-    github.com/go-playground/validator/v10 v10.15.5 // indirect
-)
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(2);
-    expect(modules[0]).toMatchObject({
-      name: 'github.com/gin-gonic/gin',
-      indirect: false,
-    });
-    expect(modules[1]).toMatchObject({
-      name: 'github.com/go-playground/validator/v10',
-      indirect: true,
-    });
-  });
-
-  it('parses single-line require', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require github.com/pkg/errors v0.9.1
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(1);
-    expect(modules[0]).toMatchObject({
-      name: 'github.com/pkg/errors',
-      version: 'v0.9.1',
-      indirect: false,
-    });
-  });
-
-  it('excludes modules replaced with local paths (block form)', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/local/pkg v0.1.0
-    github.com/remote/pkg v1.0.0
-)
-
-replace github.com/local/pkg => ./local/pkg
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(1);
-    expect(modules[0].name).toBe('github.com/remote/pkg');
-  });
-
-  it('excludes modules replaced with local paths (replace block form)', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/local/pkg v0.1.0
-    github.com/also/local v0.2.0
-    github.com/remote/pkg v1.0.0
-)
-
-replace (
-    github.com/local/pkg v0.1.0 => ./local/pkg
-    github.com/also/local => ../sibling
-)
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(1);
-    expect(modules[0].name).toBe('github.com/remote/pkg');
-  });
-
-  it('keeps module when versioned local replace targets a different version', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require example.com/foo v1.5.0
-
-replace example.com/foo v1.2.3 => ./local
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(1);
-    expect(modules[0]).toMatchObject({
-      name: 'example.com/foo',
-      version: 'v1.5.0',
-    });
-  });
-
-  it('excludes module when versioned local replace targets the required version', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require example.com/foo v1.2.3
-
-replace example.com/foo v1.2.3 => ./local
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toEqual([]);
-  });
-
-  it('versionless local replace excludes regardless of required version', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require example.com/foo v9.9.9
-
-replace example.com/foo => ./local
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toEqual([]);
-  });
-
-  it('substitutes module-path replaces with the replacement name and version', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require github.com/old/pkg v1.0.0
-
-replace github.com/old/pkg => github.com/new/pkg v2.0.0
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toEqual([
-      {
-        name: 'github.com/new/pkg',
-        version: 'v2.0.0',
-        indirect: false,
-      },
-    ]);
-  });
-
-  it('preserves indirect status when substituting via replace', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/direct v1.0.0
-    github.com/indirect v1.0.0 // indirect
-)
-
-replace github.com/indirect => github.com/forked v2.0.0
-`;
-    const { modules } = parseGoMod(content);
-    const forked = modules.find(m => m.name === 'github.com/forked');
-    expect(forked).toMatchObject({ version: 'v2.0.0', indirect: true });
-  });
-
-  it('substitutes only the matching version for a versioned module replace', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require github.com/foo v1.5.0
-
-replace github.com/foo v1.2.3 => github.com/bar v2.0.0
-`;
-    const { modules } = parseGoMod(content);
-    // require version (v1.5.0) doesn't match replace LHS (v1.2.3), so the
-    // replace doesn't apply and the original entry is preserved.
-    expect(modules).toEqual([
-      { name: 'github.com/foo', version: 'v1.5.0', indirect: false },
-    ]);
-  });
-
-  it('substitutes version-only replace (same name, new version)', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require github.com/foo v1.0.0
-
-replace github.com/foo v1.0.0 => github.com/foo v1.0.5
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toEqual([
-      { name: 'github.com/foo', version: 'v1.0.5', indirect: false },
-    ]);
-  });
-
-  it('prefers specific-version replace over wildcard replace', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/foo v1.0.0
-    github.com/foo-also v2.0.0
-)
-
-replace github.com/foo => github.com/wildcard v9.9.9
-replace github.com/foo v1.0.0 => github.com/specific v1.0.1
-`;
-    const { modules } = parseGoMod(content);
-    const names = modules.map(m => `${m.name}@${m.version}`).sort();
-    // foo v1.0.0 → specific (matches version)
-    // foo-also v2.0.0 → no rule matches, kept as-is
-    expect(names).toEqual([
-      'github.com/foo-also@v2.0.0',
-      'github.com/specific@v1.0.1',
-    ]);
-  });
-
-  it('excludes modules replaced with absolute local paths', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/local/pkg v0.1.0
-    github.com/remote/pkg v1.0.0
-)
-
-replace github.com/local/pkg => /absolute/path
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(1);
-    expect(modules[0].name).toBe('github.com/remote/pkg');
-  });
-
-  it('excludes modules replaced with bare local paths in block form', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/a v1.0.0
-    github.com/b v1.0.0
-    github.com/c v1.0.0
-)
-
-replace (
-    github.com/a => ./local
-    github.com/b => /abs/path
-    github.com/c v1.0.0 => ../sibling
-)
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(0);
-  });
-
-  it('handles trailing comments on replace directives', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require github.com/foo v1.0.0
-
-replace github.com/foo => ./local // pinned for debugging
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(0);
-  });
-
-  it('handles indirect comment without leading space', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/foo v1.0.0 //indirect
-    github.com/bar v2.0.0// indirect
-)
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toEqual([
-      { name: 'github.com/foo', version: 'v1.0.0', indirect: true },
-      { name: 'github.com/bar', version: 'v2.0.0', indirect: true },
-    ]);
-  });
-
-  it('does not pollute version with trailing comment', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require github.com/foo v1.0.0 // some note
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(1);
-    expect(modules[0].version).toBe('v1.0.0');
-  });
-
-  it('handles multiple require blocks', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require github.com/pkg/a v1.0.0
-
-require (
-    github.com/pkg/b v2.0.0
-    github.com/pkg/c v3.0.0 // indirect
-)
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(3);
-  });
-
-  it('ignores exclude directives', () => {
-    const content = `module example.com/app
-
-go 1.21
-
-require github.com/pkg/a v1.0.0
-
-exclude github.com/old/dep v1.0.0
-
-exclude (
-    github.com/another/excluded v0.5.0
-    github.com/yet/another v2.0.0
-)
-`;
-    const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(1);
-    expect(modules[0].name).toBe('github.com/pkg/a');
-  });
-
-  it('ignores toolchain directive', () => {
-    const content = `module example.com/app
-
-go 1.21
-toolchain go1.22.1
-
-require github.com/pkg/a v1.0.0
-`;
-    const { goVersion, modules } = parseGoMod(content);
-    expect(goVersion).toBe('1.21');
-    expect(modules).toHaveLength(1);
-    expect(modules[0].name).toBe('github.com/pkg/a');
-  });
-
-  it('returns empty modules when go.mod has no requires', () => {
-    const content = `module example.com/app
-
-go 1.21
-`;
-    const { goVersion, modules } = parseGoMod(content);
-    expect(goVersion).toBe('1.21');
-    expect(modules).toEqual([]);
-  });
-
-  it('ignores godebug, retract, ignore, and tool directives without false matches', () => {
-    const content = `module example.com/mymodule
-
-go 1.24
-
-toolchain go1.24.1
-
-godebug asynctimerchan=0
-
-godebug (
-    default=go1.21
-    panicnil=1
-)
-
-require (
-    github.com/keep/me v1.0.0
-    golang.org/x/tools v0.20.0 // indirect
-)
-
-tool example.com/mymodule/cmd/mytool
-
-tool (
-    golang.org/x/tools/cmd/stringer
-    github.com/foo/bar/cmd/foo
-)
-
-retract v1.0.0 // accidental release
-
-retract (
-    [v1.1.0, v1.1.5]
-    v1.2.0 // contains retraction only
-)
-
-ignore ./node_modules
-
-ignore (
-    static
-    generated
-)
-`;
-    const { goVersion, modules } = parseGoMod(content);
-    expect(goVersion).toBe('1.24');
-    expect(modules.map(m => m.name).sort()).toEqual([
-      'github.com/keep/me',
-      'golang.org/x/tools',
-    ]);
-  });
-});
-
 describe('generateProjectManifest', () => {
-  it('skips manifest generation when goModPath is undefined', async () => {
+  it('skips manifest generation when goModJson is undefined', async () => {
     const workPath = makeTempDir();
     await generateProjectManifest({
       workPath,
-      goModPath: undefined,
+      goModJson: null,
       resolvedGoVersion: '1.21.13',
     });
     expect(fs.existsSync(path.join(workPath, DIAGNOSTICS_PATH))).toBe(false);
@@ -476,26 +33,27 @@ describe('generateProjectManifest', () => {
 
   it('writes manifest with direct and transitive deps', async () => {
     const workPath = makeTempDir();
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/gin-gonic/gin v1.9.1
-    github.com/go-playground/validator/v10 v10.15.5 // indirect
-)
-`;
-    const goModPath = writeGoMod(workPath, content);
+    const goModJson: GoModJson = {
+      Module: { Path: 'example.com/app' },
+      Go: '1.21',
+      Require: [
+        { Path: 'github.com/gin-gonic/gin', Version: 'v1.9.1' },
+        {
+          Path: 'github.com/go-playground/validator/v10',
+          Version: 'v10.15.5',
+          Indirect: true,
+        },
+      ],
+    };
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson,
       resolvedGoVersion: '1.21.13',
     });
 
-    const manifestFile = path.join(workPath, DIAGNOSTICS_PATH);
-    expect(fs.existsSync(manifestFile)).toBe(true);
-
-    const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf-8'));
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
     expect(manifest.version).toBe(MANIFEST_VERSION);
     expect(manifest.runtime).toBe('go');
     expect(manifest.runtimeVersion.requested).toBe('1.21');
@@ -505,39 +63,45 @@ require (
     const direct = manifest.dependencies.find(
       (d: { name: string }) => d.name === 'github.com/gin-gonic/gin'
     );
-    expect(direct.type).toBe('direct');
-    expect(direct.scopes).toEqual(['prod']);
-    expect(direct.resolved).toBe('v1.9.1');
-    expect(direct.source).toBe('registry');
-    expect(direct.sourceUrl).toBe('https://proxy.golang.org');
+    expect(direct).toEqual({
+      name: 'github.com/gin-gonic/gin',
+      type: 'direct',
+      scopes: ['prod'],
+      requested: 'v1.9.1',
+      resolved: 'v1.9.1',
+      source: 'registry',
+      sourceUrl: 'https://proxy.golang.org',
+    });
 
     const transitive = manifest.dependencies.find(
       (d: { name: string }) =>
         d.name === 'github.com/go-playground/validator/v10'
     );
-    expect(transitive.type).toBe('transitive');
-    expect(transitive.scopes).toEqual(['prod']);
-    expect(transitive.resolved).toBe('v10.15.5');
-    expect(transitive.source).toBe('registry');
-    expect(transitive.sourceUrl).toBe('https://proxy.golang.org');
+    expect(transitive).toEqual({
+      name: 'github.com/go-playground/validator/v10',
+      type: 'transitive',
+      scopes: ['prod'],
+      requested: 'v10.15.5',
+      resolved: 'v10.15.5',
+      source: 'registry',
+      sourceUrl: 'https://proxy.golang.org',
+    });
   });
 
   it('sorts direct deps before transitive, each alphabetically', async () => {
     const workPath = makeTempDir();
-    const content = `module example.com/app
-
-go 1.21
-
-require (
-    github.com/zzz/pkg v1.0.0
-    github.com/aaa/indirect v0.1.0 // indirect
-    github.com/aaa/direct v2.0.0
-)
-`;
-    const goModPath = writeGoMod(workPath, content);
+    const goModJson: GoModJson = {
+      Module: { Path: 'example.com/app' },
+      Go: '1.21',
+      Require: [
+        { Path: 'github.com/zzz/pkg', Version: 'v1.0.0' },
+        { Path: 'github.com/aaa/indirect', Version: 'v0.1.0', Indirect: true },
+        { Path: 'github.com/aaa/direct', Version: 'v2.0.0' },
+      ],
+    };
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson,
       resolvedGoVersion: '1.21.13',
     });
 
@@ -552,16 +116,15 @@ require (
     ]);
   });
 
-  it('omits requested when go.mod has no go directive', async () => {
+  it('omits requested when goModJson has no Go field', async () => {
     const workPath = makeTempDir();
-    const content = `module example.com/app
-
-require github.com/pkg/errors v0.9.1
-`;
-    const goModPath = writeGoMod(workPath, content);
+    const goModJson: GoModJson = {
+      Module: { Path: 'example.com/app' },
+      Require: [{ Path: 'github.com/pkg/errors', Version: 'v0.9.1' }],
+    };
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson,
       resolvedGoVersion: '1.21.13',
     });
 
@@ -572,27 +135,15 @@ require github.com/pkg/errors v0.9.1
     expect(manifest.runtimeVersion.resolved).toBe('1.21.13');
   });
 
-  it('does not throw when go.mod is missing', async () => {
+  it('writes manifest with empty dependencies when goModJson has no Require', async () => {
     const workPath = makeTempDir();
-    const goModPath = path.join(workPath, 'go.mod');
-    await expect(
-      generateProjectManifest({
-        workPath,
-        goModPath,
-        resolvedGoVersion: '1.21.13',
-      })
-    ).resolves.toBeUndefined();
-  });
-
-  it('writes manifest with empty dependencies when go.mod has no requires', async () => {
-    const workPath = makeTempDir();
-    const goModPath = writeGoMod(
-      workPath,
-      'module example.com/app\n\ngo 1.21\n'
-    );
+    const goModJson: GoModJson = {
+      Module: { Path: 'example.com/app' },
+      Go: '1.21',
+    };
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson,
       resolvedGoVersion: '1.21.13',
     });
 
@@ -608,16 +159,17 @@ require github.com/pkg/errors v0.9.1
 
   it('does not include the project module itself as a dependency', async () => {
     const workPath = makeTempDir();
-    const content = `module example.com/myapp
-
-go 1.21
-
-require github.com/pkg/errors v0.9.1
-`;
-    const goModPath = writeGoMod(workPath, content);
+    const goModJson: GoModJson = {
+      Module: { Path: 'example.com/myapp' },
+      Go: '1.21',
+      Require: [
+        { Path: 'example.com/myapp', Version: 'v0.0.0' },
+        { Path: 'github.com/pkg/errors', Version: 'v0.9.1' },
+      ],
+    };
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson,
       resolvedGoVersion: '1.21.13',
     });
 
@@ -629,15 +181,67 @@ require github.com/pkg/errors v0.9.1
     expect(names).toContain('github.com/pkg/errors');
   });
 
-  it('includes framework in manifest when provided', async () => {
+  it('drops locally-replaced modules from the dependency list', async () => {
     const workPath = makeTempDir();
-    const goModPath = writeGoMod(
-      workPath,
-      'module example.com/app\n\ngo 1.21\n'
-    );
+    const goModJson: GoModJson = {
+      Module: { Path: 'example.com/app' },
+      Go: '1.21',
+      Require: [
+        { Path: 'github.com/foo/bar', Version: 'v1.0.0' },
+        { Path: 'github.com/keep/me', Version: 'v0.1.0' },
+      ],
+      Replace: [
+        {
+          Old: { Path: 'github.com/foo/bar' },
+          New: { Path: '../local' },
+        },
+      ],
+    };
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson,
+      resolvedGoVersion: '1.21.13',
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    const names = manifest.dependencies.map((d: { name: string }) => d.name);
+    expect(names).toEqual(['github.com/keep/me']);
+  });
+
+  it('substitutes module-path replaces in the dependency list', async () => {
+    const workPath = makeTempDir();
+    const goModJson: GoModJson = {
+      Module: { Path: 'example.com/app' },
+      Go: '1.21',
+      Require: [{ Path: 'github.com/foo/bar', Version: 'v1.0.0' }],
+      Replace: [
+        {
+          Old: { Path: 'github.com/foo/bar' },
+          New: { Path: 'github.com/fork/bar', Version: 'v2.0.0' },
+        },
+      ],
+    };
+    await generateProjectManifest({
+      workPath,
+      goModJson,
+      resolvedGoVersion: '1.21.13',
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    const names = manifest.dependencies.map((d: { name: string }) => d.name);
+    expect(names).toEqual(['github.com/fork/bar']);
+    expect(manifest.dependencies[0].resolved).toBe('v2.0.0');
+  });
+
+  it('includes framework in manifest when provided', async () => {
+    const workPath = makeTempDir();
+    await generateProjectManifest({
+      workPath,
+      goModJson: { Module: { Path: 'example.com/app' }, Go: '1.21' },
       resolvedGoVersion: '1.21.13',
       framework: 'go',
     });
@@ -650,13 +254,9 @@ require github.com/pkg/errors v0.9.1
 
   it('omits framework from manifest when not provided', async () => {
     const workPath = makeTempDir();
-    const goModPath = writeGoMod(
-      workPath,
-      'module example.com/app\n\ngo 1.21\n'
-    );
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson: { Module: { Path: 'example.com/app' }, Go: '1.21' },
       resolvedGoVersion: '1.21.13',
     });
 
@@ -668,13 +268,9 @@ require github.com/pkg/errors v0.9.1
 
   it('omits framework from manifest when empty string provided', async () => {
     const workPath = makeTempDir();
-    const goModPath = writeGoMod(
-      workPath,
-      'module example.com/app\n\ngo 1.21\n'
-    );
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson: { Module: { Path: 'example.com/app' }, Go: '1.21' },
       resolvedGoVersion: '1.21.13',
       framework: '',
     });
@@ -687,13 +283,9 @@ require github.com/pkg/errors v0.9.1
 
   it('includes serviceType in manifest when provided', async () => {
     const workPath = makeTempDir();
-    const goModPath = writeGoMod(
-      workPath,
-      'module example.com/app\n\ngo 1.21\n'
-    );
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson: { Module: { Path: 'example.com/app' }, Go: '1.21' },
       resolvedGoVersion: '1.21.13',
       serviceType: 'web',
     });
@@ -706,13 +298,9 @@ require github.com/pkg/errors v0.9.1
 
   it('omits serviceType from manifest when not provided', async () => {
     const workPath = makeTempDir();
-    const goModPath = writeGoMod(
-      workPath,
-      'module example.com/app\n\ngo 1.21\n'
-    );
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson: { Module: { Path: 'example.com/app' }, Go: '1.21' },
       resolvedGoVersion: '1.21.13',
     });
 
@@ -724,13 +312,9 @@ require github.com/pkg/errors v0.9.1
 
   it('omits serviceType from manifest when empty string provided', async () => {
     const workPath = makeTempDir();
-    const goModPath = writeGoMod(
-      workPath,
-      'module example.com/app\n\ngo 1.21\n'
-    );
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson: { Module: { Path: 'example.com/app' }, Go: '1.21' },
       resolvedGoVersion: '1.21.13',
       serviceType: '',
     });
@@ -743,13 +327,9 @@ require github.com/pkg/errors v0.9.1
 
   it('omits serviceType from manifest when null provided', async () => {
     const workPath = makeTempDir();
-    const goModPath = writeGoMod(
-      workPath,
-      'module example.com/app\n\ngo 1.21\n'
-    );
     await generateProjectManifest({
       workPath,
-      goModPath,
+      goModJson: { Module: { Path: 'example.com/app' }, Go: '1.21' },
       resolvedGoVersion: '1.21.13',
       serviceType: null,
     });
@@ -782,5 +362,106 @@ describe('diagnostics callback', () => {
       version: MANIFEST_VERSION,
       test: true,
     });
+  });
+});
+
+describe('applyReplaces', () => {
+  it('passes requires through when no replaces are present', () => {
+    const result = applyReplaces({
+      Require: [
+        { Path: 'github.com/foo/bar', Version: 'v1.0.0' },
+        { Path: 'github.com/baz/qux', Version: 'v2.1.0', Indirect: true },
+      ],
+    });
+    expect(result).toEqual([
+      { name: 'github.com/foo/bar', version: 'v1.0.0', indirect: false },
+      { name: 'github.com/baz/qux', version: 'v2.1.0', indirect: true },
+    ]);
+  });
+
+  it('drops modules replaced with a local path (New.Version absent)', () => {
+    const result = applyReplaces({
+      Require: [
+        { Path: 'github.com/foo/bar', Version: 'v1.0.0' },
+        { Path: 'github.com/keep/me', Version: 'v0.1.0' },
+      ],
+      Replace: [
+        {
+          Old: { Path: 'github.com/foo/bar' },
+          New: { Path: '../local' },
+        },
+      ],
+    });
+    expect(result).toEqual([
+      { name: 'github.com/keep/me', version: 'v0.1.0', indirect: false },
+    ]);
+  });
+
+  it('substitutes module-path replaces with the replacement name and version', () => {
+    const result = applyReplaces({
+      Require: [{ Path: 'github.com/foo/bar', Version: 'v1.0.0' }],
+      Replace: [
+        {
+          Old: { Path: 'github.com/foo/bar' },
+          New: { Path: 'github.com/fork/bar', Version: 'v2.0.0' },
+        },
+      ],
+    });
+    expect(result).toEqual([
+      { name: 'github.com/fork/bar', version: 'v2.0.0', indirect: false },
+    ]);
+  });
+
+  it('preserves indirect status when substituting via replace', () => {
+    const result = applyReplaces({
+      Require: [
+        { Path: 'github.com/foo/bar', Version: 'v1.0.0', Indirect: true },
+      ],
+      Replace: [
+        {
+          Old: { Path: 'github.com/foo/bar' },
+          New: { Path: 'github.com/fork/bar', Version: 'v2.0.0' },
+        },
+      ],
+    });
+    expect(result[0].indirect).toBe(true);
+  });
+
+  it('applies a versioned replace only when the version matches', () => {
+    const result = applyReplaces({
+      Require: [{ Path: 'github.com/foo/bar', Version: 'v1.0.0' }],
+      Replace: [
+        {
+          Old: { Path: 'github.com/foo/bar', Version: 'v2.0.0' },
+          New: { Path: 'github.com/fork/bar', Version: 'v2.0.1' },
+        },
+      ],
+    });
+    expect(result).toEqual([
+      { name: 'github.com/foo/bar', version: 'v1.0.0', indirect: false },
+    ]);
+  });
+
+  it('prefers a version-specific replace over a wildcard replace', () => {
+    const result = applyReplaces({
+      Require: [{ Path: 'github.com/foo/bar', Version: 'v1.0.0' }],
+      Replace: [
+        {
+          Old: { Path: 'github.com/foo/bar' },
+          New: { Path: 'github.com/wildcard/bar', Version: 'v9.0.0' },
+        },
+        {
+          Old: { Path: 'github.com/foo/bar', Version: 'v1.0.0' },
+          New: { Path: 'github.com/specific/bar', Version: 'v1.5.0' },
+        },
+      ],
+    });
+    expect(result).toEqual([
+      { name: 'github.com/specific/bar', version: 'v1.5.0', indirect: false },
+    ]);
+  });
+
+  it('returns empty when Require is absent', () => {
+    expect(applyReplaces({})).toEqual([]);
   });
 });

--- a/packages/go/test/diagnostics.test.ts
+++ b/packages/go/test/diagnostics.test.ts
@@ -1,0 +1,504 @@
+import fs from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import {
+  FileBlob,
+  MANIFEST_FILENAME,
+  MANIFEST_VERSION,
+  manifestPath,
+} from '@vercel/build-utils';
+import {
+  generateProjectManifest,
+  parseGoMod,
+  diagnostics,
+} from '../src/diagnostics';
+
+const DIAGNOSTICS_PATH = manifestPath('go');
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(tmpdir(), 'vc-go-diag-test-'));
+}
+
+function writeGoMod(dir: string, content: string): string {
+  const goModPath = path.join(dir, 'go.mod');
+  fs.writeFileSync(goModPath, content);
+  return goModPath;
+}
+
+describe('parseGoMod', () => {
+  it('extracts go version from go directive', () => {
+    const { goVersion } = parseGoMod('module example.com/app\n\ngo 1.21\n');
+    expect(goVersion).toBe('1.21');
+  });
+
+  it('extracts go version with patch', () => {
+    const { goVersion } = parseGoMod('module example.com/app\n\ngo 1.21.3\n');
+    expect(goVersion).toBe('1.21.3');
+  });
+
+  it('returns empty string when no go directive', () => {
+    const { goVersion } = parseGoMod('module example.com/app\n');
+    expect(goVersion).toBe('');
+  });
+
+  it('parses direct deps from require block', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/gin-gonic/gin v1.9.1
+    github.com/stretchr/testify v1.8.4
+)
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(2);
+    expect(modules[0]).toMatchObject({
+      name: 'github.com/gin-gonic/gin',
+      version: 'v1.9.1',
+      indirect: false,
+    });
+    expect(modules[1]).toMatchObject({
+      name: 'github.com/stretchr/testify',
+      version: 'v1.8.4',
+      indirect: false,
+    });
+  });
+
+  it('parses indirect deps', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/gin-gonic/gin v1.9.1
+    github.com/go-playground/validator/v10 v10.15.5 // indirect
+)
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(2);
+    expect(modules[0]).toMatchObject({
+      name: 'github.com/gin-gonic/gin',
+      indirect: false,
+    });
+    expect(modules[1]).toMatchObject({
+      name: 'github.com/go-playground/validator/v10',
+      indirect: true,
+    });
+  });
+
+  it('parses single-line require', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require github.com/pkg/errors v0.9.1
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(1);
+    expect(modules[0]).toMatchObject({
+      name: 'github.com/pkg/errors',
+      version: 'v0.9.1',
+      indirect: false,
+    });
+  });
+
+  it('excludes modules replaced with local paths (block form)', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/local/pkg v0.1.0
+    github.com/remote/pkg v1.0.0
+)
+
+replace github.com/local/pkg => ./local/pkg
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].name).toBe('github.com/remote/pkg');
+  });
+
+  it('excludes modules replaced with local paths (replace block form)', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/local/pkg v0.1.0
+    github.com/also/local v0.2.0
+    github.com/remote/pkg v1.0.0
+)
+
+replace (
+    github.com/local/pkg v0.1.0 => ./local/pkg
+    github.com/also/local => ../sibling
+)
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].name).toBe('github.com/remote/pkg');
+  });
+
+  it('keeps modules replaced with remote modules', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require github.com/old/pkg v1.0.0
+
+replace github.com/old/pkg => github.com/new/pkg v2.0.0
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].name).toBe('github.com/old/pkg');
+  });
+
+  it('excludes modules replaced with absolute local paths', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/local/pkg v0.1.0
+    github.com/remote/pkg v1.0.0
+)
+
+replace github.com/local/pkg => /absolute/path
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].name).toBe('github.com/remote/pkg');
+  });
+
+  it('excludes modules replaced with bare local paths in block form', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/a v1.0.0
+    github.com/b v1.0.0
+    github.com/c v1.0.0
+)
+
+replace (
+    github.com/a => ./local
+    github.com/b => /abs/path
+    github.com/c v1.0.0 => ../sibling
+)
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(0);
+  });
+
+  it('handles trailing comments on replace directives', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require github.com/foo v1.0.0
+
+replace github.com/foo => ./local // pinned for debugging
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(0);
+  });
+
+  it('handles indirect comment without leading space', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/foo v1.0.0 //indirect
+    github.com/bar v2.0.0// indirect
+)
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toEqual([
+      { name: 'github.com/foo', version: 'v1.0.0', indirect: true },
+      { name: 'github.com/bar', version: 'v2.0.0', indirect: true },
+    ]);
+  });
+
+  it('does not pollute version with trailing comment', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require github.com/foo v1.0.0 // some note
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].version).toBe('v1.0.0');
+  });
+
+  it('handles multiple require blocks', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require github.com/pkg/a v1.0.0
+
+require (
+    github.com/pkg/b v2.0.0
+    github.com/pkg/c v3.0.0 // indirect
+)
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(3);
+  });
+
+  it('ignores exclude directives', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require github.com/pkg/a v1.0.0
+
+exclude github.com/old/dep v1.0.0
+
+exclude (
+    github.com/another/excluded v0.5.0
+    github.com/yet/another v2.0.0
+)
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].name).toBe('github.com/pkg/a');
+  });
+
+  it('ignores toolchain directive', () => {
+    const content = `module example.com/app
+
+go 1.21
+toolchain go1.22.1
+
+require github.com/pkg/a v1.0.0
+`;
+    const { goVersion, modules } = parseGoMod(content);
+    expect(goVersion).toBe('1.21');
+    expect(modules).toHaveLength(1);
+    expect(modules[0].name).toBe('github.com/pkg/a');
+  });
+
+  it('returns empty modules when go.mod has no requires', () => {
+    const content = `module example.com/app
+
+go 1.21
+`;
+    const { goVersion, modules } = parseGoMod(content);
+    expect(goVersion).toBe('1.21');
+    expect(modules).toEqual([]);
+  });
+
+  it('ignores godebug, retract, ignore, and tool directives without false matches', () => {
+    const content = `module example.com/mymodule
+
+go 1.24
+
+toolchain go1.24.1
+
+godebug asynctimerchan=0
+
+godebug (
+    default=go1.21
+    panicnil=1
+)
+
+require (
+    github.com/keep/me v1.0.0
+    golang.org/x/tools v0.20.0 // indirect
+)
+
+tool example.com/mymodule/cmd/mytool
+
+tool (
+    golang.org/x/tools/cmd/stringer
+    github.com/foo/bar/cmd/foo
+)
+
+retract v1.0.0 // accidental release
+
+retract (
+    [v1.1.0, v1.1.5]
+    v1.2.0 // contains retraction only
+)
+
+ignore ./node_modules
+
+ignore (
+    static
+    generated
+)
+`;
+    const { goVersion, modules } = parseGoMod(content);
+    expect(goVersion).toBe('1.24');
+    expect(modules.map(m => m.name).sort()).toEqual([
+      'github.com/keep/me',
+      'golang.org/x/tools',
+    ]);
+  });
+});
+
+describe('generateProjectManifest', () => {
+  it('skips manifest generation when goModPath is undefined', async () => {
+    const workPath = makeTempDir();
+    await generateProjectManifest({
+      workPath,
+      goModPath: undefined,
+      goVersion: '',
+    });
+    expect(fs.existsSync(path.join(workPath, DIAGNOSTICS_PATH))).toBe(false);
+  });
+
+  it('writes manifest with direct and transitive deps', async () => {
+    const workPath = makeTempDir();
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/gin-gonic/gin v1.9.1
+    github.com/go-playground/validator/v10 v10.15.5 // indirect
+)
+`;
+    const goModPath = writeGoMod(workPath, content);
+    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
+
+    const manifestFile = path.join(workPath, DIAGNOSTICS_PATH);
+    expect(fs.existsSync(manifestFile)).toBe(true);
+
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf-8'));
+    expect(manifest.version).toBe(MANIFEST_VERSION);
+    expect(manifest.runtime).toBe('go');
+    expect(manifest.runtimeVersion.resolved).toBe('1.21');
+    expect(manifest.dependencies).toHaveLength(2);
+
+    const direct = manifest.dependencies.find(
+      (d: { name: string }) => d.name === 'github.com/gin-gonic/gin'
+    );
+    expect(direct.type).toBe('direct');
+    expect(direct.scopes).toEqual(['prod']);
+    expect(direct.resolved).toBe('v1.9.1');
+    expect(direct.source).toBe('registry');
+    expect(direct.sourceUrl).toBe('https://proxy.golang.org');
+
+    const transitive = manifest.dependencies.find(
+      (d: { name: string }) =>
+        d.name === 'github.com/go-playground/validator/v10'
+    );
+    expect(transitive.type).toBe('transitive');
+  });
+
+  it('sorts direct deps before transitive, each alphabetically', async () => {
+    const workPath = makeTempDir();
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/zzz/pkg v1.0.0
+    github.com/aaa/indirect v0.1.0 // indirect
+    github.com/aaa/direct v2.0.0
+)
+`;
+    const goModPath = writeGoMod(workPath, content);
+    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    const names = manifest.dependencies.map((d: { name: string }) => d.name);
+    expect(names).toEqual([
+      'github.com/aaa/direct',
+      'github.com/zzz/pkg',
+      'github.com/aaa/indirect',
+    ]);
+  });
+
+  it('uses goVersion fallback when go.mod has no go directive', async () => {
+    const workPath = makeTempDir();
+    const content = `module example.com/app
+
+require github.com/pkg/errors v0.9.1
+`;
+    const goModPath = writeGoMod(workPath, content);
+    await generateProjectManifest({ workPath, goModPath, goVersion: '1.20' });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.runtimeVersion.resolved).toBe('1.20');
+  });
+
+  it('does not throw when go.mod is missing', async () => {
+    const workPath = makeTempDir();
+    const goModPath = path.join(workPath, 'go.mod');
+    await expect(
+      generateProjectManifest({ workPath, goModPath, goVersion: '' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('writes manifest with empty dependencies when go.mod has no requires', async () => {
+    const workPath = makeTempDir();
+    const goModPath = writeGoMod(
+      workPath,
+      'module example.com/app\n\ngo 1.21\n'
+    );
+    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.version).toBe(MANIFEST_VERSION);
+    expect(manifest.runtime).toBe('go');
+    expect(manifest.runtimeVersion.resolved).toBe('1.21');
+    expect(manifest.dependencies).toEqual([]);
+  });
+
+  it('does not include the project module itself as a dependency', async () => {
+    const workPath = makeTempDir();
+    const content = `module example.com/myapp
+
+go 1.21
+
+require github.com/pkg/errors v0.9.1
+`;
+    const goModPath = writeGoMod(workPath, content);
+    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    const names = manifest.dependencies.map((d: { name: string }) => d.name);
+    expect(names).not.toContain('example.com/myapp');
+    expect(names).toContain('github.com/pkg/errors');
+  });
+});
+
+describe('diagnostics callback', () => {
+  it('returns empty object when manifest file does not exist', async () => {
+    const workPath = makeTempDir();
+    const result = await diagnostics({ workPath } as any);
+    expect(result).toEqual({});
+  });
+
+  it('returns FileBlob for manifest with correct content', async () => {
+    const workPath = makeTempDir();
+    const manifestFile = path.join(workPath, DIAGNOSTICS_PATH);
+    fs.mkdirSync(path.dirname(manifestFile), { recursive: true });
+    const content = JSON.stringify({ version: MANIFEST_VERSION, test: true });
+    fs.writeFileSync(manifestFile, content);
+
+    const result = await diagnostics({ workPath } as any);
+    const blob = result[MANIFEST_FILENAME] as FileBlob;
+    expect(blob).toBeInstanceOf(FileBlob);
+    expect(JSON.parse(blob.data as string)).toEqual({
+      version: MANIFEST_VERSION,
+      test: true,
+    });
+  });
+});

--- a/packages/go/test/diagnostics.test.ts
+++ b/packages/go/test/diagnostics.test.ts
@@ -141,7 +141,50 @@ replace (
     expect(modules[0].name).toBe('github.com/remote/pkg');
   });
 
-  it('keeps modules replaced with remote modules', () => {
+  it('keeps module when versioned local replace targets a different version', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require example.com/foo v1.5.0
+
+replace example.com/foo v1.2.3 => ./local
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toHaveLength(1);
+    expect(modules[0]).toMatchObject({
+      name: 'example.com/foo',
+      version: 'v1.5.0',
+    });
+  });
+
+  it('excludes module when versioned local replace targets the required version', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require example.com/foo v1.2.3
+
+replace example.com/foo v1.2.3 => ./local
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toEqual([]);
+  });
+
+  it('versionless local replace excludes regardless of required version', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require example.com/foo v9.9.9
+
+replace example.com/foo => ./local
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toEqual([]);
+  });
+
+  it('substitutes module-path replaces with the replacement name and version', () => {
     const content = `module example.com/app
 
 go 1.21
@@ -151,8 +194,85 @@ require github.com/old/pkg v1.0.0
 replace github.com/old/pkg => github.com/new/pkg v2.0.0
 `;
     const { modules } = parseGoMod(content);
-    expect(modules).toHaveLength(1);
-    expect(modules[0].name).toBe('github.com/old/pkg');
+    expect(modules).toEqual([
+      {
+        name: 'github.com/new/pkg',
+        version: 'v2.0.0',
+        indirect: false,
+      },
+    ]);
+  });
+
+  it('preserves indirect status when substituting via replace', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/direct v1.0.0
+    github.com/indirect v1.0.0 // indirect
+)
+
+replace github.com/indirect => github.com/forked v2.0.0
+`;
+    const { modules } = parseGoMod(content);
+    const forked = modules.find(m => m.name === 'github.com/forked');
+    expect(forked).toMatchObject({ version: 'v2.0.0', indirect: true });
+  });
+
+  it('substitutes only the matching version for a versioned module replace', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require github.com/foo v1.5.0
+
+replace github.com/foo v1.2.3 => github.com/bar v2.0.0
+`;
+    const { modules } = parseGoMod(content);
+    // require version (v1.5.0) doesn't match replace LHS (v1.2.3), so the
+    // replace doesn't apply and the original entry is preserved.
+    expect(modules).toEqual([
+      { name: 'github.com/foo', version: 'v1.5.0', indirect: false },
+    ]);
+  });
+
+  it('substitutes version-only replace (same name, new version)', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require github.com/foo v1.0.0
+
+replace github.com/foo v1.0.0 => github.com/foo v1.0.5
+`;
+    const { modules } = parseGoMod(content);
+    expect(modules).toEqual([
+      { name: 'github.com/foo', version: 'v1.0.5', indirect: false },
+    ]);
+  });
+
+  it('prefers specific-version replace over wildcard replace', () => {
+    const content = `module example.com/app
+
+go 1.21
+
+require (
+    github.com/foo v1.0.0
+    github.com/foo-also v2.0.0
+)
+
+replace github.com/foo => github.com/wildcard v9.9.9
+replace github.com/foo v1.0.0 => github.com/specific v1.0.1
+`;
+    const { modules } = parseGoMod(content);
+    const names = modules.map(m => `${m.name}@${m.version}`).sort();
+    // foo v1.0.0 → specific (matches version)
+    // foo-also v2.0.0 → no rule matches, kept as-is
+    expect(names).toEqual([
+      'github.com/foo-also@v2.0.0',
+      'github.com/specific@v1.0.1',
+    ]);
   });
 
   it('excludes modules replaced with absolute local paths', () => {

--- a/packages/go/test/diagnostics.test.ts
+++ b/packages/go/test/diagnostics.test.ts
@@ -469,7 +469,7 @@ describe('generateProjectManifest', () => {
     await generateProjectManifest({
       workPath,
       goModPath: undefined,
-      goVersion: '',
+      resolvedGoVersion: '1.21.13',
     });
     expect(fs.existsSync(path.join(workPath, DIAGNOSTICS_PATH))).toBe(false);
   });
@@ -486,7 +486,11 @@ require (
 )
 `;
     const goModPath = writeGoMod(workPath, content);
-    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+    });
 
     const manifestFile = path.join(workPath, DIAGNOSTICS_PATH);
     expect(fs.existsSync(manifestFile)).toBe(true);
@@ -494,7 +498,8 @@ require (
     const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf-8'));
     expect(manifest.version).toBe(MANIFEST_VERSION);
     expect(manifest.runtime).toBe('go');
-    expect(manifest.runtimeVersion.resolved).toBe('1.21');
+    expect(manifest.runtimeVersion.requested).toBe('1.21');
+    expect(manifest.runtimeVersion.resolved).toBe('1.21.13');
     expect(manifest.dependencies).toHaveLength(2);
 
     const direct = manifest.dependencies.find(
@@ -511,6 +516,10 @@ require (
         d.name === 'github.com/go-playground/validator/v10'
     );
     expect(transitive.type).toBe('transitive');
+    expect(transitive.scopes).toEqual(['prod']);
+    expect(transitive.resolved).toBe('v10.15.5');
+    expect(transitive.source).toBe('registry');
+    expect(transitive.sourceUrl).toBe('https://proxy.golang.org');
   });
 
   it('sorts direct deps before transitive, each alphabetically', async () => {
@@ -526,7 +535,11 @@ require (
 )
 `;
     const goModPath = writeGoMod(workPath, content);
-    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+    });
 
     const manifest = JSON.parse(
       fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
@@ -539,26 +552,35 @@ require (
     ]);
   });
 
-  it('uses goVersion fallback when go.mod has no go directive', async () => {
+  it('omits requested when go.mod has no go directive', async () => {
     const workPath = makeTempDir();
     const content = `module example.com/app
 
 require github.com/pkg/errors v0.9.1
 `;
     const goModPath = writeGoMod(workPath, content);
-    await generateProjectManifest({ workPath, goModPath, goVersion: '1.20' });
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+    });
 
     const manifest = JSON.parse(
       fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
     );
-    expect(manifest.runtimeVersion.resolved).toBe('1.20');
+    expect(manifest.runtimeVersion).not.toHaveProperty('requested');
+    expect(manifest.runtimeVersion.resolved).toBe('1.21.13');
   });
 
   it('does not throw when go.mod is missing', async () => {
     const workPath = makeTempDir();
     const goModPath = path.join(workPath, 'go.mod');
     await expect(
-      generateProjectManifest({ workPath, goModPath, goVersion: '' })
+      generateProjectManifest({
+        workPath,
+        goModPath,
+        resolvedGoVersion: '1.21.13',
+      })
     ).resolves.toBeUndefined();
   });
 
@@ -568,14 +590,19 @@ require github.com/pkg/errors v0.9.1
       workPath,
       'module example.com/app\n\ngo 1.21\n'
     );
-    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+    });
 
     const manifest = JSON.parse(
       fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
     );
     expect(manifest.version).toBe(MANIFEST_VERSION);
     expect(manifest.runtime).toBe('go');
-    expect(manifest.runtimeVersion.resolved).toBe('1.21');
+    expect(manifest.runtimeVersion.requested).toBe('1.21');
+    expect(manifest.runtimeVersion.resolved).toBe('1.21.13');
     expect(manifest.dependencies).toEqual([]);
   });
 
@@ -588,7 +615,11 @@ go 1.21
 require github.com/pkg/errors v0.9.1
 `;
     const goModPath = writeGoMod(workPath, content);
-    await generateProjectManifest({ workPath, goModPath, goVersion: '' });
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+    });
 
     const manifest = JSON.parse(
       fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
@@ -596,6 +627,137 @@ require github.com/pkg/errors v0.9.1
     const names = manifest.dependencies.map((d: { name: string }) => d.name);
     expect(names).not.toContain('example.com/myapp');
     expect(names).toContain('github.com/pkg/errors');
+  });
+
+  it('includes framework in manifest when provided', async () => {
+    const workPath = makeTempDir();
+    const goModPath = writeGoMod(
+      workPath,
+      'module example.com/app\n\ngo 1.21\n'
+    );
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+      framework: 'go',
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.framework).toBe('go');
+  });
+
+  it('omits framework from manifest when not provided', async () => {
+    const workPath = makeTempDir();
+    const goModPath = writeGoMod(
+      workPath,
+      'module example.com/app\n\ngo 1.21\n'
+    );
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest).not.toHaveProperty('framework');
+  });
+
+  it('omits framework from manifest when empty string provided', async () => {
+    const workPath = makeTempDir();
+    const goModPath = writeGoMod(
+      workPath,
+      'module example.com/app\n\ngo 1.21\n'
+    );
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+      framework: '',
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest).not.toHaveProperty('framework');
+  });
+
+  it('includes serviceType in manifest when provided', async () => {
+    const workPath = makeTempDir();
+    const goModPath = writeGoMod(
+      workPath,
+      'module example.com/app\n\ngo 1.21\n'
+    );
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+      serviceType: 'web',
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.serviceType).toBe('web');
+  });
+
+  it('omits serviceType from manifest when not provided', async () => {
+    const workPath = makeTempDir();
+    const goModPath = writeGoMod(
+      workPath,
+      'module example.com/app\n\ngo 1.21\n'
+    );
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest).not.toHaveProperty('serviceType');
+  });
+
+  it('omits serviceType from manifest when empty string provided', async () => {
+    const workPath = makeTempDir();
+    const goModPath = writeGoMod(
+      workPath,
+      'module example.com/app\n\ngo 1.21\n'
+    );
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+      serviceType: '',
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest).not.toHaveProperty('serviceType');
+  });
+
+  it('omits serviceType from manifest when null provided', async () => {
+    const workPath = makeTempDir();
+    const goModPath = writeGoMod(
+      workPath,
+      'module example.com/app\n\ngo 1.21\n'
+    );
+    await generateProjectManifest({
+      workPath,
+      goModPath,
+      resolvedGoVersion: '1.21.13',
+      serviceType: null,
+    });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest).not.toHaveProperty('serviceType');
   });
 });
 


### PR DESCRIPTION
Emit project manifest from `go` builder, similar to existing behaviour in `backends`, `python`, and `node`.

The manifest includes:
- `framework` and `serviceType` from services framework
- `runtimeVersion` with `resolved` from `GoWrapper` and `requested` from `go.mod`
- `dependencies` parsed directly from `go.mod`

Parse `go.mod` for dependencies and handles `require` and `replace` statements. Interprets dependencies commented with `// indirect` as indirect. Local path replaces are dropped.