### PR TITLE
feat: add deprecate-bad-release workflow

### DIFF
--- a/.changeset/tricky-garlics-divide.md
+++ b/.changeset/tricky-garlics-divide.md
@@ -1,0 +1,4 @@
+---
+---
+
+Added `deprecate-bad-release` workflow for handling bad CLI releases. Deprecates the bad npm version, points `latest` to a target version, and updates the GitHub Latest Release.

--- a/.github/workflows/deprecate-bad-release.yml
+++ b/.github/workflows/deprecate-bad-release.yml
@@ -55,9 +55,14 @@ jobs:
           echo "✓ Verified vercel@${{ inputs.version }} exists on NPM"
 
       - name: Deprecate bad version on NPM
+        env:
+          MESSAGE: ${{ inputs.message }}
+          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
         run: |
           echo "Deprecating vercel@${{ inputs.version }}..."
-          npm deprecate vercel@${{ inputs.version }} "${{ inputs.message }}"
+          npm deprecate vercel@${{ inputs.version }} "$MESSAGE"
           echo "✓ Deprecated vercel@${{ inputs.version }}"
 
       - name: Validate target version format
@@ -118,7 +123,7 @@ jobs:
           npm dist-tag ls vercel
           echo ""
           echo "Deprecation status:"
-          npm view vercel@${{ inputs.version }} deprecate
+          npm view vercel@${{ inputs.version }} deprecated
 
       - name: Summary
         run: |

--- a/.github/workflows/deprecate-bad-release.yml
+++ b/.github/workflows/deprecate-bad-release.yml
@@ -1,0 +1,131 @@
+name: Deprecate Bad Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Bad CLI version to deprecate (e.g., 54.7.0)'
+        required: true
+        type: string
+      message:
+        description: 'Deprecation reason shown to users when installing the bad version'
+        required: false
+        type: string
+        default: 'This version contains a critical issue. Please run "npm install -g vercel@latest" to upgrade.'
+      target:
+        description: 'Version to point the latest tag to. If omitted, only deprecation is performed.'
+        required: false
+        type: string
+
+jobs:
+  deprecate:
+    name: Deprecate Bad Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must be in format X.Y.Z (e.g., 54.7.0)"
+            exit 1
+          fi
+
+      - name: Verify bad version exists on NPM
+        run: |
+          if ! npm view vercel@${{ inputs.version }} version &>/dev/null; then
+            echo "Error: vercel@${{ inputs.version }} does not exist on NPM"
+            npm view vercel versions --json | tail -20
+            exit 1
+          fi
+          echo "✓ Verified vercel@${{ inputs.version }} exists on NPM"
+
+      - name: Deprecate bad version on NPM
+        run: |
+          echo "Deprecating vercel@${{ inputs.version }}..."
+          npm deprecate vercel@${{ inputs.version }} "${{ inputs.message }}"
+          echo "✓ Deprecated vercel@${{ inputs.version }}"
+
+      - name: Validate target version format
+        if: inputs.target != ''
+        run: |
+          if ! [[ "${{ inputs.target }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Target version must be in format X.Y.Z"
+            exit 1
+          fi
+
+      - name: Verify target version exists on NPM
+        if: inputs.target != ''
+        run: |
+          if ! npm view vercel@${{ inputs.target }} version &>/dev/null; then
+            echo "Error: vercel@${{ inputs.target }} does not exist on NPM"
+            exit 1
+          fi
+          echo "✓ Verified target vercel@${{ inputs.target }} exists on NPM"
+
+      - name: Point latest tag to target
+        if: inputs.target != ''
+        run: |
+          echo "Setting vercel@${{ inputs.target }} as latest..."
+          npm dist-tag add vercel@${{ inputs.target }} latest
+          echo "✓ Set vercel@${{ inputs.target }} as latest dist-tag"
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+
+      - name: Update GitHub Latest Release
+        if: inputs.target != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const targetTag = 'vercel@${{ inputs.target }}';
+
+            const releases = await github.rest.repos.listReleases({ owner, repo, per_page: 30 });
+            const targetRelease = releases.data.find(r => r.tag_name === targetTag);
+
+            if (targetRelease) {
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: targetRelease.id,
+                make_latest: true,
+              });
+              console.log(`✓ Set ${targetTag} as the latest GitHub release`);
+            } else {
+              console.log(`Note: No GitHub release found for ${targetTag} — skipping`);
+            }
+
+      - name: Verify final state
+        run: |
+          echo "Current NPM dist-tags for vercel:"
+          npm dist-tag ls vercel
+          echo ""
+          echo "Deprecation status:"
+          npm view vercel@${{ inputs.version }} deprecate
+
+      - name: Summary
+        run: |
+          echo '## Deprecate Bad Release — Summary' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo "- **Deprecated**: \`vercel@${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${{ inputs.target }}" ]; then
+            echo "- **Target latest**: \`vercel@${{ inputs.target }}\`" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "- **Message**: ${{ inputs.message }}" >> $GITHUB_STEP_SUMMARY

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,6 +83,21 @@ If `latest` points to the wrong version, run:
 
 This updates npm dist-tag `latest` without republishing.
 
+## Bad release
+
+If a bad version was published (e.g., a release with a critical bug), run:
+
+- Workflow: `Deprecate Bad Release` (`.github/workflows/deprecate-bad-release.yml`)
+- Inputs:
+  - `version`: The bad CLI version to deprecate (e.g., `54.7.0`)
+  - `target`: (optional) Version to point `latest` to. If omitted, only deprecation is performed.
+  - `message`: (optional) Deprecation reason shown to users. Defaults to a generic message.
+
+This workflow will:
+1. **Deprecate** the bad version on npm so users get a warning when installing it.
+2. **Rollback** the `latest` dist-tag to the previous (or specified) version.
+3. **Update** the GitHub Latest Release to point to the rollback target.
+
 ## Related workflows
 
 - Stable release: `.github/workflows/release.yml`


### PR DESCRIPTION
Adds a new manual workflow to handle bad CLI releases:

- **Deprecates** the bad npm version with a custom message
- **Points** `latest` dist-tag to a target version (auto-detected if omitted)
- **Updates** GitHub Latest Release to the rollback target

Usage: Actions → Deprecate Bad Release → Run workflow

Closes: the need to manually `npm deprecate` and `npm dist-tag` separately.