### PR TITLE
fix(build-utils): make Node entrypoint comment stripping string/regex aware

### DIFF
--- a/.changeset/node-entrypoint-string-aware-comments.md
+++ b/.changeset/node-entrypoint-string-aware-comments.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Fixed Node.js API entrypoint detection dropping functions whose source contains a `*/`-bearing string literal (e.g. an `Accept: */*` header) before a real block comment. The comment stripper used for entrypoint detection is now string-, template-literal-, and regex-aware, so it no longer treats `/*` inside a string as the start of a block comment and swallows the handler export.

--- a/packages/build-utils/src/node-entrypoint.ts
+++ b/packages/build-utils/src/node-entrypoint.ts
@@ -27,12 +27,164 @@ const VALID_EXPORT_PATTERNS = [
 
 /**
  * Strip single-line (//) and multi-line (/* ... *​/) comments from source code.
- * This is a simple heuristic to avoid false positives from commented-out exports.
+ * This is a heuristic to avoid false positives from commented-out exports.
+ *
+ * A naive regex-based stripper is string/regex-unaware: a string literal such as
+ * the `Accept: ... *​/*; q=0.8` header contains the sequence `/*`, which a regex
+ * treats as the start of a block comment and then deletes everything up to the
+ * next real `*​/` later in the file — frequently swallowing the actual handler
+ * export. To avoid that, this scanner walks the source character by character and
+ * only treats `//` and `/* *​/` as comments when they appear in code context
+ * (i.e. not inside a string, template literal, or regex literal).
  */
 function stripComments(content: string): string {
-  return content
-    .replace(/\/\/.*$/gm, '') // single-line comments
-    .replace(/\/\*[\s\S]*?\*\//g, ''); // multi-line comments
+  let result = '';
+  let i = 0;
+  const len = content.length;
+
+  while (i < len) {
+    const char = content[i];
+    const next = content[i + 1];
+
+    // Line comment: skip until end of line (preserve the newline).
+    if (char === '/' && next === '/') {
+      i += 2;
+      while (i < len && content[i] !== '\n') i++;
+      continue;
+    }
+
+    // Block comment: skip until the closing */ (preserve newlines inside it so
+    // that line-anchored regexes downstream still behave).
+    if (char === '/' && next === '*') {
+      i += 2;
+      while (i < len && !(content[i] === '*' && content[i + 1] === '/')) {
+        if (content[i] === '\n') result += '\n';
+        i++;
+      }
+      i += 2; // skip the closing */
+      continue;
+    }
+
+    // String literal: copy verbatim until the matching unescaped quote.
+    if (char === '"' || char === "'") {
+      const quote = char;
+      result += char;
+      i++;
+      while (i < len) {
+        result += content[i];
+        if (content[i] === '\\') {
+          // copy the escaped character too
+          i++;
+          if (i < len) result += content[i];
+          i++;
+          continue;
+        }
+        if (content[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    // Template literal: copy verbatim until the matching unescaped backtick.
+    // Nested `${ ... }` expressions are copied as-is; any `/*` inside them is
+    // unlikely to matter for export detection and keeping it simple is safer
+    // than mis-stripping real code.
+    if (char === '`') {
+      result += char;
+      i++;
+      while (i < len) {
+        result += content[i];
+        if (content[i] === '\\') {
+          i++;
+          if (i < len) result += content[i];
+          i++;
+          continue;
+        }
+        if (content[i] === '`') {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    // Regex literal: only when a `/` appears in a position where a regex is
+    // valid (i.e. preceded by a token that cannot end an expression). This
+    // prevents treating division operators as regex while still copying real
+    // regex literals verbatim so their contents aren't mistaken for comments.
+    if (char === '/' && isRegexContext(result)) {
+      result += char;
+      i++;
+      let inClass = false;
+      while (i < len) {
+        result += content[i];
+        if (content[i] === '\\') {
+          i++;
+          if (i < len) result += content[i];
+          i++;
+          continue;
+        }
+        if (content[i] === '[') inClass = true;
+        else if (content[i] === ']') inClass = false;
+        else if (content[i] === '/' && !inClass) {
+          i++;
+          break;
+        } else if (content[i] === '\n') {
+          // Unterminated regex (shouldn't happen in valid code); bail out.
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    result += char;
+    i++;
+  }
+
+  return result;
+}
+
+/**
+ * Determine whether a `/` should start a regex literal based on the code emitted
+ * so far. A regex can appear where an expression is expected, which is after
+ * operators, keywords, opening brackets, etc. — but not after an identifier,
+ * number, or closing bracket (which would make `/` a division operator).
+ */
+function isRegexContext(prefix: string): boolean {
+  const trimmed = prefix.replace(/\s+$/, '');
+  if (trimmed === '') return true;
+  const last = trimmed[trimmed.length - 1];
+  // After these, a `/` is division, not a regex.
+  if (/[A-Za-z0-9_$)\]}.]/.test(last)) {
+    // `return/.../`, `typeof/.../` etc. are regex contexts; check for keywords.
+    const keywordMatch = trimmed.match(/(?:^|[^A-Za-z0-9_$])([A-Za-z]+)$/);
+    if (keywordMatch) {
+      const REGEX_PRECEDING_KEYWORDS = new Set([
+        'return',
+        'typeof',
+        'instanceof',
+        'in',
+        'of',
+        'new',
+        'delete',
+        'void',
+        'do',
+        'else',
+        'yield',
+        'await',
+        'case',
+      ]);
+      if (REGEX_PRECEDING_KEYWORDS.has(keywordMatch[1])) return true;
+    }
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/build-utils/test/unit.node-entrypoint.test.ts
+++ b/packages/build-utils/test/unit.node-entrypoint.test.ts
@@ -177,6 +177,72 @@ describe('isNodeEntrypoint()', () => {
     });
   });
 
+  describe('string- and regex-aware comment stripping', () => {
+    // Regression for PIPE-6655: a string literal containing `*/*` (e.g. an
+    // Accept header) followed by a real block comment after the handler export
+    // caused the naive comment stripper to treat the `/*` inside the string as
+    // the start of a block comment and delete everything up to the real `*/`,
+    // swallowing the export and dropping the function from the build manifest.
+    it('Accept header string with */* before a later block comment', async () => {
+      const content = [
+        'const headers = {',
+        "  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',",
+        '};',
+        '',
+        'export async function GET(request) {',
+        '  /* fall through to puppeteer */',
+        '  return new Response(JSON.stringify({ error: "bad request" }), { status: 400 });',
+        '}',
+      ].join('\n');
+      expect(await check(content)).toBe(true);
+    });
+
+    it('module.exports with */* string and a trailing block comment', async () => {
+      const content = [
+        "const accept = '*/*';",
+        'module.exports = async (req, res) => {',
+        '  res.statusCode = 400;',
+        '  res.end(accept);',
+        '};',
+        '/* helper notes below */',
+      ].join('\n');
+      expect(await check(content)).toBe(true);
+    });
+
+    it('export default with /* inside a single-quoted string', async () => {
+      const content = [
+        "const pattern = '/* not a comment */';",
+        'export default function handler(req, res) { res.end(pattern); }',
+      ].join('\n');
+      expect(await check(content)).toBe(true);
+    });
+
+    it('export inside a template literal context is detected', async () => {
+      const content = [
+        'const msg = `value with */* sequence`;',
+        'export function POST(request) { return new Response(msg); }',
+      ].join('\n');
+      expect(await check(content)).toBe(true);
+    });
+
+    it('regex literal containing */ does not hide the export', async () => {
+      const content = [
+        'const re = /foo\\/*bar/;',
+        'export function GET(request) { return new Response(String(re)); }',
+      ].join('\n');
+      expect(await check(content)).toBe(true);
+    });
+
+    it('still strips genuine block comments wrapping an export', async () => {
+      const content = [
+        "const accept = '*/*';",
+        '/* export default function handler(req, res) { res.end(accept); } */',
+        'export function helper() { return accept; }',
+      ].join('\n');
+      expect(await check(content)).toBe(false);
+    });
+  });
+
   describe('returns false for non-entrypoints', () => {
     it('empty file', async () => {
       expect(await check('')).toBe(false);


### PR DESCRIPTION
isNodeEntrypoint stripped comments with naive regexes that were not string- or regex-aware. A string literal containing a `*/*` sequence (e.g. an Accept header) before a real block comment was treated as a block-comment start, deleting everything up to the next real `*/` and swallowing the handler export. The file was then silently dropped from the build manifest under VERCEL_NODE_FILTER_ENTRYPOINTS.

Replace the regex stripper with a single-pass scanner that only treats // and /* */ as comments in code context, copying strings, template literals, and regex literals verbatim.

Fixes PIPE-6655.