### PR TITLE
[codex] expose websocket upgrade helper

### DIFF
--- a/.changeset/functions-websocket-upgrade.md
+++ b/.changeset/functions-websocket-upgrade.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': minor
+---
+
+Expose a `getWebSocketUpgrade()` helper from `@vercel/functions/websocket` for framework adapters that need access to Vercel-provided WebSocket upgrade primitives.

--- a/packages/functions/docs/README.md
+++ b/packages/functions/docs/README.md
@@ -8,3 +8,4 @@
 
 - [index](index/README.md)
 - [oidc](oidc/README.md)
+- [websocket](websocket/README.md)

--- a/packages/functions/docs/websocket/README.md
+++ b/packages/functions/docs/websocket/README.md
@@ -1,0 +1,13 @@
+[**@vercel/functions**](../README.md)
+
+---
+
+# websocket
+
+## Interfaces
+
+- [WebSocketUpgrade](interfaces/WebSocketUpgrade.md)
+
+## Functions
+
+- [getWebSocketUpgrade](functions/getWebSocketUpgrade.md)

--- a/packages/functions/docs/websocket/functions/getWebSocketUpgrade.md
+++ b/packages/functions/docs/websocket/functions/getWebSocketUpgrade.md
@@ -1,0 +1,27 @@
+[**@vercel/functions**](../../README.md)
+
+***
+
+# Function: getWebSocketUpgrade()
+
+> **getWebSocketUpgrade**(): [`WebSocketUpgrade`](../interfaces/WebSocketUpgrade.md) \| `undefined`
+
+Defined in: [packages/functions/src/websocket.ts:40](https://github.com/vercel/vercel/blob/main/packages/functions/src/websocket.ts#L40)
+
+Returns the WebSocket upgrade primitives for the current request when the
+Vercel runtime provides them.
+
+## Returns
+
+[`WebSocketUpgrade`](../interfaces/WebSocketUpgrade.md) \| `undefined`
+
+## Example
+
+```js
+import { getWebSocketUpgrade } from '@vercel/functions/websocket';
+
+const upgrade = getWebSocketUpgrade();
+if (upgrade) {
+  // Pass upgrade.req, upgrade.socket, and upgrade.head to a WebSocket server.
+}
+```

--- a/packages/functions/docs/websocket/interfaces/WebSocketUpgrade.md
+++ b/packages/functions/docs/websocket/interfaces/WebSocketUpgrade.md
@@ -1,0 +1,39 @@
+[**@vercel/functions**](../../README.md)
+
+***
+
+# Interface: WebSocketUpgrade
+
+Defined in: [packages/functions/src/websocket.ts:10](https://github.com/vercel/vercel/blob/main/packages/functions/src/websocket.ts#L10)
+
+WebSocket upgrade primitives for the current request.
+
+## Properties
+
+### head
+
+> **head**: `Buffer`
+
+Defined in: [packages/functions/src/websocket.ts:22](https://github.com/vercel/vercel/blob/main/packages/functions/src/websocket.ts#L22)
+
+The first packet of the upgraded stream.
+
+***
+
+### req
+
+> **req**: `IncomingMessage`
+
+Defined in: [packages/functions/src/websocket.ts:14](https://github.com/vercel/vercel/blob/main/packages/functions/src/websocket.ts#L14)
+
+The Node.js request associated with the upgrade.
+
+***
+
+### socket
+
+> **socket**: `Duplex`
+
+Defined in: [packages/functions/src/websocket.ts:18](https://github.com/vercel/vercel/blob/main/packages/functions/src/websocket.ts#L18)
+
+The underlying network socket for the upgrade.

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -28,6 +28,10 @@
     "./middleware": {
       "import": "./middleware.js",
       "require": "./middleware.js"
+    },
+    "./websocket": {
+      "import": "./websocket.js",
+      "require": "./websocket.js"
     }
   },
   "version": "3.6.2",

--- a/packages/functions/src/get-context.ts
+++ b/packages/functions/src/get-context.ts
@@ -1,6 +1,7 @@
 import { RuntimeCache } from './cache/types';
 import { PurgeApi } from './purge/types';
 import { AddCacheTagApi } from './addcachetag/types';
+import type { WebSocketUpgrade } from './websocket';
 
 type Context = {
   waitUntil?: (promise: Promise<unknown>) => void;
@@ -8,6 +9,7 @@ type Context = {
   purge?: PurgeApi;
   addCacheTag?: AddCacheTagApi;
   headers?: Record<string, string>;
+  upgradeWebSocket?: () => WebSocketUpgrade;
 };
 
 export const SYMBOL_FOR_REQ_CONTEXT = Symbol.for('@vercel/request-context');

--- a/packages/functions/src/websocket.ts
+++ b/packages/functions/src/websocket.ts
@@ -1,0 +1,42 @@
+import type { Buffer } from 'node:buffer';
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+
+import { getContext } from './get-context';
+
+/**
+ * WebSocket upgrade primitives for the current request.
+ */
+export interface WebSocketUpgrade {
+  /**
+   * The Node.js request associated with the upgrade.
+   */
+  req: IncomingMessage;
+  /**
+   * The underlying network socket for the upgrade.
+   */
+  socket: Duplex;
+  /**
+   * The first packet of the upgraded stream.
+   */
+  head: Buffer;
+}
+
+/**
+ * Returns the WebSocket upgrade primitives for the current request when the
+ * Vercel runtime provides them.
+ *
+ * @example
+ *
+ * ```js
+ * import { getWebSocketUpgrade } from '@vercel/functions/websocket';
+ *
+ * const upgrade = getWebSocketUpgrade();
+ * if (upgrade) {
+ *   // Pass upgrade.req, upgrade.socket, and upgrade.head to a WebSocket server.
+ * }
+ * ```
+ */
+export function getWebSocketUpgrade(): WebSocketUpgrade | undefined {
+  return getContext().upgradeWebSocket?.();
+}

--- a/packages/functions/test/unit/index.test.ts
+++ b/packages/functions/test/unit/index.test.ts
@@ -7,8 +7,16 @@ evalScript.esm = code => evalScript(code, ['--input-type', 'module']);
 
 describe('@vercel/functions', () => {
   const EXPECTED_METHODS = [
+    'addCacheTag',
+    'attachDatabasePool',
+    'dangerouslyDeleteBySrcImage',
+    'dangerouslyDeleteByTag',
+    'experimental_attachDatabasePool',
     'geolocation',
+    'getCache',
     'getEnv',
+    'invalidateBySrcImage',
+    'invalidateByTag',
     'ipAddress',
     'next',
     'rewrite',
@@ -114,6 +122,30 @@ describe('@vercel/functions/middleware', () => {
   test('load as ESM', async () => {
     const code =
       "import f from '@vercel/functions/middleware'; console.log(JSON.stringify(Object.keys(f)))";
+    const exportedMethods = await evalScript
+      .esm(code)
+      .then(output => JSON.parse(output));
+
+    expect(exportedMethods).toEqual(EXPECTED_METHODS);
+  });
+});
+
+describe('@vercel/functions/websocket', () => {
+  const EXPECTED_METHODS = ['getWebSocketUpgrade'];
+
+  test('load as CommonJS', async () => {
+    const code =
+      "console.log(JSON.stringify(Object.keys(require('@vercel/functions/websocket'))))";
+    const exportedMethods = await evalScript(code).then(output =>
+      JSON.parse(output)
+    );
+
+    expect(exportedMethods).toEqual(EXPECTED_METHODS);
+  });
+
+  test('load as ESM', async () => {
+    const code =
+      "import f from '@vercel/functions/websocket'; console.log(JSON.stringify(Object.keys(f)))";
     const exportedMethods = await evalScript
       .esm(code)
       .then(output => JSON.parse(output));

--- a/packages/functions/test/unit/websocket.test.ts
+++ b/packages/functions/test/unit/websocket.test.ts
@@ -1,0 +1,41 @@
+import { Buffer } from 'node:buffer';
+import { PassThrough } from 'node:stream';
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { SYMBOL_FOR_REQ_CONTEXT } from '../../src/get-context';
+import {
+  getWebSocketUpgrade,
+  type WebSocketUpgrade,
+} from '../../src/websocket';
+
+afterEach(() => {
+  delete globalThis[SYMBOL_FOR_REQ_CONTEXT];
+});
+
+test.each([
+  null,
+  undefined,
+  {},
+  { get: undefined },
+  { get: () => ({}) },
+])('getWebSocketUpgrade returns undefined when context is %s', input => {
+  globalThis[SYMBOL_FOR_REQ_CONTEXT] = input;
+  expect(getWebSocketUpgrade()).toBeUndefined();
+});
+
+test('getWebSocketUpgrade returns the runtime upgrade primitives when available', () => {
+  const upgrade: WebSocketUpgrade = {
+    req: {} as WebSocketUpgrade['req'],
+    socket: new PassThrough(),
+    head: Buffer.alloc(0),
+  };
+  const upgradeWebSocket = vi.fn(() => upgrade);
+
+  globalThis[SYMBOL_FOR_REQ_CONTEXT] = {
+    get: () => ({ upgradeWebSocket }),
+  };
+
+  expect(getWebSocketUpgrade()).toBe(upgrade);
+  expect(upgradeWebSocket).toHaveBeenCalledOnce();
+});

--- a/packages/functions/typedoc.json
+++ b/packages/functions/typedoc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/index.ts", "src/oidc/index.ts"],
+  "entryPoints": ["src/index.ts", "src/oidc/index.ts", "src/websocket.ts"],
   "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-mdn-links"],
   "out": "docs",
   "githubPages": false,


### PR DESCRIPTION
## Summary

- Add a Node-specific `@vercel/functions/websocket` subpath.
- Export `getWebSocketUpgrade()` plus a `WebSocketUpgrade` type for `{ req, socket, head }` upgrade primitives.
- Type the internal request context with an optional `upgradeWebSocket` capability while keeping the raw request-context symbol private.
- Generate Typedoc output for the new websocket entrypoint and add a minor changeset for `@vercel/functions`.
- Extend package export tests to cover the new subpath in CommonJS and ESM.

## Why

Framework adapters need stable public access to Vercel-provided WebSocket upgrade primitives. Exposing a narrow helper avoids downstream adapters depending on private `globalThis[Symbol.for("@vercel/request-context")]` wiring or making the whole request context public API.

## Testing

- `pnpm turbo --no-update-notifier run build --filter @vercel/functions`
- `pnpm vitest run test/unit/websocket.test.ts test/unit/index.test.ts`
- `pnpm vitest run test/integration/docs.test.ts`
- `pnpm exec tsc --noEmit` from `packages/functions`
- `pnpm lint`
- `pnpm format:check`

Additional notes:

- `pnpm test --run` from `packages/functions` still fails in existing cache, database connection, OIDC, and get-env tests unrelated to this helper; the new websocket tests, export tests, and docs test pass.
- `pnpm type-check` still fails in this local clone because `@vercel/python-analysis` requires a Rust toolchain to build its WASM artifacts, which then cascades into dependent packages.
