### PR TITLE
feat(build-utils): gate client-side maxDuration upper bound behind env var

### DIFF
--- a/.changeset/extended-max-duration-flag.md
+++ b/.changeset/extended-max-duration-flag.md
@@ -4,4 +4,4 @@
 'vercel': patch
 ---
 
-Gate the client-side 900-second `maxDuration` upper bound behind the `VERCEL_ALLOW_EXTENDED_MAX_DURATION` environment variable. The limit is now owned by a single helper in `@vercel/build-utils` instead of being hardcoded in multiple validators. When the variable is set to `1`, the client-side maximum is dropped and validation defers to the server, so the limit can be raised centrally without requiring a CLI upgrade. Default behavior is unchanged — the lower bound and integer checks are always enforced.
+Gate the client-side 900-second `maxDuration` upper bound behind the `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` environment variable. The limit is now owned by a single helper in `@vercel/build-utils` instead of being hardcoded in multiple validators. When the variable is set to `1`, the client-side maximum is skipped and validation defers to the server. Default behavior is unchanged — the maximum, the lower bound, and the integer check are all still enforced when the variable is unset.

--- a/.changeset/extended-max-duration-flag.md
+++ b/.changeset/extended-max-duration-flag.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': patch
+'@vercel/fs-detectors': patch
+'vercel': patch
+---
+
+Gate the client-side 900-second `maxDuration` upper bound behind the `VERCEL_ALLOW_EXTENDED_MAX_DURATION` environment variable. The limit is now owned by a single helper in `@vercel/build-utils` instead of being hardcoded in multiple validators. When the variable is set to `1`, the client-side maximum is dropped and validation defers to the server, so the limit can be raised centrally without requiring a CLI upgrade. Default behavior is unchanged — the lower bound and integer checks are always enforced.

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -142,6 +142,12 @@ export { getOsRelease, getProvidedRuntime } from './os';
 
 export * from './should-serve';
 export * from './schemas';
+export {
+  DEFAULT_MAX_DURATION_LIMIT,
+  ALLOW_EXTENDED_MAX_DURATION_ENV,
+  getMaxDurationLimit,
+  getMaxDurationSchema,
+} from './max-duration';
 export * from './package-manifest';
 export { generateProjectManifest } from './node-diagnostics';
 export * from './types';

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -144,7 +144,7 @@ export * from './should-serve';
 export * from './schemas';
 export {
   DEFAULT_MAX_DURATION_LIMIT,
-  ALLOW_EXTENDED_MAX_DURATION_ENV,
+  SKIP_MAX_DURATION_LIMIT_ENV,
   getMaxDurationLimit,
   getMaxDurationSchema,
 } from './max-duration';

--- a/packages/build-utils/src/max-duration.ts
+++ b/packages/build-utils/src/max-duration.ts
@@ -1,0 +1,58 @@
+/**
+ * Vercel Functions have historically had a hard timeout limit of 900 seconds
+ * (15 minutes), which has long doubled as the client-side upper bound for
+ * `maxDuration` in `vercel.json` and zero-config function detection.
+ *
+ * The authoritative limit is plan-aware and enforced server-side (vercel/api):
+ * it varies by billing plan and compute mode (e.g. Fluid, Active CPU). The CLI
+ * and `@vercel/build-utils` cannot know any of that at build time, so this
+ * client-side bound is intentionally coarse — it exists only to give fast local
+ * feedback on obviously-invalid values.
+ */
+export const DEFAULT_MAX_DURATION_LIMIT = 900;
+
+/**
+ * Internal env var used to opt out of the client-side `maxDuration` upper bound.
+ * When set to `'1'`, the CLI / build-utils stop enforcing the coarse
+ * {@link DEFAULT_MAX_DURATION_LIMIT} and defer entirely to the plan-aware
+ * server-side validation. This lets the platform raise the limit centrally
+ * (typically by setting the variable in the build environment) without
+ * requiring users to upgrade their CLI.
+ */
+export const ALLOW_EXTENDED_MAX_DURATION_ENV =
+  'VERCEL_ALLOW_EXTENDED_MAX_DURATION';
+
+/**
+ * Returns the client-side upper bound for `maxDuration` in seconds, or
+ * `undefined` when the bound is disabled via
+ * {@link ALLOW_EXTENDED_MAX_DURATION_ENV} (server-side validation governs the
+ * real limit in that case). The lower bound and integer checks are always
+ * enforced by callers regardless of this flag.
+ */
+export function getMaxDurationLimit(): number | undefined {
+  if (process.env[ALLOW_EXTENDED_MAX_DURATION_ENV] === '1') {
+    return undefined;
+  }
+  return DEFAULT_MAX_DURATION_LIMIT;
+}
+
+/**
+ * Returns the JSON Schema fragment used to validate a function's `maxDuration`
+ * in `vercel.json`. When the client-side upper bound is active the integer
+ * branch includes a `maximum`; when disabled via
+ * {@link ALLOW_EXTENDED_MAX_DURATION_ENV} the `maximum` is omitted so any
+ * positive integer passes schema validation and the server enforces the limit.
+ */
+export function getMaxDurationSchema() {
+  const limit = getMaxDurationLimit();
+  return {
+    oneOf: [
+      {
+        type: 'integer',
+        minimum: 1,
+        ...(limit !== undefined ? { maximum: limit } : {}),
+      },
+      { type: 'string', enum: ['max'] },
+    ],
+  };
+}

--- a/packages/build-utils/src/max-duration.ts
+++ b/packages/build-utils/src/max-duration.ts
@@ -3,34 +3,30 @@
  * (15 minutes), which has long doubled as the client-side upper bound for
  * `maxDuration` in `vercel.json` and zero-config function detection.
  *
- * The authoritative limit is plan-aware and enforced server-side (vercel/api):
- * it varies by billing plan and compute mode (e.g. Fluid, Active CPU). The CLI
- * and `@vercel/build-utils` cannot know any of that at build time, so this
- * client-side bound is intentionally coarse — it exists only to give fast local
- * feedback on obviously-invalid values.
+ * The authoritative limit is enforced by server-side validation at deploy time.
+ * The CLI and `@vercel/build-utils` cannot know that limit at build time, so
+ * this client-side bound is intentionally coarse — it exists only to give fast
+ * local feedback on obviously-invalid values.
  */
 export const DEFAULT_MAX_DURATION_LIMIT = 900;
 
 /**
- * Internal env var used to opt out of the client-side `maxDuration` upper bound.
- * When set to `'1'`, the CLI / build-utils stop enforcing the coarse
- * {@link DEFAULT_MAX_DURATION_LIMIT} and defer entirely to the plan-aware
- * server-side validation. This lets the platform raise the limit centrally
- * (typically by setting the variable in the build environment) without
- * requiring users to upgrade their CLI.
+ * Internal env var used to skip the client-side `maxDuration` upper-bound check.
+ * When set to `'1'`, the client-side maximum ({@link DEFAULT_MAX_DURATION_LIMIT})
+ * is not applied and validation defers to the server, so the limit can be
+ * adjusted centrally without requiring users to upgrade their CLI. The lower
+ * bound and integer checks are always enforced regardless of this flag.
  */
-export const ALLOW_EXTENDED_MAX_DURATION_ENV =
-  'VERCEL_ALLOW_EXTENDED_MAX_DURATION';
+export const SKIP_MAX_DURATION_LIMIT_ENV = 'VERCEL_CLI_SKIP_MAX_DURATION_LIMIT';
 
 /**
  * Returns the client-side upper bound for `maxDuration` in seconds, or
- * `undefined` when the bound is disabled via
- * {@link ALLOW_EXTENDED_MAX_DURATION_ENV} (server-side validation governs the
- * real limit in that case). The lower bound and integer checks are always
- * enforced by callers regardless of this flag.
+ * `undefined` when the bound is skipped via {@link SKIP_MAX_DURATION_LIMIT_ENV}
+ * (server-side validation governs the real limit in that case). The lower bound
+ * and integer checks are always enforced by callers regardless of this flag.
  */
 export function getMaxDurationLimit(): number | undefined {
-  if (process.env[ALLOW_EXTENDED_MAX_DURATION_ENV] === '1') {
+  if (process.env[SKIP_MAX_DURATION_LIMIT_ENV] === '1') {
     return undefined;
   }
   return DEFAULT_MAX_DURATION_LIMIT;
@@ -39,9 +35,9 @@ export function getMaxDurationLimit(): number | undefined {
 /**
  * Returns the JSON Schema fragment used to validate a function's `maxDuration`
  * in `vercel.json`. When the client-side upper bound is active the integer
- * branch includes a `maximum`; when disabled via
- * {@link ALLOW_EXTENDED_MAX_DURATION_ENV} the `maximum` is omitted so any
- * positive integer passes schema validation and the server enforces the limit.
+ * branch includes a `maximum`; when skipped via
+ * {@link SKIP_MAX_DURATION_LIMIT_ENV} the `maximum` is omitted so any positive
+ * integer passes schema validation and the server enforces the limit.
  */
 export function getMaxDurationSchema() {
   const limit = getMaxDurationLimit();

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -1,3 +1,5 @@
+import { getMaxDurationSchema } from './max-duration';
+
 const triggerEventSchemaV1 = {
   type: 'object',
   properties: {
@@ -92,12 +94,7 @@ export const functionsSchema = {
           minimum: 128,
           maximum: 10240,
         },
-        maxDuration: {
-          oneOf: [
-            { type: 'integer', minimum: 1, maximum: 900 },
-            { type: 'string', enum: ['max'] },
-          ],
-        },
+        maxDuration: getMaxDurationSchema(),
         regions: {
           type: 'array',
           items: {

--- a/packages/build-utils/test/unit.max-duration.test.ts
+++ b/packages/build-utils/test/unit.max-duration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
-  ALLOW_EXTENDED_MAX_DURATION_ENV,
+  SKIP_MAX_DURATION_LIMIT_ENV,
   DEFAULT_MAX_DURATION_LIMIT,
   getMaxDurationLimit,
   getMaxDurationSchema,
@@ -8,7 +8,7 @@ import {
 
 describe('getMaxDurationLimit', () => {
   afterEach(() => {
-    delete process.env[ALLOW_EXTENDED_MAX_DURATION_ENV];
+    delete process.env[SKIP_MAX_DURATION_LIMIT_ENV];
   });
 
   it('returns the default 900s limit when the flag is unset', () => {
@@ -17,19 +17,19 @@ describe('getMaxDurationLimit', () => {
   });
 
   it('returns undefined (no client-side limit) when the flag is enabled', () => {
-    process.env[ALLOW_EXTENDED_MAX_DURATION_ENV] = '1';
+    process.env[SKIP_MAX_DURATION_LIMIT_ENV] = '1';
     expect(getMaxDurationLimit()).toBeUndefined();
   });
 
   it('only opts out for the exact value "1"', () => {
-    process.env[ALLOW_EXTENDED_MAX_DURATION_ENV] = 'true';
+    process.env[SKIP_MAX_DURATION_LIMIT_ENV] = 'true';
     expect(getMaxDurationLimit()).toBe(DEFAULT_MAX_DURATION_LIMIT);
   });
 });
 
 describe('getMaxDurationSchema', () => {
   afterEach(() => {
-    delete process.env[ALLOW_EXTENDED_MAX_DURATION_ENV];
+    delete process.env[SKIP_MAX_DURATION_LIMIT_ENV];
   });
 
   it('includes a 900 maximum on the integer branch by default', () => {
@@ -43,7 +43,7 @@ describe('getMaxDurationSchema', () => {
   });
 
   it('omits the maximum (but keeps minimum/integer) when the flag is enabled', () => {
-    process.env[ALLOW_EXTENDED_MAX_DURATION_ENV] = '1';
+    process.env[SKIP_MAX_DURATION_LIMIT_ENV] = '1';
     const schema = getMaxDurationSchema();
     expect(schema).toEqual({
       oneOf: [

--- a/packages/build-utils/test/unit.max-duration.test.ts
+++ b/packages/build-utils/test/unit.max-duration.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ALLOW_EXTENDED_MAX_DURATION_ENV,
+  DEFAULT_MAX_DURATION_LIMIT,
+  getMaxDurationLimit,
+  getMaxDurationSchema,
+} from '../src/max-duration';
+
+describe('getMaxDurationLimit', () => {
+  afterEach(() => {
+    delete process.env[ALLOW_EXTENDED_MAX_DURATION_ENV];
+  });
+
+  it('returns the default 900s limit when the flag is unset', () => {
+    expect(getMaxDurationLimit()).toBe(DEFAULT_MAX_DURATION_LIMIT);
+    expect(DEFAULT_MAX_DURATION_LIMIT).toBe(900);
+  });
+
+  it('returns undefined (no client-side limit) when the flag is enabled', () => {
+    process.env[ALLOW_EXTENDED_MAX_DURATION_ENV] = '1';
+    expect(getMaxDurationLimit()).toBeUndefined();
+  });
+
+  it('only opts out for the exact value "1"', () => {
+    process.env[ALLOW_EXTENDED_MAX_DURATION_ENV] = 'true';
+    expect(getMaxDurationLimit()).toBe(DEFAULT_MAX_DURATION_LIMIT);
+  });
+});
+
+describe('getMaxDurationSchema', () => {
+  afterEach(() => {
+    delete process.env[ALLOW_EXTENDED_MAX_DURATION_ENV];
+  });
+
+  it('includes a 900 maximum on the integer branch by default', () => {
+    const schema = getMaxDurationSchema();
+    expect(schema).toEqual({
+      oneOf: [
+        { type: 'integer', minimum: 1, maximum: 900 },
+        { type: 'string', enum: ['max'] },
+      ],
+    });
+  });
+
+  it('omits the maximum (but keeps minimum/integer) when the flag is enabled', () => {
+    process.env[ALLOW_EXTENDED_MAX_DURATION_ENV] = '1';
+    const schema = getMaxDurationSchema();
+    expect(schema).toEqual({
+      oneOf: [
+        { type: 'integer', minimum: 1 },
+        { type: 'string', enum: ['max'] },
+      ],
+    });
+    const integerBranch = schema.oneOf[0] as Record<string, unknown>;
+    expect(integerBranch).not.toHaveProperty('maximum');
+  });
+});

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -11,6 +11,7 @@ import type { VercelConfig } from './dev/types';
 import {
   functionsSchema,
   buildsSchema,
+  getMaxDurationSchema,
   NowBuildError,
   getPrettyError,
 } from '@vercel/build-utils';
@@ -302,12 +303,7 @@ const experimentalServicesCommonProperties = {
     minimum: 128,
     maximum: 10240,
   },
-  maxDuration: {
-    oneOf: [
-      { type: 'integer', minimum: 1, maximum: 900 },
-      { type: 'string', enum: ['max'] },
-    ],
-  },
+  maxDuration: getMaxDurationSchema(),
   includeFiles: {
     oneOf: [
       { type: 'string', minLength: 1 },

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -20,6 +20,7 @@ import {
   BACKEND_BUILDERS,
   UNIFIED_BACKEND_BUILDER,
   isExperimentalBackendsEnabled,
+  getMaxDurationLimit,
 } from '@vercel/build-utils';
 import { getServicesBuilders } from './services/get-services-builders';
 
@@ -729,17 +730,25 @@ function validateFunctions({ functions = {} }: Options) {
       };
     }
 
+    // The upper bound is plan-aware and enforced server-side; only apply a
+    // client-side maximum when it has not been disabled via
+    // `VERCEL_ALLOW_EXTENDED_MAX_DURATION`. The lower bound and integer check
+    // are always enforced.
+    const maxDurationLimit = getMaxDurationLimit();
     if (
       func.maxDuration !== undefined &&
       func.maxDuration !== 'max' &&
       (func.maxDuration < 1 ||
-        func.maxDuration > 900 ||
+        (maxDurationLimit !== undefined &&
+          func.maxDuration > maxDurationLimit) ||
         !Number.isInteger(func.maxDuration))
     ) {
       return {
         code: 'invalid_function_duration',
         message:
-          'Functions must have a maxDuration between 1 and 900, or "max".',
+          maxDurationLimit !== undefined
+            ? `Functions must have a maxDuration between 1 and ${maxDurationLimit}, or "max".`
+            : 'Functions must have a positive integer maxDuration, or "max".',
       };
     }
 

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -730,9 +730,9 @@ function validateFunctions({ functions = {} }: Options) {
       };
     }
 
-    // The upper bound is plan-aware and enforced server-side; only apply a
-    // client-side maximum when it has not been disabled via
-    // `VERCEL_ALLOW_EXTENDED_MAX_DURATION`. The lower bound and integer check
+    // The upper bound is enforced by server-side validation; only apply a
+    // client-side maximum when it has not been skipped via
+    // `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT`. The lower bound and integer check
     // are always enforced.
     const maxDurationLimit = getMaxDurationLimit();
     if (

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -847,6 +847,67 @@ describe('Test `detectBuilders`', () => {
     expect(builders.length).toBe(1);
   });
 
+  it('rejects maxDuration above the default 900s limit', async () => {
+    const functions = { 'pages/index.ts': { maxDuration: 1200 } };
+    const files = ['pages/index.ts'];
+    const { builders, errors } = await invokeDetectBuilders(files, null, {
+      functions,
+    });
+
+    expect(builders).toHaveLength(0);
+    expect(errors.length).toBe(1);
+    expect(errors[0].code).toBe('invalid_function_duration');
+  });
+
+  describe('with VERCEL_ALLOW_EXTENDED_MAX_DURATION=1', () => {
+    beforeEach(() => {
+      process.env.VERCEL_ALLOW_EXTENDED_MAX_DURATION = '1';
+    });
+
+    afterEach(() => {
+      delete process.env.VERCEL_ALLOW_EXTENDED_MAX_DURATION;
+    });
+
+    it('allows maxDuration above 900s, deferring to server-side validation', async () => {
+      const pkg = {
+        scripts: { build: 'next build' },
+        dependencies: { next: '9.0.0' },
+      };
+      const functions = { 'pages/api/long.ts': { maxDuration: 1200 } };
+      const files = ['package.json', 'pages/index.js', 'pages/api/long.ts'];
+      const { builders, errors } = await invokeDetectBuilders(files, pkg, {
+        functions,
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(builders.length).toBe(1);
+    });
+
+    it('still rejects a non-integer maxDuration', async () => {
+      const functions = { 'pages/index.ts': { maxDuration: 1.5 } };
+      const files = ['pages/index.ts'];
+      const { builders, errors } = await invokeDetectBuilders(files, null, {
+        functions,
+      });
+
+      expect(builders).toHaveLength(0);
+      expect(errors.length).toBe(1);
+      expect(errors[0].code).toBe('invalid_function_duration');
+    });
+
+    it('still rejects a maxDuration below 1', async () => {
+      const functions = { 'pages/index.ts': { maxDuration: 0 } };
+      const files = ['pages/index.ts'];
+      const { builders, errors } = await invokeDetectBuilders(files, null, {
+        functions,
+      });
+
+      expect(builders).toHaveLength(0);
+      expect(errors.length).toBe(1);
+      expect(errors[0].code).toBe('invalid_function_duration');
+    });
+  });
+
   it('invalid function memory', async () => {
     const functions = { 'pages/index.ts': { memory: 127 } };
     const files = ['pages/index.ts'];

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -859,13 +859,13 @@ describe('Test `detectBuilders`', () => {
     expect(errors[0].code).toBe('invalid_function_duration');
   });
 
-  describe('with VERCEL_ALLOW_EXTENDED_MAX_DURATION=1', () => {
+  describe('with VERCEL_CLI_SKIP_MAX_DURATION_LIMIT=1', () => {
     beforeEach(() => {
-      process.env.VERCEL_ALLOW_EXTENDED_MAX_DURATION = '1';
+      process.env.VERCEL_CLI_SKIP_MAX_DURATION_LIMIT = '1';
     });
 
     afterEach(() => {
-      delete process.env.VERCEL_ALLOW_EXTENDED_MAX_DURATION;
+      delete process.env.VERCEL_CLI_SKIP_MAX_DURATION_LIMIT;
     });
 
     it('allows maxDuration above 900s, deferring to server-side validation', async () => {


### PR DESCRIPTION
## Summary

The client-side 900-second upper bound for a function's `maxDuration` is hardcoded across multiple validators (`vercel.json` schema validation and zero-config function detection), duplicating a limit that is ultimately enforced by server-side validation at deploy time.

This consolidates that bound into a single `@vercel/build-utils` helper and makes it configurable via the `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` environment variable. When set to `1`, the client-side maximum is not applied and validation defers to the server. Default behavior is unchanged: the 900-second maximum, the lower bound, and the integer check are all still enforced when the variable is unset.

## TODO

Once this is rolled out 100%, we should clean up and remove all hard-coded checks from this repository

## Validation

- Unit tests for the new helper covering the flag on/off.
- `detectBuilders` tests: rejects `maxDuration > 900` by default, allows it when the variable is set, and still rejects non-integer / below-1 values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
