### PR TITLE
[cli] show `claim` in `integration resource --help`

### DIFF
--- a/.changeset/integration-resource-claim-help.md
+++ b/.changeset/integration-resource-claim-help.md
@@ -1,0 +1,7 @@
+---
+"vercel": patch
+---
+
+[cli] Show `claim` in `vercel integration resource --help`
+
+The `claim` subcommand was missing from `resourceSubcommand.subcommands`, so `vercel integration resource --help` only listed `connect`, `disconnect`, `remove`, and `create-threshold`. The legacy `vercel integration-resource --help` and the dispatcher's runtime resolution both already included `claim` — this was purely a help/discoverability gap on the canonical nested path. Adds `claimSubcommand` to the subcommand list and updates the parent description accordingly.

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -1,6 +1,7 @@
 import { formatOption, jsonOption, yesOption } from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
 import {
+  claimSubcommand,
   connectSubcommand,
   createThresholdSubcommand,
   disconnectSubcommand,
@@ -587,7 +588,7 @@ export const resourceSubcommand = {
   name: 'resource',
   aliases: [],
   description:
-    'Manage marketplace integration resources (connect, disconnect, remove, create-threshold)',
+    'Manage marketplace integration resources (connect, disconnect, remove, create-threshold, claim)',
   options: [],
   arguments: [],
   subcommands: [
@@ -595,6 +596,7 @@ export const resourceSubcommand = {
     createThresholdSubcommand,
     disconnectSubcommand,
     resourceRemoveSubcommand,
+    claimSubcommand,
   ],
   examples: [
     {

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3723,6 +3723,7 @@ exports[`help command > integration help output snapshots > integration help col
                                   di…
                                   re…
                                   cr…
+                                  cl…
   update         integration      Up…
                                   a  
                                   ma…
@@ -3921,7 +3922,7 @@ exports[`help command > integration help output snapshots > integration help col
                                   resource's dashboard via SSO               
   resource                        Manage marketplace integration resources   
                                   (connect, disconnect, remove,              
-                                  create-threshold)                          
+                                  create-threshold, claim)                   
   update         integration      Update a marketplace integration           
                                   installation (billing plan or which        
                                   projects can access it). Install, remove,  
@@ -3992,7 +3993,7 @@ exports[`help command > integration help output snapshots > integration help col
   list           [project]        List resources from marketplace integrations for the current project               
   open           name [resource]  Opens a marketplace integration's or resource's dashboard via SSO                  
   resource                        Manage marketplace integration resources (connect, disconnect, remove,             
-                                  create-threshold)                                                                  
+                                  create-threshold, claim)                                                           
   update         integration      Update a marketplace integration installation (billing plan or which projects can  
                                   access it). Install, remove, and connect flows are separate (integration add,      
                                   integration remove, integration-resource, env pull, etc.) — not part of update.    


### PR DESCRIPTION
## Summary

- `resourceSubcommand.subcommands` in `integration/command.ts` was missing `claimSubcommand`, so `vercel integration resource --help` listed only `connect`, `disconnect`, `remove`, and `create-threshold`.
- The legacy `vercel integration-resource --help` (and `vc ir --help`) already listed all five, and the dispatcher's `COMMAND_CONFIG` resolves `claim` correctly at runtime — this was a help/discoverability gap on the new canonical nested path only.
- Adds `claimSubcommand` to the subcommand list and updates the one-line parent description to match.

Followup to #16509 (nesting) + #16481 (claim), which landed close together. The arg-forwarding fix in 44f3cf881 (on `cli/integration-claim`) covered the runtime side; this covers the help surface.

## Test plan

- [x] `npx vitest run packages/cli/test/unit/commands/help.test.ts` — 140 tests pass, 3 snapshots updated (column-40 and column-120 renderings of `integration` parent help, plus parent description).
- [x] `npx vitest run packages/cli/test/unit/commands/integration-resource/ packages/cli/test/unit/commands/integration/` — 338 tests pass, no regressions.
- [ ] Smoke: `vc integration resource --help` should now list `claim` alongside the other four subcommands. `vc integration-resource --help` (alias) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)