### PR TITLE
Improve deployment scope lookup speed

### DIFF
--- a/.changeset/fast-cli-scope-lookups.md
+++ b/.changeset/fast-cli-scope-lookups.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Reduce duplicate user and team lookups during CLI scope resolution.

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -37,9 +37,11 @@ import type {
   AuthConfig,
   GlobalConfig,
   JSONObject,
+  Team,
   Stdio,
   ReadableTTY,
   PaginationOptions,
+  User,
 } from '@vercel-internals/types';
 import { sharedPromise } from './promise';
 import { APIError } from './errors-ts';
@@ -140,6 +142,11 @@ export default class Client extends EventEmitter implements Stdio {
   /** Track if we've already logged the token source debug message */
   private _loggedTokenSource: boolean = false;
   private _parsedArgsCache?: ParsedArgsCache;
+  /** Request-scoped identity caches used to avoid repeated scope lookups. */
+  user?: User;
+  userPromise?: Promise<User>;
+  teams?: Team[];
+  teamsPromise?: Promise<Team[]>;
 
   constructor(opts: ClientOptions) {
     super();
@@ -350,10 +357,20 @@ export default class Client extends EventEmitter implements Stdio {
   }
 
   updateAuthConfig(authConfig: Partial<AuthConfig>) {
+    if (authConfig.token && authConfig.token !== this.authConfig.token) {
+      this.user = undefined;
+      this.userPromise = undefined;
+      this.teams = undefined;
+      this.teamsPromise = undefined;
+    }
     this.authConfig = { ...this.authConfig, ...authConfig };
   }
 
   emptyAuthConfig() {
+    this.user = undefined;
+    this.userPromise = undefined;
+    this.teams = undefined;
+    this.teamsPromise = undefined;
     this.authConfig = this.authConfig.skipWrite ? { skipWrite: true } : {};
   }
 

--- a/packages/cli/src/util/events.ts
+++ b/packages/cli/src/util/events.ts
@@ -35,7 +35,7 @@ async function printEvents(
   abortController?: AbortController
 ) {
   const { log, debug } = output;
-  const { contextName } = await getScope(client);
+  const scope = mode === 'deploy' ? await getScope(client) : null;
 
   // we keep track of how much we log in case we
   // drop the connection and have to start over
@@ -80,7 +80,7 @@ async function printEvents(
                   try {
                     const json = await getDeployment(
                       client,
-                      contextName,
+                      scope!.contextName,
                       urlOrDeploymentId
                     );
                     if (json.readyState === 'READY') {

--- a/packages/cli/src/util/get-user.ts
+++ b/packages/cli/src/util/get-user.ts
@@ -4,6 +4,22 @@ import { APIError, InvalidToken, MissingUser } from './errors-ts';
 import output from '../output-manager';
 
 export default async function getUser(client: Client) {
+  if (client.user) {
+    return client.user;
+  }
+
+  if (client.userPromise) {
+    return client.userPromise;
+  }
+
+  client.userPromise = fetchUser(client).finally(() => {
+    client.userPromise = undefined;
+  });
+
+  return client.userPromise;
+}
+
+async function fetchUser(client: Client) {
   try {
     const res = await client.fetch<{ user: User }>('/v2/user', {
       useCurrentTeam: false,
@@ -23,10 +39,13 @@ export default async function getUser(client: Client) {
     }
 
     client.telemetryEventStore.updateUserId(res.user.id);
+    client.user = res.user;
 
     return res.user;
   } catch (error) {
     if (error instanceof APIError && error.status === 403) {
+      client.user = undefined;
+      client.userPromise = undefined;
       if (client.authConfig.userId) {
         client.updateAuthConfig({ userId: undefined });
         try {

--- a/packages/cli/src/util/input/select-org.ts
+++ b/packages/cli/src/util/input/select-org.ts
@@ -1,5 +1,6 @@
 import type Client from '../client';
 import getUser from '../get-user';
+import getTeamById from '../teams/get-team-by-id';
 import getTeams from '../teams/get-teams';
 import type { User, Team, Org } from '@vercel-internals/types';
 import output from '../../output-manager';
@@ -40,6 +41,44 @@ export default async function selectOrg(
   const {
     config: { currentTeam },
   } = client;
+
+  if (autoConfirm && !client.nonInteractive) {
+    if (currentTeam) {
+      output.spinner('Loading team…', 1000);
+      try {
+        const team = await getTeamById(client, currentTeam);
+        return { type: 'team', id: team.id, slug: team.slug };
+      } catch (err) {
+        output.debug(`Unable to load current team directly: ${err}`);
+      } finally {
+        output.stopSpinner();
+      }
+    }
+
+    output.spinner('Loading user…', 1000);
+    let user: User;
+    try {
+      user = await getUser(client);
+    } finally {
+      output.stopSpinner();
+    }
+
+    if (user.version !== 'northstar') {
+      return { type: 'user', id: user.id, slug: user.username };
+    }
+
+    if (user.defaultTeamId) {
+      output.spinner('Loading team…', 1000);
+      try {
+        const team = await getTeamById(client, user.defaultTeamId);
+        return { type: 'team', id: team.id, slug: team.slug };
+      } catch (err) {
+        output.debug(`Unable to load default team directly: ${err}`);
+      } finally {
+        output.stopSpinner();
+      }
+    }
+  }
 
   output.spinner('Loading teams…', 1000);
   let user: User;

--- a/packages/cli/src/util/teams/get-teams.ts
+++ b/packages/cli/src/util/teams/get-teams.ts
@@ -2,6 +2,7 @@ import { URLSearchParams } from 'url';
 import type Client from '../client';
 import type { Team } from '@vercel-internals/types';
 import { APIError, InvalidToken } from '../errors-ts';
+import { teamCache } from './get-team-by-id';
 
 export interface GetTeamsV1Options {
   apiVersion?: 1;
@@ -36,6 +37,37 @@ export default async function getTeams(
 ): Promise<Team[] | GetTeamsV2Response> {
   const { apiVersion = 1 } = opts;
 
+  if (apiVersion === 1) {
+    if (client.teams) {
+      return client.teams;
+    }
+
+    if (client.teamsPromise) {
+      return client.teamsPromise;
+    }
+
+    client.teamsPromise = fetchTeams(client, opts).then(result => {
+      const teams = Array.isArray(result) ? result : result.teams;
+      client.teams = teams;
+      return teams;
+    });
+
+    try {
+      return await client.teamsPromise;
+    } finally {
+      client.teamsPromise = undefined;
+    }
+  }
+
+  return fetchTeams(client, opts);
+}
+
+async function fetchTeams(
+  client: Client,
+  opts: GetTeamsV1Options | GetTeamsV2Options = {}
+): Promise<Team[] | GetTeamsV2Response> {
+  const { apiVersion = 1 } = opts;
+
   let query = '';
 
   if (opts.apiVersion === 2) {
@@ -57,7 +89,11 @@ export default async function getTeams(
       }
     );
     if (apiVersion === 1) {
-      return body.teams || [];
+      const teams = body.teams || [];
+      for (const team of teams) {
+        teamCache.set(team.id, team);
+      }
+      return teams;
     }
     return body;
   } catch (error) {

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -266,6 +266,10 @@ export class MockClient extends Client {
     this.config = {};
     this.localConfig = {};
     this.localConfigPath = undefined;
+    this.user = undefined;
+    this.userPromise = undefined;
+    this.teams = undefined;
+    this.teamsPromise = undefined;
 
     this.scenario = Router();
 

--- a/packages/cli/test/unit/util/get-user.test.ts
+++ b/packages/cli/test/unit/util/get-user.test.ts
@@ -29,6 +29,27 @@ describe('getUser', () => {
     expect(client.telemetryEventStore.hasUserId).toBe(true);
   });
 
+  it('reuses the fetched user within the same client invocation', async () => {
+    const user = {
+      id: 'user_cached',
+      email: 'cached@example.com',
+      name: 'Cached User',
+      username: 'cached-user',
+    };
+    let fetchCount = 0;
+    client.scenario.get('/v2/user', (_req, res) => {
+      fetchCount++;
+      res.json({ user });
+    });
+
+    const first = await getUser(client);
+    const second = await getUser(client);
+
+    expect(first.id).toBe(user.id);
+    expect(second.id).toBe(user.id);
+    expect(fetchCount).toBe(1);
+  });
+
   it('clears cached userId in best-effort mode when the token is invalid', async () => {
     client.authConfig.userId = 'user_stale';
 

--- a/packages/cli/test/unit/util/input/select-org.test.ts
+++ b/packages/cli/test/unit/util/input/select-org.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Router } from 'express';
 import { client } from '../../../mocks/client';
 import { isActionRequiredPayload } from '../../../../src/util/agent-output';
 import selectOrg from '../../../../src/util/input/select-org';
@@ -44,6 +45,23 @@ describe('selectOrg', () => {
       await expect(selectOrgPromise).resolves.toHaveProperty('id', user.id);
     });
 
+    it('does not fetch teams when autoconfirm selects the personal account', async () => {
+      client.useScenario(Router());
+      client.scenario.get('/v2/user', (_req, res) => {
+        res.json({ user });
+      });
+      let teamsFetchCount = 0;
+      client.scenario.get('/v1/teams', (_req, res) => {
+        teamsFetchCount++;
+        res.json({ teams: [team] });
+      });
+
+      const result = await selectOrg(client, 'Select the scope', true);
+
+      expect(result).toHaveProperty('id', user.id);
+      expect(teamsFetchCount).toBe(0);
+    });
+
     describe('with a selected team scope', () => {
       beforeEach(() => {
         client.config.currentTeam = team.id;
@@ -71,6 +89,26 @@ describe('selectOrg', () => {
       it('automatically selects the correct scope when autoconfirm flag is passed', async () => {
         const selectOrgPromise = selectOrg(client, 'Select the scope', true);
         await expect(selectOrgPromise).resolves.toHaveProperty('id', team.id);
+      });
+
+      it('fetches only the current team when autoconfirm has a selected team scope', async () => {
+        client.useScenario(Router());
+        let teamsFetchCount = 0;
+        let teamFetchCount = 0;
+        client.scenario.get('/v1/teams', (_req, res) => {
+          teamsFetchCount++;
+          res.json({ teams: [team] });
+        });
+        client.scenario.get(`/teams/${team.id}`, (_req, res) => {
+          teamFetchCount++;
+          res.json(team);
+        });
+
+        const result = await selectOrg(client, 'Select the scope', true);
+
+        expect(result).toHaveProperty('id', team.id);
+        expect(teamFetchCount).toBe(1);
+        expect(teamsFetchCount).toBe(0);
       });
     });
   });

--- a/packages/cli/test/unit/util/teams/get-teams.test.ts
+++ b/packages/cli/test/unit/util/teams/get-teams.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import getTeamById from '../../../../src/util/teams/get-team-by-id';
+import getTeams from '../../../../src/util/teams/get-teams';
+import { client } from '../../../mocks/client';
+import { createTeam } from '../../../mocks/team';
+
+describe('getTeams', () => {
+  it('reuses v1 teams within the same client invocation', async () => {
+    const team = createTeam('team_second', 'second', 'Second');
+    let fetchCount = 0;
+    client.scenario.get('/v1/teams', (_req, res) => {
+      fetchCount++;
+      res.json({ teams: [team] });
+    });
+
+    const first = await getTeams(client);
+    const second = await getTeams(client);
+
+    expect(first).toEqual([team]);
+    expect(second).toEqual([team]);
+    expect(fetchCount).toBe(1);
+  });
+
+  it('hydrates the team-by-id cache from the v1 teams response', async () => {
+    const team = createTeam('team_cached', 'cached', 'Cached');
+    let listFetchCount = 0;
+    let teamFetchCount = 0;
+    client.scenario.get('/v1/teams', (_req, res) => {
+      listFetchCount++;
+      res.json({ teams: [team] });
+    });
+    client.scenario.get('/teams/team_cached', (_req, res) => {
+      teamFetchCount++;
+      res.json(team);
+    });
+
+    await getTeams(client);
+    const fetchedTeam = await getTeamById(client, team.id);
+
+    expect(fetchedTeam).toEqual(team);
+    expect(listFetchCount).toBe(1);
+    expect(teamFetchCount).toBe(0);
+  });
+});


### PR DESCRIPTION
Avoid full team list and duplicate user lookup during deploy scope resolution.

Compared two calls:
```
  What Improved

  Your branch removes:

  GET /v1/teams        773ms in this run
  extra GET /v2/user   219ms in this run
  repeated aborted /events retries after Ready

  It replaces /v1/teams with:

  GET /teams/team_wZtvAJQmuvE1SVUB6uD1nAg3 121ms

  773ms - 121ms = ~652ms saved during setup
  + 219ms saved after deployment creation
  = ~871ms fewer user/team lookup latency

  Plus the installed CLI continues making aborted /events requests after Ready, while
  your branch does not.
  ```