### PR TITLE
feat(build-utils,next): add hasPostponed signal to Prerender

### DIFF
--- a/.changeset/prerender-has-postponed.md
+++ b/.changeset/prerender-has-postponed.md
@@ -1,0 +1,10 @@
+---
+'@vercel/build-utils': minor
+'@vercel/next': patch
+---
+
+Add a per-route `hasPostponed` signal to `Prerender`.
+
+`@vercel/build-utils` exposes a new optional `hasPostponed?: boolean` field on `Prerender` / `PrerenderOptions`. It is a tri-state: `true` when the route's `.meta` postponed state is present (React suspended during the build-time prerender), `false` when the framework prerendered a Prerender route without postponing, and `undefined` when the framework did not provide the signal.
+
+`@vercel/next` populates it for app-router PPR routes (computed from the route's postponed state) and leaves it `undefined` for pages-router and other non-app-router prerenders. This is an additive, finer-grained signal — it does not change the existing `chain` / `experimentalStreamingLambdaPath` behavior — so downstream consumers can distinguish a route that actually postponed from one that has PPR machinery but fully prerendered (e.g. under `cacheComponents: true`).

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -19,6 +19,7 @@ interface PrerenderOptions {
   chain?: Chain;
   exposeErrBody?: boolean;
   partialFallback?: boolean;
+  hasPostponed?: boolean;
 }
 
 export class Prerender {
@@ -49,6 +50,13 @@ export class Prerender {
   public chain?: Chain;
   public exposeErrBody?: boolean;
   public partialFallback?: boolean;
+  /**
+   * Set to `true` when the route's `.meta` postponed state is present (React
+   * suspended during build prerender). `false` when the framework prerendered
+   * a Prerender route without postponing. `undefined` when the framework did
+   * not provide the signal.
+   */
+  public hasPostponed?: boolean;
 
   constructor({
     expiration,
@@ -68,11 +76,17 @@ export class Prerender {
     chain,
     exposeErrBody,
     partialFallback,
+    hasPostponed,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
     this.staleExpiration = staleExpiration;
     this.sourcePath = sourcePath;
+    // Assigned unconditionally (like `staleExpiration`) so the tri-state
+    // (`true` | `false` | `undefined`) round-trips intact. Do not adopt the
+    // `partialFallback`/`exposeErrBody` idiom below, which collapses `false`
+    // into `undefined`.
+    this.hasPostponed = hasPostponed;
 
     this.lambda = lambda;
     if (this.lambda) {

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -86,6 +86,11 @@ export class Prerender {
     // (`true` | `false` | `undefined`) round-trips intact. Do not adopt the
     // `partialFallback`/`exposeErrBody` idiom below, which collapses `false`
     // into `undefined`.
+    if (hasPostponed !== undefined && typeof hasPostponed !== 'boolean') {
+      throw new Error(
+        'The `hasPostponed` argument for `Prerender` must be a boolean or undefined.'
+      );
+    }
     this.hasPostponed = hasPostponed;
 
     this.lambda = lambda;

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -552,6 +552,37 @@ it('should support experimentalBypassFor correctly', async () => {
   );
 });
 
+it('should round-trip hasPostponed as a tri-state', async () => {
+  // The api repo relies on telling `false` (PPR machinery but fully static)
+  // apart from `undefined` (no signal), so `false` must NOT collapse to
+  // `undefined` the way other boolean options do.
+  const postponed = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    hasPostponed: true,
+  });
+  expect(postponed.hasPostponed).toBe(true);
+
+  const notPostponed = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    hasPostponed: false,
+  });
+  expect(notPostponed.hasPostponed).toBe(false);
+
+  const omitted = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+  });
+  expect(omitted.hasPostponed).toBeUndefined();
+});
+
 it('should support passQuery correctly', async () => {
   new Prerender({
     expiration: 1,

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -581,6 +581,18 @@ it('should round-trip hasPostponed as a tri-state', async () => {
     bypassToken: 'some-long-bypass-token-to-make-it-work',
   });
   expect(omitted.hasPostponed).toBeUndefined();
+
+  expect(
+    () =>
+      new Prerender({
+        expiration: 1,
+        fallback: null,
+        group: 1,
+        bypassToken: 'some-long-bypass-token-to-make-it-work',
+        // @ts-expect-error - intentionally invalid to assert validation
+        hasPostponed: 'yes',
+      })
+  ).toThrow('The `hasPostponed` argument for `Prerender` must be a boolean');
 });
 
 it('should support passQuery correctly', async () => {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2649,6 +2649,13 @@ export const onPrerenderRoute =
     let postponedPrerender: string | undefined;
     let postponedState: string | null = null;
     let didPostpone = false;
+    // Tri-state postpone signal surfaced on the resulting `Prerender` objects:
+    // `true`/`false` only for app-router PPR routes whose `.meta` we actually
+    // inspect below, `undefined` everywhere else (pages router, non-PPR app
+    // routes, blocking routes). Distinct from `didPostpone`, which also
+    // requires the `.html` file to exist and can't distinguish "inspected, no
+    // postpone" from "never inspected".
+    let hasPostponed: boolean | undefined;
     if (
       renderingMode === RenderingMode.PARTIALLY_STATIC &&
       appDir &&
@@ -2656,6 +2663,7 @@ export const onPrerenderRoute =
       !isBlocking
     ) {
       postponedState = getHTMLPostponedState({ appDir, routeFileNoExt });
+      hasPostponed = Boolean(postponedState);
 
       const htmlPath = path.join(appDir, `${routeFileNoExt}.html`);
       if (fs.existsSync(htmlPath)) {
@@ -3108,6 +3116,7 @@ export const onPrerenderRoute =
           chain,
           allowHeader,
           partialFallback: partialFallback || undefined,
+          hasPostponed,
 
           ...(isNotFound
             ? {
@@ -3158,6 +3167,7 @@ export const onPrerenderRoute =
           experimentalBypassFor,
           allowHeader,
           partialFallback: undefined,
+          hasPostponed,
 
           ...(isNotFound
             ? {
@@ -3263,6 +3273,7 @@ export const onPrerenderRoute =
               experimentalBypassFor,
               allowHeader,
               partialFallback: undefined,
+              hasPostponed,
               chain: {
                 outputPath: normalizePathData(outputPathData),
                 headers: routesManifest.ppr.chain.headers,
@@ -3391,6 +3402,7 @@ export const onPrerenderRoute =
                 group: prerenderGroup,
                 allowHeader,
                 partialFallback: undefined,
+                hasPostponed,
 
                 // These routes are always only static, so they should not
                 // permit any bypass unless it's for preview

--- a/packages/next/test/integration/segment-cache-cc.test.js
+++ b/packages/next/test/integration/segment-cache-cc.test.js
@@ -39,4 +39,61 @@ describe('clientSegmentCache prerender headers', () => {
       expect(output[staticKey].initialHeaders).toBeDefined();
     }
   });
+
+  it('should surface hasPostponed as a tri-state on Prerender outputs', async () => {
+    const fixturePath = path.join(__dirname, 'segment-cache-cc');
+
+    const {
+      buildResult: { output },
+    } = await runBuildLambda(fixturePath);
+
+    const prerender = key => {
+      expect(output[key], `expected output[${key}] to exist`).toBeDefined();
+      expect(output[key].type).toBe('Prerender');
+      return output[key];
+    };
+
+    // App-router PPR route that postpones (Suspense around an async component
+    // reading `headers()`): the static shell is generated and the dynamic hole
+    // is postponed, so its `.meta` carries a postponed state.
+    expect(prerender('dynamic-suspense').hasPostponed).toBe(true);
+    // The signal mirrors onto the route's data (`.rsc`) and segment outputs.
+    expect(prerender('dynamic-suspense.rsc').hasPostponed).toBe(true);
+    expect(
+      prerender('dynamic-suspense.segments/_full.segment.rsc').hasPostponed
+    ).toBe(true);
+
+    // `cacheComponents: true` route that fully prerenders (no postpone). PPR
+    // machinery still exists, but `hasPostponed` distinguishes it as static.
+    expect(prerender('index').hasPostponed).toBe(false);
+    expect(prerender('index.rsc').hasPostponed).toBe(false);
+    expect(prerender('careers').hasPostponed).toBe(false);
+    // A prerendered dynamic param (from `generateStaticParams`) is static too.
+    expect(prerender('careers/foobar-1').hasPostponed).toBe(false);
+
+    // The `[slug]` dynamic fallback shell postpones, matching existing PPR
+    // fallback machinery.
+    expect(prerender('careers/[slug]').hasPostponed).toBe(true);
+    expect(prerender('careers/[slug].rsc').hasPostponed).toBe(true);
+
+    // Pages-router route: `hasPostponed` is an app-router signal, so it is left
+    // `undefined` on both the HTML prerender and its data route.
+    expect(prerender('legacy').hasPostponed).toBeUndefined();
+    expect(
+      prerender('_next/data/' + buildId(output) + '/legacy.json').hasPostponed
+    ).toBeUndefined();
+  });
 });
+
+// The pages-router data route key embeds the build ID, which varies per build.
+// Resolve it from the emitted output keys rather than hardcoding.
+function buildId(output) {
+  const match = Object.keys(output).find(k =>
+    /^_next\/data\/[^/]+\/legacy\.json$/.test(k)
+  );
+  expect(
+    match,
+    'expected a _next/data/<buildId>/legacy.json output'
+  ).toBeDefined();
+  return match.split('/')[2];
+}

--- a/packages/next/test/integration/segment-cache-cc/app/dynamic-suspense/page.jsx
+++ b/packages/next/test/integration/segment-cache-cc/app/dynamic-suspense/page.jsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react';
+import { headers } from 'next/headers';
+
+// Reading `headers()` is request-time work. Wrapped in a Suspense boundary, the
+// route prerenders a static shell and postpones the dynamic hole — so its
+// `.meta` carries a postponed state and `hasPostponed` should be `true`.
+async function Dynamic() {
+  const list = await headers();
+  return <div id="needle">ua:{list.get('user-agent') ?? 'null'}</div>;
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div id="loading">Loading...</div>}>
+      <Dynamic />
+    </Suspense>
+  );
+}

--- a/packages/next/test/integration/segment-cache-cc/pages/legacy.js
+++ b/packages/next/test/integration/segment-cache-cc/pages/legacy.js
@@ -1,0 +1,11 @@
+// Pages-router route. `hasPostponed` is an app-router PPR signal, so the
+// Prerender produced here must leave it `undefined`. `revalidate` makes this an
+// ISR Prerender (rather than a plain static file) so the assertion has an
+// output entry to inspect.
+export async function getStaticProps() {
+  return { props: { now: Date.now() }, revalidate: 60 };
+}
+
+export default function Legacy({ now }) {
+  return <div id="legacy">legacy:{now}</div>;
+}


### PR DESCRIPTION
## What

Exposes a per-route tri-state **`hasPostponed`** signal on `Prerender`:

- `true` — the route's `.meta` postponed state is present (React suspended during the build-time prerender)
- `false` — a Prerender route that prerendered **without** postponing
- `undefined` — the framework did not provide the signal

This is the source-of-truth answer to *"did React suspend during the build-time prerender for this route?"* — currently only inferable indirectly via `chain` / `experimentalStreamingLambdaPath` presence, which over-reports as PPR under `cacheComponents: true` (PPR machinery exists even for fully-static routes).

## Changes

**`@vercel/build-utils`** (`prerender.ts`)
- Add optional `hasPostponed?: boolean` to `PrerenderOptions` and as a public `Prerender` field.
- Store it **unconditionally** so the tri-state round-trips intact — the existing boolean idiom (`partialFallback`/`exposeErrBody`/`passQuery`) collapses `false` into `undefined`, which would defeat the signal.

**`@vercel/next`** (`utils.ts`)
- Compute `Boolean(postponedState)` inside the existing `PARTIALLY_STATIC && appDir && !isBlocking` block and pass it to all four `new Prerender(...)` sites (HTML page, data/prefetch, dynamic-RSC chain, segment).
- Pages-router and other non-app-router prerenders leave it `undefined`.

This is **additive** — it does not touch the existing `chain` / `experimentalStreamingLambdaPath` logic. Downstream consumers can now distinguish a route that actually postponed from one that has PPR machinery but fully prerendered (e.g. under `cacheComponents: true`).

## Tests

Tested it in this deployment https://vercel.com/curated-tests/o11y-playground-app-with-cache-components/AUUKS8MDrwbzWmLkLs7XD27VL8hr