### PR TITLE
[connect] Preserve vendor error payloads

### DIFF
--- a/.changeset/connect-vendor-error-payload.md
+++ b/.changeset/connect-vendor-error-payload.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Preserve Vercel Connect vendor error payloads on Connect errors.

--- a/packages/connect/src/betterauth/connect-provider.ts
+++ b/packages/connect/src/betterauth/connect-provider.ts
@@ -31,6 +31,7 @@ import { getVercelOidcToken } from '@vercel/oidc';
 import { getOAuth2Tokens, type OAuth2UserInfo } from 'better-auth/oauth2';
 import type { GenericOAuthConfig } from 'better-auth/plugins/generic-oauth';
 import { tryGetVercelTeamId, withTeamId } from '../internal/team-id.js';
+import { ConnectError, createConnectErrorFromResponse } from '../token.js';
 
 const CONNECT_AUTHORIZATION_URL = 'https://connect.vercel.com/oauth/authorize';
 const CONNECT_TOKEN_URL = 'https://connect.vercel.com/oauth/token';
@@ -115,24 +116,29 @@ export function connect(options: BetterAuthConnectOptions): GenericOAuthConfig {
         body: body.toString(),
       });
       if (!response.ok) {
-        throw new Error(
-          `Failed to exchange Vercel Connect authorization code: ${response.status} ${response.statusText}: ${await response.text()}`
+        throw await createConnectErrorFromResponse(
+          response,
+          'Failed to exchange Vercel Connect authorization code'
         );
       }
       return getOAuth2Tokens(await response.json());
     },
     getUserInfo: async (tokens): Promise<OAuth2UserInfo | null> => {
       if (!tokens.accessToken) {
-        throw new Error(
-          'Missing access token for Vercel Connect userinfo request'
+        throw new ConnectError(
+          'Missing access token for Vercel Connect userinfo request',
+          {
+            code: 'missing_access_token',
+          }
         );
       }
       const response = await fetch(CONNECT_USERINFO_URL, {
         headers: { Authorization: `Bearer ${tokens.accessToken}` },
       });
       if (!response.ok) {
-        throw new Error(
-          `Failed to fetch Vercel Connect user info: ${response.status} ${response.statusText}: ${await response.text()}`
+        throw await createConnectErrorFromResponse(
+          response,
+          'Failed to fetch Vercel Connect user info'
         );
       }
       const user = (await response.json()) as {

--- a/packages/connect/src/betterauth/index.ts
+++ b/packages/connect/src/betterauth/index.ts
@@ -8,3 +8,9 @@
  * without it.
  */
 export { connect, type BetterAuthConnectOptions } from './connect-provider.js';
+
+export {
+  ConnectError,
+  type ConnectErrorOptions,
+  type ConnectVendorErrorPayload,
+} from '../token.js';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,12 +1,15 @@
 export {
   getToken,
   getTokenResponse,
+  ConnectError,
   NoValidTokenError,
   UserAuthorizationRequiredError,
   ConnectorInstallationRequiredError,
+  type ConnectErrorOptions,
   type ConnectOptions,
   type ConnectTokenParams,
   type ConnectTokenResponse,
+  type ConnectVendorErrorPayload,
 } from './token.js';
 
 export {

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -36,23 +36,48 @@ export interface ConnectTokenResponse {
   metadata?: Record<string, unknown>;
 }
 
-export class NoValidTokenError extends Error {
-  constructor(message: string) {
+export type ConnectVendorErrorPayload = Record<string, unknown>;
+
+export interface ConnectErrorOptions {
+  code?: string;
+  status?: number;
+  statusText?: string;
+  vendor?: ConnectVendorErrorPayload;
+}
+
+export class ConnectError extends Error {
+  readonly code?: string;
+  readonly status?: number;
+  readonly statusText?: string;
+  readonly vendor?: ConnectVendorErrorPayload;
+
+  constructor(message: string, options: ConnectErrorOptions = {}) {
     super(message);
+    this.name = 'ConnectError';
+    this.code = options.code;
+    this.status = options.status;
+    this.statusText = options.statusText;
+    this.vendor = options.vendor;
+  }
+}
+
+export class NoValidTokenError extends ConnectError {
+  constructor(message: string, options?: ConnectErrorOptions) {
+    super(message, options);
     this.name = 'NoValidTokenError';
   }
 }
 
-export class UserAuthorizationRequiredError extends Error {
-  constructor(message: string) {
-    super(message);
+export class UserAuthorizationRequiredError extends ConnectError {
+  constructor(message: string, options?: ConnectErrorOptions) {
+    super(message, options);
     this.name = 'UserAuthorizationRequiredError';
   }
 }
 
-export class ConnectorInstallationRequiredError extends Error {
-  constructor(message: string) {
-    super(message);
+export class ConnectorInstallationRequiredError extends ConnectError {
+  constructor(message: string, options?: ConnectErrorOptions) {
+    super(message, options);
     this.name = 'ConnectorInstallationRequiredError';
   }
 }
@@ -103,48 +128,7 @@ export async function getTokenResponse(
   });
 
   if (!response.ok) {
-    let errorText: string | undefined;
-    let errorObject:
-      | { error?: { code?: string; message?: string } }
-      | undefined;
-    try {
-      errorText = await response.text();
-      const errorJson = JSON.parse(errorText);
-      if (typeof errorJson === 'object' && errorJson !== null) {
-        errorObject = errorJson;
-      }
-    } catch {}
-    const code = errorObject?.error?.code;
-    const message = errorObject?.error?.message;
-    if (code === 'no_token') {
-      throw new NoValidTokenError(
-        message || errorText || 'No valid token available'
-      );
-    }
-    if (code === 'user_authorization_required') {
-      throw new UserAuthorizationRequiredError(
-        message || errorText || 'User authorization is required'
-      );
-    }
-    if (
-      code === 'client_installation_required' ||
-      code === 'connector_installation_required'
-    ) {
-      throw new ConnectorInstallationRequiredError(
-        message || errorText || 'Connector installation is required'
-      );
-    }
-    throw new Error(
-      [
-        'Failed to get token:',
-        `${response.status}`,
-        response.statusText,
-        code ? ` - ${code}` : '',
-        errorText ? ` - ${errorText}` : '',
-      ]
-        .filter(Boolean)
-        .join(' ')
-    );
+    throw await createConnectErrorFromResponse(response, 'Failed to get token');
   }
 
   const data: ConnectTokenResponse = await response.json();
@@ -179,4 +163,146 @@ function evictLru(): void {
   if (oldestKey !== undefined) {
     cache.delete(oldestKey);
   }
+}
+
+interface ParsedConnectErrorResponse {
+  bodyText?: string;
+  code?: string;
+  message?: string;
+  vendor?: ConnectVendorErrorPayload;
+}
+
+export async function createConnectErrorFromResponse(
+  response: Response,
+  fallbackMessage: string
+): Promise<ConnectError> {
+  const parsedError = await readConnectErrorResponse(response);
+  return createConnectError(response, parsedError, fallbackMessage);
+}
+
+function createConnectError(
+  response: Response,
+  parsedError: ParsedConnectErrorResponse,
+  fallbackMessage: string
+): ConnectError {
+  const { code, message, bodyText } = parsedError;
+  const errorOptions = connectErrorOptions(response, parsedError);
+
+  if (code === 'no_token') {
+    return new NoValidTokenError(
+      message || bodyText || 'No valid token available',
+      errorOptions
+    );
+  }
+
+  if (code === 'user_authorization_required') {
+    return new UserAuthorizationRequiredError(
+      message || bodyText || 'User authorization is required',
+      errorOptions
+    );
+  }
+
+  if (
+    code === 'client_installation_required' ||
+    code === 'connector_installation_required'
+  ) {
+    return new ConnectorInstallationRequiredError(
+      message || bodyText || 'Connector installation is required',
+      errorOptions
+    );
+  }
+
+  return new ConnectError(
+    buildConnectResponseErrorMessage(response, parsedError, fallbackMessage),
+    errorOptions
+  );
+}
+
+async function readConnectErrorResponse(
+  response: Response
+): Promise<ParsedConnectErrorResponse> {
+  let bodyText: string | undefined;
+  try {
+    bodyText = await response.text();
+  } catch {}
+
+  if (!bodyText) {
+    return {};
+  }
+
+  try {
+    const body = JSON.parse(bodyText);
+    if (!isRecord(body)) {
+      return { bodyText };
+    }
+
+    const error = isRecord(body.error)
+      ? body.error
+      : isRecord(body.err)
+        ? body.err
+        : undefined;
+
+    if (!error) {
+      return { bodyText, vendor: vendorPayload(body) };
+    }
+
+    return {
+      bodyText,
+      code: typeof error.code === 'string' ? error.code : undefined,
+      message: typeof error.message === 'string' ? error.message : undefined,
+      vendor: vendorPayload(error) ?? vendorPayload(body),
+    };
+  } catch {
+    return { bodyText };
+  }
+}
+
+function connectErrorOptions(
+  response: Response,
+  parsedError: ParsedConnectErrorResponse
+): ConnectErrorOptions {
+  return {
+    code: parsedError.code,
+    status: response.status,
+    statusText: response.statusText,
+    vendor: parsedError.vendor,
+  };
+}
+
+function buildConnectResponseErrorMessage(
+  response: Response,
+  parsedError: ParsedConnectErrorResponse,
+  fallbackMessage: string
+): string {
+  if (parsedError.message) {
+    return parsedError.message;
+  }
+
+  return [
+    `${fallbackMessage}:`,
+    `${response.status}`,
+    response.statusText,
+    parsedError.code ? ` - ${parsedError.code}` : '',
+    parsedError.bodyText ? ` - ${parsedError.bodyText}` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function vendorPayload(
+  error: Record<string, unknown>
+): ConnectVendorErrorPayload | undefined {
+  if (isRecord(error.vendor)) {
+    return error.vendor;
+  }
+
+  if (isRecord(error.meta) && isRecord(error.meta.vendor)) {
+    return error.meta.vendor;
+  }
+
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary
- Add a shared ConnectError base class with code, status, statusText, and vendor fields.
- Derive existing token errors from ConnectError and preserve vendor payloads from Connect API error responses.
- Use the shared error handling in the Better Auth provider token and userinfo failure paths.

## Validation
- pnpm --filter @vercel/connect typecheck