### PR TITLE
[@vercel/connect] Support authorization request device codes

### DIFF
--- a/.changeset/vercel-connect.md
+++ b/.changeset/vercel-connect.md
@@ -3,6 +3,7 @@
 ---
 
 - Add `connect()` helper for Ash via the new `@vercel/connect/ash` subpath. Returned authorization definitions carry a `vercelConnect: { connector }` marker for downstream tooling (requires `experimental-ash >=0.8.2`).
+- Add authorization request device code and expiration fields for Ash authorization challenges.
 - Rename the authorization browser redirect option from `returnUrl` to `callbackUrl`.
 - Map new `/v1/connect/token/:connector` error codes to typed errors: `NoValidTokenError` (renamed from `no_valid_token`), `UserAuthorizationRequiredError`, `ConnectorInstallationRequiredError`.
 - Add driver-specific metadata field to the token response.

--- a/packages/connect/src/ash/connection-authorization.ts
+++ b/packages/connect/src/ash/connection-authorization.ts
@@ -303,10 +303,23 @@ function buildInteractiveDefinition(
         const response = await startAuthorization(
           options.connector,
           buildTokenParams(options, principal),
-          { ...options.connectOptions, callbackUrl: callbackUrl ?? webhook }
+          {
+            ...options.connectOptions,
+            callbackUrl: callbackUrl ?? webhook,
+            deviceCode: true,
+          }
         );
         return {
-          challenge: buildChallenge(options, response.url),
+          challenge: {
+            url: response.url,
+            ...(response.deviceCode ? { userCode: response.deviceCode } : null),
+            ...(response.expiresAt
+              ? { expiresAt: new Date(response.expiresAt).toISOString() }
+              : null),
+            ...(options.instructions
+              ? { instructions: options.instructions }
+              : null),
+          } satisfies ConnectionAuthorizationChallenge,
           state: { verifier: response.verifier },
         };
       } catch (error) {
@@ -368,16 +381,6 @@ function principalToSubject(
     return { type: 'app' };
   }
   return { type: 'user', id: principal.id, issuer: principal.issuer };
-}
-
-function buildChallenge(
-  options: AshAuthorizationOptions,
-  url: string
-): ConnectionAuthorizationChallenge {
-  if (options.instructions === undefined) {
-    return { url };
-  }
-  return { url, instructions: options.instructions };
 }
 
 /**

--- a/packages/connect/src/authorization.ts
+++ b/packages/connect/src/authorization.ts
@@ -5,12 +5,16 @@ export interface ConnectAuthorizationOptions {
   vercelToken?: string;
   callbackUrl?: string;
   webhook?: string;
+  deviceCode?: boolean;
+  expiresInMs?: number;
 }
 
 export interface ConnectAuthorizationResponse {
   request: string;
   verifier: string;
   url: string;
+  deviceCode?: string;
+  expiresAt?: number;
 }
 
 export async function startAuthorization(
@@ -37,6 +41,12 @@ export async function startAuthorization(
       returnUrl: options.callbackUrl,
     }),
     ...(options?.webhook !== undefined && { webhook: options.webhook }),
+    ...(options?.deviceCode !== undefined && {
+      deviceCode: options.deviceCode,
+    }),
+    ...(options?.expiresInMs !== undefined && {
+      expiresInMs: options.expiresInMs,
+    }),
   };
 
   const response = await fetch(endpoint, {
@@ -59,9 +69,8 @@ export async function startAuthorization(
     );
   }
 
-  const { request, verifier, url }: ConnectAuthorizationResponse =
-    await response.json();
-  return { request, verifier, url };
+  const data: ConnectAuthorizationResponse = await response.json();
+  return data;
 }
 
 function validateCallbackUrl(value: string): void {


### PR DESCRIPTION
## Summary
- Align @vercel/connect authorization requests with vercel/api#74272.
- Forward deviceCode and expiresInMs to the Connex authorize endpoint, and preserve deviceCode/expiresAt in the SDK response.
- Map the returned device code and expiration into Ash authorization challenges.

## Validation
- pnpm --filter @vercel/connect typecheck
- pnpm --filter @vercel/connect build
- pre-commit lint-staged (biome format/lint)