### PR TITLE
[connect] Forward token scopes/installation into authorize URL

### DIFF
--- a/.changeset/connect-token-authorize-scopes.md
+++ b/.changeset/connect-token-authorize-scopes.md
@@ -1,0 +1,7 @@
+---
+"vercel": patch
+---
+
+[connect] Forward `--scopes` and `--installation-id` into the authorize/install recovery URL
+
+When `vercel connect token` hits an action-required error (`user_authorization_required` or `client_installation_required`), the CLI builds an authorize/install URL for the user to complete consent in the browser. Previously this URL carried only `teamId` and `request_code`, dropping the `--scopes` and `--installation-id` the user supplied. As a result the consent flow fell back to provider defaults (e.g. Slack's `users.profile:read`), and the post-authorization token retry mismatched the requested scopes. The CLI now forwards `scopes` (comma-joined) and `installationId` as query params, which the authorize and install endpoints already accept.

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -65,11 +65,13 @@ export async function token(
     // it's reliably available here for authenticated callers.
     body.subject = { type: 'user', id: client.authConfig.userId };
   }
-  if (flags['--installation-id']) {
-    body.installationId = flags['--installation-id'];
+  const installationId = flags['--installation-id'];
+  const scopes = flags['--scopes'] ? parseScopes(flags['--scopes']) : undefined;
+  if (installationId) {
+    body.installationId = installationId;
   }
-  if (flags['--scopes']) {
-    body.scopes = parseScopes(flags['--scopes']);
+  if (scopes) {
+    body.scopes = scopes;
   }
 
   output.spinner('Fetching token...');
@@ -123,7 +125,10 @@ export async function token(
 
   if (!attemptRecovery) {
     const { requestCode } = generateRequestCode();
-    const actionUrl = buildActionUrl(errorCode, clientId, teamId, requestCode);
+    const actionUrl = buildActionUrl(errorCode, clientId, teamId, requestCode, {
+      scopes,
+      installationId,
+    });
     output.error(errorMessage);
     output.log(`To ${actionLabel}, open: ${actionUrl}`);
     output.log(
@@ -147,7 +152,10 @@ export async function token(
   }
 
   const { verifier, requestCode } = generateRequestCode();
-  const actionUrl = buildActionUrl(errorCode, clientId, teamId, requestCode);
+  const actionUrl = buildActionUrl(errorCode, clientId, teamId, requestCode, {
+    scopes,
+    installationId,
+  });
 
   output.log(`Opening browser for ${actionLabel}...`);
   output.log(`If the browser doesn't open, visit:\n${actionUrl}`);
@@ -202,13 +210,21 @@ function buildActionUrl(
   code: ActionableErrorCode,
   clientId: string,
   teamId: string,
-  requestCode: string
+  requestCode: string,
+  options?: { scopes?: string[]; installationId?: string }
 ): string {
   const path = code === 'user_authorization_required' ? 'authorize' : 'install';
   const params = new URLSearchParams({
     teamId,
     request_code: requestCode,
   });
+
+  if (options?.scopes && options.scopes.length > 0) {
+    params.set('scopes', options.scopes.join(','));
+  }
+  if (options?.installationId) {
+    params.set('installationId', options.installationId);
+  }
   return `https://vercel.com/api/v1/connect/${path}/${encodeURIComponent(clientId)}?${params.toString()}`;
 }
 

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -22,12 +22,7 @@ type ActionableErrorCode =
   | 'user_authorization_required'
   | 'client_installation_required';
 
-/**
- * Token request params that must be honored by BOTH the `POST /connect/token`
- * body and the authorize/install recovery URL. Keeping them in one object
- * means a new flag is forwarded to both surfaces by construction — the
- * recovery URL can't silently drop a param the token request used.
- */
+/** Token params shared by the token request and the recovery URL. */
 interface TokenRequestParams {
   installationId?: string;
   scopes?: string[];

--- a/packages/cli/src/commands/connex/token.ts
+++ b/packages/cli/src/commands/connex/token.ts
@@ -22,6 +22,17 @@ type ActionableErrorCode =
   | 'user_authorization_required'
   | 'client_installation_required';
 
+/**
+ * Token request params that must be honored by BOTH the `POST /connect/token`
+ * body and the authorize/install recovery URL. Keeping them in one object
+ * means a new flag is forwarded to both surfaces by construction — the
+ * recovery URL can't silently drop a param the token request used.
+ */
+interface TokenRequestParams {
+  installationId?: string;
+  scopes?: string[];
+}
+
 export async function token(
   client: Client,
   args: string[],
@@ -57,21 +68,23 @@ export async function token(
 
   await selectConnexTeam(client, 'Select the team for this token request');
 
-  const body: Record<string, unknown> = {};
+  const tokenParams: TokenRequestParams = {};
+  if (flags['--installation-id']) {
+    tokenParams.installationId = flags['--installation-id'];
+  }
+  if (flags['--scopes']) {
+    tokenParams.scopes = parseScopes(flags['--scopes']);
+  }
+
+  // Spread token params into the body; `subject` is body-only (the
+  // authorize/install endpoints derive the subject from the caller).
+  const body: Record<string, unknown> = { ...tokenParams };
   if (subject === 'app') {
     body.subject = { type: 'app' };
   } else if (subject === 'user') {
     // selectConnexTeam → selectOrg → getUser populates authConfig.userId, so
     // it's reliably available here for authenticated callers.
     body.subject = { type: 'user', id: client.authConfig.userId };
-  }
-  const installationId = flags['--installation-id'];
-  const scopes = flags['--scopes'] ? parseScopes(flags['--scopes']) : undefined;
-  if (installationId) {
-    body.installationId = installationId;
-  }
-  if (scopes) {
-    body.scopes = scopes;
   }
 
   output.spinner('Fetching token...');
@@ -125,10 +138,13 @@ export async function token(
 
   if (!attemptRecovery) {
     const { requestCode } = generateRequestCode();
-    const actionUrl = buildActionUrl(errorCode, clientId, teamId, requestCode, {
-      scopes,
-      installationId,
-    });
+    const actionUrl = buildActionUrl(
+      errorCode,
+      clientId,
+      teamId,
+      requestCode,
+      tokenParams
+    );
     output.error(errorMessage);
     output.log(`To ${actionLabel}, open: ${actionUrl}`);
     output.log(
@@ -152,10 +168,13 @@ export async function token(
   }
 
   const { verifier, requestCode } = generateRequestCode();
-  const actionUrl = buildActionUrl(errorCode, clientId, teamId, requestCode, {
-    scopes,
-    installationId,
-  });
+  const actionUrl = buildActionUrl(
+    errorCode,
+    clientId,
+    teamId,
+    requestCode,
+    tokenParams
+  );
 
   output.log(`Opening browser for ${actionLabel}...`);
   output.log(`If the browser doesn't open, visit:\n${actionUrl}`);
@@ -211,7 +230,7 @@ function buildActionUrl(
   clientId: string,
   teamId: string,
   requestCode: string,
-  options?: { scopes?: string[]; installationId?: string }
+  tokenParams: TokenRequestParams
 ): string {
   const path = code === 'user_authorization_required' ? 'authorize' : 'install';
   const params = new URLSearchParams({
@@ -219,11 +238,15 @@ function buildActionUrl(
     request_code: requestCode,
   });
 
-  if (options?.scopes && options.scopes.length > 0) {
-    params.set('scopes', options.scopes.join(','));
-  }
-  if (options?.installationId) {
-    params.set('installationId', options.installationId);
+  // Merge the same token params the POST body carried so the consent flow
+  // grants what the user asked for. Array values (e.g. scopes) are
+  // comma-joined; the authorize/install endpoints split them via
+  // parseListParam. The query-param names match the body field names.
+  for (const [key, value] of Object.entries(tokenParams)) {
+    if (value === undefined) {
+      continue;
+    }
+    params.set(key, Array.isArray(value) ? value.join(',') : value);
   }
   return `https://vercel.com/api/v1/connect/${path}/${encodeURIComponent(clientId)}?${params.toString()}`;
 }

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -225,6 +225,38 @@ describe('connex token', () => {
     expect(exitCode).toBe(1);
   });
 
+  it('should forward --scopes and --installation-id into the authorize URL', async () => {
+    client.scenario.post('/v1/connect/token/:clientId', (_req, res) => {
+      res.statusCode = 422;
+      res.json({
+        error: {
+          code: 'user_authorization_required',
+          message: 'User authorization required',
+        },
+      });
+    });
+
+    client.setArgv(
+      'connect',
+      'token',
+      'scl_abc123',
+      '--scopes',
+      'chat:write,channels:read',
+      '--installation-id',
+      'inst_42'
+    );
+    (client.stdout as any).isTTY = false;
+
+    const exitCode = await connect(client);
+
+    // scopes are comma-joined; URLSearchParams encodes the colon as %3A
+    // and the comma as %2C. installationId follows scopes in the query string.
+    await expect(client.stderr).toOutput(
+      'scopes=chat%3Awrite%2Cchannels%3Aread&installationId=inst_42'
+    );
+    expect(exitCode).toBe(1);
+  });
+
   it('should fail fast and print install URL when stdin is not a TTY', async () => {
     client.scenario.post('/v1/connect/token/:clientId', (_req, res) => {
       res.statusCode = 422;

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -249,10 +249,11 @@ describe('connex token', () => {
 
     const exitCode = await connect(client);
 
-    // scopes are comma-joined; URLSearchParams encodes the colon as %3A
-    // and the comma as %2C. installationId follows scopes in the query string.
+    // Params follow tokenParams insertion order (installationId, then
+    // scopes); query-param order is not semantically significant. scopes are
+    // comma-joined; URLSearchParams encodes the colon as %3A and comma as %2C.
     await expect(client.stderr).toOutput(
-      'scopes=chat%3Awrite%2Cchannels%3Aread&installationId=inst_42'
+      'installationId=inst_42&scopes=chat%3Awrite%2Cchannels%3Aread'
     );
     expect(exitCode).toBe(1);
   });


### PR DESCRIPTION
## Summary

`vercel connect token` drops the user-supplied `--scopes` and `--installation-id` when it builds the authorize/install **recovery URL** on an action-required `422`. 

This forwards `scopes` (comma-joined) and `installationId` as query params. The `authorize` and `install` endpoints already accept these (parsed via `parseListParam`), so no API change is needed.

## Testing
- `npx vitest run packages/cli/test/unit/commands/connex/token.test.ts` — 19/19 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)