### PR TITLE
[static-build] Warn to upgrade @lovable.dev/vite-tanstack-config when no Build Output API detected

### DIFF
--- a/.changeset/lovable-config-upgrade-warning.md
+++ b/.changeset/lovable-config-upgrade-warning.md
@@ -1,0 +1,5 @@
+---
+'@vercel/static-build': patch
+---
+
+Warn when `@lovable.dev/vite-tanstack-config` is a dependency but no valid Build Output API directory was produced, prompting the user to upgrade `@lovable.dev/vite-tanstack-config` and `nitro` to compatible versions.

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -809,6 +809,23 @@ export const build: BuildV2 = async ({
         return await BuildOutputV2.createBuildOutput(workPath);
       }
 
+      // At this point neither the Build Output v3 nor v2 API produced output.
+      // If the project depends on `@lovable.dev/vite-tanstack-config`, this
+      // most likely means an outdated version that doesn't emit Build Output
+      // API artifacts is installed, so warn the user to upgrade.
+      if (pkg) {
+        const allDependencies = Object.assign(
+          {},
+          pkg.dependencies,
+          pkg.devDependencies
+        );
+        if (allDependencies['@lovable.dev/vite-tanstack-config']) {
+          console.warn(
+            'WARN: Upgrade @lovable.dev/vite-tanstack-config to ^2.3.2 and nitro to 3.0.260603-beta (or newer)'
+          );
+        }
+      }
+
       const extraOutputs = await BuildOutputV1.readBuildOutputDirectory({
         workPath,
         nodeVersion,


### PR DESCRIPTION
When the static builder detects `@lovable.dev/vite-tanstack-config` as a dependency **and** neither the Build Output API v3 nor v2 produced valid output, print a warning telling the user to upgrade.

### Behavior

After both `BuildOutputV3.getBuildOutputDirectory` and `BuildOutputV2.getBuildOutputDirectory` return no output, if the project's `package.json` lists `@lovable.dev/vite-tanstack-config` in `dependencies` or `devDependencies`, we emit:

```
WARN: Upgrade @lovable.dev/vite-tanstack-config to ^2.3.2 and nitro to 3.0.260603-beta (or newer)
```

This is a no-op when a valid Build Output API directory is produced.

### Changes
- `packages/static-build/src/index.ts` — add the dependency check + warning after the v2 fallthrough.
- Changeset (`@vercel/static-build` patch).