### PR TITLE
Add Eve framework declaration

### DIFF
--- a/.changeset/eve-framework.md
+++ b/.changeset/eve-framework.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': minor
+---
+
+Add Eve as an experimental framework declaration alongside Ash.

--- a/packages/frameworks/logos/eve-dark.svg
+++ b/packages/frameworks/logos/eve-dark.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Eve">
+  <title>Eve</title>
+  <rect width="48" height="48" rx="8" fill="#fff"/>
+  <text x="24" y="24" fill="#000"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-size="14" font-weight="700" letter-spacing="1"
+        text-anchor="middle" dominant-baseline="central">EVE</text>
+</svg>

--- a/packages/frameworks/logos/eve.svg
+++ b/packages/frameworks/logos/eve.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Eve">
+  <title>Eve</title>
+  <rect width="48" height="48" rx="8" fill="#000"/>
+  <text x="24" y="24" fill="#fff"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-size="14" font-weight="700" letter-spacing="1"
+        text-anchor="middle" dominant-baseline="central">EVE</text>
+</svg>

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2313,6 +2313,44 @@ export const frameworks = [
     experimental: true,
   },
   {
+    name: 'Eve',
+    slug: 'eve',
+    logo: 'https://api-frameworks.vercel.sh/framework-logos/eve.svg',
+    darkModeLogo:
+      'https://api-frameworks.vercel.sh/framework-logos/eve-dark.svg',
+    tagline:
+      'A filesystem-first framework for durable backend agents on Vercel.',
+    description:
+      'An Eve app: agents authored as a directory of files, compiled and served on Vercel.',
+    detectors: {
+      every: [
+        {
+          path: 'package.json',
+          matchContent:
+            '"(dev)?(d|D)ependencies":\\s*{[^}]*"eve":\\s*".+?"[^}]*}',
+        },
+      ],
+    },
+    settings: {
+      installCommand: {
+        placeholder: '`pnpm install`, `yarn install`, or `npm install`',
+      },
+      buildCommand: {
+        value: 'eve build',
+        placeholder: '`npm run build` or `eve build`',
+      },
+      devCommand: {
+        value: 'eve dev',
+        placeholder: 'eve dev',
+      },
+      outputDirectory: {
+        value: '.output',
+      },
+    },
+    getOutputDirName: async () => '.output',
+    experimental: true,
+  },
+  {
     name: 'Sanity',
     slug: 'sanity',
     demo: 'https://template-studio-clean.sanity.dev',


### PR DESCRIPTION
Summary:
- Add Eve as an experimental framework declaration alongside Ash.
- Detect the eve package and use eve build/eve dev defaults.
- Add Eve framework logo assets.

Testing:
- pnpm --filter @vercel/frameworks type-check
- pnpm --filter @vercel/frameworks test -- test/frameworks.unit.test.ts