### PR TITLE
Reorder env add sensitive prompt before value and environment selection

### DIFF
--- a/.changeset/env-add-sensitive-prompt-order.md
+++ b/.changeset/env-add-sensitive-prompt-order.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Reorder `vercel env add` to ask whether a value is sensitive before collecting the value and selecting environments. Sensitive adds hide Development; teams with the sensitive env policy still prompt, and non-sensitive adds are limited to Development with clearer messaging.

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -40,25 +40,67 @@ import {
 
 type EnvType = 'encrypted' | 'sensitive';
 
-/**
- * Per-target type resolution. The server silently promotes encrypted → sensitive
- * on policy-on teams for Production/Preview, and rejects sensitive on Development.
- * We mirror that server contract client-side so output and logs are honest.
- */
-function resolveTypeForTarget(
-  target: string,
+type EnvChoice = {
+  name: string;
+  value: string;
+  checked?: boolean;
+  disabled?: boolean | string;
+};
+
+const SENSITIVE_SECRET_PROMPT = 'Is the value a sensitive secret?';
+
+function filterEnvChoicesForSensitivity(
+  choices: EnvChoice[],
+  opts: { isSensitive: boolean; policyOn: boolean }
+): EnvChoice[] {
+  if (opts.isSensitive) {
+    return choices.filter(c => c.value !== 'development');
+  }
+  if (opts.policyOn) {
+    return choices.filter(c => c.value === 'development');
+  }
+  return choices;
+}
+
+function getTargetCompatibilityError(
+  envTargets: string[],
+  isSensitive: boolean,
+  policyOn: boolean
+): string | null {
+  const hasDevelopment = envTargets.includes('development');
+  const hasSensitiveCapable = envTargets.some(t => t !== 'development');
+
+  if (isSensitive && hasDevelopment) {
+    return `Sensitive Environment Variables are not supported on the Development Environment. Run ${getCommandName(
+      'env add'
+    )} separately for Development with a non-sensitive value.`;
+  }
+
+  if (!isSensitive && policyOn && hasSensitiveCapable) {
+    return `Your team requires sensitive Environment Variables for Production and Preview. To add a non-sensitive value, target the Development Environment only. Run ${getCommandName(
+      'env add'
+    )} with the development target instead.`;
+  }
+
+  return null;
+}
+
+function resolveFinalType(
+  envTargets: string[],
+  isSensitive: boolean,
   opts: { forceSensitive: boolean; forceEncrypted: boolean; policyOn: boolean }
 ): EnvType {
-  if (target === 'development') {
-    // Development never supports sensitive; caller is expected to have already
-    // rejected --sensitive when only development is selected.
+  const hasDevelopment = envTargets.includes('development');
+  if (hasDevelopment) {
     return 'encrypted';
   }
-  if (opts.forceEncrypted) return 'encrypted';
-  if (opts.forceSensitive) return 'sensitive';
-  if (opts.policyOn) return 'sensitive';
-  // Default for Production/Preview/custom environments.
-  return 'sensitive';
+  if (opts.forceEncrypted && !opts.policyOn) {
+    return 'encrypted';
+  }
+  if (isSensitive || opts.forceSensitive || opts.policyOn) {
+    return 'sensitive';
+  }
+  return 'encrypted';
 }
 
 /**
@@ -523,12 +565,7 @@ export default async function add(client: Client, argv: string[]) {
       }
     }
   }
-  const choices: Array<{
-    name: string;
-    value: string;
-    checked?: boolean;
-    disabled?: boolean | string;
-  }> = [
+  const choices: EnvChoice[] = [
     ...envTargetChoices
       .filter(c => !existingTargets.has(c.value))
       .map(c => ({ name: c.name, value: c.value })),
@@ -570,14 +607,107 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  // When policy is on, Production/Preview values are sensitive by default.
-  // Development stays available because it is stored as encrypted.
-  if (policyOn) {
-    for (const choice of choices) {
+  const isDevelopmentOnlyTarget =
+    envTargets.length === 1 && envTargets[0] === 'development';
+  const userWasExplicit = forceSensitive || forceEncrypted;
+  const skipSensitivePrompt =
+    userWasExplicit ||
+    client.nonInteractive ||
+    skipConfirm ||
+    isDevelopmentOnlyTarget;
+
+  let isSensitive: boolean;
+  if (forceSensitive) {
+    isSensitive = true;
+  } else if (forceEncrypted) {
+    isSensitive = false;
+  } else if (isDevelopmentOnlyTarget) {
+    isSensitive = false;
+  } else if (skipSensitivePrompt) {
+    isSensitive = true;
+  } else {
+    output.log(
+      `Sensitive values cannot be retrieved later from the dashboard or CLI.`
+    );
+    isSensitive = await client.input.confirm(SENSITIVE_SECRET_PROMPT, true);
+    if (policyOn && !isSensitive) {
+      output.log(
+        `Your team requires sensitive Environment Variables for Production and Preview. To add a non-sensitive value, you can only target the Development Environment.`
+      );
+    }
+  }
+
+  if (forceSensitive && envTargets.includes('development')) {
+    const msg = `--sensitive is not allowed with the Development Environment. Sensitive Environment Variables are only supported on Production and Preview.`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'sensitive_not_allowed_on_development',
+          message: msg,
+        },
+        1
+      );
+    }
+    output.error(msg);
+    return 1;
+  }
+
+  if (envTargets.length > 0) {
+    const compatibilityError = getTargetCompatibilityError(
+      envTargets,
+      isSensitive,
+      policyOn
+    );
+    if (compatibilityError) {
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          {
+            status: 'error',
+            reason: isSensitive
+              ? 'sensitive_not_allowed_on_development'
+              : 'non_sensitive_not_allowed_on_production_preview',
+            message: compatibilityError,
+          },
+          1
+        );
+      }
+      output.error(compatibilityError);
+      return 1;
+    }
+  }
+
+  const envChoices = filterEnvChoicesForSensitivity(choices, {
+    isSensitive,
+    policyOn,
+  });
+
+  if (policyOn && isSensitive) {
+    for (const choice of envChoices) {
       if (choice.value === 'production' || choice.value === 'preview') {
         choice.checked = true;
       }
     }
+  } else if (envChoices.length === 1) {
+    envChoices[0].checked = true;
+  }
+
+  if (
+    !envGitBranch &&
+    envChoices.length === 0 &&
+    envTargets.length === 0 &&
+    !opts['--force']
+  ) {
+    output.error(
+      `No Environments are available for this variable with the selected sensitivity. ${
+        isSensitive
+          ? 'Sensitive Environment Variables cannot be added to Development.'
+          : 'Your team requires sensitive Environment Variables for Production and Preview.'
+      }`
+    );
+    return 1;
   }
 
   let envValue: string;
@@ -607,10 +737,17 @@ export default async function add(client: Client, argv: string[]) {
         ],
       });
     }
-    envValue = await client.input.password({
-      message: `What's the value of ${envName}?`,
-      mask: true,
-    });
+    if (isSensitive) {
+      envValue = await client.input.password({
+        message: `What's the value of ${envName}?`,
+        mask: true,
+      });
+    } else {
+      envValue = await client.input.text({
+        message: `What's the value of ${envName}?`,
+        validate: val => (val ? true : 'Value cannot be empty'),
+      });
+    }
   }
 
   const { finalValue } = await validateEnvValue({
@@ -618,10 +755,15 @@ export default async function add(client: Client, argv: string[]) {
     initialValue: envValue,
     skipConfirm,
     promptForValue: () =>
-      client.input.password({
-        message: `What's the value of ${envName}?`,
-        mask: true,
-      }),
+      isSensitive
+        ? client.input.password({
+            message: `What's the value of ${envName}?`,
+            mask: true,
+          })
+        : client.input.text({
+            message: `What's the value of ${envName}?`,
+            validate: val => (val ? true : 'Value cannot be empty'),
+          }),
     selectAction: choices =>
       client.input.select({ message: 'How to proceed?', choices }),
     showWarning: msg => output.warn(msg),
@@ -629,7 +771,7 @@ export default async function add(client: Client, argv: string[]) {
   });
 
   while (envTargets.length === 0) {
-    if (client.nonInteractive && choices.length > 0) {
+    if (client.nonInteractive && envChoices.length > 0) {
       outputActionRequired(client, {
         status: 'action_required',
         reason: 'missing_environment',
@@ -637,11 +779,11 @@ export default async function add(client: Client, argv: string[]) {
           client.argv,
           `env add ${envName} <environment> --value <value> --yes`
         )}`,
-        choices: choices.map(c => ({
+        choices: envChoices.map(c => ({
           id: c.value,
           name: typeof c.name === 'string' ? c.name : c.value,
         })),
-        next: choices.slice(0, 5).map(c => ({
+        next: envChoices.slice(0, 5).map(c => ({
           command: buildEnvAddCommandWithPreservedArgs(
             client.argv,
             `env add ${envName} ${c.value} --value <value> --yes`
@@ -651,12 +793,22 @@ export default async function add(client: Client, argv: string[]) {
     }
     envTargets = await client.input.checkbox({
       message: `Add ${envName} to which Environments (select multiple)?`,
-      choices,
+      choices: envChoices,
     });
 
     if (envTargets.length === 0) {
       output.error('Please select at least one Environment');
     }
+  }
+
+  const postSelectionError = getTargetCompatibilityError(
+    envTargets,
+    isSensitive,
+    policyOn
+  );
+  if (postSelectionError) {
+    output.error(postSelectionError);
+    return 1;
   }
 
   if (
@@ -698,73 +850,14 @@ export default async function add(client: Client, argv: string[]) {
   }
 
   const hasDevelopment = envTargets.includes('development');
-  const hasSensitiveCapable = envTargets.some(t => t !== 'development');
 
-  if (forceSensitive && hasDevelopment) {
-    const msg = `--sensitive is not allowed with the Development Environment. Sensitive Environment Variables are only supported on Production and Preview.`;
-    if (client.nonInteractive) {
-      outputAgentError(
-        client,
-        {
-          status: 'error',
-          reason: 'sensitive_not_allowed_on_development',
-          message: msg,
-        },
-        1
-      );
-    }
-    output.error(msg);
-    return 1;
-  }
+  let finalType = resolveFinalType(envTargets, isSensitive, {
+    forceSensitive,
+    forceEncrypted,
+    policyOn,
+  });
 
-  if (hasDevelopment && hasSensitiveCapable) {
-    const msg = `Development cannot be combined with other Environments because Development does not support sensitive Environment Variables. Run ${getCommandName(
-      'env add'
-    )} separately for Development.`;
-    if (client.nonInteractive) {
-      outputAgentError(
-        client,
-        {
-          status: 'error',
-          reason: 'mixed_development_and_sensitive_capable_targets',
-          message: msg,
-        },
-        1
-      );
-    }
-    output.error(msg);
-    return 1;
-  }
-
-  // At this point envTargets is either all-development or all non-development.
-  let finalType: EnvType = resolveTypeForTarget(
-    hasDevelopment ? 'development' : 'production',
-    { forceSensitive, forceEncrypted, policyOn }
-  );
-
-  // Ask whether to keep it sensitive only when the user didn't say, the
-  // policy isn't enforcing, and at least one target would actually use it.
-  const userWasExplicit = forceSensitive || forceEncrypted;
-  const canPromptForType =
-    !client.nonInteractive &&
-    !userWasExplicit &&
-    !policyOn &&
-    hasSensitiveCapable &&
-    !skipConfirm;
-  if (canPromptForType) {
-    output.log(
-      `Sensitive values cannot be retrieved later from the dashboard or CLI.`
-    );
-    const keepSensitive = await client.input.confirm(
-      `Make it sensitive?`,
-      true
-    );
-    if (!keepSensitive) {
-      finalType = 'encrypted';
-    }
-  }
-
-  if (policyOn && hasSensitiveCapable) {
+  if (policyOn && !hasDevelopment) {
     if (forceEncrypted) {
       // User asked for encrypted on Production/Preview, but the team policy
       // will promote it to sensitive server-side regardless. Surface that so
@@ -773,10 +866,6 @@ export default async function add(client: Client, argv: string[]) {
         `--no-sensitive is ignored: your team enforces sensitive Environment Variables for Production and Preview.`
       );
       finalType = 'sensitive';
-    } else if (!userWasExplicit) {
-      output.log(
-        `Your team requires sensitive Environment Variables for Production and Preview.`
-      );
     }
   }
 

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -114,11 +114,13 @@ describe('env add', () => {
         );
         const exitCodePromise = env(client);
         await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('y\n');
+        await expect(client.stderr).toOutput(
           "What's the value of DEFAULT_SENSITIVE?"
         );
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('y\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
         expect(spy).toHaveBeenCalled();
@@ -145,11 +147,13 @@ describe('env add', () => {
         );
         const exitCodePromise = env(client);
         await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
           "What's the value of DECLINED_SENSITIVE?"
         );
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
         expect(spy).toHaveBeenCalled();
@@ -283,20 +287,103 @@ describe('env add', () => {
           .spyOn(addEnvRecordModule, 'default')
           .mockResolvedValue(undefined);
 
-        client.setArgv(
-          'env',
-          'add',
-          'DEV_UNDER_POLICY',
-          'development',
-          '--value',
-          'foo',
-          '--yes'
+        try {
+          client.setArgv(
+            'env',
+            'add',
+            'DEV_UNDER_POLICY',
+            'development',
+            '--value',
+            'foo',
+            '--yes'
+          );
+          const exitCodePromise = env(client);
+          await expect(exitCodePromise).resolves.toBe(0);
+
+          expect(addSpy).toHaveBeenCalled();
+          const [, , , type, , , targets] = addSpy.mock.calls[0] as unknown as [
+            unknown,
+            unknown,
+            unknown,
+            string,
+            unknown,
+            unknown,
+            string[],
+          ];
+          expect(type).toBe('encrypted');
+          expect(targets).toEqual(['development']);
+        } finally {
+          teamSpy.mockRestore();
+          addSpy.mockRestore();
+        }
+      });
+    });
+
+    describe('--no-sensitive with team policy on', () => {
+      it('errors when Production is targeted with --no-sensitive', async () => {
+        const teamModule = await import(
+          '../../../../src/util/teams/get-team-by-id'
         );
+
+        const teamSpy = vi.spyOn(teamModule, 'default').mockResolvedValue({
+          sensitiveEnvironmentVariablePolicy: 'on',
+        } as any);
+
+        try {
+          client.setArgv(
+            'env',
+            'add',
+            'POLICY_OVERRIDE',
+            'production',
+            '--value',
+            'foo',
+            '--no-sensitive',
+            '--yes'
+          );
+          const exitCodePromise = env(client);
+          await expect(client.stderr).toOutput(
+            'Your team requires sensitive Environment Variables for Production and Preview. To add a non-sensitive value, target the Development Environment only.'
+          );
+          await expect(exitCodePromise).resolves.toBe(1);
+        } finally {
+          teamSpy.mockRestore();
+        }
+      });
+    });
+
+    describe('mixed Development + other Environments', () => {
+      it('allows selecting all environments when the value is not sensitive', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv('env', 'add', 'MIXED_TARGETS');
         const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of MIXED_TARGETS?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput(
+          'Add MIXED_TARGETS to which Environments (select multiple)?'
+        );
+        // Select Production, Preview, and Development.
+        client.stdin.write(' '); // toggle Production (first row)
+        client.stdin.write('\x1B[B'); // down to Preview
+        client.stdin.write(' '); // toggle Preview
+        client.stdin.write('\x1B[B'); // down to Development
+        client.stdin.write(' '); // toggle Development
+        client.stdin.write('\r'); // submit
         await expect(exitCodePromise).resolves.toBe(0);
 
-        expect(addSpy).toHaveBeenCalled();
-        const [, , , type, , , targets] = addSpy.mock.calls[0] as unknown as [
+        expect(spy).toHaveBeenCalled();
+        const [, , , type, , , targets] = spy.mock.calls[0] as unknown as [
           unknown,
           unknown,
           unknown,
@@ -306,15 +393,63 @@ describe('env add', () => {
           string[],
         ];
         expect(type).toBe('encrypted');
-        expect(targets).toEqual(['development']);
+        expect(targets).toEqual(
+          expect.arrayContaining(['production', 'preview', 'development'])
+        );
 
-        teamSpy.mockRestore();
-        addSpy.mockRestore();
+        spy.mockRestore();
+      });
+
+      it('omits Development when the value is sensitive', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        client.setArgv('env', 'add', 'SENSITIVE_MIXED');
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('y\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of SENSITIVE_MIXED?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(client.stderr).toOutput(
+          'Add SENSITIVE_MIXED to which Environments (select multiple)?'
+        );
+        // Select Production and Preview only; Development is not listed.
+        client.stdin.write(' '); // toggle Production
+        client.stdin.write('\x1B[B'); // down to Preview
+        client.stdin.write(' '); // toggle Preview
+        client.stdin.write('\r'); // submit
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(spy).toHaveBeenCalled();
+        const [, , , type, , , targets] = spy.mock.calls[0] as unknown as [
+          unknown,
+          unknown,
+          unknown,
+          string,
+          unknown,
+          unknown,
+          string[],
+        ];
+        expect(type).toBe('sensitive');
+        expect(targets).toEqual(
+          expect.arrayContaining(['production', 'preview'])
+        );
+        expect(targets).not.toContain('development');
+
+        spy.mockRestore();
       });
     });
 
-    describe('--no-sensitive with team policy on', () => {
-      it('warns that --no-sensitive is ignored and stores as sensitive', async () => {
+    describe('team policy on', () => {
+      it('still asks about sensitivity and limits non-sensitive adds to Development', async () => {
         const teamModule = await import(
           '../../../../src/util/teams/get-team-by-id'
         );
@@ -329,52 +464,42 @@ describe('env add', () => {
           .spyOn(addEnvRecordModule, 'default')
           .mockResolvedValue(undefined);
 
-        client.setArgv(
-          'env',
-          'add',
-          'POLICY_OVERRIDE',
-          'production',
-          '--value',
-          'foo',
-          '--no-sensitive',
-          '--yes'
-        );
-        const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          '--no-sensitive is ignored: your team enforces sensitive Environment Variables for Production and Preview.'
-        );
-        await expect(exitCodePromise).resolves.toBe(0);
+        try {
+          client.setArgv('env', 'add', 'POLICY_DEV_ONLY');
+          const exitCodePromise = env(client);
+          await expect(client.stderr).toOutput(
+            'Is the value a sensitive secret?'
+          );
+          client.stdin.write('n\n');
+          await expect(client.stderr).toOutput(
+            'Your team requires sensitive Environment Variables for Production and Preview. To add a non-sensitive value, you can only target the Development Environment.'
+          );
+          await expect(client.stderr).toOutput(
+            "What's the value of POLICY_DEV_ONLY?"
+          );
+          client.stdin.write('testvalue\n');
+          await expect(client.stderr).toOutput(
+            'Add POLICY_DEV_ONLY to which Environments (select multiple)?'
+          );
+          client.stdin.write('\r'); // accept Development only
+          await expect(exitCodePromise).resolves.toBe(0);
 
-        expect(addSpy).toHaveBeenCalled();
-        const type = addSpy.mock.calls[0][3];
-        expect(type).toBe('sensitive');
-
-        teamSpy.mockRestore();
-        addSpy.mockRestore();
-      });
-    });
-
-    describe('mixed Development + other Environments', () => {
-      it('errors when the interactive checkbox picks Development alongside Production/Preview', async () => {
-        client.setArgv('env', 'add', 'MIXED_TARGETS');
-        const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          "What's the value of MIXED_TARGETS?"
-        );
-        client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput(
-          'Add MIXED_TARGETS to which Environments (select multiple)?'
-        );
-        // Select Production and Development.
-        client.stdin.write(' '); // toggle Production (first row)
-        client.stdin.write('\x1B[B'); // down to Preview
-        client.stdin.write('\x1B[B'); // down to Development
-        client.stdin.write(' '); // toggle Development
-        client.stdin.write('\r'); // submit
-        await expect(client.stderr).toOutput(
-          'Development cannot be combined with other Environments'
-        );
-        await expect(exitCodePromise).resolves.toBe(1);
+          expect(addSpy).toHaveBeenCalled();
+          const [, , , type, , , targets] = addSpy.mock.calls[0] as unknown as [
+            unknown,
+            unknown,
+            unknown,
+            string,
+            unknown,
+            unknown,
+            string[],
+          ];
+          expect(type).toBe('encrypted');
+          expect(targets).toEqual(['development']);
+        } finally {
+          teamSpy.mockRestore();
+          addSpy.mockRestore();
+        }
       });
     });
 
@@ -389,10 +514,12 @@ describe('env add', () => {
           '--force'
         );
         const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -432,10 +559,12 @@ describe('env add', () => {
           '--guidance'
         );
         const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -543,11 +672,13 @@ describe('env add', () => {
           'NEXT_PUBLIC_ variables can be seen by anyone visiting your site'
         );
         await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
           "What's the value of NEXT_PUBLIC_TEST?"
         );
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
@@ -567,11 +698,13 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\n'); // Select "Leave as is"
         await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
           "What's the value of NEXT_PUBLIC_API_KEY?"
         );
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
@@ -591,10 +724,12 @@ describe('env add', () => {
         // Select "Rename to SECRET" (second option)
         client.stdin.write('\x1B[B\n');
         await expect(client.stderr).toOutput('Renamed to SECRET');
+        await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of SECRET?");
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
@@ -602,20 +737,26 @@ describe('env add', () => {
         client.setArgv('env', 'add', 'QUOTED_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
         await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
           "What's the value of QUOTED_VALUE?"
         );
         client.stdin.write('"my-value"\n');
         await expect(client.stderr).toOutput('includes surrounding quotes');
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\n'); // Select "Leave as is"
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
       it('allows re-entering value when warned', async () => {
         client.setArgv('env', 'add', 'REENTER_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of REENTER_VALUE?"
         );
@@ -627,8 +768,6 @@ describe('env add', () => {
           "What's the value of REENTER_VALUE?"
         );
         client.stdin.write('clean-value\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
@@ -642,6 +781,10 @@ describe('env add', () => {
         );
         const exitCodePromise = env(client);
         await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
           "What's the value of WHITESPACE_VALUE?"
         );
         client.stdin.write(' spaced \n');
@@ -649,14 +792,16 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\x1B[B\x1B[B\n'); // Select Trim
         await expect(client.stderr).toOutput('Trimmed whitespace');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
       it('re-validates trimmed value when it becomes empty', async () => {
         client.setArgv('env', 'add', 'TRIMMED_EMPTY', 'preview', 'branchName');
         const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of TRIMMED_EMPTY?"
         );
@@ -669,8 +814,6 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('Value is empty');
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\n'); // Leave as is
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
 
@@ -697,10 +840,12 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('How to proceed?');
         client.stdin.write('\x1B[B\n'); // Rename again to SECRET
         await expect(client.stderr).toOutput('Renamed to SECRET');
+        await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of SECRET?");
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
     });
@@ -710,11 +855,13 @@ describe('env add', () => {
         client.setArgv('env', 'add', 'environment-variable', 'custom-env-name');
         const exitCodePromise = env(client);
         await expect(client.stderr).toOutput(
+          'Is the value a sensitive secret?'
+        );
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
           "What's the value of environment-variable?"
         );
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput('Make it sensitive?');
-        client.stdin.write('n\n');
         await expect(exitCodePromise).resolves.toEqual(0);
 
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -744,11 +891,13 @@ describe('env add', () => {
           );
           const exitCodePromise = env(client);
           await expect(client.stderr).toOutput(
+            'Is the value a sensitive secret?'
+          );
+          client.stdin.write('n\n');
+          await expect(client.stderr).toOutput(
             "What's the value of REDIS_CONNECTION_STRING?"
           );
           client.stdin.write('testvalue\n');
-          await expect(client.stderr).toOutput('Make it sensitive?');
-          client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             'Added Environment Variable REDIS_CONNECTION_STRING to Project vercel-env-pull'
           );
@@ -766,11 +915,13 @@ describe('env add', () => {
           );
           const exitCodePromise = env(client);
           await expect(client.stderr).toOutput(
+            'Is the value a sensitive secret?'
+          );
+          client.stdin.write('n\n');
+          await expect(client.stderr).toOutput(
             "What's the value of TELEMETRY_EVENTS?"
           );
           client.stdin.write('testvalue\n');
-          await expect(client.stderr).toOutput('Make it sensitive?');
-          client.stdin.write('n\n');
           await expect(exitCodePromise).resolves.toEqual(0);
 
           expect(client.telemetryEventStore).toHaveTelemetryEvents([

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -321,6 +321,8 @@ describe('env pull', () => {
       client.setArgv('env', 'add', 'NEW_VAR');
       const addPromise = env(client);
 
+      await expect(client.stderr).toOutput('Is the value a sensitive secret?');
+      client.stdin.write('n\n');
       await expect(client.stderr).toOutput("What's the value of NEW_VAR?");
       client.stdin.write('testvalue\n');
 


### PR DESCRIPTION
## Summary
- Ask "Is the value a sensitive secret?" before collecting the value or selecting environments in interactive `vercel env add`
- Hide Development when the value is sensitive; allow all environments in one add when it is not
- On teams with the sensitive env policy, still prompt and limit non-sensitive adds to Development with clearer messaging

## Test plan
- [x] `npx vitest run packages/cli/test/unit/commands/env/add.test.ts --pool=forks --poolOptions.forks.singleFork=true` (40/40 passing)
- [ ] Manually run `vc env add` and confirm sensitive vs non-sensitive flows
- [ ] On a policy-on team, confirm answering "no" only offers Development


Made with [Cursor](https://cursor.com)