### PR TITLE
[@vercel/connect] Add JWT bearer subject types

### DIFF
--- a/.changeset/connect-jwt-bearer-subject.md
+++ b/.changeset/connect-jwt-bearer-subject.md
@@ -1,0 +1,6 @@
+---
+'@vercel/connect': patch
+---
+
+Add the JWT bearer token subject type to the public Connect token params and
+allow the Ash helper to customize principal-to-subject mapping.

--- a/packages/connect/docs/ash-authorization-helper.md
+++ b/packages/connect/docs/ash-authorization-helper.md
@@ -113,7 +113,11 @@ import {
   type TokenResult,
 } from "experimental-ash/connections";
 
-import type { ConnectOptions, ConnectTokenParams } from "./token.js";
+import type {
+  ConnectOptions,
+  ConnectTokenParams,
+  ConnectTokenSubject,
+} from "./token.js";
 
 /**
  * State journaled by Ash between `startAuthorization` and
@@ -157,6 +161,14 @@ export interface AshAuthorizationOptions {
    * from the principal; any other field is passed through verbatim.
    */
   readonly tokenParams?: Omit<ConnectTokenParams, "subject">;
+
+  /**
+   * Override how Ash's framework-resolved principal is mapped to a
+   * Vercel Connect token subject.
+   */
+  readonly principalToSubject?: (
+    principal: ConnectionPrincipal
+  ) => ConnectTokenSubject | Promise<ConnectTokenSubject>;
 
   /**
    * Forwarded to `@vercel/connect`. Primarily for tests that inject
@@ -298,6 +310,22 @@ authorization: connect({
 ```
 
 Same pattern for `resources`, `installationId`, and `authorizationDetails`.
+
+### Custom subject mapping
+
+By default, app principals map to `{ type: "app" }` and user principals map to
+`{ type: "user", id, issuer }`. Use `principalToSubject` when a connector needs
+a different subject shape:
+
+```ts
+authorization: connect({
+  connector: process.env.CONNECTOR_OAUTH!,
+  principalToSubject: principal => ({
+    type: "jwt-bearer",
+    sub: principal.type === "user" ? principal.id : "app",
+  }),
+}),
+```
 
 ### Custom error translation
 

--- a/packages/connect/docs/ash-authorization-helper.md
+++ b/packages/connect/docs/ash-authorization-helper.md
@@ -20,12 +20,12 @@ That boilerplate is where subtle bugs live — swap one error mapping and the ag
 
 ```ts
 // agent/connections/linear.ts — target shape
-import { connect } from "@vercel/connect/ash";
-import { defineMcpClientConnection } from "experimental-ash/connections";
+import { connect } from '@vercel/connect/ash';
+import { defineMcpClientConnection } from 'experimental-ash/connections';
 
 export default defineMcpClientConnection({
-  url: "https://mcp.linear.app/sse",
-  description: "Linear workspace — issues, projects, cycles, and comments.",
+  url: 'https://mcp.linear.app/sse',
+  description: 'Linear workspace — issues, projects, cycles, and comments.',
   authorization: connect({
     connector: process.env.CONNECTOR_LINEAR!,
   }),
@@ -67,7 +67,7 @@ Ash's `NonInteractiveAuthorizationDefinition` technically accepts `principalType
 
 ```ts
 interface InteractiveAuthorizationDefinition<State extends JsonValue> {
-  readonly principalType: "user";
+  readonly principalType: 'user';
   getToken(opts: { principal: ConnectionPrincipal }): Promise<TokenResult>;
   startAuthorization(opts: {
     principal: ConnectionPrincipal;
@@ -111,13 +111,13 @@ import {
   type JsonValue,
   type NonInteractiveAuthorizationDefinition,
   type TokenResult,
-} from "experimental-ash/connections";
+} from 'experimental-ash/connections';
 
 import type {
   ConnectOptions,
   ConnectTokenParams,
   ConnectTokenSubject,
-} from "./token.js";
+} from './token.js';
 
 /**
  * State journaled by Ash between `startAuthorization` and
@@ -131,9 +131,9 @@ export type ConnectAuthorizationState = {
 };
 
 export type ConnectAuthorizationPhase =
-  | "getToken"
-  | "startAuthorization"
-  | "completeAuthorization";
+  | 'getToken'
+  | 'startAuthorization'
+  | 'completeAuthorization';
 
 export interface AshAuthorizationOptions {
   /**
@@ -154,13 +154,13 @@ export interface AshAuthorizationOptions {
    *   Returns a non-interactive definition (`getToken` only). Ash
    *   v1 does not support interactive OAuth in app mode.
    */
-  readonly principalType?: "app" | "user";
+  readonly principalType?: 'app' | 'user';
 
   /**
    * Forwarded on every token request. The helper derives `subject`
    * from the principal; any other field is passed through verbatim.
    */
-  readonly tokenParams?: Omit<ConnectTokenParams, "subject">;
+  readonly tokenParams?: Omit<ConnectTokenParams, 'subject'>;
 
   /**
    * Override how Ash's framework-resolved principal is mapped to a
@@ -192,7 +192,7 @@ export interface AshAuthorizationOptions {
    */
   readonly onError?: (
     error: unknown,
-    phase: ConnectAuthorizationPhase,
+    phase: ConnectAuthorizationPhase
   ) => Error | undefined;
 }
 
@@ -203,13 +203,13 @@ export interface AshAuthorizationOptions {
  * Drop directly into `defineMcpClientConnection`.
  */
 export function connect(
-  options: AshAuthorizationOptions & { readonly principalType?: "user" },
+  options: AshAuthorizationOptions & { readonly principalType?: 'user' }
 ): InteractiveAuthorizationDefinition<ConnectAuthorizationState>;
 export function connect(
-  options: AshAuthorizationOptions & { readonly principalType: "app" },
+  options: AshAuthorizationOptions & { readonly principalType: 'app' }
 ): NonInteractiveAuthorizationDefinition;
 export function connect(
-  options: AshAuthorizationOptions,
+  options: AshAuthorizationOptions
 ):
   | InteractiveAuthorizationDefinition<ConnectAuthorizationState>
   | NonInteractiveAuthorizationDefinition;
@@ -241,17 +241,17 @@ export function connect(
 
 ```ts
 // agent/connections/linear.ts
-import { connect } from "@vercel/connect/ash";
-import { defineMcpClientConnection } from "experimental-ash/connections";
+import { connect } from '@vercel/connect/ash';
+import { defineMcpClientConnection } from 'experimental-ash/connections';
 
 const connector = process.env.CONNECTOR_LINEAR;
 if (!connector) {
-  throw new Error("CONNECTOR_LINEAR is required to use the linear connection.");
+  throw new Error('CONNECTOR_LINEAR is required to use the linear connection.');
 }
 
 export default defineMcpClientConnection({
-  url: "https://mcp.linear.app/sse",
-  description: "Linear workspace — issues, projects, cycles, and comments.",
+  url: 'https://mcp.linear.app/sse',
+  description: 'Linear workspace — issues, projects, cycles, and comments.',
   authorization: connect({
     connector,
   }),
@@ -265,15 +265,15 @@ A missing env var fails at module load (i.e. agent boot). The check lives at the
 ```ts
 // agent/connections/status-api.ts — a shared service the agent polls
 // on its own identity, no end-user consent.
-import { connect } from "@vercel/connect/ash";
-import { defineMcpClientConnection } from "experimental-ash/connections";
+import { connect } from '@vercel/connect/ash';
+import { defineMcpClientConnection } from 'experimental-ash/connections';
 
 export default defineMcpClientConnection({
-  url: "https://status.internal.example.com/mcp",
-  description: "Internal status API (agent-owned credential).",
+  url: 'https://status.internal.example.com/mcp',
+  description: 'Internal status API (agent-owned credential).',
   authorization: connect({
     connector: process.env.CONNECTOR_STATUS!,
-    principalType: "app",
+    principalType: 'app',
   }),
 });
 ```
@@ -322,7 +322,7 @@ authorization: connect({
   connector: process.env.CONNECTOR_OAUTH!,
   principalToSubject: principal => ({
     type: "jwt-bearer",
-    sub: principal.type === "user" ? principal.id : "app",
+    sub: principal.attributes.email,
   }),
 }),
 ```
@@ -434,17 +434,17 @@ After migration, `agent/connections/linear.ts` and `agent/connections/notion.ts`
 
 ```ts
 // agent/connections/linear.ts (after)
-import { connect } from "@vercel/connect/ash";
-import { defineMcpClientConnection } from "experimental-ash/connections";
+import { connect } from '@vercel/connect/ash';
+import { defineMcpClientConnection } from 'experimental-ash/connections';
 
 const connector = process.env.CONNECTOR_LINEAR;
 if (!connector) {
-  throw new Error("CONNECTOR_LINEAR is required to use the linear connection.");
+  throw new Error('CONNECTOR_LINEAR is required to use the linear connection.');
 }
 
 export default defineMcpClientConnection({
-  url: "https://mcp.linear.app/sse",
-  description: "Linear workspace — issues, projects, cycles, and comments.",
+  url: 'https://mcp.linear.app/sse',
+  description: 'Linear workspace — issues, projects, cycles, and comments.',
   authorization: connect({
     connector,
   }),
@@ -460,12 +460,14 @@ export default defineMcpClientConnection({
 Sequential; each step validates the next.
 
 1. **Ash prereq PR — [DONE].**
+
    - The principal-model branch already exposes `AuthorizationDefinition`, `ConnectionPrincipal`, `TokenResult`, `ConnectionAuthorizationChallenge`, and the two error classes from `experimental-ash/connections`.
    - `isConnectionAuthorizationRequiredError` / `isConnectionAuthorizationFailedError` discriminate on `err.name` (not `instanceof`), which already addresses the cross-realm/duplicate-package risk.
    - `withDefaultAuthorizationInstructions(challenge, connectionName)` in `src/execution/authorization-challenge-defaults.ts` fills in the default `"Authorize <ConnectionName> in your browser to continue."` text using the slot name; capitalization helper covers hyphenated/empty cases.
    - Pending follow-up: publish a new Ash alpha that includes the principal-model surface so consumers don't need a workspace override. Until then the Vercel Connect repo uses a pnpm `overrides` entry that links `experimental-ash` to a local checkout.
 
 2. **Vercel Connect SDK change — [DONE locally, pending publish].**
+
    - Add `experimental-ash` as an optional peer dep (`peerDependenciesMeta.experimental-ash.optional: true`) and as a devDep.
    - Add `./ash` subpath export pointing to `./dist/ash.{js,d.ts}`.
    - Implement `connect` in `src/ash.ts` with type-only imports from `experimental-ash/connections`. Drop the structural mirror types and the local error class lookalikes.
@@ -485,6 +487,7 @@ Sequential; each step validates the next.
 3. **Changeset.** Minor bump on `@vercel/connect`; call out required Ash version range.
 
 4. **Demo app migration — [DONE].**
+
    - Rewrote `linear.ts` / `notion.ts` to use the helper, with a top-level env-var check that throws on import if the connector id is unset.
    - Deleted `agent/lib/connect.ts`.
    - Added `@types/node` to devDeps and `"types": ["node"]` to `tsconfig.json`.

--- a/packages/connect/src/ash/connection-authorization.ts
+++ b/packages/connect/src/ash/connection-authorization.ts
@@ -40,7 +40,11 @@ import {
 } from 'experimental-ash/connections';
 
 import { startAuthorization } from '../authorization.js';
-import type { ConnectOptions, ConnectTokenParams } from '../token.js';
+import type {
+  ConnectOptions,
+  ConnectTokenParams,
+  ConnectTokenSubject,
+} from '../token.js';
 import {
   ConnectorInstallationRequiredError,
   getTokenResponse,
@@ -121,6 +125,16 @@ export interface AshAuthorizationOptions {
    * `authorizationDetails`. Passed through verbatim.
    */
   readonly tokenParams?: Omit<ConnectTokenParams, 'subject'>;
+
+  /**
+   * Override how Ash's framework-resolved principal is mapped to a
+   * Vercel Connect token subject. When omitted, app principals map to
+   * `{ type: "app" }` and user principals map to
+   * `{ type: "user", id, issuer }`.
+   */
+  readonly principalToSubject?: (
+    principal: ConnectionPrincipal
+  ) => ConnectTokenSubject | Promise<ConnectTokenSubject>;
 
   /**
    * Low-level Vercel Connect SDK options (currently `vercelToken`
@@ -261,7 +275,7 @@ function buildInteractiveDefinition(
       try {
         const response = await getTokenResponse(
           options.connector,
-          buildTokenParams(options, principal),
+          await buildTokenParams(options, principal),
           options.connectOptions
         );
         return { token: response.token, expiresAt: response.expiresAt };
@@ -302,7 +316,7 @@ function buildInteractiveDefinition(
         // in production.
         const response = await startAuthorization(
           options.connector,
-          buildTokenParams(options, principal),
+          await buildTokenParams(options, principal),
           {
             ...options.connectOptions,
             callbackUrl: callbackUrl ?? webhook,
@@ -333,7 +347,7 @@ function buildInteractiveDefinition(
       try {
         const response = await getTokenResponse(
           options.connector,
-          buildTokenParams(options, principal),
+          await buildTokenParams(options, principal),
           options.connectOptions
         );
         return { token: response.token, expiresAt: response.expiresAt };
@@ -353,7 +367,7 @@ function buildNonInteractiveDefinition(
       try {
         const response = await getTokenResponse(
           options.connector,
-          buildTokenParams(options, principal),
+          await buildTokenParams(options, principal),
           options.connectOptions
         );
         return { token: response.token, expiresAt: response.expiresAt };
@@ -364,19 +378,20 @@ function buildNonInteractiveDefinition(
   };
 }
 
-function buildTokenParams(
+async function buildTokenParams(
   options: AshAuthorizationOptions,
   principal: ConnectionPrincipal
-): ConnectTokenParams {
+): Promise<ConnectTokenParams> {
+  const toSubject = options.principalToSubject ?? principalToSubject;
   return {
     ...options.tokenParams,
-    subject: principalToSubject(principal),
+    subject: await toSubject(principal),
   };
 }
 
 function principalToSubject(
   principal: ConnectionPrincipal
-): ConnectTokenParams['subject'] {
+): ConnectTokenSubject {
   if (principal.type === 'app') {
     return { type: 'app' };
   }

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -9,6 +9,7 @@ export {
   type ConnectOptions,
   type ConnectTokenParams,
   type ConnectTokenResponse,
+  type ConnectTokenSubject,
   type ConnectVendorErrorPayload,
 } from './token.js';
 

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -1,8 +1,35 @@
 import { getVercelOidcToken } from '@vercel/oidc';
 import type { ConnectAuthorizationDetail } from './authorization-details.js';
 
+export type ConnectSubjectType = 'app' | 'user' | 'jwt-bearer';
+
+export type ConnectTokenSubject =
+  | ConnectAppTokenSubject
+  | ConnectUserTokenSubject
+  | ConnectJwtBearerTokenSubject;
+
+export interface ConnectAppTokenSubject {
+  type: 'app';
+}
+
+export interface ConnectUserTokenSubject {
+  type: 'user';
+  id: string;
+  issuer?: string;
+}
+
+export interface ConnectJwtBearerTokenSubject {
+  type: 'jwt-bearer';
+  sub: string;
+  /** Defaults to the connector's OAuth client id. */
+  iss?: string;
+  /** Defaults to the connector's OAuth token endpoint. */
+  aud?: string;
+  additionalClaims?: Record<string, unknown>;
+}
+
 export interface ConnectTokenParams {
-  subject: { type: 'app' } | { type: 'user'; id: string; issuer?: string };
+  subject: ConnectTokenSubject;
   installationId?: string;
   audience?: string[];
   scopes?: string[];


### PR DESCRIPTION
## Summary
- add public Connect token subject aliases, including the new jwt-bearer subject shape
- allow the Ash helper to override principal-to-subject mapping with sync or async callbacks
- document custom subject mapping and add a patch changeset

## Testing
- pnpm --filter @vercel/connect typecheck
- pnpm --filter @vercel/connect build