### PR TITLE
[cli] don't retry intentionally aborted requests

### DIFF
--- a/.changeset/no-retry-aborted-requests.md
+++ b/.changeset/no-retry-aborted-requests.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Stop retrying intentionally aborted requests so the CLI exits promptly after a deployment is ready.

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -505,7 +505,15 @@ export default class Client extends EventEmitter implements Stdio {
   fetch<T>(url: string, opts?: FetchOptions): Promise<T>;
   fetch(url: string, opts: FetchOptions = {}) {
     return this.retry(async bail => {
-      const res = await this._fetch(url, opts);
+      let res: Awaited<ReturnType<Client['_fetch']>>;
+      try {
+        res = await this._fetch(url, opts);
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          return bail(err);
+        }
+        throw err;
+      }
 
       printIndications(res);
 

--- a/packages/cli/test/unit/util/client.test.ts
+++ b/packages/cli/test/unit/util/client.test.ts
@@ -73,6 +73,31 @@ describe('Client', () => {
       }
     });
 
+    it('does not retry a request aborted via its signal', async () => {
+      client.scenario.get('/v2/user', (_req, res) => {
+        res.json({ user: { uid: 'abc' } });
+      });
+
+      const onRetry = vi.spyOn(
+        client as unknown as { _onRetry: (error: Error) => void },
+        '_onRetry'
+      );
+
+      const abortController = new AbortController();
+      abortController.abort();
+
+      await expect(
+        client.fetch('/v2/user', {
+          json: false,
+          retry: { retries: 3 },
+          // @ts-expect-error: signal types differ between node-fetch and web
+          signal: abortController.signal,
+        })
+      ).rejects.toThrowError(/abort/i);
+
+      expect(onRetry).not.toHaveBeenCalled();
+    });
+
     it('should return 3xx responses directly when redirect is manual', async () => {
       client.scenario.get('/v1/test-redirect', (_req, res) => {
         res.writeHead(302, { Location: 'https://example.com/target' });


### PR DESCRIPTION
## Summary

- `Client.fetch` retried on `AbortError`, so aborting the deployment events stream at READY re-fired the request with an already-aborted signal until the retry budget ran out — keeping the process alive ~7s after the deploy completed (and causing the `Telemetry subprocess killed due to timeout` noise).
- Bail on `AbortError` instead of retrying.
- Added a regression test asserting an aborted request rejects without invoking the retry handler.