### PR TITLE
[@vercel/connect] cascade token cache eviction via deleteTokenCacheEntry + connect() evict()

### DIFF
--- a/.changeset/connect-evict-token-cache.md
+++ b/.changeset/connect-evict-token-cache.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add a targeted `deleteTokenCacheEntry(connector, params)` export that drops a single in-process token cache entry, and wire it into the Eve `connect()` adapter as an `evict()` hook. When Eve rejects a resolved bearer (a downstream `401` mapped to `requireAuth()`, or an MCP server rejecting the token) it now cascades invalidation from its own per-step cache down into the Connect adapter's cache, so the next `getToken` performs a genuine refresh instead of re-serving the revoked-but-unexpired token.

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -46,6 +46,7 @@ import type {
 } from '../token.js';
 import {
   ConnectorInstallationRequiredError,
+  deleteTokenCacheEntry,
   getTokenResponse,
   NoValidTokenError,
   UserAuthorizationRequiredError,
@@ -209,6 +210,18 @@ export type EveConnectAuthorizationDefinition<
     | NonInteractiveAuthorizationDefinition,
 > = TAuthorization & {
   readonly vercelConnect: VercelConnectMetadata;
+
+  /**
+   * Drops the in-process Vercel Connect token cache entry for
+   * `principal` so the next `getToken` re-fetches instead of re-serving a
+   * rejected bearer. Eve's runtime calls this from its shared eviction
+   * path when a resolved token is rejected (a downstream `401` mapped to
+   * `requireAuth()`, or an MCP server rejecting the bearer), cascading
+   * invalidation from Eve's per-step cache down into this adapter's cache.
+   */
+  readonly evict: (opts: {
+    readonly principal: ConnectionPrincipal;
+  }) => Promise<void>;
 };
 
 /**
@@ -249,10 +262,28 @@ export function connect(
 > {
   const options = normalizeAuthorizationOptions(input);
   const vercelConnect: VercelConnectMetadata = { connector: options.connector };
+  const evict = makeEvict(options);
   if (options.principalType === 'app') {
-    return { ...buildNonInteractiveDefinition(options), vercelConnect };
+    return { ...buildNonInteractiveDefinition(options), vercelConnect, evict };
   }
-  return { ...buildInteractiveDefinition(options), vercelConnect };
+  return { ...buildInteractiveDefinition(options), vercelConnect, evict };
+}
+
+/**
+ * Builds the {@link EveConnectAuthorizationDefinition.evict} callback for
+ * a connector. Resolves the same token params {@link getToken} uses for
+ * `principal`, then drops exactly that cache entry — leaving every other
+ * principal's cached token intact.
+ */
+function makeEvict(
+  options: EveAuthorizationOptions
+): (opts: { readonly principal: ConnectionPrincipal }) => Promise<void> {
+  return async ({ principal }) => {
+    deleteTokenCacheEntry(
+      options.connector,
+      await buildTokenParams(options, principal)
+    );
+  };
 }
 
 function normalizeAuthorizationOptions(

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  deleteTokenCacheEntry,
   getToken,
   getTokenResponse,
   revokeToken,

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -146,7 +146,7 @@ export async function getTokenResponse(
   options?: ConnectOptions
 ): Promise<ConnectTokenResponse> {
   const bufferMs = params.validityBufferMs ?? DEFAULT_VALIDITY_BUFFER_MS;
-  const cacheKey = JSON.stringify({ connector, ...params });
+  const cacheKey = tokenCacheKey(connector, params);
 
   if (options?.forceRefresh) {
     cache.delete(cacheKey);
@@ -221,6 +221,30 @@ export async function revokeToken(
   cache.clear();
 }
 
+/**
+ * Remove a single cached token entry for `(connector, params)` from the
+ * in-process cache.
+ *
+ * Targeted counterpart to {@link revokeToken}'s `cache.clear()`: it drops
+ * exactly the entry {@link getTokenResponse} would serve for these
+ * arguments, leaving every other connector/principal untouched. Use it
+ * when a credential is known to be bad (the resource server rejected the
+ * bearer with a `401`) so the next {@link getTokenResponse} re-fetches
+ * instead of re-serving the rejected token — without paying for a Connect
+ * round trip on every call the way {@link ConnectOptions.forceRefresh}
+ * does.
+ *
+ * The cache key is derived from `connector` plus every field of `params`,
+ * so pass the same `params` used for the original {@link getTokenResponse}
+ * call. No-op when no matching entry exists.
+ */
+export function deleteTokenCacheEntry(
+  connector: string,
+  params: ConnectTokenParams
+): void {
+  cache.delete(tokenCacheKey(connector, params));
+}
+
 const DEFAULT_VALIDITY_BUFFER_MS = 30_000;
 const MAX_CACHE_SIZE = 100;
 
@@ -230,6 +254,15 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>();
+
+/**
+ * Cache key for a `(connector, params)` pair. Stable across calls with
+ * equal arguments so {@link getTokenResponse} and
+ * {@link deleteTokenCacheEntry} address the same entry.
+ */
+function tokenCacheKey(connector: string, params: ConnectTokenParams): string {
+  return JSON.stringify({ connector, ...params });
+}
 
 function evictLru(): void {
   let oldestKey: string | undefined;

--- a/packages/connect/test/eve/connection-authorization.test.ts
+++ b/packages/connect/test/eve/connection-authorization.test.ts
@@ -1,0 +1,73 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+import type {
+  ConnectionPrincipal,
+  InteractiveAuthorizationDefinition,
+} from 'eve/connections';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { connect } from '../../src/eve/index.js';
+
+vi.mock('@vercel/oidc', () => ({
+  getVercelOidcToken: vi.fn(),
+}));
+
+const PRINCIPAL: ConnectionPrincipal = {
+  type: 'user',
+  id: 'user_evict',
+  issuer: 'https://oidc.vercel.com',
+};
+
+describe('connect() adapter evict', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(getVercelOidcToken).mockResolvedValue('oidc_token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('purges the connector token cache so the next getToken re-fetches', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonTokenResponse('tok_stale'))
+      .mockResolvedValueOnce(jsonTokenResponse('tok_fresh'));
+
+    const definition = connect(
+      'oauth/connection-auth-evict'
+    ) as InteractiveAuthorizationDefinition & {
+      readonly evict: (opts: {
+        readonly principal: ConnectionPrincipal;
+      }) => Promise<void>;
+    };
+
+    const first = await definition.getToken({ principal: PRINCIPAL });
+    // Without eviction this would serve `tok_stale` from the cache.
+    const cached = await definition.getToken({ principal: PRINCIPAL });
+
+    await definition.evict({ principal: PRINCIPAL });
+    const refetched = await definition.getToken({ principal: PRINCIPAL });
+
+    expect(first.token).toBe('tok_stale');
+    expect(cached.token).toBe('tok_stale');
+    expect(refetched.token).toBe('tok_fresh');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+function jsonTokenResponse(token: string): Response {
+  return new Response(
+    JSON.stringify({
+      token,
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      connector: {
+        id: 'scl_evict',
+        uid: 'oauth/connection-auth-evict',
+        type: 'oauth',
+      },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}

--- a/packages/connect/test/token.test.ts
+++ b/packages/connect/test/token.test.ts
@@ -2,6 +2,7 @@ import { getVercelOidcToken } from '@vercel/oidc';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ConnectError,
+  deleteTokenCacheEntry,
   getTokenResponse,
   revokeToken,
   UserAuthorizationRequiredError,
@@ -129,6 +130,29 @@ describe('getTokenResponse cache', () => {
     expect(first.token).toBe('tok_a');
     expect(second.token).toBe('tok_a');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('deleteTokenCacheEntry drops only the matching entry, forcing a re-fetch', async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('tok_evicted_old'))
+      .mockResolvedValueOnce(tokenResponse('tok_other'))
+      .mockResolvedValueOnce(tokenResponse('tok_evicted_new'));
+    const evicted = { subject: { type: 'user' as const, id: 'evicted' } };
+    const other = { subject: { type: 'user' as const, id: 'other' } };
+
+    await getTokenResponse('oauth/linear', evicted);
+    await getTokenResponse('oauth/linear', other);
+
+    deleteTokenCacheEntry('oauth/linear', evicted);
+
+    // The evicted principal re-fetches a fresh token; the untouched
+    // principal still serves from cache (no third fetch for it).
+    const refetched = await getTokenResponse('oauth/linear', evicted);
+    const stillCached = await getTokenResponse('oauth/linear', other);
+
+    expect(refetched.token).toBe('tok_evicted_new');
+    expect(stillCached.token).toBe('tok_other');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it('forceRefresh bypasses the cache and re-fetches', async () => {


### PR DESCRIPTION
## Why

Follow-up to #16578 (revalidate revoked grants). That PR added an opt-in `validate` flag that pays a Connect round trip on **every** `getToken`. This PR adds the cheaper, reactive half of the story: when a credential is already known to be bad — Eve resolved a bearer, the resource server rejected it with a `401` (mapped to `requireAuth()`), or an MCP server rejected it — we should drop exactly that cached token so the *next* call refreshes, without re-validating on the hot path.

The gap today is two independent, stacked caches with no shared invalidation:

- **Eve per-step cache** (short-lived, in the harness)
- **Connect in-process LRU** (`@vercel/connect`)

Eve already evicts its own per-step entry on rejection, but the re-authorization then re-reads the same revoked-but-unexpired token from the Connect LRU below it, so the tool keeps failing. This adds a cascading eviction primitive so invalidation flows from Eve's cache down into Connect's.

## What

- **`deleteTokenCacheEntry(connector, params)`** (new export): targeted counterpart to `revokeToken`'s `cache.clear()` — drops exactly the entry `getTokenResponse` would serve for those args, leaving every other connector/principal untouched. Extracted a shared `tokenCacheKey()` helper so the delete addresses the same key `getTokenResponse` writes.
- **`connect()` adapter `evict()` hook**: every `connect()` definition now carries an `evict({ principal })` that resolves the same token params `getToken` uses and calls `deleteTokenCacheEntry`. Eve's runtime calls this from its shared eviction path (the matching Eve-side change adds an optional `evict?()` to its `AuthorizationDefinition` and is on a stacked PR in `vercel/ash`).

## Validation

- `packages/connect/test/token.test.ts`: new case asserts `deleteTokenCacheEntry` drops only the matching entry (evicted principal re-fetches, untouched principal still serves from cache).
- `packages/connect/test/eve/connection-authorization.test.ts`: new suite asserts `connect().evict({ principal })` purges the connector cache so the next `getToken` re-fetches.
- The Eve-dependent suites (`test/eve/*`) require the optional `eve` peer to be installed to run, which CI provides. Token-layer tests run standalone.

> Note: the cross-repo half lands in `vercel/ash` first (purely additive `evict?()` on `AuthorizationDefinition`, backward compatible); this adapter implements that interface.