### PR TITLE
[cli] fix _deploy eval grader

### DIFF
--- a/.changeset/fix-deploy-eval-grader-token.md
+++ b/.changeset/fix-deploy-eval-grader-token.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Internal: fix `_deploy` eval grader passing `--token ""` in the Docker sandbox where `VERCEL_TOKEN` isn't in process env. Only pass `--token` when set; CLI falls back to `auth.json` otherwise.

--- a/packages/cli/evals/evals/_deploy/EVAL.ts
+++ b/packages/cli/evals/evals/_deploy/EVAL.ts
@@ -6,53 +6,27 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const INSPECT_TIMEOUT_MS = 30_000;
-const INSPECT_POLL_MS = 1_000;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-function inspectProject(cwd: string): string {
+test('build completed successfully', () => {
+  const folders = readdirSync('.', { withFileTypes: true });
+  const fixtureFolder = folders.find(folder =>
+    folder.name.startsWith('fixture')
+  );
+  if (!fixtureFolder) {
+    throw new Error('Fixture folder not found');
+  }
+  const projectJsonExists = existsSync(
+    path.join(fixtureFolder.name, '.vercel/project.json')
+  );
+  expect(projectJsonExists).toBe(true);
   const args = ['project', 'inspect', '--scope', 'agentic-zero-conf'];
   const token = process.env.VERCEL_TOKEN;
   if (token) {
     args.push('--token', token);
   }
-  const result = spawnSync('vercel', args, {
-    cwd,
+  const projectInspect = spawnSync('vercel', args, {
+    cwd: fixtureFolder.name,
     env: process.env,
     encoding: 'utf-8',
   });
-  return result.stderr ?? '';
-}
-
-test(
-  'build completed successfully',
-  async () => {
-    const folders = readdirSync('.', { withFileTypes: true });
-    const fixtureFolder = folders.find(folder =>
-      folder.name.startsWith('fixture')
-    );
-    if (!fixtureFolder) {
-      throw new Error('Fixture folder not found');
-    }
-    const projectJsonExists = existsSync(
-      path.join(fixtureFolder.name, '.vercel/project.json')
-    );
-    expect(projectJsonExists).toBe(true);
-
-    // Framework detection lands asynchronously after deploy → READY.
-    const deadline = Date.now() + INSPECT_TIMEOUT_MS;
-    let lastStderr = '';
-    while (Date.now() < deadline) {
-      lastStderr = inspectProject(fixtureFolder.name);
-      if (lastStderr.includes('Hono')) {
-        return;
-      }
-      await sleep(INSPECT_POLL_MS);
-    }
-    expect(lastStderr).toContain('Hono');
-  },
-  INSPECT_TIMEOUT_MS + 5_000
-);
+  expect(projectInspect.stderr).toContain('Hono');
+});

--- a/packages/cli/evals/evals/_deploy/EVAL.ts
+++ b/packages/cli/evals/evals/_deploy/EVAL.ts
@@ -6,33 +6,53 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-test('build completed successfully', () => {
-  const folders = readdirSync('.', { withFileTypes: true });
-  const fixtureFolder = folders.find(folder =>
-    folder.name.startsWith('fixture')
-  );
-  if (!fixtureFolder) {
-    throw new Error('Fixture folder not found');
+const INSPECT_TIMEOUT_MS = 30_000;
+const INSPECT_POLL_MS = 1_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function inspectProject(cwd: string): string {
+  const args = ['project', 'inspect', '--scope', 'agentic-zero-conf'];
+  const token = process.env.VERCEL_TOKEN;
+  if (token) {
+    args.push('--token', token);
   }
-  const projectJsonExists = existsSync(
-    path.join(fixtureFolder.name, '.vercel/project.json')
-  );
-  expect(projectJsonExists).toBe(true);
-  const projectInspect = spawnSync(
-    'vercel',
-    [
-      'project',
-      'inspect',
-      '--scope',
-      'agentic-zero-conf',
-      '--token',
-      process.env.VERCEL_TOKEN ?? '',
-    ],
-    {
-      cwd: fixtureFolder.name,
-      env: process.env,
-      encoding: 'utf-8',
+  const result = spawnSync('vercel', args, {
+    cwd,
+    env: process.env,
+    encoding: 'utf-8',
+  });
+  return result.stderr ?? '';
+}
+
+test(
+  'build completed successfully',
+  async () => {
+    const folders = readdirSync('.', { withFileTypes: true });
+    const fixtureFolder = folders.find(folder =>
+      folder.name.startsWith('fixture')
+    );
+    if (!fixtureFolder) {
+      throw new Error('Fixture folder not found');
     }
-  );
-  expect(projectInspect.stderr).toContain('Hono');
-});
+    const projectJsonExists = existsSync(
+      path.join(fixtureFolder.name, '.vercel/project.json')
+    );
+    expect(projectJsonExists).toBe(true);
+
+    // Framework detection lands asynchronously after deploy → READY.
+    const deadline = Date.now() + INSPECT_TIMEOUT_MS;
+    let lastStderr = '';
+    while (Date.now() < deadline) {
+      lastStderr = inspectProject(fixtureFolder.name);
+      if (lastStderr.includes('Hono')) {
+        return;
+      }
+      await sleep(INSPECT_POLL_MS);
+    }
+    expect(lastStderr).toContain('Hono');
+  },
+  INSPECT_TIMEOUT_MS + 5_000
+);


### PR DESCRIPTION
## Summary

- `_deploy` grader passed `--token ""` in the Docker sandbox because `VERCEL_TOKEN` isn't in process env there (it's in `auth.json` / `~/.profile`).
- CLI rejects empty `--token` with `Error: You defined "--token", but it's missing a value`, so the grader bailed before checking framework — every dashboard `_deploy` was red even when the agent's deploy succeeded.
- Fix: only pass `--token` when the env var is set; CLI falls back to `auth.json`. Local behavior unchanged.
- Verified: 4/4 real agent variants (`cli`, `cli-claude-opus-4.6`, `cli-claude-opus-4.7`, `cli-gpt-5.4-medium`) now pass `_deploy` in ~145–155s.