### PR TITLE
[@vercel/aws] introduce package with createOpenSearch()

### DIFF
--- a/.changeset/vercel-aws-opensearch.md
+++ b/.changeset/vercel-aws-opensearch.md
@@ -1,0 +1,5 @@
+---
+'@vercel/aws': minor
+---
+
+Introduce `@vercel/aws` with `createOpenSearch()`, a one-line factory that wires up an `@opensearch-project/opensearch` client using the env vars Vercel injects for a Marketplace OpenSearch Serverless resource. Credentials are resolved via Vercel OIDC + `sts:AssumeRoleWithWebIdentity`, so no static keys are required.

--- a/packages/aws/README.md
+++ b/packages/aws/README.md
@@ -1,0 +1,36 @@
+# @vercel/aws
+
+Pre-configured AWS service clients for [Vercel Marketplace](https://vercel.com/marketplace) resources.
+
+Credentials are resolved automatically via [Vercel OIDC](https://vercel.com/docs/security/secure-backend-access/oidc) — no static access keys required.
+
+## Install
+
+```sh
+pnpm add @vercel/aws @opensearch-project/opensearch
+```
+
+## OpenSearch
+
+After installing the [Amazon OpenSearch Serverless](https://vercel.com/marketplace/amazon-opensearch-serverless) integration and connecting it to a project, Vercel injects the configuration as environment variables. `createOpenSearch()` reads them automatically:
+
+```ts
+import { createOpenSearch } from '@vercel/aws';
+
+const os = createOpenSearch();
+
+const results = await os.search({
+  index: 'docs',
+  body: { query: { match: { title: 'vercel' } } },
+});
+```
+
+You can override any field explicitly — useful for local development or for connecting to a second collection:
+
+```ts
+const os = createOpenSearch({
+  endpoint: process.env.MY_OTHER_OPENSEARCH_ENDPOINT,
+  region: 'us-east-2',
+  roleArn: process.env.MY_OTHER_ROLE_ARN,
+});
+```

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -1,0 +1,13 @@
+**@vercel/aws**
+
+---
+
+# @vercel/aws
+
+## Interfaces
+
+- [CreateOpenSearchOptions](interfaces/CreateOpenSearchOptions.md)
+
+## Functions
+
+- [createOpenSearch](functions/createOpenSearch.md)

--- a/packages/aws/docs/functions/createOpenSearch.md
+++ b/packages/aws/docs/functions/createOpenSearch.md
@@ -1,0 +1,35 @@
+[**@vercel/aws**](../README.md)
+
+---
+
+# Function: createOpenSearch()
+
+> **createOpenSearch**(`opts?`): `Client`
+
+Defined in: [packages/aws/src/opensearch.ts:49](https://github.com/vercel/vercel/blob/main/packages/aws/src/opensearch.ts#L49)
+
+Creates an OpenSearch `Client` pre-configured for a Vercel
+Marketplace OpenSearch Serverless resource.
+
+Credentials are obtained via Vercel OIDC + `sts:AssumeRoleWithWebIdentity`.
+The role, region, and endpoint default to env vars Vercel injects
+automatically when the project is connected to an OpenSearch resource.
+
+## Parameters
+
+### opts?
+
+[`CreateOpenSearchOptions`](../interfaces/CreateOpenSearchOptions.md) = `{}`
+
+## Returns
+
+`Client`
+
+## Example
+
+```ts
+import { createOpenSearch } from '@vercel/aws';
+
+const os = createOpenSearch();
+await os.search({ index: 'my-index', body: { query: { match_all: {} } } });
+```

--- a/packages/aws/docs/interfaces/CreateOpenSearchOptions.md
+++ b/packages/aws/docs/interfaces/CreateOpenSearchOptions.md
@@ -1,0 +1,449 @@
+[**@vercel/aws**](../README.md)
+
+---
+
+# Interface: CreateOpenSearchOptions
+
+Defined in: [packages/aws/src/opensearch.ts:14](https://github.com/vercel/vercel/blob/main/packages/aws/src/opensearch.ts#L14)
+
+Options for [createOpenSearch](../functions/createOpenSearch.md).
+
+All fields are optional — when omitted, values are read from the
+environment variables that Vercel injects for an OpenSearch
+Marketplace resource. Any field on the underlying `ClientOptions`
+from `@opensearch-project/opensearch` may also be passed and will
+be forwarded to the `Client`.
+
+## Extends
+
+- [`Partial`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype)\<`ClientOptions`\>
+
+## Properties
+
+### agent?
+
+> `optional` **agent?**: `false` \| `AgentOptions` \| `agentFn`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:84
+
+#### Inherited from
+
+`Partial.agent`
+
+---
+
+### auth?
+
+> `optional` **auth?**: `BasicAuth` \| `AwsSigv4Auth`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:91
+
+#### Inherited from
+
+`Partial.auth`
+
+---
+
+### cloud?
+
+> `optional` **cloud?**: `object`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:95
+
+#### id
+
+> **id**: `string`
+
+#### password?
+
+> `optional` **password?**: `string`
+
+#### username?
+
+> `optional` **username?**: `string`
+
+#### Inherited from
+
+`Partial.cloud`
+
+---
+
+### compression?
+
+> `optional` **compression?**: `"gzip"`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:82
+
+#### Inherited from
+
+`Partial.compression`
+
+---
+
+### Connection?
+
+> `optional` **Connection?**: _typeof_ `default`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:69
+
+#### Inherited from
+
+`Partial.Connection`
+
+---
+
+### ConnectionPool?
+
+> `optional` **ConnectionPool?**: _typeof_ `ConnectionPool`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:70
+
+#### Inherited from
+
+`Partial.ConnectionPool`
+
+---
+
+### context?
+
+> `optional` **context?**: `unknown`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:92
+
+#### Inherited from
+
+`Partial.context`
+
+---
+
+### disablePrototypePoisoningProtection?
+
+> `optional` **disablePrototypePoisoningProtection?**: `boolean` \| `"proto"` \| `"constructor"`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:100
+
+#### Inherited from
+
+`Partial.disablePrototypePoisoningProtection`
+
+---
+
+### enableLongNumeralSupport?
+
+> `optional` **enableLongNumeralSupport?**: `boolean`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:102
+
+#### Inherited from
+
+`Partial.enableLongNumeralSupport`
+
+---
+
+### enableMetaHeader?
+
+> `optional` **enableMetaHeader?**: `boolean`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:94
+
+#### Inherited from
+
+`Partial.enableMetaHeader`
+
+---
+
+### endpoint?
+
+> `optional` **endpoint?**: `string`
+
+Defined in: [packages/aws/src/opensearch.ts:19](https://github.com/vercel/vercel/blob/main/packages/aws/src/opensearch.ts#L19)
+
+The OpenSearch collection endpoint. Defaults to
+`process.env.OPENSEARCH_DASHBOARD_ENDPOINT`.
+
+---
+
+### generateRequestId?
+
+> `optional` **generateRequestId?**: `generateRequestIdFn`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:89
+
+#### Inherited from
+
+`Partial.generateRequestId`
+
+---
+
+### headers?
+
+> `optional` **headers?**: [`Record`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type)\<`string`, `any`\>
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:87
+
+#### Inherited from
+
+`Partial.headers`
+
+---
+
+### maxRetries?
+
+> `optional` **maxRetries?**: `number`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:73
+
+#### Inherited from
+
+`Partial.maxRetries`
+
+---
+
+### memoryCircuitBreaker?
+
+> `optional` **memoryCircuitBreaker?**: `MemoryCircuitBreakerOptions`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:101
+
+#### Inherited from
+
+`Partial.memoryCircuitBreaker`
+
+---
+
+### name?
+
+> `optional` **name?**: `string` \| `symbol`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:90
+
+#### Inherited from
+
+`Partial.name`
+
+---
+
+### node?
+
+> `optional` **node?**: `string` \| `string`[] \| `NodeOptions` \| `NodeOptions`[]
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:67
+
+#### Inherited from
+
+`Partial.node`
+
+---
+
+### nodeFilter?
+
+> `optional` **nodeFilter?**: `nodeFilterFn`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:85
+
+#### Inherited from
+
+`Partial.nodeFilter`
+
+---
+
+### nodes?
+
+> `optional` **nodes?**: `string` \| `string`[] \| `NodeOptions` \| `NodeOptions`[]
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:68
+
+#### Inherited from
+
+`Partial.nodes`
+
+---
+
+### nodeSelector?
+
+> `optional` **nodeSelector?**: `string` \| `nodeSelectorFn`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:86
+
+#### Inherited from
+
+`Partial.nodeSelector`
+
+---
+
+### opaqueIdPrefix?
+
+> `optional` **opaqueIdPrefix?**: `string`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:88
+
+#### Inherited from
+
+`Partial.opaqueIdPrefix`
+
+---
+
+### pingTimeout?
+
+> `optional` **pingTimeout?**: `number`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:75
+
+#### Inherited from
+
+`Partial.pingTimeout`
+
+---
+
+### proxy?
+
+> `optional` **proxy?**: `string` \| `URL`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:93
+
+#### Inherited from
+
+`Partial.proxy`
+
+---
+
+### region?
+
+> `optional` **region?**: `string`
+
+Defined in: [packages/aws/src/opensearch.ts:24](https://github.com/vercel/vercel/blob/main/packages/aws/src/opensearch.ts#L24)
+
+The AWS region the collection lives in. Defaults to
+`process.env.OPENSEARCH_REGION`.
+
+---
+
+### requestTimeout?
+
+> `optional` **requestTimeout?**: `number`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:74
+
+#### Inherited from
+
+`Partial.requestTimeout`
+
+---
+
+### resurrectStrategy?
+
+> `optional` **resurrectStrategy?**: `"ping"` \| `"optimistic"` \| `"none"`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:80
+
+#### Inherited from
+
+`Partial.resurrectStrategy`
+
+---
+
+### roleArn?
+
+> `optional` **roleArn?**: `string`
+
+Defined in: [packages/aws/src/opensearch.ts:30](https://github.com/vercel/vercel/blob/main/packages/aws/src/opensearch.ts#L30)
+
+The IAM role to assume when signing requests. Defaults to
+`process.env.AWS_ROLE_ARN`, which Vercel sets when the
+project is connected to an AWS Marketplace resource.
+
+---
+
+### Serializer?
+
+> `optional` **Serializer?**: _typeof_ `default`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:72
+
+#### Inherited from
+
+`Partial.Serializer`
+
+---
+
+### sniffEndpoint?
+
+> `optional` **sniffEndpoint?**: `string`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:78
+
+#### Inherited from
+
+`Partial.sniffEndpoint`
+
+---
+
+### sniffInterval?
+
+> `optional` **sniffInterval?**: `number` \| `boolean`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:76
+
+#### Inherited from
+
+`Partial.sniffInterval`
+
+---
+
+### sniffOnConnectionFault?
+
+> `optional` **sniffOnConnectionFault?**: `boolean`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:79
+
+#### Inherited from
+
+`Partial.sniffOnConnectionFault`
+
+---
+
+### sniffOnStart?
+
+> `optional` **sniffOnStart?**: `boolean`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:77
+
+#### Inherited from
+
+`Partial.sniffOnStart`
+
+---
+
+### ssl?
+
+> `optional` **ssl?**: `ConnectionOptions`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:83
+
+#### Inherited from
+
+`Partial.ssl`
+
+---
+
+### suggestCompression?
+
+> `optional` **suggestCompression?**: `boolean`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:81
+
+#### Inherited from
+
+`Partial.suggestCompression`
+
+---
+
+### Transport?
+
+> `optional` **Transport?**: _typeof_ `default`
+
+Defined in: node_modules/.pnpm/@opensearch-project+opensearch@3.3.0/node_modules/@opensearch-project/opensearch/lib/Client.d.ts:71
+
+#### Inherited from
+
+`Partial.Transport`

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@vercel/aws",
+  "description": "Pre-configured AWS service clients for Vercel Marketplace resources",
+  "homepage": "https://vercel.com",
+  "files": [
+    "**/*.js",
+    "**/*.d.ts",
+    "**/*.md"
+  ],
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./opensearch": {
+      "import": "./dist/opensearch.js",
+      "require": "./dist/opensearch.js"
+    }
+  },
+  "version": "0.1.0",
+  "repository": {
+    "directory": "packages/aws",
+    "type": "git",
+    "url": "git+https://github.com/vercel/vercel.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/vercel/issues"
+  },
+  "devDependencies": {
+    "@opensearch-project/opensearch": "3.3.0",
+    "tinyspawn": "1.3.1",
+    "typedoc": "0.24.6",
+    "typedoc-plugin-markdown": "4.1.2",
+    "typedoc-plugin-mdn-links": "3.2.3",
+    "typescript": "4.9.5",
+    "vitest": "2.0.1"
+  },
+  "peerDependencies": {
+    "@opensearch-project/opensearch": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@opensearch-project/opensearch": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">= 20"
+  },
+  "scripts": {
+    "pretest": "pnpm run build:code",
+    "test": "vitest",
+    "build": "pnpm run build:code && pnpm run build:docs",
+    "build:code": "node ../../utils/build.mjs",
+    "build:docs": "typedoc && prettier --write docs/**/*.md docs/*.md"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@vercel/oidc-aws-credentials-provider": "workspace:*"
+  }
+}

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -29,11 +29,11 @@
   },
   "devDependencies": {
     "@opensearch-project/opensearch": "3.3.0",
+    "prettier": "3.8.3",
     "tinyspawn": "1.3.1",
-    "typedoc": "0.24.6",
-    "typedoc-plugin-markdown": "4.1.2",
-    "typedoc-plugin-mdn-links": "3.2.3",
-    "typescript": "4.9.5",
+    "typedoc": "0.28.19",
+    "typedoc-plugin-markdown": "4.11.0",
+    "typedoc-plugin-mdn-links": "5.1.1",
     "vitest": "2.0.1"
   },
   "peerDependencies": {

--- a/packages/aws/src/index.ts
+++ b/packages/aws/src/index.ts
@@ -1,0 +1,2 @@
+export type { CreateOpenSearchOptions } from './opensearch';
+export { createOpenSearch } from './opensearch';

--- a/packages/aws/src/opensearch.test.ts
+++ b/packages/aws/src/opensearch.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@opensearch-project/opensearch', () => {
+  class Client {
+    public options: unknown;
+    constructor(options: unknown) {
+      this.options = options;
+    }
+  }
+  return { Client };
+});
+
+vi.mock('@opensearch-project/opensearch/aws', () => ({
+  AwsSigv4Signer: vi.fn((args: unknown) => ({ __signer: args })),
+}));
+
+vi.mock('@vercel/oidc-aws-credentials-provider', () => ({
+  awsCredentialsProvider: vi.fn(() => async () => ({
+    accessKeyId: 'AKIA_TEST',
+    secretAccessKey: 'SECRET_TEST',
+  })),
+}));
+
+import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws';
+import { awsCredentialsProvider } from '@vercel/oidc-aws-credentials-provider';
+import { createOpenSearch } from './opensearch';
+
+const ENV_KEYS = [
+  'OPENSEARCH_DASHBOARD_ENDPOINT',
+  'OPENSEARCH_REGION',
+  'AWS_ROLE_ARN',
+] as const;
+
+describe('createOpenSearch', () => {
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+  });
+
+  test('uses Vercel-injected env vars when no options are provided', async () => {
+    process.env.OPENSEARCH_DASHBOARD_ENDPOINT =
+      'https://example.aoss.amazonaws.com';
+    process.env.OPENSEARCH_REGION = 'us-east-2';
+    process.env.AWS_ROLE_ARN = 'arn:aws:iam::1234567890:role/vercel-opensearch';
+
+    const client = createOpenSearch();
+
+    expect(AwsSigv4Signer).toHaveBeenCalledTimes(1);
+    const signerArgs = (AwsSigv4Signer as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as {
+      region: string;
+      service: string;
+      getCredentials: () => Promise<unknown>;
+    };
+    expect(signerArgs.region).toBe('us-east-2');
+    expect(signerArgs.service).toBe('aoss');
+
+    // Calling getCredentials should defer to awsCredentialsProvider with the role.
+    await signerArgs.getCredentials();
+    expect(awsCredentialsProvider).toHaveBeenCalledWith({
+      roleArn: 'arn:aws:iam::1234567890:role/vercel-opensearch',
+    });
+
+    expect(
+      (client as unknown as { options: { node: string } }).options.node
+    ).toBe('https://example.aoss.amazonaws.com');
+  });
+
+  test('explicit options override env', () => {
+    process.env.OPENSEARCH_DASHBOARD_ENDPOINT = 'https://env-endpoint.example';
+    process.env.OPENSEARCH_REGION = 'us-east-2';
+    process.env.AWS_ROLE_ARN = 'arn:aws:iam::1:role/env';
+
+    createOpenSearch({
+      endpoint: 'https://override-endpoint.example',
+      region: 'eu-west-1',
+      roleArn: 'arn:aws:iam::2:role/override',
+    });
+
+    const signerArgs = (AwsSigv4Signer as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as { region: string };
+    expect(signerArgs.region).toBe('eu-west-1');
+    expect(awsCredentialsProvider).not.toHaveBeenCalled();
+  });
+
+  test('throws a helpful error when env vars are missing', () => {
+    expect(() => createOpenSearch()).toThrow(
+      /OPENSEARCH_DASHBOARD_ENDPOINT.*OPENSEARCH_REGION.*AWS_ROLE_ARN/
+    );
+  });
+
+  test('lists only the missing env vars in the error', () => {
+    process.env.OPENSEARCH_DASHBOARD_ENDPOINT = 'https://example';
+    process.env.OPENSEARCH_REGION = 'us-east-2';
+    // AWS_ROLE_ARN intentionally missing.
+
+    expect(() => createOpenSearch()).toThrow(/AWS_ROLE_ARN/);
+    expect(() => createOpenSearch()).not.toThrow(
+      /OPENSEARCH_DASHBOARD_ENDPOINT/
+    );
+  });
+});

--- a/packages/aws/src/opensearch.ts
+++ b/packages/aws/src/opensearch.ts
@@ -7,9 +7,9 @@ import { awsCredentialsProvider } from '@vercel/oidc-aws-credentials-provider';
  *
  * All fields are optional — when omitted, values are read from the
  * environment variables that Vercel injects for an OpenSearch
- * Marketplace resource. Any field on the underlying
- * {@link ClientOptions} may also be passed and will be forwarded
- * to the `@opensearch-project/opensearch` `Client`.
+ * Marketplace resource. Any field on the underlying `ClientOptions`
+ * from `@opensearch-project/opensearch` may also be passed and will
+ * be forwarded to the `Client`.
  */
 export interface CreateOpenSearchOptions extends Partial<ClientOptions> {
   /**

--- a/packages/aws/src/opensearch.ts
+++ b/packages/aws/src/opensearch.ts
@@ -1,0 +1,78 @@
+import { Client, type ClientOptions } from '@opensearch-project/opensearch';
+import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws';
+import { awsCredentialsProvider } from '@vercel/oidc-aws-credentials-provider';
+
+/**
+ * Options for {@link createOpenSearch}.
+ *
+ * All fields are optional — when omitted, values are read from the
+ * environment variables that Vercel injects for an OpenSearch
+ * Marketplace resource. Any field on the underlying
+ * {@link ClientOptions} may also be passed and will be forwarded
+ * to the `@opensearch-project/opensearch` `Client`.
+ */
+export interface CreateOpenSearchOptions extends Partial<ClientOptions> {
+  /**
+   * The OpenSearch collection endpoint. Defaults to
+   * `process.env.OPENSEARCH_DASHBOARD_ENDPOINT`.
+   */
+  endpoint?: string;
+  /**
+   * The AWS region the collection lives in. Defaults to
+   * `process.env.OPENSEARCH_REGION`.
+   */
+  region?: string;
+  /**
+   * The IAM role to assume when signing requests. Defaults to
+   * `process.env.AWS_ROLE_ARN`, which Vercel sets when the
+   * project is connected to an AWS Marketplace resource.
+   */
+  roleArn?: string;
+}
+
+/**
+ * Creates an OpenSearch `Client` pre-configured for a Vercel
+ * Marketplace OpenSearch Serverless resource.
+ *
+ * Credentials are obtained via Vercel OIDC + `sts:AssumeRoleWithWebIdentity`.
+ * The role, region, and endpoint default to env vars Vercel injects
+ * automatically when the project is connected to an OpenSearch resource.
+ *
+ * @example
+ * ```ts
+ * import { createOpenSearch } from '@vercel/aws';
+ *
+ * const os = createOpenSearch();
+ * await os.search({ index: 'my-index', body: { query: { match_all: {} } } });
+ * ```
+ */
+export function createOpenSearch(opts: CreateOpenSearchOptions = {}): Client {
+  const endpoint = opts.endpoint ?? process.env.OPENSEARCH_DASHBOARD_ENDPOINT;
+  const region = opts.region ?? process.env.OPENSEARCH_REGION;
+  const roleArn = opts.roleArn ?? process.env.AWS_ROLE_ARN;
+
+  const missing: string[] = [];
+  if (!endpoint) missing.push('OPENSEARCH_DASHBOARD_ENDPOINT');
+  if (!region) missing.push('OPENSEARCH_REGION');
+  if (!roleArn) missing.push('AWS_ROLE_ARN');
+  if (missing.length > 0) {
+    throw new Error(
+      `createOpenSearch: missing required environment variable${
+        missing.length === 1 ? '' : 's'
+      } ${missing.join(', ')}. Connect an OpenSearch resource from the Vercel Marketplace, or pass { endpoint, region, roleArn } explicitly.`
+    );
+  }
+
+  const { endpoint: _e, region: _r, roleArn: _ra, ...rest } = opts;
+
+  return new Client({
+    ...AwsSigv4Signer({
+      region: region as string,
+      service: 'aoss',
+      getCredentials: () =>
+        awsCredentialsProvider({ roleArn: roleArn as string })(),
+    }),
+    node: endpoint as string,
+    ...rest,
+  });
+}

--- a/packages/aws/tsconfig.json
+++ b/packages/aws/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"]
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/aws/turbo.json
+++ b/packages/aws/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["**/*.js", "**/*.d.ts", "**/*.md"]
+    }
+  }
+}

--- a/packages/aws/typedoc.json
+++ b/packages/aws/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-mdn-links"],
+  "out": "docs",
+  "githubPages": false,
+  "gitRevision": "main",
+  "hideBreadcrumbs": true,
+  "readme": "none"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,34 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  packages/aws:
+    dependencies:
+      '@vercel/oidc-aws-credentials-provider':
+        specifier: workspace:*
+        version: link:../oidc-aws-credentials-provider
+    devDependencies:
+      '@opensearch-project/opensearch':
+        specifier: 3.3.0
+        version: 3.3.0
+      tinyspawn:
+        specifier: 1.3.1
+        version: 1.3.1
+      typedoc:
+        specifier: 0.24.6
+        version: 0.24.6(typescript@4.9.5)
+      typedoc-plugin-markdown:
+        specifier: 4.1.2
+        version: 4.1.2(typedoc@0.24.6)
+      typedoc-plugin-mdn-links:
+        specifier: 3.2.3
+        version: 3.2.3(typedoc@0.24.6)
+      typescript:
+        specifier: 4.9.5
+        version: 4.9.5
+      vitest:
+        specifier: 2.0.1
+        version: 2.0.1(@types/node@20.11.0)
+
   packages/backends:
     dependencies:
       '@vercel/build-utils':
@@ -6548,6 +6576,20 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
+  /@opensearch-project/opensearch@3.3.0:
+    resolution: {integrity: sha512-EJSeyVEy4fMLsbIoCYisz2VFRRXBfkxKSEBVSFEzXMT71pAF26+XhQiv+nhzqAu5w18qS1bhAAIMUriT5bThNQ==}
+    engines: {node: '>=14', yarn: ^1.22.10}
+    dependencies:
+      aws4: 1.13.2
+      debug: 4.4.3(supports-color@8.1.1)
+      hpagent: 1.2.0
+      json11: 2.0.2
+      ms: 2.1.3
+      secure-json-parse: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@opentelemetry/api-logs@0.215.0:
     resolution: {integrity: sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==}
     engines: {node: '>=8.0.0'}
@@ -10672,6 +10714,10 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /ansi-sequence-parser@1.1.3:
+    resolution: {integrity: sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==}
+    dev: true
+
   /ansi-styles@2.2.1:
     resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
     engines: {node: '>=0.10.0'}
@@ -10991,6 +11037,10 @@ packages:
   /aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
+    dev: true
+
+  /aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
     dev: true
 
   /axe-core@4.10.3:
@@ -14360,6 +14410,11 @@ packages:
       lru-cache: 10.4.3
     dev: true
 
+  /hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
+    dev: true
+
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
@@ -15355,6 +15410,11 @@ packages:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     dev: true
 
+  /json11@2.0.2:
+    resolution: {integrity: sha512-HIrd50UPYmP6sqLuLbFVm75g16o0oZrVfxrsY0EEys22klz8mRoWlX9KAEDOSOR9Q34rcxsyC8oDveGrCz5uLQ==}
+    hasBin: true
+    dev: true
+
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -15737,12 +15797,6 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /magic-string@0.30.17:
-    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-    dev: true
-
   /magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
     dependencies:
@@ -15796,6 +15850,12 @@ packages:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+    dev: true
+
+  /marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
     dev: true
 
   /math-intrinsics@1.1.0:
@@ -18307,6 +18367,15 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  /shiki@0.14.7:
+    resolution: {integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==}
+    dependencies:
+      ansi-sequence-parser: 1.1.3
+      jsonc-parser: 3.3.1
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 8.0.0
+    dev: true
+
   /side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -19813,6 +19882,15 @@ packages:
       reflect.getprototypeof: 1.0.10
     dev: true
 
+  /typedoc-plugin-markdown@4.1.2(typedoc@0.24.6):
+    resolution: {integrity: sha512-jZt8jmQLbmg9jmFQyfJrjLf6ljRwJ5fKMeqmFr0oPXmeX5ZRYYtCe6y/058vDESE/R+TwEvNua6SuG43UBbszw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      typedoc: 0.26.x
+    dependencies:
+      typedoc: 0.24.6(typescript@4.9.5)
+    dev: true
+
   /typedoc-plugin-markdown@4.11.0(typedoc@0.28.19):
     resolution: {integrity: sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==}
     engines: {node: '>= 18'}
@@ -19822,12 +19900,34 @@ packages:
       typedoc: 0.28.19(typescript@5.9.3)
     dev: true
 
+  /typedoc-plugin-mdn-links@3.2.3(typedoc@0.24.6):
+    resolution: {integrity: sha512-hz22UgFuzdtgpBXet2dxKf9d2HVixL2VcE9Ke1+X1Nu8W8jSGIB2awIA6HFVsD0vk1OLe3ehU0ibyD5sN7wh4w==}
+    peerDependencies:
+      typedoc: '>= 0.23.14 || 0.24.x || 0.25.x || 0.26.x'
+    dependencies:
+      typedoc: 0.24.6(typescript@4.9.5)
+    dev: true
+
   /typedoc-plugin-mdn-links@5.1.1(typedoc@0.28.19):
     resolution: {integrity: sha512-fLlYudnlGkE9uspOEm/SBXwr+G0RbxoDZiHAVsCg+5NwKe2aUxjZK1YyQfleNZydImanzkX2oUJF29xbEeOSWw==}
     peerDependencies:
       typedoc: 0.27.x || 0.28.x
     dependencies:
       typedoc: 0.28.19(typescript@5.9.3)
+    dev: true
+
+  /typedoc@0.24.6(typescript@4.9.5):
+    resolution: {integrity: sha512-c3y3h45xJv3qYwKDAwU6Cl+26CjT0ZvblHzfHJ+SjQDM4p1mZxtgHky4lhmG0+nNarRht8kADfZlbspJWdZarQ==}
+    engines: {node: '>= 14.14'}
+    hasBin: true
+    peerDependencies:
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
+    dependencies:
+      lunr: 2.3.9
+      marked: 4.3.0
+      minimatch: 9.0.5
+      shiki: 0.14.7
+      typescript: 4.9.5
     dev: true
 
   /typedoc@0.28.19(typescript@5.9.3):
@@ -20278,9 +20378,9 @@ packages:
       '@vitest/spy': 2.0.1
       '@vitest/utils': 2.0.1
       chai: 5.2.0
-      debug: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
       execa: 8.0.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 1.1.2
       picocolors: 1.1.1
       std-env: 3.9.0
@@ -20410,6 +20510,14 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /vscode-oniguruma@1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
+    dev: true
+
+  /vscode-textmate@8.0.0:
+    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
     dev: true
 
   /wcwidth@1.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,21 +211,21 @@ importers:
       '@opensearch-project/opensearch':
         specifier: 3.3.0
         version: 3.3.0
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
       tinyspawn:
         specifier: 1.3.1
         version: 1.3.1
       typedoc:
-        specifier: 0.24.6
-        version: 0.24.6(typescript@4.9.5)
+        specifier: 0.28.19
+        version: 0.28.19(typescript@5.9.3)
       typedoc-plugin-markdown:
-        specifier: 4.1.2
-        version: 4.1.2(typedoc@0.24.6)
+        specifier: 4.11.0
+        version: 4.11.0(typedoc@0.28.19)
       typedoc-plugin-mdn-links:
-        specifier: 3.2.3
-        version: 3.2.3(typedoc@0.24.6)
-      typescript:
-        specifier: 4.9.5
-        version: 4.9.5
+        specifier: 5.1.1
+        version: 5.1.1(typedoc@0.28.19)
       vitest:
         specifier: 2.0.1
         version: 2.0.1(@types/node@20.11.0)
@@ -10714,10 +10714,6 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /ansi-sequence-parser@1.1.3:
-    resolution: {integrity: sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==}
-    dev: true
-
   /ansi-styles@2.2.1:
     resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
     engines: {node: '>=0.10.0'}
@@ -15852,12 +15848,6 @@ packages:
       uc.micro: 2.1.0
     dev: true
 
-  /marked@4.3.0:
-    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
-    engines: {node: '>= 12'}
-    hasBin: true
-    dev: true
-
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -18367,15 +18357,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  /shiki@0.14.7:
-    resolution: {integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==}
-    dependencies:
-      ansi-sequence-parser: 1.1.3
-      jsonc-parser: 3.3.1
-      vscode-oniguruma: 1.7.0
-      vscode-textmate: 8.0.0
-    dev: true
-
   /side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -19882,15 +19863,6 @@ packages:
       reflect.getprototypeof: 1.0.10
     dev: true
 
-  /typedoc-plugin-markdown@4.1.2(typedoc@0.24.6):
-    resolution: {integrity: sha512-jZt8jmQLbmg9jmFQyfJrjLf6ljRwJ5fKMeqmFr0oPXmeX5ZRYYtCe6y/058vDESE/R+TwEvNua6SuG43UBbszw==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      typedoc: 0.26.x
-    dependencies:
-      typedoc: 0.24.6(typescript@4.9.5)
-    dev: true
-
   /typedoc-plugin-markdown@4.11.0(typedoc@0.28.19):
     resolution: {integrity: sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==}
     engines: {node: '>= 18'}
@@ -19900,34 +19872,12 @@ packages:
       typedoc: 0.28.19(typescript@5.9.3)
     dev: true
 
-  /typedoc-plugin-mdn-links@3.2.3(typedoc@0.24.6):
-    resolution: {integrity: sha512-hz22UgFuzdtgpBXet2dxKf9d2HVixL2VcE9Ke1+X1Nu8W8jSGIB2awIA6HFVsD0vk1OLe3ehU0ibyD5sN7wh4w==}
-    peerDependencies:
-      typedoc: '>= 0.23.14 || 0.24.x || 0.25.x || 0.26.x'
-    dependencies:
-      typedoc: 0.24.6(typescript@4.9.5)
-    dev: true
-
   /typedoc-plugin-mdn-links@5.1.1(typedoc@0.28.19):
     resolution: {integrity: sha512-fLlYudnlGkE9uspOEm/SBXwr+G0RbxoDZiHAVsCg+5NwKe2aUxjZK1YyQfleNZydImanzkX2oUJF29xbEeOSWw==}
     peerDependencies:
       typedoc: 0.27.x || 0.28.x
     dependencies:
       typedoc: 0.28.19(typescript@5.9.3)
-    dev: true
-
-  /typedoc@0.24.6(typescript@4.9.5):
-    resolution: {integrity: sha512-c3y3h45xJv3qYwKDAwU6Cl+26CjT0ZvblHzfHJ+SjQDM4p1mZxtgHky4lhmG0+nNarRht8kADfZlbspJWdZarQ==}
-    engines: {node: '>= 14.14'}
-    hasBin: true
-    peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
-    dependencies:
-      lunr: 2.3.9
-      marked: 4.3.0
-      minimatch: 9.0.5
-      shiki: 0.14.7
-      typescript: 4.9.5
     dev: true
 
   /typedoc@0.28.19(typescript@5.9.3):
@@ -20510,14 +20460,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vscode-oniguruma@1.7.0:
-    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
-    dev: true
-
-  /vscode-textmate@8.0.0:
-    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
     dev: true
 
   /wcwidth@1.0.1:


### PR DESCRIPTION
## Why

customers go from this:

```ts
import { Client } from '@opensearch-project/opensearch';
import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws';
import { awsCredentialsProvider } from '@vercel/functions/oidc';

const client = new Client({
  ...AwsSigv4Signer({
    region: process.env.OPENSEARCH_REGION!,
    service: 'aoss',
    getCredentials: () =>
      awsCredentialsProvider({ roleArn: process.env.AWS_ROLE_ARN! })(),
  }),
  node: process.env.OPENSEARCH_DASHBOARD_ENDPOINT,
});
```

to this:

```ts
import { createOpenSearch } from '@vercel/aws';
const os = createOpenSearch();
```

## Summary

- New package `@vercel/aws@0.1.0` at `packages/aws/`.
- One public export: `createOpenSearch(opts?)`. Defaults `endpoint`, `region`, `roleArn` to `OPENSEARCH_DASHBOARD_ENDPOINT` / `OPENSEARCH_REGION` / `AWS_ROLE_ARN` (the env vars Vercel injects when a Marketplace OpenSearch resource is connected). Explicit options override env. Helpful error names the specific missing var(s).
- Credentials flow through `@vercel/oidc-aws-credentials-provider` (existing workspace package) → STS `AssumeRoleWithWebIdentity`.
- `@opensearch-project/opensearch` is a peer dependency (optional) so consumers pin their own version.
- Scope intentionally narrow for now

## Validation

- `pnpm --filter @vercel/aws build:code` clean (tsc + esbuild).
- `pnpm --filter @vercel/aws exec vitest run` — 4/4 pass: env defaults applied, explicit overrides, full-missing error message, partial-missing names only the missing var.
- `pnpm biome check packages/aws/src packages/aws/package.json` clean.