### PR TITLE
[connect] forward token params/options through connectSlackCredentials

### DIFF
--- a/.changeset/connect-slack-credentials-params.md
+++ b/.changeset/connect-slack-credentials-params.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Allow `connectSlackCredentials` to forward `ConnectTokenParams` (e.g. `installationId`, `scopes`, `validityBufferMs`) and `ConnectOptions` through to `getToken`. The `subject` field stays pinned to `{ type: 'app' }` so the helper still enforces app-scoped Slack bot tokens.

--- a/packages/connect/src/ash/slack-credentials.ts
+++ b/packages/connect/src/ash/slack-credentials.ts
@@ -1,7 +1,21 @@
 import type { SlackChannelCredentials } from 'experimental-ash/channels/slack';
 
-import { getToken } from '../index.js';
+import {
+  getToken,
+  type ConnectOptions,
+  type ConnectTokenParams,
+} from '../index.js';
 import { vercelOidc } from 'experimental-ash/channels/auth';
+
+/**
+ * Token parameters accepted by {@link connectSlackCredentials}.
+ *
+ * Mirrors {@link ConnectTokenParams} from `@vercel/connect`, minus
+ * `subject` — Slack bot tokens are always app-scoped, so `subject`
+ * is pinned to `{ type: "app" }` by this helper and cannot be
+ * overridden.
+ */
+export type ConnectSlackCredentialsParams = Omit<ConnectTokenParams, 'subject'>;
 
 /**
  * Build {@link SlackChannelCredentials} backed by a Vercel Connect
@@ -17,6 +31,10 @@ import { vercelOidc } from 'experimental-ash/channels/auth';
  * with `subject: { type: "app" }`. End-user identity (per-user OAuth
  * into Slack) is a separate concern handled elsewhere.
  *
+ * The optional `params` and `options` arguments mirror the signature
+ * of {@link getToken}, allowing callers to pass through fields like
+ * `installationId`, `scopes`, or `validityBufferMs`.
+ *
  * ```ts
  * import { slackRoute } from "experimental-ash/channels/slack";
  * import { connectSlackCredentials } from "@vercel/connect/ash";
@@ -25,12 +43,22 @@ import { vercelOidc } from 'experimental-ash/channels/auth';
  *   credentials: connectSlackCredentials("scl_..."),
  * });
  * ```
+ *
+ * Multi-workspace deployments can select a specific workspace install
+ * via `installationId`:
+ *
+ * ```ts
+ * connectSlackCredentials("scl_...", { installationId: workspaceId });
+ * ```
  */
 export function connectSlackCredentials(
-  connector: string
+  connector: string,
+  params: ConnectSlackCredentialsParams = {},
+  options?: ConnectOptions
 ): SlackChannelCredentials {
   return {
-    botToken: () => getToken(connector, { subject: { type: 'app' } }),
+    botToken: () =>
+      getToken(connector, { ...params, subject: { type: 'app' } }, options),
     webhookVerifier: vercelOidc(),
   };
 }


### PR DESCRIPTION
## Summary

- Add optional `params` and `options` arguments to `connectSlackCredentials` that mirror the `(params, options)` shape of `getToken`, so callers can pass through `installationId`, `scopes`, `audience`, `resources`, `authorizationDetails`, `validityBufferMs`, and `vercelToken`.
- Export `ConnectSlackCredentialsParams` = `Omit<ConnectTokenParams, 'subject'>` so the type system blocks attempts to override `subject`.
- Spread order is `{ ...params, subject: { type: 'app' } }` so the "Slack bot tokens are app-scoped" invariant holds at runtime even for untyped (`as any` / JS) callers.
- JSDoc updated with an `installationId` example for multi-workspace deployments.

This is backwards-compatible — the existing `connectSlackCredentials("scl_...")` call continues to work unchanged.

## Test plan

- [x] `pnpm typecheck` passes in `packages/connect`
- [x] Prettier + Biome (pre-commit) pass
- [ ] Manual sanity check: an `installationId` passed via `params` reaches the Vercel Connect token endpoint
- [ ] Manual sanity check: a `subject` snuck in via `as any` does **not** override the pinned app subject