### PR TITLE
Support non-managed Connex connector creation

### DIFF
--- a/.changeset/connex-non-managed-create.md
+++ b/.changeset/connex-non-managed-create.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Added non-managed Connex connector creation with `--data` and optional `--connector-type`.

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -28,6 +28,24 @@ export const createSubcommand = {
       description: 'Enable webhook triggers for this connector',
     },
     {
+      name: 'data',
+      shorthand: null,
+      type: String,
+      argument: 'JSON',
+      deprecated: false,
+      description:
+        'JSON object for non-managed connector creation. When set, posts directly to the connector create API.',
+    },
+    {
+      name: 'connector-type',
+      shorthand: null,
+      type: String,
+      argument: 'TYPE',
+      deprecated: false,
+      description:
+        'Connector type for non-managed creation. By default, the backend infers the type from the service.',
+    },
+    {
       name: 'icon',
       shorthand: null,
       type: String,
@@ -70,6 +88,14 @@ export const createSubcommand = {
     {
       name: 'Create with branding (icon and colors)',
       value: `${packageName} connect create slack --name my-bot --icon ./logo.png --background-color '#1A2B3C' --accent-color '#FF0066'`,
+    },
+    {
+      name: 'Create a non-managed connector from explicit data',
+      value: `${packageName} connect create mcp.linear.app --name linear --data '{"clientId":"abc123"}'`,
+    },
+    {
+      name: 'Create a non-managed connector with an explicit connector type',
+      value: `${packageName} connect create slack --name my-bot --connector-type slack --data '{"appId":"A123","appName":"my-bot","clientId":"abc","clientSecret":"secret"}'`,
     },
     {
       name: 'Output as JSON',

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -43,7 +43,7 @@ export const createSubcommand = {
       argument: 'TYPE',
       deprecated: false,
       description:
-        'Connector type for non-managed creation. By default, the backend infers the type from the service.',
+        'Connector type for non-managed creation. By default, the type is resolved from the service.',
     },
     {
       name: 'icon',

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -18,6 +18,13 @@ import {
 } from '../../util/connex/upload-icon';
 import type { ConnexClient } from './types';
 
+interface ConnexServiceInfo {
+  types?: Array<{
+    type?: string;
+    createInputSchema?: Record<string, unknown>;
+  }>;
+}
+
 export async function create(
   client: Client,
   args: string[],
@@ -29,6 +36,8 @@ export async function create(
     '--icon'?: string;
     '--background-color'?: string;
     '--accent-color'?: string;
+    '--data'?: string;
+    '--connector-type'?: string;
   }
 ): Promise<number> {
   const formatResult = validateJsonOutput(flags);
@@ -43,6 +52,26 @@ export async function create(
     output.error('Missing service type. Usage: vercel connect create <type>');
     return 1;
   }
+
+  const dataFlag = flags['--data'];
+  const connectorType = flags['--connector-type'];
+  if (connectorType && dataFlag === undefined) {
+    output.error('The --connector-type flag requires --data.');
+    return 1;
+  }
+
+  const hasDataFlag = dataFlag !== undefined;
+  const isDataFlagEmpty = hasDataFlag && dataFlag.trim().length === 0;
+  let nonManagedData: JSONObject | undefined;
+  if (hasDataFlag && !isDataFlagEmpty) {
+    try {
+      nonManagedData = parseDataFlag(dataFlag);
+    } catch (err) {
+      output.error((err as Error).message);
+      return 1;
+    }
+  }
+  const isNonManagedCreate = hasDataFlag;
 
   // Preflight branding validation BEFORE team selection / network / upload.
   // This includes hex format, icon path readability, AND magic-byte check —
@@ -79,6 +108,10 @@ export async function create(
     'Select the team where you want to create this connector'
   );
 
+  if (isDataFlagEmpty) {
+    return await outputMissingDataError(client, serviceType, connectorType);
+  }
+
   // Get app name from flag or interactive prompt
   let name = flags['--name'];
   if (!name) {
@@ -110,14 +143,11 @@ export async function create(
     output.stopSpinner();
   }
 
-  // Generate request code and attempt to create the managed client directly
-  const { verifier, requestCode } = generateRequestCode();
   const link = await getProjectLink(client, client.cwd);
 
   const body: JSONObject = {
     service: serviceType,
     name,
-    request_code: requestCode,
   };
   if (link?.projectId) {
     body.projectId = link.projectId;
@@ -136,25 +166,61 @@ export async function create(
   output.spinner('Setting up...');
   let createdClient: ConnexClient | null = null;
   let browserUrl: string | undefined;
-  try {
-    createdClient = await client.fetch<ConnexClient>(
-      '/v1/connect/connectors/managed?autoinstall=true',
-      { method: 'POST', body }
-    );
-  } catch (err: unknown) {
-    const apiErr = err as { status?: number; registerUrl?: string };
-    if (apiErr.status === 422 && apiErr.registerUrl) {
-      browserUrl = apiErr.registerUrl;
-    } else if (apiErr.status === 404) {
-      output.stopSpinner();
-      output.error(
-        'Connect is not enabled for this team. Contact support to enable it.'
+
+  let verifier: string | undefined;
+  if (isNonManagedCreate) {
+    try {
+      const resolvedConnectorType =
+        connectorType ??
+        (await discoverConnectorType(client, serviceType)) ??
+        'oauth';
+
+      body.data = nonManagedData;
+      body.type = resolvedConnectorType;
+
+      createdClient = await client.fetch<ConnexClient>(
+        '/v1/connect/connectors',
+        { method: 'POST', body }
       );
-      return 1;
-    } else {
+    } catch (err: unknown) {
+      const apiErr = err as { status?: number };
+      if (apiErr.status === 404) {
+        output.stopSpinner();
+        output.error(
+          'Connect is not enabled for this team. Contact support to enable it.'
+        );
+        return 1;
+      }
       output.stopSpinner();
       printError(err);
       return 1;
+    }
+  } else {
+    // Generate request code and attempt to create the managed client directly.
+    const request = generateRequestCode();
+    verifier = request.verifier;
+    body.request_code = request.requestCode;
+
+    try {
+      createdClient = await client.fetch<ConnexClient>(
+        '/v1/connect/connectors/managed?autoinstall=true',
+        { method: 'POST', body }
+      );
+    } catch (err: unknown) {
+      const apiErr = err as { status?: number; registerUrl?: string };
+      if (apiErr.status === 422 && apiErr.registerUrl) {
+        browserUrl = apiErr.registerUrl;
+      } else if (apiErr.status === 404) {
+        output.stopSpinner();
+        output.error(
+          'Connect is not enabled for this team. Contact support to enable it.'
+        );
+        return 1;
+      } else {
+        output.stopSpinner();
+        printError(err);
+        return 1;
+      }
     }
   }
   output.stopSpinner();
@@ -186,6 +252,11 @@ export async function create(
     );
 
     output.spinner('Waiting for you to complete setup in the browser...');
+    if (!verifier) {
+      output.stopSpinner();
+      output.error('Missing browser setup verifier.');
+      return 1;
+    }
     const resultFromBrowser = await awaitConnexResult(client, verifier);
     output.stopSpinner();
 
@@ -271,4 +342,104 @@ export async function create(
     );
   }
   return brandingPatchFailed ? 1 : 0;
+}
+
+function parseDataFlag(raw: string): JSONObject {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('Invalid JSON for --data. Expected a JSON object.');
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('The --data value must be a JSON object.');
+  }
+
+  return parsed as JSONObject;
+}
+
+async function discoverConnectorType(
+  client: Client,
+  service: string
+): Promise<string | undefined> {
+  const serviceInfo = await fetchServiceInfo(client, service);
+  return defaultConnectorType(serviceInfo);
+}
+
+async function outputMissingDataError(
+  client: Client,
+  service: string,
+  inputConnectorType?: string
+): Promise<number> {
+  const { connectorType, createInputSchema } =
+    await resolveMissingDataSchemaInfo(client, service, inputConnectorType);
+
+  let message = '--data requires a non-empty JSON object.';
+  if (createInputSchema) {
+    message += `\n\nExpected --data schema for connector type "${connectorType}":\n${JSON.stringify(
+      createInputSchema,
+      null,
+      2
+    )}`;
+  }
+
+  output.error(message);
+  return 1;
+}
+
+async function resolveMissingDataSchemaInfo(
+  client: Client,
+  service: string,
+  inputConnectorType?: string
+): Promise<{
+  connectorType: string;
+  createInputSchema?: Record<string, unknown>;
+}> {
+  let serviceInfo = await fetchServiceInfo(client, service);
+  const connectorType =
+    inputConnectorType ?? defaultConnectorType(serviceInfo) ?? 'oauth';
+
+  if (!serviceInfo) {
+    serviceInfo = await fetchServiceInfo(client, inputConnectorType || 'oauth');
+  }
+
+  return {
+    connectorType,
+    createInputSchema: createInputSchemaForType(serviceInfo, connectorType),
+  };
+}
+
+async function fetchServiceInfo(
+  client: Client,
+  service: string
+): Promise<ConnexServiceInfo | undefined> {
+  try {
+    return await client.fetch<ConnexServiceInfo>(
+      `/v1/connect/services/${encodeURIComponent(service)}?schemas=true`
+    );
+  } catch (err) {
+    const apiErr = err as { status?: number };
+    if (apiErr.status === 404) {
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+function defaultConnectorType(
+  serviceInfo: ConnexServiceInfo | undefined
+): string | undefined {
+  const discoveredType = serviceInfo?.types?.[0]?.type;
+  if (typeof discoveredType === 'string' && discoveredType.length > 0) {
+    return discoveredType;
+  }
+}
+
+function createInputSchemaForType(
+  serviceInfo: ConnexServiceInfo | undefined,
+  connectorType: string
+): Record<string, unknown> | undefined {
+  return serviceInfo?.types?.find(typeInfo => typeInfo.type === connectorType)
+    ?.createInputSchema;
 }

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -98,13 +98,20 @@ export default async function connex(client: Client): Promise<number> {
         telemetry.trackCliSubcommandCreate(subcommandOriginal);
 
         const createFlagsSpec = getFlagsSpecification(createSubcommand.options);
-        const createParsedArgs = parseArguments(subArgs, createFlagsSpec);
+        const createParsedArgs = parseArguments(
+          normalizeCreateDataArgs(subArgs),
+          createFlagsSpec
+        );
         telemetry.trackCliOptionIcon(createParsedArgs.flags['--icon']);
         telemetry.trackCliOptionBackgroundColor(
           createParsedArgs.flags['--background-color']
         );
         telemetry.trackCliOptionAccentColor(
           createParsedArgs.flags['--accent-color']
+        );
+        telemetry.trackCliOptionData(createParsedArgs.flags['--data']);
+        telemetry.trackCliOptionConnectorType(
+          createParsedArgs.flags['--connector-type']
         );
         return await create(
           client,
@@ -328,4 +335,20 @@ export default async function connex(client: Client): Promise<number> {
     printError(err);
     return 1;
   }
+}
+
+function normalizeCreateDataArgs(args: string[]): string[] {
+  const normalized: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    normalized.push(arg);
+
+    if (arg === '--data') {
+      const next = args[i + 1];
+      if (next === undefined || next.startsWith('-')) {
+        normalized.push('');
+      }
+    }
+  }
+  return normalized;
 }

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -119,6 +119,24 @@ export class ConnexTelemetryClient
     }
   }
 
+  trackCliOptionData(v: string | undefined) {
+    if (v !== undefined) {
+      this.trackCliOption({
+        option: 'data',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionConnectorType(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'connector-type',
+        value: v,
+      });
+    }
+  }
+
   trackCliFlagYes(v: boolean | undefined) {
     if (v) {
       this.trackCliFlag('yes');

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -825,6 +825,10 @@ exports[`help command > connex help output snapshots > connex create subcommand 
 
        --accent-color <HEX>      Accent color for the connector icon (e.g. #1A2B3C)                                          
        --background-color <HEX>  Background color for the connector icon (e.g. #1A2B3C)                                      
+       --connector-type <TYPE>   Connector type for non-managed creation. By default, the backend infers the type from the   
+                                 service.                                                                                    
+       --data <JSON>             JSON object for non-managed connector creation. When set, posts directly to the connector   
+                                 create API.                                                                                 
   -F,  --format <FORMAT>         Specify the output format (json)                                                            
        --icon <PATH>             Path to a PNG or JPEG image to use as the connector icon (uploaded to Vercel)               
   -n,  --name <NAME>             Name of the connector                                                                       
@@ -862,6 +866,14 @@ exports[`help command > connex help output snapshots > connex create subcommand 
   - Create with branding (icon and colors)
 
     $ vercel connect create slack --name my-bot --icon ./logo.png --background-color '#1A2B3C' --accent-color '#FF0066'
+
+  - Create a non-managed connector from explicit data
+
+    $ vercel connect create mcp.linear.app --name linear --data '{"clientId":"abc123"}'
+
+  - Create a non-managed connector with an explicit connector type
+
+    $ vercel connect create slack --name my-bot --connector-type slack --data '{"appId":"A123","appName":"my-bot","clientId":"abc","clientSecret":"secret"}'
 
   - Output as JSON
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -825,8 +825,7 @@ exports[`help command > connex help output snapshots > connex create subcommand 
 
        --accent-color <HEX>      Accent color for the connector icon (e.g. #1A2B3C)                                          
        --background-color <HEX>  Background color for the connector icon (e.g. #1A2B3C)                                      
-       --connector-type <TYPE>   Connector type for non-managed creation. By default, the backend infers the type from the   
-                                 service.                                                                                    
+       --connector-type <TYPE>   Connector type for non-managed creation. By default, the type is resolved from the service. 
        --data <JSON>             JSON object for non-managed connector creation. When set, posts directly to the connector   
                                  create API.                                                                                 
   -F,  --format <FORMAT>         Specify the output format (json)                                                            

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -133,6 +133,472 @@ describe('connex create', () => {
     expect(postBody.service).toBe('jira');
   });
 
+  it('should create a non-managed connector when --data is provided', async () => {
+    let managedHit = false;
+    let discoveryHit = false;
+    let discoveryUrl = '';
+    let postBody: any;
+    client.scenario.post('/v1/connect/connectors/managed', (_req, res) => {
+      managedHit = true;
+      res.json(fakeConnexClient());
+    });
+    client.scenario.get('/v1/connect/services/:service', (req, res) => {
+      discoveryHit = true;
+      discoveryUrl = req.url ?? '';
+      expect((req.params as { service: string }).service).toBe(
+        'mcp.linear.app'
+      );
+      res.json({
+        types: [
+          {
+            type: 'api-key',
+          },
+        ],
+      });
+    });
+    client.scenario.post('/v1/connect/connectors', (req, res) => {
+      postBody = req.body;
+      res.json(
+        fakeConnexClient({
+          id: 'scl_nonmanaged1',
+          uid: 'uid_nonmanaged1',
+          type: 'oauth',
+          service: 'mcp.linear.app',
+        })
+      );
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'mcp.linear.app',
+      '--name',
+      'linear',
+      '--triggers',
+      '--data',
+      '{"clientId":"abc123","serverUrl":"https://linear.app/oauth"}'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(managedHit).toBe(false);
+    expect(discoveryHit).toBe(true);
+    expect(discoveryUrl).toContain('schemas=true');
+    expect(discoveryUrl).toContain(`teamId=${team.id}`);
+    expect(postBody).toMatchObject({
+      service: 'mcp.linear.app',
+      name: 'linear',
+      type: 'api-key',
+      triggers: { enabled: true },
+      data: {
+        clientId: 'abc123',
+        serverUrl: 'https://linear.app/oauth',
+      },
+    });
+    expect(postBody.request_code).toBeUndefined();
+    await expect(client.stderr).toOutput(
+      'mcp.linear.app connector created: scl_nonmanaged1 (UID uid_nonmanaged1)'
+    );
+  });
+
+  it('should default non-managed connector type to oauth when service discovery returns 404', async () => {
+    let discoveryHit = false;
+    let postBody: any;
+    client.scenario.get('/v1/connect/services/:service', (_req, res) => {
+      discoveryHit = true;
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+    client.scenario.post('/v1/connect/connectors', (req, res) => {
+      postBody = req.body;
+      res.json(
+        fakeConnexClient({
+          id: 'scl_nonmanaged_404',
+          uid: 'uid_nonmanaged_404',
+          type: 'oauth',
+        })
+      );
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'unknown-service',
+      '--name',
+      'unknown',
+      '--data',
+      '{"clientId":"abc123"}'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(discoveryHit).toBe(true);
+    expect(postBody).toMatchObject({
+      service: 'unknown-service',
+      name: 'unknown',
+      type: 'oauth',
+      data: {
+        clientId: 'abc123',
+      },
+    });
+  });
+
+  it('should default non-managed connector type to oauth when service discovery has no types', async () => {
+    let postBody: any;
+    client.scenario.get('/v1/connect/services/:service', (_req, res) => {
+      res.json({ types: [] });
+    });
+    client.scenario.post('/v1/connect/connectors', (req, res) => {
+      postBody = req.body;
+      res.json(
+        fakeConnexClient({
+          id: 'scl_nonmanaged_no_types',
+          uid: 'uid_nonmanaged_no_types',
+          type: 'oauth',
+        })
+      );
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'unknown-service',
+      '--name',
+      'unknown',
+      '--data',
+      '{"clientId":"abc123"}'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(postBody.type).toBe('oauth');
+  });
+
+  it('should send connector type for non-managed creation when --connector-type is provided', async () => {
+    let discoveryHit = false;
+    let postBody: any;
+    client.scenario.get('/v1/connect/services/:service', (_req, res) => {
+      discoveryHit = true;
+      res.json({ types: [{ type: 'oauth' }] });
+    });
+    client.scenario.post('/v1/connect/connectors', (req, res) => {
+      postBody = req.body;
+      res.json(
+        fakeConnexClient({
+          id: 'scl_nonmanaged_type',
+          uid: 'uid_nonmanaged_type',
+          type: 'slack',
+        })
+      );
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'slack',
+      '--name',
+      'my-bot',
+      '--connector-type',
+      'slack',
+      '--data',
+      '{"appId":"A123","appName":"my-bot","clientId":"abc","clientSecret":"secret"}'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(discoveryHit).toBe(false);
+    expect(postBody).toMatchObject({
+      service: 'slack',
+      name: 'my-bot',
+      type: 'slack',
+      data: {
+        appId: 'A123',
+        appName: 'my-bot',
+        clientId: 'abc',
+        clientSecret: 'secret',
+      },
+    });
+  });
+
+  it('should show create input schema when --data has no value', async () => {
+    let discoveryUrl = '';
+    let postHit = false;
+    client.scenario.get('/v1/connect/services/:service', (req, res) => {
+      discoveryUrl = req.url ?? '';
+      res.json({
+        types: [
+          {
+            type: 'slack',
+            createInputSchema: {
+              type: 'object',
+              required: ['clientId', 'clientSecret'],
+              properties: {
+                clientId: { type: 'string' },
+                clientSecret: { type: 'string' },
+              },
+            },
+          },
+        ],
+      });
+    });
+    client.scenario.post('/v1/connect/connectors', (_req, res) => {
+      postHit = true;
+      res.json(fakeConnexClient());
+    });
+
+    client.setArgv('connect', 'create', 'slack', '--data');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(postHit).toBe(false);
+    expect(discoveryUrl).toContain('schemas=true');
+    expect(discoveryUrl).toContain(`teamId=${team.id}`);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('--data requires a non-empty JSON object.');
+    expect(stderr).toContain(
+      'Expected --data schema for connector type "slack"'
+    );
+    expect(stderr).toContain('"clientSecret"');
+  });
+
+  it('should show schema for the user-specified type when --data is empty', async () => {
+    let postHit = false;
+    client.scenario.get('/v1/connect/services/:service', (_req, res) => {
+      res.json({
+        types: [
+          {
+            type: 'oauth',
+            createInputSchema: {
+              properties: {
+                clientId: { type: 'string' },
+              },
+            },
+          },
+          {
+            type: 'slack',
+            createInputSchema: {
+              properties: {
+                appId: { type: 'string' },
+              },
+            },
+          },
+        ],
+      });
+    });
+    client.scenario.post('/v1/connect/connectors', (_req, res) => {
+      postHit = true;
+      res.json(fakeConnexClient());
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'slack',
+      '--connector-type',
+      'slack',
+      '--data',
+      ''
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(postHit).toBe(false);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain(
+      'Expected --data schema for connector type "slack"'
+    );
+    expect(stderr).toContain('"appId"');
+    expect(stderr).not.toContain('"clientId"');
+  });
+
+  it('should fetch oauth service schema when service discovery returns 404 and no connector type is specified', async () => {
+    const fetchedServices: string[] = [];
+    client.scenario.get('/v1/connect/services/:service', (req, res) => {
+      const service = (req.params as { service: string }).service;
+      fetchedServices.push(service);
+      if (service === 'unknown-service') {
+        res.statusCode = 404;
+        res.json({ error: { code: 'not_found', message: 'Not Found' } });
+        return;
+      }
+      res.json({
+        types: [
+          {
+            type: 'oauth',
+            createInputSchema: {
+              properties: {
+                clientId: { type: 'string' },
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    client.setArgv('connect', 'create', 'unknown-service', '--data');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(fetchedServices).toEqual(['unknown-service', 'oauth']);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain(
+      'Expected --data schema for connector type "oauth"'
+    );
+    expect(stderr).toContain('"clientId"');
+  });
+
+  it('should fetch the specified connector type schema when service discovery returns 404', async () => {
+    const fetchedServices: string[] = [];
+    client.scenario.get('/v1/connect/services/:service', (req, res) => {
+      const service = (req.params as { service: string }).service;
+      fetchedServices.push(service);
+      if (service === 'unknown-service') {
+        res.statusCode = 404;
+        res.json({ error: { code: 'not_found', message: 'Not Found' } });
+        return;
+      }
+      res.json({
+        types: [
+          {
+            type: 'slack',
+            createInputSchema: {
+              properties: {
+                appId: { type: 'string' },
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'unknown-service',
+      '--data',
+      '--connector-type',
+      'slack'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(fetchedServices).toEqual(['unknown-service', 'slack']);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain(
+      'Expected --data schema for connector type "slack"'
+    );
+    expect(stderr).toContain('"appId"');
+  });
+
+  it('should only show missing data error when no create input schema is found', async () => {
+    const fetchedServices: string[] = [];
+    client.scenario.get('/v1/connect/services/:service', (req, res) => {
+      fetchedServices.push((req.params as { service: string }).service);
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv('connect', 'create', 'unknown-service', '--data');
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(fetchedServices).toEqual(['unknown-service', 'oauth']);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('--data requires a non-empty JSON object.');
+    expect(stderr).not.toContain('Expected --data schema');
+  });
+
+  it('should reject invalid --data JSON before any network call', async () => {
+    let postHit = false;
+    client.scenario.post('/v1/connect/connectors', (_req, res) => {
+      postHit = true;
+      res.json(fakeConnexClient());
+    });
+    client.scenario.post('/v1/connect/connectors/managed', (_req, res) => {
+      postHit = true;
+      res.json(fakeConnexClient());
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'slack',
+      '--name',
+      'my-bot',
+      '--data',
+      '{not json}'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(postHit).toBe(false);
+    await expect(client.stderr).toOutput(
+      'Invalid JSON for --data. Expected a JSON object.'
+    );
+  });
+
+  it('should reject non-object --data before any network call', async () => {
+    let postHit = false;
+    client.scenario.post('/v1/connect/connectors', (_req, res) => {
+      postHit = true;
+      res.json(fakeConnexClient());
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'slack',
+      '--name',
+      'my-bot',
+      '--data',
+      '["clientId"]'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(postHit).toBe(false);
+    await expect(client.stderr).toOutput(
+      'The --data value must be a JSON object.'
+    );
+  });
+
+  it('should reject --connector-type without --data', async () => {
+    let postHit = false;
+    client.scenario.post('/v1/connect/connectors/managed', (_req, res) => {
+      postHit = true;
+      res.json(fakeConnexClient());
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'slack',
+      '--name',
+      'my-bot',
+      '--connector-type',
+      'slack'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(postHit).toBe(false);
+    await expect(client.stderr).toOutput(
+      'The --connector-type flag requires --data.'
+    );
+  });
+
   it('should output JSON when --format=json is used', async () => {
     client.scenario.post('/v1/connect/connectors/managed', (_req, res) => {
       res.json(


### PR DESCRIPTION
## Summary

- Add non-managed Connex connector creation through `vercel connect create <service> --data <json>`
- Support optional `--connector-type`, with service discovery fallback through `GET /v1/connect/services/{service}?schemas=true`
- Show `createInputSchema` in the error output when `--data` is omitted or empty

## Manual examples

Create a Slack connector from an existing Slack app:

```bash
vercel connect create slack \
  --name "Acme Support Slack" \
  --connector-type slack \
  --data '{
    "appId": "A0123456789",
    "appName": "Acme Support",
    "clientId": "1234567890.1234567890123",
    "clientSecret": "00000000000000000000000000000000",
    "signingSecret": "11111111111111111111111111111111",
    "botScopes": ["commands", "chat:write", "users:read"],
    "userScopes": ["users:read"]
  }'
```

Create an OAuth connector for `mcp.linear.app`:

```bash
vercel connect create mcp.linear.app \
  --name "Linear MCP" \
  --data '{
    "serverUrl": "https://mcp.linear.app/oauth",
    "serverConfig": {
      "token_endpoint": "https://mcp.linear.app/oauth/token"
    },
    "clientId": "lin_mcp_client_123",
    "clientSecret": "lin_mcp_secret_456",
    "tokenEndpointAuthMethod": "client_secret_post",
    "defaultAudience": "https://mcp.linear.app"
  }'
```

If the OAuth service is not discoverable, callers can specify the type explicitly:

```bash
vercel connect create mcp.linear.app \
  --name "Linear MCP" \
  --connector-type oauth \
  --data '{"serverUrl":"https://mcp.linear.app/oauth","serverConfig":{"token_endpoint":"https://mcp.linear.app/oauth/token"},"clientId":"lin_mcp_client_123","clientSecret":"lin_mcp_secret_456"}'
```

## Testing

- `pnpm --filter vercel test test/unit/commands/connex/create.test.ts`
- `pnpm --filter vercel test test/unit/commands/help.test.ts -u`
- `pnpm --filter vercel type-check`
