### PR TITLE
[CLI] adding version and auto update fixes

### DIFF
--- a/.changeset/silent-native-updates.md
+++ b/.changeset/silent-native-updates.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Disable automatic update prompts and automatic upgrades for native CLI installs.
+Handle CLI update flows safely for native binary installs.

--- a/packages/cli/pkg.js
+++ b/packages/cli/pkg.js
@@ -4,6 +4,8 @@ import { basename } from 'node:path';
 
 const [, , script] = process.argv;
 
+process.env.VERCEL_VC_NATIVE = '1';
+
 // In the standalone binary, process.execPath points back to this binary.
 // Route internal worker invocations here so script paths are not parsed as CLI args.
 if (script && basename(script) === 'get-latest-worker.cjs') {

--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -2,6 +2,9 @@ import { readFile, realpath } from 'fs-extra';
 import { sep, dirname, join, resolve } from 'path';
 import { scanParentDirs } from '@vercel/build-utils';
 import { packageName } from './pkg-name';
+import { isNativeBinaryInstall } from './native-install';
+
+const nativePackageName = '@vercel/vc-native';
 
 async function getConfigPrefix() {
   const paths = [
@@ -80,6 +83,10 @@ export async function isGlobal() {
 }
 
 export default async function getUpdateCommand(): Promise<string> {
+  if (isNativeBinaryInstall()) {
+    return `npm i -g ${nativePackageName}@latest --force`;
+  }
+
   const pkgAndVersion = `${packageName}@latest`;
 
   const entrypoint = await realpath(process.argv[1]);

--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -83,11 +83,8 @@ export async function isGlobal() {
 }
 
 export default async function getUpdateCommand(): Promise<string> {
-  if (isNativeBinaryInstall()) {
-    return `npm i -g ${nativePackageName}@latest --force`;
-  }
-
-  const pkgAndVersion = `${packageName}@latest`;
+  const nativeInstall = isNativeBinaryInstall();
+  const pkgAndVersion = `${nativeInstall ? nativePackageName : packageName}@latest`;
 
   const entrypoint = await realpath(process.argv[1]);
   let { cliType, lockfilePath } = await scanParentDirs(
@@ -108,5 +105,7 @@ export default async function getUpdateCommand(): Promise<string> {
     }
   }
 
-  return `${cliType} ${install} ${pkgAndVersion}`;
+  const force = nativeInstall && cliType === 'npm' ? ' --force' : '';
+
+  return `${cliType} ${install} ${pkgAndVersion}${force}`;
 }

--- a/packages/cli/src/util/native-install.ts
+++ b/packages/cli/src/util/native-install.ts
@@ -1,0 +1,3 @@
+export function isNativeBinaryInstall(): boolean {
+  return process.env.VERCEL_VC_NATIVE === '1';
+}

--- a/packages/cli/src/util/updates.ts
+++ b/packages/cli/src/util/updates.ts
@@ -3,6 +3,9 @@ import type { GlobalConfig } from '@vercel-internals/types';
 import type Client from './client';
 import { writeToConfigFile } from './config/files';
 import { isGlobal } from './get-update-command';
+import { isNativeBinaryInstall } from './native-install';
+
+export { isNativeBinaryInstall };
 
 export function isAutoUpdateEnabled(config: GlobalConfig): boolean {
   return config.updates?.auto === true;
@@ -22,10 +25,6 @@ export function setAutoUpdate(client: Client, enabled: boolean): void {
   };
 
   writeToConfigFile(client.config);
-}
-
-export function isNativeBinaryInstall(): boolean {
-  return process.env.VERCEL_VC_NATIVE === '1';
 }
 
 export async function canAutoUpdate(

--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -16,7 +16,8 @@ if (
   (process.argv[2] === '--version' || process.argv[2] === '-v')
 ) {
   const { version } = await import('./version.mjs');
-  console.error(`Vercel CLI ${version}`);
+  const binaryLabel = process.env.VERCEL_VC_NATIVE === '1' ? ' (native)' : '';
+  console.error(`Vercel CLI ${version}${binaryLabel}`);
   console.log(version);
   process.exit(0);
 }

--- a/packages/cli/test/unit/commands/upgrade/index.test.ts
+++ b/packages/cli/test/unit/commands/upgrade/index.test.ts
@@ -67,9 +67,8 @@ describe('upgrade', () => {
       const exitCode = await upgrade(client);
 
       expect(exitCode).toBe(0);
-      await expect(client.stderr).toOutput(
-        'Upgrade command: npm i -g @vercel/vc-native@latest --force'
-      );
+      await expect(client.stderr).toOutput('Upgrade command:');
+      await expect(client.stderr).toOutput('@vercel/vc-native@latest');
     });
   });
 
@@ -111,10 +110,8 @@ describe('upgrade', () => {
 
       expect(exitCode).toBe(0);
       const json = JSON.parse(client.stdout.getFullOutput());
-      expect(json).toHaveProperty(
-        'upgradeCommand',
-        'npm i -g @vercel/vc-native@latest --force'
-      );
+      expect(json.upgradeCommand).toContain('@vercel/vc-native@latest');
+      expect(json.upgradeCommand.split(' ')).not.toContain('vercel@latest');
     });
   });
 

--- a/packages/cli/test/unit/commands/upgrade/index.test.ts
+++ b/packages/cli/test/unit/commands/upgrade/index.test.ts
@@ -6,8 +6,15 @@ import * as configFilesUtil from '../../../../src/util/config/files';
 const writeConfigSpy = vi.spyOn(configFilesUtil, 'writeToConfigFile');
 
 describe('upgrade', () => {
+  const originalVercelVcNative = process.env.VERCEL_VC_NATIVE;
+
   afterEach(() => {
     writeConfigSpy.mockClear();
+    if (originalVercelVcNative === undefined) {
+      delete process.env.VERCEL_VC_NATIVE;
+    } else {
+      process.env.VERCEL_VC_NATIVE = originalVercelVcNative;
+    }
   });
 
   describe('--help', () => {
@@ -42,6 +49,7 @@ describe('upgrade', () => {
     });
 
     it('prints upgrade information without executing', async () => {
+      delete process.env.VERCEL_VC_NATIVE;
       client.setArgv('upgrade', '--dry-run');
       const exitCode = await upgrade(client);
       expect(exitCode).toBe(0);
@@ -50,6 +58,18 @@ describe('upgrade', () => {
       await expect(client.stderr).toOutput('Installation type:');
       await expect(client.stderr).toOutput('Upgrade command:');
       await expect(client.stderr).toOutput('Automatic updates: Disabled');
+    });
+
+    it('prints native upgrade command for vc-native installs', async () => {
+      process.env.VERCEL_VC_NATIVE = '1';
+      client.setArgv('upgrade', '--dry-run');
+
+      const exitCode = await upgrade(client);
+
+      expect(exitCode).toBe(0);
+      await expect(client.stderr).toOutput(
+        'Upgrade command: npm i -g @vercel/vc-native@latest --force'
+      );
     });
   });
 
@@ -68,6 +88,7 @@ describe('upgrade', () => {
     });
 
     it('outputs valid JSON', async () => {
+      delete process.env.VERCEL_VC_NATIVE;
       client.setArgv('upgrade', '--json');
       const exitCode = await upgrade(client);
       expect(exitCode).toBe(0);
@@ -80,6 +101,20 @@ describe('upgrade', () => {
       expect(json).toHaveProperty('upgradeCommand');
       expect(json).toHaveProperty('autoUpdatesEnabled', false);
       expect(['global', 'local']).toContain(json.installationType);
+    });
+
+    it('outputs native upgrade command for vc-native installs', async () => {
+      process.env.VERCEL_VC_NATIVE = '1';
+      client.setArgv('upgrade', '--json');
+
+      const exitCode = await upgrade(client);
+
+      expect(exitCode).toBe(0);
+      const json = JSON.parse(client.stdout.getFullOutput());
+      expect(json).toHaveProperty(
+        'upgradeCommand',
+        'npm i -g @vercel/vc-native@latest --force'
+      );
     });
   });
 

--- a/packages/cli/test/unit/commands/upgrade/index.test.ts
+++ b/packages/cli/test/unit/commands/upgrade/index.test.ts
@@ -67,8 +67,10 @@ describe('upgrade', () => {
       const exitCode = await upgrade(client);
 
       expect(exitCode).toBe(0);
-      await expect(client.stderr).toOutput('Upgrade command:');
-      await expect(client.stderr).toOutput('@vercel/vc-native@latest');
+      const output = client.stderr.getFullOutput();
+      expect(output).toContain('Upgrade command:');
+      expect(output).toContain('@vercel/vc-native@latest');
+      expect(output.split(' ')).not.toContain('vercel@latest');
     });
   });
 

--- a/packages/cli/test/unit/esm/version-banner.test.ts
+++ b/packages/cli/test/unit/esm/version-banner.test.ts
@@ -1,0 +1,33 @@
+import { execFile } from 'node:child_process';
+import { copyFile, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+describe('vc.js version banner', () => {
+  it('labels native binary installs on stderr while preserving stdout semver', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'vc-version-banner-'));
+    await copyFile('src/vc.js', join(dir, 'vc.js'));
+    await writeFile(
+      join(dir, 'version.mjs'),
+      'export const version = "1.2.3";\n'
+    );
+
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [join(dir, 'vc.js'), '--version'],
+      {
+        env: {
+          ...process.env,
+          VERCEL_VC_NATIVE: '1',
+        },
+      }
+    );
+
+    expect(stdout.trim()).toBe('1.2.3');
+    expect(stderr.trim()).toBe('Vercel CLI 1.2.3 (native)');
+  });
+});

--- a/packages/cli/test/unit/util/get-update-command.test.ts
+++ b/packages/cli/test/unit/util/get-update-command.test.ts
@@ -28,8 +28,9 @@ describe('getUpdateCommand', () => {
   it('should update the native package when running through vc-native', async () => {
     process.env.VERCEL_VC_NATIVE = '1';
 
-    await expect(getUpdateCommand()).resolves.toEqual(
-      'npm i -g @vercel/vc-native@latest --force'
-    );
+    const updateCommand = await getUpdateCommand();
+
+    expect(updateCommand).toContain('@vercel/vc-native@latest');
+    expect(updateCommand.split(' ')).not.toContain('vercel@latest');
   });
 });

--- a/packages/cli/test/unit/util/get-update-command.test.ts
+++ b/packages/cli/test/unit/util/get-update-command.test.ts
@@ -1,15 +1,35 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import getUpdateCommand, {
   isGlobal,
 } from '../../../src/util/get-update-command';
 
 describe('getUpdateCommand', () => {
+  const originalVercelVcNative = process.env.VERCEL_VC_NATIVE;
+
+  afterEach(() => {
+    if (originalVercelVcNative === undefined) {
+      delete process.env.VERCEL_VC_NATIVE;
+    } else {
+      process.env.VERCEL_VC_NATIVE = originalVercelVcNative;
+    }
+  });
+
   it('should detect update command', async () => {
+    delete process.env.VERCEL_VC_NATIVE;
+
     const updateCommand = await getUpdateCommand();
     if (await isGlobal()) {
       expect(updateCommand).toEqual(`pnpm i -g vercel@latest`);
     } else {
       expect(updateCommand).toEqual(`pnpm i vercel@latest`);
     }
+  });
+
+  it('should update the native package when running through vc-native', async () => {
+    process.env.VERCEL_VC_NATIVE = '1';
+
+    await expect(getUpdateCommand()).resolves.toEqual(
+      'npm i -g @vercel/vc-native@latest --force'
+    );
   });
 });

--- a/packages/cli/test/unit/util/upgrade.test.ts
+++ b/packages/cli/test/unit/util/upgrade.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import { spawn } from 'child_process';
 import output from '../../../src/output-manager';
 import { executeUpgrade } from '../../../src/util/upgrade';
+import getUpdateCommand from '../../../src/util/get-update-command';
 
 // Mock child_process
 vi.mock('child_process', () => ({
@@ -27,6 +28,7 @@ vi.mock('../../../src/util/get-update-command', () => ({
 
 const spawnMock = vi.mocked(spawn);
 const outputMock = vi.mocked(output);
+const getUpdateCommandMock = vi.mocked(getUpdateCommand);
 
 describe('executeUpgrade', () => {
   beforeEach(() => {
@@ -177,6 +179,29 @@ describe('executeUpgrade', () => {
     expect(spawnMock).toHaveBeenCalledWith(
       'npm',
       ['i', '-g', 'vercel@latest'],
+      {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        shell: false,
+      }
+    );
+  });
+
+  it('should spawn with native package arguments', async () => {
+    getUpdateCommandMock.mockResolvedValueOnce(
+      'npm i -g @vercel/vc-native@latest --force'
+    );
+    const mockProcess = createMockProcess();
+    spawnMock.mockReturnValue(mockProcess as any);
+
+    const exitCodePromise = executeUpgrade();
+    await tick();
+
+    mockProcess.emit('close', 0);
+    await exitCodePromise;
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'npm',
+      ['i', '-g', '@vercel/vc-native@latest', '--force'],
       {
         stdio: ['inherit', 'pipe', 'pipe'],
         shell: false,


### PR DESCRIPTION
• Fix native CLI update handling.

  - Mark packaged/native CLI runs with VERCEL_VC_NATIVE=1
  - Keep native installs out of automatic update prompts/upgrades
  - Make vercel upgrade use @vercel/vc-native@latest --force instead of vercel@latest
  - Show (native) in the human-facing --version banner while preserving raw semver stdout
  - Add focused tests for native update commands and version output