### PR TITLE
[oidc] add edge-light export

### DIFF
--- a/.changeset/oidc-edge-light-export.md
+++ b/.changeset/oidc-edge-light-export.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+Add conditional edge-light export to support Edge Runtime

--- a/.changeset/oidc-edge-light-export.md
+++ b/.changeset/oidc-edge-light-export.md
@@ -1,5 +1,5 @@
 ---
-'@vercel/oidc': patch
+'@vercel/oidc': minor
 ---
 
 Add conditional edge-light export to support Edge Runtime

--- a/packages/functions/docs/oidc/functions/getVercelOidcToken.md
+++ b/packages/functions/docs/oidc/functions/getVercelOidcToken.md
@@ -6,7 +6,7 @@
 
 > **getVercelOidcToken**(`options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`string`\>
 
-Defined in: packages/oidc/dist/get-vercel-oidc-token.d.ts:60
+Defined in: packages/oidc/dist/get-vercel-oidc-token-with-refresh.d.ts:60
 
 Gets the current OIDC token from the request context or the environment variable.
 

--- a/packages/functions/docs/oidc/functions/getVercelOidcTokenSync.md
+++ b/packages/functions/docs/oidc/functions/getVercelOidcTokenSync.md
@@ -6,7 +6,7 @@
 
 > **getVercelOidcTokenSync**(): `string`
 
-Defined in: packages/oidc/dist/get-vercel-oidc-token.d.ts:82
+Defined in: packages/oidc/dist/get-vercel-oidc-token-sync.d.ts:22
 
 Gets the current OIDC token from the request context or the environment variable.
 

--- a/packages/functions/test/unit/oidc/aws-credentials-provider.test.ts
+++ b/packages/functions/test/unit/oidc/aws-credentials-provider.test.ts
@@ -6,7 +6,7 @@ const fromWebTokenExectionMock = vi.fn();
 const fromWebTokenMock = vi.fn().mockReturnValue(fromWebTokenExectionMock);
 
 describe('awsCredentialsProvider', () => {
-  vi.mock('../../../src/oidc/get-vercel-oidc-token', () => {
+  vi.mock('../../../src/oidc/get-vercel-oidc-token-sync', () => {
     return {
       getVercelOidcTokenSync: async () => getVercelOidcTokenSyncMock(),
     };

--- a/packages/oidc/docs/functions/getVercelOidcToken.md
+++ b/packages/oidc/docs/functions/getVercelOidcToken.md
@@ -6,7 +6,7 @@
 
 > **getVercelOidcToken**(`options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`string`\>
 
-Defined in: [packages/oidc/src/get-vercel-oidc-token.ts:64](https://github.com/vercel/vercel/blob/main/packages/oidc/src/get-vercel-oidc-token.ts#L64)
+Defined in: [packages/oidc/src/get-vercel-oidc-token-with-refresh.ts:64](https://github.com/vercel/vercel/blob/main/packages/oidc/src/get-vercel-oidc-token-with-refresh.ts#L64)
 
 Gets the current OIDC token from the request context or the environment variable.
 

--- a/packages/oidc/docs/functions/getVercelOidcTokenSync.md
+++ b/packages/oidc/docs/functions/getVercelOidcTokenSync.md
@@ -6,7 +6,7 @@
 
 > **getVercelOidcTokenSync**(): `string`
 
-Defined in: [packages/oidc/src/get-vercel-oidc-token.ts:124](https://github.com/vercel/vercel/blob/main/packages/oidc/src/get-vercel-oidc-token.ts#L124)
+Defined in: [packages/oidc/src/get-vercel-oidc-token-sync.ts:24](https://github.com/vercel/vercel/blob/main/packages/oidc/src/get-vercel-oidc-token-sync.ts#L24)
 
 Gets the current OIDC token from the request context or the environment variable.
 

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -10,6 +10,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "edge-light": "./dist/index-edge-light.js",
       "browser": "./dist/index-browser.js",
       "react-native": "./dist/index-browser.js",
       "workflow": "./dist/index-browser.js",

--- a/packages/oidc/src/get-vercel-oidc-token-sync.ts
+++ b/packages/oidc/src/get-vercel-oidc-token-sync.ts
@@ -1,0 +1,36 @@
+import { getContext } from './get-context';
+
+/**
+ * Gets the current OIDC token from the request context or the environment variable.
+ *
+ * Do not cache this value, as it is subject to change in production!
+ *
+ * This function is used to retrieve the OIDC token from the request context or the environment variable.
+ * It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
+ *
+ * This function will not refresh the token if it is expired. For refreshing the token, use the @{link getVercelOidcToken} function.
+ *
+ * @returns {string} The OIDC token.
+ * @throws {Error} If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set.
+ *
+ * @example
+ *
+ * ```js
+ * // Using the OIDC token
+ * const token = getVercelOidcTokenSync();
+ * console.log('OIDC Token:', token);
+ * ```
+ */
+export function getVercelOidcTokenSync(): string {
+  const token =
+    getContext().headers?.['x-vercel-oidc-token'] ??
+    process.env.VERCEL_OIDC_TOKEN;
+
+  if (!token) {
+    throw new Error(
+      `The 'x-vercel-oidc-token' header is missing from the request.`
+    );
+  }
+
+  return token;
+}

--- a/packages/oidc/src/get-vercel-oidc-token-with-refresh.test.ts
+++ b/packages/oidc/src/get-vercel-oidc-token-with-refresh.test.ts
@@ -10,7 +10,7 @@ vi.mock('./get-context', () => ({
 }));
 
 import { findRootDir, getUserDataDir } from './token-io';
-import { getVercelOidcToken } from './get-vercel-oidc-token';
+import { getVercelOidcToken } from './get-vercel-oidc-token-with-refresh';
 import * as tokenUtil from './token-util';
 
 describe('getVercelOidcToken - Error Scenarios', () => {

--- a/packages/oidc/src/get-vercel-oidc-token-with-refresh.ts
+++ b/packages/oidc/src/get-vercel-oidc-token-with-refresh.ts
@@ -1,4 +1,4 @@
-import { getContext } from './get-context';
+import { getVercelOidcTokenSync } from './get-vercel-oidc-token-sync';
 import { VercelOidcTokenError } from './token-error';
 
 /**
@@ -97,40 +97,5 @@ export async function getVercelOidcToken(
     }
     throw error;
   }
-  return token;
-}
-
-/**
- * Gets the current OIDC token from the request context or the environment variable.
- *
- * Do not cache this value, as it is subject to change in production!
- *
- * This function is used to retrieve the OIDC token from the request context or the environment variable.
- * It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
- *
- * This function will not refresh the token if it is expired. For refreshing the token, use the @{link getVercelOidcToken} function.
- *
- * @returns {string} The OIDC token.
- * @throws {Error} If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set.
- *
- * @example
- *
- * ```js
- * // Using the OIDC token
- * const token = getVercelOidcTokenSync();
- * console.log('OIDC Token:', token);
- * ```
- */
-export function getVercelOidcTokenSync(): string {
-  const token =
-    getContext().headers?.['x-vercel-oidc-token'] ??
-    process.env.VERCEL_OIDC_TOKEN;
-
-  if (!token) {
-    throw new Error(
-      `The 'x-vercel-oidc-token' header is missing from the request. Do you have the OIDC option enabled in the Vercel project settings?`
-    );
-  }
-
   return token;
 }

--- a/packages/oidc/src/index-edge-light.ts
+++ b/packages/oidc/src/index-edge-light.ts
@@ -7,6 +7,12 @@ export {
 } from './auth-errors';
 export { getVercelOidcTokenSync } from './get-vercel-oidc-token-sync';
 
+/**
+ * Gets the current OIDC token in Edge Runtime.
+ *
+ * Edge Runtime does not support automatic token refresh, so this returns the
+ * request-scoped token without checking expiration.
+ */
 export async function getVercelOidcToken(): Promise<string> {
   return getVercelOidcTokenSync();
 }

--- a/packages/oidc/src/index-edge-light.ts
+++ b/packages/oidc/src/index-edge-light.ts
@@ -1,0 +1,16 @@
+import { getVercelOidcTokenSync } from './get-vercel-oidc-token-sync';
+
+export { getContext } from './get-context';
+export {
+  AccessTokenMissingError,
+  RefreshAccessTokenFailedError,
+} from './auth-errors';
+export { getVercelOidcTokenSync } from './get-vercel-oidc-token-sync';
+
+export async function getVercelOidcToken(): Promise<string> {
+  return getVercelOidcTokenSync();
+}
+
+export async function getVercelToken(): Promise<string> {
+  throw new Error('getVercelToken is not supported in Edge Runtime');
+}

--- a/packages/oidc/src/index.ts
+++ b/packages/oidc/src/index.ts
@@ -1,7 +1,5 @@
-export {
-  getVercelOidcToken,
-  getVercelOidcTokenSync,
-} from './get-vercel-oidc-token';
+export { getVercelOidcToken } from './get-vercel-oidc-token-with-refresh';
+export { getVercelOidcTokenSync } from './get-vercel-oidc-token-sync';
 export { getContext } from './get-context';
 export {
   AccessTokenMissingError,


### PR DESCRIPTION
## Summary

Before this: the edge runtime would use the browser export and therefor oidc wouldn't work since the token resolves to an empty string

- Add a new OIDC export for edge-light
- Split the OIDC helper implementation into separate sync and refresh modules so it can be used without Node.js modules