### PR TITLE
[cli] support self-update for standalone native binary installs

### DIFF
--- a/.changeset/native-standalone-self-update.md
+++ b/.changeset/native-standalone-self-update.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] support self-update for standalone (install.sh) native binary installs

--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -2,7 +2,10 @@ import { readFile, realpath } from 'fs-extra';
 import { sep, dirname, join, resolve } from 'path';
 import { scanParentDirs } from '@vercel/build-utils';
 import { packageName } from './pkg-name';
-import { isNativeBinaryInstall } from './native-install';
+import {
+  getNativeInstallMethod,
+  isNativeBinaryInstall,
+} from './native-install';
 
 const nativePackageName = '@vercel/vc-native';
 
@@ -88,6 +91,15 @@ export async function isGlobal() {
 
 export default async function getUpdateCommand(): Promise<string> {
   const nativeInstall = isNativeBinaryInstall();
+
+  if (
+    nativeInstall &&
+    process.platform !== 'win32' &&
+    getNativeInstallMethod() === 'standalone'
+  ) {
+    return `${packageName} upgrade`;
+  }
+
   const pkgAndVersion = `${getUpdatePackageName()}@latest`;
 
   const entrypoint = await realpath(process.argv[1]);

--- a/packages/cli/src/util/native-install.ts
+++ b/packages/cli/src/util/native-install.ts
@@ -1,3 +1,20 @@
+import { realpathSync } from 'fs';
+import { sep } from 'path';
+
 export function isNativeBinaryInstall(): boolean {
   return process.env.VERCEL_VC_NATIVE === '1';
+}
+
+export type NativeInstallMethod = 'npm' | 'standalone';
+
+export function getNativeInstallMethod(): NativeInstallMethod {
+  try {
+    const real = realpathSync(process.execPath);
+    if (real.includes(`node_modules${sep}@vercel${sep}vc-native`)) {
+      return 'npm';
+    }
+    return 'standalone';
+  } catch {
+    return 'npm';
+  }
 }

--- a/packages/cli/src/util/native-upgrade.ts
+++ b/packages/cli/src/util/native-upgrade.ts
@@ -1,0 +1,191 @@
+import { spawnSync } from 'child_process';
+import { createHash } from 'crypto';
+import {
+  chmodSync,
+  createReadStream,
+  createWriteStream,
+  realpathSync,
+  rmSync,
+} from 'fs';
+import { rename } from 'fs/promises';
+import https from 'https';
+import type { IncomingMessage } from 'http';
+import { dirname, join } from 'path';
+import { pipeline } from 'stream/promises';
+import output from '../output-manager';
+
+const REPO = 'vercel/vercel';
+
+function detectTarget(): string | undefined {
+  let os: string | undefined;
+  if (process.platform === 'darwin') {
+    os = 'darwin';
+  } else if (process.platform === 'linux') {
+    os = 'linux';
+  }
+
+  let arch: string | undefined;
+  if (process.arch === 'arm64') {
+    arch = 'arm64';
+  } else if (process.arch === 'x64') {
+    arch = 'x64';
+  }
+
+  if (!os || !arch) {
+    return undefined;
+  }
+  return `vercel-${os}-${arch}`;
+}
+
+function request(url: string, redirects = 5): Promise<IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, res => {
+        const { statusCode, headers } = res;
+        if (
+          statusCode &&
+          statusCode >= 300 &&
+          statusCode < 400 &&
+          headers.location
+        ) {
+          res.resume();
+          if (redirects === 0) {
+            reject(new Error(`Too many redirects fetching ${url}`));
+            return;
+          }
+          resolve(
+            request(new URL(headers.location, url).toString(), redirects - 1)
+          );
+          return;
+        }
+        if (!statusCode || statusCode >= 400) {
+          res.resume();
+          reject(new Error(`Request failed (${statusCode}) fetching ${url}`));
+          return;
+        }
+        resolve(res);
+      })
+      .on('error', reject);
+  });
+}
+
+async function fetchText(url: string): Promise<string> {
+  const res = await request(url);
+  let body = '';
+  for await (const chunk of res) {
+    body += chunk;
+  }
+  return body;
+}
+
+async function downloadToFile(url: string, dest: string): Promise<void> {
+  const res = await request(url);
+  await pipeline(res, createWriteStream(dest));
+}
+
+async function fileChecksum(file: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(file), hash);
+  return hash.digest('hex');
+}
+
+async function resolveLatestVersion(): Promise<string | undefined> {
+  try {
+    const body = await fetchText('https://registry.npmjs.org/vercel/latest');
+    const parsed = JSON.parse(body);
+    return typeof parsed?.version === 'string' ? parsed.version : undefined;
+  } catch (err) {
+    output.debug(`Failed to resolve latest version: ${err}`);
+    return undefined;
+  }
+}
+
+export async function executeStandaloneUpgrade(
+  version?: string
+): Promise<number> {
+  const target = detectTarget();
+  if (!target) {
+    output.error(
+      `Automatic upgrade is not supported on ${process.platform}/${process.arch}.`
+    );
+    return 1;
+  }
+
+  const resolvedVersion = version ?? (await resolveLatestVersion());
+  if (!resolvedVersion) {
+    output.error('Could not determine the latest version to install.');
+    return 1;
+  }
+
+  let targetPath: string;
+  try {
+    targetPath = realpathSync(process.execPath);
+  } catch (err) {
+    output.error(`Could not resolve the running binary path: ${err}`);
+    return 1;
+  }
+
+  const base = `https://github.com/${REPO}/releases/download/vercel@${resolvedVersion}`;
+  const tmpFile = join(
+    dirname(targetPath),
+    `.vercel-upgrade-${process.pid}.tmp`
+  );
+
+  output.log('Upgrading Vercel CLI...');
+  output.spinner(`Downloading Vercel CLI ${resolvedVersion}`);
+
+  try {
+    await downloadToFile(`${base}/${target}`, tmpFile);
+
+    try {
+      const sums = await fetchText(`${base}/${target}.sha256`);
+      const expected = sums.trim().split(/\s+/)[0];
+      const actual = await fileChecksum(tmpFile);
+      if (expected && expected !== actual) {
+        throw new Error(
+          `checksum mismatch (expected ${expected}, got ${actual})`
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('checksum mismatch')) {
+        throw err;
+      }
+      output.warn(`Skipping checksum verification: ${message}`);
+    }
+
+    chmodSync(tmpFile, 0o755);
+
+    const check = spawnSync(tmpFile, ['--version'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    if (check.status !== 0) {
+      throw new Error('downloaded binary failed to execute');
+    }
+
+    await rename(tmpFile, targetPath);
+    output.stopSpinner();
+    output.success(`Vercel CLI has been upgraded to ${resolvedVersion}!`);
+    return 0;
+  } catch (err) {
+    output.stopSpinner();
+    rmSync(tmpFile, { force: true });
+
+    const isPermission =
+      err instanceof Error &&
+      'code' in err &&
+      (err as NodeJS.ErrnoException).code === 'EACCES';
+
+    if (isPermission) {
+      output.error(
+        `Could not write to ${targetPath} (permission denied). Re-run the install script or check the file permissions.`
+      );
+    } else {
+      output.error(
+        `Upgrade failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/util/upgrade.ts
+++ b/packages/cli/src/util/upgrade.ts
@@ -1,5 +1,10 @@
 import { spawn } from 'child_process';
 import getUpdateCommand from './get-update-command';
+import {
+  getNativeInstallMethod,
+  isNativeBinaryInstall,
+} from './native-install';
+import { executeStandaloneUpgrade } from './native-upgrade';
 import output from '../output-manager';
 
 /**
@@ -7,6 +12,14 @@ import output from '../output-manager';
  * Returns the exit code from the upgrade process.
  */
 export async function executeUpgrade(): Promise<number> {
+  if (
+    isNativeBinaryInstall() &&
+    process.platform !== 'win32' &&
+    getNativeInstallMethod() === 'standalone'
+  ) {
+    return executeStandaloneUpgrade();
+  }
+
   const updateCommand = await getUpdateCommand();
   const [command, ...args] = updateCommand.split(' ');
 

--- a/packages/cli/test/unit/util/get-update-command.test.ts
+++ b/packages/cli/test/unit/util/get-update-command.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import getUpdateCommand, {
   getUpdatePackageName,
   isGlobal,
 } from '../../../src/util/get-update-command';
+import * as nativeInstall from '../../../src/util/native-install';
 
 describe('getUpdateCommand', () => {
   const originalVercelVcNative = process.env.VERCEL_VC_NATIVE;
@@ -28,11 +29,27 @@ describe('getUpdateCommand', () => {
 
   it('should update the native package when running through vc-native', async () => {
     process.env.VERCEL_VC_NATIVE = '1';
+    const methodSpy = vi
+      .spyOn(nativeInstall, 'getNativeInstallMethod')
+      .mockReturnValue('npm');
 
     const updateCommand = await getUpdateCommand();
 
     expect(updateCommand).toContain('@vercel/vc-native@latest');
     expect(updateCommand.split(' ')).not.toContain('vercel@latest');
+    methodSpy.mockRestore();
+  });
+
+  it('should self-upgrade for standalone native installs', async () => {
+    process.env.VERCEL_VC_NATIVE = '1';
+    const methodSpy = vi
+      .spyOn(nativeInstall, 'getNativeInstallMethod')
+      .mockReturnValue('standalone');
+
+    const updateCommand = await getUpdateCommand();
+
+    expect(updateCommand).toBe('vercel upgrade');
+    methodSpy.mockRestore();
   });
 
   describe('getUpdatePackageName', () => {

--- a/packages/cli/test/unit/util/native-install.test.ts
+++ b/packages/cli/test/unit/util/native-install.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { realpathSync } from 'fs';
+import { sep } from 'path';
+import { getNativeInstallMethod } from '../../../src/util/native-install';
+
+vi.mock('fs', async importActual => {
+  const actual = await importActual<typeof import('fs')>();
+  return { ...actual, realpathSync: vi.fn() };
+});
+
+const realpathMock = vi.mocked(realpathSync);
+
+describe('getNativeInstallMethod', () => {
+  afterEach(() => {
+    realpathMock.mockReset();
+  });
+
+  it('detects npm installs by their node_modules path', () => {
+    const npmPath = [
+      '',
+      'usr',
+      'local',
+      'lib',
+      'node_modules',
+      '@vercel',
+      'vc-native',
+      'bin',
+      'vercel',
+    ].join(sep);
+    realpathMock.mockReturnValue(npmPath);
+
+    expect(getNativeInstallMethod()).toBe('npm');
+  });
+
+  it('treats other locations as standalone', () => {
+    const standalonePath = [
+      '',
+      'home',
+      'user',
+      '.vercel',
+      'bin',
+      'vercel',
+    ].join(sep);
+    realpathMock.mockReturnValue(standalonePath);
+
+    expect(getNativeInstallMethod()).toBe('standalone');
+  });
+
+  it('falls back to npm when the path cannot be resolved', () => {
+    realpathMock.mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    expect(getNativeInstallMethod()).toBe('npm');
+  });
+});

--- a/packages/cli/test/unit/util/upgrade.test.ts
+++ b/packages/cli/test/unit/util/upgrade.test.ts
@@ -4,10 +4,24 @@ import { spawn } from 'child_process';
 import output from '../../../src/output-manager';
 import { executeUpgrade } from '../../../src/util/upgrade';
 import getUpdateCommand from '../../../src/util/get-update-command';
+import {
+  getNativeInstallMethod,
+  isNativeBinaryInstall,
+} from '../../../src/util/native-install';
+import { executeStandaloneUpgrade } from '../../../src/util/native-upgrade';
 
 // Mock child_process
 vi.mock('child_process', () => ({
   spawn: vi.fn(),
+}));
+
+vi.mock('../../../src/util/native-install', () => ({
+  isNativeBinaryInstall: vi.fn(),
+  getNativeInstallMethod: vi.fn(),
+}));
+
+vi.mock('../../../src/util/native-upgrade', () => ({
+  executeStandaloneUpgrade: vi.fn(),
 }));
 
 // Mock output-manager
@@ -29,6 +43,9 @@ vi.mock('../../../src/util/get-update-command', () => ({
 const spawnMock = vi.mocked(spawn);
 const outputMock = vi.mocked(output);
 const getUpdateCommandMock = vi.mocked(getUpdateCommand);
+const isNativeBinaryInstallMock = vi.mocked(isNativeBinaryInstall);
+const getNativeInstallMethodMock = vi.mocked(getNativeInstallMethod);
+const executeStandaloneUpgradeMock = vi.mocked(executeStandaloneUpgrade);
 
 describe('executeUpgrade', () => {
   beforeEach(() => {
@@ -223,5 +240,32 @@ describe('executeUpgrade', () => {
     expect(outputMock.debug).toHaveBeenCalledWith(
       'Executing: npm i -g vercel@latest'
     );
+  });
+
+  it('should use the in-process updater for standalone native installs', async () => {
+    isNativeBinaryInstallMock.mockReturnValue(true);
+    getNativeInstallMethodMock.mockReturnValue('standalone');
+    executeStandaloneUpgradeMock.mockResolvedValue(0);
+
+    const exitCode = await executeUpgrade();
+
+    expect(exitCode).toBe(0);
+    expect(executeStandaloneUpgradeMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should use the package manager for npm native installs', async () => {
+    isNativeBinaryInstallMock.mockReturnValue(true);
+    getNativeInstallMethodMock.mockReturnValue('npm');
+    const mockProcess = createMockProcess();
+    spawnMock.mockReturnValue(mockProcess as any);
+
+    const exitCodePromise = executeUpgrade();
+    await tick();
+    mockProcess.emit('close', 0);
+    await exitCodePromise;
+
+    expect(executeStandaloneUpgradeMock).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## summary
- stacked on #16566. that pr re-enabled notifications + auto-update for native installs but the upgrade action always ran the npm command, which can't update a binary installed via install.sh (lives in `~/.vercel/bin`, npm not involved)
- this makes the upgrade action method-aware so install.sh installs get working auto-update, notifications, and `vc upgrade`
- detection is by elimination: native binaries resolving under `node_modules/@vercel/vc-native` are npm installs; anything else native is standalone. needs no install.sh changes, no manifest, no hosted url
- standalone upgrade is in-process: download the release binary, verify the sha256, and atomically overwrite `realpath(process.execpath)` — reuses the github release artifacts and the exact running binary path, so a custom `VERCEL_INSTALL_DIR` is handled automatically

## changes
- add `getNativeInstallMethod()` to `native-install.ts` (npm vs standalone via `realpath(process.execPath)`)
- add `native-upgrade.ts` with `executeStandaloneUpgrade()` (download + sha256 verify + run-check + atomic replace), mirroring install.sh/postinstall
- branch `executeUpgrade()` to the standalone updater for standalone native installs (covers both auto-update and `vc upgrade`)
- return `vercel upgrade` as the displayed upgrade hint for standalone installs in `getUpdateCommand()`
- tests for detection + upgrade routing + display command; changeset