### PR TITLE
[services] wire experimentalServicesV2 to fs-detectors

### DIFF
--- a/.changeset/rotten-points-dream.md
+++ b/.changeset/rotten-points-dream.md
@@ -1,0 +1,7 @@
+---
+'@vercel/fs-detectors': patch
+'@vercel/build-utils': patch
+'vercel': patch
+---
+
+[services] wire `experimentalServicesV2` into `fs-detectors`.

--- a/packages/build-utils/src/get-service-url-env-vars.ts
+++ b/packages/build-utils/src/get-service-url-env-vars.ts
@@ -1,4 +1,5 @@
 import type { EnvVars, Service } from './types';
+import { isExperimentalService } from './types';
 
 type Envs = { [key: string]: string | undefined };
 
@@ -92,7 +93,10 @@ export function getServiceUrlEnvVars(
   const baseUrl = origin || deploymentUrl;
   if (!baseUrl) return {};
 
-  const servicesByName = new Map(services.map(s => [s.name, s]));
+  // Implicit URL injection is a feature for `experimentalServices`, V2 services
+  // will use explicit `bindings` and have no `routePrefix`.
+  const v1Services = services.filter(isExperimentalService);
+  const servicesByName = new Map(v1Services.map(s => [s.name, s]));
   const consumerEnvPrefix = getFrameworkEnvPrefix(
     consumerService?.framework,
     frameworkList
@@ -156,20 +160,23 @@ export function getExperimentalServiceUrlEnvVars(
     return {};
   }
 
+  // Legacy implicit injection only applies to `experimentalServices`.
+  const v1Services = services.filter(isExperimentalService);
+
   const envVars: Record<string, string> = {};
 
   // Collect framework prefixes from any frontend services in the deployment,
   // so each web service gets a prefixed twin per framework (NEXT_PUBLIC_*,
   // VITE_*, …) for client-side use.
   const frameworkPrefixes = new Set<string>();
-  for (const service of services) {
+  for (const service of v1Services) {
     const prefix = getFrameworkEnvPrefix(service.framework, frameworkList);
     if (prefix) {
       frameworkPrefixes.add(prefix);
     }
   }
 
-  for (const service of services) {
+  for (const service of v1Services) {
     if (service.type !== 'web' || !service.routePrefix) {
       continue;
     }

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -610,7 +610,8 @@ export type EnvVar = ServiceRefEnvVar;
 
 export type EnvVars = Record<string, EnvVar>;
 
-export interface Service {
+export interface ExperimentalService {
+  schema: 'experimentalServices';
   name: string;
   type: ServiceType;
   trigger?: JobTrigger;
@@ -635,6 +636,49 @@ export interface Service {
   topics?: ServiceTopics;
   /* environment variables declared by the user to be injected into this service. */
   env?: EnvVars;
+}
+
+export interface ExperimentalServiceV2 {
+  schema: 'experimentalServicesV2';
+  name: string;
+  /** Path to the service root, relative to the project root. */
+  root: string;
+  framework?: string;
+  runtime?: string;
+  /** Resolved entrypoint, relative to the service root. */
+  entrypoint?: string;
+  /** Builder selected by the resolver. */
+  builder: Builder;
+  installCommand?: string;
+  buildCommand?: string;
+  devCommand?: string;
+  ignoreCommand?: string;
+  outputDirectory?: string;
+  /** Caller-side bindings to other services. */
+  bindings?: ExperimentalServiceV2Binding[];
+  /** Function configuration scoped to this service. */
+  functions?: BuilderFunctions;
+  /* Per-service route table. Applied only after top-level routing. */
+  headers?: Header[];
+  redirects?: Redirect[];
+  rewrites?: Rewrite[];
+  routes?: Route[];
+  cleanUrls?: boolean;
+  trailingSlash?: boolean;
+}
+
+export type Service = ExperimentalService | ExperimentalServiceV2;
+
+export function isExperimentalService(
+  service: Service
+): service is ExperimentalService {
+  return service.schema === 'experimentalServices';
+}
+
+export function isExperimentalServiceV2(
+  service: Service
+): service is ExperimentalServiceV2 {
+  return service.schema === 'experimentalServicesV2';
 }
 
 export function getServiceQueueTopicConfigs(config: {

--- a/packages/build-utils/test/unit.get-service-url-env-vars.test.ts
+++ b/packages/build-utils/test/unit.get-service-url-env-vars.test.ts
@@ -3,6 +3,7 @@ import type { Service } from '../src';
 import { describe, expect, it } from 'vitest';
 
 const createService = (overrides: Partial<Service>): Service => ({
+  schema: 'experimentalServices',
   name: 'test',
   type: 'web',
   workspace: '.',

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -35,7 +35,8 @@ import {
   type Meta,
   type PackageJson,
   glob,
-  type Service,
+  type ExperimentalService,
+  isExperimentalService,
   getInternalServiceCronPath,
   getInternalServiceFunctionPath,
   getServiceQueueTopicConfigs,
@@ -161,7 +162,7 @@ interface BuildOutputConfig {
   };
   crons?: Cron[];
   experimentalServices?: ExperimentalServices;
-  services?: Service[];
+  services?: ExperimentalService[];
   deploymentId?: string;
 }
 
@@ -740,7 +741,7 @@ async function doBuild(
   let builds = localConfig.builds || [];
   let zeroConfigRoutes: Route[] = [];
   let zeroConfigFallbackRoutes: Route[] = [];
-  let detectedServices: Service[] | undefined;
+  let detectedServices: ExperimentalService[] | undefined;
   const hasExperimentalServicesConfiguredInVercelConfig = hasNonEmptyObject(
     localConfig.experimentalServices
   );
@@ -781,8 +782,9 @@ async function doBuild(
       builds = [{ src: '**', use: '@vercel/static' }];
     }
 
-    // Capture detected services for the config.json
-    detectedServices = detectedBuilders.services;
+    // Capture detected services for the config.json. Only `experimentalServices`
+    // flows is supported right now.
+    detectedServices = detectedBuilders.services?.filter(isExperimentalService);
 
     // Legacy URL injection for `experimentalServices`.
     if (
@@ -912,7 +914,7 @@ async function doBuild(
     workspace: string;
     key: string;
     manifest: Record<string, unknown>;
-    service?: Service;
+    service?: ExperimentalService;
     builderUse: string;
   }> = [];
 
@@ -921,7 +923,7 @@ async function doBuild(
   const getHasQueueServices = () =>
     getHasDetectedServices() && detectedServices!.some(isQueueBackedService);
   const synthesizedServiceCrons: Cron[] = [];
-  const serviceByBuilder = new Map<Builder, Service>();
+  const serviceByBuilder = new Map<Builder, ExperimentalService>();
   if (getHasDetectedServices()) {
     for (const service of detectedServices!) {
       serviceByBuilder.set(service.builder, service);
@@ -1528,7 +1530,7 @@ async function doBuild(
     );
   };
 
-  const appendServiceRoutes = (services: Service[]) => {
+  const appendServiceRoutes = (services: ExperimentalService[]) => {
     const serviceRoutes = generateServicesRoutes(services);
     zeroConfigRoutes = appendRoutesToPhase({
       routes: zeroConfigRoutes,
@@ -1586,7 +1588,9 @@ async function doBuild(
         output.warn(w.message, null, w.link, w.action || 'Learn More');
       }
 
-      detectedServices = generatedBuilders.services;
+      detectedServices = generatedBuilders.services?.filter(
+        isExperimentalService
+      );
       if (!detectedServices || detectedServices.length === 0) {
         detectedServices = undefined;
       } else {
@@ -2361,7 +2365,7 @@ function normalizeServiceRoutePrefix(routePrefix: string): string {
  * output paths, or routing destinations.
  */
 function getServicesMergeEntrypoint(
-  service: Service,
+  service: ExperimentalService,
   buildSrc: string
 ): string {
   const routePrefix =
@@ -2373,7 +2377,7 @@ function getServicesMergeEntrypoint(
 
 function attachQueueServiceTrigger(
   buildOutput: BuildResultV2Typical['output'] | BuildResultV3['output'],
-  service: Service
+  service: ExperimentalService
 ): void {
   const topics = getServiceQueueTopicConfigs(service);
   const consumer = sanitizeConsumerName(

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -2,7 +2,10 @@ import chalk from 'chalk';
 import ms from 'ms';
 import { resolve, join } from 'path';
 import fs from 'fs-extra';
-import type { ResolvedService } from '@vercel/fs-detectors';
+import {
+  isExperimentalService,
+  type ExperimentalService,
+} from '@vercel/fs-detectors';
 
 import DevServer, { DevCommandExitError } from '../../util/dev/server';
 import { parseListen } from '../../util/dev/parse-listen';
@@ -152,13 +155,21 @@ export default async function dev(
       .env;
   }
 
-  let services: ResolvedService[] | undefined;
+  let services: ExperimentalService[] | undefined;
   let useImplicitServicesEnvInjection = true;
   const servicesResult = await tryDetectServices(cwd);
   const foundServices = servicesResult && servicesResult.services.length > 0;
   if (foundServices) {
-    displayDetectedServices(servicesResult.services);
-    services = servicesResult.services;
+    // `vercel dev` only supports `experimentalServices` services for now.
+    services = servicesResult.services.filter(isExperimentalService);
+    if (servicesResult.services.length !== services.length) {
+      output.error(
+        `${getCommandName('dev')} supports only \`experimentalServices\`.`
+      );
+      return 1;
+    }
+
+    displayDetectedServices(services);
     useImplicitServicesEnvInjection = servicesResult.useImplicitEnvInjection;
   }
 

--- a/packages/cli/src/util/build/service-route-ownership.ts
+++ b/packages/cli/src/util/build/service-route-ownership.ts
@@ -3,19 +3,19 @@ import {
   normalizeRoutePrefix,
   scopeRouteSourceToOwnership,
 } from '@vercel/routing-utils';
-import type { Service } from '@vercel/build-utils';
+import type { ExperimentalService } from '@vercel/build-utils';
 import type { Route } from '@vercel/routing-utils';
 interface ScopeRoutesToServiceOwnershipOptions {
   routes: Route[];
-  owner: Service;
-  allServices: Service[];
+  owner: ExperimentalService;
+  allServices: ExperimentalService[];
 }
 function isWebServiceWithPrefix(
-  service: Service
-): service is Service & { type: 'web'; routePrefix: string } {
+  service: ExperimentalService
+): service is ExperimentalService & { type: 'web'; routePrefix: string } {
   return service.type === 'web' && typeof service.routePrefix === 'string';
 }
-function getWebRoutePrefixes(services: Service[]): string[] {
+function getWebRoutePrefixes(services: ExperimentalService[]): string[] {
   const unique = new Set<string>();
   for (const service of services) {
     if (!isWebServiceWithPrefix(service)) continue;

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -32,7 +32,7 @@ import {
   type TriggerEvent,
   isBackendBuilder,
   isExperimentalBackendsEnabled,
-  type Service,
+  type ExperimentalService,
   isExternalSymlink,
 } from '@vercel/build-utils';
 import { getInternalServiceFunctionPath } from '@vercel/fs-detectors';
@@ -73,7 +73,7 @@ export async function writeBuildResult(args: {
   vercelConfig: VercelConfig | null;
   standalone: boolean;
   workPath: string;
-  service?: Service;
+  service?: ExperimentalService;
   stripServiceRoutePrefix?: boolean;
 }) {
   const {
@@ -154,7 +154,7 @@ export interface PathOverride {
 
 function injectServiceEnvVars(
   lambda: Lambda,
-  service?: Service,
+  service?: ExperimentalService,
   stripServiceRoutePrefix: boolean = false
 ): void {
   if (service?.name) {
@@ -195,7 +195,7 @@ async function writeBuildResultV2(args: {
   vercelConfig: VercelConfig | null;
   standalone: boolean;
   workPath: string;
-  service?: Service;
+  service?: ExperimentalService;
   stripServiceRoutePrefix: boolean;
 }) {
   const {
@@ -342,7 +342,7 @@ async function writeBuildResultV3(args: {
   vercelConfig: VercelConfig | null;
   standalone: boolean;
   workPath: string;
-  service?: Service;
+  service?: ExperimentalService;
   stripServiceRoutePrefix: boolean;
 }) {
   const {

--- a/packages/cli/src/util/dev/queue-broker.ts
+++ b/packages/cli/src/util/dev/queue-broker.ts
@@ -3,7 +3,7 @@
 import ms from 'ms';
 import { randomBytes } from 'crypto';
 import nodeFetch from 'node-fetch';
-import type { Service } from '@vercel/fs-detectors';
+import type { ExperimentalService } from '@vercel/fs-detectors';
 import {
   getServiceQueueTopicConfigs,
   isQueueBackedService,
@@ -79,7 +79,7 @@ export class QueueBroker {
   private tickTimer: ReturnType<typeof setInterval>;
 
   constructor(
-    services: Service[],
+    services: ExperimentalService[],
     private getServiceOrigin: (name: string) => string | null
   ) {
     for (const service of services) {

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -47,7 +47,7 @@ import {
   detectApiDirectory,
   detectApiExtensions,
   isOfficialRuntime,
-  type Service,
+  type ExperimentalService,
 } from '@vercel/fs-detectors';
 import { frameworkList } from '@vercel/frameworks';
 
@@ -180,7 +180,7 @@ export default class DevServer {
   >;
   private originalProjectSettings?: ProjectSettings;
   private projectSettings?: ProjectSettings;
-  private services?: Service[];
+  private services?: ExperimentalService[];
   private orchestrator?: ServicesOrchestrator;
   private queueBroker?: QueueBroker;
 

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -8,7 +8,7 @@ import {
   getInternalServiceCronPath,
   getInternalServiceCronPathPrefix,
   getInternalServiceWorkerPathPrefix,
-  type Service,
+  type ExperimentalService,
 } from '@vercel/fs-detectors';
 import type { Cron } from '@vercel/build-utils';
 import { frameworkList, type Framework } from '@vercel/frameworks';
@@ -148,7 +148,7 @@ interface ServiceDevProcess {
   crons?: Cron[];
 }
 
-function getServiceRoutePrefixes(service: Service): string[] {
+function getServiceRoutePrefixes(service: ExperimentalService): string[] {
   if (isQueueTriggeredService(service) || isWorkflowTriggeredService(service)) {
     return [getInternalServiceWorkerPathPrefix(service.name)];
   }
@@ -162,7 +162,7 @@ function getServiceRoutePrefixes(service: Service): string[] {
 }
 
 interface ServicesOrchestratorOptions {
-  services: Service[];
+  services: ExperimentalService[];
   cwd: string;
   repoRoot: string;
   env: NodeJS.ProcessEnv;
@@ -253,7 +253,7 @@ export class ServicesOrchestrator {
   private stopping = false;
   private exitBackstop: (() => void) | undefined;
 
-  private services: Service[];
+  private services: ExperimentalService[];
   private cwd: string;
   private repoRoot: string;
   private envFilesValues: NodeJS.ProcessEnv;
@@ -505,7 +505,7 @@ export class ServicesOrchestrator {
   }
 
   private async startService(
-    service: Service,
+    service: ExperimentalService,
     colorIndex: number
   ): Promise<ServiceDevProcess> {
     const workspacePath = path.join(this.cwd, service.workspace || '.');
@@ -605,7 +605,7 @@ export class ServicesOrchestrator {
   }
 
   private async tryStartWithBuilder(
-    service: Service,
+    service: ExperimentalService,
     builderSpec: string,
     workspacePath: string,
     env: NodeJS.ProcessEnv,
@@ -705,7 +705,7 @@ export class ServicesOrchestrator {
 
   // Adapted from DevServer
   private async startServiceWithDevCommand(
-    service: Service,
+    service: ExperimentalService,
     framework: Framework | undefined,
     workspacePath: string,
     env: NodeJS.ProcessEnv,

--- a/packages/cli/src/util/dev/types.ts
+++ b/packages/cli/src/util/dev/types.ts
@@ -16,7 +16,7 @@ import type {
 import { VercelConfig } from '@vercel/client';
 import type { HandleValue, Route } from '@vercel/routing-utils';
 import type { ProjectSettings } from '@vercel-internals/types';
-import type { ResolvedService } from '@vercel/fs-detectors';
+import type { ExperimentalService } from '@vercel/fs-detectors';
 import type { BuilderWithPkg } from '../build/import-builders';
 
 export { VercelConfig };
@@ -25,7 +25,7 @@ export interface DevServerOptions {
   projectSettings?: ProjectSettings;
   envValues?: Record<string, string>;
   repoRoot?: string;
-  services?: ResolvedService[];
+  services?: ExperimentalService[];
   useImplicitServicesEnvInjection?: boolean;
   projectId?: string;
   orgId?: string;

--- a/packages/cli/src/util/input/display-services.ts
+++ b/packages/cli/src/util/input/display-services.ts
@@ -1,5 +1,8 @@
 import { frameworkList } from '@vercel/frameworks';
-import type { Service, ServiceDetectionError } from '@vercel/fs-detectors';
+import type {
+  ExperimentalService,
+  ServiceDetectionError,
+} from '@vercel/fs-detectors';
 import {
   getServiceQueueTopics,
   isQueueTriggeredService,
@@ -75,7 +78,9 @@ const jobTriggerLabels: Record<string, string> = {
   workflow: 'Job/Workflow',
 };
 
-function getServiceDescriptionInfo(service: Service): ServiceDescriptionInfo {
+function getServiceDescriptionInfo(
+  service: ExperimentalService
+): ServiceDescriptionInfo {
   if (
     service.type === 'worker' ||
     service.type === 'job' ||
@@ -113,7 +118,7 @@ function getServiceDescriptionInfo(service: Service): ServiceDescriptionInfo {
   return { label: 'unknown', colorFn: chalk.dim };
 }
 
-function getServiceTarget(service: Service): string {
+function getServiceTarget(service: ExperimentalService): string {
   if (isScheduleTriggeredService(service)) {
     return `schedule: ${service.schedule ?? 'none'}`;
   }
@@ -140,7 +145,7 @@ function getServiceTarget(service: Service): string {
  *   cleanup           [node]      →  schedule: 0 0 * * *
  *   processor         [node]      →  topics: jobs
  */
-export function displayDetectedServices(services: Service[]): void {
+export function displayDetectedServices(services: ExperimentalService[]): void {
   output.print(`Detected services:\n`);
 
   const outputOrder: Record<string, number> = {

--- a/packages/cli/src/util/link/services-setup.ts
+++ b/packages/cli/src/util/link/services-setup.ts
@@ -2,9 +2,10 @@ import { normalizePath } from '@vercel/build-utils';
 import { join, relative } from 'path';
 import {
   detectServices,
+  isExperimentalService,
   LocalFileSystemDetector,
   type DetectServicesResult,
-  type Service,
+  type ExperimentalService,
 } from '@vercel/fs-detectors';
 import output from '../../output-manager';
 import type Client from '../client';
@@ -67,8 +68,12 @@ export function displayConfiguredServicesSetup(
   detectServicesResult: DetectServicesResult,
   configFileName = 'vercel.json'
 ): void {
-  if (detectServicesResult.services.length > 0) {
-    displayDetectedServices(detectServicesResult.services);
+  // display only `experimentalServices` for now
+  const v1Services = detectServicesResult.services.filter(
+    isExperimentalService
+  );
+  if (v1Services.length > 0) {
+    displayDetectedServices(v1Services);
   }
   if (detectServicesResult.errors.length > 0) {
     displayServiceErrors(detectServicesResult.errors);
@@ -76,7 +81,9 @@ export function displayConfiguredServicesSetup(
   displayServicesConfigNote(configFileName);
 }
 
-function formatDetectedServicesSummary(services: Service[]): string {
+function formatDetectedServicesSummary(
+  services: ExperimentalService[]
+): string {
   if (services.length === 0) {
     return '';
   }

--- a/packages/cli/test/unit/util/build/service-route-ownership.test.ts
+++ b/packages/cli/test/unit/util/build/service-route-ownership.test.ts
@@ -1,10 +1,14 @@
-import type { Service } from '@vercel/build-utils';
+import type { ExperimentalService } from '@vercel/build-utils';
 import type { Route } from '@vercel/routing-utils';
 import { describe, expect, test } from 'vitest';
 import { scopeRoutesToServiceOwnership } from '../../../../src/util/build/service-route-ownership';
 
-function createWebService(name: string, routePrefix: string): Service {
+function createWebService(
+  name: string,
+  routePrefix: string
+): ExperimentalService {
   return {
+    schema: 'experimentalServices',
     name,
     type: 'web',
     workspace: '.',

--- a/packages/cli/test/unit/util/dev/queue-broker.test.ts
+++ b/packages/cli/test/unit/util/dev/queue-broker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import type { Service } from '@vercel/fs-detectors';
+import type { ExperimentalService } from '@vercel/fs-detectors';
 import {
   QueueBroker,
   topicPatternToRegex,
@@ -19,15 +19,16 @@ const mockFetch = vi.mocked(nodeFetch);
 function makeWorkerService(
   name: string,
   topics: string[] = ['default']
-): Service {
+): ExperimentalService {
   return {
+    schema: 'experimentalServices',
     name,
     type: 'worker',
     consumer: name,
     workspace: '.',
     builder: { src: 'index.ts', use: '@vercel/node' },
     topics,
-  } as Service;
+  } as ExperimentalService;
 }
 
 function makeQueueJobService(
@@ -37,25 +38,27 @@ function makeQueueJobService(
     retryAfterSeconds?: number;
     initialDelaySeconds?: number;
   }>
-): Service {
+): ExperimentalService {
   return {
+    schema: 'experimentalServices',
     name,
     type: 'job',
     trigger: 'queue',
     workspace: '.',
     builder: { src: 'index.ts', use: '@vercel/node' },
     topics,
-  } as Service;
+  } as ExperimentalService;
 }
 
-function makeWebService(name: string): Service {
+function makeWebService(name: string): ExperimentalService {
   return {
+    schema: 'experimentalServices',
     name,
     type: 'web',
     routePrefix: '/',
     workspace: '.',
     builder: { src: 'index.ts', use: '@vercel/node' },
-  } as Service;
+  } as ExperimentalService;
 }
 
 /** Extract headers from a specific mockFetch call (defaults to the last one). */

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -11,6 +11,7 @@ import type {
   ExperimentalServices,
   ProjectSettings,
   Service,
+  ExperimentalServicesV2,
 } from '@vercel/build-utils';
 import { isOfficialRuntime } from './is-official-runtime';
 import {
@@ -65,6 +66,7 @@ export interface Options {
   tag?: string;
   functions?: BuilderFunctions;
   experimentalServices?: ExperimentalServices;
+  experimentalServicesV2?: ExperimentalServicesV2;
   ignoreBuildScript?: boolean;
   projectSettings?: ProjectSettings;
   cleanUrls?: boolean;
@@ -141,10 +143,16 @@ export async function detectBuilders(
   services?: Service[];
   useImplicitEnvInjection?: boolean;
 }> {
-  const { experimentalServices, projectSettings = {} } = options;
+  const {
+    experimentalServices,
+    experimentalServicesV2,
+    projectSettings = {},
+  } = options;
   const { framework } = projectSettings;
-  const configuredServices = experimentalServices;
-  const configuredServicesType = 'experimentalServices';
+  const configuredServices = experimentalServices ?? experimentalServicesV2;
+  const configuredServicesType = experimentalServices
+    ? 'experimentalServices'
+    : 'experimentalServicesV2';
   const hasServicesConfig =
     configuredServices != null && typeof configuredServices === 'object';
 

--- a/packages/fs-detectors/src/index.ts
+++ b/packages/fs-detectors/src/index.ts
@@ -9,6 +9,15 @@ export {
   detectServices,
   generateServicesRoutes,
 } from './services/detect-services';
+export {
+  resolveAllConfiguredServicesV2,
+  resolveConfiguredServiceV2,
+  validateServiceConfigV2,
+} from './services/resolve-v2';
+export {
+  isExperimentalService,
+  isExperimentalServiceV2,
+} from '@vercel/build-utils';
 export { autoDetectServices } from './services/auto-detect';
 export type {
   AutoDetectOptions,
@@ -34,6 +43,11 @@ export type {
   InferredServicesResult,
   ResolvedService,
   Service,
+  ExperimentalService,
+  ExperimentalServiceV2,
+  ExperimentalServiceV2Config,
+  ExperimentalServicesV2,
+  ExperimentalServiceV2Binding,
   ServicesRoutes,
   ServiceDetectionError,
 } from './services/types';

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -1,5 +1,8 @@
 import type { HasField, Route } from '@vercel/routing-utils';
-import { isScheduleTriggeredService } from '@vercel/build-utils';
+import {
+  isScheduleTriggeredService,
+  isExperimentalService,
+} from '@vercel/build-utils';
 import {
   getOwnershipGuard,
   normalizeRoutePrefix,
@@ -10,6 +13,8 @@ import type {
   DetectServicesOptions,
   DetectServicesResult,
   ExperimentalServices,
+  ExperimentalServicesV2,
+  ExperimentalService,
   InferredServicesConfig,
   InferredServicesResult,
   ResolvedServicesResult,
@@ -28,6 +33,7 @@ import {
 } from './utils';
 import type { DetectorFilesystem } from '../detectors/filesystem';
 import { resolveAllConfiguredServices } from './resolve';
+import { resolveAllConfiguredServicesV2 } from './resolve-v2';
 import { autoDetectServices } from './auto-detect';
 import { detectRailwayServices } from './detect-railway';
 import { detectRenderServices } from './detect-render';
@@ -133,6 +139,7 @@ export async function detectServices(
     workPath,
     detectEntrypoint,
     configuredServices: providedConfiguredServices,
+    configuredServicesType,
   } = options;
 
   // Scope filesystem to workPath if provided
@@ -156,6 +163,35 @@ export async function detectServices(
   const hasProvidedConfiguredServices =
     providedConfiguredServices &&
     Object.keys(providedConfiguredServices).length > 0;
+
+  // `experimentalServicesV2` dispatch
+  const experimentalServicesV2 =
+    hasProvidedConfiguredServices &&
+    configuredServicesType === 'experimentalServicesV2'
+      ? (providedConfiguredServices as ExperimentalServicesV2)
+      : hasProvidedConfiguredServices
+        ? undefined
+        : vercelConfig?.experimentalServicesV2;
+  if (
+    experimentalServicesV2 &&
+    Object.keys(experimentalServicesV2).length > 0
+  ) {
+    const result = await resolveAllConfiguredServicesV2(
+      experimentalServicesV2,
+      scopedFs
+    );
+    return withResolvedResult({
+      services: result.services,
+      source: 'configured',
+      // V2 uses explicit `bindings`, so no implicit `{NAME}_URL` injection.
+      useImplicitEnvInjection: false,
+      // V2 routes are explicitly carried per-service to output them separately.
+      routes: emptyRoutes(),
+      errors: result.errors,
+      warnings: [],
+    });
+  }
+
   const configuredServices = hasProvidedConfiguredServices
     ? providedConfiguredServices
     : vercelConfig?.experimentalServices;
@@ -351,7 +387,11 @@ async function tryResolveInferred(
  *   Internal cron callback routes under `/_svc/{serviceName}/crons/{entry}/{handler}`
  *   that rewrite to `/_svc/{serviceName}/index`.
  */
-export function generateServicesRoutes(services: Service[]): ServicesRoutes {
+export function generateServicesRoutes(allServices: Service[]): ServicesRoutes {
+  // Route generation only applies to `experimentalServices`, V2 carries
+  // its own per-service route tables to be applied later.
+  const services = allServices.filter(isExperimentalService);
+
   const hostRewrites: Route[] = [];
   const rewrites: Route[] = [];
   const defaults: Route[] = [];
@@ -363,7 +403,7 @@ export function generateServicesRoutes(services: Service[]): ServicesRoutes {
   // so more specific routes match before broader ones.
   const sortedWebServices = services
     .filter(
-      (s): s is Service & { routePrefix: string } =>
+      (s): s is ExperimentalService & { routePrefix: string } =>
         s.type === 'web' && typeof s.routePrefix === 'string'
     )
     .sort((a, b) => b.routePrefix.length - a.routePrefix.length);
@@ -462,7 +502,7 @@ function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function getWebRoutePrefixes(services: Service[]): string[] {
+function getWebRoutePrefixes(services: ExperimentalService[]): string[] {
   const unique = new Set<string>();
   for (const service of services) {
     if (service.type !== 'web' || typeof service.routePrefix !== 'string') {
@@ -493,7 +533,7 @@ function getExplicitHostPrefixNegativeLookahead(
   return `(?!(?:${explicitPrefixes.join('|')})(?:/|$))`;
 }
 
-function getHostCondition(service: Service): HasField | undefined {
+function getHostCondition(service: ExperimentalService): HasField | undefined {
   if (service.type !== 'web') {
     return undefined;
   }

--- a/packages/fs-detectors/src/services/get-services-builders.ts
+++ b/packages/fs-detectors/src/services/get-services-builders.ts
@@ -1,6 +1,10 @@
 import type { Route } from '@vercel/routing-utils';
 import type { Builder } from '@vercel/build-utils';
-import type { ConfiguredServices, ResolvedService } from './types';
+import type {
+  ConfiguredServices,
+  ConfiguredServicesType,
+  Service,
+} from './types';
 import { detectServices } from './detect-services';
 import { LocalFileSystemDetector } from '../detectors/local-file-system-detector';
 
@@ -14,7 +18,7 @@ export interface ErrorResponse {
 export interface GetServicesBuildersOptions {
   workPath?: string;
   configuredServices?: ConfiguredServices;
-  configuredServicesType?: 'experimentalServices';
+  configuredServicesType?: ConfiguredServicesType;
   projectFramework?: string | null;
 }
 
@@ -28,7 +32,7 @@ export interface ServicesBuildersResult {
   redirectRoutes: Route[] | null;
   rewriteRoutes: Route[] | null;
   errorRoutes: Route[] | null;
-  services?: ResolvedService[];
+  services?: Service[];
   useImplicitEnvInjection?: boolean;
 }
 

--- a/packages/fs-detectors/src/services/resolve-v2.ts
+++ b/packages/fs-detectors/src/services/resolve-v2.ts
@@ -1,0 +1,318 @@
+import { posix as posixPath } from 'path';
+import { isNodeBackendFramework } from '@vercel/build-utils';
+import { frameworkList } from '@vercel/frameworks';
+import type {
+  ExperimentalServiceV2,
+  ExperimentalServiceV2Config,
+  ExperimentalServicesV2,
+  ServiceDetectionError,
+  ServiceRuntime,
+} from './types';
+import { RUNTIME_BUILDERS, STATIC_BUILDERS } from './types';
+import {
+  getServiceFs,
+  resolveEntrypointPath,
+  detectFrameworkFromWorkspace,
+  parsePyModuleAttrEntrypoint,
+} from './resolve';
+import {
+  getBuilderForRuntime,
+  inferRuntimeFromFramework,
+  inferServiceRuntime,
+} from './utils';
+import type { DetectorFilesystem } from '../detectors/filesystem';
+
+const frameworksBySlug = new Map(frameworkList.map(f => [f.slug, f]));
+
+const SERVICE_NAME_REGEX = /^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$/;
+
+export function validateServiceConfigV2(
+  name: string,
+  config: ExperimentalServiceV2Config
+): ServiceDetectionError | null {
+  if (!SERVICE_NAME_REGEX.test(name)) {
+    return {
+      code: 'INVALID_SERVICE_NAME',
+      message: `Service name "${name}" is invalid. Names must start with a letter, end with an alphanumeric character, and contain only alphanumeric characters, hyphens, and underscores.`,
+      serviceName: name,
+    };
+  }
+  if (!config || typeof config !== 'object') {
+    return {
+      code: 'INVALID_SERVICE_CONFIG',
+      message: `Service "${name}" has an invalid configuration. Expected an object.`,
+      serviceName: name,
+    };
+  }
+  if (typeof config.root !== 'string' || config.root.length === 0) {
+    return {
+      code: 'MISSING_ROOT',
+      message: `Service "${name}" must specify a "root".`,
+      serviceName: name,
+    };
+  }
+  const normalizedRoot = posixPath.normalize(config.root);
+  if (normalizedRoot.startsWith('/')) {
+    return {
+      code: 'INVALID_ROOT',
+      message: `Service "${name}" has invalid "root" "${config.root}". Must be a relative path.`,
+      serviceName: name,
+    };
+  }
+  if (normalizedRoot === '..' || normalizedRoot.startsWith('../')) {
+    return {
+      code: 'INVALID_ROOT',
+      message: `Service "${name}" has invalid "root" "${config.root}". Must not escape the project root.`,
+      serviceName: name,
+    };
+  }
+  if (config.runtime && !(config.runtime in RUNTIME_BUILDERS)) {
+    return {
+      code: 'INVALID_RUNTIME',
+      message: `Service "${name}" has invalid runtime "${config.runtime}".`,
+      serviceName: name,
+    };
+  }
+  if (config.framework && !frameworksBySlug.has(config.framework)) {
+    return {
+      code: 'INVALID_FRAMEWORK',
+      message: `Service "${name}" has invalid framework "${config.framework}".`,
+      serviceName: name,
+    };
+  }
+  if (config.runtime && config.framework) {
+    const frameworkRuntime = inferRuntimeFromFramework(config.framework);
+    if (frameworkRuntime && frameworkRuntime !== config.runtime) {
+      return {
+        code: 'RUNTIME_FRAMEWORK_MISMATCH',
+        message:
+          `Service "${name}" has conflicting runtime/framework: runtime "${config.runtime}" is incompatible ` +
+          `with framework "${config.framework}" (runtime "${frameworkRuntime}").`,
+        serviceName: name,
+      };
+    }
+  }
+  if (!config.framework && !config.entrypoint) {
+    return {
+      code: 'MISSING_SERVICE_CONFIG',
+      message: `Service "${name}" must specify "framework" or "entrypoint".`,
+      serviceName: name,
+    };
+  }
+  return null;
+}
+
+export async function resolveConfiguredServiceV2(
+  name: string,
+  config: ExperimentalServiceV2Config,
+  fs: DetectorFilesystem
+): Promise<{ service?: ExperimentalServiceV2; error?: ServiceDetectionError }> {
+  const root = config.root;
+  const normalizedRoot = posixPath.normalize(root);
+
+  // Scope the filesystem to the service root for entrypoint/framework detection.
+  // A root of "." is the project root itself, so there is nothing to chdir into.
+  const serviceFsResult =
+    normalizedRoot === '.' ? { fs } : await getServiceFs(fs, name, root);
+  if (serviceFsResult.error) {
+    return { error: serviceFsResult.error };
+  }
+  const serviceFs = serviceFsResult.fs;
+
+  // Resolve the entrypoint, Python `module:attr` references
+  // resolve against their underlying file.
+  const rawEntrypoint = config.entrypoint;
+  const moduleAttr =
+    typeof rawEntrypoint === 'string'
+      ? parsePyModuleAttrEntrypoint(rawEntrypoint)
+      : null;
+  let normalizedEntrypoint: string | undefined;
+  let entrypointIsDirectory = false;
+  if (typeof rawEntrypoint === 'string') {
+    const entrypointToResolve = moduleAttr
+      ? moduleAttr.filePath
+      : rawEntrypoint;
+    const resolved = await resolveEntrypointPath({
+      fs: serviceFs,
+      serviceName: name,
+      entrypoint: entrypointToResolve,
+    });
+    if (resolved.error) {
+      return { error: resolved.error };
+    }
+    normalizedEntrypoint = resolved.entrypoint?.normalized;
+    entrypointIsDirectory = Boolean(resolved.entrypoint?.isDirectory);
+  }
+
+  const entrypointFile =
+    entrypointIsDirectory || !normalizedEntrypoint
+      ? undefined
+      : normalizedEntrypoint;
+
+  const inferredRuntime = inferServiceRuntime({
+    runtime: config.runtime,
+    framework: config.framework,
+    entrypoint: entrypointFile,
+  });
+
+  let framework = config.framework;
+  if (!framework && normalizedEntrypoint) {
+    const workspace = entrypointIsDirectory
+      ? normalizedEntrypoint
+      : posixPath.dirname(normalizedEntrypoint) || '.';
+    const detection = await detectFrameworkFromWorkspace({
+      fs: serviceFs,
+      workspace,
+      serviceName: name,
+      runtime: inferredRuntime,
+    });
+    if (detection.error) {
+      return { error: detection.error };
+    }
+    framework = detection.framework;
+  }
+
+  if (entrypointIsDirectory && !framework) {
+    return {
+      error: {
+        code: 'MISSING_SERVICE_FRAMEWORK',
+        message:
+          `Service "${name}" uses directory entrypoint "${config.entrypoint}" but no framework could be detected. ` +
+          `Specify "framework" explicitly or use a file entrypoint.`,
+        serviceName: name,
+      },
+    };
+  }
+
+  const frameworkDefinition = framework
+    ? frameworksBySlug.get(framework)
+    : undefined;
+  let builderUse: string;
+  let builderSrc: string;
+  if (framework) {
+    builderUse = isNodeBackendFramework(framework)
+      ? '@vercel/backends'
+      : frameworkDefinition?.useRuntime?.use || '@vercel/static-build';
+    builderSrc =
+      entrypointFile || frameworkDefinition?.useRuntime?.src || 'package.json';
+  } else {
+    if (!inferredRuntime) {
+      return {
+        error: {
+          code: 'MISSING_SERVICE_CONFIG',
+          message: `Service "${name}" must specify "framework" or a runtime-resolvable "entrypoint".`,
+          serviceName: name,
+        },
+      };
+    }
+    builderUse =
+      inferredRuntime === 'node'
+        ? '@vercel/backends'
+        : getBuilderForRuntime(inferredRuntime as ServiceRuntime);
+    builderSrc = entrypointFile as string;
+  }
+
+  // builder.src must be project-root-relative.
+  const isRoot = normalizedRoot === '.';
+  const projectRelativeSrc = isRoot
+    ? builderSrc
+    : posixPath.join(normalizedRoot, builderSrc);
+
+  // Services are built via the zero-config pipeline (multiple builders, merged routes).
+  // Ensure `zeroConfig` is set on the Builder spec so downstream steps (like
+  // CLI `writeBuildResultV3()`) can compute correct extensionless function paths.
+  const builderConfig: Record<string, unknown> = { zeroConfig: true };
+  if (builderUse === '@vercel/backends') {
+    builderConfig.serviceName = name;
+  }
+  if (framework) {
+    builderConfig.framework = framework;
+  }
+  if (!isRoot) {
+    builderConfig.workspace = normalizedRoot;
+  }
+  if (moduleAttr) {
+    builderConfig.handlerFunction = moduleAttr.attrName;
+  }
+
+  const runtime = STATIC_BUILDERS.has(builderUse) ? undefined : inferredRuntime;
+
+  return {
+    service: {
+      schema: 'experimentalServicesV2',
+      name,
+      root,
+      framework,
+      runtime,
+      entrypoint: entrypointFile,
+      builder: {
+        src: projectRelativeSrc,
+        use: builderUse,
+        config: builderConfig,
+      },
+      installCommand: config.installCommand,
+      buildCommand: config.buildCommand,
+      devCommand: config.devCommand,
+      ignoreCommand: config.ignoreCommand,
+      outputDirectory: config.outputDirectory,
+      bindings: config.bindings,
+      functions: config.functions,
+      headers: config.headers,
+      redirects: config.redirects,
+      rewrites: config.rewrites,
+      routes: config.routes,
+      cleanUrls: config.cleanUrls,
+      trailingSlash: config.trailingSlash,
+    },
+  };
+}
+
+export async function resolveAllConfiguredServicesV2(
+  services: ExperimentalServicesV2,
+  fs: DetectorFilesystem
+): Promise<{
+  services: ExperimentalServiceV2[];
+  errors: ServiceDetectionError[];
+}> {
+  const resolved: ExperimentalServiceV2[] = [];
+  const errors: ServiceDetectionError[] = [];
+
+  for (const name of Object.keys(services)) {
+    const config = services[name];
+
+    const validationError = validateServiceConfigV2(name, config);
+    if (validationError) {
+      errors.push(validationError);
+      continue;
+    }
+
+    const { service, error } = await resolveConfiguredServiceV2(
+      name,
+      config,
+      fs
+    );
+    if (error) {
+      errors.push(error);
+      continue;
+    }
+    if (service) {
+      resolved.push(service);
+    }
+  }
+
+  // every binding must reference a declared service.
+  const serviceNames = new Set(Object.keys(services));
+  for (const service of resolved) {
+    for (const binding of service.bindings ?? []) {
+      if (!serviceNames.has(binding.service)) {
+        errors.push({
+          code: 'UNKNOWN_SERVICE_BINDING',
+          message: `Service "${service.name}" declares a binding to unknown service "${binding.service}".`,
+          serviceName: service.name,
+        });
+      }
+    }
+  }
+
+  return { services: resolved, errors };
+}

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -1,7 +1,7 @@
 import { posix as posixPath } from 'path';
 import type {
   EnvVars,
-  Service,
+  ExperimentalService,
   ConfiguredServices,
   ExperimentalServiceConfig,
   ServiceDetectionError,
@@ -44,7 +44,7 @@ const frameworksBySlug = new Map(frameworkList.map(f => [f.slug, f]));
 const PYTHON_MODULE_ATTR_RE =
   /^([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*):([A-Za-z_][\w]*)$/;
 
-function parsePyModuleAttrEntrypoint(entrypoint: string): {
+export function parsePyModuleAttrEntrypoint(entrypoint: string): {
   attrName: string;
   filePath: string;
 } | null {
@@ -72,7 +72,7 @@ interface ResolvedEntrypointPath {
   isDirectory: boolean;
 }
 
-async function getServiceFs(
+export async function getServiceFs(
   fs: DetectorFilesystem,
   serviceName: string,
   root?: string
@@ -161,7 +161,7 @@ function validateBackendFileEntrypoint(
   };
 }
 
-async function resolveEntrypointPath({
+export async function resolveEntrypointPath({
   fs,
   serviceName,
   entrypoint,
@@ -231,7 +231,7 @@ function toWorkspaceRelativeEntrypoint(
   return relativeEntrypoint;
 }
 
-async function inferWorkspaceFromNearestManifest({
+export async function inferWorkspaceFromNearestManifest({
   fs,
   entrypoint,
   runtime,
@@ -277,7 +277,7 @@ async function inferWorkspaceFromNearestManifest({
   return undefined;
 }
 
-async function detectFrameworkFromWorkspace({
+export async function detectFrameworkFromWorkspace({
   fs,
   workspace,
   serviceName,
@@ -718,7 +718,7 @@ export function validateServiceEntrypoint(
  */
 export async function resolveConfiguredService(
   options: ResolveConfiguredServiceOptions
-): Promise<Service> {
+): Promise<ExperimentalService> {
   const {
     name,
     config,
@@ -924,6 +924,7 @@ export async function resolveConfiguredService(
   }
 
   return {
+    schema: 'experimentalServices',
     name,
     type,
     trigger,
@@ -960,10 +961,10 @@ export async function resolveAllConfiguredServices(
   routePrefixSource: RoutePrefixSource = 'configured',
   options: ResolveAllConfiguredServicesOptions = {}
 ): Promise<{
-  services: Service[];
+  services: ExperimentalService[];
   errors: ServiceDetectionError[];
 }> {
-  const resolved: Service[] = [];
+  const resolved: ExperimentalService[] = [];
   const errors: ServiceDetectionError[] = [];
   const webServicesByRoutePrefix = new Map<string, string>();
 
@@ -1136,7 +1137,7 @@ export async function resolveAllConfiguredServices(
 function validateEnvRefs(
   env: EnvVars,
   serviceName: string,
-  servicesByName: Map<string, Service>,
+  servicesByName: Map<string, ExperimentalService>,
   errors: ServiceDetectionError[]
 ): void {
   const pathPrefix = `Service "${serviceName}" env`;

--- a/packages/fs-detectors/src/services/types.ts
+++ b/packages/fs-detectors/src/services/types.ts
@@ -6,6 +6,11 @@ import type {
   ExperimentalServiceConfig,
   ExperimentalServiceGroups,
   ExperimentalServices,
+  ExperimentalServiceV2Config,
+  ExperimentalServicesV2,
+  ExperimentalServiceV2Binding,
+  ExperimentalService,
+  ExperimentalServiceV2,
   ServiceRuntime,
   ServiceType,
   ServiceRefEnvVar,
@@ -21,6 +26,11 @@ export type {
   ExperimentalServiceConfig,
   ExperimentalServiceGroups,
   ExperimentalServices,
+  ExperimentalServiceV2Config,
+  ExperimentalServicesV2,
+  ExperimentalServiceV2Binding,
+  ExperimentalService,
+  ExperimentalServiceV2,
   ServiceRuntime,
   ServiceType,
   ServiceRefEnvVar,
@@ -36,7 +46,7 @@ export type ResolvedService = Service;
 export interface DetectServicesOptions {
   fs: DetectorFilesystem;
   configuredServices?: ConfiguredServices;
-  configuredServicesType?: 'experimentalServices';
+  configuredServicesType?: ConfiguredServicesType;
   /**
    * Working directory path (relative to fs root).
    * If provided, vercel.json is read from this path.
@@ -71,7 +81,10 @@ export interface ServicesRoutes {
   workers: Route[];
 }
 
-export type ConfiguredServices = ExperimentalServices;
+export type ConfiguredServicesType =
+  | 'experimentalServices'
+  | 'experimentalServicesV2';
+export type ConfiguredServices = ExperimentalServices | ExperimentalServicesV2;
 export type InferredServicesConfig = ExperimentalServices;
 
 export interface ResolvedServicesResult {
@@ -86,7 +99,8 @@ export interface ResolvedServicesResult {
 export interface InferredServicesResult {
   source: 'layout' | 'procfile' | 'railway' | 'render';
   config: InferredServicesConfig;
-  services: Service[];
+  // Inferred services are always produced from `experimentalServices` so far, so no V2
+  services: ExperimentalService[];
   warnings: ServiceDetectionWarning[];
 }
 

--- a/packages/fs-detectors/src/services/utils.ts
+++ b/packages/fs-detectors/src/services/utils.ts
@@ -14,6 +14,7 @@ import type { DetectorFilesystem } from '../detectors/filesystem';
 import type {
   ServiceRuntime,
   ExperimentalServices,
+  ExperimentalServicesV2,
   ServiceDetectionError,
   ServiceDetectionWarning,
   ResolvedService,
@@ -206,6 +207,7 @@ export function inferServiceRuntime(config: {
 export interface ReadVercelConfigResult {
   config: {
     experimentalServices?: ExperimentalServices;
+    experimentalServicesV2?: ExperimentalServicesV2;
   } | null;
   error: ServiceDetectionError | null;
 }

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -4,6 +4,8 @@ import type {
   RouteWithSrc as Source,
 } from '@vercel/routing-utils';
 import { join } from 'path';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 import type { PackageJson } from '@vercel/build-utils';
 import {
   detectBuilders,
@@ -216,6 +218,56 @@ describe('Test `detectBuilders`', () => {
       } else {
         process.env.VERCEL_USE_EXPERIMENTAL_SERVICES = originalEnv;
       }
+    }
+  });
+
+  it('should build experimentalServicesV2 services configured inline', async () => {
+    // `detectBuilders` resolves services against a real filesystem (workPath).
+    // V2 isn't deployable yet, so build using a temp dir
+    const workPath = mkdtempSync(join(tmpdir(), 'vc-services-v2-'));
+    try {
+      mkdirSync(join(workPath, 'api'), { recursive: true });
+      writeFileSync(
+        join(workPath, 'api', 'package.json'),
+        JSON.stringify({ dependencies: { express: '4.0.0' } })
+      );
+      mkdirSync(join(workPath, 'web'), { recursive: true });
+      writeFileSync(
+        join(workPath, 'web', 'package.json'),
+        JSON.stringify({ dependencies: { next: 'latest' } })
+      );
+
+      const { builders, errors, services } = await detectBuilders(
+        [],
+        undefined,
+        {
+          experimentalServicesV2: {
+            api: { root: 'api', framework: 'express' },
+            web: { root: 'web', framework: 'nextjs' },
+          },
+          projectSettings: {
+            framework: null,
+          },
+          workPath,
+        }
+      );
+
+      expect(errors).toBeNull();
+      expect(services).toHaveLength(2);
+      expect(services?.every(s => s.schema === 'experimentalServicesV2')).toBe(
+        true
+      );
+      expect(builders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            src: 'api/index.js',
+            use: '@vercel/backends',
+          }),
+          expect.objectContaining({ use: '@vercel/next' }),
+        ])
+      );
+    } finally {
+      rmSync(workPath, { recursive: true, force: true });
     }
   });
 

--- a/packages/fs-detectors/test/unit.detect-services-v2.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services-v2.test.ts
@@ -1,0 +1,497 @@
+import { detectServices, isStaticBuild, isRouteOwningBuilder } from '../src';
+import type { ExperimentalServiceV2 } from '../src';
+import VirtualFilesystem from './virtual-file-system';
+
+function vercelJson(config: object): string {
+  return JSON.stringify(config);
+}
+
+function servicesV2(services: { schema: string }[]): ExperimentalServiceV2[] {
+  return services.filter(
+    (s): s is ExperimentalServiceV2 => s.schema === 'experimentalServicesV2'
+  );
+}
+
+describe('detectServices (experimentalServicesV2)', () => {
+  it('resolves a node backend framework service to @vercel/backends', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          api: { root: 'api', framework: 'express' },
+        },
+      }),
+      'api/package.json': JSON.stringify({
+        dependencies: { express: '4.0.0' },
+      }),
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.errors).toEqual([]);
+    expect(result.source).toBe('configured');
+    expect(result.useImplicitEnvInjection).toBe(false);
+    expect(result.services).toHaveLength(1);
+
+    const [api] = servicesV2(result.services);
+    expect(api).toMatchObject({
+      schema: 'experimentalServicesV2',
+      name: 'api',
+      root: 'api',
+      framework: 'express',
+      runtime: 'node',
+    });
+    expect(api.builder.use).toBe('@vercel/backends');
+    expect(api.builder.src).toBe('api/index.js');
+  });
+
+  it('resolves a runtime + file entrypoint service to the runtime builder', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          worker: { root: 'svc', runtime: 'python', entrypoint: 'main.py' },
+        },
+      }),
+      'svc/main.py': 'print("hi")',
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.errors).toEqual([]);
+    const [worker] = servicesV2(result.services);
+    expect(worker).toMatchObject({
+      schema: 'experimentalServicesV2',
+      name: 'worker',
+      root: 'svc',
+      runtime: 'python',
+      entrypoint: 'main.py',
+    });
+    expect(worker.builder.use).toBe('@vercel/python');
+    expect(worker.builder.src).toBe('svc/main.py');
+  });
+
+  it('returns empty routes for V2', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          api: { root: 'api', framework: 'express' },
+        },
+      }),
+      'api/package.json': '{}',
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.routes).toEqual({
+      hostRewrites: [],
+      rewrites: [],
+      defaults: [],
+      fallbacks: [],
+      crons: [],
+      workers: [],
+    });
+  });
+
+  it('carries bindings, functions and route tables', async () => {
+    const functions = { 'api/**': { memory: 1024 } };
+    const routes = [{ src: '/health', dest: '/health' }];
+    const rewrites = [{ source: '/old', destination: '/new' }];
+    const headers = [
+      { source: '/(.*)', headers: [{ key: 'x-svc', value: '1' }] },
+    ];
+    const bindings = [
+      { type: 'service', service: 'api', format: 'url', env: 'API_URL' },
+    ];
+
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          web: {
+            root: 'apps/web',
+            framework: 'express',
+            installCommand: 'npm ci',
+            buildCommand: 'npm run build',
+            devCommand: 'npm run dev',
+            ignoreCommand: 'exit 0',
+            outputDirectory: 'dist',
+            bindings,
+            functions,
+            routes,
+            rewrites,
+            headers,
+            cleanUrls: true,
+            trailingSlash: false,
+          },
+          api: { root: 'api', framework: 'express' },
+        },
+      }),
+      'apps/web/package.json': '{}',
+      'api/package.json': '{}',
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.errors).toEqual([]);
+    const services = servicesV2(result.services);
+    const web = services.find(s => s.name === 'web');
+    expect(web).toMatchObject({
+      installCommand: 'npm ci',
+      buildCommand: 'npm run build',
+      devCommand: 'npm run dev',
+      ignoreCommand: 'exit 0',
+      outputDirectory: 'dist',
+      bindings,
+      functions,
+      routes,
+      rewrites,
+      headers,
+      cleanUrls: true,
+      trailingSlash: false,
+    });
+  });
+
+  it('resolves a frontend framework to a route-owning builder', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          web: { root: 'web', framework: 'nextjs' },
+        },
+      }),
+      'web/package.json': JSON.stringify({ dependencies: { next: 'latest' } }),
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.errors).toEqual([]);
+    const [web] = servicesV2(result.services);
+    expect(web).toMatchObject({ name: 'web', framework: 'nextjs' });
+    expect(web.builder.use).toBe('@vercel/next');
+    expect(isRouteOwningBuilder(web)).toBe(true);
+  });
+
+  it('resolves a static framework to @vercel/static-build', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          site: { root: 'site', framework: 'vite' },
+        },
+      }),
+      'site/package.json': JSON.stringify({ dependencies: { vite: 'latest' } }),
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.errors).toEqual([]);
+    const [site] = servicesV2(result.services);
+    expect(site).toMatchObject({ name: 'site', framework: 'vite' });
+    expect(site.builder.use).toBe('@vercel/static-build');
+    expect(isStaticBuild(site)).toBe(true);
+    // Static builds have no runtime.
+    expect(site.runtime).toBeUndefined();
+  });
+
+  it('resolves a Python module:attr entrypoint to its underlying file', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          api: { root: 'api', runtime: 'python', entrypoint: 'main:app' },
+        },
+      }),
+      'api/main.py': 'app = object()',
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.errors).toEqual([]);
+    const [api] = servicesV2(result.services);
+    expect(api).toMatchObject({
+      name: 'api',
+      runtime: 'python',
+      entrypoint: 'main.py',
+    });
+    expect(api.builder.use).toBe('@vercel/python');
+    expect(api.builder.src).toBe('api/main.py');
+    expect(api.builder.config).toMatchObject({ handlerFunction: 'app' });
+  });
+
+  it('resolves a service rooted at the project root (".")', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          api: { root: '.', framework: 'express' },
+        },
+      }),
+      'package.json': JSON.stringify({ dependencies: { express: '4.0.0' } }),
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.errors).toEqual([]);
+    const [api] = servicesV2(result.services);
+    expect(api).toMatchObject({ name: 'api', root: '.', framework: 'express' });
+    expect(api.builder.use).toBe('@vercel/backends');
+    expect(api.builder.src).toBe('index.js');
+  });
+
+  it('resolves multiple services independently', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          web: { root: 'web', framework: 'nextjs' },
+          api: { root: 'api', framework: 'express' },
+        },
+      }),
+      'web/package.json': JSON.stringify({ dependencies: { next: 'latest' } }),
+      'api/package.json': JSON.stringify({
+        dependencies: { express: '4.0.0' },
+      }),
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.errors).toEqual([]);
+    const services = servicesV2(result.services);
+    expect(services).toHaveLength(2);
+    expect(services.every(s => s.schema === 'experimentalServicesV2')).toBe(
+      true
+    );
+    expect(services.find(s => s.name === 'web')?.builder.use).toBe(
+      '@vercel/next'
+    );
+    expect(services.find(s => s.name === 'api')?.builder.use).toBe(
+      '@vercel/backends'
+    );
+  });
+
+  it('reads experimentalServicesV2 from a nested workPath', async () => {
+    const fs = new VirtualFilesystem({
+      'app/vercel.json': vercelJson({
+        experimentalServicesV2: {
+          api: { root: 'api', framework: 'express' },
+        },
+      }),
+      'app/api/package.json': '{}',
+    });
+
+    const result = await detectServices({ fs, workPath: 'app' });
+
+    expect(result.errors).toEqual([]);
+    expect(servicesV2(result.services)).toHaveLength(1);
+  });
+
+  describe('errors', () => {
+    it('errors when root does not exist', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            a: { root: 'missing', framework: 'express' },
+          },
+        }),
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.services).toEqual([]);
+      expect(result.errors[0]).toMatchObject({ code: 'ROOT_NOT_FOUND' });
+    });
+
+    it('errors when root is a file', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            a: { root: 'file.txt', framework: 'express' },
+          },
+        }),
+        'file.txt': 'x',
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({ code: 'ROOT_NOT_DIRECTORY' });
+    });
+
+    it('errors when entrypoint does not exist', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            a: { root: 'svc', runtime: 'python', entrypoint: 'nope.py' },
+          },
+        }),
+        'svc/other.py': 'x',
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({ code: 'ENTRYPOINT_NOT_FOUND' });
+    });
+
+    it('errors when a directory entrypoint has no resolvable framework', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            a: { root: 'svc', runtime: 'python', entrypoint: 'pkg' },
+          },
+        }),
+        'svc/pkg/__init__.py': '',
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.services).toEqual([]);
+      expect(result.errors[0]).toMatchObject({
+        code: 'MISSING_SERVICE_FRAMEWORK',
+      });
+    });
+
+    it('errors on an invalid framework', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: { a: { root: 'svc', framework: 'nope' } },
+        }),
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({ code: 'INVALID_FRAMEWORK' });
+    });
+
+    it('errors on an invalid runtime', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            a: { root: 'svc', runtime: 'cobol', entrypoint: 'x' },
+          },
+        }),
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({ code: 'INVALID_RUNTIME' });
+    });
+
+    it('errors on a runtime/framework mismatch', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            a: { root: 'svc', runtime: 'python', framework: 'express' },
+          },
+        }),
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({
+        code: 'RUNTIME_FRAMEWORK_MISMATCH',
+      });
+    });
+
+    it('errors when neither framework nor entrypoint is given', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: { a: { root: 'svc' } },
+        }),
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({
+        code: 'MISSING_SERVICE_CONFIG',
+      });
+    });
+
+    it('errors when root is missing', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: { a: { framework: 'express' } },
+        }),
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({ code: 'MISSING_ROOT' });
+    });
+
+    it('errors when root is an absolute path', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: { a: { root: '/etc', framework: 'express' } },
+        }),
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({ code: 'INVALID_ROOT' });
+    });
+
+    it('errors when root escapes the project root', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            a: { root: '../outside', framework: 'express' },
+          },
+        }),
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({ code: 'INVALID_ROOT' });
+    });
+
+    it('errors on an invalid service name', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            '1bad': { root: 'svc', framework: 'express' },
+          },
+        }),
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({ code: 'INVALID_SERVICE_NAME' });
+    });
+
+    it('reports errors per service and resolves the valid ones', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            ok: { root: 'ok', framework: 'express' },
+            bad: { root: 'svc', runtime: 'cobol', entrypoint: 'x' },
+          },
+        }),
+        'ok/package.json': '{}',
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(servicesV2(result.services).map(s => s.name)).toEqual(['ok']);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        code: 'INVALID_RUNTIME',
+        serviceName: 'bad',
+      });
+    });
+
+    it('errors when a binding references an unknown service', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          experimentalServicesV2: {
+            web: {
+              root: 'apps/web',
+              framework: 'express',
+              bindings: [
+                { type: 'service', service: 'ghost', format: 'url', env: 'G' },
+              ],
+            },
+          },
+        }),
+        'apps/web/package.json': '{}',
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors[0]).toMatchObject({
+        code: 'UNKNOWN_SERVICE_BINDING',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Wire `experimentalServicesV2` into `fs-detectors` only with parsing, validation and builders output. Build, dev and other pipelines still rely only on `experimentalServices` through new guards