### PR TITLE
fix(cli): allow preview env add without branch

### DIFF
--- a/.changeset/env-add-preview-all-branches.md
+++ b/.changeset/env-add-preview-all-branches.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow `vercel env add <name> preview --value <value> --yes` to target all Preview branches without prompting for a git branch.

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -662,39 +662,13 @@ export default async function add(client: Client, argv: string[]) {
   if (
     envGitBranch === undefined &&
     envTargets.length === 1 &&
-    envTargets[0] === 'preview'
+    envTargets[0] === 'preview' &&
+    !client.nonInteractive &&
+    !opts['--yes']
   ) {
-    if (client.nonInteractive) {
-      outputActionRequired(
-        client,
-        {
-          status: 'action_required',
-          reason: 'git_branch_required',
-          message: `Add ${envName} to which Git branch for Preview? Pass branch as third argument, or omit for all Preview branches.`,
-          next: [
-            {
-              command: buildEnvAddCommandWithPreservedArgs(
-                client.argv,
-                `env add ${envName} preview <gitbranch> --value <value> --yes`
-              ),
-              when: 'Add to a specific Git branch',
-            },
-            {
-              command: buildEnvAddCommandWithPreservedArgs(
-                client.argv,
-                `env add ${envName} preview --value <value> --yes`
-              ),
-              when: 'Add to all Preview branches',
-            },
-          ],
-        },
-        1
-      );
-    } else {
-      envGitBranch = await client.input.text({
-        message: `Add ${envName} to which Git branch? (leave empty for all Preview branches)?`,
-      });
-    }
+    envGitBranch = await client.input.text({
+      message: `Add ${envName} to which Git branch? (leave empty for all Preview branches)?`,
+    });
   }
 
   const hasDevelopment = envTargets.includes('development');

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -6,6 +6,11 @@ import { defaultProject, envs, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 
+// Mock the auto-install agent tooling so it doesn't prompt during env add tests.
+vi.mock('../../../../src/util/agent/auto-install-agentic', () => ({
+  autoInstallVercelPlugin: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe('env add', () => {
   beforeEach(() => {
     useUser();
@@ -1075,75 +1080,63 @@ describe('env add', () => {
         logSpy.mockRestore();
       });
 
-      it('uses --value when provided and reaches next prompt (e.g. git_branch_required)', async () => {
-        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-          throw new Error('exit');
-        });
-        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
+      it('adds to all Preview branches when --value is provided without a branch', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+        const envName = 'PREVIEW_ALL_BRANCHES_VALUE';
         client.nonInteractive = true;
         client.setArgv(
           'env',
           'add',
-          'PREVIEW_VAR',
+          envName,
           'preview',
           '--value',
           'my-secret-value',
           '--yes'
         );
-        const exitCodePromise = env(client);
 
-        await expect(exitCodePromise).rejects.toThrow('exit');
-        const payload = JSON.parse(
-          logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
-        );
-        expect(payload.reason).toBe('git_branch_required');
-        expect(
-          payload.next.some(
-            (n: { command: string }) =>
-              n.command.includes('preview') && n.command.includes('<gitbranch>')
-          )
-        ).toBe(true);
+        try {
+          await expect(env(client)).resolves.toBe(0);
 
-        exitSpy.mockRestore();
-        logSpy.mockRestore();
+          expect(spy).toHaveBeenCalledOnce();
+          expect(spy.mock.calls[0][4]).toBe(envName);
+          expect(spy.mock.calls[0][5]).toBe('my-secret-value');
+          expect(spy.mock.calls[0][6]).toEqual(['preview']);
+          expect(spy.mock.calls[0][7]).toBeUndefined();
+        } finally {
+          spy.mockRestore();
+        }
       });
 
-      it('outputs action_required when preview target and git branch not passed (no third argument)', async () => {
-        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-          throw new Error('exit');
-        });
-        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
+      it('adds stdin value to all Preview branches without a branch', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const spy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+        const envName = 'PREVIEW_ALL_BRANCHES_STDIN';
         client.nonInteractive = true;
         client.stdin.isTTY = false;
-        client.setArgv('env', 'add', 'PREVIEW_VAR', 'preview', '--yes');
+        client.setArgv('env', 'add', envName, 'preview', '--yes');
         const exitCodePromise = env(client);
         setImmediate(() => client.stdin.emit('data', 'value-via-stdin'));
 
-        await expect(exitCodePromise).rejects.toThrow('exit');
-        expect(logSpy).toHaveBeenCalled();
-        const payload = JSON.parse(
-          logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
-        );
-        expect(payload).toMatchObject({
-          status: 'action_required',
-          reason: 'git_branch_required',
-          message: expect.stringMatching(/Git branch|third argument|Preview/),
-          next: expect.any(Array),
-        });
-        expect(payload.next.length).toBeGreaterThanOrEqual(1);
-        expect(
-          payload.next.some(
-            (n: { command: string }) =>
-              n.command.includes('preview') &&
-              (n.command.includes('<gitbranch>') ||
-                n.command.includes('--value'))
-          )
-        ).toBe(true);
+        try {
+          await expect(exitCodePromise).resolves.toBe(0);
 
-        exitSpy.mockRestore();
-        logSpy.mockRestore();
+          expect(spy).toHaveBeenCalledOnce();
+          expect(spy.mock.calls[0][4]).toBe(envName);
+          expect(spy.mock.calls[0][5]).toBe('value-via-stdin');
+          expect(spy.mock.calls[0][6]).toEqual(['preview']);
+          expect(spy.mock.calls[0][7]).toBeUndefined();
+        } finally {
+          spy.mockRestore();
+        }
       });
 
       it('does not output git_branch_required when branch is passed as third argument for preview', async () => {


### PR DESCRIPTION
Fixes #16190.

## Summary
- allow non-interactive `vercel env add <name> preview --value <value> --yes` to target all Preview branches without requiring a git branch
- keep the branch prompt for interactive preview adds
- update env add unit coverage for `--value` and stdin flows that target all Preview branches
- add a changeset for the CLI package

## Tests
- `pnpm exec vitest run --config ./vitest.config.mts test/unit/commands/env/add.test.ts --reporter verbose --no-file-parallelism --maxWorkers=1 --testTimeout=20000`
- `pnpm --filter vercel exec tsc --noEmit`
- `git diff --check`
