### PR TITLE
Add Connect authorization detail types

### DIFF
--- a/.changeset/connex-authorization-details-types.md
+++ b/.changeset/connex-authorization-details-types.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add typed support for well-known Connect authorization details.

--- a/packages/connect/src/authorization-details.ts
+++ b/packages/connect/src/authorization-details.ts
@@ -1,0 +1,15 @@
+export type ConnectAuthorizationDetail =
+  | ConnectGitHubAppInstallationAuthorizationDetail
+  | ConnectCustomAuthorizationDetail;
+
+export interface ConnectCustomAuthorizationDetail {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface ConnectGitHubAppInstallationAuthorizationDetail {
+  type: 'github_app_installation';
+  org?: string;
+  permissions?: string | string[];
+  repositories?: string | string[];
+}

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -17,3 +17,5 @@ export {
   type ConnectAuthorizationOptions,
   type ConnectAuthorizationResponse,
 } from './authorization.js';
+
+export type { ConnectAuthorizationDetail } from './authorization-details.js';

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -1,4 +1,5 @@
 import { getVercelOidcToken } from '@vercel/oidc';
+import type { ConnectAuthorizationDetail } from './authorization-details.js';
 
 export interface ConnectTokenParams {
   subject: { type: 'app' } | { type: 'user'; id: string; issuer?: string };
@@ -6,7 +7,7 @@ export interface ConnectTokenParams {
   audience?: string[];
   scopes?: string[];
   resources?: string[];
-  authorizationDetails?: Array<{ type: string } & Record<string, unknown>>;
+  authorizationDetails?: ConnectAuthorizationDetail[];
 
   /**
    * Buffer time in milliseconds before token expiration to consider it invalid.


### PR DESCRIPTION
## Summary
- add a separate authorization details type module for Connect token params
- support open custom authorization details and the well-known github_app_installation detail
- update ConnectTokenParams.authorizationDetails to use the shared detail type

## Tests
- pnpm --filter @vercel/connect typecheck