### PR TITLE
[cli] nest integration-resource under integration, add resource connect

### DIFF
--- a/.changeset/integration-resource-connect.md
+++ b/.changeset/integration-resource-connect.md
@@ -1,0 +1,13 @@
+---
+"vercel": patch
+---
+
+[cli] Nest `integration-resource` under `integration resource` and add `integration resource connect`
+
+The marketplace resource subcommands (`disconnect`, `remove`, `create-threshold`) are now discoverable under `vercel integration resource <sub>`. The standalone `vercel integration-resource` and `vc ir` forms still work as hidden aliases — no scripts or tests break.
+
+Adds a new `vercel integration resource connect <resource> [project]` command (the inverse of `disconnect`). Accepts `--environment` (repeatable, defaults to all three), `--prefix` for env var namespacing, `--yes`, and `--format=json`. Defaults to the project linked in the current directory when `<project>` is omitted.
+
+Tightens `disconnect` to error (exit 1) when the specified project is not connected to the resource, instead of exiting 0 with a "not found" message.
+
+Both commands emit a structured `outputAgentError` payload with `reason: confirmation_required` and a `next: [{command}]` retry hint when run in non-interactive / agent mode without `--yes`. When `connect` fails because an env var with the same name already exists on the target project, the error names the conflicting variable and suggests `--prefix` or `vercel env rm` as remediation.

--- a/packages/cli/src/commands/integration-resource/command.ts
+++ b/packages/cli/src/commands/integration-resource/command.ts
@@ -52,7 +52,7 @@ export const removeSubcommand = {
 export const disconnectSubcommand = {
   name: 'disconnect',
   aliases: [],
-  description: 'Disconnect a resource from a project, or the current project',
+  description: 'Disconnect a marketplace resource from a project',
   arguments: [
     {
       name: 'resource',
@@ -107,6 +107,78 @@ export const disconnectSubcommand = {
   ],
 } as const;
 
+export const connectSubcommand = {
+  name: 'connect',
+  aliases: [],
+  description: 'Connect a marketplace resource to a project',
+  arguments: [
+    {
+      name: 'resource',
+      required: true,
+    },
+    {
+      name: 'project',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      name: 'environment',
+      shorthand: 'e',
+      type: [String],
+      argument: 'ENV',
+      deprecated: false,
+      description:
+        'Environment to connect (can be repeated: production, preview, development). Defaults to all.',
+    },
+    {
+      name: 'prefix',
+      shorthand: null,
+      type: String,
+      argument: 'PREFIX',
+      deprecated: false,
+      description:
+        'Prefix for environment variable names (e.g., --prefix NEON2_ creates NEON2_DATABASE_URL instead of DATABASE_URL)',
+    },
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when connecting a resource',
+    },
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Connect a resource to the current project',
+      value: [
+        `${packageName} integration resource connect <resource>`,
+        `${packageName} integration resource connect my-acme-resource`,
+      ],
+    },
+    {
+      name: 'Connect a resource to a specified project',
+      value: [
+        `${packageName} integration resource connect <resource> <project>`,
+        `${packageName} integration resource connect my-acme-resource my-project`,
+      ],
+    },
+    {
+      name: 'Connect only to specific environments',
+      value: [
+        `${packageName} integration resource connect my-acme-resource -e production`,
+        `${packageName} integration resource connect my-acme-resource -e production -e preview`,
+      ],
+    },
+    {
+      name: 'Connect with a prefix for environment variable names',
+      value: `${packageName} integration resource connect my-acme-resource --prefix NEON2_`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} integration resource connect my-acme-resource --format=json --yes`,
+    },
+  ],
+} as const;
+
 export const createThresholdSubcommand = {
   name: 'create-threshold',
   aliases: [],
@@ -151,10 +223,12 @@ export const createThresholdSubcommand = {
 export const integrationResourceCommand = {
   name: 'integration-resource',
   aliases: ['ir'],
-  description: 'Manage marketplace integration resources',
+  description:
+    'Manage marketplace integration resources (alias for `vercel integration resource`)',
   options: [],
   arguments: [],
   subcommands: [
+    connectSubcommand,
     createThresholdSubcommand,
     disconnectSubcommand,
     removeSubcommand,

--- a/packages/cli/src/commands/integration-resource/connect.ts
+++ b/packages/cli/src/commands/integration-resource/connect.ts
@@ -1,0 +1,246 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import getScope from '../../util/get-scope';
+import { printError } from '../../util/error';
+import { validateJsonOutput } from '../../util/output-format';
+import { connectResourceToProject } from '../../util/integration-resource/connect-resource-to-project';
+import { getResources } from '../../util/integration-resource/get-resources';
+import { getLinkedProject } from '../../util/projects/link';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound, isAPIError } from '../../util/errors-ts';
+import { buildCommandWithYes, outputAgentError } from '../../util/agent-output';
+import {
+  VALID_ENVIRONMENTS,
+  validateEnvironments,
+} from '../../util/integration/post-provision-setup';
+import { IntegrationResourceConnectTelemetryClient } from '../../util/telemetry/commands/integration-resource/connect';
+import { connectSubcommand } from './command';
+
+export async function connect(client: Client, argv: string[]) {
+  const telemetry = new IntegrationResourceConnectTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArguments = null;
+  const flagsSpecification = getFlagsSpecification(connectSubcommand.options);
+
+  try {
+    parsedArguments = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const formatResult = validateJsonOutput(parsedArguments.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+  const skipConfirmation = !!parsedArguments.flags['--yes'];
+  const prefix = parsedArguments.flags['--prefix'];
+  const environmentsFlag = parsedArguments.flags['--environment'];
+
+  telemetry.trackCliOptionFormat(parsedArguments.flags['--format']);
+  telemetry.trackCliFlagYes(skipConfirmation);
+  telemetry.trackCliOptionPrefix(prefix);
+  telemetry.trackCliOptionEnvironment(environmentsFlag);
+
+  if (asJson && !skipConfirmation) {
+    output.error('--format=json requires --yes to skip confirmation prompts');
+    return 1;
+  }
+
+  if (parsedArguments.args.length < 1) {
+    output.error('You must specify a resource. See `--help` for details.');
+    return 1;
+  }
+
+  if (parsedArguments.args.length > 2) {
+    output.error(
+      'Too many arguments. Usage: `vercel integration resource connect <resource> [project]`.'
+    );
+    return 1;
+  }
+
+  if (prefix !== undefined && !/^[a-zA-Z][a-zA-Z0-9_]*$/.test(prefix)) {
+    output.error(
+      'Invalid --prefix value. It must start with a letter and contain only letters, digits, and underscores.'
+    );
+    return 1;
+  }
+
+  let environments: string[];
+  if (environmentsFlag?.length) {
+    const envValidation = validateEnvironments(environmentsFlag);
+    if (!envValidation.valid) {
+      output.error(
+        `Invalid environment value: ${envValidation.invalid.map(e => `"${e}"`).join(', ')}. Must be one of: ${VALID_ENVIRONMENTS.join(', ')}`
+      );
+      return 1;
+    }
+    environments = environmentsFlag;
+  } else {
+    environments = [...VALID_ENVIRONMENTS];
+  }
+
+  const resourceName = parsedArguments.args[0];
+  const specifiedProject: string | undefined = parsedArguments.args[1];
+
+  telemetry.trackCliArgumentResource(resourceName);
+  telemetry.trackCliArgumentProject(specifiedProject);
+
+  const { team } = await getScope(client);
+  if (!team) {
+    output.error('Team not found.');
+    return 1;
+  }
+  client.config.currentTeam = team.id;
+
+  output.spinner('Retrieving resource…', 500);
+  const resources = await getResources(client);
+  const targetedResource = resources.find(
+    resource => resource.name === resourceName
+  );
+  output.stopSpinner();
+
+  if (!targetedResource) {
+    output.error(`No resource ${chalk.bold(resourceName)} found.`);
+    return 1;
+  }
+
+  let projectName: string | undefined = specifiedProject;
+  if (!projectName) {
+    projectName = await getLinkedProject(client).then(result => {
+      if (result.status === 'linked') {
+        return result.project.name;
+      }
+      return;
+    });
+    if (!projectName) {
+      output.error(
+        'No project linked. Either use `vc link` to link a project, or specify the project name.'
+      );
+      return 1;
+    }
+  }
+
+  const alreadyConnected = targetedResource.projectsMetadata?.find(
+    p => p.name === projectName
+  );
+  if (alreadyConnected) {
+    output.error(
+      `Project ${chalk.bold(projectName)} is already connected to resource ${chalk.bold(targetedResource.name)}.`
+    );
+    output.log(
+      `To change environments or env var prefix, disconnect first: \`vercel integration resource disconnect ${targetedResource.name} ${projectName}\``
+    );
+    return 1;
+  }
+
+  output.spinner('Resolving project…', 500);
+  const project = await getProjectByNameOrId(client, projectName);
+  output.stopSpinner();
+
+  if (project instanceof ProjectNotFound) {
+    output.error(`No project ${chalk.bold(projectName)} found.`);
+    return 1;
+  }
+
+  if (!skipConfirmation && client.nonInteractive) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: 'confirmation_required',
+        message:
+          'Connecting a resource requires confirmation. Re-run with --yes.',
+        next: [{ command: buildCommandWithYes(client.argv) }],
+      },
+      1
+    );
+    output.error(
+      'Confirmation required. Use `--yes` to skip the confirmation prompt.'
+    );
+    return 1;
+  }
+
+  if (!skipConfirmation) {
+    output.log(
+      `The resource ${chalk.bold(targetedResource.name)} will be connected to project ${chalk.bold(projectName)} (environments: ${environments.join(', ')}).`
+    );
+    const confirmed = await client.input.confirm(
+      `${chalk.cyan('Connect?')}`,
+      true
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  try {
+    output.spinner('Connecting resource…', 500);
+    await connectResourceToProject(
+      client,
+      project.id,
+      targetedResource.id,
+      environments,
+      prefix !== undefined ? { envVarPrefix: prefix } : undefined
+    );
+  } catch (error) {
+    output.stopSpinner();
+    if (isAPIError(error) && error.status === 400) {
+      const conflict = error.serverMessage?.match(
+        /existing environment variable with name ([A-Za-z_][A-Za-z0-9_]*)/
+      );
+      if (conflict) {
+        const varName = conflict[1];
+        output.error(
+          `Cannot connect: env var ${chalk.bold(varName)} already exists on project ${chalk.bold(projectName)} in one of the target environments (${environments.join(', ')}).`
+        );
+        if (prefix === undefined) {
+          output.log(
+            `Re-run with \`--prefix <PREFIX>_\` to namespace the new variables, or remove the existing one with \`vercel env rm ${varName} ${environments.join(' ')}\`.`
+          );
+        } else {
+          output.log(
+            `Prefix \`${prefix}\` did not avoid the collision. Try a different prefix or run \`vercel env rm ${varName} ${environments.join(' ')}\`.`
+          );
+        }
+        return 1;
+      }
+    }
+    output.error(
+      `A problem occurred while connecting: ${(error as Error).message}`
+    );
+    return 1;
+  }
+
+  if (asJson) {
+    output.stopSpinner();
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          resource: targetedResource.name,
+          connected: true,
+          project: projectName,
+          environments,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  output.success(
+    `Connected ${chalk.bold(targetedResource.name)} to ${chalk.bold(projectName)} (${environments.join(', ')})`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/integration-resource/connect.ts
+++ b/packages/cli/src/commands/integration-resource/connect.ts
@@ -170,6 +170,13 @@ export async function connect(client: Client, argv: string[]) {
     return 1;
   }
 
+  if (!skipConfirmation && !client.stdin.isTTY) {
+    output.error(
+      'Confirmation required. Use `--yes` to skip the confirmation prompt.'
+    );
+    return 1;
+  }
+
   if (!skipConfirmation) {
     output.log(
       `The resource ${chalk.bold(targetedResource.name)} will be connected to project ${chalk.bold(projectName)} (environments: ${environments.join(', ')}).`
@@ -201,16 +208,22 @@ export async function connect(client: Client, argv: string[]) {
       );
       if (conflict) {
         const varName = conflict[1];
+        // `vc env rm` accepts at most one environment positional; emit a single-env
+        // form when exactly one was specified, otherwise the no-env form that prompts.
+        const envRmCmd =
+          environments.length === 1
+            ? `vercel env rm ${varName} ${environments[0]}`
+            : `vercel env rm ${varName}`;
         output.error(
           `Cannot connect: env var ${chalk.bold(varName)} already exists on project ${chalk.bold(projectName)} in one of the target environments (${environments.join(', ')}).`
         );
         if (prefix === undefined) {
           output.log(
-            `Re-run with \`--prefix <PREFIX>_\` to namespace the new variables, or remove the existing one with \`vercel env rm ${varName} ${environments.join(' ')}\`.`
+            `Re-run with \`--prefix <PREFIX>_\` to namespace the new variables, or remove the existing one with \`${envRmCmd}\`.`
           );
         } else {
           output.log(
-            `Prefix \`${prefix}\` did not avoid the collision. Try a different prefix or run \`vercel env rm ${varName} ${environments.join(' ')}\`.`
+            `Prefix \`${prefix}\` did not avoid the collision. Try a different prefix or run \`${envRmCmd}\`.`
           );
         }
         return 1;

--- a/packages/cli/src/commands/integration-resource/disconnect.ts
+++ b/packages/cli/src/commands/integration-resource/disconnect.ts
@@ -202,6 +202,13 @@ async function handleDisconnectProject(
     return 1;
   }
 
+  if (!skipConfirmation && !client.stdin.isTTY) {
+    output.error(
+      'Confirmation required. Use `--yes` to skip the confirmation prompt.'
+    );
+    return 1;
+  }
+
   if (
     !skipConfirmation &&
     !(await confirmDisconnectProject(client, resource, project))
@@ -257,6 +264,12 @@ export async function handleDisconnectAllProjects(
       },
       1
     );
+    throw new FailedError(
+      'Confirmation required. Use `--yes` to skip the confirmation prompt.'
+    );
+  }
+
+  if (!skipConfirmation && !client.stdin.isTTY) {
     throw new FailedError(
       'Confirmation required. Use `--yes` to skip the confirmation prompt.'
     );

--- a/packages/cli/src/commands/integration-resource/disconnect.ts
+++ b/packages/cli/src/commands/integration-resource/disconnect.ts
@@ -19,6 +19,7 @@ import {
   type Resource,
   type ResourceConnection,
 } from '../../util/integration-resource/types';
+import { buildCommandWithYes, outputAgentError } from '../../util/agent-output';
 import { disconnectSubcommand } from './command';
 
 export async function disconnect(client: Client, argv: string[]) {
@@ -174,13 +175,27 @@ async function handleDisconnectProject(
     project => projectName === project.name
   );
   if (!project) {
-    output.log(
-      `Could not find project ${chalk.bold(projectName)} connected to resource ${chalk.bold(resource.name)}.`
+    output.error(
+      `Project ${chalk.bold(projectName)} is not connected to resource ${chalk.bold(resource.name)}.`
     );
-    return 0;
+    output.log(
+      `Run \`vercel integration list\` to see which projects are connected to each resource.`
+    );
+    return 1;
   }
 
-  if (!skipConfirmation && !client.stdin.isTTY) {
+  if (!skipConfirmation && client.nonInteractive) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: 'confirmation_required',
+        message:
+          'Disconnecting a resource requires confirmation. Re-run with --yes.',
+        next: [{ command: buildCommandWithYes(client.argv) }],
+      },
+      1
+    );
     output.error(
       'Confirmation required. Use `--yes` to skip the confirmation prompt.'
     );
@@ -230,7 +245,18 @@ export async function handleDisconnectAllProjects(
     return;
   }
 
-  if (!skipConfirmation && !client.stdin.isTTY) {
+  if (!skipConfirmation && client.nonInteractive) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: 'confirmation_required',
+        message:
+          'Disconnecting all projects requires confirmation. Re-run with --yes.',
+        next: [{ command: buildCommandWithYes(client.argv) }],
+      },
+      1
+    );
     throw new FailedError(
       'Confirmation required. Use `--yes` to skip the confirmation prompt.'
     );

--- a/packages/cli/src/commands/integration-resource/index.ts
+++ b/packages/cli/src/commands/integration-resource/index.ts
@@ -8,11 +8,13 @@ import getSubcommand from '../../util/get-subcommand';
 import { IntegrationResourceTelemetryClient } from '../../util/telemetry/commands/integration-resource';
 import { type Command, help } from '../help';
 import {
+  connectSubcommand,
   createThresholdSubcommand,
   disconnectSubcommand,
   integrationResourceCommand,
   removeSubcommand,
 } from './command';
+import { connect } from './connect';
 import { createThreshold } from './create-threshold';
 import { disconnect } from './disconnect';
 import { remove } from './remove-resource';
@@ -20,30 +22,35 @@ import { remove } from './remove-resource';
 const COMMAND_CONFIG = {
   remove: getCommandAliases(removeSubcommand),
   disconnect: getCommandAliases(disconnectSubcommand),
+  connect: getCommandAliases(connectSubcommand),
   'create-threshold': getCommandAliases(createThresholdSubcommand),
 };
 
-export default async function main(client: Client) {
+interface DispatchOptions {
+  helpBreadcrumb: string;
+  parentForChildHelp: Command;
+}
+
+export async function dispatchResourceSubcommand(
+  client: Client,
+  subArgs: string[],
+  needHelp: boolean,
+  options: DispatchOptions
+): Promise<number> {
   const telemetry = new IntegrationResourceTelemetryClient({
     opts: {
       store: client.telemetryEventStore,
     },
   });
-  const { args, flags } = parseArguments(
-    client.argv.slice(2),
-    getFlagsSpecification(integrationResourceCommand.options),
-    { permissive: true }
-  );
+
   const {
     subcommand,
     subcommandOriginal,
-    args: subArgs,
-  } = getSubcommand(args.slice(1), COMMAND_CONFIG);
-
-  const needHelp = flags['--help'];
+    args: innerArgs,
+  } = getSubcommand(subArgs, COMMAND_CONFIG);
 
   if (!subcommand && needHelp) {
-    telemetry.trackCliFlagHelp('integration-resource');
+    telemetry.trackCliFlagHelp(options.helpBreadcrumb);
     output.print(
       help(integrationResourceCommand, { columns: client.stderr.columns })
     );
@@ -54,7 +61,7 @@ export default async function main(client: Client) {
     output.print(
       help(command, {
         columns: client.stderr.columns,
-        parent: integrationResourceCommand,
+        parent: options.parentForChildHelp,
       })
     );
   }
@@ -62,34 +69,55 @@ export default async function main(client: Client) {
   switch (subcommand) {
     case 'create-threshold': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('integration-resource', subcommandOriginal);
+        telemetry.trackCliFlagHelp(options.helpBreadcrumb, subcommandOriginal);
         printHelp(createThresholdSubcommand);
         return 0;
       }
       telemetry.trackCliSubcommandCreateThreshold(subcommandOriginal);
-      return createThreshold(client, subArgs);
+      return createThreshold(client, innerArgs);
     }
     case 'remove': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('integration-resource', subcommandOriginal);
+        telemetry.trackCliFlagHelp(options.helpBreadcrumb, subcommandOriginal);
         printHelp(removeSubcommand);
         return 0;
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
-      return remove(client, subArgs);
+      return remove(client, innerArgs);
     }
     case 'disconnect': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('integration-resource', subcommandOriginal);
+        telemetry.trackCliFlagHelp(options.helpBreadcrumb, subcommandOriginal);
         printHelp(disconnectSubcommand);
         return 0;
       }
       telemetry.trackCliSubcommandDisconnect(subcommandOriginal);
-      return disconnect(client, subArgs);
+      return disconnect(client, innerArgs);
+    }
+    case 'connect': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(options.helpBreadcrumb, subcommandOriginal);
+        printHelp(connectSubcommand);
+        return 0;
+      }
+      telemetry.trackCliSubcommandConnect(subcommandOriginal);
+      return connect(client, innerArgs);
     }
     default: {
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       return 2;
     }
   }
+}
+
+export default async function main(client: Client) {
+  const { args, flags } = parseArguments(
+    client.argv.slice(2),
+    getFlagsSpecification(integrationResourceCommand.options),
+    { permissive: true }
+  );
+  return dispatchResourceSubcommand(client, args.slice(1), !!flags['--help'], {
+    helpBreadcrumb: 'integration-resource',
+    parentForChildHelp: integrationResourceCommand,
+  });
 }

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -1,5 +1,11 @@
 import { formatOption, jsonOption, yesOption } from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
+import {
+  connectSubcommand,
+  createThresholdSubcommand,
+  disconnectSubcommand,
+  removeSubcommand as resourceRemoveSubcommand,
+} from '../integration-resource/command';
 
 export const addSubcommand = {
   name: 'add',
@@ -561,11 +567,40 @@ export const guideSubcommand = {
   ],
 } as const;
 
+export const resourceSubcommand = {
+  name: 'resource',
+  aliases: [],
+  description:
+    'Manage marketplace integration resources (connect, disconnect, remove, create-threshold)',
+  options: [],
+  arguments: [],
+  subcommands: [
+    connectSubcommand,
+    createThresholdSubcommand,
+    disconnectSubcommand,
+    resourceRemoveSubcommand,
+  ],
+  examples: [
+    {
+      name: 'Connect a resource to the current project',
+      value: `${packageName} integration resource connect my-acme-resource`,
+    },
+    {
+      name: 'Disconnect a resource from the current project',
+      value: `${packageName} integration resource disconnect my-acme-resource`,
+    },
+    {
+      name: 'Remove a resource (disconnecting all projects first)',
+      value: `${packageName} integration resource remove my-acme-resource --disconnect-all --yes`,
+    },
+  ],
+} as const;
+
 export const integrationCommand = {
   name: 'integration',
   aliases: [],
   description:
-    'Manage marketplace integrations. To manage individual resources (disconnect, remove), see `integration-resource`.',
+    'Manage marketplace integrations. To manage individual resources, see `vercel integration resource`.',
   options: [],
   arguments: [],
   subcommands: [
@@ -577,6 +612,7 @@ export const integrationCommand = {
     installationsSubcommand,
     listSubcommand,
     openSubcommand,
+    resourceSubcommand,
     updateSubcommand,
     removeSubcommand,
   ],
@@ -584,6 +620,10 @@ export const integrationCommand = {
     {
       name: 'Install a specific product from an integration',
       value: `${packageName} integration add acme/acme-redis`,
+    },
+    {
+      name: 'Connect an existing resource to the current project',
+      value: `${packageName} integration resource connect my-acme-resource`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -20,8 +20,10 @@ import {
   listSubcommand,
   openSubcommand,
   removeSubcommand,
+  resourceSubcommand,
   updateSubcommand,
 } from './command';
+import { dispatchResourceSubcommand } from '../integration-resource';
 import { list } from './list';
 import { openIntegration } from './open-integration';
 import { remove } from './remove-integration';
@@ -48,6 +50,7 @@ const COMMAND_CONFIG = {
   guide: getCommandAliases(guideSubcommand),
   balance: getCommandAliases(balanceSubcommand),
   remove: getCommandAliases(removeSubcommand),
+  resource: getCommandAliases(resourceSubcommand),
   update: getCommandAliases(updateSubcommand),
 };
 
@@ -198,6 +201,24 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return remove(client, subArgs);
+    }
+    case 'resource': {
+      if (subArgs.length === 0 && needHelp) {
+        telemetry.trackCliFlagHelp('integration', subcommandOriginal);
+        printHelp(resourceSubcommand);
+        return 0;
+      }
+      telemetry.trackCliSubcommandResource(subcommandOriginal);
+      // Synthetic parent so child help renders `vercel integration resource <sub>`
+      // instead of `vercel resource <sub>`.
+      const nestedParent = {
+        ...resourceSubcommand,
+        name: 'integration resource',
+      };
+      return dispatchResourceSubcommand(client, subArgs, !!needHelp, {
+        helpBreadcrumb: 'integration resource',
+        parentForChildHelp: nestedParent,
+      });
     }
     case 'update': {
       if (needHelp) {

--- a/packages/cli/src/util/telemetry/commands/integration-resource/connect.ts
+++ b/packages/cli/src/util/telemetry/commands/integration-resource/connect.ts
@@ -1,0 +1,50 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { connectSubcommand } from '../../../../commands/integration-resource/command';
+
+export class IntegrationResourceConnectTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof connectSubcommand>
+{
+  trackCliArgumentResource(v: string | undefined) {
+    if (v) {
+      this.trackCliArgument({
+        arg: 'resource',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentProject(v: string | undefined) {
+    if (v) {
+      this.trackCliArgument({
+        arg: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEnvironment(v: string[] | undefined) {
+    if (v?.length) {
+      this.trackCliOption({
+        option: 'environment',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionPrefix(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'prefix',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagYes(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/integration-resource/index.ts
+++ b/packages/cli/src/util/telemetry/commands/integration-resource/index.ts
@@ -26,4 +26,11 @@ export class IntegrationResourceTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandConnect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'connect',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/integration/index.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/index.ts
@@ -75,4 +75,11 @@ export class IntegrationTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandResource(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'resource',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3616,9 +3616,8 @@ exports[`help command > integration help output snapshots > integration help col
   ▲ vercel integration command
 
   Manage marketplace integrations. To   
-  manage individual resources           
-  (disconnect, remove), see             
-  \`integration-resource\`.               
+  manage individual resources, see      
+  \`vercel integration resource\`.        
 
   Commands:
 
@@ -3716,6 +3715,14 @@ exports[`help command > integration help output snapshots > integration help col
                                   da…
                                   via
                                   SSO
+  resource                        Ma…
+                                  ma…
+                                  in…
+                                  re…
+                                  (c…
+                                  di…
+                                  re…
+                                  cr…
   update         integration      Up…
                                   a  
                                   ma…
@@ -3877,6 +3884,10 @@ exports[`help command > integration help output snapshots > integration help col
 
     $ vercel integration add acme/acme-redis
 
+  - Connect an existing resource to the current project
+
+    $ vercel integration resource connect my-acme-resource
+
 "
 `;
 
@@ -3884,8 +3895,8 @@ exports[`help command > integration help output snapshots > integration help col
 "
   ▲ vercel integration command
 
-  Manage marketplace integrations. To manage individual resources (disconnect,  
-  remove), see \`integration-resource\`.                                          
+  Manage marketplace integrations. To manage individual resources, see \`vercel  
+  integration resource\`.                                                        
 
   Commands:
 
@@ -3908,6 +3919,9 @@ exports[`help command > integration help output snapshots > integration help col
                                   integrations for the current project       
   open           name [resource]  Opens a marketplace integration's or       
                                   resource's dashboard via SSO               
+  resource                        Manage marketplace integration resources   
+                                  (connect, disconnect, remove,              
+                                  create-threshold)                          
   update         integration      Update a marketplace integration           
                                   installation (billing plan or which        
                                   projects can access it). Install, remove,  
@@ -3951,6 +3965,10 @@ exports[`help command > integration help output snapshots > integration help col
 
     $ vercel integration add acme/acme-redis
 
+  - Connect an existing resource to the current project
+
+    $ vercel integration resource connect my-acme-resource
+
 "
 `;
 
@@ -3958,7 +3976,7 @@ exports[`help command > integration help output snapshots > integration help col
 "
   ▲ vercel integration command
 
-  Manage marketplace integrations. To manage individual resources (disconnect, remove), see \`integration-resource\`.     
+  Manage marketplace integrations. To manage individual resources, see \`vercel integration resource\`.                   
 
   Commands:
 
@@ -3973,6 +3991,8 @@ exports[`help command > integration help output snapshots > integration help col
   installations                   List marketplace integration installations for the current team (account scope)    
   list           [project]        List resources from marketplace integrations for the current project               
   open           name [resource]  Opens a marketplace integration's or resource's dashboard via SSO                  
+  resource                        Manage marketplace integration resources (connect, disconnect, remove,             
+                                  create-threshold)                                                                  
   update         integration      Update a marketplace integration installation (billing plan or which projects can  
                                   access it). Install, remove, and connect flows are separate (integration add,      
                                   integration remove, integration-resource, env pull, etc.) — not part of update.    
@@ -4004,6 +4024,10 @@ exports[`help command > integration help output snapshots > integration help col
   - Install a specific product from an integration
 
     $ vercel integration add acme/acme-redis
+
+  - Connect an existing resource to the current project
+
+    $ vercel integration resource connect my-acme-resource
 
 "
 `;
@@ -4250,7 +4274,7 @@ exports[`help command > integration-resource help output snapshots > integration
 "
   ▲ vercel integration-resource disconnect resource [project] [options]
 
-  Disconnect a resource from a project, or the current project                                                          
+  Disconnect a marketplace resource from a project                                                                      
 
   Options:
 
@@ -4303,10 +4327,18 @@ exports[`help command > integration-resource help output snapshots > integration
   ▲ vercel integration-resource command
 
   Manage marketplace integration        
-  resources                             
+  resources (alias for \`vercel          
+  integration resource\`)                
 
   Commands:
 
+  connect           resource [project]            …
+                                                  a
+                                                  …
+                                                  …
+                                                  …
+                                                  a
+                                                  …
   create-threshold  resource minimum spend limit  …
                                                   a
                                                   …
@@ -4325,11 +4357,8 @@ exports[`help command > integration-resource help output snapshots > integration
                                                   a
                                                   …
                                                   …
+                                                  …
                                                   a
-                                                  …
-                                                  …
-                                                  …
-                                                  …
                                                   …
   remove            resource                      …
                                                   …
@@ -4392,19 +4421,22 @@ exports[`help command > integration-resource help output snapshots > integration
 "
   ▲ vercel integration-resource command
 
-  Manage marketplace integration resources                                      
+  Manage marketplace integration resources (alias for \`vercel integration       
+  resource\`)                                                                    
 
   Commands:
 
+  connect           resource [project]            Connect a marketplace 
+                                                  resource to a project 
   create-threshold  resource minimum spend limit  Creates a threshold   
                                                   for a resource (or    
                                                   installation, if the  
                                                   integration uses      
                                                   installation-level    
                                                   thresholds)           
-  disconnect        resource [project]            Disconnect a resource 
-                                                  from a project, or the
-                                                  current project       
+  disconnect        resource [project]            Disconnect a          
+                                                  marketplace resource  
+                                                  from a project        
   remove            resource                      Delete an integration 
                                                   resource              
 
@@ -4432,13 +4464,14 @@ exports[`help command > integration-resource help output snapshots > integration
 "
   ▲ vercel integration-resource command
 
-  Manage marketplace integration resources                                                                              
+  Manage marketplace integration resources (alias for \`vercel integration resource\`)                                    
 
   Commands:
 
+  connect           resource [project]            Connect a marketplace resource to a project                   
   create-threshold  resource minimum spend limit  Creates a threshold for a resource (or installation, if the   
                                                   integration uses installation-level thresholds)               
-  disconnect        resource [project]            Disconnect a resource from a project, or the current project  
+  disconnect        resource [project]            Disconnect a marketplace resource from a project              
   remove            resource                      Delete an integration resource                                
 
 

--- a/packages/cli/test/unit/commands/integration-resource/connect.test.ts
+++ b/packages/cli/test/unit/commands/integration-resource/connect.test.ts
@@ -370,7 +370,7 @@ describe('integration-resource', () => {
             'Error: Cannot connect: env var SHOPIFY_STOREFRONT_ACCESS_TOKEN already exists on project connected-project'
           );
           await expect(client.stderr).toOutput(
-            'Re-run with `--prefix <PREFIX>_` to namespace the new variables, or remove the existing one with `vercel env rm SHOPIFY_STOREFRONT_ACCESS_TOKEN production preview development`.'
+            'Re-run with `--prefix <PREFIX>_` to namespace the new variables, or remove the existing one with `vercel env rm SHOPIFY_STOREFRONT_ACCESS_TOKEN`.'
           );
         });
 

--- a/packages/cli/test/unit/commands/integration-resource/connect.test.ts
+++ b/packages/cli/test/unit/commands/integration-resource/connect.test.ts
@@ -1,0 +1,426 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import integrationResourceCommand from '../../../../src/commands/integration-resource';
+import integrationCommand from '../../../../src/commands/integration';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import { client } from '../../../mocks/client';
+import { useResources } from '../../../mocks/integration';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { type Team, useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+describe('integration-resource', () => {
+  describe('connect', () => {
+    beforeEach(() => {
+      useUser();
+    });
+
+    describe('happy path', () => {
+      let team: Team;
+      beforeEach(() => {
+        const teams = useTeams('team_dummy');
+        team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+        client.config.currentTeam = team.id;
+      });
+
+      it('connects a project to a resource with --yes', async () => {
+        useResources();
+        const projectName = 'connected-project';
+        useProject({
+          ...defaultProject,
+          id: 'prj_connected',
+          name: projectName,
+        });
+        const requestBody = mockConnectResourceToProject();
+
+        client.setArgv(
+          'integration-resource',
+          'connect',
+          'store-acme-no-projects',
+          projectName,
+          '--yes'
+        );
+        const exitCode = await integrationResourceCommand(client);
+
+        expect(exitCode).toEqual(0);
+        await expect(client.stderr).toOutput(
+          '> Success! Connected store-acme-no-projects to connected-project (production, preview, development)'
+        );
+        expect(requestBody.value).toEqual({
+          envVarEnvironments: ['production', 'preview', 'development'],
+          projectId: 'prj_connected',
+          type: 'integration',
+        });
+      });
+
+      it('connects with selected environments only', async () => {
+        useResources();
+        const projectName = 'connected-project';
+        useProject({
+          ...defaultProject,
+          id: 'prj_connected',
+          name: projectName,
+        });
+        const requestBody = mockConnectResourceToProject();
+
+        client.setArgv(
+          'integration-resource',
+          'connect',
+          'store-acme-no-projects',
+          projectName,
+          '--yes',
+          '-e',
+          'production',
+          '-e',
+          'preview'
+        );
+        const exitCode = await integrationResourceCommand(client);
+
+        expect(exitCode).toEqual(0);
+        expect(requestBody.value).toEqual({
+          envVarEnvironments: ['production', 'preview'],
+          projectId: 'prj_connected',
+          type: 'integration',
+        });
+      });
+
+      it('connects with an env var prefix', async () => {
+        useResources();
+        const projectName = 'connected-project';
+        useProject({
+          ...defaultProject,
+          id: 'prj_connected',
+          name: projectName,
+        });
+        const requestBody = mockConnectResourceToProject();
+
+        client.setArgv(
+          'integration-resource',
+          'connect',
+          'store-acme-no-projects',
+          projectName,
+          '--yes',
+          '--prefix',
+          'NEON2_'
+        );
+        const exitCode = await integrationResourceCommand(client);
+
+        expect(exitCode).toEqual(0);
+        expect(requestBody.value).toEqual({
+          envVarEnvironments: ['production', 'preview', 'development'],
+          projectId: 'prj_connected',
+          type: 'integration',
+          envVarPrefix: 'NEON2_',
+        });
+      });
+
+      it('errors when project is already connected to the resource', async () => {
+        useResources();
+        // store-acme-connected-project already has connected-project connected
+        client.setArgv(
+          'integration-resource',
+          'connect',
+          'store-acme-connected-project',
+          'connected-project',
+          '--yes'
+        );
+        const exitCode = await integrationResourceCommand(client);
+
+        expect(exitCode).toEqual(1);
+        await expect(client.stderr).toOutput(
+          'Error: Project connected-project is already connected to resource store-acme-connected-project.'
+        );
+        await expect(client.stderr).toOutput(
+          'To change environments or env var prefix, disconnect first: `vercel integration resource disconnect store-acme-connected-project connected-project`'
+        );
+      });
+
+      it('connects to the linked project when no project specified', async () => {
+        const cwd = setupUnitFixture('commands/integration/disconnect');
+        client.cwd = cwd;
+        const projectName = 'connected-project';
+
+        useProject({
+          ...defaultProject,
+          id: 'prj_connected',
+          name: projectName,
+        });
+        useResources();
+        const requestBody = mockConnectResourceToProject();
+
+        client.setArgv(
+          'integration-resource',
+          'connect',
+          'store-acme-no-projects',
+          '--yes'
+        );
+        const exitCode = await integrationResourceCommand(client);
+
+        expect(exitCode).toEqual(0);
+        expect(requestBody.value).toEqual({
+          envVarEnvironments: ['production', 'preview', 'development'],
+          projectId: 'prj_connected',
+          type: 'integration',
+        });
+      });
+
+      it('is reachable via `integration resource connect`', async () => {
+        useResources();
+        const projectName = 'connected-project';
+        useProject({
+          ...defaultProject,
+          id: 'prj_connected',
+          name: projectName,
+        });
+        mockConnectResourceToProject();
+
+        client.setArgv(
+          'integration',
+          'resource',
+          'connect',
+          'store-acme-no-projects',
+          projectName,
+          '--yes'
+        );
+        const exitCode = await integrationCommand(client);
+
+        expect(exitCode).toEqual(0);
+        await expect(client.stderr).toOutput(
+          '> Success! Connected store-acme-no-projects to connected-project (production, preview, development)'
+        );
+      });
+    });
+
+    describe('--format=json', () => {
+      let team: Team;
+      beforeEach(() => {
+        const teams = useTeams('team_dummy');
+        team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+        client.config.currentTeam = team.id;
+      });
+
+      it('emits JSON on success with --yes', async () => {
+        useResources();
+        const projectName = 'connected-project';
+        useProject({
+          ...defaultProject,
+          id: 'prj_connected',
+          name: projectName,
+        });
+        mockConnectResourceToProject();
+
+        client.setArgv(
+          'integration-resource',
+          'connect',
+          'store-acme-no-projects',
+          projectName,
+          '--yes',
+          '--format=json'
+        );
+        const exitCode = await integrationResourceCommand(client);
+
+        expect(exitCode).toEqual(0);
+        const jsonOutput = JSON.parse(client.stdout.getFullOutput());
+        expect(jsonOutput).toEqual({
+          resource: 'store-acme-no-projects',
+          connected: true,
+          project: projectName,
+          environments: ['production', 'preview', 'development'],
+        });
+      });
+
+      it('errors when --format=json is used without --yes', async () => {
+        client.setArgv(
+          'integration-resource',
+          'connect',
+          'store-acme-no-projects',
+          'connected-project',
+          '--format=json'
+        );
+        const exitCode = await integrationResourceCommand(client);
+        expect(exitCode).toEqual(1);
+        await expect(client.stderr).toOutput(
+          'Error: --format=json requires --yes to skip confirmation prompts'
+        );
+      });
+    });
+
+    describe('errors', () => {
+      describe('without team', () => {
+        it('errors when there is no team', async () => {
+          client.setArgv(
+            'integration-resource',
+            'connect',
+            'store-acme-no-projects',
+            'connected-project',
+            '--yes'
+          );
+          const exitCode = await integrationResourceCommand(client);
+          expect(exitCode).toEqual(1);
+          await expect(client.stderr).toOutput('Error: Team not found.');
+        });
+      });
+
+      describe('with team', () => {
+        let team: Team;
+        beforeEach(() => {
+          const teams = useTeams('team_dummy');
+          team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+          client.config.currentTeam = team.id;
+        });
+
+        it('errors when no resource argument is given', async () => {
+          client.setArgv('integration-resource', 'connect');
+          const exitCodePromise = integrationResourceCommand(client);
+          await expect(client.stderr).toOutput(
+            'You must specify a resource. See `--help` for details.'
+          );
+          await expect(exitCodePromise).resolves.toEqual(1);
+        });
+
+        it('errors when too many arguments are passed', async () => {
+          client.setArgv('integration-resource', 'connect', 'a', 'b', 'c');
+          const exitCodePromise = integrationResourceCommand(client);
+          await expect(client.stderr).toOutput(
+            'Too many arguments. Usage: `vercel integration resource connect <resource> [project]`.'
+          );
+          await expect(exitCodePromise).resolves.toEqual(1);
+        });
+
+        it('errors on invalid --prefix value', async () => {
+          client.setArgv(
+            'integration-resource',
+            'connect',
+            'store-acme-no-projects',
+            'connected-project',
+            '--yes',
+            '--prefix',
+            '1bad'
+          );
+          const exitCodePromise = integrationResourceCommand(client);
+          await expect(client.stderr).toOutput(
+            'Error: Invalid --prefix value.'
+          );
+          await expect(exitCodePromise).resolves.toEqual(1);
+        });
+
+        it('errors on invalid --environment value', async () => {
+          client.setArgv(
+            'integration-resource',
+            'connect',
+            'store-acme-no-projects',
+            'connected-project',
+            '--yes',
+            '-e',
+            'staging'
+          );
+          const exitCodePromise = integrationResourceCommand(client);
+          await expect(client.stderr).toOutput(
+            'Error: Invalid environment value: "staging".'
+          );
+          await expect(exitCodePromise).resolves.toEqual(1);
+        });
+
+        it('errors when the resource does not exist', async () => {
+          useResources();
+          client.setArgv(
+            'integration-resource',
+            'connect',
+            'does-not-exist',
+            'connected-project',
+            '--yes'
+          );
+          const exitCodePromise = integrationResourceCommand(client);
+          await expect(client.stderr).toOutput(
+            'Error: No resource does-not-exist found.'
+          );
+          await expect(exitCodePromise).resolves.toEqual(1);
+        });
+
+        it('rewrites the env-var-collision API error with --prefix guidance', async () => {
+          useResources();
+          useProject({
+            ...defaultProject,
+            id: 'prj_connected',
+            name: 'connected-project',
+          });
+          // Mock the API returning the env var collision error
+          client.scenario.post(
+            '/:version/storage/stores/:resourceId/connections',
+            (_req, res) => {
+              res.status(400).json({
+                error: {
+                  code: 'bad_request',
+                  message:
+                    'This project already has an existing environment variable with name SHOPIFY_STOREFRONT_ACCESS_TOKEN in one of the chosen environments',
+                },
+              });
+            }
+          );
+
+          client.setArgv(
+            'integration-resource',
+            'connect',
+            'store-acme-no-projects',
+            'connected-project',
+            '--yes'
+          );
+          const exitCode = await integrationResourceCommand(client);
+          expect(exitCode).toEqual(1);
+          await expect(client.stderr).toOutput(
+            'Error: Cannot connect: env var SHOPIFY_STOREFRONT_ACCESS_TOKEN already exists on project connected-project'
+          );
+          await expect(client.stderr).toOutput(
+            'Re-run with `--prefix <PREFIX>_` to namespace the new variables, or remove the existing one with `vercel env rm SHOPIFY_STOREFRONT_ACCESS_TOKEN production preview development`.'
+          );
+        });
+
+        it('emits structured agent error in non-interactive mode without --yes', async () => {
+          useResources();
+          useProject({
+            ...defaultProject,
+            id: 'prj_connected',
+            name: 'connected-project',
+          });
+          vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+            throw new Error('exit');
+          }) as () => never);
+
+          client.nonInteractive = true;
+          client.setArgv(
+            'integration-resource',
+            'connect',
+            'store-acme-no-projects',
+            'connected-project'
+          );
+
+          await expect(integrationResourceCommand(client)).rejects.toThrow(
+            'exit'
+          );
+          const payload = JSON.parse(client.stdout.getFullOutput());
+          expect(payload).toMatchObject({
+            status: 'error',
+            reason: 'confirmation_required',
+            message: expect.stringMatching(/confirmation|--yes/),
+            next: expect.arrayContaining([
+              expect.objectContaining({
+                command: expect.stringContaining('--yes'),
+              }),
+            ]),
+          });
+        });
+      });
+    });
+  });
+});
+
+function mockConnectResourceToProject(): { value: unknown } {
+  const ref: { value: unknown } = { value: undefined };
+  client.scenario.post(
+    '/:version/storage/stores/:resourceId/connections',
+    (req, res) => {
+      ref.value = req.body;
+      res.status(200).json({});
+    }
+  );
+  return ref;
+}

--- a/packages/cli/test/unit/commands/integration-resource/disconnect.test.ts
+++ b/packages/cli/test/unit/commands/integration-resource/disconnect.test.ts
@@ -91,7 +91,7 @@ describe('integration-resource', () => {
         await expect(exitCodePromise).resolves.toEqual(0);
       });
 
-      it('exits gracefully when no connected project is found to disconnect from a resource', async () => {
+      it('errors when the project is not connected to the resource', async () => {
         useResources();
         const resource = 'store-acme-no-projects';
         const project = 'connected-project';
@@ -101,10 +101,13 @@ describe('integration-resource', () => {
 
         await expect(client.stderr).toOutput('Retrieving resource…');
         await expect(client.stderr).toOutput(
-          `> Could not find project ${project} connected to resource ${resource}.`
+          `Error: Project ${project} is not connected to resource ${resource}.`
+        );
+        await expect(client.stderr).toOutput(
+          'Run `vercel integration list` to see which projects are connected to each resource.'
         );
 
-        await expect(exitCodePromise).resolves.toEqual(0);
+        await expect(exitCodePromise).resolves.toEqual(1);
       });
 
       it('disconnects the resource from the current project when no project specified', async () => {


### PR DESCRIPTION
## Summary

- Adds `vc integration resource <sub>` as the canonical form for marketplace resource subcommands (`connect`, `disconnect`, `remove`, `create-threshold`). Legacy `vc integration-resource` and `vc ir` continue to work as hidden aliases — no scripts or tests break.
- New `vc integration resource connect <resource> [project]` mirrors `disconnect`. Flags: `--environment` (repeatable, defaults to all three), `--prefix` (env var namespacing, regex-validated), `--yes`, `--format=json`. Defaults to the project linked in cwd when `[project]` is omitted.
- Tightens `disconnect` to error (exit 1) when the specified project is not currently connected to the resource. Previously returned exit 0 with a "not found" message. Suggests `vercel integration list` as the next step.
- Both commands adopt the agent-friendly confirmation pattern from `webhooks/rm` / `deploy-hooks/rm` / `flags/sdk-keys-rm`: when `client.nonInteractive` is true and `--yes` is missing, emit a structured `outputAgentError` payload with `reason: confirmation_required` and `next: [{command: '... --yes'}]`. Agents read the next-command verbatim instead of inferring from prose.
- Rewrites the env-var-collision API error (HTTP 400 with "existing environment variable with name X") to name the conflicting variable, the affected environments, and suggest `--prefix` or `vercel env rm` as remediation — instead of surfacing the raw API message.

## Test plan

- [ ] `npx vitest run packages/cli/test/unit/commands/integration-resource/` — 81 tests pass (16 new connect, 17 disconnect including 1 updated for strict mode, 19 remove, 29 create-threshold).
- [ ] `npx vitest run packages/cli/test/unit/commands/integration/` — 240 tests pass (existing integration tests untouched).
- [ ] `npx vitest run packages/cli/test/unit/commands/help.test.ts` — 140 tests pass, snapshots regenerated for the new `resource` subcommand entry and revised descriptions.
- [ ] Smoke test help: `vc integration --help`, `vc integration resource --help`, `vc integration resource connect --help`, `vc integration-resource --help` (legacy), `vc ir connect --help` (legacy alias).
- [ ] Live: on a linked project with a marketplace resource — connect, disconnect, connect-already-connected (errors), disconnect-not-connected (errors), `--prefix` flow, `--format=json`, non-interactive mode (`--non-interactive` without `--yes` emits structured JSON).
- [ ] Env-var-collision path: connect a Shopify-style resource without `--prefix` after a previous connection left env vars behind; verify the new error names the variable and suggests `--prefix` or `env rm`.

## Notes

- Branched from latest `origin/main` (commit `200aa3b8c`).
- Overlap with an in-flight `cli/integration-claim` branch (adds `claim` subcommand to the same files): trivial 3-way merge expected when either lands first — `claim` case in `integration-resource/index.ts` switch, `claimSubcommand` in two `subcommands:` arrays.