### PR TITLE
Support experimentalServices from generated build output config

### DIFF
--- a/.changeset/build-output-services.md
+++ b/.changeset/build-output-services.md
@@ -1,0 +1,6 @@
+---
+'@vercel/fs-detectors': patch
+'vercel': patch
+---
+
+Support discovering `experimentalServices` from Build Output API config during `vercel build`.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -29,6 +29,7 @@ import {
   type BuildResultVX,
   type Config,
   type Cron,
+  type ExperimentalServices,
   type Files,
   type FlagDefinitions,
   type Meta,
@@ -54,6 +55,7 @@ import {
   detectFrameworkRecord,
   detectFrameworkVersion,
   detectInstrumentation,
+  generateServicesRoutes,
   LocalFileSystemDetector,
 } from '@vercel/fs-detectors';
 import {
@@ -158,8 +160,18 @@ interface BuildOutputConfig {
     version: string;
   };
   crons?: Cron[];
+  experimentalServices?: ExperimentalServices;
   services?: Service[];
   deploymentId?: string;
+}
+
+function hasNonEmptyObject(value: unknown): value is Record<string, unknown> {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).length > 0
+  );
 }
 
 /**
@@ -729,6 +741,10 @@ async function doBuild(
   let zeroConfigRoutes: Route[] = [];
   let zeroConfigFallbackRoutes: Route[] = [];
   let detectedServices: Service[] | undefined;
+  const hasExperimentalServicesConfiguredInVercelConfig = hasNonEmptyObject(
+    localConfig.experimentalServices
+  );
+  let detectedExperimentalServicesConfig: ExperimentalServices | undefined;
   let isZeroConfig = false;
 
   if (builds.length > 0) {
@@ -817,7 +833,7 @@ async function doBuild(
 
   const builderSpecs = new Set(builds.map(b => b.use));
 
-  const buildersWithPkgs = await span
+  let buildersWithPkgs = await span
     .child('vc.importBuilders')
     .trace(() => importBuilders(builderSpecs, cwd, span));
 
@@ -837,27 +853,43 @@ async function doBuild(
   const ops: Promise<Error | void>[] = [];
 
   // Write the `detectedBuilders` result to output dir
-  const buildsJsonBuilds = new Map<Builder, SerializedBuilder>(
-    builds.map(build => {
+  const buildsJsonBuilds = new Map<Builder, SerializedBuilder>();
+  const ensureBuildersImported = async (buildsToImport: Builder[]) => {
+    const missingBuilderSpecs = new Set(
+      buildsToImport
+        .map(build => build.use)
+        .filter(builderSpec => !buildersWithPkgs.has(builderSpec))
+    );
+    if (missingBuilderSpecs.size === 0) return;
+
+    const importedBuilders = await span
+      .child('vc.importBuilders')
+      .trace(() => importBuilders(missingBuilderSpecs, cwd, span));
+    buildersWithPkgs = new Map([
+      ...buildersWithPkgs.entries(),
+      ...importedBuilders.entries(),
+    ]);
+  };
+  const addBuildsToBuildJson = async (buildsToAdd: Builder[]) => {
+    await ensureBuildersImported(buildsToAdd);
+    for (const build of buildsToAdd) {
+      if (buildsJsonBuilds.has(build)) continue;
       const builderWithPkg = buildersWithPkgs.get(build.use);
       if (!builderWithPkg) {
         throw new Error(`Failed to load Builder "${build.use}"`);
       }
       const { builder, pkg: builderPkg } = builderWithPkg;
-      return [
-        build,
-        {
-          require: builderPkg.name,
-          requirePath: builderWithPkg.path,
-          apiVersion: builder.version,
-          ...build,
-        },
-      ];
-    })
-  );
+      buildsJsonBuilds.set(build, {
+        require: builderPkg.name,
+        requirePath: builderWithPkg.path,
+        apiVersion: builder.version,
+        ...build,
+      });
+    }
 
-  buildsJson.builds = Array.from(buildsJsonBuilds.values());
-  await writeBuildJson(buildsJson, outputDir);
+    buildsJson.builds = Array.from(buildsJsonBuilds.values());
+    await writeBuildJson(buildsJson, outputDir);
+  };
 
   // The `meta` config property is re-used for each Builder
   // invocation so that Builders can share state between
@@ -869,7 +901,7 @@ async function doBuild(
 
   // Execute Builders for detected entrypoints
   // TODO: parallelize builds (except for frontend)
-  const sortedBuilders = sortBuilders(builds);
+  const executedBuilds: Builder[] = [];
   const buildResults: Map<Builder, BuildResult | BuildOutputConfig> = new Map();
   const overrides: PathOverride[] = [];
   const repoRootPath = cwd;
@@ -886,13 +918,13 @@ async function doBuild(
     builderUse: string;
   }> = [];
 
-  const hasDetectedServices =
+  const getHasDetectedServices = () =>
     detectedServices !== undefined && detectedServices.length > 0;
-  const hasQueueServices =
-    hasDetectedServices && detectedServices!.some(isQueueBackedService);
+  const getHasQueueServices = () =>
+    getHasDetectedServices() && detectedServices!.some(isQueueBackedService);
   const synthesizedServiceCrons: Cron[] = [];
   const serviceByBuilder = new Map<Builder, Service>();
-  if (hasDetectedServices) {
+  if (getHasDetectedServices()) {
     for (const service of detectedServices!) {
       serviceByBuilder.set(service.builder, service);
     }
@@ -903,537 +935,702 @@ async function doBuild(
     callback?: () => Promise<void>;
   }[] = [];
 
-  for (const build of sortedBuilders) {
-    if (typeof build.src !== 'string') continue;
+  const runBuilders = async (buildsToRun: Builder[]) => {
+    await addBuildsToBuildJson(buildsToRun);
 
-    const builderWithPkg = buildersWithPkgs.get(build.use);
-    if (!builderWithPkg) {
-      throw new Error(`Failed to load Builder "${build.use}"`);
-    }
+    for (const build of sortBuilders(buildsToRun)) {
+      if (typeof build.src !== 'string') continue;
 
-    try {
-      const { builder, pkg: builderPkg } = builderWithPkg;
+      const builderWithPkg = buildersWithPkgs.get(build.use);
+      if (!builderWithPkg) {
+        throw new Error(`Failed to load Builder "${build.use}"`);
+      }
 
-      // When a service lives in a subdirectory, e.g. /frontend
-      // (workspace !== '.'), we need to:
-      // 1. Set workPath to the service's workspace directory
-      // 2. Strip the workspace prefix from the entrypoint
-      // 3. Scope the files map to only include files within the workspace
-      // This ensures builders like Next.js receive the correct workPath and
-      // entrypoint, so their routes are emitted relative to the workspace root
-      // (not polluted with the workspace directory prefix).
-      const service = hasDetectedServices
-        ? serviceByBuilder.get(build)
-        : undefined;
-      const stripServiceRoutePrefix =
-        !!service?.routePrefix && service.routePrefix !== '/';
+      try {
+        const { builder, pkg: builderPkg } = builderWithPkg;
 
-      let buildWorkPath = workPath;
-      let buildEntrypoint = build.src;
-      let buildFiles: Files = filesMap;
+        // When a service lives in a subdirectory, e.g. /frontend
+        // (workspace !== '.'), we need to:
+        // 1. Set workPath to the service's workspace directory
+        // 2. Strip the workspace prefix from the entrypoint
+        // 3. Scope the files map to only include files within the workspace
+        // This ensures builders like Next.js receive the correct workPath and
+        // entrypoint, so their routes are emitted relative to the workspace root
+        // (not polluted with the workspace directory prefix).
+        const service = getHasDetectedServices()
+          ? serviceByBuilder.get(build)
+          : undefined;
+        const stripServiceRoutePrefix =
+          !!service?.routePrefix && service.routePrefix !== '/';
 
-      if (service && service.workspace !== '.') {
-        const wsPrefix = service.workspace + '/';
-        buildWorkPath = join(workPath, service.workspace);
+        let buildWorkPath = workPath;
+        let buildEntrypoint = build.src;
+        let buildFiles: Files = filesMap;
 
-        // Strip workspace prefix from entrypoint:
-        // e.g., "frontend/package.json" → "package.json"
-        buildEntrypoint = build.src.startsWith(wsPrefix)
-          ? build.src.slice(wsPrefix.length)
-          : build.src;
+        if (service && service.workspace !== '.') {
+          const wsPrefix = service.workspace + '/';
+          buildWorkPath = join(workPath, service.workspace);
 
-        // Scope files to the service workspace — re-key paths relative to
-        // the workspace root so builders see "package.json" not "frontend/package.json"
-        buildFiles = {};
-        for (const [filePath, file] of Object.entries(filesMap)) {
-          if (filePath.startsWith(wsPrefix)) {
-            buildFiles[filePath.slice(wsPrefix.length)] = file;
+          // Strip workspace prefix from entrypoint:
+          // e.g., "frontend/package.json" → "package.json"
+          buildEntrypoint = build.src.startsWith(wsPrefix)
+            ? build.src.slice(wsPrefix.length)
+            : build.src;
+
+          // Scope files to the service workspace — re-key paths relative to
+          // the workspace root so builders see "package.json" not "frontend/package.json"
+          buildFiles = {};
+          for (const [filePath, file] of Object.entries(filesMap)) {
+            if (filePath.startsWith(wsPrefix)) {
+              buildFiles[filePath.slice(wsPrefix.length)] = file;
+            }
+          }
+
+          output.debug(
+            `Service "${service.name}": workspace-rooted build at "${buildWorkPath}", ` +
+              `entrypoint "${buildEntrypoint}" (original: "${build.src}")`
+          );
+        }
+
+        // Set VERCEL_PROJECT_SETTINGS_* env vars.
+        // For services: use service-specific values instead of project-level settings
+        // (the project-level framework is "services", which is meaningless to individual builders).
+        const settingsForEnv = service
+          ? {
+              buildCommand: service.buildCommand ?? undefined,
+              installCommand: service.installCommand ?? undefined,
+              outputDirectory: projectSettings.outputDirectory ?? undefined,
+              nodeVersion: projectSettings.nodeVersion ?? undefined,
+            }
+          : projectSettings;
+
+        for (const key of [
+          'buildCommand',
+          'installCommand',
+          'outputDirectory',
+          'nodeVersion',
+        ] as const) {
+          const value = settingsForEnv[key];
+          const envKey =
+            `VERCEL_PROJECT_SETTINGS_` +
+            key.replace(/[A-Z]/g, letter => `_${letter}`).toUpperCase();
+          if (typeof value === 'string') {
+            process.env[envKey] = value;
+            output.debug(`Setting env ${envKey} to "${value}"`);
+          } else {
+            delete process.env[envKey];
           }
         }
 
+        const isFrontendBuilder = build.config && 'framework' in build.config;
+        // For services builds, the builder framework is set by the service resolver,
+        // the project-level framework is 'services'.
+        const builderFramework =
+          build.config?.framework ?? projectSettings.framework;
+
+        let buildConfig: Config;
+
+        if (isZeroConfig) {
+          if (service) {
+            // Services build: use service-specific config from resolution.
+            // build.config already contains framework, routePrefix, memory, etc.
+            buildConfig = {
+              ...build.config,
+              ...(getHasQueueServices()
+                ? { hasWorkerServices: true }
+                : undefined),
+              // Override project-level settings with service-specific ones.
+              // The project-level framework is "services" which must NOT be
+              // propagated to individual builders.
+              projectSettings: {
+                ...projectSettings,
+                framework: service.framework ?? null,
+                buildCommand: service.buildCommand ?? null,
+                installCommand: service.installCommand ?? null,
+              },
+              installCommand: service.installCommand ?? undefined,
+              buildCommand: service.buildCommand ?? undefined,
+              preDeployCommand: service.preDeployCommand ?? undefined,
+              framework: builderFramework,
+              nodeVersion: projectSettings.nodeVersion,
+              bunVersion: localConfig.bunVersion ?? undefined,
+            };
+          } else {
+            buildConfig = {
+              outputDirectory: projectSettings.outputDirectory ?? undefined,
+              ...build.config,
+              projectSettings,
+              installCommand: projectSettings.installCommand ?? undefined,
+              devCommand: projectSettings.devCommand ?? undefined,
+              buildCommand: projectSettings.buildCommand ?? undefined,
+              framework: projectSettings.framework,
+              nodeVersion: projectSettings.nodeVersion,
+              bunVersion: localConfig.bunVersion ?? undefined,
+            };
+          }
+        } else {
+          buildConfig = {
+            ...(build.config || {}),
+            bunVersion: localConfig.bunVersion ?? undefined,
+          };
+        }
+
+        const builderSpan = span.child('vc.builder', {
+          'builder.name': builderPkg.name,
+          'builder.version': builderPkg.version,
+          'builder.dynamicallyInstalled': String(
+            builderWithPkg.dynamicallyInstalled
+          ),
+        });
+
+        const serviceRoutePrefix = build.config?.routePrefix;
+        const serviceWorkspace = build.config?.workspace;
+        const preDeployCmd = service?.preDeployCommand?.trim();
+
+        const preDeployEntry =
+          preDeployCmd && service
+            ? ({ service: service.name } as (typeof preDeployEntries)[number])
+            : undefined;
+        if (preDeployEntry) {
+          preDeployEntries.push(preDeployEntry);
+        }
+
+        const buildOptions: BuildOptions = {
+          files: buildFiles,
+          entrypoint: buildEntrypoint,
+          workPath: buildWorkPath,
+          repoRootPath,
+          config: buildConfig,
+          meta,
+          span: builderSpan,
+          ...(preDeployCmd
+            ? {
+                registerPreDeploy: (callback: () => Promise<void>) => {
+                  preDeployEntry!.callback = callback;
+                },
+              }
+            : undefined),
+          ...(service
+            ? {
+                service: {
+                  name: service.name,
+                  type: service.type,
+                  trigger: service.trigger,
+                  routePrefix:
+                    typeof serviceRoutePrefix === 'string'
+                      ? serviceRoutePrefix
+                      : undefined,
+                  workspace:
+                    typeof serviceWorkspace === 'string'
+                      ? serviceWorkspace
+                      : undefined,
+                  schedule: service.schedule,
+                },
+              }
+            : undefined),
+        };
         output.debug(
-          `Service "${service.name}": workspace-rooted build at "${buildWorkPath}", ` +
-            `entrypoint "${buildEntrypoint}" (original: "${build.src}")`
+          `Building entrypoint "${build.src}" with "${builderPkg.name}"`
+        );
+
+        // Inject per-service URL environment variables so they're available during builds.
+        // for frontend frameworks like Vite (VITE_) or Next.js (NEXT_PUBLIC_) where
+        // these env vars are baked into the client bundle so they can be accessed in the client code.
+        // User-defined env takes precedence and won't be overwritten. The env will be cleared
+        // after the build is complete
+        const restoreEnv = new Map<string, string | undefined>();
+        if (detectedServices && service?.env) {
+          const perServiceEnv = getServiceUrlEnvVars({
+            requestedEnv: service.env,
+            consumerService: service,
+            services: detectedServices,
+            frameworkList,
+            currentEnv: process.env,
+            deploymentUrl: process.env.VERCEL_URL,
+          });
+          for (const [key, value] of Object.entries(perServiceEnv)) {
+            if (key in process.env) continue;
+            restoreEnv.set(key, process.env[key]);
+            process.env[key] = value;
+            output.debug(`Injected service URL env var: ${key}=${value}`);
+          }
+        }
+        let buildResult: BuildResultV2 | BuildResultV3;
+        let rawBuildResult: BuildResultV2 | BuildResultV3 | BuildResultVX;
+        try {
+          rawBuildResult = await builderSpan.trace<
+            BuildResultV2 | BuildResultV3 | BuildResultVX
+          >(async () => builder.build(buildOptions));
+          if (builder.version === -1) {
+            const vx = rawBuildResult as BuildResultVX;
+            buildResult = vx.result;
+          } else {
+            buildResult = rawBuildResult as BuildResultV2 | BuildResultV3;
+          }
+
+          // If the build result has no routes and the framework has default routes,
+          // then add the default routes to the build result
+          if (
+            !getHasDetectedServices() &&
+            buildConfig.zeroConfig &&
+            isFrontendBuilder &&
+            'output' in buildResult &&
+            !buildResult.routes
+          ) {
+            const framework = frameworkList.find(
+              f => f.slug === buildConfig.framework
+            );
+            if (framework) {
+              const defaultRoutes = await getFrameworkRoutes(
+                framework,
+                buildWorkPath
+              );
+              buildResult.routes = defaultRoutes;
+            }
+          }
+        } finally {
+          // Restore any process.env keys we set from service envVars so the
+          // next builder iteration starts from a clean slate.
+          for (const [key, prior] of restoreEnv) {
+            if (prior === undefined) {
+              delete process.env[key];
+            } else {
+              process.env[key] = prior;
+            }
+          }
+          // Make sure we don't fail the build
+          try {
+            const builderDiagnostics = await builderSpan
+              .child('vc.builder.diagnostics')
+              .trace(async () => {
+                return await builder.diagnostics?.(buildOptions);
+              });
+            if (builderDiagnostics) {
+              const prefix =
+                service && service.workspace !== '.'
+                  ? service.workspace + '/' + builderPkg.name + '/'
+                  : '';
+              for (const [key, value] of Object.entries(builderDiagnostics)) {
+                const fullKey = prefix + key;
+                if (key.endsWith('package-manifest.json')) {
+                  try {
+                    let data: string;
+                    if (value.type === 'FileBlob') {
+                      data = (value as unknown as FileBlob).data.toString();
+                    } else {
+                      data = await streamToString(value.toStream());
+                    }
+                    const packageManifest = JSON.parse(data);
+                    const validationError =
+                      validatePackageManifest(packageManifest);
+                    if (validationError) {
+                      output.warn(
+                        `Invalid package-manifest.json from ${fullKey}: ${validationError}`
+                      );
+                    } else {
+                      const workspace =
+                        service && service.workspace !== '.'
+                          ? service.workspace
+                          : '.';
+                      packageManifests.push({
+                        workspace,
+                        key: fullKey,
+                        manifest: packageManifest,
+                        service,
+                        builderUse: builderPkg.name,
+                      });
+                    }
+                  } catch (e) {
+                    output.debug(
+                      `Failed to parse ${fullKey}: ${e instanceof Error ? e.message : String(e)}`
+                    );
+                  }
+                } else {
+                  diagnostics[fullKey] = value;
+                }
+              }
+            }
+          } catch (error) {
+            output.error('Collecting diagnostics failed');
+            output.debug(error);
+          }
+        }
+
+        if (
+          buildResult &&
+          'output' in buildResult &&
+          'runtime' in buildResult.output &&
+          'type' in buildResult.output &&
+          buildResult.output.type === 'Lambda'
+        ) {
+          const lambdaRuntime = buildResult.output.runtime;
+          if (
+            getDiscontinuedNodeVersions().some(o => o.runtime === lambdaRuntime)
+          ) {
+            throw new NowBuildError({
+              code: 'NODEJS_DISCONTINUED_VERSION',
+              message: `The Runtime "${build.use}" is using "${lambdaRuntime}", which is discontinued. Please upgrade your Runtime to a more recent version or consult the author for more details.`,
+              link: 'https://vercel.link/function-runtimes',
+            });
+          }
+        }
+
+        if (
+          'output' in buildResult &&
+          buildResult.output &&
+          (isBackendBuilder(build) || build.use === '@vercel/python')
+        ) {
+          // Use service workspace path for routes.json lookup, since the builder
+          // writes routes.json relative to its workPath
+          const routesJsonPath = join(buildWorkPath, '.vercel', 'routes.json');
+          if (existsSync(routesJsonPath)) {
+            try {
+              const routesJson = await readJSONFile(routesJsonPath);
+              if (
+                routesJson &&
+                typeof routesJson === 'object' &&
+                'routes' in routesJson &&
+                Array.isArray(routesJson.routes)
+              ) {
+                // This is a v2 build output, so only remap the outputs
+                // if we have an index lambda
+                const indexLambda =
+                  'index' in buildResult.output
+                    ? (buildResult.output['index'] as Lambda)
+                    : undefined;
+                // Convert routes from introspection format to Vercel routing format
+                const convertedRoutes = [];
+                const convertedOutputs: Record<string, Lambda> = indexLambda
+                  ? { index: indexLambda }
+                  : {};
+                for (const route of routesJson.routes) {
+                  if (typeof route.source !== 'string') {
+                    continue;
+                  }
+                  const { src } = sourceToRegex(route.source);
+                  const newRoute: Route = {
+                    src,
+                    dest: route.source,
+                  };
+                  if (route.methods) {
+                    newRoute.methods = route.methods;
+                  }
+                  if (route.source === '/') {
+                    continue;
+                  }
+                  if (indexLambda) {
+                    convertedOutputs[route.source] = indexLambda;
+                  }
+                  convertedRoutes.push(newRoute);
+                }
+                // Wrap routes with filesystem handler and catch-all
+                (buildResult as BuildResultV2Typical).routes = [
+                  { handle: 'filesystem' },
+                  ...convertedRoutes,
+                  { src: '/(.*)', dest: '/' },
+                ];
+                if (indexLambda) {
+                  (buildResult as BuildResultV2Typical).output =
+                    convertedOutputs;
+                }
+              }
+            } catch (error) {
+              output.error(`Failed to read routes.json: ${error}`);
+            }
+          }
+        }
+
+        if (
+          getHasDetectedServices() &&
+          service &&
+          'routes' in buildResult &&
+          Array.isArray(buildResult.routes) &&
+          detectedServices
+        ) {
+          buildResult.routes = scopeRoutesToServiceOwnership({
+            routes: buildResult.routes as Route[],
+            owner: service,
+            allServices: detectedServices,
+          });
+        }
+
+        if (
+          service &&
+          isQueueBackedService(service) &&
+          'output' in buildResult
+        ) {
+          attachQueueServiceTrigger(buildResult.output, service);
+        }
+
+        if (
+          service &&
+          isScheduleTriggeredService(service) &&
+          !('crons' in buildResult && buildResult.crons?.length)
+        ) {
+          const staticSchedules = getStaticServiceSchedules(service.schedule);
+          if (
+            typeof service.runtime === 'string' &&
+            staticSchedules.length > 0
+          ) {
+            const cronEntrypoint =
+              service.entrypoint || service.builder.src || 'index';
+            for (const schedule of staticSchedules) {
+              synthesizedServiceCrons.push({
+                path: getInternalServiceCronPath(
+                  service.name,
+                  cronEntrypoint,
+                  service.handlerFunction || 'cron'
+                ),
+                schedule,
+              });
+            }
+          } else {
+            throw new NowBuildError({
+              code: 'CRON_SERVICE_NO_CRONS',
+              message: `Scheduled service "${service.name}" did not produce any cron entries. The builder "${builderPkg.name}" may not support scheduled services.`,
+            });
+          }
+        }
+
+        let mergedBuildResult: BuildResult | BuildOutputConfig = buildResult;
+        if ('buildOutputPath' in buildResult) {
+          // Read this builder's own Build Output API config directly. When
+          // multiple builders write into `.vercel/output`, a later filesystem
+          // merge can overwrite `config.json` from a sibling builder.
+          const buildOutputConfigPath = join(
+            buildResult.buildOutputPath,
+            'config.json'
+          );
+          const buildOutputConfig = await readJSONFile<BuildOutputConfig>(
+            buildOutputConfigPath
+          );
+          if (buildOutputConfig instanceof CantParseJSONFile) {
+            throw buildOutputConfig;
+          }
+
+          if (buildOutputConfig) {
+            if (!hasExperimentalServicesConfiguredInVercelConfig) {
+              const outputConfigPath = join(outputDir, 'config.json');
+              const outputConfig =
+                await readJSONFile<BuildOutputConfig>(outputConfigPath);
+              if (outputConfig instanceof CantParseJSONFile) {
+                throw outputConfig;
+              }
+              if (
+                hasNonEmptyObject(outputConfig?.experimentalServices) &&
+                !hasNonEmptyObject(buildOutputConfig.experimentalServices)
+              ) {
+                buildOutputConfig.experimentalServices =
+                  outputConfig.experimentalServices;
+                await fs.writeJSON(buildOutputConfigPath, buildOutputConfig, {
+                  spaces: 2,
+                });
+              }
+            }
+            if (buildOutputConfig.overrides) {
+              overrides.push(buildOutputConfig.overrides);
+            }
+            if (
+              getHasDetectedServices() &&
+              service &&
+              Array.isArray(buildOutputConfig.routes) &&
+              detectedServices
+            ) {
+              buildOutputConfig.routes = scopeRoutesToServiceOwnership({
+                routes: buildOutputConfig.routes as Route[],
+                owner: service,
+                allServices: detectedServices,
+              });
+            }
+            mergedBuildResult = buildOutputConfig;
+          }
+        }
+        // Store the build result to generate the final `config.json` after
+        // all builds have completed
+        buildResults.set(build, mergedBuildResult);
+        executedBuilds.push(build);
+
+        let buildOutputLength = 0;
+        if ('output' in buildResult) {
+          buildOutputLength = Array.isArray(buildResult.output)
+            ? buildResult.output.length
+            : 1;
+        }
+
+        // Start flushing the file outputs to the filesystem asynchronously
+        ops.push(
+          builderSpan
+            .child('vc.builder.writeBuildResult', {
+              buildOutputLength: String(buildOutputLength),
+            })
+            .trace<Record<string, PathOverride> | undefined | void>(() =>
+              writeBuildResult({
+                repoRootPath,
+                outputDir,
+                buildResult: rawBuildResult,
+                build,
+                builder,
+                builderPkg,
+                vercelConfig: localConfig,
+                standalone,
+                workPath: buildWorkPath,
+                service,
+                stripServiceRoutePrefix,
+              })
+            )
+            .then(
+              (override: Record<string, PathOverride> | undefined | void) => {
+                if (override) overrides.push(override);
+              },
+              (err: Error) => err
+            )
+        );
+      } catch (err: any) {
+        const buildJsonBuild = buildsJsonBuilds.get(build);
+        if (buildJsonBuild) {
+          buildJsonBuild.error = toEnumerableError(err);
+        }
+        throw err;
+      } finally {
+        ops.push(
+          download(diagnostics, join(outputDir, 'diagnostics')).then(
+            () => undefined,
+            err => err
+          )
         );
       }
+    }
+  };
 
-      // Set VERCEL_PROJECT_SETTINGS_* env vars.
-      // For services: use service-specific values instead of project-level settings
-      // (the project-level framework is "services", which is meaningless to individual builders).
-      const settingsForEnv = service
-        ? {
-            buildCommand: service.buildCommand ?? undefined,
-            installCommand: service.installCommand ?? undefined,
-            outputDirectory: projectSettings.outputDirectory ?? undefined,
-            nodeVersion: projectSettings.nodeVersion ?? undefined,
-          }
-        : projectSettings;
-
-      for (const key of [
-        'buildCommand',
-        'installCommand',
-        'outputDirectory',
-        'nodeVersion',
-      ] as const) {
-        const value = settingsForEnv[key];
-        const envKey =
-          `VERCEL_PROJECT_SETTINGS_` +
-          key.replace(/[A-Z]/g, letter => `_${letter}`).toUpperCase();
-        if (typeof value === 'string') {
-          process.env[envKey] = value;
-          output.debug(`Setting env ${envKey} to "${value}"`);
-        } else {
-          delete process.env[envKey];
-        }
+  const flushOps = async () => {
+    const errors = await Promise.all(ops.splice(0));
+    for (const error of errors) {
+      if (error) {
+        throw error;
       }
+    }
+  };
 
-      const isFrontendBuilder = build.config && 'framework' in build.config;
-      // For services builds, the builder framework is set by the service resolver,
-      // the project-level framework is 'services'.
-      const builderFramework =
-        build.config?.framework ?? projectSettings.framework;
+  const normalizeBuilderSrc = (src: Builder['src']) =>
+    typeof src === 'string'
+      ? normalizePath(src).replace(/^\.\//, '')
+      : undefined;
 
-      let buildConfig: Config;
+  const getBuilderIdentity = (build: Builder) => {
+    const normalizedSrc = normalizeBuilderSrc(build.src);
+    return normalizedSrc ? `${build.use}:${normalizedSrc}` : undefined;
+  };
 
-      if (isZeroConfig) {
-        if (service) {
-          // Services build: use service-specific config from resolution.
-          // build.config already contains framework, routePrefix, memory, etc.
-          buildConfig = {
-            ...build.config,
-            ...(hasQueueServices ? { hasWorkerServices: true } : undefined),
-            // Override project-level settings with service-specific ones.
-            // The project-level framework is "services" which must NOT be
-            // propagated to individual builders.
-            projectSettings: {
-              ...projectSettings,
-              framework: service.framework ?? null,
-              buildCommand: service.buildCommand ?? null,
-              installCommand: service.installCommand ?? null,
-            },
-            installCommand: service.installCommand ?? undefined,
-            buildCommand: service.buildCommand ?? undefined,
-            preDeployCommand: service.preDeployCommand ?? undefined,
-            framework: builderFramework,
-            nodeVersion: projectSettings.nodeVersion,
-            bunVersion: localConfig.bunVersion ?? undefined,
-          };
-        } else {
-          buildConfig = {
-            outputDirectory: projectSettings.outputDirectory ?? undefined,
-            ...build.config,
+  const getAlreadyExecutedBuild = (candidate: Builder) => {
+    const candidateIdentity = getBuilderIdentity(candidate);
+    if (!candidateIdentity) return undefined;
+
+    return executedBuilds.find(
+      build => getBuilderIdentity(build) === candidateIdentity
+    );
+  };
+
+  const appendServiceRoutes = (services: Service[]) => {
+    const serviceRoutes = generateServicesRoutes(services);
+    zeroConfigRoutes = appendRoutesToPhase({
+      routes: zeroConfigRoutes,
+      newRoutes: serviceRoutes.hostRewrites.length
+        ? serviceRoutes.hostRewrites
+        : null,
+      phase: null,
+    });
+    zeroConfigRoutes.push(
+      ...appendRoutesToPhase({
+        routes: [],
+        newRoutes: [
+          ...serviceRoutes.rewrites,
+          ...serviceRoutes.workers,
+          ...serviceRoutes.crons,
+        ],
+        phase: 'filesystem',
+      })
+    );
+    zeroConfigRoutes.push(...serviceRoutes.defaults);
+    zeroConfigFallbackRoutes.push(...serviceRoutes.fallbacks);
+  };
+
+  await runBuilders(builds);
+  await flushOps();
+
+  if (!hasExperimentalServicesConfiguredInVercelConfig) {
+    const generatedConfigPath = join(outputDir, 'config.json');
+    const generatedConfig =
+      await readJSONFile<BuildOutputConfig>(generatedConfigPath);
+    if (generatedConfig instanceof CantParseJSONFile) {
+      throw generatedConfig;
+    }
+
+    if (hasNonEmptyObject(generatedConfig?.experimentalServices)) {
+      detectedExperimentalServicesConfig = generatedConfig.experimentalServices;
+      const generatedBuilders = await span
+        .child('vc.detectGeneratedServices')
+        .trace(() =>
+          detectBuilders(files, pkg, {
+            ...localConfig,
+            services: undefined,
+            experimentalServices: generatedConfig.experimentalServices,
             projectSettings,
-            installCommand: projectSettings.installCommand ?? undefined,
-            devCommand: projectSettings.devCommand ?? undefined,
-            buildCommand: projectSettings.buildCommand ?? undefined,
-            framework: projectSettings.framework,
-            nodeVersion: projectSettings.nodeVersion,
-            bunVersion: localConfig.bunVersion ?? undefined,
-          };
-        }
+            ignoreBuildScript: true,
+            featHandleMiss: true,
+            workPath,
+          })
+        );
+
+      if (generatedBuilders.errors && generatedBuilders.errors.length > 0) {
+        throw generatedBuilders.errors[0];
+      }
+
+      for (const w of generatedBuilders.warnings) {
+        output.warn(w.message, null, w.link, w.action || 'Learn More');
+      }
+
+      detectedServices = generatedBuilders.services;
+      if (!detectedServices || detectedServices.length === 0) {
+        detectedServices = undefined;
       } else {
-        buildConfig = {
-          ...(build.config || {}),
-          bunVersion: localConfig.bunVersion ?? undefined,
-        };
+        appendServiceRoutes(detectedServices);
       }
 
-      const builderSpan = span.child('vc.builder', {
-        'builder.name': builderPkg.name,
-        'builder.version': builderPkg.version,
-        'builder.dynamicallyInstalled': String(
-          builderWithPkg.dynamicallyInstalled
-        ),
-      });
-
-      const serviceRoutePrefix = build.config?.routePrefix;
-      const serviceWorkspace = build.config?.workspace;
-      const preDeployCmd = service?.preDeployCommand?.trim();
-
-      const preDeployEntry =
-        preDeployCmd && service
-          ? ({ service: service.name } as (typeof preDeployEntries)[number])
-          : undefined;
-      if (preDeployEntry) {
-        preDeployEntries.push(preDeployEntry);
-      }
-
-      const buildOptions: BuildOptions = {
-        files: buildFiles,
-        entrypoint: buildEntrypoint,
-        workPath: buildWorkPath,
-        repoRootPath,
-        config: buildConfig,
-        meta,
-        span: builderSpan,
-        ...(preDeployCmd
-          ? {
-              registerPreDeploy: (callback: () => Promise<void>) => {
-                preDeployEntry!.callback = callback;
-              },
-            }
-          : undefined),
-        ...(service
-          ? {
-              service: {
-                name: service.name,
-                type: service.type,
-                trigger: service.trigger,
-                routePrefix:
-                  typeof serviceRoutePrefix === 'string'
-                    ? serviceRoutePrefix
-                    : undefined,
-                workspace:
-                  typeof serviceWorkspace === 'string'
-                    ? serviceWorkspace
-                    : undefined,
-                schedule: service.schedule,
-              },
-            }
-          : undefined),
-      };
-      output.debug(
-        `Building entrypoint "${build.src}" with "${builderPkg.name}"`
-      );
-
-      // Inject per-service URL environment variables so they're available during builds.
-      // for frontend frameworks like Vite (VITE_) or Next.js (NEXT_PUBLIC_) where
-      // these env vars are baked into the client bundle so they can be accessed in the client code.
-      // User-defined env takes precedence and won't be overwritten. The env will be cleared
-      // after the build is complete
-      const restoreEnv = new Map<string, string | undefined>();
-      if (detectedServices && service?.env) {
-        const perServiceEnv = getServiceUrlEnvVars({
-          requestedEnv: service.env,
-          consumerService: service,
+      if (detectedServices && generatedBuilders.useImplicitEnvInjection) {
+        const serviceUrlEnvVars = getExperimentalServiceUrlEnvVars({
           services: detectedServices,
           frameworkList,
           currentEnv: process.env,
           deploymentUrl: process.env.VERCEL_URL,
         });
-        for (const [key, value] of Object.entries(perServiceEnv)) {
-          if (key in process.env) continue;
-          restoreEnv.set(key, process.env[key]);
+        for (const [key, value] of Object.entries(serviceUrlEnvVars)) {
           process.env[key] = value;
           output.debug(`Injected service URL env var: ${key}=${value}`);
         }
       }
-      let buildResult: BuildResultV2 | BuildResultV3;
-      let rawBuildResult: BuildResultV2 | BuildResultV3 | BuildResultVX;
-      try {
-        rawBuildResult = await builderSpan.trace<
-          BuildResultV2 | BuildResultV3 | BuildResultVX
-        >(async () => builder.build(buildOptions));
-        if (builder.version === -1) {
-          const vx = rawBuildResult as BuildResultVX;
-          buildResult = vx.result;
-        } else {
-          buildResult = rawBuildResult as BuildResultV2 | BuildResultV3;
-        }
 
-        // If the build result has no routes and the framework has default routes,
-        // then add the default routes to the build result
+      const buildsToRun: Builder[] = [];
+      const seenBuildsToRun = new Set<string>();
+      for (const service of detectedServices || []) {
+        serviceByBuilder.set(service.builder, service);
+        const alreadyExecutedBuild = getAlreadyExecutedBuild(service.builder);
+        if (alreadyExecutedBuild) {
+          serviceByBuilder.set(alreadyExecutedBuild, service);
+          continue;
+        }
+        const serviceBuilderIdentity = getBuilderIdentity(service.builder);
         if (
-          !hasDetectedServices &&
-          buildConfig.zeroConfig &&
-          isFrontendBuilder &&
-          'output' in buildResult &&
-          !buildResult.routes
+          serviceBuilderIdentity &&
+          !seenBuildsToRun.has(serviceBuilderIdentity)
         ) {
-          const framework = frameworkList.find(
-            f => f.slug === buildConfig.framework
-          );
-          if (framework) {
-            const defaultRoutes = await getFrameworkRoutes(
-              framework,
-              buildWorkPath
-            );
-            buildResult.routes = defaultRoutes;
-          }
-        }
-      } finally {
-        // Restore any process.env keys we set from service envVars so the
-        // next builder iteration starts from a clean slate.
-        for (const [key, prior] of restoreEnv) {
-          if (prior === undefined) {
-            delete process.env[key];
-          } else {
-            process.env[key] = prior;
-          }
-        }
-        // Make sure we don't fail the build
-        try {
-          const builderDiagnostics = await builderSpan
-            .child('vc.builder.diagnostics')
-            .trace(async () => {
-              return await builder.diagnostics?.(buildOptions);
-            });
-          if (builderDiagnostics) {
-            const prefix =
-              service && service.workspace !== '.'
-                ? service.workspace + '/' + builderPkg.name + '/'
-                : '';
-            for (const [key, value] of Object.entries(builderDiagnostics)) {
-              const fullKey = prefix + key;
-              if (key.endsWith('package-manifest.json')) {
-                try {
-                  let data: string;
-                  if (value.type === 'FileBlob') {
-                    data = (value as unknown as FileBlob).data.toString();
-                  } else {
-                    data = await streamToString(value.toStream());
-                  }
-                  const packageManifest = JSON.parse(data);
-                  const validationError =
-                    validatePackageManifest(packageManifest);
-                  if (validationError) {
-                    output.warn(
-                      `Invalid package-manifest.json from ${fullKey}: ${validationError}`
-                    );
-                  } else {
-                    const workspace =
-                      service && service.workspace !== '.'
-                        ? service.workspace
-                        : '.';
-                    packageManifests.push({
-                      workspace,
-                      key: fullKey,
-                      manifest: packageManifest,
-                      service,
-                      builderUse: builderPkg.name,
-                    });
-                  }
-                } catch (e) {
-                  output.debug(
-                    `Failed to parse ${fullKey}: ${e instanceof Error ? e.message : String(e)}`
-                  );
-                }
-              } else {
-                diagnostics[fullKey] = value;
-              }
-            }
-          }
-        } catch (error) {
-          output.error('Collecting diagnostics failed');
-          output.debug(error);
+          seenBuildsToRun.add(serviceBuilderIdentity);
+          buildsToRun.push(service.builder);
         }
       }
 
-      if (
-        buildResult &&
-        'output' in buildResult &&
-        'runtime' in buildResult.output &&
-        'type' in buildResult.output &&
-        buildResult.output.type === 'Lambda'
-      ) {
-        const lambdaRuntime = buildResult.output.runtime;
-        if (
-          getDiscontinuedNodeVersions().some(o => o.runtime === lambdaRuntime)
-        ) {
-          throw new NowBuildError({
-            code: 'NODEJS_DISCONTINUED_VERSION',
-            message: `The Runtime "${build.use}" is using "${lambdaRuntime}", which is discontinued. Please upgrade your Runtime to a more recent version or consult the author for more details.`,
-            link: 'https://vercel.link/function-runtimes',
-          });
-        }
+      if (buildsToRun.length > 0) {
+        await runBuilders(buildsToRun);
       }
-
-      if (
-        'output' in buildResult &&
-        buildResult.output &&
-        (isBackendBuilder(build) || build.use === '@vercel/python')
-      ) {
-        // Use service workspace path for routes.json lookup, since the builder
-        // writes routes.json relative to its workPath
-        const routesJsonPath = join(buildWorkPath, '.vercel', 'routes.json');
-        if (existsSync(routesJsonPath)) {
-          try {
-            const routesJson = await readJSONFile(routesJsonPath);
-            if (
-              routesJson &&
-              typeof routesJson === 'object' &&
-              'routes' in routesJson &&
-              Array.isArray(routesJson.routes)
-            ) {
-              // This is a v2 build output, so only remap the outputs
-              // if we have an index lambda
-              const indexLambda =
-                'index' in buildResult.output
-                  ? (buildResult.output['index'] as Lambda)
-                  : undefined;
-              // Convert routes from introspection format to Vercel routing format
-              const convertedRoutes = [];
-              const convertedOutputs: Record<string, Lambda> = indexLambda
-                ? { index: indexLambda }
-                : {};
-              for (const route of routesJson.routes) {
-                if (typeof route.source !== 'string') {
-                  continue;
-                }
-                const { src } = sourceToRegex(route.source);
-                const newRoute: Route = {
-                  src,
-                  dest: route.source,
-                };
-                if (route.methods) {
-                  newRoute.methods = route.methods;
-                }
-                if (route.source === '/') {
-                  continue;
-                }
-                if (indexLambda) {
-                  convertedOutputs[route.source] = indexLambda;
-                }
-                convertedRoutes.push(newRoute);
-              }
-              // Wrap routes with filesystem handler and catch-all
-              (buildResult as BuildResultV2Typical).routes = [
-                { handle: 'filesystem' },
-                ...convertedRoutes,
-                { src: '/(.*)', dest: '/' },
-              ];
-              if (indexLambda) {
-                (buildResult as BuildResultV2Typical).output = convertedOutputs;
-              }
-            }
-          } catch (error) {
-            output.error(`Failed to read routes.json: ${error}`);
-          }
-        }
-      }
-
-      if (
-        hasDetectedServices &&
-        service &&
-        'routes' in buildResult &&
-        Array.isArray(buildResult.routes) &&
-        detectedServices
-      ) {
-        buildResult.routes = scopeRoutesToServiceOwnership({
-          routes: buildResult.routes as Route[],
-          owner: service,
-          allServices: detectedServices,
-        });
-      }
-
-      if (service && isQueueBackedService(service) && 'output' in buildResult) {
-        attachQueueServiceTrigger(buildResult.output, service);
-      }
-
-      if (
-        service &&
-        isScheduleTriggeredService(service) &&
-        !('crons' in buildResult && buildResult.crons?.length)
-      ) {
-        const staticSchedules = getStaticServiceSchedules(service.schedule);
-        if (typeof service.runtime === 'string' && staticSchedules.length > 0) {
-          const cronEntrypoint =
-            service.entrypoint || service.builder.src || 'index';
-          for (const schedule of staticSchedules) {
-            synthesizedServiceCrons.push({
-              path: getInternalServiceCronPath(
-                service.name,
-                cronEntrypoint,
-                service.handlerFunction || 'cron'
-              ),
-              schedule,
-            });
-          }
-        } else {
-          throw new NowBuildError({
-            code: 'CRON_SERVICE_NO_CRONS',
-            message: `Scheduled service "${service.name}" did not produce any cron entries. The builder "${builderPkg.name}" may not support scheduled services.`,
-          });
-        }
-      }
-
-      let mergedBuildResult: BuildResult | BuildOutputConfig = buildResult;
-      if ('buildOutputPath' in buildResult) {
-        // Read this builder's own Build Output API config directly. When
-        // multiple builders write into `.vercel/output`, a later filesystem
-        // merge can overwrite `config.json` from a sibling builder.
-        const buildOutputConfigPath = join(
-          buildResult.buildOutputPath,
-          'config.json'
-        );
-        const buildOutputConfig = await readJSONFile<BuildOutputConfig>(
-          buildOutputConfigPath
-        );
-        if (buildOutputConfig instanceof CantParseJSONFile) {
-          throw buildOutputConfig;
-        }
-
-        if (buildOutputConfig) {
-          if (buildOutputConfig.overrides) {
-            overrides.push(buildOutputConfig.overrides);
-          }
-          if (
-            hasDetectedServices &&
-            service &&
-            Array.isArray(buildOutputConfig.routes) &&
-            detectedServices
-          ) {
-            buildOutputConfig.routes = scopeRoutesToServiceOwnership({
-              routes: buildOutputConfig.routes as Route[],
-              owner: service,
-              allServices: detectedServices,
-            });
-          }
-          mergedBuildResult = buildOutputConfig;
-        }
-      }
-      // Store the build result to generate the final `config.json` after
-      // all builds have completed
-      buildResults.set(build, mergedBuildResult);
-
-      let buildOutputLength = 0;
-      if ('output' in buildResult) {
-        buildOutputLength = Array.isArray(buildResult.output)
-          ? buildResult.output.length
-          : 1;
-      }
-
-      // Start flushing the file outputs to the filesystem asynchronously
-      ops.push(
-        builderSpan
-          .child('vc.builder.writeBuildResult', {
-            buildOutputLength: String(buildOutputLength),
-          })
-          .trace<Record<string, PathOverride> | undefined | void>(() =>
-            writeBuildResult({
-              repoRootPath,
-              outputDir,
-              buildResult: rawBuildResult,
-              build,
-              builder,
-              builderPkg,
-              vercelConfig: localConfig,
-              standalone,
-              workPath: buildWorkPath,
-              service,
-              stripServiceRoutePrefix,
-            })
-          )
-          .then(
-            (override: Record<string, PathOverride> | undefined | void) => {
-              if (override) overrides.push(override);
-            },
-            (err: Error) => err
-          )
-      );
-    } catch (err: any) {
-      const buildJsonBuild = buildsJsonBuilds.get(build);
-      if (buildJsonBuild) {
-        buildJsonBuild.error = toEnumerableError(err);
-      }
-      throw err;
-    } finally {
-      ops.push(
-        download(diagnostics, join(outputDir, 'diagnostics')).then(
-          () => undefined,
-          err => err
-        )
-      );
     }
   }
 
@@ -1497,12 +1694,7 @@ async function doBuild(
 
   // Wait for filesystem operations to complete
   // TODO render progress bar?
-  const errors = await Promise.all(ops);
-  for (const error of errors) {
-    if (error) {
-      throw error;
-    }
-  }
+  await flushOps();
 
   let needBuildsJsonOverride = false;
   const speedInsightsVersion = await getInstalledPackageVersion(
@@ -1572,7 +1764,7 @@ async function doBuild(
       const buildResult = b[1] as BuildResultV2Typical;
       let entrypoint = build.src!;
 
-      if (hasDetectedServices && typeof build.src === 'string') {
+      if (getHasDetectedServices() && typeof build.src === 'string') {
         const service = serviceByBuilder.get(build);
         if (
           service &&
@@ -1654,7 +1846,12 @@ async function doBuild(
     overrides: mergedOverrides,
     framework,
     crons: mergedCrons,
-    ...(detectedServices &&
+    ...(detectedExperimentalServicesConfig &&
+      Object.keys(detectedExperimentalServicesConfig).length > 0 && {
+        experimentalServices: detectedExperimentalServicesConfig,
+      }),
+    ...(!detectedExperimentalServicesConfig &&
+      detectedServices &&
       detectedServices.length > 0 && { services: detectedServices }),
     ...(mergedDeploymentId && { deploymentId: mergedDeploymentId }),
   };

--- a/packages/cli/test/helpers/prepare.js
+++ b/packages/cli/test/helpers/prepare.js
@@ -494,6 +494,105 @@ module.exports = async function prepare(session, binaryPath, tmpFixturesDir) {
         },
       }),
     },
+    'vc-build-next-generated-nitro-service': {
+      '.vercel/project.json': JSON.stringify({
+        orgId: '.',
+        projectId: '.',
+        settings: {
+          framework: 'nextjs',
+        },
+      }),
+      'package.json': JSON.stringify({
+        private: true,
+        scripts: {
+          build: 'next build',
+        },
+        dependencies: {
+          next: 'latest',
+          react: 'latest',
+          'react-dom': 'latest',
+        },
+      }),
+      'pages/index.js':
+        'export default function Home() { return <p>Latest Next.js app</p>; }',
+      'next.config.js': `
+const fs = require('node:fs');
+const path = require('node:path');
+
+const experimentalServices = {
+  web: {
+    type: 'web',
+    root: '.',
+    entrypoint: 'package.json',
+    framework: 'nextjs',
+    mount: '/',
+  },
+  'nitro-api': {
+    type: 'web',
+    root: 'nitro',
+    entrypoint: 'package.json',
+    framework: 'nitro',
+    mount: '/api',
+  },
+};
+
+function writeExperimentalServicesConfig(projectDir) {
+  const outputDir = path.join(projectDir, '.vercel', 'output');
+  const configPath = path.join(outputDir, 'config.json');
+  let config = { version: 3 };
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        ...config,
+        version: 3,
+        experimentalServices,
+      },
+      null,
+      2
+    )
+  );
+}
+
+writeExperimentalServicesConfig(__dirname);
+
+module.exports = {};
+`,
+      'nitro/package.json': JSON.stringify({
+        private: true,
+        scripts: {
+          build: 'nitro build',
+          dev: 'nitro dev',
+          prepare: 'nitro prepare',
+          preview: 'node .output/server/index.mjs',
+        },
+        devDependencies: {
+          nitropack: 'latest',
+        },
+      }),
+      'nitro/.npmrc': 'shamefully-hoist=true\nstrict-peer-dependencies=false\n',
+      'nitro/nitro.config.ts': `
+export default defineNitroConfig({
+  preset: 'vercel',
+  compatibilityDate: '2026-05-27',
+  srcDir: 'server'
+});
+`,
+      'nitro/server/routes/index.ts': `
+export default defineEventHandler(() => {
+  return 'nitro ok';
+});
+`,
+    },
     'vercel-json-configuration-overrides': {
       'vercel.json': '{}',
       'package.json': '{}',

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -28,6 +28,32 @@ const example = (name: string) =>
   path.join(__dirname, '..', '..', '..', 'examples', name);
 const session = Math.random().toString(36).split('.')[1];
 
+async function findFilesNamed(
+  dir: string,
+  fileName: string
+): Promise<string[]> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+
+  const nestedFiles = await Promise.all(
+    entries.map(async entry => {
+      const absolutePath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return findFilesNamed(absolutePath, fileName);
+      }
+      return entry.isFile() && entry.name === fileName ? [absolutePath] : [];
+    })
+  );
+  return nestedFiles.flat();
+}
+
 async function setupProject(
   process: CLIProcess,
   projectName: string,
@@ -1198,6 +1224,108 @@ test('[vc build] should build project with `@vercel/static-build`', async () => 
   expect(builds.target).toBe('preview');
   expect(builds.builds[0].src).toBe('package.json');
   expect(builds.builds[0].use).toBe('@vercel/static-build');
+});
+
+test('[vc build] should build experimentalServices emitted by latest Next.js config output', async () => {
+  const directory = await setupE2EFixture(
+    'vc-build-next-generated-nitro-service'
+  );
+  const output = await execCli(binaryPath, ['build'], {
+    cwd: directory,
+    env: {
+      NEXT_ENABLE_ADAPTER: '1',
+      NEXT_TELEMETRY_DISABLED: '1',
+    },
+  });
+  expect(output.exitCode, formatOutput(output)).toBe(0);
+  expect(`${output.stdout}\n${output.stderr}`).toMatch(
+    /Build Completed in \.vercel\/output|Build completed successfully\./
+  );
+
+  const config = await fs.readJSON(
+    path.join(directory, '.vercel/output/config.json')
+  );
+  expect(config.experimentalServices).toEqual({
+    web: expect.objectContaining({
+      framework: 'nextjs',
+      mount: '/',
+    }),
+    'nitro-api': expect.objectContaining({
+      framework: 'nitro',
+      mount: '/api',
+    }),
+  });
+  expect(config.services).toBeUndefined();
+
+  const outputDirectory = path.join(directory, '.vercel/output');
+
+  expect(
+    await fs.pathExists(path.join(outputDirectory, 'static/index.html'))
+  ).toBe(true);
+  const nextBuildManifestPaths = await findFilesNamed(
+    path.join(outputDirectory, 'static/_next/static'),
+    '_buildManifest.js'
+  );
+  expect(nextBuildManifestPaths.length).toBeGreaterThan(0);
+
+  const functionsDirectory = path.join(outputDirectory, 'functions');
+  const nitroChunkPaths = await findFilesNamed(functionsDirectory, 'nitro.mjs');
+  expect(nitroChunkPaths.length).toBeGreaterThan(0);
+  const nitroFunctionDirectory = nitroChunkPaths
+    .map(filePath =>
+      path
+        .relative(functionsDirectory, filePath)
+        .split(path.sep)
+        .find(segment => segment.endsWith('.func'))
+    )
+    .find(Boolean);
+  expect(nitroFunctionDirectory).toBeDefined();
+  const nitroFunctionName = nitroFunctionDirectory!.replace(/\.func$/, '');
+  const nitroFunctionConfig = await fs.readJSON(
+    path.join(functionsDirectory, nitroFunctionDirectory!, '.vc-config.json')
+  );
+  expect(nitroFunctionConfig).toEqual(
+    expect.objectContaining({
+      handler: 'index.mjs',
+      launcherType: 'Nodejs',
+    })
+  );
+  expect(
+    await fs.pathExists(
+      path.join(
+        functionsDirectory,
+        nitroFunctionDirectory!,
+        'chunks/routes/index.mjs'
+      )
+    )
+  ).toBe(true);
+  expect(config.routes).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        src: expect.stringContaining('/api'),
+        dest: `/${nitroFunctionName}`,
+      }),
+    ])
+  );
+
+  const builds = await fs.readJSON(path.join(outputDirectory, 'builds.json'));
+  const nextBuilds = builds.builds.filter(
+    (build: { src: string; use: string }) =>
+      build.src === 'package.json' && build.use === '@vercel/next'
+  );
+  expect(nextBuilds).toHaveLength(1);
+  expect(builds.builds).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        src: 'package.json',
+        use: '@vercel/next',
+      }),
+      expect.objectContaining({
+        src: 'nitro/package.json',
+        use: '@vercel/static-build',
+      }),
+    ])
+  );
 });
 
 test('[vc build] should build project with `@vercel/speed-insights`', async () => {

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -2537,6 +2537,181 @@ fs.writeFileSync(
     ]);
   });
 
+  it('should build experimentalServices discovered from generated Build Output config', async () => {
+    const cwd = await getWriteableDirectory();
+    const output = join(cwd, '.vercel', 'output');
+    await fs.ensureDir(join(cwd, '.vercel'));
+    await fs.writeJSON(join(cwd, '.vercel', 'project.json'), {
+      orgId: '.',
+      projectId: '.',
+      settings: {
+        framework: null,
+        installCommand: '',
+      },
+    });
+    await fs.writeJSON(join(cwd, 'package.json'), {
+      scripts: {
+        build: 'node build.mjs',
+      },
+    });
+    await fs.outputFile(
+      join(cwd, 'build.mjs'),
+      `
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const countPath = join(process.cwd(), 'build-count.txt');
+const count = existsSync(countPath) ? Number(readFileSync(countPath, 'utf8')) : 0;
+writeFileSync(countPath, String(count + 1));
+
+const outputDir = join(process.cwd(), '.vercel', 'output');
+mkdirSync(join(outputDir, 'static'), { recursive: true });
+writeFileSync(join(outputDir, 'static', 'index.html'), 'ok');
+writeFileSync(
+  join(outputDir, 'config.json'),
+  JSON.stringify({
+    version: 3,
+    routes: [{ handle: 'filesystem' }],
+    experimentalServices: {
+      web: {
+        type: 'web',
+        root: '.',
+        framework: 'vite',
+        entrypoint: 'package.json',
+        mount: '/'
+      },
+      processor: {
+        type: 'job',
+        trigger: 'queue',
+        root: '.',
+        entrypoint: 'worker.js',
+        runtime: 'node',
+        topics: ['jobs']
+      }
+    }
+  }, null, 2)
+);
+`
+    );
+    await fs.outputFile(
+      join(cwd, 'worker.js'),
+      `
+const { createServer } = require('node:http');
+
+createServer((_req, res) => {
+  res.statusCode = 200;
+  res.end('ok');
+}).listen(3000);
+`
+    );
+
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toBe(0);
+
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config.experimentalServices).toEqual({
+      processor: expect.objectContaining({
+        type: 'job',
+        trigger: 'queue',
+        entrypoint: 'worker.js',
+      }),
+      web: expect.objectContaining({
+        type: 'web',
+        framework: 'vite',
+        mount: '/',
+      }),
+    });
+    expect(config.services).toBeUndefined();
+    expect(await fs.readFile(join(cwd, 'build-count.txt'), 'utf8')).toBe('1');
+    expect(
+      await fs.pathExists(
+        join(output, 'functions/_svc/processor/index.func/.vc-config.json')
+      )
+    ).toBe(true);
+  });
+
+  it('should ignore generated experimentalServices when vercel.json configures experimentalServices', async () => {
+    const cwd = await getWriteableDirectory();
+    const output = join(cwd, '.vercel', 'output');
+    await fs.ensureDir(join(cwd, '.vercel'));
+    await fs.writeJSON(join(cwd, '.vercel', 'project.json'), {
+      orgId: '.',
+      projectId: '.',
+      settings: {
+        framework: null,
+        installCommand: '',
+      },
+    });
+    await fs.writeJSON(join(cwd, 'package.json'), {
+      scripts: {
+        build: 'node build.mjs',
+      },
+    });
+    await fs.writeJSON(join(cwd, 'vercel.json'), {
+      experimentalServices: {
+        web: {
+          type: 'web',
+          root: '.',
+          framework: 'vite',
+          entrypoint: 'package.json',
+          mount: '/',
+        },
+      },
+    });
+    await fs.outputFile(
+      join(cwd, 'build.mjs'),
+      `
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const outputDir = join(process.cwd(), '.vercel', 'output');
+mkdirSync(join(outputDir, 'static'), { recursive: true });
+writeFileSync(join(outputDir, 'static', 'index.html'), 'ok');
+writeFileSync(
+  join(outputDir, 'config.json'),
+  JSON.stringify({
+    version: 3,
+    experimentalServices: {
+      generated: {
+        type: 'job',
+        trigger: 'queue',
+        root: '.',
+        entrypoint: 'missing.js',
+        runtime: 'node',
+        topics: ['jobs']
+      }
+    }
+  }, null, 2)
+);
+`
+    );
+
+    const originalServicesEnv = process.env.VERCEL_USE_SERVICES;
+    process.env.VERCEL_USE_SERVICES = '1';
+    let exitCode;
+    try {
+      client.cwd = cwd;
+      exitCode = await build(client);
+    } finally {
+      if (originalServicesEnv === undefined) {
+        delete process.env.VERCEL_USE_SERVICES;
+      } else {
+        process.env.VERCEL_USE_SERVICES = originalServicesEnv;
+      }
+    }
+    expect(exitCode).toBe(0);
+
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config.experimentalServices).toBeUndefined();
+    expect(config.services.map((s: any) => s.name)).toEqual(['web']);
+    expect(
+      await fs.pathExists(
+        join(output, 'functions/_svc/generated/index.func/.vc-config.json')
+      )
+    ).toBe(false);
+  });
+
   it('should not generate catch-all routes for Python cron services', async () => {
     const cwd = fixture('with-services-python-cron-no-catchall');
     const output = join(cwd, '.vercel', 'output');

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -146,6 +146,8 @@ export async function detectBuilders(
   const { services, experimentalServices, projectSettings = {} } = options;
   const { framework } = projectSettings;
   const configuredServices = services ?? experimentalServices;
+  const configuredServicesType =
+    services != null ? 'services' : 'experimentalServices';
   const hasServicesConfig =
     configuredServices != null && typeof configuredServices === 'object';
 
@@ -153,6 +155,7 @@ export async function detectBuilders(
     return getServicesBuilders({
       workPath: options.workPath,
       configuredServices: configuredServices,
+      configuredServicesType,
       projectFramework: framework,
     });
   }

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -128,7 +128,13 @@ interface PlatformDetectResult {
 export async function detectServices(
   options: DetectServicesOptions
 ): Promise<DetectServicesResult> {
-  const { fs, workPath, detectEntrypoint } = options;
+  const {
+    fs,
+    workPath,
+    detectEntrypoint,
+    configuredServices: providedConfiguredServices,
+    configuredServicesType,
+  } = options;
 
   // Scope filesystem to workPath if provided
   const scopedFs = workPath ? fs.chdir(workPath) : fs;
@@ -148,11 +154,19 @@ export async function detectServices(
     });
   }
 
+  const hasProvidedConfiguredServices =
+    providedConfiguredServices &&
+    Object.keys(providedConfiguredServices).length > 0;
   const hasNonEmptyPublicServicesConfig =
-    vercelConfig?.services && Object.keys(vercelConfig.services).length > 0;
-  const configuredServices = hasNonEmptyPublicServicesConfig
-    ? vercelConfig.services
-    : vercelConfig?.experimentalServices;
+    (hasProvidedConfiguredServices && configuredServicesType === 'services') ||
+    (!hasProvidedConfiguredServices &&
+      vercelConfig?.services &&
+      Object.keys(vercelConfig.services).length > 0);
+  const configuredServices = hasProvidedConfiguredServices
+    ? providedConfiguredServices
+    : hasNonEmptyPublicServicesConfig
+      ? vercelConfig?.services
+      : vercelConfig?.experimentalServices;
   const hasConfiguredServices =
     configuredServices && Object.keys(configuredServices).length > 0;
 

--- a/packages/fs-detectors/src/services/get-services-builders.ts
+++ b/packages/fs-detectors/src/services/get-services-builders.ts
@@ -1,6 +1,6 @@
 import type { Route } from '@vercel/routing-utils';
-import type { Builder, ExperimentalServices } from '@vercel/build-utils';
-import type { ResolvedService } from './types';
+import type { Builder } from '@vercel/build-utils';
+import type { ConfiguredServices, ResolvedService } from './types';
 import { detectServices } from './detect-services';
 import { LocalFileSystemDetector } from '../detectors/local-file-system-detector';
 
@@ -13,7 +13,8 @@ export interface ErrorResponse {
 
 export interface GetServicesBuildersOptions {
   workPath?: string;
-  configuredServices?: ExperimentalServices;
+  configuredServices?: ConfiguredServices;
+  configuredServicesType?: 'services' | 'experimentalServices';
   projectFramework?: string | null;
 }
 
@@ -45,7 +46,12 @@ function isExperimentalServicesAutoDetectionEnabled(): boolean {
 export async function getServicesBuilders(
   options: GetServicesBuildersOptions
 ): Promise<ServicesBuildersResult> {
-  const { workPath, configuredServices, projectFramework } = options;
+  const {
+    workPath,
+    configuredServices,
+    configuredServicesType,
+    projectFramework,
+  } = options;
   const hasServiceDefinitions =
     configuredServices != null && Object.keys(configuredServices).length > 0;
 
@@ -93,7 +99,11 @@ export async function getServicesBuilders(
   }
 
   const fs = new LocalFileSystemDetector(workPath);
-  const result = await detectServices({ fs });
+  const result = await detectServices({
+    fs,
+    configuredServices,
+    configuredServicesType,
+  });
 
   // Transform warnings to ErrorResponse format
   const warningResponses: ErrorResponse[] = result.warnings.map(w => ({

--- a/packages/fs-detectors/src/services/types.ts
+++ b/packages/fs-detectors/src/services/types.ts
@@ -39,6 +39,8 @@ export type ResolvedService = Service;
 
 export interface DetectServicesOptions {
   fs: DetectorFilesystem;
+  configuredServices?: ConfiguredServices;
+  configuredServicesType?: 'services' | 'experimentalServices';
   /**
    * Working directory path (relative to fs root).
    * If provided, vercel.json is read from this path.


### PR DESCRIPTION
## Summary
- Discover `experimentalServices` emitted into Build Output API config during build when `vercel.json` does not already define `experimentalServices`.
- Resolve the generated `experimentalServices` map through the existing experimental service builder flow and run newly discovered service builders in the same build session.
- Preserve generated `experimentalServices` across builder output merges, and keep the final Build Output API config using the `experimentalServices` shape rather than `services`.
- Add unit coverage plus a latest Next.js fixture that builds a Nitro service through framework handling.

x-ref: [slack context](https://vercel.slack.com/archives/C0AMN8UE0TX/p1779825123129019?thread_ts=1779469268.520159&cid=C0AMN8UE0TX)

## Tests
- Focused generated-`experimentalServices` unit tests
- Focused latest Next.js/Nitro integration test
- CLI package type check