### PR TITLE
Add Connect revokeToken API

### DIFF
--- a/.changeset/connect-delete-token.md
+++ b/.changeset/connect-delete-token.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add the `deleteToken` API for revoking Connect tokens by connector and subject.

--- a/.changeset/connect-delete-token.md
+++ b/.changeset/connect-delete-token.md
@@ -1,5 +1,0 @@
----
-'@vercel/connect': patch
----
-
-Add the `deleteToken` API for revoking Connect tokens by connector and subject.

--- a/.changeset/connect-revoke-token.md
+++ b/.changeset/connect-revoke-token.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add the `revokeToken` API for revoking Connect tokens by connector and subject.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -97,4 +97,4 @@ import { connect } from '@vercel/connect/authjs';
 const providers = [connect({ connector: 'linear' })];
 ```
 
-See the source under `src/` for the full API (additional helpers like `deleteToken`, `getTokenResponse`, `startAuthorization`, typed error classes, and per-adapter options).
+See the source under `src/` for the full API (additional helpers like `revokeToken`, `getTokenResponse`, `startAuthorization`, typed error classes, and per-adapter options).

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -97,4 +97,4 @@ import { connect } from '@vercel/connect/authjs';
 const providers = [connect({ connector: 'linear' })];
 ```
 
-See the source under `src/` for the full API (additional helpers like `getTokenResponse`, `startAuthorization`, typed error classes, and per-adapter options).
+See the source under `src/` for the full API (additional helpers like `deleteToken`, `getTokenResponse`, `startAuthorization`, typed error classes, and per-adapter options).

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  deleteToken,
   getToken,
   getTokenResponse,
   ConnectError,

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,7 +1,7 @@
 export {
-  deleteToken,
   getToken,
   getTokenResponse,
+  revokeToken,
   ConnectError,
   NoValidTokenError,
   UserAuthorizationRequiredError,

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -169,7 +169,7 @@ export async function getTokenResponse(
   return data;
 }
 
-export async function deleteToken(
+export async function revokeToken(
   connector: string,
   params: {
     subject: ConnectTokenSubject;
@@ -193,7 +193,7 @@ export async function deleteToken(
   if (!response.ok) {
     throw await createConnectErrorFromResponse(
       response,
-      'Failed to delete token'
+      'Failed to revoke token'
     );
   }
 

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -197,7 +197,6 @@ export async function deleteToken(
     );
   }
 
-  await response.json();
   cache.clear();
 }
 

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -169,6 +169,38 @@ export async function getTokenResponse(
   return data;
 }
 
+export async function deleteToken(
+  connector: string,
+  params: {
+    subject: ConnectTokenSubject;
+    installationId?: string;
+  },
+  options?: ConnectOptions
+): Promise<void> {
+  const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
+  const endpoint = `https://api.vercel.com/v1/connect/connectors/${encodeURIComponent(connector)}/tokens`;
+
+  const response = await fetch(endpoint, {
+    method: 'DELETE',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${vercelToken}`,
+    },
+    body: JSON.stringify(params),
+  });
+
+  if (!response.ok) {
+    throw await createConnectErrorFromResponse(
+      response,
+      'Failed to delete token'
+    );
+  }
+
+  await response.json();
+  cache.clear();
+}
+
 const DEFAULT_VALIDITY_BUFFER_MS = 30_000;
 const MAX_CACHE_SIZE = 100;
 

--- a/packages/connect/test/token.test.ts
+++ b/packages/connect/test/token.test.ts
@@ -1,0 +1,103 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectError, deleteToken } from '../src/token.js';
+
+vi.mock('@vercel/oidc', () => ({
+  getVercelOidcToken: vi.fn(),
+}));
+
+const CONNECTOR = 'oauth/linear';
+const PARAMS: Parameters<typeof deleteToken>[1] = {
+  subject: { type: 'user', id: 'user_123' },
+  installationId: 'icfg_123',
+};
+const RESULT = {
+  tokensFound: 3,
+  deleted: 3,
+  providerRevoked: 2,
+  providerSkipped: 1,
+  providerFailed: 0,
+};
+
+describe('deleteToken', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(getVercelOidcToken).mockResolvedValue('oidc_token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('deletes connector tokens for the required subject', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(RESULT));
+
+    await expect(
+      deleteToken(CONNECTOR, PARAMS, { vercelToken: 'vercel_token' })
+    ).resolves.toBeUndefined();
+
+    expect(getVercelOidcToken).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://api.vercel.com/v1/connect/connectors/oauth%2Flinear/tokens'
+    );
+    expect(init.method).toBe('DELETE');
+    expect(init.headers).toEqual({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer vercel_token',
+    });
+    expect(JSON.parse(init.body as string)).toEqual(PARAMS);
+  });
+
+  it('uses the Vercel OIDC token when no explicit token is provided', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(RESULT));
+
+    await deleteToken(CONNECTOR, PARAMS);
+
+    expect(getVercelOidcToken).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer oidc_token',
+    });
+  });
+
+  it('maps API errors through ConnectError', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          error: {
+            code: 'forbidden',
+            message: 'Missing permission to delete tokens',
+          },
+        },
+        { status: 403, statusText: 'Forbidden' }
+      )
+    );
+
+    const promise = deleteToken(CONNECTOR, PARAMS);
+
+    await expect(promise).rejects.toBeInstanceOf(ConnectError);
+    await expect(promise).rejects.toMatchObject({
+      name: 'ConnectError',
+      code: 'forbidden',
+      status: 403,
+      statusText: 'Forbidden',
+      message: 'Missing permission to delete tokens',
+    });
+  });
+});
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}

--- a/packages/connect/test/token.test.ts
+++ b/packages/connect/test/token.test.ts
@@ -68,6 +68,12 @@ describe('deleteToken', () => {
     });
   });
 
+  it('allows empty successful delete responses', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await expect(deleteToken(CONNECTOR, PARAMS)).resolves.toBeUndefined();
+  });
+
   it('maps API errors through ConnectError', async () => {
     fetchMock.mockResolvedValue(
       jsonResponse(

--- a/packages/connect/test/token.test.ts
+++ b/packages/connect/test/token.test.ts
@@ -1,13 +1,13 @@
 import { getVercelOidcToken } from '@vercel/oidc';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ConnectError, deleteToken } from '../src/token.js';
+import { ConnectError, revokeToken } from '../src/token.js';
 
 vi.mock('@vercel/oidc', () => ({
   getVercelOidcToken: vi.fn(),
 }));
 
 const CONNECTOR = 'oauth/linear';
-const PARAMS: Parameters<typeof deleteToken>[1] = {
+const PARAMS: Parameters<typeof revokeToken>[1] = {
   subject: { type: 'user', id: 'user_123' },
   installationId: 'icfg_123',
 };
@@ -19,7 +19,7 @@ const RESULT = {
   providerFailed: 0,
 };
 
-describe('deleteToken', () => {
+describe('revokeToken', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -37,7 +37,7 @@ describe('deleteToken', () => {
     fetchMock.mockResolvedValue(jsonResponse(RESULT));
 
     await expect(
-      deleteToken(CONNECTOR, PARAMS, { vercelToken: 'vercel_token' })
+      revokeToken(CONNECTOR, PARAMS, { vercelToken: 'vercel_token' })
     ).resolves.toBeUndefined();
 
     expect(getVercelOidcToken).not.toHaveBeenCalled();
@@ -59,7 +59,7 @@ describe('deleteToken', () => {
   it('uses the Vercel OIDC token when no explicit token is provided', async () => {
     fetchMock.mockResolvedValue(jsonResponse(RESULT));
 
-    await deleteToken(CONNECTOR, PARAMS);
+    await revokeToken(CONNECTOR, PARAMS);
 
     expect(getVercelOidcToken).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -71,7 +71,7 @@ describe('deleteToken', () => {
   it('allows empty successful delete responses', async () => {
     fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
 
-    await expect(deleteToken(CONNECTOR, PARAMS)).resolves.toBeUndefined();
+    await expect(revokeToken(CONNECTOR, PARAMS)).resolves.toBeUndefined();
   });
 
   it('maps API errors through ConnectError', async () => {
@@ -80,14 +80,14 @@ describe('deleteToken', () => {
         {
           error: {
             code: 'forbidden',
-            message: 'Missing permission to delete tokens',
+            message: 'Missing permission to revoke tokens',
           },
         },
         { status: 403, statusText: 'Forbidden' }
       )
     );
 
-    const promise = deleteToken(CONNECTOR, PARAMS);
+    const promise = revokeToken(CONNECTOR, PARAMS);
 
     await expect(promise).rejects.toBeInstanceOf(ConnectError);
     await expect(promise).rejects.toMatchObject({
@@ -95,7 +95,7 @@ describe('deleteToken', () => {
       code: 'forbidden',
       status: 403,
       statusText: 'Forbidden',
-      message: 'Missing permission to delete tokens',
+      message: 'Missing permission to revoke tokens',
     });
   });
 });


### PR DESCRIPTION
Summary:
- Add the `revokeToken` root API for `@vercel/connect`, calling `DELETE /v1/connect/connectors/:connector/tokens` with a required SDK `subject`.
- Clear the in-memory token cache after successful token revocation and support empty/204 success responses.
- Add focused tests, README mention, and a patch changeset.

Tests:
- `pnpm --filter @vercel/connect test -- token.test.ts`
- `pnpm --filter @vercel/connect exec tsc --noEmit -p test/tsconfig.json`
- `pnpm --filter @vercel/connect typecheck`
- pre-commit lint-staged ran `biome format` and `biome lint` on staged JS/TS files.