### PR TITLE
[node] support useWebApi in static config

### DIFF
--- a/.changeset/use-web-api-static-config.md
+++ b/.changeset/use-web-api-static-config.md
@@ -1,0 +1,6 @@
+---
+'@vercel/static-config': minor
+'@vercel/node': patch
+---
+
+Allow opting into the Web API handler interface (`Request` → `Response`) from the static `config` export of a Node.js Serverless Function by setting `useWebApi: true`.

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -699,7 +699,7 @@ export const build = async ({
       experimentalAllowBundling: enableBundling || undefined,
       architecture: staticConfig?.architecture,
       runtime: nodeVersion.runtime,
-      useWebApi: isMiddleware ? true : useWebApi,
+      useWebApi: isMiddleware ? true : (useWebApi ?? staticConfig?.useWebApi),
       shouldAddHelpers: isMiddleware ? false : shouldAddHelpers,
       shouldAddSourcemapSupport,
       awsLambdaHandler,

--- a/packages/node/test/unit/use-web-api.test.ts
+++ b/packages/node/test/unit/use-web-api.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { prepareFilesystem } from './test-utils';
+import { build } from '../../src';
+import type { NodejsLambda } from '@vercel/build-utils';
+
+describe('useWebApi static config', () => {
+  it('should enable useWebApi when set to true in static config', async () => {
+    const filesystem = await prepareFilesystem({
+      'api/web.js': `
+        export const config = {
+          useWebApi: true,
+        };
+        export default (request) => new Response('web api');
+      `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'api/web.js',
+      config: {},
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+    expect((buildResult.output as NodejsLambda).useWebApi).toBe(true);
+  });
+
+  it('should not enable useWebApi when set to false in static config', async () => {
+    const filesystem = await prepareFilesystem({
+      'api/web.js': `
+        export const config = {
+          useWebApi: false,
+        };
+        export default (req, res) => res.send('node');
+      `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'api/web.js',
+      config: {},
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+    expect((buildResult.output as NodejsLambda).useWebApi).toBe(false);
+  });
+
+  it('should leave useWebApi undefined when not set in static config', async () => {
+    const filesystem = await prepareFilesystem({
+      'api/node.js': `
+        export default (req, res) => res.send('node');
+      `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'api/node.js',
+      config: {},
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+    expect((buildResult.output as NodejsLambda).useWebApi).toBeUndefined();
+  });
+
+  it('should prefer explicit useWebApi build option over static config', async () => {
+    const filesystem = await prepareFilesystem({
+      'api/web.js': `
+        export const config = {
+          useWebApi: false,
+        };
+        export default (request) => new Response('web api');
+      `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'api/web.js',
+      shim: undefined,
+      useWebApi: true,
+      config: {},
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+    expect((buildResult.output as NodejsLambda).useWebApi).toBe(true);
+  });
+});

--- a/packages/static-config/src/index.ts
+++ b/packages/static-config/src/index.ts
@@ -39,6 +39,9 @@ export const BaseFunctionConfigSchema = {
     preferredRegion: {
       oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
     },
+    useWebApi: {
+      type: 'boolean',
+    },
   },
 } as const;
 


### PR DESCRIPTION
## Summary

- Allow opting into the Web API handler interface (`Request` → `Response`) from the static `config` export of a Node.js Serverless Function by setting `useWebApi: true`.
- Adds `useWebApi: boolean` to `BaseFunctionConfigSchema` in `@vercel/static-config`.
- `@vercel/node`'s `build()` now forwards `staticConfig?.useWebApi` to `NodejsLambda` (an explicit `useWebApi` build option still takes precedence). Middleware behavior is unchanged — it continues to force `useWebApi: true`.

## Motivation

Previously, the only way to flag a Node lambda as Web-API style was either an internal `build()` argument (used by `@vercel/remix` and `@vercel/next`) or by being middleware. There was no user-facing knob for a plain `api/foo.ts` function. With this change, users can write:

```ts
// api/hello.ts
export const config = { useWebApi: true };
export default (request: Request) => new Response('hello');
```

and the resulting Node lambda will be launched with `VERCEL_USE_WEB_API=1`.

## Tests

- New `packages/node/test/unit/use-web-api.test.ts` covering: `useWebApi: true`, `useWebApi: false`, omitted, and explicit-build-option-wins.
- `pnpm type-check`, `pnpm test` (static-config), node `vitest` (use-web-api + middleware) all pass.