### PR TITLE
Narrow @vercel/connect/eve interactive-auth contract

### DIFF
--- a/.changeset/eve-connect-narrowed-auth.md
+++ b/.changeset/eve-connect-narrowed-auth.md
@@ -1,0 +1,7 @@
+---
+'@vercel/connect': minor
+---
+
+Narrow the `@vercel/connect/eve` interactive-authorization contract to match Eve's narrowed `InteractiveAuthorizationDefinition`. `startAuthorization` now returns only `{ challenge }` (the journaled `state` is gone), so a Connect-backed session no longer carries OAuth secrets across a workflow step boundary. Runtime behavior is unchanged — Connect still re-polls `getTokenResponse(connector, principal)` in `completeAuthorization`.
+
+Breaking public-type change: the `ConnectAuthorizationState` type is removed and `connect()` no longer parameterizes `InteractiveAuthorizationDefinition`.

--- a/packages/connect/docs/eve-authorization-helper.md
+++ b/packages/connect/docs/eve-authorization-helper.md
@@ -34,7 +34,7 @@ export default defineMcpClientConnection({
 
 `connector` is the only required field. `principalType` defaults to `"user"`; authors set `"app"` only for app-scoped credentials. `connector` is a plain string — authors do their own env-var validation at module load (the typical pattern is a top-level `if (!value) throw ...`). Eve fills in `"Authorize <ConnectionName> in your browser to continue."` as the default consent-page prompt using the slot name it already derives from the filesystem path. Authors override via the optional `instructions` field only when they want non-default phrasing.
 
-The helper imports Eve's authorization types directly via type-only imports from `eve/connections` and returns Eve's real `InteractiveAuthorizationDefinition<State>` / `NonInteractiveAuthorizationDefinition`. `eve` is declared as an **optional peer dependency** of `@vercel/connect`, and the helper lives at the `@vercel/connect/eve` subpath, so consumers that don't use Eve never load it.
+The helper imports Eve's authorization types directly via type-only imports from `eve/connections` and returns Eve's real `InteractiveAuthorizationDefinition` / `NonInteractiveAuthorizationDefinition`. `eve` is declared as an **optional peer dependency** of `@vercel/connect`, and the helper lives at the `@vercel/connect/eve` subpath, so consumers that don't use Eve never load it.
 
 ### principalType → definition shape
 
@@ -66,18 +66,18 @@ Eve's `NonInteractiveAuthorizationDefinition` technically accepts `principalType
 `AuthorizationDefinition` is a discriminated union. The interactive branch:
 
 ```ts
-interface InteractiveAuthorizationDefinition<State extends JsonValue> {
+interface InteractiveAuthorizationDefinition<Resume = JsonValue> {
   readonly principalType: 'user';
   getToken(opts: { principal: ConnectionPrincipal }): Promise<TokenResult>;
   startAuthorization(opts: {
     principal: ConnectionPrincipal;
-    webhook: string;
-  }): Promise<{ challenge: ConnectionAuthorizationChallenge; state: State }>;
+    callbackUrl: string;
+  }): Promise<{ challenge: ConnectionAuthorizationChallenge; resume?: Resume }>;
   completeAuthorization(opts: {
     principal: ConnectionPrincipal;
-    state: State;
-    webhook: string;
-    request: AuthorizationCallbackRequest;
+    callbackUrl: string;
+    resume?: Resume;
+    callback: AuthorizationCallback; // { params, method, body? } — no headers
   }): Promise<TokenResult>;
 }
 ```
@@ -95,7 +95,6 @@ interface InteractiveAuthorizationDefinition<State extends JsonValue> {
 | `ConnectorInstallationRequiredError`           | `ConnectionAuthorizationFailedError` (`retryable: false`) | deployment issue, not user-fixable                                                                                                                                         |
 | `NoValidTokenError`                            | `ConnectionAuthorizationRequiredError`                    | treat as "need consent"                                                                                                                                                    |
 | `startAuthorization` `callbackUrl` / `webhook` | `opts.webhook`                                            | always `callbackUrl: webhook` (Eve mints a browser-redirect URL with a branded landing page; `webhook:` would land the user on Vercel Connect's generic close-window page) |
-| `verifier`                                     | `state.verifier`                                          | journaled; currently unused by Eve                                                                                                                                         |
 
 ## Proposed API
 
@@ -108,7 +107,6 @@ import {
   type ConnectionAuthorizationChallenge,
   type ConnectionPrincipal,
   type InteractiveAuthorizationDefinition,
-  type JsonValue,
   type NonInteractiveAuthorizationDefinition,
   type TokenResult,
 } from 'eve/connections';
@@ -118,17 +116,6 @@ import type {
   ConnectTokenParams,
   ConnectTokenSubject,
 } from './token.js';
-
-/**
- * State journaled by Eve between `startAuthorization` and
- * `completeAuthorization`. Currently just the PKCE verifier; the
- * index signature exists to satisfy Eve's `State extends JsonValue`
- * constraint.
- */
-export type ConnectAuthorizationState = {
-  readonly verifier: string;
-  readonly [key: string]: JsonValue;
-};
 
 export type ConnectAuthorizationPhase =
   | 'getToken'
@@ -204,15 +191,13 @@ export interface EveAuthorizationOptions {
  */
 export function connect(
   options: EveAuthorizationOptions & { readonly principalType?: 'user' }
-): InteractiveAuthorizationDefinition<ConnectAuthorizationState>;
+): InteractiveAuthorizationDefinition;
 export function connect(
   options: EveAuthorizationOptions & { readonly principalType: 'app' }
 ): NonInteractiveAuthorizationDefinition;
 export function connect(
   options: EveAuthorizationOptions
-):
-  | InteractiveAuthorizationDefinition<ConnectAuthorizationState>
-  | NonInteractiveAuthorizationDefinition;
+): InteractiveAuthorizationDefinition | NonInteractiveAuthorizationDefinition;
 ```
 
 ### Behavior
@@ -227,9 +212,9 @@ export function connect(
    | `ConnectorInstallationRequiredError`                              | `ConnectionAuthorizationFailedError` (`reason: "connector_installation_required"`, `retryable: false`) |
    | anything else                                                     | passed through `onError`, then rethrown verbatim                                                       |
 
-2. **`startAuthorization`** — calls Vercel Connect with `callbackUrl: webhook`. Eve's `webhook` parameter is semantically a browser-redirect target — the runtime mints it via `createWebhook({ respondWith: buildAuthorizationCompletePage() })` so the user lands on a branded "you can close this tab" page after consent. That maps to Vercel Connect's `callbackUrl:` semantics, which already accepts both `https://` (prod) and `http://localhost` (vercel dev), so one field covers both. We deliberately do **not** route `https://` URLs into Vercel Connect's `webhook:` (server-POST) field even though that would be more robust to the user closing the consent tab right after IdP callback: that mode shows the user Vercel Connect's generic "close this window" page instead of Eve's branded landing page, and the helper would need to grow protocol-aware logic that diverges from the simple "Eve mints one URL, Vercel Connect redirects there" mental model. Revisit if tab-close timeouts become a real problem in production. Returns `{ challenge: { url, instructions? }, state: { verifier } }`. `instructions` is only set when the author provides one — otherwise Eve fills in the default in its runtime step (see `withDefaultAuthorizationInstructions`).
+2. **`startAuthorization`** — calls Vercel Connect with `callbackUrl: webhook`. Eve's `webhook` parameter is semantically a browser-redirect target — the runtime mints it via `createWebhook({ respondWith: buildAuthorizationCompletePage() })` so the user lands on a branded "you can close this tab" page after consent. That maps to Vercel Connect's `callbackUrl:` semantics, which already accepts both `https://` (prod) and `http://localhost` (vercel dev), so one field covers both. We deliberately do **not** route `https://` URLs into Vercel Connect's `webhook:` (server-POST) field even though that would be more robust to the user closing the consent tab right after IdP callback: that mode shows the user Vercel Connect's generic "close this window" page instead of Eve's branded landing page, and the helper would need to grow protocol-aware logic that diverges from the simple "Eve mints one URL, Vercel Connect redirects there" mental model. Revisit if tab-close timeouts become a real problem in production. Returns `{ challenge: { url, instructions? } }` — the narrowed contract no longer journals a `state`/`resume` blob, so the PKCE verifier never crosses the step boundary. `instructions` is only set when the author provides one — otherwise Eve fills in the default in its runtime step (see `withDefaultAuthorizationInstructions`).
 
-3. **`completeAuthorization`** — ignores the journaled `state` and `request` payload (Vercel Connect is authoritative); re-calls `getTokenResponse`. If it still throws `UserAuthorizationRequiredError` / `NoValidTokenError`, translate to `ConnectionAuthorizationFailedError` with a "Vercel Connect still reports user as unauthorized" message (defaults to `retryable: true` so the model can re-prompt — most cases are network blips or replays).
+3. **`completeAuthorization`** — ignores the journaled `resume` and the `callback` payload (Vercel Connect is authoritative); re-calls `getTokenResponse`. If it still throws `UserAuthorizationRequiredError` / `NoValidTokenError`, translate to `ConnectionAuthorizationFailedError` with a "Vercel Connect still reports user as unauthorized" message (defaults to `retryable: true` so the model can re-prompt — most cases are network blips or replays).
 
 4. **App-scoped mode** (`principalType: "app"`) — helper returns only `getToken` (no `startAuthorization` / `completeAuthorization`). Vercel Connect gets `subject: { type: "app" }` on every request. Token-fetch failure surfaces as `ConnectionAuthorizationFailedError` with `retryable: false` because there is no user to consent.
 
@@ -508,7 +493,7 @@ Sequential; each step validates the next.
 2. **Switch to Vercel Connect's `webhook:` (server-POST) mode for `https://` URLs?** Would survive the user closing the consent tab right after IdP callback, where the current `callbackUrl` browser redirect would be lost. Costs the branded landing page (user sees Vercel Connect's generic close-window page) and adds protocol-aware logic to the helper. Defer until tab-close timeouts show up as a real prod issue.
 3. **Auto-load `connector` from `CONNECTOR_<NAME>`?** Saves a line; hides magic. Recommend explicit `connector`.
 4. **Inspect `request.url` for `?error=access_denied`?** Today both connections skip this. Vercel Connect's `UserAuthorizationRequiredError` covers it from the server's perspective, but we lose the "user clicked Deny" (terminal) vs "IdP flow still pending" (retryable) distinction. Defer until Vercel Connect surfaces it, or add an `onCallback` hook.
-5. **Is `state: { verifier }` useful?** Eve journals it but does not read it. Cheap to keep for debuggability; propose: keep.
+5. **Is `state: { verifier }` useful?** ~~Eve journals it but does not read it. Cheap to keep for debuggability; propose: keep.~~ **Resolved (contract narrowing):** Eve narrowed the contract so secrets no longer cross the step boundary, and the helper now returns only `{ challenge }` from `startAuthorization`. The verifier is no longer journaled. The renamed, secrets-discouraged `resume` field remains available for non-secret correlation, but the helper does not use it.
 6. **Rename `connector` → `uid` (or similar) SDK-wide?** The Vercel Connect dashboard labels the value `UID`, the SDK calls it `connector`, and the value can be either a UID slug (`oauth/mcp-linear-app`) or an opaque SCL token (`scl_...`). The helper inherits whatever name the SDK uses. If the SDK ever wants to unify naming, that's a separate SDK-level migration (deprecate `connector`, accept `uid`, bump minor) — not in scope here, but worth raising in the Vercel Connect repo alongside this plan.
 
 ## Risk / rollback

--- a/packages/connect/fixtures/eve/connections.d.ts
+++ b/packages/connect/fixtures/eve/connections.d.ts
@@ -26,9 +26,7 @@ export interface ConnectionAuthorizationChallenge {
   readonly expiresAt?: string;
 }
 
-export interface InteractiveAuthorizationDefinition<
-  State extends JsonValue = JsonValue,
-> {
+export interface InteractiveAuthorizationDefinition<Resume = JsonValue> {
   readonly principalType: 'user';
   readonly getToken: (options: {
     readonly principal: ConnectionPrincipal;
@@ -39,7 +37,7 @@ export interface InteractiveAuthorizationDefinition<
     readonly webhook?: string;
   }) => Promise<{
     readonly challenge: ConnectionAuthorizationChallenge;
-    readonly state: State;
+    readonly resume?: Resume;
   }>;
   readonly completeAuthorization: (options: {
     readonly principal: ConnectionPrincipal;

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -34,7 +34,6 @@ import {
   type ConnectionAuthorizationChallenge,
   type ConnectionPrincipal,
   type InteractiveAuthorizationDefinition,
-  type JsonValue,
   type NonInteractiveAuthorizationDefinition,
   type TokenResult,
 } from 'eve/connections';
@@ -60,20 +59,6 @@ export type ConnectAuthorizationPhase =
   | 'getToken'
   | 'startAuthorization'
   | 'completeAuthorization';
-
-/**
- * State journaled by Eve between
- * {@link InteractiveAuthorizationDefinition.startAuthorization} and
- * {@link InteractiveAuthorizationDefinition.completeAuthorization}.
- *
- * Currently just the PKCE verifier. The index signature exists to
- * satisfy Eve's `State extends JsonValue` constraint; in practice
- * the only key the helper produces or reads is `verifier`.
- */
-export type ConnectAuthorizationState = {
-  readonly verifier: string;
-  readonly [key: string]: JsonValue;
-};
 
 interface GetTokenOptions {
   readonly principal: ConnectionPrincipal;
@@ -200,7 +185,7 @@ export interface VercelConnectMetadata {
  */
 export type EveConnectAuthorizationDefinition<
   TAuthorization extends
-    | InteractiveAuthorizationDefinition<ConnectAuthorizationState>
+    | InteractiveAuthorizationDefinition
     | NonInteractiveAuthorizationDefinition,
 > = TAuthorization & {
   readonly vercelConnect: VercelConnectMetadata;
@@ -225,28 +210,22 @@ export type EveConnectAuthorizationDefinition<
  */
 export function connect(
   connector: string
-): EveConnectAuthorizationDefinition<
-  InteractiveAuthorizationDefinition<ConnectAuthorizationState>
->;
+): EveConnectAuthorizationDefinition<InteractiveAuthorizationDefinition>;
 export function connect(
   options: EveAuthorizationOptions & { readonly principalType?: 'user' }
-): EveConnectAuthorizationDefinition<
-  InteractiveAuthorizationDefinition<ConnectAuthorizationState>
->;
+): EveConnectAuthorizationDefinition<InteractiveAuthorizationDefinition>;
 export function connect(
   options: EveAuthorizationOptions & { readonly principalType: 'app' }
 ): EveConnectAuthorizationDefinition<NonInteractiveAuthorizationDefinition>;
 export function connect(
   options: EveAuthorizationInput
 ): EveConnectAuthorizationDefinition<
-  | InteractiveAuthorizationDefinition<ConnectAuthorizationState>
-  | NonInteractiveAuthorizationDefinition
+  InteractiveAuthorizationDefinition | NonInteractiveAuthorizationDefinition
 >;
 export function connect(
   input: EveAuthorizationInput
 ): EveConnectAuthorizationDefinition<
-  | InteractiveAuthorizationDefinition<ConnectAuthorizationState>
-  | NonInteractiveAuthorizationDefinition
+  InteractiveAuthorizationDefinition | NonInteractiveAuthorizationDefinition
 > {
   const options = normalizeAuthorizationOptions(input);
   const vercelConnect: VercelConnectMetadata = { connector: options.connector };
@@ -267,7 +246,7 @@ function normalizeAuthorizationOptions(
 
 function buildInteractiveDefinition(
   options: EveAuthorizationOptions
-): InteractiveAuthorizationDefinition<ConnectAuthorizationState> {
+): InteractiveAuthorizationDefinition {
   return {
     principalType: 'user',
 
@@ -290,7 +269,6 @@ function buildInteractiveDefinition(
       webhook,
     }: StartAuthorizationOptions): Promise<{
       challenge: ConnectionAuthorizationChallenge;
-      state: ConnectAuthorizationState;
     }> {
       try {
         // Eve's `webhook` parameter is semantically a browser-redirect
@@ -334,7 +312,6 @@ function buildInteractiveDefinition(
               ? { instructions: options.instructions }
               : null),
           } satisfies ConnectionAuthorizationChallenge,
-          state: { verifier: response.verifier },
         };
       } catch (error) {
         throw translate(error, 'startAuthorization', options);

--- a/packages/connect/src/eve/index.ts
+++ b/packages/connect/src/eve/index.ts
@@ -12,7 +12,6 @@ export {
   type EveAuthorizationOptions,
   type EveConnectAuthorizationDefinition,
   type ConnectAuthorizationPhase,
-  type ConnectAuthorizationState,
   type VercelConnectMetadata,
 } from './connection-authorization.js';
 


### PR DESCRIPTION
## Stacked on #16541

Base branch: `codex/eve-connect-rename` (the ash→eve rename). **Review/merge #16541 first** — this PR's diff is only the contract narrowing on top of it.

## Why

Eve narrowed `InteractiveAuthorizationDefinition` so the framework journals only non-secret correlation across a workflow step boundary (the renamed, secrets-discouraged `resume` replaces `state`; the callback no longer captures request headers). `@vercel/connect/eve` implements that contract, so its types follow.

Connect is provider-owned: `completeAuthorization` reads only `principal` (it re-polls `getTokenResponse(connector, principal)`), and `startAuthorization` returned a `state: { verifier }` it never read back. So this is almost entirely deletion — **runtime behavior is unchanged**. After this change a Connect-backed session journals nothing sensitive across any step boundary.

## Changes

- Remove the `ConnectAuthorizationState` type and drop the generic argument from `InteractiveAuthorizationDefinition` at every site.
- `startAuthorization` returns only `{ challenge }` (the vestigial `state: { verifier }` is gone); remove the now-unused `JsonValue` import.
- `completeAuthorization` / `getToken` unchanged — already destructure only `{ principal }`.
- Drop the `ConnectAuthorizationState` barrel export.
- Narrow the vendored `fixtures/eve/connections.d.ts` contract to match (`<State extends JsonValue>` → `<Resume = JsonValue>`, `state: State` → `resume?: Resume`), so the local typecheck validates against the narrowed shape. (The narrowed contract isn't published in any installable `eve`/`experimental-ash` yet, which is why this stacks on the vendored-types branch.)
- Update `docs/eve-authorization-helper.md` to the narrowed contract.

### Not affected
- `connect-oauth.ts` — route-level `AuthFn`, unrelated to the connection-auth contract.
- `slack-credentials.ts` — `getToken`-only; no interactive surface.

## Changeset

The base PR carries a `@vercel/connect` minor changeset for the rename. This PR adds a separate `@vercel/connect` minor changeset for the narrowing — a breaking public-type change (`ConnectAuthorizationState` removed, `startAuthorization` return shape changed).

## Verification

- `pnpm --filter @vercel/connect typecheck` — green.
- `biome lint` / `biome format` — clean.
- No adapter tests under `packages/connect` assert the old `{ challenge, state }` shape (confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
