### PR TITLE
[go] Add support for preDeploy and buildCommand to Go.

### DIFF
--- a/.changeset/twelve-owls-cover.md
+++ b/.changeset/twelve-owls-cover.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': minor
+---
+
+Support preDeploy and build commands in go builder.

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -9,8 +9,10 @@ import {
   readFile,
   remove,
   symlink,
+  copy,
 } from 'fs-extra';
-import { delimiter, dirname, join } from 'path';
+import fs from 'fs';
+import { basename, delimiter, dirname, join } from 'path';
 import stringArgv from 'string-argv';
 import { cloneEnv, debug } from '@vercel/build-utils';
 import { pipeline } from 'stream';
@@ -263,6 +265,10 @@ export class GoWrapper {
       debug(`Fetching 'go' dependencies for cwd ${this.opts.cwd}`);
     }
     return this.execute(...args);
+  }
+
+  getEnv(): Env {
+    return this.env;
   }
 
   build(src: string | string[], dest: string, { vendorMode = false } = {}) {
@@ -579,6 +585,138 @@ async function parseGoModVersionFromModule(
  * @returns The version in { go: `${major}.${minor}.${patch}`, toolchain: `${major}.${minor}.${patch}` | undefined } format, or undefined if no version was found
  * @throws GoError If the go version is not supported
  */
+/**
+ * Checks if a file is an ELF binary by reading the 4-byte magic header.
+ */
+export async function isElfBinary(filePath: string): Promise<boolean> {
+  const fd = await fs.promises.open(filePath, 'r');
+  try {
+    const buf = new Uint8Array(4);
+    await fd.read(buf, 0, 4, 0);
+    // ELF magic: 0x7F 'E' 'L' 'F'
+    return (
+      buf[0] === 0x7f && buf[1] === 0x45 && buf[2] === 0x4c && buf[3] === 0x46
+    );
+  } finally {
+    await fd.close();
+  }
+}
+
+/**
+ * Extracts the module name's last path segment from a go.mod file.
+ * e.g. "github.com/user/myapp" -> "myapp"
+ */
+export async function getGoModuleName(
+  goModPath: string
+): Promise<string | undefined> {
+  try {
+    const content = await readFile(goModPath, 'utf8');
+    const match = content.match(/^\s*module\s+(.+)$/m);
+    if (match) {
+      const modulePath = match[1].trim();
+      return basename(modulePath);
+    }
+  } catch {
+    // go.mod not readable
+  }
+  return undefined;
+}
+
+/**
+ * Discovers the compiled Go binary after a custom buildCommand.
+ *
+ * Priority:
+ *  1. User wrote directly to `destPath` (via $VERCEL_OUTPUT_FILE)
+ *  2. Well-known binary names in workPath (with ELF + mtime check)
+ *  3. Scan workPath top-level for new ELF binaries (mtime check)
+ *  4. Scan workPath/bin/ for new ELF binaries (mtime check)
+ */
+export async function findGoBinary(
+  workPath: string,
+  destPath: string,
+  goModPath: string | undefined,
+  buildStartTime: number
+): Promise<void> {
+  if (await pathExists(destPath)) {
+    return;
+  }
+
+  const moduleName = goModPath ? await getGoModuleName(goModPath) : undefined;
+
+  const candidates = [moduleName, 'server', 'app', 'main', 'api'].filter(
+    (c): c is string => Boolean(c)
+  );
+
+  for (const name of candidates) {
+    const p = join(workPath, name);
+    if (await pathExists(p)) {
+      const stat = await fs.promises.stat(p);
+      if (
+        stat.isFile() &&
+        stat.mtimeMs >= buildStartTime &&
+        (await isElfBinary(p))
+      ) {
+        debug(`Found Go binary: ${name}`);
+        await copy(p, destPath);
+        return;
+      }
+    }
+  }
+
+  const found: string[] = [];
+
+  // Scan top-level workPath
+  const entries = await fs.promises.readdir(workPath);
+  for (const entry of entries) {
+    if (candidates.includes(entry)) continue;
+    const p = join(workPath, entry);
+    const stat = await fs.promises.stat(p);
+    if (
+      stat.isFile() &&
+      stat.mtimeMs >= buildStartTime &&
+      (await isElfBinary(p))
+    ) {
+      found.push(entry);
+    }
+  }
+
+  // Scan bin/ subdirectory
+  const binDir = join(workPath, 'bin');
+  if (await pathExists(binDir)) {
+    const binEntries = await fs.promises.readdir(binDir);
+    for (const entry of binEntries) {
+      const p = join(binDir, entry);
+      const stat = await fs.promises.stat(p);
+      if (
+        stat.isFile() &&
+        stat.mtimeMs >= buildStartTime &&
+        (await isElfBinary(p))
+      ) {
+        found.push(join('bin', entry));
+      }
+    }
+  }
+
+  if (found.length === 1) {
+    debug(`Found Go binary: ${found[0]}`);
+    await copy(join(workPath, found[0]), destPath);
+    return;
+  }
+
+  if (found.length > 1) {
+    throw new Error(
+      `Found multiple ELF binaries after buildCommand: ${found.join(', ')}. ` +
+        'Use `go build -o $VERCEL_OUTPUT_FILE` to specify which binary to deploy.'
+    );
+  }
+
+  throw new Error(
+    'No compiled Go binary found after buildCommand. ' +
+      'Ensure your command produces a Linux binary (GOOS=linux is set), ' +
+      'or use `go build -o $VERCEL_OUTPUT_FILE`.'
+  );
+}
+
 export function parseGoModVersion(content: string): GoVersions | undefined {
   const goMatches = /^\s*go\s+(\d+)\.(\d+)(?:\.(\d+))?\s*(?:\/\/.*)?$/gm.exec(
     content

--- a/packages/go/src/index.ts
+++ b/packages/go/src/index.ts
@@ -33,6 +33,7 @@ import {
   debug,
   cloneEnv,
   getProvidedRuntime,
+  execCommand,
 } from '@vercel/build-utils';
 
 const TMP = tmpdir();
@@ -119,7 +120,7 @@ type UndoActions = {
 export const version = 3;
 
 export async function build(options: BuildOptions) {
-  const { files, config, workPath, meta = {} } = options;
+  const { files, config, workPath, meta = {}, registerPreDeploy } = options;
   let { entrypoint } = options;
 
   const goPath = await getWriteableDirectory();
@@ -280,6 +281,19 @@ export async function build(options: BuildOptions) {
       supportsWrapper: true,
       environment: {},
     });
+
+    const preDeployCommand = config?.preDeployCommand;
+    if (registerPreDeploy && typeof preDeployCommand === 'string') {
+      const capturedEnv = { ...env };
+      const capturedCwd = workPath;
+      registerPreDeploy(async () => {
+        debug(`Running pre-deploy command: \`${preDeployCommand}\``);
+        await execCommand(preDeployCommand, {
+          env: capturedEnv,
+          cwd: capturedCwd,
+        });
+      });
+    }
 
     return {
       output: lambda,

--- a/packages/go/src/standalone-server.ts
+++ b/packages/go/src/standalone-server.ts
@@ -14,9 +14,10 @@ import {
   debug,
   cloneEnv,
   getLambdaOptionsFromFunction,
+  execCommand,
 } from '@vercel/build-utils';
 
-import { createGo } from './go-helpers';
+import { createGo, findGoBinary } from './go-helpers';
 
 /**
  * Find the go.mod file starting from a directory and scanning up.
@@ -54,6 +55,7 @@ export async function buildStandaloneServer({
   config,
   workPath,
   meta = {},
+  registerPreDeploy,
 }: BuildOptions): Promise<{ output: Lambda }> {
   debug(`Building standalone Go server: ${entrypoint}`);
 
@@ -95,21 +97,34 @@ export async function buildStandaloneServer({
     debug('Detected vendor directory, using -mod=vendor for build');
   }
 
-  // Determine build target based on entrypoint location
-  // - main.go at root: build '.'
-  // - cmd/api/main.go: build './cmd/api'
-  const buildTarget =
-    entrypoint === 'main.go' ? '.' : './' + dirname(entrypoint);
+  const buildCommand: string | undefined =
+    (config?.buildCommand as string) ??
+    (config?.projectSettings as any)?.buildCommand ??
+    undefined;
 
-  debug(
-    `Building user Go server (${architecture}): go build ${buildTarget} -> ${userServerPath}`
-  );
+  if (typeof buildCommand === 'string') {
+    debug(`Running custom build command: ${buildCommand}`);
+    const buildStartTime = Date.now();
+    await execCommand(buildCommand, {
+      env: { ...go.getEnv(), VERCEL_OUTPUT_FILE: userServerPath },
+      cwd: workPath,
+    });
+    await findGoBinary(workPath, userServerPath, goModPath, buildStartTime);
+  } else {
+    // Default: build the entrypoint with go build
+    const buildTarget =
+      entrypoint === 'main.go' ? '.' : './' + dirname(entrypoint);
 
-  try {
-    await go.build(buildTarget, userServerPath, { vendorMode: isVendored });
-  } catch (err) {
-    console.error(`Failed to build standalone Go server: ${buildTarget}`);
-    throw err;
+    debug(
+      `Building user Go server (${architecture}): go build ${buildTarget} -> ${userServerPath}`
+    );
+
+    try {
+      await go.build(buildTarget, userServerPath, { vendorMode: isVendored });
+    } catch (err) {
+      console.error(`Failed to build standalone Go server: ${buildTarget}`);
+      throw err;
+    }
   }
 
   // Build the bootstrap wrapper that handles IPC protocol
@@ -196,6 +211,19 @@ export async function buildStandaloneServer({
     architecture,
     runtimeLanguage: 'go',
   });
+
+  const preDeployCommand = config?.preDeployCommand;
+  if (registerPreDeploy && typeof preDeployCommand === 'string') {
+    const capturedEnv = { ...env };
+    const capturedCwd = workPath;
+    registerPreDeploy(async () => {
+      debug(`Running pre-deploy command: \`${preDeployCommand}\``);
+      await execCommand(preDeployCommand, {
+        env: capturedEnv,
+        cwd: capturedCwd,
+      });
+    });
+  }
 
   return { output: lambda };
 }

--- a/packages/go/test/fixtures/35-build-command-server/.gitignore
+++ b/packages/go/test/fixtures/35-build-command-server/.gitignore
@@ -1,0 +1,3 @@
+.gocache/
+.gomodcache/
+.gopath/

--- a/packages/go/test/fixtures/35-build-command-server/go.mod
+++ b/packages/go/test/fixtures/35-build-command-server/go.mod
@@ -1,0 +1,3 @@
+module build-command-server
+
+go 1.26

--- a/packages/go/test/fixtures/35-build-command-server/main.go
+++ b/packages/go/test/fixtures/35-build-command-server/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"runtime"
+)
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"status":  "ok",
+			"version": runtime.Version(),
+			"random":  "RANDOMNESS_PLACEHOLDER",
+		})
+	})
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
+
+	_ = http.ListenAndServe(":"+port, mux)
+}

--- a/packages/go/test/fixtures/35-build-command-server/probes.json
+++ b/packages/go/test/fixtures/35-build-command-server/probes.json
@@ -1,0 +1,12 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "RANDOMNESS_PLACEHOLDER",
+      "responseHeaders": {
+        "content-type": "/application\\/json/"
+      }
+    }
+  ]
+}

--- a/packages/go/test/fixtures/35-build-command-server/vercel.json
+++ b/packages/go/test/fixtures/35-build-command-server/vercel.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "buildCommand": "go build -o server .",
+  "projectSettings": {
+    "framework": "go"
+  }
+}

--- a/packages/go/test/go-helpers.test.ts
+++ b/packages/go/test/go-helpers.test.ts
@@ -5,9 +5,18 @@ vi.mock('execa', () => {
   return { __esModule: true, default: execa };
 });
 
+import fs from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { mkdirp, remove, writeFile } from 'fs-extra';
 import execa from 'execa';
 import type { Mock, MockedFunction } from 'vitest';
-import { GoWrapper } from '../src/go-helpers';
+import {
+  GoWrapper,
+  isElfBinary,
+  getGoModuleName,
+  findGoBinary,
+} from '../src/go-helpers';
 
 const mockedExeca = execa as unknown as MockedFunction<typeof execa> & {
   stdout: Mock;
@@ -144,6 +153,166 @@ describe('GoWrapper', () => {
       'go',
       ['build', '-ldflags', '-s -w', '-o', '/tmp/out', '.'],
       expect.objectContaining({ stdio: 'pipe' })
+    );
+  });
+});
+
+// ELF magic header: \x7fELF
+const ELF_HEADER = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+
+describe('isElfBinary', () => {
+  const testDir = join(tmpdir(), 'vercel-go-test-elf');
+
+  beforeEach(async () => {
+    await mkdirp(testDir);
+  });
+
+  afterEach(async () => {
+    await remove(testDir);
+  });
+
+  it('returns true for a file with ELF magic bytes', async () => {
+    const p = join(testDir, 'elf-bin');
+    await fs.promises.writeFile(
+      p,
+      Buffer.concat([ELF_HEADER, Buffer.alloc(100)])
+    );
+    expect(await isElfBinary(p)).toBe(true);
+  });
+
+  it('returns false for a non-ELF file', async () => {
+    const p = join(testDir, 'not-elf');
+    await fs.promises.writeFile(p, 'hello world');
+    expect(await isElfBinary(p)).toBe(false);
+  });
+
+  it('returns false for a file smaller than 4 bytes', async () => {
+    const p = join(testDir, 'tiny');
+    await fs.promises.writeFile(p, Buffer.from([0x7f]));
+    expect(await isElfBinary(p)).toBe(false);
+  });
+});
+
+describe('getGoModuleName', () => {
+  const testDir = join(tmpdir(), 'vercel-go-test-gomod');
+
+  beforeEach(async () => {
+    await mkdirp(testDir);
+  });
+
+  afterEach(async () => {
+    await remove(testDir);
+  });
+
+  it('extracts the last segment of a full module path', async () => {
+    const goMod = join(testDir, 'go.mod');
+    await writeFile(goMod, 'module github.com/user/myapp\n\ngo 1.22\n');
+    expect(await getGoModuleName(goMod)).toBe('myapp');
+  });
+
+  it('returns simple module name as-is', async () => {
+    const goMod = join(testDir, 'go.mod');
+    await writeFile(goMod, 'module myserver\n\ngo 1.22\n');
+    expect(await getGoModuleName(goMod)).toBe('myserver');
+  });
+
+  it('returns undefined for a missing file', async () => {
+    expect(await getGoModuleName(join(testDir, 'nope'))).toBeUndefined();
+  });
+});
+
+describe('findGoBinary', () => {
+  const testDir = join(tmpdir(), 'vercel-go-test-find-bin');
+  const destPath = join(tmpdir(), 'vercel-go-test-find-bin-dest');
+
+  beforeEach(async () => {
+    await mkdirp(testDir);
+    await remove(destPath);
+  });
+
+  afterEach(async () => {
+    await remove(testDir);
+    await remove(destPath);
+  });
+
+  it('uses destPath directly when it already exists', async () => {
+    await fs.promises.writeFile(destPath, 'binary');
+    await findGoBinary(testDir, destPath, undefined, 0);
+    expect(await fs.promises.readFile(destPath, 'utf8')).toBe('binary');
+  });
+
+  it('finds a binary matching the go.mod module name', async () => {
+    const goMod = join(testDir, 'go.mod');
+    await writeFile(goMod, 'module github.com/user/myapp\n\ngo 1.22\n');
+
+    const binPath = join(testDir, 'myapp');
+    await fs.promises.writeFile(
+      binPath,
+      Buffer.concat([ELF_HEADER, Buffer.alloc(10)])
+    );
+
+    await findGoBinary(testDir, destPath, goMod, 0);
+    expect(await isElfBinary(destPath)).toBe(true);
+  });
+
+  it('finds a binary with a well-known name', async () => {
+    const binPath = join(testDir, 'server');
+    await fs.promises.writeFile(
+      binPath,
+      Buffer.concat([ELF_HEADER, Buffer.alloc(10)])
+    );
+
+    await findGoBinary(testDir, destPath, undefined, 0);
+    expect(await isElfBinary(destPath)).toBe(true);
+  });
+
+  it('finds a binary in the bin/ subdirectory', async () => {
+    const binDir = join(testDir, 'bin');
+    await mkdirp(binDir);
+
+    const binPath = join(binDir, 'myserver');
+    await fs.promises.writeFile(
+      binPath,
+      Buffer.concat([ELF_HEADER, Buffer.alloc(10)])
+    );
+
+    await findGoBinary(testDir, destPath, undefined, 0);
+    expect(await isElfBinary(destPath)).toBe(true);
+  });
+
+  it('ignores binaries older than buildStartTime', async () => {
+    const binPath = join(testDir, 'server');
+    await fs.promises.writeFile(
+      binPath,
+      Buffer.concat([ELF_HEADER, Buffer.alloc(10)])
+    );
+
+    const futureTime = Date.now() + 60_000;
+    await expect(
+      findGoBinary(testDir, destPath, undefined, futureTime)
+    ).rejects.toThrow('No compiled Go binary found');
+  });
+
+  it('errors when multiple new ELF binaries are found via scan', async () => {
+    const bin1 = join(testDir, 'svc-one');
+    const bin2 = join(testDir, 'svc-two');
+    await fs.promises.writeFile(
+      bin1,
+      Buffer.concat([ELF_HEADER, Buffer.alloc(10)])
+    );
+    await fs.promises.writeFile(
+      bin2,
+      Buffer.concat([ELF_HEADER, Buffer.alloc(10)])
+    );
+
+    await expect(findGoBinary(testDir, destPath, undefined, 0)).rejects.toThrow(
+      'Found multiple ELF binaries'
+    );
+  });
+
+  it('errors when no binary is found', async () => {
+    await expect(findGoBinary(testDir, destPath, undefined, 0)).rejects.toThrow(
+      'No compiled Go binary found'
     );
   });
 });

--- a/packages/go/test/pre-deploy-command.test.ts
+++ b/packages/go/test/pre-deploy-command.test.ts
@@ -1,0 +1,108 @@
+import fs from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { mkdirp, remove, copy } from 'fs-extra';
+import { build } from '../src';
+import type { BuildOptions, Files } from '@vercel/build-utils';
+
+describe('preDeployCommand', () => {
+  const testDir = join(tmpdir(), 'vercel-go-test-predeploy');
+  const fixtureDir = join(__dirname, 'fixtures/35-build-command-server');
+
+  beforeEach(async () => {
+    await remove(testDir);
+    await mkdirp(testDir);
+    // Copy the fixture into a writable temp directory
+    await copy(fixtureDir, testDir);
+  });
+
+  afterEach(async () => {
+    await remove(testDir);
+  });
+
+  it('registers the preDeployCommand callback when provided', async () => {
+    let registeredCallback: (() => Promise<void>) | undefined;
+
+    const files: Files = {};
+    const entries = await fs.promises.readdir(testDir);
+    for (const entry of entries) {
+      const stat = await fs.promises.stat(join(testDir, entry));
+      if (stat.isFile()) {
+        files[entry] = {
+          type: 'FileFsRef' as const,
+          mode: stat.mode,
+          fsPath: join(testDir, entry),
+          toStreamAsync: () => {
+            throw new Error('not implemented');
+          },
+        } as any;
+      }
+    }
+
+    const options: BuildOptions = {
+      files,
+      entrypoint: 'main.go',
+      workPath: testDir,
+      repoRootPath: testDir,
+      config: {
+        framework: 'go',
+        preDeployCommand: 'touch pre-deploy-ran.txt',
+      },
+      meta: { skipDownload: true },
+      registerPreDeploy: (cb: () => Promise<void>) => {
+        registeredCallback = cb;
+      },
+    };
+
+    await build(options);
+
+    expect(registeredCallback).toBeDefined();
+
+    // Execute the callback and verify side effect
+    await registeredCallback!();
+    expect(
+      await fs.promises
+        .access(join(testDir, 'pre-deploy-ran.txt'))
+        .then(() => true)
+        .catch(() => false)
+    ).toBe(true);
+  });
+
+  it('does not register callback when preDeployCommand is absent', async () => {
+    let registeredCallback: (() => Promise<void>) | undefined;
+
+    const files: Files = {};
+    const entries = await fs.promises.readdir(testDir);
+    for (const entry of entries) {
+      const stat = await fs.promises.stat(join(testDir, entry));
+      if (stat.isFile()) {
+        files[entry] = {
+          type: 'FileFsRef' as const,
+          mode: stat.mode,
+          fsPath: join(testDir, entry),
+          toStreamAsync: () => {
+            throw new Error('not implemented');
+          },
+        } as any;
+      }
+    }
+
+    const options: BuildOptions = {
+      files,
+      entrypoint: 'main.go',
+      workPath: testDir,
+      repoRootPath: testDir,
+      config: {
+        framework: 'go',
+      },
+      meta: { skipDownload: true },
+      registerPreDeploy: (cb: () => Promise<void>) => {
+        registeredCallback = cb;
+      },
+    };
+
+    await build(options);
+
+    expect(registeredCallback).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Add `buildCommand` and `preDeployCommand` support to `@vercel/go`.

Previously, the builder always ran its own hardcoded go build and never called registerPreDeploy. 

`buildCommand` replaces the default go build step. 

The builder discovers the compiled binary by:
1. Checking `$VERCEL_OUTPUT_FILE` (explicit path, generic env var usable by future builders)
2. Checking well-known names (server, app, main, api, module name from `go.mod`)
3. Scanning `workPath` and `workPath/bin/` for new ELF binaries

The custom build command works for standalone server mode only (not serverless legacy style apps).

`preDeployCommand` is supported in both standalone server mode and serverless function mode via the registerPreDeploy callback pattern.

Proof

- `preDeployCommand` is tested via a new set of unit tests
- `buildCommand` has a new test fixture 35-build-command-server