### PR TITLE
Enable cleanUrls by default

### DIFF
--- a/.changeset/clean-urls-default.md
+++ b/.changeset/clean-urls-default.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+'@vercel/routing-utils': patch
+'@vercel/fs-detectors': patch
+---
+
+Enable `cleanUrls` by default for builds and `vercel dev`. Projects can opt out with `"cleanUrls": false` in `vercel.json`.

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -307,7 +307,7 @@ async function writeBuildResultV2(args: {
         output,
         normalizedPath,
         overrides,
-        vercelConfig?.cleanUrls
+        vercelConfig?.cleanUrls !== false
       );
     } else if (isEdgeFunction(output)) {
       await writeEdgeFunction(
@@ -478,7 +478,7 @@ async function writeStaticFile(
   file: File,
   path: string,
   overrides: Record<string, PathOverride>,
-  cleanUrls = false
+  cleanUrls = true
 ) {
   let fsPath = path;
   let override: PathOverride | null = null;

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -413,7 +413,7 @@ export async function executeBuild(
   }
 
   const { output: buildOutput } = result;
-  const { cleanUrls } = vercelConfig;
+  const cleanUrls = vercelConfig.cleanUrls !== false;
 
   // Mimic fmeta-util and perform file renaming
   for (const [originalPath, value] of Object.entries(buildOutput)) {

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -622,7 +622,8 @@ export default class DevServer {
       (!vercelConfig.builds || vercelConfig.builds.length === 0)
     ) {
       const featHandleMiss = true; // enable for zero config
-      const { projectSettings, cleanUrls, trailingSlash } = vercelConfig;
+      const { projectSettings, trailingSlash } = vercelConfig;
+      const cleanUrls = vercelConfig.cleanUrls !== false;
 
       const files = (await getFiles(this.cwd, {})).map(f =>
         relative(this.cwd, f)
@@ -2881,25 +2882,19 @@ async function shouldServe(
     ? requestPath.slice(0, -1)
     : requestPath;
 
-  if (
-    vercelConfig.cleanUrls &&
-    vercelConfig.trailingSlash &&
-    cleanSrc === trimmedPath
-  ) {
+  const cleanUrls = vercelConfig.cleanUrls !== false;
+
+  if (cleanUrls && vercelConfig.trailingSlash && cleanSrc === trimmedPath) {
     // Mimic fmeta-util and convert cleanUrls and trailingSlash
     return true;
   } else if (
-    vercelConfig.cleanUrls &&
+    cleanUrls &&
     !vercelConfig.trailingSlash &&
     cleanSrc === requestPath
   ) {
     // Mimic fmeta-util and convert cleanUrls
     return true;
-  } else if (
-    !vercelConfig.cleanUrls &&
-    vercelConfig.trailingSlash &&
-    src === trimmedPath
-  ) {
+  } else if (!cleanUrls && vercelConfig.trailingSlash && src === trimmedPath) {
     // Mimic fmeta-util and convert trailingSlash
     return true;
   } else if (typeof builder.shouldServe === 'function') {

--- a/packages/cli/test/dev/fixtures/test-clean-urls/vercel.json
+++ b/packages/cli/test/dev/fixtures/test-clean-urls/vercel.json
@@ -1,4 +1,3 @@
 {
-  "version": 2,
-  "cleanUrls": true
+  "version": 2
 }

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -894,7 +894,7 @@ function getApiRoute(
   const out = createRouteFromPath(
     fileName,
     Boolean(options.featHandleMiss),
-    Boolean(options.cleanUrls)
+    options.cleanUrls !== false
   );
 
   return {
@@ -1145,7 +1145,7 @@ function getRouteResult(
           .map(ext => ext.slice(1))
           .join('|')}))`;
 
-        if (options.cleanUrls) {
+        if (options.cleanUrls !== false) {
           redirectRoutes.push({
             src: `^/(api(?:.+)?)/index${extGroup}?/?$`,
             headers: { Location: options.trailingSlash ? '/$1/' : '/$1' },
@@ -1214,7 +1214,7 @@ function getRouteResult(
     errorRoutes.push({
       status: 404,
       src: '^(?!/api).*$',
-      dest: options.cleanUrls ? '/404' : '/404.html',
+      dest: options.cleanUrls !== false ? '/404' : '/404.html',
     });
   }
 

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -1238,13 +1238,8 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       dependencies: { next: '9.0.0' },
     };
     const files = ['package.json', 'pages/index.js'];
-    const {
-      builders,
-      defaultRoutes,
-      redirectRoutes,
-      rewriteRoutes,
-      errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, pkg, { featHandleMiss });
+    const { builders, defaultRoutes, rewriteRoutes, errorRoutes } =
+      await invokeDetectBuildersAndThrow(files, pkg, { featHandleMiss });
     expect(builders[0].use).toBe('@vercel/next');
 
     expect(defaultRoutes).toStrictEqual([]);
@@ -1259,13 +1254,8 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       devDependencies: { next: '9.0.0' },
     };
     const files = ['package.json', 'pages/index.js'];
-    const {
-      builders,
-      defaultRoutes,
-      redirectRoutes,
-      rewriteRoutes,
-      errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, pkg, { featHandleMiss });
+    const { builders, defaultRoutes, rewriteRoutes, errorRoutes } =
+      await invokeDetectBuildersAndThrow(files, pkg, { featHandleMiss });
     expect(builders[0].use).toBe('@vercel/next');
 
     expect(defaultRoutes).toStrictEqual([]);
@@ -1286,13 +1276,11 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
   it('static file', async () => {
     const files = ['index.html'];
-    const {
-      builders,
-      defaultRoutes,
-      redirectRoutes,
-      rewriteRoutes,
-      errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, null, { featHandleMiss });
+    const { builders, defaultRoutes, rewriteRoutes, errorRoutes } =
+      await invokeDetectBuildersAndThrow(files, null, {
+        featHandleMiss,
+        cleanUrls: false,
+      });
     expect(builders).toHaveLength(0);
 
     expect(defaultRoutes).toStrictEqual([]);
@@ -1304,13 +1292,11 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
   it('no package.json + public', async () => {
     const files = ['api/users.js', 'public/index.html'];
-    const {
-      builders,
-      defaultRoutes,
-      redirectRoutes,
-      rewriteRoutes,
-      errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, null, { featHandleMiss });
+    const { builders, defaultRoutes, rewriteRoutes, errorRoutes } =
+      await invokeDetectBuildersAndThrow(files, null, {
+        featHandleMiss,
+        cleanUrls: false,
+      });
     expect(builders[1].use).toBe('@vercel/static');
 
     expect(defaultRoutes.length).toBe(2);
@@ -1325,13 +1311,11 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
   it('no package.json + no build + raw static + api', async () => {
     const files = ['api/users.js', 'index.html'];
-    const {
-      builders,
-      defaultRoutes,
-      redirectRoutes,
-      rewriteRoutes,
-      errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, null, { featHandleMiss });
+    const { builders, defaultRoutes, rewriteRoutes, errorRoutes } =
+      await invokeDetectBuildersAndThrow(files, null, {
+        featHandleMiss,
+        cleanUrls: false,
+      });
 
     expect(builders[0].use).toBe('@vercel/node');
     expect(builders[0].src).toBe('api/users.js');
@@ -1368,15 +1352,11 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       'api/[endpoint]/[id].js',
     ];
 
-    const {
-      builders,
-      defaultRoutes,
-      redirectRoutes,
-      rewriteRoutes,
-      errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, undefined, {
-      featHandleMiss,
-    });
+    const { builders, defaultRoutes, rewriteRoutes, errorRoutes } =
+      await invokeDetectBuildersAndThrow(files, undefined, {
+        featHandleMiss,
+        cleanUrls: false,
+      });
     expect(builders[0].use).toBe('@vercel/node');
     expect(builders[0].src).toBe('api/[endpoint]/[id].js');
     expect(builders.length).toBe(1);
@@ -1405,7 +1385,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
       errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, pkg, { featHandleMiss });
+    } = await invokeDetectBuildersAndThrow(files, pkg, {
+      featHandleMiss,
+      cleanUrls: false,
+    });
     expect(builders[0].use).toBe('@vercel/node');
     expect(builders[0].src).toBe('api/endpoint.js');
     expect(builders[1].use).toBe('@vercel/next');
@@ -1434,7 +1417,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
       errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, pkg, { featHandleMiss });
+    } = await invokeDetectBuildersAndThrow(files, pkg, {
+      featHandleMiss,
+      cleanUrls: false,
+    });
     expect(builders[0].use).toBe('@vercel/node');
     expect(builders[0].src).toBe('api/endpoint.js');
     expect(builders[1].use).toBe('@vercel/next');
@@ -1629,7 +1615,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
       errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, null, { featHandleMiss });
+    } = await invokeDetectBuildersAndThrow(files, null, {
+      featHandleMiss,
+      cleanUrls: false,
+    });
     expect(builders[0].use).toBe('@vercel/node');
     expect(builders[0].src).toBe('api/endpoint.js');
     expect(builders[1].use).toBe('@vercel/static');
@@ -1659,7 +1648,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
       errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, pkg, { featHandleMiss });
+    } = await invokeDetectBuildersAndThrow(files, pkg, {
+      featHandleMiss,
+      cleanUrls: false,
+    });
     expect(builders[0].use).toBe('@vercel/node');
     expect(builders[0].src).toBe('api/version.js');
     expect(builders[1].use).toBe('@vercel/static');
@@ -2385,16 +2377,11 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
     const files = ['dist/index.html', 'dist/style.css'];
 
-    const {
-      builders,
-      defaultRoutes,
-      redirectRoutes,
-      rewriteRoutes,
-      errorRoutes,
-    } = await invokeDetectBuildersAndThrow(files, null, {
-      projectSettings,
-      featHandleMiss,
-    });
+    const { builders, defaultRoutes, rewriteRoutes, errorRoutes } =
+      await invokeDetectBuildersAndThrow(files, null, {
+        projectSettings,
+        featHandleMiss,
+      });
 
     expect(builders.length).toBe(1);
     expect(builders[0].src).toBe('dist/**/*');
@@ -2423,6 +2410,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     } = await invokeDetectBuildersAndThrow(files, null, {
       projectSettings,
       featHandleMiss,
+      cleanUrls: false,
     });
 
     expect(builders.length).toBe(2);
@@ -2511,7 +2499,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^(?!/api).*$',
-        dest: '/404.html',
+        dest: '/404',
       },
     ]);
   });
@@ -2522,11 +2510,16 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       framework: 'redwoodjs',
     };
 
-    const { builders, defaultRoutes, rewriteRoutes, errorRoutes } =
-      await invokeDetectBuildersAndThrow(files, null, {
-        projectSettings,
-        featHandleMiss,
-      });
+    const {
+      builders,
+      defaultRoutes,
+      redirectRoutes,
+      rewriteRoutes,
+      errorRoutes,
+    } = await invokeDetectBuildersAndThrow(files, null, {
+      projectSettings,
+      featHandleMiss,
+    });
 
     expect(builders).toStrictEqual([
       {
@@ -2552,12 +2545,17 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
         },
       },
     ]);
-    expect(defaultRoutes).toStrictEqual([
-      { handle: 'miss' },
+    expect(defaultRoutes).toStrictEqual([]);
+    expect(redirectRoutes).toStrictEqual([
       {
-        src: '^/api/(.+)(?:\\.(?:go|py))$',
-        dest: '/api/$1',
-        check: true,
+        src: '^/(api(?:.+)?)/index(?:\\.(?:go|py))?/?$',
+        headers: { Location: '/$1' },
+        status: 308,
+      },
+      {
+        src: '^/api/(.+)(?:\\.(?:go|py))/?$',
+        headers: { Location: '/api/$1' },
+        status: 308,
       },
     ]);
     expect(rewriteRoutes).toStrictEqual([]);
@@ -2565,7 +2563,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^(?!/api).*$',
-        dest: '/404.html',
+        dest: '/404',
       },
     ]);
   });
@@ -2989,15 +2987,14 @@ describe('Test `detectRoutes`', () => {
   });
 });
 
-describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
+describe('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=false`', () => {
+  const options = { featHandleMiss: true, cleanUrls: false };
+
   it('package.json is not a default route', async () => {
-    const featHandleMiss = true;
     const files = ['api/user.go', 'api/team.js', 'api/package.json'];
 
     const { defaultRoutes, rewriteRoutes, errorRoutes } =
-      await invokeDetectBuildersAndThrow(files, null, {
-        featHandleMiss,
-      });
+      await invokeDetectBuildersAndThrow(files, null, options);
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -3058,56 +3055,45 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('conflicting file path with same name', async () => {
-    const featHandleMiss = true;
     const files = ['api/user.go', 'api/user.js'];
 
-    const { errors } = await invokeDetectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { errors } = await invokeDetectBuilders(files, null, options);
     expect(errors[0].code).toBe('conflicting_file_path');
   });
 
   it('conflicting file path with placeholders', async () => {
-    const featHandleMiss = true;
     const files = ['api/[user].go', 'api/[team]/[id].js'];
 
-    const { errors } = await invokeDetectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { errors } = await invokeDetectBuilders(files, null, options);
     expect(errors[0].code).toBe('conflicting_file_path');
   });
 
   it('conflicting file path with same placeholder name', async () => {
-    const featHandleMiss = true;
     const files = ['api/[team]/[team].js'];
 
-    const { errors } = await invokeDetectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { errors } = await invokeDetectBuilders(files, null, options);
     expect(errors[0].code).toBe('conflicting_path_segment');
   });
 
   it('conflicting file path with same name at subpath', async () => {
-    const featHandleMiss = true;
     const files = ['api/date/index.js', 'api/date/index.go'];
 
-    const { defaultRoutes, errors } = await invokeDetectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { defaultRoutes, errors } = await invokeDetectBuilders(
+      files,
+      null,
+      options
+    );
     expect(defaultRoutes).toBe(null);
     expect(errors[0].code).toBe('conflicting_file_path');
   });
 
   it('works with file and directory placeholder of same name', async () => {
-    const featHandleMiss = true;
     const files = ['api/[endpoint].js', 'api/[endpoint]/[id].js'];
 
     const { defaultRoutes, rewriteRoutes } = await invokeDetectBuildersAndThrow(
       files,
       null,
-      {
-        featHandleMiss,
-      }
+      options
     );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
@@ -3136,7 +3122,6 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('works with file and directory placeholder of same name 2', async () => {
-    const featHandleMiss = true;
     const files = [
       'public/index.html',
       'api/[endpoint].js',
@@ -3146,9 +3131,7 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
     const { defaultRoutes, rewriteRoutes } = await invokeDetectBuildersAndThrow(
       files,
       null,
-      {
-        featHandleMiss,
-      }
+      options
     );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
@@ -3178,7 +3161,6 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('works with static files with api files', async () => {
-    const featHandleMiss = true;
     const pkg = {
       scripts: { build: 'next build' },
       devDependencies: { next: '9.0.0' },
@@ -3189,9 +3171,7 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
     const { defaultRoutes, rewriteRoutes } = await invokeDetectBuildersAndThrow(
       files,
       pkg,
-      {
-        featHandleMiss,
-      }
+      options
     );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
@@ -3212,13 +3192,12 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('works with api and page/api files', async () => {
-    const featHandleMiss = true;
     const files = ['api/external.js', 'pages/api/internal.js'];
     const { builders, warnings } = await invokeDetectBuildersAndThrow(
       files,
       null,
       {
-        featHandleMiss,
+        ...options,
         projectSettings: { framework: 'nextjs' },
       }
     );
@@ -3251,13 +3230,12 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('works with api and page/api files 2', async () => {
-    const featHandleMiss = true;
     const files = ['api/external.js', 'pages/api/internal.js'];
     const { builders, warnings } = await invokeDetectBuildersAndThrow(
       files,
       null,
       {
-        featHandleMiss,
+        ...options,
         tag: 'canary',
         projectSettings: { framework: 'nextjs' },
       }
@@ -3291,13 +3269,12 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('works with api and page/api files 3', async () => {
-    const featHandleMiss = true;
     const files = ['api/external.go', 'pages/api/internal.js'];
     const { builders, warnings } = await invokeDetectBuildersAndThrow(
       files,
       null,
       {
-        featHandleMiss,
+        ...options,
         projectSettings: { framework: 'nextjs' },
       }
     );
@@ -3322,25 +3299,23 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('works with static files', async () => {
-    const featHandleMiss = true;
     const files = ['public/index.html'];
 
-    const { defaultRoutes } = await invokeDetectBuildersAndThrow(files, null, {
-      featHandleMiss,
-    });
+    const { defaultRoutes } = await invokeDetectBuildersAndThrow(
+      files,
+      null,
+      options
+    );
     expect(defaultRoutes).toStrictEqual([]);
   });
 
   it('works with file and directory of same name', async () => {
-    const featHandleMiss = true;
     const files = ['api/date/index.js', 'api/date.js'];
 
     const { defaultRoutes, rewriteRoutes } = await invokeDetectBuildersAndThrow(
       files,
       null,
-      {
-        featHandleMiss,
-      }
+      options
     );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
@@ -3360,15 +3335,12 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('works with file name and directory placeholder of same name', async () => {
-    const featHandleMiss = true;
     const files = ['api/date.js', 'api/[date]/index.js'];
 
     const { defaultRoutes, rewriteRoutes } = await invokeDetectBuildersAndThrow(
       files,
       null,
-      {
-        featHandleMiss,
-      }
+      options
     );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
@@ -3392,7 +3364,6 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('works with files and type files of same names', async () => {
-    const featHandleMiss = true;
     const files = [
       'api/index.ts',
       'api/index.d.ts',
@@ -3404,9 +3375,7 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
     const { defaultRoutes, rewriteRoutes } = await invokeDetectBuildersAndThrow(
       files,
       null,
-      {
-        featHandleMiss,
-      }
+      options
     );
 
     expect(defaultRoutes).toStrictEqual([
@@ -3427,7 +3396,6 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
   });
 
   it('works with custom runtime', async () => {
-    const featHandleMiss = true;
     const functions = { 'api/user.php': { runtime: 'vercel-php@0.1.0' } };
     const files = ['api/user.php'];
 
@@ -3435,8 +3403,8 @@ describe('Test `detectRoutes` with `featHandleMiss=true`', () => {
       files,
       null,
       {
+        ...options,
         functions,
-        featHandleMiss,
       }
     );
     expect(defaultRoutes).toStrictEqual([

--- a/packages/routing-utils/src/index.ts
+++ b/packages/routing-utils/src/index.ts
@@ -307,10 +307,8 @@ export function getTransformedRoutes(
   const { routes: userRoutes = null } = vercelConfig;
   let routes: Route[] | null = null;
 
-  if (typeof cleanUrls !== 'undefined') {
-    const normalized = normalizeRoutes(
-      convertCleanUrls(cleanUrls, trailingSlash)
-    );
+  if (cleanUrls !== false) {
+    const normalized = normalizeRoutes(convertCleanUrls(true, trailingSlash));
     if (normalized.error) {
       normalized.error.code = 'invalid_clean_urls';
       return { routes, error: normalized.error };

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -255,6 +255,7 @@ describe('normalizeRoutes', () => {
 
   test('getTransformedRoutes accepts routes with source alias', () => {
     const { error, routes } = getTransformedRoutes({
+      cleanUrls: false,
       routes: [
         { source: '/about', destination: '/about.html' },
         { src: '/blog', dest: '/blog.html' },
@@ -1078,10 +1079,30 @@ describe('normalizeRoutes', () => {
 
 describe('getTransformedRoutes', () => {
   test('should normalize vercelConfig.routes', () => {
-    const vercelConfig = { routes: [{ src: '/page', dest: '/page.html' }] };
+    const vercelConfig = {
+      cleanUrls: false,
+      routes: [{ src: '/page', dest: '/page.html' }],
+    };
     const actual = getTransformedRoutes(vercelConfig);
     const expected = normalizeRoutes(vercelConfig.routes);
     assert.deepEqual(actual, expected);
+    assertValid(actual.routes);
+  });
+
+  test('should enable cleanUrls by default', () => {
+    const vercelConfig = { routes: null };
+    // @ts-expect-error intentionally passing invalid `routes: null` here
+    const actual = getTransformedRoutes(vercelConfig);
+    assert.equal(actual.error, null);
+    assert.notEqual(actual.routes, null);
+    if (actual.routes) {
+      assert.ok(
+        actual.routes.some(
+          r => !isHandler(r) && (r as any).src === '^/(.*)\\.html/?$'
+        ),
+        'cleanUrls redirect routes should be present by default'
+      );
+    }
     assertValid(actual.routes);
   });
 
@@ -1427,8 +1448,8 @@ describe('getTransformedRoutes', () => {
     assertValid(vercelConfig.trailingSlashSchema, trailingSlashSchema);
   });
 
-  test('should return null routes if no transformations are performed', () => {
-    const vercelConfig = { routes: null };
+  test('should return null routes when transformations are disabled', () => {
+    const vercelConfig = { cleanUrls: false, routes: null };
     // @ts-expect-error intentionally passing invalid `routes: null`
     const { routes } = getTransformedRoutes(vercelConfig);
     assert.equal(routes, null);
@@ -1436,6 +1457,7 @@ describe('getTransformedRoutes', () => {
 
   test('should error when segment is defined in `destination` but not `source`', () => {
     const vercelConfig = {
+      cleanUrls: false,
       redirects: [
         {
           source: '/iforgot/:id',
@@ -1455,6 +1477,7 @@ describe('getTransformedRoutes', () => {
 
   test('should error when segment is defined in HTTPS `destination` but not `source`', () => {
     const vercelConfig = {
+      cleanUrls: false,
       redirects: [
         {
           source: '/iforgot/:id',
@@ -1474,6 +1497,7 @@ describe('getTransformedRoutes', () => {
 
   test('should error when segment is defined in `destination` query string but not `source`', () => {
     const vercelConfig = {
+      cleanUrls: false,
       redirects: [
         {
           source: '/iforgot/:id',
@@ -1493,6 +1517,7 @@ describe('getTransformedRoutes', () => {
 
   test('should error when segment is defined in HTTPS `destination` query string but not `source`', () => {
     const vercelConfig = {
+      cleanUrls: false,
       redirects: [
         {
           source: '/iforgot/:id',
@@ -1512,6 +1537,7 @@ describe('getTransformedRoutes', () => {
 
   test('should work with content-security-policy header containing URL', () => {
     const vercelConfig = {
+      cleanUrls: false,
       headers: [
         {
           source: '/(.*)',


### PR DESCRIPTION
## Summary
- enable cleanUrls by default in routing transforms, build output writing, fs-detectors, and vercel dev
- preserve opt-out behavior with `cleanUrls: false`
- update tests and changeset for the new default

## Testing
- `pnpm --filter @vercel/routing-utils test-unit`
- `pnpm --filter @vercel/fs-detectors... build`
- `pnpm --filter @vercel/fs-detectors test-unit`

## Notes
- `pnpm --filter vercel test-dev` was attempted, but local runs require `VERCEL_TOKEN`/test registration env and failed before meaningful assertions.