### PR TITLE
Preserve generated services config

### DIFF
--- a/.changeset/preserve-generated-services.md
+++ b/.changeset/preserve-generated-services.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Preserve generated experimental services when builder output config files already contain services.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -402,7 +402,6 @@ export default async function main(client: Client): Promise<number> {
     project = await readProjectSettings(vercelDir);
   }
 
-  // Delete output directory from potential previous build
   const defaultOutputDir = join(cwd, projectRootDirectory, OUTPUT_DIR);
   const outputDir = parsedArgs.flags['--output']
     ? resolve(parsedArgs.flags['--output'])
@@ -1481,20 +1480,16 @@ async function doBuild(
               if (outputConfig instanceof CantParseJSONFile) {
                 throw outputConfig;
               }
-              if (
-                hasNonEmptyObject(outputConfig?.experimentalServices) &&
-                !hasNonEmptyObject(buildOutputConfig.experimentalServices)
-              ) {
-                buildOutputConfig.experimentalServices =
-                  outputConfig.experimentalServices;
-              }
-              if (
-                hasNonEmptyObject(outputConfig?.experimentalServicesV2) &&
-                !hasNonEmptyObject(buildOutputConfig.experimentalServicesV2)
-              ) {
-                buildOutputConfig.experimentalServicesV2 =
-                  outputConfig.experimentalServicesV2;
-              }
+              buildOutputConfig.experimentalServices =
+                getGeneratedExperimentalServicesV1Config([
+                  outputConfig,
+                  buildOutputConfig,
+                ]);
+              buildOutputConfig.experimentalServicesV2 =
+                getGeneratedExperimentalServicesV2Config([
+                  outputConfig,
+                  buildOutputConfig,
+                ]);
               if (
                 hasNonEmptyObject(buildOutputConfig.experimentalServices) ||
                 hasNonEmptyObject(buildOutputConfig.experimentalServicesV2)
@@ -2572,31 +2567,33 @@ function getExperimentalServicesV2Routes(
 function getGeneratedExperimentalServicesV1Config(
   buildResults: Iterable<BuildResult | BuildOutputConfig | null | undefined>
 ): ExperimentalServices | undefined {
+  const merged: ExperimentalServices = {};
   for (const result of buildResults) {
     if (
       result &&
       'experimentalServices' in result &&
       hasNonEmptyObject(result.experimentalServices)
     ) {
-      return result.experimentalServices;
+      Object.assign(merged, result.experimentalServices);
     }
   }
-  return undefined;
+  return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
 function getGeneratedExperimentalServicesV2Config(
   buildResults: Iterable<BuildResult | BuildOutputConfig | null | undefined>
 ): ExperimentalServicesV2 | undefined {
+  const merged: ExperimentalServicesV2 = {};
   for (const result of buildResults) {
     if (
       result &&
       'experimentalServicesV2' in result &&
       hasNonEmptyObject(result.experimentalServicesV2)
     ) {
-      return result.experimentalServicesV2;
+      Object.assign(merged, result.experimentalServicesV2);
     }
   }
-  return undefined;
+  return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
 async function mergeDeploymentId(

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -2810,6 +2810,105 @@ createServer((_req, res) => {
     ).toBe(true);
   });
 
+  it('should preserve generated experimentalServices when builder output config already has services', async () => {
+    const cwd = await getWriteableDirectory();
+    const appDir = join(cwd, 'app');
+    const output = join(cwd, '.vercel', 'output');
+    await fs.ensureDir(join(cwd, '.vercel'));
+    await fs.writeJSON(join(cwd, '.vercel', 'project.json'), {
+      orgId: '.',
+      projectId: '.',
+      settings: {
+        framework: null,
+        installCommand: '',
+        rootDirectory: 'app',
+      },
+    });
+    await fs.outputJSON(join(appDir, 'package.json'), {
+      scripts: {
+        build: 'node build.mjs',
+      },
+    });
+    await fs.outputFile(
+      join(appDir, 'build.mjs'),
+      `
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const rootOutputDir = join(process.cwd(), '..', '.vercel', 'output');
+mkdirSync(rootOutputDir, { recursive: true });
+writeFileSync(
+  join(rootOutputDir, 'config.json'),
+  JSON.stringify({
+    version: 3,
+    experimentalServices: {
+      worker: {
+        type: 'job',
+        trigger: 'queue',
+        root: '.',
+        entrypoint: 'worker.js',
+        runtime: 'node',
+        topics: ['jobs']
+      }
+    }
+  }, null, 2)
+);
+
+const appOutputDir = join(process.cwd(), '.vercel', 'output');
+mkdirSync(join(appOutputDir, 'static'), { recursive: true });
+writeFileSync(join(appOutputDir, 'static', 'index.html'), 'ok');
+writeFileSync(
+  join(appOutputDir, 'config.json'),
+  JSON.stringify({
+    version: 3,
+    experimentalServices: {
+      web: {
+        type: 'web',
+        root: '.',
+        framework: 'vite',
+        entrypoint: '.',
+        mount: '/'
+      }
+    }
+  }, null, 2)
+);
+`
+    );
+    await fs.outputFile(
+      join(appDir, 'worker.js'),
+      `
+module.exports = (_req, res) => {
+  res.end('ok');
+};
+`
+    );
+
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toBe(0);
+
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config.experimentalServices).toEqual({
+      web: expect.objectContaining({
+        type: 'web',
+        framework: 'vite',
+        entrypoint: '.',
+        mount: '/',
+      }),
+      worker: expect.objectContaining({
+        type: 'job',
+        trigger: 'queue',
+        entrypoint: 'worker.js',
+      }),
+    });
+    expect(config.services).toBeUndefined();
+    expect(
+      await fs.pathExists(
+        join(output, 'functions/_svc/worker/index.func/.vc-config.json')
+      )
+    ).toBe(true);
+  });
+
   it('should build experimentalServicesV2 discovered from generated Build Output config into service directories', async () => {
     const cwd = await getWriteableDirectory();
     const output = join(cwd, '.vercel', 'output');


### PR DESCRIPTION
## Summary

- Merge generated `experimentalServices` maps instead of treating the first non-empty map as complete.
- Preserve generated services written to the shared output config when a builder output config also contains generated services.
- Add regression coverage for preserving generated service config during builder output merges.

## Tests

- `pnpm exec vitest run packages/cli/test/unit/commands/build/index.test.ts -t "generated Build Output config|builder output config already has services"`
- `pnpm --filter vercel type-check`
- `pnpm exec prettier --check packages/cli/src/commands/build/index.ts packages/cli/test/unit/commands/build/index.test.ts .changeset/preserve-generated-services.md`
- `git diff --check`