### PR TITLE
fix(cli): strip global flags from curl arguments

### DIFF
--- a/.changeset/quiet-curl-flags.md
+++ b/.changeset/quiet-curl-flags.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Strip already-handled global CLI flags from `vc curl` arguments so options like `--cwd` still set the working directory without being forwarded to the underlying `curl` process.

--- a/packages/cli/src/commands/curl/shared.ts
+++ b/packages/cli/src/commands/curl/shared.ts
@@ -19,6 +19,10 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { help } from '../help';
 import { getCommandName } from '../../util/pkg-name';
+import {
+  GLOBAL_CLI_FLAG_NAMES,
+  globalCliFlagTakesValue,
+} from '../../util/arg-common';
 import type { Command } from '../help';
 import type arg from 'arg';
 
@@ -77,6 +81,33 @@ function flagValue(args: string[], index: number): string | undefined {
   return next && !next.startsWith('-') ? next : undefined;
 }
 
+function getCommandArgs(rawArgs: string[], commandName: string): string[] {
+  if (rawArgs[0] === commandName) {
+    return rawArgs.slice(1);
+  }
+
+  let argsStart = 0;
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i];
+    const name = flagName(arg);
+
+    if (arg === commandName) {
+      return rawArgs.slice(i + 1);
+    }
+
+    if (!GLOBAL_CLI_FLAG_NAMES.has(name)) {
+      break;
+    }
+
+    if (!arg.includes('=') && globalCliFlagTakesValue(name)) {
+      i++;
+    }
+    argsStart = i + 1;
+  }
+
+  return rawArgs.slice(argsStart);
+}
+
 export function parseCurlLikeArgs(
   rawArgs: string[],
   commandName: string
@@ -96,7 +127,7 @@ export function parseCurlLikeArgs(
     help: false,
     toolFlags: [] as string[],
   };
-  const args = rawArgs[0] === commandName ? rawArgs.slice(1) : [...rawArgs];
+  const args = getCommandArgs(rawArgs, commandName);
   const separatorIndex = args.indexOf('--');
   const beforeSeparator =
     separatorIndex === -1 ? args : args.slice(0, separatorIndex);

--- a/packages/cli/test/unit/commands/curl/index.test.ts
+++ b/packages/cli/test/unit/commands/curl/index.test.ts
@@ -879,6 +879,36 @@ describe('parseCurlLikeArgs', () => {
     expect(parsed.target).toBe('https://example.com');
     expect(parsed.toolFlags).toEqual(['--silent']);
   });
+
+  it('ignores global flags before the command name', () => {
+    const parsed = parseCurlLikeArgs(
+      ['--cwd', 'apps/vercel-site', 'curl', '/new'],
+      'curl'
+    );
+
+    expect(parsed.target).toBe('/new');
+    expect(parsed.toolFlags).toEqual([]);
+  });
+
+  it('ignores global flags with inline values before the command name', () => {
+    const parsed = parseCurlLikeArgs(
+      ['--cwd=apps/vercel-site', '--debug', 'curl', '/new', '--silent'],
+      'curl'
+    );
+
+    expect(parsed.target).toBe('/new');
+    expect(parsed.toolFlags).toEqual(['--silent']);
+  });
+
+  it('ignores leading global flags when the command name is absent', () => {
+    const parsed = parseCurlLikeArgs(
+      ['--cwd', 'apps/vercel-site', '/new'],
+      'curl'
+    );
+
+    expect(parsed.target).toBe('/new');
+    expect(parsed.toolFlags).toEqual([]);
+  });
 });
 
 describe('getDeploymentUrlAndToken target selection', () => {


### PR DESCRIPTION
## Summary
- Strip already-handled global CLI flags before parsing `vc curl` arguments.
- Keep flags like `--cwd` applied by the root CLI while preventing them from being forwarded to the underlying `curl` process.
- Add parser coverage for `vc --cwd <dir> curl /path` and `--cwd=<dir>` variants.

## Test plan
- `git diff --check`
- `pnpm --filter vercel test packages/cli/test/unit/commands/curl/index.test.ts` *(initially blocked before dependency install because `vitest` was unavailable in the fresh worktree)*
- Pre-commit hook ran `biome format` and `biome lint` through `lint-staged`