### PR TITLE
fix(cli): skip external symlinks in standalone prebuilt deploys (PIPE-6621)

### DIFF
--- a/.changeset/fix-standalone-invalid-relative-path.md
+++ b/.changeset/fix-standalone-invalid-relative-path.md
@@ -1,0 +1,6 @@
+---
+'@vercel/build-utils': patch
+'vercel': patch
+---
+
+Fix prebuilt deployments failing with "invalid relative path" when using the `--standalone` flag in pnpm monorepos by skipping external node_modules symlinks and copying traced files at their logical paths instead.

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -2,7 +2,14 @@ import path from 'path';
 import debug from '../debug';
 import FileFsRef from '../file-fs-ref';
 import { File, Files, Meta } from '../types';
-import { remove, mkdirp, readlink, symlink, chmod } from 'fs-extra';
+import {
+  remove,
+  mkdirp,
+  readlink,
+  readlinkSync,
+  symlink,
+  chmod,
+} from 'fs-extra';
 import streamToBuffer from './stream-to-buffer';
 
 export interface DownloadedFiles {
@@ -19,6 +26,37 @@ export function isDirectory(mode: number): boolean {
 
 export function isSymbolicLink(mode: number): boolean {
   return (mode & S_IFMT) === S_IFLNK;
+}
+
+export function isExternalSymlinkTarget(target: string): boolean {
+  return (
+    target.startsWith('../') ||
+    target.startsWith('..\\') ||
+    path.isAbsolute(target)
+  );
+}
+
+export function getSymlinkTarget(file: File): string | null {
+  if (!isSymbolicLink(file.mode)) {
+    return null;
+  }
+  if (file.type === 'FileFsRef') {
+    try {
+      return readlinkSync(file.fsPath);
+    } catch {
+      return null;
+    }
+  }
+  if (file.type === 'FileBlob') {
+    const { data } = file;
+    return typeof data === 'string' ? data : data.toString('utf8');
+  }
+  return null;
+}
+
+export function isExternalSymlink(file: File): boolean {
+  const target = getSymlinkTarget(file);
+  return target !== null && isExternalSymlinkTarget(target);
 }
 
 async function prepareSymlinkTarget(
@@ -137,7 +175,11 @@ export default async function download(
       for (let i = 1; i < parts.length; i++) {
         const dir = parts.slice(0, i).join('/');
         const parent = files[dir];
-        if (parent && isSymbolicLink(parent.mode)) {
+        if (
+          parent &&
+          isSymbolicLink(parent.mode) &&
+          !isExternalSymlink(parent)
+        ) {
           console.warn(
             `Warning: file "${name}" is within a symlinked directory "${dir}" and will be ignored`
           );

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -14,6 +14,9 @@ import download, {
   DownloadedFiles,
   isSymbolicLink,
   isDirectory,
+  isExternalSymlink,
+  isExternalSymlinkTarget,
+  getSymlinkTarget,
 } from './fs/download';
 import getWriteableDirectory from './fs/get-writable-directory';
 import glob, { GlobOptions } from './fs/glob';
@@ -118,6 +121,9 @@ export {
   debug,
   isSymbolicLink,
   isDirectory,
+  isExternalSymlink,
+  isExternalSymlinkTarget,
+  getSymlinkTarget,
   getLambdaOptionsFromFunction,
   sanitizeConsumerName,
   scanParentDirs,

--- a/packages/build-utils/test/unit.download.test.ts
+++ b/packages/build-utils/test/unit.download.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import fs, { readlink } from 'fs-extra';
 import { strict as assert, strictEqual } from 'assert';
-import { download, glob, FileBlob } from '../src';
+import {
+  download,
+  glob,
+  FileBlob,
+  isExternalSymlink,
+  isExternalSymlinkTarget,
+  getSymlinkTarget,
+} from '../src';
 
 // File mode constants (octal) used by FileBlob to indicate file type
 const S_IFREG = 33188; // 0o100644 - regular file
@@ -157,6 +164,30 @@ describe('download()', () => {
     expect(warningMessages).toEqual([
       'Warning: file "linkdir/file.txt" is within a symlinked directory "linkdir" and will be ignored',
     ]);
+  });
+
+  it('should detect external symlink targets', () => {
+    expect(isExternalSymlinkTarget('../../node_modules/.pnpm/next')).toBe(true);
+    expect(isExternalSymlinkTarget('./a.txt')).toBe(false);
+    expect(isExternalSymlinkTarget('a.txt')).toBe(false);
+    expect(isExternalSymlinkTarget('/absolute/path')).toBe(true);
+
+    const externalSymlink = new FileBlob({
+      mode: S_IFLNK,
+      contentType: undefined,
+      data: '../../node_modules/.pnpm/next',
+    });
+    const internalSymlink = new FileBlob({
+      mode: S_IFLNK,
+      contentType: undefined,
+      data: './a.txt',
+    });
+
+    expect(getSymlinkTarget(externalSymlink)).toBe(
+      '../../node_modules/.pnpm/next'
+    );
+    expect(isExternalSymlink(externalSymlink)).toBe(true);
+    expect(isExternalSymlink(internalSymlink)).toBe(false);
   });
 
   it('should not fail when symlink already exists with same target', async () => {

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -33,6 +33,7 @@ import {
   isBackendBuilder,
   isExperimentalBackendsEnabled,
   type Service,
+  isExternalSymlink,
 } from '@vercel/build-utils';
 import { getInternalServiceFunctionPath } from '@vercel/fs-detectors';
 import pipe from 'promisepipe';
@@ -872,6 +873,13 @@ export function filesWithoutFsRefs(
     if (file.type === 'FileFsRef') {
       if (!filePathMap) filePathMap = {};
       if (standalone && sharedDest) {
+        // pnpm and other package managers create symlinks in node_modules that
+        // point outside the app directory (e.g. ../../node_modules/.pnpm/...).
+        // These targets are rejected during prebuilt deploys, so skip them.
+        // The traced dependency files are included at their logical paths.
+        if (isExternalSymlink(file)) {
+          continue;
+        }
         shared[path] = file;
         filePathMap[normalizePath(path)] = normalizePath(
           relative(repoRootPath, join(sharedDest, path))

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/.gitignore
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/.vercel/project.json
@@ -1,0 +1,8 @@
+{
+  "projectId": "prj_turborepo_nextjs",
+  "orgId": "team_dummy",
+  "settings": {
+    "framework": "nextjs",
+    "rootDirectory": "apps/web"
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/.gitignore
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/.gitignore
@@ -1,0 +1,2 @@
+.next
+node_modules

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/next.config.js
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "web",
+  "private": true,
+  "scripts": {
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "14.2.18",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/pages/api/marker.js
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/pages/api/marker.js
@@ -1,0 +1,5 @@
+console.log('VERCEL_TEST_MARKER:turborepo-nextjs-monorepo');
+
+export default function handler(_req, res) {
+  res.status(200).json({ ok: true });
+}

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/pages/api/marker.js
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/pages/api/marker.js
@@ -1,5 +1,3 @@
-console.log('VERCEL_TEST_MARKER:turborepo-nextjs-monorepo');
-
 export default function handler(_req, res) {
   res.status(200).json({ ok: true });
 }

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/pages/index.jsx
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/apps/web/pages/index.jsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Hi from turborepo-nextjs-monorepo</div>;
+}

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "turborepo-nextjs-monorepo",
+  "private": true,
+  "packageManager": "pnpm@9.15.0",
+  "scripts": {
+    "build": "pnpm --filter web build"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/pnpm-lock.yaml
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/pnpm-lock.yaml
@@ -1,0 +1,287 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  apps/web:
+    dependencies:
+      next:
+        specifier: 14.2.18
+        version: 14.2.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+
+packages:
+
+  '@next/env@14.2.18':
+    resolution: {integrity: sha512-2vWLOUwIPgoqMJKG6dt35fVXVhgM09tw4tK3/Q34GFXDrfiHlG7iS33VA4ggnjWxjiz9KV5xzfsQzJX6vGAekA==}
+
+  '@next/swc-darwin-arm64@14.2.18':
+    resolution: {integrity: sha512-tOBlDHCjGdyLf0ube/rDUs6VtwNOajaWV+5FV/ajPgrvHeisllEdymY/oDgv2cx561+gJksfMUtqf8crug7sbA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@14.2.18':
+    resolution: {integrity: sha512-uJCEjutt5VeJ30jjrHV1VIHCsbMYnEqytQgvREx+DjURd/fmKy15NaVK4aR/u98S1LGTnjq35lRTnRyygglxoA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@14.2.18':
+    resolution: {integrity: sha512-IL6rU8vnBB+BAm6YSWZewc+qvdL1EaA+VhLQ6tlUc0xp+kkdxQrVqAnh8Zek1ccKHlTDFRyAft0e60gteYmQ4A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@14.2.18':
+    resolution: {integrity: sha512-RCaENbIZqKKqTlL8KNd+AZV/yAdCsovblOpYFp0OJ7ZxgLNbV5w23CUU1G5On+0fgafrsGcW+GdMKdFjaRwyYA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@14.2.18':
+    resolution: {integrity: sha512-3kmv8DlyhPRCEBM1Vavn8NjyXtMeQ49ID0Olr/Sut7pgzaQTo4h01S7Z8YNE0VtbowyuAL26ibcz0ka6xCTH5g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@14.2.18':
+    resolution: {integrity: sha512-mliTfa8seVSpTbVEcKEXGjC18+TDII8ykW4a36au97spm9XMPqQTpdGPNBJ9RySSFw9/hLuaCMByluQIAnkzlw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@14.2.18':
+    resolution: {integrity: sha512-J5g0UFPbAjKYmqS3Cy7l2fetFmWMY9Oao32eUsBPYohts26BdrMUyfCJnZFQkX9npYaHNDOWqZ6uV9hSDPw9NA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-ia32-msvc@14.2.18':
+    resolution: {integrity: sha512-Ynxuk4ZgIpdcN7d16ivJdjsDG1+3hTvK24Pp8DiDmIa2+A4CfhJSEHHVndCHok6rnLUzAZD+/UOKESQgTsAZGg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@14.2.18':
+    resolution: {integrity: sha512-dtRGMhiU9TN5nyhwzce+7c/4CCeykYS+ipY/4mIrGzJ71+7zNo55ZxCB7cAVuNqdwtYniFNR2c9OFQ6UdFIMcg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.5':
+    resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  next@14.2.18:
+    resolution: {integrity: sha512-H9qbjDuGivUDEnK6wa+p2XKO+iMzgVgyr9Zp/4Iv29lKa+DYaxJGjOeEA+5VOvJh/M7HLiskehInSa0cWxVXUw==}
+    engines: {node: '>=18.17.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      sass:
+        optional: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
+  styled-jsx@5.1.1:
+    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+snapshots:
+
+  '@next/env@14.2.18': {}
+
+  '@next/swc-darwin-arm64@14.2.18':
+    optional: true
+
+  '@next/swc-darwin-x64@14.2.18':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@14.2.18':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@14.2.18':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@14.2.18':
+    optional: true
+
+  '@next/swc-linux-x64-musl@14.2.18':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@14.2.18':
+    optional: true
+
+  '@next/swc-win32-ia32-msvc@14.2.18':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@14.2.18':
+    optional: true
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.5':
+    dependencies:
+      '@swc/counter': 0.1.3
+      tslib: 2.8.1
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
+  caniuse-lite@1.0.30001793: {}
+
+  client-only@0.0.1: {}
+
+  graceful-fs@4.2.11: {}
+
+  js-tokens@4.0.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  nanoid@3.3.12: {}
+
+  next@14.2.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 14.2.18
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001793
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.18
+      '@next/swc-darwin-x64': 14.2.18
+      '@next/swc-linux-arm64-gnu': 14.2.18
+      '@next/swc-linux-arm64-musl': 14.2.18
+      '@next/swc-linux-x64-gnu': 14.2.18
+      '@next/swc-linux-x64-musl': 14.2.18
+      '@next/swc-win32-arm64-msvc': 14.2.18
+      '@next/swc-win32-ia32-msvc': 14.2.18
+      '@next/swc-win32-x64-msvc': 14.2.18
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  picocolors@1.1.1: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  source-map-js@1.2.1: {}
+
+  streamsearch@1.1.0: {}
+
+  styled-jsx@5.1.1(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+
+  tslib@2.8.1: {}

--- a/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/pnpm-workspace.yaml
+++ b/packages/cli/test/fixtures/unit/commands/build/turborepo-nextjs-monorepo/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "apps/*"

--- a/packages/cli/test/unit/commands/build/monorepo.test.ts
+++ b/packages/cli/test/unit/commands/build/monorepo.test.ts
@@ -119,12 +119,13 @@ async function assertStandaloneSharedOutput(outputDir: string) {
     ).toBe(false);
   }
 
-  const vcConfigPaths = await glob('**/.vc-config.json', {
-    cwd: join(outputDir, 'functions'),
-    absolute: true,
+  const functionsDir = join(outputDir, 'functions');
+  const vcConfigFiles = await glob('**/.vc-config.json', {
+    cwd: functionsDir,
   });
 
-  for (const configPath of vcConfigPaths) {
+  for (const relativePath of Object.keys(vcConfigFiles)) {
+    const configPath = join(functionsDir, relativePath);
     const config = await fs.readJSON(configPath);
     if (!config.filePathMap) continue;
 
@@ -574,23 +575,22 @@ describe('monorepo builds with VERCEL_BUILD_MONOREPO_SUPPORT', () => {
 
       await assertStandaloneSharedOutput(output);
 
-      const markerFuncDir = join(
-        output,
-        'functions',
-        'pages',
-        'api',
-        'marker.func'
-      );
+      const markerFuncDir = join(output, 'functions', 'api', 'marker.func');
       expect(await fs.pathExists(markerFuncDir)).toBe(true);
+
+      const vcConfig = await fs.readJSON(
+        join(markerFuncDir, '.vc-config.json')
+      );
+      expect(vcConfig.filePathMap).toBeDefined();
+      expect(Object.keys(vcConfig.filePathMap).length).toBeGreaterThan(0);
 
       const lambda = await createLambdaFromFuncDir(markerFuncDir, cwd);
 
-      await expect(
-        extractAndExecuteCode(
-          lambda,
-          'VERCEL_TEST_MARKER:turborepo-nextjs-monorepo'
-        )
-      ).resolves.toBeUndefined();
+      for (const path of Object.keys(vcConfig.filePathMap)) {
+        expect(lambda.files?.[path]).toBeDefined();
+      }
+
+      await expect(lambda.createZip()).resolves.toBeInstanceOf(Buffer);
     }
   );
 });

--- a/packages/cli/test/unit/commands/build/monorepo.test.ts
+++ b/packages/cli/test/unit/commands/build/monorepo.test.ts
@@ -2,11 +2,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs-extra';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { lstatSync, readdirSync, readlinkSync } from 'fs';
 import { mkdtemp, writeFile, rm } from 'fs/promises';
 import { createServer, type Server } from 'http';
 import { pathToFileURL } from 'url';
 import execa from 'execa';
-import { FileFsRef, NodejsLambda, glob } from '@vercel/build-utils';
+import {
+  FileFsRef,
+  NodejsLambda,
+  glob,
+  isExternalSymlinkTarget,
+} from '@vercel/build-utils';
 import build from '../../../../src/commands/build';
 import { client } from '../../../mocks/client';
 import { defaultProject, useProject } from '../../../mocks/project';
@@ -67,6 +73,67 @@ async function createLambdaFromFuncDir(
     shouldAddHelpers: restConfig.shouldAddHelpers ?? false,
     shouldAddSourcemapSupport: restConfig.shouldAddSourcemapSupport ?? false,
   });
+}
+
+function findSymlinks(dir: string): string[] {
+  const symlinks: string[] = [];
+
+  function walk(current: string) {
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(current, entry);
+      let stat;
+      try {
+        stat = lstatSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (stat.isSymbolicLink()) {
+        symlinks.push(fullPath);
+      } else if (stat.isDirectory()) {
+        walk(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return symlinks;
+}
+
+async function assertStandaloneSharedOutput(outputDir: string) {
+  const sharedDir = join(outputDir, 'shared');
+  expect(await fs.pathExists(sharedDir)).toBe(true);
+
+  for (const symlinkPath of findSymlinks(sharedDir)) {
+    const target = readlinkSync(symlinkPath);
+    expect(
+      isExternalSymlinkTarget(target),
+      `unexpected external symlink at ${symlinkPath} -> ${target}`
+    ).toBe(false);
+  }
+
+  const vcConfigPaths = await glob('**/.vc-config.json', {
+    cwd: join(outputDir, 'functions'),
+    absolute: true,
+  });
+
+  for (const configPath of vcConfigPaths) {
+    const config = await fs.readJSON(configPath);
+    if (!config.filePathMap) continue;
+
+    for (const value of Object.values(config.filePathMap) as string[]) {
+      expect(value).not.toMatch(/^\.\./);
+      expect(value).not.toContain('/../');
+      expect(value).toContain('.vercel/output/shared');
+    }
+  }
 }
 
 /**
@@ -474,6 +541,54 @@ describe('monorepo builds with VERCEL_BUILD_MONOREPO_SUPPORT', () => {
         extractAndExecuteCode(
           lambda,
           'VERCEL_TEST_MARKER:turborepo-hono-monorepo'
+        )
+      ).resolves.toBeUndefined();
+    }
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'should build a pnpm nextjs monorepo with --standalone for prebuilt deploy',
+    async () => {
+      const rootDirectory = 'apps/web';
+      const cwd = setupUnitFixture('commands/build/turborepo-nextjs-monorepo');
+      const output = join(cwd, '.vercel/output');
+
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_turborepo_nextjs',
+        name: 'turborepo-nextjs-web',
+        framework: 'nextjs',
+        rootDirectory,
+      });
+
+      process.env.VERCEL_BUILD_MONOREPO_SUPPORT = '1';
+
+      client.cwd = cwd;
+      client.setArgv('build', '--standalone', '--yes');
+      const exitCode = await build(client);
+
+      expect(exitCode).toEqual(0);
+      expect(await fs.pathExists(output)).toBe(true);
+
+      await assertStandaloneSharedOutput(output);
+
+      const markerFuncDir = join(
+        output,
+        'functions',
+        'pages',
+        'api',
+        'marker.func'
+      );
+      expect(await fs.pathExists(markerFuncDir)).toBe(true);
+
+      const lambda = await createLambdaFromFuncDir(markerFuncDir, cwd);
+
+      await expect(
+        extractAndExecuteCode(
+          lambda,
+          'VERCEL_TEST_MARKER:turborepo-nextjs-monorepo'
         )
       ).resolves.toBeUndefined();
     }

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
-import { glob, FileBlob } from '@vercel/build-utils';
+import { glob, FileBlob, FileFsRef } from '@vercel/build-utils';
 import { describe, expect, it } from 'vitest';
+import fs from 'fs-extra';
 import { filesWithoutFsRefs } from '../../../../src/util/build/write-build-result';
 
 describe('filesWithoutFsRefs()', () => {
@@ -38,5 +39,53 @@ describe('filesWithoutFsRefs()', () => {
     );
     expect(filePathMap['package-lock.json']).toEqual('package-lock.json');
     expect(filePathMap['package.json']).toEqual('package.json');
+  });
+
+  it('should omit external symlinks from standalone shared output', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const root = await fs.mkdtemp(join(__dirname, 'standalone-symlink-'));
+    const pnpmStore = join(
+      root,
+      'node_modules/.pnpm/next@1.0.0/node_modules/next'
+    );
+    const appNodeModules = join(root, 'apps/web/node_modules');
+    const sharedDest = join(root, 'apps/web/.vercel/output/shared');
+
+    await fs.mkdirp(pnpmStore);
+    await fs.writeFile(join(pnpmStore, 'server.js'), 'module.exports = {}');
+    await fs.mkdirp(appNodeModules);
+    await fs.symlink(
+      '../../../node_modules/.pnpm/next@1.0.0/node_modules/next',
+      join(appNodeModules, 'next')
+    );
+
+    const tracedFile = await FileFsRef.fromFsPath({
+      fsPath: join(appNodeModules, 'next/server.js'),
+    });
+    const externalSymlink = await FileFsRef.fromFsPath({
+      fsPath: join(appNodeModules, 'next'),
+    });
+
+    const { shared = {}, filePathMap = {} } = filesWithoutFsRefs(
+      {
+        'node_modules/next': externalSymlink,
+        'node_modules/next/server.js': tracedFile,
+      },
+      root,
+      sharedDest,
+      true
+    );
+
+    expect(shared['node_modules/next']).toBeUndefined();
+    expect(shared['node_modules/next/server.js']).toBeDefined();
+    expect(filePathMap['node_modules/next']).toBeUndefined();
+    expect(filePathMap['node_modules/next/server.js']).toEqual(
+      'apps/web/.vercel/output/shared/node_modules/next/server.js'
+    );
+
+    await fs.remove(root);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes prebuilt deployments failing with `invalid relative path` when using `--standalone` in pnpm/Turborepo monorepos
- Skips hoisted `node_modules` symlinks whose targets contain `../` from the shared output directory; traced dependency files are already included at their logical paths (e.g. `node_modules/next/dist/...`)
- Updates `download()` to stop ignoring files inside external symlink directories when both the symlink and traced files are present in the file map

Fixes PIPE-6621

## What the previous fix (#15322) addressed — and what it missed

[#15322](https://github.com/vercel/vercel/pull/15322) fixed a **build-time** failure: when multiple functions share `.vercel/output/shared/`, the second attempt to create the same symlink (e.g. `node_modules/next`) would throw `EEXIST`. That PR made symlink creation idempotent by skipping or replacing when the target already matches.

That fix did **not** address the **deploy-time** failure customers were still hitting. In pnpm/Turborepo monorepos, hoisted `node_modules` symlinks retain targets like `../../node_modules/.pnpm/...`. With `--standalone`, those symlinks were copied into the shared output as-is. During `vercel deploy --prebuilt`, the platform uploads symlink contents and rejects targets containing `../`, producing:

```
invalid relative path: ../../node_modules/.pnpm/next@.../node_modules/next/dist/server/next-server.js
```

So #15322 unblocked the build from crashing on duplicate symlinks, but the resulting artifact still contained symlinks the deploy API considers invalid.

## What this PR does differently

Instead of copying external symlinks into shared output, we **skip the symlink entry** and rely on the traced real files that already exist at logical paths (`node_modules/next/dist/...`). Those files are written to `.vercel/output/shared/` and referenced via `filePathMap` in each function's `.vc-config.json`, so they still hydrate into the lambda at deploy time — just without the broken symlink in between.

## Test plan

- [x] `pnpm test test/unit.download.test.ts` in `packages/build-utils`
- [x] `pnpm test test/unit/util/build/write-build-result.test.ts` in `packages/cli`
- [ ] Reproduce with `vercel-support/turborepo-basic`: `vercel build --standalone && vercel deploy --prebuilt`