### PR TITLE
feat(next): instrument post-compile phases with heartbeat logs

### DIFF
--- a/.changeset/instrument-post-compile.md
+++ b/.changeset/instrument-post-compile.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Instrument post-compile phases (`buildCallback`, `glob node_modules`, legacy serverless function creation, `serverBuild`) with start/heartbeat/end log lines. Heartbeats fire every 15s so phases that wedge surface in `vercel inspect --logs` instead of producing silent stalls.

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -59,6 +59,7 @@ import url from 'url';
 import createServerlessConfig from './create-serverless-config';
 import nextLegacyVersions from './legacy-versions';
 import { serverBuild } from './server-build';
+import { tracedPhase } from './post-compile-tracing';
 import {
   collectTracedFiles,
   createLambdaFromPseudoLayers,
@@ -575,7 +576,9 @@ export const build: BuildV2 = async buildOptions => {
   }
 
   if (buildCallback) {
-    await buildCallback(buildOptions);
+    await tracedPhase(builderSpan, 'buildCallback', () =>
+      buildCallback(buildOptions)
+    );
   }
 
   let buildOutputVersion: undefined | number;
@@ -1229,7 +1232,9 @@ export const build: BuildV2 = async buildOptions => {
       entryPath
     );
     const nodeModules = excludeFiles(
-      await glob('node_modules/**', entryPath),
+      await tracedPhase(builderSpan, 'glob node_modules', () =>
+        glob('node_modules/**', entryPath)
+      ),
       file => file.startsWith('node_modules/.cache')
     );
     const nextFiles = {
@@ -1256,73 +1261,78 @@ export const build: BuildV2 = async buildOptions => {
     const launcherPath = path.join(__dirname, 'legacy-launcher.js');
     const launcherData = await readFile(launcherPath, 'utf8');
 
-    await Promise.all(
-      Object.keys(pages).map(async page => {
-        // These default pages don't have to be handled as they'd always 404
-        if (['_app.js', '_error.js', '_document.js'].includes(page)) {
-          return;
-        }
+    await tracedPhase(builderSpan, 'createLegacyServerlessFunctions', () =>
+      Promise.all(
+        Object.keys(pages).map(async page => {
+          // These default pages don't have to be handled as they'd always 404
+          if (['_app.js', '_error.js', '_document.js'].includes(page)) {
+            return;
+          }
 
-        const pathname = page.replace(/\.js$/, '');
-        const launcher = launcherData.replace(
-          'PATHNAME_PLACEHOLDER',
-          `/${pathname.replace(/(^|\/)index$/, '')}`
-        );
+          const pathname = page.replace(/\.js$/, '');
+          const launcher = launcherData.replace(
+            'PATHNAME_PLACEHOLDER',
+            `/${pathname.replace(/(^|\/)index$/, '')}`
+          );
 
-        const pageFiles = {
-          [`${outputDirectory}/server/static/${buildId}/pages/_document.js`]:
-            filesAfterBuild[
-              `${outputDirectory}/server/static/${buildId}/pages/_document.js`
-            ],
-          [`${outputDirectory}/server/static/${buildId}/pages/_app.js`]:
-            filesAfterBuild[
-              `${outputDirectory}/server/static/${buildId}/pages/_app.js`
-            ],
-          [`${outputDirectory}/server/static/${buildId}/pages/_error.js`]:
-            filesAfterBuild[
-              `${outputDirectory}/server/static/${buildId}/pages/_error.js`
-            ],
-          [`${outputDirectory}/server/static/${buildId}/pages/${page}`]:
-            filesAfterBuild[
-              `${outputDirectory}/server/static/${buildId}/pages/${page}`
-            ],
-        };
+          const pageFiles = {
+            [`${outputDirectory}/server/static/${buildId}/pages/_document.js`]:
+              filesAfterBuild[
+                `${outputDirectory}/server/static/${buildId}/pages/_document.js`
+              ],
+            [`${outputDirectory}/server/static/${buildId}/pages/_app.js`]:
+              filesAfterBuild[
+                `${outputDirectory}/server/static/${buildId}/pages/_app.js`
+              ],
+            [`${outputDirectory}/server/static/${buildId}/pages/_error.js`]:
+              filesAfterBuild[
+                `${outputDirectory}/server/static/${buildId}/pages/_error.js`
+              ],
+            [`${outputDirectory}/server/static/${buildId}/pages/${page}`]:
+              filesAfterBuild[
+                `${outputDirectory}/server/static/${buildId}/pages/${page}`
+              ],
+          };
 
-        let lambdaOptions = {};
-        if (config && config.functions) {
-          lambdaOptions = await getLambdaOptionsFromFunction({
-            sourceFile: await getSourceFilePathFromPage({
-              workPath: entryPath,
-              page,
-            }),
-            config,
-          });
-        }
+          let lambdaOptions = {};
+          if (config && config.functions) {
+            lambdaOptions = await getLambdaOptionsFromFunction({
+              sourceFile: await getSourceFilePathFromPage({
+                workPath: entryPath,
+                page,
+              }),
+              config,
+            });
+          }
 
-        debug(`Creating serverless function for page: "${page}"...`);
-        lambdas[path.posix.join(entryDirectory, pathname)] = new NodejsLambda({
-          files: {
-            ...nextFiles,
-            ...pageFiles,
-            '___next_launcher.cjs': new FileBlob({ data: launcher }),
-          },
-          handler: '___next_launcher.cjs',
-          runtime: nodeVersion.runtime,
-          ...lambdaOptions,
-          operationType: 'Page', // always Page because we're in legacy mode
-          shouldAddHelpers: false,
-          shouldAddSourcemapSupport: false,
-          supportsMultiPayloads: true,
-          framework: {
-            slug: 'nextjs',
-            version: nextVersion,
-          },
-          shouldDisableAutomaticFetchInstrumentation:
-            process.env
-              .VERCEL_TRACING_DISABLE_AUTOMATIC_FETCH_INSTRUMENTATION === '1',
-        });
-        debug(`Created serverless function for page: "${page}"`);
-      })
+          debug(`Creating serverless function for page: "${page}"...`);
+          lambdas[path.posix.join(entryDirectory, pathname)] = new NodejsLambda(
+            {
+              files: {
+                ...nextFiles,
+                ...pageFiles,
+                '___next_launcher.cjs': new FileBlob({ data: launcher }),
+              },
+              handler: '___next_launcher.cjs',
+              runtime: nodeVersion.runtime,
+              ...lambdaOptions,
+              operationType: 'Page', // always Page because we're in legacy mode
+              shouldAddHelpers: false,
+              shouldAddSourcemapSupport: false,
+              supportsMultiPayloads: true,
+              framework: {
+                slug: 'nextjs',
+                version: nextVersion,
+              },
+              shouldDisableAutomaticFetchInstrumentation:
+                process.env
+                  .VERCEL_TRACING_DISABLE_AUTOMATIC_FETCH_INSTRUMENTATION ===
+                '1',
+            }
+          );
+          debug(`Created serverless function for page: "${page}"`);
+        })
+      )
     );
   } else {
     debug('Preparing serverless function files...');
@@ -1593,55 +1603,57 @@ export const build: BuildV2 = async buildOptions => {
         ]
       );
 
-      return serverBuild({
-        config,
-        functionsConfigManifest,
-        nextVersion,
-        trailingSlash,
-        appPathRoutesManifest,
-        dynamicPages,
-        canUsePreviewMode,
-        staticPages,
-        localePrefixed404,
-        lambdaPages: pages,
-        lambdaAppPaths,
-        omittedPrerenderRoutes,
-        isCorrectLocaleAPIRoutes,
-        pagesDir,
-        headers,
-        onMatchHeaders,
-        beforeFilesRewrites,
-        afterFilesRewrites,
-        fallbackRewrites,
-        workPath,
-        redirects,
-        nodeVersion,
-        dynamicPrefix,
-        routesManifest,
-        imagesManifest,
-        wildcardConfig,
-        prerenderManifest,
-        entryDirectory,
-        entryPath,
-        baseDir,
-        dataRoutes,
-        buildId,
-        escapedBuildId,
-        outputDirectory,
-        trailingSlashRedirects,
-        requiredServerFilesManifest,
-        privateOutputs,
-        hasIsr404Page,
-        hasIsr500Page,
-        variantsManifest,
-        experimentalPPRRoutes,
-        isAppPPREnabled,
-        isAppFullPPREnabled,
-        isAppClientSegmentCacheEnabled,
-        isAppClientParamParsingEnabled,
-        clientParamParsingOrigins,
-        files,
-      });
+      return tracedPhase(builderSpan, 'serverBuild', () =>
+        serverBuild({
+          config,
+          functionsConfigManifest,
+          nextVersion,
+          trailingSlash,
+          appPathRoutesManifest,
+          dynamicPages,
+          canUsePreviewMode,
+          staticPages,
+          localePrefixed404,
+          lambdaPages: pages,
+          lambdaAppPaths,
+          omittedPrerenderRoutes,
+          isCorrectLocaleAPIRoutes,
+          pagesDir,
+          headers,
+          onMatchHeaders,
+          beforeFilesRewrites,
+          afterFilesRewrites,
+          fallbackRewrites,
+          workPath,
+          redirects,
+          nodeVersion,
+          dynamicPrefix,
+          routesManifest,
+          imagesManifest,
+          wildcardConfig,
+          prerenderManifest,
+          entryDirectory,
+          entryPath,
+          baseDir,
+          dataRoutes,
+          buildId,
+          escapedBuildId,
+          outputDirectory,
+          trailingSlashRedirects,
+          requiredServerFilesManifest,
+          privateOutputs,
+          hasIsr404Page,
+          hasIsr500Page,
+          variantsManifest,
+          experimentalPPRRoutes,
+          isAppPPREnabled,
+          isAppFullPPREnabled,
+          isAppClientSegmentCacheEnabled,
+          isAppClientParamParsingEnabled,
+          clientParamParsingOrigins,
+          files,
+        })
+      );
     }
 
     // > 1 because _error is a lambda but isn't used if a static 404 is available

--- a/packages/next/src/post-compile-tracing.ts
+++ b/packages/next/src/post-compile-tracing.ts
@@ -1,0 +1,43 @@
+import { Span } from '@vercel/build-utils';
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+function log(label: string, msg: string) {
+  console.log(`[POST_COMPILE] ${label}: ${msg}`);
+}
+
+/**
+ * Wraps an async post-compile phase in a child `Span` and additionally emits
+ * start/heartbeat/end lines to stdout.
+ *
+ * The existing `Span` only reports when `stop()` is called, so a phase that
+ * wedges never surfaces in traces. The console output here lands in the
+ * Vercel build log via Hive's stdout forwarder, giving an in-band liveness
+ * signal even when the phase never completes.
+ */
+export async function tracedPhase<T>(
+  parent: Span,
+  label: string,
+  fn: (span: Span) => Promise<T> | T
+): Promise<T> {
+  const child = parent.child(label);
+  const start = Date.now();
+  log(label, 'start');
+  const heartbeat = setInterval(() => {
+    const elapsed = ((Date.now() - start) / 1000).toFixed(0);
+    log(label, `alive +${elapsed}s`);
+  }, HEARTBEAT_INTERVAL_MS);
+  heartbeat.unref();
+  try {
+    const result = await fn(child);
+    log(label, `done in ${Date.now() - start}ms`);
+    return result;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(label, `failed in ${Date.now() - start}ms: ${msg}`);
+    throw err;
+  } finally {
+    clearInterval(heartbeat);
+    child.stop();
+  }
+}


### PR DESCRIPTION
## Summary

- The `@vercel/next` post-compile phase (everything after `next build` exits) runs without in-band logging, so a wedge there produces a silent stall until the 45-min platform timeout kills the build.
- The existing `Span` tracing only reports at `stop()` time, so a phase that never finishes is invisible.
- Add a `tracedPhase` helper that wraps a child `Span` and emits start/heartbeat (every 15s)/end lines to stdout, which Hive forwards to `vercel inspect --logs`. Liveness signal even when the phase wedges.
- Wrap four known seams: `buildCallback`, the `glob('node_modules/**')` call, legacy serverless function creation, and the main `serverBuild` call.

## Motivation

Tied to a recent vercel-site preview deployment (`dpl_GhaZFpSFJfqnhrgucQLD2Mpayn3N`) that ran the full 45-min build timeout. The build container produced no stdout, no APM spans, and no orchestrator events for ~36 minutes between `next build` printing its route manifest and the platform-side timeout kill. The Hive cell teardown record showed ~2.65 cores busy continuously the whole time — so a CPU-bound post-compile step was actively running, but completely invisible in the build log. With this change, future stalls show which phase ate the wall clock.

Sample log shape during a future stalled build:

```
[POST_COMPILE] serverBuild: start
[POST_COMPILE] serverBuild: alive +15s
[POST_COMPILE] serverBuild: alive +30s
... (no more output until timeout kill)
```

## Test plan

- [ ] Typecheck: `pnpm --filter @vercel/next type-check` — passes
- [ ] Build: `pnpm --filter @vercel/next build` — emits dist with the four `tracedPhase` call sites bundled in
- [ ] Local end-to-end run on a real Next.js project (blocked locally for vercel-site by sensitive env vars; verify on a preview deploy or a smaller project)
- [ ] On a real preview deploy, confirm `[POST_COMPILE]` lines appear in `vercel inspect --logs`

<details>
<summary>Local verification</summary>

Built the patched `@vercel/next` and ran `vercel build` against a minimal Next.js 15 app. The instrumentation fires, the build succeeds, and the previously orphaned post-compile trace lines are now bracketed by the `serverBuild` phase span:

```
> [debug] Building entrypoint "package.json" with "@vercel/next"
WARNING: You should not upload the `.next` directory.
Installing dependencies...
WARNING: You should not upload the `.next` directory.
Installing dependencies...
npm warn Unknown user config "min-release-age". This will stop working in the next major version of npm.
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'next-instr-test@0.0.1',
npm warn EBADENGINE   required: { node: '22.x' },
npm warn EBADENGINE   current: { node: 'v24.14.0', npm: '11.9.0' }
npm warn EBADENGINE }

up to date in 101ms

6 packages are looking for funding
  run `npm fund` for details
Detected Next.js version: 15.5.0
Running "npm run build"
npm warn Unknown user config "min-release-age". This will stop working in the next major version of npm.

> next-instr-test@0.0.1 build
> next build

   ▲ Next.js 15.5.0

   Creating an optimized production build ...
 ✓ Compiled successfully in 553ms
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/4) ...
   Generating static pages (1/4) 
   Generating static pages (2/4) 
   Generating static pages (3/4) 
 ✓ Generating static pages (4/4)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                 Size  First Load JS
┌ ○ /                                      127 B         102 kB
└ ○ /_not-found                            995 B         103 kB
+ First Load JS shared by all             102 kB
  ├ chunks/255-01c481785f268126.js       45.7 kB
  ├ chunks/4bd1b696-c023c6e3521b1417.js  54.2 kB
  └ other shared chunks (total)          1.88 kB


○  (Static)  prerendered as static content

(node:19573) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `node --trace-deprecation ...` to show where the warning was created)
[POST_COMPILE] serverBuild: start
Traced Next.js server files in: 27.994ms
Created all serverless functions in: 22.127ms
Collected static files (public/, static/, .next/static): 0.815ms
[POST_COMPILE] serverBuild: done in 55ms
{
  "status": "ok",
  "outputDir": "/path/to/instr-test/.vercel/output",
  "outputDirRelative": ".vercel/output",
  "target": "preview",
  "message": "Build completed successfully.",
  "next": [
    {
      "command": "vercel deploy --debug",
      "when": "Deploy the build output"
    }
  ]
}
```

`buildCallback` and the two `if (isLegacy)` wraps did not fire here because this is the modern (non-legacy) `serverBuild` code path with no `buildCallback` set — those wraps are still present and follow the same pattern.

### Repro

```bash
# 1. Symlink global @vercel/next dist to your patched checkout
GLOBAL=$(pnpm list -g @vercel/next --parseable 2>/dev/null | tail -1)/dist
mv "$GLOBAL" "$GLOBAL.orig"
ln -s /path/to/vercel/packages/next/dist "$GLOBAL"

# 2. Scaffold a minimal Next.js app
mkdir -p /tmp/instr-test/app && cd /tmp/instr-test
cat > package.json <<'JSON'
{"name":"t","private":true,"dependencies":{"next":"15.5.0","react":"19.0.0","react-dom":"19.0.0"}}
JSON
echo 'export default function P(){return <h1>hi</h1>}' > app/page.js
echo 'export default function L({children}){return <html><body>{children}</body></html>}' > app/layout.js
mkdir .vercel
echo '{"projectId":"x","orgId":"x","settings":{"framework":"nextjs"}}' > .vercel/project.json

# 3. Build and grep
vercel build --debug 2>&1 | grep POST_COMPILE
```

</details>
