### PR TITLE
[CLI] disabling auto update for binary for right now

### DIFF
--- a/.changeset/silent-native-updates.md
+++ b/.changeset/silent-native-updates.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Disable automatic update prompts and automatic upgrades for native CLI installs.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -64,6 +64,7 @@ import { executeUpgrade } from './util/upgrade';
 import {
   canAutoUpdate,
   hasAutoUpdatePreference,
+  isNativeBinaryInstall,
   setAutoUpdate,
 } from './util/updates';
 import { getCommandName, getTitleName } from './util/pkg-name';
@@ -1293,7 +1294,7 @@ const main = async () => {
 
 main()
   .then(async exitCode => {
-    if (SHOULD_CHECK_FOR_UPDATES) {
+    if (SHOULD_CHECK_FOR_UPDATES && !isNativeBinaryInstall()) {
       const latest = getLatestVersion({
         pkg,
       });

--- a/packages/cli/src/util/updates.ts
+++ b/packages/cli/src/util/updates.ts
@@ -24,11 +24,19 @@ export function setAutoUpdate(client: Client, enabled: boolean): void {
   writeToConfigFile(client.config);
 }
 
+export function isNativeBinaryInstall(): boolean {
+  return process.env.VERCEL_VC_NATIVE === '1';
+}
+
 export async function canAutoUpdate(
   client: Client,
   exitCode: number,
   command?: string
 ) {
+  if (isNativeBinaryInstall()) {
+    return false;
+  }
+
   if (!isAutoUpdateEnabled(client.config)) {
     return false;
   }

--- a/packages/cli/test/unit/util/updates.test.ts
+++ b/packages/cli/test/unit/util/updates.test.ts
@@ -6,6 +6,7 @@ import * as configFilesUtil from '../../../src/util/config/files';
 import {
   canAutoUpdate,
   hasAutoUpdatePreference,
+  isNativeBinaryInstall,
   isAutoUpdateEnabled,
   setAutoUpdate,
 } from '../../../src/util/updates';
@@ -18,6 +19,7 @@ vi.mock('ci-info', () => ({
 
 const isGlobalSpy = vi.spyOn(updateCommand, 'isGlobal');
 const writeConfigSpy = vi.spyOn(configFilesUtil, 'writeToConfigFile');
+const originalVercelVcNative = process.env.VERCEL_VC_NATIVE;
 
 function setIsCI(value: boolean) {
   Object.defineProperty(ciInfo, 'isCI', {
@@ -32,6 +34,11 @@ describe('updates', () => {
     isGlobalSpy.mockReset();
     writeConfigSpy.mockClear();
     setIsCI(false);
+    if (originalVercelVcNative === undefined) {
+      delete process.env.VERCEL_VC_NATIVE;
+    } else {
+      process.env.VERCEL_VC_NATIVE = originalVercelVcNative;
+    }
   });
 
   it('reads auto-update state from global config', () => {
@@ -55,6 +62,14 @@ describe('updates', () => {
     });
   });
 
+  it('detects native binary installs', () => {
+    delete process.env.VERCEL_VC_NATIVE;
+    expect(isNativeBinaryInstall()).toBe(false);
+
+    process.env.VERCEL_VC_NATIVE = '1';
+    expect(isNativeBinaryInstall()).toBe(true);
+  });
+
   it('allows auto-update only for successful global interactive invocations', async () => {
     client.config = { updates: { auto: true } };
     isGlobalSpy.mockResolvedValue(true);
@@ -64,6 +79,15 @@ describe('updates', () => {
 
   it('does not auto-update when disabled', async () => {
     client.config = { updates: { auto: false } };
+    isGlobalSpy.mockResolvedValue(true);
+
+    await expect(canAutoUpdate(client, 0)).resolves.toBe(false);
+    expect(isGlobalSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-update native binary installs', async () => {
+    client.config = { updates: { auto: true } };
+    process.env.VERCEL_VC_NATIVE = '1';
     isGlobalSpy.mockResolvedValue(true);
 
     await expect(canAutoUpdate(client, 0)).resolves.toBe(false);

--- a/packages/vc-native/bin/vercel
+++ b/packages/vc-native/bin/vercel
@@ -42,6 +42,10 @@ if (!binaryPath) {
 
 const result = childProcess.spawnSync(binaryPath, process.argv.slice(2), {
   stdio: 'inherit',
+  env: {
+    ...process.env,
+    VERCEL_VC_NATIVE: '1',
+  },
   windowsHide: false,
 });
 

--- a/packages/vc-native/test/shim.test.mjs
+++ b/packages/vc-native/test/shim.test.mjs
@@ -49,7 +49,7 @@ describe('@vercel/vc-native shim', () => {
     } else {
       await writeFile(
         binaryPath,
-        '#!/usr/bin/env node\nconsole.log("native shim ok:" + process.argv.slice(2).join(","));\n'
+        '#!/usr/bin/env node\nconsole.log("native shim ok:" + process.argv.slice(2).join(",") + ":" + process.env.VERCEL_VC_NATIVE);\n'
       );
     }
     await chmod(binaryPath, 0o755);
@@ -64,7 +64,7 @@ describe('@vercel/vc-native shim', () => {
     expect(stdout.trim()).toBe(
       process.platform === 'win32'
         ? process.version
-        : 'native shim ok:arg-one,arg-two'
+        : 'native shim ok:arg-one,arg-two:1'
     );
   });
 });


### PR DESCRIPTION
## Summary

  Disable CLI auto-update checks when running from @vercel/vc-native.

  The native shim now marks spawned binaries with VERCEL_VC_NATIVE=1, and the CLI skips
  auto-update prompts/upgrades for that install path so native users do not get moved
  back to the Node-based vercel package.

  ## Tests

  - pnpm --filter @vercel/vc-native test