### PR TITLE
ci: add explicit GITHUB_TOKEN permissions to CI workflows

### DIFF
--- a/.github/workflows/cli-evals.yml
+++ b/.github/workflows/cli-evals.yml
@@ -7,6 +7,9 @@ on:
     # Run weekly on Tuesday at 9:00 AM UTC.
     - cron: '0 9 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   evals:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   enforce-changeset:
     name: Enforce Changeset

--- a/.github/workflows/test-python-packages.yml
+++ b/.github/workflows/test-python-packages.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Discover Python Packages


### PR DESCRIPTION
This narrows the `GITHUB_TOKEN` for `.github/workflows/cli-evals.yml`, `.github/workflows/test-lint.yml`, `.github/workflows/test-python-packages.yml` to read-only.

- These jobs only check out the repo and run build/test steps, so `contents: read` covers them.
- Without an explicit block the token inherits the repo default, often write-enabled.
- Following the principle of least privilege from the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).

Behavior is unchanged.