### PR TITLE
Add Vercel OIDC token verifier

### DIFF
--- a/.changeset/fuzzy-bugs-verify.md
+++ b/.changeset/fuzzy-bugs-verify.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+Add `verifyVercelOidcToken` for verifying Vercel OIDC tokens against Vercel's remote JWKS.

--- a/packages/oidc/docs/README.md
+++ b/packages/oidc/docs/README.md
@@ -9,9 +9,14 @@
 - [AccessTokenMissingError](classes/AccessTokenMissingError.md)
 - [RefreshAccessTokenFailedError](classes/RefreshAccessTokenFailedError.md)
 
+## Type Aliases
+
+- [VercelOidcPayload](type-aliases/VercelOidcPayload.md)
+
 ## Functions
 
 - [getContext](functions/getContext.md)
 - [getVercelOidcToken](functions/getVercelOidcToken.md)
 - [getVercelOidcTokenSync](functions/getVercelOidcTokenSync.md)
 - [getVercelToken](functions/getVercelToken.md)
+- [verifyVercelOidcToken](functions/verifyVercelOidcToken.md)

--- a/packages/oidc/docs/functions/verifyVercelOidcToken.md
+++ b/packages/oidc/docs/functions/verifyVercelOidcToken.md
@@ -1,0 +1,56 @@
+[**@vercel/oidc**](../README.md)
+
+---
+
+# Function: verifyVercelOidcToken()
+
+> **verifyVercelOidcToken**\<`PayloadType`\>(`token`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`JWTVerifyResult`\<`PayloadType`\>\>
+
+Defined in: [packages/oidc/src/verify-vercel-oidc-token.ts:52](https://github.com/vercel/vercel/blob/main/packages/oidc/src/verify-vercel-oidc-token.ts#L52)
+
+Verifies a Vercel OIDC token against Vercel's remote JWKS.
+
+The issuer must be `https://oidc.vercel.com` or start with
+`https://oidc.vercel.com/`. The JWKS is always
+`https://oidc.vercel.com/.well-known/jwks`.
+
+Options:
+
+- `issuer`: Expected `iss` claim verified by Jose. The verified issuer must
+  still be `https://oidc.vercel.com` or start with
+  `https://oidc.vercel.com/`.
+- `projectId`: Expected `project_id` claim. Defaults to
+  `process.env.VERCEL_PROJECT_ID`. Pass `'*'` to allow any project ID. When
+  `projectId` is `'*'`, either `ownerId` or `audience` is required.
+- `environment`: Expected `environment` claim. Defaults to
+  `process.env.VERCEL_TARGET_ENV || process.env.VERCEL_ENV`. Pass `'*'` to
+  allow any environment.
+- `ownerId`: Expected `owner_id` claim. When omitted, the claim is not
+  checked.
+- Any other Jose JWT verification option.
+
+## Type Parameters
+
+### PayloadType
+
+`PayloadType` = [`VercelOidcPayload`](../type-aliases/VercelOidcPayload.md)
+
+## Parameters
+
+### token
+
+`string`
+
+The Vercel OIDC token to verify.
+
+### options?
+
+`object` & `JWTVerifyOptions`
+
+Optional Jose JWT verification options.
+
+## Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`JWTVerifyResult`\<`PayloadType`\>\>
+
+Jose's verified JWT result.

--- a/packages/oidc/docs/functions/verifyVercelOidcToken.md
+++ b/packages/oidc/docs/functions/verifyVercelOidcToken.md
@@ -6,7 +6,7 @@
 
 > **verifyVercelOidcToken**\<`PayloadType`\>(`token`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`JWTVerifyResult`\<`PayloadType`\>\>
 
-Defined in: [packages/oidc/src/verify-vercel-oidc-token.ts:52](https://github.com/vercel/vercel/blob/main/packages/oidc/src/verify-vercel-oidc-token.ts#L52)
+Defined in: [packages/oidc/src/verify-vercel-oidc-token.ts:53](https://github.com/vercel/vercel/blob/main/packages/oidc/src/verify-vercel-oidc-token.ts#L53)
 
 Verifies a Vercel OIDC token against Vercel's remote JWKS.
 
@@ -19,12 +19,13 @@ Options:
 - `issuer`: Expected `iss` claim verified by Jose. The verified issuer must
   still be `https://oidc.vercel.com` or start with
   `https://oidc.vercel.com/`.
-- `projectId`: Expected `project_id` claim. Defaults to
-  `process.env.VERCEL_PROJECT_ID`. Pass `'*'` to allow any project ID. When
-  `projectId` is `'*'`, either `ownerId` or `audience` is required.
-- `environment`: Expected `environment` claim. Defaults to
-  `process.env.VERCEL_TARGET_ENV || process.env.VERCEL_ENV`. Pass `'*'` to
-  allow any environment.
+- `projectId`: Expected `project_id` claim or claims. Defaults to
+  `process.env.VERCEL_PROJECT_ID`. Pass an array to allow any matching
+  project ID. Pass `'*'` to allow any project ID. When `projectId` is `'*'`,
+  either `ownerId` or `audience` is required.
+- `environment`: Expected `environment` claim or claims. Defaults to
+  `process.env.VERCEL_TARGET_ENV || process.env.VERCEL_ENV`. Pass an array
+  to allow any matching environment. Pass `'*'` to allow any environment.
 - `ownerId`: Expected `owner_id` claim. When omitted, the claim is not
   checked.
 - Any other Jose JWT verification option.

--- a/packages/oidc/docs/type-aliases/VercelOidcPayload.md
+++ b/packages/oidc/docs/type-aliases/VercelOidcPayload.md
@@ -1,0 +1,39 @@
+[**@vercel/oidc**](../README.md)
+
+---
+
+# Type Alias: VercelOidcPayload
+
+> **VercelOidcPayload** = `JWTPayload` & `object`
+
+Defined in: [packages/oidc/src/verify-vercel-oidc-token.ts:16](https://github.com/vercel/vercel/blob/main/packages/oidc/src/verify-vercel-oidc-token.ts#L16)
+
+## Type Declaration
+
+### aud
+
+> **aud**: `string`
+
+### environment
+
+> **environment**: `string`
+
+### external_sub?
+
+> `optional` **external_sub?**: `string`
+
+### iss
+
+> **iss**: `string`
+
+### owner_id
+
+> **owner_id**: `string`
+
+### project_id
+
+> **project_id**: `string`
+
+### sub
+
+> **sub**: `string`

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "@vercel/cli-config": "workspace:*",
-    "@vercel/cli-exec": "workspace:*"
+    "@vercel/cli-exec": "workspace:*",
+    "jose": "^5.9.6"
   },
   "devDependencies": {
     "prettier": "3.8.3",

--- a/packages/oidc/src/index-browser.ts
+++ b/packages/oidc/src/index-browser.ts
@@ -1,5 +1,9 @@
 export { getContext } from './get-context';
 export {
+  verifyVercelOidcToken,
+  type VercelOidcPayload,
+} from './verify-vercel-oidc-token';
+export {
   AccessTokenMissingError,
   RefreshAccessTokenFailedError,
 } from './auth-errors';

--- a/packages/oidc/src/index-edge-light.ts
+++ b/packages/oidc/src/index-edge-light.ts
@@ -2,6 +2,10 @@ import { getVercelOidcTokenSync } from './get-vercel-oidc-token-sync';
 
 export { getContext } from './get-context';
 export {
+  verifyVercelOidcToken,
+  type VercelOidcPayload,
+} from './verify-vercel-oidc-token';
+export {
   AccessTokenMissingError,
   RefreshAccessTokenFailedError,
 } from './auth-errors';

--- a/packages/oidc/src/index.ts
+++ b/packages/oidc/src/index.ts
@@ -2,6 +2,10 @@ export { getVercelOidcToken } from './get-vercel-oidc-token-with-refresh';
 export { getVercelOidcTokenSync } from './get-vercel-oidc-token-sync';
 export { getContext } from './get-context';
 export {
+  verifyVercelOidcToken,
+  type VercelOidcPayload,
+} from './verify-vercel-oidc-token';
+export {
   AccessTokenMissingError,
   RefreshAccessTokenFailedError,
 } from './auth-errors';

--- a/packages/oidc/src/verify-vercel-oidc-token.test.ts
+++ b/packages/oidc/src/verify-vercel-oidc-token.test.ts
@@ -1,0 +1,321 @@
+import { describe, afterEach, beforeEach, test, vi, expect } from 'vitest';
+import { jwtVerify } from 'jose';
+import { verifyVercelOidcToken } from './verify-vercel-oidc-token';
+
+const mocks = vi.hoisted(() => {
+  const remoteJwks = vi.fn();
+
+  return {
+    remoteJwks,
+    createRemoteJWKSet: vi.fn(() => remoteJwks),
+    jwtVerify: vi.fn(),
+  };
+});
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: mocks.createRemoteJWKSet,
+  jwtVerify: mocks.jwtVerify,
+}));
+
+describe('verifyVercelOidcToken', () => {
+  const verifyResult = {
+    payload: {
+      sub: 'owner:team1:project:site:environment:production',
+      iss: 'https://oidc.vercel.com/team1',
+      aud: 'https://oidc.vercel.com/team1',
+      project_id: 'prj_test',
+      environment: 'production',
+      owner_id: 'team_team1',
+    },
+    protectedHeader: {
+      alg: 'RS256',
+    },
+  };
+
+  beforeEach(() => {
+    process.env.VERCEL_PROJECT_ID = 'prj_test';
+    process.env.VERCEL_TARGET_ENV = 'production';
+    delete process.env.VERCEL_ENV;
+
+    vi.mocked(jwtVerify).mockClear();
+    mockVerifiedPayload();
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_PROJECT_ID;
+    delete process.env.VERCEL_TARGET_ENV;
+    delete process.env.VERCEL_ENV;
+  });
+
+  test('verifies a token using the Vercel issuer and JWKS', async () => {
+    const result = await verifyVercelOidcToken('token', {
+      audience: 'https://oidc.vercel.com/team1',
+      subject: 'owner:team1:project:site:environment:production',
+    });
+
+    expect(result).toStrictEqual(verifyResult);
+    expect(jwtVerify).toHaveBeenCalledWith('token', mocks.remoteJwks, {
+      algorithms: ['RS256'],
+      audience: 'https://oidc.vercel.com/team1',
+      subject: 'owner:team1:project:site:environment:production',
+    });
+  });
+
+  test('verifies a token without additional options', async () => {
+    await verifyVercelOidcToken('token');
+
+    expect(jwtVerify).toHaveBeenCalledWith('token', mocks.remoteJwks, {
+      algorithms: ['RS256'],
+    });
+  });
+
+  test('reuses the Vercel remote JWKS resolver', async () => {
+    await verifyVercelOidcToken('first-token');
+    await verifyVercelOidcToken('second-token');
+
+    expect(mocks.createRemoteJWKSet).toHaveBeenCalledTimes(1);
+    expect(jwtVerify).toHaveBeenCalledTimes(2);
+  });
+
+  test('passes custom algorithms to Jose verification', async () => {
+    await verifyVercelOidcToken('token', {
+      algorithms: ['RS512'],
+    });
+
+    expect(jwtVerify).toHaveBeenCalledWith('token', mocks.remoteJwks, {
+      algorithms: ['RS512'],
+    });
+  });
+
+  test('accepts a team issuer by default', async () => {
+    await verifyVercelOidcToken('token');
+
+    expect(jwtVerify).toHaveBeenCalledTimes(1);
+  });
+
+  test('accepts the global issuer', async () => {
+    mockVerifiedPayload({
+      iss: 'https://oidc.vercel.com',
+    });
+
+    await verifyVercelOidcToken('token');
+
+    expect(jwtVerify).toHaveBeenCalledTimes(1);
+  });
+
+  test('accepts a matching explicit issuer option', async () => {
+    mockVerifiedPayload({
+      iss: 'https://oidc.vercel.com/acme',
+    });
+
+    await verifyVercelOidcToken('token', {
+      issuer: 'https://oidc.vercel.com/acme',
+    });
+
+    expect(jwtVerify).toHaveBeenCalledTimes(1);
+    expect(jwtVerify).toHaveBeenCalledWith('token', mocks.remoteJwks, {
+      algorithms: ['RS256'],
+      issuer: 'https://oidc.vercel.com/acme',
+    });
+  });
+
+  test('uses VERCEL_ENV when VERCEL_TARGET_ENV is missing', async () => {
+    delete process.env.VERCEL_TARGET_ENV;
+    process.env.VERCEL_ENV = 'production';
+
+    await verifyVercelOidcToken('token');
+
+    expect(jwtVerify).toHaveBeenCalledTimes(1);
+  });
+
+  test('accepts custom projectId and environment options', async () => {
+    mockVerifiedPayload({
+      project_id: 'prj_custom',
+      environment: 'preview',
+    });
+
+    const result = await verifyVercelOidcToken('token', {
+      projectId: 'prj_custom',
+      environment: 'preview',
+    });
+
+    expect(result.payload.project_id).toBe('prj_custom');
+    expect(result.payload.environment).toBe('preview');
+  });
+
+  test('accepts a matching ownerId option', async () => {
+    const result = await verifyVercelOidcToken('token', {
+      ownerId: 'team_team1',
+    });
+
+    expect(result.payload.owner_id).toBe('team_team1');
+  });
+
+  test('does not require ownerId by default', async () => {
+    mockVerifiedPayload({
+      owner_id: 'team_other',
+    });
+
+    await verifyVercelOidcToken('token');
+
+    expect(jwtVerify).toHaveBeenCalledTimes(1);
+  });
+
+  test('allows any project_id claim with projectId wildcard', async () => {
+    mockVerifiedPayload({
+      project_id: 'prj_other',
+    });
+
+    await verifyVercelOidcToken('token', {
+      projectId: '*',
+      ownerId: 'team_team1',
+    });
+
+    expect(jwtVerify).toHaveBeenCalledTimes(1);
+  });
+
+  test('allows projectId wildcard with audience verification', async () => {
+    mockVerifiedPayload({
+      project_id: 'prj_other',
+    });
+
+    await verifyVercelOidcToken('token', {
+      projectId: '*',
+      audience: 'https://oidc.vercel.com/team1',
+    });
+
+    expect(jwtVerify).toHaveBeenCalledWith('token', mocks.remoteJwks, {
+      algorithms: ['RS256'],
+      audience: 'https://oidc.vercel.com/team1',
+    });
+  });
+
+  test('requires ownerId or audience when projectId wildcard is used', async () => {
+    await expect(
+      verifyVercelOidcToken('token', {
+        projectId: '*',
+      })
+    ).rejects.toThrow(
+      "Expected ownerId or audience to be provided when projectId is '*'."
+    );
+    expect(jwtVerify).not.toHaveBeenCalled();
+  });
+
+  test('requires ownerId or a non-empty audience when projectId wildcard is used', async () => {
+    await expect(
+      verifyVercelOidcToken('token', {
+        projectId: '*',
+        audience: [],
+      })
+    ).rejects.toThrow(
+      "Expected ownerId or audience to be provided when projectId is '*'."
+    );
+    expect(jwtVerify).not.toHaveBeenCalled();
+  });
+
+  test('allows any environment claim with environment wildcard', async () => {
+    mockVerifiedPayload({
+      environment: 'preview',
+    });
+
+    await verifyVercelOidcToken('token', {
+      environment: '*',
+    });
+
+    expect(jwtVerify).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects a token from a different project', async () => {
+    mockVerifiedPayload({
+      project_id: 'prj_other',
+    });
+
+    await expect(verifyVercelOidcToken('token')).rejects.toThrow(
+      'Expected Vercel OIDC token project_id claim to be "prj_test".'
+    );
+  });
+
+  test('rejects a token from a different owner', async () => {
+    mockVerifiedPayload({
+      owner_id: 'team_other',
+    });
+
+    await expect(
+      verifyVercelOidcToken('token', {
+        ownerId: 'team_team1',
+      })
+    ).rejects.toThrow(
+      'Expected Vercel OIDC token owner_id claim to be "team_team1".'
+    );
+  });
+
+  test('rejects a token from a non-Vercel issuer', async () => {
+    mockVerifiedPayload({
+      iss: 'https://example.com',
+    });
+
+    await expect(verifyVercelOidcToken('token')).rejects.toThrow(
+      'Expected Vercel OIDC token iss claim to be "https://oidc.vercel.com" or to start with "https://oidc.vercel.com/".'
+    );
+  });
+
+  test('passes explicit issuer option to Jose verification', async () => {
+    await verifyVercelOidcToken('token', {
+      issuer: 'https://oidc.vercel.com/other-team',
+    });
+
+    expect(jwtVerify).toHaveBeenCalledWith('token', mocks.remoteJwks, {
+      algorithms: ['RS256'],
+      issuer: 'https://oidc.vercel.com/other-team',
+    });
+  });
+
+  test('rejects a token from an issuer that only shares the prefix text', async () => {
+    mockVerifiedPayload({
+      iss: 'https://oidc.vercel.com.evil.example',
+    });
+
+    await expect(verifyVercelOidcToken('token')).rejects.toThrow(
+      'Expected Vercel OIDC token iss claim to be "https://oidc.vercel.com" or to start with "https://oidc.vercel.com/".'
+    );
+  });
+
+  test('rejects a token from a different environment', async () => {
+    mockVerifiedPayload({
+      environment: 'preview',
+    });
+
+    await expect(verifyVercelOidcToken('token')).rejects.toThrow(
+      'Expected Vercel OIDC token environment claim to be "production".'
+    );
+  });
+
+  test('requires a projectId default or wildcard', async () => {
+    delete process.env.VERCEL_PROJECT_ID;
+
+    await expect(verifyVercelOidcToken('token')).rejects.toThrow(
+      "Expected VERCEL_PROJECT_ID to be set or projectId to be provided. Pass projectId: '*' to allow any project_id claim."
+    );
+  });
+
+  test('requires an environment default or wildcard', async () => {
+    delete process.env.VERCEL_TARGET_ENV;
+    delete process.env.VERCEL_ENV;
+
+    await expect(verifyVercelOidcToken('token')).rejects.toThrow(
+      "Expected VERCEL_TARGET_ENV or VERCEL_ENV to be set or environment to be provided. Pass environment: '*' to allow any environment claim."
+    );
+  });
+
+  function mockVerifiedPayload(
+    payload?: Partial<typeof verifyResult.payload>
+  ): void {
+    vi.mocked(jwtVerify).mockResolvedValue({
+      ...verifyResult,
+      payload: {
+        ...verifyResult.payload,
+        ...payload,
+      },
+    } as Awaited<ReturnType<typeof jwtVerify>>);
+  }
+});

--- a/packages/oidc/src/verify-vercel-oidc-token.test.ts
+++ b/packages/oidc/src/verify-vercel-oidc-token.test.ts
@@ -143,6 +143,18 @@ describe('verifyVercelOidcToken', () => {
     expect(result.payload.environment).toBe('preview');
   });
 
+  test('accepts a matching projectId array option', async () => {
+    mockVerifiedPayload({
+      project_id: 'prj_allowed',
+    });
+
+    const result = await verifyVercelOidcToken('token', {
+      projectId: ['prj_first', 'prj_allowed'],
+    });
+
+    expect(result.payload.project_id).toBe('prj_allowed');
+  });
+
   test('accepts a matching ownerId option', async () => {
     const result = await verifyVercelOidcToken('token', {
       ownerId: 'team_team1',
@@ -225,6 +237,18 @@ describe('verifyVercelOidcToken', () => {
     expect(jwtVerify).toHaveBeenCalledTimes(1);
   });
 
+  test('accepts a matching environment array option', async () => {
+    mockVerifiedPayload({
+      environment: 'preview',
+    });
+
+    const result = await verifyVercelOidcToken('token', {
+      environment: ['production', 'preview'],
+    });
+
+    expect(result.payload.environment).toBe('preview');
+  });
+
   test('rejects a token from a different project', async () => {
     mockVerifiedPayload({
       project_id: 'prj_other',
@@ -232,6 +256,30 @@ describe('verifyVercelOidcToken', () => {
 
     await expect(verifyVercelOidcToken('token')).rejects.toThrow(
       'Expected Vercel OIDC token project_id claim to be "prj_test".'
+    );
+  });
+
+  test('rejects a token from a project outside the projectId array', async () => {
+    mockVerifiedPayload({
+      project_id: 'prj_other',
+    });
+
+    await expect(
+      verifyVercelOidcToken('token', {
+        projectId: ['prj_first', 'prj_second'],
+      })
+    ).rejects.toThrow(
+      'Expected Vercel OIDC token project_id claim to be one of: "prj_first", "prj_second".'
+    );
+  });
+
+  test('requires a non-empty projectId array', async () => {
+    await expect(
+      verifyVercelOidcToken('token', {
+        projectId: [],
+      })
+    ).rejects.toThrow(
+      "Expected VERCEL_PROJECT_ID to be set or projectId to be provided. Pass projectId: '*' to allow any project_id claim."
     );
   });
 
@@ -290,6 +338,20 @@ describe('verifyVercelOidcToken', () => {
     );
   });
 
+  test('rejects a token from an environment outside the environment array', async () => {
+    mockVerifiedPayload({
+      environment: 'preview',
+    });
+
+    await expect(
+      verifyVercelOidcToken('token', {
+        environment: ['production', 'development'],
+      })
+    ).rejects.toThrow(
+      'Expected Vercel OIDC token environment claim to be one of: "production", "development".'
+    );
+  });
+
   test('requires a projectId default or wildcard', async () => {
     delete process.env.VERCEL_PROJECT_ID;
 
@@ -303,6 +365,16 @@ describe('verifyVercelOidcToken', () => {
     delete process.env.VERCEL_ENV;
 
     await expect(verifyVercelOidcToken('token')).rejects.toThrow(
+      "Expected VERCEL_TARGET_ENV or VERCEL_ENV to be set or environment to be provided. Pass environment: '*' to allow any environment claim."
+    );
+  });
+
+  test('requires a non-empty environment array', async () => {
+    await expect(
+      verifyVercelOidcToken('token', {
+        environment: [],
+      })
+    ).rejects.toThrow(
       "Expected VERCEL_TARGET_ENV or VERCEL_ENV to be set or environment to be provided. Pass environment: '*' to allow any environment claim."
     );
   });

--- a/packages/oidc/src/verify-vercel-oidc-token.test.ts
+++ b/packages/oidc/src/verify-vercel-oidc-token.test.ts
@@ -316,6 +316,6 @@ describe('verifyVercelOidcToken', () => {
         ...verifyResult.payload,
         ...payload,
       },
-    } as Awaited<ReturnType<typeof jwtVerify>>);
+    } as unknown as Awaited<ReturnType<typeof jwtVerify>>);
   }
 });

--- a/packages/oidc/src/verify-vercel-oidc-token.ts
+++ b/packages/oidc/src/verify-vercel-oidc-token.ts
@@ -35,12 +35,13 @@ export type VercelOidcPayload = JWTPayload & {
  * - `issuer`: Expected `iss` claim verified by Jose. The verified issuer must
  *   still be `https://oidc.vercel.com` or start with
  *   `https://oidc.vercel.com/`.
- * - `projectId`: Expected `project_id` claim. Defaults to
- *   `process.env.VERCEL_PROJECT_ID`. Pass `'*'` to allow any project ID. When
- *   `projectId` is `'*'`, either `ownerId` or `audience` is required.
- * - `environment`: Expected `environment` claim. Defaults to
- *   `process.env.VERCEL_TARGET_ENV || process.env.VERCEL_ENV`. Pass `'*'` to
- *   allow any environment.
+ * - `projectId`: Expected `project_id` claim or claims. Defaults to
+ *   `process.env.VERCEL_PROJECT_ID`. Pass an array to allow any matching
+ *   project ID. Pass `'*'` to allow any project ID. When `projectId` is `'*'`,
+ *   either `ownerId` or `audience` is required.
+ * - `environment`: Expected `environment` claim or claims. Defaults to
+ *   `process.env.VERCEL_TARGET_ENV || process.env.VERCEL_ENV`. Pass an array
+ *   to allow any matching environment. Pass `'*'` to allow any environment.
  * - `ownerId`: Expected `owner_id` claim. When omitted, the claim is not
  *   checked.
  * - Any other Jose JWT verification option.
@@ -52,8 +53,8 @@ export type VercelOidcPayload = JWTPayload & {
 export async function verifyVercelOidcToken<PayloadType = VercelOidcPayload>(
   token: string,
   options?: {
-    projectId?: string;
-    environment?: string;
+    projectId?: string | string[] | '*';
+    environment?: string | string[] | '*';
     ownerId?: string;
   } & JWTVerifyOptions
 ): Promise<JWTVerifyResult<PayloadType>> {
@@ -131,22 +132,32 @@ function validateClaim({
   actual: unknown;
   claim: string;
   env: string;
-  expected: string | undefined;
+  expected: string | string[] | undefined;
   option: string;
 }): void {
   if (expected === '*') {
     return;
   }
 
-  if (!expected) {
+  if (expected === undefined || expected.length === 0) {
     throw new TypeError(
       `Expected ${env} to be set or ${option} to be provided. Pass ${option}: '*' to allow any ${claim} claim.`
     );
   }
 
+  if (
+    Array.isArray(expected) &&
+    typeof actual === 'string' &&
+    expected.includes(actual)
+  ) {
+    return;
+  }
+
   if (actual !== expected) {
     throw new TypeError(
-      `Expected Vercel OIDC token ${claim} claim to be "${expected}".`
+      Array.isArray(expected)
+        ? `Expected Vercel OIDC token ${claim} claim to be one of: ${expected.map(value => `"${value}"`).join(', ')}.`
+        : `Expected Vercel OIDC token ${claim} claim to be "${expected}".`
     );
   }
 }

--- a/packages/oidc/src/verify-vercel-oidc-token.ts
+++ b/packages/oidc/src/verify-vercel-oidc-token.ts
@@ -1,0 +1,172 @@
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTVerifyOptions,
+  type JWTVerifyResult,
+  type JWTPayload,
+} from 'jose';
+
+const VERCEL_OIDC_ISSUER = 'https://oidc.vercel.com';
+const VERCEL_OIDC_JWKS_URL = new URL(
+  'https://oidc.vercel.com/.well-known/jwks'
+);
+const DEFAULT_ALGORITHMS = ['RS256'];
+const VERCEL_OIDC_JWKS = createRemoteJWKSet(VERCEL_OIDC_JWKS_URL);
+
+export type VercelOidcPayload = JWTPayload & {
+  owner_id: string;
+  project_id: string;
+  environment: string;
+  external_sub?: string;
+  sub: string;
+  aud: string;
+  iss: string;
+};
+
+/**
+ * Verifies a Vercel OIDC token against Vercel's remote JWKS.
+ *
+ * The issuer must be `https://oidc.vercel.com` or start with
+ * `https://oidc.vercel.com/`. The JWKS is always
+ * `https://oidc.vercel.com/.well-known/jwks`.
+ *
+ * Options:
+ *
+ * - `issuer`: Expected `iss` claim verified by Jose. The verified issuer must
+ *   still be `https://oidc.vercel.com` or start with
+ *   `https://oidc.vercel.com/`.
+ * - `projectId`: Expected `project_id` claim. Defaults to
+ *   `process.env.VERCEL_PROJECT_ID`. Pass `'*'` to allow any project ID. When
+ *   `projectId` is `'*'`, either `ownerId` or `audience` is required.
+ * - `environment`: Expected `environment` claim. Defaults to
+ *   `process.env.VERCEL_TARGET_ENV || process.env.VERCEL_ENV`. Pass `'*'` to
+ *   allow any environment.
+ * - `ownerId`: Expected `owner_id` claim. When omitted, the claim is not
+ *   checked.
+ * - Any other Jose JWT verification option.
+ *
+ * @param token The Vercel OIDC token to verify.
+ * @param options Optional Jose JWT verification options.
+ * @returns Jose's verified JWT result.
+ */
+export async function verifyVercelOidcToken<PayloadType = VercelOidcPayload>(
+  token: string,
+  options?: {
+    projectId?: string;
+    environment?: string;
+    ownerId?: string;
+  } & JWTVerifyOptions
+): Promise<JWTVerifyResult<PayloadType>> {
+  const {
+    algorithms,
+    projectId = process.env.VERCEL_PROJECT_ID,
+    environment = process.env.VERCEL_TARGET_ENV || process.env.VERCEL_ENV,
+    ownerId,
+    ...verifyOptions
+  } = options ?? {};
+
+  if (
+    projectId === '*' &&
+    ownerId === undefined &&
+    !hasAudienceVerification(verifyOptions.audience)
+  ) {
+    throw new TypeError(
+      "Expected ownerId or audience to be provided when projectId is '*'."
+    );
+  }
+
+  const result = await jwtVerify<PayloadType>(token, VERCEL_OIDC_JWKS, {
+    ...verifyOptions,
+    algorithms: algorithms ?? DEFAULT_ALGORITHMS,
+  });
+
+  validateIssuer(result.payload.iss);
+  validateClaim({
+    actual: result.payload.project_id,
+    claim: 'project_id',
+    env: 'VERCEL_PROJECT_ID',
+    expected: projectId,
+    option: 'projectId',
+  });
+  validateClaim({
+    actual: result.payload.environment,
+    claim: 'environment',
+    env: 'VERCEL_TARGET_ENV or VERCEL_ENV',
+    expected: environment,
+    option: 'environment',
+  });
+  validateOptionalClaim({
+    actual: result.payload.owner_id,
+    claim: 'owner_id',
+    expected: ownerId,
+  });
+
+  return result;
+}
+
+function hasAudienceVerification(
+  audience: JWTVerifyOptions['audience']
+): boolean {
+  return Array.isArray(audience) ? audience.length > 0 : audience !== undefined;
+}
+
+function validateIssuer(actual: unknown): void {
+  if (
+    actual !== VERCEL_OIDC_ISSUER &&
+    (typeof actual !== 'string' || !actual.startsWith(`${VERCEL_OIDC_ISSUER}/`))
+  ) {
+    throw new TypeError(
+      `Expected Vercel OIDC token iss claim to be "${VERCEL_OIDC_ISSUER}" or to start with "${VERCEL_OIDC_ISSUER}/".`
+    );
+  }
+}
+
+function validateClaim({
+  actual,
+  claim,
+  env,
+  expected,
+  option,
+}: {
+  actual: unknown;
+  claim: string;
+  env: string;
+  expected: string | undefined;
+  option: string;
+}): void {
+  if (expected === '*') {
+    return;
+  }
+
+  if (!expected) {
+    throw new TypeError(
+      `Expected ${env} to be set or ${option} to be provided. Pass ${option}: '*' to allow any ${claim} claim.`
+    );
+  }
+
+  if (actual !== expected) {
+    throw new TypeError(
+      `Expected Vercel OIDC token ${claim} claim to be "${expected}".`
+    );
+  }
+}
+
+function validateOptionalClaim({
+  actual,
+  claim,
+  expected,
+}: {
+  actual: unknown;
+  claim: string;
+  expected: string | undefined;
+}): void {
+  if (expected === undefined) {
+    return;
+  }
+
+  if (actual !== expected) {
+    throw new TypeError(
+      `Expected Vercel OIDC token ${claim} claim to be "${expected}".`
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1957,6 +1957,9 @@ importers:
       '@vercel/cli-exec':
         specifier: workspace:*
         version: link:../cli-exec
+      jose:
+        specifier: ^5.9.6
+        version: 5.9.6
     devDependencies:
       prettier:
         specifier: 3.8.3


### PR DESCRIPTION
## Summary
- add verifyVercelOidcToken using Jose remote JWKS verification
- validate Vercel issuer shape, project_id, environment, and optional owner_id claims
- export the verifier and payload type across oidc entrypoints, with docs and changeset

## Tests
- pnpm --filter @vercel/oidc exec vitest run src/verify-vercel-oidc-token.test.ts
- pnpm --filter @vercel/oidc exec tsc --noEmit --pretty false --skipLibCheck --target ES2021 --module commonjs --moduleResolution node --lib ES2021,DOM,DOM.Iterable src/verify-vercel-oidc-token.ts