### PR TITLE
[@vercel/connect] rename connector param to connectorId

### DIFF
--- a/.changeset/rename-connector-to-connector-id.md
+++ b/.changeset/rename-connector-to-connector-id.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Rename the `connector` identifier parameter to `connectorId` across the public API. This affects the positional argument of `getToken`, `getTokenResponse`, `startAuthorization`, `connectSlackCredentials` (`/eve`), `connectAuthProvider` (`/mcp`, `/ai-sdk`), and the `connect()` helper (`/eve`), as well as the `connector` option on the Auth.js and Better Auth providers and the `connector` field on `ConsentChallenge`, `ConsentRequiredError`, and the Eve `vercelConnect` metadata. The `connector` object on `ConnectTokenResponse` (the resolved connector entity) is unchanged. Update call sites to pass `connectorId`.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -86,7 +86,7 @@ export default defineMcpClientConnection({
 import { genericOAuth } from 'better-auth/plugins';
 import { connect } from '@vercel/connect/betterauth';
 
-genericOAuth({ config: [connect({ connector: 'linear' })] });
+genericOAuth({ config: [connect({ connectorId: 'linear' })] });
 ```
 
 ### Auth.js
@@ -94,7 +94,7 @@ genericOAuth({ config: [connect({ connector: 'linear' })] });
 ```ts
 import { connect } from '@vercel/connect/authjs';
 
-const providers = [connect({ connector: 'linear' })];
+const providers = [connect({ connectorId: 'linear' })];
 ```
 
 See the source under `src/` for the full API (additional helpers like `getTokenResponse`, `startAuthorization`, typed error classes, and per-adapter options).

--- a/packages/connect/docs/ai-sdk-mcp-integration.md
+++ b/packages/connect/docs/ai-sdk-mcp-integration.md
@@ -50,11 +50,11 @@ developer never sees any of it.
 
 Key building blocks already in this package (pre-existing, not new):
 
-- `getTokenResponse(connector, params, options?)` → `{ token, expiresAt, … }`
+- `getTokenResponse(connectorId, params, options?)` → `{ token, expiresAt, … }`
   (`src/token.ts`). Throws `UserAuthorizationRequiredError` when the subject has
   no grant yet, and `ConnectorInstallationRequiredError` when the connector is
   not installed.
-- `startAuthorization(connector, params, options?)` → `{ url, request, verifier, deviceCode? }`
+- `startAuthorization(connectorId, params, options?)` → `{ url, request, verifier, deviceCode? }`
   (`src/authorization.ts`). `url` is the Connect-hosted consent page to send the
   user to.
 
@@ -169,15 +169,15 @@ no-op for us. We only need two methods to do real work: `tokens()` and
 `src/mcp/connect-auth-provider.ts`. It returns an `OAuthClientProvider` whose
 methods map onto Connect:
 
-| Interface member        | Our implementation |
-| ----------------------- | ------------------ |
-| `tokens()`              | Calls `getTokenResponse`. Maps `{ token, expiresAt }` → `{ access_token, token_type: 'Bearer', expires_in }`. On `UserAuthorizationRequiredError` returns **`undefined`** (the spec signal for "no token, start auth"). On `ConnectorInstallationRequiredError` throws (config error, not a per-user consent issue). |
-| `redirectToAuthorization(url)` | **Ignores** the SDK-discovered `url`. Calls Connect's `startAuthorization` to get Connect's own consent URL, then either throws `ConsentRequiredError` (default) or invokes the `onConsentRequired` callback. |
-| `saveTokens` / `saveCodeVerifier` | No-ops — Connect owns persistence and PKCE. |
-| `codeVerifier()`        | Throws loudly. A correctly-wired transport never calls it (we own PKCE server-side); failing visibly beats fabricating a fake verifier. |
-| `redirectUrl`           | Configurable, defaults to `''`. The same value is forwarded to Connect's `startAuthorization` as the post-consent return URL (`callbackUrl`); empty string falls back to the connector's registered redirect. |
-| `clientMetadata`        | Minimal `{ redirect_uris: [] }` (only used during dynamic registration, which we never trigger). |
-| `clientInformation()`   | `{ client_id: connector }` — the connector UID stands in as the client id, so the orchestrator skips dynamic registration. |
+| Interface member                  | Our implementation                                                                                                                                                                                                                                                                                                   |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tokens()`                        | Calls `getTokenResponse`. Maps `{ token, expiresAt }` → `{ access_token, token_type: 'Bearer', expires_in }`. On `UserAuthorizationRequiredError` returns **`undefined`** (the spec signal for "no token, start auth"). On `ConnectorInstallationRequiredError` throws (config error, not a per-user consent issue). |
+| `redirectToAuthorization(url)`    | **Ignores** the SDK-discovered `url`. Calls Connect's `startAuthorization` to get Connect's own consent URL, then either throws `ConsentRequiredError` (default) or invokes the `onConsentRequired` callback.                                                                                                        |
+| `saveTokens` / `saveCodeVerifier` | No-ops — Connect owns persistence and PKCE.                                                                                                                                                                                                                                                                          |
+| `codeVerifier()`                  | Throws loudly. A correctly-wired transport never calls it (we own PKCE server-side); failing visibly beats fabricating a fake verifier.                                                                                                                                                                              |
+| `redirectUrl`                     | Configurable, defaults to `''`. The same value is forwarded to Connect's `startAuthorization` as the post-consent return URL (`callbackUrl`); empty string falls back to the connector's registered redirect.                                                                                                        |
+| `clientMetadata`                  | Minimal `{ redirect_uris: [] }` (only used during dynamic registration, which we never trigger).                                                                                                                                                                                                                     |
+| `clientInformation()`             | `{ client_id: connectorId }` — the connector UID stands in as the client id, so the orchestrator skips dynamic registration.                                                                                                                                                                                         |
 
 ### End-to-end consent sequence
 
@@ -260,7 +260,7 @@ them is the main review concern.
 1. **OAuth consent (Connect's job).** "Allow this app to access your Linear
    account at all." Happens once per user; handled by `connectAuthProvider`.
 2. **Tool-call approval (AI SDK HITL).** "Are you sure you want the agent to
-   create *this* issue right now?" Happens per action; handled by the AI SDK v7
+   create _this_ issue right now?" Happens per action; handled by the AI SDK v7
    `toolApproval` primitive.
 
 **This package only handles #1.** Tool-call approval is deliberately left to
@@ -293,8 +293,8 @@ cookbook (HITL via the AI SDK's own primitives, no new Connect code).
 **Reviewer feedback (dvoytenko):**
 
 - On a doc sample that fetches a token once and threads the raw string into
-  `createMCPClient`: *"This looks bad because token can expire and MCP client
-  won't be able to re-request it. The callback is the way."* This is the core
+  `createMCPClient`: _"This looks bad because token can expire and MCP client
+  won't be able to re-request it. The callback is the way."_ This is the core
   point — a captured token string goes stale; the client needs a callback
   (`tokens()`) it can re-invoke. This **validates the V1 adapter** over the V0
   raw-string pattern.
@@ -309,20 +309,20 @@ against drift in `@ai-sdk/mcp`'s `OAuthClientProvider`.
 
 **Reviewer feedback (dvoytenko, requested changes) — and how it was addressed:**
 
-1. `with-consent-approval.ts` *"wholly independent from Connect?"* → **Removed**
+1. `with-consent-approval.ts` _"wholly independent from Connect?"_ → **Removed**
    (AI SDK glue, duplicated `wrapMcpTools`; see [§7](#7-tool-calling-hitl-and-the-two-consents)).
-2. `vercelToken?: string` *"make it a callback?"* → **Done.** Now accepts
+2. `vercelToken?: string` _"make it a callback?"_ → **Done.** Now accepts
    `string | (() => string | Promise<string>)`, resolved at call time.
-3. `callbackUrl` vs `redirectUrl` *"What's the difference?"* → **Consolidated**
+3. `callbackUrl` vs `redirectUrl` _"What's the difference?"_ → **Consolidated**
    onto one `redirectUrl` (both the provider value and the post-consent return URL).
-4. `ConsentChallenge` *"Add optional `userCode`/`deviceCode`"* → **Done.**
+4. `ConsentChallenge` _"Add optional `userCode`/`deviceCode`"_ → **Done.**
    `deviceCode` + `expiresAt` thread onto the challenge and `ConsentRequiredError`.
-5. `redirectToAuthorization` *"...no redirect URL of any kind"* → **Confirmed.**
+5. `redirectToAuthorization` _"...no redirect URL of any kind"_ → **Confirmed.**
    The SDK-discovered URL is ignored; the consent URL comes from `startAuthorization`.
-6. *"Pass redirectUrl"* → **Done.** A non-empty `redirectUrl` is forwarded as
+6. _"Pass redirectUrl"_ → **Done.** A non-empty `redirectUrl` is forwarded as
    `callbackUrl` (Connect's `returnUrl`).
-7. Version bump *"Why is it here?"* → **Reverted** to `0.1.2`; changeset drives it.
-8. Imports *"Where are these files?"* → `../authorization.js` is sibling
+7. Version bump _"Why is it here?"_ → **Reverted** to `0.1.2`; changeset drives it.
+8. Imports _"Where are these files?"_ → `../authorization.js` is sibling
    `src/authorization.ts` (`.js` required by NodeNext); OAuth types are the
    optional `@ai-sdk/mcp` peer dep.
 
@@ -344,13 +344,13 @@ Remaining open items:
 
 ## 10. Reference map
 
-| Concept | File |
-| --- | --- |
-| Connect token fetch + error types | `src/token.ts` |
-| Connect consent / authorization start | `src/authorization.ts` |
-| MCP `OAuthClientProvider` adapter | `src/mcp/connect-auth-provider.ts` |
-| `/mcp` public surface | `src/mcp/index.ts` |
-| `/ai-sdk` public surface | `src/ai-sdk/index.ts` |
-| AI SDK `OAuthClientProvider` + `auth()` orchestrator | `vercel/ai` → `packages/mcp/src/tool/oauth.ts` |
+| Concept                                               | File                                                        |
+| ----------------------------------------------------- | ----------------------------------------------------------- |
+| Connect token fetch + error types                     | `src/token.ts`                                              |
+| Connect consent / authorization start                 | `src/authorization.ts`                                      |
+| MCP `OAuthClientProvider` adapter                     | `src/mcp/connect-auth-provider.ts`                          |
+| `/mcp` public surface                                 | `src/mcp/index.ts`                                          |
+| `/ai-sdk` public surface                              | `src/ai-sdk/index.ts`                                       |
+| AI SDK `OAuthClientProvider` + `auth()` orchestrator  | `vercel/ai` → `packages/mcp/src/tool/oauth.ts`              |
 | AI SDK HTTP transport (token attach + 401 → `auth()`) | `vercel/ai` → `packages/mcp/src/tool/mcp-http-transport.ts` |
-| AI SDK equivalent of our HITL helper | `vercel/ai` → `packages/policy-opa/src/wrap-mcp-tools.ts` |
+| AI SDK equivalent of our HITL helper                  | `vercel/ai` → `packages/policy-opa/src/wrap-mcp-tools.ts`   |

--- a/packages/connect/docs/eve-authorization-helper.md
+++ b/packages/connect/docs/eve-authorization-helper.md
@@ -27,7 +27,7 @@ export default defineMcpClientConnection({
   url: 'https://mcp.linear.app/sse',
   description: 'Linear workspace — issues, projects, cycles, and comments.',
   authorization: connect({
-    connector: process.env.CONNECTOR_LINEAR!,
+    connectorId: process.env.CONNECTOR_LINEAR!,
   }),
 });
 ```
@@ -128,7 +128,7 @@ export interface EveAuthorizationOptions {
    * in the Vercel Connect dashboard (e.g. `oauth/mcp-linear-app`)
    * or the opaque SCL form (e.g. `scl_V66vvAu5OJUsQll1LPOOQ`).
    */
-  readonly connector: string;
+  readonly connectorId: string;
 
   /**
    * Defaults to `"user"`.
@@ -257,7 +257,7 @@ export default defineMcpClientConnection({
   url: 'https://status.internal.example.com/mcp',
   description: 'Internal status API (agent-owned credential).',
   authorization: connect({
-    connector: process.env.CONNECTOR_STATUS!,
+    connectorId: process.env.CONNECTOR_STATUS!,
     principalType: 'app',
   }),
 });
@@ -269,7 +269,7 @@ TypeScript narrows the return type: `startAuthorization` and `completeAuthorizat
 
 ```ts
 authorization: connect({
-  connector: process.env.CONNECTOR_NOTION!,
+  connectorId: process.env.CONNECTOR_NOTION!,
   // Default would be "Authorize Notion in your browser to continue."
   instructions:
     "Notion needs one-time consent to read pages and databases. " +
@@ -283,7 +283,7 @@ All fields on `ConnectTokenParams` except `subject` (which the helper derives fr
 
 ```ts
 authorization: connect({
-  connector: process.env.CONNECTOR_LINEAR!,
+  connectorId: process.env.CONNECTOR_LINEAR!,
   tokenParams: {
     scopes: ["read:issues", "write:comments"],
     audience: ["https://api.linear.app"],
@@ -304,7 +304,7 @@ a different subject shape:
 
 ```ts
 authorization: connect({
-  connector: process.env.CONNECTOR_OAUTH!,
+  connectorId: process.env.CONNECTOR_OAUTH!,
   principalToSubject: principal => ({
     type: "jwt-bearer",
     sub: principal.attributes.email,
@@ -321,7 +321,7 @@ import { connect } from "@vercel/connect/eve";
 import { ConnectionAuthorizationFailedError } from "eve/connections";
 
 authorization: connect({
-  connector: process.env.CONNECTOR_GITHUB!,
+  connectorId: process.env.CONNECTOR_GITHUB!,
   onError(error, phase) {
     // GitHub returns org-SSO-required as a specific message shape.
     // Surface it as a non-retryable failure with actionable copy.
@@ -350,7 +350,7 @@ For unit tests that stub the Vercel API, pass `connectOptions.vercelToken` so th
 
 ```ts
 authorization: connect({
-  connector: "oauth/test-client",
+  connectorId: "oauth/test-client",
   connectOptions: { vercelToken: "stub-oidc-token" },
 }),
 ```
@@ -396,7 +396,10 @@ packages/connect/src/
 {
   "exports": {
     ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
-    "./eve": { "types": "./dist/eve/index.d.ts", "default": "./dist/eve/index.js" },
+    "./eve": {
+      "types": "./dist/eve/index.d.ts",
+      "default": "./dist/eve/index.js",
+    },
   },
   "peerDependencies": {
     "eve": ">=0.3.0-alpha.19",

--- a/packages/connect/src/authjs/connect-provider.ts
+++ b/packages/connect/src/authjs/connect-provider.ts
@@ -17,7 +17,7 @@
  *     connect({
  *       id: "slack",
  *       name: "Slack",
- *       connector: process.env.CONNECTOR_SLACK!,
+ *       connectorId: process.env.CONNECTOR_SLACK!,
  *     }),
  *   ],
  * };
@@ -58,7 +58,7 @@ export interface AuthJsConnectOptions {
    * opaque service connector key (`scl_...`) or the human-readable
    * UID (`oauth/mcp-linear-app`).
    */
-  readonly connector: string;
+  readonly connectorId: string;
 
   /**
    * Scopes to request. `offline_access` is added automatically so
@@ -91,7 +91,7 @@ export function connect(
     id: options.id,
     name: options.name,
     type: 'oauth',
-    clientId: options.connector,
+    clientId: options.connectorId,
     // The token endpoint expects client_secret_basic, but the secret
     // is a Vercel OIDC token that has to be fetched per-request. We
     // rely on the customFetch hook below to inject the token endpoint
@@ -127,7 +127,7 @@ export function connect(
       if (url.startsWith(CONNECT_TOKEN_URL)) {
         const vercelToken = await fetchVercelToken();
         const credentials = `${encodeURIComponent(
-          options.connector
+          options.connectorId
         )}:${encodeURIComponent(vercelToken)}`;
         const headers = new Headers(init?.headers);
         headers.set('authorization', `Basic ${btoa(credentials)}`);

--- a/packages/connect/src/authorization.ts
+++ b/packages/connect/src/authorization.ts
@@ -18,12 +18,12 @@ export interface ConnectAuthorizationResponse {
 }
 
 export async function startAuthorization(
-  connector: string,
+  connectorId: string,
   params: ConnectTokenParams,
   options?: ConnectAuthorizationOptions
 ): Promise<ConnectAuthorizationResponse> {
-  if (!connector) {
-    throw new Error('connector is required');
+  if (!connectorId) {
+    throw new Error('connectorId is required');
   }
   if (options?.callbackUrl !== undefined) {
     validateCallbackUrl(options.callbackUrl);
@@ -33,7 +33,7 @@ export async function startAuthorization(
   }
 
   const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
-  const endpoint = `https://api.vercel.com/v1/connect/authorize/${encodeURIComponent(connector)}`;
+  const endpoint = `https://api.vercel.com/v1/connect/authorize/${encodeURIComponent(connectorId)}`;
 
   const body = {
     ...params,

--- a/packages/connect/src/betterauth/connect-provider.ts
+++ b/packages/connect/src/betterauth/connect-provider.ts
@@ -19,7 +19,7 @@
  *       config: [
  *         connect({
  *           providerId: "slack",
- *           connector: process.env.CONNECTOR_SLACK!,
+ *           connectorId: process.env.CONNECTOR_SLACK!,
  *         }),
  *       ],
  *     }),
@@ -51,7 +51,7 @@ export interface BetterAuthConnectOptions {
    * opaque service connector key (`scl_...`) or the human-readable
    * UID (`oauth/mcp-linear-app`).
    */
-  readonly connector: string;
+  readonly connectorId: string;
 
   /**
    * Scopes to request. `offline_access` is added automatically so the
@@ -79,7 +79,7 @@ export function connect(options: BetterAuthConnectOptions): GenericOAuthConfig {
 
   return {
     providerId: options.providerId,
-    clientId: options.connector,
+    clientId: options.connectorId,
     // Best-effort: scope the Vercel Connect consent UI to the
     // deployment's Vercel team when we can read it from the OIDC
     // token. Falls back to the unqualified URL when the token isn't
@@ -94,7 +94,7 @@ export function connect(options: BetterAuthConnectOptions): GenericOAuthConfig {
     getToken: async ({ code, redirectURI, codeVerifier, deviceId }) => {
       const vercelToken = await fetchVercelToken();
       const credentials = `${encodeURIComponent(
-        options.connector
+        options.connectorId
       )}:${encodeURIComponent(vercelToken)}`;
       const basicAuth = btoa(credentials);
 

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -82,7 +82,7 @@ export interface EveAuthorizationOptions {
    * UID (`oauth/mcp-linear-app`) — both resolve to the same
    * connector on the Vercel Connect side.
    */
-  readonly connector: string;
+  readonly connectorId: string;
 
   /**
    * Whether this connection authenticates as the agent itself
@@ -161,7 +161,7 @@ export type EveAuthorizationInput = string | EveAuthorizationOptions;
  * connections at compile time and surface deep links to the matching
  * connector settings page.
  *
- * The `connector` field carries the raw value the author passed to
+ * The `connectorId` field carries the raw value the author passed to
  * {@link connect} — either the human-readable UID
  * (`"oauth/mcp-linear-app"`) or the opaque service-connector key
  * (`"scl_..."`). Consumers that need the canonical `scl_...` form
@@ -175,7 +175,7 @@ export type EveAuthorizationInput = string | EveAuthorizationOptions;
  * callbacks.
  */
 export interface VercelConnectMetadata {
-  readonly connector: string;
+  readonly connectorId: string;
 }
 
 /**
@@ -209,7 +209,7 @@ export type EveConnectAuthorizationDefinition<
  * without inspecting closure state.
  */
 export function connect(
-  connector: string
+  connectorId: string
 ): EveConnectAuthorizationDefinition<InteractiveAuthorizationDefinition>;
 export function connect(
   options: EveAuthorizationOptions & { readonly principalType?: 'user' }
@@ -228,7 +228,9 @@ export function connect(
   InteractiveAuthorizationDefinition | NonInteractiveAuthorizationDefinition
 > {
   const options = normalizeAuthorizationOptions(input);
-  const vercelConnect: VercelConnectMetadata = { connector: options.connector };
+  const vercelConnect: VercelConnectMetadata = {
+    connectorId: options.connectorId,
+  };
   if (options.principalType === 'app') {
     return { ...buildNonInteractiveDefinition(options), vercelConnect };
   }
@@ -239,7 +241,7 @@ function normalizeAuthorizationOptions(
   input: EveAuthorizationInput
 ): EveAuthorizationOptions {
   if (typeof input === 'string') {
-    return { connector: input };
+    return { connectorId: input };
   }
   return input;
 }
@@ -253,7 +255,7 @@ function buildInteractiveDefinition(
     async getToken({ principal }: GetTokenOptions): Promise<TokenResult> {
       try {
         const response = await getTokenResponse(
-          options.connector,
+          options.connectorId,
           await buildTokenParams(options, principal),
           options.connectOptions
         );
@@ -293,7 +295,7 @@ function buildInteractiveDefinition(
         // model. Revisit if tab-close timeouts become a real problem
         // in production.
         const response = await startAuthorization(
-          options.connector,
+          options.connectorId,
           await buildTokenParams(options, principal),
           {
             ...options.connectOptions,
@@ -323,7 +325,7 @@ function buildInteractiveDefinition(
     }: CompleteAuthorizationOptions): Promise<TokenResult> {
       try {
         const response = await getTokenResponse(
-          options.connector,
+          options.connectorId,
           await buildTokenParams(options, principal),
           options.connectOptions
         );
@@ -343,7 +345,7 @@ function buildNonInteractiveDefinition(
     async getToken({ principal }: GetTokenOptions): Promise<TokenResult> {
       try {
         const response = await getTokenResponse(
-          options.connector,
+          options.connectorId,
           await buildTokenParams(options, principal),
           options.connectOptions
         );

--- a/packages/connect/src/eve/slack-credentials.ts
+++ b/packages/connect/src/eve/slack-credentials.ts
@@ -52,13 +52,13 @@ export type ConnectSlackCredentialsParams = Omit<ConnectTokenParams, 'subject'>;
  * ```
  */
 export function connectSlackCredentials(
-  connector: string,
+  connectorId: string,
   params: ConnectSlackCredentialsParams = {},
   options?: ConnectOptions
 ): SlackChannelCredentials {
   return {
     botToken: () =>
-      getToken(connector, { ...params, subject: { type: 'app' } }, options),
+      getToken(connectorId, { ...params, subject: { type: 'app' } }, options),
     webhookVerifier: vercelOidc(),
   };
 }

--- a/packages/connect/src/mcp/connect-auth-provider.ts
+++ b/packages/connect/src/mcp/connect-auth-provider.ts
@@ -65,7 +65,7 @@ export interface ConnectAuthProviderOptions {
  * the consent URL.
  */
 export interface ConsentChallenge {
-  readonly connector: string;
+  readonly connectorId: string;
   readonly subject: ConnectTokenParams['subject'];
   /** Consent URL to redirect the user to. */
   readonly url: string;
@@ -90,7 +90,7 @@ export interface ConsentChallenge {
  */
 export class ConsentRequiredError extends Error {
   readonly name = 'ConsentRequiredError';
-  readonly connector: string;
+  readonly connectorId: string;
   readonly subject: ConnectTokenParams['subject'];
   readonly url: string;
   readonly request: string;
@@ -100,9 +100,9 @@ export class ConsentRequiredError extends Error {
 
   constructor(challenge: ConsentChallenge) {
     super(
-      `Vercel Connect: user authorization required for connector "${challenge.connector}". Redirect the user to challenge.url to grant access.`
+      `Vercel Connect: user authorization required for connector "${challenge.connectorId}". Redirect the user to challenge.url to grant access.`
     );
-    this.connector = challenge.connector;
+    this.connectorId = challenge.connectorId;
     this.subject = challenge.subject;
     this.url = challenge.url;
     this.request = challenge.request;
@@ -124,7 +124,7 @@ const EMPTY_CLIENT_METADATA: OAuthClientMetadata = {
  * state, and the callback handshake server-side, so most of the
  * `OAuthClientProvider` surface is intentionally a no-op.
  *
- * @param connector Vercel Connect connector UID (e.g. `oauth/linear`)
+ * @param connectorId Vercel Connect connector UID (e.g. `oauth/linear`)
  *   or opaque connector id.
  * @param params Token request parameters — always specify a
  *   `subject`; the three subject types
@@ -133,7 +133,7 @@ const EMPTY_CLIENT_METADATA: OAuthClientMetadata = {
  * @param options Optional adapter behavior overrides.
  */
 export function connectAuthProvider(
-  connector: string,
+  connectorId: string,
   params: ConnectTokenParams,
   options?: ConnectAuthProviderOptions
 ): OAuthClientProvider {
@@ -152,7 +152,7 @@ export function connectAuthProvider(
       try {
         const vercelToken = await resolveVercelToken();
         const response = await getTokenResponse(
-          connector,
+          connectorId,
           params,
           vercelToken !== undefined ? { vercelToken } : undefined
         );
@@ -186,7 +186,7 @@ export function connectAuthProvider(
       // endpoint. We ignore it — Connect has its own consent URL
       // backed by the connector's registered OAuth client.
       const vercelToken = await resolveVercelToken();
-      const response = await startAuthorization(connector, params, {
+      const response = await startAuthorization(connectorId, params, {
         ...(vercelToken !== undefined && { vercelToken }),
         // Forward the post-consent return URL so the user lands back
         // in the app. Falsy (the default empty string) => Connect uses
@@ -195,7 +195,7 @@ export function connectAuthProvider(
         ...(options?.deviceCode && { deviceCode: true }),
       });
       const challenge: ConsentChallenge = {
-        connector,
+        connectorId,
         subject: params.subject,
         url: response.url,
         request: response.request,
@@ -249,7 +249,7 @@ export function connectAuthProvider(
       // MCP transport uses this for cache keys and debug output;
       // tying it to the Connect identifier is more useful than
       // returning a synthetic value.
-      return { client_id: connector };
+      return { client_id: connectorId };
     },
   };
 }

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -115,21 +115,21 @@ export interface ConnectOptions {
 }
 
 export async function getToken(
-  connector: string,
+  connectorId: string,
   params: ConnectTokenParams,
   options?: ConnectOptions
 ): Promise<string> {
-  const { token } = await getTokenResponse(connector, params, options);
+  const { token } = await getTokenResponse(connectorId, params, options);
   return token;
 }
 
 export async function getTokenResponse(
-  connector: string,
+  connectorId: string,
   params: ConnectTokenParams,
   options?: ConnectOptions
 ): Promise<ConnectTokenResponse> {
   const bufferMs = params.validityBufferMs ?? DEFAULT_VALIDITY_BUFFER_MS;
-  const cacheKey = JSON.stringify({ connector, ...params });
+  const cacheKey = JSON.stringify({ connectorId, ...params });
 
   const cached = cache.get(cacheKey);
   if (cached) {
@@ -143,7 +143,7 @@ export async function getTokenResponse(
 
   const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
 
-  const endpoint = `https://api.vercel.com/v1/connect/token/${encodeURIComponent(connector)}`;
+  const endpoint = `https://api.vercel.com/v1/connect/token/${encodeURIComponent(connectorId)}`;
 
   const response = await fetch(endpoint, {
     method: 'POST',

--- a/packages/connect/test/mcp/connect-auth-provider.test.ts
+++ b/packages/connect/test/mcp/connect-auth-provider.test.ts
@@ -125,7 +125,7 @@ describe('connectAuthProvider', () => {
         provider.redirectToAuthorization(ignoredUrl)
       ).rejects.toMatchObject({
         name: 'ConsentRequiredError',
-        connector: CONNECTOR,
+        connectorId: CONNECTOR,
         subject: PARAMS.subject,
         url: 'https://connect.vercel.com/consent/oauth/linear?req=abc',
         request: 'req_abc',
@@ -287,14 +287,14 @@ describe('connectAuthProvider', () => {
   describe('ConsentRequiredError', () => {
     it('exposes the consent metadata as enumerable fields', () => {
       const err = new ConsentRequiredError({
-        connector: CONNECTOR,
+        connectorId: CONNECTOR,
         subject: PARAMS.subject,
         url: 'https://connect.vercel.com/consent',
         request: 'req',
         verifier: 'ver',
       });
       expect(err.name).toBe('ConsentRequiredError');
-      expect(err.connector).toBe(CONNECTOR);
+      expect(err.connectorId).toBe(CONNECTOR);
       expect(err.url).toBe('https://connect.vercel.com/consent');
       expect(err.request).toBe('req');
       expect(err.verifier).toBe('ver');
@@ -303,7 +303,7 @@ describe('connectAuthProvider', () => {
 
     it('is an instanceof Error and ConsentRequiredError', () => {
       const err = new ConsentRequiredError({
-        connector: CONNECTOR,
+        connectorId: CONNECTOR,
         subject: PARAMS.subject,
         url: 'u',
         request: 'r',


### PR DESCRIPTION
## Why

The positional/option name `connector` for the connector **identifier** is ambiguous — it reads like the resolved connector entity. This renames the identifier to `connectorId` so call sites clearly distinguish the id string from the connector object returned on `ConnectTokenResponse.connector`.

## What changed

Renamed the connector identifier parameter to `connectorId` across the public API:

- `getToken(connectorId, …)` / `getTokenResponse(connectorId, …)`
- `startAuthorization(connectorId, …)`
- `connectSlackCredentials(connectorId, …)` (`/eve`)
- `connectAuthProvider({ connectorId, … })` (`/mcp`, `/ai-sdk`)
- `connect({ connectorId })` eve helper
- `connector` option → `connectorId` on the Auth.js and Better Auth providers
- `connector` field → `connectorId` on `ConsentChallenge`, `ConsentRequiredError`, and the eve `vercelConnect` metadata

The `connector` object on `ConnectTokenResponse` (the resolved connector entity) is **unchanged**. README + docs + tests updated. Changeset included (`minor`, breaking pre-1.0).

## Validation

- `pnpm --filter @vercel/connect test` — 21 passing