### PR TITLE
Fix connect package repository metadata

### DIFF
--- a/.changeset/metal-owls-shop.md
+++ b/.changeset/metal-owls-shop.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add repository metadata for npm provenance validation.

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
+  "repository": {
+    "directory": "packages/connect",
+    "type": "git",
+    "url": "git+https://github.com/vercel/vercel.git"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- add repository metadata to @vercel/connect so npm provenance can validate the package source
- add a patch changeset for the package metadata update

## Verification
- node -e "const pkg=require('./packages/connect/package.json'); if (pkg.repository.url !== 'git+https://github.com/vercel/vercel.git') process.exit(1); if (pkg.repository.directory !== 'packages/connect') process.exit(1); console.log('repository metadata ok')"

Fixes the release failure where npm expected the package repository to match https://github.com/vercel/vercel.