### PR TITLE
Add warning when api/ dir is ignored by experimental services.

### DIFF
--- a/.changeset/gentle-hotels-sit.md
+++ b/.changeset/gentle-hotels-sit.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': minor
+---
+
+Add warning when api/ dir is ignored by experimental services.

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -21,7 +21,10 @@ import {
   UNIFIED_BACKEND_BUILDER,
   isExperimentalBackendsEnabled,
 } from '@vercel/build-utils';
-import { getServicesBuilders } from './services/get-services-builders';
+import {
+  getServicesBuilders,
+  warnIgnoredDirectories,
+} from './services/get-services-builders';
 
 /**
  * Pattern for finding all supported middleware files.
@@ -157,12 +160,20 @@ export async function detectBuilders(
     configuredServices != null && typeof configuredServices === 'object';
 
   if (hasServicesConfig || framework === 'services') {
-    return getServicesBuilders({
+    const result = await getServicesBuilders({
       workPath: options.workPath,
       configuredServices: configuredServices,
       configuredServicesType,
       projectFramework: framework,
     });
+
+    if (configuredServices != null) {
+      result.warnings.push(
+        ...warnIgnoredDirectories(files, configuredServices)
+      );
+    }
+
+    return result;
   }
 
   const errors: ErrorResponse[] = [];

--- a/packages/fs-detectors/src/services/get-services-builders.ts
+++ b/packages/fs-detectors/src/services/get-services-builders.ts
@@ -182,3 +182,34 @@ export async function getServicesBuilders(
     useImplicitEnvInjection: result.useImplicitEnvInjection,
   };
 }
+
+/**
+ * Returns warnings for ignored directories that are not covered by services
+ */
+export function warnIgnoredDirectories(
+  files: string[],
+  configuredServices: ConfiguredServices
+): ErrorResponse[] {
+  const warnings: ErrorResponse[] = [];
+
+  if (files.some(f => f.startsWith('api/'))) {
+    const serviceCoversApi = Object.values(configuredServices).some(service => {
+      const root = service.root ?? '.';
+      const entrypoint = service.entrypoint ?? '';
+      return (
+        root === 'api' ||
+        root.startsWith('api/') ||
+        (root === '.' && entrypoint.startsWith('api/'))
+      );
+    });
+    if (!serviceCoversApi) {
+      warnings.push({
+        code: 'api_dir_ignored',
+        message:
+          'The `api/` directory will not be built because `experimentalServices` is configured. To serve these files, declare them as a service in your `vercel.json`.',
+      });
+    }
+  }
+
+  return warnings;
+}

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -271,6 +271,52 @@ describe('Test `detectBuilders`', () => {
     }
   });
 
+  it('should warn when api/ files exist but no service covers them', async () => {
+    const { warnings } = await detectBuilders(
+      ['api/index.py', 'pages/index.js', 'package.json', 'requirements.txt'],
+      undefined,
+      {
+        experimentalServices: {
+          frontend: {
+            framework: 'nextjs',
+            entrypoint: '.',
+            routePrefix: '/',
+          },
+        },
+        projectSettings: { framework: null },
+      }
+    );
+
+    expect(warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'api_dir_ignored' }),
+      ])
+    );
+  });
+
+  it('should not warn when a service explicitly covers the api/ directory', async () => {
+    const { warnings } = await detectBuilders(
+      ['api/index.py', 'pages/index.js', 'package.json', 'requirements.txt'],
+      undefined,
+      {
+        experimentalServices: {
+          frontend: {
+            framework: 'nextjs',
+            entrypoint: '.',
+            routePrefix: '/',
+          },
+          backend: {
+            entrypoint: 'api/index.py',
+            routePrefix: '/api',
+          },
+        },
+        projectSettings: { framework: null },
+      }
+    );
+
+    expect(warnings.every(w => w.code !== 'api_dir_ignored')).toBe(true);
+  });
+
   it('should never select now.json src', async () => {
     const files = ['docs/index.md', 'mkdocs.yml', 'now.json'];
     const { builders } = await invokeDetectBuildersAndThrow(files, null, {


### PR DESCRIPTION
Produces a warning like:
<img width="845" height="446" alt="image" src="https://github.com/user-attachments/assets/6d6155c2-3837-44de-b090-2f294638dc60" />

It's kinda hard to see, open to suggestions.