### PR TITLE
Add domains search command

### DIFF
--- a/.changeset/domains-discovery-cli.md
+++ b/.changeset/domains-discovery-cli.md
@@ -2,4 +2,4 @@
 "vercel": patch
 ---
 
-Add `vercel domains search <query>` for client-side Domain Discovery with fast bulk availability and registrar pricing, renewal pricing, `--available` and exact TLD filters, ordering, pagination of up to 200 candidates, and JSON output.
+Add `vercel domains search <query>` for client-side Domain Discovery with fast bulk availability and registrar pricing, renewal pricing, `--available` and exact TLD filters, ordering, candidate windows of up to 200 domains, and JSON output.

--- a/.changeset/domains-discovery-cli.md
+++ b/.changeset/domains-discovery-cli.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add `vercel domains search <query>` for client-side Domain Discovery with registrar pricing, renewal pricing, ordering, pagination, JSON output, and registry-invalid candidate recovery.

--- a/.changeset/domains-discovery-cli.md
+++ b/.changeset/domains-discovery-cli.md
@@ -2,4 +2,4 @@
 "vercel": patch
 ---
 
-Add `vercel domains search <query>` for client-side Domain Discovery with registrar pricing, renewal pricing, ordering, pagination, JSON output, and registry-invalid candidate recovery.
+Add `vercel domains search <query>` for client-side Domain Discovery with fast bulk availability and registrar pricing, renewal pricing, exact TLD filters, ordering, pagination of up to 200 candidates, and JSON output.

--- a/.changeset/domains-discovery-cli.md
+++ b/.changeset/domains-discovery-cli.md
@@ -2,4 +2,4 @@
 "vercel": patch
 ---
 
-Add `vercel domains search <query>` for client-side Domain Discovery with fast bulk availability and registrar pricing, renewal pricing, exact TLD filters, ordering, pagination of up to 200 candidates, and JSON output.
+Add `vercel domains search <query>` for client-side Domain Discovery with fast bulk availability and registrar pricing, renewal pricing, `--available` and exact TLD filters, ordering, pagination of up to 200 candidates, and JSON output.

--- a/packages/cli/src/commands/domains/command.ts
+++ b/packages/cli/src/commands/domains/command.ts
@@ -143,7 +143,15 @@ export const searchSubcommand = {
       type: Number,
       argument: 'NUMBER',
       description:
-        'Number of candidates to return per page (default: 20, max: 50)',
+        'Number of candidates to return per page (default: 20, max: 200)',
+      deprecated: false,
+    },
+    {
+      name: 'tld',
+      shorthand: null,
+      type: [String],
+      argument: 'TLD',
+      description: 'Filter candidates by exact TLD. Repeatable.',
       deprecated: false,
     },
     {
@@ -164,6 +172,10 @@ export const searchSubcommand = {
     {
       name: 'Narrow candidates with a TLD fragment',
       value: `${packageName} domains search acme.d`,
+    },
+    {
+      name: 'Filter candidates by TLD',
+      value: `${packageName} domains search acme --tld com --tld dev`,
     },
     {
       name: 'JSON output',

--- a/packages/cli/src/commands/domains/command.ts
+++ b/packages/cli/src/commands/domains/command.ts
@@ -117,6 +117,61 @@ export const priceSubcommand = {
   ],
 } as const;
 
+export const searchSubcommand = {
+  name: 'search',
+  aliases: [],
+  description: 'Discover domain-name candidates from a keyword or fragment',
+  arguments: [
+    {
+      name: 'query',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'order',
+      shorthand: null,
+      type: String,
+      argument: 'ORDER',
+      description:
+        'Order candidates by relevance, alphabetical order, or length (default: relevance)',
+      deprecated: false,
+    },
+    {
+      name: 'limit',
+      shorthand: null,
+      type: Number,
+      argument: 'NUMBER',
+      description:
+        'Number of candidates to return per page (default: 20, max: 50)',
+      deprecated: false,
+    },
+    {
+      name: 'next',
+      shorthand: null,
+      type: String,
+      argument: 'CURSOR',
+      description: 'Show the next page of candidates',
+      deprecated: false,
+    },
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Discover domain-name candidates',
+      value: `${packageName} domains search acme`,
+    },
+    {
+      name: 'Narrow candidates with a TLD fragment',
+      value: `${packageName} domains search acme.d`,
+    },
+    {
+      name: 'JSON output',
+      value: `${packageName} domains search acme --format=json`,
+    },
+  ],
+} as const;
+
 export const buySubcommand = {
   name: 'buy',
   aliases: [],
@@ -217,6 +272,7 @@ export const domainsCommand = {
     checkSubcommand,
     moveSubcommand,
     priceSubcommand,
+    searchSubcommand,
     transferInSubcommand,
     removeSubcommand,
   ],

--- a/packages/cli/src/commands/domains/command.ts
+++ b/packages/cli/src/commands/domains/command.ts
@@ -129,6 +129,13 @@ export const searchSubcommand = {
   ],
   options: [
     {
+      name: 'available',
+      shorthand: null,
+      type: Boolean,
+      description: 'Show only candidates available to register',
+      deprecated: false,
+    },
+    {
       name: 'order',
       shorthand: null,
       type: String,
@@ -176,6 +183,10 @@ export const searchSubcommand = {
     {
       name: 'Filter candidates by TLD',
       value: `${packageName} domains search acme --tld com --tld dev`,
+    },
+    {
+      name: 'Show only available candidates',
+      value: `${packageName} domains search acme --available`,
     },
     {
       name: 'JSON output',

--- a/packages/cli/src/commands/domains/command.ts
+++ b/packages/cli/src/commands/domains/command.ts
@@ -150,7 +150,7 @@ export const searchSubcommand = {
       type: Number,
       argument: 'NUMBER',
       description:
-        'Number of candidates to return per page (default: 20, max: 200)',
+        'Number of candidates to check per page (default: 20, max: 200)',
       deprecated: false,
     },
     {

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -11,6 +11,7 @@ import ls from './ls';
 import rm from './rm';
 import move from './move';
 import price from './price';
+import search from './search';
 import {
   addSubcommand,
   buySubcommand,
@@ -20,6 +21,7 @@ import {
   moveSubcommand,
   priceSubcommand,
   removeSubcommand,
+  searchSubcommand,
   transferInSubcommand,
 } from './command';
 import { type Command, help } from '../help';
@@ -35,6 +37,7 @@ const COMMAND_CONFIG = {
   ls: ['ls', 'list'],
   move: ['move'],
   price: ['price'],
+  search: ['search'],
   rm: ['rm', 'remove'],
   transferIn: ['transfer-in'],
 };
@@ -120,6 +123,13 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandPrice(subcommandOriginal);
       return price(client, args);
+    case 'search':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('domains', subcommandOriginal);
+        return printHelp(searchSubcommand);
+      }
+      telemetry.trackCliSubcommandSearch(subcommandOriginal);
+      return search(client, args);
     case 'rm':
       if (needHelp) {
         telemetry.trackCliFlagHelp('domains', subcommandOriginal);

--- a/packages/cli/src/commands/domains/search.ts
+++ b/packages/cli/src/commands/domains/search.ts
@@ -63,6 +63,7 @@ type ContinuationCursor = {
   fragment: string | null;
   order: SupportedTldsOrder;
   tlds: string[];
+  availableOnly: boolean;
   lastTld: string;
 };
 
@@ -113,6 +114,7 @@ export default async function search(
   const order = orderResult.order;
   const limit = limitResult.limit;
   const tlds = tldsResult.tlds;
+  const availableOnly = parsedArgs.flags['--available'] ?? false;
   const cursorResult = decodeCursor(parsedArgs.flags['--next']);
   if (!cursorResult.valid) {
     output.error(cursorResult.error);
@@ -125,10 +127,11 @@ export default async function search(
     (cursor.query !== query ||
       cursor.fragment !== fragment ||
       cursor.order !== order ||
-      !areStringArraysEqual(cursor.tlds, tlds))
+      !areStringArraysEqual(cursor.tlds, tlds) ||
+      cursor.availableOnly !== availableOnly)
   ) {
     output.error(
-      'The continuation cursor does not match the current query, order, or TLD filters.'
+      'The continuation cursor does not match the current query, order, or filters.'
     );
     return 1;
   }
@@ -142,22 +145,25 @@ export default async function search(
       return 1;
     }
 
-    const offset = offsetResult.offset;
-    const page = matchingTlds.slice(offset, offset + limit);
+    const page = await getCandidatePage(
+      client,
+      keyword,
+      matchingTlds,
+      offsetResult.offset,
+      limit,
+      availableOnly
+    );
     const next =
-      page.length > 0 && offset + page.length < matchingTlds.length
+      page.lastTld !== null && page.hasMore
         ? encodeCursor({
             query,
             fragment,
             order,
             tlds,
-            lastTld: page[page.length - 1],
+            availableOnly,
+            lastTld: page.lastTld,
           })
         : null;
-    const results = await quoteCandidates(
-      client,
-      page.map(tld => `${keyword}.${tld}`)
-    );
 
     if (formatResult.jsonOutput) {
       client.stdout.write(
@@ -165,7 +171,7 @@ export default async function search(
           {
             query,
             order,
-            results,
+            results: page.results,
             pagination: {
               next,
               limit,
@@ -178,11 +184,11 @@ export default async function search(
       return 0;
     }
 
-    output.log(renderTable(results));
+    output.log(renderTable(page.results));
     if (next) {
       output.log('');
       output.log(
-        `To continue, run ${getCommandName(getContinuationCommand(query, order, tlds, next))}`
+        `To continue, run ${getCommandName(getContinuationCommand(query, order, tlds, availableOnly, next))}`
       );
     }
     return 0;
@@ -305,8 +311,8 @@ function isContinuationCursor(value: unknown): value is ContinuationCursor {
   const cursor = value as Record<string, unknown>;
   const keys = Object.keys(cursor).sort();
   if (
-    keys.length !== 5 ||
-    keys.join(',') !== 'fragment,lastTld,order,query,tlds'
+    keys.length !== 6 ||
+    keys.join(',') !== 'availableOnly,fragment,lastTld,order,query,tlds'
   ) {
     return false;
   }
@@ -318,6 +324,7 @@ function isContinuationCursor(value: unknown): value is ContinuationCursor {
     ORDERS.includes(cursor.order as SupportedTldsOrder) &&
     Array.isArray(cursor.tlds) &&
     cursor.tlds.every(tld => typeof tld === 'string') &&
+    typeof cursor.availableOnly === 'boolean' &&
     typeof cursor.lastTld === 'string' &&
     cursor.lastTld.length > 0
   );
@@ -427,6 +434,7 @@ function getContinuationCommand(
   query: string,
   order: SupportedTldsOrder,
   tlds: string[],
+  availableOnly: boolean,
   cursor: string
 ): string {
   const flags: string[] = [];
@@ -434,6 +442,9 @@ function getContinuationCommand(
     flags.push(`--order=${order}`);
   }
   flags.push(...tlds.map(tld => `--tld=${tld}`));
+  if (availableOnly) {
+    flags.push('--available');
+  }
   flags.push(`--next ${cursor}`);
 
   return `domains search ${query} ${flags.join(' ')}`;
@@ -499,6 +510,60 @@ function filterTlds(
         a === fragment ? -1 : b === fragment ? 1 : 0
       )
     : matchingTlds;
+}
+
+async function getCandidatePage(
+  client: Client,
+  keyword: string,
+  tlds: string[],
+  offset: number,
+  limit: number,
+  availableOnly: boolean
+): Promise<{
+  results: DomainCandidate[];
+  lastTld: string | null;
+  hasMore: boolean;
+}> {
+  if (!availableOnly) {
+    const pageTlds = tlds.slice(offset, offset + limit);
+    return {
+      results: await quoteCandidates(
+        client,
+        pageTlds.map(tld => `${keyword}.${tld}`)
+      ),
+      lastTld: pageTlds.at(-1) ?? null,
+      hasMore: offset + pageTlds.length < tlds.length,
+    };
+  }
+
+  const results: DomainCandidate[] = [];
+  let currentOffset = offset;
+  let lastTld: string | null = null;
+
+  while (currentOffset < tlds.length && results.length < limit) {
+    const batchTlds = tlds.slice(currentOffset, currentOffset + MAX_LIMIT);
+    const candidates = await quoteCandidates(
+      client,
+      batchTlds.map(tld => `${keyword}.${tld}`)
+    );
+
+    for (let index = 0; index < candidates.length; index++) {
+      lastTld = batchTlds[index];
+      currentOffset++;
+      if (candidates[index].available) {
+        results.push(candidates[index]);
+      }
+      if (results.length === limit) {
+        break;
+      }
+    }
+  }
+
+  return {
+    results,
+    lastTld,
+    hasMore: currentOffset < tlds.length,
+  };
 }
 
 async function quoteCandidates(

--- a/packages/cli/src/commands/domains/search.ts
+++ b/packages/cli/src/commands/domains/search.ts
@@ -406,11 +406,12 @@ async function quoteCandidates(
       if (!quote) {
         throw new Error(`Missing registrar quote for ${domain}.`);
       }
+      const available = quote.purchasePrice !== null;
       return {
         domain: quote.domain,
-        available: quote.purchasePrice !== null,
+        available,
         purchasePrice: quote.purchasePrice,
-        renewalPrice: quote.renewalPrice,
+        renewalPrice: available ? quote.renewalPrice : null,
         years: quote.years,
       };
     });

--- a/packages/cli/src/commands/domains/search.ts
+++ b/packages/cli/src/commands/domains/search.ts
@@ -1,0 +1,459 @@
+import { URLSearchParams } from 'url';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
+import output from '../../output-manager';
+import table from '../../util/output/table';
+import { validateJsonOutput } from '../../util/output-format';
+import { getCommandName } from '../../util/pkg-name';
+import { searchSubcommand } from './command';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+const DEFAULT_ORDER = 'relevance';
+const ORDERS = ['relevance', 'alphabetical', 'length'] as const;
+
+type SupportedTldsOrder = (typeof ORDERS)[number];
+
+type DomainPriceQuote = {
+  domain: string;
+  purchasePrice: number | null;
+  renewalPrice: number | null;
+  transferPrice: number | null;
+  years: number;
+};
+
+type DomainCandidate = {
+  domain: string;
+  available: boolean;
+  purchasePrice: number | null;
+  renewalPrice: number | null;
+  years: number | null;
+};
+
+type BulkDomainPriceResponse =
+  | DomainPriceQuote[]
+  | {
+      results: DomainPriceQuote[];
+    };
+
+type ContinuationCursor = {
+  query: string;
+  fragment: string | null;
+  order: SupportedTldsOrder;
+  lastTld: string;
+};
+
+export default async function search(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(searchSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+
+  const queryResult = normalizeQuery(parsedArgs.args);
+  if (!queryResult.valid) {
+    output.error(queryResult.error);
+    return 1;
+  }
+
+  const orderResult = getOrder(parsedArgs.flags['--order']);
+  if (!orderResult.valid) {
+    output.error(orderResult.error);
+    return 1;
+  }
+
+  const limitResult = getLimit(parsedArgs.flags['--limit']);
+  if (!limitResult.valid) {
+    output.error(limitResult.error);
+    return 1;
+  }
+
+  const { query, keyword, fragment } = queryResult;
+  const order = orderResult.order;
+  const limit = limitResult.limit;
+  const cursorResult = decodeCursor(parsedArgs.flags['--next']);
+  if (!cursorResult.valid) {
+    output.error(cursorResult.error);
+    return 1;
+  }
+
+  const cursor = cursorResult.cursor;
+  if (
+    cursor &&
+    (cursor.query !== query ||
+      cursor.fragment !== fragment ||
+      cursor.order !== order)
+  ) {
+    output.error(
+      'The continuation cursor does not match the current query or order.'
+    );
+    return 1;
+  }
+
+  try {
+    const params = new URLSearchParams({ order });
+    const supportedTlds = await client.fetch<string[]>(
+      `/v1/registrar/tlds/supported?${params}`
+    );
+    const matchingTlds = filterTlds(supportedTlds, fragment, order);
+    const offsetResult = getOffset(matchingTlds, cursor);
+    if (!offsetResult.valid) {
+      output.error(offsetResult.error);
+      return 1;
+    }
+
+    const offset = offsetResult.offset;
+    const page = matchingTlds.slice(offset, offset + limit);
+    const next =
+      page.length > 0 && offset + page.length < matchingTlds.length
+        ? encodeCursor({
+            query,
+            fragment,
+            order,
+            lastTld: page[page.length - 1],
+          })
+        : null;
+    const results = await quoteCandidates(
+      client,
+      page.map(tld => `${keyword}.${tld}`)
+    );
+
+    if (formatResult.jsonOutput) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            query,
+            order,
+            results,
+            pagination: {
+              next,
+              limit,
+            },
+          },
+          null,
+          2
+        )}\n`
+      );
+      return 0;
+    }
+
+    output.log(renderTable(results));
+    if (next) {
+      output.log('');
+      output.log(
+        `To continue, run ${getCommandName(getContinuationCommand(query, order, next))}`
+      );
+    }
+    return 0;
+  } catch (error) {
+    if (isAPIError(error)) {
+      const message = error.serverMessage || `API error (${error.status})`;
+      if (formatResult.jsonOutput) {
+        client.stdout.write(
+          `${JSON.stringify(
+            { error: error.code || 'api_error', message },
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        output.error(message);
+      }
+      return 1;
+    }
+
+    printError(error);
+    return 1;
+  }
+}
+
+function encodeCursor(cursor: ContinuationCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodeCursor(
+  value: string | undefined
+):
+  | { valid: true; cursor: ContinuationCursor | null }
+  | { valid: false; error: string } {
+  if (value === undefined) {
+    return { valid: true, cursor: null };
+  }
+
+  try {
+    if (!value || !/^[A-Za-z0-9_-]+$/.test(value)) {
+      throw new Error('Invalid base64url value');
+    }
+
+    const cursor: unknown = JSON.parse(
+      Buffer.from(value, 'base64url').toString('utf8')
+    );
+    if (!isContinuationCursor(cursor)) {
+      throw new Error('Invalid cursor shape');
+    }
+    return { valid: true, cursor };
+  } catch {
+    return {
+      valid: false,
+      error:
+        'Invalid continuation cursor. Run Domain Discovery again without `--next`.',
+    };
+  }
+}
+
+function isContinuationCursor(value: unknown): value is ContinuationCursor {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const cursor = value as Record<string, unknown>;
+  const keys = Object.keys(cursor).sort();
+  if (keys.length !== 4 || keys.join(',') !== 'fragment,lastTld,order,query') {
+    return false;
+  }
+
+  return (
+    typeof cursor.query === 'string' &&
+    (typeof cursor.fragment === 'string' || cursor.fragment === null) &&
+    typeof cursor.order === 'string' &&
+    ORDERS.includes(cursor.order as SupportedTldsOrder) &&
+    typeof cursor.lastTld === 'string' &&
+    cursor.lastTld.length > 0
+  );
+}
+
+function getOffset(
+  tlds: string[],
+  cursor: ContinuationCursor | null
+): { valid: true; offset: number } | { valid: false; error: string } {
+  if (!cursor) {
+    return { valid: true, offset: 0 };
+  }
+
+  const lastTldIndex = tlds.indexOf(cursor.lastTld);
+  if (lastTldIndex === -1) {
+    return {
+      valid: false,
+      error:
+        'The continuation cursor is stale. Run Domain Discovery again without `--next`.',
+    };
+  }
+
+  return { valid: true, offset: lastTldIndex + 1 };
+}
+
+function normalizeQuery(
+  args: string[]
+):
+  | { valid: true; query: string; keyword: string; fragment: string | null }
+  | { valid: false; error: string } {
+  if (args.length === 0) {
+    return {
+      valid: false,
+      error: 'Missing query. Usage: `vercel domains search <query>`',
+    };
+  }
+
+  if (args.length > 1) {
+    return {
+      valid: false,
+      error: 'Please provide one keyword or domain fragment.',
+    };
+  }
+
+  const query = args[0].trim().toLowerCase();
+  if (query.length === 0) {
+    return { valid: false, error: 'Query cannot be empty.' };
+  }
+  if (!/^[\x00-\x7F]+$/.test(query)) {
+    return {
+      valid: false,
+      error: 'Only ASCII queries are supported in Domain Discovery.',
+    };
+  }
+  if (query.includes('://') || /[/?#]/.test(query)) {
+    return {
+      valid: false,
+      error: 'URLs are not supported. Provide one keyword or domain fragment.',
+    };
+  }
+  if (/\s/.test(query)) {
+    return {
+      valid: false,
+      error:
+        'Queries cannot contain whitespace. Provide one keyword or domain fragment.',
+    };
+  }
+
+  const [keyword, ...fragmentParts] = query.split('.');
+  const fragment = fragmentParts.length > 0 ? fragmentParts.join('.') : null;
+  if (!isValidLabel(keyword)) {
+    return {
+      valid: false,
+      error: `Invalid keyword: "${keyword}".`,
+    };
+  }
+  if (fragment !== null && !fragment.split('.').every(isValidLabel)) {
+    return {
+      valid: false,
+      error: `Invalid TLD fragment: "${fragment}".`,
+    };
+  }
+
+  return { valid: true, query, keyword, fragment };
+}
+
+function isValidLabel(value: string): boolean {
+  return value.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(value);
+}
+
+function getOrder(
+  value: string | undefined
+):
+  | { valid: true; order: SupportedTldsOrder }
+  | { valid: false; error: string } {
+  const order = value ?? DEFAULT_ORDER;
+  if (!ORDERS.includes(order as SupportedTldsOrder)) {
+    return {
+      valid: false,
+      error: `Invalid order: "${order}". Valid orders: ${ORDERS.join(', ')}`,
+    };
+  }
+  return { valid: true, order: order as SupportedTldsOrder };
+}
+
+function getContinuationCommand(
+  query: string,
+  order: SupportedTldsOrder,
+  cursor: string
+): string {
+  const flags = [`--next ${cursor}`];
+  if (order !== DEFAULT_ORDER) {
+    flags.unshift(`--order=${order}`);
+  }
+
+  return `domains search ${query} ${flags.join(' ')}`;
+}
+
+function getLimit(
+  value: number | undefined
+): { valid: true; limit: number } | { valid: false; error: string } {
+  const limit = value ?? DEFAULT_LIMIT;
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return {
+      valid: false,
+      error: `Invalid limit: "${limit}". Provide a number from 1 to ${MAX_LIMIT}.`,
+    };
+  }
+  return { valid: true, limit };
+}
+
+function filterTlds(
+  tlds: string[],
+  fragment: string | null,
+  order: SupportedTldsOrder
+): string[] {
+  if (fragment === null) {
+    return tlds;
+  }
+
+  const matchingTlds = tlds.filter(tld => tld.startsWith(fragment));
+  return order === 'relevance'
+    ? matchingTlds.sort((a, b) =>
+        a === fragment ? -1 : b === fragment ? 1 : 0
+      )
+    : matchingTlds;
+}
+
+async function quoteCandidates(
+  client: Client,
+  domains: string[]
+): Promise<DomainCandidate[]> {
+  if (domains.length === 0) {
+    return [];
+  }
+
+  try {
+    const response = await client.fetch<BulkDomainPriceResponse>(
+      '/v1/registrar/domains/price',
+      {
+        method: 'POST',
+        body: {
+          domains,
+        },
+      }
+    );
+    const quotes = Array.isArray(response) ? response : response.results;
+    const quotesByDomain = new Map(quotes.map(quote => [quote.domain, quote]));
+
+    return domains.map(domain => {
+      const quote = quotesByDomain.get(domain);
+      if (!quote) {
+        throw new Error(`Missing registrar quote for ${domain}.`);
+      }
+      return {
+        domain: quote.domain,
+        available: quote.purchasePrice !== null,
+        purchasePrice: quote.purchasePrice,
+        renewalPrice: quote.renewalPrice,
+        years: quote.years,
+      };
+    });
+  } catch (error) {
+    if (!isAPIError(error) || error.code !== 'domain_too_short') {
+      throw error;
+    }
+
+    if (domains.length === 1) {
+      return [
+        {
+          domain: domains[0],
+          available: false,
+          purchasePrice: null,
+          renewalPrice: null,
+          years: null,
+        },
+      ];
+    }
+
+    const middle = Math.floor(domains.length / 2);
+    return [
+      ...(await quoteCandidates(client, domains.slice(0, middle))),
+      ...(await quoteCandidates(client, domains.slice(middle))),
+    ];
+  }
+}
+
+function renderTable(results: DomainCandidate[]): string {
+  return table([
+    ['Domain', 'Availability', 'Purchase', 'Renewal'],
+    ...results.map(result => [
+      result.domain,
+      result.available ? 'Available' : 'Unavailable',
+      result.available ? formatPrice(result.purchasePrice, result.years) : '-',
+      result.available ? formatPrice(result.renewalPrice, result.years) : '-',
+    ]),
+  ]);
+}
+
+function formatPrice(price: number | null, years: number | null): string {
+  if (price === null || years === null) {
+    return '-';
+  }
+  return `$${price} / ${years} ${years === 1 ? 'year' : 'years'}`;
+}

--- a/packages/cli/src/commands/domains/search.ts
+++ b/packages/cli/src/commands/domains/search.ts
@@ -524,45 +524,18 @@ async function getCandidatePage(
   lastTld: string | null;
   hasMore: boolean;
 }> {
-  if (!availableOnly) {
-    const pageTlds = tlds.slice(offset, offset + limit);
-    return {
-      results: await quoteCandidates(
-        client,
-        pageTlds.map(tld => `${keyword}.${tld}`)
-      ),
-      lastTld: pageTlds.at(-1) ?? null,
-      hasMore: offset + pageTlds.length < tlds.length,
-    };
-  }
-
-  const results: DomainCandidate[] = [];
-  let currentOffset = offset;
-  let lastTld: string | null = null;
-
-  while (currentOffset < tlds.length && results.length < limit) {
-    const batchTlds = tlds.slice(currentOffset, currentOffset + MAX_LIMIT);
-    const candidates = await quoteCandidates(
-      client,
-      batchTlds.map(tld => `${keyword}.${tld}`)
-    );
-
-    for (let index = 0; index < candidates.length; index++) {
-      lastTld = batchTlds[index];
-      currentOffset++;
-      if (candidates[index].available) {
-        results.push(candidates[index]);
-      }
-      if (results.length === limit) {
-        break;
-      }
-    }
-  }
+  const pageTlds = tlds.slice(offset, offset + limit);
+  const candidates = await quoteCandidates(
+    client,
+    pageTlds.map(tld => `${keyword}.${tld}`)
+  );
 
   return {
-    results,
-    lastTld,
-    hasMore: currentOffset < tlds.length,
+    results: availableOnly
+      ? candidates.filter(candidate => candidate.available)
+      : candidates,
+    lastTld: pageTlds.at(-1) ?? null,
+    hasMore: offset + pageTlds.length < tlds.length,
   };
 }
 

--- a/packages/cli/src/commands/domains/search.ts
+++ b/packages/cli/src/commands/domains/search.ts
@@ -1,4 +1,5 @@
 import { URLSearchParams } from 'url';
+import { z } from 'zod';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -14,8 +15,21 @@ const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
 const DEFAULT_ORDER = 'relevance';
 const ORDERS = ['relevance', 'alphabetical', 'length'] as const;
+const SUPPORTED_TLDS_CACHE_FILE = 'cache/domains-search-supported-tlds.json';
+const SUPPORTED_TLDS_CACHE_TTL_MS = 30 * 60 * 1000;
 
 type SupportedTldsOrder = (typeof ORDERS)[number];
+
+const supportedTldsSchema = z.array(z.string());
+const supportedTldsCacheSchema = z.object({
+  entries: z.record(
+    z.string(),
+    z.object({
+      fetchedAt: z.number(),
+      tlds: supportedTldsSchema,
+    })
+  ),
+});
 
 type DomainPriceQuote = {
   domain: string;
@@ -106,10 +120,7 @@ export default async function search(
   }
 
   try {
-    const params = new URLSearchParams({ order });
-    const supportedTlds = await client.fetch<string[]>(
-      `/v1/registrar/tlds/supported?${params}`
-    );
+    const supportedTlds = await getSupportedTlds(client, order);
     const matchingTlds = filterTlds(supportedTlds, fragment, order);
     const offsetResult = getOffset(matchingTlds, cursor);
     if (!offsetResult.valid) {
@@ -180,6 +191,61 @@ export default async function search(
     printError(error);
     return 1;
   }
+}
+
+async function getSupportedTlds(
+  client: Client,
+  order: SupportedTldsOrder
+): Promise<string[]> {
+  const cache = await client.maybeReadConfig(
+    SUPPORTED_TLDS_CACHE_FILE,
+    supportedTldsCacheSchema
+  );
+  const cacheKey = JSON.stringify([client.config.currentTeam ?? null, order]);
+  const cachedEntry = cache?.entries[cacheKey];
+  if (cachedEntry && isSupportedTldsCacheEntryFresh(cachedEntry.fetchedAt)) {
+    output.debug('Using cached supported TLD catalog');
+    return cachedEntry.tlds;
+  }
+
+  const params = new URLSearchParams({ order });
+  const supportedTlds = supportedTldsSchema.parse(
+    await client.fetch<unknown>(`/v1/registrar/tlds/supported?${params}`)
+  );
+
+  try {
+    const fetchedAt = Date.now();
+    const freshEntries = Object.fromEntries(
+      Object.entries(cache?.entries ?? {}).filter(([, entry]) =>
+        isSupportedTldsCacheEntryFresh(entry.fetchedAt, fetchedAt)
+      )
+    );
+    await client.writeConfig(
+      SUPPORTED_TLDS_CACHE_FILE,
+      supportedTldsCacheSchema,
+      {
+        entries: {
+          ...freshEntries,
+          [cacheKey]: {
+            fetchedAt,
+            tlds: supportedTlds,
+          },
+        },
+      }
+    );
+  } catch (error) {
+    output.debug(`Failed to cache supported TLD catalog: ${error}`);
+  }
+
+  return supportedTlds;
+}
+
+function isSupportedTldsCacheEntryFresh(
+  fetchedAt: number,
+  now = Date.now()
+): boolean {
+  const age = now - fetchedAt;
+  return age >= 0 && age <= SUPPORTED_TLDS_CACHE_TTL_MS;
 }
 
 function encodeCursor(cursor: ContinuationCursor): string {

--- a/packages/cli/src/commands/domains/search.ts
+++ b/packages/cli/src/commands/domains/search.ts
@@ -12,7 +12,7 @@ import { getCommandName } from '../../util/pkg-name';
 import { searchSubcommand } from './command';
 
 const DEFAULT_LIMIT = 20;
-const MAX_LIMIT = 50;
+const MAX_LIMIT = 200;
 const DEFAULT_ORDER = 'relevance';
 const ORDERS = ['relevance', 'alphabetical', 'length'] as const;
 const SUPPORTED_TLDS_CACHE_FILE = 'cache/domains-search-supported-tlds.json';
@@ -31,14 +31,6 @@ const supportedTldsCacheSchema = z.object({
   ),
 });
 
-type DomainPriceQuote = {
-  domain: string;
-  purchasePrice: number | null;
-  renewalPrice: number | null;
-  transferPrice: number | null;
-  years: number;
-};
-
 type DomainCandidate = {
   domain: string;
   available: boolean;
@@ -47,16 +39,30 @@ type DomainCandidate = {
   years: number | null;
 };
 
-type BulkDomainPriceResponse =
-  | DomainPriceQuote[]
-  | {
-      results: DomainPriceQuote[];
-    };
+const domainSearchResultSchema = z.discriminatedUnion('available', [
+  z.object({
+    domain: z.string(),
+    available: z.literal(false),
+  }),
+  z.object({
+    domain: z.string(),
+    available: z.literal(true),
+    years: z.number(),
+    price: z.number(),
+    renewalPrice: z.number(),
+    premium: z.boolean(),
+  }),
+]);
+
+const domainsSearchResponseSchema = z.object({
+  results: z.array(domainSearchResultSchema),
+});
 
 type ContinuationCursor = {
   query: string;
   fragment: string | null;
   order: SupportedTldsOrder;
+  tlds: string[];
   lastTld: string;
 };
 
@@ -97,9 +103,16 @@ export default async function search(
     return 1;
   }
 
+  const tldsResult = normalizeTldFilters(parsedArgs.flags['--tld']);
+  if (!tldsResult.valid) {
+    output.error(tldsResult.error);
+    return 1;
+  }
+
   const { query, keyword, fragment } = queryResult;
   const order = orderResult.order;
   const limit = limitResult.limit;
+  const tlds = tldsResult.tlds;
   const cursorResult = decodeCursor(parsedArgs.flags['--next']);
   if (!cursorResult.valid) {
     output.error(cursorResult.error);
@@ -111,17 +124,18 @@ export default async function search(
     cursor &&
     (cursor.query !== query ||
       cursor.fragment !== fragment ||
-      cursor.order !== order)
+      cursor.order !== order ||
+      !areStringArraysEqual(cursor.tlds, tlds))
   ) {
     output.error(
-      'The continuation cursor does not match the current query or order.'
+      'The continuation cursor does not match the current query, order, or TLD filters.'
     );
     return 1;
   }
 
   try {
     const supportedTlds = await getSupportedTlds(client, order);
-    const matchingTlds = filterTlds(supportedTlds, fragment, order);
+    const matchingTlds = filterTlds(supportedTlds, fragment, tlds, order);
     const offsetResult = getOffset(matchingTlds, cursor);
     if (!offsetResult.valid) {
       output.error(offsetResult.error);
@@ -136,6 +150,7 @@ export default async function search(
             query,
             fragment,
             order,
+            tlds,
             lastTld: page[page.length - 1],
           })
         : null;
@@ -167,7 +182,7 @@ export default async function search(
     if (next) {
       output.log('');
       output.log(
-        `To continue, run ${getCommandName(getContinuationCommand(query, order, next))}`
+        `To continue, run ${getCommandName(getContinuationCommand(query, order, tlds, next))}`
       );
     }
     return 0;
@@ -289,7 +304,10 @@ function isContinuationCursor(value: unknown): value is ContinuationCursor {
 
   const cursor = value as Record<string, unknown>;
   const keys = Object.keys(cursor).sort();
-  if (keys.length !== 4 || keys.join(',') !== 'fragment,lastTld,order,query') {
+  if (
+    keys.length !== 5 ||
+    keys.join(',') !== 'fragment,lastTld,order,query,tlds'
+  ) {
     return false;
   }
 
@@ -298,6 +316,8 @@ function isContinuationCursor(value: unknown): value is ContinuationCursor {
     (typeof cursor.fragment === 'string' || cursor.fragment === null) &&
     typeof cursor.order === 'string' &&
     ORDERS.includes(cursor.order as SupportedTldsOrder) &&
+    Array.isArray(cursor.tlds) &&
+    cursor.tlds.every(tld => typeof tld === 'string') &&
     typeof cursor.lastTld === 'string' &&
     cursor.lastTld.length > 0
   );
@@ -406,14 +426,47 @@ function getOrder(
 function getContinuationCommand(
   query: string,
   order: SupportedTldsOrder,
+  tlds: string[],
   cursor: string
 ): string {
-  const flags = [`--next ${cursor}`];
+  const flags: string[] = [];
   if (order !== DEFAULT_ORDER) {
-    flags.unshift(`--order=${order}`);
+    flags.push(`--order=${order}`);
   }
+  flags.push(...tlds.map(tld => `--tld=${tld}`));
+  flags.push(`--next ${cursor}`);
 
   return `domains search ${query} ${flags.join(' ')}`;
+}
+
+function normalizeTldFilters(
+  values: string[] | undefined
+): { valid: true; tlds: string[] } | { valid: false; error: string } {
+  if (values === undefined) {
+    return { valid: true, tlds: [] };
+  }
+
+  const tlds = Array.from(
+    new Set(values.map(value => value.trim().toLowerCase().replace(/^\./, '')))
+  ).sort();
+  const invalidTld = tlds.find(
+    tld => tld.length === 0 || !tld.split('.').every(isValidLabel)
+  );
+  if (invalidTld !== undefined) {
+    return {
+      valid: false,
+      error: `Invalid TLD filter: "${invalidTld}".`,
+    };
+  }
+
+  return { valid: true, tlds };
+}
+
+function areStringArraysEqual(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
 }
 
 function getLimit(
@@ -432,13 +485,15 @@ function getLimit(
 function filterTlds(
   tlds: string[],
   fragment: string | null,
+  filters: string[],
   order: SupportedTldsOrder
 ): string[] {
-  if (fragment === null) {
-    return tlds;
-  }
-
-  const matchingTlds = tlds.filter(tld => tld.startsWith(fragment));
+  const filterSet = new Set(filters);
+  const matchingTlds = tlds.filter(
+    tld =>
+      (fragment === null || tld.startsWith(fragment)) &&
+      (filterSet.size === 0 || filterSet.has(tld))
+  );
   return order === 'relevance'
     ? matchingTlds.sort((a, b) =>
         a === fragment ? -1 : b === fragment ? 1 : 0
@@ -454,56 +509,40 @@ async function quoteCandidates(
     return [];
   }
 
-  try {
-    const response = await client.fetch<BulkDomainPriceResponse>(
-      '/v1/registrar/domains/price',
-      {
-        method: 'POST',
-        body: {
-          domains,
-        },
-      }
-    );
-    const quotes = Array.isArray(response) ? response : response.results;
-    const quotesByDomain = new Map(quotes.map(quote => [quote.domain, quote]));
+  const response = domainsSearchResponseSchema.parse(
+    await client.fetch<unknown>('/v1/registrar/domains/search', {
+      method: 'POST',
+      body: {
+        domains,
+      },
+    })
+  );
+  const resultsByDomain = new Map(
+    response.results.map(result => [result.domain, result])
+  );
 
-    return domains.map(domain => {
-      const quote = quotesByDomain.get(domain);
-      if (!quote) {
-        throw new Error(`Missing registrar quote for ${domain}.`);
-      }
-      const available = quote.purchasePrice !== null;
+  return domains.map(domain => {
+    const result = resultsByDomain.get(domain);
+    if (!result) {
+      throw new Error(`Missing registrar search result for ${domain}.`);
+    }
+    if (!result.available) {
       return {
-        domain: quote.domain,
-        available,
-        purchasePrice: quote.purchasePrice,
-        renewalPrice: available ? quote.renewalPrice : null,
-        years: quote.years,
+        domain: result.domain,
+        available: false,
+        purchasePrice: null,
+        renewalPrice: null,
+        years: null,
       };
-    });
-  } catch (error) {
-    if (!isAPIError(error) || error.code !== 'domain_too_short') {
-      throw error;
     }
-
-    if (domains.length === 1) {
-      return [
-        {
-          domain: domains[0],
-          available: false,
-          purchasePrice: null,
-          renewalPrice: null,
-          years: null,
-        },
-      ];
-    }
-
-    const middle = Math.floor(domains.length / 2);
-    return [
-      ...(await quoteCandidates(client, domains.slice(0, middle))),
-      ...(await quoteCandidates(client, domains.slice(middle))),
-    ];
-  }
+    return {
+      domain: result.domain,
+      available: true,
+      purchasePrice: result.price,
+      renewalPrice: result.renewalPrice,
+      years: result.years,
+    };
+  });
 }
 
 function renderTable(results: DomainCandidate[]): string {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -25,6 +25,7 @@ import fetch, {
   type RequestInit,
   type Response,
 } from 'node-fetch';
+import pkg from './pkg';
 import ua from './ua';
 import responseError from './response-error';
 import printIndications from './print-indications';
@@ -53,6 +54,8 @@ import type { z } from 'zod';
 import output from '../output-manager';
 import { parseArguments } from './get-args';
 import { processTokenResponse, refreshTokenRequest } from './oauth';
+
+const DOMAINS_API_PATH = /^\/v\d+\/(?:domains|registrar)(?:\/|$)/;
 
 const isSAMLError = (v: any): v is SAMLError => {
   return v && v.saml;
@@ -468,6 +471,9 @@ export default class Client extends EventEmitter implements Stdio {
 
     const headers = new Headers(opts.headers);
     headers.set('user-agent', ua);
+    if (DOMAINS_API_PATH.test(url.pathname)) {
+      headers.set('x-vercel-cli-version', pkg.version);
+    }
     if (this.agentName) {
       headers.set('x-ai-agent', this.agentName);
     }

--- a/packages/cli/src/util/telemetry/commands/domains/index.ts
+++ b/packages/cli/src/util/telemetry/commands/domains/index.ts
@@ -48,6 +48,13 @@ export class DomainsTelemetryClient
     });
   }
 
+  trackCliSubcommandSearch(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'search',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandRemove(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'remove',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2427,7 +2427,7 @@ exports[`help command > domains help output snapshots > domains search help outp
 
        --available        Show only candidates available to register                                                    
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
-       --limit <NUMBER>   Number of candidates to return per page (default: 20, max: 200)                               
+       --limit <NUMBER>   Number of candidates to check per page (default: 20, max: 200)                                
        --next <CURSOR>    Show the next page of candidates                                                              
        --order <ORDER>    Order candidates by relevance, alphabetical order, or length (default: relevance)             
        --tld <TLD>        Filter candidates by exact TLD. Repeatable.                                                   

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2425,6 +2425,7 @@ exports[`help command > domains help output snapshots > domains search help outp
 
   Options:
 
+       --available        Show only candidates available to register                                                    
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
        --limit <NUMBER>   Number of candidates to return per page (default: 20, max: 200)                               
        --next <CURSOR>    Show the next page of candidates                                                              
@@ -2459,6 +2460,10 @@ exports[`help command > domains help output snapshots > domains search help outp
   - Filter candidates by TLD
 
     $ vercel domains search acme --tld com --tld dev
+
+  - Show only available candidates
+
+    $ vercel domains search acme --available
 
   - JSON output
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2103,6 +2103,14 @@ exports[`help command > domains help output snapshots > domains help column widt
                                    or  
                                    more
                                    dom…
+  search       query               Dis…
+                                   dom…
+                                   can…
+                                   from
+                                   a   
+                                   key…
+                                   or  
+                                   fra…
   transfer-in  domain              Tra…
                                    in a
                                    dom…
@@ -2189,6 +2197,8 @@ exports[`help command > domains help output snapshots > domains help column widt
                                    Vercel Team                                 
   price        domain              Show registrar price quotes for one or more 
                                    domains                                     
+  search       query               Discover domain-name candidates from a      
+                                   keyword or fragment                         
   transfer-in  domain              Transfer in a domain name to Vercel         
   remove       domain              Remove ownership of a domain name from a    
                                    Vercel Team                                 
@@ -2228,6 +2238,7 @@ exports[`help command > domains help output snapshots > domains help column widt
   check        domain              Check if a domain is available to buy                                               
   move         domain destination  Move ownership of a domain name to another Vercel Team                              
   price        domain              Show registrar price quotes for one or more domains                                 
+  search       query               Discover domain-name candidates from a keyword or fragment                          
   transfer-in  domain              Transfer in a domain name to Vercel                                                 
   remove       domain              Remove ownership of a domain name from a Vercel Team                                
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2417,6 +2417,56 @@ exports[`help command > domains help output snapshots > domains remove help outp
 "
 `;
 
+exports[`help command > domains help output snapshots > domains search help output snapshots > domains search help column width 120 1`] = `
+"
+  ▲ vercel domains search query [options]
+
+  Discover domain-name candidates from a keyword or fragment                                                            
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --limit <NUMBER>   Number of candidates to return per page (default: 20, max: 200)                               
+       --next <CURSOR>    Show the next page of candidates                                                              
+       --order <ORDER>    Order candidates by relevance, alphabetical order, or length (default: relevance)             
+       --tld <TLD>        Filter candidates by exact TLD. Repeatable.                                                   
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Discover domain-name candidates
+
+    $ vercel domains search acme
+
+  - Narrow candidates with a TLD fragment
+
+    $ vercel domains search acme.d
+
+  - Filter candidates by TLD
+
+    $ vercel domains search acme --tld com --tld dev
+
+  - JSON output
+
+    $ vercel domains search acme --format=json
+
+"
+`;
+
 exports[`help command > domains help output snapshots > domains transfer-in help output snapshots > domains transfer-in help column width 120 1`] = `
 "
   ▲ vercel domains transfer-in domain [options]

--- a/packages/cli/test/unit/commands/domains/search.test.ts
+++ b/packages/cli/test/unit/commands/domains/search.test.ts
@@ -57,7 +57,7 @@ describe('domains search', () => {
             "domain": "acme.dev",
             "available": false,
             "purchasePrice": null,
-            "renewalPrice": 30,
+            "renewalPrice": null,
             "years": 1
           }
         ],
@@ -190,7 +190,7 @@ describe('domains search', () => {
         domain: 'acme.dev',
         available: false,
         purchasePrice: null,
-        renewalPrice: 30,
+        renewalPrice: null,
         years: 1,
       },
     ]);

--- a/packages/cli/test/unit/commands/domains/search.test.ts
+++ b/packages/cli/test/unit/commands/domains/search.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import domains from '../../../../src/commands/domains';
 import { client } from '../../../mocks/client';
+
+let globalConfigDir: string;
+
+beforeEach(async () => {
+  globalConfigDir = await mkdtemp(join(tmpdir(), 'domains-search-cache-'));
+  vi.spyOn(client, 'getGlobalPathConfig').mockReturnValue(globalConfigDir);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(globalConfigDir, { recursive: true, force: true });
+});
 
 describe('domains search', () => {
   it('prints subcommand help', async () => {
@@ -68,6 +83,164 @@ describe('domains search', () => {
       }
       "
     `);
+  });
+
+  it('reuses the supported TLD catalog for 30 minutes', async () => {
+    let supportedTlds = ['com'];
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(supportedTlds);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(0);
+    const firstOutput = client.stdout.getFullOutput();
+
+    supportedTlds = ['dev'];
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(0);
+
+    expect(
+      JSON.parse(client.stdout.getFullOutput().slice(firstOutput.length))
+        .results
+    ).toMatchObject([{ domain: 'acme.com' }]);
+  });
+
+  it('refreshes the supported TLD catalog after 30 minutes', async () => {
+    const now = Date.now();
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now);
+    let supportedTlds = ['com'];
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(supportedTlds);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(0);
+    const firstOutput = client.stdout.getFullOutput();
+
+    supportedTlds = ['dev'];
+    dateNow.mockReturnValue(now + 30 * 60 * 1000 + 1);
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(0);
+
+    expect(
+      JSON.parse(client.stdout.getFullOutput().slice(firstOutput.length))
+        .results
+    ).toMatchObject([{ domain: 'acme.dev' }]);
+  });
+
+  it('ignores a malformed supported TLD cache', async () => {
+    const cachePath = join(
+      globalConfigDir,
+      'cache',
+      'domains-search-supported-tlds.json'
+    );
+    await mkdir(dirname(cachePath), { recursive: true });
+    await writeFile(cachePath, '{', 'utf8');
+
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(0);
+
+    expect(JSON.parse(client.stdout.getFullOutput()).results).toMatchObject([
+      { domain: 'acme.com' },
+    ]);
+  });
+
+  it('isolates cached TLD catalogs by order and active team', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (req, res) => {
+      if (req.query.teamId === 'team_b') {
+        res.json(['net']);
+      } else if (req.query.order === 'alphabetical') {
+        res.json(['dev']);
+      } else {
+        res.json(['com']);
+      }
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.config.currentTeam = 'team_a';
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(0);
+    const relevanceOutput = client.stdout.getFullOutput();
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--order=alphabetical',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+    const alphabeticalOutput = client.stdout
+      .getFullOutput()
+      .slice(relevanceOutput.length);
+
+    client.config.currentTeam = 'team_b';
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(0);
+    const teamOutput = client.stdout
+      .getFullOutput()
+      .slice(relevanceOutput.length + alphabeticalOutput.length);
+
+    expect(JSON.parse(relevanceOutput).results).toMatchObject([
+      { domain: 'acme.com' },
+    ]);
+    expect(JSON.parse(alphabeticalOutput).results).toMatchObject([
+      { domain: 'acme.dev' },
+    ]);
+    expect(JSON.parse(teamOutput).results).toMatchObject([
+      { domain: 'acme.net' },
+    ]);
   });
 
   it('narrows TLD fragments and renders action-oriented human output', async () => {
@@ -262,6 +435,8 @@ describe('domains search', () => {
   });
 
   it('returns an empty final page', async () => {
+    const now = Date.now();
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now);
     let catalogRequestCount = 0;
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       catalogRequestCount++;
@@ -287,6 +462,7 @@ describe('domains search', () => {
     const firstOutput = client.stdout.getFullOutput();
     const cursor = JSON.parse(firstOutput).pagination.next;
 
+    dateNow.mockReturnValue(now + 30 * 60 * 1000 + 1);
     client.setArgv(
       'domains',
       'search',
@@ -664,6 +840,8 @@ describe('domains search', () => {
   });
 
   it('rejects stale continuation cursors', async () => {
+    const now = Date.now();
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now);
     let catalogRequestCount = 0;
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       catalogRequestCount++;
@@ -686,6 +864,7 @@ describe('domains search', () => {
     expect(await domains(client)).toEqual(0);
     const cursor = JSON.parse(client.stdout.getFullOutput()).pagination.next;
 
+    dateNow.mockReturnValue(now + 30 * 60 * 1000 + 1);
     client.setArgv('domains', 'search', 'acme', '--next', cursor);
 
     expect(await domains(client)).toEqual(1);

--- a/packages/cli/test/unit/commands/domains/search.test.ts
+++ b/packages/cli/test/unit/commands/domains/search.test.ts
@@ -641,6 +641,53 @@ describe('domains search', () => {
     );
   });
 
+  it('filters unavailable candidates from human output and preserves the filter when continuing', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev', 'io']);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      expect(req.body).toEqual({
+        domains: ['acme.com', 'acme.dev', 'acme.io'],
+      });
+      res.json({
+        results: [
+          {
+            domain: 'acme.com',
+            available: false,
+          },
+          {
+            domain: 'acme.dev',
+            available: true,
+            price: 20,
+            renewalPrice: 25,
+            years: 1,
+            premium: false,
+          },
+          {
+            domain: 'acme.io',
+            available: true,
+            price: 20,
+            renewalPrice: 25,
+            years: 1,
+            premium: false,
+          },
+        ],
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--available', '--limit=1');
+    expect(await domains(client)).toEqual(0);
+
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('acme.dev');
+    expect(output).not.toContain('acme.com');
+    expect(output).not.toContain('acme.io');
+    expect(output).not.toContain('Unavailable');
+    expect(output).toContain(
+      'To continue, run `vercel domains search acme --available --next '
+    );
+  });
+
   it('keeps unavailable candidates alongside available search results', async () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'ca', 'dev']);
@@ -699,6 +746,154 @@ describe('domains search', () => {
         years: 1,
       },
     ]);
+  });
+
+  it('fills an available-only JSON page up to the requested limit', async () => {
+    let searchRequestCount = 0;
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev', 'io', 'net', 'org']);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      searchRequestCount++;
+      expect(req.body).toEqual({
+        domains: ['acme.com', 'acme.dev', 'acme.io', 'acme.net', 'acme.org'],
+      });
+      res.json({
+        results: [
+          {
+            domain: 'acme.com',
+            available: false,
+          },
+          {
+            domain: 'acme.dev',
+            available: true,
+            price: 20,
+            renewalPrice: 25,
+            years: 1,
+            premium: false,
+          },
+          {
+            domain: 'acme.io',
+            available: false,
+          },
+          {
+            domain: 'acme.net',
+            available: true,
+            price: 30,
+            renewalPrice: 35,
+            years: 1,
+            premium: false,
+          },
+          {
+            domain: 'acme.org',
+            available: true,
+            price: 40,
+            renewalPrice: 45,
+            years: 1,
+            premium: false,
+          },
+        ],
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--available',
+      '--limit=2',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+
+    const payload = JSON.parse(client.stdout.getFullOutput());
+    expect(searchRequestCount).toEqual(1);
+    expect(payload.results).toEqual([
+      {
+        domain: 'acme.dev',
+        available: true,
+        purchasePrice: 20,
+        renewalPrice: 25,
+        years: 1,
+      },
+      {
+        domain: 'acme.net',
+        available: true,
+        purchasePrice: 30,
+        renewalPrice: 35,
+        years: 1,
+      },
+    ]);
+    expect(payload.pagination).toEqual({
+      next: expect.any(String),
+      limit: 2,
+    });
+  });
+
+  it('scans multiple batches without returning an empty intermediate page', async () => {
+    const tlds = Array.from(
+      { length: 202 },
+      (_, index) => `tld${index.toString().padStart(3, '0')}`
+    );
+    const requestSizes: number[] = [];
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(tlds);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      const body = req.body as { domains: string[] };
+      requestSizes.push(body.domains.length);
+      res.json({
+        results: body.domains.map(domain => ({
+          domain,
+          ...(domain.endsWith('tld200') || domain.endsWith('tld201')
+            ? {
+                available: true,
+                price: 20,
+                renewalPrice: 25,
+                years: 1,
+                premium: false,
+              }
+            : { available: false }),
+        })),
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--available',
+      '--limit=2',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+
+    expect(requestSizes).toEqual([200, 2]);
+    expect(requestSizes.every(size => size <= 200)).toEqual(true);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      query: 'acme',
+      order: 'relevance',
+      results: [
+        {
+          domain: 'acme.tld200',
+          available: true,
+          purchasePrice: 20,
+          renewalPrice: 25,
+          years: 1,
+        },
+        {
+          domain: 'acme.tld201',
+          available: true,
+          purchasePrice: 20,
+          renewalPrice: 25,
+          years: 1,
+        },
+      ],
+      pagination: {
+        next: null,
+        limit: 2,
+      },
+    });
   });
 
   it('outputs API errors as JSON without partial results', async () => {
@@ -919,6 +1114,25 @@ describe('domains search', () => {
     );
   });
 
+  it('rejects a continuation cursor without availability state', async () => {
+    const cursor = Buffer.from(
+      JSON.stringify({
+        query: 'acme',
+        fragment: null,
+        order: 'relevance',
+        tlds: [],
+        lastTld: 'com',
+      }),
+      'utf8'
+    ).toString('base64url');
+
+    client.setArgv('domains', 'search', 'acme', '--next', cursor);
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Invalid continuation cursor'
+    );
+  });
+
   it('rejects a continuation cursor when the query changes', async () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'dev']);
@@ -946,6 +1160,55 @@ describe('domains search', () => {
     expect(await domains(client)).toEqual(1);
     expect(client.stderr.getFullOutput()).toContain(
       'does not match the current query'
+    );
+  });
+
+  it.each([
+    { firstPageFlag: '--available', continuationFlag: undefined },
+    { firstPageFlag: undefined, continuationFlag: '--available' },
+  ])('rejects a continuation cursor when the availability filter changes', async ({
+    firstPageFlag,
+    continuationFlag,
+  }) => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      const body = req.body as { domains: string[] };
+      res.json({
+        results: body.domains.map(domain => ({
+          domain,
+          available: true,
+          price: 20,
+          renewalPrice: 20,
+          years: 1,
+          premium: false,
+        })),
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      ...(firstPageFlag ? [firstPageFlag] : []),
+      '--limit=1',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+    const cursor = JSON.parse(client.stdout.getFullOutput()).pagination.next;
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      ...(continuationFlag ? [continuationFlag] : []),
+      '--next',
+      cursor
+    );
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'does not match the current query, order, or filters'
     );
   });
 
@@ -1029,7 +1292,7 @@ describe('domains search', () => {
 
     client.setArgv('domains', 'search', 'acme', '--tld=com', '--next', cursor);
     expect(await domains(client)).toEqual(1);
-    expect(client.stderr.getFullOutput()).toContain('or TLD filters');
+    expect(client.stderr.getFullOutput()).toContain('or filters');
   });
 
   it.each([

--- a/packages/cli/test/unit/commands/domains/search.test.ts
+++ b/packages/cli/test/unit/commands/domains/search.test.ts
@@ -647,7 +647,7 @@ describe('domains search', () => {
     });
     client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       expect(req.body).toEqual({
-        domains: ['acme.com', 'acme.dev', 'acme.io'],
+        domains: ['acme.com', 'acme.dev'],
       });
       res.json({
         results: [
@@ -663,19 +663,11 @@ describe('domains search', () => {
             years: 1,
             premium: false,
           },
-          {
-            domain: 'acme.io',
-            available: true,
-            price: 20,
-            renewalPrice: 25,
-            years: 1,
-            premium: false,
-          },
         ],
       });
     });
 
-    client.setArgv('domains', 'search', 'acme', '--available', '--limit=1');
+    client.setArgv('domains', 'search', 'acme', '--available', '--limit=2');
     expect(await domains(client)).toEqual(0);
 
     const output = client.stderr.getFullOutput();
@@ -748,7 +740,7 @@ describe('domains search', () => {
     ]);
   });
 
-  it('fills an available-only JSON page up to the requested limit', async () => {
+  it('filters only the current JSON page without filling the limit', async () => {
     let searchRequestCount = 0;
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'dev', 'io', 'net', 'org']);
@@ -756,7 +748,7 @@ describe('domains search', () => {
     client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       searchRequestCount++;
       expect(req.body).toEqual({
-        domains: ['acme.com', 'acme.dev', 'acme.io', 'acme.net', 'acme.org'],
+        domains: ['acme.com', 'acme.dev'],
       });
       res.json({
         results: [
@@ -769,26 +761,6 @@ describe('domains search', () => {
             available: true,
             price: 20,
             renewalPrice: 25,
-            years: 1,
-            premium: false,
-          },
-          {
-            domain: 'acme.io',
-            available: false,
-          },
-          {
-            domain: 'acme.net',
-            available: true,
-            price: 30,
-            renewalPrice: 35,
-            years: 1,
-            premium: false,
-          },
-          {
-            domain: 'acme.org',
-            available: true,
-            price: 40,
-            renewalPrice: 45,
             years: 1,
             premium: false,
           },
@@ -816,13 +788,6 @@ describe('domains search', () => {
         renewalPrice: 25,
         years: 1,
       },
-      {
-        domain: 'acme.net',
-        available: true,
-        purchasePrice: 30,
-        renewalPrice: 35,
-        years: 1,
-      },
     ]);
     expect(payload.pagination).toEqual({
       next: expect.any(String),
@@ -830,31 +795,30 @@ describe('domains search', () => {
     });
   });
 
-  it('scans multiple batches without returning an empty intermediate page', async () => {
-    const tlds = Array.from(
-      { length: 202 },
-      (_, index) => `tld${index.toString().padStart(3, '0')}`
-    );
-    const requestSizes: number[] = [];
+  it('returns an empty filtered page without scanning the next window', async () => {
+    let searchRequestCount = 0;
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
-      res.json(tlds);
+      res.json(['com', 'dev', 'io']);
     });
     client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      searchRequestCount++;
       const body = req.body as { domains: string[] };
-      requestSizes.push(body.domains.length);
+      expect(body.domains).toEqual(
+        searchRequestCount === 1 ? ['acme.com', 'acme.dev'] : ['acme.io']
+      );
       res.json({
-        results: body.domains.map(domain => ({
-          domain,
-          ...(domain.endsWith('tld200') || domain.endsWith('tld201')
-            ? {
+        results: body.domains.map(domain =>
+          searchRequestCount === 1
+            ? { domain, available: false }
+            : {
+                domain,
                 available: true,
                 price: 20,
                 renewalPrice: 25,
                 years: 1,
                 premium: false,
               }
-            : { available: false }),
-        })),
+        ),
       });
     });
 
@@ -868,32 +832,35 @@ describe('domains search', () => {
     );
     expect(await domains(client)).toEqual(0);
 
-    expect(requestSizes).toEqual([200, 2]);
-    expect(requestSizes.every(size => size <= 200)).toEqual(true);
-    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+    const firstOutput = client.stdout.getFullOutput();
+    const firstPage = JSON.parse(firstOutput);
+    expect(searchRequestCount).toEqual(1);
+    expect(firstPage).toEqual({
       query: 'acme',
       order: 'relevance',
-      results: [
-        {
-          domain: 'acme.tld200',
-          available: true,
-          purchasePrice: 20,
-          renewalPrice: 25,
-          years: 1,
-        },
-        {
-          domain: 'acme.tld201',
-          available: true,
-          purchasePrice: 20,
-          renewalPrice: 25,
-          years: 1,
-        },
-      ],
+      results: [],
       pagination: {
-        next: null,
+        next: expect.any(String),
         limit: 2,
       },
     });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--available',
+      '--next',
+      firstPage.pagination.next,
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+
+    expect(searchRequestCount).toEqual(2);
+    expect(
+      JSON.parse(client.stdout.getFullOutput().slice(firstOutput.length))
+        .results
+    ).toMatchObject([{ domain: 'acme.io', available: true }]);
   });
 
   it('outputs API errors as JSON without partial results', async () => {

--- a/packages/cli/test/unit/commands/domains/search.test.ts
+++ b/packages/cli/test/unit/commands/domains/search.test.ts
@@ -31,22 +31,21 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'dev']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      expect(req.body).toEqual({ domains: ['acme.com', 'acme.dev'] });
       res.json({
         results: [
           {
             domain: 'acme.com',
-            purchasePrice: 20,
+            available: true,
+            price: 20,
             renewalPrice: 20,
-            transferPrice: 20,
             years: 1,
+            premium: false,
           },
           {
             domain: 'acme.dev',
-            purchasePrice: null,
-            renewalPrice: 30,
-            transferPrice: null,
-            years: 1,
+            available: false,
           },
         ],
       });
@@ -73,7 +72,7 @@ describe('domains search', () => {
             "available": false,
             "purchasePrice": null,
             "renewalPrice": null,
-            "years": 1
+            "years": null
           }
         ],
         "pagination": {
@@ -90,15 +89,16 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(supportedTlds);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -124,15 +124,16 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(supportedTlds);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -164,15 +165,16 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -195,15 +197,16 @@ describe('domains search', () => {
         res.json(['com']);
       }
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -247,36 +250,32 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['co.uk', 'com', 'co', 'company']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (_req, res) => {
       res.json({
         results: [
           {
             domain: 'acme.co',
-            purchasePrice: 25,
+            available: true,
+            price: 25,
             renewalPrice: 40,
-            transferPrice: 30,
             years: 2,
+            premium: false,
           },
           {
             domain: 'acme.co.uk',
-            purchasePrice: null,
-            renewalPrice: 33,
-            transferPrice: null,
-            years: 1,
+            available: false,
           },
           {
             domain: 'acme.com',
-            purchasePrice: null,
-            renewalPrice: 22,
-            transferPrice: null,
-            years: 1,
+            available: false,
           },
           {
             domain: 'acme.company',
-            purchasePrice: 18,
+            available: true,
+            price: 18,
             renewalPrice: 24,
-            transferPrice: 20,
             years: 1,
+            premium: true,
           },
         ],
       });
@@ -302,15 +301,16 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['company', 'co.uk', 'co', 'com', 'net']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 25,
-          transferPrice: 30,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -325,63 +325,129 @@ describe('domains search', () => {
     ).toEqual(['acme.co', 'acme.company', 'acme.co.uk', 'acme.com']);
   });
 
-  it('accepts bulk quote responses returned as an array', async () => {
+  it('filters candidates by repeatable exact TLDs', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev', 'co.uk', 'net']);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      expect(req.body).toEqual({ domains: ['acme.com', 'acme.dev'] });
+      const body = req.body as { domains: string[] };
+      res.json({
+        results: body.domains.map(domain => ({
+          domain,
+          available: true,
+          price: 20,
+          renewalPrice: 25,
+          years: 1,
+          premium: false,
+        })),
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--tld',
+      '.DEV',
+      '--tld=COM',
+      '--tld',
+      'dev',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+
+    expect(
+      JSON.parse(client.stdout.getFullOutput()).results.map(
+        (result: { domain: string }) => result.domain
+      )
+    ).toEqual(['acme.com', 'acme.dev']);
+  });
+
+  it('combines a TLD fragment with exact TLD filters', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['co.uk', 'co.ug', 'com']);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      expect(req.body).toEqual({ domains: ['acme.co.uk'] });
+      res.json({
+        results: [
+          {
+            domain: 'acme.co.uk',
+            available: true,
+            price: 20,
+            renewalPrice: 25,
+            years: 1,
+            premium: false,
+          },
+        ],
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme.co.u',
+      '--tld=co.uk',
+      '--tld=com',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+    expect(JSON.parse(client.stdout.getFullOutput()).results).toMatchObject([
+      { domain: 'acme.co.uk' },
+    ]);
+  });
+
+  it('returns an empty result when exact TLD filters do not match', async () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'dev']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+
+    client.setArgv('domains', 'search', 'acme', '--tld=net', '--format=json');
+    expect(await domains(client)).toEqual(0);
+    expect(JSON.parse(client.stdout.getFullOutput()).results).toEqual([]);
+  });
+
+  it('rejects malformed search responses returned as an array', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (_req, res) => {
       res.json([
         {
           domain: 'acme.com',
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         },
         {
           domain: 'acme.dev',
-          purchasePrice: null,
-          renewalPrice: 30,
-          transferPrice: null,
-          years: 1,
+          available: false,
         },
       ]);
     });
 
     client.setArgv('domains', 'search', 'acme', '--format=json');
-    expect(await domains(client)).toEqual(0);
-
-    expect(JSON.parse(client.stdout.getFullOutput()).results).toEqual([
-      {
-        domain: 'acme.com',
-        available: true,
-        purchasePrice: 20,
-        renewalPrice: 20,
-        years: 1,
-      },
-      {
-        domain: 'acme.dev',
-        available: false,
-        purchasePrice: null,
-        renewalPrice: null,
-        years: 1,
-      },
-    ]);
+    expect(await domains(client)).toEqual(1);
+    expect(client.stdout.getFullOutput()).toEqual('');
   });
 
   it('continues after the last TLD with a different valid limit', async () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'dev', 'io', 'net']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -444,15 +510,16 @@ describe('domains search', () => {
         catalogRequestCount === 1 ? ['com', 'dev', 'io'] : ['com', 'dev']
       );
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -487,15 +554,16 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'dev']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -513,15 +581,16 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'dev']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -540,31 +609,67 @@ describe('domains search', () => {
     );
   });
 
-  it('isolates registry-invalid candidates without losing valid quotes', async () => {
+  it('preserves exact TLD filters in the human continuation command', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      const body = req.body as { domains: string[] };
+      res.json({
+        results: body.domains.map(domain => ({
+          domain,
+          available: true,
+          price: 20,
+          renewalPrice: 20,
+          years: 1,
+          premium: false,
+        })),
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--tld=dev',
+      '--tld=com',
+      '--limit=1'
+    );
+    expect(await domains(client)).toEqual(0);
+    expect(client.stderr.getFullOutput()).toContain(
+      'vercel domains search acme --tld=com --tld=dev --next '
+    );
+  });
+
+  it('keeps unavailable candidates alongside available search results', async () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'ca', 'dev']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
-      const body = req.body as { domains?: string[] };
-
-      if (body.domains?.includes('a.ca')) {
-        res.status(400).json({
-          error: {
-            code: 'domain_too_short',
-            message: 'The domain name a.ca is too short.',
-          },
-        });
-        return;
-      }
-
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      expect(req.body).toEqual({ domains: ['a.com', 'a.ca', 'a.dev'] });
       res.json({
-        results: body.domains?.map(domain => ({
-          domain,
-          purchasePrice: 20,
-          renewalPrice: 25,
-          transferPrice: 30,
-          years: 1,
-        })),
+        results: [
+          {
+            domain: 'a.com',
+            available: true,
+            price: 20,
+            renewalPrice: 25,
+            years: 1,
+            premium: false,
+          },
+          {
+            domain: 'a.ca',
+            available: false,
+          },
+          {
+            domain: 'a.dev',
+            available: true,
+            price: 20,
+            renewalPrice: 25,
+            years: 1,
+            premium: false,
+          },
+        ],
       });
     });
 
@@ -600,11 +705,11 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (_req, res) => {
       res.status(400).json({
         error: {
-          code: 'unexpected_quote_error',
-          message: 'Registrar quote failed.',
+          code: 'unexpected_search_error',
+          message: 'Registrar search failed.',
         },
       });
     });
@@ -613,8 +718,8 @@ describe('domains search', () => {
     expect(await domains(client)).toEqual(1);
 
     expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
-      error: 'unexpected_quote_error',
-      message: 'Registrar quote failed.',
+      error: 'unexpected_search_error',
+      message: 'Registrar search failed.',
     });
     expect(client.stderr.getFullOutput()).toEqual('');
   });
@@ -630,11 +735,11 @@ describe('domains search', () => {
     expect(client.stdout.getFullOutput()).toEqual('');
   });
 
-  it('fails without partial output for a malformed quote response', async () => {
+  it('fails without partial output for a malformed search response', async () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (_req, res) => {
       res.json({ quotes: [] });
     });
 
@@ -644,19 +749,20 @@ describe('domains search', () => {
     expect(client.stdout.getFullOutput()).toEqual('');
   });
 
-  it('fails without partial output when a quote response is incomplete', async () => {
+  it('fails without partial output when a search response is incomplete', async () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'dev']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (_req, res) => {
       res.json({
         results: [
           {
             domain: 'acme.com',
-            purchasePrice: 20,
+            available: true,
+            price: 20,
             renewalPrice: 20,
-            transferPrice: 20,
             years: 1,
+            premium: false,
           },
         ],
       });
@@ -667,7 +773,7 @@ describe('domains search', () => {
 
     expect(client.stdout.getFullOutput()).toEqual('');
     expect(client.stderr.getFullOutput()).toContain(
-      'Missing registrar quote for acme.dev'
+      'Missing registrar search result for acme.dev'
     );
   });
 
@@ -680,15 +786,16 @@ describe('domains search', () => {
           : unsortedTlds
       );
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -724,15 +831,16 @@ describe('domains search', () => {
           : unsortedTlds
       );
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -767,30 +875,31 @@ describe('domains search', () => {
     expect(client.stderr.getFullOutput()).toContain('--json');
   });
 
-  it.each([0, 51])('rejects invalid limit boundary %i', async limit => {
+  it.each([0, 201])('rejects invalid limit boundary %i', async limit => {
     client.setArgv('domains', 'search', 'acme', `--limit=${limit}`);
 
     expect(await domains(client)).toEqual(1);
     expect(client.stderr.getFullOutput()).toContain(
-      'Provide a number from 1 to 50'
+      'Provide a number from 1 to 200'
     );
   });
 
-  it.each([1, 50])('accepts limit boundary %i', async limit => {
+  it.each([1, 200])('accepts limit boundary %i', async limit => {
     const tlds = Array.from({ length: limit }, (_, index) => `tld${index}`);
 
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(tlds);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -814,15 +923,16 @@ describe('domains search', () => {
     client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
       res.json(['com', 'dev']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });
@@ -835,8 +945,104 @@ describe('domains search', () => {
 
     expect(await domains(client)).toEqual(1);
     expect(client.stderr.getFullOutput()).toContain(
-      'does not match the current query or order'
+      'does not match the current query'
     );
+  });
+
+  it('accepts reordered exact TLD filters with a continuation cursor', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      const body = req.body as { domains: string[] };
+      res.json({
+        results: body.domains.map(domain => ({
+          domain,
+          available: true,
+          price: 20,
+          renewalPrice: 20,
+          years: 1,
+          premium: false,
+        })),
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--tld=dev',
+      '--tld=com',
+      '--limit=1',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+    const firstOutput = client.stdout.getFullOutput();
+    const cursor = JSON.parse(firstOutput).pagination.next;
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--tld=com',
+      '--tld=dev',
+      '--next',
+      cursor,
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+    expect(
+      JSON.parse(client.stdout.getFullOutput().slice(firstOutput.length))
+        .results
+    ).toMatchObject([{ domain: 'acme.dev' }]);
+  });
+
+  it('rejects a continuation cursor when exact TLD filters change', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
+      const body = req.body as { domains: string[] };
+      res.json({
+        results: body.domains.map(domain => ({
+          domain,
+          available: true,
+          price: 20,
+          renewalPrice: 20,
+          years: 1,
+          premium: false,
+        })),
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--tld=com',
+      '--tld=dev',
+      '--limit=1',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+    const cursor = JSON.parse(client.stdout.getFullOutput()).pagination.next;
+
+    client.setArgv('domains', 'search', 'acme', '--tld=com', '--next', cursor);
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain('or TLD filters');
+  });
+
+  it.each([
+    '',
+    '.',
+    'co..uk',
+    '-com',
+    'com/',
+  ])('rejects invalid exact TLD filter %j', async tld => {
+    client.setArgv('domains', 'search', 'acme', `--tld=${tld}`);
+
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain('Invalid TLD filter');
   });
 
   it('rejects stale continuation cursors', async () => {
@@ -847,15 +1053,16 @@ describe('domains search', () => {
       catalogRequestCount++;
       res.json(catalogRequestCount === 1 ? ['com', 'dev'] : ['dev']);
     });
-    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+    client.scenario.post('/v1/registrar/domains/search', (req, res) => {
       const body = req.body as { domains?: string[] };
       res.json({
         results: body.domains?.map(domain => ({
           domain,
-          purchasePrice: 20,
+          available: true,
+          price: 20,
           renewalPrice: 20,
-          transferPrice: 20,
           years: 1,
+          premium: false,
         })),
       });
     });

--- a/packages/cli/test/unit/commands/domains/search.test.ts
+++ b/packages/cli/test/unit/commands/domains/search.test.ts
@@ -1,0 +1,712 @@
+import { describe, expect, it } from 'vitest';
+import domains from '../../../../src/commands/domains';
+import { client } from '../../../mocks/client';
+
+describe('domains search', () => {
+  it('prints subcommand help', async () => {
+    client.setArgv('domains', 'search', '--help');
+
+    expect(await domains(client)).toEqual(2);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Discover domain-name candidates from a keyword or fragment'
+    );
+  });
+
+  it('discovers and quotes domain candidates as JSON', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+      res.json({
+        results: [
+          {
+            domain: 'acme.com',
+            purchasePrice: 20,
+            renewalPrice: 20,
+            transferPrice: 20,
+            years: 1,
+          },
+          {
+            domain: 'acme.dev',
+            purchasePrice: null,
+            renewalPrice: 30,
+            transferPrice: null,
+            years: 1,
+          },
+        ],
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    const exitCode = await domains(client);
+
+    expect(exitCode).toEqual(0);
+    expect(client.stdout.getFullOutput()).toMatchInlineSnapshot(`
+      "{
+        "query": "acme",
+        "order": "relevance",
+        "results": [
+          {
+            "domain": "acme.com",
+            "available": true,
+            "purchasePrice": 20,
+            "renewalPrice": 20,
+            "years": 1
+          },
+          {
+            "domain": "acme.dev",
+            "available": false,
+            "purchasePrice": null,
+            "renewalPrice": 30,
+            "years": 1
+          }
+        ],
+        "pagination": {
+          "next": null,
+          "limit": 20
+        }
+      }
+      "
+    `);
+  });
+
+  it('narrows TLD fragments and renders action-oriented human output', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['co.uk', 'com', 'co', 'company']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+      res.json({
+        results: [
+          {
+            domain: 'acme.co',
+            purchasePrice: 25,
+            renewalPrice: 40,
+            transferPrice: 30,
+            years: 2,
+          },
+          {
+            domain: 'acme.co.uk',
+            purchasePrice: null,
+            renewalPrice: 33,
+            transferPrice: null,
+            years: 1,
+          },
+          {
+            domain: 'acme.com',
+            purchasePrice: null,
+            renewalPrice: 22,
+            transferPrice: null,
+            years: 1,
+          },
+          {
+            domain: 'acme.company',
+            purchasePrice: 18,
+            renewalPrice: 24,
+            transferPrice: 20,
+            years: 1,
+          },
+        ],
+      });
+    });
+
+    client.setArgv('domains', 'search', ' ACME.co ');
+    const exitCode = await domains(client);
+
+    expect(exitCode).toEqual(0);
+    expect(
+      client.stderr.getFullOutput().replace(/[ \t]+$/gm, '')
+    ).toMatchInlineSnapshot(`
+      "> Domain        Availability  Purchase       Renewal
+      acme.co       Available     $25 / 2 years  $40 / 2 years
+      acme.co.uk    Unavailable   -              -
+      acme.com      Unavailable   -              -
+      acme.company  Available     $18 / 1 year   $24 / 1 year
+      "
+    `);
+  });
+
+  it('handles unsorted relevance responses and prefers an exact TLD fragment', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['company', 'co.uk', 'co', 'com', 'net']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 25,
+          transferPrice: 30,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme.co', '--format=json');
+    expect(await domains(client)).toEqual(0);
+
+    expect(
+      JSON.parse(client.stdout.getFullOutput()).results.map(
+        (result: { domain: string }) => result.domain
+      )
+    ).toEqual(['acme.co', 'acme.company', 'acme.co.uk', 'acme.com']);
+  });
+
+  it('accepts bulk quote responses returned as an array', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+      res.json([
+        {
+          domain: 'acme.com',
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        },
+        {
+          domain: 'acme.dev',
+          purchasePrice: null,
+          renewalPrice: 30,
+          transferPrice: null,
+          years: 1,
+        },
+      ]);
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(0);
+
+    expect(JSON.parse(client.stdout.getFullOutput()).results).toEqual([
+      {
+        domain: 'acme.com',
+        available: true,
+        purchasePrice: 20,
+        renewalPrice: 20,
+        years: 1,
+      },
+      {
+        domain: 'acme.dev',
+        available: false,
+        purchasePrice: null,
+        renewalPrice: 30,
+        years: 1,
+      },
+    ]);
+  });
+
+  it('continues after the last TLD with a different valid limit', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev', 'io', 'net']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--limit=2', '--format=json');
+    expect(await domains(client)).toEqual(0);
+
+    const firstOutput = client.stdout.getFullOutput();
+    const firstPage = JSON.parse(firstOutput);
+    expect(
+      firstPage.results.map((result: { domain: string }) => result.domain)
+    ).toEqual(['acme.com', 'acme.dev']);
+    expect(firstPage.pagination.limit).toEqual(2);
+    expect(firstPage.pagination.next).toEqual(expect.any(String));
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--next',
+      firstPage.pagination.next,
+      '--limit=1',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+
+    const secondPage = JSON.parse(
+      client.stdout.getFullOutput().slice(firstOutput.length)
+    );
+    expect(
+      secondPage.results.map((result: { domain: string }) => result.domain)
+    ).toEqual(['acme.io']);
+    expect(secondPage.pagination.limit).toEqual(1);
+    expect(secondPage.pagination.next).toEqual(expect.any(String));
+  });
+
+  it('returns an empty result when no TLDs match', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+
+    client.setArgv('domains', 'search', 'acme.xyz', '--format=json');
+    expect(await domains(client)).toEqual(0);
+
+    expect(JSON.parse(client.stdout.getFullOutput())).toMatchObject({
+      results: [],
+      pagination: {
+        next: null,
+      },
+    });
+  });
+
+  it('returns an empty final page', async () => {
+    let catalogRequestCount = 0;
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      catalogRequestCount++;
+      res.json(
+        catalogRequestCount === 1 ? ['com', 'dev', 'io'] : ['com', 'dev']
+      );
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--limit=2', '--format=json');
+    expect(await domains(client)).toEqual(0);
+    const firstOutput = client.stdout.getFullOutput();
+    const cursor = JSON.parse(firstOutput).pagination.next;
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--next',
+      cursor,
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+
+    expect(
+      JSON.parse(client.stdout.getFullOutput().slice(firstOutput.length))
+    ).toMatchObject({
+      results: [],
+      pagination: {
+        next: null,
+      },
+    });
+  });
+
+  it('prints a readable continuation command for human output', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--limit=1');
+    expect(await domains(client)).toEqual(0);
+
+    expect(client.stderr.getFullOutput()).toContain(
+      'To continue, run `vercel domains search acme --next '
+    );
+    expect(client.stderr.getFullOutput()).not.toContain('--order=');
+  });
+
+  it('preserves non-default ordering in the human continuation command', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--order=alphabetical',
+      '--limit=1'
+    );
+    expect(await domains(client)).toEqual(0);
+
+    expect(client.stderr.getFullOutput()).toContain(
+      'To continue, run `vercel domains search acme --order=alphabetical --next '
+    );
+  });
+
+  it('isolates registry-invalid candidates without losing valid quotes', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'ca', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+
+      if (body.domains?.includes('a.ca')) {
+        res.status(400).json({
+          error: {
+            code: 'domain_too_short',
+            message: 'The domain name a.ca is too short.',
+          },
+        });
+        return;
+      }
+
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 25,
+          transferPrice: 30,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'a', '--format=json');
+    expect(await domains(client)).toEqual(0);
+
+    expect(JSON.parse(client.stdout.getFullOutput()).results).toEqual([
+      {
+        domain: 'a.com',
+        available: true,
+        purchasePrice: 20,
+        renewalPrice: 25,
+        years: 1,
+      },
+      {
+        domain: 'a.ca',
+        available: false,
+        purchasePrice: null,
+        renewalPrice: null,
+        years: null,
+      },
+      {
+        domain: 'a.dev',
+        available: true,
+        purchasePrice: 20,
+        renewalPrice: 25,
+        years: 1,
+      },
+    ]);
+  });
+
+  it('outputs API errors as JSON without partial results', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+      res.status(400).json({
+        error: {
+          code: 'unexpected_quote_error',
+          message: 'Registrar quote failed.',
+        },
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(1);
+
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      error: 'unexpected_quote_error',
+      message: 'Registrar quote failed.',
+    });
+    expect(client.stderr.getFullOutput()).toEqual('');
+  });
+
+  it('fails without partial output for a malformed TLD response', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json({ results: ['com'] });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(1);
+
+    expect(client.stdout.getFullOutput()).toEqual('');
+  });
+
+  it('fails without partial output for a malformed quote response', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+      res.json({ quotes: [] });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(1);
+
+    expect(client.stdout.getFullOutput()).toEqual('');
+  });
+
+  it('fails without partial output when a quote response is incomplete', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (_req, res) => {
+      res.json({
+        results: [
+          {
+            domain: 'acme.com',
+            purchasePrice: 20,
+            renewalPrice: 20,
+            transferPrice: 20,
+            years: 1,
+          },
+        ],
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--format=json');
+    expect(await domains(client)).toEqual(1);
+
+    expect(client.stdout.getFullOutput()).toEqual('');
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing registrar quote for acme.dev'
+    );
+  });
+
+  it('orders multi-label fragment results alphabetically', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (req, res) => {
+      const unsortedTlds = ['com', 'co.uk', 'co.ug'];
+      res.json(
+        req.query.order === 'alphabetical'
+          ? [...unsortedTlds].sort()
+          : unsortedTlds
+      );
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme.co.u',
+      '--order=alphabetical',
+      '--limit=1',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+
+    const payload = JSON.parse(client.stdout.getFullOutput());
+    expect(payload.query).toEqual('acme.co.u');
+    expect(payload.order).toEqual('alphabetical');
+    expect(
+      payload.results.map((result: { domain: string }) => result.domain)
+    ).toEqual(['acme.co.ug']);
+    expect(payload.pagination.limit).toEqual(1);
+    expect(payload.pagination.next).toEqual(expect.any(String));
+  });
+
+  it('orders results by TLD length', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (req, res) => {
+      const unsortedTlds = ['technology', 'dev', 'io', 'com'];
+      res.json(
+        req.query.order === 'length'
+          ? [...unsortedTlds].sort(
+              (a, b) => a.length - b.length || a.localeCompare(b)
+            )
+          : unsortedTlds
+      );
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv(
+      'domains',
+      'search',
+      'acme',
+      '--order=length',
+      '--format=json'
+    );
+    expect(await domains(client)).toEqual(0);
+    expect(
+      JSON.parse(client.stdout.getFullOutput()).results.map(
+        (result: { domain: string }) => result.domain
+      )
+    ).toEqual(['acme.io', 'acme.com', 'acme.dev', 'acme.technology']);
+  });
+
+  it('rejects an invalid order', async () => {
+    client.setArgv('domains', 'search', 'acme', '--order=recent');
+
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain('Invalid order: "recent"');
+  });
+
+  it('rejects the deprecated --json alias', async () => {
+    client.setArgv('domains', 'search', 'acme', '--json');
+
+    expect(await domains(client)).toEqual(1);
+    expect(client.stdout.getFullOutput()).toEqual('');
+    expect(client.stderr.getFullOutput()).toContain('--json');
+  });
+
+  it.each([0, 51])('rejects invalid limit boundary %i', async limit => {
+    client.setArgv('domains', 'search', 'acme', `--limit=${limit}`);
+
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Provide a number from 1 to 50'
+    );
+  });
+
+  it.each([1, 50])('accepts limit boundary %i', async limit => {
+    const tlds = Array.from({ length: limit }, (_, index) => `tld${index}`);
+
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(tlds);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', `--limit=${limit}`);
+    expect(await domains(client)).toEqual(0);
+
+    expect(client.stderr.getFullOutput()).toContain(`acme.tld${limit - 1}`);
+  });
+
+  it('rejects a malformed continuation cursor', async () => {
+    client.setArgv('domains', 'search', 'acme', '--next', 'not-a-cursor');
+
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Invalid continuation cursor'
+    );
+  });
+
+  it('rejects a continuation cursor when the query changes', async () => {
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      res.json(['com', 'dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--limit=1', '--format=json');
+    expect(await domains(client)).toEqual(0);
+    const cursor = JSON.parse(client.stdout.getFullOutput()).pagination.next;
+
+    client.setArgv('domains', 'search', 'other', '--next', cursor);
+
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'does not match the current query or order'
+    );
+  });
+
+  it('rejects stale continuation cursors', async () => {
+    let catalogRequestCount = 0;
+    client.scenario.get('/v1/registrar/tlds/supported', (_req, res) => {
+      catalogRequestCount++;
+      res.json(catalogRequestCount === 1 ? ['com', 'dev'] : ['dev']);
+    });
+    client.scenario.post('/v1/registrar/domains/price', (req, res) => {
+      const body = req.body as { domains?: string[] };
+      res.json({
+        results: body.domains?.map(domain => ({
+          domain,
+          purchasePrice: 20,
+          renewalPrice: 20,
+          transferPrice: 20,
+          years: 1,
+        })),
+      });
+    });
+
+    client.setArgv('domains', 'search', 'acme', '--limit=1', '--format=json');
+    expect(await domains(client)).toEqual(0);
+    const cursor = JSON.parse(client.stdout.getFullOutput()).pagination.next;
+
+    client.setArgv('domains', 'search', 'acme', '--next', cursor);
+
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'continuation cursor is stale'
+    );
+  });
+
+  it.each([
+    ['', 'Query cannot be empty'],
+    ['https://vercel.com', 'URLs are not supported'],
+    ['acme domains', 'whitespace'],
+    ['acme-', 'Invalid keyword'],
+    ['acme_', 'Invalid keyword'],
+    ['café', 'ASCII'],
+    ['acme..dev', 'Invalid TLD fragment'],
+    ['acme.', 'Invalid TLD fragment'],
+  ])('rejects unsupported query %j', async (query, expectedError) => {
+    client.setArgv('domains', 'search', query);
+
+    expect(await domains(client)).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(expectedError);
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -291,6 +291,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('domains search help output snapshots', () => {
+      it('domains search help column width 120', () => {
+        expect(
+          help(domains.searchSubcommand, {
+            columns: 120,
+            parent: domains.domainsCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
     describe('domains inspect help output snapshots', () => {
       it('domains inspect help column width 120', () => {
         expect(

--- a/packages/cli/test/unit/util/client.test.ts
+++ b/packages/cli/test/unit/util/client.test.ts
@@ -9,6 +9,7 @@ import { ProxyAgent } from 'proxy-agent';
 import { createServer } from 'http';
 import { client } from '../../mocks/client';
 import * as getArgs from '../../../src/util/get-args';
+import pkg from '../../../src/util/pkg';
 
 const testConfigSchema = z.object({
   enabled: z.boolean(),
@@ -122,6 +123,28 @@ describe('Client', () => {
       });
 
       await client.fetch('/v9/projects?teamId=team_explicit', { json: false });
+    });
+
+    it.each([
+      '/v1/registrar/domains/example.com/availability',
+      '/v1/registrar/tlds/supported',
+      '/v5/domains/example.com',
+    ])('sends the CLI version with domain API requests to %s', async path => {
+      client.scenario.get(path, (req, res) => {
+        expect(req.headers['x-vercel-cli-version']).toBe(pkg.version);
+        res.json({ ok: true });
+      });
+
+      await client.fetch(path);
+    });
+
+    it('does not send the domains CLI version header to unrelated APIs', async () => {
+      client.scenario.get('/v2/user', (req, res) => {
+        expect(req.headers['x-vercel-cli-version']).toBeUndefined();
+        res.json({ user: { uid: 'abc' } });
+      });
+
+      await client.fetch('/v2/user');
     });
 
     it('should treat 3xx as errors when redirect is not manual', async () => {

--- a/skills/vercel-cli/references/domains-and-dns.md
+++ b/skills/vercel-cli/references/domains-and-dns.md
@@ -3,6 +3,7 @@
 ## Overview
 
 - `vercel domains` — manage domain ownership and project assignment
+- `vercel domains search` — discover available domains and registrar pricing
 - `vercel domains check` — check registrar availability (single or bulk)
 - `vercel domains price` — get registrar quotes (single or bulk)
 - `vercel domains buy` — purchase a domain
@@ -21,6 +22,15 @@ Most users only need `vercel alias` — domains and DNS are auto-configured when
 Or manually alias: `vercel alias set <deployment-url> example.com`
 
 ## Domain Discovery
+
+### Search
+
+```bash
+vercel domains search acme
+vercel domains search acme --available --tld .com --limit 200
+```
+
+Search returns availability, purchase pricing, and renewal pricing in bulk. Use the continuation command printed by the CLI to fetch the next page.
 
 ### Availability
 

--- a/skills/vercel-cli/references/domains-and-dns.md
+++ b/skills/vercel-cli/references/domains-and-dns.md
@@ -31,6 +31,7 @@ vercel domains search acme --available --tld .com --limit 200
 ```
 
 Search returns availability, purchase pricing, and renewal pricing in bulk. Use the continuation command printed by the CLI to fetch the next page.
+`--limit` controls how many candidates are checked per page. `--available` filters that window, so a page can return fewer results than the limit.
 
 ### Availability
 


### PR DESCRIPTION
Adds `vercel domains search <query>` for discovering available domain candidates across supported TLDs.

- Supports keyword and TLD-fragment searches
- Supports relevance, alphabetical, and length ordering
- Adds configurable limits and continuation cursors
- Fetches registrar pricing in bulk
- Handles both supported bulk-pricing response envelopes
- Supports machine-readable output through `--format=json`
- Emits standardized JSON API errors
