### PR TITLE
[services] add experimentalServicesV2 to schema

### DIFF
--- a/.changeset/experimental-services-v2.md
+++ b/.changeset/experimental-services-v2.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': patch
+'@vercel/client': patch
+'vercel': patch
+---
+
+[services] Add `experimentalServicesV2` field to `vercel.json` implementing the new schema for services.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -5,7 +5,13 @@ import type { Lambda, LambdaArchitecture } from './lambda';
 import type { Prerender } from './prerender';
 import type { EdgeFunction } from './edge-function';
 import type { Span } from './trace';
-import type { HasField } from '@vercel/routing-utils';
+import type {
+  HasField,
+  Route,
+  Rewrite,
+  Redirect,
+  Header,
+} from '@vercel/routing-utils';
 
 export interface Env {
   [name: string]: string | undefined;
@@ -1026,6 +1032,70 @@ export type Services = Record<string, ServiceConfig>;
  * }
  */
 export type ExperimentalServiceGroups = Record<string, string[]>;
+
+export interface ExperimentalServiceV2Binding {
+  /** Must be `"service"` for Service-to-Service HTTP bindings. */
+  type: 'service';
+  /** Target service name from `experimentalServicesV2`. */
+  service: string;
+  /** Generated value shape, must be `"url"`. */
+  format: 'url';
+  /** Environment variable name that will store the generated value */
+  env: string;
+}
+
+/**
+ * Configuration for a service in `experimentalServicesV2` in `vercel.json`.
+ *
+ * @experimental This feature is experimental and may change.
+ */
+export interface ExperimentalServiceV2Config {
+  /** Path to the service root, relative to `vercel.json`. */
+  root: string;
+  /** Framework for this service. */
+  framework?: string;
+  /** Runtime for this service. */
+  runtime?: string;
+  /**
+   * Service entrypoint, relative to the service root directory.
+   * Can be a file path or a module specification (for Python).
+   */
+  entrypoint?: string;
+
+  /* Service-level build setting overrides. */
+  installCommand?: string;
+  buildCommand?: string;
+  devCommand?: string;
+  ignoreCommand?: string;
+  outputDirectory?: string;
+
+  /** Literal environment variables for a service. */
+  env?: Record<string, string>;
+
+  /** Caller-side bindings that grant this service access to another service. */
+  bindings?: ExperimentalServiceV2Binding[];
+
+  /** Function configuration scoped to this service root. */
+  functions?: BuilderFunctions;
+
+  /* Service's route table. Applied only after top-level routing. */
+  headers?: Header[];
+  redirects?: Redirect[];
+  rewrites?: Rewrite[];
+  routes?: Route[];
+  cleanUrls?: boolean;
+  trailingSlash?: boolean;
+}
+
+/**
+ * Map of service name to service configuration for `experimentalServicesV2`.
+ *
+ * @experimental This feature is experimental and may change.
+ */
+export type ExperimentalServicesV2 = Record<
+  string,
+  ExperimentalServiceV2Config
+>;
 
 /**
  * Result of a runtime builder's normalized entrypoint detection.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -1069,9 +1069,6 @@ export interface ExperimentalServiceV2Config {
   ignoreCommand?: string;
   outputDirectory?: string;
 
-  /** Literal environment variables for a service. */
-  env?: Record<string, string>;
-
   /** Caller-side bindings that grant this service access to another service. */
   bindings?: ExperimentalServiceV2Binding[];
 

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -625,13 +625,6 @@ const experimentalServicesV2CommandSchema = {
   maxLength: 2048,
 };
 
-const experimentalServicesV2EnvSchema = {
-  type: 'object',
-  maxProperties: 1000,
-  additionalProperties: { type: 'string', maxLength: 65536 },
-  propertyNames: envVarNamesSchema,
-};
-
 const experimentalServicesV2BindingSchema = {
   type: 'object',
   additionalProperties: false,
@@ -680,7 +673,6 @@ const experimentalServicesV2ServiceConfigSchema = {
     devCommand: experimentalServicesV2CommandSchema,
     ignoreCommand: experimentalServicesV2CommandSchema,
     outputDirectory: experimentalServicesV2PathSchema,
-    env: experimentalServicesV2EnvSchema,
     bindings: experimentalServicesV2BindingsSchema,
     functions: functionsSchema,
     headers: headersSchema,

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -613,6 +613,94 @@ const experimentalServiceGroupsSchema = {
   },
 };
 
+const experimentalServicesV2PathSchema = {
+  type: 'string',
+  minLength: 1,
+  maxLength: 512,
+};
+
+const experimentalServicesV2CommandSchema = {
+  type: 'string',
+  minLength: 1,
+  maxLength: 2048,
+};
+
+const experimentalServicesV2EnvSchema = {
+  type: 'object',
+  maxProperties: 1000,
+  additionalProperties: { type: 'string', maxLength: 65536 },
+  propertyNames: envVarNamesSchema,
+};
+
+const experimentalServicesV2BindingSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['type', 'service', 'format', 'env'],
+  properties: {
+    type: { const: 'service' },
+    service: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 64,
+      pattern: '^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$',
+    },
+    format: { const: 'url' },
+    env: {
+      type: 'string',
+      ...envVarNamesSchema,
+    },
+  },
+};
+
+const experimentalServicesV2BindingsSchema = {
+  type: 'array',
+  maxItems: 100,
+  items: experimentalServicesV2BindingSchema,
+};
+
+const experimentalServicesV2ServiceConfigSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['root'],
+  properties: {
+    root: experimentalServicesV2PathSchema,
+    framework: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 256,
+    },
+    runtime: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 256,
+    },
+    entrypoint: experimentalServicesV2PathSchema,
+    installCommand: experimentalServicesV2CommandSchema,
+    buildCommand: experimentalServicesV2CommandSchema,
+    devCommand: experimentalServicesV2CommandSchema,
+    ignoreCommand: experimentalServicesV2CommandSchema,
+    outputDirectory: experimentalServicesV2PathSchema,
+    env: experimentalServicesV2EnvSchema,
+    bindings: experimentalServicesV2BindingsSchema,
+    functions: functionsSchema,
+    headers: headersSchema,
+    redirects: redirectsSchema,
+    rewrites: rewritesSchema,
+    routes: routesSchema,
+    cleanUrls: cleanUrlsSchema,
+    trailingSlash: trailingSlashSchema,
+  },
+};
+
+const experimentalServicesV2Schema = {
+  type: 'object',
+  propertyNames: {
+    pattern: '^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$',
+    maxLength: 64,
+  },
+  additionalProperties: experimentalServicesV2ServiceConfigSchema,
+};
+
 const vercelConfigSchema = {
   type: 'object',
   // These are not all possibilities because `vc dev`
@@ -633,6 +721,7 @@ const vercelConfigSchema = {
     services: servicesSchema,
     experimentalServices: experimentalServicesSchema,
     experimentalServiceGroups: experimentalServiceGroupsSchema,
+    experimentalServicesV2: experimentalServicesV2Schema,
   },
 };
 
@@ -712,6 +801,88 @@ export function validateConfig(config: VercelConfig): NowBuildError | null {
       message:
         'The `experimentalServiceGroups` property requires `experimentalServices` to be defined. Service groups reference services by name.',
     });
+  }
+
+  const hasExperimentalServicesV2 = Boolean(config.experimentalServicesV2);
+
+  if (hasExperimentalServicesV2 && hasServices) {
+    return new NowBuildError({
+      code: 'EXPERIMENTAL_SERVICES_V2_AND_SERVICES',
+      message:
+        'The `experimentalServicesV2` property cannot be used in conjunction with the `services` property. Please use only one services configuration.',
+    });
+  }
+
+  if (hasExperimentalServicesV2 && hasExperimentalServices) {
+    return new NowBuildError({
+      code: 'EXPERIMENTAL_SERVICES_V2_AND_EXPERIMENTAL_SERVICES',
+      message:
+        'The `experimentalServicesV2` property cannot be used in conjunction with the `experimentalServices` property. Please use only one services configuration.',
+    });
+  }
+
+  if (hasExperimentalServicesV2 && config.builds) {
+    return new NowBuildError({
+      code: 'EXPERIMENTAL_SERVICES_V2_AND_BUILDS',
+      message:
+        'The `experimentalServicesV2` property cannot be used in conjunction with the `builds` property. Please remove one of them.',
+    });
+  }
+
+  // with `experimentalServicesV2` some fields could be present only in services declaration
+  if (hasExperimentalServicesV2) {
+    const ambiguousTopLevel: string[] = [];
+    if (config.functions != null) {
+      ambiguousTopLevel.push('functions');
+    }
+    if (config.installCommand != null) {
+      ambiguousTopLevel.push('installCommand');
+    }
+    if (config.buildCommand != null) {
+      ambiguousTopLevel.push('buildCommand');
+    }
+    if (config.devCommand != null) {
+      ambiguousTopLevel.push('devCommand');
+    }
+    if (config.ignoreCommand != null) {
+      ambiguousTopLevel.push('ignoreCommand');
+    }
+    if (config.outputDirectory != null) {
+      ambiguousTopLevel.push('outputDirectory');
+    }
+    if (config.framework != null) {
+      ambiguousTopLevel.push('framework');
+    }
+
+    if (ambiguousTopLevel.length > 0) {
+      const count = ambiguousTopLevel.length;
+      const fields = ambiguousTopLevel.map(field => `\`${field}\``).join(', ');
+      return new NowBuildError({
+        code: 'EXPERIMENTAL_SERVICES_V2_AND_TOP_LEVEL_BUILD_SETTINGS',
+        message:
+          `The top-level ${count > 1 ? 'properties' : 'property'} ${fields} cannot be used with \`experimentalServicesV2\` ` +
+          `because the owning service is ambiguous. ` +
+          `Move ${count > 1 ? 'them' : 'it'} under the relevant service in \`experimentalServicesV2\`.`,
+      });
+    }
+  }
+
+  if (config.experimentalServicesV2) {
+    const serviceNames = new Set(Object.keys(config.experimentalServicesV2));
+    for (const [serviceName, serviceConfig] of Object.entries(
+      config.experimentalServicesV2
+    )) {
+      for (const binding of serviceConfig.bindings ?? []) {
+        if (!serviceNames.has(binding.service)) {
+          return new NowBuildError({
+            code: 'EXPERIMENTAL_SERVICES_V2_BINDING_UNKNOWN_SERVICE',
+            message:
+              `Service "${serviceName}" declares a binding to unknown service "${binding.service}". ` +
+              `Add "${binding.service}" to \`experimentalServicesV2\` or fix the binding.`,
+          });
+        }
+      }
+    }
   }
 
   return null;

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -12,6 +12,211 @@ describe('validateConfig', () => {
     }
   });
 
+  describe('experimentalServicesV2', () => {
+    it('should not error with a valid config', () => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          my_frontend: {
+            root: 'frontend/',
+            framework: 'nextjs',
+            bindings: [
+              {
+                type: 'service',
+                service: 'my_backend',
+                format: 'url',
+                env: 'BACKEND_URL',
+              },
+            ],
+          },
+          my_backend: {
+            root: 'backend/',
+            runtime: 'python',
+            entrypoint: 'main:app',
+            env: { LOG_LEVEL: 'info' },
+          },
+        },
+      } satisfies Parameters<typeof validateConfig>[0]);
+      expect(error).toBeNull();
+    });
+
+    it('should not error with a service-local route table and functions', () => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          web: {
+            root: '.',
+            headers: [{ source: '/', headers: [{ key: 'x-id', value: '1' }] }],
+            redirects: [{ source: '/old', destination: '/new' }],
+            rewrites: [{ source: '/a', destination: '/b' }],
+            cleanUrls: true,
+            trailingSlash: false,
+            functions: { 'api/*.ts': { memory: 256, maxDuration: 10 } },
+          },
+        },
+      });
+      expect(error).toBeNull();
+    });
+
+    it('should accept per-service build overrides', () => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          api: {
+            root: 'api/',
+            installCommand: 'pnpm install',
+            buildCommand: 'pnpm build',
+            devCommand: 'pnpm dev',
+            ignoreCommand: 'echo test',
+            outputDirectory: 'dist',
+          },
+        },
+      });
+      expect(error).toBeNull();
+    });
+
+    it('should require root', () => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          api: { framework: 'nextjs' } as any,
+        },
+      });
+      expect(error?.message).toContain('missing required property `root`');
+    });
+
+    it.each([
+      ['type', { type: 'web' }],
+      ['trigger', { trigger: 'schedule' }],
+      ['mount', { mount: '/api' }],
+      ['routePrefix', { routePrefix: '/api' }],
+      ['subdomain', { subdomain: 'api' }],
+      ['schedule', { schedule: '0 0 * * *' }],
+      ['topics', { topics: ['orders'] }],
+      ['memory', { memory: 1024 }],
+      ['maxDuration', { maxDuration: 10 }],
+      ['includeFiles', { includeFiles: 'config/*.json' }],
+      ['excludeFiles', { excludeFiles: 'fixtures/**' }],
+      ['workspace', { workspace: '.' }],
+      ['builder', { builder: '@vercel/node' }],
+      ['preDeployCommand', { preDeployCommand: 'pnpm migrate' }],
+      ['consumer', { consumer: 'group' }],
+    ])('should reject removed service field %s', (_, serviceConfig) => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          api: { root: '.', ...serviceConfig } as any,
+        },
+      });
+      expect(error).not.toBeNull();
+    });
+
+    it('should reject a binding to an unknown service', () => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          web: {
+            root: '.',
+            bindings: [
+              {
+                type: 'service',
+                service: 'ghost',
+                format: 'url',
+                env: 'GHOST_URL',
+              },
+            ],
+          },
+        },
+      });
+      expect(error?.code).toBe(
+        'EXPERIMENTAL_SERVICES_V2_BINDING_UNKNOWN_SERVICE'
+      );
+    });
+
+    it('should reject a binding missing a required field', () => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          web: { root: '.' },
+          api: {
+            root: 'api/',
+            bindings: [
+              { type: 'service', service: 'web', format: 'url' } as any,
+            ],
+          },
+        },
+      });
+      expect(error).not.toBeNull();
+    });
+
+    it.each([
+      ['type', { type: 'queue', service: 'web', format: 'url', env: 'X' }],
+      ['format', { type: 'service', service: 'web', format: 'grpc', env: 'X' }],
+    ])('should reject a binding with invalid %s', (_, binding) => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          web: { root: '.', bindings: [binding] } as any,
+        },
+      });
+      expect(error).not.toBeNull();
+    });
+
+    it('should reject service-ref object env values', () => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          web: {
+            root: '.',
+            env: {
+              API_URL: { type: 'service-ref', service: 'api' },
+            },
+          } as any,
+        },
+      });
+      expect(error).not.toBeNull();
+    });
+
+    it.each([
+      ['functions', { functions: { 'api/*.ts': { memory: 128 } } }],
+      ['installCommand', { installCommand: 'pnpm install' }],
+      ['buildCommand', { buildCommand: 'pnpm build' }],
+      ['devCommand', { devCommand: 'pnpm dev' }],
+      ['ignoreCommand', { ignoreCommand: 'exit 0' }],
+      ['outputDirectory', { outputDirectory: 'dist' }],
+      ['framework', { framework: 'nextjs' }],
+    ])('should reject top-level %s in experimentalServicesV2 mode', (_, topLevel) => {
+      const error = validateConfig({
+        experimentalServicesV2: { web: { root: '.' } },
+        ...topLevel,
+      } as any);
+      expect(error).not.toBeNull();
+    });
+
+    it('should report all confusing top-level fields at once', () => {
+      const error = validateConfig({
+        experimentalServicesV2: { web: { root: '.' } },
+        framework: 'nextjs',
+        outputDirectory: 'dist',
+      } as any);
+      expect(error?.code).toBe(
+        'EXPERIMENTAL_SERVICES_V2_AND_TOP_LEVEL_BUILD_SETTINGS'
+      );
+      expect(error?.message).toContain('`framework`');
+      expect(error?.message).toContain('`outputDirectory`');
+    });
+
+    it('should reject experimentalServicesV2 together with services', () => {
+      process.env.VERCEL_USE_SERVICES = '1';
+      const error = validateConfig({
+        services: { api: { type: 'web', root: '.' } } as any,
+        experimentalServicesV2: { web: { root: '.' } },
+      });
+      expect(error?.code).toBe('EXPERIMENTAL_SERVICES_V2_AND_SERVICES');
+    });
+
+    it('should reject experimentalServicesV2 together with experimentalServices', () => {
+      const error = validateConfig({
+        experimentalServices: { api: { entrypoint: 'api/index.ts' } },
+        experimentalServicesV2: { web: { root: '.' } },
+      });
+      expect(error?.code).toBe(
+        'EXPERIMENTAL_SERVICES_V2_AND_EXPERIMENTAL_SERVICES'
+      );
+    });
+  });
+
   it('should not error with empty config', async () => {
     const config = {};
     const error = validateConfig(config);

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -32,7 +32,6 @@ describe('validateConfig', () => {
             root: 'backend/',
             runtime: 'python',
             entrypoint: 'main:app',
-            env: { LOG_LEVEL: 'info' },
           },
         },
       } satisfies Parameters<typeof validateConfig>[0]);
@@ -154,14 +153,12 @@ describe('validateConfig', () => {
       expect(error).not.toBeNull();
     });
 
-    it('should reject service-ref object env values', () => {
+    it('should reject the removed `env` field', () => {
       const error = validateConfig({
         experimentalServicesV2: {
           web: {
             root: '.',
-            env: {
-              API_URL: { type: 'service-ref', service: 'api' },
-            },
+            env: { LOG_LEVEL: 'info' },
           } as any,
         },
       });

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -8,6 +8,7 @@ import type {
   Services,
   ExperimentalServices,
   ExperimentalServiceGroups,
+  ExperimentalServicesV2,
 } from '@vercel/build-utils';
 import type { Header, Route, Redirect, Rewrite } from '@vercel/routing-utils';
 
@@ -199,6 +200,10 @@ export interface VercelConfig {
    * @experimental This feature is experimental and may change.
    */
   experimentalServiceGroups?: ExperimentalServiceGroups;
+  /**
+   * @experimental This feature is experimental and may change.
+   */
+  experimentalServicesV2?: ExperimentalServicesV2;
 }
 
 export interface GitMetadata {


### PR DESCRIPTION
Adds `expertimentalServicesV2` to `vercel.json`, schema only change, no wiring yet