### PR TITLE
Document default Connect token scopes

### DIFF
--- a/.changeset/connect-default-scopes.md
+++ b/.changeset/connect-default-scopes.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Document `ConnectTokenParams.scopes` support for `["*"]` default scopes.

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -32,6 +32,10 @@ export interface ConnectTokenParams {
   subject: ConnectTokenSubject;
   installationId?: string;
   audience?: string[];
+  /**
+   * Access scopes to request. Use `['*']` to request the default scopes for
+   * the specified subject type.
+   */
   scopes?: string[];
   resources?: string[];
   authorizationDetails?: ConnectAuthorizationDetail[];


### PR DESCRIPTION
## Summary
- Document that ConnectTokenParams.scopes accepts ["*"] for default scopes for the specified subject type
- Add a patch changeset for @vercel/connect

## Tests
- pnpm --filter @vercel/connect typecheck