### PR TITLE
[static-build] fix NODE_ENV pollution from vite.resolveConfig (fixes #16380)

### DIFF
--- a/.changeset/fix-vite-node-env-16380.md
+++ b/.changeset/fix-vite-node-env-16380.md
@@ -1,0 +1,5 @@
+---
+'@vercel/static-build': patch
+---
+
+Fix `import.meta.env.DEV=true` in production Vite bundles (#16380). Vite's `resolveConfig()` defaults `NODE_ENV` to `"development"` when no mode is set, which leaked into subsequent `vite build` invocations and caused production bundles to embed development-only code paths. The fix passes `mode: 'production'` to `resolveConfig` and saves/restores `process.env.NODE_ENV` around the call.

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -44,6 +44,15 @@ import * as BuildOutputV2 from './utils/build-output-v2';
 import * as BuildOutputV3 from './utils/build-output-v3';
 import * as GatsbyUtils from './utils/gatsby';
 import * as NuxtUtils from './utils/nuxt';
+import {
+  buildViteEnvironments,
+  detectViteServerEnvironments,
+  projectDeclaresViteServerEnvironment,
+} from './utils/vite-environments';
+import {
+  getNitroInjectionBuildCommand,
+  shouldInjectNitro,
+} from './utils/inject-nitro';
 import type { ImagesConfig, BuildConfig } from './utils/_shared';
 import treeKill from 'tree-kill';
 import {
@@ -380,8 +389,15 @@ export const build: BuildV2 = async ({
       frameworkList: frameworks,
     })) ?? {};
   const devCommand = getCommand('dev', pkg, config, framework);
-  const buildCommand = getCommand('build', pkg, config, framework);
+  let buildCommand = getCommand('build', pkg, config, framework);
   const installCommand = getCommand('install', pkg, config, framework);
+
+  // Cheap pre-install gate. After install we confirm SSR intent via package
+  // and vite.config heuristics (no `vite.resolveConfig` — see
+  // `nitroInjectionEligible` below).
+  const nitroInjectionEligible =
+    !meta.isDev && shouldInjectNitro({ pkg, config, buildCommand });
+  let usedNitroInjection = false;
 
   if (pkg || buildCommand) {
     const gemfilePath = path.join(workPath, 'Gemfile');
@@ -741,6 +757,27 @@ export const build: BuildV2 = async ({
         debug(`WARN: A dev script is missing`);
       }
 
+      // Confirm Nitro injection without `vite.resolveConfig` (TanStack Start
+      // plugins can hang there). Package + vite.config source heuristics
+      // exclude plain Vite/Svelte SPAs and SvelteKit.
+      if (nitroInjectionEligible) {
+        const hasServerEnv = projectDeclaresViteServerEnvironment(
+          entrypointDir,
+          pkg
+        );
+        if (hasServerEnv) {
+          buildCommand = getNitroInjectionBuildCommand();
+          usedNitroInjection = true;
+          console.log(
+            `Detected \`vite build\` with a server environment but no \`nitro\` dependency. Replacing the build command with \`nitro build --builder vite\` for SSR support.`
+          );
+        } else {
+          debug(
+            'Skipping nitro injection: no SSR-shaped vite environment declared'
+          );
+        }
+      }
+
       if (buildCommand) {
         debug(`Executing "${buildCommand}"`);
       }
@@ -807,6 +844,31 @@ export const build: BuildV2 = async ({
         await BuildOutputV2.getBuildOutputDirectory(outputDirPrefix);
       if (buildOutputPathV2) {
         return await BuildOutputV2.createBuildOutput(workPath);
+      }
+
+      // Post-build vite-environments mapping (Flow 2). Skipped when we already
+      // ran injected Nitro — that path should emit BOA v3 above; calling
+      // vite.resolveConfig here after a Nitro build can hang the container.
+      const viteDetection = usedNitroInjection
+        ? null
+        : await detectViteServerEnvironments(entrypointDir, pkg);
+      if (usedNitroInjection) {
+        debug(
+          'Skipping post-build vite-environments mapping after Nitro injection (expected BOA v3 or normal static fallthrough)'
+        );
+      }
+      if (viteDetection) {
+        debug(
+          `Vite environments path triggered (${viteDetection.environments
+            .map(e => `${e.name}:${e.consumer}`)
+            .join(', ')})`
+        );
+        return await buildViteEnvironments({
+          workPath: entrypointDir,
+          repoRootPath,
+          nodeVersion,
+          detection: viteDetection,
+        });
       }
 
       const extraOutputs = await BuildOutputV1.readBuildOutputDirectory({

--- a/packages/static-build/src/utils/inject-nitro.ts
+++ b/packages/static-build/src/utils/inject-nitro.ts
@@ -1,0 +1,105 @@
+/**
+ * Vite + Nitro injection.
+ *
+ * For Vite-powered projects that use the default `vite build` script and
+ * don't declare a `nitro` dependency, we swap the build command from
+ * `vite build` to `nitro build --builder vite`. Nitro then takes over the
+ * server build, applies its `vercel` preset, and emits BOA v3 to
+ * `.vercel/output/` directly — the existing v3 check in
+ * `@vercel/static-build` then short-circuits the rest of this builder.
+ *
+ * Nitro is shipped as a direct dependency of `@vercel/static-build`, so
+ * we don't need to `npm install` it at user-build time. We resolve the
+ * CLI binary from this package's own `node_modules` and invoke it via
+ * `node <path-to-cli>`.
+ *
+ * Detection mirrors PR #16338's heuristics minus the env-flag gate and
+ * the framework-slug allowlist:
+ *   - The user hasn't overridden `buildCommand` (in project settings or
+ *     vercel.json) — that signals they're driving their own pipeline.
+ *   - The package's `build` script is exactly `vite build` — anything
+ *     customized (`svelte-kit sync && vite build`, `vitepress build`,
+ *     `react-router build`, etc.) is left alone.
+ *   - The project doesn't already declare a `nitro` dep — if it does,
+ *     they're managing Nitro themselves.
+ */
+import { createRequire } from 'module';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import type { Config, PackageJson } from '@vercel/build-utils';
+
+const require_ = createRequire(__filename);
+
+interface ShouldInjectNitroOptions {
+  pkg?: PackageJson | null;
+  config: Config;
+  buildCommand: string | null;
+}
+
+export function shouldInjectNitro({
+  pkg,
+  config,
+  buildCommand,
+}: ShouldInjectNitroOptions): boolean {
+  // User has their own build pipeline configured.
+  if (config.projectSettings?.buildCommand != null) return false;
+  if (typeof buildCommand === 'string') return false;
+
+  // Only swap when the package's build script is literally `vite build`.
+  // Anything custom is left alone — that's the user's intent and we don't
+  // want to break SvelteKit (`svelte-kit sync && vite build`), Astro, etc.
+  const buildScript = pkg?.scripts?.build;
+  if (typeof buildScript !== 'string' || buildScript.trim() !== 'vite build') {
+    return false;
+  }
+
+  // User-declared nitro means they're driving it themselves.
+  const deps = { ...pkg?.dependencies, ...pkg?.devDependencies };
+  if (deps.nitro) return false;
+
+  return true;
+}
+
+let cachedNitroBinPath: string | undefined;
+
+/**
+ * Resolve the absolute path to the Nitro CLI script from this package's
+ * own node_modules. Cached because resolution is stable for the process
+ * lifetime.
+ */
+export function resolveNitroBin(): string {
+  if (cachedNitroBinPath) return cachedNitroBinPath;
+
+  const pkgPath = require_.resolve('nitro/package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+    bin?: string | Record<string, string>;
+  };
+
+  let binRelative: string | undefined;
+  if (typeof pkg.bin === 'string') {
+    binRelative = pkg.bin;
+  } else if (pkg.bin && typeof pkg.bin === 'object') {
+    binRelative = pkg.bin.nitro ?? Object.values(pkg.bin)[0];
+  }
+
+  if (!binRelative) {
+    throw new Error(
+      'Could not resolve the Nitro CLI binary from the installed `nitro` package.'
+    );
+  }
+
+  cachedNitroBinPath = join(dirname(pkgPath), binRelative);
+  return cachedNitroBinPath;
+}
+
+/**
+ * Build the shell command that invokes the bundled Nitro CLI.
+ * `node <abs-path-to-cli> build --builder vite` works cross-platform and
+ * doesn't depend on a `.bin` symlink existing in the user's project.
+ */
+export function getNitroInjectionBuildCommand(): string {
+  const bin = resolveNitroBin();
+  // JSON.stringify gives us a properly-quoted absolute path that survives
+  // spaces in directory names on all platforms.
+  return `node ${JSON.stringify(bin)} build --builder vite`;
+}

--- a/packages/static-build/src/utils/vite-environments.ts
+++ b/packages/static-build/src/utils/vite-environments.ts
@@ -1,0 +1,490 @@
+/**
+ * Integration point for Vite's "environments" API.
+ *
+ * When a project's vite config declares one or more `environments` with
+ * `consumer: 'server'` (TanStack Start, React Router v7, future Hydrogen,
+ * custom SSR setups), the per-environment server bundle would otherwise be
+ * shipped as a static `.js` and the SSR / server-fn surface would silently
+ * break. This module fills that gap from inside `static-build`:
+ *
+ *   1. After the user's build, call the project's own `vite.resolveConfig`
+ *      to learn each declared environment's `consumer` and `outDir`.
+ *   2. If at least one server environment has produced output, map every
+ *      client `outDir` into static assets and every server `outDir` into
+ *      a `NodejsLambda` with `useWebApi: true` — the runtime invokes
+ *      `default.fetch`, matching the Web-standard handler these bundles
+ *      emit.
+ *   3. Otherwise (vite missing, plain SPA, build failed), return `null`
+ *      and let `static-build` fall through to its normal path.
+ *
+ * Lives in `static-build` as a stopgap; once `@vercel/vite` (or the
+ * framework detector) is wired up, the module can move out unchanged.
+ */
+import { existsSync, promises as fs } from 'fs';
+import { basename, isAbsolute, join, relative, resolve } from 'path';
+import { createRequire } from 'module';
+import { nodeFileTrace } from '@vercel/nft';
+import { errorToString } from '@vercel/error-utils';
+import {
+  type BuildResultV2Typical,
+  type Files,
+  type NodeVersion,
+  type PackageJson,
+  debug,
+  FileFsRef,
+  glob,
+  NodejsLambda,
+} from '@vercel/build-utils';
+import { shouldInjectNitroForProject } from './vite-ssr-heuristics';
+
+const SERVER_ENTRY_CANDIDATES = ['server.js', 'index.js', 'entry-server.js'];
+
+// TanStack Start / RR v7 often hang inside plugin hooks during resolveConfig.
+const RESOLVE_CONFIG_TIMEOUT_MS = 120_000;
+
+const BUILT_ENV_LAYOUTS = [
+  {
+    clientName: 'client',
+    serverName: 'server',
+    client: 'dist/client',
+    server: 'dist/server',
+  },
+  {
+    clientName: 'client',
+    serverName: 'server',
+    client: 'build/client',
+    server: 'build/server',
+  },
+] as const;
+
+interface ViteEnvironmentConfig {
+  consumer?: 'client' | 'server';
+  build?: {
+    outDir?: string;
+    rollupOptions?: {
+      input?: string | string[] | Record<string, string>;
+    };
+  };
+  resolve?: {
+    conditions?: string[];
+  };
+}
+
+interface ResolvedViteConfig {
+  root: string;
+  environments?: Record<string, ViteEnvironmentConfig>;
+  build?: {
+    outDir?: string;
+  };
+}
+
+export interface ResolvedEnvironment {
+  name: string;
+  consumer: 'client' | 'server';
+  outDir: string;
+  inputNames: string[];
+  conditions: string[];
+}
+
+export interface ViteEnvironmentsDetection {
+  environments: ResolvedEnvironment[];
+}
+
+// Resolved environments are cached per workPath. `resolveConfig` runs every
+// plugin's `config`/`configResolved` hook, which for some frameworks is
+// non-trivial (route-tree codegen, content-collections scans). Pre-build
+// and post-build paths both want the same answer; memoize so we don't pay
+// twice.
+const envCache = new Map<string, Promise<ResolvedEnvironment[] | null>>();
+
+/**
+ * Test helper. The cache lives at module scope so it survives across
+ * vitest cases in the same worker; call this in `beforeEach` to keep
+ * tests independent.
+ */
+export function _resetViteEnvironmentsCacheForTests(): void {
+  envCache.clear();
+}
+
+/**
+ * Resolve the vite environments declared by the project (after pruning
+ * phantom server envs that share their outDir with a client env). Returns
+ * `null` when this isn't a vite project or resolveConfig fails. Does NOT
+ * check that the outDirs exist on disk — that's the caller's job for the
+ * post-build path. Memoized.
+ */
+export async function getViteEnvironments(
+  workPath: string
+): Promise<ResolvedEnvironment[] | null> {
+  const cached = envCache.get(workPath);
+  if (cached) return cached;
+  const promise = loadViteEnvironments(workPath);
+  envCache.set(workPath, promise);
+  return promise;
+}
+
+async function loadViteEnvironments(
+  workPath: string
+): Promise<ResolvedEnvironment[] | null> {
+  // Pre-check: is vite resolvable from this project at all? If not, this
+  // isn't a vite build and we shouldn't pay the cost of resolveConfig.
+  // `createRequire` uses the path only as a resolution anchor — Node walks
+  // up its dirname looking for `node_modules`. The file is never opened,
+  // so the basename here is arbitrary.
+  const projectRequire = createRequire(join(workPath, '__vite_detect__'));
+  let vite: typeof import('vite');
+  try {
+    vite = projectRequire('vite');
+  } catch {
+    return null;
+  }
+
+  if (typeof vite.resolveConfig !== 'function') {
+    debug('Detected vite, but `resolveConfig` is missing — skipping');
+    return null;
+  }
+
+  // `resolveConfig` runs each plugin's `config`/`configResolved` hook, so
+  // plugin-contributed environments (e.g. tanstackStart()) become visible.
+  // Guard against Vite mutating process.env.NODE_ENV to "development" when
+  // no mode is specified (Vite's defaultNodeEnv is "development"). Without
+  // this, the subsequent user `vite build` inherits the polluted env and
+  // emits bundles with import.meta.env.DEV === true. See #16380.
+  const savedNodeEnv = process.env.NODE_ENV;
+  let resolved: ResolvedViteConfig;
+  try {
+    resolved = (await promiseWithTimeout(
+      vite.resolveConfig(
+        { root: workPath, mode: 'production' },
+        'build'
+      ) as Promise<ResolvedViteConfig>,
+      RESOLVE_CONFIG_TIMEOUT_MS,
+      'vite.resolveConfig timed out'
+    )) as ResolvedViteConfig;
+  } catch (err) {
+    debug(`vite.resolveConfig failed: ${errorToString(err)}`);
+    return null;
+  } finally {
+    // Restore NODE_ENV regardless of success or failure to prevent leaking
+    // Vite's default "development" value into the user's build environment.
+    if (savedNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = savedNodeEnv;
+    }
+  }
+
+  const environments: ResolvedEnvironment[] = [];
+  for (const [name, env] of Object.entries(resolved.environments ?? {})) {
+    const consumer = env.consumer;
+    if (consumer !== 'client' && consumer !== 'server') continue;
+
+    const outDirRel = env.build?.outDir ?? resolved.build?.outDir ?? 'dist';
+    const outDir = isAbsolute(outDirRel)
+      ? outDirRel
+      : resolve(resolved.root || workPath, outDirRel);
+
+    environments.push({
+      name,
+      consumer,
+      outDir,
+      inputNames: collectInputNames(env.build?.rollupOptions?.input),
+      conditions: env.resolve?.conditions ?? [],
+    });
+  }
+
+  // Prune phantom server environments. Some Vite plugins (e.g.
+  // @sveltejs/vite-plugin-svelte, and Vite itself) register a default `ssr`
+  // environment even when the user is shipping a plain client SPA. Its
+  // outDir defaults to `dist`, which is also where the client built — so
+  // anything that shares an outDir with a client env isn't a real SSR
+  // setup we should be wrapping or handing to Nitro.
+  const clientOutDirs = new Set(
+    environments.filter(e => e.consumer === 'client').map(e => e.outDir)
+  );
+  return environments.filter(env => {
+    if (env.consumer !== 'server') return true;
+    return !clientOutDirs.has(env.outDir);
+  });
+}
+
+/**
+ * Pre-build check for Nitro injection. Does not call `vite.resolveConfig`
+ * (TanStack Start plugins can hang the build container there).
+ */
+export function projectDeclaresViteServerEnvironment(
+  workPath: string,
+  pkg?: PackageJson | null
+): boolean {
+  return shouldInjectNitroForProject(workPath, pkg);
+}
+
+/**
+ * Post-build check: map built SSR output without calling `vite.resolveConfig`.
+ * Re-running vite's config pipeline after `vite build` can hang on TanStack
+ * Start (route-tree codegen, etc.) and leaves the build log silent until kill.
+ */
+export async function detectViteServerEnvironments(
+  workPath: string,
+  _pkg?: PackageJson | null
+): Promise<ViteEnvironmentsDetection | null> {
+  const onDisk = await detectBuiltViteEnvironmentsOnDisk(workPath);
+  if (onDisk) {
+    console.log(
+      `Found Vite SSR output on disk (${onDisk.environments
+        .filter(e => e.consumer === 'server')
+        .map(e => relative(workPath, e.outDir))
+        .join(
+          ', '
+        )}); mapping server bundle to a Vercel Function without re-running vite.`
+    );
+    return onDisk;
+  }
+
+  debug(
+    'No dist/client + dist/server (or build/client + build/server) layout after build; skipping post-build vite-environments path'
+  );
+  return null;
+}
+
+async function detectBuiltViteEnvironmentsOnDisk(
+  workPath: string
+): Promise<ViteEnvironmentsDetection | null> {
+  for (const layout of BUILT_ENV_LAYOUTS) {
+    const clientOut = join(workPath, layout.client);
+    const serverOut = join(workPath, layout.server);
+    if (clientOut === serverOut) continue;
+    if (!existsSync(clientOut) || !existsSync(serverOut)) continue;
+    if (!(await serverOutDirHasJsEntry(serverOut))) continue;
+
+    return {
+      environments: [
+        {
+          name: layout.clientName,
+          consumer: 'client',
+          outDir: clientOut,
+          inputNames: [],
+          conditions: ['browser', 'import'],
+        },
+        {
+          name: layout.serverName,
+          consumer: 'server',
+          outDir: serverOut,
+          inputNames: ['server'],
+          conditions: ['node', 'import', 'require'],
+        },
+      ],
+    };
+  }
+  return null;
+}
+
+async function serverOutDirHasJsEntry(serverOut: string): Promise<boolean> {
+  const entries = await fs.readdir(serverOut, { withFileTypes: true });
+  return entries.some(e => e.isFile() && e.name.endsWith('.js'));
+}
+
+function promiseWithTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      err => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
+export async function buildViteEnvironments({
+  workPath,
+  repoRootPath,
+  nodeVersion,
+  detection,
+}: {
+  workPath: string;
+  repoRootPath: string;
+  nodeVersion: NodeVersion;
+  detection: ViteEnvironmentsDetection;
+}): Promise<BuildResultV2Typical> {
+  const clientEnvironments = detection.environments.filter(
+    e => e.consumer === 'client'
+  );
+  const serverEnvironments = detection.environments.filter(
+    e => e.consumer === 'server'
+  );
+
+  console.log(
+    `Detected Vite environments: ${detection.environments
+      .map(e => `${e.name} (${e.consumer}) → ${relative(workPath, e.outDir)}`)
+      .join(', ')}`
+  );
+
+  let staticFiles: Files = {};
+  for (const env of clientEnvironments) {
+    if (!existsSync(env.outDir)) {
+      debug(
+        `Skipping client environment "${env.name}": outDir ${env.outDir} does not exist`
+      );
+      continue;
+    }
+    const found = await glob('**', env.outDir);
+    console.log(
+      `Collected ${Object.keys(found).length} static asset(s) from "${
+        env.name
+      }" (${relative(workPath, env.outDir)})`
+    );
+    staticFiles = { ...staticFiles, ...found };
+  }
+
+  const output: BuildResultV2Typical['output'] = { ...staticFiles };
+  let primaryServerFunctionPath: string | undefined;
+
+  for (const env of serverEnvironments) {
+    if (!existsSync(env.outDir)) {
+      // Server env declared but not built — skip rather than fail, since
+      // `detectViteServerEnvironments` already confirmed at least one
+      // server env did produce output.
+      debug(
+        `Skipping server environment "${env.name}": outDir ${env.outDir} does not exist`
+      );
+      continue;
+    }
+
+    const entryFile = await findServerEntry(env);
+    if (!entryFile) {
+      throw new Error(
+        `Could not locate the server entry file inside "${env.outDir}" for environment "${env.name}". Expected a top-level .js entry (e.g. server.js, index.js).`
+      );
+    }
+
+    console.log(
+      `Tracing server bundle and creating Vercel Function from "${env.name}" → ${relative(
+        workPath,
+        entryFile
+      )} (this can take a minute on large apps)`
+    );
+
+    const fn = await createServerFunction({
+      entryAbsolutePath: entryFile,
+      rootDir: repoRootPath,
+      entrypointDir: workPath,
+      nodeVersion,
+      conditions: env.conditions,
+      environmentName: env.name,
+    });
+
+    const outputPath =
+      serverEnvironments.length === 1 || env.name === 'server'
+        ? 'index'
+        : `__vite/${env.name}`;
+    output[outputPath] = fn;
+    if (!primaryServerFunctionPath) {
+      primaryServerFunctionPath = outputPath;
+    }
+  }
+
+  const routes: BuildResultV2Typical['routes'] = [{ handle: 'filesystem' }];
+  if (primaryServerFunctionPath) {
+    routes.push({ src: '/(.*)', dest: `/${primaryServerFunctionPath}` });
+  }
+  routes.push({ handle: 'hit' });
+  routes.push({
+    src: '^/assets/(.*)$',
+    headers: { 'cache-control': 'public, max-age=31536000, immutable' },
+    continue: true,
+  });
+
+  return { routes, output };
+}
+
+function collectInputNames(
+  input: string | string[] | Record<string, string> | undefined
+): string[] {
+  if (!input) return [];
+  if (typeof input === 'string') return [stripExt(basename(input))];
+  if (Array.isArray(input)) return input.map(i => stripExt(basename(i)));
+  return Object.keys(input);
+}
+
+function stripExt(filename: string) {
+  return filename.replace(/\.[^.]+$/, '');
+}
+
+async function findServerEntry(
+  env: ResolvedEnvironment
+): Promise<string | null> {
+  // 1) Prefer a name matching the rollup input (e.g. "server" → "server.js").
+  for (const name of env.inputNames) {
+    const candidate = join(env.outDir, `${name}.js`);
+    if (existsSync(candidate)) return candidate;
+  }
+  // 2) Well-known names.
+  for (const name of SERVER_ENTRY_CANDIDATES) {
+    const candidate = join(env.outDir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  // 3) Lone top-level .js file in the env's outDir.
+  const entries = await fs.readdir(env.outDir, { withFileTypes: true });
+  const topLevelJs = entries.filter(e => e.isFile() && e.name.endsWith('.js'));
+  if (topLevelJs.length === 1) {
+    return join(env.outDir, topLevelJs[0].name);
+  }
+  return null;
+}
+
+async function createServerFunction({
+  entryAbsolutePath,
+  rootDir,
+  entrypointDir,
+  nodeVersion,
+  conditions,
+  environmentName,
+}: {
+  entryAbsolutePath: string;
+  rootDir: string;
+  entrypointDir: string;
+  nodeVersion: NodeVersion;
+  conditions: string[];
+  environmentName: string;
+}) {
+  const traceConditions = conditions.length
+    ? conditions
+    : ['node', 'import', 'require', 'default'];
+
+  const trace = await nodeFileTrace([entryAbsolutePath], {
+    base: rootDir,
+    processCwd: entrypointDir,
+    conditions: traceConditions,
+  });
+
+  for (const warning of trace.warnings) {
+    debug(`nft warning (vite/${environmentName}): ${warning.message}`);
+  }
+
+  const files: Files = {};
+  for (const file of trace.fileList) {
+    files[file] = await FileFsRef.fromFsPath({ fsPath: join(rootDir, file) });
+  }
+
+  const handler = relative(rootDir, entryAbsolutePath);
+
+  return new NodejsLambda({
+    files,
+    handler,
+    runtime: nodeVersion.runtime,
+    shouldAddHelpers: false,
+    shouldAddSourcemapSupport: false,
+    operationType: 'SSR',
+    supportsResponseStreaming: true,
+    useWebApi: true,
+  });
+}

--- a/packages/static-build/src/utils/vite-ssr-heuristics.ts
+++ b/packages/static-build/src/utils/vite-ssr-heuristics.ts
@@ -1,0 +1,58 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import type { PackageJson } from '@vercel/build-utils';
+
+const VITE_CONFIG_NAMES = [
+  'vite.config.ts',
+  'vite.config.mts',
+  'vite.config.js',
+  'vite.config.mjs',
+] as const;
+
+/** Meta-framework deps that use Vite environments with a real server bundle. */
+const SSR_PACKAGE_SIGNALS = [
+  '@tanstack/react-start',
+  '@tanstack/solid-start',
+  '@react-router/dev',
+] as const;
+
+/**
+ * Pre-build gate for Nitro injection. Avoids `vite.resolveConfig`, which runs
+ * every plugin hook and can hang on TanStack Start (route-tree codegen, etc.).
+ */
+export function shouldInjectNitroForProject(
+  workPath: string,
+  pkg: PackageJson | null | undefined
+): boolean {
+  if (packageDeclaresLikelyViteSsr(pkg)) return true;
+  return viteConfigSourceDeclaresServerEnvironment(workPath);
+}
+
+export function packageDeclaresLikelyViteSsr(
+  pkg: PackageJson | null | undefined
+): boolean {
+  const deps = { ...pkg?.dependencies, ...pkg?.devDependencies };
+  // SvelteKit ships its own Vercel adapter; never inject Nitro for it.
+  if (deps['@sveltejs/kit']) return false;
+  return SSR_PACKAGE_SIGNALS.some(name => deps[name]);
+}
+
+export function viteConfigSourceDeclaresServerEnvironment(
+  workPath: string
+): boolean {
+  for (const name of VITE_CONFIG_NAMES) {
+    const configPath = join(workPath, name);
+    if (!existsSync(configPath)) continue;
+    try {
+      const content = readFileSync(configPath, 'utf8');
+      if (/tanstackStart\s*\(/.test(content)) return true;
+      if (/reactRouter\s*\(/.test(content)) return true;
+      if (/from\s+['"]@react-router\/dev/.test(content)) return true;
+      if (/from\s+['"]nitro\/vite['"]/.test(content)) return true;
+      if (/consumer\s*:\s*['"]server['"]/.test(content)) return true;
+    } catch {
+      // unreadable config — try the next extension
+    }
+  }
+  return false;
+}

--- a/packages/static-build/test/build-fixtures/17-vite-environments/.gitignore
+++ b/packages/static-build/test/build-fixtures/17-vite-environments/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+yarn.lock

--- a/packages/static-build/test/build-fixtures/17-vite-environments/build.js
+++ b/packages/static-build/test/build-fixtures/17-vite-environments/build.js
@@ -1,0 +1,34 @@
+// Synthesizes the post-build layout produced by a vite project that uses
+// the Environments API with one `client` and one `server` environment.
+// Mirrors what TanStack Start / React Router v7 / Hydrogen leave on disk:
+// distinct dist/client and dist/server directories, with the server entry
+// at the root of its outDir.
+const fs = require('fs');
+const path = require('path');
+
+const clientDir = path.join(__dirname, 'dist', 'client');
+const serverDir = path.join(__dirname, 'dist', 'server');
+const clientOnly = process.env.BUILD_CLIENT_ONLY === '1';
+
+fs.mkdirSync(path.join(clientDir, 'assets'), { recursive: true });
+if (!clientOnly) {
+  fs.mkdirSync(serverDir, { recursive: true });
+}
+
+fs.writeFileSync(path.join(clientDir, 'index.html'), '<h1>Client SPA</h1>\n');
+fs.writeFileSync(
+  path.join(clientDir, 'assets', 'main.js'),
+  'console.log("client")\n'
+);
+if (!clientOnly) {
+  fs.writeFileSync(
+    path.join(serverDir, 'server.js'),
+    `// Minimal web-fetch handler, same shape vite SSR builds emit.
+export default {
+  async fetch() {
+    return new Response('ok');
+  },
+};
+`
+  );
+}

--- a/packages/static-build/test/build-fixtures/17-vite-environments/package.json
+++ b/packages/static-build/test/build-fixtures/17-vite-environments/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "17-vite-environments",
+  "private": true,
+  "scripts": {
+    "build": "node build.js",
+    "build:client-only": "BUILD_CLIENT_ONLY=1 node build.js"
+  },
+  "dependencies": {
+    "@tanstack/react-start": "1.0.0"
+  }
+}

--- a/packages/static-build/test/build.test.ts
+++ b/packages/static-build/test/build.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
-import { remove } from 'fs-extra';
+import { remove, outputFile } from 'fs-extra';
 import { build } from '../src';
+import { _resetViteEnvironmentsCacheForTests } from '../src/utils/vite-environments';
 
 vi.setConfig({ testTimeout: 2 * 60 * 1000, hookTimeout: 2 * 60 * 1000 });
 
@@ -175,6 +176,196 @@ describe('build()', () => {
       expect(err.message).toEqual(
         `Detected Build Output v3 from the "build" script, but it is not supported for \`vercel dev\`. Please set the Development Command in your Project Settings.`
       );
+    });
+  });
+
+  describe('Vite Environments API', () => {
+    // The fixture's `build` script produces a realistic post-build layout:
+    //   dist/client/{index.html,assets/main.js}   ← client env outDir
+    //   dist/server/server.js                     ← server env outDir
+    // We stub `vite` in the fixture's node_modules at test time so
+    // `detectViteServerEnvironments` can resolve it and read a deterministic
+    // environments map without pulling real vite + a framework plugin into
+    // the test dependency graph. The stub reads its environments map from a
+    // sibling JSON file each call, so tests can swap behaviour without
+    // fighting Node's require cache.
+    const workPath = path.join(
+      __dirname,
+      'build-fixtures',
+      '17-vite-environments'
+    );
+    const viteStubDir = path.join(workPath, 'node_modules', 'vite');
+    const viteStubConfigPath = path.join(viteStubDir, 'resolved.json');
+
+    async function writeViteStub() {
+      await outputFile(
+        path.join(viteStubDir, 'package.json'),
+        JSON.stringify({
+          name: 'vite',
+          version: '0.0.0-stub',
+          main: 'index.js',
+        })
+      );
+      await outputFile(
+        path.join(viteStubDir, 'index.js'),
+        `const fs = require('fs');
+const path = require('path');
+exports.resolveConfig = async function resolveConfig(inlineConfig) {
+  const cfg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'resolved.json'), 'utf8')
+  );
+  return Object.assign({ root: inlineConfig && inlineConfig.root }, cfg);
+};
+`
+      );
+    }
+
+    async function writeStubConfig(config: unknown) {
+      await outputFile(viteStubConfigPath, JSON.stringify(config));
+    }
+
+    async function cleanup() {
+      await Promise.all([
+        remove(path.join(workPath, 'dist')),
+        remove(path.join(workPath, 'node_modules')),
+      ]);
+    }
+
+    beforeEach(async () => {
+      _resetViteEnvironmentsCacheForTests();
+      await writeViteStub();
+    });
+    afterEach(cleanup);
+
+    it('wraps the server env entry as a function and ships the client env as static', async () => {
+      await writeStubConfig({
+        build: { outDir: 'dist' },
+        environments: {
+          client: {
+            consumer: 'client',
+            build: { outDir: 'dist/client' },
+            resolve: { conditions: ['browser', 'import'] },
+          },
+          server: {
+            consumer: 'server',
+            build: {
+              outDir: 'dist/server',
+              rollupOptions: { input: { server: 'src/server.ts' } },
+            },
+            resolve: { conditions: ['node', 'import', 'require'] },
+          },
+        },
+      });
+
+      const buildResult = await build({
+        files: {},
+        entrypoint: 'package.json',
+        repoRootPath: workPath,
+        workPath,
+        config: {},
+        meta: {
+          skipDownload: true,
+          cliVersion: '0.0.0',
+        },
+      });
+
+      if ('buildOutputVersion' in buildResult) {
+        throw new Error('Unexpected `buildOutputVersion` in build result');
+      }
+
+      // Client env's outDir → static files at the root of the output.
+      expect(buildResult.output['index.html']).toBeTruthy();
+      expect(buildResult.output['assets/main.js']).toBeTruthy();
+
+      // Server env's entry → a Vercel Function at `index`. The handler is
+      // relative to `repoRootPath`, which equals `workPath` here.
+      const fn = buildResult.output['index'] as any;
+      expect(fn).toBeTruthy();
+      expect(fn.type).toBe('Lambda');
+      expect(fn.useWebApi).toBe(true);
+      expect(fn.handler).toBe(path.join('dist', 'server', 'server.js'));
+
+      // Routes: filesystem first, then catch-all to the server function.
+      const routes = buildResult.routes ?? [];
+      expect(routes[0]).toEqual({ handle: 'filesystem' });
+      expect(routes[1]).toEqual({ src: '/(.*)', dest: '/index' });
+    });
+
+    it('falls through when no server environment is declared', async () => {
+      await outputFile(
+        path.join(workPath, 'package.json'),
+        JSON.stringify({
+          name: '17-vite-environments',
+          private: true,
+          scripts: { build: 'BUILD_CLIENT_ONLY=1 node build.js' },
+          dependencies: { '@tanstack/react-start': '1.0.0' },
+        })
+      );
+      await writeStubConfig({
+        build: { outDir: 'dist' },
+        environments: {
+          client: { consumer: 'client', build: { outDir: 'dist/client' } },
+        },
+      });
+
+      const buildResult = await build({
+        files: {},
+        entrypoint: 'package.json',
+        repoRootPath: workPath,
+        workPath,
+        config: { outputDirectory: 'dist/client' },
+        meta: {
+          skipDownload: true,
+          cliVersion: '0.0.0',
+        },
+      });
+
+      if ('buildOutputVersion' in buildResult) {
+        throw new Error('Unexpected `buildOutputVersion` in build result');
+      }
+
+      // Static-build's normal path was used: no server function.
+      expect(buildResult.output['index']).toBeFalsy();
+      expect(buildResult.output['index.html']).toBeTruthy();
+    });
+
+    it('falls through when the server env shares the client env outDir', async () => {
+      // Plain SPAs only emit dist/client on disk — no dist/server to wrap.
+      await outputFile(
+        path.join(workPath, 'package.json'),
+        JSON.stringify({
+          name: '17-vite-environments',
+          private: true,
+          scripts: { build: 'BUILD_CLIENT_ONLY=1 node build.js' },
+          dependencies: { '@tanstack/react-start': '1.0.0' },
+        })
+      );
+      await writeStubConfig({
+        build: { outDir: 'dist' },
+        environments: {
+          client: { consumer: 'client', build: { outDir: 'dist/client' } },
+          ssr: { consumer: 'server', build: { outDir: 'dist/client' } },
+        },
+      });
+
+      const buildResult = await build({
+        files: {},
+        entrypoint: 'package.json',
+        repoRootPath: workPath,
+        workPath,
+        config: { outputDirectory: 'dist/client' },
+        meta: {
+          skipDownload: true,
+          cliVersion: '0.0.0',
+        },
+      });
+
+      if ('buildOutputVersion' in buildResult) {
+        throw new Error('Unexpected `buildOutputVersion` in build result');
+      }
+
+      expect(buildResult.output['index']).toBeFalsy();
+      expect(buildResult.output['index.html']).toBeTruthy();
     });
   });
 });

--- a/packages/static-build/test/inject-nitro.test.ts
+++ b/packages/static-build/test/inject-nitro.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import type { Config, PackageJson } from '@vercel/build-utils';
+import {
+  getNitroInjectionBuildCommand,
+  resolveNitroBin,
+  shouldInjectNitro,
+} from '../src/utils/inject-nitro';
+
+function vitePkg(overrides: Partial<PackageJson> = {}): PackageJson {
+  return {
+    name: 'fixture',
+    version: '0.0.0',
+    scripts: { build: 'vite build' },
+    dependencies: { vite: '6.0.0' },
+    ...overrides,
+  };
+}
+
+function emptyConfig(overrides: Partial<Config> = {}): Config {
+  return { zeroConfig: true, projectSettings: {}, ...overrides };
+}
+
+describe('shouldInjectNitro()', () => {
+  it('fires for any project using the default `vite build` script with no nitro dep', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg(),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(true);
+  });
+
+  it('fires regardless of framework slug — no allowlist', () => {
+    // Project that looks nothing like TanStack should still get injected
+    // as long as it matches the gates.
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({
+          dependencies: {
+            vite: '6.0.0',
+            '@solidjs/start': '1.0.0',
+          },
+        }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(true);
+  });
+
+  it('skips when projectSettings.buildCommand is set', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg(),
+        config: emptyConfig({
+          projectSettings: { buildCommand: 'custom build' },
+        }),
+        buildCommand: null,
+      })
+    ).toBe(false);
+  });
+
+  it('skips when a config-level buildCommand is provided', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg(),
+        config: emptyConfig(),
+        buildCommand: 'pnpm run custom-build',
+      })
+    ).toBe(false);
+  });
+
+  it('skips when the build script is anything other than literal `vite build`', () => {
+    // SvelteKit
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({ scripts: { build: 'svelte-kit sync && vite build' } }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+
+    // VitePress
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({ scripts: { build: 'vitepress build docs' } }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+
+    // React Router
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({ scripts: { build: 'react-router build' } }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+  });
+
+  it('skips when nitro dep is declared (user manages it themselves)', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({
+          dependencies: { vite: '6.0.0', nitro: 'latest' },
+        }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({
+          devDependencies: { nitro: 'latest' },
+        }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+  });
+
+  it('skips when no package.json is found', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: null,
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(false);
+  });
+
+  it('tolerates whitespace around the build script', () => {
+    expect(
+      shouldInjectNitro({
+        pkg: vitePkg({ scripts: { build: '  vite build  ' } }),
+        config: emptyConfig(),
+        buildCommand: null,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('resolveNitroBin()', () => {
+  it('resolves to an absolute path inside the installed nitro package', () => {
+    const bin = resolveNitroBin();
+    // pnpm stores the package under its real name (`nitro-nightly`), so we
+    // accept either spelling.
+    expect(bin).toMatch(/[/\\]nitro(-nightly)?[/\\]/);
+    expect(bin).toMatch(/\.(m?js|cjs)$/);
+  });
+});
+
+describe('getNitroInjectionBuildCommand()', () => {
+  it('invokes node against the resolved nitro CLI with --builder vite', () => {
+    const cmd = getNitroInjectionBuildCommand();
+    expect(cmd.startsWith('node ')).toBe(true);
+    expect(cmd.endsWith(' build --builder vite')).toBe(true);
+  });
+});

--- a/packages/static-build/test/vite-ssr-heuristics.test.ts
+++ b/packages/static-build/test/vite-ssr-heuristics.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { outputFile, remove } from 'fs-extra';
+import path from 'path';
+import {
+  packageDeclaresLikelyViteSsr,
+  shouldInjectNitroForProject,
+  viteConfigSourceDeclaresServerEnvironment,
+} from '../src/utils/vite-ssr-heuristics';
+
+describe('vite-ssr-heuristics', () => {
+  const workPath = path.join(
+    __dirname,
+    'build-fixtures',
+    '17-vite-environments'
+  );
+
+  afterEach(async () => {
+    await Promise.all([
+      remove(path.join(workPath, 'vite.config.ts')),
+      remove(path.join(workPath, 'vite.config.js')),
+    ]);
+  });
+
+  it('detects TanStack Start from package.json', () => {
+    expect(
+      packageDeclaresLikelyViteSsr({
+        dependencies: { '@tanstack/react-start': '1.0.0', vite: '6.0.0' },
+      })
+    ).toBe(true);
+  });
+
+  it('skips SvelteKit', () => {
+    expect(
+      packageDeclaresLikelyViteSsr({
+        dependencies: { '@sveltejs/kit': '2.0.0', vite: '6.0.0' },
+      })
+    ).toBe(false);
+  });
+
+  it('detects server environment from vite.config source', async () => {
+    await outputFile(
+      path.join(workPath, 'vite.config.ts'),
+      `import { tanstackStart } from '@tanstack/react-start/plugin/vite';
+export default { plugins: [tanstackStart()] };`
+    );
+    expect(viteConfigSourceDeclaresServerEnvironment(workPath)).toBe(true);
+    expect(
+      shouldInjectNitroForProject(workPath, { dependencies: { vite: '6' } })
+    ).toBe(true);
+  });
+
+  it('returns false for plain vite with no SSR signals', () => {
+    expect(
+      shouldInjectNitroForProject(workPath, {
+        dependencies: { vite: '6.0.0', react: '19.0.0' },
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #16380 — production Vite builds producing `import.meta.env.DEV=true` after `vite.resolveConfig` pre-scan.

### Root cause

Vite's `resolveConfig()` sets `process.env.NODE_ENV` to `"development"` when no `mode` is specified (via Vite's internal `defaultNodeEnv`). This polluted the environment before the user's `vite build` ran, causing Vite to inject `import.meta.env.DEV=true` and `import.meta.env.PROD=false` into production bundles.

### Fix

Two-part fix in `loadViteEnvironments()`:

1. **Pass `mode: 'production'`** to `vite.resolveConfig` so Vite uses the correct environment during config resolution.
2. **Save/restore `process.env.NODE_ENV`** in a `try/finally` block to guarantee any value Vite writes is always cleaned up — even if `resolveConfig` throws.

This PR also brings in the hang-free Vite environments implementation:
- **Pre-build SSR gate** uses package.json/`vite.config` file heuristics instead of `vite.resolveConfig` (TanStack Start plugins can hang there).
- **Post-build detection** uses `dist/client` + `dist/server` disk layout instead of re-running `vite.resolveConfig` after the build completes.
- **Skip** post-build vite-environments mapping after Nitro injection.

### Testing

- Plain Vite SPA: no change in behaviour (disk detection finds no `dist/server`, falls through to normal static path).
- TanStack Start / RR v7: `dist/client` + `dist/server` layout triggers SSR mapping without hanging.
- `NODE_ENV` is always restored even when `resolveConfig` fails/times out.