### PR TITLE
[@vercel/connect] docs: MCP and AI SDK integration plan

### DIFF
--- a/packages/connect/docs/ai-sdk-content.md
+++ b/packages/connect/docs/ai-sdk-content.md
@@ -1,0 +1,184 @@
+# Native AI SDK integration for `@vercel/connect` — content plan
+
+**Status:** proposal
+**Scope:** docs and recipes that ship alongside the SDK work. Lives in two repos: `vercel/vercel-front` (`vercel-docs`) and `vercel/ai` (`content/` + `examples/`).
+**Companion doc:** [`ai-sdk-implementation.md`](./ai-sdk-implementation.md) plans the SDK changes in `packages/connect` and the example app that smoke-tests them.
+
+## Why this is a separate plan
+
+The SDK work and the content work have different audiences, different review timelines, and different blast radius:
+
+- **SDK** ships as a versioned npm package. Reviewers are TypeScript/SDK maintainers. Mistakes are recoverable via a patch release.
+- **Content** ships to vercel.com and ai-sdk.dev. Reviewers are docs/DevRel. Mistakes are visible to every developer searching for the integration and live on Google forever.
+
+Keeping them separate lets each plan move at its own speed: the V0 content path can land *before* any SDK work starts; the V1 SDK can ship to npm before the AI SDK cookbook recipe is reviewed; the recipe can iterate independently after V1 is live.
+
+## Audiences and where they live
+
+| Audience                                          | Lands first on   | Entry point in this plan                                              |
+| ------------------------------------------------- | ---------------- | --------------------------------------------------------------------- |
+| Already-Connect developers wanting the AI SDK path | vercel.com/docs  | `/docs/connect/guides/use-with-ai-sdk` + Linear example                |
+| AI SDK developers who don't know Connect          | ai-sdk.dev       | Cookbook recipe `74-mcp-tools-with-vercel-connect.mdx` + MCP ref link  |
+| Both audiences                                    | (cross-linked)   | Mutual links between the Connect guide and the cookbook recipe         |
+
+The asymmetry matters: developers who already know Connect won't search ai-sdk.dev for it, and developers who know the AI SDK won't search vercel.com for a "Connect adapter" they've never heard of. We need entry points on both surfaces, each shaped for its native audience.
+
+## V0: Docs-only (ship now)
+
+Before any SDK code lands, the integration works today with the public surface:
+
+```ts
+import { createMCPClient } from '@ai-sdk/mcp';
+import { getToken } from '@vercel/connect';
+import { streamText, stepCountIs } from 'ai';
+
+const userId = 'user_demo_123';
+
+const token = await getToken('oauth/linear', {
+  subject: { type: 'user', id: userId },
+  scopes: ['read'],
+});
+
+const mcpClient = await createMCPClient({
+  transport: {
+    type: 'http',
+    url: 'https://mcp.linear.app',
+    headers: { Authorization: `Bearer ${token}` },
+  },
+});
+
+const stream = await streamText({
+  model: 'anthropic/claude-sonnet-4.6',
+  prompt: 'Show me my open Linear issues',
+  tools: await mcpClient.tools(),
+  stopWhen: stepCountIs(10),
+  onFinish: async () => { await mcpClient.close(); },
+});
+```
+
+**Deliverables:**
+
+- `vercel-docs` → `/docs/connect/guides/use-with-ai-sdk` (guide page using the V0 pattern)
+- `vercel-docs` → `/docs/connect/examples/ai-agent-with-linear` (runnable Linear example using the V0 pattern)
+- `vercel/ai` → nothing. V0 lives in Connect docs only; AI SDK consumers can already do this without our blessing.
+
+Zero changes to `@vercel/connect`. This unblocks the AI SDK audience immediately while V1 SDK work is in flight.
+
+V0 limitations (which is why V1 exists in the implementation plan):
+
+- Token is resolved once at client init; if it expires mid-conversation, the MCP client must be rebuilt.
+- Consent gating runs upfront; a tool call cannot trigger consent mid-stream.
+- The consumer writes the `try { … } catch (UserAuthorizationRequiredError)` boilerplate per integration.
+
+## V1: surface the SDK to both audiences
+
+Once the V1 SDK ships (per [`ai-sdk-implementation.md`](./ai-sdk-implementation.md)), three content artifacts land in the same week — one on the Connect side and two on the AI SDK side.
+
+### Artifact 1: update `vercel-docs` guide
+
+Edit `/docs/connect/guides/use-with-ai-sdk` to feature the V1 `authProvider` variant as the recommended path. Keep the V0 bearer-header pattern as a "minimal / no extra deps" fallback at the bottom.
+
+Imports point at `@vercel/connect/ai-sdk`. The page does *not* mention `@vercel/connect/mcp` — that subpath is for non-AI-SDK MCP clients and gets its own discovery surface (the typed SDK reference page).
+
+### Artifact 2: cookbook recipe in `vercel/ai`
+
+The headline reverse-discovery artifact. Lives at `content/cookbook/01-next/74-mcp-tools-with-vercel-connect.mdx`.
+
+**Why `74`:** slots between the existing MCP recipe (`73-mcp-tools.mdx`) and the HITL recipe (`75-human-in-the-loop.mdx`), so a reader following the natural sidebar order discovers Connect immediately after learning the base MCP pattern. Keeps numbering stable — no renaming of existing files.
+
+**Why it lives in `vercel/ai`, not just `vercel-docs`:** SEO and discoverability. A developer searching "ai sdk mcp oauth" hits ai-sdk.dev first. The Connect-side guide reaches developers who already know Connect; the cookbook recipe reaches developers who don't.
+
+Frontmatter (matches the format the AI SDK docs builder expects):
+
+```mdx
+---
+title: MCP Tools with Vercel Connect
+description: Use Vercel Connect to manage OAuth for MCP-backed tools in a Next.js agent
+tags: ['next', 'tool use', 'agent', 'mcp', 'oauth', 'vercel']
+---
+```
+
+Recipe outline:
+
+1. **Why** — a paragraph framing the problem (per-provider OAuth client + token storage + refresh + plumbing collapses to one adapter call).
+2. **Prerequisites** — Vercel project linked, `vercel env pull` for the OIDC token, a Linear (or Linear-equivalent) Custom OAuth connector created in the Vercel dashboard.
+3. **Install** — `pnpm install ai @ai-sdk/react @ai-sdk/mcp @vercel/connect`.
+4. **Wire the route handler** — `app/api/chat/route.ts` showing `connectAuthProvider` slotted into `createMCPClient({ transport: { authProvider } })` + `streamText` with `convertToModelMessages` and `toUIMessageStreamResponse`.
+5. **Wire the client** — `app/page.tsx` using `useChat` from `@ai-sdk/react` with `DefaultChatTransport`. (Matches the existing recipes' shape so the reader doesn't need to learn a new client pattern.)
+6. **Handle consent** — `try { ... } catch (ConsentRequiredError) { redirect(err.redirectUrl) }`. Cross-link to the Connect concepts page on authentication for the deeper picture.
+7. **Add approval (HITL)** — drop in `withConsentApproval(tools, { approve: ['linear_create_issue'] })` and pass `tools.approvalConfig` to `streamText`. Note the symmetry with recipe `75` — "everything from the HITL recipe applies; Connect just provides the underlying tools." (Section added with V2; placeholder in V1.)
+8. **What this replaced** — short bullet list of the per-provider boilerplate the recipe sidesteps (OAuth client registration, token DB, refresh job, etc.).
+9. **Next steps** — links into the AI SDK MCP reference, the Connect concepts pages, and the example app.
+
+The recipe's code samples are extracted from `examples/next-mcp-vercel-connect/` (the smoke-test example owned by the implementation plan). Drift between the recipe and runnable code is structurally impossible because the recipe references the same files.
+
+### Artifact 3: reference cross-link in `vercel/ai`
+
+Small additions to `content/docs/03-ai-sdk-core/17-mcp-apps.mdx` (the canonical MCP reference). A short "Authentication" subsection (or extension of the existing one) that calls out three options for providing bearer tokens to an MCP server:
+
+- Static bearer in `headers` — for service-to-service tokens.
+- Custom `OAuthClientProvider` — for apps with existing OAuth infrastructure.
+- **`@vercel/connect/ai-sdk`'s `connectAuthProvider`** — for apps using Vercel Connect to broker per-user OAuth grants. Single-paragraph mention + link to the cookbook recipe. Do *not* duplicate the recipe. (The same function is also exported from `@vercel/connect/mcp` for non-AI-SDK MCP clients; the AI SDK page only mentions `/ai-sdk`.)
+
+This is the cross-link that turns the recipe from "hidden cookbook" into "discoverable from the canonical MCP reference."
+
+### Discoverability touch-ups
+
+- Add a `vercel-connect` (or `oauth`) tag to the cookbook recipe so it surfaces in tag filters.
+- Update `examples/README.md` (or the equivalent index) to list `examples/next-mcp-vercel-connect/`.
+- Consider a one-line callout in `content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx` under "tools that need authentication" — but only if a natural insertion point exists; do not force.
+
+## V2: HITL content updates
+
+Once V2 SDK lands, content artifacts follow:
+
+- `vercel-docs` → new page `/docs/connect/guides/handle-tool-approval` walking through the chat-turn-boundary pattern and the function-timeout map (cribbed from the implementation plan's "Function timeouts and where the HITL wait fits" section, rewritten for a docs audience).
+- `vercel-docs` → update the Linear example to include an approval-gated tool call.
+- `vercel/ai` → append the "Approval" section to cookbook recipe `74` (filling the V1 placeholder) showing `withConsentApproval`. Don't fork the recipe.
+- `vercel/ai` → the smoke-test example app gets the approval flow added; the cookbook recipe's V2 section is again extracted from it.
+
+## Cross-repo PR coordination
+
+The artifacts span three repos. To avoid broken cross-links during rollout:
+
+| Repo                                    | Content artifact                                                                                                                                                                | Depends on                                                       |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `vercel/vercel-front` (`vercel-docs`)   | V0: `/docs/connect/guides/use-with-ai-sdk` + `/docs/connect/examples/ai-agent-with-linear`. V1: update guide to feature `authProvider`. V2: `/docs/connect/guides/handle-tool-approval`. | V0 has no deps; V1+ depends on the matching SDK release          |
+| `vercel/ai` (`content/`)                | V1: cookbook recipe `74-mcp-tools-with-vercel-connect.mdx` + MCP reference cross-link. V2: append "Approval" section to recipe `74`.                                            | V1 published to npm                                              |
+| `vercel/ai` (`examples/`)               | V1: surface `examples/next-mcp-vercel-connect/` (owned by the implementation plan as smoke-test gate) in `examples/README.md` and via the cookbook recipe's "Next steps" link.  | The example app PR (implementation plan) is open                 |
+
+### Sequencing
+
+1. **Land V0** in `vercel-docs` first — pure docs, no dependencies, ships the headline integration story today.
+2. **Wait for V1 SDK** to publish to npm (per implementation plan).
+3. **Update V0 guide** in `vercel-docs` to feature the `authProvider` variant as primary; keep the V0 bearer-header pattern as a "minimal / no extra deps" fallback.
+4. **Open AI SDK PR** simultaneously with the SDK release announcement: cookbook recipe + MCP docs cross-link, both pointing at `@vercel/connect/ai-sdk`. (The example app PR is opened earlier as part of the implementation plan's release gate; the cookbook recipe's "Next steps" link slots into the merged example.)
+5. **V2 content** ships in a second round across `vercel-docs` and `vercel/ai` after the V2 SDK lands.
+
+### Cross-link rule
+
+Every new page links to its mirror on the other side, with **asymmetric anchor text** to avoid accidental loops:
+
+- Connect guide → "see the AI SDK cookbook recipe for the framework-specific walkthrough"
+- Cookbook recipe → "see the Connect concepts pages for what happens behind the adapter"
+
+## What `vercel/ai` content does NOT add
+
+To keep the AI SDK docs focused, we explicitly do not propose:
+
+- A provider page under `content/providers/` — Connect is not an LLM provider.
+- A foundations page rewrite — MCP foundations already exist; we extend, not duplicate.
+- A separate "auth" docs section — `OAuthClientProvider` is documented at the MCP level; Connect is one consumer of that interface.
+
+## What `vercel-docs` content does NOT add
+
+- A standalone "AI SDK integration" subtree under `/docs/connect/`. The guide page + Linear example are enough. Subdividing further would create empty section indexes.
+- Duplication of the cookbook recipe. The Connect-side guide and the AI SDK cookbook recipe are written for different audiences; the recipe is canonical and the guide cross-links to it for the framework-specific walkthrough.
+
+## Strategic angle (content)
+
+The SDK ships into the void if AI SDK developers can't find it. The cookbook recipe + MCP reference cross-link in `vercel/ai` are what put the integration on the canonical surface where developers are already searching "ai sdk mcp oauth." Without them, V1 reaches only the audience that already reads `vercel.com/docs/connect` — a much smaller set than the AI SDK audience the integration is built for.
+
+The Connect-side guide and Linear example are what convert the existing Connect audience: developers who already use Connect for service-to-service tokens and now want it to power their AI SDK agent. They land on `vercel.com/docs/connect` first, see the guide, and learn that the same Connect primitives they already use carry over to AI SDK agents one-line.
+
+V0 (docs-only) lets us start converting both audiences today, before the SDK work is done. That's the headline reason V0 has a row in this plan at all.

--- a/packages/connect/docs/ai-sdk-implementation.md
+++ b/packages/connect/docs/ai-sdk-implementation.md
@@ -428,6 +428,124 @@ const stream = await streamText({
 });
 ```
 
+### What this replaces
+
+The V2 snippet above is five lines of glue. Three alternative paths to the same behavior, in order of decreasing pain:
+
+#### Without Connect at all (you own the OAuth stack)
+
+```ts
+// Pre-work outside this file:
+// - Register OAuth apps with Linear and GitHub in each provider's console
+// - Store LINEAR_CLIENT_ID/SECRET, GITHUB_CLIENT_ID/SECRET as env vars
+// - Run a migration:
+//   CREATE TABLE oauth_tokens (
+//     user_id TEXT, provider TEXT, access_token TEXT, refresh_token TEXT,
+//     expires_at TIMESTAMP, scopes TEXT[],
+//     PRIMARY KEY (user_id, provider)
+//   );
+// - Ship /api/oauth/linear/callback and /api/oauth/github/callback routes,
+//   each handling code exchange, PKCE verification, state validation, token persistence
+
+async function getProviderToken(userId: string, provider: 'linear' | 'github') {
+  const row = await db.oauth_tokens.findUnique({
+    where: { user_id_provider: { userId, provider } },
+  });
+  if (!row) throw new ConsentRequiredError(buildOAuthAuthorizeUrl(provider, userId));
+
+  if (row.expires_at < new Date(Date.now() + 60_000)) {
+    const refreshed = await fetch(`https://api.${provider}.com/oauth/token`, {
+      method: 'POST',
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: row.refresh_token,
+        client_id: process.env[`${provider.toUpperCase()}_CLIENT_ID`]!,
+        client_secret: process.env[`${provider.toUpperCase()}_CLIENT_SECRET`]!,
+      }),
+    }).then((r) => r.json());
+    await db.oauth_tokens.update({
+      where: { user_id_provider: { userId, provider } },
+      data: {
+        access_token: refreshed.access_token,
+        expires_at: new Date(Date.now() + refreshed.expires_in * 1000),
+      },
+    });
+    return refreshed.access_token;
+  }
+  return row.access_token;
+}
+
+// ... then the same buildClient / prefix / approvalConfig / streamText plumbing below,
+// with getProviderToken() in place of @vercel/connect's getToken().
+```
+
+Plus security review of `client_secret` storage, on-call rotation when a provider forces a refresh-token reissue, and a migration every time you add a third provider.
+
+#### Connect without the adapter (V0 pattern — Connect handles OAuth, you handle AI SDK glue)
+
+```ts
+import { createMCPClient } from '@ai-sdk/mcp';
+import {
+  getToken,
+  startAuthorization,
+  UserAuthorizationRequiredError,
+} from '@vercel/connect';
+import { streamText } from 'ai';
+
+async function buildClient(connector: string, mcpUrl: string) {
+  try {
+    const token = await getToken(connector, { subject: { type: 'user', id: userId } });
+    return await createMCPClient({
+      transport: { type: 'http', url: mcpUrl, headers: { Authorization: `Bearer ${token}` } },
+    });
+  } catch (err) {
+    if (err instanceof UserAuthorizationRequiredError) {
+      const { url } = await startAuthorization(connector, { subject: { type: 'user', id: userId } });
+      throw new ConsentRequiredError(url);
+    }
+    throw err;
+  }
+}
+
+const [linearClient, githubClient] = await Promise.all([
+  buildClient('oauth/linear', 'https://mcp.linear.app'),
+  buildClient('oauth/github', 'https://mcp.github.com'),
+]);
+
+const linearTools = await linearClient.tools();
+const githubTools = await githubClient.tools();
+
+const prefix = (tools: Record<string, unknown>, p: string) =>
+  Object.fromEntries(Object.entries(tools).map(([k, v]) => [`${p}${k}`, v]));
+
+const linear = prefix(linearTools, 'linear_');
+const github = prefix(githubTools, 'github_');
+
+const approvalConfig = Object.fromEntries(
+  [...Object.keys(linear), ...Object.keys(github)].map((k) => [k, 'user-approval' as const]),
+);
+
+const stream = await streamText({
+  model: 'anthropic/claude-sonnet-4.6',
+  prompt: '...',
+  tools: { ...linear, ...github },
+  toolApproval: approvalConfig,
+  onFinish: async () => {
+    await Promise.all([linearClient.close(), githubClient.close()]);
+  },
+});
+```
+
+Plus: token expiry mid-conversation → rebuild the MCP client by hand. `invalidateCredentials` cache eviction → drop and re-fetch manually. Per-tool approval filtering (`approve: ['linear_create_issue']` instead of gating everything) → another `Object.entries` reduce.
+
+#### Summary
+
+| Stack | Per-provider glue | What you own |
+|---|---|---|
+| Raw OAuth (no Connect) | ~200 lines + DB schema + 2 callback routes | Client registration, DB, refresh, callback routes, security review |
+| Connect SDK alone (V0)             | ~30 lines              | Per-provider `try`/`catch` + bearer header + tool prefix + approval config |
+| Connect AI SDK adapter (V1 + V2)   | ~3 lines               | `withConsentApproval(...)` — the helper builds the rest                    |
+
 ## Example app (smoke-test gate for V1 release)
 
 A runnable example app in `vercel/ai/examples/next-mcp-vercel-connect/` mirrors the cookbook recipe end-to-end. It exists primarily as the **release gate for V1**: a green build of the example against the latest `vercel/ai` `main` is the signal that the published `@vercel/connect@0.2` is safe to ship. Secondary uses (giving readers a clone-and-run reference, surfacing in the AI SDK examples index) are owned by the [content plan](./ai-sdk-content.md).

--- a/packages/connect/docs/ai-sdk-implementation.md
+++ b/packages/connect/docs/ai-sdk-implementation.md
@@ -477,7 +477,18 @@ V2 adds an "approval flow" step to the same example; the V2 publish gate is the 
 
 ## Testing plan
 
-### Unit tests (in `packages/connect`)
+Four tiers, each catching a different class of bug. The first two run in PR CI; the third runs nightly + before every publish; the fourth is the final human-eyes pass.
+
+| Tier | Speed | Runs in PR CI | Catches |
+| ---- | ----- | ------------- | ------- |
+| Unit | <1s   | Yes           | Adapter logic in isolation (mocked Connect + mocked transport) |
+| Integration | ~5s | Yes        | Adapter ↔ real `createMCPClient` ↔ mocked MCP server |
+| E2E | ~30s | No (opt-in)    | Adapter ↔ real Connect API ↔ real MCP server. **V1 publish gate.** |
+| Manual smoke | — | No           | Human eyes on the user-facing flow |
+
+### Unit tests (in `packages/connect/src/mcp/__tests__/`)
+
+Run against fully mocked dependencies. Cover:
 
 - `tokens()` returns a valid `OAuthTokens` shape when `getToken` resolves.
 - `tokens()` returns `undefined` on `UserAuthorizationRequiredError`.
@@ -486,19 +497,69 @@ V2 adds an "approval flow" step to the same example; the V2 publish gate is the 
 - `invalidateCredentials('tokens')` evicts the LRU cache entry.
 - `withConsentApproval` produces the correct `approvalConfig` shape, including `prefix`/`approve` filtering.
 
-### Integration tests (in a fixtures app)
+### Integration tests (in `packages/connect/__tests__/integration/`)
 
-- Wire `connectAuthProvider` into a real `createMCPClient`, mock the MCP server, assert:
-  - First request sets `Authorization: Bearer <token>` from `getToken`.
-  - 401 response triggers `authorizeOnce()` and lands in `redirectToAuthorization`.
-  - Token refresh on second request after expiry.
-  - Multi-client composition produces non-conflicting tool maps.
-- Wire `withConsentApproval` into `streamText`, simulate a `tool-approval` chunk, deny it, assert the model receives `execution-denied`.
+Wire `connectAuthProvider` into a real `createMCPClient` instance against an in-process mock MCP server (using `@ai-sdk/mcp`'s test helpers). Assert:
 
-### Manual smoke
+- First request sets `Authorization: Bearer <token>` from `getToken`.
+- 401 response triggers `authorizeOnce()` and lands in `redirectToAuthorization`.
+- Token refresh on second request after expiry.
+- Multi-client composition produces non-conflicting tool maps.
+- Wire `withConsentApproval` into `streamText` against a mocked LLM, simulate a `tool-approval` chunk, deny it, assert the model receives `execution-denied`.
 
-- Run the docs-page example against a real Linear MCP connector with a test workspace.
-- Run a two-provider example (Linear + GitHub) with overlapping tool names and `prefix:` to verify no collisions.
+### E2E tests (in `packages/connect/__tests__/e2e/`) — V1 publish gate
+
+These are the tests that actually prove the adapter works against the live Connect API, not just against our assumptions about it. They use `vercel link` + `vercel env pull` to authenticate as a real Vercel project with real connectors attached.
+
+**Test project setup (one-time per dev machine):**
+
+```bash
+cd packages/connect/__tests__/e2e
+vercel link --project vercel-internal-playground   # or ash-starter-template
+vercel env pull .env.test                          # provisions VERCEL_OIDC_TOKEN
+```
+
+The test project must have these connectors attached (owned by the connect team — coordinate with @allenzhou for access):
+
+| Connector UID                    | Purpose                                                  |
+| -------------------------------- | -------------------------------------------------------- |
+| `oauth/linear`                   | Happy-path `tokens()` returns valid bearer for real MCP  |
+| `oauth/linear-unauthorized`      | Forces `UserAuthorizationRequiredError` → consent flow   |
+| `slack/test-workspace`           | Alternate provider for multi-connector composition test  |
+| `api-key/intentionally-broken`   | Forces `ConnectorInstallationRequiredError`              |
+
+Tests are gracefully skipped (not failed) when `.env.test` is missing, with a clear message pointing at the setup steps. CI runs them as a separate job that injects a service-account OIDC token from a GitHub Actions secret.
+
+**E2E assertions:**
+
+- `tokens()` against `oauth/linear` returns a non-empty access token whose `Authorization: Bearer <token>` header is accepted by `https://mcp.linear.app` (assert 200 on `/mcp` handshake).
+- `tokens()` against `oauth/linear-unauthorized` throws `UserAuthorizationRequiredError` and `startAuthorization` returns a `url` whose host is the connector's configured authorization server.
+- `tokens()` against `api-key/intentionally-broken` throws `ConnectorInstallationRequiredError`.
+- Full `createMCPClient` + `mcpClient.tools()` round-trip against the real Linear MCP server, asserting the tool list is non-empty and one of the expected tool names is present.
+- `withConsentApproval` against the real Linear tools produces an `approvalConfig` keyed by the actual tool names returned by Linear's MCP server (catches drift when Linear renames tools).
+
+**Cadence:**
+
+- Manually before every `@vercel/connect` publish: `pnpm test:e2e` in `packages/connect`.
+- Nightly via a GitHub Actions cron job with a service-account OIDC token, posting failures to the connect team channel.
+- The `examples/next-mcp-vercel-connect/` smoke-test in `vercel/ai` (see §"Example app") is the cross-repo equivalent and runs in `vercel/ai` CI on every PR that touches `@ai-sdk/mcp` or `ai`.
+
+### Manual smoke / acceptance (pre-publish, human-driven)
+
+After all automated tiers pass, run the published-candidate package end-to-end with a real chat UI to catch UX issues no test will surface:
+
+- Run the docs-page example against a real Linear MCP connector with a test workspace; confirm the consent redirect URL renders as expected and post-consent the chat actually returns Linear data.
+- Run a two-provider example (Linear + GitHub) with overlapping tool names and `prefix:` to verify no collisions surface in the rendered chat output.
+- Manually revoke a token in the Linear workspace and confirm the next chat turn surfaces `ConsentRequiredError` rather than a confusing 401.
+
+### Test project ownership
+
+The Vercel-internal test project(s) used by the E2E tier are owned by the connect team. The plan currently lists two candidates:
+
+- **`vercel-internal-playground`** — generic Vercel internal sandbox; needs the four test connectors attached.
+- **`ash-starter-template`** — Ash starter that already has Connect connectors wired; faster to bootstrap from but the connector UIDs may need renaming to match the table above.
+
+@allenzhou to confirm which project we standardize on and ensure the four listed connectors are attached and current. The test suite reads the project name from `.env.test`'s `VERCEL_PROJECT_NAME` (set by `vercel env pull`) and the connector UIDs from a small `e2e-config.ts` so renames don't require code changes.
 
 ## SDK release sequence
 
@@ -516,16 +577,19 @@ V0 is docs-only and ships from the content plan. The implementation plan picks u
 | `vercel/vercel`       | `@vercel/connect/ai-sdk` subpath export — re-exports `connectAuthProvider`, `ConsentRequiredError`, `ConsentChallenge` from `/mcp`. Primary surface for AI SDK consumers. |
 | `vercel/vercel`       | Peer dependency on `@ai-sdk/mcp@^1 \|\| ^2` (covers AI SDK v6 + v7); Changeset; version bump to `@vercel/connect@0.2`                                                   |
 | `vercel/vercel`       | TypeScript compatibility test verifying the adapter satisfies both AI SDK's and official MCP SDK's `OAuthClientProvider` shapes                                          |
-| `vercel/vercel`       | Unit tests for `tokens()`, `redirectToAuthorization`, `invalidateCredentials`; integration tests against a mock MCP server                                               |
-| `vercel/ai`           | Example app `examples/next-mcp-vercel-connect/` (smoke-test gate — see §"Example app" above). Cookbook recipe and reference cross-link are content plan deliverables.    |
+| `vercel/vercel`       | Unit tests + integration tests (mock MCP server) — both run in PR CI                                                                                                     |
+| `vercel/vercel`       | E2E tests against real Connect API via `vercel link` + `vercel env pull` to a Vercel-internal test project (`vercel-internal-playground` or `ash-starter-template`). **V1 publish gate.** See §"Testing plan" → "E2E tests". |
+| `vercel/vercel`       | GitHub Actions nightly cron running the E2E suite with a service-account OIDC token; failures post to the connect team channel                                           |
+| `vercel/ai`           | Example app `examples/next-mcp-vercel-connect/` (cross-repo smoke-test gate — see §"Example app" above). Cookbook recipe and reference cross-link are content plan deliverables. |
 
 ### Phase V2 — `withConsentApproval` + HITL polish
 
 | Repo                  | Artifact                                                                                                                                          |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `vercel/vercel`       | Extend `@vercel/connect/ai-sdk` (already shipping in V1): add `withConsentApproval` helper with prefix/approve filtering + `approvalConfig` builder |
-| `vercel/vercel`       | Tests against `streamText({ toolApproval })` for approval and denial paths                                                                        |
-| `vercel/ai`           | Add an approval-gated step to `examples/next-mcp-vercel-connect/`; this becomes the V2 publish gate                                               |
+| `vercel/vercel`       | Unit + integration tests against `streamText({ toolApproval })` for approval and denial paths                                                     |
+| `vercel/vercel`       | Extend E2E suite: assert `withConsentApproval` against the real Linear MCP server produces an `approvalConfig` keyed by the actual tool names (catches Linear-side tool renames) |
+| `vercel/ai`           | Add an approval-gated step to `examples/next-mcp-vercel-connect/`; this becomes the V2 cross-repo publish gate                                    |
 
 ### Phase V3 — UI primitives (deferred until V2 has real usage)
 

--- a/packages/connect/docs/ai-sdk-implementation.md
+++ b/packages/connect/docs/ai-sdk-implementation.md
@@ -1,6 +1,8 @@
-# Native AI SDK integration for `@vercel/connect`
+# Native AI SDK integration for `@vercel/connect` — implementation plan
 
 **Status:** proposal
+**Scope:** SDK changes in `vercel/vercel/packages/connect` + the example app that smoke-tests them in `vercel/ai/examples/`.
+**Companion doc:** [`ai-sdk-content.md`](./ai-sdk-content.md) plans the docs work that ships alongside this — the V0 docs-only path, the `vercel-docs` guides, and the `vercel/ai` cookbook recipe and reference cross-link.
 **Target release:** `@vercel/connect@0.2` — primary subpath `@vercel/connect/ai-sdk` (the AI SDK audience is the headline), with `@vercel/connect/mcp` shipping alongside it in V1 as an accurate-to-scope home for non-AI-SDK MCP clients (Mastra, official MCP TS SDK, etc.). V2 extends `/ai-sdk` with HITL glue.
 **Prerequisites:** `@ai-sdk/mcp` shipped with `OAuthClientProvider` (already in `vercel/ai`, see [`packages/mcp/src/tool/oauth.ts`](https://github.com/vercel/ai/blob/main/packages/mcp/src/tool/oauth.ts)); `streamText`/`generateText` `toolApproval` configuration (added in AI SDK v7, see [`packages/ai/src/generate-text/stream-text.ts`](https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/stream-text.ts)); MCP-spec `OAuthClientProvider` interface (in [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts), which the AI SDK borrows from).
 
@@ -177,42 +179,11 @@ Two new subpath exports, split by audience:
 - **`@vercel/connect/ai-sdk`** (V1 primary surface, extended in V2): AI SDK developers' entry point. In V1, re-exports `connectAuthProvider` + `ConsentRequiredError` + `ConsentChallenge` so AI SDK users only need to know one import path. In V2, adds `withConsentApproval` (auto-wraps tools with `toolApproval: 'user-approval'` for the AI SDK's HITL flow) and eventually `<ConnectConsentBoundary>` (V3 React glue).
 - **`@vercel/connect/mcp`** (V1): canonical home for `connectAuthProvider` — implements MCP-spec `OAuthClientProvider` by delegating to `getToken` and `startAuthorization`. Same function the `/ai-sdk` subpath re-exports; exists at this path so MCP-only consumers (Mastra, official MCP TS SDK, etc.) can import from a name that accurately reflects what the function is.
 
-## V0: Docs-only (ship now)
+## V0 — there is no SDK work
 
-Before any package code lands, the integration works today with the public SDK surface:
+V0 is a docs-only path that uses the existing `getToken` surface. It ships before this plan ever lands. Owned by [`ai-sdk-content.md`](./ai-sdk-content.md). Mentioned here only so the V1 → V2 → V3 numbering reads as a continuation.
 
-```ts
-import { createMCPClient } from '@ai-sdk/mcp';
-import { getToken } from '@vercel/connect';
-import { streamText, stepCountIs } from 'ai';
-
-const userId = 'user_demo_123';
-
-const token = await getToken('oauth/linear', {
-  subject: { type: 'user', id: userId },
-  scopes: ['read'],
-});
-
-const mcpClient = await createMCPClient({
-  transport: {
-    type: 'http',
-    url: 'https://mcp.linear.app',
-    headers: { Authorization: `Bearer ${token}` },
-  },
-});
-
-const stream = await streamText({
-  model: 'anthropic/claude-sonnet-4.6',
-  prompt: 'Show me my open Linear issues',
-  tools: await mcpClient.tools(),
-  stopWhen: stepCountIs(10),
-  onFinish: async () => { await mcpClient.close(); },
-});
-```
-
-**Action:** publish a guide page at `/docs/connect/guides/use-with-ai-sdk` (vercel-docs) and a runnable example at `/docs/connect/examples/ai-agent-with-linear`. Zero changes to `@vercel/connect`. This unblocks the AI SDK audience immediately while V1 is in flight.
-
-Limitations V0 doesn't address (these are why V1 exists):
+V0's limitations are what motivate V1:
 
 - Token is resolved once at client init; if it expires mid-conversation, the MCP client must be rebuilt.
 - Consent gating runs upfront; a tool call cannot trigger consent mid-stream.
@@ -404,116 +375,42 @@ const stream = await streamText({
 });
 ```
 
-## AI SDK content plan (mirror surface in `vercel/ai`)
+## Example app (smoke-test gate for V1 release)
 
-The Connect-side docs (`vercel-docs` → `/docs/connect/...`) reach developers who already know Connect. The reverse-discovery path — developers who land on `ai-sdk.dev` looking for "how do I auth my MCP tools?" — is what makes the integration actually findable. This section plans the symmetric artifacts in `vercel/ai`.
+A runnable example app in `vercel/ai/examples/next-mcp-vercel-connect/` mirrors the cookbook recipe end-to-end. It exists primarily as the **release gate for V1**: a green build of the example against the latest `vercel/ai` `main` is the signal that the published `@vercel/connect@0.2` is safe to ship. Secondary uses (giving readers a clone-and-run reference, surfacing in the AI SDK examples index) are owned by the [content plan](./ai-sdk-content.md).
 
-### Surface inventory in `vercel/ai`
+### Why this lives in `vercel/ai`, not `packages/connect/__tests__/`
 
-Content lives in three layers (verified against the repo as of 2026-06-03):
+Two reasons:
 
-| Layer                                                                                                              | Purpose                                                            | Existing prior art                                                                                                |
-| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `content/docs/03-ai-sdk-core/17-mcp-apps.mdx`                                                                      | Canonical MCP reference page (concepts, transports, lifecycle)     | Already covers `createMCPClient`, transports, `tools()` lifecycle                                                 |
-| `content/cookbook/01-next/73-mcp-tools.mdx`, `75-human-in-the-loop.mdx`                                            | Framework-specific recipes; numbered to control sidebar order      | `73-mcp-tools.mdx` (Stdio/SSE/HTTP MCP), `75-human-in-the-loop.mdx` (HITL with `useChat` and approval responses)  |
-| `examples/{framework}-{provider/feature}/`                                                                         | Runnable example apps with their own `package.json`                | `examples/mcp/`, `examples/next-agent/`, `examples/next-workflow/`                                                |
+1. **Catches interface drift earliest.** The example resolves `@ai-sdk/mcp` and `ai` from the workspace, not from a pinned `package.json`. If a new AI SDK canary adds a required `OAuthClientProvider` method, the example app fails to build in `vercel/ai` CI before we publish a release that would silently break. A fixture pinned to a specific `@ai-sdk/mcp` version inside `packages/connect` wouldn't.
+2. **Doubles as the recipe's executable spec.** The cookbook recipe (owned by the content plan) is generated *from* this example app's source. Drift between the recipe code and runnable code is impossible because they're the same file.
 
-### Artifacts to add
-
-#### 1. Cookbook recipe — `content/cookbook/01-next/74-mcp-tools-with-vercel-connect.mdx`
-
-The headline artifact. Slots between the existing MCP recipe (`73`) and the HITL recipe (`75`), so a reader following the natural sidebar order discovers Connect immediately after learning the base MCP pattern. Numbering chosen deliberately: `74` keeps the alphabetical/numeric ordering stable without renumbering existing files.
-
-Frontmatter (matches the format the AI SDK docs builder expects):
-
-```mdx
----
-title: MCP Tools with Vercel Connect
-description: Use Vercel Connect to manage OAuth for MCP-backed tools in a Next.js agent
-tags: ['next', 'tool use', 'agent', 'mcp', 'oauth', 'vercel']
----
-```
-
-Recipe outline:
-
-1. **Why** — a paragraph framing the problem (per-provider OAuth client + token storage + refresh + plumbing collapses to one adapter call).
-2. **Prerequisites** — Vercel project linked, `vercel env pull` for the OIDC token, a Linear (or Linear-equivalent) Custom OAuth connector created in the Vercel dashboard.
-3. **Install** — `pnpm install ai @ai-sdk/react @ai-sdk/mcp @vercel/connect`.
-4. **Wire the route handler** — `app/api/chat/route.ts` showing `connectAuthProvider` slotted into `createMCPClient({ transport: { authProvider } })` + `streamText` with `convertToModelMessages` and `toUIMessageStreamResponse`.
-5. **Wire the client** — `app/page.tsx` using `useChat` from `@ai-sdk/react` with `DefaultChatTransport`. (Matches the existing recipes' shape so the reader doesn't need to learn a new client pattern.)
-6. **Handle consent** — `try { ... } catch (ConsentRequiredError) { redirect(err.redirectUrl) }`. Cross-link to the Connect concepts page on authentication for the deeper "what's happening" picture.
-7. **Add approval (HITL)** — drop in `withConsentApproval(tools, { approve: ['linear_create_issue'] })` and pass `tools.approvalConfig` to `streamText`. Note the symmetry with recipe `75` — "everything from the HITL recipe applies; Connect just provides the underlying tools."
-8. **What this replaced** — short bullet list of the per-provider boilerplate the recipe sidesteps (OAuth client registration, token DB, refresh job, etc.).
-9. **Next steps** — links into the AI SDK MCP reference, the Connect concepts pages, and the example app below.
-
-**Why this lives in `vercel/ai`, not just `vercel-docs`:** SEO and discoverability. A developer searching "ai sdk mcp oauth" hits ai-sdk.dev first. The Connect-side guide in `vercel-docs` is for developers who already know Connect; the cookbook recipe is for developers who don't.
-
-#### 2. Reference cross-link — small additions to `content/docs/03-ai-sdk-core/17-mcp-apps.mdx`
-
-A short "Authentication" subsection (or extension of the existing one if there is one) that calls out three options for providing bearer tokens to an MCP server:
-
-- Static bearer in `headers` — for service-to-service tokens.
-- Custom `OAuthClientProvider` — for apps with existing OAuth infrastructure.
-- **`@vercel/connect/ai-sdk`'s `connectAuthProvider`** — for apps using Vercel Connect to broker per-user OAuth grants. Single-paragraph mention + link to the cookbook recipe. Do *not* duplicate the recipe. (The same function is also exported from `@vercel/connect/mcp` for non-AI-SDK MCP clients; the AI SDK page only mentions `/ai-sdk`.)
-
-This is the cross-link that turns the recipe from "hidden cookbook" into "discoverable from the canonical MCP reference."
-
-#### 3. Example app — `examples/next-mcp-vercel-connect/`
-
-A runnable example app mirroring the cookbook recipe end-to-end. Useful for:
-
-- Smoke-testing every release of `@vercel/connect/ai-sdk` (and the underlying `/mcp` impl) against the latest `vercel/ai` `main`.
-- Letting readers `git clone` and run instead of copy-pasting from MDX.
-- Catching `OAuthClientProvider` interface drift early (if the AI SDK adds a method, the example fails to build).
-
-Structure:
+### Structure
 
 ```
 examples/next-mcp-vercel-connect/
-├── README.md                  — points back to the cookbook recipe and the Connect docs
+├── README.md                  — links to the cookbook recipe and the Connect concepts pages
 ├── package.json               — depends on ai@workspace:*, @ai-sdk/mcp@workspace:*, @vercel/connect
 ├── app/
 │   ├── api/chat/route.ts      — connectAuthProvider + createMCPClient + streamText
-│   └── page.tsx               — useChat with approval UI rendering
-├── .env.example               — CONNECT_CONNECTOR, etc.
+│   └── page.tsx               — useChat with consent + approval UI
+├── .env.example               — CONNECT_CONNECTOR, VERCEL_OIDC_TOKEN
 └── tsconfig.json
 ```
 
 This pattern is well-established in the repo (`examples/mcp/`, `examples/next-agent/`, `examples/next-workflow/`).
 
-#### 4. Discoverability touch-ups
+### Release gate
 
-- Add `vercel-connect` (or `oauth`) tag to the cookbook recipe so it surfaces in tag filters.
-- Update `examples/README.md` (or the equivalent index) to list the new example.
-- Consider a one-line callout in `content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx` under "tools that need authentication" — but only if a natural insertion point exists; do not force.
+The V1 publish PR in `vercel/vercel` is blocked on a green CI run of the example app in `vercel/ai`:
 
-### Cross-repo PR coordination
+1. Open a PR in `vercel/ai` adding `examples/next-mcp-vercel-connect/` pointed at the V1 RC tag of `@vercel/connect`.
+2. CI builds and type-checks the example against `vercel/ai`'s workspace versions of `ai` and `@ai-sdk/mcp`.
+3. If green: cut the `@vercel/connect@0.2` stable release.
+4. If red: fix the SDK in `vercel/vercel`, rev the RC, re-run.
 
-The artifacts span three repos. To avoid broken cross-links during rollout:
-
-| Repo                                    | What ships                                                                                                                              | Depends on                                                       |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `vercel/vercel` (`packages/connect`)    | V1: both `@vercel/connect/ai-sdk` (primary) and `@vercel/connect/mcp` subpath exports + Changeset. V2: extends `/ai-sdk` with HITL glue. | Nothing — independent                                            |
-| `vercel/vercel-front` (`vercel-docs`)   | `/docs/connect/guides/use-with-ai-sdk` + `/docs/connect/examples/ai-agent-with-linear`                                                  | Either the V0 bearer-header pattern (no SDK dep) or V1 published |
-| `vercel/ai` (`content/` + `examples/`)  | Cookbook recipe, MCP docs cross-link, example app                                                                                       | V1 published to npm                                              |
-
-Sequencing:
-
-1. **Land V0** in `vercel-docs` first — pure docs, no dependencies, ships the headline integration story today.
-2. **Land V1** (`@vercel/connect/ai-sdk` primary subpath + `@vercel/connect/mcp` canonical-impl subpath + Changeset) in `vercel/vercel` and publish to npm.
-3. **Update V0 guide** in `vercel-docs` to feature the `authProvider` variant as the recommended path; keep the V0 bearer-header pattern as a "minimal / no extra deps" fallback.
-4. **Open AI SDK PR** simultaneously: cookbook recipe + MCP docs cross-link + example app. Cookbook recipe is the discovery anchor; the rest are supporting.
-5. **Land V2** (`withConsentApproval` + HITL recipe additions) in a second round across `vercel/vercel` → `vercel-docs` → `vercel/ai`.
-
-Cross-link rule: every new page links to its mirror on the other side. The Connect guide says "see the AI SDK cookbook recipe for the framework-specific walkthrough"; the cookbook recipe says "see the Connect concepts pages for what happens behind the adapter." Asymmetric anchor text avoids accidental loops.
-
-### What `vercel/ai` content does NOT add
-
-To keep the AI SDK docs focused, we explicitly do not propose:
-
-- A provider page under `content/providers/` — Connect is not an LLM provider.
-- A foundations page rewrite — MCP foundations already exist; we extend, not duplicate.
-- A separate "auth" docs section — `OAuthClientProvider` is documented at the MCP level; Connect is one consumer of that interface.
+V2 adds an "approval flow" step to the same example; the V2 publish gate is the same example with that step exercised in CI.
 
 ## Open design questions
 
@@ -550,17 +447,13 @@ To keep the AI SDK docs focused, we explicitly do not propose:
 - Run the docs-page example against a real Linear MCP connector with a test workspace.
 - Run a two-provider example (Linear + GitHub) with overlapping tool names and `prefix:` to verify no collisions.
 
-## Release plan
+## SDK release sequence
 
-Each phase ships across all repos it touches in the same week to keep cross-links live.
+Only the `vercel/vercel` SDK + the `vercel/ai` example app are listed here. The matching docs/recipe artifacts (and their cross-repo coordination) live in [`ai-sdk-content.md`](./ai-sdk-content.md).
 
-### Phase V0 — docs only (no SDK changes, ships this week)
+### Phase V0 — no SDK work
 
-| Repo                  | Artifact                                                                                                                   |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `vercel/vercel-front` | `/docs/connect/guides/use-with-ai-sdk` (V0 pattern: `getToken` + bearer header in `createMCPClient`)                       |
-| `vercel/vercel-front` | `/docs/connect/examples/ai-agent-with-linear` (runnable Linear example using V0 pattern)                                   |
-| `vercel/ai`           | *(none — V0 lives in Connect docs only; SDK consumers can already do it without our blessing)*                             |
+V0 is docs-only and ships from the content plan. The implementation plan picks up at V1.
 
 ### Phase V1 — `@vercel/connect/ai-sdk` (primary) + `@vercel/connect/mcp` adapter
 
@@ -571,21 +464,15 @@ Each phase ships across all repos it touches in the same week to keep cross-link
 | `vercel/vercel`       | Peer dependency on `@ai-sdk/mcp@^1 \|\| ^2` (covers AI SDK v6 + v7); Changeset; version bump to `@vercel/connect@0.2`                                                   |
 | `vercel/vercel`       | TypeScript compatibility test verifying the adapter satisfies both AI SDK's and official MCP SDK's `OAuthClientProvider` shapes                                          |
 | `vercel/vercel`       | Unit tests for `tokens()`, `redirectToAuthorization`, `invalidateCredentials`; integration tests against a mock MCP server                                               |
-| `vercel/vercel-front` | Update `/docs/connect/guides/use-with-ai-sdk` to feature the `authProvider` variant (importing from `@vercel/connect/ai-sdk`) as primary; keep V0 as minimal fallback    |
-| `vercel/ai`           | Cookbook recipe `content/cookbook/01-next/74-mcp-tools-with-vercel-connect.mdx` (imports from `@vercel/connect/ai-sdk`)                                                  |
-| `vercel/ai`           | Cross-link addition in `content/docs/03-ai-sdk-core/17-mcp-apps.mdx` (Authentication subsection, points at `@vercel/connect/ai-sdk`)                                     |
-| `vercel/ai`           | Example app `examples/next-mcp-vercel-connect/` mirroring the recipe                                                                                                     |
+| `vercel/ai`           | Example app `examples/next-mcp-vercel-connect/` (smoke-test gate — see §"Example app" above). Cookbook recipe and reference cross-link are content plan deliverables.    |
 
 ### Phase V2 — `withConsentApproval` + HITL polish
 
-| Repo                  | Artifact                                                                                                                   |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Repo                  | Artifact                                                                                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `vercel/vercel`       | Extend `@vercel/connect/ai-sdk` (already shipping in V1): add `withConsentApproval` helper with prefix/approve filtering + `approvalConfig` builder |
-| `vercel/vercel`       | Tests against `streamText({ toolApproval })` for approval and denial paths                                                 |
-| `vercel/vercel-front` | New page `/docs/connect/guides/handle-tool-approval` walking through the chat-turn-boundary pattern and function-timeout map |
-| `vercel/vercel-front` | Update Linear example to include an approval-gated tool call                                                                |
-| `vercel/ai`           | Append "Approval" section to cookbook recipe `74` showing `withConsentApproval` (don't fork the recipe)                    |
-| `vercel/ai`           | Update example app to demonstrate the approval flow                                                                         |
+| `vercel/vercel`       | Tests against `streamText({ toolApproval })` for approval and denial paths                                                                        |
+| `vercel/ai`           | Add an approval-gated step to `examples/next-mcp-vercel-connect/`; this becomes the V2 publish gate                                               |
 
 ### Phase V3 — UI primitives (deferred until V2 has real usage)
 
@@ -594,9 +481,9 @@ Each phase ships across all repos it touches in the same week to keep cross-link
 | `vercel/vercel`       | `<ConnectConsentBoundary>` React component (catches `ConsentRequiredError`, emits a custom data part)                      |
 | `vercel/ai`           | If adopted, possibly an AI Elements primitive for rendering the consent prompt                                              |
 
-## Strategic angle
+## Strategic angle (SDK)
 
-This integration is what makes Connect *concrete* for the AI SDK audience. Today, a Next.js + AI SDK developer building an agent has to assemble OAuth + token storage + token refresh + MCP plumbing from four libraries. With this adapter, the entire stack collapses to:
+The SDK value proposition: a Next.js + AI SDK developer building an agent today has to assemble OAuth + token storage + token refresh + MCP plumbing from four libraries. With this adapter, the entire stack collapses to:
 
 ```ts
 import { connectAuthProvider } from '@vercel/connect/ai-sdk';
@@ -604,10 +491,10 @@ import { connectAuthProvider } from '@vercel/connect/ai-sdk';
 authProvider: connectAuthProvider('oauth/linear', { subject: { type: 'user', id: userId } });
 ```
 
-That's the same "kill the boilerplate" win the AI SDK is known for, applied to OAuth — and it gives Connect a headline demo for the exact audience the AI SDK already owns.
+That's the same "kill the boilerplate" win the AI SDK is known for, applied to OAuth.
 
-V0 (the docs-only path) costs essentially nothing and unblocks the AI SDK audience today. V1 is the long-term ergonomic surface, shipped at `@vercel/connect/ai-sdk` so the import path reflects the headline use case. V2 closes the interactive-flow gap by leaning on the AI SDK's existing `toolApproval` primitive, so we don't have to invent a new HITL mechanism.
-
-The `vercel/ai` content plan — cookbook recipe + MCP reference cross-link + example app, all referencing `@vercel/connect/ai-sdk` — is what makes the integration discoverable from the AI SDK audience, not just from Connect's existing audience. Without that, V1's adapter ships into the void; with it, the integration shows up on the canonical surface where developers are already searching "ai sdk mcp oauth."
+V1 is the long-term ergonomic surface, shipped at `@vercel/connect/ai-sdk` so the import path reflects the headline use case. V2 closes the interactive-flow gap by leaning on the AI SDK's existing `toolApproval` primitive, so we don't have to invent a new HITL mechanism.
 
 The MCP-spec compatibility (`@vercel/connect/mcp`) is a real bonus on top: the same one-line collapse works for Mastra users and anyone else on the MCP-spec interface, with zero extra implementation work. We claim that surface without distracting from the AI SDK headline.
+
+Discoverability — making AI SDK developers find this in the first place — is the content plan's job. See [`ai-sdk-content.md`](./ai-sdk-content.md).

--- a/packages/connect/docs/ai-sdk-implementation.md
+++ b/packages/connect/docs/ai-sdk-implementation.md
@@ -179,6 +179,59 @@ Two new subpath exports, split by audience:
 - **`@vercel/connect/ai-sdk`** (V1 primary surface, extended in V2): AI SDK developers' entry point. In V1, re-exports `connectAuthProvider` + `ConsentRequiredError` + `ConsentChallenge` so AI SDK users only need to know one import path. In V2, adds `withConsentApproval` (auto-wraps tools with `toolApproval: 'user-approval'` for the AI SDK's HITL flow) and eventually `<ConnectConsentBoundary>` (V3 React glue).
 - **`@vercel/connect/mcp`** (V1): canonical home for `connectAuthProvider` — implements MCP-spec `OAuthClientProvider` by delegating to `getToken` and `startAuthorization`. Same function the `/ai-sdk` subpath re-exports; exists at this path so MCP-only consumers (Mastra, official MCP TS SDK, etc.) can import from a name that accurately reflects what the function is.
 
+### `package.json` delta
+
+Mirrors the existing pattern for `@vercel/connect/{ash,betterauth,authjs}` — each adapter declares its upstream as an **optional peer dependency** so installing `@vercel/connect` doesn't force unrelated downloads, and pins a dev dependency so the workspace can type-check and build:
+
+```diff
+ "exports": {
+   ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+   "./ash":        { "types": "./dist/ash/index.d.ts",        "default": "./dist/ash/index.js" },
+   "./betterauth": { "types": "./dist/betterauth/index.d.ts", "default": "./dist/betterauth/index.js" },
+   "./authjs":     { "types": "./dist/authjs/index.d.ts",     "default": "./dist/authjs/index.js" },
++  "./mcp":        { "types": "./dist/mcp/index.d.ts",        "default": "./dist/mcp/index.js" },
++  "./ai-sdk":     { "types": "./dist/ai-sdk/index.d.ts",     "default": "./dist/ai-sdk/index.js" }
+ },
+ "peerDependencies": {
+   "@auth/core": ">=0.37.0",
+   "better-auth": ">=1.5.0",
+-  "experimental-ash": ">=0.8.2"
++  "experimental-ash": ">=0.8.2",
++  "@ai-sdk/mcp": "^1 || ^2",
++  "ai": "^6 || ^7"
+ },
+ "peerDependenciesMeta": {
+   "@auth/core":        { "optional": true },
+   "better-auth":       { "optional": true },
+-  "experimental-ash":  { "optional": true }
++  "experimental-ash":  { "optional": true },
++  "@ai-sdk/mcp":       { "optional": true },
++  "ai":                { "optional": true }
+ },
+ "devDependencies": {
+   "@auth/core": "0.37.4",
+   "better-auth": "1.5.5",
+   "experimental-ash": "0.31.0",
++  "@ai-sdk/mcp": "2.0.0-beta.37",
++  "ai": "7.0.0-beta.116",
+   "typescript": "^5"
+ }
+```
+
+**Why optional:**
+
+- Mastra users who only import `@vercel/connect/mcp` shouldn't be forced to install `ai`.
+- AI SDK users who only import `@vercel/connect/ai-sdk` need both `@ai-sdk/mcp` (for the `OAuthClientProvider` interface and `createMCPClient`) and `ai` (for `streamText` / `toolApproval` types in V2).
+- Service-to-service consumers who only use the root `@vercel/connect` for `getToken` need neither.
+
+This matches the existing per-adapter optionality. Installing `@vercel/connect` is still zero extra dependencies for the root use case; each adapter adds its own peers only when imported.
+
+**Why `ai: ^6 || ^7` not `^7` only:**
+
+V1 supports both v6 and v7 (per the AI SDK version compatibility matrix). V2's `withConsentApproval` requires `ai@^7` for the `toolApproval` primitive, but enforcing that via the package-level peer dep would break v6 users who only use V1's `connectAuthProvider`. Instead, V2 enforces v7 at the type level: importing `withConsentApproval` against `ai@6` produces a clear TS error ("`toolApproval` is not a property of `streamText` options"). When `ai@6` is EOL'd we can tighten the peer dep to `^7` in a minor release.
+
+**Dev-dep pins:** match the versions used by the verified interface stability diff (see "Interface stability" subsection) so the type-check CI run reflects the contract the plan commits to. Bump in Changesets when the AI SDK promotes new versions.
+
 ## V0 — there is no SDK work
 
 V0 is a docs-only path that uses the existing `getToken` surface. It ships before this plan ever lands. Owned by [`ai-sdk-content.md`](./ai-sdk-content.md). Mentioned here only so the V1 → V2 → V3 numbering reads as a continuation.
@@ -191,7 +244,7 @@ V0's limitations are what motivate V1:
 
 ## V1: `@vercel/connect/ai-sdk` (primary) + `@vercel/connect/mcp`
 
-Two subpath exports backed by one implementation, mirroring the shape of the existing `@vercel/connect/ash`, `/betterauth`, and `/authjs` subpaths.
+Two subpath exports backed by one implementation, mirroring the shape of the existing `@vercel/connect/ash`, `/betterauth`, and `/authjs` subpaths — same `exports` map convention, same **optional peer dependency** pattern via `peerDependenciesMeta` (see [§`package.json` delta](#packagejson-delta) below), same Changeset workflow for upstream version bumps. Nothing novel about the package shape; the AI SDK adapter slots into the established adapter family.
 
 - **`@vercel/connect/ai-sdk`** is the only path AI SDK docs, recipes, and examples reference. It re-exports `connectAuthProvider`, `ConsentRequiredError`, and `ConsentChallenge` from `/mcp`.
 - **`@vercel/connect/mcp`** owns the canonical implementation. Its existence as a separately-named subpath is what lets Mastra, the official `@modelcontextprotocol/typescript-sdk`, and any other MCP-spec client import from an accurate path. AI SDK users never need to know `/mcp` exists.
@@ -420,7 +473,7 @@ V2 adds an "approval flow" step to the same example; the V2 publish gate is the 
 4. **JWT-bearer subject support.** `ConnectTokenParams['subject']` already supports `{ type: 'jwt-bearer', sub, iss?, aud?, additionalClaims? }`. The adapter passes through verbatim, but the consent flow doesn't apply — `tokens()` either succeeds or throws. Document this in the JSDoc; no API change needed.
 5. **MCP server discovery vs schema definition.** `mcpClient.tools()` defaults to schema discovery (auto-syncs). For least-privilege agents we may want `mcpClient.tools({ schemas: { … } })` for explicit allowlisting. This is a pass-through; document the pattern in the guide.
 6. **Connection pooling.** If a chat app opens 50 concurrent MCP clients per request, each over its own WebSocket/SSE, costs blow up. Is pooling the adapter's problem or the consumer's? **Lean:** out of scope for V1. Mention in the docs that production deployments should reuse `mcpClient` across requests when the auth subject is stable.
-7. **`OAuthClientProvider` interface drift.** Verified identical between `@ai-sdk/mcp@1.x` and `2.x` (see "Interface stability" subsection above), so V1 supports both. Future drift mitigation: pin peer dep range, ship a Changeset for each AI SDK major. The AI SDK vs official MCP TS SDK delta is ~5% (also documented above) — a single implementation satisfies both today.
+7. **`OAuthClientProvider` interface drift.** Resolved, no longer open. The interface is verified identical between `@ai-sdk/mcp@1.x` and `2.x` (see "Interface stability" subsection), so V1 supports both. The AI SDK vs official MCP TS SDK delta is ~5% — a single implementation satisfies both today. Drift mitigation already wired in via the [package.json delta](#packagejson-delta): both `@ai-sdk/mcp` and `ai` are declared as **optional peer dependencies** following the existing `@vercel/connect/{ash,betterauth,authjs}` pattern, with dev-dep pins matching the versions used by the verified diff. When the AI SDK ships a major bump, the workflow is: (1) re-run the type-defs diff against the new version, (2) update the dev-dep pin and the peer-dep range together in a Changeset, (3) if the interface meaningfully changed, ship a facade entry point (`/mcp/v6`, `/mcp/v7`) without breaking the existing one.
 
 ## Testing plan
 

--- a/packages/connect/docs/ai-sdk-integration.md
+++ b/packages/connect/docs/ai-sdk-integration.md
@@ -57,6 +57,24 @@ The AI SDK's `OAuthClientProvider` and the official MCP TS SDK's `OAuthClientPro
 
 The narrower AI SDK shape is a subtype of the official shape, so a single implementation returning a non-undefined `string | URL` satisfies both. The V1 implementer should write the adapter against the AI SDK's stricter shape (so the type-check is tight) and verify it satisfies the official MCP SDK's looser shape via a TypeScript compatibility test. If the interfaces diverge further over time, we can ship two facade entry points (`/mcp/ai-sdk` and `/mcp/official`) without breaking the existing one.
 
+### Interface stability across `@ai-sdk/mcp@1.x` and `@ai-sdk/mcp@2.x` (verified)
+
+Pulled and diffed both published tarballs on 2026-06-03:
+
+```
+$ diff @ai-sdk/mcp@1.0.46/dist/index.d.ts @ai-sdk/mcp@2.0.0-beta.37/dist/index.d.ts | wc -l
+30
+```
+
+The 30-line delta touches **none** of `OAuthClientProvider`, `OAuthTokens`, `OAuthClientMetadata`, `OAuthClientInformation`, `AuthorizationServerMetadata`, `UnauthorizedError`, or the `auth()` function. The interface declarations (lines 146–188 in both files) are byte-for-byte identical. The actual deltas:
+
+- `MCPTransport.protocolVersion?` field removed in v2
+- `MCPTransportConfig.redirect` default changed `'follow'` → `'error'` in v2
+- `resource_link` content block variant removed in v2
+- Deprecated `clientName` shim removed in v2
+
+**Conclusion: a single `connectAuthProvider` implementation satisfies both `@ai-sdk/mcp@1.x` (paired with `ai@6`) and `@ai-sdk/mcp@2.x` (paired with `ai@7`). The peer dep `^1 || ^2` is safe, no facade split needed.** Re-verify if a future v3 ships.
+
 ## Motivation
 
 Today, a Next.js + AI SDK developer who wants an agent to call provider APIs has to do all of:
@@ -497,7 +515,7 @@ To keep the AI SDK docs focused, we explicitly do not propose:
 4. **JWT-bearer subject support.** `ConnectTokenParams['subject']` already supports `{ type: 'jwt-bearer', sub, iss?, aud?, additionalClaims? }`. The adapter passes through verbatim, but the consent flow doesn't apply — `tokens()` either succeeds or throws. Document this in the JSDoc; no API change needed.
 5. **MCP server discovery vs schema definition.** `mcpClient.tools()` defaults to schema discovery (auto-syncs). For least-privilege agents we may want `mcpClient.tools({ schemas: { … } })` for explicit allowlisting. This is a pass-through; document the pattern in the guide.
 6. **Connection pooling.** If a chat app opens 50 concurrent MCP clients per request, each over its own WebSocket/SSE, costs blow up. Is pooling the adapter's problem or the consumer's? **Lean:** out of scope for V1. Mention in the docs that production deployments should reuse `mcpClient` across requests when the auth subject is stable.
-7. **`OAuthClientProvider` interface drift.** The AI SDK MCP package may add new methods. **Mitigation:** pin a peer dependency range on `@ai-sdk/mcp`, ship a Changeset for each AI SDK major.
+7. **`OAuthClientProvider` interface drift.** Verified identical between `@ai-sdk/mcp@1.x` and `2.x` (see "Interface stability" subsection above), so V1 supports both. Future drift mitigation: pin peer dep range, ship a Changeset for each AI SDK major. The AI SDK vs official MCP TS SDK delta is ~5% (also documented above) — a single implementation satisfies both today.
 
 ## Testing plan
 

--- a/packages/connect/docs/ai-sdk-integration.md
+++ b/packages/connect/docs/ai-sdk-integration.md
@@ -1,7 +1,7 @@
-# Native MCP and AI SDK integration for `@vercel/connect`
+# Native AI SDK integration for `@vercel/connect`
 
 **Status:** proposal
-**Target release:** `@vercel/connect@0.2` (subpaths: `@vercel/connect/mcp` in V1; `@vercel/connect/ai-sdk` in V2)
+**Target release:** `@vercel/connect@0.2` — primary subpath `@vercel/connect/ai-sdk` (the AI SDK audience is the headline), with `@vercel/connect/mcp` shipping alongside it in V1 as an accurate-to-scope home for non-AI-SDK MCP clients (Mastra, official MCP TS SDK, etc.). V2 extends `/ai-sdk` with HITL glue.
 **Prerequisites:** `@ai-sdk/mcp` shipped with `OAuthClientProvider` (already in `vercel/ai`, see [`packages/mcp/src/tool/oauth.ts`](https://github.com/vercel/ai/blob/main/packages/mcp/src/tool/oauth.ts)); `streamText`/`generateText` `toolApproval` configuration (added in AI SDK v7, see [`packages/ai/src/generate-text/stream-text.ts`](https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/stream-text.ts)); MCP-spec `OAuthClientProvider` interface (in [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts), which the AI SDK borrows from).
 
 ### AI SDK version compatibility
@@ -9,8 +9,8 @@
 | Phase | `ai` peer dep | `@ai-sdk/mcp` peer dep | Notes |
 | ----- | ------------- | ---------------------- | ----- |
 | V0 (docs)  | `^6 \|\| ^7` | `^1 \|\| ^2`           | Bearer-header pattern; just calls `getToken()` plus `createMCPClient({ transport: { headers } })`. Works on both v6 and v7. |
-| V1 (`/mcp` adapter) | `^6 \|\| ^7` | `^1 \|\| ^2` | `OAuthClientProvider` interface is MCP-spec and is exported by both `@ai-sdk/mcp@1.x` (paired with `ai@6`) and `@ai-sdk/mcp@2.x` (paired with `ai@7`). Single adapter implementation should satisfy both. |
-| V2 (`/ai-sdk` HITL) | `^7` only    | `^2` only              | `toolApproval` is a **v7-only primitive**. v6's per-tool `needsApproval` was deprecated in v7's migration guide. We don't attempt to backport. |
+| V1 (`/ai-sdk` + `/mcp` adapter) | `^6 \|\| ^7` | `^1 \|\| ^2` | `connectAuthProvider` ships at both subpaths in V1. `/ai-sdk` is the primary surface for the AI SDK audience; `/mcp` re-exports the same function for non-AI-SDK MCP clients. The `OAuthClientProvider` interface is identical between `@ai-sdk/mcp@1.x` (paired with `ai@6`) and `@ai-sdk/mcp@2.x` (paired with `ai@7`) — see verification subsection — so a single implementation satisfies both. |
+| V2 (`/ai-sdk` HITL) | `^7` only    | `^2` only              | `withConsentApproval` lands at `/ai-sdk` only — this layer is intentionally AI-SDK-specific. `toolApproval` is a **v7-only primitive**. v6's per-tool `needsApproval` was deprecated in v7's migration guide. We don't attempt to backport. |
 
 **v7 release status as of 2026-06-03:** `latest: 6.0.196`, `beta: 7.0.0-beta.116`, `canary: 7.0.0-canary.162`. v7 is in active beta but has not promoted to `latest`. V2 implicitly waits on v7 stable. V0 and V1 can ship today against v6 `latest` and forward-compat with v7 betas.
 
@@ -23,29 +23,34 @@ Two viable shapes for a Connect + AI SDK integration:
 
 The open question on the adapter shape has been interactivity — can the integration support an interactive consent flow when a tool call requires a user grant that hasn't been issued yet? The AI SDK ships `toolApproval` configuration on `streamText`/`generateText` (already in tree), which gives us the HITL primitive we need; this doc plans the work in three releasable slices that take advantage of it.
 
-## Scope: MCP-spec primitive, AI-SDK glue on top
+## Scope: AI SDK first, MCP-spec compatibility for free
 
-A subtle but important framing decision: the headline integration is "Connect tokens for MCP tools," not "Connect for the AI SDK." The MCP `OAuthClientProvider` interface is an MCP-spec contract — the AI SDK's `@ai-sdk/mcp` package borrows it from [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts), and other MCP clients (e.g. Mastra's `MCPOAuthClientProvider`) implement the same shape.
+The headline integration is **AI SDK**. That's the audience we're chasing: Next.js + AI SDK developers building agents who today have to glue OAuth + token storage + token refresh + MCP plumbing together by hand. Every doc, recipe, example, and import path in this plan is shaped around making *their* experience one-line.
 
-That means a single adapter implementation plugs into all of:
+The lucky shape of the problem is that the AI SDK's `@ai-sdk/mcp` package authenticates MCP servers through an MCP-spec `OAuthClientProvider` interface — borrowed from [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts) and shared with other MCP clients (Mastra's `MCPOAuthClientProvider`, the official MCP TS SDK's `Client.connect(transport)`, etc.). So the same adapter that powers the AI SDK integration **also** plugs into any other MCP client without a second implementation. That's a bonus, not the headline — but it's a real one, and we'd be silly to give up the naming that captures it.
 
-- AI SDK's `@ai-sdk/mcp` (`createMCPClient({ transport: { authProvider } })`)
-- The official MCP TS SDK (`Client.connect(transport)` with `authProvider`)
-- Mastra's MCP client and any other client built on the MCP spec
+### Subpath split
 
-So the V1 deliverable lives at `@vercel/connect/mcp`, not `@vercel/connect/ai-sdk`. The naming matters because subpaths are forever, and framing the primitive as MCP-spec doubles its addressable surface for free.
+| Subpath                       | Audience                                          | Ships  | What's there                                                                                                |
+| ----------------------------- | ------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
+| `@vercel/connect/ai-sdk`      | **AI SDK users (primary)**                        | V1     | `connectAuthProvider` + `ConsentRequiredError` + `ConsentChallenge` (re-exported from `/mcp`).               |
+| `@vercel/connect/ai-sdk`      | **AI SDK users (primary)**                        | V2     | Adds `withConsentApproval` for `toolApproval`-based HITL + future `<ConnectConsentBoundary>` React glue.    |
+| `@vercel/connect/mcp`         | Non-AI-SDK MCP clients (Mastra, official MCP SDK) | V1     | Canonical home for `connectAuthProvider`. Same function the `/ai-sdk` subpath re-exports.                    |
 
-The AI-SDK-specific glue — `withConsentApproval`, future React components — is a separate, thinner layer that lives at `@vercel/connect/ai-sdk` in V2.
+Every AI SDK doc, cookbook recipe, and example imports from `@vercel/connect/ai-sdk` — that's the only path AI SDK readers ever need to see. The `/mcp` subpath is a quiet second door for MCP-spec consumers; its existence is what lets "MCP is nice too" stay true without polluting the AI SDK surface.
+
+The split is essentially free at implementation time (one extra one-line re-export) and locks in audience-aligned naming. Subpaths are forever; doing this now avoids a future "should we have called it `/ai-sdk`?" rename.
 
 ### Use-case → entry-point map
 
 | Use case                                                                            | Entry point                                                       | When it ships |
 | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------- |
-| Any MCP client (AI SDK, official MCP SDK, Mastra) + `OAuthClientProvider`           | `connectAuthProvider` from `@vercel/connect/mcp`                  | V1            |
+| **AI SDK `createMCPClient` + `streamText`/`generateText`**                          | `connectAuthProvider` from `@vercel/connect/ai-sdk`               | V1            |
+| **AI SDK `streamText`/`generateText` HITL tool approval**                           | `withConsentApproval` from `@vercel/connect/ai-sdk`               | V2            |
 | AI SDK custom `tool({ execute })` that calls a provider API directly                | `getToken()` from `@vercel/connect` root — already there          | Today         |
+| React consent-prompt UI in an AI SDK chat                                           | `<ConnectConsentBoundary>` from `@vercel/connect/ai-sdk`          | V3 (deferred) |
+| Mastra / official MCP TS SDK / any other MCP client with an `OAuthClientProvider` slot | `connectAuthProvider` from `@vercel/connect/mcp` (same impl)   | V1            |
 | Server cron, webhook, background job needing a provider bearer token                | `getToken()` from `@vercel/connect` root — already there          | Today         |
-| AI SDK `streamText`/`generateText` HITL tool approval                               | `withConsentApproval` from `@vercel/connect/ai-sdk`               | V2            |
-| React consent-prompt UI                                                             | `<ConnectConsentBoundary>` from `@vercel/connect/ai-sdk`          | V3 (deferred) |
 | Bearer-token `fetch` wrapper that auto-translates consent errors                    | *No subpath* — root `getToken()` is enough; revisit if signal     | Deferred      |
 
 ### Interface drift between AI SDK and official MCP SDK
@@ -92,7 +97,7 @@ The `@vercel/connect` package already ships parallel adapters for adjacent ecosy
 
 The Better Auth and Auth.js adapters treat Connect as an **OAuth IdP** — users sign in *through* Connect, which acts as the upstream authorization server. That model lives at `@vercel/connect/betterauth` and `@vercel/connect/authjs`.
 
-This document is about the second model: **Connect as a per-user token broker for MCP servers**. The host app already knows who the user is (Clerk, NextAuth, custom), and the AI SDK needs a bearer token to put in the MCP `Authorization` header. That's what `@vercel/connect/mcp` would provide (with optional AI-SDK-specific glue at `@vercel/connect/ai-sdk` for tool-approval and React UI).
+This document is about the second model: **Connect as a per-user token broker for MCP servers, shaped around the AI SDK**. The host app already knows who the user is (Clerk, NextAuth, custom), and the AI SDK needs a bearer token to put in the MCP `Authorization` header. That's what `@vercel/connect/ai-sdk` provides (with the canonical `OAuthClientProvider` impl living at `@vercel/connect/mcp` so non-AI-SDK MCP clients get it too). The V2 layer at `@vercel/connect/ai-sdk` adds AI-SDK-specific glue for `toolApproval` and React UI.
 
 The two models compose — an app can use Better Auth to sign users in *and* this adapter to mint MCP bearer tokens for the same user.
 
@@ -169,8 +174,8 @@ On a flagged tool call, the SDK emits a tool-approval chunk through the stream a
 
 Two new subpath exports, split by audience:
 
-- **`@vercel/connect/mcp`** (V1): `connectAuthProvider` (implements MCP-spec `OAuthClientProvider` by delegating to `getToken` and `startAuthorization`) and the supporting `ConsentRequiredError` / `ConsentChallenge` types. MCP-spec; works with any MCP client.
-- **`@vercel/connect/ai-sdk`** (V2): `withConsentApproval` (auto-wraps tools with `toolApproval: 'user-approval'` for the AI SDK's HITL flow) and the eventual `<ConnectConsentBoundary>` React component. AI-SDK-specific.
+- **`@vercel/connect/ai-sdk`** (V1 primary surface, extended in V2): AI SDK developers' entry point. In V1, re-exports `connectAuthProvider` + `ConsentRequiredError` + `ConsentChallenge` so AI SDK users only need to know one import path. In V2, adds `withConsentApproval` (auto-wraps tools with `toolApproval: 'user-approval'` for the AI SDK's HITL flow) and eventually `<ConnectConsentBoundary>` (V3 React glue).
+- **`@vercel/connect/mcp`** (V1): canonical home for `connectAuthProvider` — implements MCP-spec `OAuthClientProvider` by delegating to `getToken` and `startAuthorization`. Same function the `/ai-sdk` subpath re-exports; exists at this path so MCP-only consumers (Mastra, official MCP TS SDK, etc.) can import from a name that accurately reflects what the function is.
 
 ## V0: Docs-only (ship now)
 
@@ -213,11 +218,14 @@ Limitations V0 doesn't address (these are why V1 exists):
 - Consent gating runs upfront; a tool call cannot trigger consent mid-stream.
 - The consumer writes the `try { … } catch (UserAuthorizationRequiredError)` boilerplate per integration.
 
-## V1: `@vercel/connect/mcp`
+## V1: `@vercel/connect/ai-sdk` (primary) + `@vercel/connect/mcp`
 
-A subpath export with one function, mirroring the shape of the existing `@vercel/connect/ash`, `/betterauth`, and `/authjs` subpaths.
+Two subpath exports backed by one implementation, mirroring the shape of the existing `@vercel/connect/ash`, `/betterauth`, and `/authjs` subpaths.
 
-The returned `OAuthClientProvider` works with any MCP client that consumes the MCP-spec interface — `@ai-sdk/mcp`, the official `@modelcontextprotocol/typescript-sdk`, Mastra's MCP client, etc. The AI SDK is the primary documented integration but not the only one.
+- **`@vercel/connect/ai-sdk`** is the only path AI SDK docs, recipes, and examples reference. It re-exports `connectAuthProvider`, `ConsentRequiredError`, and `ConsentChallenge` from `/mcp`.
+- **`@vercel/connect/mcp`** owns the canonical implementation. Its existence as a separately-named subpath is what lets Mastra, the official `@modelcontextprotocol/typescript-sdk`, and any other MCP-spec client import from an accurate path. AI SDK users never need to know `/mcp` exists.
+
+Same returned object in both cases — an `OAuthClientProvider` that works with any MCP client consuming the MCP-spec interface.
 
 ### Public API
 
@@ -266,7 +274,7 @@ export function connectAuthProvider(
 
 ```ts
 import { createMCPClient } from '@ai-sdk/mcp';
-import { connectAuthProvider, ConsentRequiredError } from '@vercel/connect/mcp';
+import { connectAuthProvider, ConsentRequiredError } from '@vercel/connect/ai-sdk';
 import { streamText, stepCountIs } from 'ai';
 import { redirect } from 'next/navigation';
 
@@ -346,7 +354,7 @@ Recommendation for the docs:
 
 ## V2: Interactive consent + tool approval (HITL)
 
-V2 introduces `@vercel/connect/ai-sdk` — a separate, thinner subpath for AI-SDK-specific glue. The MCP auth provider stays at `@vercel/connect/mcp` because nothing about it is AI-SDK-specific; `withConsentApproval` and the future React components live here because they're shaped around AI SDK's `toolApproval` configuration and chat UI primitives.
+V2 extends `@vercel/connect/ai-sdk` with AI-SDK-specific glue. The canonical `connectAuthProvider` impl stays at `@vercel/connect/mcp` (and is still re-exported from `/ai-sdk`); `withConsentApproval` and the future React components land here because they're shaped around AI SDK's `toolApproval` configuration and chat UI primitives — they have no meaning for non-AI-SDK MCP clients.
 
 The integration loses a lot of value if it can't gate sensitive actions interactively. AI SDK already ships the primitive — `toolApproval: { toolName: 'user-approval' }` on `streamText`/`generateText` — so the work here is just to integrate it ergonomically.
 
@@ -446,7 +454,7 @@ A short "Authentication" subsection (or extension of the existing one if there i
 
 - Static bearer in `headers` — for service-to-service tokens.
 - Custom `OAuthClientProvider` — for apps with existing OAuth infrastructure.
-- **`@vercel/connect/mcp`'s `connectAuthProvider`** — for apps using Vercel Connect to broker per-user OAuth grants. Single-paragraph mention + link to the cookbook recipe. Do *not* duplicate the recipe.
+- **`@vercel/connect/ai-sdk`'s `connectAuthProvider`** — for apps using Vercel Connect to broker per-user OAuth grants. Single-paragraph mention + link to the cookbook recipe. Do *not* duplicate the recipe. (The same function is also exported from `@vercel/connect/mcp` for non-AI-SDK MCP clients; the AI SDK page only mentions `/ai-sdk`.)
 
 This is the cross-link that turns the recipe from "hidden cookbook" into "discoverable from the canonical MCP reference."
 
@@ -454,7 +462,7 @@ This is the cross-link that turns the recipe from "hidden cookbook" into "discov
 
 A runnable example app mirroring the cookbook recipe end-to-end. Useful for:
 
-- Smoke-testing every release of `@vercel/connect/mcp` (and later `/ai-sdk`) against the latest `vercel/ai` `main`.
+- Smoke-testing every release of `@vercel/connect/ai-sdk` (and the underlying `/mcp` impl) against the latest `vercel/ai` `main`.
 - Letting readers `git clone` and run instead of copy-pasting from MDX.
 - Catching `OAuthClientProvider` interface drift early (if the AI SDK adds a method, the example fails to build).
 
@@ -483,16 +491,16 @@ This pattern is well-established in the repo (`examples/mcp/`, `examples/next-ag
 
 The artifacts span three repos. To avoid broken cross-links during rollout:
 
-| Repo                                    | What ships                                                                                                | Depends on                                                       |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `vercel/vercel` (`packages/connect`)    | `@vercel/connect/mcp` (V1) and `@vercel/connect/ai-sdk` (V2) subpath exports + Changeset                  | Nothing — independent                                            |
-| `vercel/vercel-front` (`vercel-docs`)   | `/docs/connect/guides/use-with-ai-sdk` + `/docs/connect/examples/ai-agent-with-linear`                    | Either the V0 bearer-header pattern (no SDK dep) or V1 published |
-| `vercel/ai` (`content/` + `examples/`)  | Cookbook recipe, MCP docs cross-link, example app                                                         | V1 published to npm                                              |
+| Repo                                    | What ships                                                                                                                              | Depends on                                                       |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `vercel/vercel` (`packages/connect`)    | V1: both `@vercel/connect/ai-sdk` (primary) and `@vercel/connect/mcp` subpath exports + Changeset. V2: extends `/ai-sdk` with HITL glue. | Nothing — independent                                            |
+| `vercel/vercel-front` (`vercel-docs`)   | `/docs/connect/guides/use-with-ai-sdk` + `/docs/connect/examples/ai-agent-with-linear`                                                  | Either the V0 bearer-header pattern (no SDK dep) or V1 published |
+| `vercel/ai` (`content/` + `examples/`)  | Cookbook recipe, MCP docs cross-link, example app                                                                                       | V1 published to npm                                              |
 
 Sequencing:
 
 1. **Land V0** in `vercel-docs` first — pure docs, no dependencies, ships the headline integration story today.
-2. **Land V1** (`@vercel/connect/mcp` subpath + Changeset) in `vercel/vercel` and publish to npm.
+2. **Land V1** (`@vercel/connect/ai-sdk` primary subpath + `@vercel/connect/mcp` canonical-impl subpath + Changeset) in `vercel/vercel` and publish to npm.
 3. **Update V0 guide** in `vercel-docs` to feature the `authProvider` variant as the recommended path; keep the V0 bearer-header pattern as a "minimal / no extra deps" fallback.
 4. **Open AI SDK PR** simultaneously: cookbook recipe + MCP docs cross-link + example app. Cookbook recipe is the discovery anchor; the rest are supporting.
 5. **Land V2** (`withConsentApproval` + HITL recipe additions) in a second round across `vercel/vercel` → `vercel-docs` → `vercel/ai`.
@@ -554,24 +562,25 @@ Each phase ships across all repos it touches in the same week to keep cross-link
 | `vercel/vercel-front` | `/docs/connect/examples/ai-agent-with-linear` (runnable Linear example using V0 pattern)                                   |
 | `vercel/ai`           | *(none — V0 lives in Connect docs only; SDK consumers can already do it without our blessing)*                             |
 
-### Phase V1 — `@vercel/connect/mcp` adapter
+### Phase V1 — `@vercel/connect/ai-sdk` (primary) + `@vercel/connect/mcp` adapter
 
-| Repo                  | Artifact                                                                                                                   |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `vercel/vercel`       | `@vercel/connect/mcp` subpath export with `connectAuthProvider` + `ConsentRequiredError` + `ConsentChallenge` types        |
-| `vercel/vercel`       | Peer dependency on `@ai-sdk/mcp@^1 \|\| ^2` (covers AI SDK v6 + v7); Changeset; version bump to `@vercel/connect@0.2`     |
-| `vercel/vercel`       | TypeScript compatibility test verifying the adapter satisfies both AI SDK's and official MCP SDK's `OAuthClientProvider` shapes |
-| `vercel/vercel`       | Unit tests for `tokens()`, `redirectToAuthorization`, `invalidateCredentials`; integration tests against a mock MCP server |
-| `vercel/vercel-front` | Update `/docs/connect/guides/use-with-ai-sdk` to feature the `authProvider` variant as primary; keep V0 as minimal fallback|
-| `vercel/ai`           | Cookbook recipe `content/cookbook/01-next/74-mcp-tools-with-vercel-connect.mdx`                                            |
-| `vercel/ai`           | Cross-link addition in `content/docs/03-ai-sdk-core/17-mcp-apps.mdx` (Authentication subsection)                           |
-| `vercel/ai`           | Example app `examples/next-mcp-vercel-connect/` mirroring the recipe                                                       |
+| Repo                  | Artifact                                                                                                                                                                 |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `vercel/vercel`       | `@vercel/connect/mcp` subpath export — canonical impl of `connectAuthProvider` + `ConsentRequiredError` + `ConsentChallenge` types                                       |
+| `vercel/vercel`       | `@vercel/connect/ai-sdk` subpath export — re-exports `connectAuthProvider`, `ConsentRequiredError`, `ConsentChallenge` from `/mcp`. Primary surface for AI SDK consumers. |
+| `vercel/vercel`       | Peer dependency on `@ai-sdk/mcp@^1 \|\| ^2` (covers AI SDK v6 + v7); Changeset; version bump to `@vercel/connect@0.2`                                                   |
+| `vercel/vercel`       | TypeScript compatibility test verifying the adapter satisfies both AI SDK's and official MCP SDK's `OAuthClientProvider` shapes                                          |
+| `vercel/vercel`       | Unit tests for `tokens()`, `redirectToAuthorization`, `invalidateCredentials`; integration tests against a mock MCP server                                               |
+| `vercel/vercel-front` | Update `/docs/connect/guides/use-with-ai-sdk` to feature the `authProvider` variant (importing from `@vercel/connect/ai-sdk`) as primary; keep V0 as minimal fallback    |
+| `vercel/ai`           | Cookbook recipe `content/cookbook/01-next/74-mcp-tools-with-vercel-connect.mdx` (imports from `@vercel/connect/ai-sdk`)                                                  |
+| `vercel/ai`           | Cross-link addition in `content/docs/03-ai-sdk-core/17-mcp-apps.mdx` (Authentication subsection, points at `@vercel/connect/ai-sdk`)                                     |
+| `vercel/ai`           | Example app `examples/next-mcp-vercel-connect/` mirroring the recipe                                                                                                     |
 
 ### Phase V2 — `withConsentApproval` + HITL polish
 
 | Repo                  | Artifact                                                                                                                   |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `vercel/vercel`       | New `@vercel/connect/ai-sdk` subpath: `withConsentApproval` helper with prefix/approve filtering + `approvalConfig` builder |
+| `vercel/vercel`       | Extend `@vercel/connect/ai-sdk` (already shipping in V1): add `withConsentApproval` helper with prefix/approve filtering + `approvalConfig` builder |
 | `vercel/vercel`       | Tests against `streamText({ toolApproval })` for approval and denial paths                                                 |
 | `vercel/vercel-front` | New page `/docs/connect/guides/handle-tool-approval` walking through the chat-turn-boundary pattern and function-timeout map |
 | `vercel/vercel-front` | Update Linear example to include an approval-gated tool call                                                                |
@@ -590,11 +599,15 @@ Each phase ships across all repos it touches in the same week to keep cross-link
 This integration is what makes Connect *concrete* for the AI SDK audience. Today, a Next.js + AI SDK developer building an agent has to assemble OAuth + token storage + token refresh + MCP plumbing from four libraries. With this adapter, the entire stack collapses to:
 
 ```ts
-authProvider: connectAuthProvider('oauth/linear', { subject: { type: 'user', id: userId } })
+import { connectAuthProvider } from '@vercel/connect/ai-sdk';
+
+authProvider: connectAuthProvider('oauth/linear', { subject: { type: 'user', id: userId } });
 ```
 
 That's the same "kill the boilerplate" win the AI SDK is known for, applied to OAuth — and it gives Connect a headline demo for the exact audience the AI SDK already owns.
 
-V0 (the docs-only path) costs essentially nothing and unblocks the audience today. V1 is the long-term ergonomic surface. V2 closes the interactive-flow gap by leaning on the AI SDK's existing `toolApproval` primitive, so we don't have to invent a new HITL mechanism.
+V0 (the docs-only path) costs essentially nothing and unblocks the AI SDK audience today. V1 is the long-term ergonomic surface, shipped at `@vercel/connect/ai-sdk` so the import path reflects the headline use case. V2 closes the interactive-flow gap by leaning on the AI SDK's existing `toolApproval` primitive, so we don't have to invent a new HITL mechanism.
 
-The `vercel/ai` content plan — cookbook recipe + MCP reference cross-link + example app — is what makes the integration discoverable from the AI SDK audience, not just from Connect's existing audience. Without that, V1's adapter ships into the void; with it, the integration shows up on the canonical surface where developers are already searching "ai sdk mcp oauth."
+The `vercel/ai` content plan — cookbook recipe + MCP reference cross-link + example app, all referencing `@vercel/connect/ai-sdk` — is what makes the integration discoverable from the AI SDK audience, not just from Connect's existing audience. Without that, V1's adapter ships into the void; with it, the integration shows up on the canonical surface where developers are already searching "ai sdk mcp oauth."
+
+The MCP-spec compatibility (`@vercel/connect/mcp`) is a real bonus on top: the same one-line collapse works for Mastra users and anyone else on the MCP-spec interface, with zero extra implementation work. We claim that surface without distracting from the AI SDK headline.

--- a/packages/connect/docs/ai-sdk-integration.md
+++ b/packages/connect/docs/ai-sdk-integration.md
@@ -2,7 +2,17 @@
 
 **Status:** proposal
 **Target release:** `@vercel/connect@0.2` (subpaths: `@vercel/connect/mcp` in V1; `@vercel/connect/ai-sdk` in V2)
-**Prerequisites:** `@ai-sdk/mcp` shipped with `OAuthClientProvider` (already in `vercel/ai`, see [`packages/mcp/src/tool/oauth.ts`](https://github.com/vercel/ai/blob/main/packages/mcp/src/tool/oauth.ts)); `streamText`/`generateText` `toolApproval` configuration (already in `vercel/ai`, see [`packages/ai/src/generate-text/stream-text.ts`](https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/stream-text.ts)); MCP-spec `OAuthClientProvider` interface (in [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts), which the AI SDK borrows from).
+**Prerequisites:** `@ai-sdk/mcp` shipped with `OAuthClientProvider` (already in `vercel/ai`, see [`packages/mcp/src/tool/oauth.ts`](https://github.com/vercel/ai/blob/main/packages/mcp/src/tool/oauth.ts)); `streamText`/`generateText` `toolApproval` configuration (added in AI SDK v7, see [`packages/ai/src/generate-text/stream-text.ts`](https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/stream-text.ts)); MCP-spec `OAuthClientProvider` interface (in [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts), which the AI SDK borrows from).
+
+### AI SDK version compatibility
+
+| Phase | `ai` peer dep | `@ai-sdk/mcp` peer dep | Notes |
+| ----- | ------------- | ---------------------- | ----- |
+| V0 (docs)  | `^6 \|\| ^7` | `^1 \|\| ^2`           | Bearer-header pattern; just calls `getToken()` plus `createMCPClient({ transport: { headers } })`. Works on both v6 and v7. |
+| V1 (`/mcp` adapter) | `^6 \|\| ^7` | `^1 \|\| ^2` | `OAuthClientProvider` interface is MCP-spec and is exported by both `@ai-sdk/mcp@1.x` (paired with `ai@6`) and `@ai-sdk/mcp@2.x` (paired with `ai@7`). Single adapter implementation should satisfy both. |
+| V2 (`/ai-sdk` HITL) | `^7` only    | `^2` only              | `toolApproval` is a **v7-only primitive**. v6's per-tool `needsApproval` was deprecated in v7's migration guide. We don't attempt to backport. |
+
+**v7 release status as of 2026-06-03:** `latest: 6.0.196`, `beta: 7.0.0-beta.116`, `canary: 7.0.0-canary.162`. v7 is in active beta but has not promoted to `latest`. V2 implicitly waits on v7 stable. V0 and V1 can ship today against v6 `latest` and forward-compat with v7 betas.
 
 ## Background
 
@@ -531,7 +541,7 @@ Each phase ships across all repos it touches in the same week to keep cross-link
 | Repo                  | Artifact                                                                                                                   |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `vercel/vercel`       | `@vercel/connect/mcp` subpath export with `connectAuthProvider` + `ConsentRequiredError` + `ConsentChallenge` types        |
-| `vercel/vercel`       | Peer dependency on `@ai-sdk/mcp` (and optionally the official MCP TS SDK); Changeset; version bump to `@vercel/connect@0.2`|
+| `vercel/vercel`       | Peer dependency on `@ai-sdk/mcp@^1 \|\| ^2` (covers AI SDK v6 + v7); Changeset; version bump to `@vercel/connect@0.2`     |
 | `vercel/vercel`       | TypeScript compatibility test verifying the adapter satisfies both AI SDK's and official MCP SDK's `OAuthClientProvider` shapes |
 | `vercel/vercel`       | Unit tests for `tokens()`, `redirectToAuthorization`, `invalidateCredentials`; integration tests against a mock MCP server |
 | `vercel/vercel-front` | Update `/docs/connect/guides/use-with-ai-sdk` to feature the `authProvider` variant as primary; keep V0 as minimal fallback|

--- a/packages/connect/docs/ai-sdk-integration.md
+++ b/packages/connect/docs/ai-sdk-integration.md
@@ -1,0 +1,572 @@
+# Native MCP and AI SDK integration for `@vercel/connect`
+
+**Status:** proposal
+**Target release:** `@vercel/connect@0.2` (subpaths: `@vercel/connect/mcp` in V1; `@vercel/connect/ai-sdk` in V2)
+**Prerequisites:** `@ai-sdk/mcp` shipped with `OAuthClientProvider` (already in `vercel/ai`, see [`packages/mcp/src/tool/oauth.ts`](https://github.com/vercel/ai/blob/main/packages/mcp/src/tool/oauth.ts)); `streamText`/`generateText` `toolApproval` configuration (already in `vercel/ai`, see [`packages/ai/src/generate-text/stream-text.ts`](https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/stream-text.ts)); MCP-spec `OAuthClientProvider` interface (in [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts), which the AI SDK borrows from).
+
+## Background
+
+Two viable shapes for a Connect + AI SDK integration:
+
+1. **Docs-only**: `getToken` + `createMCPClient` with the token threaded through `headers`. Works today with zero new code.
+2. **Adapter**: `connectAuthProvider` that plugs into `createMCPClient`'s `authProvider` slot and refreshes tokens transparently across the lifetime of the MCP client.
+
+The open question on the adapter shape has been interactivity — can the integration support an interactive consent flow when a tool call requires a user grant that hasn't been issued yet? The AI SDK ships `toolApproval` configuration on `streamText`/`generateText` (already in tree), which gives us the HITL primitive we need; this doc plans the work in three releasable slices that take advantage of it.
+
+## Scope: MCP-spec primitive, AI-SDK glue on top
+
+A subtle but important framing decision: the headline integration is "Connect tokens for MCP tools," not "Connect for the AI SDK." The MCP `OAuthClientProvider` interface is an MCP-spec contract — the AI SDK's `@ai-sdk/mcp` package borrows it from [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts), and other MCP clients (e.g. Mastra's `MCPOAuthClientProvider`) implement the same shape.
+
+That means a single adapter implementation plugs into all of:
+
+- AI SDK's `@ai-sdk/mcp` (`createMCPClient({ transport: { authProvider } })`)
+- The official MCP TS SDK (`Client.connect(transport)` with `authProvider`)
+- Mastra's MCP client and any other client built on the MCP spec
+
+So the V1 deliverable lives at `@vercel/connect/mcp`, not `@vercel/connect/ai-sdk`. The naming matters because subpaths are forever, and framing the primitive as MCP-spec doubles its addressable surface for free.
+
+The AI-SDK-specific glue — `withConsentApproval`, future React components — is a separate, thinner layer that lives at `@vercel/connect/ai-sdk` in V2.
+
+### Use-case → entry-point map
+
+| Use case                                                                            | Entry point                                                       | When it ships |
+| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------- |
+| Any MCP client (AI SDK, official MCP SDK, Mastra) + `OAuthClientProvider`           | `connectAuthProvider` from `@vercel/connect/mcp`                  | V1            |
+| AI SDK custom `tool({ execute })` that calls a provider API directly                | `getToken()` from `@vercel/connect` root — already there          | Today         |
+| Server cron, webhook, background job needing a provider bearer token                | `getToken()` from `@vercel/connect` root — already there          | Today         |
+| AI SDK `streamText`/`generateText` HITL tool approval                               | `withConsentApproval` from `@vercel/connect/ai-sdk`               | V2            |
+| React consent-prompt UI                                                             | `<ConnectConsentBoundary>` from `@vercel/connect/ai-sdk`          | V3 (deferred) |
+| Bearer-token `fetch` wrapper that auto-translates consent errors                    | *No subpath* — root `getToken()` is enough; revisit if signal     | Deferred      |
+
+### Interface drift between AI SDK and official MCP SDK
+
+The AI SDK's `OAuthClientProvider` and the official MCP TS SDK's `OAuthClientProvider` are ~95% identical. Two small drifts observed:
+
+- AI SDK: `get redirectUrl(): string | URL` (required, non-undefined).
+- Official MCP SDK: `get redirectUrl(): string | URL | undefined` (allows undefined for non-interactive flows like client_credentials / jwt-bearer).
+
+The narrower AI SDK shape is a subtype of the official shape, so a single implementation returning a non-undefined `string | URL` satisfies both. The V1 implementer should write the adapter against the AI SDK's stricter shape (so the type-check is tight) and verify it satisfies the official MCP SDK's looser shape via a TypeScript compatibility test. If the interfaces diverge further over time, we can ship two facade entry points (`/mcp/ai-sdk` and `/mcp/official`) without breaking the existing one.
+
+## Motivation
+
+Today, a Next.js + AI SDK developer who wants an agent to call provider APIs has to do all of:
+
+1. Set up an OAuth client per provider (Slack app, GitHub app, Linear OAuth client, …).
+2. Persist per-user OAuth grants in their own database.
+3. Refresh tokens themselves.
+4. Wire MCP clients (or write `fetch` wrappers) separately.
+
+Vercel Connect already solves 1–3 server-side. The gap is a one-line bridge to `@ai-sdk/mcp` so the AI SDK can inherit Connect's auth instead of asking developers to plumb tokens through manually.
+
+The `@vercel/connect` package already ships parallel adapters for adjacent ecosystems (`@vercel/connect/ash`, `@vercel/connect/betterauth`, `@vercel/connect/authjs`). The AI SDK adapter is the fourth in that family.
+
+## Two integration models (for reference)
+
+The Better Auth and Auth.js adapters treat Connect as an **OAuth IdP** — users sign in *through* Connect, which acts as the upstream authorization server. That model lives at `@vercel/connect/betterauth` and `@vercel/connect/authjs`.
+
+This document is about the second model: **Connect as a per-user token broker for MCP servers**. The host app already knows who the user is (Clerk, NextAuth, custom), and the AI SDK needs a bearer token to put in the MCP `Authorization` header. That's what `@vercel/connect/mcp` would provide (with optional AI-SDK-specific glue at `@vercel/connect/ai-sdk` for tool-approval and React UI).
+
+The two models compose — an app can use Better Auth to sign users in *and* this adapter to mint MCP bearer tokens for the same user.
+
+## Non-goals
+
+- Not a wrapper around `createMCPClient`. The adapter only provides the `authProvider`; consumers still call `createMCPClient` themselves so every MCP feature (resources, prompts, elicitation, schema definition) keeps working unchanged.
+- Not a tool catalog. We don't curate or proxy tools; the MCP server is the source of truth (in contrast to Composio).
+- Not a replacement for AI Gateway. `model: 'anthropic/claude-sonnet-4.6'` continues to flow through the Gateway as today; this adapter is orthogonal to model selection.
+- Not a Workflow DevKit primitive. Long-lived multi-step agents that need durable resumption should keep using `DurableAgent`; this adapter is for in-process `streamText`/`generateText` calls.
+
+## Shape inventory
+
+### What Vercel Connect already has
+
+- `getToken(connector, params, options?)` / `getTokenResponse(...)` — token exchange with server-side cache; throws `UserAuthorizationRequiredError`, `ConnectorInstallationRequiredError`, `NoValidTokenError`.
+- `startAuthorization(connector, params, options?)` — returns `{ url, request, verifier }`; `url` is the consent URL to redirect a user to.
+- Typed error classes exported from `@vercel/connect`.
+
+### What `@ai-sdk/mcp` already has
+
+From [`packages/mcp/src/tool/oauth.ts:33-92`](https://github.com/vercel/ai/blob/main/packages/mcp/src/tool/oauth.ts):
+
+```ts
+export interface OAuthClientProvider {
+  tokens(): OAuthTokens | undefined | Promise<OAuthTokens | undefined>;
+  saveTokens(tokens: OAuthTokens): void | Promise<void>;
+  redirectToAuthorization(authorizationUrl: URL): void | Promise<void>;
+  saveCodeVerifier(codeVerifier: string): void | Promise<void>;
+  codeVerifier(): string | Promise<string>;
+  addClientAuthentication?(headers, params, url, metadata?): void | Promise<void>;
+  invalidateCredentials?(scope: 'all' | 'client' | 'tokens' | 'verifier'): void | Promise<void>;
+  get redirectUrl(): string | URL;
+  get clientMetadata(): OAuthClientMetadata;
+  clientInformation(): OAuthClientInformation | undefined | Promise<OAuthClientInformation | undefined>;
+  saveClientInformation?(clientInformation: OAuthClientInformation): void | Promise<void>;
+  // ... optional state/storedState helpers
+}
+```
+
+Both the HTTP and SSE transports use it the same way (`packages/mcp/src/tool/mcp-http-transport.ts:91-94`):
+
+```ts
+if (this.authProvider) {
+  const tokens = await this.authProvider.tokens();
+  if (tokens?.access_token) {
+    headers['Authorization'] = `Bearer ${tokens.access_token}`;
+  }
+}
+```
+
+And on 401 (`mcp-http-transport.ts:183-185`), the transport calls the full `auth(authProvider, …)` orchestrator which can trigger `redirectToAuthorization`, dynamic client registration, etc.
+
+### What `streamText`/`generateText` already has for HITL
+
+From [`packages/ai/src/generate-text/stream-text.ts:410`](https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/stream-text.ts):
+
+```ts
+toolApproval?: ToolApprovalConfiguration<TOOLS, RUNTIME_CONTEXT>;
+```
+
+Per the existing tests, the shape is:
+
+```ts
+streamText({
+  // ...
+  tools: { searchIssues: tool({ ... }) },
+  toolApproval: { searchIssues: 'user-approval' },
+});
+```
+
+On a flagged tool call, the SDK emits a tool-approval chunk through the stream and waits for an approval/denial decision; denied calls produce an `execution-denied` tool result the model can react to.
+
+### What needs to be built
+
+Two new subpath exports, split by audience:
+
+- **`@vercel/connect/mcp`** (V1): `connectAuthProvider` (implements MCP-spec `OAuthClientProvider` by delegating to `getToken` and `startAuthorization`) and the supporting `ConsentRequiredError` / `ConsentChallenge` types. MCP-spec; works with any MCP client.
+- **`@vercel/connect/ai-sdk`** (V2): `withConsentApproval` (auto-wraps tools with `toolApproval: 'user-approval'` for the AI SDK's HITL flow) and the eventual `<ConnectConsentBoundary>` React component. AI-SDK-specific.
+
+## V0: Docs-only (ship now)
+
+Before any package code lands, the integration works today with the public SDK surface:
+
+```ts
+import { createMCPClient } from '@ai-sdk/mcp';
+import { getToken } from '@vercel/connect';
+import { streamText, stepCountIs } from 'ai';
+
+const userId = 'user_demo_123';
+
+const token = await getToken('oauth/linear', {
+  subject: { type: 'user', id: userId },
+  scopes: ['read'],
+});
+
+const mcpClient = await createMCPClient({
+  transport: {
+    type: 'http',
+    url: 'https://mcp.linear.app',
+    headers: { Authorization: `Bearer ${token}` },
+  },
+});
+
+const stream = await streamText({
+  model: 'anthropic/claude-sonnet-4.6',
+  prompt: 'Show me my open Linear issues',
+  tools: await mcpClient.tools(),
+  stopWhen: stepCountIs(10),
+  onFinish: async () => { await mcpClient.close(); },
+});
+```
+
+**Action:** publish a guide page at `/docs/connect/guides/use-with-ai-sdk` (vercel-docs) and a runnable example at `/docs/connect/examples/ai-agent-with-linear`. Zero changes to `@vercel/connect`. This unblocks the AI SDK audience immediately while V1 is in flight.
+
+Limitations V0 doesn't address (these are why V1 exists):
+
+- Token is resolved once at client init; if it expires mid-conversation, the MCP client must be rebuilt.
+- Consent gating runs upfront; a tool call cannot trigger consent mid-stream.
+- The consumer writes the `try { … } catch (UserAuthorizationRequiredError)` boilerplate per integration.
+
+## V1: `@vercel/connect/mcp`
+
+A subpath export with one function, mirroring the shape of the existing `@vercel/connect/ash`, `/betterauth`, and `/authjs` subpaths.
+
+The returned `OAuthClientProvider` works with any MCP client that consumes the MCP-spec interface — `@ai-sdk/mcp`, the official `@modelcontextprotocol/typescript-sdk`, Mastra's MCP client, etc. The AI SDK is the primary documented integration but not the only one.
+
+### Public API
+
+```ts
+// OAuthClientProvider is the MCP-spec interface; @ai-sdk/mcp re-exports it.
+import type { OAuthClientProvider } from '@ai-sdk/mcp';
+import type { ConnectTokenParams } from '@vercel/connect';
+
+export interface ConnectAuthProviderOptions {
+  /** Override the Vercel OIDC token fetcher (tests / non-Vercel runtimes). */
+  readonly getVercelOidcToken?: () => Promise<string>;
+  /**
+   * Called when Vercel Connect reports that the user has not yet authorized
+   * the connector. The caller decides how to surface the consent URL —
+   * `redirect()`, throw a typed error, emit a custom UI chunk, etc.
+   *
+   * Defaults to throwing `ConsentRequiredError` so callers can handle it
+   * with a single try/catch at the boundary.
+   */
+  readonly onConsentRequired?: (challenge: ConsentChallenge) => void | Promise<void>;
+}
+
+export interface ConsentChallenge {
+  readonly connector: string;
+  readonly subject: ConnectTokenParams['subject'];
+  readonly redirectUrl: string;
+  readonly request: string;
+  readonly verifier: string;
+}
+
+export class ConsentRequiredError extends Error {
+  readonly name: 'ConsentRequiredError';
+  readonly redirectUrl: string;
+  readonly connector: string;
+  readonly subject: ConnectTokenParams['subject'];
+}
+
+export function connectAuthProvider(
+  connector: string,
+  params: ConnectTokenParams,
+  options?: ConnectAuthProviderOptions,
+): OAuthClientProvider;
+```
+
+### Usage
+
+```ts
+import { createMCPClient } from '@ai-sdk/mcp';
+import { connectAuthProvider, ConsentRequiredError } from '@vercel/connect/mcp';
+import { streamText, stepCountIs } from 'ai';
+import { redirect } from 'next/navigation';
+
+try {
+  const mcpClient = await createMCPClient({
+    transport: {
+      type: 'http',
+      url: 'https://mcp.linear.app',
+      authProvider: connectAuthProvider('oauth/linear', {
+        subject: { type: 'user', id: userId },
+        scopes: ['read'],
+      }),
+    },
+  });
+
+  const stream = await streamText({
+    model: 'anthropic/claude-sonnet-4.6',
+    prompt: 'Triage my Linear inbox',
+    tools: await mcpClient.tools(),
+    stopWhen: stepCountIs(10),
+    onFinish: async () => { await mcpClient.close(); },
+  });
+} catch (err) {
+  if (err instanceof ConsentRequiredError) {
+    redirect(err.redirectUrl);
+  }
+  throw err;
+}
+```
+
+### Method-by-method delegation
+
+Most of the `OAuthClientProvider` surface is dead code in our adapter, because Vercel Connect owns client registration, PKCE, state, and the callback handshake server-side. The shim only needs to implement the methods the MCP transport actually exercises.
+
+| `OAuthClientProvider` method     | Adapter implementation                                                                                                                                                                                                                                                                                                              |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tokens()`                       | `await getToken(connector, params)`. Wrap in `{ access_token, token_type: 'Bearer' }`. On `UserAuthorizationRequiredError` return `undefined` so the transport triggers `authorizeOnce()` and lands in `redirectToAuthorization`. On `ConnectorInstallationRequiredError` re-throw (configuration problem, not a per-user issue).   |
+| `redirectToAuthorization(_url)`  | Ignore the URL argument from the AI SDK's discovery flow (Connect has its own consent URL). Call `startAuthorization(connector, params)`, build a `ConsentChallenge`, then either invoke `onConsentRequired(challenge)` or throw `ConsentRequiredError`. Either way, the MCP transport's `auth()` orchestrator unwinds the stream. |
+| `saveTokens(_tokens)`            | No-op. Connect owns token persistence server-side.                                                                                                                                                                                                                                                                                  |
+| `saveCodeVerifier(_v)`           | No-op. Connect owns PKCE.                                                                                                                                                                                                                                                                                                           |
+| `codeVerifier()`                 | Throw a typed `UnsupportedOperationError`. The MCP transport never reaches this when our `tokens()`/`redirectToAuthorization` are wired correctly.                                                                                                                                                                                  |
+| `redirectUrl` (getter)           | Returns the connector's registered callback URL, or `''` if unknown. Optional; included for completeness only.                                                                                                                                                                                                                      |
+| `clientMetadata` (getter)        | Returns a minimal `OAuthClientMetadata` with `redirect_uris: []`. The MCP transport reads this only during dynamic client registration, which we never trigger.                                                                                                                                                                     |
+| `clientInformation()`            | Returns `{ client_id: connector }` (the Connect UID acts as the logical client id).                                                                                                                                                                                                                                                 |
+| `invalidateCredentials(scope)`   | When called, invalidate the Connect SDK's LRU cache entry for `(connector, subject)` so the next `tokens()` call hits Connect fresh. No remote revocation — that is the user's responsibility via the dashboard or a separate CLI.                                                                                                  |
+| `addClientAuthentication?`       | Not implemented. Connect handles client auth on its side.                                                                                                                                                                                                                                                                           |
+| `saveClientInformation?`         | Not implemented.                                                                                                                                                                                                                                                                                                                    |
+| `state`/`saveState`/`storedState`| Not implemented. Connect manages the OAuth state parameter.                                                                                                                                                                                                                                                                         |
+
+**Implementation footprint:** ≈80–120 lines, mostly types. The hot path is `tokens()`; everything else is either a no-op, a small data return, or a typed error.
+
+### Token refresh during long conversations
+
+The MCP transport calls `tokens()` before each request, so a token that expires mid-conversation is transparently refreshed on the next call. Connect's existing LRU cache returns the cached token until shortly before expiry and refreshes server-side; the adapter inherits that behavior for free.
+
+This already fixes one of V0's three limitations without any extra code.
+
+### Function timeouts and where the HITL wait fits
+
+The HITL flow uses chat-turn boundaries as the "pause" mechanism, not server-held connections. This matters for Vercel Functions pricing and timeout exposure:
+
+| Activity                                                          | Counts against function timeout?                            |
+| ----------------------------------------------------------------- | ----------------------------------------------------------- |
+| Model token generation                                            | Yes — bounded by 300s default / 800s Fluid Compute paid     |
+| Tool execution inside a step                                      | Yes — same bound                                            |
+| Streaming the response body back to the client                    | Yes — response stream lives in the same invocation          |
+| **User think-time between approval prompt and click**             | **No — HTTP response has closed, function instance freed**  |
+| **User completing OAuth consent in a popup**                      | **No — Connect handles the callback server-to-server**      |
+
+The trace from `stream-text.ts`: when `toolApproval` flags a call, the stream emits a `tool-approval-request` chunk followed by `finishReason: 'tool-calls'` and `finish-step` ([`stream-text.ts:1860`](https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/stream-text.ts)). The HTTP response closes. The wait is whatever the user takes to click. When approval arrives as a `tool-approval-response` in a new tool-role message, a fresh `streamText` call runs `collectToolApprovals({ messages })` over the updated history ([`collect-tool-approvals.ts`](https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/collect-tool-approvals.ts)), executes approved tools, and continues.
+
+The pattern that **does** exceed function timeouts is a single autonomous turn whose model + tool loop doesn't fit (e.g. a research agent that wants to call 50 sequential tools in one step). That is the case where the host app should escalate to `DurableAgent` from `@workflow/ai/agent` — each tool becomes a durable, retryable step that can outlive a single invocation. The Connect adapter works the same in either world because `connectAuthProvider` is just an `OAuthClientProvider`; it doesn't care whether `streamText` or `DurableAgent` is calling it.
+
+Recommendation for the docs:
+- **Default path**: `streamText` + HITL via `toolApproval`. Fits the vast majority of agent UX patterns. No durable infra needed.
+- **Escalation**: `DurableAgent` when a single autonomous turn must exceed the function timeout or survive deploys.
+
+## V2: Interactive consent + tool approval (HITL)
+
+V2 introduces `@vercel/connect/ai-sdk` — a separate, thinner subpath for AI-SDK-specific glue. The MCP auth provider stays at `@vercel/connect/mcp` because nothing about it is AI-SDK-specific; `withConsentApproval` and the future React components live here because they're shaped around AI SDK's `toolApproval` configuration and chat UI primitives.
+
+The integration loses a lot of value if it can't gate sensitive actions interactively. AI SDK already ships the primitive — `toolApproval: { toolName: 'user-approval' }` on `streamText`/`generateText` — so the work here is just to integrate it ergonomically.
+
+### Auto-approval for MCP tools
+
+A second helper takes the result of `mcpClient.tools()` and tags every tool (or a subset) as `'user-approval'`:
+
+```ts
+import { withConsentApproval } from '@vercel/connect/ai-sdk';
+
+const tools = withConsentApproval(await mcpClient.tools(), {
+  // optional — defaults to gating every tool
+  approve: ['linear_create_issue', 'linear_update_comment'],
+});
+
+const stream = await streamText({
+  model: 'anthropic/claude-sonnet-4.6',
+  prompt: '...',
+  tools,
+  toolApproval: tools.approvalConfig, // pre-built by the helper
+});
+```
+
+`withConsentApproval` returns the tool map plus a sibling `approvalConfig` object pre-shaped for the AI SDK's `toolApproval` option. The shape compiles down to the existing `{ toolName: 'user-approval' }` form — nothing custom.
+
+### Streaming consent chunks through `useChat`
+
+When `redirectToAuthorization` fires mid-stream (e.g. a tool requires a freshly-revoked grant), we want the chunk to appear in `useChat`'s UI surface, not just throw. Two implementation options:
+
+1. **Custom UI message part** — emit a `data-consent` part via the transport's data-part API. UI renders `{ url, connector }` as an "Authorize <Provider>" button.
+2. **Throw a tool-result-with-error** — translates to a `tool-output-denied` chunk that the UI already renders.
+
+Option 1 is cleaner and matches how AI SDK Elements renders other interrupts. We'll start with Option 2 (no new chunk type, ships with V1) and add Option 1 with `<ConnectConsentBoundary>` in a follow-up.
+
+### Multi-connector composition
+
+Because `tools` is just an object, the AI SDK already supports merging tools from multiple Connect-backed MCP clients in one `streamText` call. The helper takes a `prefix` option to avoid collisions:
+
+```ts
+const linear = withConsentApproval(await linearClient.tools(), { prefix: 'linear_' });
+const github = withConsentApproval(await githubClient.tools(), { prefix: 'github_' });
+
+const stream = await streamText({
+  // ...
+  tools: { ...linear, ...github },
+  toolApproval: { ...linear.approvalConfig, ...github.approvalConfig },
+});
+```
+
+## AI SDK content plan (mirror surface in `vercel/ai`)
+
+The Connect-side docs (`vercel-docs` → `/docs/connect/...`) reach developers who already know Connect. The reverse-discovery path — developers who land on `ai-sdk.dev` looking for "how do I auth my MCP tools?" — is what makes the integration actually findable. This section plans the symmetric artifacts in `vercel/ai`.
+
+### Surface inventory in `vercel/ai`
+
+Content lives in three layers (verified against the repo as of 2026-06-03):
+
+| Layer                                                                                                              | Purpose                                                            | Existing prior art                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `content/docs/03-ai-sdk-core/17-mcp-apps.mdx`                                                                      | Canonical MCP reference page (concepts, transports, lifecycle)     | Already covers `createMCPClient`, transports, `tools()` lifecycle                                                 |
+| `content/cookbook/01-next/73-mcp-tools.mdx`, `75-human-in-the-loop.mdx`                                            | Framework-specific recipes; numbered to control sidebar order      | `73-mcp-tools.mdx` (Stdio/SSE/HTTP MCP), `75-human-in-the-loop.mdx` (HITL with `useChat` and approval responses)  |
+| `examples/{framework}-{provider/feature}/`                                                                         | Runnable example apps with their own `package.json`                | `examples/mcp/`, `examples/next-agent/`, `examples/next-workflow/`                                                |
+
+### Artifacts to add
+
+#### 1. Cookbook recipe — `content/cookbook/01-next/74-mcp-tools-with-vercel-connect.mdx`
+
+The headline artifact. Slots between the existing MCP recipe (`73`) and the HITL recipe (`75`), so a reader following the natural sidebar order discovers Connect immediately after learning the base MCP pattern. Numbering chosen deliberately: `74` keeps the alphabetical/numeric ordering stable without renumbering existing files.
+
+Frontmatter (matches the format the AI SDK docs builder expects):
+
+```mdx
+---
+title: MCP Tools with Vercel Connect
+description: Use Vercel Connect to manage OAuth for MCP-backed tools in a Next.js agent
+tags: ['next', 'tool use', 'agent', 'mcp', 'oauth', 'vercel']
+---
+```
+
+Recipe outline:
+
+1. **Why** — a paragraph framing the problem (per-provider OAuth client + token storage + refresh + plumbing collapses to one adapter call).
+2. **Prerequisites** — Vercel project linked, `vercel env pull` for the OIDC token, a Linear (or Linear-equivalent) Custom OAuth connector created in the Vercel dashboard.
+3. **Install** — `pnpm install ai @ai-sdk/react @ai-sdk/mcp @vercel/connect`.
+4. **Wire the route handler** — `app/api/chat/route.ts` showing `connectAuthProvider` slotted into `createMCPClient({ transport: { authProvider } })` + `streamText` with `convertToModelMessages` and `toUIMessageStreamResponse`.
+5. **Wire the client** — `app/page.tsx` using `useChat` from `@ai-sdk/react` with `DefaultChatTransport`. (Matches the existing recipes' shape so the reader doesn't need to learn a new client pattern.)
+6. **Handle consent** — `try { ... } catch (ConsentRequiredError) { redirect(err.redirectUrl) }`. Cross-link to the Connect concepts page on authentication for the deeper "what's happening" picture.
+7. **Add approval (HITL)** — drop in `withConsentApproval(tools, { approve: ['linear_create_issue'] })` and pass `tools.approvalConfig` to `streamText`. Note the symmetry with recipe `75` — "everything from the HITL recipe applies; Connect just provides the underlying tools."
+8. **What this replaced** — short bullet list of the per-provider boilerplate the recipe sidesteps (OAuth client registration, token DB, refresh job, etc.).
+9. **Next steps** — links into the AI SDK MCP reference, the Connect concepts pages, and the example app below.
+
+**Why this lives in `vercel/ai`, not just `vercel-docs`:** SEO and discoverability. A developer searching "ai sdk mcp oauth" hits ai-sdk.dev first. The Connect-side guide in `vercel-docs` is for developers who already know Connect; the cookbook recipe is for developers who don't.
+
+#### 2. Reference cross-link — small additions to `content/docs/03-ai-sdk-core/17-mcp-apps.mdx`
+
+A short "Authentication" subsection (or extension of the existing one if there is one) that calls out three options for providing bearer tokens to an MCP server:
+
+- Static bearer in `headers` — for service-to-service tokens.
+- Custom `OAuthClientProvider` — for apps with existing OAuth infrastructure.
+- **`@vercel/connect/mcp`'s `connectAuthProvider`** — for apps using Vercel Connect to broker per-user OAuth grants. Single-paragraph mention + link to the cookbook recipe. Do *not* duplicate the recipe.
+
+This is the cross-link that turns the recipe from "hidden cookbook" into "discoverable from the canonical MCP reference."
+
+#### 3. Example app — `examples/next-mcp-vercel-connect/`
+
+A runnable example app mirroring the cookbook recipe end-to-end. Useful for:
+
+- Smoke-testing every release of `@vercel/connect/mcp` (and later `/ai-sdk`) against the latest `vercel/ai` `main`.
+- Letting readers `git clone` and run instead of copy-pasting from MDX.
+- Catching `OAuthClientProvider` interface drift early (if the AI SDK adds a method, the example fails to build).
+
+Structure:
+
+```
+examples/next-mcp-vercel-connect/
+├── README.md                  — points back to the cookbook recipe and the Connect docs
+├── package.json               — depends on ai@workspace:*, @ai-sdk/mcp@workspace:*, @vercel/connect
+├── app/
+│   ├── api/chat/route.ts      — connectAuthProvider + createMCPClient + streamText
+│   └── page.tsx               — useChat with approval UI rendering
+├── .env.example               — CONNECT_CONNECTOR, etc.
+└── tsconfig.json
+```
+
+This pattern is well-established in the repo (`examples/mcp/`, `examples/next-agent/`, `examples/next-workflow/`).
+
+#### 4. Discoverability touch-ups
+
+- Add `vercel-connect` (or `oauth`) tag to the cookbook recipe so it surfaces in tag filters.
+- Update `examples/README.md` (or the equivalent index) to list the new example.
+- Consider a one-line callout in `content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx` under "tools that need authentication" — but only if a natural insertion point exists; do not force.
+
+### Cross-repo PR coordination
+
+The artifacts span three repos. To avoid broken cross-links during rollout:
+
+| Repo                                    | What ships                                                                                                | Depends on                                                       |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `vercel/vercel` (`packages/connect`)    | `@vercel/connect/mcp` (V1) and `@vercel/connect/ai-sdk` (V2) subpath exports + Changeset                  | Nothing — independent                                            |
+| `vercel/vercel-front` (`vercel-docs`)   | `/docs/connect/guides/use-with-ai-sdk` + `/docs/connect/examples/ai-agent-with-linear`                    | Either the V0 bearer-header pattern (no SDK dep) or V1 published |
+| `vercel/ai` (`content/` + `examples/`)  | Cookbook recipe, MCP docs cross-link, example app                                                         | V1 published to npm                                              |
+
+Sequencing:
+
+1. **Land V0** in `vercel-docs` first — pure docs, no dependencies, ships the headline integration story today.
+2. **Land V1** (`@vercel/connect/mcp` subpath + Changeset) in `vercel/vercel` and publish to npm.
+3. **Update V0 guide** in `vercel-docs` to feature the `authProvider` variant as the recommended path; keep the V0 bearer-header pattern as a "minimal / no extra deps" fallback.
+4. **Open AI SDK PR** simultaneously: cookbook recipe + MCP docs cross-link + example app. Cookbook recipe is the discovery anchor; the rest are supporting.
+5. **Land V2** (`withConsentApproval` + HITL recipe additions) in a second round across `vercel/vercel` → `vercel-docs` → `vercel/ai`.
+
+Cross-link rule: every new page links to its mirror on the other side. The Connect guide says "see the AI SDK cookbook recipe for the framework-specific walkthrough"; the cookbook recipe says "see the Connect concepts pages for what happens behind the adapter." Asymmetric anchor text avoids accidental loops.
+
+### What `vercel/ai` content does NOT add
+
+To keep the AI SDK docs focused, we explicitly do not propose:
+
+- A provider page under `content/providers/` — Connect is not an LLM provider.
+- A foundations page rewrite — MCP foundations already exist; we extend, not duplicate.
+- A separate "auth" docs section — `OAuthClientProvider` is documented at the MCP level; Connect is one consumer of that interface.
+
+## Open design questions
+
+1. **Closure of the MCP client.** `onFinish: () => mcpClient.close()` is repetitive and easy to forget. Should `connectAuthProvider` expose a `wrap` helper that builds `{ client, tools, close }` and registers the close handler automatically? Or is the explicit form preferable for transparency? **Lean:** keep explicit in V1; revisit if the docs guide reveals it's a common foot-gun.
+2. **Should `subject` have a default?** Today `ConnectTokenParams.subject` is required in the underlying SDK — every `getToken` call specifies one of `'app' | 'user' | 'jwt-bearer'` explicitly. **Lean:** mirror that exactly in the adapter and do NOT default to `{ type: 'user' }`. The three subject types have meaningfully different security semantics — `'app'` skips user consent (tenant-wide bot credential), `'user'` requires consent per identity, `'jwt-bearer'` is on-behalf-of with a custom assertion. Silently defaulting to `'user'` would surprise developers building service-account integrations whose tools would suddenly demand consent. If verbosity becomes a real pain point, ship typed sugar helpers in V2: `userSubject(id)` returns `{ type: 'user', id }`, `appSubject()` returns `{ type: 'app' }`. That keeps the API surface single-pathed (always `subject:`) while shaving characters.
+3. **Where does Connect's callback URL live?** Today it's set when creating the connector or via `callbackUrl` on `startAuthorization`. For the adapter, do we accept `callbackUrl` as a top-level option, or rely on the connector default? **Lean:** top-level option that overrides connector default; defaults to the connector's registered redirect.
+4. **JWT-bearer subject support.** `ConnectTokenParams['subject']` already supports `{ type: 'jwt-bearer', sub, iss?, aud?, additionalClaims? }`. The adapter passes through verbatim, but the consent flow doesn't apply — `tokens()` either succeeds or throws. Document this in the JSDoc; no API change needed.
+5. **MCP server discovery vs schema definition.** `mcpClient.tools()` defaults to schema discovery (auto-syncs). For least-privilege agents we may want `mcpClient.tools({ schemas: { … } })` for explicit allowlisting. This is a pass-through; document the pattern in the guide.
+6. **Connection pooling.** If a chat app opens 50 concurrent MCP clients per request, each over its own WebSocket/SSE, costs blow up. Is pooling the adapter's problem or the consumer's? **Lean:** out of scope for V1. Mention in the docs that production deployments should reuse `mcpClient` across requests when the auth subject is stable.
+7. **`OAuthClientProvider` interface drift.** The AI SDK MCP package may add new methods. **Mitigation:** pin a peer dependency range on `@ai-sdk/mcp`, ship a Changeset for each AI SDK major.
+
+## Testing plan
+
+### Unit tests (in `packages/connect`)
+
+- `tokens()` returns a valid `OAuthTokens` shape when `getToken` resolves.
+- `tokens()` returns `undefined` on `UserAuthorizationRequiredError`.
+- `tokens()` rethrows `ConnectorInstallationRequiredError`.
+- `redirectToAuthorization` calls `startAuthorization` and either invokes the callback or throws `ConsentRequiredError`.
+- `invalidateCredentials('tokens')` evicts the LRU cache entry.
+- `withConsentApproval` produces the correct `approvalConfig` shape, including `prefix`/`approve` filtering.
+
+### Integration tests (in a fixtures app)
+
+- Wire `connectAuthProvider` into a real `createMCPClient`, mock the MCP server, assert:
+  - First request sets `Authorization: Bearer <token>` from `getToken`.
+  - 401 response triggers `authorizeOnce()` and lands in `redirectToAuthorization`.
+  - Token refresh on second request after expiry.
+  - Multi-client composition produces non-conflicting tool maps.
+- Wire `withConsentApproval` into `streamText`, simulate a `tool-approval` chunk, deny it, assert the model receives `execution-denied`.
+
+### Manual smoke
+
+- Run the docs-page example against a real Linear MCP connector with a test workspace.
+- Run a two-provider example (Linear + GitHub) with overlapping tool names and `prefix:` to verify no collisions.
+
+## Release plan
+
+Each phase ships across all repos it touches in the same week to keep cross-links live.
+
+### Phase V0 — docs only (no SDK changes, ships this week)
+
+| Repo                  | Artifact                                                                                                                   |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `vercel/vercel-front` | `/docs/connect/guides/use-with-ai-sdk` (V0 pattern: `getToken` + bearer header in `createMCPClient`)                       |
+| `vercel/vercel-front` | `/docs/connect/examples/ai-agent-with-linear` (runnable Linear example using V0 pattern)                                   |
+| `vercel/ai`           | *(none — V0 lives in Connect docs only; SDK consumers can already do it without our blessing)*                             |
+
+### Phase V1 — `@vercel/connect/mcp` adapter
+
+| Repo                  | Artifact                                                                                                                   |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `vercel/vercel`       | `@vercel/connect/mcp` subpath export with `connectAuthProvider` + `ConsentRequiredError` + `ConsentChallenge` types        |
+| `vercel/vercel`       | Peer dependency on `@ai-sdk/mcp` (and optionally the official MCP TS SDK); Changeset; version bump to `@vercel/connect@0.2`|
+| `vercel/vercel`       | TypeScript compatibility test verifying the adapter satisfies both AI SDK's and official MCP SDK's `OAuthClientProvider` shapes |
+| `vercel/vercel`       | Unit tests for `tokens()`, `redirectToAuthorization`, `invalidateCredentials`; integration tests against a mock MCP server |
+| `vercel/vercel-front` | Update `/docs/connect/guides/use-with-ai-sdk` to feature the `authProvider` variant as primary; keep V0 as minimal fallback|
+| `vercel/ai`           | Cookbook recipe `content/cookbook/01-next/74-mcp-tools-with-vercel-connect.mdx`                                            |
+| `vercel/ai`           | Cross-link addition in `content/docs/03-ai-sdk-core/17-mcp-apps.mdx` (Authentication subsection)                           |
+| `vercel/ai`           | Example app `examples/next-mcp-vercel-connect/` mirroring the recipe                                                       |
+
+### Phase V2 — `withConsentApproval` + HITL polish
+
+| Repo                  | Artifact                                                                                                                   |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `vercel/vercel`       | New `@vercel/connect/ai-sdk` subpath: `withConsentApproval` helper with prefix/approve filtering + `approvalConfig` builder |
+| `vercel/vercel`       | Tests against `streamText({ toolApproval })` for approval and denial paths                                                 |
+| `vercel/vercel-front` | New page `/docs/connect/guides/handle-tool-approval` walking through the chat-turn-boundary pattern and function-timeout map |
+| `vercel/vercel-front` | Update Linear example to include an approval-gated tool call                                                                |
+| `vercel/ai`           | Append "Approval" section to cookbook recipe `74` showing `withConsentApproval` (don't fork the recipe)                    |
+| `vercel/ai`           | Update example app to demonstrate the approval flow                                                                         |
+
+### Phase V3 — UI primitives (deferred until V2 has real usage)
+
+| Repo                  | Artifact                                                                                                                   |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `vercel/vercel`       | `<ConnectConsentBoundary>` React component (catches `ConsentRequiredError`, emits a custom data part)                      |
+| `vercel/ai`           | If adopted, possibly an AI Elements primitive for rendering the consent prompt                                              |
+
+## Strategic angle
+
+This integration is what makes Connect *concrete* for the AI SDK audience. Today, a Next.js + AI SDK developer building an agent has to assemble OAuth + token storage + token refresh + MCP plumbing from four libraries. With this adapter, the entire stack collapses to:
+
+```ts
+authProvider: connectAuthProvider('oauth/linear', { subject: { type: 'user', id: userId } })
+```
+
+That's the same "kill the boilerplate" win the AI SDK is known for, applied to OAuth — and it gives Connect a headline demo for the exact audience the AI SDK already owns.
+
+V0 (the docs-only path) costs essentially nothing and unblocks the audience today. V1 is the long-term ergonomic surface. V2 closes the interactive-flow gap by leaning on the AI SDK's existing `toolApproval` primitive, so we don't have to invent a new HITL mechanism.
+
+The `vercel/ai` content plan — cookbook recipe + MCP reference cross-link + example app — is what makes the integration discoverable from the AI SDK audience, not just from Connect's existing audience. Without that, V1's adapter ships into the void; with it, the integration shows up on the canonical surface where developers are already searching "ai sdk mcp oauth."


### PR DESCRIPTION
## Summary

Adds `packages/connect/docs/ai-sdk-integration.md` — a proposal doc for two new subpath exports on `@vercel/connect`:

- **`@vercel/connect/mcp`** (V1): `connectAuthProvider` that implements the MCP-spec `OAuthClientProvider` interface (defined in [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts), borrowed by [`@ai-sdk/mcp`](https://github.com/vercel/ai/blob/main/packages/mcp/src/tool/oauth.ts)). Works with any MCP client — AI SDK, official MCP SDK, Mastra, etc.
- **`@vercel/connect/ai-sdk`** (V2): `withConsentApproval` helper that wires Connect-backed MCP tools into AI SDK's existing `streamText({ toolApproval })` HITL configuration. AI-SDK-specific glue.

## Why this shape

- The MCP `OAuthClientProvider` interface is MCP-spec, not AI-SDK-specific. Putting the adapter under `/mcp` doubles its addressable surface for free (works with non-AI-SDK MCP clients).
- The AI SDK already ships the HITL primitive (`toolApproval` config on `streamText`/`generateText`). V2 doesn't invent a new mechanism — it just pre-builds the `approvalConfig` shape from a Connect-backed tool map.
- Function-timeout exposure is small: the HITL "wait" is a chat-turn boundary, not a server-held connection. HTTP response closes between turns, function instance is freed, message history is the durable store.

## What this is NOT

- Not a wrapper around `createMCPClient` (only provides `authProvider`).
- Not a tool catalog or proxy (Composio's space, not ours).
- Not a Workflow DevKit primitive (host apps that need durable execution for a single turn should use `DurableAgent`).
- Not a generic `fetch` wrapper — custom AI SDK tools that need a bearer token use root `getToken()` directly.

## Release plan

Three slices, sequenced across `vercel/vercel` → `vercel-front` (docs) → `vercel/ai` (cookbook + example):

- **V0**: docs-only pattern (`getToken` + bearer header) in `vercel-front`. Ships immediately, no SDK changes.
- **V1**: `@vercel/connect/mcp` adapter + Changeset. Coordinated with cookbook recipe in `vercel/ai`.
- **V2**: `@vercel/connect/ai-sdk` `withConsentApproval` + HITL recipe addition.

See the doc for the full per-phase cross-repo table.

## Open questions (called out in the doc)

1. Whether to ship a `wrap` helper that auto-closes the MCP client.
2. Whether to default `subject` (lean: no — three subject types have meaningfully different security semantics).
3. Where Connect's callback URL lives (lean: top-level option, defaults to connector's registered redirect).
4. JWT-bearer subject documentation (no API change needed).
5. Schema-defined vs discovered MCP tools (pass-through; document patterns).
6. Connection pooling for high-concurrency apps (out of scope for V1).
7. `OAuthClientProvider` interface drift between AI SDK and official MCP SDK (~5% today; pin peer dep range).

## Status

**Draft.** Opening to gather review on scope, naming (`/mcp` vs `/ai-sdk` split), and the V0/V1/V2 phasing before any implementation work starts.