### PR TITLE
Add Connect authorization prompt option

### DIFF
--- a/.changeset/connect-authorization-prompt.md
+++ b/.changeset/connect-authorization-prompt.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Forward the `prompt` authorization option to Vercel Connect.

--- a/packages/connect/src/authorization.ts
+++ b/packages/connect/src/authorization.ts
@@ -7,6 +7,7 @@ export interface ConnectAuthorizationOptions {
   webhook?: string;
   deviceCode?: boolean;
   expiresInMs?: number;
+  prompt?: string;
 }
 
 export interface ConnectAuthorizationResponse {
@@ -47,6 +48,7 @@ export async function startAuthorization(
     ...(options?.expiresInMs !== undefined && {
       expiresInMs: options.expiresInMs,
     }),
+    ...(options?.prompt !== undefined && { prompt: options.prompt }),
   };
 
   const response = await fetch(endpoint, {

--- a/packages/connect/test/authorization.test.ts
+++ b/packages/connect/test/authorization.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { startAuthorization } from '../src/authorization.js';
+
+describe('startAuthorization', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends prompt in the request body when specified', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          request: 'req_abc',
+          verifier: 'verifier_xyz',
+          url: 'https://connect.vercel.com/consent',
+        }),
+        { status: 200 }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await startAuthorization(
+      'oauth/linear',
+      { subject: { type: 'user', id: 'user_123' } },
+      { prompt: 'consent', vercelToken: 'vercel_oidc_token' }
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.vercel.com/v1/connect/authorize/oauth%2Flinear',
+      expect.objectContaining({
+        body: JSON.stringify({
+          subject: { type: 'user', id: 'user_123' },
+          prompt: 'consent',
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `prompt?: string` to `ConnectAuthorizationOptions`
- Forward `prompt` into the `startAuthorization()` request body when provided
- Add unit coverage for the request body behavior

## Testing
- `pnpm --filter @vercel/connect test`
- `pnpm --filter @vercel/connect typecheck`
- `pnpm prettier --check packages/connect/src/authorization.ts packages/connect/test/authorization.test.ts .changeset/connect-authorization-prompt.md`