### PR TITLE
[services] support workflow trigger with JS jobs

### DIFF
--- a/.changeset/workflow-js-dispatch.md
+++ b/.changeset/workflow-js-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Support workflow-triggered job services for JavaScript/TypeScript. Build workflow entrypoints into a VM-compatible bundle and serve them via a dispatch shim that initializes the workflow runtime.

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,6 +1,5 @@
 import { existsSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { delimiter, dirname, join, relative } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
 import {
@@ -20,7 +19,6 @@ import {
   type Lambda,
   type NodejsLambdaOptions,
   isBunVersion,
-  FileFsRef,
 } from '@vercel/build-utils';
 import { findEntrypointOrThrow } from './cervel/index.js';
 import { applyServiceVcInit } from './service-vc-init.js';
@@ -225,20 +223,6 @@ export const build: BuildV2 = async args => {
         ? userBuildResult?.localBuildFiles
         : rolldownResult.localBuildFiles;
 
-    // For workflow services the dispatch shim imports `workflow/runtime`
-    // which is not referenced by the user's entrypoint. Add it as an
-    // extra nft trace root so its dependencies end up in the lambda.
-    let workflowRuntimePath: string | undefined;
-    if (isWorkflowService) {
-      try {
-        const userRequire = createRequire(join(args.workPath, 'package.json'));
-        workflowRuntimePath = userRequire.resolve('workflow/runtime');
-        localBuildFiles.add(workflowRuntimePath);
-      } catch {
-        debug('Could not resolve workflow/runtime for nft tracing');
-      }
-    }
-
     const files = userBuildResult?.files || rolldownResult.files;
     const handler = userBuildResult?.handler || rolldownResult.handler;
     const nftWorkPath = userBuildResult?.outputDir || args.workPath;
@@ -253,53 +237,6 @@ export const build: BuildV2 = async args => {
       conditions: isBun ? ['bun'] : undefined,
       span: buildSpan,
     });
-
-    // nft skips `localBuildFiles` entries (they are trace roots, not
-    // outputs). The workflow runtime file itself must still be in the
-    // lambda so add it explicitly after tracing. We also need the
-    // package.json of the `workflow` package so Node can determine
-    // the module format (ESM via "type": "module").
-    if (workflowRuntimePath) {
-      const repoRoot = args.repoRootPath || args.workPath;
-      const outputPath = relative(repoRoot, workflowRuntimePath).replace(
-        /\\/g,
-        '/'
-      );
-      if (!files[outputPath]) {
-        files[outputPath] = new FileFsRef({
-          fsPath: workflowRuntimePath,
-        });
-      }
-      // Include the workflow package.json so Node knows it's ESM.
-      const userRequire = createRequire(join(args.workPath, 'package.json'));
-      try {
-        const pkgJsonPath = userRequire.resolve('workflow/package.json');
-        const pkgOutputPath = relative(repoRoot, pkgJsonPath).replace(
-          /\\/g,
-          '/'
-        );
-        if (!files[pkgOutputPath]) {
-          files[pkgOutputPath] = new FileFsRef({ fsPath: pkgJsonPath });
-        }
-      } catch {
-        // workflow/package.json may not be exported; try the directory.
-        try {
-          const workflowDir = dirname(userRequire.resolve('workflow'));
-          const pkgJsonPath = join(workflowDir, '..', 'package.json');
-          if (existsSync(pkgJsonPath)) {
-            const pkgOutputPath = relative(repoRoot, pkgJsonPath).replace(
-              /\\/g,
-              '/'
-            );
-            if (!files[pkgOutputPath]) {
-              files[pkgOutputPath] = new FileFsRef({ fsPath: pkgJsonPath });
-            }
-          }
-        } catch {
-          debug('Could not resolve workflow package.json');
-        }
-      }
-    }
 
     try {
       await generateProjectManifest({
@@ -366,6 +303,7 @@ export const build: BuildV2 = async args => {
         handler,
         workPath: nftWorkPath,
         workflowBundlePath: workflowBundle.bundlePath,
+        runtimeBundlePath: workflowBundle.runtimeBundlePath,
       });
       lambdaFiles = dispatched.files;
       lambdaHandler = dispatched.handler;

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { delimiter, join } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
@@ -223,6 +224,19 @@ export const build: BuildV2 = async args => {
         ? userBuildResult?.localBuildFiles
         : rolldownResult.localBuildFiles;
 
+    // For workflow services the dispatch shim imports `workflow/runtime`
+    // which is not referenced by the user's entrypoint. Add it as an
+    // extra nft trace root so its dependencies end up in the lambda.
+    if (isWorkflowService) {
+      try {
+        const userRequire = createRequire(join(args.workPath, 'package.json'));
+        const runtimePath = userRequire.resolve('workflow/runtime');
+        localBuildFiles.add(runtimePath);
+      } catch {
+        debug('Could not resolve workflow/runtime for nft tracing');
+      }
+    }
+
     const files = userBuildResult?.files || rolldownResult.files;
     const handler = userBuildResult?.handler || rolldownResult.handler;
     const nftWorkPath = userBuildResult?.outputDir || args.workPath;
@@ -303,7 +317,6 @@ export const build: BuildV2 = async args => {
         handler,
         workPath: nftWorkPath,
         workflowBundlePath: workflowBundle.bundlePath,
-        runtimeBundlePath: workflowBundle.runtimeBundlePath,
       });
       lambdaFiles = dispatched.files;
       lambdaHandler = dispatched.handler;

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { delimiter, join, relative } from 'node:path';
+import { delimiter, dirname, join, relative } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
 import {
@@ -256,7 +256,9 @@ export const build: BuildV2 = async args => {
 
     // nft skips `localBuildFiles` entries (they are trace roots, not
     // outputs). The workflow runtime file itself must still be in the
-    // lambda so add it explicitly after tracing.
+    // lambda so add it explicitly after tracing. We also need the
+    // package.json of the `workflow` package so Node can determine
+    // the module format (ESM via "type": "module").
     if (workflowRuntimePath) {
       const repoRoot = args.repoRootPath || args.workPath;
       const outputPath = relative(repoRoot, workflowRuntimePath).replace(
@@ -267,6 +269,35 @@ export const build: BuildV2 = async args => {
         files[outputPath] = new FileFsRef({
           fsPath: workflowRuntimePath,
         });
+      }
+      // Include the workflow package.json so Node knows it's ESM.
+      const userRequire = createRequire(join(args.workPath, 'package.json'));
+      try {
+        const pkgJsonPath = userRequire.resolve('workflow/package.json');
+        const pkgOutputPath = relative(repoRoot, pkgJsonPath).replace(
+          /\\/g,
+          '/'
+        );
+        if (!files[pkgOutputPath]) {
+          files[pkgOutputPath] = new FileFsRef({ fsPath: pkgJsonPath });
+        }
+      } catch {
+        // workflow/package.json may not be exported; try the directory.
+        try {
+          const workflowDir = dirname(userRequire.resolve('workflow'));
+          const pkgJsonPath = join(workflowDir, '..', 'package.json');
+          if (existsSync(pkgJsonPath)) {
+            const pkgOutputPath = relative(repoRoot, pkgJsonPath).replace(
+              /\\/g,
+              '/'
+            );
+            if (!files[pkgOutputPath]) {
+              files[pkgOutputPath] = new FileFsRef({ fsPath: pkgJsonPath });
+            }
+          }
+        } catch {
+          debug('Could not resolve workflow package.json');
+        }
       }
     }
 

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { delimiter, join } from 'node:path';
+import { delimiter, join, relative } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
 import {
@@ -20,6 +20,7 @@ import {
   type Lambda,
   type NodejsLambdaOptions,
   isBunVersion,
+  FileFsRef,
 } from '@vercel/build-utils';
 import { findEntrypointOrThrow } from './cervel/index.js';
 import { applyServiceVcInit } from './service-vc-init.js';
@@ -227,11 +228,14 @@ export const build: BuildV2 = async args => {
     // For workflow services the dispatch shim imports `workflow/runtime`
     // which is not referenced by the user's entrypoint. Add it as an
     // extra nft trace root so its dependencies end up in the lambda.
+    // We also track the resolved path to add it explicitly after nft,
+    // because nft skips localBuildFiles entries in its output.
+    let workflowRuntimeResolved: string | undefined;
     if (isWorkflowService) {
       try {
         const userRequire = createRequire(join(args.workPath, 'package.json'));
-        const runtimePath = userRequire.resolve('workflow/runtime');
-        localBuildFiles.add(runtimePath);
+        workflowRuntimeResolved = userRequire.resolve('workflow/runtime');
+        localBuildFiles.add(workflowRuntimeResolved);
       } catch {
         debug('Could not resolve workflow/runtime for nft tracing');
       }
@@ -251,6 +255,21 @@ export const build: BuildV2 = async args => {
       conditions: isBun ? ['bun'] : undefined,
       span: buildSpan,
     });
+
+    // nft skips localBuildFiles entries (they are trace roots, not outputs).
+    // Explicitly add workflow/runtime to the lambda files.
+    if (workflowRuntimeResolved) {
+      const repoRoot = args.repoRootPath || args.workPath;
+      const relPath = relative(repoRoot, workflowRuntimeResolved).replace(
+        /\\/g,
+        '/'
+      );
+      if (!files[relPath]) {
+        files[relPath] = new FileFsRef({
+          fsPath: workflowRuntimeResolved,
+        });
+      }
+    }
 
     try {
       await generateProjectManifest({

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { delimiter, join } from 'node:path';
+import { delimiter, join, relative } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
 import {
@@ -20,6 +20,7 @@ import {
   type Lambda,
   type NodejsLambdaOptions,
   isBunVersion,
+  FileFsRef,
 } from '@vercel/build-utils';
 import { findEntrypointOrThrow } from './cervel/index.js';
 import { applyServiceVcInit } from './service-vc-init.js';
@@ -227,11 +228,12 @@ export const build: BuildV2 = async args => {
     // For workflow services the dispatch shim imports `workflow/runtime`
     // which is not referenced by the user's entrypoint. Add it as an
     // extra nft trace root so its dependencies end up in the lambda.
+    let workflowRuntimePath: string | undefined;
     if (isWorkflowService) {
       try {
         const userRequire = createRequire(join(args.workPath, 'package.json'));
-        const runtimePath = userRequire.resolve('workflow/runtime');
-        localBuildFiles.add(runtimePath);
+        workflowRuntimePath = userRequire.resolve('workflow/runtime');
+        localBuildFiles.add(workflowRuntimePath);
       } catch {
         debug('Could not resolve workflow/runtime for nft tracing');
       }
@@ -251,6 +253,22 @@ export const build: BuildV2 = async args => {
       conditions: isBun ? ['bun'] : undefined,
       span: buildSpan,
     });
+
+    // nft skips `localBuildFiles` entries (they are trace roots, not
+    // outputs). The workflow runtime file itself must still be in the
+    // lambda so add it explicitly after tracing.
+    if (workflowRuntimePath) {
+      const repoRoot = args.repoRootPath || args.workPath;
+      const outputPath = relative(repoRoot, workflowRuntimePath).replace(
+        /\\/g,
+        '/'
+      );
+      if (!files[outputPath]) {
+        files[outputPath] = new FileFsRef({
+          fsPath: workflowRuntimePath,
+        });
+      }
+    }
 
     try {
       await generateProjectManifest({

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { delimiter, join } from 'node:path';
 import { downloadInstallAndBundle } from './utils.js';
 import { generateProjectManifest } from './diagnostics.js';
@@ -12,6 +13,7 @@ import {
   debug,
   getNodeVersion,
   getLambdaOptionsFromFunction,
+  isWorkflowTriggeredService,
   Span,
   type PrepareCache,
   type BuildV2,
@@ -23,6 +25,8 @@ import { findEntrypointOrThrow } from './cervel/index.js';
 import { applyServiceVcInit } from './service-vc-init.js';
 import { applyCronDispatch } from './cron-dispatch.js';
 import { buildCronRouteTable, getServiceCrons } from './crons.js';
+import { applyWorkflowDispatch } from './workflow-dispatch.js';
+import { buildWorkflowBundle } from './workflow-bundle.js';
 // Re-export cervel functions for use by other packages
 export {
   build as cervelBuild,
@@ -115,6 +119,19 @@ export const build: BuildV2 = async args => {
       entrypoint,
     });
     const isCronService = cronEntries !== undefined;
+    const isWorkflowService =
+      !!args.service && isWorkflowTriggeredService(args.service);
+
+    // Build the workflow bundle (a single CJS file for VM execution) when
+    // the service is workflow-triggered. This is separate from the normal
+    // rolldown build which produces the lambda handler.
+    const workflowBundlePromise = isWorkflowService
+      ? buildWorkflowBundle({
+          entrypoint,
+          workPath: args.workPath,
+          repoRootPath: args.repoRootPath || args.workPath,
+        })
+      : undefined;
 
     const userBuildResult = await maybeDoBuildCommand(args, downloadResult);
 
@@ -157,16 +174,19 @@ export const build: BuildV2 = async args => {
     const rolldownResult = await rolldown({
       ...args,
       span: buildSpan,
-      // Cron-service users may have just an entrypoint and a
-      // vercel.json with no package.json. Default `.js` to CJS so the
+      // Cron- and workflow-service users may have just an entrypoint and
+      // a vercel.json with no package.json. Default `.js` to CJS so the
       // bundle step can resolve the format like Node would at runtime.
-      defaultFormat: isCronService ? 'cjs' : undefined,
+      defaultFormat: isCronService || isWorkflowService ? 'cjs' : undefined,
     });
 
     // Only hono's introspection is supported for now.
-    // Cron services should have no public routes, so introspection is skipped.
+    // Cron and workflow services should have no public routes, so
+    // introspection is skipped.
     const introspectionPromise =
-      !isCronService && rolldownResult.framework.slug === 'hono'
+      !isCronService &&
+      !isWorkflowService &&
+      rolldownResult.framework.slug === 'hono'
         ? introspection({
             ...args,
             span: buildSpan,
@@ -203,6 +223,19 @@ export const build: BuildV2 = async args => {
       userBuildResult?.localBuildFiles.size > 0
         ? userBuildResult?.localBuildFiles
         : rolldownResult.localBuildFiles;
+
+    // For workflow services the dispatch shim imports `workflow/runtime`
+    // which is not referenced by the user's entrypoint. Add it as an
+    // extra nft trace root so its dependencies end up in the lambda.
+    if (isWorkflowService) {
+      try {
+        const userRequire = createRequire(join(args.workPath, 'package.json'));
+        const runtimePath = userRequire.resolve('workflow/runtime');
+        localBuildFiles.add(runtimePath);
+      } catch {
+        debug('Could not resolve workflow/runtime for nft tracing');
+      }
+    }
 
     const files = userBuildResult?.files || rolldownResult.files;
     const handler = userBuildResult?.handler || rolldownResult.handler;
@@ -275,6 +308,18 @@ export const build: BuildV2 = async args => {
       });
       lambdaFiles = dispatched.files;
       lambdaHandler = dispatched.handler;
+    } else if (isWorkflowService && workflowBundlePromise) {
+      const workflowBundle = await workflowBundlePromise;
+      // Merge the workflow bundle file into the lambda files.
+      const mergedFiles = { ...files, ...workflowBundle.files };
+      const dispatched = await applyWorkflowDispatch({
+        files: mergedFiles,
+        handler,
+        workPath: nftWorkPath,
+        workflowBundlePath: workflowBundle.bundlePath,
+      });
+      lambdaFiles = dispatched.files;
+      lambdaHandler = dispatched.handler;
     } else if (shouldStripServiceRoutePrefix) {
       const shimmedLambda = await applyServiceVcInit({
         files,
@@ -334,19 +379,21 @@ export const build: BuildV2 = async args => {
     };
 
     // Build routes: filesystem handler, then introspected routes, then catch-all.
-    // Cron services only respond at their internal cron path (`_svc/{name}/crons/...`),
-    // which the CLI services pipeline rewrites to `_svc/{name}/index` independently
-    // of this builder.
-    const routes = isCronService
-      ? [{ handle: 'filesystem' }]
-      : [
-          { handle: 'filesystem' },
-          ...introspectionResult.routes.map(remapRouteDestination),
-          {
-            src: getServiceCatchallSource(serviceRoutePrefix),
-            dest: internalServiceFunctionPath ?? '/',
-          },
-        ];
+    // Cron and workflow services only respond at their internal service path
+    // (`_svc/{name}/crons/...` or `_svc/{name}/workers/...`), which the CLI
+    // services pipeline rewrites to `_svc/{name}/index` independently of
+    // this builder.
+    const routes =
+      isCronService || isWorkflowService
+        ? [{ handle: 'filesystem' }]
+        : [
+            { handle: 'filesystem' },
+            ...introspectionResult.routes.map(remapRouteDestination),
+            {
+              src: getServiceCatchallSource(serviceRoutePrefix),
+              dest: internalServiceFunctionPath ?? '/',
+            },
+          ];
 
     const output: Record<string, Lambda> = internalServiceOutputPath
       ? { [internalServiceOutputPath]: lambda }

--- a/packages/backends/src/workflow-bundle.ts
+++ b/packages/backends/src/workflow-bundle.ts
@@ -1,0 +1,155 @@
+import { type Files, FileBlob, debug } from '@vercel/build-utils';
+import { build as rolldownBuild, type Plugin } from 'rolldown';
+import { createRequire, builtinModules } from 'node:module';
+import { join, relative, extname } from 'node:path';
+
+const WORKFLOW_BUNDLE_FILENAME = '__vc_workflow_bundle.cjs';
+
+/**
+ * Build the workflow code into a single CJS bundle suitable for VM execution.
+ *
+ * The workflow runtime (`workflowEntrypoint`) evaluates the bundled source
+ * string inside a `vm.runInContext()` call. Because the VM context does not
+ * have `require()`, every dependency must be inlined. The SWC `@workflow`
+ * plugin transforms `"use workflow"` and `"use step"` directives so that
+ * workflow functions are registered on `globalThis.__private_workflows`.
+ *
+ * This mirrors the `BaseBuilder.createWorkflowsBundle()` method in the
+ * `@workflow/builders` package but uses rolldown instead of esbuild and
+ * loads the SWC toolchain from the user's project.
+ */
+export async function buildWorkflowBundle(args: {
+  entrypoint: string;
+  workPath: string;
+  repoRootPath: string;
+}): Promise<{ files: Files; bundlePath: string }> {
+  const { entrypoint, workPath } = args;
+
+  // Dynamically load the SWC transform from the user's node_modules.
+  // The `@workflow/builders` package provides `applySwcTransform` which
+  // handles the SWC plugin resolution and transformation.
+  const userRequire = createRequire(join(workPath, 'package.json'));
+
+  let applySwcTransform: (
+    filename: string,
+    source: string,
+    mode: string,
+    absolutePath?: string,
+    projectRoot?: string
+  ) => Promise<{ code: string; workflowManifest: Record<string, unknown> }>;
+
+  try {
+    const builders = userRequire('@workflow/builders');
+    applySwcTransform = builders.applySwcTransform;
+  } catch {
+    throw new Error(
+      'Workflow-triggered job services require the "workflow" package. ' +
+        'Install it with: npm install workflow'
+    );
+  }
+
+  const swcTransformPlugin = (): Plugin => ({
+    name: 'workflow:swc-transform',
+    async transform(code, id) {
+      // Only transform user source files, not node_modules
+      if (id.includes('node_modules')) return null;
+
+      const ext = extname(id);
+      const transformable = [
+        '.ts',
+        '.tsx',
+        '.mts',
+        '.cts',
+        '.js',
+        '.jsx',
+        '.mjs',
+        '.cjs',
+      ];
+      if (!transformable.includes(ext)) return null;
+
+      // Compute relative filename (the SWC plugin uses it to generate workflowId)
+      const relFilename = relative(workPath, id).replace(/\\/g, '/');
+
+      try {
+        const result = await applySwcTransform(
+          relFilename,
+          code,
+          'workflow',
+          id,
+          workPath
+        );
+        return { code: result.code };
+      } catch (err) {
+        debug(
+          `SWC transform failed for ${id}: ${err instanceof Error ? err.message : String(err)}`
+        );
+        return null;
+      }
+    },
+  });
+
+  // Plugin that bundles everything inline — no externals except Node builtins.
+  // The VM context does not have `require()` so every dependency must be
+  // resolved and inlined at build time.
+  const inlineAllPlugin = (): Plugin => ({
+    name: 'workflow:inline-all',
+    resolveId: {
+      order: 'pre',
+      async handler(id) {
+        // Node builtins must stay external — they are available in the VM
+        // context via the sandbox's `require` shim.
+        const normalizedId = id.includes(':') ? id.split(':')[1] : id;
+        if (builtinModules.includes(normalizedId)) {
+          return {
+            id: id.startsWith('node:') ? id : `node:${id}`,
+            external: true,
+          };
+        }
+
+        // Let rolldown resolve everything else (including node_modules).
+        return null;
+      },
+    },
+  });
+
+  const out = await rolldownBuild({
+    input: entrypoint,
+    write: false,
+    cwd: workPath,
+    platform: 'neutral',
+    plugins: [swcTransformPlugin(), inlineAllPlugin()],
+    resolve: {
+      conditionNames: ['workflow', 'import', 'require', 'default'],
+    },
+    output: {
+      format: 'cjs',
+      entryFileNames: WORKFLOW_BUNDLE_FILENAME,
+      // Single file — do not preserve module structure.
+      sourcemap: 'inline',
+      banner: 'globalThis.__private_workflows = new Map();',
+    },
+  });
+
+  let bundleCode: string | null = null;
+  for (const file of out.output) {
+    if (file.type === 'chunk' && file.isEntry) {
+      bundleCode = file.code;
+    }
+  }
+
+  if (!bundleCode) {
+    throw new Error(
+      `Failed to build workflow bundle for entrypoint: ${entrypoint}`
+    );
+  }
+
+  return {
+    bundlePath: WORKFLOW_BUNDLE_FILENAME,
+    files: {
+      [WORKFLOW_BUNDLE_FILENAME]: new FileBlob({
+        data: bundleCode,
+        mode: 0o644,
+      }),
+    },
+  };
+}

--- a/packages/backends/src/workflow-bundle.ts
+++ b/packages/backends/src/workflow-bundle.ts
@@ -168,6 +168,9 @@ export async function buildWorkflowBundle(args: {
         entryFileNames: WORKFLOW_RUNTIME_FILENAME,
         exports: 'named',
         sourcemap: 'inline',
+        // Inline dynamic imports to produce a single file and avoid
+        // code-split chunks that would be missing from the lambda.
+        inlineDynamicImports: true,
       },
     });
 

--- a/packages/backends/src/workflow-bundle.ts
+++ b/packages/backends/src/workflow-bundle.ts
@@ -4,6 +4,7 @@ import { createRequire, builtinModules } from 'node:module';
 import { join, relative, extname } from 'node:path';
 
 const WORKFLOW_BUNDLE_FILENAME = '__vc_workflow_bundle.cjs';
+const WORKFLOW_RUNTIME_FILENAME = '__vc_workflow_runtime.cjs';
 
 /**
  * Build the workflow code into a single CJS bundle suitable for VM execution.
@@ -143,13 +144,61 @@ export async function buildWorkflowBundle(args: {
     );
   }
 
+  // Also bundle `workflow/runtime` into a self-contained CJS file.
+  // The dispatch shim needs `createWorld`, `setWorld`, and
+  // `workflowEntrypoint` at runtime. Rather than relying on
+  // node_modules being present in the lambda (which nft may not
+  // include properly), we bundle the runtime and all its deps.
+  let runtimeCode: string | null = null;
+  try {
+    const userRequire = createRequire(join(workPath, 'package.json'));
+    const runtimeEntry = userRequire.resolve('workflow/runtime');
+
+    const runtimeOut = await rolldownBuild({
+      input: runtimeEntry,
+      write: false,
+      cwd: workPath,
+      platform: 'node',
+      plugins: [inlineAllPlugin()],
+      resolve: {
+        conditionNames: ['import', 'require', 'default'],
+      },
+      output: {
+        format: 'cjs',
+        entryFileNames: WORKFLOW_RUNTIME_FILENAME,
+        exports: 'named',
+        sourcemap: 'inline',
+      },
+    });
+
+    for (const file of runtimeOut.output) {
+      if (file.type === 'chunk' && file.isEntry) {
+        runtimeCode = file.code;
+      }
+    }
+  } catch (err) {
+    debug(
+      `Failed to bundle workflow/runtime: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
+  const files: Files = {
+    [WORKFLOW_BUNDLE_FILENAME]: new FileBlob({
+      data: bundleCode,
+      mode: 0o644,
+    }),
+  };
+
+  if (runtimeCode) {
+    files[WORKFLOW_RUNTIME_FILENAME] = new FileBlob({
+      data: runtimeCode,
+      mode: 0o644,
+    });
+  }
+
   return {
     bundlePath: WORKFLOW_BUNDLE_FILENAME,
-    files: {
-      [WORKFLOW_BUNDLE_FILENAME]: new FileBlob({
-        data: bundleCode,
-        mode: 0o644,
-      }),
-    },
+    runtimeBundlePath: runtimeCode ? WORKFLOW_RUNTIME_FILENAME : undefined,
+    files,
   };
 }

--- a/packages/backends/src/workflow-bundle.ts
+++ b/packages/backends/src/workflow-bundle.ts
@@ -4,7 +4,6 @@ import { createRequire, builtinModules } from 'node:module';
 import { join, relative, extname } from 'node:path';
 
 const WORKFLOW_BUNDLE_FILENAME = '__vc_workflow_bundle.cjs';
-const WORKFLOW_RUNTIME_FILENAME = '__vc_workflow_runtime.cjs';
 
 /**
  * Build the workflow code into a single CJS bundle suitable for VM execution.
@@ -144,64 +143,13 @@ export async function buildWorkflowBundle(args: {
     );
   }
 
-  // Also bundle `workflow/runtime` into a self-contained CJS file.
-  // The dispatch shim needs `createWorld`, `setWorld`, and
-  // `workflowEntrypoint` at runtime. Rather than relying on
-  // node_modules being present in the lambda (which nft may not
-  // include properly), we bundle the runtime and all its deps.
-  let runtimeCode: string | null = null;
-  try {
-    const userRequire = createRequire(join(workPath, 'package.json'));
-    const runtimeEntry = userRequire.resolve('workflow/runtime');
-
-    const runtimeOut = await rolldownBuild({
-      input: runtimeEntry,
-      write: false,
-      cwd: workPath,
-      platform: 'node',
-      plugins: [inlineAllPlugin()],
-      resolve: {
-        conditionNames: ['import', 'require', 'default'],
-      },
-      output: {
-        format: 'cjs',
-        entryFileNames: WORKFLOW_RUNTIME_FILENAME,
-        exports: 'named',
-        sourcemap: 'inline',
-        // Inline dynamic imports to produce a single file and avoid
-        // code-split chunks that would be missing from the lambda.
-        inlineDynamicImports: true,
-      },
-    });
-
-    for (const file of runtimeOut.output) {
-      if (file.type === 'chunk' && file.isEntry) {
-        runtimeCode = file.code;
-      }
-    }
-  } catch (err) {
-    debug(
-      `Failed to bundle workflow/runtime: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
-
-  const files: Files = {
-    [WORKFLOW_BUNDLE_FILENAME]: new FileBlob({
-      data: bundleCode,
-      mode: 0o644,
-    }),
-  };
-
-  if (runtimeCode) {
-    files[WORKFLOW_RUNTIME_FILENAME] = new FileBlob({
-      data: runtimeCode,
-      mode: 0o644,
-    });
-  }
-
   return {
     bundlePath: WORKFLOW_BUNDLE_FILENAME,
-    runtimeBundlePath: runtimeCode ? WORKFLOW_RUNTIME_FILENAME : undefined,
-    files,
+    files: {
+      [WORKFLOW_BUNDLE_FILENAME]: new FileBlob({
+        data: bundleCode,
+        mode: 0o644,
+      }),
+    },
   };
 }

--- a/packages/backends/src/workflow-dispatch.ts
+++ b/packages/backends/src/workflow-dispatch.ts
@@ -1,7 +1,6 @@
 import { FileBlob, type Files } from '@vercel/build-utils';
 import { readFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { dirname, extname, join, posix, relative } from 'node:path';
+import { dirname, extname, join, posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveEntrypointAndFormat } from './rolldown/resolve-format.js';
 
@@ -28,7 +27,7 @@ const RUNTIME_PATH_PLACEHOLDER = /['"]__VC_WORKFLOW_RUNTIME_PATH__['"]/g;
 /**
  * Wrap a workflow service with a dispatcher shim that:
  *   - reads the pre-built workflow bundle (a CJS string for VM execution)
- *   - initialises the workflow world via `createWorld` / `setWorld`
+ *   - loads the pre-bundled workflow runtime via require()
  *   - calls `workflowEntrypoint(bundleCode)` to get a Web API handler
  *   - adapts it to the Node.js `(req, res)` signature the lambda expects
  *
@@ -41,6 +40,8 @@ export async function applyWorkflowDispatch(args: {
   workPath: string;
   /** Relative path to the workflow bundle file inside the lambda files map. */
   workflowBundlePath: string;
+  /** Relative path to the bundled workflow runtime file. */
+  runtimeBundlePath?: string;
 }): Promise<{ files: Files; handler: string }> {
   const { format, extension } = await resolveShimFormat(args);
 
@@ -59,32 +60,17 @@ export async function applyWorkflowDispatch(args: {
       ? args.workflowBundlePath
       : posix.relative(dispatchDir, args.workflowBundlePath);
 
-  // Resolve the absolute path to `workflow/runtime` from the service's
-  // workPath so the dispatch shim can import it regardless of where the
-  // shim file ends up in the lambda. Node module resolution from a service
-  // subdirectory would fail if `workflow` is only installed at the repo root.
-  let runtimeImportPath = 'workflow/runtime';
-  try {
-    const userRequire = createRequire(join(args.workPath, 'package.json'));
-    const resolvedRuntime = userRequire.resolve('workflow/runtime');
-    // Compute a relative path from the dispatch shim to the resolved runtime.
-    const shimAbsDir = join(args.workPath, dispatchDir);
-    const runtimeRelative = relative(shimAbsDir, resolvedRuntime).replace(
-      /\\/g,
-      '/'
-    );
-    // Ensure the path starts with ./ for a relative import.
-    runtimeImportPath = runtimeRelative.startsWith('.')
-      ? runtimeRelative
-      : `./${runtimeRelative}`;
-  } catch {
-    // Fall back to bare specifier if resolution fails.
-  }
+  // Compute the relative path from the dispatch shim to the runtime bundle.
+  const runtimePath = args.runtimeBundlePath || 'workflow/runtime';
+  const runtimeRelative =
+    args.runtimeBundlePath && dispatchDir !== '.'
+      ? posix.relative(dispatchDir, args.runtimeBundlePath)
+      : runtimePath;
 
   const template = format === 'esm' ? ESM_TEMPLATE : CJS_TEMPLATE;
   const dispatchSource = template
     .replace(BUNDLE_PATH_PLACEHOLDER, JSON.stringify(bundleRelative))
-    .replace(RUNTIME_PATH_PLACEHOLDER, JSON.stringify(runtimeImportPath));
+    .replace(RUNTIME_PATH_PLACEHOLDER, JSON.stringify(runtimeRelative));
 
   return {
     handler: dispatchHandler,

--- a/packages/backends/src/workflow-dispatch.ts
+++ b/packages/backends/src/workflow-dispatch.ts
@@ -22,12 +22,11 @@ const CJS_TEMPLATE = readFileSync(
 );
 
 const BUNDLE_PATH_PLACEHOLDER = /['"]__VC_WORKFLOW_BUNDLE_PATH__['"]/g;
-const RUNTIME_PATH_PLACEHOLDER = /['"]__VC_WORKFLOW_RUNTIME_PATH__['"]/g;
 
 /**
  * Wrap a workflow service with a dispatcher shim that:
  *   - reads the pre-built workflow bundle (a CJS string for VM execution)
- *   - loads the pre-bundled workflow runtime via require()
+ *   - initialises the workflow world via `createWorld` / `setWorld`
  *   - calls `workflowEntrypoint(bundleCode)` to get a Web API handler
  *   - adapts it to the Node.js `(req, res)` signature the lambda expects
  *
@@ -40,8 +39,6 @@ export async function applyWorkflowDispatch(args: {
   workPath: string;
   /** Relative path to the workflow bundle file inside the lambda files map. */
   workflowBundlePath: string;
-  /** Relative path to the bundled workflow runtime file. */
-  runtimeBundlePath?: string;
 }): Promise<{ files: Files; handler: string }> {
   const { format, extension } = await resolveShimFormat(args);
 
@@ -60,17 +57,11 @@ export async function applyWorkflowDispatch(args: {
       ? args.workflowBundlePath
       : posix.relative(dispatchDir, args.workflowBundlePath);
 
-  // Compute the relative path from the dispatch shim to the runtime bundle.
-  const runtimePath = args.runtimeBundlePath || 'workflow/runtime';
-  const runtimeRelative =
-    args.runtimeBundlePath && dispatchDir !== '.'
-      ? posix.relative(dispatchDir, args.runtimeBundlePath)
-      : runtimePath;
-
   const template = format === 'esm' ? ESM_TEMPLATE : CJS_TEMPLATE;
-  const dispatchSource = template
-    .replace(BUNDLE_PATH_PLACEHOLDER, JSON.stringify(bundleRelative))
-    .replace(RUNTIME_PATH_PLACEHOLDER, JSON.stringify(runtimeRelative));
+  const dispatchSource = template.replace(
+    BUNDLE_PATH_PLACEHOLDER,
+    JSON.stringify(bundleRelative)
+  );
 
   return {
     handler: dispatchHandler,

--- a/packages/backends/src/workflow-dispatch.ts
+++ b/packages/backends/src/workflow-dispatch.ts
@@ -1,0 +1,90 @@
+import { FileBlob, type Files } from '@vercel/build-utils';
+import { readFileSync } from 'node:fs';
+import { dirname, extname, join, posix } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveEntrypointAndFormat } from './rolldown/resolve-format.js';
+
+type ModuleFormat = 'esm' | 'cjs';
+
+const TEMPLATES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'templates'
+);
+
+const ESM_TEMPLATE = readFileSync(
+  join(TEMPLATES_DIR, 'vc_workflow_dispatch.mjs'),
+  'utf-8'
+);
+const CJS_TEMPLATE = readFileSync(
+  join(TEMPLATES_DIR, 'vc_workflow_dispatch.cjs'),
+  'utf-8'
+);
+
+const BUNDLE_PATH_PLACEHOLDER = /['"]__VC_WORKFLOW_BUNDLE_PATH__['"]/g;
+
+/**
+ * Wrap a workflow service with a dispatcher shim that:
+ *   - reads the pre-built workflow bundle (a CJS string for VM execution)
+ *   - initialises the workflow world via `createWorld` / `setWorld`
+ *   - calls `workflowEntrypoint(bundleCode)` to get a Web API handler
+ *   - adapts it to the Node.js `(req, res)` signature the lambda expects
+ *
+ * The dispatcher source lives in `templates/vc_workflow_dispatch.{mjs,cjs}`.
+ */
+export async function applyWorkflowDispatch(args: {
+  files: Files;
+  /** Path of the current lambda handler produced by rolldown. */
+  handler: string;
+  workPath: string;
+  /** Relative path to the workflow bundle file inside the lambda files map. */
+  workflowBundlePath: string;
+}): Promise<{ files: Files; handler: string }> {
+  const { format, extension } = await resolveShimFormat(args);
+
+  // Use POSIX path utilities — lambda `files` map keys are always
+  // forward-slash separated regardless of build host OS.
+  const handlerDir = posix.dirname(args.handler);
+  const handlerBaseName = posix.basename(args.handler, extname(args.handler));
+  const dispatchName = `${handlerBaseName}.__vc_workflow_dispatch${extension}`;
+  const dispatchHandler =
+    handlerDir === '.' ? dispatchName : posix.join(handlerDir, dispatchName);
+
+  // Compute the relative path from the dispatch shim to the workflow bundle.
+  const dispatchDir = posix.dirname(dispatchHandler);
+  const bundleRelative =
+    dispatchDir === '.'
+      ? args.workflowBundlePath
+      : posix.relative(dispatchDir, args.workflowBundlePath);
+
+  const template = format === 'esm' ? ESM_TEMPLATE : CJS_TEMPLATE;
+  const dispatchSource = template.replace(
+    BUNDLE_PATH_PLACEHOLDER,
+    JSON.stringify(bundleRelative)
+  );
+
+  return {
+    handler: dispatchHandler,
+    files: {
+      ...args.files,
+      [dispatchHandler]: new FileBlob({
+        data: dispatchSource,
+        mode: 0o644,
+      }),
+    },
+  };
+}
+
+async function resolveShimFormat(args: {
+  handler: string;
+  workPath: string;
+}): Promise<{ format: ModuleFormat; extension: string }> {
+  const { format } = await resolveEntrypointAndFormat({
+    entrypoint: args.handler,
+    workPath: args.workPath,
+    defaultFormat: 'cjs',
+  });
+  const extension =
+    extname(args.handler) || (format === 'esm' ? '.mjs' : '.cjs');
+  return { format, extension };
+}

--- a/packages/backends/src/workflow-dispatch.ts
+++ b/packages/backends/src/workflow-dispatch.ts
@@ -1,6 +1,7 @@
 import { FileBlob, type Files } from '@vercel/build-utils';
 import { readFileSync } from 'node:fs';
-import { dirname, extname, join, posix } from 'node:path';
+import { createRequire } from 'node:module';
+import { dirname, extname, join, posix, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveEntrypointAndFormat } from './rolldown/resolve-format.js';
 
@@ -22,6 +23,7 @@ const CJS_TEMPLATE = readFileSync(
 );
 
 const BUNDLE_PATH_PLACEHOLDER = /['"]__VC_WORKFLOW_BUNDLE_PATH__['"]/g;
+const RUNTIME_PATH_PLACEHOLDER = /['"]__VC_WORKFLOW_RUNTIME_PATH__['"]/g;
 
 /**
  * Wrap a workflow service with a dispatcher shim that:
@@ -57,11 +59,32 @@ export async function applyWorkflowDispatch(args: {
       ? args.workflowBundlePath
       : posix.relative(dispatchDir, args.workflowBundlePath);
 
+  // Resolve the absolute path to `workflow/runtime` from the service's
+  // workPath so the dispatch shim can import it regardless of where the
+  // shim file ends up in the lambda. Node module resolution from a service
+  // subdirectory would fail if `workflow` is only installed at the repo root.
+  let runtimeImportPath = 'workflow/runtime';
+  try {
+    const userRequire = createRequire(join(args.workPath, 'package.json'));
+    const resolvedRuntime = userRequire.resolve('workflow/runtime');
+    // Compute a relative path from the dispatch shim to the resolved runtime.
+    const shimAbsDir = join(args.workPath, dispatchDir);
+    const runtimeRelative = relative(shimAbsDir, resolvedRuntime).replace(
+      /\\/g,
+      '/'
+    );
+    // Ensure the path starts with ./ for a relative import.
+    runtimeImportPath = runtimeRelative.startsWith('.')
+      ? runtimeRelative
+      : `./${runtimeRelative}`;
+  } catch {
+    // Fall back to bare specifier if resolution fails.
+  }
+
   const template = format === 'esm' ? ESM_TEMPLATE : CJS_TEMPLATE;
-  const dispatchSource = template.replace(
-    BUNDLE_PATH_PLACEHOLDER,
-    JSON.stringify(bundleRelative)
-  );
+  const dispatchSource = template
+    .replace(BUNDLE_PATH_PLACEHOLDER, JSON.stringify(bundleRelative))
+    .replace(RUNTIME_PATH_PLACEHOLDER, JSON.stringify(runtimeImportPath));
 
   return {
     handler: dispatchHandler,

--- a/packages/backends/templates/vc_workflow_dispatch.cjs
+++ b/packages/backends/templates/vc_workflow_dispatch.cjs
@@ -4,8 +4,7 @@
 // queue handler returned by `workflowEntrypoint`.
 //
 // Placeholders replaced at build time:
-//   __VC_WORKFLOW_BUNDLE_PATH__   – relative path to the CJS bundle file
-//   __VC_WORKFLOW_RUNTIME_PATH__  – relative path to the bundled runtime
+//   __VC_WORKFLOW_BUNDLE_PATH__  – relative path to the CJS bundle file
 
 const { readFileSync } = require('node:fs');
 const { join } = require('node:path');
@@ -15,15 +14,21 @@ const __vc_bundle_code = readFileSync(
   'utf-8'
 );
 
-// Load the pre-bundled workflow runtime (CJS). This avoids depending on
-// node_modules being present in the lambda — the runtime and all its
-// dependencies are bundled at build time by rolldown.
-const { createWorld, setWorld, workflowEntrypoint } = require(
-  join(__dirname, '__VC_WORKFLOW_RUNTIME_PATH__')
-);
+// `workflow/runtime` is ESM-only. Use a dynamic import (supported in CJS
+// since Node 14) and cache the handler promise so it resolves once.
+let __vc_handler_promise;
 
-setWorld(createWorld());
-const __vc_handler = workflowEntrypoint(__vc_bundle_code);
+function getHandler() {
+  if (!__vc_handler_promise) {
+    __vc_handler_promise = import('workflow/runtime').then(
+      ({ createWorld, setWorld, workflowEntrypoint }) => {
+        setWorld(createWorld());
+        return workflowEntrypoint(__vc_bundle_code);
+      },
+    );
+  }
+  return __vc_handler_promise;
+}
 
 /**
  * Adapt the Web API handler to the Node.js (req, res) signature expected by
@@ -31,6 +36,8 @@ const __vc_handler = workflowEntrypoint(__vc_bundle_code);
  */
 module.exports = async function vcWorkflowDispatch(req, res) {
   try {
+    const handler = await getHandler();
+
     const protocol = req.headers['x-forwarded-proto'] || 'http';
     const host = req.headers.host || 'localhost';
     const url = new URL(req.url || '/', protocol + '://' + host);
@@ -61,7 +68,7 @@ module.exports = async function vcWorkflowDispatch(req, res) {
       duplex: 'half',
     });
 
-    const webRes = await __vc_handler(webReq);
+    const webRes = await handler(webReq);
 
     res.statusCode = webRes.status;
     for (const [key, value] of webRes.headers.entries()) {

--- a/packages/backends/templates/vc_workflow_dispatch.cjs
+++ b/packages/backends/templates/vc_workflow_dispatch.cjs
@@ -16,11 +16,13 @@ const __vc_bundle_code = readFileSync(
 
 // `workflow/runtime` is ESM-only. Use a dynamic import (supported in CJS
 // since Node 14) and cache the handler promise so it resolves once.
+// The path is resolved at build time to avoid Node module resolution
+// issues when the dispatch shim lives in a service subdirectory.
 let __vc_handler_promise;
 
 function getHandler() {
   if (!__vc_handler_promise) {
-    __vc_handler_promise = import('workflow/runtime').then(
+    __vc_handler_promise = import('__VC_WORKFLOW_RUNTIME_PATH__').then(
       ({ createWorld, setWorld, workflowEntrypoint }) => {
         setWorld(createWorld());
         return workflowEntrypoint(__vc_bundle_code);

--- a/packages/backends/templates/vc_workflow_dispatch.cjs
+++ b/packages/backends/templates/vc_workflow_dispatch.cjs
@@ -1,0 +1,99 @@
+// Runtime workflow dispatcher (CJS). Generated into a Vercel workflow job
+// service lambda by `applyWorkflowDispatch` in @vercel/backends. Reads the
+// pre-built workflow bundle, initialises the workflow world, and serves the
+// queue handler returned by `workflowEntrypoint`.
+//
+// Placeholders replaced at build time:
+//   __VC_WORKFLOW_BUNDLE_PATH__  – relative path to the CJS bundle file
+
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const __vc_bundle_code = readFileSync(
+  join(__dirname, '__VC_WORKFLOW_BUNDLE_PATH__'),
+  'utf-8'
+);
+
+// `workflow/runtime` is ESM-only. Use a dynamic import (supported in CJS
+// since Node 14) and cache the handler promise so it resolves once.
+let __vc_handler_promise;
+
+function getHandler() {
+  if (!__vc_handler_promise) {
+    __vc_handler_promise = import('workflow/runtime').then(
+      ({ createWorld, setWorld, workflowEntrypoint }) => {
+        setWorld(createWorld());
+        return workflowEntrypoint(__vc_bundle_code);
+      }
+    );
+  }
+  return __vc_handler_promise;
+}
+
+/**
+ * Adapt the Web API handler to the Node.js (req, res) signature expected by
+ * the Vercel Lambda runtime.
+ */
+module.exports = async function vcWorkflowDispatch(req, res) {
+  try {
+    const handler = await getHandler();
+
+    const protocol = req.headers['x-forwarded-proto'] || 'http';
+    const host = req.headers.host || 'localhost';
+    const url = new URL(req.url || '/', protocol + '://' + host);
+
+    // Collect the request body.
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+    const body = chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+
+    const headers = {};
+    const keys = Object.keys(req.headers);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const value = req.headers[key];
+      if (value != null)
+        headers[key] = Array.isArray(value) ? value.join(', ') : value;
+    }
+
+    const webReq = new Request(url.href, {
+      method: req.method,
+      headers: headers,
+      body:
+        body && req.method !== 'GET' && req.method !== 'HEAD'
+          ? body
+          : undefined,
+      duplex: 'half',
+    });
+
+    const webRes = await handler(webReq);
+
+    res.statusCode = webRes.status;
+    for (const [key, value] of webRes.headers.entries()) {
+      res.setHeader(key, value);
+    }
+
+    if (webRes.body) {
+      const reader = webRes.body.getReader();
+      try {
+        for (;;) {
+          const { done, value: chunk } = await reader.read();
+          if (done) break;
+          res.write(chunk);
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    }
+    res.end();
+  } catch (err) {
+    console.error('[workflow dispatch]', err);
+    if (!res.headersSent) {
+      res.statusCode = 500;
+      res.setHeader('content-type', 'application/json');
+    }
+    res.end(JSON.stringify({ error: 'internal' }));
+  }
+};

--- a/packages/backends/templates/vc_workflow_dispatch.cjs
+++ b/packages/backends/templates/vc_workflow_dispatch.cjs
@@ -18,11 +18,9 @@ const __vc_bundle_code = readFileSync(
 // Load the pre-bundled workflow runtime (CJS). This avoids depending on
 // node_modules being present in the lambda — the runtime and all its
 // dependencies are bundled at build time by rolldown.
-const {
-  createWorld,
-  setWorld,
-  workflowEntrypoint,
-} = require(join(__dirname, '__VC_WORKFLOW_RUNTIME_PATH__'));
+const { createWorld, setWorld, workflowEntrypoint } = require(
+  join(__dirname, '__VC_WORKFLOW_RUNTIME_PATH__')
+);
 
 setWorld(createWorld());
 const __vc_handler = workflowEntrypoint(__vc_bundle_code);

--- a/packages/backends/templates/vc_workflow_dispatch.cjs
+++ b/packages/backends/templates/vc_workflow_dispatch.cjs
@@ -4,7 +4,8 @@
 // queue handler returned by `workflowEntrypoint`.
 //
 // Placeholders replaced at build time:
-//   __VC_WORKFLOW_BUNDLE_PATH__  – relative path to the CJS bundle file
+//   __VC_WORKFLOW_BUNDLE_PATH__   – relative path to the CJS bundle file
+//   __VC_WORKFLOW_RUNTIME_PATH__  – relative path to the bundled runtime
 
 const { readFileSync } = require('node:fs');
 const { join } = require('node:path');
@@ -14,23 +15,17 @@ const __vc_bundle_code = readFileSync(
   'utf-8'
 );
 
-// `workflow/runtime` is ESM-only. Use a dynamic import (supported in CJS
-// since Node 14) and cache the handler promise so it resolves once.
-// The path is resolved at build time to avoid Node module resolution
-// issues when the dispatch shim lives in a service subdirectory.
-let __vc_handler_promise;
+// Load the pre-bundled workflow runtime (CJS). This avoids depending on
+// node_modules being present in the lambda — the runtime and all its
+// dependencies are bundled at build time by rolldown.
+const {
+  createWorld,
+  setWorld,
+  workflowEntrypoint,
+} = require(join(__dirname, '__VC_WORKFLOW_RUNTIME_PATH__'));
 
-function getHandler() {
-  if (!__vc_handler_promise) {
-    __vc_handler_promise = import('__VC_WORKFLOW_RUNTIME_PATH__').then(
-      ({ createWorld, setWorld, workflowEntrypoint }) => {
-        setWorld(createWorld());
-        return workflowEntrypoint(__vc_bundle_code);
-      }
-    );
-  }
-  return __vc_handler_promise;
-}
+setWorld(createWorld());
+const __vc_handler = workflowEntrypoint(__vc_bundle_code);
 
 /**
  * Adapt the Web API handler to the Node.js (req, res) signature expected by
@@ -38,8 +33,6 @@ function getHandler() {
  */
 module.exports = async function vcWorkflowDispatch(req, res) {
   try {
-    const handler = await getHandler();
-
     const protocol = req.headers['x-forwarded-proto'] || 'http';
     const host = req.headers.host || 'localhost';
     const url = new URL(req.url || '/', protocol + '://' + host);
@@ -70,7 +63,7 @@ module.exports = async function vcWorkflowDispatch(req, res) {
       duplex: 'half',
     });
 
-    const webRes = await handler(webReq);
+    const webRes = await __vc_handler(webReq);
 
     res.statusCode = webRes.status;
     for (const [key, value] of webRes.headers.entries()) {

--- a/packages/backends/templates/vc_workflow_dispatch.cjs
+++ b/packages/backends/templates/vc_workflow_dispatch.cjs
@@ -1,7 +1,7 @@
 // Runtime workflow dispatcher (CJS). Generated into a Vercel workflow job
 // service lambda by `applyWorkflowDispatch` in @vercel/backends. Reads the
 // pre-built workflow bundle, initialises the workflow world, and serves the
-// queue handler returned by `workflowEntrypoint`.
+// queue handler returned by `workflowEntrypoint` and `stepEntrypoint`.
 //
 // Placeholders replaced at build time:
 //   __VC_WORKFLOW_BUNDLE_PATH__  – relative path to the CJS bundle file
@@ -15,19 +15,24 @@ const __vc_bundle_code = readFileSync(
 );
 
 // `workflow/runtime` is ESM-only. Use a dynamic import (supported in CJS
-// since Node 14) and cache the handler promise so it resolves once.
-let __vc_handler_promise;
+// since Node 14) and cache the handlers promise so it resolves once.
+let __vc_handlers_promise;
 
-function getHandler() {
-  if (!__vc_handler_promise) {
-    __vc_handler_promise = import('workflow/runtime').then(
-      ({ createWorld, setWorld, workflowEntrypoint }) => {
+function getHandlers() {
+  if (!__vc_handlers_promise) {
+    __vc_handlers_promise = import('workflow/runtime').then(
+      ({ createWorld, setWorld, workflowEntrypoint, stepEntrypoint }) => {
         setWorld(createWorld());
-        return workflowEntrypoint(__vc_bundle_code);
-      },
+        // workflowEntrypoint evaluates the bundle code in a VM context,
+        // registering both workflow and step functions. Must be called
+        // before stepEntrypoint is used.
+        const workflowHandler = workflowEntrypoint(__vc_bundle_code);
+        const stepHandler = stepEntrypoint;
+        return { workflowHandler, stepHandler };
+      }
     );
   }
-  return __vc_handler_promise;
+  return __vc_handlers_promise;
 }
 
 /**
@@ -36,7 +41,7 @@ function getHandler() {
  */
 module.exports = async function vcWorkflowDispatch(req, res) {
   try {
-    const handler = await getHandler();
+    const { workflowHandler, stepHandler } = await getHandlers();
 
     const protocol = req.headers['x-forwarded-proto'] || 'http';
     const host = req.headers.host || 'localhost';
@@ -58,7 +63,7 @@ module.exports = async function vcWorkflowDispatch(req, res) {
         headers[key] = Array.isArray(value) ? value.join(', ') : value;
     }
 
-    const webReq = new Request(url.href, {
+    const reqInit = {
       method: req.method,
       headers: headers,
       body:
@@ -66,8 +71,15 @@ module.exports = async function vcWorkflowDispatch(req, res) {
           ? body
           : undefined,
       duplex: 'half',
-    });
+    };
 
+    // Route to the appropriate handler based on URL path.
+    // The platform sends workflow messages to /flow and step messages to /step.
+    const handler = url.pathname.endsWith('/step')
+      ? stepHandler
+      : workflowHandler;
+
+    const webReq = new Request(url.href, reqInit);
     const webRes = await handler(webReq);
 
     res.statusCode = webRes.status;

--- a/packages/backends/templates/vc_workflow_dispatch.mjs
+++ b/packages/backends/templates/vc_workflow_dispatch.mjs
@@ -21,11 +21,9 @@ const __vc_bundle_code = readFileSync(
 // Load the pre-bundled workflow runtime (CJS). This avoids depending on
 // node_modules being present in the lambda.
 const __vc_require = createRequire(import.meta.url);
-const {
-  createWorld,
-  setWorld,
-  workflowEntrypoint,
-} = __vc_require(join(__vc_dirname, '__VC_WORKFLOW_RUNTIME_PATH__'));
+const { createWorld, setWorld, workflowEntrypoint } = __vc_require(
+  join(__vc_dirname, '__VC_WORKFLOW_RUNTIME_PATH__')
+);
 
 // Initialise the workflow world (picks Vercel or local based on env).
 setWorld(createWorld());

--- a/packages/backends/templates/vc_workflow_dispatch.mjs
+++ b/packages/backends/templates/vc_workflow_dispatch.mjs
@@ -1,0 +1,91 @@
+// Runtime workflow dispatcher (ESM). Generated into a Vercel workflow job
+// service lambda by `applyWorkflowDispatch` in @vercel/backends. Reads the
+// pre-built workflow bundle, initialises the workflow world, and serves the
+// queue handler returned by `workflowEntrypoint`.
+//
+// Placeholders replaced at build time:
+//   __VC_WORKFLOW_BUNDLE_PATH__  – relative path to the CJS bundle file
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createWorld, setWorld, workflowEntrypoint } from 'workflow/runtime';
+
+const __vc_dirname = dirname(fileURLToPath(import.meta.url));
+const __vc_bundle_code = readFileSync(
+  join(__vc_dirname, '__VC_WORKFLOW_BUNDLE_PATH__'),
+  'utf-8'
+);
+
+// Initialise the workflow world (picks Vercel or local based on env).
+setWorld(createWorld());
+
+// `workflowEntrypoint` evaluates the bundle in a VM context and returns a
+// Web-API-style handler: (Request) => Promise<Response>.
+const __vc_handler = workflowEntrypoint(__vc_bundle_code);
+
+/**
+ * Adapt the Web API handler to the Node.js (req, res) signature expected by
+ * the Vercel Lambda runtime.
+ */
+export default async function vcWorkflowDispatch(req, res) {
+  try {
+    const protocol = req.headers['x-forwarded-proto'] || 'http';
+    const host = req.headers.host || 'localhost';
+    const url = new URL(req.url || '/', `${protocol}://${host}`);
+
+    // Collect the request body.
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+    const body = chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+
+    const headers = {};
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (value != null)
+        headers[key] = Array.isArray(value) ? value.join(', ') : value;
+    }
+
+    const webReq = new Request(url.href, {
+      method: req.method,
+      headers,
+      body:
+        body && req.method !== 'GET' && req.method !== 'HEAD'
+          ? body
+          : undefined,
+      // Node 18+ requires duplex for streams; a Buffer is fine without it,
+      // but set it defensively.
+      duplex: 'half',
+    });
+
+    const webRes = await __vc_handler(webReq);
+
+    res.statusCode = webRes.status;
+    for (const [key, value] of webRes.headers.entries()) {
+      res.setHeader(key, value);
+    }
+
+    // Stream the response body if present.
+    if (webRes.body) {
+      const reader = webRes.body.getReader();
+      try {
+        for (;;) {
+          const { done, value: chunk } = await reader.read();
+          if (done) break;
+          res.write(chunk);
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    }
+    res.end();
+  } catch (err) {
+    console.error('[workflow dispatch]', err);
+    if (!res.headersSent) {
+      res.statusCode = 500;
+      res.setHeader('content-type', 'application/json');
+    }
+    res.end(JSON.stringify({ error: 'internal' }));
+  }
+}

--- a/packages/backends/templates/vc_workflow_dispatch.mjs
+++ b/packages/backends/templates/vc_workflow_dispatch.mjs
@@ -4,18 +4,28 @@
 // queue handler returned by `workflowEntrypoint`.
 //
 // Placeholders replaced at build time:
-//   __VC_WORKFLOW_BUNDLE_PATH__  – relative path to the CJS bundle file
+//   __VC_WORKFLOW_BUNDLE_PATH__   – relative path to the CJS bundle file
+//   __VC_WORKFLOW_RUNTIME_PATH__  – relative path to the bundled runtime
 
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createWorld, setWorld, workflowEntrypoint } from '__VC_WORKFLOW_RUNTIME_PATH__';
+import { createRequire } from 'node:module';
 
 const __vc_dirname = dirname(fileURLToPath(import.meta.url));
 const __vc_bundle_code = readFileSync(
   join(__vc_dirname, '__VC_WORKFLOW_BUNDLE_PATH__'),
   'utf-8'
 );
+
+// Load the pre-bundled workflow runtime (CJS). This avoids depending on
+// node_modules being present in the lambda.
+const __vc_require = createRequire(import.meta.url);
+const {
+  createWorld,
+  setWorld,
+  workflowEntrypoint,
+} = __vc_require(join(__vc_dirname, '__VC_WORKFLOW_RUNTIME_PATH__'));
 
 // Initialise the workflow world (picks Vercel or local based on env).
 setWorld(createWorld());

--- a/packages/backends/templates/vc_workflow_dispatch.mjs
+++ b/packages/backends/templates/vc_workflow_dispatch.mjs
@@ -1,7 +1,7 @@
 // Runtime workflow dispatcher (ESM). Generated into a Vercel workflow job
 // service lambda by `applyWorkflowDispatch` in @vercel/backends. Reads the
 // pre-built workflow bundle, initialises the workflow world, and serves the
-// queue handler returned by `workflowEntrypoint`.
+// queue handler returned by `workflowEntrypoint` and `stepEntrypoint`.
 //
 // Placeholders replaced at build time:
 //   __VC_WORKFLOW_BUNDLE_PATH__  – relative path to the CJS bundle file
@@ -9,20 +9,27 @@
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createWorld, setWorld, workflowEntrypoint } from 'workflow/runtime';
+import {
+  createWorld,
+  setWorld,
+  workflowEntrypoint,
+  stepEntrypoint,
+} from 'workflow/runtime';
 
 const __vc_dirname = dirname(fileURLToPath(import.meta.url));
 const __vc_bundle_code = readFileSync(
   join(__vc_dirname, '__VC_WORKFLOW_BUNDLE_PATH__'),
-  'utf-8',
+  'utf-8'
 );
 
 // Initialise the workflow world (picks Vercel or local based on env).
 setWorld(createWorld());
 
-// `workflowEntrypoint` evaluates the bundle in a VM context and returns a
-// Web-API-style handler: (Request) => Promise<Response>.
-const __vc_handler = workflowEntrypoint(__vc_bundle_code);
+// `workflowEntrypoint` evaluates the bundle in a VM context, registering
+// both workflow and step functions. Must be called before stepEntrypoint
+// is used.
+const __vc_workflow_handler = workflowEntrypoint(__vc_bundle_code);
+const __vc_step_handler = stepEntrypoint;
 
 /**
  * Adapt the Web API handler to the Node.js (req, res) signature expected by
@@ -47,19 +54,24 @@ export default async function vcWorkflowDispatch(req, res) {
         headers[key] = Array.isArray(value) ? value.join(', ') : value;
     }
 
-    const webReq = new Request(url.href, {
+    const reqInit = {
       method: req.method,
       headers,
       body:
         body && req.method !== 'GET' && req.method !== 'HEAD'
           ? body
           : undefined,
-      // Node 18+ requires duplex for streams; a Buffer is fine without it,
-      // but set it defensively.
       duplex: 'half',
-    });
+    };
 
-    const webRes = await __vc_handler(webReq);
+    // Route to the appropriate handler based on URL path.
+    // The platform sends workflow messages to /flow and step messages to /step.
+    const handler = url.pathname.endsWith('/step')
+      ? __vc_step_handler
+      : __vc_workflow_handler;
+
+    const webReq = new Request(url.href, reqInit);
+    const webRes = await handler(webReq);
 
     res.statusCode = webRes.status;
     for (const [key, value] of webRes.headers.entries()) {

--- a/packages/backends/templates/vc_workflow_dispatch.mjs
+++ b/packages/backends/templates/vc_workflow_dispatch.mjs
@@ -4,25 +4,17 @@
 // queue handler returned by `workflowEntrypoint`.
 //
 // Placeholders replaced at build time:
-//   __VC_WORKFLOW_BUNDLE_PATH__   – relative path to the CJS bundle file
-//   __VC_WORKFLOW_RUNTIME_PATH__  – relative path to the bundled runtime
+//   __VC_WORKFLOW_BUNDLE_PATH__  – relative path to the CJS bundle file
 
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createRequire } from 'node:module';
+import { createWorld, setWorld, workflowEntrypoint } from 'workflow/runtime';
 
 const __vc_dirname = dirname(fileURLToPath(import.meta.url));
 const __vc_bundle_code = readFileSync(
   join(__vc_dirname, '__VC_WORKFLOW_BUNDLE_PATH__'),
-  'utf-8'
-);
-
-// Load the pre-bundled workflow runtime (CJS). This avoids depending on
-// node_modules being present in the lambda.
-const __vc_require = createRequire(import.meta.url);
-const { createWorld, setWorld, workflowEntrypoint } = __vc_require(
-  join(__vc_dirname, '__VC_WORKFLOW_RUNTIME_PATH__')
+  'utf-8',
 );
 
 // Initialise the workflow world (picks Vercel or local based on env).

--- a/packages/backends/templates/vc_workflow_dispatch.mjs
+++ b/packages/backends/templates/vc_workflow_dispatch.mjs
@@ -9,7 +9,7 @@
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createWorld, setWorld, workflowEntrypoint } from 'workflow/runtime';
+import { createWorld, setWorld, workflowEntrypoint } from '__VC_WORKFLOW_RUNTIME_PATH__';
 
 const __vc_dirname = dirname(fileURLToPath(import.meta.url));
 const __vc_bundle_code = readFileSync(

--- a/packages/backends/test/unit.workflow-dispatch.test.ts
+++ b/packages/backends/test/unit.workflow-dispatch.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { applyWorkflowDispatch } from '../src/workflow-dispatch';
+
+async function setupWorkPath(packageJson?: object): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'be-wf-dispatch-'));
+  if (packageJson) {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify(packageJson),
+      'utf-8'
+    );
+  }
+  return dir;
+}
+
+function getShimSource(
+  result: Awaited<ReturnType<typeof applyWorkflowDispatch>>
+): string {
+  const blob = result.files[result.handler];
+  return (blob as unknown as { data: string }).data;
+}
+
+describe('applyWorkflowDispatch', () => {
+  it('produces an ESM shim for an .mjs handler', async () => {
+    const workPath = await setupWorkPath();
+    try {
+      const result = await applyWorkflowDispatch({
+        files: {},
+        handler: 'index.mjs',
+        workPath,
+        workflowBundlePath: '__vc_workflow_bundle.cjs',
+      });
+      expect(result.handler).toBe('index.__vc_workflow_dispatch.mjs');
+      const src = getShimSource(result);
+      expect(src).toContain('workflow/runtime');
+      expect(src).toContain('workflowEntrypoint');
+      expect(src).toContain('createWorld');
+      expect(src).toContain('setWorld');
+      expect(src).toContain('__vc_workflow_bundle.cjs');
+      expect(src).toContain('export default');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('produces a CJS shim for a .cjs handler', async () => {
+    const workPath = await setupWorkPath();
+    try {
+      const result = await applyWorkflowDispatch({
+        files: {},
+        handler: 'index.cjs',
+        workPath,
+        workflowBundlePath: '__vc_workflow_bundle.cjs',
+      });
+      expect(result.handler).toBe('index.__vc_workflow_dispatch.cjs');
+      const src = getShimSource(result);
+      expect(src).toContain('workflow/runtime');
+      expect(src).toContain('workflowEntrypoint');
+      expect(src).toContain('module.exports');
+      expect(src).toContain('__vc_workflow_bundle.cjs');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('treats .js as ESM when package.json "type" is "module"', async () => {
+    const workPath = await setupWorkPath({ type: 'module' });
+    try {
+      const result = await applyWorkflowDispatch({
+        files: {},
+        handler: 'index.js',
+        workPath,
+        workflowBundlePath: '__vc_workflow_bundle.cjs',
+      });
+      expect(result.handler).toBe('index.__vc_workflow_dispatch.js');
+      const src = getShimSource(result);
+      expect(src).toContain('export default');
+      expect(src).toContain('import');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('treats .js as CJS by default (no package.json)', async () => {
+    const workPath = await setupWorkPath();
+    try {
+      const result = await applyWorkflowDispatch({
+        files: {},
+        handler: 'index.js',
+        workPath,
+        workflowBundlePath: '__vc_workflow_bundle.cjs',
+      });
+      expect(result.handler).toBe('index.__vc_workflow_dispatch.js');
+      const src = getShimSource(result);
+      expect(src).toContain('module.exports');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('computes correct relative path when handler is in a subdirectory', async () => {
+    const workPath = await setupWorkPath();
+    try {
+      const result = await applyWorkflowDispatch({
+        files: {},
+        handler: 'dist/index.mjs',
+        workPath,
+        workflowBundlePath: '__vc_workflow_bundle.cjs',
+      });
+      expect(result.handler).toBe('dist/index.__vc_workflow_dispatch.mjs');
+      const src = getShimSource(result);
+      // The bundle path should be relative from dist/ back to root.
+      expect(src).toContain('../__vc_workflow_bundle.cjs');
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves existing files in the returned files map', async () => {
+    const workPath = await setupWorkPath();
+    try {
+      const result = await applyWorkflowDispatch({
+        files: { 'existing.js': {} as any },
+        handler: 'index.mjs',
+        workPath,
+        workflowBundlePath: '__vc_workflow_bundle.cjs',
+      });
+      expect(result.files['existing.js']).toBeDefined();
+      expect(result.files[result.handler]).toBeDefined();
+    } finally {
+      await rm(workPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -839,9 +839,10 @@ export async function resolveConfiguredService(
       'package.json';
   } else if (config.framework) {
     const isCronService = isScheduleTriggeredService({ type, trigger });
+    const isWorkflowJob = type === 'job' && trigger === 'workflow';
     if (
       isNodeBackendFramework(config.framework) &&
-      (type === 'web' || isCronService)
+      (type === 'web' || isCronService || isWorkflowJob)
     ) {
       builderUse = '@vercel/backends';
     } else {
@@ -861,8 +862,11 @@ export async function resolveConfiguredService(
     }
     if (inferredRuntime === 'node') {
       const isCronService = isScheduleTriggeredService({ type, trigger });
+      const isWorkflowJob = type === 'job' && trigger === 'workflow';
       builderUse =
-        type === 'web' || isCronService ? '@vercel/backends' : '@vercel/node';
+        type === 'web' || isCronService || isWorkflowJob
+          ? '@vercel/backends'
+          : '@vercel/node';
     } else {
       builderUse = getBuilderForRuntime(inferredRuntime);
     }


### PR DESCRIPTION
Support workflow-triggered job services for JavaScript/TypeScript. Build workflow entrypoints into a VM-compatible bundle and serve them via a dispatch shim that initializes the workflow runtime.