### PR TITLE
Increase deployment log retry window

### DIFF
--- a/.changeset/build-log-retry-window.md
+++ b/.changeset/build-log-retry-window.md
@@ -1,0 +1,4 @@
+---
+---
+
+Increase the deployment log polling window used by integration test probes.

--- a/.changeset/build-log-retry-window.md
+++ b/.changeset/build-log-retry-window.md
@@ -1,4 +1,0 @@
----
----
-
-Increase the deployment log polling window used by integration test probes.

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -34,6 +34,10 @@ async function packAndDeploy(builderPath, shouldUnlink = true) {
 }
 
 const RANDOMNESS_PLACEHOLDER_STRING = 'RANDOMNESS_PLACEHOLDER';
+const DEPLOYMENT_LOG_FETCH_RETRY_DELAY_MS = 2000;
+const DEPLOYMENT_LOG_FETCH_ATTEMPTS = Math.ceil(
+  15000 / DEPLOYMENT_LOG_FETCH_RETRY_DELAY_MS
+);
 
 async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
   if (probe.delay) {
@@ -54,7 +58,7 @@ async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
     if (!ctx.deploymentLogs) {
       let lastErr;
 
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < DEPLOYMENT_LOG_FETCH_ATTEMPTS; i++) {
         try {
           const logsRes = await fetchWithAuth(
             `/v1/now/deployments/${deploymentId}/events?limit=-1`
@@ -76,16 +80,19 @@ async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
         } catch (err) {
           lastErr = err;
         }
+        const logLineCount = Array.isArray(ctx.deploymentLogs)
+          ? ctx.deploymentLogs.length
+          : typeof ctx.deploymentLogs;
         ctx.deploymentLogs = null;
         console.log(
           'Retrying to fetch logs for',
           deploymentId,
-          'in 2 seconds. Read lines:',
-          Array.isArray(ctx.deploymentLogs)
-            ? ctx.deploymentLogs.length
-            : typeof ctx.deploymentLogs
+          `in ${DEPLOYMENT_LOG_FETCH_RETRY_DELAY_MS}ms. Read lines:`,
+          logLineCount
         );
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        await new Promise(resolve =>
+          setTimeout(resolve, DEPLOYMENT_LOG_FETCH_RETRY_DELAY_MS)
+        );
       }
       if (
         !Array.isArray(ctx.deploymentLogs) ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Why/Summary
- Deployment-log ingestion can exceed the previous ~10s polling window, causing CLI integration probes to fail before logs arrive.
- Extend the empty-log polling budget to about 15s while keeping the existing expected-text retry path unchanged.

### Validation
- Confirmed the changed helper parses and passes targeted Biome checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caa15d88-7648-4544-a6b4-d31b91df04d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caa15d88-7648-4544-a6b4-d31b91df04d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

