### PR TITLE
[services] Support schedule arrays for JS/TS cron services.

### DIFF
--- a/.changeset/happy-carpets-attend.md
+++ b/.changeset/happy-carpets-attend.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': minor
+---
+
+Support schedule arrays for JS/TS cron services.

--- a/packages/backends/src/crons.ts
+++ b/packages/backends/src/crons.ts
@@ -43,7 +43,13 @@ export async function getServiceCrons(opts: {
   if (!service || !isScheduleTriggeredService(service)) {
     return undefined;
   }
-  if (!service.name || typeof service.schedule !== 'string') {
+  if (
+    !service.name ||
+    !(
+      typeof service.schedule === 'string' ||
+      (Array.isArray(service.schedule) && service.schedule.length > 0)
+    )
+  ) {
     return undefined;
   }
 
@@ -57,11 +63,9 @@ export async function getServiceCrons(opts: {
     );
   }
 
-  return [
-    {
-      path: getInternalServiceCronPath(service.name, entrypoint, 'cron'),
-      schedule: service.schedule,
-      exportName: 'default',
-    },
-  ];
+  const path = getInternalServiceCronPath(service.name, entrypoint, 'cron');
+  const schedules = Array.isArray(service.schedule)
+    ? service.schedule
+    : [service.schedule];
+  return schedules.map(schedule => ({ path, schedule, exportName: 'default' }));
 }

--- a/packages/backends/test/unit.crons.test.ts
+++ b/packages/backends/test/unit.crons.test.ts
@@ -36,6 +36,12 @@ describe('getServiceCrons', () => {
         entrypoint: 'cleanup.ts',
       })
     ).toBeUndefined();
+    expect(
+      await getServiceCrons({
+        service: { type: 'cron', name: 'cleanup', schedule: [] },
+        entrypoint: 'cleanup.ts',
+      })
+    ).toBeUndefined();
   });
 
   it('produces a single entry for a static schedule on a cron service', async () => {
@@ -79,6 +85,30 @@ describe('getServiceCrons', () => {
         service: { type: 'cron', name: 'cleanup', schedule: '0 0 * * *' },
       })
     ).rejects.toThrow(/missing an entrypoint/);
+  });
+
+  it('produces multiple entries for an array of schedules', async () => {
+    expect(
+      await getServiceCrons({
+        service: {
+          type: 'cron',
+          name: 'cleanup',
+          schedule: ['0 0 * * *', '0 12 * * *'],
+        },
+        entrypoint: 'cleanup.ts',
+      })
+    ).toEqual([
+      {
+        path: '/_svc/cleanup/crons/cleanup/cron',
+        schedule: '0 0 * * *',
+        exportName: 'default',
+      },
+      {
+        path: '/_svc/cleanup/crons/cleanup/cron',
+        schedule: '0 12 * * *',
+        exportName: 'default',
+      },
+    ]);
   });
 
   it('throws on a <dynamic> schedule (not yet supported for JS/TS)', async () => {


### PR DESCRIPTION
Extends `getServiceCrons` in `@vercel/backends` to accept `schedule: string | string[]`.