### PR TITLE
[cli] add domains check command and bulk price/availability

### DIFF
--- a/.changeset/quick-bulldogs-cough.md
+++ b/.changeset/quick-bulldogs-cough.md
@@ -2,4 +2,5 @@
 'vercel': patch
 ---
 
-Add a `vercel domains check` subcommand that checks registrar availability via the Domains Registrar API.
+Add a `vercel domains check` subcommand for registrar availability and extend
+`vercel domains price` to support bulk price lookups for multiple domains.

--- a/.changeset/quick-bulldogs-cough.md
+++ b/.changeset/quick-bulldogs-cough.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add a `vercel domains check` subcommand that checks registrar availability via the Domains Registrar API.

--- a/packages/cli/src/commands/domains/check.ts
+++ b/packages/cli/src/commands/domains/check.ts
@@ -1,0 +1,84 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import output from '../../output-manager';
+import { checkSubcommand } from './command';
+import { validateJsonOutput } from '../../util/output-format';
+import getDomainStatus from '../../util/domains/get-domain-status';
+import { isAPIError } from '../../util/errors-ts';
+import isRootDomain from '../../util/is-root-domain';
+import { getCommandName } from '../../util/pkg-name';
+import param from '../../util/output/param';
+
+export default async function check(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(checkSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const { args, flags } = parsedArgs;
+  const domain = args[0];
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+
+  if (!domain) {
+    output.error('Missing domain name. Usage: `vercel domains check <domain>`');
+    return 1;
+  }
+
+  if (!isRootDomain(domain)) {
+    output.error(
+      `Invalid domain name ${param(domain)}. Run ${getCommandName(`domains --help`)}`
+    );
+    return 1;
+  }
+
+  try {
+    const { available } = await getDomainStatus(client, domain);
+
+    if (formatResult.jsonOutput) {
+      client.stdout.write(
+        `${JSON.stringify({ domain, available: Boolean(available) }, null, 2)}\n`
+      );
+      return 0;
+    }
+
+    output.log(
+      `The domain ${param(domain)} is ${chalk.underline(
+        available ? 'available' : 'unavailable'
+      )}.`
+    );
+    return 0;
+  } catch (error) {
+    if (isAPIError(error)) {
+      const message = error.serverMessage || `API error (${error.status})`;
+      if (formatResult.jsonOutput) {
+        client.stdout.write(
+          `${JSON.stringify(
+            { error: error.code || 'api_error', message },
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        output.error(message);
+      }
+      return 1;
+    }
+
+    printError(error);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/domains/check.ts
+++ b/packages/cli/src/commands/domains/check.ts
@@ -12,6 +12,13 @@ import isRootDomain from '../../util/is-root-domain';
 import { getCommandName } from '../../util/pkg-name';
 import param from '../../util/output/param';
 
+type BulkDomainAvailabilityResponse = {
+  results: {
+    domain: string;
+    available: boolean;
+  }[];
+};
+
 export default async function check(
   client: Client,
   argv: string[]
@@ -26,40 +33,92 @@ export default async function check(
   }
 
   const { args, flags } = parsedArgs;
-  const domain = args[0];
+  const domains = args;
   const formatResult = validateJsonOutput(flags);
   if (!formatResult.valid) {
     output.error(formatResult.error);
     return 1;
   }
 
-  if (!domain) {
+  if (domains.length === 0) {
     output.error('Missing domain name. Usage: `vercel domains check <domain>`');
     return 1;
   }
 
-  if (!isRootDomain(domain)) {
+  if (domains.length > 50) {
     output.error(
-      `Invalid domain name ${param(domain)}. Run ${getCommandName(`domains --help`)}`
+      'Too many domains. You can check up to 50 domains per request.'
+    );
+    return 1;
+  }
+
+  const invalidDomains = domains.filter(domain => !isRootDomain(domain));
+  if (invalidDomains.length > 0) {
+    output.error(
+      `Invalid domain name(s): ${invalidDomains
+        .map(domain => param(domain))
+        .join(', ')}. Run ${getCommandName(`domains --help`)}`
     );
     return 1;
   }
 
   try {
-    const { available } = await getDomainStatus(client, domain);
+    const results =
+      domains.length === 1
+        ? [
+            {
+              domain: domains[0],
+              available: (await getDomainStatus(client, domains[0])).available,
+            },
+          ]
+        : (
+            await client.fetch<BulkDomainAvailabilityResponse>(
+              '/v1/registrar/domains/availability',
+              {
+                method: 'POST',
+                body: {
+                  domains,
+                },
+              }
+            )
+          ).results;
 
     if (formatResult.jsonOutput) {
-      client.stdout.write(
-        `${JSON.stringify({ domain, available: Boolean(available) }, null, 2)}\n`
-      );
+      if (results.length === 1) {
+        client.stdout.write(
+          `${JSON.stringify(
+            {
+              domain: results[0].domain,
+              available: Boolean(results[0].available),
+            },
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        client.stdout.write(
+          `${JSON.stringify(
+            {
+              results: results.map(result => ({
+                domain: result.domain,
+                available: Boolean(result.available),
+              })),
+            },
+            null,
+            2
+          )}\n`
+        );
+      }
       return 0;
     }
 
-    output.log(
-      `The domain ${param(domain)} is ${chalk.underline(
-        available ? 'available' : 'unavailable'
-      )}.`
-    );
+    for (const result of results) {
+      output.log(
+        `The domain ${param(result.domain)} is ${chalk.underline(
+          result.available ? 'available' : 'unavailable'
+        )}.`
+      );
+    }
     return 0;
   } catch (error) {
     if (isAPIError(error)) {

--- a/packages/cli/src/commands/domains/check.ts
+++ b/packages/cli/src/commands/domains/check.ts
@@ -34,6 +34,7 @@ export default async function check(
 
   const { args, flags } = parsedArgs;
   const domains = args;
+  const hasMultipleInputDomains = domains.length > 1;
   const formatResult = validateJsonOutput(flags);
   if (!formatResult.valid) {
     output.error(formatResult.error);
@@ -84,7 +85,7 @@ export default async function check(
           ).results;
 
     if (formatResult.jsonOutput) {
-      if (results.length === 1) {
+      if (!hasMultipleInputDomains && results.length === 1) {
         client.stdout.write(
           `${JSON.stringify(
             {

--- a/packages/cli/src/commands/domains/command.ts
+++ b/packages/cli/src/commands/domains/command.ts
@@ -126,6 +126,29 @@ export const buySubcommand = {
   examples: [],
 } as const;
 
+export const checkSubcommand = {
+  name: 'check',
+  aliases: [],
+  description: 'Check if a domain is available to buy',
+  arguments: [
+    {
+      name: 'domain',
+      required: true,
+    },
+  ],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'Check if a domain is available',
+      value: `${packageName} domains check example.com`,
+    },
+    {
+      name: 'JSON output',
+      value: `${packageName} domains check example.com --format json`,
+    },
+  ],
+} as const;
+
 export const moveSubcommand = {
   name: 'move',
   aliases: [],
@@ -181,6 +204,7 @@ export const domainsCommand = {
     inspectSubcommand,
     addSubcommand,
     buySubcommand,
+    checkSubcommand,
     moveSubcommand,
     priceSubcommand,
     transferInSubcommand,

--- a/packages/cli/src/commands/domains/command.ts
+++ b/packages/cli/src/commands/domains/command.ts
@@ -92,11 +92,12 @@ export const removeSubcommand = {
 export const priceSubcommand = {
   name: 'price',
   aliases: [],
-  description: 'Show registrar price quote for a domain',
+  description: 'Show registrar price quotes for one or more domains',
   arguments: [
     {
       name: 'domain',
       required: true,
+      multiple: true,
     },
   ],
   options: [formatOption],
@@ -104,6 +105,10 @@ export const priceSubcommand = {
     {
       name: 'Price quote for a domain',
       value: `${packageName} domains price example.com`,
+    },
+    {
+      name: 'Price quotes for multiple domains',
+      value: `${packageName} domains price one.com two.com three.com`,
     },
     {
       name: 'JSON output',

--- a/packages/cli/src/commands/domains/command.ts
+++ b/packages/cli/src/commands/domains/command.ts
@@ -134,6 +134,7 @@ export const checkSubcommand = {
     {
       name: 'domain',
       required: true,
+      multiple: true,
     },
   ],
   options: [formatOption],
@@ -141,6 +142,10 @@ export const checkSubcommand = {
     {
       name: 'Check if a domain is available',
       value: `${packageName} domains check example.com`,
+    },
+    {
+      name: 'Check availability for multiple domains',
+      value: `${packageName} domains check one.com two.com three.com`,
     },
     {
       name: 'JSON output',

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -4,6 +4,7 @@ import getSubcommand from '../../util/get-subcommand';
 import { printError } from '../../util/error';
 import add from './add';
 import buy from './buy';
+import check from './check';
 import transferIn from './transfer-in';
 import inspect from './inspect';
 import ls from './ls';
@@ -13,6 +14,7 @@ import price from './price';
 import {
   addSubcommand,
   buySubcommand,
+  checkSubcommand,
   domainsCommand,
   inspectSubcommand,
   moveSubcommand,
@@ -28,6 +30,7 @@ import output from '../../output-manager';
 const COMMAND_CONFIG = {
   add: ['add'],
   buy: ['buy'],
+  check: ['check'],
   inspect: ['inspect'],
   ls: ['ls', 'list'],
   move: ['move'],
@@ -103,6 +106,13 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandBuy(subcommandOriginal);
       return buy(client, args);
+    case 'check':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('domains', subcommandOriginal);
+        return printHelp(checkSubcommand);
+      }
+      telemetry.trackCliSubcommandCheck(subcommandOriginal);
+      return check(client, args);
     case 'price':
       if (needHelp) {
         telemetry.trackCliFlagHelp('domains', subcommandOriginal);

--- a/packages/cli/src/commands/domains/price.ts
+++ b/packages/cli/src/commands/domains/price.ts
@@ -13,6 +13,20 @@ import {
 } from '../../util/errors-ts';
 import chalk from 'chalk';
 
+type DomainPriceQuote = {
+  domain: string;
+  purchasePrice: number | null;
+  renewalPrice: number | null;
+  transferPrice: number | null;
+  years: number;
+};
+
+type BulkDomainPriceResponse =
+  | DomainPriceQuote[]
+  | {
+      results: DomainPriceQuote[];
+    };
+
 export default async function price(
   client: Client,
   argv: string[]
@@ -26,76 +40,140 @@ export default async function price(
     return 1;
   }
 
-  const domain = parsedArgs.args[0];
+  const domains = parsedArgs.args;
+  const hasMultipleInputDomains = domains.length > 1;
   const formatResult = validateJsonOutput(parsedArgs.flags);
   if (!formatResult.valid) {
     output.error(formatResult.error);
     return 1;
   }
 
-  if (!domain) {
+  if (domains.length === 0) {
     output.error('Missing domain name. Usage: `vercel domains price <domain>`');
     return 1;
   }
 
+  try {
+    const quotes: DomainPriceQuote[] =
+      domains.length === 1
+        ? await getSingleDomainQuote(client, domains[0])
+        : await getBulkDomainQuotes(client, domains);
+
+    if (formatResult.jsonOutput) {
+      if (!hasMultipleInputDomains && quotes.length === 1) {
+        client.stdout.write(`${JSON.stringify(quotes[0], null, 2)}\n`);
+      } else {
+        client.stdout.write(
+          `${JSON.stringify({ results: quotes }, null, 2)}\n`
+        );
+      }
+      return 0;
+    }
+
+    for (let i = 0; i < quotes.length; i++) {
+      const quote = quotes[i];
+      output.log(
+        `${chalk.bold('Registrar pricing')} for ${chalk.cyan(quote.domain)}`
+      );
+      output.log(
+        `  Purchase: ${quote.purchasePrice != null ? `$${quote.purchasePrice}` : 'n/a'}`
+      );
+      output.log(
+        `  Renewal:  ${quote.renewalPrice != null ? `$${quote.renewalPrice}` : 'n/a'}`
+      );
+      output.log(
+        `  Transfer: ${quote.transferPrice != null ? `$${quote.transferPrice}` : 'n/a'}`
+      );
+      output.log(`  Term:     ${quote.years} year(s)`);
+
+      if (i < quotes.length - 1) {
+        output.log('');
+      }
+    }
+    return 0;
+  } catch (error) {
+    if (isAPIError(error)) {
+      const msg = error.serverMessage || `API error (${error.status})`;
+      if (formatResult.jsonOutput) {
+        client.stdout.write(
+          `${JSON.stringify(
+            { error: error.code || 'api_error', message: msg },
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        output.error(msg);
+      }
+      return 1;
+    }
+
+    printError(error);
+    return 1;
+  }
+}
+
+async function getSingleDomainQuote(
+  client: Client,
+  domain: string
+): Promise<DomainPriceQuote[]> {
   const result = await getDomainPrice(client, domain);
   if (result instanceof UnsupportedTLD) {
-    const msg = `TLD not supported for price lookup: ${result.meta.domain}`;
-    if (formatResult.jsonOutput) {
-      client.stdout.write(
-        `${JSON.stringify({ error: 'unsupported_tld', message: msg }, null, 2)}\n`
-      );
-    } else {
-      output.error(msg);
-    }
-    return 1;
+    throw createApiLikeError(
+      'unsupported_tld',
+      `TLD not supported for price lookup: ${result.meta.domain}`
+    );
   }
   if (result instanceof InvalidDomain) {
-    const msg = `Invalid domain: ${result.meta.domain}`;
-    if (formatResult.jsonOutput) {
-      client.stdout.write(
-        `${JSON.stringify({ error: 'invalid_domain', message: msg }, null, 2)}\n`
-      );
-    } else {
-      output.error(msg);
-    }
-    return 1;
+    throw createApiLikeError(
+      'invalid_domain',
+      `Invalid domain: ${result.meta.domain}`
+    );
   }
   if (isAPIError(result)) {
-    const msg = result.serverMessage || `API error (${result.status})`;
-    if (formatResult.jsonOutput) {
-      client.stdout.write(
-        `${JSON.stringify({ error: result.code || 'api_error', message: msg }, null, 2)}\n`
-      );
-    } else {
-      output.error(msg);
+    throw result;
+  }
+
+  return [
+    {
+      domain,
+      purchasePrice: result.purchasePrice,
+      renewalPrice: result.renewalPrice,
+      transferPrice: result.transferPrice,
+      years: result.years,
+    },
+  ];
+}
+
+async function getBulkDomainQuotes(
+  client: Client,
+  domains: string[]
+): Promise<DomainPriceQuote[]> {
+  const response = await client.fetch<BulkDomainPriceResponse>(
+    '/v1/registrar/domains/price',
+    {
+      method: 'POST',
+      body: {
+        domains,
+      },
     }
-    return 1;
+  );
+
+  if (Array.isArray(response)) {
+    return response;
   }
 
-  const payload = {
-    domain,
-    purchasePrice: result.purchasePrice,
-    renewalPrice: result.renewalPrice,
-    transferPrice: result.transferPrice,
-    years: result.years,
+  return response.results;
+}
+
+function createApiLikeError(code: string, serverMessage: string) {
+  const error = new Error(serverMessage) as Error & {
+    code: string;
+    status: number;
+    serverMessage: string;
   };
-
-  if (formatResult.jsonOutput) {
-    client.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-    return 0;
-  }
-
-  output.log(`${chalk.bold('Registrar pricing')} for ${chalk.cyan(domain)}`);
-  output.log(
-    `  Purchase: ${result.purchasePrice != null ? `$${result.purchasePrice}` : 'n/a'}`
-  );
-  output.log(
-    `  Renewal:  ${result.renewalPrice != null ? `$${result.renewalPrice}` : 'n/a'}`
-  );
-  output.log(
-    `  Transfer: ${result.transferPrice != null ? `$${result.transferPrice}` : 'n/a'}`
-  );
-  output.log(`  Term:     ${result.years} year(s)`);
-  return 0;
+  error.code = code;
+  error.status = 400;
+  error.serverMessage = serverMessage;
+  return error;
 }

--- a/packages/cli/src/util/telemetry/commands/domains/index.ts
+++ b/packages/cli/src/util/telemetry/commands/domains/index.ts
@@ -34,6 +34,13 @@ export class DomainsTelemetryClient
     });
   }
 
+  trackCliSubcommandCheck(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'check',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandPrice(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'price',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2000,7 +2000,7 @@ exports[`help command > domains help output snapshots > domains buy help output 
 
 exports[`help command > domains help output snapshots > domains check help output snapshots > domains check help column width 120 1`] = `
 "
-  ▲ vercel domains check domain [options]
+  ▲ vercel domains check domain ... [options]
 
   Check if a domain is available to buy                                                                                 
 
@@ -2028,6 +2028,10 @@ exports[`help command > domains help output snapshots > domains check help outpu
   - Check if a domain is available
 
     $ vercel domains check example.com
+
+  - Check availability for multiple domains
+
+    $ vercel domains check one.com two.com three.com
 
   - JSON output
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2096,7 +2096,9 @@ exports[`help command > domains help output snapshots > domains help column widt
                                    pri…
                                    quo…
                                    for 
-                                   a   
+                                   one 
+                                   or  
+                                   more
                                    dom…
   transfer-in  domain              Tra…
                                    in a
@@ -2182,7 +2184,8 @@ exports[`help command > domains help output snapshots > domains help column widt
   check        domain              Check if a domain is available to buy       
   move         domain destination  Move ownership of a domain name to another  
                                    Vercel Team                                 
-  price        domain              Show registrar price quote for a domain     
+  price        domain              Show registrar price quotes for one or more 
+                                   domains                                     
   transfer-in  domain              Transfer in a domain name to Vercel         
   remove       domain              Remove ownership of a domain name from a    
                                    Vercel Team                                 
@@ -2221,7 +2224,7 @@ exports[`help command > domains help output snapshots > domains help column widt
   buy          domain              Purchase a new domain name                                                          
   check        domain              Check if a domain is available to buy                                               
   move         domain destination  Move ownership of a domain name to another Vercel Team                              
-  price        domain              Show registrar price quote for a domain                                             
+  price        domain              Show registrar price quotes for one or more domains                                 
   transfer-in  domain              Transfer in a domain name to Vercel                                                 
   remove       domain              Remove ownership of a domain name from a Vercel Team                                
 
@@ -2332,9 +2335,9 @@ exports[`help command > domains help output snapshots > domains move help output
 
 exports[`help command > domains help output snapshots > domains price help output snapshots > domains price help column width 120 1`] = `
 "
-  ▲ vercel domains price domain [options]
+  ▲ vercel domains price domain ... [options]
 
-  Show registrar price quote for a domain                                                                               
+  Show registrar price quotes for one or more domains                                                                   
 
   Options:
 
@@ -2360,6 +2363,10 @@ exports[`help command > domains help output snapshots > domains price help outpu
   - Price quote for a domain
 
     $ vercel domains price example.com
+
+  - Price quotes for multiple domains
+
+    $ vercel domains price one.com two.com three.com
 
   - JSON output
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1998,6 +1998,44 @@ exports[`help command > domains help output snapshots > domains buy help output 
 "
 `;
 
+exports[`help command > domains help output snapshots > domains check help output snapshots > domains check help column width 120 1`] = `
+"
+  ▲ vercel domains check domain [options]
+
+  Check if a domain is available to buy                                                                                 
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Check if a domain is available
+
+    $ vercel domains check example.com
+
+  - JSON output
+
+    $ vercel domains check example.com --format json
+
+"
+`;
+
 exports[`help command > domains help output snapshots > domains help column width 40 1`] = `
 "
   ▲ vercel domains [command]
@@ -2033,6 +2071,13 @@ exports[`help command > domains help output snapshots > domains help column widt
                                    new 
                                    dom…
                                    name
+  check        domain              Che…
+                                   if a
+                                   dom…
+                                   is  
+                                   ava…
+                                   to  
+                                   buy 
   move         domain destination  Move
                                    own…
                                    of a
@@ -2130,6 +2175,7 @@ exports[`help command > domains help output snapshots > domains help column widt
   add          domain project      Add a domain name that you already own to a 
                                    Vercel Team                                 
   buy          domain              Purchase a new domain name                  
+  check        domain              Check if a domain is available to buy       
   move         domain destination  Move ownership of a domain name to another  
                                    Vercel Team                                 
   price        domain              Show registrar price quote for a domain     
@@ -2169,6 +2215,7 @@ exports[`help command > domains help output snapshots > domains help column widt
   inspect      domain              Displays information related to a domain                                            
   add          domain project      Add a domain name that you already own to a Vercel Team                             
   buy          domain              Purchase a new domain name                                                          
+  check        domain              Check if a domain is available to buy                                               
   move         domain destination  Move ownership of a domain name to another Vercel Team                              
   price        domain              Show registrar price quote for a domain                                             
   transfer-in  domain              Transfer in a domain name to Vercel                                                 

--- a/packages/cli/test/unit/commands/domains/check.test.ts
+++ b/packages/cli/test/unit/commands/domains/check.test.ts
@@ -87,5 +87,65 @@ describe('domains check', () => {
         "
       `);
     });
+
+    it('accepts multiple domains and checks bulk availability', async () => {
+      useUser();
+      let body: { domains?: string[] } | undefined;
+      client.scenario.post('/v1/registrar/domains/availability', (req, res) => {
+        body = req.body as { domains?: string[] };
+        res.json({
+          results: [
+            { domain: 'one.com', available: true },
+            { domain: 'two.com', available: false },
+            { domain: 'three.com', available: true },
+          ],
+        });
+      });
+
+      client.setArgv('domains', 'check', 'one.com', 'two.com', 'three.com');
+      const exitCode = await domains(client);
+      expect(exitCode).toEqual(0);
+
+      await expect(client.stderr).toOutput('one.com');
+      await expect(client.stderr).toOutput('two.com');
+      await expect(client.stderr).toOutput('three.com');
+      expect(body).toEqual({
+        domains: ['one.com', 'two.com', 'three.com'],
+      });
+    });
+
+    it('outputs json for multiple domains', async () => {
+      useUser();
+      client.scenario.post(
+        '/v1/registrar/domains/availability',
+        (_req, res) => {
+          res.json({
+            results: [
+              { domain: 'one.com', available: true },
+              { domain: 'two.com', available: false },
+            ],
+          });
+        }
+      );
+
+      client.setArgv('domains', 'check', 'one.com', 'two.com', '--format=json');
+      const exitCode = await domains(client);
+      expect(exitCode).toEqual(0);
+      expect(client.stdout.getFullOutput()).toMatchInlineSnapshot(`
+        "{
+          "results": [
+            {
+              "domain": "one.com",
+              "available": true
+            },
+            {
+              "domain": "two.com",
+              "available": false
+            }
+          ]
+        }
+        "
+      `);
+    });
   });
 });

--- a/packages/cli/test/unit/commands/domains/check.test.ts
+++ b/packages/cli/test/unit/commands/domains/check.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import domains from '../../../../src/commands/domains';
+import { useUser } from '../../../mocks/user';
+
+describe('domains check', () => {
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'domains';
+      const subcommand = 'check';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = domains(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  describe('[domain]', () => {
+    it('prints when the domain is available', async () => {
+      useUser();
+      client.scenario.get(
+        '/v1/registrar/domains/example.com/availability',
+        (_req, res) => {
+          res.json({
+            available: true,
+          });
+        }
+      );
+
+      client.setArgv('domains', 'check', 'example.com');
+      const exitCode = await domains(client);
+      expect(exitCode).toEqual(0);
+
+      await expect(client.stderr).toOutput('is available');
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:check',
+          value: 'check',
+        },
+      ]);
+    });
+
+    it('prints when the domain is unavailable', async () => {
+      useUser();
+      client.scenario.get(
+        '/v1/registrar/domains/example.com/availability',
+        (_req, res) => {
+          res.json({
+            available: false,
+          });
+        }
+      );
+
+      client.setArgv('domains', 'check', 'example.com');
+      const exitCode = await domains(client);
+      expect(exitCode).toEqual(0);
+
+      await expect(client.stderr).toOutput('is unavailable');
+    });
+
+    it('outputs json when requested', async () => {
+      useUser();
+      client.scenario.get(
+        '/v1/registrar/domains/example.com/availability',
+        (_req, res) => {
+          res.json({
+            available: true,
+          });
+        }
+      );
+
+      client.setArgv('domains', 'check', 'example.com', '--format=json');
+      const exitCode = await domains(client);
+      expect(exitCode).toEqual(0);
+      expect(client.stdout.getFullOutput()).toMatchInlineSnapshot(`
+        "{
+          "domain": "example.com",
+          "available": true
+        }
+        "
+      `);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/domains/check.test.ts
+++ b/packages/cli/test/unit/commands/domains/check.test.ts
@@ -147,5 +147,32 @@ describe('domains check', () => {
         "
       `);
     });
+
+    it('outputs results array for multiple inputs even with one api result', async () => {
+      useUser();
+      client.scenario.post(
+        '/v1/registrar/domains/availability',
+        (_req, res) => {
+          res.json({
+            results: [{ domain: 'one.com', available: true }],
+          });
+        }
+      );
+
+      client.setArgv('domains', 'check', 'one.com', 'two.com', '--format=json');
+      const exitCode = await domains(client);
+      expect(exitCode).toEqual(0);
+      expect(client.stdout.getFullOutput()).toMatchInlineSnapshot(`
+        "{
+          "results": [
+            {
+              "domain": "one.com",
+              "available": true
+            }
+          ]
+        }
+        "
+      `);
+    });
   });
 });

--- a/packages/cli/test/unit/commands/domains/price.test.ts
+++ b/packages/cli/test/unit/commands/domains/price.test.ts
@@ -55,5 +55,76 @@ describe('domains price', () => {
         },
       ]);
     });
+
+    it('supports bulk registrar pricing lookup', async () => {
+      useUser();
+      let body: { domains?: string[] } | undefined;
+      client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+        body = req.body as { domains?: string[] };
+        res.json([
+          {
+            domain: 'one.com',
+            purchasePrice: 10,
+            renewalPrice: 20,
+            transferPrice: 30,
+            years: 1,
+          },
+          {
+            domain: 'two.com',
+            purchasePrice: 11,
+            renewalPrice: 21,
+            transferPrice: 31,
+            years: 1,
+          },
+        ]);
+      });
+
+      client.setArgv('domains', 'price', 'one.com', 'two.com');
+      const exitCode = await domains(client);
+      expect(exitCode).toEqual(0);
+
+      const out = client.stderr.getFullOutput();
+      expect(out).toContain('Registrar pricing for one.com');
+      expect(out).toContain('Purchase: $10');
+      expect(out).toContain('Registrar pricing for two.com');
+      expect(out).toContain('Purchase: $11');
+      expect(body).toEqual({
+        domains: ['one.com', 'two.com'],
+      });
+    });
+
+    it('outputs JSON results array for bulk lookup', async () => {
+      useUser();
+      client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+        res.json([
+          {
+            domain: 'one.com',
+            purchasePrice: 10,
+            renewalPrice: 20,
+            transferPrice: 30,
+            years: 1,
+          },
+        ]);
+      });
+
+      client.setArgv('domains', 'price', 'one.com', 'two.com', '--format=json');
+      const exitCode = await domains(client);
+      expect(exitCode).toEqual(0);
+
+      expect(client.stdout.getFullOutput()).toMatchInlineSnapshot(`
+        "{
+          "results": [
+            {
+              "domain": "one.com",
+              "purchasePrice": 10,
+              "renewalPrice": 20,
+              "transferPrice": 30,
+              "years": 1
+            }
+          ]
+        }
+        "
+      `);
+    });
   });
 });

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -271,6 +271,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('domains check help output snapshots', () => {
+      it('domains check help column width 120', () => {
+        expect(
+          help(domains.checkSubcommand, {
+            columns: 120,
+            parent: domains.domainsCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
     describe('domains price help output snapshots', () => {
       it('domains price help column width 120', () => {
         expect(


### PR DESCRIPTION
Adds `vercel domains check` command that accepts one or multiple domains as arguments and returns their availability 
<img width="1478" height="606" alt="CleanShot 2026-05-26 at 11 18 13@2x" src="https://github.com/user-attachments/assets/0edb3c73-f0de-4b74-bbc6-f3694ba54871" />
<img width="1492" height="588" alt="CleanShot 2026-05-26 at 11 18 03@2x" src="https://github.com/user-attachments/assets/18ac8d96-1c4d-48e2-aeeb-4d68e5401be0" />
<img width="1478" height="690" alt="CleanShot 2026-05-26 at 11 17 36@2x" src="https://github.com/user-attachments/assets/dcc7abdd-5a66-4b7e-a3f2-708256b6fc50" />

Also adds bulk availability 
<img width="1436" height="688" alt="CleanShot 2026-05-26 at 13 38 16@2x" src="https://github.com/user-attachments/assets/8ae7eb44-5d1c-4a10-9f66-70051b545673" />
<img width="1416" height="672" alt="CleanShot 2026-05-26 at 13 37 30@2x" src="https://github.com/user-attachments/assets/d357d175-b93b-4236-b8a6-db5b4c9dfaec" />
