### PR TITLE
Improve vc link UX

### DIFF
--- a/.changeset/cli-link-ux.md
+++ b/.changeset/cli-link-ux.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improved the `vc link` setup prompts and output.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -296,7 +296,6 @@ async function handleInitDeployment(
 
   const link = await ensureLink('deploy', client, cwd, {
     autoConfirm,
-    setupMsg: 'Set up',
     projectName:
       projectNameOrId ??
       getProjectName({
@@ -887,7 +886,6 @@ async function handleContinueSubcommand(
 
   const link = await ensureLink('deploy', client, cwd, {
     autoConfirm: true,
-    setupMsg: 'Set up',
     projectName: getProjectName({
       nameParam: undefined,
       nowConfig: localConfig,
@@ -1189,7 +1187,6 @@ async function handleDefaultDeploy(
 
   const link = await ensureLink('deploy', client, cwd, {
     autoConfirm,
-    setupMsg: 'Set up',
     projectName:
       projectNameOrId ??
       getProjectName({

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -78,7 +78,6 @@ export default async function dev(
         autoConfirm: opts['--yes'],
         link,
         successEmoji: 'link',
-        setupMsg: 'Set up',
         nonInteractive: client.nonInteractive,
       });
 

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -3,9 +3,7 @@ import { outputFile } from 'fs-extra';
 import { closeSync, openSync, readSync } from 'fs';
 import { resolve } from 'path';
 import type Client from '../../util/client';
-import { emoji, prependEmoji } from '../../util/emoji';
 import param from '../../util/output/param';
-import stamp from '../../util/output/stamp';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import {
   type EnvRecordsSource,
@@ -36,6 +34,7 @@ import {
   outputActionRequired,
   outputAgentError,
 } from '../../util/agent-output';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
 
 const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
 
@@ -235,7 +234,6 @@ export async function envPullCommandLogic(
 
   output.log(downloadMessage);
 
-  const pullStamp = stamp();
   output.spinner('Downloading');
 
   const pullId = deploymentId || link.project.id;
@@ -291,13 +289,11 @@ export async function envPullCommandLogic(
     isGitIgnoreUpdated = await addToGitIgnore(rootPath, '.env*');
   }
 
-  output.print(
-    `${prependEmoji(
-      `${exists ? 'Updated' : 'Created'} ${chalk.bold(filename)} file ${
-        isGitIgnoreUpdated ? 'and added it to .gitignore' : ''
-      } ${chalk.gray(pullStamp())}`,
-      emoji('success')
-    )}\n`
+  output.print('\n');
+  printAlignedLabel(
+    exists ? 'Updated' : 'Created',
+    `${filename} file${isGitIgnoreUpdated ? ' and added it to .gitignore' : ''}`,
+    { gutter: '✓' }
   );
 }
 

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -225,12 +225,12 @@ export async function envPullCommandLogic(
   const downloadMessage = gitBranch
     ? `Downloading \`${chalk.cyan(
         environment
-      )}\` Environment Variables for ${projectSlugLink} and any overrides for branch ${chalk.cyan(
+      )}\` environment variables for ${projectSlugLink} and any overrides for branch ${chalk.cyan(
         gitBranch
       )}`
     : `Downloading \`${chalk.cyan(
         environment
-      )}\` Environment Variables for ${projectSlugLink}`;
+      )}\` environment variables for ${projectSlugLink}`;
 
   output.log(downloadMessage);
 

--- a/packages/cli/src/commands/env/run.ts
+++ b/packages/cli/src/commands/env/run.ts
@@ -88,7 +88,7 @@ export default async function run(client: Client): Promise<number> {
 
   const gitBranch = parsedArgs.flags['--git-branch'];
 
-  output.spinner(`Downloading \`${environment}\` Environment Variables`);
+  output.spinner(`Downloading \`${environment}\` environment variables`);
 
   const records = await pullEnvRecords(
     client,

--- a/packages/cli/src/commands/link/command.ts
+++ b/packages/cli/src/commands/link/command.ts
@@ -4,7 +4,8 @@ import { confirmOption, projectOption, yesOption } from '../../util/arg-common';
 export const addSubcommand = {
   name: 'add',
   aliases: [],
-  description: 'Add projects to an existing repository link',
+  description:
+    'Add projects to an existing repository link created by link --repo',
   arguments: [],
   options: [
     {
@@ -38,11 +39,13 @@ export const linkCommand = {
     {
       ...projectOption,
       shorthand: 'p',
-      description: 'Set the project name or ID to link',
+      description:
+        'Set the project name or ID to link; required for non-interactive existing-project links',
     },
     {
       name: 'team',
-      description: 'Set the team ID or slug',
+      description:
+        'Set the team ID or slug; use with --project for non-interactive links',
       shorthand: null,
       argument: 'TEAM_ID_OR_SLUG',
       type: String,

--- a/packages/cli/src/commands/link/command.ts
+++ b/packages/cli/src/commands/link/command.ts
@@ -4,14 +4,13 @@ import { confirmOption, projectOption, yesOption } from '../../util/arg-common';
 export const addSubcommand = {
   name: 'add',
   aliases: [],
-  description:
-    'Add additional Vercel Projects to an existing repository link. Requires an existing repo.json (created by `link --repo`).',
+  description: 'Add projects to an existing repository link',
   arguments: [],
   options: [
     {
       ...yesOption,
       description:
-        'Skip questions when adding projects using default scope and settings',
+        'Skip questions when adding projects with default team and settings',
     },
   ],
   examples: [
@@ -25,13 +24,13 @@ export const addSubcommand = {
 export const linkCommand = {
   name: 'link',
   aliases: [],
-  description: 'Link a local directory to a Vercel Project.',
+  description: 'Link a local directory to a Vercel project',
   arguments: [],
   subcommands: [addSubcommand],
   options: [
     {
       name: 'repo',
-      description: 'Link multiple projects based on Git repository (alpha)',
+      description: 'Link multiple projects from the Git repository (alpha)',
       shorthand: 'r',
       type: Boolean,
       deprecated: false,
@@ -39,13 +38,11 @@ export const linkCommand = {
     {
       ...projectOption,
       shorthand: 'p',
-      description:
-        'Project name or ID to link to (required for non-interactive)',
+      description: 'Set the project name or ID to link',
     },
     {
       name: 'team',
-      description:
-        'Scope: team ID or slug (use with --project for non-interactive)',
+      description: 'Set the team ID or slug',
       shorthand: null,
       argument: 'TEAM_ID_OR_SLUG',
       type: String,
@@ -54,13 +51,13 @@ export const linkCommand = {
     {
       ...yesOption,
       description:
-        'Skip questions when setting up new project using default scope and settings',
+        'Skip questions when setting up with default team and settings',
     },
     confirmOption,
   ],
   examples: [
     {
-      name: 'Link current directory to a Vercel Project',
+      name: 'Link current directory to a Vercel project',
       value: `${packageName} link`,
     },
     {
@@ -68,15 +65,15 @@ export const linkCommand = {
       value: `${packageName} link --yes`,
     },
     {
-      name: 'Non-interactive: link to an existing project (CI/agents)',
+      name: 'Link to an existing project in CI or agent mode',
       value: `${packageName} link --yes --team <team-id> --project <project-name-or-id>`,
     },
     {
-      name: 'Link a specific directory to a Vercel Project',
+      name: 'Link a specific directory to a Vercel project',
       value: `${packageName} link --cwd /path/to/project`,
     },
     {
-      name: 'Link to the current Git repository, allowing for multiple Vercel Projects to be linked simultaneously (useful for monorepos)',
+      name: 'Link multiple projects from the current Git repository',
       value: `${packageName} link --repo`,
     },
     {

--- a/packages/cli/src/util/env/diff-env-files.ts
+++ b/packages/cli/src/util/env/diff-env-files.ts
@@ -67,7 +67,7 @@ export function buildDeltaString(
   deltaString += chalk.red(addDeltaSection('-', removed));
 
   return deltaString
-    ? chalk.gray('Changes:\n') + deltaString + '\n'
+    ? chalk.gray('  Changes:\n') + deltaString + '\n'
     : deltaString;
 }
 
@@ -80,7 +80,7 @@ function addDeltaSection(
   return (
     arr
       .sort()
-      .map(item => `${prefix} ${item}${changed ? ' (Updated)' : ''}`)
+      .map(item => `  ${prefix} ${item}${changed ? ' (Updated)' : ''}`)
       .join('\n') + '\n'
   );
 }

--- a/packages/cli/src/util/input/edit-project-settings.ts
+++ b/packages/cli/src/util/input/edit-project-settings.ts
@@ -91,6 +91,8 @@ export async function editProjectSettings(
     return settings;
   }
 
+  output.print('\n');
+
   // A missing framework slug implies the "Other" framework was selected
   if (!framework.slug) {
     output.print(`  No framework detected. Default Project Settings:\n`);
@@ -112,7 +114,7 @@ export async function editProjectSettings(
       outputDir ? `${settingMap.outputDirectory}: ${outputDir}` : null,
     ].filter(Boolean);
     const detail = inline.length ? chalk.dim(` (${inline.join(', ')})`) : '';
-    // 2-space indent matches the Set up status line and the printAlignedLabel block.
+    // 2-space indent matches the Directory setup row and printAlignedLabel block.
     // Framework name is plain (not bold) per prototype — only "Detected" is bold.
     output.print(`  ${chalk.bold('Detected')} ${framework.name}${detail}\n`);
   }

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -6,11 +6,6 @@ import type { Project, Org } from '@vercel-internals/types';
 import slugify from '@sindresorhus/slugify';
 import output from '../../output-manager';
 import { printAlignedLabel } from '../output/print-aligned-label';
-import toHumanPath from '../humanize-path';
-
-type LinkPromptContext = {
-  directory?: string;
-};
 
 type ProjectDecision = 'create' | 'existing';
 
@@ -41,8 +36,7 @@ export default async function inputProject(
   org: Org,
   detectedProjectName: string,
   autoConfirm = false,
-  skipAutoDetect = false,
-  linkPromptContext: LinkPromptContext = {}
+  skipAutoDetect = false
 ): Promise<Project | string> {
   const slugifiedName = slugify(detectedProjectName);
 
@@ -96,9 +90,6 @@ export default async function inputProject(
   } else {
     // auto-detected a project to link
     output.print(`  ${chalk.bold('Found existing project')}\n`);
-    if (linkPromptContext.directory) {
-      printAlignedLabel('Directory', toHumanPath(linkPromptContext.directory));
-    }
     printAlignedLabel('Project', `${org.slug}/${detectedProject.name}`);
     if (await client.input.confirm(`Link directory to project?`, true)) {
       return detectedProject;

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -5,6 +5,7 @@ import { ProjectNotFound } from '../../util/errors-ts';
 import type { Project, Org } from '@vercel-internals/types';
 import slugify from '@sindresorhus/slugify';
 import output from '../../output-manager';
+import { printAlignedLabel } from '../output/print-aligned-label';
 
 export default async function inputProject(
   client: Client,
@@ -64,14 +65,9 @@ export default async function inputProject(
     );
   } else {
     // auto-detected a project to link
-    if (
-      await client.input.confirm(
-        `Found project ${chalk.cyan(
-          `"${org.slug}/${detectedProject.name}"`
-        )}. Link to it?`,
-        true
-      )
-    ) {
+    output.print('  Found project\n');
+    printAlignedLabel('Project', `${org.slug}/${detectedProject.name}`);
+    if (await client.input.confirm(`Link to this project?`, true)) {
       return detectedProject;
     }
 
@@ -120,7 +116,7 @@ export default async function inputProject(
         }));
 
       const toLink = await client.input.select<Project>({
-        message: 'Which existing project do you want to link?',
+        message: 'Which project?',
         choices,
       });
 

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -12,6 +12,30 @@ type LinkPromptContext = {
   directory?: string;
 };
 
+type ProjectDecision = 'create' | 'existing';
+
+async function inputProjectDecision(
+  client: Client,
+  defaultDecision: ProjectDecision
+): Promise<ProjectDecision> {
+  const createChoice = {
+    name: 'Create new project',
+    value: 'create' as const,
+  };
+  const existingChoice = {
+    name: 'Link existing project',
+    value: 'existing' as const,
+  };
+
+  return await client.input.select<ProjectDecision>({
+    message: 'Project?',
+    choices:
+      defaultDecision === 'existing'
+        ? [existingChoice, createChoice]
+        : [createChoice, existingChoice],
+  });
+}
+
 export default async function inputProject(
   client: Client,
   org: Org,
@@ -64,11 +88,11 @@ export default async function inputProject(
   let shouldLinkProject;
 
   if (!detectedProject) {
-    // did not auto-detect a project to link
-    shouldLinkProject = await client.input.confirm(
-      `Link to existing project?`,
-      false
+    const decision = await inputProjectDecision(
+      client,
+      skipAutoDetect ? 'existing' : 'create'
     );
+    shouldLinkProject = decision === 'existing';
   } else {
     // auto-detected a project to link
     output.print(`  ${chalk.bold('Found existing project')}\n`);
@@ -81,10 +105,8 @@ export default async function inputProject(
     }
 
     // user doesn't want to link the auto-detected project
-    shouldLinkProject = await client.input.confirm(
-      `Link to different existing project?`,
-      true
-    );
+    const decision = await inputProjectDecision(client, 'existing');
+    shouldLinkProject = decision === 'existing';
   }
 
   if (shouldLinkProject) {

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -6,13 +6,19 @@ import type { Project, Org } from '@vercel-internals/types';
 import slugify from '@sindresorhus/slugify';
 import output from '../../output-manager';
 import { printAlignedLabel } from '../output/print-aligned-label';
+import toHumanPath from '../humanize-path';
+
+type LinkPromptContext = {
+  directory?: string;
+};
 
 export default async function inputProject(
   client: Client,
   org: Org,
   detectedProjectName: string,
   autoConfirm = false,
-  skipAutoDetect = false
+  skipAutoDetect = false,
+  linkPromptContext: LinkPromptContext = {}
 ): Promise<Project | string> {
   const slugifiedName = slugify(detectedProjectName);
 
@@ -65,9 +71,12 @@ export default async function inputProject(
     );
   } else {
     // auto-detected a project to link
-    output.print('  Found project\n');
+    output.print(`  ${chalk.bold('Found existing project')}\n`);
+    if (linkPromptContext.directory) {
+      printAlignedLabel('Directory', toHumanPath(linkPromptContext.directory));
+    }
     printAlignedLabel('Project', `${org.slug}/${detectedProject.name}`);
-    if (await client.input.confirm(`Link to this project?`, true)) {
+    if (await client.input.confirm(`Link directory to project?`, true)) {
       return detectedProject;
     }
 

--- a/packages/cli/src/util/input/input-root-directory.ts
+++ b/packages/cli/src/util/input/input-root-directory.ts
@@ -15,7 +15,7 @@ export async function inputRootDirectory(
 
   while (true) {
     const rootDirectory = await client.input.text({
-      message: `In which directory is your code located?`,
+      message: `Code directory?`,
       transformer: (input: string) => {
         return `${chalk.dim(`./`)}${input}`;
       },

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -206,6 +206,7 @@ export async function linkRepoProject(
   await writeReadme(repoLink.rootPath);
   await addToGitIgnore(repoLink.rootPath);
 
+  output.print('\n');
   printAlignedLabel('Linked', `${orgSlug}/${project.name}`);
 
   return {

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -207,7 +207,7 @@ export async function linkRepoProject(
   await addToGitIgnore(repoLink.rootPath);
 
   output.print('\n');
-  printAlignedLabel('Linked', `${orgSlug}/${project.name}`);
+  printAlignedLabel('Linked', `${orgSlug}/${project.name}`, { gutter: '✓' });
 
   return {
     repoConfig,
@@ -477,7 +477,8 @@ export async function ensureRepoLink(
 
     printAlignedLabel(
       'Linked',
-      `${pluralize('Project', result.projects.length, true)} under ${result.orgSlug}`
+      `${pluralize('Project', result.projects.length, true)} under ${result.orgSlug}`,
+      { gutter: '✓' }
     );
   }
 
@@ -552,7 +553,8 @@ export async function addRepoLink(
 
   printAlignedLabel(
     'Added',
-    `${pluralize('Project', result.projects.length, true)} under ${result.orgSlug}`
+    `${pluralize('Project', result.projects.length, true)} under ${result.orgSlug}`,
+    { gutter: '✓' }
   );
 
   return {

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -97,15 +97,6 @@ function formatMatchSource(match: CrossTeamMatch): string {
   return match.reason === 'repo-root' ? 'Git repository' : 'Folder name';
 }
 
-function formatTeamList(slugs: string[]): string {
-  const shown = slugs.slice(0, 5);
-  const suffix =
-    slugs.length > shown.length
-      ? `, and ${slugs.length - shown.length} more`
-      : '';
-  return `${shown.join(', ')}${suffix}`;
-}
-
 const CHECKBOX_INSTRUCTIONS = [
   '\n  ',
   chalk.dim('('),
@@ -125,7 +116,13 @@ function printCrossTeamSearchScope({
   searchedTeamSlugs: string[];
 }): void {
   if (searchedTeamSlugs.length > 0) {
-    output.print(`  Searched teams: ${formatTeamList(searchedTeamSlugs)}\n`);
+    output.print(
+      `  ${chalk.dim(
+        `Searched ${searchedTeamSlugs.length} ${
+          searchedTeamSlugs.length === 1 ? 'team' : 'teams'
+        }`
+      )}\n`
+    );
   }
 }
 
@@ -290,7 +287,7 @@ async function promptForLimitedTeams(
   }
 
   return await client.input.checkbox<Team>({
-    message: 'Select teams that require SSO to search',
+    message: 'Select teams that require SSO',
     instructions: CHECKBOX_INSTRUCTIONS,
     choices: teams.map(team => ({
       name: team.name ? `${team.name} (${team.slug})` : team.slug,
@@ -317,12 +314,7 @@ async function searchSelectedLimitedTeams({
     return [];
   }
 
-  output.spinner(
-    `Searching ${selectedTeams.length} ${
-      selectedTeams.length === 1 ? 'team' : 'teams'
-    } that ${selectedTeams.length === 1 ? 'requires' : 'require'} SSO…`,
-    1000
-  );
+  output.spinner('Searching selected teams that require SSO…', 1000);
   try {
     const result = await searchProjectAcrossTeams(client, projectName, path, {
       teams: selectedTeams,
@@ -334,7 +326,7 @@ async function searchSelectedLimitedTeams({
     });
     return result.matches;
   } catch (err) {
-    output.debug(`Selected SSO team search failed: ${err}`);
+    output.debug(`Selected team search requiring SSO failed: ${err}`);
     return [];
   } finally {
     output.stopSpinner();

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -48,6 +48,7 @@ import {
   type VercelAuthSetting,
   DEFAULT_VERCEL_AUTH_SETTING,
 } from '../input/vercel-auth';
+import { printAlignedLabel } from '../output/print-aligned-label';
 import {
   displayConfiguredServicesSetup,
   getServicesSetupState,
@@ -91,6 +92,10 @@ function formatCrossTeamMatch(match: CrossTeamMatch): string {
   return `${chalk.bold(match.org.slug)}/${match.project.name} ${formatMatchReason(
     match
   )}`;
+}
+
+function formatMatchSource(match: CrossTeamMatch): string {
+  return match.reason === 'repo-root' ? 'Git repository' : 'Folder name';
 }
 
 function formatTeamList(slugs: string[]): string {
@@ -192,10 +197,7 @@ async function maybePullEnvAfterLink(
 
   const pullEnvConfirmed =
     autoConfirm ||
-    (await client.input.confirm(
-      'Would you like to pull environment variables now?',
-      true
-    ));
+    (await client.input.confirm('Pull environment variables now?', true));
 
   if (!pullEnvConfirmed) {
     return;
@@ -278,7 +280,7 @@ async function promptForLimitedTeams(
   }
 
   return await client.input.checkbox<Team>({
-    message: 'Which SSO-protected teams should be searched?',
+    message: 'Which SSO-protected teams?',
     choices: teams.map(team => ({
       name: team.name ? `${team.name} (${team.slug})` : team.slug,
       value: team,
@@ -359,10 +361,10 @@ async function linkCrossTeamMatches({
       });
     }
 
-    const confirmed = await client.input.confirm(
-      `Found project ${formatCrossTeamMatch(match)}. Link to it?`,
-      true
-    );
+    output.print('  Found project\n');
+    printAlignedLabel('Project', `${match.org.slug}/${match.project.name}`);
+    printAlignedLabel('Source', formatMatchSource(match));
+    const confirmed = await client.input.confirm('Link to this project?', true);
     if (confirmed) {
       return await linkCrossTeamMatch({
         client,
@@ -404,9 +406,9 @@ async function linkCrossTeamMatches({
     value: null,
   });
 
+  output.print('  Found matching projects across teams\n');
   const selected = await client.input.select<CrossTeamMatch | null>({
-    message:
-      'Found matching projects across teams. Which one do you want to link?',
+    message: 'Which project?',
     choices,
     default: currentTeamMatch ?? undefined,
   });
@@ -784,7 +786,7 @@ export default async function setupAndLink(
     let changeAdditionalSettings = false;
     if (!autoConfirm) {
       changeAdditionalSettings = await client.input.confirm(
-        'Do you want to change additional project settings?',
+        'Customize advanced settings?',
         false
       );
     }
@@ -862,10 +864,7 @@ export async function connectGitRepository(
 
     const shouldConnect =
       autoConfirm ||
-      (await client.input.confirm(
-        `Detected a repository. Connect it to this project?`,
-        true
-      ));
+      (await client.input.confirm(`Connect detected Git repository?`, true));
 
     if (!shouldConnect) {
       return;

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -107,20 +107,26 @@ function formatTeamList(slugs: string[]): string {
   return `${shown.join(', ')}${suffix}`;
 }
 
+const CHECKBOX_INSTRUCTIONS = [
+  '\n  ',
+  chalk.dim('('),
+  chalk.cyan('<space>'),
+  chalk.dim(' select, '),
+  chalk.cyan('<a>'),
+  chalk.dim(' toggle all, '),
+  chalk.cyan('<i>'),
+  chalk.dim(' invert, '),
+  chalk.cyan('<enter>'),
+  chalk.dim(' confirm)'),
+].join('');
+
 function printCrossTeamSearchScope({
   searchedTeamSlugs,
-  skippedLimitedTeamSlugs,
 }: {
   searchedTeamSlugs: string[];
-  skippedLimitedTeamSlugs: string[];
 }): void {
   if (searchedTeamSlugs.length > 0) {
     output.print(`  Searched teams: ${formatTeamList(searchedTeamSlugs)}\n`);
-  }
-  if (skippedLimitedTeamSlugs.length > 0) {
-    output.print(
-      `  Skipped ${skippedLimitedTeamSlugs.length} SSO-protected ${skippedLimitedTeamSlugs.length === 1 ? 'team' : 'teams'}\n`
-    );
   }
 }
 
@@ -197,7 +203,10 @@ async function maybePullEnvAfterLink(
 
   const pullEnvConfirmed =
     autoConfirm ||
-    (await client.input.confirm('Pull environment variables now?', true));
+    (await client.input.confirm(
+      'Pull Development Environment Variables into .env.local?',
+      true
+    ));
 
   if (!pullEnvConfirmed) {
     return;
@@ -280,7 +289,8 @@ async function promptForLimitedTeams(
   }
 
   return await client.input.checkbox<Team>({
-    message: 'Which SSO-protected teams?',
+    message: 'Select teams that require SSO to search',
+    instructions: CHECKBOX_INSTRUCTIONS,
     choices: teams.map(team => ({
       name: team.name ? `${team.name} (${team.slug})` : team.slug,
       value: team,
@@ -306,7 +316,7 @@ async function searchSelectedLimitedTeams({
     return [];
   }
 
-  output.spinner('Searching selected SSO-protected teams…', 1000);
+  output.spinner('Searching teams that require SSO…', 1000);
   try {
     const result = await searchProjectAcrossTeams(client, projectName, path, {
       teams: selectedTeams,
@@ -315,11 +325,10 @@ async function searchSelectedLimitedTeams({
     });
     printCrossTeamSearchScope({
       searchedTeamSlugs: result.searchedTeamSlugs,
-      skippedLimitedTeamSlugs: [],
     });
     return result.matches;
   } catch (err) {
-    output.debug(`Selected SSO-protected team search failed: ${err}`);
+    output.debug(`Selected SSO team search failed: ${err}`);
     return [];
   } finally {
     output.stopSpinner();
@@ -361,10 +370,20 @@ async function linkCrossTeamMatches({
       });
     }
 
-    output.print('  Found project\n');
-    printAlignedLabel('Project', `${match.org.slug}/${match.project.name}`);
-    printAlignedLabel('Source', formatMatchSource(match));
-    const confirmed = await client.input.confirm('Link to this project?', true);
+    output.print(`  ${chalk.bold('Found existing project')}\n`);
+    if (match.reason === 'repo-root') {
+      printAlignedLabel('Project', `${match.org.slug}/${match.project.name}`);
+      printAlignedLabel('Source', formatMatchSource(match));
+    } else {
+      printAlignedLabel('Directory', toHumanPath(path));
+      printAlignedLabel('Project', `${match.org.slug}/${match.project.name}`);
+    }
+    const confirmed = await client.input.confirm(
+      match.reason === 'repo-root'
+        ? 'Link repository to project?'
+        : 'Link directory to project?',
+      true
+    );
     if (confirmed) {
       return await linkCrossTeamMatch({
         client,
@@ -406,7 +425,7 @@ async function linkCrossTeamMatches({
     value: null,
   });
 
-  output.print('  Found matching projects across teams\n');
+  printAlignedLabel('Projects', `${matches.length} matches across teams`);
   const selected = await client.input.select<CrossTeamMatch | null>({
     message: 'Which project?',
     choices,
@@ -485,7 +504,6 @@ export default async function setupAndLink(
     // Search for existing projects across all teams
     let crossTeamMatches: CrossTeamMatch[] = [];
     let searchedTeamSlugs: string[] = [];
-    let skippedLimitedTeamSlugs: string[] = [];
     let skippedLimitedTeams: Team[] = [];
     output.spinner('Searching for existing projects…', 1000);
     try {
@@ -501,7 +519,6 @@ export default async function setupAndLink(
       );
       crossTeamMatches = searchResult.matches;
       searchedTeamSlugs = searchResult.searchedTeamSlugs;
-      skippedLimitedTeamSlugs = searchResult.skippedLimitedTeamSlugs;
       skippedLimitedTeams = searchResult.skippedLimitedTeams;
     } catch (err) {
       output.debug(`Cross-team search failed: ${err}`);
@@ -512,7 +529,6 @@ export default async function setupAndLink(
     if (crossTeamMatches.length > 0 && !autoConfirm && !nonInteractive) {
       printCrossTeamSearchScope({
         searchedTeamSlugs,
-        skippedLimitedTeamSlugs,
       });
     }
 
@@ -532,7 +548,7 @@ export default async function setupAndLink(
     if (!autoConfirm && !nonInteractive && skippedLimitedTeams.length > 0) {
       if (crossTeamMatches.length === 0) {
         output.print(
-          `  No matching projects found in the ${searchedTeamSlugs.length} ${searchedTeamSlugs.length === 1 ? 'team' : 'teams'} available in your current session.\n`
+          `  Searched    ${searchedTeamSlugs.length} ${searchedTeamSlugs.length === 1 ? 'team' : 'teams'} available without SSO\n  No matching projects found\n`
         );
       }
       const limitedTeamMatches = await searchSelectedLimitedTeams({
@@ -555,9 +571,7 @@ export default async function setupAndLink(
         return linkedLimitedMatch;
       }
       if (limitedTeamMatches.length === 0) {
-        output.print(
-          '  No matching projects found in the selected SSO-protected teams.\n'
-        );
+        output.print('  No matching projects found in the selected teams.\n');
       }
       skipAutoDetect =
         skipAutoDetect ||
@@ -593,7 +607,8 @@ export default async function setupAndLink(
       org,
       projectName,
       autoConfirm,
-      skipAutoDetect
+      skipAutoDetect,
+      { directory: path }
     );
   } catch (err) {
     if (

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -112,12 +112,12 @@ const CHECKBOX_INSTRUCTIONS = [
   chalk.dim('('),
   chalk.cyan('<space>'),
   chalk.dim(' select, '),
+  chalk.cyan('<enter>'),
+  chalk.dim(' confirm, '),
   chalk.cyan('<a>'),
   chalk.dim(' toggle all, '),
   chalk.cyan('<i>'),
-  chalk.dim(' invert, '),
-  chalk.cyan('<enter>'),
-  chalk.dim(' confirm)'),
+  chalk.dim(' invert)'),
 ].join('');
 
 function printCrossTeamSearchScope({
@@ -547,9 +547,13 @@ export default async function setupAndLink(
 
     if (!autoConfirm && !nonInteractive && skippedLimitedTeams.length > 0) {
       if (crossTeamMatches.length === 0) {
-        output.print(
-          `  Searched    ${searchedTeamSlugs.length} ${searchedTeamSlugs.length === 1 ? 'team' : 'teams'} available without SSO\n  No matching projects found\n`
+        printAlignedLabel(
+          'Searched',
+          `${searchedTeamSlugs.length} ${
+            searchedTeamSlugs.length === 1 ? 'team' : 'teams'
+          } available without SSO`
         );
+        output.print('  No matching projects found\n');
       }
       const limitedTeamMatches = await searchSelectedLimitedTeams({
         client,

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -317,7 +317,12 @@ async function searchSelectedLimitedTeams({
     return [];
   }
 
-  output.spinner('Searching teams that require SSO…', 1000);
+  output.spinner(
+    `Searching ${selectedTeams.length} ${
+      selectedTeams.length === 1 ? 'team' : 'teams'
+    } that ${selectedTeams.length === 1 ? 'requires' : 'require'} SSO…`,
+    1000
+  );
   try {
     const result = await searchProjectAcrossTeams(client, projectName, path, {
       teams: selectedTeams,

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -202,7 +202,7 @@ async function maybePullEnvAfterLink(
   const pullEnvConfirmed =
     autoConfirm ||
     (await client.input.confirm(
-      'Pull Development Environment Variables into .env.local?',
+      'Pull development environment variables into .env.local?',
       true
     ));
 

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -64,7 +64,6 @@ export interface SetupAndLinkOptions {
   forceDelete?: boolean;
   link?: ProjectLinkResult;
   successEmoji?: EmojiLabel;
-  setupMsg?: string;
   projectName?: string;
   /** When true, avoid prompts and return action_required payload when scope/project choice is needed */
   nonInteractive?: boolean;
@@ -200,6 +199,8 @@ async function maybePullEnvAfterLink(
   if (!pullEnv || !client.stdin.isTTY || client.nonInteractive) {
     return;
   }
+
+  output.print('\n');
 
   const pullEnvConfirmed =
     autoConfirm ||
@@ -370,12 +371,12 @@ async function linkCrossTeamMatches({
       });
     }
 
+    output.print('\n');
     output.print(`  ${chalk.bold('Found existing project')}\n`);
     if (match.reason === 'repo-root') {
       printAlignedLabel('Project', `${match.org.slug}/${match.project.name}`);
       printAlignedLabel('Source', formatMatchSource(match));
     } else {
-      printAlignedLabel('Directory', toHumanPath(path));
       printAlignedLabel('Project', `${match.org.slug}/${match.project.name}`);
     }
     const confirmed = await client.input.confirm(
@@ -425,6 +426,7 @@ async function linkCrossTeamMatches({
     value: null,
   });
 
+  output.print('\n');
   printAlignedLabel('Projects', `${matches.length} matches across teams`);
   const selected = await client.input.select<CrossTeamMatch | null>({
     message: 'Which project?',
@@ -454,7 +456,6 @@ export default async function setupAndLink(
     forceDelete = false,
     link,
     successEmoji = 'link',
-    setupMsg = 'Set up',
     projectName,
     nonInteractive = false,
     pullEnv = true,
@@ -492,12 +493,10 @@ export default async function setupAndLink(
     return { status: 'error', exitCode: 1, reason: 'HEADLESS' };
   }
 
-  // Status line — intent is implied by the user running `vc` in this directory.
-  // The "Set up and deploy?" confirmation prompt is gone; Ctrl-C is the escape hatch.
-  // Single leading newline, 2-space indent, straight quotes — matches the prototype.
-  output.print(
-    `\n  ${chalk.bold(setupMsg)} ${chalk.dim(`"${toHumanPath(path)}"`)}\n`
-  );
+  // The command invocation carries setup intent; show the local target as state.
+  output.print('\n');
+  printAlignedLabel('Directory', toHumanPath(path));
+  output.print('\n');
 
   let skipAutoDetect = false;
   if (searchAcrossTeams) {
@@ -526,7 +525,12 @@ export default async function setupAndLink(
       output.stopSpinner();
     }
 
-    if (crossTeamMatches.length > 0 && !autoConfirm && !nonInteractive) {
+    if (
+      crossTeamMatches.length > 0 &&
+      searchedTeamSlugs.length > 1 &&
+      !autoConfirm &&
+      !nonInteractive
+    ) {
       printCrossTeamSearchScope({
         searchedTeamSlugs,
       });
@@ -611,8 +615,7 @@ export default async function setupAndLink(
       org,
       projectName,
       autoConfirm,
-      skipAutoDetect,
-      { directory: path }
+      skipAutoDetect
     );
   } catch (err) {
     if (
@@ -839,7 +842,8 @@ export default async function setupAndLink(
       org.slug,
       successEmoji,
       autoConfirm,
-      false // don't prompt to pull env for newly created projects
+      false, // don't prompt to pull env for newly created projects
+      'Created'
     );
 
     await connectGitRepository(client, path, project, autoConfirm, org);
@@ -880,6 +884,8 @@ export async function connectGitRepository(
     if (!remoteUrls || Object.keys(remoteUrls).length === 0) {
       return;
     }
+
+    output.print('\n');
 
     const shouldConnect =
       autoConfirm ||

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -479,7 +479,7 @@ export async function linkFolderToProject(
   await addToGitIgnore(path);
 
   output.print('\n');
-  printAlignedLabel(resultLabel, `${orgSlug}/${projectName}`);
+  printAlignedLabel(resultLabel, `${orgSlug}/${projectName}`, { gutter: '✓' });
 
   if (!pullEnv) {
     return;

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -26,6 +26,7 @@ import output from '../../output-manager';
 import { printAlignedLabel } from '../output/print-aligned-label';
 import pull from '../../commands/env/pull';
 import { resolveProjectCwd } from './find-project-root';
+import toHumanPath from '../humanize-path';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -478,6 +479,8 @@ export async function linkFolderToProject(
   await addToGitIgnore(path);
 
   printAlignedLabel('Linked', `${orgSlug}/${projectName}`);
+  printAlignedLabel('Directory', toHumanPath(path));
+  printAlignedLabel('Settings', join(VERCEL_DIR, VERCEL_DIR_PROJECT));
 
   if (!pullEnv) {
     return;
@@ -490,10 +493,7 @@ export async function linkFolderToProject(
 
   const pullEnvConfirmed =
     autoConfirm ||
-    (await client.input.confirm(
-      'Would you like to pull environment variables now?',
-      true
-    ));
+    (await client.input.confirm('Pull environment variables now?', true));
 
   if (pullEnvConfirmed) {
     const originalCwd = client.cwd;

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -446,7 +446,8 @@ export async function linkFolderToProject(
   orgSlug: string,
   successEmoji: EmojiLabel = 'link',
   autoConfirm: boolean = false,
-  pullEnv: boolean = true
+  pullEnv: boolean = true,
+  resultLabel: 'Linked' | 'Created' = 'Linked'
 ) {
   // if the project is already linked, we skip linking
   if (await hasProjectLink(client, projectLink, path)) {
@@ -477,7 +478,8 @@ export async function linkFolderToProject(
   // update .gitignore (silent — git status surfaces the change on demand)
   await addToGitIgnore(path);
 
-  printAlignedLabel('Linked', `${orgSlug}/${projectName}`);
+  output.print('\n');
+  printAlignedLabel(resultLabel, `${orgSlug}/${projectName}`);
 
   if (!pullEnv) {
     return;
@@ -487,6 +489,8 @@ export async function linkFolderToProject(
   if (!client.stdin.isTTY || client.nonInteractive) {
     return;
   }
+
+  output.print('\n');
 
   const pullEnvConfirmed =
     autoConfirm ||

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -480,7 +480,7 @@ export async function linkFolderToProject(
 
   printAlignedLabel('Linked', `${orgSlug}/${projectName}`);
   printAlignedLabel('Directory', toHumanPath(path));
-  printAlignedLabel('Settings', join(VERCEL_DIR, VERCEL_DIR_PROJECT));
+  printAlignedLabel('Config', join(VERCEL_DIR, VERCEL_DIR_PROJECT));
 
   if (!pullEnv) {
     return;

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -495,7 +495,7 @@ export async function linkFolderToProject(
   const pullEnvConfirmed =
     autoConfirm ||
     (await client.input.confirm(
-      'Pull Development Environment Variables into .env.local?',
+      'Pull development environment variables into .env.local?',
       true
     ));
 

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -26,7 +26,6 @@ import output from '../../output-manager';
 import { printAlignedLabel } from '../output/print-aligned-label';
 import pull from '../../commands/env/pull';
 import { resolveProjectCwd } from './find-project-root';
-import toHumanPath from '../humanize-path';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -479,8 +478,6 @@ export async function linkFolderToProject(
   await addToGitIgnore(path);
 
   printAlignedLabel('Linked', `${orgSlug}/${projectName}`);
-  printAlignedLabel('Directory', toHumanPath(path));
-  printAlignedLabel('Config', join(VERCEL_DIR, VERCEL_DIR_PROJECT));
 
   if (!pullEnv) {
     return;
@@ -493,7 +490,10 @@ export async function linkFolderToProject(
 
   const pullEnvConfirmed =
     autoConfirm ||
-    (await client.input.confirm('Pull environment variables now?', true));
+    (await client.input.confirm(
+      'Pull Development Environment Variables into .env.local?',
+      true
+    ));
 
   if (pullEnvConfirmed) {
     const originalCwd = client.cwd;

--- a/packages/cli/test/helpers/prepare.js
+++ b/packages/cli/test/helpers/prepare.js
@@ -445,7 +445,7 @@ module.exports = async function prepare(session, binaryPath, tmpFixturesDir) {
     },
     'zero-config-next-js-nested': {
       // `pnpm-workspace.yaml` makes this fixture a workspace, which is what
-      // triggers the "In which directory is your code located?" prompt under
+      // triggers the "Code directory?" prompt under
       // the new input-root-directory behavior (prompt fires only when
       // `getWorkspaces()` returns non-empty).
       'pnpm-workspace.yaml': "packages:\n  - 'app'\n",

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -373,7 +373,7 @@ test('deploy from a nested directory', async () => {
     },
   });
 
-  await waitForPrompt(vc, /Set up [“"]/);
+  await waitForPrompt(vc, 'Directory');
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
@@ -409,7 +409,7 @@ test('deploy from a nested directory with `--archive=tgz` option', async () => {
     }
   );
 
-  await waitForPrompt(vc, /Set up [“"]/);
+  await waitForPrompt(vc, 'Directory');
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -377,8 +377,8 @@ test('deploy from a nested directory', async () => {
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
-  await waitForPrompt(vc, 'Link to existing project?');
-  vc.stdin?.write('no\n');
+  await waitForPrompt(vc, 'Project?');
+  vc.stdin?.write('\n');
 
   await waitForPrompt(vc, `Name? (${projectName})`);
   vc.stdin?.write(`\n`);
@@ -413,8 +413,8 @@ test('deploy from a nested directory with `--archive=tgz` option', async () => {
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
-  await waitForPrompt(vc, 'Link to existing project?');
-  vc.stdin?.write('no\n');
+  await waitForPrompt(vc, 'Project?');
+  vc.stdin?.write('\n');
 
   await waitForPrompt(vc, `Name? (${projectName})`);
   vc.stdin?.write(`\n`);

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -383,7 +383,7 @@ test('deploy from a nested directory', async () => {
   await waitForPrompt(vc, `Name? (${projectName})`);
   vc.stdin?.write(`\n`);
 
-  await waitForPrompt(vc, 'In which directory is your code located?');
+  await waitForPrompt(vc, 'Code directory?');
   vc.stdin?.write('app\n');
 
   // This means the framework detection worked!
@@ -419,7 +419,7 @@ test('deploy from a nested directory with `--archive=tgz` option', async () => {
   await waitForPrompt(vc, `Name? (${projectName})`);
   vc.stdin?.write(`\n`);
 
-  await waitForPrompt(vc, 'In which directory is your code located?');
+  await waitForPrompt(vc, 'Code directory?');
   vc.stdin?.write('app\n');
 
   // This means the framework detection worked!

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -89,7 +89,7 @@ async function setupProject(
   // `project-link-deploy` with empty package.json). Wait for whichever fires.
   let sawDirectoryPrompt = false;
   await waitForPrompt(process, chunk => {
-    if (chunk.includes('In which directory is your code located?')) {
+    if (chunk.includes('Code directory?')) {
       sawDirectoryPrompt = true;
       return true;
     }
@@ -125,10 +125,7 @@ async function setupProject(
   }
 
   const hasAdditionalProjectSettingsToChange = vercelAuth !== 'standard';
-  await waitForPrompt(
-    process,
-    'Do you want to change additional project settings?'
-  );
+  await waitForPrompt(process, 'Customize advanced settings?');
 
   if (hasAdditionalProjectSettingsToChange) {
     process.stdin?.write('y\n');
@@ -352,16 +349,13 @@ test('should prefill "project name" prompt with vercel.json `name`', async () =>
   await waitForPrompt(now, `Name? (${projectName})`);
   now.stdin?.write(`\n`);
 
-  await waitForPrompt(now, 'In which directory is your code located?');
+  await waitForPrompt(now, 'Code directory?');
   now.stdin?.write('\n');
 
   await waitForPrompt(now, 'Customize settings?');
   now.stdin?.write('no\n');
 
-  await waitForPrompt(
-    now,
-    'Do you want to change additional project settings?'
-  );
+  await waitForPrompt(now, 'Customize advanced settings?');
   now.stdin?.write('\n');
 
   await waitForPrompt(now, /Linked\s+/);
@@ -1025,7 +1019,7 @@ test('[vc link] should detect frameworks in project rootDirectory', async () => 
   await waitForPrompt(vc, 'Name?');
   vc.stdin?.write(`${projectName}\n`);
 
-  await waitForPrompt(vc, 'In which directory is your code located?');
+  await waitForPrompt(vc, 'Code directory?');
   vc.stdin?.write(`${projectRootDir}\n`);
 
   // This means the framework detection worked!
@@ -1136,10 +1130,10 @@ test('[vc link] should show project prompts but not framework when `builds` defi
   await waitForPrompt(vc, 'Name?');
   vc.stdin?.write(`${projectName}\n`);
 
-  await waitForPrompt(vc, 'In which directory is your code located?');
+  await waitForPrompt(vc, 'Code directory?');
   vc.stdin?.write('\n');
 
-  await waitForPrompt(vc, 'Do you want to change additional project settings?');
+  await waitForPrompt(vc, 'Customize advanced settings?');
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, /Linked\s+/);
@@ -1572,7 +1566,7 @@ test.skip('vercel.json configuration overrides in a new project prompt user and 
   // otherwise the output from the build command will not be the index route and the page text assertion below will fail.
   await waitForPrompt(vc, 'Output Directory?');
   vc.stdin?.write('output\n');
-  await waitForPrompt(vc, 'Do you want to change additional project settings?');
+  await waitForPrompt(vc, 'Customize advanced settings?');
   vc.stdin?.write('n\n');
   await waitForPrompt(
     vc,
@@ -1686,66 +1680,69 @@ test.each([
     vercelAuth: 'standard',
     expectedStatus: 401,
   },
-] as const)('[vc deploy] should allow a project to be created with Vercel Auth disabled or enabled with prompts - vercelAuth: %s', async ({
-  vercelAuth,
-  expectedStatus,
-}: {
-  vercelAuth: 'none' | 'standard';
-  expectedStatus: number;
-}) => {
-  const dir = await setupE2EFixture('project-vercel-auth');
-  const projectName = `project-vercel-auth-${
-    Math.random().toString(36).split('.')[1]
-  }`;
+] as const)(
+  '[vc deploy] should allow a project to be created with Vercel Auth disabled or enabled with prompts - vercelAuth: %s',
+  async ({
+    vercelAuth,
+    expectedStatus,
+  }: {
+    vercelAuth: 'none' | 'standard';
+    expectedStatus: number;
+  }) => {
+    const dir = await setupE2EFixture('project-vercel-auth');
+    const projectName = `project-vercel-auth-${
+      Math.random().toString(36).split('.')[1]
+    }`;
 
-  // remove previously linked project if it exists
-  await remove(path.join(dir, '.vercel'));
+    // remove previously linked project if it exists
+    await remove(path.join(dir, '.vercel'));
 
-  const now = execCli(binaryPath, [dir], {
-    env: {
-      FORCE_TTY: '1',
-    },
-  });
+    const now = execCli(binaryPath, [dir], {
+      env: {
+        FORCE_TTY: '1',
+      },
+    });
 
-  await setupProject(
-    now,
-    projectName,
-    {
-      buildCommand: `mkdir -p o && echo '<h1>custom hello</h1>' > o/index.html`,
-      outputDirectory: 'o',
-    },
-    {
-      vercelAuth,
-    }
-  );
+    await setupProject(
+      now,
+      projectName,
+      {
+        buildCommand: `mkdir -p o && echo '<h1>custom hello</h1>' > o/index.html`,
+        outputDirectory: 'o',
+      },
+      {
+        vercelAuth,
+      }
+    );
 
-  const output = await now;
+    const output = await now;
 
-  // Ensure the exit code is right
-  expect(output.exitCode, formatOutput(output)).toBe(0);
+    // Ensure the exit code is right
+    expect(output.exitCode, formatOutput(output)).toBe(0);
 
-  // Ensure .gitignore is created
-  const gitignore = await readFile(path.join(dir, '.gitignore'), 'utf8');
-  expect(gitignore).toBe('.vercel\n');
+    // Ensure .gitignore is created
+    const gitignore = await readFile(path.join(dir, '.gitignore'), 'utf8');
+    expect(gitignore).toBe('.vercel\n');
 
-  // Ensure .vercel/project.json and .vercel/README.txt are created
-  expect(
-    fs.existsSync(path.join(dir, '.vercel', 'project.json')),
-    'project.json'
-  ).toBe(true);
-  expect(
-    fs.existsSync(path.join(dir, '.vercel', 'README.txt')),
-    'README.txt'
-  ).toBe(true);
+    // Ensure .vercel/project.json and .vercel/README.txt are created
+    expect(
+      fs.existsSync(path.join(dir, '.vercel', 'project.json')),
+      'project.json'
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(dir, '.vercel', 'README.txt')),
+      'README.txt'
+    ).toBe(true);
 
-  const { href } = new URL(output.stdout);
+    const { href } = new URL(output.stdout);
 
-  // Send a test request to the deployment
-  const response = await nodeFetch(href);
-  expect(response.status).toBe(expectedStatus);
+    // Send a test request to the deployment
+    const response = await nodeFetch(href);
+    expect(response.status).toBe(expectedStatus);
 
-  const projectResponse = await apiFetch(`/projects/${projectName}`, {
-    method: 'DELETE',
-  });
-  expect(projectResponse.status).toBe(204);
-});
+    const projectResponse = await apiFetch(`/projects/${projectName}`, {
+      method: 'DELETE',
+    });
+    expect(projectResponse.status).toBe(204);
+  }
+);

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -70,10 +70,7 @@ async function setupProject(
     vercelAuth: 'standard',
   }
 ) {
-  await waitForPrompt(
-    process,
-    /Set up (?:and (?:deploy|develop) )?[“"][^”"]+[”"]/
-  );
+  await waitForPrompt(process, 'Directory');
   await waitForPrompt(process, /Which team[^?]*\?/);
   process.stdin?.write('\n');
 
@@ -339,7 +336,7 @@ test('should prefill "project name" prompt with vercel.json `name`', async () =>
     }
   });
 
-  await waitForPrompt(now, /Set up [“"]/);
+  await waitForPrompt(now, 'Directory');
   await waitForPrompt(now, 'Which team?');
   now.stdin?.write('\n');
 
@@ -451,8 +448,8 @@ test('deploy shows notice when project in `.vercel` does not exists', async () =
 
   let detectedNotice = false;
 
-  // Terminate after the first status line. The "Set up and deploy?" prompt was
-  // removed, so writing to stdin would leak into the next real prompt.
+  // Terminate after the first setup-state row. The old "Set up and deploy?"
+  // prompt is gone, so writing to stdin would leak into the next real prompt.
   await waitForPrompt(now, chunk => {
     detectedNotice =
       detectedNotice ||
@@ -460,7 +457,7 @@ test('deploy shows notice when project in `.vercel` does not exists', async () =
         'Your Project was either deleted, transferred to a new Team, or you don’t have access to it anymore'
       );
 
-    return /Set up [“"][^”"]+[”"]/.test(chunk);
+    return /Directory\s+/.test(chunk);
   });
   now.kill('SIGTERM');
 
@@ -1009,7 +1006,7 @@ test('[vc link] should detect frameworks in project rootDirectory', async () => 
     },
   });
 
-  await waitForPrompt(vc, /Set up [“"]/);
+  await waitForPrompt(vc, 'Directory');
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
@@ -1120,7 +1117,7 @@ test('[vc link] should show project prompts but not framework when `builds` defi
     },
   });
 
-  await waitForPrompt(vc, /Set up [“"]/);
+  await waitForPrompt(vc, 'Directory');
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
@@ -1546,7 +1543,7 @@ test.skip('vercel.json configuration overrides in a new project prompt user and 
     },
   });
 
-  await waitForPrompt(vc, 'Set up');
+  await waitForPrompt(vc, 'Directory');
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
   await waitForPrompt(vc, 'Project?');

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -77,8 +77,8 @@ async function setupProject(
   await waitForPrompt(process, /Which team[^?]*\?/);
   process.stdin?.write('\n');
 
-  await waitForPrompt(process, 'Link to existing project?');
-  process.stdin?.write('no\n');
+  await waitForPrompt(process, 'Project?');
+  process.stdin?.write('\n');
 
   await waitForPrompt(process, 'Name?');
   process.stdin?.write(`${projectName}\n`);
@@ -343,8 +343,8 @@ test('should prefill "project name" prompt with vercel.json `name`', async () =>
   await waitForPrompt(now, 'Which team?');
   now.stdin?.write('\n');
 
-  await waitForPrompt(now, 'Link to existing project?');
-  now.stdin?.write('no\n');
+  await waitForPrompt(now, 'Project?');
+  now.stdin?.write('\n');
 
   await waitForPrompt(now, `Name? (${projectName})`);
   now.stdin?.write(`\n`);
@@ -1013,8 +1013,8 @@ test('[vc link] should detect frameworks in project rootDirectory', async () => 
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
-  await waitForPrompt(vc, 'Link to existing project?');
-  vc.stdin?.write('no\n');
+  await waitForPrompt(vc, 'Project?');
+  vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'Name?');
   vc.stdin?.write(`${projectName}\n`);
@@ -1124,8 +1124,8 @@ test('[vc link] should show project prompts but not framework when `builds` defi
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
-  await waitForPrompt(vc, 'Link to existing project?');
-  vc.stdin?.write('no\n');
+  await waitForPrompt(vc, 'Project?');
+  vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'Name?');
   vc.stdin?.write(`${projectName}\n`);
@@ -1549,8 +1549,8 @@ test.skip('vercel.json configuration overrides in a new project prompt user and 
   await waitForPrompt(vc, 'Set up');
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
-  await waitForPrompt(vc, 'Link to existing project?');
-  vc.stdin?.write('n\n');
+  await waitForPrompt(vc, 'Project?');
+  vc.stdin?.write('\n');
   await waitForPrompt(vc, 'Name?');
   vc.stdin?.write('\n');
   await waitForPrompt(vc, 'Customize settings?');

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -1680,69 +1680,66 @@ test.each([
     vercelAuth: 'standard',
     expectedStatus: 401,
   },
-] as const)(
-  '[vc deploy] should allow a project to be created with Vercel Auth disabled or enabled with prompts - vercelAuth: %s',
-  async ({
-    vercelAuth,
-    expectedStatus,
-  }: {
-    vercelAuth: 'none' | 'standard';
-    expectedStatus: number;
-  }) => {
-    const dir = await setupE2EFixture('project-vercel-auth');
-    const projectName = `project-vercel-auth-${
-      Math.random().toString(36).split('.')[1]
-    }`;
+] as const)('[vc deploy] should allow a project to be created with Vercel Auth disabled or enabled with prompts - vercelAuth: %s', async ({
+  vercelAuth,
+  expectedStatus,
+}: {
+  vercelAuth: 'none' | 'standard';
+  expectedStatus: number;
+}) => {
+  const dir = await setupE2EFixture('project-vercel-auth');
+  const projectName = `project-vercel-auth-${
+    Math.random().toString(36).split('.')[1]
+  }`;
 
-    // remove previously linked project if it exists
-    await remove(path.join(dir, '.vercel'));
+  // remove previously linked project if it exists
+  await remove(path.join(dir, '.vercel'));
 
-    const now = execCli(binaryPath, [dir], {
-      env: {
-        FORCE_TTY: '1',
-      },
-    });
+  const now = execCli(binaryPath, [dir], {
+    env: {
+      FORCE_TTY: '1',
+    },
+  });
 
-    await setupProject(
-      now,
-      projectName,
-      {
-        buildCommand: `mkdir -p o && echo '<h1>custom hello</h1>' > o/index.html`,
-        outputDirectory: 'o',
-      },
-      {
-        vercelAuth,
-      }
-    );
+  await setupProject(
+    now,
+    projectName,
+    {
+      buildCommand: `mkdir -p o && echo '<h1>custom hello</h1>' > o/index.html`,
+      outputDirectory: 'o',
+    },
+    {
+      vercelAuth,
+    }
+  );
 
-    const output = await now;
+  const output = await now;
 
-    // Ensure the exit code is right
-    expect(output.exitCode, formatOutput(output)).toBe(0);
+  // Ensure the exit code is right
+  expect(output.exitCode, formatOutput(output)).toBe(0);
 
-    // Ensure .gitignore is created
-    const gitignore = await readFile(path.join(dir, '.gitignore'), 'utf8');
-    expect(gitignore).toBe('.vercel\n');
+  // Ensure .gitignore is created
+  const gitignore = await readFile(path.join(dir, '.gitignore'), 'utf8');
+  expect(gitignore).toBe('.vercel\n');
 
-    // Ensure .vercel/project.json and .vercel/README.txt are created
-    expect(
-      fs.existsSync(path.join(dir, '.vercel', 'project.json')),
-      'project.json'
-    ).toBe(true);
-    expect(
-      fs.existsSync(path.join(dir, '.vercel', 'README.txt')),
-      'README.txt'
-    ).toBe(true);
+  // Ensure .vercel/project.json and .vercel/README.txt are created
+  expect(
+    fs.existsSync(path.join(dir, '.vercel', 'project.json')),
+    'project.json'
+  ).toBe(true);
+  expect(
+    fs.existsSync(path.join(dir, '.vercel', 'README.txt')),
+    'README.txt'
+  ).toBe(true);
 
-    const { href } = new URL(output.stdout);
+  const { href } = new URL(output.stdout);
 
-    // Send a test request to the deployment
-    const response = await nodeFetch(href);
-    expect(response.status).toBe(expectedStatus);
+  // Send a test request to the deployment
+  const response = await nodeFetch(href);
+  expect(response.status).toBe(expectedStatus);
 
-    const projectResponse = await apiFetch(`/projects/${projectName}`, {
-      method: 'DELETE',
-    });
-    expect(projectResponse.status).toBe(204);
-  }
-);
+  const projectResponse = await apiFetch(`/projects/${projectName}`, {
+    method: 'DELETE',
+  });
+  expect(projectResponse.status).toBe(204);
+});

--- a/packages/cli/test/integration-link-env-pull.test.ts
+++ b/packages/cli/test/integration-link-env-pull.test.ts
@@ -59,13 +59,13 @@ test('[vc link] should skip env pull prompt when creating new project', async ()
   await waitForPrompt(vc, `Name? (${projectName})`);
   vc.stdin?.write('\n');
 
-  await waitForPrompt(vc, 'In which directory is your code located?');
+  await waitForPrompt(vc, 'Code directory?');
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'Customize settings?');
   vc.stdin?.write('no\n');
 
-  await waitForPrompt(vc, 'Do you want to change additional project settings?');
+  await waitForPrompt(vc, 'Customize advanced settings?');
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, /Linked\s+/);
@@ -102,13 +102,13 @@ test('[vc link] should not create .env.local when linking new project', async ()
   await waitForPrompt(vc, `Name? (${projectName})`);
   vc.stdin?.write('\n');
 
-  await waitForPrompt(vc, 'In which directory is your code located?');
+  await waitForPrompt(vc, 'Code directory?');
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'Customize settings?');
   vc.stdin?.write('no\n');
 
-  await waitForPrompt(vc, 'Do you want to change additional project settings?');
+  await waitForPrompt(vc, 'Customize advanced settings?');
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, /Linked\s+/);

--- a/packages/cli/test/integration-link-env-pull.test.ts
+++ b/packages/cli/test/integration-link-env-pull.test.ts
@@ -49,7 +49,7 @@ test('[vc link] should skip env pull prompt when creating new project', async ()
     },
   });
 
-  await waitForPrompt(vc, /Set up [“"]/);
+  await waitForPrompt(vc, 'Directory');
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
@@ -92,7 +92,7 @@ test('[vc link] should not create .env.local when linking new project', async ()
     },
   });
 
-  await waitForPrompt(vc, /Set up [“"]/);
+  await waitForPrompt(vc, 'Directory');
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 

--- a/packages/cli/test/integration-link-env-pull.test.ts
+++ b/packages/cli/test/integration-link-env-pull.test.ts
@@ -53,8 +53,8 @@ test('[vc link] should skip env pull prompt when creating new project', async ()
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
-  await waitForPrompt(vc, 'Link to existing project?');
-  vc.stdin?.write('no\n');
+  await waitForPrompt(vc, 'Project?');
+  vc.stdin?.write('\n');
 
   await waitForPrompt(vc, `Name? (${projectName})`);
   vc.stdin?.write('\n');
@@ -96,8 +96,8 @@ test('[vc link] should not create .env.local when linking new project', async ()
   await waitForPrompt(vc, 'Which team?');
   vc.stdin?.write('\n');
 
-  await waitForPrompt(vc, 'Link to existing project?');
-  vc.stdin?.write('no\n');
+  await waitForPrompt(vc, 'Project?');
+  vc.stdin?.write('\n');
 
   await waitForPrompt(vc, `Name? (${projectName})`);
   vc.stdin?.write('\n');

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -4668,50 +4668,39 @@ exports[`help command > link help output snapshots > link help column width 40 1
   ▲ vercel link command [options]
 
   Link a local directory to a Vercel    
-  Project.                              
+  project                               
 
   Commands:
 
-  add    Add additional Vercel  
-         Projects to an existing
-         repository link.       
-         Requires an existing   
-         repo.json (created by  
-         \`link --repo\`).        
+  add    Add projects to an     
+         existing repository    
+         link                   
 
 
   Options:
 
-  -p,  --project <NAME_OR_ID>    Project  
+  -p,  --project <NAME_OR_ID>    Set the  
+                                 project  
                                  name or  
                                  ID to    
-                                 link to  
-                                 (required
-                                 for      
-                                 non-inte…
+                                 link     
   -r,  --repo                    Link     
                                  multiple 
                                  projects 
-                                 based on 
+                                 from the 
                                  Git      
                                  reposito…
                                  (alpha)  
-       --team <TEAM_ID_OR_SLUG>  Scope:   
+       --team <TEAM_ID_OR_SLUG>  Set the  
                                  team ID  
                                  or slug  
-                                 (use with
-                                 --project
-                                 for      
-                                 non-inte…
   -y,  --yes                     Skip     
                                  questions
                                  when     
                                  setting  
-                                 up new   
-                                 project  
-                                 using    
+                                 up with  
                                  default  
-                                 scope and
+                                 team and 
                                  settings 
 
 
@@ -4765,7 +4754,7 @@ exports[`help command > link help output snapshots > link help column width 40 1
 
   Examples:
 
-  - Link current directory to a Vercel Project
+  - Link current directory to a Vercel project
 
     $ vercel link
 
@@ -4773,15 +4762,15 @@ exports[`help command > link help output snapshots > link help column width 40 1
 
     $ vercel link --yes
 
-  - Non-interactive: link to an existing project (CI/agents)
+  - Link to an existing project in CI or agent mode
 
     $ vercel link --yes --team <team-id> --project <project-name-or-id>
 
-  - Link a specific directory to a Vercel Project
+  - Link a specific directory to a Vercel project
 
     $ vercel link --cwd /path/to/project
 
-  - Link to the current Git repository, allowing for multiple Vercel Projects to be linked simultaneously (useful for monorepos)
+  - Link multiple projects from the current Git repository
 
     $ vercel link --repo
 
@@ -4796,24 +4785,21 @@ exports[`help command > link help output snapshots > link help column width 80 1
 "
   ▲ vercel link command [options]
 
-  Link a local directory to a Vercel Project.                                   
+  Link a local directory to a Vercel project                                    
 
   Commands:
 
-  add    Add additional Vercel Projects to an existing repository link. 
-         Requires an existing repo.json (created by \`link --repo\`).     
+  add    Add projects to an existing repository link                    
 
 
   Options:
 
-  -p,  --project <NAME_OR_ID>    Project name or ID to link to (required for      
-                                 non-interactive)                                 
-  -r,  --repo                    Link multiple projects based on Git repository   
+  -p,  --project <NAME_OR_ID>    Set the project name or ID to link               
+  -r,  --repo                    Link multiple projects from the Git repository   
                                  (alpha)                                          
-       --team <TEAM_ID_OR_SLUG>  Scope: team ID or slug (use with --project for   
-                                 non-interactive)                                 
-  -y,  --yes                     Skip questions when setting up new project using 
-                                 default scope and settings                       
+       --team <TEAM_ID_OR_SLUG>  Set the team ID or slug                          
+  -y,  --yes                     Skip questions when setting up with default team 
+                                 and settings                                     
 
 
   Global Options:
@@ -4834,7 +4820,7 @@ exports[`help command > link help output snapshots > link help column width 80 1
 
   Examples:
 
-  - Link current directory to a Vercel Project
+  - Link current directory to a Vercel project
 
     $ vercel link
 
@@ -4842,15 +4828,15 @@ exports[`help command > link help output snapshots > link help column width 80 1
 
     $ vercel link --yes
 
-  - Non-interactive: link to an existing project (CI/agents)
+  - Link to an existing project in CI or agent mode
 
     $ vercel link --yes --team <team-id> --project <project-name-or-id>
 
-  - Link a specific directory to a Vercel Project
+  - Link a specific directory to a Vercel project
 
     $ vercel link --cwd /path/to/project
 
-  - Link to the current Git repository, allowing for multiple Vercel Projects to be linked simultaneously (useful for monorepos)
+  - Link multiple projects from the current Git repository
 
     $ vercel link --repo
 
@@ -4865,20 +4851,19 @@ exports[`help command > link help output snapshots > link help column width 120 
 "
   ▲ vercel link command [options]
 
-  Link a local directory to a Vercel Project.                                                                           
+  Link a local directory to a Vercel project                                                                            
 
   Commands:
 
-  add    Add additional Vercel Projects to an existing repository link. Requires an existing repo.json (created 
-         by \`link --repo\`).                                                                                     
+  add    Add projects to an existing repository link                                                            
 
 
   Options:
 
-  -p,  --project <NAME_OR_ID>    Project name or ID to link to (required for non-interactive)                             
-  -r,  --repo                    Link multiple projects based on Git repository (alpha)                                   
-       --team <TEAM_ID_OR_SLUG>  Scope: team ID or slug (use with --project for non-interactive)                          
-  -y,  --yes                     Skip questions when setting up new project using default scope and settings              
+  -p,  --project <NAME_OR_ID>    Set the project name or ID to link                                                       
+  -r,  --repo                    Link multiple projects from the Git repository (alpha)                                   
+       --team <TEAM_ID_OR_SLUG>  Set the team ID or slug                                                                  
+  -y,  --yes                     Skip questions when setting up with default team and settings                            
 
 
   Global Options:
@@ -4897,7 +4882,7 @@ exports[`help command > link help output snapshots > link help column width 120 
 
   Examples:
 
-  - Link current directory to a Vercel Project
+  - Link current directory to a Vercel project
 
     $ vercel link
 
@@ -4905,15 +4890,15 @@ exports[`help command > link help output snapshots > link help column width 120 
 
     $ vercel link --yes
 
-  - Non-interactive: link to an existing project (CI/agents)
+  - Link to an existing project in CI or agent mode
 
     $ vercel link --yes --team <team-id> --project <project-name-or-id>
 
-  - Link a specific directory to a Vercel Project
+  - Link a specific directory to a Vercel project
 
     $ vercel link --cwd /path/to/project
 
-  - Link to the current Git repository, allowing for multiple Vercel Projects to be linked simultaneously (useful for monorepos)
+  - Link multiple projects from the current Git repository
 
     $ vercel link --repo
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -4674,7 +4674,8 @@ exports[`help command > link help output snapshots > link help column width 40 1
 
   add    Add projects to an     
          existing repository    
-         link                   
+         link created by link   
+         --repo                 
 
 
   Options:
@@ -4683,7 +4684,12 @@ exports[`help command > link help output snapshots > link help column width 40 1
                                  project  
                                  name or  
                                  ID to    
-                                 link     
+                                 link;    
+                                 required 
+                                 for      
+                                 non-inte…
+                                 existing…
+                                 links    
   -r,  --repo                    Link     
                                  multiple 
                                  projects 
@@ -4693,7 +4699,12 @@ exports[`help command > link help output snapshots > link help column width 40 1
                                  (alpha)  
        --team <TEAM_ID_OR_SLUG>  Set the  
                                  team ID  
-                                 or slug  
+                                 or slug; 
+                                 use with 
+                                 --project
+                                 for      
+                                 non-inte…
+                                 links    
   -y,  --yes                     Skip     
                                  questions
                                  when     
@@ -4789,15 +4800,18 @@ exports[`help command > link help output snapshots > link help column width 80 1
 
   Commands:
 
-  add    Add projects to an existing repository link                    
+  add    Add projects to an existing repository link created by link    
+         --repo                                                         
 
 
   Options:
 
-  -p,  --project <NAME_OR_ID>    Set the project name or ID to link               
+  -p,  --project <NAME_OR_ID>    Set the project name or ID to link; required for 
+                                 non-interactive existing-project links           
   -r,  --repo                    Link multiple projects from the Git repository   
                                  (alpha)                                          
-       --team <TEAM_ID_OR_SLUG>  Set the team ID or slug                          
+       --team <TEAM_ID_OR_SLUG>  Set the team ID or slug; use with --project for  
+                                 non-interactive links                            
   -y,  --yes                     Skip questions when setting up with default team 
                                  and settings                                     
 
@@ -4855,14 +4869,14 @@ exports[`help command > link help output snapshots > link help column width 120 
 
   Commands:
 
-  add    Add projects to an existing repository link                                                            
+  add    Add projects to an existing repository link created by link --repo                                     
 
 
   Options:
 
-  -p,  --project <NAME_OR_ID>    Set the project name or ID to link                                                       
+  -p,  --project <NAME_OR_ID>    Set the project name or ID to link; required for non-interactive existing-project links  
   -r,  --repo                    Link multiple projects from the Git repository (alpha)                                   
-       --team <TEAM_ID_OR_SLUG>  Set the team ID or slug                                                                  
+       --team <TEAM_ID_OR_SLUG>  Set the team ID or slug; use with --project for non-interactive links                    
   -y,  --yes                     Skip questions when setting up with default team and settings                            
 
 

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1635,7 +1635,7 @@ describe('deploy', () => {
 
         // I'd like to include project path in this assertion, but it ends up containing
         // a line break in a non-determinsitic location.
-        await expect(client.stderr).toOutput('Set up');
+        await expect(client.stderr).toOutput('Directory');
         await expect(client.stderr).toOutput('? Which team?');
         client.stdin.write('\n');
 
@@ -1672,7 +1672,7 @@ describe('deploy', () => {
 
         // I'd like to include project path in this assertion, but it ends up containing
         // a line break in a non-determinsitic location.
-        await expect(client.stderr).toOutput('Set up');
+        await expect(client.stderr).toOutput('Directory');
         await expect(client.stderr).toOutput('? Which team?');
         client.stdin.write('\n');
 

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1639,8 +1639,8 @@ describe('deploy', () => {
         await expect(client.stderr).toOutput('? Which team?');
         client.stdin.write('\n');
 
-        await expect(client.stderr).toOutput('Link to existing project?');
-        client.stdin.write('no\n');
+        await expect(client.stderr).toOutput('Project?');
+        client.stdin.write('\n');
 
         // The one expecation that the test is actually about!
         await expect(client.stderr).toOutput(`Name? (${nameOption})`);
@@ -1676,8 +1676,8 @@ describe('deploy', () => {
         await expect(client.stderr).toOutput('? Which team?');
         client.stdin.write('\n');
 
-        await expect(client.stderr).toOutput('Link to existing project?');
-        client.stdin.write('no\n');
+        await expect(client.stderr).toOutput('Project?');
+        client.stdin.write('\n');
 
         // The one expecation that the test is actually about!
         await expect(client.stderr).toOutput(`Name? (${directoryName})`);

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1647,20 +1647,23 @@ describe('deploy', () => {
         client.stdin.write('\n');
         // Fixture has no detectable framework at the root, so the
         // root-directory prompt now fires (nested-monolith guard).
-        await expect(client.stderr).toOutput(
-          'In which directory is your code located?'
-        );
+        await expect(client.stderr).toOutput('Code directory?');
         client.stdin.write('\n');
         await expect(client.stderr).toOutput('Customize settings?');
         client.stdin.write('\n');
 
-        await expect(client.stderr).toOutput(
-          'Do you want to change additional project settings?'
-        );
+        await expect(client.stderr).toOutput('Customize advanced settings?');
         client.stdin.write('\n');
 
         const exitCode = await exitCodePromise;
         expect(exitCode).toEqual(0);
+        const output = client.stderr.getFullOutput();
+        expect(output).not.toContain(
+          'In which directory is your code located?'
+        );
+        expect(output).not.toContain(
+          'Do you want to change additional project settings?'
+        );
       });
 
       it('prefills "project name" prompt based on directory name', async () => {
@@ -1681,20 +1684,23 @@ describe('deploy', () => {
         client.stdin.write('\n');
         // Fixture has no detectable framework at the root, so the
         // root-directory prompt now fires (nested-monolith guard).
-        await expect(client.stderr).toOutput(
-          'In which directory is your code located?'
-        );
+        await expect(client.stderr).toOutput('Code directory?');
         client.stdin.write('\n');
         await expect(client.stderr).toOutput('Customize settings?');
         client.stdin.write('\n');
 
-        await expect(client.stderr).toOutput(
-          'Do you want to change additional project settings?'
-        );
+        await expect(client.stderr).toOutput('Customize advanced settings?');
         client.stdin.write('\n');
 
         const exitCode = await exitCodePromise;
         expect(exitCode).toEqual(0);
+        const output = client.stderr.getFullOutput();
+        expect(output).not.toContain(
+          'In which directory is your code located?'
+        );
+        expect(output).not.toContain(
+          'Do you want to change additional project settings?'
+        );
       });
     });
   });

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -86,8 +86,10 @@ describe('env pull', () => {
       'Downloading `development` Environment Variables for'
     );
     await expect(client.stderr).toOutput(
-      'Created .env.local file and added it to .gitignore'
+      'Created         .env.local file and added it to .gitignore'
     );
+    expect(client.stderr.getFullOutput()).not.toContain('✅');
+    expect(client.stderr.getFullOutput()).not.toMatch(/\[\d+(?:ms|s)\]/);
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "env"').toEqual(0);
 
@@ -160,7 +162,7 @@ describe('env pull', () => {
       'Sensitive Environment Variables require fresh authentication.'
     );
     await expect(client.stderr).toOutput(
-      'Created .env.local file and added it to .gitignore'
+      'Created         .env.local file and added it to .gitignore'
     );
 
     await expect(exitCodePromise).resolves.toEqual(0);
@@ -189,7 +191,7 @@ describe('env pull', () => {
       'Downloading `preview` Environment Variables for'
     );
     await expect(client.stderr).toOutput(
-      'Created .env.local file and added it to .gitignore'
+      'Created         .env.local file and added it to .gitignore'
     );
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "env"').toEqual(0);
@@ -230,7 +232,7 @@ describe('env pull', () => {
       'vercel-env-pull and any overrides for branch feat/awesome-thing'
     );
     await expect(client.stderr).toOutput(
-      'Created .env.local file and added it to .gitignore'
+      'Created         .env.local file and added it to .gitignore'
     );
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "env"').toEqual(0);
@@ -286,7 +288,7 @@ describe('env pull', () => {
     await expect(client.stderr).toOutput(
       'Downloading `development` Environment Variables for'
     );
-    await expect(client.stderr).toOutput('Created other.env file');
+    await expect(client.stderr).toOutput('Created         other.env file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "env"').toEqual(0);
@@ -329,7 +331,7 @@ describe('env pull', () => {
       `Downloading \`production\` Environment Variables for`
     );
     await expect(client.stderr).toOutput(
-      'Created .env.local file and added it to .gitignore'
+      'Created         .env.local file and added it to .gitignore'
     );
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "env"').toEqual(0);
@@ -366,7 +368,7 @@ describe('env pull', () => {
     await expect(client.stderr).toOutput(
       'Downloading `production` Environment Variables for'
     );
-    await expect(client.stderr).toOutput('Created other.env file');
+    await expect(client.stderr).toOutput('Created         other.env file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "env"').toEqual(0);
@@ -395,7 +397,7 @@ describe('env pull', () => {
     await expect(client.stderr).toOutput(
       'Downloading `development` Environment Variables for'
     );
-    await expect(client.stderr).toOutput('Created other.env file');
+    await expect(client.stderr).toOutput('Created         other.env file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "env"').toEqual(0);
@@ -448,10 +450,10 @@ describe('env pull', () => {
         'Downloading `development` Environment Variables for'
       );
       await expect(client.stderr).toOutput(
-        '+ SPECIAL_FLAG (Updated)\n+ NEW_VAR\n- TEST\n'
+        '  Changes:\n  + SPECIAL_FLAG (Updated)\n  + NEW_VAR\n  - TEST\n'
       );
       await expect(client.stderr).toOutput(
-        'Updated .env.local file and added it to .gitignore'
+        'Updated         .env.local file and added it to .gitignore'
       );
 
       await expect(pullPromise).resolves.toEqual(0);
@@ -474,7 +476,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--yes');
     const pullPromise = env(client);
     await expect(client.stderr).toOutput(
-      'Updated .env.local file and added it to .gitignore'
+      'Updated         .env.local file and added it to .gitignore'
     );
     await expect(pullPromise).resolves.toEqual(0);
   });
@@ -492,7 +494,7 @@ describe('env pull', () => {
     const pullPromise = env(client);
     await expect(client.stderr).toOutput('> No changes found.');
     await expect(client.stderr).toOutput(
-      'Updated .env.local file and added it to .gitignore'
+      'Updated         .env.local file and added it to .gitignore'
     );
     await expect(pullPromise).resolves.toEqual(0);
   });
@@ -531,7 +533,7 @@ describe('env pull', () => {
       );
       await expect(client.stderr).toOutput('No changes found.\n');
       await expect(client.stderr).toOutput(
-        'Updated .env.local file and added it to .gitignore'
+        'Updated         .env.local file and added it to .gitignore'
       );
 
       await expect(pullPromise).resolves.toEqual(0);
@@ -574,7 +576,9 @@ describe('env pull', () => {
         'Downloading `development` Environment Variables for'
       );
       await expect(client.stderr).toOutput('No changes found.\n');
-      await expect(client.stderr).toOutput('Updated .env.testquotes file');
+      await expect(client.stderr).toOutput(
+        'Updated         .env.testquotes file'
+      );
 
       await expect(pullPromise).resolves.toEqual(0);
     } finally {
@@ -603,7 +607,7 @@ describe('env pull', () => {
     await expect(client.stderr).toOutput(
       'Downloading `development` Environment Variables for'
     );
-    await expect(client.stderr).toOutput('Created .env.local file');
+    await expect(client.stderr).toOutput('Created         .env.local file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "env"').toEqual(0);
@@ -675,7 +679,7 @@ describe('env pull', () => {
     await expect(client.stderr).toOutput(
       'Downloading `development` Environment Variables for'
     );
-    await expect(client.stderr).toOutput('Created .env.local file');
+    await expect(client.stderr).toOutput('Created         .env.local file');
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "env"').toEqual(0);
 

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -83,7 +83,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput(
       'Created         .env.local file and added it to .gitignore'
@@ -188,7 +188,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--yes', '--environment', 'preview');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `preview` Environment Variables for'
+      'Downloading `preview` environment variables for'
     );
     await expect(client.stderr).toOutput(
       'Created         .env.local file and added it to .gitignore'
@@ -226,7 +226,7 @@ describe('env pull', () => {
       'feat/awesome-thing'
     );
     const exitCodePromise = env(client);
-    // Full output: "Downloading `preview` Environment Variables for jqkgv/vercel-env-pull and any overrides for branch feat/awesome-thing"
+    // Full output: "Downloading `preview` environment variables for jqkgv/vercel-env-pull and any overrides for branch feat/awesome-thing"
     // Note: Can't match the full string due to hyperlink ANSI codes around the org/project slug
     await expect(client.stderr).toOutput(
       'vercel-env-pull and any overrides for branch feat/awesome-thing'
@@ -286,7 +286,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', 'other.env', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput('Created         other.env file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
@@ -328,7 +328,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--environment', 'production');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`production\` Environment Variables for`
+      `Downloading \`production\` environment variables for`
     );
     await expect(client.stderr).toOutput(
       'Created         .env.local file and added it to .gitignore'
@@ -366,7 +366,7 @@ describe('env pull', () => {
     );
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `production` Environment Variables for'
+      'Downloading `production` environment variables for'
     );
     await expect(client.stderr).toOutput('Created         other.env file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
@@ -395,7 +395,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', 'other.env', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput('Created         other.env file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
@@ -447,7 +447,7 @@ describe('env pull', () => {
       client.setArgv('env', 'pull', '--yes');
       const pullPromise = env(client);
       await expect(client.stderr).toOutput(
-        'Downloading `development` Environment Variables for'
+        'Downloading `development` environment variables for'
       );
       await expect(client.stderr).toOutput(
         '  Changes:\n  + SPECIAL_FLAG (Updated)\n  + NEW_VAR\n  - TEST\n'
@@ -529,7 +529,7 @@ describe('env pull', () => {
       client.setArgv('env', 'pull', '--yes');
       const pullPromise = env(client);
       await expect(client.stderr).toOutput(
-        'Downloading `development` Environment Variables for'
+        'Downloading `development` environment variables for'
       );
       await expect(client.stderr).toOutput('No changes found.\n');
       await expect(client.stderr).toOutput(
@@ -573,7 +573,7 @@ describe('env pull', () => {
       client.setArgv('env', 'pull', '.env.testquotes', '--yes');
       const pullPromise = env(client);
       await expect(client.stderr).toOutput(
-        'Downloading `development` Environment Variables for'
+        'Downloading `development` environment variables for'
       );
       await expect(client.stderr).toOutput('No changes found.\n');
       await expect(client.stderr).toOutput(
@@ -605,7 +605,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput('Created         .env.local file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
@@ -677,7 +677,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput('Created         .env.local file');
     const exitCode = await exitCodePromise;

--- a/packages/cli/test/unit/commands/env/run.test.ts
+++ b/packages/cli/test/unit/commands/env/run.test.ts
@@ -142,7 +142,7 @@ describe('env run', () => {
       const exitCodePromise = env(client);
 
       await expect(client.stderr).toOutput(
-        'Downloading `development` Environment Variables'
+        'Downloading `development` environment variables'
       );
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -188,7 +188,7 @@ describe('env run', () => {
       const exitCodePromise = env(client);
 
       await expect(client.stderr).toOutput(
-        'Downloading `production` Environment Variables'
+        'Downloading `production` environment variables'
       );
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -231,7 +231,7 @@ describe('env run', () => {
       const exitCodePromise = env(client);
 
       await expect(client.stderr).toOutput(
-        'Downloading `preview` Environment Variables'
+        'Downloading `preview` environment variables'
       );
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -93,7 +93,7 @@ describe('git connect', () => {
         client.setArgv('git', 'connect', remoteUrl);
         const gitPromise = git(client);
 
-        await expect(client.stderr).toOutput('Set up');
+        await expect(client.stderr).toOutput('Directory');
 
         await expect(client.stderr).toOutput('Which team?');
         client.stdin.write('\r');
@@ -200,7 +200,7 @@ describe('git connect', () => {
       client.setArgv('git', 'connect');
       const gitPromise = git(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
 
       await expect(client.stderr).toOutput('Which team?');
       client.stdin.write('\r');
@@ -254,7 +254,7 @@ describe('git connect', () => {
       client.setArgv('git', 'connect', 'https://github.com/user2/repo2');
       const gitPromise = git(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
 
       await expect(client.stderr).toOutput('Which team?');
       client.stdin.write('\r');

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -102,7 +102,7 @@ describe('git connect', () => {
         client.stdin.write('y\n');
 
         await expect(client.stderr).toOutput(
-          'Pull Development Environment Variables into .env.local?'
+          'Pull development environment variables into .env.local?'
         );
         client.stdin.write('n\n');
 
@@ -209,7 +209,7 @@ describe('git connect', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 
@@ -263,7 +263,7 @@ describe('git connect', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach, afterEach, expect, it, vi } from 'vitest';
 import { join } from 'path';
 import fs from 'fs-extra';
+import stripAnsi from 'strip-ansi';
 import { useUser } from '../../../mocks/user';
 import { useTeams, createTeam } from '../../../mocks/team';
 import { defaultProject, useProject } from '../../../mocks/project';
@@ -671,10 +672,13 @@ describe('git connect', () => {
       const gitPromise = git(client);
 
       await expect(client.stderr).toOutput(
-        `Found multiple Git repositories in your local Git config:\n• origin: https://github.com/user/repo.git\n• secondary: https://github.com/user/repo2.git`
+        `Found multiple Git repositories in your local Git config:`
       );
       await expect(client.stderr).toOutput(
         `Do you still want to connect https://github.com/user3/repo3? (y/N)`
+      );
+      expect(stripAnsi(client.stderr.getFullOutput())).toMatch(
+        /Found multiple Git repositories in your local Git config:\n\s{0,2}• origin: https:\/\/github\.com\/user\/repo\.git\n\s{0,2}• secondary: https:\/\/github\.com\/user\/repo2\.git/
       );
       client.stdin.write('y\n');
 

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -98,10 +98,12 @@ describe('git connect', () => {
         await expect(client.stderr).toOutput('Which team?');
         client.stdin.write('\r');
 
-        await expect(client.stderr).toOutput('Found project');
+        await expect(client.stderr).toOutput('Found existing project');
         client.stdin.write('y\n');
 
-        await expect(client.stderr).toOutput('Pull environment variables now?');
+        await expect(client.stderr).toOutput(
+          'Pull Development Environment Variables into .env.local?'
+        );
         client.stdin.write('n\n');
 
         await expect(client.stderr).toOutput(
@@ -203,10 +205,12 @@ describe('git connect', () => {
       await expect(client.stderr).toOutput('Which team?');
       client.stdin.write('\r');
 
-      await expect(client.stderr).toOutput('Found project');
+      await expect(client.stderr).toOutput('Found existing project');
       client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       await expect(client.stderr).toOutput(
@@ -255,10 +259,12 @@ describe('git connect', () => {
       await expect(client.stderr).toOutput('Which team?');
       client.stdin.write('\r');
 
-      await expect(client.stderr).toOutput('Found project');
+      await expect(client.stderr).toOutput('Found existing project');
       client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       await expect(client.stderr).toOutput(

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -100,9 +100,7 @@ describe('git connect', () => {
         await expect(client.stderr).toOutput('Found project');
         client.stdin.write('y\n');
 
-        await expect(client.stderr).toOutput(
-          'Would you like to pull environment variables now?'
-        );
+        await expect(client.stderr).toOutput('Pull environment variables now?');
         client.stdin.write('n\n');
 
         await expect(client.stderr).toOutput(
@@ -118,6 +116,9 @@ describe('git connect', () => {
         await expect(client.stderr).toOutput('Connected');
 
         expect(exitCode).toEqual(0);
+        expect(client.stderr.getFullOutput()).not.toContain(
+          'Would you like to pull environment variables now?'
+        );
         expect(client.telemetryEventStore).toHaveTelemetryEvents([
           {
             key: 'subcommand:connect',
@@ -204,9 +205,7 @@ describe('git connect', () => {
       await expect(client.stderr).toOutput('Found project');
       client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       await expect(client.stderr).toOutput(
@@ -217,6 +216,9 @@ describe('git connect', () => {
       await expect(client.stderr).toOutput('Connected');
 
       expect(exitCode).toEqual(0);
+      expect(client.stderr.getFullOutput()).not.toContain(
+        'Would you like to pull environment variables now?'
+      );
 
       const project: Project = await client.fetch(`/v8/projects/unlinked`);
       expect(project.link).toMatchObject({
@@ -255,9 +257,7 @@ describe('git connect', () => {
       await expect(client.stderr).toOutput('Found project');
       client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       await expect(client.stderr).toOutput(
@@ -273,6 +273,9 @@ describe('git connect', () => {
       await expect(client.stderr).toOutput('Connected');
 
       expect(exitCode).toEqual(0);
+      expect(client.stderr.getFullOutput()).not.toContain(
+        'Would you like to pull environment variables now?'
+      );
 
       const project: Project = await client.fetch(`/v8/projects/unlinked`);
       expect(project.link).toMatchObject({
@@ -668,7 +671,7 @@ describe('git connect', () => {
       const gitPromise = git(client);
 
       await expect(client.stderr).toOutput(
-        `Found multiple Git repositories in your local Git config:\n  • origin: https://github.com/user/repo.git\n  • secondary: https://github.com/user/repo2.git`
+        `Found multiple Git repositories in your local Git config:\n• origin: https://github.com/user/repo.git\n• secondary: https://github.com/user/repo2.git`
       );
       await expect(client.stderr).toOutput(
         `Do you still want to connect https://github.com/user3/repo3? (y/N)`

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -917,8 +917,8 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput('Link to existing project?');
-    client.stdin.write('n\n');
+    await expect(client.stderr).toOutput('Project?');
+    client.stdin.write('\n');
 
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('awesome-app\n');
@@ -963,6 +963,8 @@ describe('link', () => {
     expect(fullOutput).not.toContain(
       'Would you like to pull environment variables now?'
     );
+    expect(fullOutput).not.toContain('Link to existing project?');
+    expect(fullOutput).not.toContain('Link to different existing project?');
   });
 
   it('should write vercel.json for inferred multi-service layouts', async () => {
@@ -990,8 +992,8 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput('Link to existing project?');
-    client.stdin.write('n\n');
+    await expect(client.stderr).toOutput('Project?');
+    client.stdin.write('\n');
 
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('multi-service-app\n');
@@ -1063,8 +1065,8 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput('Link to existing project?');
-    client.stdin.write('n\n');
+    await expect(client.stderr).toOutput('Project?');
+    client.stdin.write('\n');
 
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('declined-multi-service-app\n');
@@ -1123,8 +1125,8 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput('Link to existing project?');
-    client.stdin.write('n\n');
+    await expect(client.stderr).toOutput('Project?');
+    client.stdin.write('\n');
 
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('single-fastapi-app\n');
@@ -1202,8 +1204,8 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput('Link to existing project?');
-    client.stdin.write('n\n');
+    await expect(client.stderr).toOutput('Project?');
+    client.stdin.write('\n');
 
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('selected-directory-multi-service-app\n');
@@ -1289,8 +1291,8 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput('Link to existing project?');
-    client.stdin.write('n\n');
+    await expect(client.stderr).toOutput('Project?');
+    client.stdin.write('\n');
 
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('nested-multi-service-app\n');
@@ -1356,8 +1358,8 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput('Link to existing project?');
-    client.stdin.write('n\n');
+    await expect(client.stderr).toOutput('Project?');
+    client.stdin.write('\n');
 
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('invalid-selected-root-config-app\n');
@@ -1408,8 +1410,8 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput('Link to existing project?');
-    client.stdin.write('n\n');
+    await expect(client.stderr).toOutput('Project?');
+    client.stdin.write('\n');
 
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('services-with-builds\n');
@@ -1959,8 +1961,8 @@ describe('link', () => {
       client.stdin.write('\n');
 
       // inputProject runs with skipAutoDetect, so no duplicate search
-      await expect(client.stderr).toOutput('Link to existing project?');
-      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput('Project?');
+      client.stdin.write('\n');
 
       // Mock pagination returns {}, so hasMoreProjects is true → text input
       await expect(client.stderr).toOutput('Existing project name?');
@@ -1994,8 +1996,8 @@ describe('link', () => {
       client.stdin.write('\n');
 
       // inputProject runs auto-detect (skipAutoDetect=false), finds nothing
-      await expect(client.stderr).toOutput('Link to existing project?');
-      client.stdin.write('n\n');
+      await expect(client.stderr).toOutput('Project?');
+      client.stdin.write('\n');
 
       await expect(client.stderr).toOutput('Name?');
       client.stdin.write(`${basename(cwd)}\n`);
@@ -2484,7 +2486,7 @@ describe('link', () => {
         'Select teams that require SSO to search'
       );
       expect(stripAnsi(client.stderr.getFullOutput())).toContain(
-        '<space> select, <a> toggle all, <i> invert, <enter> confirm'
+        '<space> select, <enter> confirm, <a> toggle all, <i> invert'
       );
       client.stdin.write(' \n');
 

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -2523,6 +2523,9 @@ describe('link', () => {
       );
       client.stdin.write(' \n');
 
+      await expect(client.stderr).toOutput(
+        'Searching 1 team that requires SSO…'
+      );
       await expect(client.stderr).toOutput('Found existing project');
       client.stdin.write('y\n');
 

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -37,13 +37,12 @@ vi.mock('../../../../src/util/agent/auto-install-agentic', () => ({
   autoInstallVercelPlugin: vi.fn().mockResolvedValue(undefined),
 }));
 
-function expectLinkRowsUseNonProductionGutter(
-  output: string,
-  labels: string[]
-) {
+function expectLinkRowsUseExpectedGlyphs(output: string, labels: string[]) {
   const plain = stripAnsi(output);
   const completedLabels = new Set(['Created', 'Linked', 'Added']);
 
+  // Exact blank-gutter spacing is covered by printAlignedLabel() unit tests.
+  // Command transcripts assert row presence plus the semantic glyph contract.
   for (const label of labels) {
     const prefix = completedLabels.has(label) ? '✓ ' : '\\s{0,2}';
     expect(plain).toMatch(new RegExp(`^${prefix}${label.padEnd(16)}`, 'm'));
@@ -901,7 +900,7 @@ describe('link', () => {
     expect(plainOutput).toMatch(
       /✓ Linked\s+.+\n\n\? Pull development environment variables into \.env\.local\?/
     );
-    expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
+    expectLinkRowsUseExpectedGlyphs(client.stderr.getFullOutput(), [
       'Directory',
       'Project',
       'Linked',
@@ -992,7 +991,7 @@ describe('link', () => {
     expect(fullOutput).not.toContain(
       `✓ Linked          ${user.username}/awesome-app`
     );
-    expectLinkRowsUseNonProductionGutter(fullOutput, ['Directory', 'Created']);
+    expectLinkRowsUseExpectedGlyphs(fullOutput, ['Directory', 'Created']);
   });
 
   it('should write vercel.json for inferred multi-service layouts', async () => {
@@ -1608,7 +1607,7 @@ describe('link', () => {
       selectSpy.mockRestore();
 
       expect(exitCode).toEqual(0);
-      expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
+      expectLinkRowsUseExpectedGlyphs(client.stderr.getFullOutput(), [
         'Directory',
         'Project',
         'Linked',
@@ -2268,7 +2267,7 @@ describe('link', () => {
       expect(plainOutput).toMatch(
         /Link repository to project\?.*\n\n✓ Linked\s+/
       );
-      expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
+      expectLinkRowsUseExpectedGlyphs(client.stderr.getFullOutput(), [
         'Directory',
         'Project',
         'Source',
@@ -2411,7 +2410,7 @@ describe('link', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
-      expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
+      expectLinkRowsUseExpectedGlyphs(client.stderr.getFullOutput(), [
         'Project',
         'Source',
         'Linked',
@@ -2546,7 +2545,7 @@ describe('link', () => {
         'Searched        1 team available without SSO\nNo matching projects found'
       );
       expect(plainOutput).toMatch(
-        /^\s{0,2}Searched 1 team\n\n\s{0,2}Found existing project/m
+        /^\s{0,2}Searched\s+1 team\n\n\s{0,2}Found existing project/m
       );
       expect(plainOutput).not.toContain('Searched teams:');
       expect(plainOutput).toMatch(
@@ -2562,7 +2561,7 @@ describe('link', () => {
       const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
       expect(projectJson.projectId).toEqual(limitedProject.id);
       expect(projectJson.orgId).toEqual(limitedTeam.id);
-      expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
+      expectLinkRowsUseExpectedGlyphs(client.stderr.getFullOutput(), [
         'Directory',
         'Searched',
         'Project',

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -48,7 +48,7 @@ function expectLinkRowsUseNonProductionGutter(
   }
 
   expect(plain).not.toMatch(
-    /^[▲✓] (Project|Source|Linked|Directory|Config)\s/m
+    /^[▲✓] (Project|Source|Created|Linked|Added|Directory|Searched|Projects|Config)\s/m
   );
 }
 
@@ -866,9 +866,8 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
-    await expect(client.stderr).toOutput('Found existing project');
     await expect(client.stderr).toOutput('Directory');
+    await expect(client.stderr).toOutput('Found existing project');
     await expect(client.stderr).toOutput(
       `Project     ${team.slug}/${project.name}`
     );
@@ -889,7 +888,18 @@ describe('link', () => {
 
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
+    const plainOutput = stripAnsi(client.stderr.getFullOutput());
+    expect(plainOutput).toMatch(
+      /^\s{0,2}Directory\s+.+\n\nSearching for existing projects…\n\n\s{0,2}Found existing project/m
+    );
+    expect(plainOutput).toMatch(
+      /Link directory to project\?.*\n\n\s{0,2}Linked\s+/
+    );
+    expect(plainOutput).toMatch(
+      /\s{0,2}Linked\s+.+\n\n\? Pull Development Environment Variables into \.env\.local\?/
+    );
     expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
+      'Directory',
       'Project',
       'Linked',
     ]);
@@ -913,7 +923,7 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
+    await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
@@ -934,19 +944,30 @@ describe('link', () => {
     client.stdin.write('\n');
 
     await expect(client.stderr).toOutput(
-      `Linked          ${user.username}/awesome-app`
+      `Created         ${user.username}/awesome-app`
     );
 
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
 
     // Anti-regression: old "Set up and deploy <path>?" confirm prompt is gone.
-    // Status line is "Set up <path>" with no trailing "?" question mark.
+    // Setup state is an aligned Directory row, not a prompt/status sentence.
     const fullOutput = client.stderr.getFullOutput();
+    const plainOutput = stripAnsi(fullOutput);
+    expect(plainOutput).toMatch(
+      /^\s{0,2}Directory\s+.+\n\n(?:Searching for existing projects…\nLoading teams…\n)?\? Which team\?/m
+    );
+    expect(plainOutput).toMatch(
+      /Code directory\?.*\n\n\s{0,2}Detected Next\.js/
+    );
+    expect(plainOutput).toMatch(
+      /Customize advanced settings\?.*\n\n\s{0,2}Created\s+/
+    );
     // Old: `Set up and deploy "${path}"?`
     expect(fullOutput).not.toMatch(/Set up and deploy "[^"]+"\?/);
     // Old inquirer prefix: `? Set up and deploy ...`
     expect(fullOutput).not.toMatch(/\? Set up and deploy/);
+    expect(stripAnsi(fullOutput)).not.toMatch(/^\s*Set up ["“]/m);
     // Anti-regression: "Which scope" was renamed to "Which team".
     expect(fullOutput).not.toContain(
       'Which scope should contain your project?'
@@ -965,6 +986,10 @@ describe('link', () => {
     );
     expect(fullOutput).not.toContain('Link to existing project?');
     expect(fullOutput).not.toContain('Link to different existing project?');
+    expect(fullOutput).not.toContain(
+      `Linked      ${user.username}/awesome-app`
+    );
+    expectLinkRowsUseNonProductionGutter(fullOutput, ['Directory', 'Created']);
   });
 
   it('should write vercel.json for inferred multi-service layouts', async () => {
@@ -988,7 +1013,7 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
+    await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
@@ -1061,7 +1086,7 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
+    await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
@@ -1121,7 +1146,7 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
+    await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
@@ -1200,7 +1225,7 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
+    await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
@@ -1287,7 +1312,7 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
+    await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
@@ -1354,7 +1379,7 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
+    await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
@@ -1406,7 +1431,7 @@ describe('link', () => {
     client.cwd = cwd;
     const exitCodePromise = link(client);
 
-    await expect(client.stderr).toOutput('Set up');
+    await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput('Which team?');
     client.stdin.write('\n');
 
@@ -1562,7 +1587,7 @@ describe('link', () => {
 
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Found existing project');
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
@@ -1608,7 +1633,7 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
@@ -1646,7 +1671,7 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
@@ -1684,7 +1709,7 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
@@ -1729,7 +1754,7 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
@@ -1771,7 +1796,7 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
@@ -1811,7 +1836,7 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
@@ -1851,7 +1876,7 @@ describe('link', () => {
       client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
@@ -1914,7 +1939,7 @@ describe('link', () => {
       client.cwd = cwd;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
@@ -1951,7 +1976,7 @@ describe('link', () => {
       client.setArgv();
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       // Decline cross-team match
       await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('n\n');
@@ -1990,7 +2015,7 @@ describe('link', () => {
       client.cwd = cwd;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       // No match found during cross-team search, should go to selectOrg
       await expect(client.stderr).toOutput('Which team?');
       client.stdin.write('\n');
@@ -2011,7 +2036,7 @@ describe('link', () => {
       await expect(client.stderr).toOutput('Customize advanced settings?');
       client.stdin.write('\n');
 
-      await expect(client.stderr).toOutput('Linked          ');
+      await expect(client.stderr).toOutput('Created         ');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -2217,8 +2242,7 @@ describe('link', () => {
       client.cwd = projectDir;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Searched teams:');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Found existing project');
       await expect(client.stderr).toOutput('Link repository to project?');
       client.stdin.write('y\n');
@@ -2233,7 +2257,16 @@ describe('link', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+      const plainOutput = stripAnsi(client.stderr.getFullOutput());
+      expect(plainOutput).toMatch(
+        /^\s{0,2}Directory\s+.+\n\nSearching for existing projects…\n\n\s{0,2}Found existing project/m
+      );
+      expect(plainOutput).not.toContain('Searched teams:');
+      expect(plainOutput).toMatch(
+        /Link repository to project\?.*\n\n\s{0,2}Linked\s+/
+      );
       expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
+        'Directory',
         'Project',
         'Source',
         'Linked',
@@ -2360,7 +2393,7 @@ describe('link', () => {
       client.setArgv('--project', expectedProject.name);
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Found existing project');
       await expect(client.stderr).toOutput('Link repository to project?');
       client.stdin.write('y\n');
@@ -2436,7 +2469,7 @@ describe('link', () => {
       client.cwd = projectDir;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput('Not one of these projects');
       client.stdin.write('\n');
 
@@ -2481,7 +2514,7 @@ describe('link', () => {
       client.cwd = cwd;
       const exitCodePromise = link(client);
 
-      await expect(client.stderr).toOutput('Set up');
+      await expect(client.stderr).toOutput('Directory');
       await expect(client.stderr).toOutput(
         'Select teams that require SSO to search'
       );
@@ -2503,6 +2536,17 @@ describe('link', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+      const plainOutput = stripAnsi(client.stderr.getFullOutput());
+      expect(plainOutput).toMatch(/^\s{0,2}Directory\s+.+/m);
+      expect(plainOutput).toContain(
+        'Searched    1 team available without SSO\nNo matching projects found'
+      );
+      expect(plainOutput).toMatch(
+        /Searched teams: .+\n\n\s{0,2}Found existing project/
+      );
+      expect(plainOutput).toMatch(
+        /Link directory to project\?.*\n\n\s{0,2}Linked\s+/
+      );
       expect(stripAnsi(client.stderr.getFullOutput())).not.toContain(
         'Press <space> to select'
       );
@@ -2513,6 +2557,12 @@ describe('link', () => {
       const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
       expect(projectJson.projectId).toEqual(limitedProject.id);
       expect(projectJson.orgId).toEqual(limitedTeam.id);
+      expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
+        'Directory',
+        'Searched',
+        'Project',
+        'Linked',
+      ]);
     });
 
     describe('multiple matches', () => {
@@ -2640,7 +2690,7 @@ describe('link', () => {
         client.cwd = cwd;
         const exitCodePromise = link(client);
 
-        await expect(client.stderr).toOutput('Set up');
+        await expect(client.stderr).toOutput('Directory');
         await expect(client.stderr).toOutput(
           'Projects    2 matches across teams'
         );
@@ -2695,7 +2745,7 @@ describe('link', () => {
         client.cwd = cwd;
         const exitCodePromise = link(client);
 
-        await expect(client.stderr).toOutput('Set up');
+        await expect(client.stderr).toOutput('Directory');
         await expect(client.stderr).toOutput(
           'Projects    2 matches across teams'
         );

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -37,7 +37,10 @@ vi.mock('../../../../src/util/agent/auto-install-agentic', () => ({
   autoInstallVercelPlugin: vi.fn().mockResolvedValue(undefined),
 }));
 
-function expectLinkRowsUseBlankGutter(output: string, labels: string[]) {
+function expectLinkRowsUseNonProductionGutter(
+  output: string,
+  labels: string[]
+) {
   const plain = stripAnsi(output);
 
   for (const label of labels) {
@@ -45,7 +48,7 @@ function expectLinkRowsUseBlankGutter(output: string, labels: string[]) {
   }
 
   expect(plain).not.toMatch(
-    /^[▲✓] (Project|Source|Linked|Directory|Settings)\s/m
+    /^[▲✓] (Project|Source|Linked|Directory|Config)\s/m
   );
 }
 
@@ -875,18 +878,18 @@ describe('link', () => {
       `Linked          ${team.slug}/${project.name}`
     );
     await expect(client.stderr).toOutput('Directory');
-    await expect(client.stderr).toOutput('Settings    .vercel/project.json');
+    await expect(client.stderr).toOutput('Config      .vercel/project.json');
 
     await expect(client.stderr).toOutput('Pull environment variables now?');
     client.stdin.write('n\n');
 
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
-    expectLinkRowsUseBlankGutter(client.stderr.getFullOutput(), [
+    expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
       'Project',
       'Linked',
       'Directory',
-      'Settings',
+      'Config',
     ]);
 
     const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
@@ -1570,7 +1573,7 @@ describe('link', () => {
       selectSpy.mockRestore();
 
       expect(exitCode).toEqual(0);
-      expectLinkRowsUseBlankGutter(client.stderr.getFullOutput(), [
+      expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
         'Project',
         'Source',
         'Linked',
@@ -2203,7 +2206,7 @@ describe('link', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
-      expectLinkRowsUseBlankGutter(client.stderr.getFullOutput(), [
+      expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
         'Project',
         'Source',
         'Linked',
@@ -2342,7 +2345,7 @@ describe('link', () => {
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
-      expectLinkRowsUseBlankGutter(client.stderr.getFullOutput(), [
+      expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
         'Project',
         'Source',
         'Linked',

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -887,7 +887,7 @@ describe('link', () => {
     );
 
     await expect(client.stderr).toOutput(
-      'Pull Development Environment Variables into .env.local?'
+      'Pull development environment variables into .env.local?'
     );
     client.stdin.write('n\n');
 
@@ -899,7 +899,7 @@ describe('link', () => {
     );
     expect(plainOutput).toMatch(/Link directory to project\?.*\n\n✓ Linked\s+/);
     expect(plainOutput).toMatch(
-      /✓ Linked\s+.+\n\n\? Pull Development Environment Variables into \.env\.local\?/
+      /✓ Linked\s+.+\n\n\? Pull development environment variables into \.env\.local\?/
     );
     expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
       'Directory',
@@ -1600,7 +1600,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 
@@ -1645,7 +1645,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('y\n');
 
@@ -1683,7 +1683,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 
@@ -1721,7 +1721,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('y\n');
 
@@ -1766,7 +1766,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('y\n');
 
@@ -1808,7 +1808,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('y\n');
 
@@ -1848,7 +1848,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('y\n');
 
@@ -1888,7 +1888,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('y\n');
 
@@ -1951,7 +1951,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 
@@ -2001,7 +2001,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 
@@ -2254,7 +2254,7 @@ describe('link', () => {
         `✓ Linked          ${teamA.slug}/${projectA.name}`
       );
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 
@@ -2405,7 +2405,7 @@ describe('link', () => {
         `✓ Linked          ${teamA.slug}/${expectedProject.name}`
       );
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 
@@ -2480,7 +2480,7 @@ describe('link', () => {
         `✓ Linked          ${teamA.slug}/${repoProject.name}`
       );
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 
@@ -2534,7 +2534,7 @@ describe('link', () => {
         `✓ Linked          ${limitedTeam.slug}/${limitedProject.name}`
       );
       await expect(client.stderr).toOutput(
-        'Pull Development Environment Variables into .env.local?'
+        'Pull development environment variables into .env.local?'
       );
       client.stdin.write('n\n');
 
@@ -2705,7 +2705,7 @@ describe('link', () => {
         await expect(client.stderr).toOutput('✓ Linked          ');
 
         await expect(client.stderr).toOutput(
-          'Pull Development Environment Variables into .env.local?'
+          'Pull development environment variables into .env.local?'
         );
         client.stdin.write('n\n');
 
@@ -2759,7 +2759,7 @@ describe('link', () => {
         await expect(client.stderr).toOutput('✓ Linked          ');
 
         await expect(client.stderr).toOutput(
-          'Pull Development Environment Variables into .env.local?'
+          'Pull development environment variables into .env.local?'
         );
         client.stdin.write('n\n');
 

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -44,7 +44,7 @@ function expectLinkRowsUseNonProductionGutter(
   const plain = stripAnsi(output);
 
   for (const label of labels) {
-    expect(plain).toMatch(new RegExp(`^${label.padEnd(12)}`, 'm'));
+    expect(plain).toMatch(new RegExp(`^\\s{0,2}${label.padEnd(12)}`, 'm'));
   }
 
   expect(plain).not.toMatch(

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -2,6 +2,7 @@ import { EOL } from 'node:os';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { basename, join } from 'path';
 import { readFile } from 'fs-extra';
+import stripAnsi from 'strip-ansi';
 import {
   readJSON,
   mkdirp,
@@ -35,6 +36,18 @@ const mockPull = vi.mocked(pull);
 vi.mock('../../../../src/util/agent/auto-install-agentic', () => ({
   autoInstallVercelPlugin: vi.fn().mockResolvedValue(undefined),
 }));
+
+function expectLinkRowsUseBlankGutter(output: string, labels: string[]) {
+  const plain = stripAnsi(output);
+
+  for (const label of labels) {
+    expect(plain).toMatch(new RegExp(`^${label.padEnd(12)}`, 'm'));
+  }
+
+  expect(plain).not.toMatch(
+    /^[▲✓] (Project|Source|Linked|Directory|Settings)\s/m
+  );
+}
 
 describe('link', () => {
   beforeEach(() => {
@@ -851,25 +864,38 @@ describe('link', () => {
     const exitCodePromise = link(client);
 
     await expect(client.stderr).toOutput('Set up');
-    await expect(client.stderr).toOutput('Link to it?');
+    await expect(client.stderr).toOutput('Found project');
+    await expect(client.stderr).toOutput(
+      `Project     ${team.slug}/${project.name}`
+    );
+    await expect(client.stderr).toOutput('Link to this project?');
     client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       `Linked          ${team.slug}/${project.name}`
     );
+    await expect(client.stderr).toOutput('Directory');
+    await expect(client.stderr).toOutput('Settings    .vercel/project.json');
 
-    await expect(client.stderr).toOutput(
-      'Would you like to pull environment variables now?'
-    );
+    await expect(client.stderr).toOutput('Pull environment variables now?');
     client.stdin.write('n\n');
 
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
+    expectLinkRowsUseBlankGutter(client.stderr.getFullOutput(), [
+      'Project',
+      'Linked',
+      'Directory',
+      'Settings',
+    ]);
 
     const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
     expect(projectJson.orgId).toEqual(team.id);
     expect(projectJson.projectId).toEqual(project.id);
     expect(projectJson.projectName).toEqual(project.name);
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Would you like to pull environment variables now?'
+    );
   });
 
   it('should create new Project', async () => {
@@ -892,18 +918,14 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('awesome-app\n');
 
-    await expect(client.stderr).toOutput(
-      'In which directory is your code located? ./'
-    );
+    await expect(client.stderr).toOutput('Code directory? ./');
     client.stdin.write('apps/nextjs\n');
 
     await expect(client.stderr).toOutput('Detected Next.js');
     await expect(client.stderr).toOutput('Customize settings?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput(
-      'Do you want to change additional project settings?'
-    );
+    await expect(client.stderr).toOutput('Customize advanced settings?');
     client.stdin.write('\n');
 
     await expect(client.stderr).toOutput(
@@ -927,6 +949,15 @@ describe('link', () => {
     // Anti-regression: "What's your project's name?" was renamed to "Name?".
     // Use regex to match both straight ' and curly ’ apostrophes (source on main uses curly).
     expect(fullOutput).not.toMatch(/What.s your project.s name\?/);
+    expect(fullOutput).not.toContain(
+      'In which directory is your code located?'
+    );
+    expect(fullOutput).not.toContain(
+      'Do you want to change additional project settings?'
+    );
+    expect(fullOutput).not.toContain(
+      'Would you like to pull environment variables now?'
+    );
   });
 
   it('should write vercel.json for inferred multi-service layouts', async () => {
@@ -974,9 +1005,7 @@ describe('link', () => {
     );
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput(
-      'Do you want to change additional project settings?'
-    );
+    await expect(client.stderr).toOutput('Customize advanced settings?');
     client.stdin.write('\n');
 
     const exitCode = await exitCodePromise;
@@ -1047,18 +1076,14 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Customize settings?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput(
-      'Do you want to change additional project settings?'
-    );
+    await expect(client.stderr).toOutput('Customize advanced settings?');
     client.stdin.write('\n');
 
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
 
     expect(await pathExists(join(cwd, 'vercel.json'))).toBe(false);
-    expect(client.stderr.getFullOutput()).not.toContain(
-      'In which directory is your code located?'
-    );
+    expect(client.stderr.getFullOutput()).not.toContain('Code directory?');
 
     const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
     const project = await getProjectByNameOrId(client, projectJson.projectId);
@@ -1111,18 +1136,14 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Customize settings?');
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput(
-      'Do you want to change additional project settings?'
-    );
+    await expect(client.stderr).toOutput('Customize advanced settings?');
     client.stdin.write('\n');
 
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
 
     expect(await pathExists(join(cwd, 'vercel.json'))).toBe(false);
-    expect(client.stderr.getFullOutput()).not.toContain(
-      'In which directory is your code located?'
-    );
+    expect(client.stderr.getFullOutput()).not.toContain('Code directory?');
 
     const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
     const project = await getProjectByNameOrId(client, projectJson.projectId);
@@ -1190,9 +1211,7 @@ describe('link', () => {
     );
     client.stdin.write('\x1B[B\x1B[B\x1B[B\n');
 
-    await expect(client.stderr).toOutput(
-      'In which directory is your code located? ./'
-    );
+    await expect(client.stderr).toOutput('Code directory? ./');
     client.stdin.write('apps/web\n');
 
     await expect(client.stderr).toOutput(
@@ -1200,9 +1219,7 @@ describe('link', () => {
     );
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput(
-      'Do you want to change additional project settings?'
-    );
+    await expect(client.stderr).toOutput('Customize advanced settings?');
     client.stdin.write('\n');
 
     const exitCode = await exitCodePromise;
@@ -1240,7 +1257,7 @@ describe('link', () => {
 
     await mkdirp(join(cwd, 'apps/web/services/api'));
     // `pnpm-workspace.yaml` marks the repo root as a workspace, which is what
-    // triggers the "In which directory is your code located?" prompt under
+    // triggers the "Code directory?" prompt under
     // the standard (no-inferred-services) flow.
     await writeFile(
       join(cwd, 'pnpm-workspace.yaml'),
@@ -1273,9 +1290,7 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('nested-multi-service-app\n');
 
-    await expect(client.stderr).toOutput(
-      'In which directory is your code located? ./'
-    );
+    await expect(client.stderr).toOutput('Code directory? ./');
     client.stdin.write('apps/web\n');
 
     await expect(client.stderr).toOutput(
@@ -1283,9 +1298,7 @@ describe('link', () => {
     );
     client.stdin.write('\n');
 
-    await expect(client.stderr).toOutput(
-      'Do you want to change additional project settings?'
-    );
+    await expect(client.stderr).toOutput('Customize advanced settings?');
     client.stdin.write('\n');
 
     const exitCode = await exitCodePromise;
@@ -1323,7 +1336,7 @@ describe('link', () => {
 
     await mkdirp(join(cwd, 'apps/web'));
     // `pnpm-workspace.yaml` marks the repo root as a workspace, which is what
-    // triggers the "In which directory is your code located?" prompt under
+    // triggers the "Code directory?" prompt under
     // the standard (no-inferred-services) flow.
     await writeFile(
       join(cwd, 'pnpm-workspace.yaml'),
@@ -1344,14 +1357,10 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Name?');
     client.stdin.write('invalid-selected-root-config-app\n');
 
-    await expect(client.stderr).toOutput(
-      'In which directory is your code located? ./'
-    );
+    await expect(client.stderr).toOutput('Code directory? ./');
     client.stdin.write('apps/web\n');
 
-    await expect(client.stderr).toOutput(
-      'Do you want to change additional project settings?'
-    );
+    await expect(client.stderr).toOutput('Customize advanced settings?');
     client.stdin.write('\n');
 
     const exitCode = await exitCodePromise;
@@ -1403,9 +1412,7 @@ describe('link', () => {
     await expect(client.stderr).toOutput(
       'Multiple services were detected, but your existing project config uses `builds`. To deploy multiple services in one project, see Services (https://vercel.com/docs/services).'
     );
-    await expect(client.stderr).toOutput(
-      'Do you want to change additional project settings?'
-    );
+    await expect(client.stderr).toOutput('Customize advanced settings?');
     client.stdin.write('\n');
 
     const exitCode = await exitCodePromise;
@@ -1556,15 +1563,18 @@ describe('link', () => {
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
       selectSpy.mockRestore();
 
       expect(exitCode).toEqual(0);
+      expectLinkRowsUseBlankGutter(client.stderr.getFullOutput(), [
+        'Project',
+        'Source',
+        'Linked',
+      ]);
       expect(sawRepoProjectSelector).toBe(false);
       expect(client.stderr.getFullOutput()).not.toContain(
         'Please select a Project:'
@@ -1589,16 +1599,14 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to it?');
+      await expect(client.stderr).toOutput('Link to this project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('y\n');
 
       const exitCode = await exitCodePromise;
@@ -1627,16 +1635,14 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to it?');
+      await expect(client.stderr).toOutput('Link to this project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -1665,16 +1671,14 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to it?');
+      await expect(client.stderr).toOutput('Link to this project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
@@ -1710,16 +1714,14 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to it?');
+      await expect(client.stderr).toOutput('Link to this project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
@@ -1752,16 +1754,14 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to it?');
+      await expect(client.stderr).toOutput('Link to this project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('y\n');
 
       const exitCode = await exitCodePromise;
@@ -1792,16 +1792,14 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to it?');
+      await expect(client.stderr).toOutput('Link to this project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('y\n');
 
       const exitCode = await exitCodePromise;
@@ -1832,16 +1830,14 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to it?');
+      await expect(client.stderr).toOutput('Link to this project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
@@ -1895,16 +1891,14 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to it?');
+      await expect(client.stderr).toOutput('Link to this project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -1933,7 +1927,7 @@ describe('link', () => {
 
       await expect(client.stderr).toOutput('Set up');
       // Decline cross-team match
-      await expect(client.stderr).toOutput('Link to it?');
+      await expect(client.stderr).toOutput('Link to this project?');
       client.stdin.write('n\n');
 
       // Should fall through to selectOrg
@@ -1952,9 +1946,7 @@ describe('link', () => {
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -1983,16 +1975,12 @@ describe('link', () => {
       client.stdin.write(`${basename(cwd)}\n`);
       // Tmp dir has no detectable framework at the root, so the
       // root-directory prompt now fires (nested-monolith guard).
-      await expect(client.stderr).toOutput(
-        'In which directory is your code located?'
-      );
+      await expect(client.stderr).toOutput('Code directory?');
       client.stdin.write('\n');
       await expect(client.stderr).toOutput('Customize settings?');
       client.stdin.write('\n');
 
-      await expect(client.stderr).toOutput(
-        'Do you want to change additional project settings?'
-      );
+      await expect(client.stderr).toOutput('Customize advanced settings?');
       client.stdin.write('\n');
 
       await expect(client.stderr).toOutput('Linked          ');
@@ -2210,13 +2198,16 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `Linked          ${teamA.slug}/${projectA.name}`
       );
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+      expectLinkRowsUseBlankGutter(client.stderr.getFullOutput(), [
+        'Project',
+        'Source',
+        'Linked',
+      ]);
 
       const repoJson = await readJSON(join(repoRoot, '.vercel/repo.json'));
       expect(repoJson).toEqual({
@@ -2346,13 +2337,16 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `Linked          ${teamA.slug}/${expectedProject.name}`
       );
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+      expectLinkRowsUseBlankGutter(client.stderr.getFullOutput(), [
+        'Project',
+        'Source',
+        'Linked',
+      ]);
 
       const repoJson = await readJSON(join(repoRoot, '.vercel/repo.json'));
       expect(repoJson.projects).toEqual([
@@ -2416,9 +2410,7 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `Linked          ${teamA.slug}/${repoProject.name}`
       );
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -2455,9 +2447,7 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput(
-        'Which SSO-protected teams should be searched?'
-      );
+      await expect(client.stderr).toOutput('Which SSO-protected teams?');
       client.stdin.write(' \n');
 
       await expect(client.stderr).toOutput('Found project');
@@ -2466,9 +2456,7 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `Linked          ${limitedTeam.slug}/${limitedProject.name}`
       );
-      await expect(client.stderr).toOutput(
-        'Would you like to pull environment variables now?'
-      );
+      await expect(client.stderr).toOutput('Pull environment variables now?');
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -2613,9 +2601,7 @@ describe('link', () => {
 
         await expect(client.stderr).toOutput('Linked          ');
 
-        await expect(client.stderr).toOutput(
-          'Would you like to pull environment variables now?'
-        );
+        await expect(client.stderr).toOutput('Pull environment variables now?');
         client.stdin.write('n\n');
 
         const exitCode = await exitCodePromise;
@@ -2667,9 +2653,7 @@ describe('link', () => {
 
         await expect(client.stderr).toOutput('Linked          ');
 
-        await expect(client.stderr).toOutput(
-          'Would you like to pull environment variables now?'
-        );
+        await expect(client.stderr).toOutput('Pull environment variables now?');
         client.stdin.write('n\n');
 
         const exitCode = await exitCodePromise;

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -42,13 +42,18 @@ function expectLinkRowsUseNonProductionGutter(
   labels: string[]
 ) {
   const plain = stripAnsi(output);
+  const completedLabels = new Set(['Created', 'Linked', 'Added']);
 
   for (const label of labels) {
-    expect(plain).toMatch(new RegExp(`^\\s{0,2}${label.padEnd(12)}`, 'm'));
+    const prefix = completedLabels.has(label) ? '✓ ' : '\\s{0,2}';
+    expect(plain).toMatch(new RegExp(`^${prefix}${label.padEnd(16)}`, 'm'));
   }
 
   expect(plain).not.toMatch(
-    /^[▲✓] (Project|Source|Created|Linked|Added|Directory|Searched|Projects|Config)\s/m
+    /^▲ (Project|Source|Created|Linked|Added|Directory|Searched|Projects|Config)\s/m
+  );
+  expect(plain).not.toMatch(
+    /^✓ (Project|Source|Directory|Searched|Projects|Config)\s/m
   );
 }
 
@@ -120,7 +125,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          1 Project under ${user.username}`
+        `✓ Linked          1 Project under ${user.username}`
       );
 
       const exitCode = await exitCodePromise;
@@ -192,7 +197,7 @@ describe('link', () => {
       client.stdin.write('\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          1 Project under ${user.username}`
+        `✓ Linked          1 Project under ${user.username}`
       );
 
       const exitCode = await exitCodePromise;
@@ -283,7 +288,7 @@ describe('link', () => {
       client.stdin.write('\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          2 Projects under ${user.username}`
+        `✓ Linked          2 Projects under ${user.username}`
       );
 
       const exitCode = await exitCodePromise;
@@ -500,7 +505,7 @@ describe('link', () => {
       );
       client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput('Added           1 Project under');
+      await expect(client.stderr).toOutput('✓ Added           1 Project under');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -683,7 +688,7 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       const exitCode = await exitCodePromise;
@@ -749,7 +754,7 @@ describe('link', () => {
 
       await expect(client.stderr).toOutput('Searching for existing projects');
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       const exitCode = await exitCodePromise;
@@ -869,16 +874,16 @@ describe('link', () => {
     await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput('Found existing project');
     await expect(client.stderr).toOutput(
-      `Project     ${team.slug}/${project.name}`
+      `Project         ${team.slug}/${project.name}`
     );
     await expect(client.stderr).toOutput('Link directory to project?');
     client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
-      `Linked          ${team.slug}/${project.name}`
+      `✓ Linked          ${team.slug}/${project.name}`
     );
-    expect(client.stderr.getFullOutput()).not.toContain(
-      'Config      .vercel/project.json'
+    expect(stripAnsi(client.stderr.getFullOutput())).not.toMatch(
+      /^\s{0,2}Config\s+\.vercel\/project\.json/m
     );
 
     await expect(client.stderr).toOutput(
@@ -892,11 +897,9 @@ describe('link', () => {
     expect(plainOutput).toMatch(
       /^\s{0,2}Directory\s+.+\n\nSearching for existing projects…\n\n\s{0,2}Found existing project/m
     );
+    expect(plainOutput).toMatch(/Link directory to project\?.*\n\n✓ Linked\s+/);
     expect(plainOutput).toMatch(
-      /Link directory to project\?.*\n\n\s{0,2}Linked\s+/
-    );
-    expect(plainOutput).toMatch(
-      /\s{0,2}Linked\s+.+\n\n\? Pull Development Environment Variables into \.env\.local\?/
+      /✓ Linked\s+.+\n\n\? Pull Development Environment Variables into \.env\.local\?/
     );
     expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
       'Directory',
@@ -944,7 +947,7 @@ describe('link', () => {
     client.stdin.write('\n');
 
     await expect(client.stderr).toOutput(
-      `Created         ${user.username}/awesome-app`
+      `✓ Created         ${user.username}/awesome-app`
     );
 
     const exitCode = await exitCodePromise;
@@ -961,7 +964,7 @@ describe('link', () => {
       /Code directory\?.*\n\n\s{0,2}Detected Next\.js/
     );
     expect(plainOutput).toMatch(
-      /Customize advanced settings\?.*\n\n\s{0,2}Created\s+/
+      /Customize advanced settings\?.*\n\n✓ Created\s+/
     );
     // Old: `Set up and deploy "${path}"?`
     expect(fullOutput).not.toMatch(/Set up and deploy "[^"]+"\?/);
@@ -987,7 +990,7 @@ describe('link', () => {
     expect(fullOutput).not.toContain('Link to existing project?');
     expect(fullOutput).not.toContain('Link to different existing project?');
     expect(fullOutput).not.toContain(
-      `Linked      ${user.username}/awesome-app`
+      `✓ Linked          ${user.username}/awesome-app`
     );
     expectLinkRowsUseNonProductionGutter(fullOutput, ['Directory', 'Created']);
   });
@@ -1593,7 +1596,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -1638,7 +1641,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -1676,7 +1679,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -1714,7 +1717,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -1759,7 +1762,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -1801,7 +1804,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -1841,7 +1844,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -1881,7 +1884,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -1944,7 +1947,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -1994,7 +1997,7 @@ describe('link', () => {
       client.stdin.write(`${basename(cwd)}\n`);
 
       await expect(client.stderr).toOutput(
-        `Linked          ${team.slug}/${project.name}`
+        `✓ Linked          ${team.slug}/${project.name}`
       );
 
       await expect(client.stderr).toOutput(
@@ -2036,7 +2039,7 @@ describe('link', () => {
       await expect(client.stderr).toOutput('Customize advanced settings?');
       client.stdin.write('\n');
 
-      await expect(client.stderr).toOutput('Created         ');
+      await expect(client.stderr).toOutput('✓ Created         ');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -2248,7 +2251,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${teamA.slug}/${projectA.name}`
+        `✓ Linked          ${teamA.slug}/${projectA.name}`
       );
       await expect(client.stderr).toOutput(
         'Pull Development Environment Variables into .env.local?'
@@ -2263,7 +2266,7 @@ describe('link', () => {
       );
       expect(plainOutput).not.toContain('Searched teams:');
       expect(plainOutput).toMatch(
-        /Link repository to project\?.*\n\n\s{0,2}Linked\s+/
+        /Link repository to project\?.*\n\n✓ Linked\s+/
       );
       expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
         'Directory',
@@ -2399,7 +2402,7 @@ describe('link', () => {
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${teamA.slug}/${expectedProject.name}`
+        `✓ Linked          ${teamA.slug}/${expectedProject.name}`
       );
       await expect(client.stderr).toOutput(
         'Pull Development Environment Variables into .env.local?'
@@ -2474,7 +2477,7 @@ describe('link', () => {
       client.stdin.write('\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${teamA.slug}/${repoProject.name}`
+        `✓ Linked          ${teamA.slug}/${repoProject.name}`
       );
       await expect(client.stderr).toOutput(
         'Pull Development Environment Variables into .env.local?'
@@ -2515,22 +2518,20 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Directory');
-      await expect(client.stderr).toOutput(
-        'Select teams that require SSO to search'
-      );
+      await expect(client.stderr).toOutput('Select teams that require SSO');
       expect(stripAnsi(client.stderr.getFullOutput())).toContain(
         '<space> select, <enter> confirm, <a> toggle all, <i> invert'
       );
       client.stdin.write(' \n');
 
       await expect(client.stderr).toOutput(
-        'Searching 1 team that requires SSO…'
+        'Searching selected teams that require SSO…'
       );
       await expect(client.stderr).toOutput('Found existing project');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
-        `Linked          ${limitedTeam.slug}/${limitedProject.name}`
+        `✓ Linked          ${limitedTeam.slug}/${limitedProject.name}`
       );
       await expect(client.stderr).toOutput(
         'Pull Development Environment Variables into .env.local?'
@@ -2542,13 +2543,14 @@ describe('link', () => {
       const plainOutput = stripAnsi(client.stderr.getFullOutput());
       expect(plainOutput).toMatch(/^\s{0,2}Directory\s+.+/m);
       expect(plainOutput).toContain(
-        'Searched    1 team available without SSO\nNo matching projects found'
+        'Searched        1 team available without SSO\nNo matching projects found'
       );
       expect(plainOutput).toMatch(
-        /Searched teams: .+\n\n\s{0,2}Found existing project/
+        /^\s{0,2}Searched 1 team\n\n\s{0,2}Found existing project/m
       );
+      expect(plainOutput).not.toContain('Searched teams:');
       expect(plainOutput).toMatch(
-        /Link directory to project\?.*\n\n\s{0,2}Linked\s+/
+        /Link directory to project\?.*\n\n✓ Linked\s+/
       );
       expect(stripAnsi(client.stderr.getFullOutput())).not.toContain(
         'Press <space> to select'
@@ -2648,7 +2650,7 @@ describe('link', () => {
         const exitCodePromise = link(client);
 
         await expect(client.stderr).toOutput(
-          'Projects    2 matches across teams'
+          'Projects        2 matches across teams'
         );
         // Select first option (team_a)
         client.stdin.write('\n');
@@ -2695,12 +2697,12 @@ describe('link', () => {
 
         await expect(client.stderr).toOutput('Directory');
         await expect(client.stderr).toOutput(
-          'Projects    2 matches across teams'
+          'Projects        2 matches across teams'
         );
         // Select first option
         client.stdin.write('\n');
 
-        await expect(client.stderr).toOutput('Linked          ');
+        await expect(client.stderr).toOutput('✓ Linked          ');
 
         await expect(client.stderr).toOutput(
           'Pull Development Environment Variables into .env.local?'
@@ -2750,11 +2752,11 @@ describe('link', () => {
 
         await expect(client.stderr).toOutput('Directory');
         await expect(client.stderr).toOutput(
-          'Projects    2 matches across teams'
+          'Projects        2 matches across teams'
         );
         client.stdin.write('\n');
 
-        await expect(client.stderr).toOutput('Linked          ');
+        await expect(client.stderr).toOutput('✓ Linked          ');
 
         await expect(client.stderr).toOutput(
           'Pull Development Environment Variables into .env.local?'

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -867,20 +867,24 @@ describe('link', () => {
     const exitCodePromise = link(client);
 
     await expect(client.stderr).toOutput('Set up');
-    await expect(client.stderr).toOutput('Found project');
+    await expect(client.stderr).toOutput('Found existing project');
+    await expect(client.stderr).toOutput('Directory');
     await expect(client.stderr).toOutput(
       `Project     ${team.slug}/${project.name}`
     );
-    await expect(client.stderr).toOutput('Link to this project?');
+    await expect(client.stderr).toOutput('Link directory to project?');
     client.stdin.write('y\n');
 
     await expect(client.stderr).toOutput(
       `Linked          ${team.slug}/${project.name}`
     );
-    await expect(client.stderr).toOutput('Directory');
-    await expect(client.stderr).toOutput('Config      .vercel/project.json');
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Config      .vercel/project.json'
+    );
 
-    await expect(client.stderr).toOutput('Pull environment variables now?');
+    await expect(client.stderr).toOutput(
+      'Pull Development Environment Variables into .env.local?'
+    );
     client.stdin.write('n\n');
 
     const exitCode = await exitCodePromise;
@@ -888,8 +892,6 @@ describe('link', () => {
     expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
       'Project',
       'Linked',
-      'Directory',
-      'Config',
     ]);
 
     const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
@@ -1559,14 +1561,17 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Found project');
+      await expect(client.stderr).toOutput('Found existing project');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -1574,8 +1579,8 @@ describe('link', () => {
 
       expect(exitCode).toEqual(0);
       expectLinkRowsUseNonProductionGutter(client.stderr.getFullOutput(), [
+        'Directory',
         'Project',
-        'Source',
         'Linked',
       ]);
       expect(sawRepoProjectSelector).toBe(false);
@@ -1602,14 +1607,16 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to this project?');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('y\n');
 
       const exitCode = await exitCodePromise;
@@ -1638,14 +1645,16 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to this project?');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -1674,14 +1683,16 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to this project?');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
@@ -1717,14 +1728,16 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to this project?');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
@@ -1757,14 +1770,16 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to this project?');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('y\n');
 
       const exitCode = await exitCodePromise;
@@ -1795,14 +1810,16 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to this project?');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('y\n');
 
       const exitCode = await exitCodePromise;
@@ -1833,14 +1850,16 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to this project?');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
@@ -1894,14 +1913,16 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Link to this project?');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -1930,7 +1951,7 @@ describe('link', () => {
 
       await expect(client.stderr).toOutput('Set up');
       // Decline cross-team match
-      await expect(client.stderr).toOutput('Link to this project?');
+      await expect(client.stderr).toOutput('Link directory to project?');
       client.stdin.write('n\n');
 
       // Should fall through to selectOrg
@@ -1949,7 +1970,9 @@ describe('link', () => {
         `Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -2194,14 +2217,16 @@ describe('link', () => {
 
       await expect(client.stderr).toOutput('Set up');
       await expect(client.stderr).toOutput('Searched teams:');
-      await expect(client.stderr).toOutput('Skipped 1 SSO-protected team');
-      await expect(client.stderr).toOutput('Found project');
+      await expect(client.stderr).toOutput('Found existing project');
+      await expect(client.stderr).toOutput('Link repository to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${teamA.slug}/${projectA.name}`
       );
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -2334,13 +2359,16 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Found project');
+      await expect(client.stderr).toOutput('Found existing project');
+      await expect(client.stderr).toOutput('Link repository to project?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${teamA.slug}/${expectedProject.name}`
       );
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
@@ -2413,14 +2441,16 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `Linked          ${teamA.slug}/${repoProject.name}`
       );
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
     });
 
-    it('should search selected SSO-protected teams after no first-pass matches', async () => {
+    it('should search selected teams that require SSO after no first-pass matches', async () => {
       useUser({ version: 'northstar' });
       const cwd = setupTmpDir();
       const projectName = basename(cwd);
@@ -2450,20 +2480,33 @@ describe('link', () => {
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
-      await expect(client.stderr).toOutput('Which SSO-protected teams?');
+      await expect(client.stderr).toOutput(
+        'Select teams that require SSO to search'
+      );
+      expect(stripAnsi(client.stderr.getFullOutput())).toContain(
+        '<space> select, <a> toggle all, <i> invert, <enter> confirm'
+      );
       client.stdin.write(' \n');
 
-      await expect(client.stderr).toOutput('Found project');
+      await expect(client.stderr).toOutput('Found existing project');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked          ${limitedTeam.slug}/${limitedProject.name}`
       );
-      await expect(client.stderr).toOutput('Pull environment variables now?');
+      await expect(client.stderr).toOutput(
+        'Pull Development Environment Variables into .env.local?'
+      );
       client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+      expect(stripAnsi(client.stderr.getFullOutput())).not.toContain(
+        'Press <space> to select'
+      );
+      expect(stripAnsi(client.stderr.getFullOutput())).not.toContain(
+        'to proceed'
+      );
 
       const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
       expect(projectJson.projectId).toEqual(limitedProject.id);
@@ -2550,7 +2593,7 @@ describe('link', () => {
         const exitCodePromise = link(client);
 
         await expect(client.stderr).toOutput(
-          'Found matching projects across teams'
+          'Projects    2 matches across teams'
         );
         // Select first option (team_a)
         client.stdin.write('\n');
@@ -2597,14 +2640,16 @@ describe('link', () => {
 
         await expect(client.stderr).toOutput('Set up');
         await expect(client.stderr).toOutput(
-          'Found matching projects across teams'
+          'Projects    2 matches across teams'
         );
         // Select first option
         client.stdin.write('\n');
 
         await expect(client.stderr).toOutput('Linked          ');
 
-        await expect(client.stderr).toOutput('Pull environment variables now?');
+        await expect(client.stderr).toOutput(
+          'Pull Development Environment Variables into .env.local?'
+        );
         client.stdin.write('n\n');
 
         const exitCode = await exitCodePromise;
@@ -2650,13 +2695,15 @@ describe('link', () => {
 
         await expect(client.stderr).toOutput('Set up');
         await expect(client.stderr).toOutput(
-          'Found matching projects across teams'
+          'Projects    2 matches across teams'
         );
         client.stdin.write('\n');
 
         await expect(client.stderr).toOutput('Linked          ');
 
-        await expect(client.stderr).toOutput('Pull environment variables now?');
+        await expect(client.stderr).toOutput(
+          'Pull Development Environment Variables into .env.local?'
+        );
         client.stdin.write('n\n');
 
         const exitCode = await exitCodePromise;

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -75,10 +75,10 @@ describe('pull', () => {
     client.setArgv('pull', cwd);
     const exitCodePromise = pull(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`development\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+      `Downloading \`development\` environment variables for ${teams[0].slug}/vercel-pull-next`
     );
     await expect(client.stderr).toOutput(
-      `Created .vercel${path.sep}.env.development.local file`
+      `✓ Created         .vercel${path.sep}.env.development.local file`
     );
     await expect(client.stderr).toOutput(
       `Downloaded project settings to ${cwd}${path.sep}.vercel${path.sep}project.json`
@@ -154,10 +154,10 @@ describe('pull', () => {
       client.setArgv('pull', cwd);
       const exitCodePromise = pull(client);
       await expect(client.stderr).toOutput(
-        `Downloading \`development\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+        `Downloading \`development\` environment variables for ${teams[0].slug}/vercel-pull-next`
       );
       await expect(client.stderr).toOutput(
-        `Created .vercel${path.sep}.env.development.local file`
+        `✓ Created         .vercel${path.sep}.env.development.local file`
       );
       await expect(client.stderr).toOutput(
         `Downloaded project settings to ${cwd}${path.sep}.vercel${path.sep}project.json`
@@ -195,10 +195,10 @@ describe('pull', () => {
     client.setArgv('pull', '--environment=preview', cwd);
     const exitCodePromise = pull(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`preview\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+      `Downloading \`preview\` environment variables for ${teams[0].slug}/vercel-pull-next`
     );
     await expect(client.stderr).toOutput(
-      `Created .vercel${path.sep}.env.preview.local file`
+      `✓ Created         .vercel${path.sep}.env.preview.local file`
     );
     await expect(client.stderr).toOutput(
       `Downloaded project settings to ${cwd}${path.sep}.vercel${path.sep}project.json`
@@ -240,10 +240,10 @@ describe('pull', () => {
     client.setArgv('pull', '--environment=production', cwd);
     const exitCodePromise = pull(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`production\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+      `Downloading \`production\` environment variables for ${teams[0].slug}/vercel-pull-next`
     );
     await expect(client.stderr).toOutput(
-      `Created .vercel${path.sep}.env.production.local file`
+      `✓ Created         .vercel${path.sep}.env.production.local file`
     );
     await expect(client.stderr).toOutput(
       `Downloaded project settings to ${cwd}${path.sep}.vercel${path.sep}project.json`
@@ -291,10 +291,10 @@ describe('pull', () => {
     client.setArgv('pull');
     const exitCodePromise = pull(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`development\` Environment Variables for ${teams[0].slug}/dashboard`
+      `Downloading \`development\` environment variables for ${teams[0].slug}/dashboard`
     );
     await expect(client.stderr).toOutput(
-      `Created .vercel${path.sep}.env.development.local file`
+      `✓ Created         .vercel${path.sep}.env.development.local file`
     );
     await expect(client.stderr).toOutput(
       `Downloaded project settings to ${cwd}${path.sep}dashboard${path.sep}.vercel${path.sep}project.json`
@@ -446,7 +446,7 @@ describe('pull', () => {
       const exitCodePromise = pull(client);
 
       await expect(client.stderr).toOutput(
-        `Downloading \`production\` Environment Variables for ${teams[0].slug}/project-via-flag`
+        `Downloading \`production\` environment variables for ${teams[0].slug}/project-via-flag`
       );
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "pull"').toEqual(0);

--- a/packages/cli/test/unit/util/input/input-root-directory.test.ts
+++ b/packages/cli/test/unit/util/input/input-root-directory.test.ts
@@ -10,17 +10,13 @@ describe('inputRootDirectory', () => {
   it('returns null without prompting when autoConfirm is true', async () => {
     const result = await inputRootDirectory(client, '/tmp', true);
     expect(result).toBeNull();
-    expect(client.stderr.getFullOutput()).not.toContain(
-      'In which directory is your code located?'
-    );
+    expect(client.stderr.getFullOutput()).not.toContain('Code directory?');
   });
 
   it('prompts and returns null when the user submits empty input', async () => {
     const resultPromise = inputRootDirectory(client, '/tmp', false);
 
-    await expect(client.stderr).toOutput(
-      'In which directory is your code located?'
-    );
+    await expect(client.stderr).toOutput('Code directory?');
     client.stdin.write('\n');
 
     await expect(resultPromise).resolves.toBeNull();

--- a/packages/cli/test/unit/util/link/setup-and-link-git-repository.test.ts
+++ b/packages/cli/test/unit/util/link/setup-and-link-git-repository.test.ts
@@ -190,7 +190,7 @@ describe('connectGitRepository()', () => {
 
     // Should ask for confirmation
     expect(client.input.confirm).toHaveBeenCalledWith(
-      'Detected a repository. Connect it to this project?',
+      'Connect detected Git repository?',
       true
     );
 


### PR DESCRIPTION
- Show directory/project state before link confirmation.
- Replace vague link prompts with `Link directory to project?` and `Link repository to project?`.
- Use the checkmark gutter for completed link/create/env-pull receipts.
- Clarify cross-team search and SSO-team fallback output.
- Use sentence-case env-pull copy.
- Tighten `vc link` help copy while preserving non-interactive `--project` / `--team` guidance.
- Update shared-helper tests across link, deploy, git connect, pull, and integration paths.