### PR TITLE
Improve vc env add UX

### DIFF
--- a/.changeset/compact-env-add-output.md
+++ b/.changeset/compact-env-add-output.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Tighten `vc env add` interactive output and mark completed CLI actions with the check gutter.

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
+import type { CustomEnvironment, ProjectLinked } from '@vercel-internals/types';
 import type Client from '../../util/client';
-import stamp from '../../util/output/stamp';
 import addEnvRecord from '../../util/env/add-env-record';
 import getEnvRecords from '../../util/env/get-env-records';
 import {
@@ -9,7 +9,6 @@ import {
 } from '../../util/env/env-target';
 import readStandardInput from '../../util/input/read-standard-input';
 import param from '../../util/output/param';
-import { emoji, prependEmoji } from '../../util/emoji';
 import { isKnownError } from '../../util/env/known-error';
 import {
   getEnvKeyWarnings,
@@ -30,6 +29,7 @@ import { getLinkedProject } from '../../util/projects/link';
 import { determineAgent } from '@vercel/detect-agent';
 import { suggestNextCommands } from '../../util/suggest-next-commands';
 import getTeamById from '../../util/teams/get-team-by-id';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
 import {
   outputActionRequired,
   outputAgentError,
@@ -47,7 +47,19 @@ type EnvChoice = {
   disabled?: boolean | string;
 };
 
-const SENSITIVE_SECRET_PROMPT = 'Is the value a sensitive secret?';
+const SENSITIVE_SECRET_PROMPT = 'Store as sensitive?';
+const CHECKBOX_INSTRUCTIONS = [
+  '\n  ',
+  chalk.dim('('),
+  chalk.cyan('<space>'),
+  chalk.dim(' select, '),
+  chalk.cyan('<enter>'),
+  chalk.dim(' confirm, '),
+  chalk.cyan('<a>'),
+  chalk.dim(' toggle all, '),
+  chalk.cyan('<i>'),
+  chalk.dim(' invert)'),
+].join('');
 
 function filterEnvChoicesForSensitivity(
   choices: EnvChoice[],
@@ -104,37 +116,127 @@ function resolveFinalType(
 }
 
 /**
- * For use in suggested "next" commands: escapes a value for shell if it contains spaces or quotes.
- */
-function valueForNextCommand(value: string): string {
-  if (!/[\s'"\\]/.test(value)) return value;
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
-}
-
-/**
- * Replaces placeholders in an env add command template with actual values when provided.
+ * Replaces safe placeholders in an env add command template. Secret values stay
+ * as placeholders so suggested commands never echo them.
  */
 function fillEnvAddTemplate(
   template: string,
   opts: {
     envName?: string;
     envTargetArg?: string;
-    valueFromFlag?: string;
     envGitBranch?: string;
   }
 ): string {
   const targetPlaceholder = getEnvTargetPlaceholder();
-  let out = template
+  const out = template
     .replace(/<name>/g, opts.envName ?? '<name>')
     .split(targetPlaceholder)
     .join(opts.envTargetArg ?? targetPlaceholder)
     .replace(/<gitbranch>/g, opts.envGitBranch ?? '<gitbranch>');
-  if (opts.valueFromFlag !== undefined) {
-    out = out.replace(/<value>/g, valueForNextCommand(opts.valueFromFlag));
-  } else {
-    out = out.replace(/<value>/g, '<value>');
+  return out.replace(/<value>/g, '<value>');
+}
+
+function redactEnvValueArgs(argv: string[]): string[] {
+  const redacted = [...argv];
+  for (let i = 0; i < redacted.length; i++) {
+    if (redacted[i] === '--value' && i + 1 < redacted.length) {
+      redacted[i + 1] = '"<value>"';
+      i++;
+    } else if (redacted[i].startsWith('--value=')) {
+      redacted[i] = '--value="<value>"';
+    }
   }
-  return out;
+  return redacted;
+}
+
+function projectLabel(link: ProjectLinked): string {
+  return `${link.org.slug}/${link.project.name}`;
+}
+
+function formatEnvironmentTarget(
+  target: string,
+  customEnvironments: CustomEnvironment[]
+): string {
+  const standardTarget = envTargetChoices.find(
+    choice => choice.value === target
+  );
+  if (standardTarget) {
+    return standardTarget.name;
+  }
+  const customEnvironment = customEnvironments.find(
+    env => env.id === target || env.slug === target
+  );
+  return customEnvironment?.slug ?? target;
+}
+
+function formatEnvironmentTargets(
+  envTargets: string[],
+  customEnvironments: CustomEnvironment[]
+): string {
+  return envTargets
+    .map(target => formatEnvironmentTarget(target, customEnvironments))
+    .join(', ');
+}
+
+function environmentLabel(
+  envTargets: string[]
+): 'Environment' | 'Environments' {
+  return envTargets.length === 1 ? 'Environment' : 'Environments';
+}
+
+function typeLabel(type: EnvType): 'Encrypted' | 'Sensitive' {
+  return type === 'sensitive' ? 'Sensitive' : 'Encrypted';
+}
+
+function printEnvAddPreview(
+  link: ProjectLinked,
+  envName: string,
+  envTargets: string[],
+  envGitBranch: string | undefined,
+  customEnvironments: CustomEnvironment[]
+): void {
+  output.print('\n');
+  printAlignedLabel('Project', projectLabel(link));
+  printAlignedLabel('Variable', envName);
+  if (envTargets.length > 0) {
+    printAlignedLabel(
+      environmentLabel(envTargets),
+      formatEnvironmentTargets(envTargets, customEnvironments)
+    );
+  }
+  if (envGitBranch) {
+    printAlignedLabel('Branch', envGitBranch);
+  }
+  output.print('\n');
+}
+
+function printEnvAddResult(
+  link: ProjectLinked,
+  envName: string,
+  envTargets: string[],
+  envGitBranch: string | undefined,
+  customEnvironments: CustomEnvironment[],
+  finalType: EnvType,
+  force: boolean
+): void {
+  output.print('\n');
+  printAlignedLabel(force ? 'Overrode' : 'Added', envName);
+  printAlignedLabel('Project', projectLabel(link));
+  printAlignedLabel(
+    environmentLabel(envTargets),
+    formatEnvironmentTargets(envTargets, customEnvironments)
+  );
+  if (envGitBranch) {
+    printAlignedLabel('Branch', envGitBranch);
+  }
+  printAlignedLabel('Type', typeLabel(finalType));
+}
+
+function promptEnvValue(client: Client): Promise<string> {
+  return client.input.password({
+    message: `Value?`,
+    mask: true,
+  });
 }
 
 export default async function add(client: Client, argv: string[]) {
@@ -173,7 +275,9 @@ export default async function add(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentName(envName);
   telemetryClient.trackCliArgumentEnvironment(envTargetArg);
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
-  telemetryClient.trackCliOptionValue(opts['--value']);
+  telemetryClient.trackCliOptionValue(
+    valueFromFlag === undefined ? undefined : '<redacted>'
+  );
   telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
   telemetryClient.trackCliFlagNoSensitive(opts['--no-sensitive']);
   telemetryClient.trackCliFlagForce(opts['--force']);
@@ -224,7 +328,7 @@ export default async function add(client: Client, argv: string[]) {
         '<scope>',
         ...linkPreserved,
       ];
-      let envAddRetryArgv = client.argv;
+      let envAddRetryArgv = redactEnvValueArgs(client.argv);
       if (envTargetArg === 'preview' && envGitBranch === undefined) {
         const argvArgs = client.argv.slice(2);
         const addIdx = argvArgs.indexOf('add');
@@ -240,11 +344,11 @@ export default async function add(client: Client, argv: string[]) {
             pos++;
           }
           const insertAt = 2 + pos;
-          envAddRetryArgv = [
+          envAddRetryArgv = redactEnvValueArgs([
             ...client.argv.slice(0, insertAt),
             '<gitbranch>',
             ...client.argv.slice(insertAt),
-          ];
+          ]);
         }
       }
       outputAgentError(
@@ -320,11 +424,10 @@ export default async function add(client: Client, argv: string[]) {
           return 'third argument <gitbranch> for Preview, or omit for all Preview branches';
         return m;
       });
-      const fullTemplate = `env add <name> ${getEnvTargetPlaceholder()} <gitbranch> --value <value> --yes`;
+      const fullTemplate = `env add <name> ${getEnvTargetPlaceholder()} <gitbranch> --value "<value>" --yes`;
       const filledTemplate = fillEnvAddTemplate(fullTemplate, {
         envName,
         envTargetArg,
-        valueFromFlag,
         envGitBranch,
       });
       const next: Array<{ command: string; when?: string }> = [];
@@ -345,12 +448,12 @@ export default async function add(client: Client, argv: string[]) {
         (valueFromFlag !== undefined || stdInput)
       ) {
         const branchSpecific = fillEnvAddTemplate(
-          'env add <name> preview <gitbranch> --value <value> --yes',
-          { envName, envTargetArg: 'preview', valueFromFlag }
+          'env add <name> preview <gitbranch> --value "<value>" --yes',
+          { envName, envTargetArg: 'preview' }
         );
         const branchAll = fillEnvAddTemplate(
-          'env add <name> preview --value <value> --yes',
-          { envName, envTargetArg: 'preview', valueFromFlag }
+          'env add <name> preview --value "<value>" --yes',
+          { envName, envTargetArg: 'preview' }
         );
         next.push(
           {
@@ -385,7 +488,7 @@ export default async function add(client: Client, argv: string[]) {
 
   if (!envName) {
     envName = await client.input.text({
-      message: `What's the name of the variable?`,
+      message: `Name?`,
       validate: val => (val ? true : 'Name cannot be empty'),
     });
   }
@@ -422,14 +525,14 @@ export default async function add(client: Client, argv: string[]) {
             {
               command: buildEnvAddCommandWithPreservedArgs(
                 client.argv,
-                `env add ${envName} ${getEnvTargetPlaceholder()} --value <value> --yes`
+                `env add ${envName} ${getEnvTargetPlaceholder()} --value "<value>" --yes`
               ),
               when: 'Leave as is',
             },
             {
               command: buildEnvAddCommandWithPreservedArgs(
                 client.argv,
-                `env add ${nameWithoutPrefix} ${getEnvTargetPlaceholder()} --value <value> --yes`
+                `env add ${nameWithoutPrefix} ${getEnvTargetPlaceholder()} --value "<value>" --yes`
               ),
               when: 'Rename',
             },
@@ -444,13 +547,13 @@ export default async function add(client: Client, argv: string[]) {
 
       const nameWithoutPrefix = removePublicPrefix(envName);
       const choices = [
-        { name: 'Leave as is', value: 'c' },
+        { name: `Keep ${envName}`, value: 'c' },
         { name: `Rename to ${nameWithoutPrefix}`, value: 'p' },
-        { name: 'Re-enter', value: 'r' },
+        { name: 'Re-enter name', value: 'r' },
       ];
 
       const action = await client.input.select({
-        message: 'How to proceed?',
+        message: 'Variable name?',
         choices,
       });
 
@@ -462,7 +565,7 @@ export default async function add(client: Client, argv: string[]) {
         // Loop back to re-validate (might have nested prefix)
       } else {
         envName = await client.input.text({
-          message: `What's the name of the variable?`,
+          message: `Name?`,
           validate: val => (val ? true : 'Name cannot be empty'),
         });
       }
@@ -494,7 +597,7 @@ export default async function add(client: Client, argv: string[]) {
         ...(link.status === 'not_linked' ? ['--scope', '<scope>'] : []),
         ...linkPreserved,
       ];
-      let envAddRetryArgv = client.argv;
+      let envAddRetryArgv = redactEnvValueArgs(client.argv);
       if (envTargetArg === 'preview' && envGitBranch === undefined) {
         const argvArgs = client.argv.slice(2);
         const addIdx = argvArgs.indexOf('add');
@@ -510,11 +613,11 @@ export default async function add(client: Client, argv: string[]) {
             pos++;
           }
           const insertAt = 2 + pos;
-          envAddRetryArgv = [
+          envAddRetryArgv = redactEnvValueArgs([
             ...client.argv.slice(0, insertAt),
             '<gitbranch>',
             ...client.argv.slice(insertAt),
-          ];
+          ]);
         }
       }
       outputAgentError(
@@ -626,13 +729,43 @@ export default async function add(client: Client, argv: string[]) {
   } else if (skipSensitivePrompt) {
     isSensitive = true;
   } else {
-    output.log(
-      `Sensitive values cannot be retrieved later from the dashboard or CLI.`
-    );
+    if (!client.nonInteractive) {
+      printEnvAddPreview(
+        link,
+        envName,
+        envTargets,
+        envGitBranch,
+        customEnvironments
+      );
+      output.print(
+        `  ${chalk.dim(
+          'Sensitive values cannot be read later from the dashboard or CLI.'
+        )}\n`
+      );
+    }
     isSensitive = await client.input.confirm(SENSITIVE_SECRET_PROMPT, true);
     if (policyOn && !isSensitive) {
-      output.log(
-        `Your team requires sensitive Environment Variables for Production and Preview. To add a non-sensitive value, you can only target the Development Environment.`
+      output.print(
+        `  ${chalk.dim(
+          'Team policy limits non-sensitive values to Development.'
+        )}\n`
+      );
+    }
+  }
+
+  if (!client.nonInteractive && skipSensitivePrompt) {
+    printEnvAddPreview(
+      link,
+      envName,
+      envTargets,
+      envGitBranch,
+      customEnvironments
+    );
+    if (policyOn && !isSensitive && envTargets.length === 0) {
+      output.print(
+        `  ${chalk.dim(
+          'Team policy limits non-sensitive values to Development.'
+        )}\n`
       );
     }
   }
@@ -726,46 +859,27 @@ export default async function add(client: Client, argv: string[]) {
         status: 'action_required',
         reason: 'missing_value',
         message:
-          "In non-interactive mode provide the value via --value or stdin. Example: vercel env add <name> <environment> --value 'value' --yes",
+          'In non-interactive mode provide the value via --value or stdin. Example: vercel env add <name> <environment> --value "<value>" --yes',
         next: [
           {
             command: buildEnvAddCommandWithPreservedArgs(
               client.argv,
-              `env add <name> ${getEnvTargetPlaceholder()} --value <value> --yes`
+              `env add <name> ${getEnvTargetPlaceholder()} --value "<value>" --yes`
             ),
           },
         ],
       });
     }
-    if (isSensitive) {
-      envValue = await client.input.password({
-        message: `What's the value of ${envName}?`,
-        mask: true,
-      });
-    } else {
-      envValue = await client.input.text({
-        message: `What's the value of ${envName}?`,
-        validate: val => (val ? true : 'Value cannot be empty'),
-      });
-    }
+    envValue = await promptEnvValue(client);
   }
 
   const { finalValue } = await validateEnvValue({
     envName,
     initialValue: envValue,
     skipConfirm,
-    promptForValue: () =>
-      isSensitive
-        ? client.input.password({
-            message: `What's the value of ${envName}?`,
-            mask: true,
-          })
-        : client.input.text({
-            message: `What's the value of ${envName}?`,
-            validate: val => (val ? true : 'Value cannot be empty'),
-          }),
+    promptForValue: () => promptEnvValue(client),
     selectAction: choices =>
-      client.input.select({ message: 'How to proceed?', choices }),
+      client.input.select({ message: 'Value?', choices }),
     showWarning: msg => output.warn(msg),
     showLog: msg => output.log(msg),
   });
@@ -777,7 +891,7 @@ export default async function add(client: Client, argv: string[]) {
         reason: 'missing_environment',
         message: `Specify at least one environment. Add as argument or use: ${buildEnvAddCommandWithPreservedArgs(
           client.argv,
-          `env add ${envName} <environment> --value <value> --yes`
+          `env add ${envName} <environment> --value "<value>" --yes`
         )}`,
         choices: envChoices.map(c => ({
           id: c.value,
@@ -786,13 +900,14 @@ export default async function add(client: Client, argv: string[]) {
         next: envChoices.slice(0, 5).map(c => ({
           command: buildEnvAddCommandWithPreservedArgs(
             client.argv,
-            `env add ${envName} ${c.value} --value <value> --yes`
+            `env add ${envName} ${c.value} --value "<value>" --yes`
           ),
         })),
       });
     }
     envTargets = await client.input.checkbox({
-      message: `Add ${envName} to which Environments (select multiple)?`,
+      message: `Environments?`,
+      instructions: CHECKBOX_INSTRUCTIONS,
       choices: envChoices,
     });
 
@@ -814,7 +929,8 @@ export default async function add(client: Client, argv: string[]) {
   if (
     envGitBranch === undefined &&
     envTargets.length === 1 &&
-    envTargets[0] === 'preview'
+    envTargets[0] === 'preview' &&
+    !(client.nonInteractive && args.length === 2)
   ) {
     if (client.nonInteractive) {
       outputActionRequired(
@@ -827,14 +943,14 @@ export default async function add(client: Client, argv: string[]) {
             {
               command: buildEnvAddCommandWithPreservedArgs(
                 client.argv,
-                `env add ${envName} preview <gitbranch> --value <value> --yes`
+                `env add ${envName} preview <gitbranch> --value "<value>" --yes`
               ),
               when: 'Add to a specific Git branch',
             },
             {
               command: buildEnvAddCommandWithPreservedArgs(
                 client.argv,
-                `env add ${envName} preview --value <value> --yes`
+                `env add ${envName} preview --value "<value>" --yes`
               ),
               when: 'Add to all Preview branches',
             },
@@ -843,8 +959,11 @@ export default async function add(client: Client, argv: string[]) {
         1
       );
     } else {
+      output.print(
+        `  ${chalk.dim('Leave empty to apply to all Preview branches.')}\n`
+      );
       envGitBranch = await client.input.text({
-        message: `Add ${envName} to which Git branch? (leave empty for all Preview branches)?`,
+        message: `Git branch?`,
       });
     }
   }
@@ -871,9 +990,8 @@ export default async function add(client: Client, argv: string[]) {
 
   const upsert = opts['--force'] ? 'true' : '';
 
-  const addStamp = stamp();
   try {
-    output.spinner('Saving');
+    output.spinner('Saving…');
     await addEnvRecord(
       client,
       project.id,
@@ -908,15 +1026,14 @@ export default async function add(client: Client, argv: string[]) {
     throw err;
   }
 
-  output.print(
-    `${prependEmoji(
-      `${
-        opts['--force'] ? 'Overrode' : 'Added'
-      } Environment Variable ${chalk.bold(envName)} to Project ${chalk.bold(
-        project.name
-      )} ${chalk.gray(addStamp())}`,
-      emoji('success')
-    )}\n`
+  printEnvAddResult(
+    link,
+    envName,
+    envTargets,
+    envGitBranch,
+    customEnvironments,
+    finalType,
+    Boolean(opts['--force'])
   );
 
   const { isAgent } = await determineAgent();

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -178,36 +178,8 @@ function formatEnvironmentTargets(
     .join(', ');
 }
 
-function environmentLabel(
-  envTargets: string[]
-): 'Environment' | 'Environments' {
-  return envTargets.length === 1 ? 'Environment' : 'Environments';
-}
-
-function typeLabel(type: EnvType): 'Encrypted' | 'Sensitive' {
-  return type === 'sensitive' ? 'Sensitive' : 'Encrypted';
-}
-
-function printEnvAddPreview(
-  link: ProjectLinked,
-  envName: string,
-  envTargets: string[],
-  envGitBranch: string | undefined,
-  customEnvironments: CustomEnvironment[]
-): void {
-  output.print('\n');
-  printAlignedLabel('Project', projectLabel(link));
-  printAlignedLabel('Variable', envName);
-  if (envTargets.length > 0) {
-    printAlignedLabel(
-      environmentLabel(envTargets),
-      formatEnvironmentTargets(envTargets, customEnvironments)
-    );
-  }
-  if (envGitBranch) {
-    printAlignedLabel('Branch', envGitBranch);
-  }
-  output.print('\n');
+function typeLabel(type: EnvType): 'Non-sensitive' | 'Sensitive' {
+  return type === 'sensitive' ? 'Sensitive' : 'Non-sensitive';
 }
 
 function printEnvAddResult(
@@ -220,10 +192,10 @@ function printEnvAddResult(
   force: boolean
 ): void {
   output.print('\n');
-  printAlignedLabel(force ? 'Overrode' : 'Added', envName);
+  printAlignedLabel(force ? 'Overrode' : 'Added', envName, { gutter: '✓' });
   printAlignedLabel('Project', projectLabel(link));
   printAlignedLabel(
-    environmentLabel(envTargets),
+    'Environments',
     formatEnvironmentTargets(envTargets, customEnvironments)
   );
   if (envGitBranch) {
@@ -730,17 +702,8 @@ export default async function add(client: Client, argv: string[]) {
     isSensitive = true;
   } else {
     if (!client.nonInteractive) {
-      printEnvAddPreview(
-        link,
-        envName,
-        envTargets,
-        envGitBranch,
-        customEnvironments
-      );
       output.print(
-        `  ${chalk.dim(
-          'Sensitive values cannot be read later from the dashboard or CLI.'
-        )}\n`
+        `  ${chalk.dim('Sensitive values cannot be read later.')}\n`
       );
     }
     isSensitive = await client.input.confirm(SENSITIVE_SECRET_PROMPT, true);
@@ -753,21 +716,18 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  if (!client.nonInteractive && skipSensitivePrompt) {
-    printEnvAddPreview(
-      link,
-      envName,
-      envTargets,
-      envGitBranch,
-      customEnvironments
+  if (
+    !client.nonInteractive &&
+    skipSensitivePrompt &&
+    policyOn &&
+    !isSensitive &&
+    envTargets.length === 0
+  ) {
+    output.print(
+      `  ${chalk.dim(
+        'Team policy limits non-sensitive values to Development.'
+      )}\n`
     );
-    if (policyOn && !isSensitive && envTargets.length === 0) {
-      output.print(
-        `  ${chalk.dim(
-          'Team policy limits non-sensitive values to Development.'
-        )}\n`
-      );
-    }
   }
 
   if (forceSensitive && envTargets.includes('development')) {

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -47,10 +47,12 @@ type EnvChoice = {
   disabled?: boolean | string;
 };
 
-const SENSITIVE_SECRET_PROMPT = 'Store as sensitive?';
+const SENSITIVE_VALUE_HINT = 'Sensitive values cannot be read later';
+const SENSITIVE_SECRET_PROMPT = `Store as sensitive? ${chalk.dim(
+  SENSITIVE_VALUE_HINT
+)}`;
 const CHECKBOX_INSTRUCTIONS = [
-  '\n  ',
-  chalk.dim('('),
+  ' ',
   chalk.cyan('<space>'),
   chalk.dim(' select, '),
   chalk.cyan('<enter>'),
@@ -58,7 +60,7 @@ const CHECKBOX_INSTRUCTIONS = [
   chalk.cyan('<a>'),
   chalk.dim(' toggle all, '),
   chalk.cyan('<i>'),
-  chalk.dim(' invert)'),
+  chalk.dim(' invert'),
 ].join('');
 
 function filterEnvChoicesForSensitivity(
@@ -204,10 +206,19 @@ function printEnvAddResult(
   printAlignedLabel('Type', typeLabel(finalType));
 }
 
-function promptEnvValue(client: Client): Promise<string> {
-  return client.input.password({
+function printEnvAddWarning(message: string): void {
+  output.print(`${chalk.yellow('!')} ${message}\n`);
+}
+
+function promptEnvValue(
+  client: Client,
+  opts: { isSensitive: boolean }
+): Promise<string> {
+  return client.input.text({
     message: `Value?`,
-    mask: true,
+    ...(opts.isSensitive
+      ? { transformer: (value: string) => '*'.repeat(value.length) }
+      : {}),
   });
 }
 
@@ -477,7 +488,7 @@ export default async function add(client: Client, argv: string[]) {
       if (!sensitiveWarning) {
         // Non-sensitive public prefix: just show info, no action needed
         for (const w of keyWarnings) {
-          output.warn(w.message);
+          printEnvAddWarning(w.message);
         }
         keyAccepted = true;
         break;
@@ -514,7 +525,7 @@ export default async function add(client: Client, argv: string[]) {
 
       // Sensitive public variable: show all warnings then options
       for (const w of keyWarnings) {
-        output.warn(w.message);
+        printEnvAddWarning(w.message);
       }
 
       const nameWithoutPrefix = removePublicPrefix(envName);
@@ -546,7 +557,7 @@ export default async function add(client: Client, argv: string[]) {
     // Non-interactive: just show warnings
     const keyWarnings = getEnvKeyWarnings(envName);
     for (const w of keyWarnings) {
-      output.warn(w.message);
+      printEnvAddWarning(w.message);
     }
   }
 
@@ -701,11 +712,6 @@ export default async function add(client: Client, argv: string[]) {
   } else if (skipSensitivePrompt) {
     isSensitive = true;
   } else {
-    if (!client.nonInteractive) {
-      output.print(
-        `  ${chalk.dim('Sensitive values cannot be read later.')}\n`
-      );
-    }
     isSensitive = await client.input.confirm(SENSITIVE_SECRET_PROMPT, true);
     if (policyOn && !isSensitive) {
       output.print(
@@ -830,17 +836,17 @@ export default async function add(client: Client, argv: string[]) {
         ],
       });
     }
-    envValue = await promptEnvValue(client);
+    envValue = await promptEnvValue(client, { isSensitive });
   }
 
   const { finalValue } = await validateEnvValue({
     envName,
     initialValue: envValue,
     skipConfirm,
-    promptForValue: () => promptEnvValue(client),
+    promptForValue: () => promptEnvValue(client, { isSensitive }),
     selectAction: choices =>
       client.input.select({ message: 'Value?', choices }),
-    showWarning: msg => output.warn(msg),
+    showWarning: msg => printEnvAddWarning(msg),
     showLog: msg => output.log(msg),
   });
 
@@ -941,7 +947,7 @@ export default async function add(client: Client, argv: string[]) {
       // User asked for encrypted on Production/Preview, but the team policy
       // will promote it to sensitive server-side regardless. Surface that so
       // the user isn't surprised later.
-      output.warn(
+      printEnvAddWarning(
         `--no-sensitive is ignored: your team enforces sensitive Environment Variables for Production and Preview.`
       );
       finalType = 'sensitive';

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -34,7 +34,7 @@ export const listSubcommand = {
 export const addSubcommand = {
   name: 'add',
   aliases: [],
-  description: 'Add an Environment Variable (see examples below)',
+  description: 'Add an Environment Variable',
   arguments: [
     {
       name: 'name',
@@ -52,23 +52,21 @@ export const addSubcommand = {
   options: [
     {
       name: 'sensitive',
-      description:
-        'Force the Environment Variable to be sensitive, even when adding to Development (will fail server-side)',
+      description: 'Store the value as sensitive for Production or Preview',
       shorthand: null,
       type: Boolean,
       deprecated: false,
     },
     {
       name: 'no-sensitive',
-      description:
-        'Opt out of the sensitive default on Production and Preview; value remains readable later',
+      description: 'Store the value as non-sensitive when policy allows',
       shorthand: null,
       type: Boolean,
       deprecated: false,
     },
     {
       ...forceOption,
-      description: 'Force overwrites when a command would normally fail',
+      description: 'Overwrite an existing variable for the same target',
       shorthand: null,
     },
     {
@@ -78,7 +76,7 @@ export const addSubcommand = {
     },
     {
       name: 'guidance',
-      description: 'Receive command suggestions once command is complete',
+      description: 'Show command suggestions after completion',
       shorthand: null,
       type: Boolean,
       deprecated: false,
@@ -86,7 +84,7 @@ export const addSubcommand = {
     {
       name: 'value',
       description:
-        'Value for the variable (non-interactive). Otherwise use stdin or you will be prompted.',
+        'Set the variable value for non-interactive use; otherwise use stdin or the prompt',
       shorthand: null,
       type: String,
       argument: 'VALUE',
@@ -132,8 +130,8 @@ export const addSubcommand = {
       ],
     },
     {
-      name: 'Add with value as argument (non-interactive)',
-      value: `${packageName} env add API_TOKEN production --value "secret" --yes`,
+      name: 'Add with --value for non-interactive use',
+      value: `${packageName} env add API_TOKEN production --value "<value>" --yes`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -226,12 +226,12 @@ export async function envPullCommandLogic(
   const downloadMessage = gitBranch
     ? `Downloading \`${chalk.cyan(
         environment
-      )}\` Environment Variables for ${projectSlugLink} and any overrides for branch ${chalk.cyan(
+      )}\` environment variables for ${projectSlugLink} and any overrides for branch ${chalk.cyan(
         gitBranch
       )}`
     : `Downloading \`${chalk.cyan(
         environment
-      )}\` Environment Variables for ${projectSlugLink}`;
+      )}\` environment variables for ${projectSlugLink}`;
 
   output.log(downloadMessage);
 

--- a/packages/cli/src/commands/env/run.ts
+++ b/packages/cli/src/commands/env/run.ts
@@ -88,7 +88,7 @@ export default async function run(client: Client): Promise<number> {
 
   const gitBranch = parsedArgs.flags['--git-branch'];
 
-  output.spinner(`Downloading \`${environment}\` Environment Variables`);
+  output.spinner(`Downloading \`${environment}\` environment variables`);
 
   const records = await pullEnvRecords(
     client,

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -495,22 +495,14 @@ test.skip('deploy `api-env` fixture and test `vercel env` command', async () => 
       cwd: target,
     });
 
-    await waitForPrompt(vc, "What's the name of the variable?");
+    await waitForPrompt(vc, 'Name?');
     vc.stdin?.write(`${promptEnvVar}\n`);
-    await waitForPrompt(vc, 'Mark as sensitive?');
+    await waitForPrompt(vc, 'Store as sensitive?');
     vc.stdin?.write('n\n');
-    await waitForPrompt(
-      vc,
-      chunk =>
-        chunk.includes("What's the value of") && chunk.includes(promptEnvVar)
-    );
+    await waitForPrompt(vc, 'Value?');
     vc.stdin?.write('my plaintext value\n');
 
-    await waitForPrompt(
-      vc,
-      chunk =>
-        chunk.includes('which Environments') && chunk.includes(promptEnvVar)
-    );
+    await waitForPrompt(vc, 'Environments?');
     vc.stdin?.write('a\n'); // select all
 
     const { exitCode, stdout, stderr } = await vc;

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -586,9 +586,10 @@ test('add a sensitive env var', async () => {
   );
 
   expect(output.exitCode, formatOutput(output)).toBe(0);
-  expect(output.stderr).toContain(
-    'Added Environment Variable envVarName to Project'
-  );
+  expect(output.stderr).toContain('Added       envVarName');
+  expect(output.stderr).toContain('Project     ');
+  expect(output.stderr).toContain('Environment Production');
+  expect(output.stderr).toContain('Type        Sensitive');
 
   await apiFetch(`/v2/projects/${projectName}`, { method: 'DELETE' });
 });
@@ -635,9 +636,8 @@ test('override an existing env var', async () => {
   );
 
   expect(output.exitCode, formatOutput(output)).toBe(0);
-  expect(output.stderr).toContain(
-    'Added Environment Variable envVarName to Project'
-  );
+  expect(output.stderr).toContain('Added       envVarName');
+  expect(output.stderr).toContain('Environment Production');
 
   // 2. Override
   const outputOverride = await execCli(
@@ -650,9 +650,8 @@ test('override an existing env var', async () => {
   );
 
   expect(outputOverride.exitCode, formatOutput(outputOverride)).toBe(0);
-  expect(outputOverride.stderr).toContain(
-    'Overrode Environment Variable envVarName to Project'
-  );
+  expect(outputOverride.stderr).toContain('Overrode    envVarName');
+  expect(outputOverride.stderr).toContain('Environment Production');
 
   await apiFetch(`/v2/projects/${projectName}`, { method: 'DELETE' });
 });

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -586,10 +586,10 @@ test('add a sensitive env var', async () => {
   );
 
   expect(output.exitCode, formatOutput(output)).toBe(0);
-  expect(output.stderr).toContain('Added       envVarName');
-  expect(output.stderr).toContain('Project     ');
-  expect(output.stderr).toContain('Environment Production');
-  expect(output.stderr).toContain('Type        Sensitive');
+  expect(output.stderr).toContain('✓ Added           envVarName');
+  expect(output.stderr).toContain('Project         ');
+  expect(output.stderr).toContain('Environments    Production');
+  expect(output.stderr).toContain('Type            Sensitive');
 
   await apiFetch(`/v2/projects/${projectName}`, { method: 'DELETE' });
 });
@@ -636,8 +636,8 @@ test('override an existing env var', async () => {
   );
 
   expect(output.exitCode, formatOutput(output)).toBe(0);
-  expect(output.stderr).toContain('Added       envVarName');
-  expect(output.stderr).toContain('Environment Production');
+  expect(output.stderr).toContain('✓ Added           envVarName');
+  expect(output.stderr).toContain('Environments    Production');
 
   // 2. Override
   const outputOverride = await execCli(
@@ -650,8 +650,8 @@ test('override an existing env var', async () => {
   );
 
   expect(outputOverride.exitCode, formatOutput(outputOverride)).toBe(0);
-  expect(outputOverride.stderr).toContain('Overrode    envVarName');
-  expect(outputOverride.stderr).toContain('Environment Production');
+  expect(outputOverride.stderr).toContain('✓ Overrode         envVarName');
+  expect(outputOverride.stderr).toContain('Environments    Production');
 
   await apiFetch(`/v2/projects/${projectName}`, { method: 'DELETE' });
 });

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2531,16 +2531,15 @@ exports[`help command > env help output snapshots > env add help output snapshot
 "
   ▲ vercel env add name [environment] [git-branch] [options]
 
-  Add an Environment Variable (see examples below)                                                                      
+  Add an Environment Variable                                                                                           
 
   Options:
 
-       --force          Force overwrites when a command would normally fail                                                  
-       --guidance       Receive command suggestions once command is complete                                                 
-       --no-sensitive   Opt out of the sensitive default on Production and Preview; value remains readable later             
-       --sensitive      Force the Environment Variable to be sensitive, even when adding to Development (will fail           
-                        server-side)                                                                                         
-       --value <VALUE>  Value for the variable (non-interactive). Otherwise use stdin or you will be prompted.               
+       --force          Overwrite an existing variable for the same target                                                   
+       --guidance       Show command suggestions after completion                                                            
+       --no-sensitive   Store the value as non-sensitive when policy allows                                                  
+       --sensitive      Store the value as sensitive for Production or Preview                                               
+       --value <VALUE>  Set the variable value for non-interactive use; otherwise use stdin or the prompt                    
   -y,  --yes            Skip the confirmation prompt when adding an Environment Variable                                     
 
 
@@ -2589,9 +2588,9 @@ exports[`help command > env help output snapshots > env add help output snapshot
     $ cat ~/.npmrc | vercel env add NPM_RC preview
     $ vercel env add API_URL production < url.txt
 
-  - Add with value as argument (non-interactive)
+  - Add with --value for non-interactive use
 
-    $ vercel env add API_TOKEN production --value "secret" --yes
+    $ vercel env add API_TOKEN production --value "<value>" --yes
 
 "
 `;
@@ -2606,9 +2605,6 @@ exports[`help command > env help output snapshots > env help column width 40 1`]
   Commands:
 
   add     name [environment] [git-branch]  …
-                                           …
-                                           …
-                                           …
                                            …
                                            …
                                            …
@@ -2729,8 +2725,7 @@ exports[`help command > env help output snapshots > env help column width 80 1`]
 
   Commands:
 
-  add     name [environment] [git-branch]  Add an Environment Variable (see
-                                           examples below)                 
+  add     name [environment] [git-branch]  Add an Environment Variable     
   list    [environment] [git-branch]       List all Environment Variables  
                                            for a Project                   
   pull    [filename]                       Pull all Development Environment
@@ -2779,7 +2774,7 @@ exports[`help command > env help output snapshots > env help column width 120 1`
 
   Commands:
 
-  add     name [environment] [git-branch]  Add an Environment Variable (see examples below)                        
+  add     name [environment] [git-branch]  Add an Environment Variable                                             
   list    [environment] [git-branch]       List all Environment Variables for a Project                            
   pull    [filename]                       Pull all Development Environment Variables from the cloud and write to a
                                            file [.env.local]                                                       

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -122,6 +122,7 @@ describe('env add', () => {
 
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput('Value?');
+        // Regression guard: the input cursor must land after the prompt gap.
         expect(client.stderr.getFullOutput()).toMatch(
           /Value\?\x1b\[[0-9;]*m\x1b\[10G/
         );
@@ -898,12 +899,12 @@ describe('env add', () => {
           await expect(client.stderr).toOutput(
             '✓ Added           REDIS_CONNECTION_STRING'
           );
-          await expect(client.stderr).toOutput('Project         ');
-          await expect(client.stderr).toOutput('Environments    Preview');
-          await expect(client.stderr).toOutput('Branch          branchName');
           await expect(client.stderr).toOutput('Type            Non-sensitive');
           const exitCode = await exitCodePromise;
           expect(exitCode, 'exit code for "env"').toEqual(0);
+          expect(stripAnsi(client.stderr.getFullOutput())).toMatch(
+            /\n✓ Added\s+REDIS_CONNECTION_STRING\n\s{0,2}Project\s+\S+\/vercel-env-pull\n\s{0,2}Environments\s+Preview\n\s{0,2}Branch\s+branchName\n\s{0,2}Type\s+Non-sensitive\n/
+          );
         });
 
         it('tracks telemetry events', async () => {

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -96,16 +96,22 @@ describe('env add', () => {
     });
 
     describe('sensitive prompt', () => {
-      it('prints compact result without redundant preview rows or echoing the value', async () => {
-        const secretValue = 'super-secret-output-guard';
+      it('prints compact result without redundant preview rows or repeating the non-sensitive value', async () => {
+        const visibleValue = 'https://api.example.com';
 
         client.setArgv('env', 'add', 'TRANSCRIPT_VAR', 'preview', 'branchName');
         const exitCodePromise = env(client);
 
         await expect(client.stderr).toOutput('Store as sensitive?');
         const previewOutput = stripAnsi(client.stderr.getFullOutput());
-        expect(previewOutput).toContain(
-          'Sensitive values cannot be read later.'
+        expect(previewOutput).toMatch(
+          /Store as sensitive\? Sensitive values cannot be read later/
+        );
+        expect(previewOutput).not.toContain(
+          '(Sensitive values cannot be read later.)'
+        );
+        expect(previewOutput).not.toMatch(
+          /\n\s{0,2}Sensitive values cannot be read later\./
         );
         expect(previewOutput).not.toContain(
           'Sensitive values cannot be read later from the dashboard or CLI.'
@@ -116,7 +122,10 @@ describe('env add', () => {
 
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput('Value?');
-        client.stdin.write(`${secretValue}\n`);
+        expect(client.stderr.getFullOutput()).toMatch(
+          /Value\?\x1b\[[0-9;]*m\x1b\[10G/
+        );
+        client.stdin.write(`${visibleValue}\n`);
 
         await expect(client.stderr).toOutput(
           '✓ Added           TRANSCRIPT_VAR'
@@ -128,7 +137,10 @@ describe('env add', () => {
           /\n✓ Added\s+TRANSCRIPT_VAR\n\s{0,2}Project\s+\S+\/vercel-env-pull\n\s{0,2}Environments\s+Preview\n\s{0,2}Branch\s+branchName\n\s{0,2}Type\s+Non-sensitive\n/
         );
         expect(fullOutput).not.toMatch(/\n\s{0,2}Variable\s+TRANSCRIPT_VAR\n/);
-        expect(fullOutput).not.toContain(secretValue);
+        expect(fullOutput).toContain(visibleValue);
+        expect(fullOutput.slice(fullOutput.indexOf('✓ Added'))).not.toContain(
+          visibleValue
+        );
         expect(fullOutput).not.toMatch(
           /Added Environment Variable|✅|successfully/
         );
@@ -138,6 +150,7 @@ describe('env add', () => {
       });
 
       it('creates the variable as sensitive when the user keeps it at the prompt', async () => {
+        const secretValue = 'super-secret-output-guard';
         const addEnvRecordModule = await import(
           '../../../../src/util/env/add-env-record'
         );
@@ -156,12 +169,15 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('y\n');
         await expect(client.stderr).toOutput('Value?');
-        client.stdin.write('testvalue\n');
+        client.stdin.write(`${secretValue}\n`);
         await expect(exitCodePromise).resolves.toBe(0);
 
         expect(spy).toHaveBeenCalled();
         const type = spy.mock.calls[0][3];
         expect(type).toBe('sensitive');
+        expect(stripAnsi(client.stderr.getFullOutput())).not.toContain(
+          secretValue
+        );
 
         spy.mockRestore();
       });
@@ -397,6 +413,13 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(client.stderr).toOutput('Environments?');
+        const outputWithInstructions = stripAnsi(client.stderr.getFullOutput());
+        expect(outputWithInstructions).toContain(
+          'Environments? <space> select, <enter> confirm, <a> toggle all, <i> invert'
+        );
+        expect(outputWithInstructions).not.toContain(
+          'Environments?\n  (<space>'
+        );
         // Select Production, Preview, and Development.
         client.stdin.write(' '); // toggle Production (first row)
         client.stdin.write('\x1B[B'); // down to Preview
@@ -697,6 +720,11 @@ describe('env add', () => {
         await expect(client.stderr).toOutput(
           'The NEXT_PUBLIC_ prefix will make API_KEY visible to anyone visiting your site'
         );
+        const warningOutput = stripAnsi(client.stderr.getFullOutput());
+        expect(warningOutput).toContain(
+          '! The NEXT_PUBLIC_ prefix will make API_KEY visible to anyone visiting your site'
+        );
+        expect(warningOutput).not.toContain('WARNING!');
         await expect(client.stderr).toOutput('Variable name?');
         client.stdin.write('\n'); // Select "Leave as is"
         await expect(client.stderr).toOutput('Store as sensitive?');

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -96,7 +96,7 @@ describe('env add', () => {
     });
 
     describe('sensitive prompt', () => {
-      it('prints resolved preview and compact result without echoing the value', async () => {
+      it('prints compact result without redundant preview rows or echoing the value', async () => {
         const secretValue = 'super-secret-output-guard';
 
         client.setArgv('env', 'add', 'TRANSCRIPT_VAR', 'preview', 'branchName');
@@ -104,30 +104,36 @@ describe('env add', () => {
 
         await expect(client.stderr).toOutput('Store as sensitive?');
         const previewOutput = stripAnsi(client.stderr.getFullOutput());
-        expect(previewOutput).toMatch(
-          /\n\s{0,2}Project\s+\S+\/vercel-env-pull\n\s{0,2}Variable\s+TRANSCRIPT_VAR\n\s{0,2}Environment\s+Preview\n\s{0,2}Branch\s+branchName\n/
-        );
         expect(previewOutput).toContain(
+          'Sensitive values cannot be read later.'
+        );
+        expect(previewOutput).not.toContain(
           'Sensitive values cannot be read later from the dashboard or CLI.'
+        );
+        expect(previewOutput).not.toMatch(
+          /\n\s{0,2}(Project|Variable|Environments|Branch)\s+/
         );
 
         client.stdin.write('n\n');
         await expect(client.stderr).toOutput('Value?');
         client.stdin.write(`${secretValue}\n`);
 
-        await expect(client.stderr).toOutput('Added       TRANSCRIPT_VAR');
+        await expect(client.stderr).toOutput(
+          '✓ Added           TRANSCRIPT_VAR'
+        );
         await expect(exitCodePromise).resolves.toBe(0);
 
         const fullOutput = stripAnsi(client.stderr.getFullOutput());
         expect(fullOutput).toMatch(
-          /\n\s{0,2}Added\s+TRANSCRIPT_VAR\n\s{0,2}Project\s+\S+\/vercel-env-pull\n\s{0,2}Environment\s+Preview\n\s{0,2}Branch\s+branchName\n\s{0,2}Type\s+Encrypted\n/
+          /\n✓ Added\s+TRANSCRIPT_VAR\n\s{0,2}Project\s+\S+\/vercel-env-pull\n\s{0,2}Environments\s+Preview\n\s{0,2}Branch\s+branchName\n\s{0,2}Type\s+Non-sensitive\n/
         );
+        expect(fullOutput).not.toMatch(/\n\s{0,2}Variable\s+TRANSCRIPT_VAR\n/);
         expect(fullOutput).not.toContain(secretValue);
         expect(fullOutput).not.toMatch(
           /Added Environment Variable|✅|successfully/
         );
         expect(fullOutput).not.toMatch(
-          /^[▲✓] (Project|Variable|Environment|Branch|Type|Added)\s/m
+          /^[▲✓] (Project|Variable|Environments|Branch|Type)\s/m
         );
       });
 
@@ -650,7 +656,9 @@ describe('env add', () => {
         await expect(client.stderr).toOutput('Value?');
         client.stdin.write('\n');
         await expect(client.stderr).toOutput('Value is empty');
-        await expect(client.stderr).toOutput('Added       EMPTY_VALUE_YES');
+        await expect(client.stderr).toOutput(
+          '✓ Added           EMPTY_VALUE_YES'
+        );
         await expect(exitCodePromise).resolves.toBe(0);
       });
     });
@@ -860,12 +868,12 @@ describe('env add', () => {
           await expect(client.stderr).toOutput('Value?');
           client.stdin.write('testvalue\n');
           await expect(client.stderr).toOutput(
-            'Added       REDIS_CONNECTION_STRING'
+            '✓ Added           REDIS_CONNECTION_STRING'
           );
-          await expect(client.stderr).toOutput('Project     ');
-          await expect(client.stderr).toOutput('Environment Preview');
-          await expect(client.stderr).toOutput('Branch      branchName');
-          await expect(client.stderr).toOutput('Type        Encrypted');
+          await expect(client.stderr).toOutput('Project         ');
+          await expect(client.stderr).toOutput('Environments    Preview');
+          await expect(client.stderr).toOutput('Branch          branchName');
+          await expect(client.stderr).toOutput('Type            Non-sensitive');
           const exitCode = await exitCodePromise;
           expect(exitCode, 'exit code for "env"').toEqual(0);
         });
@@ -1208,7 +1216,9 @@ describe('env add', () => {
 
         await expect(exitCodePromise).resolves.toBe(0);
         expect(logSpy).not.toHaveBeenCalled();
-        expect(client.stderr.getFullOutput()).toContain('Environment Preview');
+        expect(client.stderr.getFullOutput()).toContain(
+          'Environments    Preview'
+        );
         expect(client.stderr.getFullOutput()).not.toContain('my-secret-value');
 
         exitSpy.mockRestore();
@@ -1229,7 +1239,9 @@ describe('env add', () => {
 
         await expect(exitCodePromise).resolves.toBe(0);
         expect(logSpy).not.toHaveBeenCalled();
-        expect(client.stderr.getFullOutput()).toContain('Environment Preview');
+        expect(client.stderr.getFullOutput()).toContain(
+          'Environments    Preview'
+        );
         expect(client.stderr.getFullOutput()).not.toContain('value-via-stdin');
 
         exitSpy.mockRestore();

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
+import stripAnsi from 'strip-ansi';
 import env from '../../../../src/commands/env';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
@@ -65,9 +66,7 @@ describe('env add', () => {
           '--sensitive'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          "What's the value of SENSITIVE_FLAG?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
@@ -97,6 +96,41 @@ describe('env add', () => {
     });
 
     describe('sensitive prompt', () => {
+      it('prints resolved preview and compact result without echoing the value', async () => {
+        const secretValue = 'super-secret-output-guard';
+
+        client.setArgv('env', 'add', 'TRANSCRIPT_VAR', 'preview', 'branchName');
+        const exitCodePromise = env(client);
+
+        await expect(client.stderr).toOutput('Store as sensitive?');
+        const previewOutput = stripAnsi(client.stderr.getFullOutput());
+        expect(previewOutput).toMatch(
+          /\n\s{0,2}Project\s+\S+\/vercel-env-pull\n\s{0,2}Variable\s+TRANSCRIPT_VAR\n\s{0,2}Environment\s+Preview\n\s{0,2}Branch\s+branchName\n/
+        );
+        expect(previewOutput).toContain(
+          'Sensitive values cannot be read later from the dashboard or CLI.'
+        );
+
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput('Value?');
+        client.stdin.write(`${secretValue}\n`);
+
+        await expect(client.stderr).toOutput('Added       TRANSCRIPT_VAR');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        const fullOutput = stripAnsi(client.stderr.getFullOutput());
+        expect(fullOutput).toMatch(
+          /\n\s{0,2}Added\s+TRANSCRIPT_VAR\n\s{0,2}Project\s+\S+\/vercel-env-pull\n\s{0,2}Environment\s+Preview\n\s{0,2}Branch\s+branchName\n\s{0,2}Type\s+Encrypted\n/
+        );
+        expect(fullOutput).not.toContain(secretValue);
+        expect(fullOutput).not.toMatch(
+          /Added Environment Variable|✅|successfully/
+        );
+        expect(fullOutput).not.toMatch(
+          /^[▲✓] (Project|Variable|Environment|Branch|Type|Added)\s/m
+        );
+      });
+
       it('creates the variable as sensitive when the user keeps it at the prompt', async () => {
         const addEnvRecordModule = await import(
           '../../../../src/util/env/add-env-record'
@@ -113,13 +147,9 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('y\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of DEFAULT_SENSITIVE?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
@@ -146,13 +176,9 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of DECLINED_SENSITIVE?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
@@ -173,7 +199,7 @@ describe('env add', () => {
 
         client.setArgv('env', 'add', 'DEV_ONLY', 'development');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput("What's the value of DEV_ONLY?");
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
@@ -212,9 +238,7 @@ describe('env add', () => {
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          "What's the value of NO_SENSITIVE_FLAG?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
@@ -362,17 +386,11 @@ describe('env add', () => {
 
         client.setArgv('env', 'add', 'MIXED_TARGETS');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of MIXED_TARGETS?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput(
-          'Add MIXED_TARGETS to which Environments (select multiple)?'
-        );
+        await expect(client.stderr).toOutput('Environments?');
         // Select Production, Preview, and Development.
         client.stdin.write(' '); // toggle Production (first row)
         client.stdin.write('\x1B[B'); // down to Preview
@@ -410,17 +428,11 @@ describe('env add', () => {
 
         client.setArgv('env', 'add', 'SENSITIVE_MIXED');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('y\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of SENSITIVE_MIXED?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
-        await expect(client.stderr).toOutput(
-          'Add SENSITIVE_MIXED to which Environments (select multiple)?'
-        );
+        await expect(client.stderr).toOutput('Environments?');
         // Select Production and Preview only; Development is not listed.
         client.stdin.write(' '); // toggle Production
         client.stdin.write('\x1B[B'); // down to Preview
@@ -467,20 +479,14 @@ describe('env add', () => {
         try {
           client.setArgv('env', 'add', 'POLICY_DEV_ONLY');
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput(
-            'Is the value a sensitive secret?'
-          );
+          await expect(client.stderr).toOutput('Store as sensitive?');
           client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
-            'Your team requires sensitive Environment Variables for Production and Preview. To add a non-sensitive value, you can only target the Development Environment.'
+            'Team policy limits non-sensitive values to Development.'
           );
-          await expect(client.stderr).toOutput(
-            "What's the value of POLICY_DEV_ONLY?"
-          );
+          await expect(client.stderr).toOutput('Value?');
           client.stdin.write('testvalue\n');
-          await expect(client.stderr).toOutput(
-            'Add POLICY_DEV_ONLY to which Environments (select multiple)?'
-          );
+          await expect(client.stderr).toOutput('Environments?');
           client.stdin.write('\r'); // accept Development only
           await expect(exitCodePromise).resolves.toBe(0);
 
@@ -514,11 +520,9 @@ describe('env add', () => {
           '--force'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
@@ -559,11 +563,9 @@ describe('env add', () => {
           '--guidance'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
@@ -607,9 +609,7 @@ describe('env add', () => {
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          "What's the value of TEST_YES_FLAG?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
 
@@ -647,12 +647,10 @@ describe('env add', () => {
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          "What's the value of EMPTY_VALUE_YES?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('\n');
         await expect(client.stderr).toOutput('Value is empty');
-        await expect(client.stderr).toOutput('Added Environment Variable');
+        await expect(client.stderr).toOutput('Added       EMPTY_VALUE_YES');
         await expect(exitCodePromise).resolves.toBe(0);
       });
     });
@@ -671,13 +669,9 @@ describe('env add', () => {
         await expect(client.stderr).toOutput(
           'NEXT_PUBLIC_ variables can be seen by anyone visiting your site'
         );
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of NEXT_PUBLIC_TEST?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
@@ -695,15 +689,11 @@ describe('env add', () => {
         await expect(client.stderr).toOutput(
           'The NEXT_PUBLIC_ prefix will make API_KEY visible to anyone visiting your site'
         );
-        await expect(client.stderr).toOutput('How to proceed?');
+        await expect(client.stderr).toOutput('Variable name?');
         client.stdin.write('\n'); // Select "Leave as is"
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of NEXT_PUBLIC_API_KEY?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
@@ -720,15 +710,13 @@ describe('env add', () => {
         await expect(client.stderr).toOutput(
           'The NEXT_PUBLIC_ prefix will make SECRET visible to anyone visiting your site'
         );
-        await expect(client.stderr).toOutput('How to proceed?');
+        await expect(client.stderr).toOutput('Variable name?');
         // Select "Rename to SECRET" (second option)
         client.stdin.write('\x1B[B\n');
         await expect(client.stderr).toOutput('Renamed to SECRET');
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput("What's the value of SECRET?");
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
@@ -736,16 +724,12 @@ describe('env add', () => {
       it('warns for quoted value and allows continue', async () => {
         client.setArgv('env', 'add', 'QUOTED_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of QUOTED_VALUE?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('"my-value"\n');
         await expect(client.stderr).toOutput('includes surrounding quotes');
-        await expect(client.stderr).toOutput('How to proceed?');
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('\n'); // Select "Leave as is"
         await expect(exitCodePromise).resolves.toBe(0);
       });
@@ -753,20 +737,15 @@ describe('env add', () => {
       it('allows re-entering value when warned', async () => {
         client.setArgv('env', 'add', 'REENTER_VALUE', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of REENTER_VALUE?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('"quoted"\n');
         await expect(client.stderr).toOutput('includes surrounding quotes');
-        await expect(client.stderr).toOutput('How to proceed?');
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('\x1B[B\n'); // Select Re-enter
-        await expect(client.stderr).toOutput(
-          "What's the value of REENTER_VALUE?"
-        );
+        await expect(client.stderr).toOutput('Value? Re-enter');
+        await new Promise(resolve => setTimeout(resolve, 0));
         client.stdin.write('clean-value\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
@@ -780,16 +759,12 @@ describe('env add', () => {
           'branchName'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of WHITESPACE_VALUE?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write(' spaced \n');
         await expect(client.stderr).toOutput('starts and ends with whitespace');
-        await expect(client.stderr).toOutput('How to proceed?');
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('\x1B[B\x1B[B\n'); // Select Trim
         await expect(client.stderr).toOutput('Trimmed whitespace');
         await expect(exitCodePromise).resolves.toBe(0);
@@ -798,21 +773,17 @@ describe('env add', () => {
       it('re-validates trimmed value when it becomes empty', async () => {
         client.setArgv('env', 'add', 'TRIMMED_EMPTY', 'preview', 'branchName');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of TRIMMED_EMPTY?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('   \n'); // Whitespace only
         await expect(client.stderr).toOutput('starts and ends with whitespace');
-        await expect(client.stderr).toOutput('How to proceed?');
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('\x1B[B\x1B[B\n'); // Select Trim
         await expect(client.stderr).toOutput('Trimmed whitespace');
         // After trimming, value becomes empty - should show empty warning
         await expect(client.stderr).toOutput('Value is empty');
-        await expect(client.stderr).toOutput('How to proceed?');
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('\n'); // Leave as is
         await expect(exitCodePromise).resolves.toBe(0);
       });
@@ -830,21 +801,19 @@ describe('env add', () => {
         await expect(client.stderr).toOutput(
           'The NEXT_PUBLIC_ prefix will make NEXT_PUBLIC_SECRET visible'
         );
-        await expect(client.stderr).toOutput('How to proceed?');
+        await expect(client.stderr).toOutput('Variable name?');
         client.stdin.write('\x1B[B\n'); // Select rename to NEXT_PUBLIC_SECRET
         await expect(client.stderr).toOutput('Renamed to NEXT_PUBLIC_SECRET');
         // Now should warn again for inner prefix
         await expect(client.stderr).toOutput(
           'The NEXT_PUBLIC_ prefix will make SECRET visible'
         );
-        await expect(client.stderr).toOutput('How to proceed?');
+        await expect(client.stderr).toOutput('Variable name?');
         client.stdin.write('\x1B[B\n'); // Rename again to SECRET
         await expect(client.stderr).toOutput('Renamed to SECRET');
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput("What's the value of SECRET?");
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
       });
@@ -854,13 +823,9 @@ describe('env add', () => {
       it('should redact custom [environment] values', async () => {
         client.setArgv('env', 'add', 'environment-variable', 'custom-env-name');
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'Is the value a sensitive secret?'
-        );
+        await expect(client.stderr).toOutput('Store as sensitive?');
         client.stdin.write('n\n');
-        await expect(client.stderr).toOutput(
-          "What's the value of environment-variable?"
-        );
+        await expect(client.stderr).toOutput('Value?');
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toEqual(0);
 
@@ -890,17 +855,17 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput(
-            'Is the value a sensitive secret?'
-          );
+          await expect(client.stderr).toOutput('Store as sensitive?');
           client.stdin.write('n\n');
-          await expect(client.stderr).toOutput(
-            "What's the value of REDIS_CONNECTION_STRING?"
-          );
+          await expect(client.stderr).toOutput('Value?');
           client.stdin.write('testvalue\n');
           await expect(client.stderr).toOutput(
-            'Added Environment Variable REDIS_CONNECTION_STRING to Project vercel-env-pull'
+            'Added       REDIS_CONNECTION_STRING'
           );
+          await expect(client.stderr).toOutput('Project     ');
+          await expect(client.stderr).toOutput('Environment Preview');
+          await expect(client.stderr).toOutput('Branch      branchName');
+          await expect(client.stderr).toOutput('Type        Encrypted');
           const exitCode = await exitCodePromise;
           expect(exitCode, 'exit code for "env"').toEqual(0);
         });
@@ -914,13 +879,9 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput(
-            'Is the value a sensitive secret?'
-          );
+          await expect(client.stderr).toOutput('Store as sensitive?');
           client.stdin.write('n\n');
-          await expect(client.stderr).toOutput(
-            "What's the value of TELEMETRY_EVENTS?"
-          );
+          await expect(client.stderr).toOutput('Value?');
           client.stdin.write('testvalue\n');
           await expect(exitCodePromise).resolves.toEqual(0);
 
@@ -1097,7 +1058,8 @@ describe('env add', () => {
         expect(payload.next[0].command).not.toMatch(/--value|secret/);
         expect(payload.next[1].command).toMatch(/env add/);
         expect(payload.next[1].command).toContain('--value');
-        expect(payload.next[1].command).toContain('secret');
+        expect(payload.next[1].command).not.toContain('secret');
+        expect(payload.next[1].command).toContain('--value "<value>"');
 
         exitSpy.mockRestore();
         logSpy.mockRestore();
@@ -1220,13 +1182,13 @@ describe('env add', () => {
         const cmd = payload.next[0].command;
         expect(cmd).not.toMatch(/--yes\s+--yes/);
         expect(cmd).toContain('--yes');
-        expect(cmd).toContain('--value <value>');
+        expect(cmd).toContain('--value "<value>"');
 
         exitSpy.mockRestore();
         logSpy.mockRestore();
       });
 
-      it('uses --value when provided and reaches next prompt (e.g. git_branch_required)', async () => {
+      it('uses --value with preview and no branch as all Preview branches', async () => {
         const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
           throw new Error('exit');
         });
@@ -1244,23 +1206,16 @@ describe('env add', () => {
         );
         const exitCodePromise = env(client);
 
-        await expect(exitCodePromise).rejects.toThrow('exit');
-        const payload = JSON.parse(
-          logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
-        );
-        expect(payload.reason).toBe('git_branch_required');
-        expect(
-          payload.next.some(
-            (n: { command: string }) =>
-              n.command.includes('preview') && n.command.includes('<gitbranch>')
-          )
-        ).toBe(true);
+        await expect(exitCodePromise).resolves.toBe(0);
+        expect(logSpy).not.toHaveBeenCalled();
+        expect(client.stderr.getFullOutput()).toContain('Environment Preview');
+        expect(client.stderr.getFullOutput()).not.toContain('my-secret-value');
 
         exitSpy.mockRestore();
         logSpy.mockRestore();
       });
 
-      it('outputs action_required when preview target and git branch not passed (no third argument)', async () => {
+      it('uses stdin with preview and no branch as all Preview branches', async () => {
         const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
           throw new Error('exit');
         });
@@ -1272,26 +1227,10 @@ describe('env add', () => {
         const exitCodePromise = env(client);
         setImmediate(() => client.stdin.emit('data', 'value-via-stdin'));
 
-        await expect(exitCodePromise).rejects.toThrow('exit');
-        expect(logSpy).toHaveBeenCalled();
-        const payload = JSON.parse(
-          logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
-        );
-        expect(payload).toMatchObject({
-          status: 'action_required',
-          reason: 'git_branch_required',
-          message: expect.stringMatching(/Git branch|third argument|Preview/),
-          next: expect.any(Array),
-        });
-        expect(payload.next.length).toBeGreaterThanOrEqual(1);
-        expect(
-          payload.next.some(
-            (n: { command: string }) =>
-              n.command.includes('preview') &&
-              (n.command.includes('<gitbranch>') ||
-                n.command.includes('--value'))
-          )
-        ).toBe(true);
+        await expect(exitCodePromise).resolves.toBe(0);
+        expect(logSpy).not.toHaveBeenCalled();
+        expect(client.stderr.getFullOutput()).toContain('Environment Preview');
+        expect(client.stderr.getFullOutput()).not.toContain('value-via-stdin');
 
         exitSpy.mockRestore();
         logSpy.mockRestore();

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -83,7 +83,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput(
       'Created .env.local file and added it to .gitignore'
@@ -186,7 +186,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--yes', '--environment', 'preview');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `preview` Environment Variables for'
+      'Downloading `preview` environment variables for'
     );
     await expect(client.stderr).toOutput(
       'Created .env.local file and added it to .gitignore'
@@ -224,7 +224,7 @@ describe('env pull', () => {
       'feat/awesome-thing'
     );
     const exitCodePromise = env(client);
-    // Full output: "Downloading `preview` Environment Variables for jqkgv/vercel-env-pull and any overrides for branch feat/awesome-thing"
+    // Full output: "Downloading `preview` environment variables for jqkgv/vercel-env-pull and any overrides for branch feat/awesome-thing"
     // Note: Can't match the full string due to hyperlink ANSI codes around the org/project slug
     await expect(client.stderr).toOutput(
       'vercel-env-pull and any overrides for branch feat/awesome-thing'
@@ -284,7 +284,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', 'other.env', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput('Created other.env file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
@@ -326,7 +326,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--environment', 'production');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`production\` Environment Variables for`
+      `Downloading \`production\` environment variables for`
     );
     await expect(client.stderr).toOutput(
       'Created .env.local file and added it to .gitignore'
@@ -364,7 +364,7 @@ describe('env pull', () => {
     );
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `production` Environment Variables for'
+      'Downloading `production` environment variables for'
     );
     await expect(client.stderr).toOutput('Created other.env file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
@@ -393,7 +393,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', 'other.env', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput('Created other.env file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
@@ -443,7 +443,7 @@ describe('env pull', () => {
       client.setArgv('env', 'pull', '--yes');
       const pullPromise = env(client);
       await expect(client.stderr).toOutput(
-        'Downloading `development` Environment Variables for'
+        'Downloading `development` environment variables for'
       );
       await expect(client.stderr).toOutput(
         '+ SPECIAL_FLAG (Updated)\n+ NEW_VAR\n- TEST\n'
@@ -525,7 +525,7 @@ describe('env pull', () => {
       client.setArgv('env', 'pull', '--yes');
       const pullPromise = env(client);
       await expect(client.stderr).toOutput(
-        'Downloading `development` Environment Variables for'
+        'Downloading `development` environment variables for'
       );
       await expect(client.stderr).toOutput('No changes found.\n');
       await expect(client.stderr).toOutput(
@@ -569,7 +569,7 @@ describe('env pull', () => {
       client.setArgv('env', 'pull', '.env.testquotes', '--yes');
       const pullPromise = env(client);
       await expect(client.stderr).toOutput(
-        'Downloading `development` Environment Variables for'
+        'Downloading `development` environment variables for'
       );
       await expect(client.stderr).toOutput('No changes found.\n');
       await expect(client.stderr).toOutput('Updated .env.testquotes file');
@@ -599,7 +599,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput('Created .env.local file');
     await expect(client.stderr).not.toOutput('and added it to .gitignore');
@@ -671,7 +671,7 @@ describe('env pull', () => {
     client.setArgv('env', 'pull', '--yes');
     const exitCodePromise = env(client);
     await expect(client.stderr).toOutput(
-      'Downloading `development` Environment Variables for'
+      'Downloading `development` environment variables for'
     );
     await expect(client.stderr).toOutput('Created .env.local file');
     const exitCode = await exitCodePromise;

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -427,14 +427,12 @@ describe('env pull', () => {
       client.setArgv('env', 'add', 'NEW_VAR');
       const addPromise = env(client);
 
-      await expect(client.stderr).toOutput('Is the value a sensitive secret?');
+      await expect(client.stderr).toOutput('Store as sensitive?');
       client.stdin.write('n\n');
-      await expect(client.stderr).toOutput("What's the value of NEW_VAR?");
+      await expect(client.stderr).toOutput('Value?');
       client.stdin.write('testvalue\n');
 
-      await expect(client.stderr).toOutput(
-        'Add NEW_VAR to which Environments (select multiple)?'
-      );
+      await expect(client.stderr).toOutput('Environments?');
       client.stdin.write('\x1B[B'); // Down arrow
       client.stdin.write('\x1B[B');
       client.stdin.write(' ');

--- a/packages/cli/test/unit/commands/env/run.test.ts
+++ b/packages/cli/test/unit/commands/env/run.test.ts
@@ -142,7 +142,7 @@ describe('env run', () => {
       const exitCodePromise = env(client);
 
       await expect(client.stderr).toOutput(
-        'Downloading `development` Environment Variables'
+        'Downloading `development` environment variables'
       );
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -188,7 +188,7 @@ describe('env run', () => {
       const exitCodePromise = env(client);
 
       await expect(client.stderr).toOutput(
-        'Downloading `production` Environment Variables'
+        'Downloading `production` environment variables'
       );
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -231,7 +231,7 @@ describe('env run', () => {
       const exitCodePromise = env(client);
 
       await expect(client.stderr).toOutput(
-        'Downloading `preview` Environment Variables'
+        'Downloading `preview` environment variables'
       );
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -75,7 +75,7 @@ describe('pull', () => {
     client.setArgv('pull', cwd);
     const exitCodePromise = pull(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`development\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+      `Downloading \`development\` environment variables for ${teams[0].slug}/vercel-pull-next`
     );
     await expect(client.stderr).toOutput(
       `Created .vercel${path.sep}.env.development.local file`
@@ -154,7 +154,7 @@ describe('pull', () => {
       client.setArgv('pull', cwd);
       const exitCodePromise = pull(client);
       await expect(client.stderr).toOutput(
-        `Downloading \`development\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+        `Downloading \`development\` environment variables for ${teams[0].slug}/vercel-pull-next`
       );
       await expect(client.stderr).toOutput(
         `Created .vercel${path.sep}.env.development.local file`
@@ -195,7 +195,7 @@ describe('pull', () => {
     client.setArgv('pull', '--environment=preview', cwd);
     const exitCodePromise = pull(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`preview\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+      `Downloading \`preview\` environment variables for ${teams[0].slug}/vercel-pull-next`
     );
     await expect(client.stderr).toOutput(
       `Created .vercel${path.sep}.env.preview.local file`
@@ -240,7 +240,7 @@ describe('pull', () => {
     client.setArgv('pull', '--environment=production', cwd);
     const exitCodePromise = pull(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`production\` Environment Variables for ${teams[0].slug}/vercel-pull-next`
+      `Downloading \`production\` environment variables for ${teams[0].slug}/vercel-pull-next`
     );
     await expect(client.stderr).toOutput(
       `Created .vercel${path.sep}.env.production.local file`
@@ -291,7 +291,7 @@ describe('pull', () => {
     client.setArgv('pull');
     const exitCodePromise = pull(client);
     await expect(client.stderr).toOutput(
-      `Downloading \`development\` Environment Variables for ${teams[0].slug}/dashboard`
+      `Downloading \`development\` environment variables for ${teams[0].slug}/dashboard`
     );
     await expect(client.stderr).toOutput(
       `Created .vercel${path.sep}.env.development.local file`
@@ -446,7 +446,7 @@ describe('pull', () => {
       const exitCodePromise = pull(client);
 
       await expect(client.stderr).toOutput(
-        `Downloading \`production\` Environment Variables for ${teams[0].slug}/project-via-flag`
+        `Downloading \`production\` environment variables for ${teams[0].slug}/project-via-flag`
       );
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "pull"').toEqual(0);


### PR DESCRIPTION
- Shorten `vc env add` prompts for name, sensitivity, value, and environment selection.
- Keep sensitive-value guidance inline with the sensitivity prompt.
- Mask sensitive values and show non-sensitive typed values normally.
- Print compact checkmark-gutter receipts with key, project, environments, branch, and type.
- Redact env values in non-interactive/agent output and use quoted `"<value>"` placeholders.
- Use sentence-case env download copy across `env pull`, `pull`, and `env run`.
- Add the `vc env add` command contract and tests for interactive, warning, and agent paths.