### PR TITLE
[aws] add package boilerplate with createOpenSearch stub

### DIFF
--- a/.changeset/aws-package-boilerplate.md
+++ b/.changeset/aws-package-boilerplate.md
@@ -1,0 +1,5 @@
+---
+'@vercel/aws': patch
+---
+
+Add initial package boilerplate with createOpenSearch stub

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@vercel/aws",
+  "description": "",
+  "homepage": "https://vercel.com",
+  "files": [
+    "**/*.js",
+    "**/*.d.ts",
+    "**/*.md"
+  ],
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "version": "0.0.0",
+  "repository": {
+    "directory": "packages/aws",
+    "type": "git",
+    "url": "git+https://github.com/vercel/vercel.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/vercel/issues"
+  },
+  "devDependencies": {
+    "vitest": "2.0.1"
+  },
+  "engines": {
+    "node": ">= 20"
+  },
+  "scripts": {
+    "test": "vitest",
+    "build": "node ../../utils/build.mjs"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/aws/src/index.ts
+++ b/packages/aws/src/index.ts
@@ -1,0 +1,1 @@
+export { createOpenSearch } from './opensearch';

--- a/packages/aws/src/opensearch.ts
+++ b/packages/aws/src/opensearch.ts
@@ -1,0 +1,3 @@
+export function createOpenSearch(): null {
+  return null;
+}

--- a/packages/aws/tsconfig.json
+++ b/packages/aws/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"]
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/aws/turbo.json
+++ b/packages/aws/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["**/*.js", "**/*.d.ts", "**/*.md"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,12 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  packages/aws:
+    devDependencies:
+      vitest:
+        specifier: 2.0.1
+        version: 2.0.1(@types/node@20.11.0)
+
   packages/backends:
     dependencies:
       '@vercel/build-utils':
@@ -15737,12 +15743,6 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /magic-string@0.30.17:
-    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-    dev: true
-
   /magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
     dependencies:
@@ -20278,9 +20278,9 @@ packages:
       '@vitest/spy': 2.0.1
       '@vitest/utils': 2.0.1
       chai: 5.2.0
-      debug: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
       execa: 8.0.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 1.1.2
       picocolors: 1.1.1
       std-env: 3.9.0


### PR DESCRIPTION
## Summary
- Adds a new `@vercel/aws` workspace package under `packages/aws/` with the minimal layout used by other Vercel SDK packages (`package.json`, `tsconfig.json`, `turbo.json`, `src/`)
- Includes a stub `createOpenSearch` function in `src/opensearch.ts` (returns `null`), re-exported from `src/index.ts`

## Test plan
- [ ] `pnpm install` at repo root picks up the new workspace package
- [ ] `pnpm --filter @vercel/aws build` succeeds
- [ ] `import { createOpenSearch } from '@vercel/aws'` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)