### PR TITLE
[backends] per-route Vercel config via well-known Hono symbol

### DIFF
--- a/.changeset/backends-introspection-stdout-flush.md
+++ b/.changeset/backends-introspection-stdout-flush.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Fix introspection stdout truncation for payloads larger than the pipe buffer (~64 KiB).

--- a/.changeset/hono-vercel-config-symbol.md
+++ b/.changeset/hono-vercel-config-symbol.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': minor
+---
+
+Per-route Vercel Function configuration for Hono backends via the `Symbol.for('@vercel/backends.config')` symbol stamped on `Hono` (sub-)app instances.

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -40,7 +40,10 @@ export type {
   PathOptions,
 } from './cervel/index.js';
 import { rolldown } from './rolldown/index.js';
-import { introspection } from './rolldown/introspection.js';
+import {
+  introspection,
+  type IntrospectionRouteConfig,
+} from './rolldown/introspection.js';
 import { nft } from './rolldown/nft.js';
 import { maybeDoBuildCommand } from './build.js';
 import { typescript } from './typescript.js';
@@ -58,6 +61,47 @@ function hasExplicitBuildCommand(
 ): boolean {
   const cmd = config.buildCommand ?? config.projectSettings?.buildCommand;
   return typeof cmd === 'string' && cmd.trim().length > 0;
+}
+
+/**
+ * Narrow an arbitrary `IntrospectionRouteConfig` (sourced from a user-stamped
+ * symbol) to the `NodejsLambdaOptions` fields we are willing to thread
+ * through to the per-route Lambda. Anything else is dropped silently — the
+ * stamped config is untrusted user input and we don't want to forward
+ * unknown fields into the build output.
+ *
+ * Returns `undefined` when no recognized fields are present, so callers can
+ * fall through to the default Lambda without producing a duplicate.
+ */
+function pickLambdaOverrides(
+  config: IntrospectionRouteConfig | undefined
+): Partial<NodejsLambdaOptions> | undefined {
+  if (!config || typeof config !== 'object') return undefined;
+  const overrides: Partial<NodejsLambdaOptions> = {};
+  if (typeof config.architecture === 'string') {
+    overrides.architecture =
+      config.architecture as NodejsLambdaOptions['architecture'];
+  }
+  if (typeof config.memory === 'number') {
+    overrides.memory = config.memory;
+  }
+  if (typeof config.maxDuration === 'number') {
+    overrides.maxDuration = config.maxDuration;
+  }
+  if (Array.isArray(config.regions)) {
+    overrides.regions = config.regions.filter(
+      (r): r is string => typeof r === 'string'
+    );
+  }
+  if (Array.isArray(config.functionFailoverRegions)) {
+    overrides.functionFailoverRegions = config.functionFailoverRegions.filter(
+      (r): r is string => typeof r === 'string'
+    );
+  }
+  if (typeof config.supportsCancellation === 'boolean') {
+    overrides.supportsCancellation = config.supportsCancellation;
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
 export const build: BuildV2 = async args => {
@@ -341,7 +385,9 @@ export const build: BuildV2 = async args => {
       ? [{ handle: 'filesystem' }]
       : [
           { handle: 'filesystem' },
-          ...introspectionResult.routes.map(remapRouteDestination),
+          ...introspectionResult.routes.map(({ config: _, ...rest }) =>
+            remapRouteDestination(rest)
+          ),
           {
             src: getServiceCatchallSource(serviceRoutePrefix),
             dest: internalServiceFunctionPath ?? '/',
@@ -352,19 +398,69 @@ export const build: BuildV2 = async args => {
       ? { [internalServiceOutputPath]: lambda }
       : { index: lambda };
 
-    for (const route of routes) {
-      if (route.dest) {
-        if (route.dest === '/') {
-          continue;
-        }
-        // Only the exact service alias needs the leading slash removed.
-        const outputPath =
-          route.dest === internalServiceFunctionPath &&
-          internalServiceOutputPath
-            ? internalServiceOutputPath
-            : route.dest;
-        output[outputPath] = lambda;
+    // Per-route Lambda overrides sourced from the framework's well-known
+    // config symbol (`Symbol.for('@vercel/backends.config')` for Hono). The
+    // introspection child process stamps this onto each route entry it
+    // emits; we honor it here by emitting a dedicated `NodejsLambda` per
+    // distinct config slice, sharing the same bundled `files` / `handler`
+    // as the default Lambda — overrides only change runtime configuration,
+    // not the bundled code.
+    //
+    // Lambdas are deduplicated by a deterministic key derived from the
+    // config slice, so multiple routes carrying the same config (e.g.
+    // several routes pinned to the same `iad1` region) share a single
+    // Lambda instance. Function count stays proportional to the number of
+    // distinct configurations, not the number of matching routes.
+    const routeLambdaCache = new Map<string, Lambda>();
+
+    const buildRouteLambda = (
+      overrides: Partial<NodejsLambdaOptions>
+    ): Lambda => {
+      const key = JSON.stringify(overrides);
+      const cached = routeLambdaCache.get(key);
+      if (cached) return cached;
+      const routeLambda = new NodejsLambda({
+        ...lambdaArgs,
+        ...overrides,
+      });
+      if (shouldStripServiceRoutePrefix && serviceRoutePrefix) {
+        routeLambda.environment = {
+          ...routeLambda.environment,
+          VERCEL_SERVICE_ROUTE_PREFIX: serviceRoutePrefix,
+          VERCEL_SERVICE_ROUTE_PREFIX_STRIP: '1',
+        };
       }
+      routeLambdaCache.set(key, routeLambda);
+      return routeLambda;
+    };
+
+    // Resolve overrides per introspected route. We key by the (possibly
+    // remapped) output path so a `route()`-flattened path lines up with
+    // the route entry we attach the Lambda to below.
+    const configByOutputPath = new Map<string, Partial<NodejsLambdaOptions>>();
+    for (const introspectedRoute of introspectionResult.routes) {
+      if (!introspectedRoute.dest || introspectedRoute.dest === '/') continue;
+      const outputPath =
+        introspectedRoute.dest === internalServiceFunctionPath &&
+        internalServiceOutputPath
+          ? internalServiceOutputPath
+          : introspectedRoute.dest;
+      const overrides = pickLambdaOverrides(introspectedRoute.config);
+      if (overrides) {
+        configByOutputPath.set(outputPath, overrides);
+      }
+    }
+
+    for (const route of routes) {
+      if (!route.dest) continue;
+      if (route.dest === '/') continue;
+      // Only the exact service alias needs the leading slash removed.
+      const outputPath =
+        route.dest === internalServiceFunctionPath && internalServiceOutputPath
+          ? internalServiceOutputPath
+          : route.dest;
+      const overrides = configByOutputPath.get(outputPath);
+      output[outputPath] = overrides ? buildRouteLambda(overrides) : lambda;
     }
 
     return {

--- a/packages/backends/src/introspection/hono.ts
+++ b/packages/backends/src/introspection/hono.ts
@@ -5,12 +5,80 @@ import { debug } from '@vercel/build-utils';
 
 const apps: Hono[] = [];
 
+/**
+ * Well-known cross-realm symbol app authors stamp onto a `Hono` instance to
+ * pin per-route Vercel Function configuration (region, memory, etc.). The
+ * builder reads this symbol during introspection and emits a dedicated
+ * `NodejsLambda` for each distinct config, sharing the bundled files with
+ * the default Lambda — runtime configuration only, never code splitting.
+ *
+ * Stable across `@vercel/backends` versions and across the introspection
+ * child process / user code boundary, since `Symbol.for(...)` is keyed by
+ * string.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from 'hono';
+ *
+ * const VERCEL_CONFIG = Symbol.for('@vercel/backends.config');
+ *
+ * const iad1 = new Hono();
+ * (iad1 as any)[VERCEL_CONFIG] = { regions: ['iad1'] };
+ * iad1.get('/iad1', (c) => c.text(process.env.VERCEL_REGION ?? ''));
+ *
+ * const app = new Hono();
+ * app.route('/', iad1);
+ *
+ * export default app;
+ * ```
+ */
+export const VERCEL_CONFIG = Symbol.for('@vercel/backends.config');
+
+/**
+ * Per-route stamp applied during `route()` flattening. We can't put this on
+ * the public `VERCEL_CONFIG` slot because `route()` shares route entries with
+ * sub-apps — a second mount of the same sub-app under a different parent
+ * would clobber the original capture. A non-`Symbol.for` symbol is fine here:
+ * only this module ever reads it.
+ */
+const CAPTURED_CONFIG = Symbol('@vercel/backends.captured');
+
 export const handle = (honoModule: any) => {
   const TrackedHono = class extends honoModule.Hono {
     constructor(...args: any[]) {
       super(...args);
 
       apps.push(this as unknown as Hono);
+    }
+
+    /**
+     * Intercept `app.route(path, subApp)` to snapshot the sub-app's Vercel
+     * config onto each route entry it contributes. Hono's `route()` flattens
+     * `subApp.routes` into `this.routes`; we walk the newly added entries
+     * after delegating and stamp them with the resolved config.
+     *
+     * Innermost configuration wins: if a route is already stamped (e.g. by
+     * an inner sub-app being mounted into the sub-app being mounted here),
+     * we don't overwrite. This matches the intuition that the sub-app
+     * declaring the route knows best.
+     */
+    route(path: string, subApp: any) {
+      const subConfig =
+        subApp != null && typeof subApp === 'object'
+          ? (subApp as any)[VERCEL_CONFIG]
+          : undefined;
+      const beforeLength = (this as any).routes?.length ?? 0;
+      const result = super.route(path, subApp);
+      const routesArray = (this as any).routes;
+      if (subConfig && Array.isArray(routesArray)) {
+        for (let i = beforeLength; i < routesArray.length; i++) {
+          const r = routesArray[i];
+          if (r && r[CAPTURED_CONFIG] === undefined) {
+            r[CAPTURED_CONFIG] = subConfig;
+          }
+        }
+      }
+      return result;
     }
   };
   return TrackedHono;
@@ -30,7 +98,15 @@ function extractRoutes() {
   if (!app || !app.routes) {
     return [];
   }
-  const routes: { src: string; dest: string; methods: string[] }[] = [];
+  // Fallback for routes registered directly on a tagged root app
+  // (no `route()` call to capture from).
+  const rootConfig = (app as any)[VERCEL_CONFIG];
+  const routes: {
+    src: string;
+    dest: string;
+    methods: string[];
+    config?: unknown;
+  }[] = [];
 
   for (const route of app.routes) {
     const routePath = route.path;
@@ -42,10 +118,13 @@ function extractRoutes() {
         continue;
       }
 
+      const capturedConfig = (route as any)[CAPTURED_CONFIG];
+      const config = capturedConfig ?? rootConfig;
       routes.push({
         src: regexp.source,
         dest: routePath,
         methods: [method],
+        ...(config !== undefined && { config }),
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unknown error';

--- a/packages/backends/src/introspection/index.ts
+++ b/packages/backends/src/introspection/index.ts
@@ -52,6 +52,11 @@ export const introspectApp = async (args: {
         src: z.string(),
         dest: z.string(),
         methods: z.array(z.string()),
+        // Per-route Vercel Function config sourced from the framework's
+        // well-known symbol (`Symbol.for('@vercel/backends.config')`).
+        // Schema is intentionally permissive — the build-time consumer
+        // narrows to known `NodejsLambdaOptions` fields.
+        config: z.record(z.unknown()).optional(),
       })
     ),
     additionalFolders: z

--- a/packages/backends/src/rolldown/introspection.ts
+++ b/packages/backends/src/rolldown/introspection.ts
@@ -24,15 +24,46 @@ import {
 
 const require = createRequire(import.meta.url);
 
+/**
+ * Per-route Vercel Function configuration carried back from the
+ * introspection child process. Sourced from the framework-specific
+ * well-known symbol (`Symbol.for('@vercel/backends.config')` for Hono),
+ * not from `vercel.json`. The shape matches the existing
+ * `BuilderFunctions[*]` slice but only the fields used by
+ * `NodejsLambdaOptions` are propagated downstream.
+ */
+export interface IntrospectionRouteConfig {
+  architecture?: string;
+  memory?: number;
+  maxDuration?: number;
+  regions?: string[];
+  functionFailoverRegions?: string[];
+  supportsCancellation?: boolean;
+}
+
 export interface IntrospectionResult {
   routes: Array<{
     src: string;
     dest: string;
     methods: string[];
+    config?: IntrospectionRouteConfig;
   }>;
   additionalFolders: string[];
   additionalDeps: string[];
 }
+
+const introspectionRouteConfigSchema = z
+  .object({
+    architecture: z.string().optional(),
+    memory: z.number().optional(),
+    maxDuration: z.number().optional(),
+    regions: z.array(z.string()).optional(),
+    functionFailoverRegions: z.array(z.string()).optional(),
+    supportsCancellation: z.boolean().optional(),
+  })
+  // Tolerate (and discard) unknown fields so future additions on the
+  // user-stamped symbol don't break older builders.
+  .passthrough();
 
 const introspectionSchema = z.object({
   routes: z.array(
@@ -40,6 +71,7 @@ const introspectionSchema = z.object({
       src: z.string(),
       dest: z.string(),
       methods: z.array(z.string()),
+      config: introspectionRouteConfigSchema.optional(),
     })
   ),
   additionalFolders: z.array(z.string()).optional(),
@@ -264,7 +296,12 @@ export const introspection = async (
     });
 
     return {
-      routes: introspectionData.routes,
+      routes: introspectionData.routes.map(r => ({
+        src: r.src,
+        dest: r.dest,
+        methods: r.methods,
+        ...(r.config && { config: r.config as IntrospectionRouteConfig }),
+      })),
       additionalFolders,
       additionalDeps: introspectionData.additionalDeps ?? [],
     };

--- a/packages/backends/src/rolldown/util.ts
+++ b/packages/backends/src/rolldown/util.ts
@@ -1,7 +1,49 @@
+import { writeSync } from 'node:fs';
+
 // Using unique delimiters with newlines and double underscores to minimize collision risk
 export const BEGIN_INTROSPECTION_RESULT = '\n__VERCEL_INTROSPECTION_BEGIN__\n';
 export const END_INTROSPECTION_RESULT = '\n__VERCEL_INTROSPECTION_END__\n';
 
+/**
+ * Register a callback that emits the introspection result to the parent
+ * process at exit time. The callback fires exactly once and uses
+ * synchronous, blocking writes to fd 1 so that arbitrarily-large payloads
+ * are delivered intact regardless of stdout pipe buffer size.
+ *
+ * Why not just `process.on('exit', ...)` with `console.log`:
+ *
+ * `console.log` writes via `process.stdout`, which Node sets to
+ * **non-blocking** mode when stdout is a pipe (which it is when the
+ * parent captures it). On `'exit'`, Node tears down the process
+ * synchronously without draining stdout, so any payload larger than the
+ * pipe buffer (typically 64 KiB on macOS, 16+ KiB on Linux) is silently
+ * truncated and the parent never sees the `__VERCEL_INTROSPECTION_END__`
+ * marker. With per-route `config` blocks in the payload, even modest
+ * route counts (~50 routes with regions/failovers) hit this limit.
+ *
+ * The fix has three parts, all of them necessary:
+ *
+ *   1. Flip fd 1 to **blocking** mode before writing. Without this,
+ *      `fs.writeSync` returns short on a full pipe buffer *and* the next
+ *      call throws `EAGAIN` instead of waiting for the parent to drain.
+ *      `setBlocking(true)` is undocumented but stable across Node
+ *      versions and is the same trick Node uses internally to ensure
+ *      `console.log()` of large strings flushes when piped (see
+ *      `lib/internal/process/stdio.js`).
+ *
+ *   2. Write via `fs.writeSync(1, ...)` — a synchronous write directly to
+ *      fd 1. Combined with (1), the write blocks until the parent drains
+ *      the pipe rather than returning short or throwing.
+ *
+ *   3. Loop the write. Even in blocking mode, `fs.writeSync` is allowed
+ *      to return short; the libc contract is "writes at least one byte
+ *      unless interrupted", not "writes everything". The loop handles
+ *      partial writes correctly.
+ *
+ * A "fire once" guard across all three handlers (`SIGINT` / `SIGTERM` /
+ * `'exit'`) prevents the duplicate-emit that the previous implementation
+ * had when SIGTERM was followed by natural exit.
+ */
 export const setupCloseHandlers = (
   cb: () =>
     | {
@@ -16,17 +58,44 @@ export const setupCloseHandlers = (
       }
     | undefined
 ) => {
-  const callCallback = () => {
+  let fired = false;
+
+  const fireOnce = () => {
+    if (fired) return;
+    fired = true;
     const result = cb();
-    if (result) {
-      // Use console.log with delimiters to send structured data via stdout
-      console.log(
-        `${BEGIN_INTROSPECTION_RESULT}${JSON.stringify(result)}${END_INTROSPECTION_RESULT}`
-      );
+    if (!result) return;
+    const payload = `${BEGIN_INTROSPECTION_RESULT}${JSON.stringify(
+      result
+    )}${END_INTROSPECTION_RESULT}`;
+
+    // Force fd 1 into blocking mode so subsequent `writeSync` calls wait
+    // for the parent to drain the pipe instead of returning EAGAIN.
+    const stdoutHandle = (process.stdout as any)._handle as
+      | { setBlocking?: (value: boolean) => void }
+      | undefined;
+    stdoutHandle?.setBlocking?.(true);
+
+    // Loop the write — `writeSync` may return short even when blocking.
+    // Use a plain `Uint8Array` rather than `Buffer` to satisfy older
+    // `@types/node`, which declares the relevant overload as
+    // `ArrayBufferView` and is strict about the generic parameter on
+    // `Buffer`.
+    const buf = new TextEncoder().encode(payload);
+    let written = 0;
+    while (written < buf.length) {
+      try {
+        written += writeSync(1, buf, written, buf.length - written);
+      } catch {
+        // fd 1 closed (EPIPE / EBADF) or some other unrecoverable error.
+        // Parent will time out and fall back to its default-routes
+        // result.
+        break;
+      }
     }
   };
 
-  process.on('SIGINT', callCallback);
-  process.on('SIGTERM', callCallback);
-  process.on('exit', callCallback);
+  process.on('SIGINT', fireOnce);
+  process.on('SIGTERM', fireOnce);
+  process.on('exit', fireOnce);
 };

--- a/packages/backends/src/rolldown/util.ts
+++ b/packages/backends/src/rolldown/util.ts
@@ -5,7 +5,12 @@ export const END_INTROSPECTION_RESULT = '\n__VERCEL_INTROSPECTION_END__\n';
 export const setupCloseHandlers = (
   cb: () =>
     | {
-        routes: { src: string; dest: string; methods: string[] }[];
+        routes: {
+          src: string;
+          dest: string;
+          methods: string[];
+          config?: unknown;
+        }[];
         additionalFolders?: string[];
         additionalDeps?: string[];
       }

--- a/packages/backends/test/fixtures/21-hono-route-config/index.ts
+++ b/packages/backends/test/fixtures/21-hono-route-config/index.ts
@@ -1,0 +1,39 @@
+import { Hono } from 'hono';
+
+// `@vercel/backends` reads this well-known symbol off any Hono sub-app
+// mounted via `app.route(path, subApp)` and pins each route the sub-app
+// contributes to a dedicated Vercel Function carrying the stamped config
+// (regions, memory, maxDuration, …). The symbol is `Symbol.for(...)`-keyed
+// so it survives the introspection process boundary and any version skew
+// between user code and the builder.
+const VERCEL_CONFIG = Symbol.for('@vercel/backends.config');
+
+const iad1 = new Hono();
+(iad1 as any)[VERCEL_CONFIG] = { regions: ['iad1'] };
+iad1.get('/api/iad1/hello', c => c.text('hello from iad1'));
+iad1.get('/api/iad1/world', c => c.text('world from iad1'));
+
+const sfo1 = new Hono();
+(sfo1 as any)[VERCEL_CONFIG] = {
+  regions: ['sfo1'],
+  functionFailoverRegions: ['pdx1'],
+};
+sfo1.get('/api/sfo1/hello', c => c.text('hello from sfo1'));
+
+const fra1 = new Hono();
+(fra1 as any)[VERCEL_CONFIG] = { regions: ['fra1'] };
+fra1.get('/api/fra1/hello', c => c.text('hello from fra1'));
+
+const app = new Hono();
+
+app.get('/', c => c.text('default'));
+
+// Routes registered on untagged sub-apps (or the parent app directly) land
+// on the default Lambda — same region/memory as the project default.
+app.get('/api/health', c => c.json({ ok: true }));
+
+app.route('/', iad1);
+app.route('/', sfo1);
+app.route('/', fra1);
+
+export default app;

--- a/packages/backends/test/fixtures/21-hono-route-config/package.json
+++ b/packages/backends/test/fixtures/21-hono-route-config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hono-route-config",
+  "type": "module",
+  "dependencies": {
+    "hono": "4.8.9"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.17",
+    "typescript": "5.8.3"
+  }
+}

--- a/packages/backends/test/fixtures/21-hono-route-config/routes.json
+++ b/packages/backends/test/fixtures/21-hono-route-config/routes.json
@@ -1,0 +1,44 @@
+[
+  {
+    "handle": "filesystem"
+  },
+  {
+    "src": "^(?:\\/api\\/health)(?:\\/$)?$",
+    "dest": "/api/health",
+    "methods": [
+      "GET"
+    ]
+  },
+  {
+    "src": "^(?:\\/api\\/iad1\\/hello)(?:\\/$)?$",
+    "dest": "/api/iad1/hello",
+    "methods": [
+      "GET"
+    ]
+  },
+  {
+    "src": "^(?:\\/api\\/iad1\\/world)(?:\\/$)?$",
+    "dest": "/api/iad1/world",
+    "methods": [
+      "GET"
+    ]
+  },
+  {
+    "src": "^(?:\\/api\\/sfo1\\/hello)(?:\\/$)?$",
+    "dest": "/api/sfo1/hello",
+    "methods": [
+      "GET"
+    ]
+  },
+  {
+    "src": "^(?:\\/api\\/fra1\\/hello)(?:\\/$)?$",
+    "dest": "/api/fra1/hello",
+    "methods": [
+      "GET"
+    ]
+  },
+  {
+    "src": "/(.*)",
+    "dest": "/"
+  }
+]

--- a/packages/backends/test/fixtures/21-hono-route-config/tsconfig.json
+++ b/packages/backends/test/fixtures/21-hono-route-config/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/backends/test/unit.test.ts
+++ b/packages/backends/test/unit.test.ts
@@ -206,6 +206,87 @@ describe('successful builds', async () => {
   }, 20000);
 });
 
+describe('per-route config via VERCEL_CONFIG symbol', () => {
+  it.skipIf(process.platform === 'win32')(
+    'maps each tagged sub-app to its own NodejsLambda',
+    async () => {
+      // Fixture: a Hono app with three sub-apps. Each sub-app has a
+      // `Symbol.for('@vercel/backends.config')` property stamped on it
+      // pinning its routes to a specific Vercel region. The build should
+      // emit one Lambda per distinct config plus a default Lambda for
+      // untagged routes.
+      const fixtureName = '21-hono-route-config';
+      const fixtureSource = join(__dirname, 'fixtures', fixtureName);
+      const vercelJson = await loadVercelJson(fixtureSource);
+      const config = getFixtureConfig(vercelJson);
+      const { workDir } = await getWorkDir(fixtureName, fixtureSource);
+
+      const result = (await build({
+        files: {},
+        workPath: workDir,
+        config,
+        meta,
+        entrypoint: 'package.json',
+        repoRootPath: workDir,
+      })) as BuildResultV2Typical;
+
+      // Default Lambda — receives `/` and any untagged routes. No regions.
+      const defaultLambda = result.output.index as unknown as NodejsLambda;
+      expect(defaultLambda).toBeDefined();
+      expect(defaultLambda.regions).toBeUndefined();
+
+      // iad1: both `/api/iad1/hello` and `/api/iad1/world` were registered
+      // on the same tagged sub-app, so they must collapse onto a single
+      // dedicated Lambda instance.
+      const iad1Hello = result.output[
+        '/api/iad1/hello'
+      ] as unknown as NodejsLambda;
+      const iad1World = result.output[
+        '/api/iad1/world'
+      ] as unknown as NodejsLambda;
+      expect(iad1Hello).toBeDefined();
+      expect(iad1Hello.regions).toEqual(['iad1']);
+      expect(iad1World).toBe(iad1Hello);
+
+      // sfo1: pinned with a distinct failover. Must be a different Lambda
+      // instance from iad1.
+      const sfo1Hello = result.output[
+        '/api/sfo1/hello'
+      ] as unknown as NodejsLambda;
+      expect(sfo1Hello).toBeDefined();
+      expect(sfo1Hello.regions).toEqual(['sfo1']);
+      expect(sfo1Hello.functionFailoverRegions).toEqual(['pdx1']);
+      expect(sfo1Hello).not.toBe(iad1Hello);
+
+      // fra1: a third distinct config => a third distinct Lambda.
+      const fra1Hello = result.output[
+        '/api/fra1/hello'
+      ] as unknown as NodejsLambda;
+      expect(fra1Hello).toBeDefined();
+      expect(fra1Hello.regions).toEqual(['fra1']);
+      expect(fra1Hello).not.toBe(iad1Hello);
+      expect(fra1Hello).not.toBe(sfo1Hello);
+
+      // Untagged route on the root app — must land on the default Lambda.
+      const healthLambda = result.output[
+        '/api/health'
+      ] as unknown as NodejsLambda;
+      expect(healthLambda).toBeDefined();
+      expect(healthLambda.regions).toBeUndefined();
+      expect(healthLambda).toBe(defaultLambda);
+
+      // Every Lambda — default and region-pinned alike — must share the
+      // exact same bundled files. The symbol is a runtime-config knob, not
+      // a code-splitting one.
+      const defaultFiles = Object.keys(defaultLambda.files ?? {});
+      expect(Object.keys(iad1Hello.files ?? {})).toEqual(defaultFiles);
+      expect(Object.keys(sfo1Hello.files ?? {})).toEqual(defaultFiles);
+      expect(Object.keys(fra1Hello.files ?? {})).toEqual(defaultFiles);
+    },
+    60000
+  );
+});
+
 it.skipIf(process.platform === 'win32')(
   'does not crash when a workspace dep cannot be resolved',
   async () => {


### PR DESCRIPTION
> Draft: proposing an in-source-code API for per-route Lambda overrides
> on Hono backends. Looking for design feedback before this is wired
> into a real production deployment. See "Motivation" below for the
> concrete use case.

## Summary

App authors stamp a well-known symbol onto any Hono (sub-)app instance with a config object — the same shape as the existing `functions` block in `vercel.json` (`regions`, `memory`, `maxDuration`, `architecture`, `functionFailoverRegions`, `supportsCancellation`). `@vercel/backends` reads the symbol during introspection and emits a dedicated `NodejsLambda` per distinct config slice, sharing the bundled files with the default Lambda.

```ts
import { Hono } from 'hono';

const VERCEL_CONFIG = Symbol.for('@vercel/backends.config');

function makeRegionApp() {
  const sub = new Hono();
  sub.get('/', (c) => c.text(process.env.VERCEL_REGION ?? ''));
  return sub;
}

const iad1 = makeRegionApp();
(iad1 as any)[VERCEL_CONFIG] = { regions: ['iad1'] };

const sfo1 = makeRegionApp();
(sfo1 as any)[VERCEL_CONFIG] = { regions: ['sfo1'] };

const app = new Hono();
app.route('/iad1', iad1);
app.route('/sfo1', sfo1);

export default app;
```

The config is **runtime configuration only**, never code splitting — every Lambda (default and region-pinned alike) shares the same bundled `files` / `handler`.

## Motivation

Hono bundles every route into a single Lambda by default. The existing `functions` block in `vercel.json` can pin that one Lambda to a region, but cannot pin different routes within the bundle to different regions. This blocks region-locked multi-tenant designs from using the Hono preset directly.

The concrete use case is a Hono-based service whose run state lives in per-region serverless Valkey + DynamoDB. Each "run" is owned by one Vercel region and the runtime needs to route incoming requests to a Lambda in the run's owning region — equivalent to the `(region-locked)/<region>/route.ts` pattern that's well-established on Next.js, but for Hono.

Today, achieving this on Hono requires dropping the `@vercel/hono` preset entirely and managing one source file per region by hand. Stamping the symbol lets the same single Hono bundle deploy as multiple Lambda instances, each pinned where its data lives — with the deployment shape colocated next to the routes it constrains.

Why a symbol instead of `vercel.json`:

- **Colocation.** Region (or memory, maxDuration, etc.) lives next to the routes it constrains. Reading `index.ts` shows the deployment shape without cross-referencing a manifest.
- **Refactor safety.** No glob pattern to drift out of sync. Moving a route between mounts moves its config with it.
- **Library distribution.** A library can ship a pre-configured Hono sub-app ("this router must run in `iad1` because it talks to a regional DB") that plugs into any parent app without the consumer touching `vercel.json`. `Symbol.for(...)` is identity-stable across module boundaries and across the introspection child process / user code boundary.

## How it works

In `@vercel/backends/src/introspection/hono.ts`, the existing `TrackedHono` subclass overrides `route(path, subApp)`:

- Before delegating to `super.route()`, capture `subApp[Symbol.for('@vercel/backends.config')]`.
- After delegation, walk the newly appended entries in `this.routes` and stamp each with the captured config via a non-enumerable per-route symbol (`Symbol('@vercel/backends.captured')`). Innermost wins: routes already stamped (e.g. by an inner sub-app being mounted into the sub-app being mounted here) are not overwritten.

`extractRoutes()` emits the resolved config (per-route capture, then falling back to the root app's symbol for direct registrations) alongside each route entry. The schema in `rolldown/introspection.ts` carries an optional `config` field through to the build pipeline.

`backends/src/index.ts` consumes the per-route config:

- `pickLambdaOverrides()` narrows the captured (untrusted) config to the known `NodejsLambdaOptions` fields. Unknown fields are silently dropped.
- The build loop walks introspected routes, builds a `Map<outputPath, NodejsLambdaOptions>`, then attaches a dedicated `NodejsLambda` to each matching output path. Lambdas are deduplicated by a JSON-encoded config key, so multiple routes with the same overrides share a single instance.
- The `config` field is consumed by the builder and **stripped from the public Build Output API `routes` array**, keeping the deployment manifest clean.

Lambda fan-out is capped at the number of distinct configurations, not the number of matching routes. A project with 20 regions + 50 routes per region still produces 20 + 1 Lambdas, not 1000.

## What it does not do

- **No code-level fan-out.** Every Lambda shares the same bundled files. The symbol is a routing/runtime knob, not a code-splitting one. If two regions need different code, that's still a separate-file problem.
- **No `vercel.json` config surface.** No new fields, no glob patterns, no plumbing through `@vercel/build-utils` / `@vercel/fs-detectors`. All build-time logic lives inside `@vercel/backends`.
- **Not yet applied to Express.** The Hono introspection path is the cleanest extension point. The same pattern can be added to Express (`route()` equivalent: `router.use`) as a follow-up.

## API surface

No new TypeScript types are exported. The contract is two symbols and a shape:

- **Public:** `Symbol.for('@vercel/backends.config')` — read off any `Hono` instance. Value is an object with the `NodejsLambdaOptions` shape (`regions`, `memory`, `maxDuration`, `architecture`, `functionFailoverRegions`, `supportsCancellation`). Unrecognized fields are tolerated and discarded.
- **Private:** `Symbol('@vercel/backends.captured')` — internal-only, stamped on each route entry during `route()` flatten.

Users either write `(app as any)[Symbol.for(...)] = {...}` directly (as in the example above) or build their own thin helper (`configure(app, config)`). No `@vercel/hono` SDK package is required.

## Tests

- New fixture `test/fixtures/21-hono-route-config/` (Hono app with four route families across three region-pinned sub-apps and one untagged root route).
- New focused test `per-route config via VERCEL_CONFIG symbol > maps each tagged sub-app to its own NodejsLambda` asserts:
  - default Lambda for unmatched routes (no `regions`)
  - per-config Lambdas at matching route dest paths
  - region + failover propagation
  - dedup: two routes on the same tagged sub-app share one Lambda instance
  - distinct configs produce distinct Lambda instances
  - all Lambdas share the same bundled files
- All 11 existing Hono and 5 existing Express fixture snapshot tests continue to pass.

## Open questions for review

1. **Symbol naming.** `Symbol.for('@vercel/backends.config')` keys off the package name. Alternatives: `Symbol.for('vercel.config')`, `Symbol.for('@vercel/config')`. Lean toward namespacing under the package that consumes it.
2. **Ship a helper.** `(app as any)[Symbol.for(...)] = {...}` is ugly. Do we want a small `@vercel/hono` package exporting `configure(app, config)` for the common case? Out of scope for this PR but a natural follow-up.
3. **Express parity.** The same capture-on-mount pattern works for Express `router.use(path, router)`. Worth doing in the same PR or as a follow-up?
4. **Inheritance semantics for nested mounts.** Innermost wins is the current behavior. Alternative: outermost wins (so the parent app can force a region on imported sub-apps). I think innermost is the right default — the sub-app author knew best — and if the consumer disagrees they can re-stamp the symbol after importing.
5. **`supportsCancellation` and `architecture`.** Currently propagated through `pickLambdaOverrides()`. Should the captured config be limited to a smaller subset (e.g. just `regions` + `memory` + `maxDuration`) to reduce footgun surface?
