### PR TITLE
Fix React Router /__manifest returning HTML when index is prerendered

### DIFF
--- a/.changeset/react-router-manifest-prerender-fix.md
+++ b/.changeset/react-router-manifest-prerender-fix.md
@@ -1,0 +1,7 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Fix React Router `/__manifest` returning prerendered HTML when the root route is statically generated.
+
+When `prerender()` emitted static HTML for the index route, the SSR function was removed from the catch-all target, so runtime-only paths like `/__manifest` fell through to the prerendered `index.html`. The builder now keeps the index SSR function for the catch-all, adds an explicit `/` → `/index.html` prerender rewrite, and skips overwriting prerendered `.data` artifacts.

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -19,11 +19,14 @@ import {
 import {
   findPrerenderedHtmlFile,
   getPathFromRoute,
+  getPrerenderDocumentRewrite,
+  getReactRouterCatchAllDest,
   getReactRouterDataPaths,
   getRegExpFromPath,
   getPackageVersion,
   hasScript,
   logNftWarnings,
+  shouldRegisterSsrForPrerenderedRoute,
 } from './utils';
 import type { BuildV2, Files, NodeVersion } from '@vercel/build-utils';
 
@@ -542,19 +545,24 @@ export const build: BuildV2 = async ({
     // but we skip the per-route overrides that would shadow the prerender
     // artifacts. `<path>.data` files are emitted as-is by RR and already
     // present in `output` from the static glob, so they resolve naturally.
+    //
+    // The index route is special: even when prerendered, we still register
+    // its SSR function so the catch-all can handle internal runtime routes
+    // like `/__manifest` (which return JSON, not prerendered HTML). A
+    // pre-filesystem rewrite maps `/` to `/index.html` so document requests
+    // still serve the prerender artifact instead of invoking the function.
     if (isReactRouter) {
       const htmlFile = findPrerenderedHtmlFile(path, staticFileKeys);
       if (htmlFile) {
-        if (path !== 'index') {
-          // BOA's filesystem handle matches keys exactly, so requests for
-          // `/about` won't auto-resolve `about.html`. Add an explicit
-          // rewrite that runs before the filesystem handle.
-          prerenderRewrites.push({
-            src: `^/${path}/?$`,
-            dest: `/${htmlFile}`,
-          });
+        // BOA's filesystem handle matches keys exactly, so requests for
+        // `/about` won't auto-resolve `about.html`. Add an explicit rewrite
+        // that runs before the filesystem handle. The root route needs the
+        // same treatment: without it, the catch-all `/(.*) -> index` would
+        // serve the prerendered homepage for runtime-only paths.
+        prerenderRewrites.push(getPrerenderDocumentRewrite(path, htmlFile));
+        if (!shouldRegisterSsrForPrerenderedRoute(path)) {
+          continue;
         }
-        continue;
       }
     }
 
@@ -568,8 +576,11 @@ export const build: BuildV2 = async ({
       // Emit parallel entries so the filesystem handle resolves the
       // single-fetch URL(s) for this route to the same bundle. Note that
       // the root index route uses `/_root.data` rather than `/index.data`.
+      // Skip keys that already have prerendered static artifacts.
       for (const dataPath of getReactRouterDataPaths(path)) {
-        output[dataPath] = func;
+        if (!staticFileKeys.has(dataPath)) {
+          output[dataPath] = func;
+        }
       }
     }
 
@@ -603,9 +614,12 @@ export const build: BuildV2 = async ({
 
   // For the 404 case, invoke the Function (or serve the static file
   // for `ssr: false` mode) at the `/` path. Remix will serve its 404 route.
+  // React Router uses the `index` output key (not `/`) so runtime-only paths
+  // like `/__manifest` reach the SSR handler instead of a prerendered
+  // `index.html` when the root route was statically generated.
   routes.push({
     src: '/(.*)',
-    dest: '/',
+    dest: isReactRouter ? getReactRouterCatchAllDest() : '/',
   });
 
   // Routes to call after a file has been matched.

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -333,6 +333,35 @@ export function findPrerenderedHtmlFile(
 }
 
 /**
+ * Pre-filesystem rewrite that maps a prerendered document URL to its static
+ * HTML artifact (e.g. `/about` -> `/about.html`, `/` -> `/index.html`).
+ */
+export function getPrerenderDocumentRewrite(
+  path: string,
+  htmlFile: string
+): { src: string; dest: string } {
+  return {
+    src: path === 'index' ? '^/$' : `^/${path}/?$`,
+    dest: `/${htmlFile}`,
+  };
+}
+
+/**
+ * When a route was prerendered to static HTML, the SSR function override is
+ * normally skipped so the filesystem can serve the artifact. The index route
+ * is an exception: its SSR function must remain registered so runtime-only
+ * paths like `/__manifest` reach the handler via the catch-all route.
+ */
+export function shouldRegisterSsrForPrerenderedRoute(path: string): boolean {
+  return path === 'index';
+}
+
+/** Catch-all destination for React Router SSR apps. */
+export function getReactRouterCatchAllDest(): 'index' {
+  return 'index';
+}
+
+/**
  * Updates the `dest` process.env object to match the `source` one.
  * A function is returned to restore the `dest` env back to how
  * it was originally.

--- a/packages/remix/test/unit.find-prerendered-html-file.test.ts
+++ b/packages/remix/test/unit.find-prerendered-html-file.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect } from 'vitest';
 import {
   findPrerenderedHtmlFile,
   getPathFromRoute,
+  getPrerenderDocumentRewrite,
+  getReactRouterCatchAllDest,
   getReactRouterDataPaths,
   getRegExpFromPath,
+  shouldRegisterSsrForPrerenderedRoute,
 } from '../src/utils';
 import type { RouteManifest } from '../src/types';
 
@@ -37,6 +40,127 @@ describe('findPrerenderedHtmlFile()', () => {
     // `posts/:slug` never match (RR doesn't emit a `posts/:slug.html` file).
     const keys = new Set(['posts/foo.html', 'posts/foo.data']);
     expect(findPrerenderedHtmlFile('posts/:slug', keys)).toBeUndefined();
+  });
+});
+
+describe('getPrerenderDocumentRewrite()', () => {
+  it('rewrites the root path to `index.html`', () => {
+    expect(getPrerenderDocumentRewrite('index', 'index.html')).toEqual({
+      src: '^/$',
+      dest: '/index.html',
+    });
+  });
+
+  it('rewrites nested prerender paths to their HTML artifact', () => {
+    expect(getPrerenderDocumentRewrite('about', 'about.html')).toEqual({
+      src: '^/about/?$',
+      dest: '/about.html',
+    });
+  });
+});
+
+describe('shouldRegisterSsrForPrerenderedRoute()', () => {
+  it('keeps the SSR function only for the prerendered index route', () => {
+    expect(shouldRegisterSsrForPrerenderedRoute('index')).toBe(true);
+    expect(shouldRegisterSsrForPrerenderedRoute('about')).toBe(false);
+    expect(shouldRegisterSsrForPrerenderedRoute('__manifest')).toBe(false);
+  });
+});
+
+describe('getReactRouterCatchAllDest()', () => {
+  it('targets the index SSR function output key', () => {
+    expect(getReactRouterCatchAllDest()).toBe('index');
+  });
+});
+
+type RouteResolution = 'static-html' | 'ssr-function';
+
+function resolveReactRouterRequest(
+  requestPath: string,
+  options: {
+    prerenderRewrites: { src: string; dest: string }[];
+    catchAllDest: string;
+    hasIndexSsrFunction: boolean;
+    staticFiles: Set<string>;
+  }
+): RouteResolution {
+  for (const rewrite of options.prerenderRewrites) {
+    if (new RegExp(rewrite.src).test(requestPath)) {
+      const staticKey = rewrite.dest.replace(/^\//, '');
+      if (options.staticFiles.has(staticKey)) {
+        return 'static-html';
+      }
+    }
+  }
+
+  const staticKey = requestPath.replace(/^\//, '');
+  if (options.staticFiles.has(staticKey)) {
+    return 'static-html';
+  }
+
+  if (options.hasIndexSsrFunction && options.catchAllDest === 'index') {
+    return 'ssr-function';
+  }
+
+  if (options.staticFiles.has('index.html')) {
+    return 'static-html';
+  }
+
+  return 'ssr-function';
+}
+
+describe('react-router runtime route resolution with prerendered index', () => {
+  const prerenderRewrites = [
+    getPrerenderDocumentRewrite('index', 'index.html'),
+    getPrerenderDocumentRewrite('about', 'about.html'),
+  ];
+  const staticFiles = new Set([
+    'index.html',
+    '_root.data',
+    'about.html',
+    'about.data',
+  ]);
+
+  it('serves prerendered HTML for document requests', () => {
+    expect(
+      resolveReactRouterRequest('/', {
+        prerenderRewrites,
+        catchAllDest: getReactRouterCatchAllDest(),
+        hasIndexSsrFunction: true,
+        staticFiles,
+      })
+    ).toBe('static-html');
+    expect(
+      resolveReactRouterRequest('/about', {
+        prerenderRewrites,
+        catchAllDest: getReactRouterCatchAllDest(),
+        hasIndexSsrFunction: true,
+        staticFiles,
+      })
+    ).toBe('static-html');
+  });
+
+  it('routes `/__manifest` to the SSR function instead of prerendered HTML', () => {
+    expect(
+      resolveReactRouterRequest('/__manifest', {
+        prerenderRewrites,
+        catchAllDest: getReactRouterCatchAllDest(),
+        hasIndexSsrFunction: true,
+        staticFiles,
+      })
+    ).toBe('ssr-function');
+  });
+
+  it('regression: prerendered index without SSR catch-all served HTML for `/__manifest`', () => {
+    // Mirrors the broken CLI >=54.2.0 behavior from CICD-2715.
+    expect(
+      resolveReactRouterRequest('/__manifest', {
+        prerenderRewrites: [getPrerenderDocumentRewrite('about', 'about.html')],
+        catchAllDest: '/',
+        hasIndexSsrFunction: false,
+        staticFiles,
+      })
+    ).toBe('static-html');
   });
 });
 
@@ -103,19 +227,18 @@ describe('react-router prerender build output', () => {
 
       const htmlFile = findPrerenderedHtmlFile(path, staticFileKeys);
       if (htmlFile) {
-        assignments.push({ kind: 'static', path, htmlFile });
-        if (path !== 'index') {
-          prerenderRewrites.push({
-            src: `^/${path}/?$`,
-            dest: `/${htmlFile}`,
-          });
+        prerenderRewrites.push(getPrerenderDocumentRewrite(path, htmlFile));
+        if (!shouldRegisterSsrForPrerenderedRoute(path)) {
+          assignments.push({ kind: 'static', path, htmlFile });
+          continue;
         }
-        continue;
       }
 
       assignments.push({ kind: 'function', path });
       for (const dataPath of getReactRouterDataPaths(path)) {
-        dataAssignments.push({ dataPath, kind: 'function' });
+        if (!staticFileKeys.has(dataPath)) {
+          dataAssignments.push({ dataPath, kind: 'function' });
+        }
       }
       const reData = getRegExpFromPath(`${rePath}.data`);
       if (reData) {
@@ -127,7 +250,13 @@ describe('react-router prerender build output', () => {
       }
     }
 
-    return { assignments, dataAssignments, prerenderRewrites, dynamicRules };
+    return {
+      assignments,
+      dataAssignments,
+      prerenderRewrites,
+      dynamicRules,
+      catchAllDest: getReactRouterCatchAllDest(),
+    };
   }
 
   it('does not install an SSR function override for prerendered routes', () => {
@@ -140,11 +269,9 @@ describe('react-router prerender build output', () => {
     });
 
     const indexAssignment = assignments.find(a => a.path === 'index');
-    expect(indexAssignment).toEqual({
-      kind: 'static',
-      path: 'index',
-      htmlFile: 'index.html',
-    });
+    // The index route is prerendered but still registers its SSR function
+    // so runtime-only paths like `/__manifest` can reach the handler.
+    expect(indexAssignment).toEqual({ kind: 'function', path: 'index' });
   });
 
   it('still installs an SSR function override for non-prerendered routes', () => {
@@ -159,7 +286,7 @@ describe('react-router prerender build output', () => {
     });
   });
 
-  it('does not overwrite the prerendered `.data` file with the SSR function', () => {
+  it('does not overwrite prerendered `.data` files with the SSR function', () => {
     // For a prerendered route, the `.data` file was emitted by RR's prerender
     // step and is already in `staticFiles`. The build loop must NOT assign
     // the SSR function over the static `.data` key.
@@ -170,9 +297,12 @@ describe('react-router prerender build output', () => {
     expect(
       dataAssignments.find(d => d.dataPath === '_root.data')
     ).toBeUndefined();
-    expect(
-      dataAssignments.find(d => d.dataPath === 'index.data')
-    ).toBeUndefined();
+    // The root single-fetch URL is `/_root.data`; `index.data` is not
+    // prerendered and may still map to the SSR function.
+    expect(dataAssignments.find(d => d.dataPath === 'index.data')).toEqual({
+      dataPath: 'index.data',
+      kind: 'function',
+    });
   });
 
   it('emits a pre-filesystem rewrite from `/<path>` to the prerendered HTML file', () => {
@@ -184,12 +314,20 @@ describe('react-router prerender build output', () => {
       src: '^/about/?$',
       dest: '/about.html',
     });
-    // No rewrite needed for the root because BOA's filesystem handle
-    // already resolves `/` to `index.html` via the conventional index
-    // lookup; emitting a redundant rule would just be noise.
-    expect(
-      prerenderRewrites.find(r => r.dest === '/index.html')
-    ).toBeUndefined();
+    // The root route also needs an explicit rewrite so the catch-all SSR
+    // handler does not serve prerendered HTML for runtime-only paths.
+    expect(prerenderRewrites).toContainEqual({
+      src: '^/$',
+      dest: '/index.html',
+    });
+  });
+
+  it('routes the catch-all to the index SSR function for runtime-only paths', () => {
+    const { catchAllDest } = simulateBuildOutput();
+    // Internal React Router routes like `/__manifest` are not in the route
+    // manifest and rely on the catch-all reaching the SSR handler instead
+    // of a prerendered `index.html`.
+    expect(catchAllDest).toBe('index');
   });
 
   it('does not emit dynamic regex rules for prerendered routes', () => {


### PR DESCRIPTION
## Summary
- Fixes CICD-2715: when React Router apps use `prerender: true`, `/__manifest` returned prerendered `index.html` instead of JSON after CLI 54.2.0
- Regression introduced by #16363: skipping the index SSR function removed the catch-all handler, so runtime-only paths fell through to static HTML
- Keeps the index SSR function for catch-all routing, adds an explicit `/` → `/index.html` prerender rewrite, and routes the React Router catch-all to the `index` output key

## Test plan
- [x] `pnpm exec vitest run test/unit.find-prerendered-html-file.test.ts test/unit.get-react-router-data-paths.test.ts` (29 tests)
- [x] Added unit tests for prerender rewrite helpers, `/__manifest` route resolution, and regression case mirroring CLI >=54.2.0 behavior
- [ ] Deploy customer's `my-react-router-app` demo project and verify `curl -I /__manifest` returns `content-type: application/json`
- [ ] Verify `/` and prerendered routes still serve static HTML


Made with [Cursor](https://cursor.com)