### PR TITLE
Add TanStack Start + Lovable framework preset

### DIFF
--- a/.changeset/lovable-tanstack-preset.md
+++ b/.changeset/lovable-tanstack-preset.md
@@ -1,0 +1,6 @@
+---
+'@vercel/frameworks': patch
+'@vercel/config': patch
+---
+
+Add 'TanStack Start + Lovable' framework preset that detects `@lovable.dev/vite-tanstack-config` in addition to standard TanStack Start packages.

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -49,6 +49,7 @@ export type Framework =
   | 'hydrogen'
   | 'vite'
   | 'tanstack-start'
+  | 'tanstack-start-lovable'
   | 'vitepress'
   | 'vuepress'
   | 'parcel'

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1946,6 +1946,47 @@ export const frameworks = [
     getOutputDirName: async () => 'dist',
   },
   {
+    name: 'TanStack Start + Lovable',
+    slug: 'tanstack-start-lovable',
+    logo: 'https://api-frameworks.vercel.sh/framework-logos/tanstack-start.svg',
+    darkModeLogo:
+      'https://api-frameworks.vercel.sh/framework-logos/tanstack-start-dark.svg',
+    tagline:
+      'Full-stack Framework powered by TanStack Router for React and Solid, with Lovable.',
+    description:
+      'Full-document SSR, Streaming, Server Functions, bundling and more, powered by TanStack Router and Vite - Deployed via Lovable.',
+    website: 'https://tanstack.com/start',
+    supersedes: ['tanstack-start'],
+    detectors: {
+      every: [
+        { matchPackage: '@tanstack/router-plugin' },
+        { matchPackage: '@lovable.dev/vite-tanstack-config' },
+      ],
+      some: [
+        { matchPackage: '@tanstack/react-start' },
+        { matchPackage: '@tanstack/solid-start' },
+      ],
+    },
+    settings: {
+      installCommand: {
+        placeholder:
+          '`yarn install`, `pnpm install`, `npm install`, or `bun install`',
+      },
+      buildCommand: {
+        placeholder: '`npm run build` or `vite build`',
+        value: 'vite build',
+      },
+      devCommand: {
+        placeholder: 'vite',
+        value: 'vite --port $PORT',
+      },
+      outputDirectory: {
+        value: 'dist',
+      },
+    },
+    getOutputDirName: async () => 'dist',
+  },
+  {
     name: 'VitePress',
     slug: 'vitepress',
     demo: 'https://vitepress-starter-template.vercel.app',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -228,7 +228,8 @@ describe('frameworks', () => {
     'sanity-v3',
     'scully',
     'solidstart',
-    'sanity', // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+    'sanity',
+    'tanstack-start-lovable', // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
     'vuepress', // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
     'hydrogen',
     'storybook',


### PR DESCRIPTION
Adds a new framework preset 'TanStack Start + Lovable' that detects `@lovable.dev/vite-tanstack-config` alongside the standard TanStack Start packages. When detected, it supersedes the regular `tanstack-start` preset so the Lovable-specific experience is used.