### PR TITLE
Improve Vercel link project detection

### DIFF
--- a/.changeset/quiet-envs-link.md
+++ b/.changeset/quiet-envs-link.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Stop prompting to pull environment variables after running `vc link` and add `vc link inspect` for local link diagnostics.

--- a/packages/cli/src/commands/link/command.ts
+++ b/packages/cli/src/commands/link/command.ts
@@ -22,12 +22,27 @@ export const addSubcommand = {
   ],
 } as const;
 
+export const inspectSubcommand = {
+  name: 'inspect',
+  aliases: [],
+  description:
+    'Inspect whether the current directory is linked to a Vercel Project.',
+  arguments: [],
+  options: [],
+  examples: [
+    {
+      name: 'Inspect the current directory link',
+      value: `${packageName} link inspect`,
+    },
+  ],
+} as const;
+
 export const linkCommand = {
   name: 'link',
   aliases: [],
   description: 'Link a local directory to a Vercel Project.',
   arguments: [],
-  subcommands: [addSubcommand],
+  subcommands: [addSubcommand, inspectSubcommand],
   options: [
     {
       name: 'repo',
@@ -85,6 +100,10 @@ export const linkCommand = {
     {
       name: 'Add additional projects to an existing repository link',
       value: `${packageName} link add`,
+    },
+    {
+      name: 'Inspect the current directory link',
+      value: `${packageName} link inspect`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -5,7 +5,7 @@ import cmd from '../../util/output/cmd';
 import { ensureLink } from '../../util/link/ensure-link';
 import { addRepoLink, ensureRepoLink } from '../../util/link/repo';
 import { type Command, help } from '../help';
-import { addSubcommand, linkCommand } from './command';
+import { addSubcommand, inspectSubcommand, linkCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
@@ -13,9 +13,11 @@ import { LinkTelemetryClient } from '../../util/telemetry/commands/link';
 import { getCommandAliases } from '..';
 import { autoInstallVercelPlugin } from '../../util/agent/auto-install-agentic';
 import getScope, { detectExplicitScope } from '../../util/get-scope';
+import inspectLink from './inspect';
 
 const COMMAND_CONFIG = {
   add: getCommandAliases(addSubcommand),
+  inspect: getCommandAliases(inspectSubcommand),
 };
 
 export default async function link(client: Client) {
@@ -75,6 +77,23 @@ export default async function link(client: Client) {
     });
 
     return 0;
+  }
+
+  if (subcommand === 'inspect') {
+    if (parsedArgs.flags['--help']) {
+      telemetry.trackCliFlagHelp('link', subcommandOriginal);
+      printHelp(inspectSubcommand);
+      return 2;
+    }
+
+    telemetry.trackCliSubcommandInspect(subcommandOriginal);
+
+    try {
+      return await inspectLink(client);
+    } catch (err) {
+      output.prettyError(err);
+      return 1;
+    }
   }
 
   // Default behavior (no subcommand) - original `vc link` flow
@@ -140,6 +159,7 @@ export default async function link(client: Client) {
       projectName: parsedArgs.flags['--project'],
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
+      pullEnv: false,
       searchAcrossTeams: !explicitScopeProvided,
     });
 

--- a/packages/cli/src/commands/link/inspect.ts
+++ b/packages/cli/src/commands/link/inspect.ts
@@ -1,0 +1,95 @@
+import { join } from 'path';
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import humanizePath from '../../util/humanize-path';
+import param from '../../util/output/param';
+import { emoji, prependEmoji } from '../../util/emoji';
+import {
+  getLinkFromDir,
+  getVercelDirectory,
+  VERCEL_DIR_PROJECT,
+  VERCEL_DIR_REPO,
+} from '../../util/projects/link';
+import { getRepoLink } from '../../util/link/repo';
+import type { ProjectLink } from '@vercel-internals/types';
+
+function printField(label: string, value: string) {
+  output.print(`  ${chalk.gray(label.padEnd(10))} ${value}\n`);
+}
+
+export default async function inspectLink(client: Client): Promise<number> {
+  const cwd = client.cwd;
+  const vercelDirectory = getVercelDirectory(cwd);
+  const directoryLink = await getLinkFromDir<ProjectLink>(vercelDirectory);
+
+  if (directoryLink) {
+    output.print(
+      `${prependEmoji(
+        `Linked Project found for ${param(humanizePath(cwd))}`,
+        emoji('success')
+      )}\n\n`
+    );
+    printField(
+      'Project',
+      chalk.bold(directoryLink.projectName || directoryLink.projectId)
+    );
+    printField('Project ID', chalk.cyan(directoryLink.projectId));
+    printField('Org ID', chalk.cyan(directoryLink.orgId));
+    output.print(
+      `  ${chalk.gray('Config'.padEnd(10))} ${chalk.dim(
+        humanizePath(join(vercelDirectory, VERCEL_DIR_PROJECT))
+      )}\n`
+    );
+    return 0;
+  }
+
+  const repoLink = await getRepoLink(client, cwd);
+  if (!repoLink?.repoConfig) {
+    output.print(
+      `${prependEmoji(
+        `No Vercel Project link found for ${param(humanizePath(cwd))}`,
+        emoji('warning')
+      )}\n`
+    );
+    return 1;
+  }
+
+  output.print(
+    `${prependEmoji(
+      `No directory Project link found for ${param(humanizePath(cwd))}`,
+      emoji('warning')
+    )}\n\n`
+  );
+  output.print(
+    `${prependEmoji(
+      `Repository link found at ${param(humanizePath(repoLink.rootPath))}`,
+      emoji('link')
+    )}\n`
+  );
+  output.print(
+    `  ${chalk.gray('Config'.padEnd(10))} ${chalk.dim(
+      humanizePath(join(repoLink.rootPath, '.vercel', VERCEL_DIR_REPO))
+    )}\n`
+  );
+  output.print(`\n${chalk.bold('Linked repository projects')}\n`);
+
+  for (const project of repoLink.repoConfig.projects) {
+    output.print(`\n  ${chalk.bold(project.name || project.id)}\n`);
+    output.print(
+      `    ${chalk.gray('Directory'.padEnd(10))} ${project.directory}\n`
+    );
+    output.print(
+      `    ${chalk.gray('Project ID'.padEnd(10))} ${chalk.cyan(project.id)}\n`
+    );
+    if (project.orgId || repoLink.repoConfig.orgId) {
+      output.print(
+        `    ${chalk.gray('Org ID'.padEnd(10))} ${chalk.cyan(
+          project.orgId ?? repoLink.repoConfig.orgId
+        )}\n`
+      );
+    }
+  }
+
+  return 0;
+}

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -87,6 +87,18 @@ function formatCrossTeamMatch(match: CrossTeamMatch): string {
   )}`;
 }
 
+function formatOtherTeamMatch(
+  match: CrossTeamMatch,
+  currentTeamSlug?: string
+): string {
+  if (!currentTeamSlug) {
+    return formatCrossTeamMatch(match);
+  }
+  return `${formatCrossTeamMatch(match)} ${chalk.gray(
+    `(current scope: ${currentTeamSlug})`
+  )}`;
+}
+
 function formatTeamList(slugs: string[]): string {
   const shown = slugs.slice(0, 5);
   const suffix =
@@ -222,6 +234,8 @@ async function linkCrossTeamMatch({
   successEmoji,
   autoConfirm,
   pullEnv,
+  currentTeamId,
+  currentTeamSlug,
 }: {
   client: Client;
   path: string;
@@ -229,7 +243,17 @@ async function linkCrossTeamMatch({
   successEmoji: EmojiLabel;
   autoConfirm: boolean;
   pullEnv: boolean;
+  currentTeamId?: string;
+  currentTeamSlug?: string;
 }): Promise<ProjectLinkResult> {
+  if (currentTeamId && match.org.id !== currentTeamId) {
+    output.print(
+      `  Linking project under ${chalk.bold(
+        match.org.slug
+      )}; your current scope is ${chalk.bold(currentTeamSlug || currentTeamId)}.\n`
+    );
+  }
+
   client.config.currentTeam =
     match.org.type === 'team' ? match.org.id : undefined;
 
@@ -326,6 +350,8 @@ async function linkCrossTeamMatches({
   autoConfirm,
   nonInteractive,
   pullEnv,
+  currentTeamId,
+  currentTeamSlug,
 }: {
   client: Client;
   path: string;
@@ -334,6 +360,8 @@ async function linkCrossTeamMatches({
   autoConfirm: boolean;
   nonInteractive: boolean;
   pullEnv: boolean;
+  currentTeamId?: string;
+  currentTeamSlug?: string;
 }): Promise<ProjectLinkResult | null> {
   if (matches.length === 0) {
     return null;
@@ -350,11 +378,21 @@ async function linkCrossTeamMatches({
         successEmoji,
         autoConfirm,
         pullEnv,
+        currentTeamId,
+        currentTeamSlug,
       });
     }
 
+    const isOtherTeam = Boolean(
+      currentTeamId && match.org.id !== currentTeamId
+    );
     const confirmed = await client.input.confirm(
-      `Found project ${formatCrossTeamMatch(match)}. Link to it?`,
+      isOtherTeam
+        ? `Found project ${formatOtherTeamMatch(
+            match,
+            currentTeamSlug
+          )}. Link to this other team's project?`
+        : `Found project ${formatCrossTeamMatch(match)}. Link to it?`,
       true
     );
     if (confirmed) {
@@ -365,14 +403,16 @@ async function linkCrossTeamMatches({
         successEmoji,
         autoConfirm,
         pullEnv,
+        currentTeamId,
+        currentTeamSlug,
       });
     }
     return null;
   }
 
-  const currentTeamMatch = matches.find(
-    match => match.org.id === client.config.currentTeam
-  );
+  const currentTeamMatch = currentTeamId
+    ? matches.find(match => match.org.id === currentTeamId)
+    : undefined;
 
   if (autoConfirm && currentTeamMatch) {
     return await linkCrossTeamMatch({
@@ -382,6 +422,8 @@ async function linkCrossTeamMatches({
       successEmoji,
       autoConfirm,
       pullEnv,
+      currentTeamId,
+      currentTeamSlug,
     });
   }
 
@@ -390,7 +432,10 @@ async function linkCrossTeamMatches({
   }
 
   const choices = matches.map(match => ({
-    name: formatCrossTeamMatch(match),
+    name:
+      currentTeamId && match.org.id !== currentTeamId
+        ? formatOtherTeamMatch(match, currentTeamSlug)
+        : formatCrossTeamMatch(match),
     value: match as CrossTeamMatch | null,
   }));
   choices.push({
@@ -399,8 +444,9 @@ async function linkCrossTeamMatches({
   });
 
   const selected = await client.input.select<CrossTeamMatch | null>({
-    message:
-      'Found matching projects across teams. Which one do you want to link?',
+    message: currentTeamSlug
+      ? `No matching project found under ${currentTeamSlug}. Found matching projects in other teams. Which one do you want to link?`
+      : 'Found matching projects across teams. Which one do you want to link?',
     choices,
     default: currentTeamMatch ?? undefined,
   });
@@ -416,6 +462,8 @@ async function linkCrossTeamMatches({
     successEmoji,
     autoConfirm,
     pullEnv,
+    currentTeamId,
+    currentTeamSlug,
   });
 }
 
@@ -479,7 +527,22 @@ export default async function setupAndLink(
     let searchedTeamSlugs: string[] = [];
     let skippedLimitedTeamSlugs: string[] = [];
     let skippedLimitedTeams: Team[] = [];
-    output.spinner('Searching for existing projects…', 1000);
+    let currentTeamId: string | undefined;
+    let currentTeamSlug: string | undefined;
+    let otherTeamSearch:
+      | Promise<{
+          matches: CrossTeamMatch[];
+          searchedTeamSlugs: string[];
+        }>
+      | undefined;
+    let searchSpinnerActive = false;
+    const setSearchSpinner = (message: string) => {
+      if (searchSpinnerActive) {
+        output.stopSpinner();
+      }
+      output.spinner(message, 1000);
+      searchSpinnerActive = true;
+    };
     try {
       const searchResult = await searchProjectAcrossTeams(
         client,
@@ -489,16 +552,30 @@ export default async function setupAndLink(
           autoConfirm,
           nonInteractive,
           gitProjectName,
+          onSearchPhase: phase => {
+            if (phase === 'current-team') {
+              setSearchSpinner('Searching current team for existing projects…');
+            } else if (phase === 'other-teams') {
+              setSearchSpinner('Searching other teams for existing projects…');
+            } else {
+              setSearchSpinner('Searching teams for existing projects…');
+            }
+          },
         }
       );
       crossTeamMatches = searchResult.matches;
       searchedTeamSlugs = searchResult.searchedTeamSlugs;
       skippedLimitedTeamSlugs = searchResult.skippedLimitedTeamSlugs;
       skippedLimitedTeams = searchResult.skippedLimitedTeams;
+      currentTeamId = searchResult.currentTeamId;
+      currentTeamSlug = searchResult.currentTeamSlug;
+      otherTeamSearch = searchResult.otherTeamSearch;
     } catch (err) {
       output.debug(`Cross-team search failed: ${err}`);
     } finally {
-      output.stopSpinner();
+      if (searchSpinnerActive) {
+        output.stopSpinner();
+      }
     }
 
     if (crossTeamMatches.length > 0 && !autoConfirm && !nonInteractive) {
@@ -516,9 +593,55 @@ export default async function setupAndLink(
       autoConfirm,
       nonInteractive,
       pullEnv,
+      currentTeamId,
+      currentTeamSlug,
     });
     if (linkedMatch) {
       return linkedMatch;
+    }
+
+    if (otherTeamSearch) {
+      output.spinner('Searching other teams for existing projects…', 1000);
+      let otherTeamResult:
+        | {
+            matches: CrossTeamMatch[];
+            searchedTeamSlugs: string[];
+          }
+        | undefined;
+      try {
+        otherTeamResult = await otherTeamSearch;
+      } finally {
+        output.stopSpinner();
+      }
+
+      if (otherTeamResult.searchedTeamSlugs.length > 0) {
+        searchedTeamSlugs.push(...otherTeamResult.searchedTeamSlugs);
+      }
+
+      if (otherTeamResult.matches.length > 0) {
+        if (!autoConfirm && !nonInteractive) {
+          printCrossTeamSearchScope({
+            searchedTeamSlugs,
+            skippedLimitedTeamSlugs,
+          });
+        }
+
+        const linkedOtherTeamMatch = await linkCrossTeamMatches({
+          client,
+          path,
+          matches: otherTeamResult.matches,
+          successEmoji,
+          autoConfirm,
+          nonInteractive,
+          pullEnv,
+          currentTeamId,
+          currentTeamSlug,
+        });
+        if (linkedOtherTeamMatch) {
+          return linkedOtherTeamMatch;
+        }
+        skipAutoDetect = true;
+      }
     }
 
     if (!autoConfirm && !nonInteractive && skippedLimitedTeams.length > 0) {
@@ -542,6 +665,8 @@ export default async function setupAndLink(
         autoConfirm,
         nonInteractive,
         pullEnv,
+        currentTeamId,
+        currentTeamSlug,
       });
       if (linkedLimitedMatch) {
         return linkedLimitedMatch;

--- a/packages/cli/src/util/projects/search-project-across-teams.ts
+++ b/packages/cli/src/util/projects/search-project-across-teams.ts
@@ -1,6 +1,7 @@
 import type Client from '../client';
 import type { Project, Org, Team } from '@vercel-internals/types';
 import getTeams from '../teams/get-teams';
+import getUser from '../get-user';
 import getProjectByIdOrName from './get-project-by-id-or-name';
 import { ProjectNotFound } from '../errors-ts';
 import slugify from '@sindresorhus/slugify';
@@ -28,6 +29,19 @@ export interface CrossTeamSearchResult {
   searchedTeamSlugs: string[];
   skippedLimitedTeamSlugs: string[];
   skippedLimitedTeams: Team[];
+  currentTeamId?: string;
+  currentTeamSlug?: string;
+  otherTeamSearch?: Promise<{
+    matches: CrossTeamMatch[];
+    searchedTeamSlugs: string[];
+  }>;
+}
+
+type SearchPhase = 'current-team' | 'other-teams' | 'all-teams';
+
+interface RepoSearchContext {
+  remote: ResolvedGitRemote;
+  relativePath: string;
 }
 
 export default async function searchProjectAcrossTeams(
@@ -40,25 +54,34 @@ export default async function searchProjectAcrossTeams(
     teams,
     skipLimited,
     gitProjectName,
+    onSearchPhase,
   }: {
     autoConfirm?: boolean;
     nonInteractive?: boolean;
     teams?: Team[];
     skipLimited?: boolean;
     gitProjectName?: string;
+    onSearchPhase?: (phase: SearchPhase) => void;
   } = {}
 ): Promise<CrossTeamSearchResult> {
-  const teamsToSearch = teams ?? (await getTeams(client));
+  const [teamsToSearch, user] = await Promise.all([
+    teams ? Promise.resolve(teams) : getTeams(client),
+    teams ? Promise.resolve(null) : getUser(client),
+  ]);
+  const currentTeamId = client.config.currentTeam || user?.defaultTeamId;
   const shouldSkipLimited = skipLimited ?? true;
 
   // Skip "limited" (SAML-enforced) teams here to avoid forcing re-auth
   // during auto-detect. If nothing matches, `setupAndLink` falls through to
   // `selectOrg`, where picking a limited team triggers re-auth deliberately.
+  // The active team is still searched first: it is the user's current scope, so
+  // preferring it avoids linking to a project in another team just because that
+  // slower search happened to finish later.
   const accessibleTeams: typeof teamsToSearch = [];
   const skippedTeams: Team[] = [];
   const skippedSlugs: string[] = [];
   for (const t of teamsToSearch) {
-    if (shouldSkipLimited && t.limited) {
+    if (shouldSkipLimited && t.limited && t.id !== currentTeamId) {
       skippedTeams.push(t);
       skippedSlugs.push(t.slug);
     } else {
@@ -72,20 +95,109 @@ export default async function searchProjectAcrossTeams(
     );
   }
 
-  const searchedTeamSlugs = accessibleTeams.map(team => team.slug);
   const orgs: Org[] = accessibleTeams.map(t => ({
     type: 'team' as const,
     id: t.id,
     slug: t.slug,
   }));
+  const currentTeam = currentTeamId
+    ? accessibleTeams.find(team => team.id === currentTeamId)
+    : undefined;
+  const currentTeamOrg = currentTeam
+    ? orgs.find(org => org.id === currentTeam.id)
+    : undefined;
+  const otherOrgs = currentTeamOrg
+    ? orgs.filter(org => org.id !== currentTeamOrg.id)
+    : orgs;
+
+  const repoSearchContextPromise = getRepoSearchContext({
+    client,
+    cwd,
+    autoConfirm,
+    nonInteractive,
+  });
+
+  const otherMatchesPromise = searchProjectsForOrgs({
+    client,
+    projectName,
+    gitProjectName,
+    orgs: otherOrgs,
+    repoSearchContextPromise,
+  }).catch(error => {
+    output.debug(`Failed to search projects outside current team: ${error}`);
+    return [];
+  });
+  const otherTeamSearch = otherMatchesPromise.then(matches => ({
+    matches,
+    searchedTeamSlugs: otherOrgs.map(org => org.slug),
+  }));
+
+  const searchedTeamSlugs: string[] = [];
+  if (currentTeamOrg) {
+    onSearchPhase?.('current-team');
+    const currentTeamMatches = await searchProjectsForOrgs({
+      client,
+      projectName,
+      gitProjectName,
+      orgs: [currentTeamOrg],
+      repoSearchContextPromise,
+    });
+    searchedTeamSlugs.push(currentTeamOrg.slug);
+
+    if (currentTeamMatches.length > 0) {
+      // Keep the other-team search running but make this result deterministic.
+      void otherMatchesPromise;
+      return {
+        matches: currentTeamMatches,
+        searchedTeamSlugs,
+        skippedLimitedTeamSlugs: skippedSlugs,
+        skippedLimitedTeams: skippedTeams,
+        currentTeamId,
+        currentTeamSlug: currentTeamOrg.slug,
+        otherTeamSearch,
+      };
+    }
+
+    onSearchPhase?.('other-teams');
+  } else {
+    onSearchPhase?.('all-teams');
+  }
+
+  const otherTeamResult = await otherTeamSearch;
+  searchedTeamSlugs.push(...otherTeamResult.searchedTeamSlugs);
+
+  return {
+    matches: otherTeamResult.matches,
+    searchedTeamSlugs,
+    skippedLimitedTeamSlugs: skippedSlugs,
+    skippedLimitedTeams: skippedTeams,
+    currentTeamId,
+    currentTeamSlug: currentTeamOrg?.slug,
+  };
+}
+
+async function searchProjectsForOrgs({
+  client,
+  projectName,
+  gitProjectName,
+  orgs,
+  repoSearchContextPromise,
+}: {
+  client: Client;
+  projectName: string;
+  gitProjectName?: string;
+  orgs: Org[];
+  repoSearchContextPromise: Promise<RepoSearchContext | null>;
+}): Promise<CrossTeamMatch[]> {
+  if (orgs.length === 0) {
+    return [];
+  }
 
   const repoMatchesPromise = searchProjectsByRepoRoot({
     client,
-    cwd,
     gitProjectName,
     orgs,
-    autoConfirm,
-    nonInteractive,
+    repoSearchContextPromise,
   });
 
   const slugifiedName = slugify(projectName);
@@ -122,32 +234,23 @@ export default async function searchProjectAcrossTeams(
     }
   }
 
-  return {
-    matches,
-    searchedTeamSlugs,
-    skippedLimitedTeamSlugs: skippedSlugs,
-    skippedLimitedTeams: skippedTeams,
-  };
+  return matches;
 }
 
-async function searchProjectsByRepoRoot({
+async function getRepoSearchContext({
   client,
   cwd,
-  gitProjectName,
-  orgs,
   autoConfirm,
   nonInteractive,
 }: {
   client: Client;
   cwd: string;
-  gitProjectName?: string;
-  orgs: Org[];
   autoConfirm: boolean;
   nonInteractive: boolean;
-}): Promise<CrossTeamMatch[]> {
+}): Promise<RepoSearchContext | null> {
   const rootPath = await findRepoRoot(cwd);
   if (!rootPath) {
-    return [];
+    return null;
   }
 
   let remote: ResolvedGitRemote | undefined;
@@ -159,14 +262,33 @@ async function searchProjectsByRepoRoot({
     output.debug(
       `Failed to resolve Git remote for cross-team search: ${error}`
     );
-    return [];
+    return null;
   }
 
   if (!remote) {
+    return null;
+  }
+
+  return { remote, relativePath: relative(rootPath, cwd) };
+}
+
+async function searchProjectsByRepoRoot({
+  client,
+  gitProjectName,
+  orgs,
+  repoSearchContextPromise,
+}: {
+  client: Client;
+  gitProjectName?: string;
+  orgs: Org[];
+  repoSearchContextPromise: Promise<RepoSearchContext | null>;
+}): Promise<CrossTeamMatch[]> {
+  const repoSearchContext = await repoSearchContextPromise;
+  if (!repoSearchContext) {
     return [];
   }
 
-  const relativePath = relative(rootPath, cwd);
+  const { remote, relativePath } = repoSearchContext;
   const results = await Promise.all(
     orgs.map(async org => {
       try {

--- a/packages/cli/src/util/telemetry/commands/link/index.ts
+++ b/packages/cli/src/util/telemetry/commands/link/index.ts
@@ -64,4 +64,11 @@ export class LinkTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandInspect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect',
+      value: actual,
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Prefer the current scoped team when `vc link` searches for existing projects, while still surfacing other-team matches if the scoped result is declined.
- Make other-team link prompts explicit about switching away from the current scope and stop prompting to pull env vars after `vc link`.
- Add `vc link inspect` to show direct directory links or repo-level project mappings with formatted output.

## Test plan
- `pnpm --filter vercel type-check`
- `pnpm exec biome lint packages/cli/src/commands/link/index.ts packages/cli/src/commands/link/command.ts packages/cli/src/commands/link/inspect.ts packages/cli/src/util/link/setup-and-link.ts packages/cli/src/util/projects/search-project-across-teams.ts packages/cli/src/util/telemetry/commands/link/index.ts`
- `pnpm --filter vercel build && node packages/cli/dist/vc.js link inspect`


Made with [Cursor](https://cursor.com)