### PR TITLE
[python] Force compileall to rewrite existing .pyc into unchecked-hash

### DIFF
--- a/.changeset/force-python-bytecode.md
+++ b/.changeset/force-python-bytecode.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Force Python bytecode precompilation to rewrite existing `.pyc` files with unchecked-hash invalidation.

--- a/packages/python/src/compileall.ts
+++ b/packages/python/src/compileall.ts
@@ -77,6 +77,7 @@ export async function runCompileAll({
     '-q',
     '-j',
     '0',
+    '-f',
     '--invalidation-mode',
     'unchecked-hash',
     ...(excludeRegex ? ['-x', excludeRegex] : []),

--- a/packages/python/test/compileall.test.ts
+++ b/packages/python/test/compileall.test.ts
@@ -169,7 +169,7 @@ describe('shouldUseCompileAll', () => {
 });
 
 describe('runCompileAll', () => {
-  it('passes -j 0 and exclude regex to compileall when provided', async () => {
+  it('passes -j 0, -f, and exclude regex to compileall when provided', async () => {
     mockedExeca.mockResolvedValue({} as any);
     const env = { VIRTUAL_ENV: '/work/.vercel/python/.venv' };
 
@@ -188,6 +188,7 @@ describe('runCompileAll', () => {
         '-q',
         '-j',
         '0',
+        '-f',
         '--invalidation-mode',
         'unchecked-hash',
         '-x',


### PR DESCRIPTION
## Summary

- Force Python compileall to use -f so existing pyc files are rewritten with unchecked-hash invalidation.
- Update the compileall argument assertion and add a changeset.

## Testing

- Not run (per request).