### PR TITLE
[cli] Split CLI eval result uploads into discoverable chunks

### DIFF
--- a/.changeset/chunky-cli-evals.md
+++ b/.changeset/chunky-cli-evals.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Split CLI eval result uploads into size-limited multipart requests to avoid centralized ingest payload limits.

--- a/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
+++ b/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
@@ -177,6 +177,21 @@ function isTimestampSegment(segment) {
   return /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d+)?Z$/.test(segment);
 }
 
+function toDiscoverablePath(relativePath) {
+  const segments = relativePath.split('/');
+  const timestampIndex = segments.findIndex(isTimestampSegment);
+  if (timestampIndex <= 1) return relativePath;
+
+  const modelSegments = segments.slice(1, timestampIndex);
+  if (modelSegments.length <= 1) return relativePath;
+
+  return [
+    segments[0],
+    modelSegments.join('-'),
+    ...segments.slice(timestampIndex),
+  ].join('/');
+}
+
 function getRunGroup(relativePath) {
   const segments = relativePath.split('/');
   const timestampIndex = segments.findIndex(isTimestampSegment);
@@ -388,6 +403,13 @@ async function chunkRunGroupByEstimatedRequestSize({
   payload,
   maxRequestBytes,
 }) {
+  const allFilesBytes =
+    estimatePayloadPartBytes(payload) +
+    (await estimateFilesPartBytes(resultsDir, files));
+  if (allFilesBytes <= maxRequestBytes) {
+    return [files];
+  }
+
   const chunks = [];
   const evalGroups = groupFilesByEval(files, resultsDir);
 
@@ -417,10 +439,11 @@ async function uploadFileGroup({
 
   for (const fullPath of files) {
     const relativePath = getRelativePath(resultsDir, fullPath);
+    const uploadPath = toDiscoverablePath(relativePath);
     const buffer = await readFile(fullPath);
     formData.append(
       'results_file',
-      new File([buffer], relativePath, {
+      new File([buffer], uploadPath, {
         type: contentTypeFor(relativePath),
       })
     );

--- a/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
+++ b/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
@@ -284,42 +284,61 @@ async function estimateRequestBytes(payload, resultsDir, files) {
   );
 }
 
-async function chunkFilesWithoutResults({
+async function packFilesIntoChunks({
   files,
   resultsDir,
-  payload,
+  seedFiles,
+  baseBytes,
   maxRequestBytes,
 }) {
   const chunks = [];
-  const payloadBytes = estimatePayloadPartBytes(payload);
-  let currentChunk = [];
-  let currentBytes = payloadBytes;
+  let currentChunk = [...seedFiles];
+  let currentBytes = baseBytes;
 
   for (const fullPath of files) {
     const relativePath = getRelativePath(resultsDir, fullPath);
     const fileBytes = await estimateFilePartBytes(resultsDir, fullPath);
 
-    if (payloadBytes + fileBytes > maxRequestBytes) {
+    if (baseBytes + fileBytes > maxRequestBytes) {
+      const seedNote = seedFiles.length > 0 ? ' plus results files' : '';
       console.warn(
-        `Warning: ${relativePath} is approximately ${fileBytes} bytes before multipart framing and exceeds --max-request-bytes=${maxRequestBytes}; uploading it in its own request.`
+        `Warning: ${relativePath}${seedNote} is approximately ${baseBytes + fileBytes} bytes before multipart framing and exceeds --max-request-bytes=${maxRequestBytes}; uploading it in its own request.`
       );
     }
 
-    if (currentChunk.length > 0 && currentBytes + fileBytes > maxRequestBytes) {
+    if (
+      currentChunk.length > seedFiles.length &&
+      currentBytes + fileBytes > maxRequestBytes
+    ) {
       chunks.push(currentChunk);
-      currentChunk = [];
-      currentBytes = payloadBytes;
+      currentChunk = [...seedFiles];
+      currentBytes = baseBytes;
     }
 
     currentChunk.push(fullPath);
     currentBytes += fileBytes;
   }
 
-  if (currentChunk.length > 0) {
+  if (currentChunk.length > seedFiles.length) {
     chunks.push(currentChunk);
   }
 
   return chunks;
+}
+
+async function chunkFilesWithoutResults({
+  files,
+  resultsDir,
+  payload,
+  maxRequestBytes,
+}) {
+  return packFilesIntoChunks({
+    files,
+    resultsDir,
+    seedFiles: [],
+    baseBytes: estimatePayloadPartBytes(payload),
+    maxRequestBytes,
+  });
 }
 
 async function chunkEvalFilesByEstimatedRequestSize({
@@ -371,38 +390,13 @@ async function chunkEvalFilesByEstimatedRequestSize({
     return [sortedFiles];
   }
 
-  const chunks = [];
-  let currentChunk = [...resultsFiles];
-  let currentBytes = baseBytes;
-
-  for (const fullPath of artifactFiles) {
-    const relativePath = getRelativePath(resultsDir, fullPath);
-    const fileBytes = await estimateFilePartBytes(resultsDir, fullPath);
-
-    if (baseBytes + fileBytes > maxRequestBytes) {
-      console.warn(
-        `Warning: ${relativePath} plus results files is approximately ${baseBytes + fileBytes} bytes before multipart framing and exceeds --max-request-bytes=${maxRequestBytes}; uploading it in its own request.`
-      );
-    }
-
-    if (
-      currentChunk.length > resultsFiles.length &&
-      currentBytes + fileBytes > maxRequestBytes
-    ) {
-      chunks.push(currentChunk);
-      currentChunk = [...resultsFiles];
-      currentBytes = baseBytes;
-    }
-
-    currentChunk.push(fullPath);
-    currentBytes += fileBytes;
-  }
-
-  if (currentChunk.length > resultsFiles.length) {
-    chunks.push(currentChunk);
-  }
-
-  return chunks;
+  return packFilesIntoChunks({
+    files: artifactFiles,
+    resultsDir,
+    seedFiles: resultsFiles,
+    baseBytes,
+    maxRequestBytes,
+  });
 }
 
 async function chunkRunGroupByEstimatedRequestSize({

--- a/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
+++ b/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const DEFAULT_MAX_REQUEST_BYTES = 3_500_000;
 const MULTIPART_PAYLOAD_OVERHEAD_BYTES = 2048;
@@ -634,7 +635,28 @@ async function main() {
   );
 }
 
-main().catch(error => {
-  console.error(error);
-  process.exitCode = 1;
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+export {
+  parseMaxRequestBytes,
+  splitAtTimestamp,
+  normalizeUploadPath,
+  getRunGroup,
+  getEvalGroup,
+  isResultsFile,
+  estimatePayloadPartBytes,
+  estimateFilePartBytes,
+  estimateFilesPartBytes,
+  estimateRequestBytes,
+  packFilesIntoChunks,
+  chunkFilesWithoutResults,
+  chunkEvalFilesByEstimatedRequestSize,
+  chunkRunGroupByEstimatedRequestSize,
+  groupFilesByRun,
+  groupFilesByEval,
+};

--- a/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
+++ b/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
@@ -177,9 +177,14 @@ function isTimestampSegment(segment) {
   return /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d+)?Z$/.test(segment);
 }
 
-function toDiscoverablePath(relativePath) {
+function splitAtTimestamp(relativePath) {
   const segments = relativePath.split('/');
   const timestampIndex = segments.findIndex(isTimestampSegment);
+  return { segments, timestampIndex };
+}
+
+function normalizeUploadPath(relativePath) {
+  const { segments, timestampIndex } = splitAtTimestamp(relativePath);
   if (timestampIndex <= 1) return relativePath;
 
   const modelSegments = segments.slice(1, timestampIndex);
@@ -193,15 +198,13 @@ function toDiscoverablePath(relativePath) {
 }
 
 function getRunGroup(relativePath) {
-  const segments = relativePath.split('/');
-  const timestampIndex = segments.findIndex(isTimestampSegment);
+  const { segments, timestampIndex } = splitAtTimestamp(relativePath);
   if (timestampIndex === -1) return 'ungrouped';
   return segments.slice(0, timestampIndex + 1).join('/');
 }
 
 function getEvalGroup(relativePath) {
-  const segments = relativePath.split('/');
-  const timestampIndex = segments.findIndex(isTimestampSegment);
+  const { segments, timestampIndex } = splitAtTimestamp(relativePath);
   if (timestampIndex === -1) return 'ungrouped';
 
   const runIndex = segments.findIndex(
@@ -214,7 +217,7 @@ function getEvalGroup(relativePath) {
   return segments.slice(0, -1).join('/');
 }
 
-function isDiscoveryFile(relativePath) {
+function isResultsFile(relativePath) {
   return (
     relativePath.endsWith('/summary.json') ||
     /\/run-\d+\/result\.json$/.test(relativePath)
@@ -274,7 +277,14 @@ async function estimateFilesPartBytes(resultsDir, files) {
   return total;
 }
 
-async function chunkFilesWithoutDiscovery({
+async function estimateRequestBytes(payload, resultsDir, files) {
+  return (
+    estimatePayloadPartBytes(payload) +
+    (await estimateFilesPartBytes(resultsDir, files))
+  );
+}
+
+async function chunkFilesWithoutResults({
   files,
   resultsDir,
   payload,
@@ -321,15 +331,15 @@ async function chunkEvalFilesByEstimatedRequestSize({
   const sortedFiles = [...files].sort((a, b) =>
     getRelativePath(resultsDir, a).localeCompare(getRelativePath(resultsDir, b))
   );
-  const discoveryFiles = sortedFiles.filter(fullPath =>
-    isDiscoveryFile(getRelativePath(resultsDir, fullPath))
+  const resultsFiles = sortedFiles.filter(fullPath =>
+    isResultsFile(getRelativePath(resultsDir, fullPath))
   );
   const artifactFiles = sortedFiles.filter(
-    fullPath => !isDiscoveryFile(getRelativePath(resultsDir, fullPath))
+    fullPath => !isResultsFile(getRelativePath(resultsDir, fullPath))
   );
 
-  if (discoveryFiles.length === 0) {
-    return chunkFilesWithoutDiscovery({
+  if (resultsFiles.length === 0) {
+    return chunkFilesWithoutResults({
       files: sortedFiles,
       resultsDir,
       payload,
@@ -338,33 +348,31 @@ async function chunkEvalFilesByEstimatedRequestSize({
   }
 
   if (artifactFiles.length === 0) {
-    return [discoveryFiles];
+    return [resultsFiles];
   }
 
   const payloadBytes = estimatePayloadPartBytes(payload);
-  const discoveryBytes = await estimateFilesPartBytes(
-    resultsDir,
-    discoveryFiles
-  );
-  const baseBytes = payloadBytes + discoveryBytes;
+  const resultsBytes = await estimateFilesPartBytes(resultsDir, resultsFiles);
+  const baseBytes = payloadBytes + resultsBytes;
 
   if (baseBytes > maxRequestBytes) {
     const evalGroup = getEvalGroup(
-      getRelativePath(resultsDir, discoveryFiles[0])
+      getRelativePath(resultsDir, resultsFiles[0])
     );
     console.warn(
-      `Warning: discovery files for ${evalGroup} are approximately ${discoveryBytes} bytes before multipart framing and exceed --max-request-bytes=${maxRequestBytes}.`
+      `Warning: results files for ${evalGroup} are approximately ${resultsBytes} bytes before multipart framing and exceed --max-request-bytes=${maxRequestBytes}.`
     );
   }
 
-  const allFilesBytes =
-    baseBytes + (await estimateFilesPartBytes(resultsDir, artifactFiles));
-  if (allFilesBytes <= maxRequestBytes) {
+  if (
+    (await estimateRequestBytes(payload, resultsDir, sortedFiles)) <=
+    maxRequestBytes
+  ) {
     return [sortedFiles];
   }
 
   const chunks = [];
-  let currentChunk = [...discoveryFiles];
+  let currentChunk = [...resultsFiles];
   let currentBytes = baseBytes;
 
   for (const fullPath of artifactFiles) {
@@ -373,16 +381,16 @@ async function chunkEvalFilesByEstimatedRequestSize({
 
     if (baseBytes + fileBytes > maxRequestBytes) {
       console.warn(
-        `Warning: ${relativePath} plus discovery files is approximately ${baseBytes + fileBytes} bytes before multipart framing and exceeds --max-request-bytes=${maxRequestBytes}; uploading it in its own discoverable request.`
+        `Warning: ${relativePath} plus results files is approximately ${baseBytes + fileBytes} bytes before multipart framing and exceeds --max-request-bytes=${maxRequestBytes}; uploading it in its own request.`
       );
     }
 
     if (
-      currentChunk.length > discoveryFiles.length &&
+      currentChunk.length > resultsFiles.length &&
       currentBytes + fileBytes > maxRequestBytes
     ) {
       chunks.push(currentChunk);
-      currentChunk = [...discoveryFiles];
+      currentChunk = [...resultsFiles];
       currentBytes = baseBytes;
     }
 
@@ -390,7 +398,7 @@ async function chunkEvalFilesByEstimatedRequestSize({
     currentBytes += fileBytes;
   }
 
-  if (currentChunk.length > discoveryFiles.length) {
+  if (currentChunk.length > resultsFiles.length) {
     chunks.push(currentChunk);
   }
 
@@ -403,10 +411,9 @@ async function chunkRunGroupByEstimatedRequestSize({
   payload,
   maxRequestBytes,
 }) {
-  const allFilesBytes =
-    estimatePayloadPartBytes(payload) +
-    (await estimateFilesPartBytes(resultsDir, files));
-  if (allFilesBytes <= maxRequestBytes) {
+  if (
+    (await estimateRequestBytes(payload, resultsDir, files)) <= maxRequestBytes
+  ) {
     return [files];
   }
 
@@ -439,7 +446,7 @@ async function uploadFileGroup({
 
   for (const fullPath of files) {
     const relativePath = getRelativePath(resultsDir, fullPath);
-    const uploadPath = toDiscoverablePath(relativePath);
+    const uploadPath = normalizeUploadPath(relativePath);
     const buffer = await readFile(fullPath);
     formData.append(
       'results_file',

--- a/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
+++ b/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
@@ -184,12 +184,48 @@ function getRunGroup(relativePath) {
   return segments.slice(0, timestampIndex + 1).join('/');
 }
 
+function getEvalGroup(relativePath) {
+  const segments = relativePath.split('/');
+  const timestampIndex = segments.findIndex(isTimestampSegment);
+  if (timestampIndex === -1) return 'ungrouped';
+
+  const runIndex = segments.findIndex(
+    (segment, index) => index > timestampIndex && /^run-\d+$/.test(segment)
+  );
+  if (runIndex !== -1) {
+    return segments.slice(0, runIndex).join('/');
+  }
+
+  return segments.slice(0, -1).join('/');
+}
+
+function isDiscoveryFile(relativePath) {
+  return (
+    relativePath.endsWith('/summary.json') ||
+    /\/run-\d+\/result\.json$/.test(relativePath)
+  );
+}
+
 function groupFilesByRun(files, resultsDir) {
   const groups = new Map();
 
   for (const fullPath of files) {
     const relativePath = getRelativePath(resultsDir, fullPath);
     const group = getRunGroup(relativePath);
+    const groupFiles = groups.get(group) ?? [];
+    groupFiles.push(fullPath);
+    groups.set(group, groupFiles);
+  }
+
+  return [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
+
+function groupFilesByEval(files, resultsDir) {
+  const groups = new Map();
+
+  for (const fullPath of files) {
+    const relativePath = getRelativePath(resultsDir, fullPath);
+    const group = getEvalGroup(relativePath);
     const groupFiles = groups.get(group) ?? [];
     groupFiles.push(fullPath);
     groups.set(group, groupFiles);
@@ -205,7 +241,25 @@ function estimatePayloadPartBytes(payload) {
   );
 }
 
-async function chunkFilesByEstimatedRequestSize({
+async function estimateFilePartBytes(resultsDir, fullPath) {
+  const relativePath = getRelativePath(resultsDir, fullPath);
+  const fileInfo = await stat(fullPath);
+  return (
+    fileInfo.size +
+    Buffer.byteLength(relativePath, 'utf8') +
+    MULTIPART_FILE_OVERHEAD_BYTES
+  );
+}
+
+async function estimateFilesPartBytes(resultsDir, files) {
+  let total = 0;
+  for (const fullPath of files) {
+    total += await estimateFilePartBytes(resultsDir, fullPath);
+  }
+  return total;
+}
+
+async function chunkFilesWithoutDiscovery({
   files,
   resultsDir,
   payload,
@@ -218,11 +272,7 @@ async function chunkFilesByEstimatedRequestSize({
 
   for (const fullPath of files) {
     const relativePath = getRelativePath(resultsDir, fullPath);
-    const fileInfo = await stat(fullPath);
-    const fileBytes =
-      fileInfo.size +
-      Buffer.byteLength(relativePath, 'utf8') +
-      MULTIPART_FILE_OVERHEAD_BYTES;
+    const fileBytes = await estimateFilePartBytes(resultsDir, fullPath);
 
     if (payloadBytes + fileBytes > maxRequestBytes) {
       console.warn(
@@ -242,6 +292,114 @@ async function chunkFilesByEstimatedRequestSize({
 
   if (currentChunk.length > 0) {
     chunks.push(currentChunk);
+  }
+
+  return chunks;
+}
+
+async function chunkEvalFilesByEstimatedRequestSize({
+  files,
+  resultsDir,
+  payload,
+  maxRequestBytes,
+}) {
+  const sortedFiles = [...files].sort((a, b) =>
+    getRelativePath(resultsDir, a).localeCompare(getRelativePath(resultsDir, b))
+  );
+  const discoveryFiles = sortedFiles.filter(fullPath =>
+    isDiscoveryFile(getRelativePath(resultsDir, fullPath))
+  );
+  const artifactFiles = sortedFiles.filter(
+    fullPath => !isDiscoveryFile(getRelativePath(resultsDir, fullPath))
+  );
+
+  if (discoveryFiles.length === 0) {
+    return chunkFilesWithoutDiscovery({
+      files: sortedFiles,
+      resultsDir,
+      payload,
+      maxRequestBytes,
+    });
+  }
+
+  if (artifactFiles.length === 0) {
+    return [discoveryFiles];
+  }
+
+  const payloadBytes = estimatePayloadPartBytes(payload);
+  const discoveryBytes = await estimateFilesPartBytes(
+    resultsDir,
+    discoveryFiles
+  );
+  const baseBytes = payloadBytes + discoveryBytes;
+
+  if (baseBytes > maxRequestBytes) {
+    const evalGroup = getEvalGroup(
+      getRelativePath(resultsDir, discoveryFiles[0])
+    );
+    console.warn(
+      `Warning: discovery files for ${evalGroup} are approximately ${discoveryBytes} bytes before multipart framing and exceed --max-request-bytes=${maxRequestBytes}.`
+    );
+  }
+
+  const allFilesBytes =
+    baseBytes + (await estimateFilesPartBytes(resultsDir, artifactFiles));
+  if (allFilesBytes <= maxRequestBytes) {
+    return [sortedFiles];
+  }
+
+  const chunks = [];
+  let currentChunk = [...discoveryFiles];
+  let currentBytes = baseBytes;
+
+  for (const fullPath of artifactFiles) {
+    const relativePath = getRelativePath(resultsDir, fullPath);
+    const fileBytes = await estimateFilePartBytes(resultsDir, fullPath);
+
+    if (baseBytes + fileBytes > maxRequestBytes) {
+      console.warn(
+        `Warning: ${relativePath} plus discovery files is approximately ${baseBytes + fileBytes} bytes before multipart framing and exceeds --max-request-bytes=${maxRequestBytes}; uploading it in its own discoverable request.`
+      );
+    }
+
+    if (
+      currentChunk.length > discoveryFiles.length &&
+      currentBytes + fileBytes > maxRequestBytes
+    ) {
+      chunks.push(currentChunk);
+      currentChunk = [...discoveryFiles];
+      currentBytes = baseBytes;
+    }
+
+    currentChunk.push(fullPath);
+    currentBytes += fileBytes;
+  }
+
+  if (currentChunk.length > discoveryFiles.length) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
+}
+
+async function chunkRunGroupByEstimatedRequestSize({
+  files,
+  resultsDir,
+  payload,
+  maxRequestBytes,
+}) {
+  const chunks = [];
+  const evalGroups = groupFilesByEval(files, resultsDir);
+
+  for (const [_evalGroup, evalFiles] of evalGroups) {
+    chunks.push(
+      ...(await chunkEvalFilesByEstimatedRequestSize({
+        files: evalFiles,
+        resultsDir,
+        payload,
+        maxRequestBytes,
+      }))
+    );
   }
 
   return chunks;
@@ -412,7 +570,7 @@ async function main() {
         uploadGroup: group,
       },
     };
-    const chunks = await chunkFilesByEstimatedRequestSize({
+    const chunks = await chunkRunGroupByEstimatedRequestSize({
       files: sortedFiles,
       resultsDir,
       payload: groupPayload,

--- a/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
+++ b/packages/cli/evals/scripts/transform-agent-eval-to-canonical.js
@@ -1,5 +1,10 @@
+import { Buffer } from 'node:buffer';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
+
+const DEFAULT_MAX_REQUEST_BYTES = 3_500_000;
+const MULTIPART_PAYLOAD_OVERHEAD_BYTES = 2048;
+const MULTIPART_FILE_OVERHEAD_BYTES = 1024;
 
 function parseArgs(argv) {
   const args = {};
@@ -23,6 +28,19 @@ function appendBypassQuery(url, bypassSecret) {
     parsed.searchParams.set('x-vercel-protection-bypass', bypassSecret);
   }
   return parsed.toString();
+}
+
+function parseMaxRequestBytes(value) {
+  if (!value) return DEFAULT_MAX_REQUEST_BYTES;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(
+      `Invalid --max-request-bytes "${value}". Expected a positive number.`
+    );
+  }
+
+  return Math.floor(parsed);
 }
 
 async function listDirectories(dir) {
@@ -151,6 +169,10 @@ function shouldUploadFile(relativePath, uploadArtifacts) {
   return true;
 }
 
+function getRelativePath(resultsDir, fullPath) {
+  return path.relative(resultsDir, fullPath).replace(/\\/g, '/');
+}
+
 function isTimestampSegment(segment) {
   return /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d+)?Z$/.test(segment);
 }
@@ -166,9 +188,7 @@ function groupFilesByRun(files, resultsDir) {
   const groups = new Map();
 
   for (const fullPath of files) {
-    const relativePath = path
-      .relative(resultsDir, fullPath)
-      .replace(/\\/g, '/');
+    const relativePath = getRelativePath(resultsDir, fullPath);
     const group = getRunGroup(relativePath);
     const groupFiles = groups.get(group) ?? [];
     groupFiles.push(fullPath);
@@ -176,6 +196,55 @@ function groupFilesByRun(files, resultsDir) {
   }
 
   return [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
+
+function estimatePayloadPartBytes(payload) {
+  return (
+    Buffer.byteLength(JSON.stringify(payload), 'utf8') +
+    MULTIPART_PAYLOAD_OVERHEAD_BYTES
+  );
+}
+
+async function chunkFilesByEstimatedRequestSize({
+  files,
+  resultsDir,
+  payload,
+  maxRequestBytes,
+}) {
+  const chunks = [];
+  const payloadBytes = estimatePayloadPartBytes(payload);
+  let currentChunk = [];
+  let currentBytes = payloadBytes;
+
+  for (const fullPath of files) {
+    const relativePath = getRelativePath(resultsDir, fullPath);
+    const fileInfo = await stat(fullPath);
+    const fileBytes =
+      fileInfo.size +
+      Buffer.byteLength(relativePath, 'utf8') +
+      MULTIPART_FILE_OVERHEAD_BYTES;
+
+    if (payloadBytes + fileBytes > maxRequestBytes) {
+      console.warn(
+        `Warning: ${relativePath} is approximately ${fileBytes} bytes before multipart framing and exceeds --max-request-bytes=${maxRequestBytes}; uploading it in its own request.`
+      );
+    }
+
+    if (currentChunk.length > 0 && currentBytes + fileBytes > maxRequestBytes) {
+      chunks.push(currentChunk);
+      currentChunk = [];
+      currentBytes = payloadBytes;
+    }
+
+    currentChunk.push(fullPath);
+    currentBytes += fileBytes;
+  }
+
+  if (currentChunk.length > 0) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
 }
 
 async function uploadFileGroup({
@@ -189,9 +258,7 @@ async function uploadFileGroup({
   formData.append('payload', JSON.stringify(payload));
 
   for (const fullPath of files) {
-    const relativePath = path
-      .relative(resultsDir, fullPath)
-      .replace(/\\/g, '/');
+    const relativePath = getRelativePath(resultsDir, fullPath);
     const buffer = await readFile(fullPath);
     formData.append(
       'results_file',
@@ -209,7 +276,13 @@ async function uploadFileGroup({
 
   const responseBody = await response.text();
   if (!response.ok) {
-    throw new Error(`Batch upload failed: ${response.status} ${responseBody}`);
+    const hint =
+      response.status === 413
+        ? ' Try lowering --max-request-bytes, or use --upload-artifacts results if an individual artifact is too large for the ingest endpoint.'
+        : '';
+    throw new Error(
+      `Batch upload failed: ${response.status} ${responseBody}${hint}`
+    );
   }
 
   return responseBody;
@@ -274,6 +347,9 @@ async function main() {
 
   const runMetadata = await collectRunMetadata(allFiles);
   const uploadArtifacts = args['upload-artifacts'] ?? 'all';
+  const maxRequestBytes = parseMaxRequestBytes(
+    args['max-request-bytes'] ?? process.env.CLI_EVAL_UPLOAD_MAX_REQUEST_BYTES
+  );
 
   if (!['results', 'all'].includes(uploadArtifacts)) {
     throw new Error(
@@ -282,9 +358,7 @@ async function main() {
   }
 
   const filesToUpload = allFiles.filter(fullPath => {
-    const relativePath = path
-      .relative(resultsDir, fullPath)
-      .replace(/\\/g, '/');
+    const relativePath = getRelativePath(resultsDir, fullPath);
     return shouldUploadFile(relativePath, uploadArtifacts);
   });
 
@@ -323,8 +397,14 @@ async function main() {
   }
 
   const fileGroups = groupFilesByRun(filesToUpload, resultsDir);
+  let uploadRequestCount = 0;
 
   for (const [group, files] of fileGroups) {
+    const sortedFiles = [...files].sort((a, b) =>
+      getRelativePath(resultsDir, a).localeCompare(
+        getRelativePath(resultsDir, b)
+      )
+    );
     const groupPayload = {
       ...payload,
       metadata: {
@@ -332,20 +412,43 @@ async function main() {
         uploadGroup: group,
       },
     };
-    const responseBody = await uploadFileGroup({
-      files,
+    const chunks = await chunkFilesByEstimatedRequestSize({
+      files: sortedFiles,
       resultsDir,
       payload: groupPayload,
-      ingestUrl,
-      headers,
+      maxRequestBytes,
     });
-    console.log(
-      `Uploaded batch ${args['batch-id']} group ${group} with ${files.length} file(s): ${responseBody}`
-    );
+
+    for (let index = 0; index < chunks.length; index += 1) {
+      const chunk = chunks[index];
+      const chunkPayload = {
+        ...groupPayload,
+        metadata: {
+          ...groupPayload.metadata,
+          uploadGroupFileCount: sortedFiles.length,
+          uploadPart: index + 1,
+          uploadParts: chunks.length,
+          uploadMaxRequestBytes: maxRequestBytes,
+        },
+      };
+      const responseBody = await uploadFileGroup({
+        files: chunk,
+        resultsDir,
+        payload: chunkPayload,
+        ingestUrl,
+        headers,
+      });
+      uploadRequestCount += 1;
+      const partLabel =
+        chunks.length > 1 ? ` part ${index + 1}/${chunks.length}` : '';
+      console.log(
+        `Uploaded batch ${args['batch-id']} group ${group}${partLabel} with ${chunk.length}/${sortedFiles.length} file(s): ${responseBody}`
+      );
+    }
   }
 
   console.log(
-    `Uploaded batch ${args['batch-id']} in ${fileGroups.length} request(s) with ${filesToUpload.length}/${allFiles.length} file(s).`
+    `Uploaded batch ${args['batch-id']} in ${uploadRequestCount} request(s) across ${fileGroups.length} group(s) with ${filesToUpload.length}/${allFiles.length} file(s).`
   );
 }
 

--- a/packages/cli/test/unit/evals/transform-agent-eval-to-canonical.test.ts
+++ b/packages/cli/test/unit/evals/transform-agent-eval-to-canonical.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  chunkEvalFilesByEstimatedRequestSize,
+  getEvalGroup,
+  getRunGroup,
+  isResultsFile,
+  normalizeUploadPath,
+  packFilesIntoChunks,
+  parseMaxRequestBytes,
+  splitAtTimestamp,
+} from '../../../evals/scripts/transform-agent-eval-to-canonical.js';
+
+const TIMESTAMP = '2026-01-01T00-00-00Z';
+
+describe('parseMaxRequestBytes', () => {
+  it('falls back to the default when nothing is provided', () => {
+    expect(parseMaxRequestBytes(undefined)).toBe(3_500_000);
+    expect(parseMaxRequestBytes('')).toBe(3_500_000);
+  });
+
+  it('parses and floors a positive number', () => {
+    expect(parseMaxRequestBytes('1000')).toBe(1000);
+    expect(parseMaxRequestBytes('1000.9')).toBe(1000);
+  });
+
+  it('throws on non-numeric or non-positive input', () => {
+    expect(() => parseMaxRequestBytes('abc')).toThrow();
+    expect(() => parseMaxRequestBytes('0')).toThrow();
+    expect(() => parseMaxRequestBytes('-5')).toThrow();
+  });
+});
+
+describe('splitAtTimestamp', () => {
+  it('locates the timestamp segment', () => {
+    expect(
+      splitAtTimestamp(`exp/m/${TIMESTAMP}/_deploy/run-1/result.json`)
+    ).toEqual({
+      segments: ['exp', 'm', TIMESTAMP, '_deploy', 'run-1', 'result.json'],
+      timestampIndex: 2,
+    });
+  });
+
+  it('reports -1 when there is no timestamp', () => {
+    expect(splitAtTimestamp('no/timestamp/here').timestampIndex).toBe(-1);
+  });
+});
+
+describe('normalizeUploadPath', () => {
+  it('leaves a single-segment model unchanged', () => {
+    const p = `exp/model/${TIMESTAMP}/_deploy/run-1/result.json`;
+    expect(normalizeUploadPath(p)).toBe(p);
+  });
+
+  it('leaves a path without a model segment unchanged', () => {
+    const p = `exp/${TIMESTAMP}/_deploy/run-1/result.json`;
+    expect(normalizeUploadPath(p)).toBe(p);
+  });
+
+  it('collapses a multi-segment model into one dashed segment', () => {
+    expect(
+      normalizeUploadPath(
+        `exp/openai/gpt-5.5/${TIMESTAMP}/_deploy/run-1/x.json`
+      )
+    ).toBe(`exp/openai-gpt-5.5/${TIMESTAMP}/_deploy/run-1/x.json`);
+  });
+});
+
+describe('getRunGroup', () => {
+  it('groups by experiment/model/timestamp', () => {
+    expect(getRunGroup(`exp/m/${TIMESTAMP}/_deploy/run-1/result.json`)).toBe(
+      `exp/m/${TIMESTAMP}`
+    );
+  });
+
+  it('returns ungrouped without a timestamp', () => {
+    expect(getRunGroup('no/timestamp')).toBe('ungrouped');
+  });
+});
+
+describe('getEvalGroup', () => {
+  it('merges all runs of the same eval into one group', () => {
+    expect(getEvalGroup(`exp/m/${TIMESTAMP}/_deploy/run-1/result.json`)).toBe(
+      `exp/m/${TIMESTAMP}/_deploy`
+    );
+    expect(getEvalGroup(`exp/m/${TIMESTAMP}/_deploy/run-2/result.json`)).toBe(
+      `exp/m/${TIMESTAMP}/_deploy`
+    );
+  });
+
+  it('keeps different evals in different groups', () => {
+    expect(getEvalGroup(`exp/m/${TIMESTAMP}/build/run-1/result.json`)).toBe(
+      `exp/m/${TIMESTAMP}/build`
+    );
+  });
+});
+
+describe('isResultsFile', () => {
+  it('matches summary.json and run-N/result.json', () => {
+    expect(isResultsFile(`exp/m/${TIMESTAMP}/_deploy/run-1/result.json`)).toBe(
+      true
+    );
+    expect(isResultsFile(`exp/m/${TIMESTAMP}/_deploy/summary.json`)).toBe(true);
+  });
+
+  it('does not match artifacts', () => {
+    expect(
+      isResultsFile(`exp/m/${TIMESTAMP}/_deploy/run-1/outputs/a.txt`)
+    ).toBe(false);
+    expect(
+      isResultsFile(`exp/m/${TIMESTAMP}/_deploy/run-1/transcript.json`)
+    ).toBe(false);
+  });
+});
+
+describe('chunking', () => {
+  let resultsDir: string;
+
+  async function writeFixture(relPath: string, content = '{}') {
+    const full = path.join(resultsDir, relPath);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, content);
+    return full;
+  }
+
+  beforeEach(async () => {
+    resultsDir = await mkdtemp(path.join(os.tmpdir(), 'eval-transform-'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(resultsDir, { recursive: true, force: true });
+  });
+
+  it('returns a single chunk when everything fits', async () => {
+    const base = `exp/model/${TIMESTAMP}/_deploy/run-1`;
+    const files = [
+      await writeFixture(`${base}/result.json`),
+      await writeFixture(`${base}/summary.json`),
+      await writeFixture(`${base}/outputs/a.txt`, 'a'.repeat(500)),
+      await writeFixture(`${base}/outputs/b.txt`, 'b'.repeat(500)),
+    ];
+
+    const chunks = await chunkEvalFilesByEstimatedRequestSize({
+      files,
+      resultsDir,
+      payload: {},
+      maxRequestBytes: 10_000_000,
+    });
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toEqual(expect.arrayContaining(files));
+    expect(chunks[0]).toHaveLength(4);
+  });
+
+  it('seeds results files into every chunk when splitting', async () => {
+    const base = `exp/model/${TIMESTAMP}/_deploy/run-1`;
+    const result = await writeFixture(`${base}/result.json`);
+    const summary = await writeFixture(`${base}/summary.json`);
+    const a = await writeFixture(`${base}/outputs/a.txt`, 'a'.repeat(500));
+    const b = await writeFixture(`${base}/outputs/b.txt`, 'b'.repeat(500));
+
+    const chunks = await chunkEvalFilesByEstimatedRequestSize({
+      files: [result, summary, a, b],
+      resultsDir,
+      payload: {},
+      maxRequestBytes: 1,
+    });
+
+    expect(chunks).toHaveLength(2);
+    for (const chunk of chunks) {
+      expect(chunk).toContain(result);
+      expect(chunk).toContain(summary);
+    }
+    const artifacts = chunks.flat().filter(f => f === a || f === b);
+    expect(artifacts).toHaveLength(2);
+    expect(new Set(artifacts)).toEqual(new Set([a, b]));
+  });
+
+  it('falls back to plain size packing when there are no results files', async () => {
+    const base = `exp/model/${TIMESTAMP}/_deploy/run-1`;
+    const a = await writeFixture(`${base}/outputs/a.txt`, 'a'.repeat(500));
+    const b = await writeFixture(`${base}/outputs/b.txt`, 'b'.repeat(500));
+
+    const chunks = await chunkEvalFilesByEstimatedRequestSize({
+      files: [a, b],
+      resultsDir,
+      payload: {},
+      maxRequestBytes: 1,
+    });
+
+    expect(chunks).toHaveLength(2);
+    for (const chunk of chunks) {
+      expect(chunk).toHaveLength(1);
+    }
+    expect(new Set(chunks.flat())).toEqual(new Set([a, b]));
+  });
+
+  it('packFilesIntoChunks keeps the seed in each chunk and never splits the seed alone', async () => {
+    const base = `exp/model/${TIMESTAMP}/_deploy/run-1`;
+    const seed = [await writeFixture(`${base}/result.json`)];
+    const a = await writeFixture(`${base}/outputs/a.txt`, 'a'.repeat(500));
+    const b = await writeFixture(`${base}/outputs/b.txt`, 'b'.repeat(500));
+
+    const chunks = await packFilesIntoChunks({
+      files: [a, b],
+      resultsDir,
+      seedFiles: seed,
+      baseBytes: 0,
+      maxRequestBytes: 1,
+    });
+
+    expect(chunks).toHaveLength(2);
+    for (const chunk of chunks) {
+      expect(chunk).toContain(seed[0]);
+      expect(chunk.length).toBeGreaterThan(seed.length);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Split CLI eval result uploads into size-limited multipart requests to avoid centralized ingest payload limits (413s).
- Keep every chunk discoverable by including each run's `summary.json`/`result.json` so the ingest endpoint can associate artifacts.
- Skip per-eval-group splitting when a whole run group already fits under `--max-request-bytes`, so groups that don't need chunking upload in a single request.
- Collapse multi-segment model names (e.g. `openai/gpt-5.5-pro`) into one path segment on upload so the ingest endpoint can still parse `experiment/model/timestamp`; fixes `400 "Could not discover any experiment/model/timestamp runs"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)