### PR TITLE
[python] detect otel layer in build

### DIFF
--- a/.changeset/six-ghosts-promise.md
+++ b/.changeset/six-ghosts-promise.md
@@ -1,0 +1,8 @@
+---
+'@vercel/python': patch
+---
+
+Reduce lambda threshold bytes when VERCEL_DEPLOYMENT_HAS_OTEL_LAYER is set.
+
+When the deployments use the otel collector it can push the deployment over the limit since we don't account
+for the size overhead added by this layer. Reduce the total uncompressed size for these types of deployments.

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -60,7 +60,7 @@ function shouldStripVendorFile(filePath: string): boolean {
 
 // AWS Lambda uncompressed size limit is 250MB, but we use 245MB to leave room
 // for the standard Lambda layers (rusty runtime, lambdawrapper). When the
-// OpenTelemetry collector layer is also attached, we reserve an additional 15MB.
+// OpenTelemetry collector layer is also attached, we reserve an additional 5MB.
 const LAMBDA_BASE_SIZE_THRESHOLD_BYTES = 245 * 1024 * 1024;
 const OTEL_LAYER_RESERVATION_BYTES = 5 * 1024 * 1024;
 

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -62,7 +62,7 @@ function shouldStripVendorFile(filePath: string): boolean {
 // for the standard Lambda layers (rusty runtime, lambdawrapper). When the
 // OpenTelemetry collector layer is also attached, we reserve an additional 15MB.
 const LAMBDA_BASE_SIZE_THRESHOLD_BYTES = 245 * 1024 * 1024;
-const OTEL_LAYER_RESERVATION_BYTES = 15 * 1024 * 1024;
+const OTEL_LAYER_RESERVATION_BYTES = 5 * 1024 * 1024;
 
 export const LAMBDA_SIZE_THRESHOLD_BYTES =
   process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER === '1'

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -58,8 +58,16 @@ function shouldStripVendorFile(filePath: string): boolean {
   return false;
 }
 
-// AWS Lambda uncompressed size limit is 250MB, but we use 245MB to leave room for Lambda layers
-export const LAMBDA_SIZE_THRESHOLD_BYTES = 245 * 1024 * 1024;
+// AWS Lambda uncompressed size limit is 250MB, but we use 245MB to leave room
+// for the standard Lambda layers (rusty runtime, lambdawrapper). When the
+// OpenTelemetry collector layer is also attached, we reserve an additional 15MB.
+const LAMBDA_BASE_SIZE_THRESHOLD_BYTES = 245 * 1024 * 1024;
+const OTEL_LAYER_RESERVATION_BYTES = 15 * 1024 * 1024;
+
+export const LAMBDA_SIZE_THRESHOLD_BYTES =
+  process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER === '1'
+    ? LAMBDA_BASE_SIZE_THRESHOLD_BYTES - OTEL_LAYER_RESERVATION_BYTES
+    : LAMBDA_BASE_SIZE_THRESHOLD_BYTES;
 
 // AWS Lambda ephemeral storage (/tmp) is 512MB. Use 500MB to leave a buffer
 // for runtime overhead (.pyc generation, uv cache, metadata, etc.)

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -214,7 +214,7 @@ describe('dependency externalizer support', () => {
       expect(LAMBDA_SIZE_THRESHOLD_BYTES).toBe(245 * 1024 * 1024);
     });
 
-    it('LAMBDA_SIZE_THRESHOLD_BYTES is 230 MB when otel layer is present', async () => {
+    it('LAMBDA_SIZE_THRESHOLD_BYTES is 240 MB when otel layer is present', async () => {
       process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER = '1';
       try {
         vi.resetModules();

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -210,8 +210,20 @@ describe('dependency externalizer support', () => {
   });
 
   describe('Lambda size constants', () => {
-    it('LAMBDA_SIZE_THRESHOLD_BYTES is 245 MB', () => {
+    it('LAMBDA_SIZE_THRESHOLD_BYTES is 245 MB by default', () => {
       expect(LAMBDA_SIZE_THRESHOLD_BYTES).toBe(245 * 1024 * 1024);
+    });
+
+    it('LAMBDA_SIZE_THRESHOLD_BYTES is 230 MB when otel layer is present', async () => {
+      process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER = '1';
+      try {
+        vi.resetModules();
+        const mod = await import('../src/dependency-externalizer');
+        expect(mod.LAMBDA_SIZE_THRESHOLD_BYTES).toBe(240 * 1024 * 1024);
+      } finally {
+        delete process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER;
+        vi.resetModules();
+      }
     });
 
     it('LAMBDA_EPHEMERAL_STORAGE_BYTES is 500 MB', () => {


### PR DESCRIPTION
## Summary

When a project is using the OTEL collector (eg via datadog integration or vercel log drains) a lambda layer is added to the function which reduces the overall size we can pack the lambda to. This was previously accounted for with a 5MB "buffer" size. This worked for a while but recently a customer hit this issue again.

The fix proposed here is:
1. Set `VERCEL_DEPLOYMENT_HAS_OTEL_LAYER=1` in the build environment on the api side
2. Check if that env var is set and further reduce the total size we can pack to

Since the user is currently over by about ~500KB the extra 5MB should be sufficient to not hit this error.