### PR TITLE
[blob] add presigning to cli

### DIFF
--- a/.changeset/blob-presign-signed-token.md
+++ b/.changeset/blob-presign-signed-token.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel blob signed-token` and `vercel blob presign` commands, and allow `blob presign` to accept explicit delegation/client-signing tokens or issue them automatically when omitted.

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -239,6 +239,196 @@ export const getSubcommand = {
   examples: [],
 } as const;
 
+export const signedTokenSubcommand = {
+  name: 'signed-token',
+  aliases: [],
+  description: 'Issue a short-lived signed token for Blob operations',
+  arguments: [],
+  options: [
+    {
+      name: 'pathname',
+      shorthand: 'p',
+      type: String,
+      deprecated: false,
+      description: 'Pathname scope for the token. Defaults to "*" when omitted',
+      argument: 'STRING',
+    },
+    {
+      name: 'operation',
+      shorthand: 'o',
+      type: [String],
+      deprecated: false,
+      description: 'Allowed operation(s): get, head, put, delete (repeatable)',
+      argument: 'OPERATION',
+      choices: ['get', 'head', 'put', 'delete'],
+    },
+    {
+      name: 'valid-until',
+      shorthand: null,
+      type: Number,
+      deprecated: false,
+      description: 'Absolute expiration time as Unix timestamp in milliseconds',
+      argument: 'TIMESTAMP_MS',
+    },
+    {
+      name: 'allowed-content-type',
+      shorthand: null,
+      type: [String],
+      deprecated: false,
+      description:
+        'Allowed content type(s) for put operations (repeatable, supports wildcards)',
+      argument: 'MIME_TYPE',
+    },
+    {
+      name: 'maximum-size-in-bytes',
+      shorthand: null,
+      type: Number,
+      deprecated: false,
+      description: 'Maximum upload size in bytes for put operations (max: 5TB)',
+      argument: 'BYTES',
+    },
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output signed token payload as JSON',
+    },
+  ],
+  examples: [
+    {
+      name: 'Issue a signed token for reads',
+      value:
+        'vercel blob signed-token --pathname media/photo.jpg --operation get',
+    },
+    {
+      name: 'Issue a signed token for uploads with constraints',
+      value:
+        'vercel blob signed-token --pathname uploads/* --operation put --allowed-content-type image/* --maximum-size-in-bytes 10485760',
+    },
+  ],
+} as const;
+
+export const presignSubcommand = {
+  name: 'presign',
+  aliases: [],
+  description: 'Generate a presigned URL for Blob operations',
+  arguments: [
+    {
+      name: 'pathname',
+      required: true,
+    },
+  ],
+  options: [
+    accessOption,
+    {
+      name: 'operation',
+      shorthand: 'o',
+      type: String,
+      deprecated: false,
+      description:
+        'Operation for the presigned URL: get, head, put, or delete (default: get)',
+      argument: 'OPERATION',
+      choices: ['get', 'head', 'put', 'delete'],
+    },
+    {
+      name: 'delegation-token',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Delegation token from `vercel blob signed-token` (must be used with --client-signing-token)',
+      argument: 'STRING',
+    },
+    {
+      name: 'client-signing-token',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Signing secret/token from `vercel blob signed-token` (must be used with --delegation-token)',
+      argument: 'STRING',
+    },
+    {
+      name: 'valid-until',
+      shorthand: null,
+      type: Number,
+      deprecated: false,
+      description: 'Absolute expiration time as Unix timestamp in milliseconds',
+      argument: 'TIMESTAMP_MS',
+    },
+    {
+      name: 'if-match',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'If-Match constraint for put or delete operations',
+      argument: 'STRING',
+    },
+    {
+      name: 'allow-overwrite',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Allow overwriting existing blobs (put only)',
+    },
+    {
+      name: 'add-random-suffix',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Add a random suffix to the pathname (put only)',
+    },
+    {
+      name: 'cache-control-max-age',
+      shorthand: null,
+      type: Number,
+      deprecated: false,
+      description: 'Cache-Control max-age in seconds (put only)',
+      argument: 'SECONDS',
+    },
+    {
+      name: 'allowed-content-type',
+      shorthand: null,
+      type: [String],
+      deprecated: false,
+      description: 'Allowed content type(s) for uploads (put only, repeatable)',
+      argument: 'MIME_TYPE',
+    },
+    {
+      name: 'maximum-size-in-bytes',
+      shorthand: null,
+      type: Number,
+      deprecated: false,
+      description: 'Maximum upload size in bytes (put only, max: 5TB)',
+      argument: 'BYTES',
+    },
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output presign result as JSON',
+    },
+  ],
+  examples: [
+    {
+      name: 'Generate a presigned GET URL',
+      value: 'vercel blob presign media/photo.jpg --access public',
+    },
+    {
+      name: 'Generate a presigned PUT URL with upload constraints',
+      value:
+        'vercel blob presign uploads/image.jpg --access private --operation put --allowed-content-type image/* --maximum-size-in-bytes 10485760',
+    },
+    {
+      name: 'Generate a presigned URL from existing signed-token output',
+      value:
+        'vercel blob presign uploads/image.jpg --access private --operation put --delegation-token <delegationToken> --client-signing-token <clientSigningToken>',
+    },
+  ],
+} as const;
+
 export const createStoreSubcommand = {
   name: 'create-store',
   aliases: [],
@@ -369,6 +559,8 @@ export const blobCommand = {
     getSubcommand,
     delSubcommand,
     copySubcommand,
+    signedTokenSubcommand,
+    presignSubcommand,
     createStoreSubcommand,
     deleteStoreSubcommand,
     getStoreInfoSubcommand,

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -267,8 +267,18 @@ export const signedTokenSubcommand = {
       shorthand: null,
       type: Number,
       deprecated: false,
-      description: 'Absolute expiration time as Unix timestamp in milliseconds',
+      description:
+        'Absolute expiration time as Unix timestamp in milliseconds (mutually exclusive with --valid-for)',
       argument: 'TIMESTAMP_MS',
+    },
+    {
+      name: 'valid-for',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Relative duration before expiration (for example: 15m, 1h, 7d; mutually exclusive with --valid-until)',
+      argument: 'DURATION',
     },
     {
       name: 'allowed-content-type',
@@ -354,8 +364,18 @@ export const presignSubcommand = {
       shorthand: null,
       type: Number,
       deprecated: false,
-      description: 'Absolute expiration time as Unix timestamp in milliseconds',
+      description:
+        'Absolute expiration time as Unix timestamp in milliseconds (mutually exclusive with --valid-for)',
       argument: 'TIMESTAMP_MS',
+    },
+    {
+      name: 'valid-for',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Relative duration before expiration (for example: 15m, 1h, 7d; mutually exclusive with --valid-until)',
+      argument: 'DURATION',
     },
     {
       name: 'if-match',

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -9,12 +9,14 @@ import {
   delSubcommand,
   getSubcommand,
   listSubcommand,
+  presignSubcommand,
   putSubcommand,
   copySubcommand,
   createStoreSubcommand,
   deleteStoreSubcommand,
   getStoreInfoSubcommand,
   listStoresSubcommand,
+  signedTokenSubcommand,
   emptyStoreSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -30,6 +32,8 @@ import removeStore from './store-remove';
 import getStore from './store-get';
 import listStores from './store-list';
 import emptyStore from './store-empty';
+import presign from './presign';
+import signedToken from './signed-token';
 import { printError } from '../../util/error';
 import { findFlagValue, getBlobRWToken } from '../../util/blob/token';
 
@@ -39,6 +43,8 @@ const COMMAND_CONFIG = {
   get: getCommandAliases(getSubcommand),
   del: getCommandAliases(delSubcommand),
   copy: getCommandAliases(copySubcommand),
+  'signed-token': getCommandAliases(signedTokenSubcommand),
+  presign: getCommandAliases(presignSubcommand),
   'create-store': getCommandAliases(createStoreSubcommand),
   'delete-store': getCommandAliases(deleteStoreSubcommand),
   'get-store': getCommandAliases(getStoreInfoSubcommand),
@@ -165,6 +171,36 @@ export default async function main(client: Client) {
       }
 
       return copy(client, args, token);
+    case 'signed-token':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(signedTokenSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandSignedToken(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
+      return signedToken(client, args, token);
+    case 'presign':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('blob', subcommandOriginal);
+        printHelp(presignSubcommand);
+        return 2;
+      }
+
+      telemetry.trackCliSubcommandPresign(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
+      return presign(client, args, token);
     case 'create-store':
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob', subcommandOriginal);

--- a/packages/cli/src/commands/blob/presign.ts
+++ b/packages/cli/src/commands/blob/presign.ts
@@ -1,0 +1,244 @@
+import * as blob from '@vercel/blob';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { printError } from '../../util/error';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { parseAccessFlag } from '../../util/blob/access';
+import { blobOpts, type BlobRWToken } from '../../util/blob/token';
+import { BlobPresignTelemetryClient } from '../../util/telemetry/commands/blob/presign';
+import { presignSubcommand } from './command';
+
+const VALID_OPERATIONS = ['get', 'head', 'put', 'delete'] as const;
+type PresignOperation = (typeof VALID_OPERATIONS)[number];
+
+function isPresignOperation(value: string): value is PresignOperation {
+  return (VALID_OPERATIONS as readonly string[]).includes(value);
+}
+
+function parseOperation(
+  operation: string | undefined
+): PresignOperation | null {
+  const operationValue = operation ?? 'get';
+  if (!isPresignOperation(operationValue)) {
+    output.error(
+      `Invalid operation value: '${operationValue}'. Must be one of: get, head, put, delete.`
+    );
+    return null;
+  }
+  return operationValue;
+}
+
+function hasUploadOnlyFlags(options: {
+  allowedContentTypes: string[] | undefined;
+  maximumSizeInBytes: number | undefined;
+  allowOverwrite: boolean | undefined;
+  addRandomSuffix: boolean | undefined;
+  cacheControlMaxAge: number | undefined;
+}) {
+  const {
+    allowedContentTypes,
+    maximumSizeInBytes,
+    allowOverwrite,
+    addRandomSuffix,
+    cacheControlMaxAge,
+  } = options;
+  return Boolean(
+    (allowedContentTypes && allowedContentTypes.length > 0) ||
+      maximumSizeInBytes !== undefined ||
+      allowOverwrite ||
+      addRandomSuffix ||
+      cacheControlMaxAge !== undefined
+  );
+}
+
+function writePresignOutput(params: {
+  client: Client;
+  asJson: boolean | undefined;
+  operation: PresignOperation;
+  presignedUrl: string;
+  validUntil?: number;
+}) {
+  const { client, asJson, operation, presignedUrl, validUntil } = params;
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          operation,
+          presignedUrl,
+          ...(validUntil !== undefined ? { validUntil } : {}),
+        },
+        null,
+        2
+      )}\n`
+    );
+  } else {
+    output.print(`${presignedUrl}\n`);
+  }
+}
+
+export default async function presign(
+  client: Client,
+  argv: string[],
+  auth: BlobRWToken
+): Promise<number> {
+  const telemetryClient = new BlobPresignTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(presignSubcommand.options);
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const {
+    flags,
+    args: [pathname],
+  } = parsedArgs;
+  const {
+    '--access': accessFlag,
+    '--operation': operationFlag,
+    '--delegation-token': delegationTokenFlag,
+    '--client-signing-token': clientSigningTokenFlag,
+    '--valid-until': validUntil,
+    '--if-match': ifMatch,
+    '--allow-overwrite': allowOverwrite,
+    '--add-random-suffix': addRandomSuffix,
+    '--cache-control-max-age': cacheControlMaxAge,
+    '--allowed-content-type': allowedContentTypes,
+    '--maximum-size-in-bytes': maximumSizeInBytes,
+    '--json': asJson,
+  } = flags;
+
+  if (!pathname) {
+    output.error('Missing required argument: pathname');
+    return 1;
+  }
+
+  const access = parseAccessFlag(accessFlag);
+  if (!access) {
+    return 1;
+  }
+
+  const operation = parseOperation(operationFlag);
+  if (!operation) {
+    return 1;
+  }
+
+  if (Boolean(delegationTokenFlag) !== Boolean(clientSigningTokenFlag)) {
+    output.error(
+      'The --delegation-token and --client-signing-token flags must be passed together. Pass both, or pass neither to issue a token automatically.'
+    );
+    return 1;
+  }
+
+  if (
+    operation !== 'put' &&
+    hasUploadOnlyFlags({
+      allowedContentTypes,
+      maximumSizeInBytes,
+      allowOverwrite,
+      addRandomSuffix,
+      cacheControlMaxAge,
+    })
+  ) {
+    output.error(
+      'The flags --allowed-content-type, --maximum-size-in-bytes, --allow-overwrite, --add-random-suffix, and --cache-control-max-age can only be used with --operation put.'
+    );
+    return 1;
+  }
+
+  if (operation === 'get' || operation === 'head') {
+    if (ifMatch) {
+      output.error(
+        'The --if-match flag can only be used with --operation put or --operation delete.'
+      );
+      return 1;
+    }
+  }
+
+  telemetryClient.trackCliArgumentPathname(pathname);
+  telemetryClient.trackCliOptionAccess(accessFlag);
+  telemetryClient.trackCliOptionOperation(operationFlag);
+  telemetryClient.trackCliOptionDelegationToken(delegationTokenFlag);
+  telemetryClient.trackCliOptionClientSigningToken(clientSigningTokenFlag);
+  telemetryClient.trackCliOptionValidUntil(validUntil);
+  telemetryClient.trackCliOptionIfMatch(ifMatch);
+  telemetryClient.trackCliFlagAllowOverwrite(allowOverwrite);
+  telemetryClient.trackCliFlagAddRandomSuffix(addRandomSuffix);
+  telemetryClient.trackCliOptionCacheControlMaxAge(cacheControlMaxAge);
+  telemetryClient.trackCliOptionAllowedContentType(allowedContentTypes);
+  telemetryClient.trackCliOptionMaximumSizeInBytes(maximumSizeInBytes);
+  telemetryClient.trackCliFlagJson(asJson);
+
+  try {
+    output.debug('Generating presigned URL');
+    output.spinner('Generating presigned URL');
+
+    const signedToken =
+      delegationTokenFlag && clientSigningTokenFlag
+        ? {
+            delegationToken: delegationTokenFlag,
+            clientSigningToken: clientSigningTokenFlag,
+          }
+        : await blob.issueSignedToken({
+            ...blobOpts(auth),
+            pathname,
+            operations: [operation],
+            validUntil,
+            ...(operation === 'put'
+              ? {
+                  allowedContentTypes,
+                  maximumSizeInBytes,
+                }
+              : {}),
+          });
+
+    const presigned = await blob.presignUrl(
+      {
+        delegationToken: signedToken.delegationToken,
+        clientSigningToken: signedToken.clientSigningToken,
+      },
+      {
+        operation,
+        pathname,
+        access,
+        validUntil,
+        ...(operation === 'put'
+          ? {
+              allowedContentTypes,
+              maximumSizeInBytes,
+              allowOverwrite,
+              addRandomSuffix,
+              cacheControlMaxAge,
+              ifMatch,
+            }
+          : operation === 'delete'
+            ? { ifMatch }
+            : {}),
+      }
+    );
+
+    output.stopSpinner();
+
+    writePresignOutput({
+      client,
+      asJson,
+      operation,
+      presignedUrl: presigned.presignedUrl,
+      validUntil:
+        'validUntil' in signedToken ? signedToken.validUntil : undefined,
+    });
+    return 0;
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/blob/presign.ts
+++ b/packages/cli/src/commands/blob/presign.ts
@@ -6,7 +6,8 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { parseArguments } from '../../util/get-args';
 import { parseAccessFlag } from '../../util/blob/access';
 import { blobOpts, type BlobRWToken } from '../../util/blob/token';
-import { BlobPresignTelemetryClient } from '../../util/telemetry/commands/blob/presign';
+import { resolveBlobValidUntil } from '../../util/blob/validity';
+import { BlobPresignTelemetryClient } from '../../util/telemetry/commands/blob';
 import { presignSubcommand } from './command';
 
 const VALID_OPERATIONS = ['get', 'head', 'put', 'delete'] as const;
@@ -107,6 +108,7 @@ export default async function presign(
     '--delegation-token': delegationTokenFlag,
     '--client-signing-token': clientSigningTokenFlag,
     '--valid-until': validUntil,
+    '--valid-for': validFor,
     '--if-match': ifMatch,
     '--allow-overwrite': allowOverwrite,
     '--add-random-suffix': addRandomSuffix,
@@ -128,6 +130,12 @@ export default async function presign(
 
   const operation = parseOperation(operationFlag);
   if (!operation) {
+    return 1;
+  }
+
+  const validity = resolveBlobValidUntil({ validUntil, validFor });
+  if (validity.error) {
+    output.error(validity.error);
     return 1;
   }
 
@@ -169,6 +177,7 @@ export default async function presign(
   telemetryClient.trackCliOptionDelegationToken(delegationTokenFlag);
   telemetryClient.trackCliOptionClientSigningToken(clientSigningTokenFlag);
   telemetryClient.trackCliOptionValidUntil(validUntil);
+  telemetryClient.trackCliOptionValidFor(validFor);
   telemetryClient.trackCliOptionIfMatch(ifMatch);
   telemetryClient.trackCliFlagAllowOverwrite(allowOverwrite);
   telemetryClient.trackCliFlagAddRandomSuffix(addRandomSuffix);
@@ -191,7 +200,7 @@ export default async function presign(
             ...blobOpts(auth),
             pathname,
             operations: [operation],
-            validUntil,
+            validUntil: validity.validUntil,
             ...(operation === 'put'
               ? {
                   allowedContentTypes,
@@ -209,7 +218,7 @@ export default async function presign(
         operation,
         pathname,
         access,
-        validUntil,
+        validUntil: validity.validUntil,
         ...(operation === 'put'
           ? {
               allowedContentTypes,

--- a/packages/cli/src/commands/blob/presign.ts
+++ b/packages/cli/src/commands/blob/presign.ts
@@ -74,7 +74,7 @@ function writePresignOutput(params: {
       )}\n`
     );
   } else {
-    output.print(`${presignedUrl}\n`);
+    client.stdout.write(`${presignedUrl}\n`);
   }
 }
 

--- a/packages/cli/src/commands/blob/presign.ts
+++ b/packages/cli/src/commands/blob/presign.ts
@@ -7,56 +7,19 @@ import { parseArguments } from '../../util/get-args';
 import { parseAccessFlag } from '../../util/blob/access';
 import { blobOpts, type BlobRWToken } from '../../util/blob/token';
 import { resolveBlobValidUntil } from '../../util/blob/validity';
+import {
+  hasPresignUploadOnlyFlags,
+  parseBlobOperation,
+  PRESIGN_UPLOAD_ONLY_FLAGS_ERROR,
+  type BlobOperation,
+} from '../../util/blob/operations';
 import { BlobPresignTelemetryClient } from '../../util/telemetry/commands/blob';
 import { presignSubcommand } from './command';
-
-const VALID_OPERATIONS = ['get', 'head', 'put', 'delete'] as const;
-type PresignOperation = (typeof VALID_OPERATIONS)[number];
-
-function isPresignOperation(value: string): value is PresignOperation {
-  return (VALID_OPERATIONS as readonly string[]).includes(value);
-}
-
-function parseOperation(
-  operation: string | undefined
-): PresignOperation | null {
-  const operationValue = operation ?? 'get';
-  if (!isPresignOperation(operationValue)) {
-    output.error(
-      `Invalid operation value: '${operationValue}'. Must be one of: get, head, put, delete.`
-    );
-    return null;
-  }
-  return operationValue;
-}
-
-function hasUploadOnlyFlags(options: {
-  allowedContentTypes: string[] | undefined;
-  maximumSizeInBytes: number | undefined;
-  allowOverwrite: boolean | undefined;
-  addRandomSuffix: boolean | undefined;
-  cacheControlMaxAge: number | undefined;
-}) {
-  const {
-    allowedContentTypes,
-    maximumSizeInBytes,
-    allowOverwrite,
-    addRandomSuffix,
-    cacheControlMaxAge,
-  } = options;
-  return Boolean(
-    (allowedContentTypes && allowedContentTypes.length > 0) ||
-      maximumSizeInBytes !== undefined ||
-      allowOverwrite ||
-      addRandomSuffix ||
-      cacheControlMaxAge !== undefined
-  );
-}
 
 function writePresignOutput(params: {
   client: Client;
   asJson: boolean | undefined;
-  operation: PresignOperation;
+  operation: BlobOperation;
   presignedUrl: string;
   validUntil?: number;
 }) {
@@ -128,7 +91,7 @@ export default async function presign(
     return 1;
   }
 
-  const operation = parseOperation(operationFlag);
+  const operation = parseBlobOperation(operationFlag);
   if (!operation) {
     return 1;
   }
@@ -148,7 +111,7 @@ export default async function presign(
 
   if (
     operation !== 'put' &&
-    hasUploadOnlyFlags({
+    hasPresignUploadOnlyFlags({
       allowedContentTypes,
       maximumSizeInBytes,
       allowOverwrite,
@@ -156,9 +119,7 @@ export default async function presign(
       cacheControlMaxAge,
     })
   ) {
-    output.error(
-      'The flags --allowed-content-type, --maximum-size-in-bytes, --allow-overwrite, --add-random-suffix, and --cache-control-max-age can only be used with --operation put.'
-    );
+    output.error(PRESIGN_UPLOAD_ONLY_FLAGS_ERROR);
     return 1;
   }
 

--- a/packages/cli/src/commands/blob/presign.ts
+++ b/packages/cli/src/commands/blob/presign.ts
@@ -242,7 +242,8 @@ export default async function presign(
       operation,
       presignedUrl: presigned.presignedUrl,
       validUntil:
-        'validUntil' in signedToken ? signedToken.validUntil : undefined,
+        ('validUntil' in signedToken ? signedToken.validUntil : undefined) ??
+        validity.validUntil,
     });
     return 0;
   } catch (err) {

--- a/packages/cli/src/commands/blob/signed-token.ts
+++ b/packages/cli/src/commands/blob/signed-token.ts
@@ -1,0 +1,118 @@
+import * as blob from '@vercel/blob';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { printError } from '../../util/error';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { blobOpts, type BlobRWToken } from '../../util/blob/token';
+import { BlobSignedTokenTelemetryClient } from '../../util/telemetry/commands/blob/signed-token';
+import { signedTokenSubcommand } from './command';
+
+const VALID_OPERATIONS = ['get', 'head', 'put', 'delete'] as const;
+type DelegationOperation = (typeof VALID_OPERATIONS)[number];
+
+function isDelegationOperation(value: string): value is DelegationOperation {
+  return (VALID_OPERATIONS as readonly string[]).includes(value);
+}
+
+function parseOperations(
+  operations: string[] | undefined
+): DelegationOperation[] | undefined | null {
+  if (!operations || operations.length === 0) {
+    return undefined;
+  }
+
+  const invalidOperation = operations.find(operation => {
+    return !isDelegationOperation(operation);
+  });
+
+  if (invalidOperation) {
+    output.error(
+      `Invalid operation value: '${invalidOperation}'. Must be one of: get, head, put, delete.`
+    );
+    return null;
+  }
+
+  return operations as DelegationOperation[];
+}
+
+function printSignedToken(result: blob.IssuedSignedToken) {
+  output.print(
+    `delegationToken=${result.delegationToken}
+clientSigningToken=${result.clientSigningToken}
+validUntil=${result.validUntil} (${new Date(result.validUntil).toISOString()})
+`
+  );
+}
+
+export default async function signedToken(
+  client: Client,
+  argv: string[],
+  auth: BlobRWToken
+): Promise<number> {
+  const telemetryClient = new BlobSignedTokenTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(
+    signedTokenSubcommand.options
+  );
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { flags } = parsedArgs;
+  const {
+    '--pathname': pathname,
+    '--operation': operationValues,
+    '--valid-until': validUntil,
+    '--allowed-content-type': allowedContentTypes,
+    '--maximum-size-in-bytes': maximumSizeInBytes,
+    '--json': asJson,
+  } = flags;
+
+  const operations = parseOperations(operationValues);
+  if (operations === null) {
+    return 1;
+  }
+
+  telemetryClient.trackCliOptionPathname(pathname);
+  telemetryClient.trackCliOptionOperation(operationValues);
+  telemetryClient.trackCliOptionValidUntil(validUntil);
+  telemetryClient.trackCliOptionAllowedContentType(allowedContentTypes);
+  telemetryClient.trackCliOptionMaximumSizeInBytes(maximumSizeInBytes);
+  telemetryClient.trackCliFlagJson(asJson);
+
+  try {
+    output.debug('Issuing signed token');
+    output.spinner('Issuing signed token');
+
+    const result = await blob.issueSignedToken({
+      ...blobOpts(auth),
+      pathname,
+      operations,
+      validUntil,
+      allowedContentTypes,
+      maximumSizeInBytes,
+    });
+
+    output.stopSpinner();
+
+    if (asJson) {
+      client.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } else {
+      printSignedToken(result);
+    }
+    return 0;
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/blob/signed-token.ts
+++ b/packages/cli/src/commands/blob/signed-token.ts
@@ -6,36 +6,14 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { parseArguments } from '../../util/get-args';
 import { blobOpts, type BlobRWToken } from '../../util/blob/token';
 import { resolveBlobValidUntil } from '../../util/blob/validity';
+import {
+  allowsUploadConstraints,
+  hasUploadConstraintFlags,
+  parseBlobOperations,
+  UPLOAD_CONSTRAINT_FLAGS_ERROR,
+} from '../../util/blob/operations';
 import { BlobSignedTokenTelemetryClient } from '../../util/telemetry/commands/blob';
 import { signedTokenSubcommand } from './command';
-
-const VALID_OPERATIONS = ['get', 'head', 'put', 'delete'] as const;
-type DelegationOperation = (typeof VALID_OPERATIONS)[number];
-
-function isDelegationOperation(value: string): value is DelegationOperation {
-  return (VALID_OPERATIONS as readonly string[]).includes(value);
-}
-
-function parseOperations(
-  operations: string[] | undefined
-): DelegationOperation[] | undefined | null {
-  if (!operations || operations.length === 0) {
-    return undefined;
-  }
-
-  const invalidOperation = operations.find(operation => {
-    return !isDelegationOperation(operation);
-  });
-
-  if (invalidOperation) {
-    output.error(
-      `Invalid operation value: '${invalidOperation}'. Must be one of: get, head, put, delete.`
-    );
-    return null;
-  }
-
-  return operations as DelegationOperation[];
-}
 
 function formatSignedToken(result: blob.IssuedSignedToken): string {
   return `delegationToken=${result.delegationToken}
@@ -77,7 +55,7 @@ export default async function signedToken(
     '--json': asJson,
   } = flags;
 
-  const operations = parseOperations(operationValues);
+  const operations = parseBlobOperations(operationValues);
   if (operations === null) {
     return 1;
   }
@@ -85,6 +63,14 @@ export default async function signedToken(
   const validity = resolveBlobValidUntil({ validUntil, validFor });
   if (validity.error) {
     output.error(validity.error);
+    return 1;
+  }
+
+  if (
+    !allowsUploadConstraints(operations) &&
+    hasUploadConstraintFlags({ allowedContentTypes, maximumSizeInBytes })
+  ) {
+    output.error(UPLOAD_CONSTRAINT_FLAGS_ERROR);
     return 1;
   }
 
@@ -105,8 +91,9 @@ export default async function signedToken(
       pathname,
       operations,
       validUntil: validity.validUntil,
-      allowedContentTypes,
-      maximumSizeInBytes,
+      ...(allowsUploadConstraints(operations)
+        ? { allowedContentTypes, maximumSizeInBytes }
+        : {}),
     });
 
     output.stopSpinner();

--- a/packages/cli/src/commands/blob/signed-token.ts
+++ b/packages/cli/src/commands/blob/signed-token.ts
@@ -37,13 +37,11 @@ function parseOperations(
   return operations as DelegationOperation[];
 }
 
-function printSignedToken(result: blob.IssuedSignedToken) {
-  output.print(
-    `delegationToken=${result.delegationToken}
+function formatSignedToken(result: blob.IssuedSignedToken): string {
+  return `delegationToken=${result.delegationToken}
 clientSigningToken=${result.clientSigningToken}
 validUntil=${result.validUntil} (${new Date(result.validUntil).toISOString()})
-`
-  );
+`;
 }
 
 export default async function signedToken(
@@ -116,7 +114,7 @@ export default async function signedToken(
     if (asJson) {
       client.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else {
-      printSignedToken(result);
+      client.stdout.write(formatSignedToken(result));
     }
     return 0;
   } catch (err) {

--- a/packages/cli/src/commands/blob/signed-token.ts
+++ b/packages/cli/src/commands/blob/signed-token.ts
@@ -5,7 +5,8 @@ import { printError } from '../../util/error';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { parseArguments } from '../../util/get-args';
 import { blobOpts, type BlobRWToken } from '../../util/blob/token';
-import { BlobSignedTokenTelemetryClient } from '../../util/telemetry/commands/blob/signed-token';
+import { resolveBlobValidUntil } from '../../util/blob/validity';
+import { BlobSignedTokenTelemetryClient } from '../../util/telemetry/commands/blob';
 import { signedTokenSubcommand } from './command';
 
 const VALID_OPERATIONS = ['get', 'head', 'put', 'delete'] as const;
@@ -72,6 +73,7 @@ export default async function signedToken(
     '--pathname': pathname,
     '--operation': operationValues,
     '--valid-until': validUntil,
+    '--valid-for': validFor,
     '--allowed-content-type': allowedContentTypes,
     '--maximum-size-in-bytes': maximumSizeInBytes,
     '--json': asJson,
@@ -82,9 +84,16 @@ export default async function signedToken(
     return 1;
   }
 
+  const validity = resolveBlobValidUntil({ validUntil, validFor });
+  if (validity.error) {
+    output.error(validity.error);
+    return 1;
+  }
+
   telemetryClient.trackCliOptionPathname(pathname);
   telemetryClient.trackCliOptionOperation(operationValues);
   telemetryClient.trackCliOptionValidUntil(validUntil);
+  telemetryClient.trackCliOptionValidFor(validFor);
   telemetryClient.trackCliOptionAllowedContentType(allowedContentTypes);
   telemetryClient.trackCliOptionMaximumSizeInBytes(maximumSizeInBytes);
   telemetryClient.trackCliFlagJson(asJson);
@@ -97,7 +106,7 @@ export default async function signedToken(
       ...blobOpts(auth),
       pathname,
       operations,
-      validUntil,
+      validUntil: validity.validUntil,
       allowedContentTypes,
       maximumSizeInBytes,
     });

--- a/packages/cli/src/util/blob/operations.ts
+++ b/packages/cli/src/util/blob/operations.ts
@@ -1,0 +1,83 @@
+import output from '../../output-manager';
+
+export const BLOB_OPERATIONS = ['get', 'head', 'put', 'delete'] as const;
+export type BlobOperation = (typeof BLOB_OPERATIONS)[number];
+
+export const UPLOAD_CONSTRAINT_FLAGS_ERROR =
+  'The flags --allowed-content-type and --maximum-size-in-bytes can only be used with --operation put.';
+
+export const PRESIGN_UPLOAD_ONLY_FLAGS_ERROR =
+  'The flags --allowed-content-type, --maximum-size-in-bytes, --allow-overwrite, --add-random-suffix, and --cache-control-max-age can only be used with --operation put.';
+
+export function isBlobOperation(value: string): value is BlobOperation {
+  return (BLOB_OPERATIONS as readonly string[]).includes(value);
+}
+
+export function parseBlobOperation(
+  operation: string | undefined,
+  defaultOperation: BlobOperation = 'get'
+): BlobOperation | null {
+  const operationValue = operation ?? defaultOperation;
+  if (!isBlobOperation(operationValue)) {
+    output.error(
+      `Invalid operation value: '${operationValue}'. Must be one of: get, head, put, delete.`
+    );
+    return null;
+  }
+  return operationValue;
+}
+
+export function parseBlobOperations(
+  operations: string[] | undefined
+): BlobOperation[] | undefined | null {
+  if (!operations || operations.length === 0) {
+    return undefined;
+  }
+
+  const invalidOperation = operations.find(operation => {
+    return !isBlobOperation(operation);
+  });
+
+  if (invalidOperation) {
+    output.error(
+      `Invalid operation value: '${invalidOperation}'. Must be one of: get, head, put, delete.`
+    );
+    return null;
+  }
+
+  return operations as BlobOperation[];
+}
+
+export function allowsUploadConstraints(
+  operations: BlobOperation[] | undefined
+): boolean {
+  return operations === undefined || operations.includes('put');
+}
+
+export function hasUploadConstraintFlags(options: {
+  allowedContentTypes: string[] | undefined;
+  maximumSizeInBytes: number | undefined;
+}): boolean {
+  const { allowedContentTypes, maximumSizeInBytes } = options;
+  return Boolean(
+    (allowedContentTypes && allowedContentTypes.length > 0) ||
+      maximumSizeInBytes !== undefined
+  );
+}
+
+export function hasPresignUploadOnlyFlags(options: {
+  allowedContentTypes: string[] | undefined;
+  maximumSizeInBytes: number | undefined;
+  allowOverwrite: boolean | undefined;
+  addRandomSuffix: boolean | undefined;
+  cacheControlMaxAge: number | undefined;
+}): boolean {
+  return (
+    hasUploadConstraintFlags(options) ||
+    Boolean(
+      options.allowOverwrite ||
+        options.addRandomSuffix ||
+        options.cacheControlMaxAge !== undefined
+    )
+  );
+}

--- a/packages/cli/src/util/blob/validity.ts
+++ b/packages/cli/src/util/blob/validity.ts
@@ -1,0 +1,35 @@
+import ms from 'ms';
+
+interface ResolveValidUntilInput {
+  validUntil: number | undefined;
+  validFor: string | undefined;
+}
+
+type ResolveValidUntilResult =
+  | { validUntil: number | undefined; error?: undefined }
+  | { validUntil?: undefined; error: string };
+
+export function resolveBlobValidUntil({
+  validUntil,
+  validFor,
+}: ResolveValidUntilInput): ResolveValidUntilResult {
+  if (validUntil !== undefined && validFor !== undefined) {
+    return {
+      error:
+        'The --valid-until and --valid-for flags are mutually exclusive. Pass only one.',
+    };
+  }
+
+  if (validFor === undefined) {
+    return { validUntil };
+  }
+
+  const durationMs = ms(validFor);
+  if (durationMs === undefined || durationMs <= 0) {
+    return {
+      error: `Invalid --valid-for value "${validFor}". Use values like "15m", "1h", or "7d".`,
+    };
+  }
+
+  return { validUntil: Date.now() + durationMs };
+}

--- a/packages/cli/src/util/telemetry/commands/blob/index.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/index.ts
@@ -1,6 +1,8 @@
 import { TelemetryClient } from '../..';
 import type { blobCommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
+export { BlobPresignTelemetryClient } from './presign';
+export { BlobSignedTokenTelemetryClient } from './signed-token';
 
 export class BlobTelemetryClient
   extends TelemetryClient

--- a/packages/cli/src/util/telemetry/commands/blob/index.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/index.ts
@@ -41,6 +41,20 @@ export class BlobTelemetryClient
     });
   }
 
+  trackCliSubcommandSignedToken(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'signed-token',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandPresign(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'presign',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandCreateStore(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'create-store',

--- a/packages/cli/src/util/telemetry/commands/blob/presign.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/presign.ts
@@ -60,6 +60,15 @@ export class BlobPresignTelemetryClient
     }
   }
 
+  trackCliOptionValidFor(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'valid-for',
+        value,
+      });
+    }
+  }
+
   trackCliOptionIfMatch(value: string | undefined) {
     if (value) {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/blob/presign.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/presign.ts
@@ -1,0 +1,116 @@
+import { TelemetryClient } from '../..';
+import type { presignSubcommand } from '../../../../commands/blob/command';
+import type { TelemetryMethods } from '../../types';
+
+export class BlobPresignTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof presignSubcommand>
+{
+  trackCliArgumentPathname(value: string | undefined) {
+    if (value) {
+      this.trackCliArgument({
+        arg: 'pathname',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionAccess(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'access',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionOperation(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'operation',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionDelegationToken(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'delegation-token',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionClientSigningToken(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'client-signing-token',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionValidUntil(value: number | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'valid-until',
+        value: String(value),
+      });
+    }
+  }
+
+  trackCliOptionIfMatch(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'if-match',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagAllowOverwrite(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('allow-overwrite');
+    }
+  }
+
+  trackCliFlagAddRandomSuffix(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('add-random-suffix');
+    }
+  }
+
+  trackCliOptionCacheControlMaxAge(value: number | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'cache-control-max-age',
+        value: String(value),
+      });
+    }
+  }
+
+  trackCliOptionAllowedContentType(value: string[] | undefined) {
+    if (value && value.length > 0) {
+      this.trackCliOption({
+        option: 'allowed-content-type',
+        value: value.join(','),
+      });
+    }
+  }
+
+  trackCliOptionMaximumSizeInBytes(value: number | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'maximum-size-in-bytes',
+        value: String(value),
+      });
+    }
+  }
+
+  trackCliFlagJson(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/blob/signed-token.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/signed-token.ts
@@ -33,6 +33,15 @@ export class BlobSignedTokenTelemetryClient
     }
   }
 
+  trackCliOptionValidFor(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'valid-for',
+        value,
+      });
+    }
+  }
+
   trackCliOptionAllowedContentType(value: string[] | undefined) {
     if (value && value.length > 0) {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/blob/signed-token.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/signed-token.ts
@@ -1,0 +1,59 @@
+import { TelemetryClient } from '../..';
+import type { signedTokenSubcommand } from '../../../../commands/blob/command';
+import type { TelemetryMethods } from '../../types';
+
+export class BlobSignedTokenTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof signedTokenSubcommand>
+{
+  trackCliOptionPathname(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'pathname',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionOperation(value: string[] | undefined) {
+    if (value && value.length > 0) {
+      this.trackCliOption({
+        option: 'operation',
+        value: value.join(','),
+      });
+    }
+  }
+
+  trackCliOptionValidUntil(value: number | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'valid-until',
+        value: String(value),
+      });
+    }
+  }
+
+  trackCliOptionAllowedContentType(value: string[] | undefined) {
+    if (value && value.length > 0) {
+      this.trackCliOption({
+        option: 'allowed-content-type',
+        value: value.join(','),
+      });
+    }
+  }
+
+  trackCliOptionMaximumSizeInBytes(value: number | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'maximum-size-in-bytes',
+        value: String(value),
+      });
+    }
+  }
+
+  trackCliFlagJson(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/blob/presign.test.ts
+++ b/packages/cli/test/unit/commands/blob/presign.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as blobModule from '@vercel/blob';
+import presign from '../../../../src/commands/blob/presign';
+import output from '../../../../src/output-manager';
+import { client } from '../../../mocks/client';
+import type { BlobRWToken } from '../../../../src/util/blob/token';
+
+vi.mock('@vercel/blob');
+vi.mock('../../../../src/output-manager');
+
+const mockedBlob = vi.mocked(blobModule);
+const mockedOutput = vi.mocked(output);
+
+describe('blob presign', () => {
+  const testAuth: BlobRWToken = {
+    success: true,
+    kind: 'rw',
+    token: 'vercel_blob_rw_test_token_123',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+
+    mockedBlob.issueSignedToken.mockResolvedValue({
+      delegationToken: 'delegation-token',
+      clientSigningToken: 'client-signing-token',
+      validUntil: 1761938400000,
+    });
+    mockedBlob.presignUrl.mockResolvedValue({
+      presignedUrl: 'https://blob.vercel-storage.com/presigned-url',
+    });
+  });
+
+  it('should generate a presigned get URL by default', async () => {
+    const exitCode = await presign(
+      client,
+      ['my-file.txt', '--access', 'public'],
+      testAuth
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).toHaveBeenCalledWith({
+      token: 'vercel_blob_rw_test_token_123',
+      pathname: 'my-file.txt',
+      operations: ['get'],
+      validUntil: undefined,
+    });
+    expect(mockedBlob.presignUrl).toHaveBeenCalledWith(
+      {
+        delegationToken: 'delegation-token',
+        clientSigningToken: 'client-signing-token',
+      },
+      {
+        operation: 'get',
+        pathname: 'my-file.txt',
+        access: 'public',
+        validUntil: undefined,
+      }
+    );
+    expect(mockedOutput.print).toHaveBeenCalledWith(
+      'https://blob.vercel-storage.com/presigned-url\n'
+    );
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'argument:pathname', value: '[REDACTED]' },
+      { key: 'option:access', value: 'public' },
+    ]);
+  });
+
+  it('should generate a presigned put URL with constraints', async () => {
+    const exitCode = await presign(
+      client,
+      [
+        'uploads/image.jpg',
+        '--access',
+        'private',
+        '--operation',
+        'put',
+        '--valid-until',
+        '1761938300000',
+        '--allowed-content-type',
+        'image/*',
+        '--maximum-size-in-bytes',
+        '1048576',
+        '--allow-overwrite',
+        '--add-random-suffix',
+        '--cache-control-max-age',
+        '3600',
+        '--if-match',
+        '"etag"',
+        '--json',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).toHaveBeenCalledWith({
+      token: 'vercel_blob_rw_test_token_123',
+      pathname: 'uploads/image.jpg',
+      operations: ['put'],
+      validUntil: 1761938300000,
+      allowedContentTypes: ['image/*'],
+      maximumSizeInBytes: 1048576,
+    });
+    expect(mockedBlob.presignUrl).toHaveBeenCalledWith(
+      {
+        delegationToken: 'delegation-token',
+        clientSigningToken: 'client-signing-token',
+      },
+      {
+        operation: 'put',
+        pathname: 'uploads/image.jpg',
+        access: 'private',
+        validUntil: 1761938300000,
+        allowedContentTypes: ['image/*'],
+        maximumSizeInBytes: 1048576,
+        allowOverwrite: true,
+        addRandomSuffix: true,
+        cacheControlMaxAge: 3600,
+        ifMatch: '"etag"',
+      }
+    );
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      operation: 'put',
+      presignedUrl: 'https://blob.vercel-storage.com/presigned-url',
+      validUntil: 1761938400000,
+    });
+  });
+
+  it('should use provided signed-token values when both are passed', async () => {
+    const exitCode = await presign(
+      client,
+      [
+        'uploads/image.jpg',
+        '--access',
+        'private',
+        '--operation',
+        'put',
+        '--delegation-token',
+        'provided-delegation-token',
+        '--client-signing-token',
+        'provided-client-signing-token',
+        '--json',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedBlob.presignUrl).toHaveBeenCalledWith(
+      {
+        delegationToken: 'provided-delegation-token',
+        clientSigningToken: 'provided-client-signing-token',
+      },
+      {
+        operation: 'put',
+        pathname: 'uploads/image.jpg',
+        access: 'private',
+        validUntil: undefined,
+        allowedContentTypes: undefined,
+        maximumSizeInBytes: undefined,
+        allowOverwrite: undefined,
+        addRandomSuffix: undefined,
+        cacheControlMaxAge: undefined,
+        ifMatch: undefined,
+      }
+    );
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      operation: 'put',
+      presignedUrl: 'https://blob.vercel-storage.com/presigned-url',
+    });
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'argument:pathname', value: '[REDACTED]' },
+      { key: 'option:access', value: 'private' },
+      { key: 'option:operation', value: 'put' },
+      { key: 'option:delegation-token', value: '[REDACTED]' },
+      { key: 'option:client-signing-token', value: '[REDACTED]' },
+      { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+
+  it('should reject upload-only flags on read operations', async () => {
+    const exitCode = await presign(
+      client,
+      [
+        'my-file.txt',
+        '--access',
+        'public',
+        '--operation',
+        'get',
+        '--maximum-size-in-bytes',
+        '1024',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      'The flags --allowed-content-type, --maximum-size-in-bytes, --allow-overwrite, --add-random-suffix, and --cache-control-max-age can only be used with --operation put.'
+    );
+  });
+
+  it('should reject if-match for get/head operations', async () => {
+    const exitCode = await presign(
+      client,
+      [
+        'my-file.txt',
+        '--access',
+        'public',
+        '--operation',
+        'head',
+        '--if-match',
+        '"etag"',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      'The --if-match flag can only be used with --operation put or --operation delete.'
+    );
+  });
+
+  it('should require pathname argument', async () => {
+    const exitCode = await presign(client, ['--access', 'public'], testAuth);
+
+    expect(exitCode).toBe(1);
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      'Missing required argument: pathname'
+    );
+  });
+
+  it('should require both token flags together', async () => {
+    const exitCode = await presign(
+      client,
+      [
+        'my-file.txt',
+        '--access',
+        'public',
+        '--delegation-token',
+        'provided-delegation-token',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedBlob.presignUrl).not.toHaveBeenCalled();
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      'The --delegation-token and --client-signing-token flags must be passed together. Pass both, or pass neither to issue a token automatically.'
+    );
+  });
+
+  it('should return 1 when SDK call fails', async () => {
+    mockedBlob.presignUrl.mockRejectedValue(new Error('Presign failed'));
+
+    const exitCode = await presign(
+      client,
+      ['my-file.txt', '--access', 'public'],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedOutput.stopSpinner).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/unit/commands/blob/presign.test.ts
+++ b/packages/cli/test/unit/commands/blob/presign.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as blobModule from '@vercel/blob';
 import presign from '../../../../src/commands/blob/presign';
 import output from '../../../../src/output-manager';
+import { PRESIGN_UPLOAD_ONLY_FLAGS_ERROR } from '../../../../src/util/blob/operations';
 import { client } from '../../../mocks/client';
 import type { BlobRWToken } from '../../../../src/util/blob/token';
 
@@ -264,6 +265,92 @@ describe('blob presign', () => {
     });
   });
 
+  it('should include validUntil in JSON output when provided tokens and --valid-for are passed', async () => {
+    const now = 1761930000000;
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const exitCode = await presign(
+      client,
+      [
+        'uploads/image.jpg',
+        '--access',
+        'private',
+        '--operation',
+        'put',
+        '--delegation-token',
+        'provided-delegation-token',
+        '--client-signing-token',
+        'provided-client-signing-token',
+        '--valid-for',
+        '30m',
+        '--json',
+      ],
+      testAuth
+    );
+
+    dateNowSpy.mockRestore();
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedBlob.presignUrl).toHaveBeenCalledWith(
+      {
+        delegationToken: 'provided-delegation-token',
+        clientSigningToken: 'provided-client-signing-token',
+      },
+      expect.objectContaining({
+        validUntil: now + 30 * 60 * 1000,
+      })
+    );
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      operation: 'put',
+      presignedUrl: 'https://blob.vercel-storage.com/presigned-url',
+      validUntil: now + 30 * 60 * 1000,
+    });
+  });
+
+  it('should generate a presigned delete URL with if-match', async () => {
+    const exitCode = await presign(
+      client,
+      [
+        'uploads/image.jpg',
+        '--access',
+        'private',
+        '--operation',
+        'delete',
+        '--if-match',
+        '"etag"',
+        '--json',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).toHaveBeenCalledWith({
+      token: 'vercel_blob_rw_test_token_123',
+      pathname: 'uploads/image.jpg',
+      operations: ['delete'],
+      validUntil: undefined,
+    });
+    expect(mockedBlob.presignUrl).toHaveBeenCalledWith(
+      {
+        delegationToken: 'delegation-token',
+        clientSigningToken: 'client-signing-token',
+      },
+      {
+        operation: 'delete',
+        pathname: 'uploads/image.jpg',
+        access: 'private',
+        validUntil: undefined,
+        ifMatch: '"etag"',
+      }
+    );
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      operation: 'delete',
+      presignedUrl: 'https://blob.vercel-storage.com/presigned-url',
+      validUntil: 1761938400000,
+    });
+  });
+
   it('should reject upload-only flags on read operations', async () => {
     const exitCode = await presign(
       client,
@@ -282,7 +369,22 @@ describe('blob presign', () => {
     expect(exitCode).toBe(1);
     expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
     expect(mockedOutput.error).toHaveBeenCalledWith(
-      'The flags --allowed-content-type, --maximum-size-in-bytes, --allow-overwrite, --add-random-suffix, and --cache-control-max-age can only be used with --operation put.'
+      PRESIGN_UPLOAD_ONLY_FLAGS_ERROR
+    );
+  });
+
+  it('should reject invalid --valid-for values', async () => {
+    const exitCode = await presign(
+      client,
+      ['my-file.txt', '--access', 'public', '--valid-for', 'bogus'],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedBlob.presignUrl).not.toHaveBeenCalled();
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      'Invalid --valid-for value "bogus". Use values like "15m", "1h", or "7d".'
     );
   });
 

--- a/packages/cli/test/unit/commands/blob/presign.test.ts
+++ b/packages/cli/test/unit/commands/blob/presign.test.ts
@@ -127,6 +127,53 @@ describe('blob presign', () => {
     });
   });
 
+  it('should convert --valid-for to validUntil', async () => {
+    const now = 1761930000000;
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const exitCode = await presign(
+      client,
+      [
+        'my-file.txt',
+        '--access',
+        'public',
+        '--operation',
+        'get',
+        '--valid-for',
+        '30m',
+      ],
+      testAuth
+    );
+
+    dateNowSpy.mockRestore();
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).toHaveBeenCalledWith({
+      token: 'vercel_blob_rw_test_token_123',
+      pathname: 'my-file.txt',
+      operations: ['get'],
+      validUntil: now + 30 * 60 * 1000,
+    });
+    expect(mockedBlob.presignUrl).toHaveBeenCalledWith(
+      {
+        delegationToken: 'delegation-token',
+        clientSigningToken: 'client-signing-token',
+      },
+      {
+        operation: 'get',
+        pathname: 'my-file.txt',
+        access: 'public',
+        validUntil: now + 30 * 60 * 1000,
+      }
+    );
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'argument:pathname', value: '[REDACTED]' },
+      { key: 'option:access', value: 'public' },
+      { key: 'option:operation', value: 'get' },
+      { key: 'option:valid-for', value: '30m' },
+    ]);
+  });
+
   it('should use provided signed-token values when both are passed', async () => {
     const exitCode = await presign(
       client,
@@ -229,6 +276,29 @@ describe('blob presign', () => {
     expect(exitCode).toBe(1);
     expect(mockedOutput.error).toHaveBeenCalledWith(
       'Missing required argument: pathname'
+    );
+  });
+
+  it('should reject --valid-until with --valid-for', async () => {
+    const exitCode = await presign(
+      client,
+      [
+        'my-file.txt',
+        '--access',
+        'public',
+        '--valid-until',
+        '1761938400000',
+        '--valid-for',
+        '1h',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedBlob.presignUrl).not.toHaveBeenCalled();
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      'The --valid-until and --valid-for flags are mutually exclusive. Pass only one.'
     );
   });
 

--- a/packages/cli/test/unit/commands/blob/presign.test.ts
+++ b/packages/cli/test/unit/commands/blob/presign.test.ts
@@ -58,7 +58,7 @@ describe('blob presign', () => {
         validUntil: undefined,
       }
     );
-    expect(mockedOutput.print).toHaveBeenCalledWith(
+    expect(client.stdout.getFullOutput()).toBe(
       'https://blob.vercel-storage.com/presigned-url\n'
     );
     expect(client.telemetryEventStore).toHaveTelemetryEvents([

--- a/packages/cli/test/unit/commands/blob/presign.test.ts
+++ b/packages/cli/test/unit/commands/blob/presign.test.ts
@@ -226,6 +226,44 @@ describe('blob presign', () => {
     ]);
   });
 
+  it('should include validUntil in JSON output when provided tokens and --valid-until are passed', async () => {
+    const exitCode = await presign(
+      client,
+      [
+        'uploads/image.jpg',
+        '--access',
+        'private',
+        '--operation',
+        'put',
+        '--delegation-token',
+        'provided-delegation-token',
+        '--client-signing-token',
+        'provided-client-signing-token',
+        '--valid-until',
+        '1761938300000',
+        '--json',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedBlob.presignUrl).toHaveBeenCalledWith(
+      {
+        delegationToken: 'provided-delegation-token',
+        clientSigningToken: 'provided-client-signing-token',
+      },
+      expect.objectContaining({
+        validUntil: 1761938300000,
+      })
+    );
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      operation: 'put',
+      presignedUrl: 'https://blob.vercel-storage.com/presigned-url',
+      validUntil: 1761938300000,
+    });
+  });
+
   it('should reject upload-only flags on read operations', async () => {
     const exitCode = await presign(
       client,

--- a/packages/cli/test/unit/commands/blob/signed-token.test.ts
+++ b/packages/cli/test/unit/commands/blob/signed-token.test.ts
@@ -74,6 +74,33 @@ describe('blob signed-token', () => {
     ]);
   });
 
+  it('should convert --valid-for to validUntil', async () => {
+    const now = 1761930000000;
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const exitCode = await signedToken(
+      client,
+      ['--operation', 'get', '--valid-for', '1h'],
+      testAuth
+    );
+
+    dateNowSpy.mockRestore();
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).toHaveBeenCalledWith({
+      token: 'vercel_blob_rw_test_token_123',
+      pathname: undefined,
+      operations: ['get'],
+      validUntil: now + 60 * 60 * 1000,
+      allowedContentTypes: undefined,
+      maximumSizeInBytes: undefined,
+    });
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:operation', value: 'get' },
+      { key: 'option:valid-for', value: '1h' },
+    ]);
+  });
+
   it('should pass upload constraints', async () => {
     const exitCode = await signedToken(
       client,
@@ -104,6 +131,27 @@ describe('blob signed-token', () => {
       { key: 'option:allowed-content-type', value: 'image/*,video/*' },
       { key: 'option:maximum-size-in-bytes', value: '1048576' },
     ]);
+  });
+
+  it('should reject --valid-until with --valid-for', async () => {
+    const exitCode = await signedToken(
+      client,
+      [
+        '--operation',
+        'get',
+        '--valid-until',
+        '1761938400000',
+        '--valid-for',
+        '1h',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      'The --valid-until and --valid-for flags are mutually exclusive. Pass only one.'
+    );
   });
 
   it('should reject invalid operation values', async () => {

--- a/packages/cli/test/unit/commands/blob/signed-token.test.ts
+++ b/packages/cli/test/unit/commands/blob/signed-token.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as blobModule from '@vercel/blob';
+import signedToken from '../../../../src/commands/blob/signed-token';
+import output from '../../../../src/output-manager';
+import { client } from '../../../mocks/client';
+import type { BlobRWToken } from '../../../../src/util/blob/token';
+
+vi.mock('@vercel/blob');
+vi.mock('../../../../src/output-manager');
+
+const mockedBlob = vi.mocked(blobModule);
+const mockedOutput = vi.mocked(output);
+
+describe('blob signed-token', () => {
+  const testAuth: BlobRWToken = {
+    success: true,
+    kind: 'rw',
+    token: 'vercel_blob_rw_test_token_123',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+
+    mockedBlob.issueSignedToken.mockResolvedValue({
+      delegationToken: 'delegation-token',
+      clientSigningToken: 'client-signing-token',
+      validUntil: 1761938400000,
+    });
+  });
+
+  it('should issue a signed token with basic options', async () => {
+    const exitCode = await signedToken(
+      client,
+      ['--pathname', 'media/photo.jpg', '--operation', 'get'],
+      testAuth
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).toHaveBeenCalledWith({
+      token: 'vercel_blob_rw_test_token_123',
+      pathname: 'media/photo.jpg',
+      operations: ['get'],
+      validUntil: undefined,
+      allowedContentTypes: undefined,
+      maximumSizeInBytes: undefined,
+    });
+    expect(mockedOutput.print).toHaveBeenCalledWith(
+      expect.stringContaining('delegationToken=delegation-token')
+    );
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:pathname', value: '[REDACTED]' },
+      { key: 'option:operation', value: 'get' },
+    ]);
+  });
+
+  it('should support json output', async () => {
+    const exitCode = await signedToken(
+      client,
+      ['--pathname', 'uploads/*', '--operation', 'put', '--json'],
+      testAuth
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      delegationToken: 'delegation-token',
+      clientSigningToken: 'client-signing-token',
+      validUntil: 1761938400000,
+    });
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:pathname', value: '[REDACTED]' },
+      { key: 'option:operation', value: 'put' },
+      { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+
+  it('should pass upload constraints', async () => {
+    const exitCode = await signedToken(
+      client,
+      [
+        '--operation',
+        'put',
+        '--allowed-content-type',
+        'image/*',
+        '--allowed-content-type',
+        'video/*',
+        '--maximum-size-in-bytes',
+        '1048576',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).toHaveBeenCalledWith({
+      token: 'vercel_blob_rw_test_token_123',
+      pathname: undefined,
+      operations: ['put'],
+      validUntil: undefined,
+      allowedContentTypes: ['image/*', 'video/*'],
+      maximumSizeInBytes: 1048576,
+    });
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:operation', value: 'put' },
+      { key: 'option:allowed-content-type', value: 'image/*,video/*' },
+      { key: 'option:maximum-size-in-bytes', value: '1048576' },
+    ]);
+  });
+
+  it('should reject invalid operation values', async () => {
+    const exitCode = await signedToken(
+      client,
+      ['--operation', 'invalid-op'],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      "Invalid operation value: 'invalid-op'. Must be one of: get, head, put, delete."
+    );
+  });
+
+  it('should return 1 when SDK call fails', async () => {
+    mockedBlob.issueSignedToken.mockRejectedValue(new Error('Request failed'));
+
+    const exitCode = await signedToken(
+      client,
+      ['--operation', 'get'],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedOutput.stopSpinner).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/unit/commands/blob/signed-token.test.ts
+++ b/packages/cli/test/unit/commands/blob/signed-token.test.ts
@@ -45,8 +45,10 @@ describe('blob signed-token', () => {
       allowedContentTypes: undefined,
       maximumSizeInBytes: undefined,
     });
-    expect(mockedOutput.print).toHaveBeenCalledWith(
-      expect.stringContaining('delegationToken=delegation-token')
+    expect(client.stdout.getFullOutput()).toBe(
+      'delegationToken=delegation-token\n' +
+        'clientSigningToken=client-signing-token\n' +
+        'validUntil=1761938400000 (2025-10-31T19:20:00.000Z)\n'
     );
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'option:pathname', value: '[REDACTED]' },

--- a/packages/cli/test/unit/commands/blob/signed-token.test.ts
+++ b/packages/cli/test/unit/commands/blob/signed-token.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as blobModule from '@vercel/blob';
 import signedToken from '../../../../src/commands/blob/signed-token';
 import output from '../../../../src/output-manager';
+import { UPLOAD_CONSTRAINT_FLAGS_ERROR } from '../../../../src/util/blob/operations';
 import { client } from '../../../mocks/client';
 import type { BlobRWToken } from '../../../../src/util/blob/token';
 
@@ -135,6 +136,47 @@ describe('blob signed-token', () => {
     ]);
   });
 
+  it('should allow upload constraints when put is included with other operations', async () => {
+    const exitCode = await signedToken(
+      client,
+      [
+        '--operation',
+        'get',
+        '--operation',
+        'put',
+        '--allowed-content-type',
+        'image/*',
+        '--maximum-size-in-bytes',
+        '1048576',
+      ],
+      testAuth
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockedBlob.issueSignedToken).toHaveBeenCalledWith({
+      token: 'vercel_blob_rw_test_token_123',
+      pathname: undefined,
+      operations: ['get', 'put'],
+      validUntil: undefined,
+      allowedContentTypes: ['image/*'],
+      maximumSizeInBytes: 1048576,
+    });
+  });
+
+  it('should reject upload constraints on non-put operations', async () => {
+    const exitCode = await signedToken(
+      client,
+      ['--operation', 'get', '--allowed-content-type', 'image/*'],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      UPLOAD_CONSTRAINT_FLAGS_ERROR
+    );
+  });
+
   it('should reject --valid-until with --valid-for', async () => {
     const exitCode = await signedToken(
       client,
@@ -153,6 +195,20 @@ describe('blob signed-token', () => {
     expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
     expect(mockedOutput.error).toHaveBeenCalledWith(
       'The --valid-until and --valid-for flags are mutually exclusive. Pass only one.'
+    );
+  });
+
+  it('should reject invalid --valid-for values', async () => {
+    const exitCode = await signedToken(
+      client,
+      ['--operation', 'get', '--valid-for', 'bogus'],
+      testAuth
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockedBlob.issueSignedToken).not.toHaveBeenCalled();
+    expect(mockedOutput.error).toHaveBeenCalledWith(
+      'Invalid --valid-for value "bogus". Use values like "15m", "1h", or "7d".'
     );
   });
 


### PR DESCRIPTION
Adds 2 commands: `vc blob signed-token` and `vc blob presign`

These were recently added to the blob SDK in version 2.4.0

Enables generating presigned urls

<img width="1358" height="46" alt="CleanShot 2026-06-01 at 10 54 17@2x" src="https://github.com/user-attachments/assets/e77c68eb-1c68-4625-b665-0456bc672b4c" />

<img width="2036" height="896" alt="CleanShot 2026-05-29 at 11 19 31@2x" src="https://github.com/user-attachments/assets/91062616-9284-4761-a74f-6602d179adaa" />
<img width="2938" height="512" alt="CleanShot 2026-05-29 at 11 18 00@2x" src="https://github.com/user-attachments/assets/e6b64904-167f-42ef-882c-1a3a35494161" />
<img width="2932" height="648" alt="CleanShot 2026-05-29 at 11 17 21@2x" src="https://github.com/user-attachments/assets/aa95b908-0752-46b9-a434-92ad90e1ff2b" />
<img width="2926" height="622" alt="CleanShot 2026-05-29 at 11 15 36@2x" src="https://github.com/user-attachments/assets/48d2a3d2-1bc5-4f4d-ba7e-b20a85cdab6b" />
<img width="2934" height="566" alt="CleanShot 2026-05-29 at 11 15 28@2x" src="https://github.com/user-attachments/assets/bb8d770c-df8e-464d-9151-c4d96d04b89c" />
