### PR TITLE
ci(release): validate canary snapshot before promoting release

### DIFF
--- a/.changeset/release-snapshot-validation.md
+++ b/.changeset/release-snapshot-validation.md
@@ -1,0 +1,4 @@
+---
+---
+
+Release workflow now publishes a `canary` snapshot of the release commit and runs the unit + e2e suites against that snapshot (with `VERCEL_CLI_VERSION` pointed at the published spec) before promoting to the real versioned release. This catches changesets that omit a workspace dependency bump before the broken versions reach the `latest` tag.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,227 @@ env:
   TURBO_TEAM: 'vercel'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# Serialize release runs on the same ref. cancel-in-progress is intentionally
+# false: the validate -> promote pipeline can take a long time (e2e deploys
+# real projects and polls for tarballs), and we never want a newer push to
+# main to cancel a release that has already been validated. Concurrent merges
+# queue behind the in-flight release instead of interleaving with it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # 1. Detect intent.
+  #
+  # The Release workflow runs on every push to main, but only some of those
+  # pushes are actual releases. When changesets remain in .changeset/, this
+  # push should (re)open the "Version Packages" PR -- no release happens.
+  # When the Version Packages PR merges, the changesets are consumed and this
+  # push is the one that publishes.
+  #
+  # We compute `shouldRelease` up front so the expensive snapshot-validation
+  # only runs on real release pushes. Everything downstream pins to this exact
+  # commit SHA so a concurrent merge to main cannot change what we publish.
+  # ---------------------------------------------------------------------------
+  detect:
+    name: Detect Release Intent
+    runs-on: ubuntu-latest
+    outputs:
+      shouldRelease: ${{ steps.detect.outputs.shouldRelease }}
+      sha: ${{ github.sha }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Detect pending changesets
+        id: detect
+        run: |
+          set -euo pipefail
+          # Count changeset markdown files (excluding README and config).
+          pending=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
+          echo "Pending changesets: $pending"
+          if [ "$pending" -eq "0" ]; then
+            # No pending changesets => the Version Packages PR just merged and
+            # package.json versions are bumped. This push is a real release.
+            echo "shouldRelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "shouldRelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ---------------------------------------------------------------------------
+  # 2. Snapshot release (pinned to the validated SHA).
+  #
+  # Publishes a snapshot of every publishable package under the `canary` dist
+  # tag with a 0.0.0-canary-<hash> version. Crucially, snapshot versions bump
+  # ALL packages together and resolve workspace:* deps to those snapshot
+  # versions at pack time, so the CLI snapshot depends on the snapshot of its
+  # workspace deps -- exactly the dependency edge that broke last time.
+  # ---------------------------------------------------------------------------
+  snapshot:
+    name: Publish Snapshot
+    needs: detect
+    if: ${{ needs.detect.outputs.shouldRelease == 'true' }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      cliVersion: ${{ steps.snapshot.outputs.cliVersion }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          # Pin to the exact commit we will eventually promote. Never HEAD.
+          ref: ${{ needs.detect.outputs.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: wasm32-wasip2
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: 'pyproject.toml'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.10.11'
+
+      - name: install npm@11
+        run: npm i -g npm@11
+
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create Canary Snapshot Versions
+        run: pnpm ci:version:canary
+
+      - name: Build Packages
+        run: pnpm build
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Capture snapshot CLI version
+        id: snapshot
+        run: |
+          set -euo pipefail
+          # After ci:version:canary, package.json holds the snapshot version.
+          cliVersion=$(node -p "require('./packages/cli/package.json').version")
+          echo "Snapshot CLI version: $cliVersion"
+          echo "cliVersion=$cliVersion" >> "$GITHUB_OUTPUT"
+
+      - name: Publish Canary Snapshots to npm
+        run: pnpm ci:publish:canary
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+
+  # ---------------------------------------------------------------------------
+  # 3. Validate the snapshot.
+  #
+  # Run unit + e2e suites against the just-published snapshot instead of the
+  # per-PR Vercel preview tarball. e2e deploys point VERCEL_CLI_VERSION at the
+  # published npm spec so the build container installs the snapshot CLI *and*
+  # its snapshot workspace deps from npm -- catching missing dependency bumps.
+  #
+  # NOTE (draft): this currently runs the full suite inline. We likely want to
+  # reuse the chunking/matrix from test.yml (utils/chunk-tests.js) instead.
+  # Left as a single job for the draft to keep the control flow readable.
+  # ---------------------------------------------------------------------------
+  validate:
+    name: Validate Snapshot
+    needs: [detect, snapshot]
+    if: ${{ needs.detect.outputs.shouldRelease == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      # Point e2e at the published snapshot spec rather than a tarball URL.
+      # The build container installs `vercel@<snapshot>` (and its snapshot
+      # workspace deps) from the `canary` tag on npm.
+      VERCEL_CLI_VERSION: vercel@${{ needs.snapshot.outputs.cliVersion }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.detect.outputs.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.10.11'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Wait for snapshot to be installable
+        run: |
+          set -euo pipefail
+          # npm publish is not instantly consistent across the registry CDN.
+          # Poll until the exact snapshot version is resolvable before we run
+          # deploys that depend on it.
+          for attempt in {1..30}; do
+            if npm view "vercel@${{ needs.snapshot.outputs.cliVersion }}" version >/dev/null 2>&1; then
+              echo "Snapshot is available on npm."
+              exit 0
+            fi
+            echo "Snapshot not yet available (attempt $attempt/30)."
+            sleep 10
+          done
+          echo "Timed out waiting for snapshot to appear on npm."
+          exit 1
+
+      - name: Unit tests
+        run: pnpm test-unit
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          FORCE_COLOR: '1'
+
+      - name: E2E tests
+        run: pnpm test-e2e
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          FORCE_COLOR: '1'
+
+  # ---------------------------------------------------------------------------
+  # 4. Promote to the real release.
+  #
+  # Only reached if snapshot validation passed. Builds from the SAME pinned SHA
+  # and runs the normal changesets publish. Because we pin to needs.detect SHA
+  # (not HEAD), a merge to main during validation cannot change what ships:
+  # those merges queue behind us via the concurrency group and validate
+  # themselves on their own run.
+  # ---------------------------------------------------------------------------
   release:
     name: Release
+    needs: [detect, validate]
+    # Run the real publish either when validation passed (release push) OR when
+    # there were pending changesets (open/update the Version Packages PR). The
+    # latter path skips snapshot/validate entirely.
+    if: ${{ always() && needs.detect.result == 'success' && (needs.detect.outputs.shouldRelease != 'true' || needs.validate.result == 'success') }}
     runs-on: ubuntu-latest
     environment: release # Must be kept for trusted publishing on PyPI
     permissions:
@@ -27,12 +243,60 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
+          # Pin to the validated SHA. Necessary for the publish step to work
+          # since it uses HEAD^ to determine if the version has changed.
+          ref: ${{ needs.detect.outputs.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Necessary for the publish step to work since it uses HEAD^ to determine if the version has changed
           fetch-depth: 2
 
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      # Staleness guard: refuse to publish if a newer release already shipped.
+      #
+      # Scenario this prevents: run for commit A fails on a retryable step;
+      # later commit B runs to completion and publishes; someone then clicks
+      # "re-run failed jobs" on A. Without this check, A would re-validate,
+      # pass, and re-publish its now-stale versions -- potentially moving the
+      # `latest` dist-tag backward over B's release.
+      #
+      # The concurrency group does NOT cover this: a manual re-run happens
+      # after B has finished, so nothing is queued to serialize against.
+      #
+      # We compare the version THIS run intends to publish against whatever is
+      # currently on the `latest` dist-tag. This is a release-vs-release check,
+      # not a git-position check: an unrelated feature merge landing on main
+      # during validation does not move `latest`, so it does not false-abort.
+      # We abort only when latest is already >= our target, i.e. an
+      # equal-or-newer release has already happened.
+      #
+      # The target version is read from the checked-out commit: this is a
+      # post-merge release commit, so the Version Packages PR has already
+      # bumped packages/cli/package.json to the version ci:version will land
+      # on.
+      - name: Abort if a newer release already shipped
+        run: |
+          set -euo pipefail
+          target=$(node -p "require('./packages/cli/package.json').version")
+          # `latest` may not exist on a first-ever publish; treat missing as 0.0.0.
+          current=$(npm view vercel@latest version 2>/dev/null || echo "0.0.0")
+          echo "Target version (this run): $target"
+          echo "Current latest on npm:     $current"
+
+          if [ "$target" = "$current" ]; then
+            echo "::error::latest ($current) already equals target ($target); this release has already shipped. Refusing to re-publish a stale release."
+            exit 1
+          fi
+
+          # Use version sort (sort -V) to order the two versions. If `current`
+          # sorts at-or-after `target`, a newer release already shipped.
+          # No semver dependency required (deps aren't installed at this step).
+          highest=$(printf '%s\n%s\n' "$target" "$current" | sort -V | tail -n1)
+          if [ "$highest" != "$target" ]; then
+            echo "::error::latest ($current) is newer than target ($target); a newer release has shipped. Refusing to publish a stale release."
+            exit 1
+          fi
+          echo "Target $target is newer than latest $current; proceeding with release."
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -74,7 +338,7 @@ jobs:
         with:
           version: pnpm ci:version
           publish: pnpm ci:publish # npm publish
-          commitMode: "github-api" # allows release commits and tags to be signed using $GITHUB_TOKEN
+          commitMode: 'github-api' # allows release commits and tags to be signed using $GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
## Problem

A PR that merged earlier in the week shipped a changeset whose frontmatter **omitted a package**. The `vercel` CLI depended on the bumped version of that package, but since the dependency wasn't bumped, the release published the CLI against a stale dependency and broke.

Our e2e tests didn't catch it because they run against the per-PR tarball that Vercel hosts for each commit (`VERCEL_CLI_VERSION=<deployment>/tarballs/vercel.tgz`) — that tarball is built from the workspace at the PR's commit, so the broken cross-package version edge never exists at test time. The bad combination only materializes **after** the real publish.

## Approach

Insert a **snapshot validation gate** into `release.yml`, between detecting a release and actually publishing:

1. When the **Version Packages** PR merges (no pending changesets remain), publish a `canary` snapshot (`0.0.0-canary-<hash>`) of the release commit.
2. Re-run the unit + e2e suites, but point `VERCEL_CLI_VERSION` at the **published snapshot spec** (`vercel@<snapshot>`) instead of the per-PR tarball. The build container then installs the CLI **and its workspace dependencies** from npm — so a missing dependency bump fails here, not in production.
3. Only if validation passes do we **promote** to the real versioned release.

Everything downstream pins to the **exact release commit SHA** (never `HEAD`), so a merge to `main` during the (long) validation window can't change what we publish.

## Pipeline

```mermaid
flowchart TD
    A[push to main] --> B{detect: pending changesets?}
    B -->|yes - changesets remain| R[release job: open/update Version Packages PR]
    B -->|no - PR just merged| S[snapshot: publish 0.0.0-canary-hash under canary tag]
    S --> V[validate: unit + e2e vs snapshot, VERCEL_CLI_VERSION=vercel@snapshot]
    V -->|pass| G{staleness guard}
    V -->|fail| X[stop - latest dist-tag never moves]
    G -->|target newer than latest| P[release job: real publish + tag latest]
    G -->|latest is equal-or-newer| X2[abort - refuse stale republish]
```

## Why concurrent merges are safe

All jobs check out the SHA captured by `detect`, and the workflow uses a non-cancelling concurrency group. A merge to `main` during validation queues behind the in-flight release and validates itself on its own run.

```mermaid
sequenceDiagram
    participant A as Release run (commit A)
    participant Main as main
    participant NPM as npm latest

    A->>A: detect + snapshot (pinned to A)
    Note over Main: commit B merges to main
    A->>A: validate (still pinned to A, B ignored)
    A->>NPM: staleness guard: latest < A? yes
    A->>NPM: promote A, move latest -> A
    Note over Main,NPM: B's run queues behind A,<br/>then validates + promotes itself
```

## Staleness guard (the retryable-failure case)

Scenario: run for commit `A` fails on a **retryable** step; later commit `B` runs to completion and publishes; someone then clicks **re-run failed jobs** on `A`. Without a guard, `A` would re-validate, pass, and republish its now-stale versions — potentially moving the `latest` dist-tag **backward** over `B`.

The concurrency group does not help here: the re-run happens after `B` has finished, so nothing is queued to serialize against.

The guard compares the version **this run intends to publish** (read from `packages/cli/package.json` at the pinned commit) against the current `latest` on npm. It is a **release-vs-release** check, not a git-position check — an unrelated feature merge during validation does not move `latest`, so it does not false-abort.

```mermaid
flowchart TD
    T[target = cli version at pinned SHA] --> C[current = npm view vercel@latest]
    C --> D{target == current?}
    D -->|yes| AB[abort: already shipped]
    D -->|no| E{latest newer than target? sort -V}
    E -->|yes| AB2[abort: a newer release shipped]
    E -->|no| OK[proceed with publish]
```

| target (this run) | latest on npm | verdict |
|---|---|---|
| 54.3.0 | 54.2.0 | proceed (we're newer) |
| 54.2.0 | 54.2.0 | abort (already shipped — re-run case) |
| 54.2.0 | 54.3.0 | abort (a newer release shipped) |
| 54.2.0 | missing | proceed (first-ever publish) |
| 54.10.0 | 54.9.0 | proceed (numeric ordering, not lexical) |

The comparison uses `sort -V` (no `semver` dependency, since `node_modules` isn't installed at that step).

## Notes / follow-ups for review

- **Validation runs the suite inline** (`pnpm test-unit` / `pnpm test-e2e`) rather than reusing the chunked matrix from `test.yml`. This is slower and unparallelized; worth deciding whether to extract a reusable workflow.
- **Guard keys on the `vercel` CLI version** as the proxy for "the release." That's the package that broke and the one whose dist-tag matters most. `utils/npm-publish.sh` already skips already-published versions per package, so the residual risk is only the `latest` dist-tag — which this tracks. Could be broadened to assert no to-be-published version already exists for belt-and-suspenders.
- **`VERCEL_CLI_VERSION` format** uses `vercel@<version>`, matching the existing convention in fixtures (e.g. `packages/backends/test/fixtures/08-elysia/vercel.json`).
