### PR TITLE
[connect] Rename user-facing "client" references to "connector"

### DIFF
--- a/.changeset/connect-rename-client-to-connector.md
+++ b/.changeset/connect-rename-client-to-connector.md
@@ -1,0 +1,7 @@
+---
+"vercel": patch
+---
+
+[connect] Rename user-facing "client" references to "connector"
+
+Updates the `vercel connect` CLI commands to use the official "connector" terminology in all user-facing surfaces: help text argument names (remove/attach/detach), usage strings in error messages, and the `--format=json` output key (`clients` → `connectors`) for `vercel connect list`.

--- a/packages/cli/src/commands/connex/attach.ts
+++ b/packages/cli/src/commands/connex/attach.ts
@@ -73,7 +73,7 @@ export async function attach(
   const clientIdOrUid = args[0];
   if (!clientIdOrUid) {
     output.error(
-      'Missing connector ID or UID. Usage: vercel connect attach <client>'
+      'Missing connector ID or UID. Usage: vercel connect attach <connector>'
     );
     return 1;
   }

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -241,7 +241,7 @@ export const removeSubcommand = {
   description: 'Delete a connector',
   arguments: [
     {
-      name: 'client',
+      name: 'connector',
       required: true,
     },
   ],
@@ -446,7 +446,7 @@ export const attachSubcommand = {
     'Attach a Vercel project to a connector for one or more environments',
   arguments: [
     {
-      name: 'client',
+      name: 'connector',
       required: true,
     },
   ],
@@ -531,7 +531,7 @@ export const detachSubcommand = {
   description: 'Detach a Vercel project from a connector',
   arguments: [
     {
-      name: 'client',
+      name: 'connector',
       required: true,
     },
   ],

--- a/packages/cli/src/commands/connex/detach.ts
+++ b/packages/cli/src/commands/connex/detach.ts
@@ -36,7 +36,7 @@ export async function detach(
   const clientIdOrUid = args[0];
   if (!clientIdOrUid) {
     output.error(
-      'Missing connector ID or UID. Usage: vercel connect detach <client>'
+      'Missing connector ID or UID. Usage: vercel connect detach <connector>'
     );
     return 1;
   }

--- a/packages/cli/src/commands/connex/list.ts
+++ b/packages/cli/src/commands/connex/list.ts
@@ -179,7 +179,7 @@ export async function list(
       return item;
     });
     client.stdout.write(
-      `${JSON.stringify({ clients: jsonClients, cursor: response.cursor }, null, 2)}\n`
+      `${JSON.stringify({ connectors: jsonClients, cursor: response.cursor }, null, 2)}\n`
     );
     return 0;
   }

--- a/packages/cli/src/commands/connex/remove.ts
+++ b/packages/cli/src/commands/connex/remove.ts
@@ -37,7 +37,7 @@ export async function remove(
   const clientIdOrUid = args[0];
   if (!clientIdOrUid) {
     output.error(
-      'Missing connector ID or UID. Usage: vercel connect remove <client>'
+      'Missing connector ID or UID. Usage: vercel connect remove <connector>'
     );
     return 1;
   }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -753,7 +753,7 @@ exports[`help command > certs help output snapshots > certs remove help output s
 
 exports[`help command > connex help output snapshots > connex attach subcommand > connex attach subcommand help column width 120 1`] = `
 "
-  ▲ vercel connect attach client [options]
+  ▲ vercel connect attach connector [options]
 
   Attach a Vercel project to a connector for one or more environments                                                   
 
@@ -872,7 +872,7 @@ exports[`help command > connex help output snapshots > connex create subcommand 
 
 exports[`help command > connex help output snapshots > connex detach subcommand > connex detach subcommand help column width 120 1`] = `
 "
-  ▲ vercel connect detach client [options]
+  ▲ vercel connect detach connector [options]
 
   Detach a Vercel project from a connector                                                                              
 
@@ -933,10 +933,10 @@ exports[`help command > connex help output snapshots > connex help column width 
   token          id         Get a token for a connector (accepts a      
                             connector ID like scl_abc or a UID like     
                             slack/my-bot)                               
-  attach         client     Attach a Vercel project to a connector for  
+  attach         connector  Attach a Vercel project to a connector for  
                             one or more environments                    
-  detach         client     Detach a Vercel project from a connector    
-  remove         client     Delete a connector                          
+  detach         connector  Detach a Vercel project from a connector    
+  remove         connector  Delete a connector                          
   revoke-tokens  connector  Revoke tokens issued from a connector       
   open           id         Open a connector in the Vercel dashboard    
 

--- a/packages/cli/test/unit/commands/connex/list.test.ts
+++ b/packages/cli/test/unit/commands/connex/list.test.ts
@@ -333,8 +333,8 @@ describe('connex list', () => {
       const stdout = client.stdout.getFullOutput();
       const parsed = JSON.parse(stdout.trim());
       expect(parsed.cursor).toBe('next-page');
-      expect(parsed.clients).toHaveLength(1);
-      const [first] = parsed.clients;
+      expect(parsed.connectors).toHaveLength(1);
+      const [first] = parsed.connectors;
       expect(Object.keys(first)[0]).toBe('uid');
       expect(first.uid).toBe('oauth/my-client');
       expect(first.projects).toEqual([{ id: 'proj_1', name: 'web' }]);
@@ -539,8 +539,8 @@ describe('connex list', () => {
     expect(exitCode).toBe(0);
     const stdout = client.stdout.getFullOutput();
     const parsed = JSON.parse(stdout.trim());
-    expect(parsed.clients).toHaveLength(1);
-    const [first] = parsed.clients;
+    expect(parsed.connectors).toHaveLength(1);
+    const [first] = parsed.connectors;
     expect(first.uid).toBe('oauth/my-client');
     expect(first).not.toHaveProperty('projects');
     expect(first).not.toHaveProperty('hasMoreProjects');
@@ -584,8 +584,8 @@ describe('connex list', () => {
     expect(exitCode).toBe(0);
     const stdout = client.stdout.getFullOutput();
     const parsed = JSON.parse(stdout.trim());
-    expect(parsed.clients).toHaveLength(2);
-    const [branded, plain] = parsed.clients;
+    expect(parsed.connectors).toHaveLength(2);
+    const [branded, plain] = parsed.connectors;
     expect(branded.icon).toBe('sha1abcdef');
     expect(branded.backgroundColor).toBe('#1a2b3c');
     expect(branded.accentColor).toBe('#ff0066');


### PR DESCRIPTION
## Summary

- Updates `vercel connect` CLI commands to use the official **connector** terminology in all user-facing surfaces
- Internal TypeScript identifiers (`ConnexClient`, function names, variable names) are **unchanged** per the Connect/Connex split convention

## Test plan

- [x] All 150 unit tests in `test/unit/commands/connex/` pass
- [x] Patch changeset added (`.changeset/connect-rename-client-to-connector.md`)
- [ ] Manually verify `vercel connect list --format=json` outputs `connectors` key
- [ ] Manually verify help text for `vercel connect remove --help`, `attach --help`, `detach --help` shows `<connector>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)