### PR TITLE
[routing-utils] service-targeted route destinations

### DIFF
--- a/.changeset/routes-service-destination.md
+++ b/.changeset/routes-service-destination.md
@@ -2,4 +2,4 @@
 '@vercel/routing-utils': minor
 ---
 
-Support a service-targeted `destination` object (`{ type: "service", service, path }`) on routes and rewrites, so a route/rewrite can delegate into a named service.
+Support a service-targeted `destination` object (`{ type: "service", service, path }`) on routes and rewrites, so a route/rewrite can delegate into a named service. The service handoff is terminal: `continue: true` together with a service `destination` is rejected during normalization.

--- a/.changeset/routes-service-destination.md
+++ b/.changeset/routes-service-destination.md
@@ -1,0 +1,5 @@
+---
+'@vercel/routing-utils': minor
+---
+
+Support a service-targeted `destination` object (`{ type: "service", service, path }`) on routes and rewrites, so a route/rewrite can delegate into a named service from `services` (RFC: Vercel Backends). The string `destination` keeps its existing alias-for-`dest` behavior; the object form is preserved through normalization.

--- a/.changeset/routes-service-destination.md
+++ b/.changeset/routes-service-destination.md
@@ -2,4 +2,4 @@
 '@vercel/routing-utils': minor
 ---
 
-Support a service-targeted `destination` object (`{ type: "service", service, path }`) on routes and rewrites, so a route/rewrite can delegate into a named service from `services` (RFC: Vercel Backends). The string `destination` keeps its existing alias-for-`dest` behavior; the object form is preserved through normalization.
+Support a service-targeted `destination` object (`{ type: "service", service, path }`) on routes and rewrites, so a route/rewrite can delegate into a named service.

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -54,7 +54,8 @@ export interface SettingValue {
 
 export type Setting = SettingValue | SettingPlaceholder;
 
-export type Redirect = Rewrite & {
+export type Redirect = Omit<Rewrite, 'destination'> & {
+  destination: string;
   statusCode?: number;
   permanent?: boolean;
 };

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -217,7 +217,10 @@ function normalizePage(page: string): string {
   return page;
 }
 
-export type Redirect = Rewrite & {
+export type Redirect = Omit<Rewrite, 'destination'> & {
+  // Redirects can't target a service, so `destination` stays a plain string
+  // (unlike `Rewrite['destination']`, which is `string | ServiceDestination`).
+  destination: string;
   statusCode?: number;
   permanent?: boolean;
 };

--- a/packages/routing-utils/src/index.ts
+++ b/packages/routing-utils/src/index.ts
@@ -154,6 +154,18 @@ export function normalizeRoutes(
         errors.push(regError);
       }
 
+      // A service-targeted `destination` is a terminal handoff into the target
+      // service's route table; routing does not continue in the current table.
+      if (
+        route.destination &&
+        typeof route.destination === 'object' &&
+        route.continue
+      ) {
+        errors.push(
+          `Route at index ${i} cannot define \`continue: true\` with a service \`destination\`. The service handoff is terminal.`
+        );
+      }
+
       // The last seen handling is the current handler
       const handleValue = handling[handling.length - 1];
       if (handleValue === 'hit') {

--- a/packages/routing-utils/src/index.ts
+++ b/packages/routing-utils/src/index.ts
@@ -74,9 +74,7 @@ function convertRouteAliases(route: RouteWithSrc, index: number): void {
         `Route at index ${index} cannot define both \`dest\` and \`destination\`. Please use only one.`
       );
     }
-    // `destination` aliases `dest` only in its string form. A service-targeted
-    // `destination` object has no `dest` equivalent, so it is NOT folded and
-    // stays on `destination`.
+    // `destination` aliases `dest` only in its string form
     if (typeof route.destination === 'string') {
       route.dest = route.destination;
       delete route.destination;
@@ -109,9 +107,7 @@ export function normalizeRoutes(
     const route = { ...r } as Route;
     routes.push(route);
 
-    // Fold input aliases into canonical fields (source -> src,
-    // statusCode -> status, and string `destination` -> dest). A service
-    // `destination` object is preserved, not aliased.
+    // Convert aliases (source -> src, destination -> dest, statusCode -> status)
     if (!isHandler(route)) {
       try {
         convertRouteAliases(route as RouteWithSrc, i);
@@ -246,11 +242,17 @@ function checkPatternSyntax(
     };
   }
 
-  // Service-targeted destinations are objects, not URL strings; skip the
-  // string-destination segment validation for them.
-  if (typeof destination === 'string') {
+  // For a service destination, validate `path` the same way as a plain string destination.
+  const destinationString =
+    typeof destination === 'string'
+      ? destination
+      : typeof destination?.path === 'string'
+        ? destination.path
+        : undefined;
+
+  if (destinationString !== undefined) {
     try {
-      const { hostname, pathname, query } = parseUrl(destination, true);
+      const { hostname, pathname, query } = parseUrl(destinationString, true);
       sourceToRegex(hostname || '').segments.forEach(name =>
         destinationSegments.add(name)
       );

--- a/packages/routing-utils/src/index.ts
+++ b/packages/routing-utils/src/index.ts
@@ -50,6 +50,13 @@ export function isValidHandleValue(handle: string): handle is HandleValue {
   return validHandleValues.has(handle);
 }
 
+/**
+ * Folds input-only aliases into their canonical fields: `source` -> `src` and
+ * `statusCode` -> `status`. `destination` is an alias for `dest` ONLY when it is a
+ * string; a service-targeted `destination` object (`{ type: 'service', ... }`)
+ * has no `dest` equivalent and is intentionally left in place. A route may not
+ * set both a canonical field and its alias.
+ */
 function convertRouteAliases(route: RouteWithSrc, index: number): void {
   if (route.source !== undefined) {
     if (route.src !== undefined) {
@@ -62,21 +69,18 @@ function convertRouteAliases(route: RouteWithSrc, index: number): void {
   }
 
   if (route.destination !== undefined) {
-    if (typeof route.destination === 'string') {
-      if (route.dest !== undefined) {
-        throw new Error(
-          `Route at index ${index} cannot define both \`dest\` and \`destination\`. Please use only one.`
-        );
-      }
-      route.dest = route.destination;
-      delete route.destination;
-    } else if (route.dest !== undefined) {
-      // A service-targeted destination object cannot coexist with `dest`.
+    if (route.dest !== undefined) {
       throw new Error(
-        `Route at index ${index} cannot define both \`dest\` and a service \`destination\`. Please use only one.`
+        `Route at index ${index} cannot define both \`dest\` and \`destination\`. Please use only one.`
       );
     }
-    // Service-targeted destination objects are preserved as-is.
+    // `destination` aliases `dest` only in its string form. A service-targeted
+    // `destination` object has no `dest` equivalent, so it is NOT folded and
+    // stays on `destination`.
+    if (typeof route.destination === 'string') {
+      route.dest = route.destination;
+      delete route.destination;
+    }
   }
 
   if (route.statusCode !== undefined) {
@@ -105,7 +109,9 @@ export function normalizeRoutes(
     const route = { ...r } as Route;
     routes.push(route);
 
-    // Convert aliases (source -> src, destination -> dest, statusCode -> status)
+    // Fold input aliases into canonical fields (source -> src,
+    // statusCode -> status, and string `destination` -> dest). A service
+    // `destination` object is preserved, not aliased.
     if (!isHandler(route)) {
       try {
         convertRouteAliases(route as RouteWithSrc, i);

--- a/packages/routing-utils/src/index.ts
+++ b/packages/routing-utils/src/index.ts
@@ -18,6 +18,7 @@ import {
   RouteInput,
   RouteWithHandle,
   RouteWithSrc,
+  ServiceDestination,
 } from './types';
 export { appendRoutesToPhase } from './append';
 export { mergeRoutes } from './merge';
@@ -61,13 +62,21 @@ function convertRouteAliases(route: RouteWithSrc, index: number): void {
   }
 
   if (route.destination !== undefined) {
-    if (route.dest !== undefined) {
+    if (typeof route.destination === 'string') {
+      if (route.dest !== undefined) {
+        throw new Error(
+          `Route at index ${index} cannot define both \`dest\` and \`destination\`. Please use only one.`
+        );
+      }
+      route.dest = route.destination;
+      delete route.destination;
+    } else if (route.dest !== undefined) {
+      // A service-targeted destination object cannot coexist with `dest`.
       throw new Error(
-        `Route at index ${index} cannot define both \`dest\` and \`destination\`. Please use only one.`
+        `Route at index ${index} cannot define both \`dest\` and a service \`destination\`. Please use only one.`
       );
     }
-    route.dest = route.destination;
-    delete route.destination;
+    // Service-targeted destination objects are preserved as-is.
   }
 
   if (route.statusCode !== undefined) {
@@ -217,7 +226,7 @@ function checkPatternSyntax(
   }: {
     source: string;
     has?: HasField;
-    destination?: string;
+    destination?: string | ServiceDestination;
   }
 ): { message: string; link: string } | null {
   let sourceSegments = new Set<string>();
@@ -231,7 +240,9 @@ function checkPatternSyntax(
     };
   }
 
-  if (destination) {
+  // Service-targeted destinations are objects, not URL strings; skip the
+  // string-destination segment validation for them.
+  if (typeof destination === 'string') {
     try {
       const { hostname, pathname, query } = parseUrl(destination, true);
       sourceToRegex(hostname || '').segments.forEach(name =>

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -12,6 +12,32 @@ const mitigateSchema = {
   },
 } as const;
 
+const serviceDestinationSchema = {
+  description:
+    'A service-targeted destination that delegates routing into a named service from `services`.',
+  type: 'object',
+  additionalProperties: false,
+  required: ['type', 'service'],
+  properties: {
+    type: {
+      description: 'Discriminator. Must be `service`.',
+      type: 'string',
+      enum: ['service'],
+    },
+    service: {
+      description: 'Target service name from `services`.',
+      type: 'string',
+      maxLength: 256,
+    },
+    path: {
+      description:
+        'Routing-only path used to select a route inside the target service. It does not mutate the URL observed by user code.',
+      type: 'string',
+      maxLength: 4096,
+    },
+  },
+} as const;
+
 const matchableValueSchema = {
   description:
     'A value to match against. Can be a string (regex) or a condition operation object',
@@ -376,8 +402,10 @@ export const routesSchema = {
             maxLength: 4096,
           },
           destination: {
-            type: 'string',
-            maxLength: 4096,
+            anyOf: [
+              { type: 'string', maxLength: 4096 },
+              serviceDestinationSchema,
+            ],
           },
           headers: {
             type: 'object',
@@ -531,9 +559,8 @@ export const rewritesSchema = {
       },
       destination: {
         description:
-          'An absolute pathname to an existing resource or an external URL.',
-        type: 'string',
-        maxLength: 4096,
+          'An absolute pathname to an existing resource, an external URL, or a service-targeted destination object.',
+        anyOf: [{ type: 'string', maxLength: 4096 }, serviceDestinationSchema],
       },
       has: hasSchema,
       missing: hasSchema,

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -12,6 +12,14 @@ const mitigateSchema = {
   },
 } as const;
 
+const serviceNameSchema = {
+  description: 'A service name identifier.',
+  type: 'string',
+  minLength: 1,
+  maxLength: 64,
+  pattern: '^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$',
+} as const;
+
 const serviceDestinationSchema = {
   description:
     'A service-targeted destination that delegates routing into a named service from `services`.',
@@ -24,11 +32,7 @@ const serviceDestinationSchema = {
       type: 'string',
       enum: ['service'],
     },
-    service: {
-      description: 'Target service name from `services`.',
-      type: 'string',
-      maxLength: 256,
-    },
+    service: serviceNameSchema,
     path: {
       description:
         'Routing-only path used to select a route inside the target service. It does not mutate the URL observed by user code.',

--- a/packages/routing-utils/src/superstatic.ts
+++ b/packages/routing-utils/src/superstatic.ts
@@ -183,24 +183,29 @@ export function convertRewrites(
     normalizeHasKeys(r.missing);
 
     try {
-      // Service-targeted rewrite (RFC: destination.type === 'service'): a
-      // terminal handoff into the target service's route table. The precise
-      // lowering (phase placement and `path` segment interpolation) is finalized
-      // by the Build Output compiler; here we preserve the destination object.
-      const route: RouteWithSrc =
-        typeof r.destination === 'string'
-          ? {
-              src,
-              dest: replaceSegments(
-                segments,
-                hasSegments,
-                r.destination,
-                false,
-                internalParamNames
-              ),
-              check: true,
-            }
-          : { src, destination: r.destination };
+      // Replace `:param` placeholders with `$1`/`$name` backrefs that point at
+      // the source's capture groups.
+      const interpolate = (value: string): string =>
+        replaceSegments(
+          segments,
+          hasSegments,
+          value,
+          false,
+          internalParamNames
+        );
+
+      let route: RouteWithSrc;
+      if (typeof r.destination === 'string') {
+        route = { src, dest: interpolate(r.destination), check: true };
+      } else {
+        // Service destination: a terminal handoff into the target service's
+        // route table. Interpolate `path` like a string `dest`.
+        const destination = { ...r.destination };
+        if (typeof destination.path === 'string') {
+          destination.path = interpolate(destination.path);
+        }
+        route = { src, destination };
+      }
 
       if (typeof r.env !== 'undefined') {
         route.env = r.env;

--- a/packages/routing-utils/src/superstatic.ts
+++ b/packages/routing-utils/src/superstatic.ts
@@ -3,7 +3,14 @@
  * See https://github.com/firebase/superstatic#configuration
  */
 import { parse as parseUrl, format as formatUrl } from 'url';
-import { Route, Redirect, Rewrite, HasField, Header } from './types';
+import {
+  Route,
+  RouteWithSrc,
+  Redirect,
+  Rewrite,
+  HasField,
+  Header,
+} from './types';
 
 /*
   [START] Temporary double-install of path-to-regexp to compare the impact of the update
@@ -176,14 +183,24 @@ export function convertRewrites(
     normalizeHasKeys(r.missing);
 
     try {
-      const dest = replaceSegments(
-        segments,
-        hasSegments,
-        r.destination,
-        false,
-        internalParamNames
-      );
-      const route: Route = { src, dest, check: true };
+      // Service-targeted rewrite (RFC: destination.type === 'service'): a
+      // terminal handoff into the target service's route table. The precise
+      // lowering (phase placement and `path` segment interpolation) is finalized
+      // by the Build Output compiler; here we preserve the destination object.
+      const route: RouteWithSrc =
+        typeof r.destination === 'string'
+          ? {
+              src,
+              dest: replaceSegments(
+                segments,
+                hasSegments,
+                r.destination,
+                false,
+                internalParamNames
+              ),
+              check: true,
+            }
+          : { src, destination: r.destination };
 
       if (typeof r.env !== 'undefined') {
         route.env = r.env;

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -63,17 +63,8 @@ type Transform = {
   env?: string[];
 };
 
-/**
- * A service-targeted destination (RFC: Vercel Backends). When a route or
- * rewrite `destination` is this object form, routing is delegated into the
- * named service's internal route table. `path` is routing-only — it selects a
- * route inside the target service and does not mutate the URL observed by user
- * code.
- */
 export type ServiceDestination = {
-  /** Discriminator. Must be `"service"` for service-targeted destinations. */
   type: 'service';
-  /** Target service name from `services`. */
   service: string;
   /** Routing-only path used to select a route inside the target service. */
   path?: string;

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -63,6 +63,22 @@ type Transform = {
   env?: string[];
 };
 
+/**
+ * A service-targeted destination (RFC: Vercel Backends). When a route or
+ * rewrite `destination` is this object form, routing is delegated into the
+ * named service's internal route table. `path` is routing-only — it selects a
+ * route inside the target service and does not mutate the URL observed by user
+ * code.
+ */
+export type ServiceDestination = {
+  /** Discriminator. Must be `"service"` for service-targeted destinations. */
+  type: 'service';
+  /** Target service name from `services`. */
+  service: string;
+  /** Routing-only path used to select a route inside the target service. */
+  path?: string;
+};
+
 export type RouteWithSrc = {
   src: string;
   dest?: string;
@@ -90,11 +106,16 @@ export type RouteWithSrc = {
   /**
    * Aliases for `src`, `dest`, and `status`. These provide consistency with the
    * `rewrites`, `redirects`, and `headers` fields which use `source`, `destination`,
-   * and `statusCode`. During normalization, these are converted to their canonical
-   * forms (`src`, `dest`, `status`) and stripped from the route object.
+   * and `statusCode`. During normalization, the string forms are converted to
+   * their canonical forms (`src`, `dest`, `status`) and stripped from the route
+   * object.
+   *
+   * `destination` may also be a service-targeted object (RFC: Vercel Backends),
+   * in which case routing is delegated into the named service's internal route
+   * table and the object is preserved as-is (not folded into `dest`).
    */
   source?: string;
-  destination?: string;
+  destination?: string | ServiceDestination;
   statusCode?: number;
   /**
    * A middleware key within the `output` key under the build result.
@@ -154,7 +175,7 @@ export interface Build {
 
 export interface Rewrite {
   source: string;
-  destination: string;
+  destination: string | ServiceDestination;
   has?: HasField;
   missing?: HasField;
   statusCode?: number;

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -101,9 +101,9 @@ export type RouteWithSrc = {
    * their canonical forms (`src`, `dest`, `status`) and stripped from the route
    * object.
    *
-   * `destination` may also be a service-targeted object (RFC: Vercel Backends),
-   * in which case routing is delegated into the named service's internal route
-   * table and the object is preserved as-is (not folded into `dest`).
+   * `destination` may also be a service-targeted object, in which case routing
+   * is delegated into the named service's internal route table and the object
+   * is preserved as-is (not folded into `dest`).
    */
   source?: string;
   destination?: string | ServiceDestination;

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -262,6 +262,24 @@ describe('normalizeRoutes', () => {
     }
   });
 
+  test('rejects a service `destination.path` referencing an unknown segment', () => {
+    const { error } = getTransformedRoutes({
+      rewrites: [
+        {
+          source: '/api/:path*',
+          destination: {
+            type: 'service',
+            service: 'my_backend',
+            path: '/:unknown*',
+          },
+        },
+      ],
+    });
+
+    assert.ok(error, 'expected a validation error');
+    assert.equal(error?.code, 'invalid_rewrite');
+  });
+
   test('normalizes src', () => {
     const expected = '^/about$';
     const sources = [

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -222,13 +222,43 @@ describe('normalizeRoutes', () => {
     );
     assert.ok(serviceRoute, 'expected a service-targeted route');
     if (serviceRoute && !isHandler(serviceRoute)) {
+      // `path` is interpolated like a string dest: `:path*` -> `$1`.
       assert.deepStrictEqual(serviceRoute.destination, {
         type: 'service',
         service: 'my_backend',
-        path: '/:path*',
+        path: '/$1',
       });
       // Terminal handoff: no filesystem re-check is added.
       assert.equal(serviceRoute.check, undefined);
+    }
+  });
+
+  test('interpolates path and query segments in a service `destination`', () => {
+    const { error, routes } = getTransformedRoutes({
+      rewrites: [
+        {
+          source: '/org/:orgSlug/api/:path*',
+          destination: {
+            type: 'service',
+            service: 'my_backend',
+            path: '/:path*?org=:orgSlug',
+          },
+        },
+      ],
+    });
+
+    assert.equal(error, null);
+    const serviceRoute = routes?.find(
+      r => !isHandler(r) && typeof r.destination === 'object'
+    );
+    assert.ok(serviceRoute, 'expected a service-targeted route');
+    if (serviceRoute && !isHandler(serviceRoute)) {
+      // orgSlug is capture $1, path is capture $2.
+      assert.deepStrictEqual(serviceRoute.destination, {
+        type: 'service',
+        service: 'my_backend',
+        path: '/$2?org=$1',
+      });
     }
   });
 

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -120,6 +120,118 @@ describe('normalizeRoutes', () => {
     assert.deepStrictEqual(normalized.routes, routes);
   });
 
+  test('accepts and preserves service `destination` dispatch routes', () => {
+    const routes: Route[] = [
+      {
+        src: '^/api/health$',
+        destination: { type: 'service', service: 'web', path: '/api/health' },
+      },
+      {
+        src: '^/api(?:/(.*))?$',
+        destination: { type: 'service', service: 'api', path: '/$1' },
+      },
+      {
+        src: '^/(.*)$',
+        destination: { type: 'service', service: 'web', path: '/$1' },
+      },
+    ];
+
+    assertValid(routes);
+
+    const normalized = normalizeRoutes(routes);
+    assert.equal(normalized.error, null);
+    // The object `destination` is preserved, not folded into `dest`.
+    assert.deepStrictEqual(normalized.routes, routes);
+  });
+
+  test('accepts a service `destination` with only type and service', () => {
+    const routes: Route[] = [
+      { src: '^/(.*)$', destination: { type: 'service', service: 'web' } },
+    ];
+
+    assertValid(routes);
+
+    const normalized = normalizeRoutes(routes);
+    assert.equal(normalized.error, null);
+    assert.deepStrictEqual(normalized.routes, routes);
+  });
+
+  test('still folds a string `destination` alias into `dest`', () => {
+    const input: RouteInput[] = [{ src: '^/a$', destination: '/b' }];
+
+    const { error, routes } = normalizeRoutes(input);
+    assert.equal(error, null);
+    assert.ok(routes);
+    if (routes) {
+      const [route] = routes;
+      assert.equal(isHandler(route), false);
+      if (!isHandler(route)) {
+        assert.equal(route.dest, '/b');
+        assert.equal(route.destination, undefined);
+      }
+    }
+  });
+
+  test('rejects a service `destination` missing `service`', () => {
+    const validate = ajv.compile(routesSchema);
+    assert.equal(
+      validate([{ src: '^/(.*)$', destination: { type: 'service' } }]),
+      false
+    );
+  });
+
+  test('rejects a service `destination` missing `type`', () => {
+    const validate = ajv.compile(routesSchema);
+    assert.equal(
+      validate([{ src: '^/(.*)$', destination: { service: 'web' } }]),
+      false
+    );
+  });
+
+  test('rejects a service `destination` with an unknown property', () => {
+    const validate = ajv.compile(routesSchema);
+    assert.equal(
+      validate([
+        {
+          src: '^/(.*)$',
+          destination: { type: 'service', service: 'web', dest: '/x' },
+        },
+      ]),
+      false
+    );
+  });
+
+  test('lowers a service-targeted rewrite into a `destination` route', () => {
+    const { error, routes } = getTransformedRoutes({
+      rewrites: [
+        {
+          source: '/api/v1/:path*',
+          destination: {
+            type: 'service',
+            service: 'my_backend',
+            path: '/:path*',
+          },
+        },
+      ],
+    });
+
+    assert.equal(error, null);
+    assert.ok(routes);
+    const serviceRoute = routes?.find(
+      r => !isHandler(r) && typeof r.destination === 'object'
+    );
+    assert.ok(serviceRoute, 'expected a service-targeted route');
+    if (serviceRoute && !isHandler(serviceRoute)) {
+      assert.deepStrictEqual(serviceRoute.destination, {
+        type: 'service',
+        service: 'my_backend',
+        path: '/:path*',
+      });
+      // Terminal handoff: no filesystem re-check is added.
+      assert.equal(serviceRoute.check, undefined);
+    }
+  });
+
   test('normalizes src', () => {
     const expected = '^/about$';
     const sources = [

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -156,6 +156,37 @@ describe('normalizeRoutes', () => {
     assert.deepStrictEqual(normalized.routes, routes);
   });
 
+  test('validates service `destination` names like service config names', () => {
+    const validate = ajv.compile(routesSchema);
+
+    for (const service of ['web', 'my_backend', 'my-backend', 'a1']) {
+      assert.equal(
+        validate([
+          { src: '^/(.*)$', destination: { type: 'service', service } },
+        ]),
+        true
+      );
+    }
+
+    for (const service of [
+      '',
+      ' my-backend',
+      'my backend',
+      'my/backend',
+      '1backend',
+      'backend-',
+      'backend_',
+      'a'.repeat(65),
+    ]) {
+      assert.equal(
+        validate([
+          { src: '^/(.*)$', destination: { type: 'service', service } },
+        ]),
+        false
+      );
+    }
+  });
+
   test('still folds a string `destination` alias into `dest`', () => {
     const input: RouteInput[] = [{ src: '^/a$', destination: '/b' }];
 

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -201,6 +201,31 @@ describe('normalizeRoutes', () => {
     );
   });
 
+  test('rejects `continue: true` with a service `destination`', () => {
+    const { error } = normalizeRoutes([
+      {
+        src: '^/api/(.*)$',
+        destination: { type: 'service', service: 'api' },
+        continue: true,
+      },
+    ]);
+
+    assert.ok(error, 'expected a validation error');
+    assert.ok(
+      error?.errors?.some(e => e.includes('service `destination`')),
+      'expected a terminal-handoff error message'
+    );
+  });
+
+  test('allows a service `destination` without `continue`', () => {
+    const routes: Route[] = [
+      { src: '^/api/(.*)$', destination: { type: 'service', service: 'api' } },
+    ];
+
+    const { error } = normalizeRoutes(routes);
+    assert.equal(error, null);
+  });
+
   test('lowers a service-targeted rewrite into a `destination` route', () => {
     const { error, routes } = getTransformedRoutes({
       rewrites: [


### PR DESCRIPTION
## Summary

Adds a service-targeted `destination` to `@vercel/routing-utils` so a route/rewrite can
delegate into a named service from `services`/`experimentalServicesV2`

```json
{
  "source": "/org/:orgSlug/api/:path*",
  "destination": {
    "type": "service",
    "service": "my_backend",
    "path": "/:path*?org=:orgSlug"
  }
}
```

`destination` can now be either the existing string (unchanged behavior — alias for dest) or a `ServiceDestination` object

