### PR TITLE
[services] Add project manifest to ruby builder.

### DIFF
--- a/.changeset/spotty-carrots-rest.md
+++ b/.changeset/spotty-carrots-rest.md
@@ -1,0 +1,5 @@
+---
+'@vercel/ruby': minor
+---
+
+Add project manifest to ruby builder.

--- a/packages/ruby/src/diagnostics.ts
+++ b/packages/ruby/src/diagnostics.ts
@@ -1,0 +1,216 @@
+import fs from 'fs';
+import {
+  writeProjectManifest,
+  createDiagnostics,
+  MANIFEST_VERSION,
+  type PackageManifest,
+  type PackageManifestDependency,
+} from '@vercel/build-utils';
+
+const GEM_SPEC_PATTERN = /^(\S+) \(([^)]+)\)$/;
+const DEPENDENCY_PATTERN = /^([^\s!]+)(!?)(?:\s+\(([^)]+)\))?$/;
+
+enum GemSource {
+  REGISTRY = 'registry',
+  GIT = 'git',
+  PLUGIN = 'plugin',
+}
+
+interface GemEntry {
+  version: string;
+  source: GemSource;
+  sourceUrl: string;
+}
+
+function parseGemfileLock(content: string): {
+  gems: Map<string, GemEntry>;
+  directGems: Map<string, string | undefined>;
+} {
+  const gems = new Map<string, GemEntry>();
+  const pathGems = new Set<string>();
+  const directGems = new Map<string, string | undefined>();
+
+  enum Section {
+    GEM = 'gem',
+    GIT = 'git',
+    PATH = 'path',
+    PLUGIN = 'plugin',
+    DEPENDENCIES = 'dependencies',
+  }
+
+  enum SubSection {
+    SPECS = 'specs',
+  }
+
+  let section: Section | null = null;
+  let subSection: SubSection | null = null;
+  let currentRemote = '';
+
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trimEnd();
+
+    if (!line) continue;
+
+    if (!line.startsWith(' ')) {
+      currentRemote = '';
+      if (line === 'GEM') section = Section.GEM;
+      else if (line === 'GIT') section = Section.GIT;
+      else if (line === 'PATH') section = Section.PATH;
+      else if (line === 'PLUGIN SOURCE') section = Section.PLUGIN;
+      else if (line === 'DEPENDENCIES') section = Section.DEPENDENCIES;
+      else section = null;
+      subSection = null;
+      continue;
+    }
+
+    const indent = line.length - line.trimStart().length;
+    const text = line.trimStart();
+
+    if (
+      section === Section.GEM ||
+      section === Section.GIT ||
+      section === Section.PLUGIN
+    ) {
+      if (indent === 2) {
+        if (text.startsWith('remote:')) {
+          currentRemote = text.slice('remote:'.length).trim();
+          subSection = null;
+        } else if (text === 'specs:') {
+          subSection = SubSection.SPECS;
+        }
+      } else if (indent === 4 && subSection === SubSection.SPECS) {
+        const m = text.match(GEM_SPEC_PATTERN);
+        if (!m) continue;
+
+        const [, name, version] = m;
+        let gem: GemEntry;
+        if (section === Section.GIT) {
+          gem = { version, source: GemSource.GIT, sourceUrl: currentRemote };
+        } else if (section === Section.PLUGIN) {
+          gem = { version, source: GemSource.PLUGIN, sourceUrl: currentRemote };
+        } else {
+          let sourceUrl = currentRemote;
+          try {
+            sourceUrl = new URL(currentRemote).origin;
+          } catch {}
+          gem = { version, source: GemSource.REGISTRY, sourceUrl };
+        }
+
+        // Prefer registry gems over git/plugin; prefer base version over platform
+        // variants (e.g. nokogiri (1.18.0) over nokogiri (1.18.0-arm64-darwin)).
+        if (gems.has(name)) {
+          const existing = gems.get(name)!;
+          const isPlatformVariant = /-[a-zA-Z]/.test(version);
+          const existingIsPlatformVariant = /-[a-zA-Z]/.test(existing.version);
+          if (isPlatformVariant) continue;
+          if (existing.source === gem.source && !existingIsPlatformVariant)
+            continue;
+          if (gem.source !== GemSource.REGISTRY) continue;
+        }
+
+        gems.set(name, gem);
+      }
+    }
+
+    if (section === Section.PATH) {
+      if (indent === 2 && text === 'specs:') {
+        subSection = SubSection.SPECS;
+      } else if (indent === 4 && subSection === SubSection.SPECS) {
+        const m = text.match(GEM_SPEC_PATTERN);
+        if (!m) continue;
+
+        const [, name] = m;
+        pathGems.add(name);
+      }
+    }
+
+    if (section === Section.DEPENDENCIES) {
+      if (indent === 2) {
+        const m = text.match(DEPENDENCY_PATTERN);
+        if (!m) continue;
+
+        const [, name, , version] = m;
+        directGems.set(name, version);
+      }
+    }
+  }
+
+  // Exclude PATH gems (local, not deployable) regardless of ! marker
+  for (const name of pathGems) {
+    directGems.delete(name);
+  }
+
+  return { gems, directGems };
+}
+
+export async function generateProjectManifest({
+  workPath,
+  gemfileLockPath,
+  framework,
+  serviceType,
+}: {
+  workPath: string;
+  gemfileLockPath: string | undefined;
+  framework?: string | null;
+  serviceType?: string | null;
+}): Promise<void> {
+  try {
+    if (!gemfileLockPath) return;
+
+    let content: string;
+    try {
+      content = await fs.promises.readFile(gemfileLockPath, 'utf-8');
+    } catch {
+      return;
+    }
+
+    const { gems, directGems } = parseGemfileLock(content);
+
+    const directEntries: PackageManifestDependency[] = [];
+    const transitiveEntries: PackageManifestDependency[] = [];
+
+    for (const [name, version] of directGems) {
+      const gem = gems.get(name);
+      const entry: PackageManifestDependency = {
+        name,
+        type: 'direct',
+        scopes: ['prod'],
+        ...(version ? { requested: version } : {}),
+        resolved: gem?.version ?? '',
+      };
+      if (gem?.source) entry.source = gem.source;
+      if (gem?.sourceUrl) entry.sourceUrl = gem.sourceUrl;
+      directEntries.push(entry);
+    }
+
+    for (const [name, gem] of gems) {
+      if (directGems.has(name)) continue;
+      const entry: PackageManifestDependency = {
+        name,
+        type: 'transitive',
+        scopes: ['prod'],
+        resolved: gem.version,
+      };
+      if (gem.source) entry.source = gem.source;
+      if (gem.sourceUrl) entry.sourceUrl = gem.sourceUrl;
+      transitiveEntries.push(entry);
+    }
+
+    const manifest: PackageManifest = {
+      version: MANIFEST_VERSION,
+      runtime: 'ruby',
+      ...(framework ? { framework } : {}),
+      ...(serviceType ? { serviceType } : {}),
+      dependencies: [
+        ...directEntries.sort((a, b) => a.name.localeCompare(b.name)),
+        ...transitiveEntries.sort((a, b) => a.name.localeCompare(b.name)),
+      ],
+    };
+
+    await writeProjectManifest(manifest, workPath, 'ruby');
+  } catch {
+    // never throw — build must succeed
+  }
+}
+
+export const diagnostics = createDiagnostics('ruby');

--- a/packages/ruby/src/index.ts
+++ b/packages/ruby/src/index.ts
@@ -18,12 +18,14 @@ import {
   walkParentDirs,
   cloneEnv,
   FileBlob,
+  getReportedServiceType,
   type GlobOptions,
   type Files,
   type BuildV3,
   type ShouldServe,
 } from '@vercel/build-utils';
 import { installBundler } from './install-ruby';
+import { generateProjectManifest } from './diagnostics';
 
 async function matchPaths(
   configPatterns: string | string[] | undefined,
@@ -169,6 +171,7 @@ export const build: BuildV3 = async ({
   entrypoint,
   config,
   meta = {},
+  service,
 }) => {
   await download(files, workPath, meta);
   const entrypointFsDirname = join(workPath, dirname(entrypoint));
@@ -327,10 +330,23 @@ export const build: BuildV3 = async ({
     environment: {},
   });
 
+  try {
+    // We ensure the lockfile is up to date in bundleLock, so we are sure it's up to date.
+    await generateProjectManifest({
+      workPath,
+      gemfileLockPath: join(dirname(gemfilePath), 'Gemfile.lock'),
+      framework: config?.framework ?? undefined,
+      serviceType: service ? getReportedServiceType(service) : undefined,
+    });
+  } catch (err) {
+    debug(`Failed to write ruby manifest: ${String(err)}`);
+  }
+
   return { output };
 };
 
 export { startDevServer } from './start-dev-server';
+export { diagnostics } from './diagnostics';
 
 // Route all requests to the Ruby dev server during `vercel dev`
 export const shouldServe: ShouldServe = () => true;

--- a/packages/ruby/test/unit.diagnostics.test.ts
+++ b/packages/ruby/test/unit.diagnostics.test.ts
@@ -1,0 +1,988 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { tmpdir } from 'os';
+import {
+  FileBlob,
+  MANIFEST_FILENAME,
+  MANIFEST_VERSION,
+  manifestPath,
+} from '@vercel/build-utils';
+import { generateProjectManifest, diagnostics } from '../src/diagnostics';
+
+const DIAGNOSTICS_PATH = manifestPath('ruby');
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(tmpdir(), 'vc-ruby-diag-test-'));
+}
+
+function writeGemfileLock(dir: string, content: string): string {
+  const lockPath = path.join(dir, 'Gemfile.lock');
+  fs.writeFileSync(lockPath, content);
+  return lockPath;
+}
+
+function readManifest(dir: string): any {
+  return JSON.parse(fs.readFileSync(path.join(dir, DIAGNOSTICS_PATH), 'utf-8'));
+}
+
+// ─── basic metadata ───────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — metadata', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('writes correct version and runtime', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra (~> 3.1)
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.version).toBe(MANIFEST_VERSION);
+    expect(manifest.runtime).toBe('ruby');
+  });
+
+  it('sorts direct deps alphabetically and transitive deps alphabetically after them', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.2.0)
+    rack (3.0.8)
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra (~> 3.1)
+  rack (~> 3.0)
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const directs = dependencies
+      .filter((d: any) => d.type === 'direct')
+      .map((d: any) => d.name);
+    const transitives = dependencies
+      .filter((d: any) => d.type === 'transitive')
+      .map((d: any) => d.name);
+
+    expect(directs).toEqual([...directs].sort());
+    expect(transitives).toEqual([...transitives].sort());
+    // all directs come before all transitives
+    const lastDirectIdx = dependencies.findLastIndex(
+      (d: any) => d.type === 'direct'
+    );
+    const firstTransIdx = dependencies.findIndex(
+      (d: any) => d.type === 'transitive'
+    );
+    if (firstTransIdx !== -1) {
+      expect(lastDirectIdx).toBeLessThan(firstTransIdx);
+    }
+  });
+});
+
+// ─── direct deps ──────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — direct deps', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('classifies direct dep with constraint, resolved version, and registry source', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra (~> 3.1)
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies).toEqual([
+      {
+        name: 'sinatra',
+        type: 'direct',
+        scopes: ['prod'],
+        requested: '~> 3.1',
+        resolved: '3.1.0',
+        source: 'registry',
+        sourceUrl: 'https://rubygems.org',
+      },
+    ]);
+  });
+
+  it('omits requested when dep has no version constraint', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    webrick (1.8.1)
+
+DEPENDENCIES
+  webrick
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const dep = readManifest(tempDir).dependencies[0];
+    expect(dep.name).toBe('webrick');
+    expect(dep.type).toBe('direct');
+    expect('requested' in dep).toBe(false);
+    expect(dep.resolved).toBe('1.8.1');
+  });
+
+  it('resolves to empty string when gem missing from specs', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+DEPENDENCIES
+  ghost-gem (~> 1.0)
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const dep = readManifest(tempDir).dependencies[0];
+    expect(dep.resolved).toBe('');
+  });
+});
+
+// ─── transitive deps ──────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — transitive deps', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('classifies gems in specs but not in DEPENDENCIES as transitive', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.8)
+    sinatra (3.1.0)
+      rack (~> 3.0)
+
+DEPENDENCIES
+  sinatra (~> 3.1)
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const rack = dependencies.find((d: any) => d.name === 'rack');
+    expect(rack.type).toBe('transitive');
+    expect(rack.resolved).toBe('3.0.8');
+    expect(rack.source).toBe('registry');
+    expect(rack.sourceUrl).toBe('https://rubygems.org');
+  });
+
+  it('direct deps appear before transitives, both alphabetical within group', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.2.0)
+    rack (3.0.8)
+    rack-protection (3.1.0)
+    sinatra (3.1.0)
+      rack (~> 3.0)
+      rack-protection (= 3.1.0)
+
+DEPENDENCIES
+  sinatra (~> 3.1)
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const directIdx = dependencies.findIndex((d: any) => d.name === 'sinatra');
+    const transIdx = dependencies.findIndex((d: any) => d.name === 'rack');
+    expect(directIdx).toBeLessThan(transIdx);
+  });
+});
+
+// ─── git gems ─────────────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — git gems', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('classifies GIT block gem as source: git with remote URL', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GIT
+  remote: https://github.com/sinatra/sinatra.git
+  revision: abc123def456
+  branch: main
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const dep = readManifest(tempDir).dependencies[0];
+    expect(dep.name).toBe('sinatra');
+    expect(dep.source).toBe('git');
+    expect(dep.sourceUrl).toBe('https://github.com/sinatra/sinatra.git');
+  });
+
+  it('git transitive dep also gets source: git', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GIT
+  remote: https://github.com/org/myapp.git
+  revision: abc123
+  specs:
+    myapp (1.0.0)
+    myapp-core (1.0.0)
+
+DEPENDENCIES
+  myapp
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const core = dependencies.find((d: any) => d.name === 'myapp-core');
+    expect(core.type).toBe('transitive');
+    expect(core.source).toBe('git');
+  });
+});
+
+// ─── PATH gems excluded ───────────────────────────────────────────────────────
+
+describe('generateProjectManifest — PATH gems excluded', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('excludes gems from PATH block', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.8)
+
+PATH
+  remote: .
+  specs:
+    local-gem (0.1.0)
+
+DEPENDENCIES
+  rack
+  local-gem
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).toContain('rack');
+    expect(names).not.toContain('local-gem');
+  });
+
+  it('PATH-only dep in DEPENDENCIES is excluded entirely', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PATH
+  remote: .
+  specs:
+    local-gem (0.1.0)
+
+DEPENDENCIES
+  local-gem
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies).toHaveLength(0);
+  });
+});
+
+// ─── multiple GEM blocks ──────────────────────────────────────────────────────
+
+describe('generateProjectManifest — multiple GEM blocks', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('parses gems from multiple GEM blocks with separate remotes', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.8)
+
+GEM
+  remote: https://my.registry.example.com/
+  specs:
+    private-gem (1.2.3)
+
+DEPENDENCIES
+  rack
+  private-gem
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const rack = dependencies.find((d: any) => d.name === 'rack');
+    expect(rack.sourceUrl).toBe('https://rubygems.org');
+
+    const priv = dependencies.find((d: any) => d.name === 'private-gem');
+    expect(priv.sourceUrl).toBe('https://my.registry.example.com');
+    expect(priv.resolved).toBe('1.2.3');
+  });
+});
+
+// ─── exclamation mark (non-default source) in DEPENDENCIES ────────────────────
+
+describe('generateProjectManifest — ! suffix in DEPENDENCIES', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('resolves git gem listed with ! in DEPENDENCIES', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GIT
+  remote: https://github.com/sinatra/sinatra.git
+  revision: abc123
+  specs:
+    sinatra (4.0.0)
+
+DEPENDENCIES
+  sinatra!
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const dep = dependencies.find((d: any) => d.name === 'sinatra');
+    expect(dep).toBeDefined();
+    expect(dep.type).toBe('direct');
+    expect(dep.resolved).toBe('4.0.0');
+    expect(dep.source).toBe('git');
+  });
+
+  it('excludes PATH gem with ! in DEPENDENCIES', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.8)
+
+PATH
+  remote: .
+  specs:
+    local-gem (0.1.0)
+
+DEPENDENCIES
+  rack
+  local-gem!
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const names = readManifest(tempDir).dependencies.map((d: any) => d.name);
+    expect(names).toContain('rack');
+    expect(names).not.toContain('local-gem');
+    expect(names).not.toContain('local-gem!');
+  });
+});
+
+// ─── platform-specific gem variants ──────────────────────────────────────────
+
+describe('generateProjectManifest — platform-specific gem variants', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('uses base version when platform variants follow it in specs', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    nokogiri (1.18.0)
+    nokogiri (1.18.0-arm64-darwin)
+    nokogiri (1.18.0-x86_64-linux-gnu)
+
+DEPENDENCIES
+  nokogiri
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const dep = readManifest(tempDir).dependencies[0];
+    expect(dep.name).toBe('nokogiri');
+    expect(dep.resolved).toBe('1.18.0');
+  });
+
+  it('uses base version when platform variant appears before it in specs', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    nokogiri (1.18.0-arm64-darwin)
+    nokogiri (1.18.0)
+
+DEPENDENCIES
+  nokogiri
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const dep = readManifest(tempDir).dependencies[0];
+    expect(dep.name).toBe('nokogiri');
+    expect(dep.resolved).toBe('1.18.0');
+  });
+});
+
+// ─── PLUGIN SOURCE section ────────────────────────────────────────────────────
+
+describe('generateProjectManifest — PLUGIN SOURCE', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('includes plugin-sourced gem with source: plugin and sourceUrl', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+PLUGIN SOURCE
+  remote: https://plugins.example.com/
+  specs:
+    my-plugin (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.8)
+
+DEPENDENCIES
+  rack
+  my-plugin
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    const plugin = dependencies.find((d: any) => d.name === 'my-plugin');
+    expect(plugin).toBeDefined();
+    expect(plugin.resolved).toBe('1.0.0');
+    expect(plugin.source).toBe('plugin');
+    expect(plugin.sourceUrl).toBe('https://plugins.example.com/');
+  });
+});
+
+// ─── sourceUrl normalization ──────────────────────────────────────────────────
+
+describe('generateProjectManifest — sourceUrl normalization', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('strips trailing path and query from registry remote URL', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/gems/?source=mirror
+  specs:
+    rack (3.0.8)
+
+DEPENDENCIES
+  rack
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const dep = readManifest(tempDir).dependencies[0];
+    expect(dep.sourceUrl).toBe('https://rubygems.org');
+  });
+
+  it('preserves full URL for git source (not normalized to origin)', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GIT
+  remote: https://github.com/org/repo.git
+  revision: abc123
+  specs:
+    mylib (1.0.0)
+
+DEPENDENCIES
+  mylib
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const dep = readManifest(tempDir).dependencies[0];
+    expect(dep.sourceUrl).toBe('https://github.com/org/repo.git');
+  });
+});
+
+// ─── cross-source deduplication ───────────────────────────────────────────────
+
+describe('generateProjectManifest — cross-source deduplication', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('prefers registry gem over git gem when both appear', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GIT
+  remote: https://github.com/sinatra/sinatra.git
+  revision: abc123
+  specs:
+    sinatra (3.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const dep = readManifest(tempDir).dependencies[0];
+    expect(dep.name).toBe('sinatra');
+    expect(dep.source).toBe('registry');
+    expect(dep.sourceUrl).toBe('https://rubygems.org');
+  });
+});
+
+// ─── framework and serviceType ───────────────────────────────────────────────
+
+describe('generateProjectManifest — framework and serviceType', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('includes framework when provided', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+      framework: 'sinatra',
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.framework).toBe('sinatra');
+  });
+
+  it('includes serviceType when provided', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+      serviceType: 'web',
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.serviceType).toBe('web');
+  });
+
+  it('omits framework and serviceType when not provided', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.framework).toBeUndefined();
+    expect(manifest.serviceType).toBeUndefined();
+  });
+
+  it('omits framework and serviceType when null', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+      framework: null,
+      serviceType: null,
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.framework).toBeUndefined();
+    expect(manifest.serviceType).toBeUndefined();
+  });
+
+  it('omits framework from manifest when empty string provided', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+      framework: '',
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.framework).toBeUndefined();
+  });
+
+  it('omits serviceType from manifest when empty string provided', async () => {
+    const lockPath = writeGemfileLock(
+      tempDir,
+      `\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sinatra (3.1.0)
+
+DEPENDENCIES
+  sinatra
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: lockPath,
+      serviceType: '',
+    });
+
+    const manifest = readManifest(tempDir);
+    expect(manifest.serviceType).toBeUndefined();
+  });
+});
+
+// ─── missing lockfile ─────────────────────────────────────────────────────────
+
+describe('generateProjectManifest — missing lockfile', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('writes no manifest when gemfileLockPath is undefined', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: undefined,
+    });
+
+    expect(fs.existsSync(path.join(tempDir, DIAGNOSTICS_PATH))).toBe(false);
+  });
+
+  it('writes no manifest when lockfile does not exist on disk', async () => {
+    await generateProjectManifest({
+      workPath: tempDir,
+      gemfileLockPath: path.join(tempDir, 'Gemfile.lock'),
+    });
+
+    expect(fs.existsSync(path.join(tempDir, DIAGNOSTICS_PATH))).toBe(false);
+  });
+
+  it('never throws even when given a corrupt lockfile', async () => {
+    const lockPath = writeGemfileLock(tempDir, '\x00\x01\x02 not valid');
+
+    await expect(
+      generateProjectManifest({ workPath: tempDir, gemfileLockPath: lockPath })
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ─── diagnostics callback ─────────────────────────────────────────────────────
+
+describe('diagnostics callback', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('returns manifest FileBlob when present', async () => {
+    const manifestFilePath = path.join(tempDir, DIAGNOSTICS_PATH);
+    fs.mkdirSync(path.dirname(manifestFilePath), { recursive: true });
+    const content = JSON.stringify({
+      version: MANIFEST_VERSION,
+      runtime: 'ruby',
+    });
+    fs.writeFileSync(manifestFilePath, content);
+
+    const files = await diagnostics({ workPath: tempDir } as any);
+
+    expect(files).toHaveProperty([MANIFEST_FILENAME]);
+    const blob = files[MANIFEST_FILENAME] as FileBlob;
+    expect(blob).toBeInstanceOf(FileBlob);
+    expect(JSON.parse(blob.data as string)).toEqual({
+      version: MANIFEST_VERSION,
+      runtime: 'ruby',
+    });
+  });
+
+  it('returns empty object when no manifest exists', async () => {
+    const files = await diagnostics({ workPath: tempDir } as any);
+    expect(files).toEqual({});
+  });
+});


### PR DESCRIPTION
Emit project manifest from ruby builder, similar to existing behaviour in `backends`, `python`, `rust`, and `node`.

The manifest includes:
- `framework` and `serviceType` from the service config
- dependencies parsed directly from `Gemfile.lock`

Parse `Gemfile.lock` for dependencies and handle `GEM` (registry), `GIT`, `PATH`, and `PLUGIN SOURCE` sections. Gems listed under `PATH` are excluded as local and non-deployable. When the same gem appears in multiple sections, prefer registry over git/plugin and base version over platform variant (e.g. `nokogiri (1.18.0)` over `nokogiri (1.18.0-arm64-darwin)`).

Note: There are difficulties with ruby static analysis we need to solve. For now we just assume all deps are `'prod'` scoped.