### PR TITLE
Add beta stale flags command

### DIFF
--- a/.changeset/stale-flags-command.md
+++ b/.changeset/stale-flags-command.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+Add the beta `vercel flags stale` command to list feature flags that have not been updated recently.
+
+By default, the command lists active flags that have not changed in 90 days. Use `--older-than` to change the threshold, `--state` to inspect archived flags, and `--json` for structured output.

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -40,6 +40,53 @@ export const listSubcommand = {
   ],
 } as const;
 
+export const staleSubcommand = {
+  name: 'stale',
+  aliases: [],
+  description: 'List stale feature flags for the current project (Beta)',
+  arguments: [],
+  options: [
+    {
+      name: 'older-than',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Minimum age since the last update before a flag is stale (default: 90d)',
+      argument: 'TIME',
+    },
+    {
+      name: 'state',
+      shorthand: 's',
+      type: String,
+      deprecated: false,
+      description: 'Filter flags by state (active or archived)',
+      argument: 'STATE',
+    },
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output in JSON format',
+    },
+  ],
+  examples: [
+    {
+      name: 'List active flags not updated in about three months',
+      value: `${packageName} flags stale`,
+    },
+    {
+      name: 'List active flags not updated in six months',
+      value: `${packageName} flags stale --older-than 180d`,
+    },
+    {
+      name: 'List archived stale flags as JSON',
+      value: `${packageName} flags stale --state archived --json`,
+    },
+  ],
+} as const;
+
 export const inspectSubcommand = {
   name: 'inspect',
   aliases: [],
@@ -756,6 +803,7 @@ export const flagsCommand = {
   arguments: [],
   subcommands: [
     listSubcommand,
+    staleSubcommand,
     inspectSubcommand,
     createSubcommand,
     openSubcommand,

--- a/packages/cli/src/commands/flags/index.ts
+++ b/packages/cli/src/commands/flags/index.ts
@@ -8,6 +8,7 @@ import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { FlagsTelemetryClient } from '../../util/telemetry/commands/flags';
 import ls from './ls';
+import stale from './stale';
 import inspect from './inspect';
 import create from './add';
 import openFlag from './open';
@@ -23,6 +24,7 @@ import { sdkKeys } from './sdk-keys';
 import {
   flagsCommand,
   listSubcommand,
+  staleSubcommand,
   inspectSubcommand,
   createSubcommand,
   openSubcommand,
@@ -43,6 +45,7 @@ import override from './override';
 
 const COMMAND_CONFIG = {
   ls: getCommandAliases(listSubcommand),
+  stale: getCommandAliases(staleSubcommand),
   inspect: getCommandAliases(inspectSubcommand),
   create: getCommandAliases(createSubcommand),
   open: getCommandAliases(openSubcommand),
@@ -106,6 +109,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);
+    case 'stale':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('flags', subcommandOriginal);
+        printHelp(staleSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandStale(subcommandOriginal);
+      return stale(client, args);
     case 'inspect':
       if (needHelp) {
         telemetry.trackCliFlagHelp('flags', subcommandOriginal);

--- a/packages/cli/src/commands/flags/stale.ts
+++ b/packages/cli/src/commands/flags/stale.ts
@@ -1,0 +1,175 @@
+import chalk from 'chalk';
+import ms from 'ms';
+import plural from 'pluralize';
+import type Client from '../../util/client';
+import { validateTimeBound } from '../../util/command-validation';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getLinkedProject } from '../../util/projects/link';
+import { getCommandName } from '../../util/pkg-name';
+import { getFlags } from '../../util/flags/get-flags';
+import formatTable from '../../util/format-table';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { FlagsStaleTelemetryClient } from '../../util/telemetry/commands/flags/stale';
+import { staleSubcommand } from './command';
+import type { Flag } from '../../util/flags/types';
+import { formatProject } from '../../util/projects/format-project';
+
+const DEFAULT_STALE_AGE = '90d';
+
+type FlagState = 'active' | 'archived';
+
+export default async function stale(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetryClient = new FlagsStaleTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(staleSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { flags } = parsedArgs;
+  const state = (flags['--state'] as FlagState | undefined) || 'active';
+  const olderThan = flags['--older-than'] || DEFAULT_STALE_AGE;
+  const json = flags['--json'] as boolean | undefined;
+
+  telemetryClient.trackCliOptionState(state);
+  telemetryClient.trackCliOptionOlderThan(olderThan);
+  telemetryClient.trackCliFlagJson(json);
+
+  if (!isFlagState(state)) {
+    output.error(
+      `Invalid state "${state}". Valid values are: active, archived.`
+    );
+    return 1;
+  }
+
+  const olderThanResult = validateTimeBound(olderThan);
+  if (!olderThanResult.valid) {
+    output.error(olderThanResult.message);
+    return 1;
+  }
+  const staleCutoff = olderThanResult.value;
+  if (staleCutoff === undefined) {
+    output.error('Missing value for --older-than.');
+    return 1;
+  }
+
+  const link = await getLinkedProject(client);
+  if (link.status === 'error') {
+    return link.exitCode;
+  } else if (link.status === 'not_linked') {
+    output.error(
+      `Your codebase isn't linked to a project on Vercel. Run ${getCommandName('link')} to begin.`
+    );
+    return 1;
+  }
+
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+
+  const { project, org } = link;
+  const projectSlugLink = formatProject(org.slug, project.name);
+  const staleStamp = stamp();
+
+  output.spinner(`Fetching ${state} feature flags for ${projectSlugLink}`);
+
+  try {
+    const flagsList = await getFlags(client, project.id, state);
+    output.stopSpinner();
+
+    const now = Date.now();
+    const cutoff = staleCutoff.getTime();
+    const staleFlags = flagsList
+      .filter(flag => flag.updatedAt < cutoff)
+      .sort((a, b) => a.updatedAt - b.updatedAt);
+
+    if (json) {
+      outputJson(client, staleFlags, {
+        cutoff,
+        olderThan,
+        now,
+      });
+    } else if (staleFlags.length === 0) {
+      output.log(
+        `No stale ${state} feature flags found for ${projectSlugLink} older than ${olderThan} ${chalk.gray(staleStamp())}`
+      );
+    } else {
+      output.log(
+        `${plural('stale feature flag', staleFlags.length, true)} found for ${projectSlugLink} older than ${olderThan} ${chalk.gray(staleStamp())}`
+      );
+      printFlagsTable(staleFlags, now);
+    }
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+
+  return 0;
+}
+
+function isFlagState(state: string): state is FlagState {
+  return state === 'active' || state === 'archived';
+}
+
+function outputJson(
+  client: Client,
+  flags: Flag[],
+  opts: {
+    cutoff: number;
+    olderThan: string;
+    now: number;
+  }
+) {
+  const jsonOutput = {
+    olderThan: {
+      value: opts.olderThan,
+      cutoff: opts.cutoff,
+    },
+    cutoff: opts.cutoff,
+    flags: flags.map(flag => ({
+      id: flag.id,
+      slug: flag.slug,
+      description: flag.description ?? null,
+      kind: flag.kind,
+      state: flag.state,
+      variants: flag.variants,
+      createdAt: flag.createdAt,
+      updatedAt: flag.updatedAt,
+      staleFor: opts.now - flag.updatedAt,
+    })),
+  };
+  client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+}
+
+function printFlagsTable(flags: Flag[], now: number) {
+  const headers = ['Name', 'Kind', 'State', 'Last Updated', 'Age'];
+
+  const rows = flags.map(flag => [
+    chalk.bold(flag.slug),
+    flag.kind,
+    flag.state === 'active' ? chalk.green(flag.state) : chalk.gray(flag.state),
+    new Date(flag.updatedAt).toISOString().slice(0, 10),
+    ms(now - flag.updatedAt) + ' ago',
+  ]);
+
+  const table = formatTable(
+    headers,
+    ['l', 'l', 'l', 'l', 'l'],
+    [{ name: '', rows }]
+  );
+  output.print(`\n${table}\n`);
+}

--- a/packages/cli/src/util/telemetry/commands/flags/index.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/index.ts
@@ -13,6 +13,13 @@ export class FlagsTelemetryClient
     });
   }
 
+  trackCliSubcommandStale(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'stale',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandInspect(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'inspect',

--- a/packages/cli/src/util/telemetry/commands/flags/stale.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/stale.ts
@@ -1,0 +1,27 @@
+import { TelemetryClient } from '../..';
+
+export class FlagsStaleTelemetryClient extends TelemetryClient {
+  trackCliOptionState(state: string | undefined) {
+    if (state) {
+      this.trackCliOption({
+        option: 'state',
+        value: state,
+      });
+    }
+  }
+
+  trackCliOptionOlderThan(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'older-than',
+        value,
+      });
+    }
+  }
+
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/flags/index.test.ts
+++ b/packages/cli/test/unit/commands/flags/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import flags from '../../../../src/commands/flags';
 import * as ls from '../../../../src/commands/flags/ls';
+import * as stale from '../../../../src/commands/flags/stale';
 import * as openFlag from '../../../../src/commands/flags/open';
 import * as rolloutFlag from '../../../../src/commands/flags/rollout';
 import * as splitFlag from '../../../../src/commands/flags/split';
@@ -9,6 +10,7 @@ import { client } from '../../../mocks/client';
 
 describe('flags', () => {
   const lsSpy = vi.spyOn(ls, 'default').mockResolvedValue(0);
+  const staleSpy = vi.spyOn(stale, 'default').mockResolvedValue(0);
   const openSpy = vi.spyOn(openFlag, 'default').mockResolvedValue(0);
   const rolloutSpy = vi.spyOn(rolloutFlag, 'default').mockResolvedValue(0);
   const splitSpy = vi.spyOn(splitFlag, 'default').mockResolvedValue(0);
@@ -16,6 +18,7 @@ describe('flags', () => {
 
   afterEach(() => {
     lsSpy.mockClear();
+    staleSpy.mockClear();
     openSpy.mockClear();
     rolloutSpy.mockClear();
     splitSpy.mockClear();
@@ -63,6 +66,14 @@ describe('flags', () => {
     client.setArgv('flags', 'open', ...args);
     await flags(client);
     expect(openSpy).toHaveBeenCalledWith(client, args);
+  });
+
+  it('routes to stale subcommand', async () => {
+    const args: string[] = ['--older-than', '6mo'];
+
+    client.setArgv('flags', 'stale', ...args);
+    await flags(client);
+    expect(staleSpy).toHaveBeenCalledWith(client, args);
   });
 
   it('routes to update subcommand', async () => {

--- a/packages/cli/test/unit/commands/flags/stale.test.ts
+++ b/packages/cli/test/unit/commands/flags/stale.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import flags from '../../../../src/commands/flags';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import { client } from '../../../mocks/client';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+import { useFlags, defaultFlags } from '../../../mocks/flags';
+import type { Flag } from '../../../../src/util/flags/types';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('flags stale', () => {
+  let flagsList: Flag[];
+
+  beforeEach(() => {
+    const now = Date.now();
+    flagsList = JSON.parse(JSON.stringify(defaultFlags)) as Flag[];
+    flagsList[0].slug = 'stale-feature';
+    flagsList[0].updatedAt = now - 91 * DAY;
+    flagsList[1].slug = 'fresh-feature';
+    flagsList[1].updatedAt = now - 10 * DAY;
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-flags-test',
+      name: 'vercel-flags-test',
+    });
+    useFlags(flagsList);
+    const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+    client.cwd = cwd;
+  });
+
+  it('tracks `stale` subcommand and default options', async () => {
+    client.setArgv('flags', 'stale');
+    await flags(client);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:stale',
+        value: 'stale',
+      },
+      {
+        key: 'option:state',
+        value: 'active',
+      },
+      {
+        key: 'option:older-than',
+        value: '90d',
+      },
+    ]);
+  });
+
+  describe('--json', () => {
+    it('outputs stale flags older than the default threshold', async () => {
+      client.setArgv('flags', 'stale', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.olderThan.value).toEqual('90d');
+      expect(parsed.olderThan.cutoff).toEqual(expect.any(Number));
+      expect(parsed.flags).toHaveLength(1);
+      expect(parsed.flags[0]).toMatchObject({
+        slug: 'stale-feature',
+        staleFor: expect.any(Number),
+      });
+    });
+
+    it('uses the configured duration threshold', async () => {
+      client.setArgv('flags', 'stale', '--older-than', '1w', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.flags.map((flag: { slug: string }) => flag.slug)).toEqual([
+        'stale-feature',
+        'fresh-feature',
+      ]);
+    });
+  });
+
+  describe('--state', () => {
+    it('lists stale archived flags', async () => {
+      flagsList[0].state = 'archived';
+      flagsList[1].state = 'archived';
+
+      client.setArgv('flags', 'stale', '--state', 'archived', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.flags).toHaveLength(1);
+      expect(parsed.flags[0]).toMatchObject({
+        slug: 'stale-feature',
+        state: 'archived',
+      });
+    });
+
+    it('errors for invalid state values', async () => {
+      client.setArgv('flags', 'stale', '--state', 'deleted');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain('Invalid state');
+    });
+  });
+
+  describe('--older-than', () => {
+    it('accepts configurable durations', async () => {
+      client.setArgv('flags', 'stale', '--older-than', '90d', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.olderThan.value).toEqual('90d');
+      expect(parsed.flags).toHaveLength(1);
+    });
+
+    it('errors for invalid durations', async () => {
+      client.setArgv('flags', 'stale', '--older-than', 'forever');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain('Invalid time format');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `vercel flags stale` as a beta subcommand to list feature flags that have not been updated within a configurable threshold.
- Default the stale window to 90 days, with `--older-than`, `--state`, and `--json` support.
- Wire the new subcommand into flags routing, telemetry, help output, and the changeset flow.

## Testing
- Added unit coverage for subcommand routing, stale listing behavior, invalid input handling, and beta help text.
- Ran targeted Vitest coverage for the flags command tests, plus TypeScript type-checking and Prettier checks.