### PR TITLE
[@vercel/connect] re-validate revoked grants via opt-in validate/forceRefresh

### DIFF
--- a/.changeset/connect-validate-on-revocation.md
+++ b/.changeset/connect-validate-on-revocation.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add an opt-in `validate` flag to the Eve `connect()` adapter (backed by a new `forceRefresh` option on `getToken`/`getTokenResponse`). When set, each `getToken` bypasses the in-process token cache and re-checks Vercel Connect, so a grant the user revoked server-side surfaces as an authorization-required prompt instead of being served as a stale, still-cached bearer.

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -129,6 +129,26 @@ export interface EveAuthorizationOptions {
   readonly connectOptions?: ConnectOptions;
 
   /**
+   * Re-validate the grant against Vercel Connect on every `getToken`
+   * instead of trusting the in-process token cache.
+   *
+   * By default `getToken` returns a cached token as long as it has not
+   * expired, so a grant the user revoked server-side keeps reaching the
+   * tool until the bearer's natural expiry. With `validate: true` each
+   * `getToken` bypasses the local cache and re-checks Connect; a revoked
+   * grant comes back as `no_token` / `user_authorization_required`, which
+   * the adapter maps to {@link ConnectionAuthorizationRequiredError} so
+   * Eve re-runs the consent flow rather than calling the tool with a dead
+   * token.
+   *
+   * This trades a Connect round trip per call for freshness — leave it
+   * off for high-frequency tools where a short revocation window is
+   * acceptable, and turn it on for sensitive actions (payments, deletes,
+   * privileged writes) that must never run on a revoked grant.
+   */
+  readonly validate?: boolean;
+
+  /**
    * Custom call-to-action rendered on the
    * `connection.authorization_required` event. When omitted, Eve
    * fills in `Authorize <ConnectionName> in your browser to continue.`
@@ -255,7 +275,7 @@ function buildInteractiveDefinition(
         const response = await getTokenResponse(
           options.connector,
           await buildTokenParams(options, principal),
-          options.connectOptions
+          getTokenConnectOptions(options)
         );
         return { token: response.token, expiresAt: response.expiresAt };
       } catch (error) {
@@ -345,7 +365,7 @@ function buildNonInteractiveDefinition(
         const response = await getTokenResponse(
           options.connector,
           await buildTokenParams(options, principal),
-          options.connectOptions
+          getTokenConnectOptions(options)
         );
         return { token: response.token, expiresAt: response.expiresAt };
       } catch (error) {
@@ -353,6 +373,21 @@ function buildNonInteractiveDefinition(
       }
     },
   };
+}
+
+/**
+ * Connect SDK options for `getToken` calls. When {@link
+ * EveAuthorizationOptions.validate} is set, forces a cache-bypassing
+ * re-fetch so a revoked-but-unexpired grant is caught instead of served
+ * from the in-process token cache.
+ */
+function getTokenConnectOptions(
+  options: EveAuthorizationOptions
+): ConnectOptions | undefined {
+  if (!options.validate) {
+    return options.connectOptions;
+  }
+  return { ...options.connectOptions, forceRefresh: true };
 }
 
 async function buildTokenParams(

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -116,6 +116,19 @@ export class ConnectorInstallationRequiredError extends ConnectError {
 
 export interface ConnectOptions {
   vercelToken?: string;
+
+  /**
+   * Bypass the in-process token cache and re-fetch from Vercel Connect.
+   *
+   * The cache normally serves any token that is not within
+   * {@link ConnectTokenParams.validityBufferMs} of expiry. That means a
+   * grant the user revoked server-side keeps being handed back from the
+   * local cache until it expires. Set `forceRefresh` when the caller
+   * needs Connect to re-validate the grant on this call — a revoked grant
+   * then surfaces as `no_token` / `user_authorization_required` instead of
+   * a stale bearer.
+   */
+  forceRefresh?: boolean;
 }
 
 export async function getToken(
@@ -135,14 +148,18 @@ export async function getTokenResponse(
   const bufferMs = params.validityBufferMs ?? DEFAULT_VALIDITY_BUFFER_MS;
   const cacheKey = JSON.stringify({ connector, ...params });
 
-  const cached = cache.get(cacheKey);
-  if (cached) {
-    const now = Date.now();
-    if (cached.response.expiresAt - now > bufferMs) {
-      cached.lastUsed = now;
-      return cached.response;
-    }
+  if (options?.forceRefresh) {
     cache.delete(cacheKey);
+  } else {
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      const now = Date.now();
+      if (cached.response.expiresAt - now > bufferMs) {
+        cached.lastUsed = now;
+        return cached.response;
+      }
+      cache.delete(cacheKey);
+    }
   }
 
   const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());

--- a/packages/connect/test/token.test.ts
+++ b/packages/connect/test/token.test.ts
@@ -1,6 +1,11 @@
 import { getVercelOidcToken } from '@vercel/oidc';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ConnectError, revokeToken } from '../src/token.js';
+import {
+  ConnectError,
+  getTokenResponse,
+  revokeToken,
+  UserAuthorizationRequiredError,
+} from '../src/token.js';
 
 vi.mock('@vercel/oidc', () => ({
   getVercelOidcToken: vi.fn(),
@@ -100,10 +105,86 @@ describe('revokeToken', () => {
   });
 });
 
+describe('getTokenResponse cache', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(getVercelOidcToken).mockResolvedValue('oidc_token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('serves a cached, unexpired token without re-fetching', async () => {
+    fetchMock.mockResolvedValue(tokenResponse('tok_a'));
+    const params = { subject: { type: 'user' as const, id: 'cache_hit' } };
+
+    const first = await getTokenResponse('oauth/linear', params);
+    const second = await getTokenResponse('oauth/linear', params);
+
+    expect(first.token).toBe('tok_a');
+    expect(second.token).toBe('tok_a');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('forceRefresh bypasses the cache and re-fetches', async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('tok_old'))
+      .mockResolvedValueOnce(tokenResponse('tok_new'));
+    const params = { subject: { type: 'user' as const, id: 'force_refresh' } };
+
+    const first = await getTokenResponse('oauth/linear', params);
+    const second = await getTokenResponse('oauth/linear', params, {
+      forceRefresh: true,
+    });
+
+    expect(first.token).toBe('tok_old');
+    expect(second.token).toBe('tok_new');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a revoked grant on re-check instead of serving the cached bearer', async () => {
+    fetchMock.mockResolvedValueOnce(tokenResponse('tok_live'));
+    const params = { subject: { type: 'user' as const, id: 'revoked' } };
+
+    await getTokenResponse('oauth/linear', params);
+
+    // Grant revoked server-side: a cache-bypassing re-check now fails
+    // closed instead of returning the still-cached, now-dead bearer.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: {
+            code: 'user_authorization_required',
+            message: 'User authorization is required',
+          },
+        },
+        { status: 401, statusText: 'Unauthorized' }
+      )
+    );
+
+    await expect(
+      getTokenResponse('oauth/linear', params, { forceRefresh: true })
+    ).rejects.toBeInstanceOf(UserAuthorizationRequiredError);
+  });
+});
+
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
     ...init,
+  });
+}
+
+function tokenResponse(token: string): Response {
+  return jsonResponse({
+    token,
+    expiresAt: Date.now() + 60 * 60 * 1000,
+    connector: { id: 'scl_1', uid: 'oauth/linear', type: 'oauth' },
   });
 }


### PR DESCRIPTION
## Why

Per-tool authorization can hand a tool a **revoked-but-unexpired** token. The Eve `connect()` adapter trusts the in-process token cache in `getTokenResponse`: it returns any cached token until it's within the expiry buffer. So when a user revokes a grant server-side, the tool keeps running on the stale bearer until the token's natural expiry — Connect is never re-consulted.

## What

- `getTokenResponse` / `ConnectOptions` gain an opt-in `forceRefresh` flag that deletes the cache entry before fetching, so the call re-validates against Connect.
- The Eve `connect()` adapter exposes this as a `validate?: boolean` option. When set, every `getToken` bypasses the cache; a revoked grant comes back as `user_authorization_required`, which the adapter already maps to `ConnectionAuthorizationRequiredError` — so Eve re-runs consent instead of calling the tool with a dead token.
- Default behavior is unchanged (cache still serves unexpired tokens). `validate` is meant for sensitive tools (payments, deletes, privileged writes) where a short revocation window is unacceptable; leave it off for high-frequency reads where the extra Connect round trip isn't worth it.

## Validation

- New unit tests in `packages/connect/test/token.test.ts` cover the cache mechanics: a cached unexpired token is served without re-fetch, `forceRefresh` bypasses the cache, and a revoked grant re-checked with `forceRefresh` surfaces `UserAuthorizationRequiredError` instead of the stale bearer. Existing `revokeToken` tests are preserved.