### PR TITLE
[cli] Strip ANSI from connect list table cells

### DIFF
--- a/.changeset/quiet-connectors-sip.md
+++ b/.changeset/quiet-connectors-sip.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Strip ANSI escape sequences from connector UID and name cells in `connect list` table output.

--- a/packages/cli/src/commands/connex/list.ts
+++ b/packages/cli/src/commands/connex/list.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import stripAnsi from 'strip-ansi';
 import output from '../../output-manager';
 import type Client from '../../util/client';
 import { validateJsonOutput } from '../../util/output-format';
@@ -207,9 +208,9 @@ export async function list(
   }
   const rows = clients.map(c => {
     const row = [
-      c.uid || chalk.gray('–'),
+      stripAnsi(c.uid || '') || chalk.gray('–'),
       c.id,
-      c.name || chalk.gray('–'),
+      stripAnsi(c.name || '') || chalk.gray('–'),
       c.typeName || c.type,
     ];
     if (unscoped) {

--- a/packages/cli/test/unit/commands/connex/list.test.ts
+++ b/packages/cli/test/unit/commands/connex/list.test.ts
@@ -267,6 +267,41 @@ describe('connex list', () => {
       expect(stderr).not.toContain('proj_gone');
     });
 
+    it('should strip ansi from uid and name in table output', async () => {
+      client.scenario.get('/v1/connect/connectors', (_req, res) => {
+        res.json({
+          clients: [
+            {
+              id: 'scl_unsafe',
+              uid: '\x1b[2Jslack/unsafe',
+              name: 'Unsafe\x1b[1A Name',
+              type: 'slack',
+              typeName: 'Slack',
+              createdAt: Date.now() - 60_000,
+              includes: {
+                projects: {
+                  items: [],
+                  hasMore: false,
+                  cursor: null,
+                },
+              },
+            },
+          ],
+        });
+      });
+
+      client.setArgv('connect', 'list', '--all-projects');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('slack/unsafe');
+      expect(stderr).toContain('Unsafe Name');
+      expect(stderr).not.toContain('\x1b[2J');
+      expect(stderr).not.toContain('\x1b[1A');
+    });
+
     it('should render empty-state without project context', async () => {
       client.scenario.get('/v1/connect/connectors', (_req, res) => {
         res.json({ clients: [] });


### PR DESCRIPTION
## Summary
- strip ANSI escape sequences from connector UID and name cells in human `connect list` table output
- keep `--format=json` output unchanged
- add regression coverage for unsafe UID/name values

## Tests
- `pnpm --filter vercel test test/unit/commands/connex/list.test.ts`