### PR TITLE
feat(cli): add --no-gitignore flag to vercel link and env pull

### DIFF
--- a/.changeset/no-gitignore-flag.md
+++ b/.changeset/no-gitignore-flag.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+Add `--no-gitignore` flag to `vercel link` and `vercel env pull`.
+
+When passed, the flag skips the automatic write to `.gitignore` that normally happens during these commands (adding `.vercel` for `link`, and `.env*` for `env pull`). Useful in monorepo setups or workflows where `.gitignore` management is handled separately.

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -227,6 +227,13 @@ export const pullSubcommand = {
       description:
         'Skip the confirmation prompt when removing an environment variable',
     },
+    {
+      name: 'no-gitignore',
+      description: 'Skip automatic addition of the env file to ".gitignore"',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
   ],
   examples: [
     {

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -109,6 +109,7 @@ export default async function pull(
 
   telemetryClient.trackCliArgumentFilename(args[0]);
   telemetryClient.trackCliFlagYes(skipConfirmation);
+  telemetryClient.trackCliFlagNoGitignore(opts['--no-gitignore']);
   telemetryClient.trackCliOptionGitBranch(gitBranch);
   telemetryClient.trackCliOptionEnvironment(opts['--environment']);
   telemetryClient.trackCliOptionId(opts['--id']);
@@ -160,6 +161,8 @@ export default async function pull(
       flags: opts,
     }) || 'development';
 
+  const noGitignore = !!opts['--no-gitignore'];
+
   await envPullCommandLogic(
     client,
     filename,
@@ -169,7 +172,8 @@ export default async function pull(
     gitBranch,
     client.cwd,
     source,
-    deploymentId
+    deploymentId,
+    noGitignore
   );
 
   return 0;
@@ -184,7 +188,8 @@ export async function envPullCommandLogic(
   gitBranch: string | undefined,
   cwd: string,
   source: EnvRecordsSource,
-  deploymentId?: string
+  deploymentId?: string,
+  noGitignore: boolean = false
 ) {
   const fullPath = resolve(cwd, filename);
   const head = tryReadHeadSync(fullPath, Buffer.byteLength(CONTENTS_PREFIX));
@@ -281,7 +286,7 @@ export async function envPullCommandLogic(
   }
 
   let isGitIgnoreUpdated = false;
-  if (filename === '.env.local') {
+  if (filename === '.env.local' && !noGitignore) {
     // When the file is `.env.local`, we also add it to `.gitignore`
     // to avoid accidentally committing it to git.
     // We use '.env*' to match the default .gitignore from

--- a/packages/cli/src/commands/link/command.ts
+++ b/packages/cli/src/commands/link/command.ts
@@ -57,6 +57,13 @@ export const linkCommand = {
         'Skip questions when setting up new project using default scope and settings',
     },
     confirmOption,
+    {
+      name: 'no-gitignore',
+      description: 'Skip automatic addition of ".vercel" to ".gitignore"',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
   ],
   examples: [
     {

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -95,6 +95,7 @@ export default async function link(client: Client) {
   telemetry.trackCliFlagRepo(parsedArgs.flags['--repo']);
   telemetry.trackCliFlagYes(parsedArgs.flags['--yes']);
   telemetry.trackCliOptionProject(parsedArgs.flags['--project']);
+  telemetry.trackCliFlagNoGitignore(parsedArgs.flags['--no-gitignore']);
 
   if ('--confirm' in parsedArgs.flags) {
     telemetry.trackCliFlagConfirm(parsedArgs.flags['--confirm']);
@@ -103,6 +104,7 @@ export default async function link(client: Client) {
   }
 
   const yes = !!parsedArgs.flags['--yes'];
+  const noGitignore = !!parsedArgs.flags['--no-gitignore'];
 
   let cwd = parsedArgs.args[1];
   if (cwd) {
@@ -119,7 +121,7 @@ export default async function link(client: Client) {
   if (parsedArgs.flags['--repo']) {
     output.warn(`The ${cmd('--repo')} flag is in alpha, please report issues`);
     try {
-      await ensureRepoLink(client, cwd, { yes, overwrite: true });
+      await ensureRepoLink(client, cwd, { yes, overwrite: true, noGitignore });
     } catch (err) {
       output.prettyError(err);
       return 1;
@@ -141,6 +143,7 @@ export default async function link(client: Client) {
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
       searchAcrossTeams: !explicitScopeProvided,
+      noGitignore,
     });
 
     if (typeof link === 'number') {

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -58,6 +58,7 @@ export interface ResolvedGitRemote {
 export interface EnsureRepoLinkOptions {
   yes: boolean;
   overwrite: boolean;
+  noGitignore?: boolean;
 }
 
 interface NewProject {
@@ -173,12 +174,14 @@ export async function linkRepoProject(
     orgSlug,
     remoteName,
     successEmoji = 'link',
+    noGitignore = false,
   }: {
     project: Project;
     orgId: string;
     orgSlug: string;
     remoteName: string;
     successEmoji?: EmojiLabel;
+    noGitignore?: boolean;
   }
 ): Promise<RepoLink> {
   const repoLink = await getRepoLink(client, cwd);
@@ -204,7 +207,9 @@ export async function linkRepoProject(
 
   await outputJSON(repoLink.repoConfigPath, repoConfig, { spaces: 2 });
   await writeReadme(repoLink.rootPath);
-  await addToGitIgnore(repoLink.rootPath);
+  if (!noGitignore) {
+    await addToGitIgnore(repoLink.rootPath);
+  }
 
   printAlignedLabel('Linked', `${orgSlug}/${project.name}`);
 
@@ -448,7 +453,7 @@ async function discoverRepoProjects(
 export async function ensureRepoLink(
   client: Client,
   cwd: string,
-  { yes, overwrite }: EnsureRepoLinkOptions
+  { yes, overwrite, noGitignore = false }: EnsureRepoLinkOptions
 ): Promise<RepoLink | undefined> {
   const repoLink = await getRepoLink(client, cwd);
   if (repoLink) {
@@ -472,7 +477,9 @@ export async function ensureRepoLink(
 
     await writeReadme(rootPath);
 
-    await addToGitIgnore(rootPath);
+    if (!noGitignore) {
+      await addToGitIgnore(rootPath);
+    }
 
     printAlignedLabel(
       'Linked',

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -68,6 +68,8 @@ export interface SetupAndLinkOptions {
   /** When true, avoid prompts and return action_required payload when scope/project choice is needed */
   nonInteractive?: boolean;
   pullEnv?: boolean;
+  /** When true, skip automatic addition of ".vercel" to ".gitignore" */
+  noGitignore?: boolean;
   /** When true, indicates the project is being created from v0 (grants V0Builder permissions) */
   v0?: boolean;
   /** When true, search matching projects across teams before standard linking flow */
@@ -228,6 +230,7 @@ async function linkCrossTeamMatch({
   successEmoji,
   autoConfirm,
   pullEnv,
+  noGitignore,
 }: {
   client: Client;
   path: string;
@@ -235,6 +238,7 @@ async function linkCrossTeamMatch({
   successEmoji: EmojiLabel;
   autoConfirm: boolean;
   pullEnv: boolean;
+  noGitignore: boolean;
 }): Promise<ProjectLinkResult> {
   client.config.currentTeam =
     match.org.type === 'team' ? match.org.id : undefined;
@@ -264,7 +268,8 @@ async function linkCrossTeamMatch({
     match.org.slug,
     successEmoji,
     autoConfirm,
-    pullEnv
+    pullEnv,
+    noGitignore
   );
   return { status: 'linked', org: match.org, project: match.project };
 }
@@ -332,6 +337,7 @@ async function linkCrossTeamMatches({
   autoConfirm,
   nonInteractive,
   pullEnv,
+  noGitignore,
 }: {
   client: Client;
   path: string;
@@ -340,6 +346,7 @@ async function linkCrossTeamMatches({
   autoConfirm: boolean;
   nonInteractive: boolean;
   pullEnv: boolean;
+  noGitignore: boolean;
 }): Promise<ProjectLinkResult | null> {
   if (matches.length === 0) {
     return null;
@@ -356,6 +363,7 @@ async function linkCrossTeamMatches({
         successEmoji,
         autoConfirm,
         pullEnv,
+        noGitignore,
       });
     }
 
@@ -371,6 +379,7 @@ async function linkCrossTeamMatches({
         successEmoji,
         autoConfirm,
         pullEnv,
+        noGitignore,
       });
     }
     return null;
@@ -388,6 +397,7 @@ async function linkCrossTeamMatches({
       successEmoji,
       autoConfirm,
       pullEnv,
+      noGitignore,
     });
   }
 
@@ -422,6 +432,7 @@ async function linkCrossTeamMatches({
     successEmoji,
     autoConfirm,
     pullEnv,
+    noGitignore,
   });
 }
 
@@ -437,6 +448,7 @@ export default async function setupAndLink(
     projectName,
     nonInteractive = false,
     pullEnv = true,
+    noGitignore = false,
     v0,
     searchAcrossTeams = false,
   }: SetupAndLinkOptions
@@ -522,6 +534,7 @@ export default async function setupAndLink(
       autoConfirm,
       nonInteractive,
       pullEnv,
+      noGitignore,
     });
     if (linkedMatch) {
       return linkedMatch;
@@ -548,6 +561,7 @@ export default async function setupAndLink(
         autoConfirm,
         nonInteractive,
         pullEnv,
+        noGitignore,
       });
       if (linkedLimitedMatch) {
         return linkedLimitedMatch;
@@ -619,7 +633,8 @@ export default async function setupAndLink(
       org.slug,
       successEmoji,
       autoConfirm,
-      pullEnv
+      pullEnv,
+      noGitignore
     );
     return { status: 'linked', org, project };
   }
@@ -818,7 +833,8 @@ export default async function setupAndLink(
       org.slug,
       successEmoji,
       autoConfirm,
-      false // don't prompt to pull env for newly created projects
+      false, // don't prompt to pull env for newly created projects
+      noGitignore
     );
 
     await connectGitRepository(client, path, project, autoConfirm, org);

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -446,7 +446,8 @@ export async function linkFolderToProject(
   orgSlug: string,
   successEmoji: EmojiLabel = 'link',
   autoConfirm: boolean = false,
-  pullEnv: boolean = true
+  pullEnv: boolean = true,
+  noGitignore: boolean = false
 ) {
   // if the project is already linked, we skip linking
   if (await hasProjectLink(client, projectLink, path)) {
@@ -475,7 +476,9 @@ export async function linkFolderToProject(
   await writeReadme(path);
 
   // update .gitignore (silent — git status surfaces the change on demand)
-  await addToGitIgnore(path);
+  if (!noGitignore) {
+    await addToGitIgnore(path);
+  }
 
   printAlignedLabel('Linked', `${orgSlug}/${projectName}`);
 

--- a/packages/cli/src/util/telemetry/commands/env/pull.ts
+++ b/packages/cli/src/util/telemetry/commands/env/pull.ts
@@ -53,4 +53,10 @@ export class EnvPullTelemetryClient
       });
     }
   }
+
+  trackCliFlagNoGitignore(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('no-gitignore');
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/link/index.ts
+++ b/packages/cli/src/util/telemetry/commands/link/index.ts
@@ -55,4 +55,10 @@ export class LinkTelemetryClient
       value: actual,
     });
   }
+
+  trackCliFlagNoGitignore(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('no-gitignore');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -834,4 +834,56 @@ describe('env pull', () => {
       ]);
     });
   });
+
+  describe('--no-gitignore', () => {
+    it('should skip writing to .gitignore when --no-gitignore is passed', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'vercel-env-pull',
+        name: 'vercel-env-pull',
+      });
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv('env', 'pull', '--yes', '--no-gitignore');
+      const exitCodePromise = env(client);
+      await expect(client.stderr).toOutput(
+        'Downloading `development` Environment Variables for'
+      );
+      // Should NOT mention gitignore in the output
+      await expect(client.stderr).toOutput('Created .env.local file');
+      await expect(client.stderr).not.toOutput('and added it to .gitignore');
+      const exitCode = await exitCodePromise;
+      expect(exitCode, 'exit code for "env pull --no-gitignore"').toEqual(0);
+
+      // .env.local should exist
+      const rawDevEnv = await fs.readFile(path.join(cwd, '.env.local'));
+      const devFileHasDevEnv = rawDevEnv.toString().includes('SPECIAL_FLAG');
+      expect(devFileHasDevEnv).toBeTruthy();
+
+      // .gitignore should NOT have been updated
+      const gitignore = await fs.readFile(path.join(cwd, '.gitignore'), 'utf8');
+      expect(gitignore).not.toContain('.env*');
+    });
+
+    it('should track --no-gitignore telemetry flag', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'vercel-env-pull',
+        name: 'vercel-env-pull',
+      });
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv('env', 'pull', '--yes', '--no-gitignore');
+      await env(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:pull', value: 'pull' },
+        { key: 'flag:yes', value: 'TRUE' },
+        { key: 'flag:no-gitignore', value: 'TRUE' },
+      ]);
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -774,6 +774,68 @@ describe('link', () => {
     });
   });
 
+  describe('--no-gitignore', () => {
+    it('should skip writing .gitignore when --no-gitignore is passed', async () => {
+      useUser({ version: 'northstar' });
+      const cwd = setupTmpDir();
+      const [team] = useTeams('team_dummy') as Team[];
+      const { project } = useProject({
+        ...defaultProject,
+        id: basename(cwd),
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('--yes', '--no-gitignore');
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Searching for existing projects');
+      await expect(client.stderr).toOutput(
+        `Linked      ${team.slug}/${project.name}`
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode, 'exit code for "link --no-gitignore"').toEqual(0);
+
+      // .vercel/project.json should still be written
+      const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+      expect(projectJson.orgId).toEqual(team.id);
+      expect(projectJson.projectId).toEqual(project.id);
+
+      // .gitignore should NOT have been created
+      expect(await pathExists(join(cwd, '.gitignore'))).toBe(false);
+    });
+
+    it('should track --no-gitignore telemetry flag', async () => {
+      useUser();
+      const cwd = setupTmpDir();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: basename(cwd),
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('--yes', '--no-gitignore');
+      const exitCode = await link(client);
+      expect(exitCode, 'exit code for "link"').toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:yes',
+          value: 'TRUE',
+        },
+        {
+          key: 'flag:no-gitignore',
+          value: 'TRUE',
+        },
+      ]);
+    });
+  });
+
   describe('--non-interactive', () => {
     it('outputs action_required JSON and exits when not linked and multiple teams (no --team)', async () => {
       const cwd = setupTmpDir();


### PR DESCRIPTION
## Summary

Closes #16416

Adds a `--no-gitignore` flag to both `vercel link` and `vercel env pull` commands. When passed, the commands skip the automatic write to `.gitignore` that normally happens during execution.

## Motivation

Some users manage their `.gitignore` manually or via tooling, and the automatic modification is unwanted. This flag provides an opt-out.

## Changes

### `vercel link --no-gitignore`
Skips adding `.vercel` to `.gitignore` during project linking. Works for all link paths:
- Standard `vercel link` (single project)
- `vercel link --repo` (repository-level linking)
- Cross-team project linking

### `vercel env pull --no-gitignore`
Skips adding `.env*` to `.gitignore` when pulling environment variables to `.env.local`.

## Files changed

- `packages/cli/src/commands/link/command.ts` — adds `no-gitignore` option to `linkCommand`
- `packages/cli/src/commands/link/index.ts` — reads flag, tracks telemetry, passes to `ensureLink`/`ensureRepoLink`
- `packages/cli/src/commands/env/command.ts` — adds `no-gitignore` option to `pullSubcommand`
- `packages/cli/src/commands/env/pull.ts` — reads flag, guards `addToGitIgnore` call, tracks telemetry
- `packages/cli/src/util/link/setup-and-link.ts` — propagates `noGitignore` through `SetupAndLinkOptions`
- `packages/cli/src/util/projects/link.ts` — guards `addToGitIgnore` in `linkFolderToProject`
- `packages/cli/src/util/link/repo.ts` — guards both `addToGitIgnore` calls in `linkRepoProject` and `ensureRepoLink`
- `packages/cli/src/util/telemetry/commands/link/index.ts` — adds `trackCliFlagNoGitignore`
- `packages/cli/src/util/telemetry/commands/env/pull.ts` — adds `trackCliFlagNoGitignore`
- `packages/cli/test/unit/commands/env/pull.test.ts` — tests for `--no-gitignore` flag behavior
- `packages/cli/test/unit/commands/link/index.test.ts` — tests for `--no-gitignore` flag behavior
- `.changeset/no-gitignore-flag.md` — changeset entry