### PR TITLE
[cli] prompt for unresolved metadata instead of opening the browser

### DIFF
--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -32,9 +32,14 @@ import {
 } from '../../util/integration/parse-metadata';
 import {
   isServerHandledRegion,
+  isHiddenOnCreate,
   getVisibleOptions,
   mergeMetadataSchemas,
 } from '../../util/integration/format-schema-help';
+import {
+  promptForMetadataFields,
+  resolvePromptableFields,
+} from '../../util/integration/prompt-for-metadata';
 import type { Metadata } from '../../util/integration/types';
 
 interface AddAutoProvisionOptions extends PostProvisionOptions {
@@ -301,39 +306,99 @@ export async function addAutoProvision(
       : 'server_default',
   });
 
-  // Provision resource
+  // Provision resource. Reads the current `metadata`/`installationMetadata`
+  // each call so it can be retried after prompting for fields the server
+  // couldn't resolve. Returns 1 (and reports) on a thrown error.
+  const provision = async (): Promise<AutoProvisionResult | 1> => {
+    output.spinner('Provisioning resource...');
+    try {
+      const res = await autoProvisionResource(
+        client,
+        integration.slug,
+        product.slug,
+        resourceName,
+        metadata,
+        acceptedPolicies,
+        options.billingPlanId,
+        browserInstallationId ?? options.installationId,
+        installationMetadata
+      );
+      output.stopSpinner();
+      return res;
+    } catch (error) {
+      output.stopSpinner();
+      telemetry.trackMarketplaceEvent(
+        'marketplace_checkout_provisioning_failed',
+        {
+          ...baseProps,
+          error_message: errorToString(error),
+        }
+      );
+      output.error(errorToString(error));
+      return 1;
+    }
+  };
+
   telemetry.trackMarketplaceEvent(
     'marketplace_checkout_provisioning_started',
     baseProps
   );
-  output.spinner('Provisioning resource...');
-  let result: AutoProvisionResult;
-  try {
-    result = await autoProvisionResource(
-      client,
-      integration.slug,
-      product.slug,
-      resourceName,
-      metadata,
-      acceptedPolicies,
-      options.billingPlanId,
-      browserInstallationId ?? options.installationId,
-      installationMetadata
-    );
-  } catch (error) {
-    output.stopSpinner();
-    telemetry.trackMarketplaceEvent(
-      'marketplace_checkout_provisioning_failed',
-      {
-        ...baseProps,
-        error_message: errorToString(error),
-      }
-    );
-    output.error(errorToString(error));
+  let result = await provision();
+  if (result === 1) {
     return 1;
   }
-  output.stopSpinner();
   output.debug(`Auto-provision result: ${JSON.stringify(result, null, 2)}`);
+
+  // The server returns a `metadata` step when a required field couldn't be
+  // resolved on its own (e.g. an AWS `vercel-region` it can't infer from the
+  // team's function regions). When interactive, collect those fields in the
+  // terminal and retry once — so an already-installed integration can be
+  // provisioned fully via the CLI instead of bouncing to the browser.
+  const metadataStep =
+    result.kind === 'metadata' ? (result as AutoProvisionFallback) : undefined;
+  if (metadataStep?.fields?.length && client.stdin.isTTY && !client.isAgent) {
+    const provided = { ...metadata, ...installationMetadata };
+    const fieldsToPrompt = resolvePromptableFields(
+      mergedParsingSchema,
+      provided,
+      metadataStep.fields
+    );
+    if (fieldsToPrompt.length > 0) {
+      output.log('Additional configuration required:');
+      const collected = await promptForMetadataFields(
+        client,
+        mergedParsingSchema,
+        fieldsToPrompt,
+        provided
+      );
+      // Route collected values into product vs installation buckets, matching
+      // how `-m` flags are split above.
+      for (const [key, value] of Object.entries(collected)) {
+        if (value === undefined) continue;
+        if (key in productSchemaProps) {
+          metadata[key] = value;
+        } else if (key in integrationSchemaProps) {
+          installationMetadata[key] = value;
+        } else {
+          metadata[key] = value;
+        }
+      }
+      telemetry.trackMarketplaceEvent(
+        'marketplace_checkout_metadata_prompted',
+        {
+          ...baseProps,
+          prompted_field_count: fieldsToPrompt.length,
+        }
+      );
+      result = await provision();
+      if (result === 1) {
+        return 1;
+      }
+      output.debug(
+        `Auto-provision result (after metadata prompt): ${JSON.stringify(result, null, 2)}`
+      );
+    }
+  }
 
   // Handle multiple installations
   if (
@@ -396,11 +461,23 @@ export async function addAutoProvision(
       return projectLink.exitCode;
     }
 
-    // Check for missing required metadata to give an actionable message
-    const missingRequired = (mergedParsingSchema.required ?? []).filter(key => {
+    // Check for missing required metadata to give an actionable message.
+    // Prefer the fields the server flagged as unresolved (which may include
+    // otherwise server-handled region fields it couldn't infer) so we can guide
+    // the user to the right `-m` flags instead of silently opening the browser.
+    const fallbackFieldKeys = fallback.fields?.map(f => f.key);
+    const missingRequired = (
+      fallbackFieldKeys ??
+      mergedParsingSchema.required ??
+      []
+    ).filter(key => {
       if (key in metadata || key in installationMetadata) return false;
       const prop = mergedParsingSchema.properties[key];
-      return prop && !isServerHandledRegion(prop);
+      if (!prop || isHiddenOnCreate(prop)) return false;
+      // When the server explicitly lists a field, it needs input even if it's a
+      // normally server-handled region.
+      if (fallbackFieldKeys) return true;
+      return !isServerHandledRegion(prop);
     });
 
     if (missingRequired.length > 0) {

--- a/packages/cli/src/util/integration/prompt-for-metadata.ts
+++ b/packages/cli/src/util/integration/prompt-for-metadata.ts
@@ -1,0 +1,167 @@
+import type Client from '../client';
+import {
+  getVisibleOptions,
+  isHiddenOnCreate,
+  isServerHandledRegion,
+} from './format-schema-help';
+import type { Metadata, MetadataSchema, MetadataSchemaProperty } from './types';
+
+/**
+ * Build `{ name, value }` choices from a field's visible `ui:options`,
+ * preserving option labels when present.
+ */
+function getOptionChoices(
+  prop: MetadataSchemaProperty
+): { name: string; value: string }[] | undefined {
+  const raw = prop['ui:options'];
+  if (!raw) return undefined;
+  const choices: { name: string; value: string }[] = [];
+  for (const opt of raw) {
+    if (typeof opt === 'string') {
+      if (opt) choices.push({ name: opt, value: opt });
+    } else if (!opt.hidden && opt.value) {
+      choices.push({ name: opt.label ?? opt.value, value: opt.value });
+    }
+  }
+  return choices.length > 0 ? choices : undefined;
+}
+
+function fieldLabel(key: string, prop: MetadataSchemaProperty): string {
+  return prop['ui:label'] || prop.description || key;
+}
+
+function isSelectLike(prop: MetadataSchemaProperty): boolean {
+  const control = prop['ui:control'];
+  return (
+    control === 'select' ||
+    control === 'radio-button' ||
+    isServerHandledRegion(prop)
+  );
+}
+
+/**
+ * Interactively prompt for the given metadata fields using the product's
+ * metadata schema. Used when the server can't resolve required fields (e.g. an
+ * AWS `vercel-region`) and returns a `metadata` step — so the CLI can collect
+ * them in-terminal and retry, instead of falling back to the browser.
+ *
+ * Only call this when `client.stdin.isTTY` is true. Fields already present in
+ * `existing` (provided via flags) or hidden on create are skipped. Returns the
+ * collected values (may be empty if there was nothing to prompt for).
+ */
+export async function promptForMetadataFields(
+  client: Client,
+  schema: MetadataSchema,
+  fieldKeys: string[],
+  existing: Metadata
+): Promise<Metadata> {
+  const collected: Metadata = {};
+
+  for (const key of fieldKeys) {
+    const prop = schema.properties[key];
+    if (!prop || isHiddenOnCreate(prop)) {
+      continue;
+    }
+    if (existing[key] !== undefined) {
+      continue;
+    }
+
+    const message = fieldLabel(key, prop);
+    const choices = getOptionChoices(prop);
+
+    // Select / region / enum-style fields
+    if (choices && (isSelectLike(prop) || prop.type === 'string')) {
+      collected[key] = await client.input.select<string>({ message, choices });
+      continue;
+    }
+
+    // Multi-value fields
+    if (prop.type === 'array') {
+      if (choices) {
+        const selected = await client.input.checkbox<string>({
+          message,
+          choices,
+        });
+        collected[key] = selected;
+      } else {
+        const raw = await client.input.text({
+          message: `${message} (comma-separated)`,
+        });
+        collected[key] = raw
+          .split(',')
+          .map(v => v.trim())
+          .filter(v => v.length > 0);
+      }
+      continue;
+    }
+
+    // Boolean / toggle
+    if (prop.type === 'boolean' || prop['ui:control'] === 'toggle') {
+      collected[key] = await client.input.confirm(
+        message,
+        prop.default === true
+      );
+      continue;
+    }
+
+    // Number
+    if (prop.type === 'number') {
+      const raw = await client.input.text({
+        message,
+        validate: (value: string) => {
+          const num = Number(value);
+          if (value.trim() === '' || Number.isNaN(num) || !Number.isFinite(num))
+            return 'Enter a valid number';
+          if (prop.minimum !== undefined && num < prop.minimum)
+            return `Must be >= ${prop.minimum}`;
+          if (prop.maximum !== undefined && num > prop.maximum)
+            return `Must be <= ${prop.maximum}`;
+          return true;
+        },
+      });
+      collected[key] = Number(raw);
+      continue;
+    }
+
+    // Free-form string (with enum validation if options exist)
+    collected[key] = await client.input.text({
+      message,
+      validate: (value: string) =>
+        value.trim().length > 0 ? true : `${message} is required`,
+    });
+  }
+
+  return collected;
+}
+
+/**
+ * The required fields the CLI should prompt for when an auto-provision
+ * `metadata` step comes back. Prefers the server-provided `fields` (which
+ * already excludes anything it resolved on its own); otherwise falls back to
+ * required fields in the schema that aren't yet satisfied. Hidden-on-create
+ * fields are never prompted for (they use server-side defaults).
+ */
+export function resolvePromptableFields(
+  schema: MetadataSchema,
+  existing: Metadata,
+  serverFields?: { key: string }[]
+): string[] {
+  const candidateKeys = serverFields?.length
+    ? serverFields.map(f => f.key)
+    : (schema.required ?? []);
+
+  return candidateKeys.filter(key => {
+    const prop = schema.properties[key];
+    if (!prop || isHiddenOnCreate(prop)) return false;
+    if (existing[key] !== undefined) return false;
+    // Only prompt for fields we can actually render a prompt for.
+    const hasOptions = Boolean(getVisibleOptions(prop));
+    return (
+      hasOptions ||
+      prop.type === 'string' ||
+      prop.type === 'number' ||
+      prop.type === 'boolean' ||
+      prop.type === 'array'
+    );
+  });
+}

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -228,6 +228,12 @@ export interface AutoProvisionFallback {
   product: AutoProvisionProduct;
   installation?: { id: string };
   installations?: AutoProvisionInstallationInfo[];
+  /**
+   * On a `metadata` step, the required fields the server could not resolve on
+   * its own (e.g. an AWS `vercel-region` field). The CLI prompts for exactly
+   * these and retries instead of falling back to the browser.
+   */
+  fields?: { key: string; message?: string }[];
 }
 
 export type AutoProvisionResult =

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -787,6 +787,15 @@ const autoProvisionResponses: Record<
     integration: autoProvisionIntegration,
     product: autoProvisionProduct,
   },
+  // A metadata step that names the unresolved required field, so the CLI can
+  // prompt for it and retry instead of falling back to the browser.
+  metadata_requires_region: {
+    kind: 'metadata',
+    url: 'https://vercel.com/acme/~/integrations/checkout/acme?productSlug=acme',
+    integration: autoProvisionIntegration,
+    product: autoProvisionProduct,
+    fields: [{ key: 'region' }],
+  },
   unknown: {
     kind: 'unknown',
     reason: 'unexpected_error',
@@ -1160,6 +1169,20 @@ export function useAutoProvision(opts?: {
       ) {
         res.status(201);
         res.json(autoProvisionResponses['provisioned']);
+        return;
+      }
+
+      // Simulate a server that needs a region it can't resolve on its own:
+      // return a metadata step until the request supplies `region`, then
+      // provision. Exercises the CLI's prompt-for-metadata + retry flow.
+      if (opts?.responseKey === 'metadata_requires_region') {
+        if (req.body.metadata?.region) {
+          res.status(201);
+          res.json(autoProvisionResponses['provisioned']);
+        } else {
+          res.status(422);
+          res.json(autoProvisionResponses['metadata_requires_region']);
+        }
         return;
       }
 

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -1172,6 +1172,64 @@ describe('integration add (auto-provision)', () => {
     });
   });
 
+  describe('interactive metadata prompting (server-provided fields)', () => {
+    it('prompts for an unresolved required field and retries instead of opening the browser', async () => {
+      const { requestBodies } = useAutoProvision({
+        responseKey: 'metadata_requires_region',
+      });
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Additional configuration required:'
+      );
+      await expect(client.stderr).toOutput('Primary Region');
+      client.stdin.write('\n'); // select first option (us-west-1)
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(openMock).not.toHaveBeenCalled();
+
+      // Two attempts: the first without region, the retry with the prompted value.
+      expect(requestBodies.length).toEqual(2);
+      expect(
+        (requestBodies[1] as { metadata?: unknown }).metadata
+      ).toMatchObject({
+        region: 'us-west-1',
+      });
+
+      expect(client.telemetryEventStore.readonlyEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: 'output:marketplace_checkout_metadata_prompted',
+            value: expect.stringContaining('"prompted_field_count":1'),
+          }),
+        ])
+      );
+    });
+
+    it('does not prompt in non-interactive mode; errors with -m guidance and no browser', async () => {
+      useAutoProvision({ responseKey: 'metadata_requires_region' });
+      client.stdin.isTTY = false;
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Missing required metadata: region.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+      expect(openMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe('--name flag', () => {
     beforeEach(() => {
       useAutoProvision({ responseKey: 'provisioned' });

--- a/packages/cli/test/unit/util/integration/prompt-for-metadata.test.ts
+++ b/packages/cli/test/unit/util/integration/prompt-for-metadata.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  promptForMetadataFields,
+  resolvePromptableFields,
+} from '../../../../src/util/integration/prompt-for-metadata';
+import type { MetadataSchema } from '../../../../src/util/integration/types';
+import { client } from '../../../mocks/client';
+
+const schema: MetadataSchema = {
+  type: 'object',
+  properties: {
+    region: {
+      type: 'string',
+      'ui:control': 'vercel-region',
+      'ui:label': 'Primary Region',
+      'ui:options': [
+        { value: 'us-east-1', label: 'East US' },
+        { value: 'us-west-2', label: 'West US' },
+      ],
+    },
+    encrypted: {
+      type: 'boolean',
+      'ui:control': 'toggle',
+      'ui:label': 'Encrypted',
+    },
+    label: {
+      type: 'string',
+      'ui:control': 'input',
+      'ui:label': 'Label',
+    },
+    internal: {
+      type: 'string',
+      'ui:control': 'input',
+      'ui:hidden': 'create',
+    },
+  },
+  required: ['region', 'encrypted', 'label', 'internal'],
+};
+
+describe('resolvePromptableFields', () => {
+  it('prefers server-provided fields', () => {
+    expect(resolvePromptableFields(schema, {}, [{ key: 'region' }])).toEqual([
+      'region',
+    ]);
+  });
+
+  it('falls back to schema.required when no server fields', () => {
+    // `internal` is hidden-on-create and is filtered out.
+    expect(resolvePromptableFields(schema, {})).toEqual([
+      'region',
+      'encrypted',
+      'label',
+    ]);
+  });
+
+  it('skips fields already provided', () => {
+    expect(
+      resolvePromptableFields(schema, { region: 'us-east-1' }, [
+        { key: 'region' },
+        { key: 'label' },
+      ])
+    ).toEqual(['label']);
+  });
+
+  it('skips hidden-on-create fields even if the server lists them', () => {
+    expect(resolvePromptableFields(schema, {}, [{ key: 'internal' }])).toEqual(
+      []
+    );
+  });
+});
+
+describe('promptForMetadataFields', () => {
+  it('prompts a select for option fields, confirm for booleans, text for free-form', async () => {
+    const resultPromise = promptForMetadataFields(
+      client,
+      schema,
+      ['region', 'encrypted', 'label'],
+      {}
+    );
+
+    await expect(client.stderr).toOutput('Primary Region');
+    client.stdin.write('\n'); // first option: us-east-1
+
+    await expect(client.stderr).toOutput('Encrypted');
+    client.stdin.write('y\n');
+
+    await expect(client.stderr).toOutput('Label');
+    client.stdin.write('my-db\n');
+
+    const result = await resultPromise;
+    expect(result).toEqual({
+      region: 'us-east-1',
+      encrypted: true,
+      label: 'my-db',
+    });
+  });
+
+  it('skips fields already provided', async () => {
+    const result = await promptForMetadataFields(client, schema, ['region'], {
+      region: 'us-west-2',
+    });
+    expect(result).toEqual({});
+  });
+});


### PR DESCRIPTION
## Why

`vercel integration add aws/<product>` opened the browser checkout even when the integration was **already installed** (e.g. via a connected AWS account):

```
➜ vc i aws/opensearch --installation-id icfg_…
> Installing Amazon OpenSearch Serverless by AWS under acme-marketplace-team
> Additional setup required. Opening browser...
```

Root cause: OpenSearch requires `region` (a `vercel-region` control) and `collectionType`. With no `-m` flags the server can't infer a region from the team's function regions, so auto-provision returns a `metadata` step. The CLI's "missing required metadata" guard **excluded** `region` (treated as server-handled), so `missingRequired` was empty and it silently fell back to the browser (`add-auto-provision.ts`).

## What

When auto-provision returns a `metadata` step that lists the fields the server couldn't resolve (new API `fields` — see vercel/api#74659):

- **Interactive (TTY):** prompt for exactly those fields using the product's metadata schema (region picker, select, boolean, number, free-form text), then retry auto-provision once. No browser.
- **Non-interactive / agent:** error with the precise `-m` flags to pass — now including unresolved region fields — instead of opening the browser.

New `util/integration/prompt-for-metadata.ts` holds the prompting + `resolvePromptableFields` (prefers the server's `fields`, skips hidden-on-create and already-provided fields).

Prompting is gated on the server explicitly returning `fields`, so behavior for integrations whose backend doesn't send them is unchanged.

## Depends on

vercel/api#74659 (adds `fields` to the metadata step).

## Testing

- `add-auto-provision.test.ts`: prompts-for-region-then-provisions (asserts the retry body carries the prompted `region`, no browser); non-TTY errors with `-m` guidance and no browser.
- `prompt-for-metadata.test.ts`: `resolvePromptableFields` + select/confirm/text prompt branches.
- Full integration suite: 348 passing; type-check + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)