### PR TITLE
[CLI] Fix release-binary and update commands

### DIFF
--- a/.changeset/fix-darwin-arm64-binary-strip.md
+++ b/.changeset/fix-darwin-arm64-binary-strip.md
@@ -1,0 +1,10 @@
+---
+'vercel': patch
+---
+
+Fix the darwin-arm64 native CLI binary crashing with SIGSEGV on most commands. The custom Node
+runtime was stripped with bare `strip`, which removes the exported `napi_*` symbols that native
+addons (`@napi-rs/keyring`) bind against at dlopen time. The runtime is now stripped with
+`strip -SXx`, which keeps exported symbols. Also makes the `@vercel/vc-native` bin shim launch
+the platform binary directly when the postinstall script did not run (pnpm blocks dependency
+build scripts by default), instead of always failing.

--- a/.changeset/fix-native-upgrade-enoent.md
+++ b/.changeset/fix-native-upgrade-enoent.md
@@ -1,0 +1,8 @@
+---
+'vercel': patch
+---
+
+Fix `vercel upgrade` crashing with `ENOENT: no such file or directory, realpath '…/.pkg-staging/pkg.js'`
+in the native binary. The command tried to `realpath` `process.argv[1]`, which points into the binary's
+virtual filesystem snapshot. Native installs now detect the package manager (npm, pnpm, or yarn) from
+the binary's real install location and suggest the matching global upgrade command.

--- a/packages/cli/scripts/build-binary-node.mjs
+++ b/packages/cli/scripts/build-binary-node.mjs
@@ -122,17 +122,17 @@ async function stripAndSignNode() {
     return false;
   }
 
-  const shouldStrip = !(nodePlatform === 'darwin' && nodeArch === 'x64');
-
-  if (shouldStrip) {
+  if (nodePlatform === 'darwin') {
+    // Bare `strip` removes the exported napi_* symbols that native addons
+    // bind against at dlopen time, crashing with SIGSEGV. `-SXx` keeps
+    // global symbols while still removing debug and local symbols.
+    await run('strip', ['-SXx', outputNode], packageRoot);
+    await run('codesign', ['-f', '--sign', '-', outputNode], packageRoot);
+  } else {
     await run('strip', [outputNode], packageRoot);
   }
 
-  if (nodePlatform === 'darwin') {
-    await run('codesign', ['-f', '--sign', '-', outputNode], packageRoot);
-  }
-
-  return shouldStrip;
+  return true;
 }
 
 function configureFlags() {

--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -86,6 +86,21 @@ export default async function getUpdateCommand(): Promise<string> {
   const nativeInstall = isNativeBinaryInstall();
   const pkgAndVersion = `${nativeInstall ? nativePackageName : packageName}@latest`;
 
+  if (nativeInstall) {
+    // The native binary's process.argv[1] points into its virtual filesystem
+    // snapshot, so detect the package manager from the real install location.
+    const segments = process.execPath.split(sep);
+    let cliType: 'npm' | 'pnpm' | 'yarn' = 'npm';
+    if (segments.includes('pnpm') || segments.includes('.pnpm')) {
+      cliType = 'pnpm';
+    } else if (segments.includes('yarn') || segments.includes('.yarn')) {
+      cliType = 'yarn';
+    }
+    const install = cliType === 'yarn' ? 'global add' : 'i -g';
+    const force = cliType === 'npm' ? ' --force' : '';
+    return `${cliType} ${install} ${pkgAndVersion}${force}`;
+  }
+
   const entrypoint = await realpath(process.argv[1]);
   let { cliType, lockfilePath } = await scanParentDirs(
     dirname(dirname(entrypoint))

--- a/packages/cli/test/unit/util/get-update-command.test.ts
+++ b/packages/cli/test/unit/util/get-update-command.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { sep } from 'path';
 import getUpdateCommand, {
   isGlobal,
 } from '../../../src/util/get-update-command';
@@ -32,5 +33,56 @@ describe('getUpdateCommand', () => {
 
     expect(updateCommand).toContain('@vercel/vc-native@latest');
     expect(updateCommand.split(' ')).not.toContain('vercel@latest');
+  });
+
+  describe('native install package manager detection', () => {
+    const originalExecPath = process.execPath;
+
+    afterEach(() => {
+      Object.defineProperty(process, 'execPath', {
+        value: originalExecPath,
+        configurable: true,
+      });
+    });
+
+    function setExecPath(value: string) {
+      Object.defineProperty(process, 'execPath', {
+        value: value.split('/').join(sep),
+        configurable: true,
+      });
+    }
+
+    it('should suggest pnpm when the binary is installed via pnpm', async () => {
+      process.env.VERCEL_VC_NATIVE = '1';
+      setExecPath(
+        '/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/@vercel+vc-native-linux-x64@1.0.0/node_modules/@vercel/vc-native-linux-x64/bin/vercel'
+      );
+
+      expect(await getUpdateCommand()).toEqual(
+        'pnpm i -g @vercel/vc-native@latest'
+      );
+    });
+
+    it('should suggest npm with --force otherwise', async () => {
+      process.env.VERCEL_VC_NATIVE = '1';
+      setExecPath(
+        '/usr/local/lib/node_modules/@vercel/vc-native/bin/vercel.exe'
+      );
+
+      expect(await getUpdateCommand()).toEqual(
+        'npm i -g @vercel/vc-native@latest --force'
+      );
+    });
+
+    it('should suggest yarn when the binary is installed via yarn', async () => {
+      process.env.VERCEL_VC_NATIVE = '1';
+      setExecPath(
+        '/home/user/.config/yarn/global/node_modules/@vercel/vc-native/bin/vercel.exe'
+      );
+
+      expect(await getUpdateCommand()).toEqual(
+        'yarn global add @vercel/vc-native@latest'
+      );
+    });
   });
 });

--- a/packages/vc-native/bin/vercel
+++ b/packages/vc-native/bin/vercel
@@ -1,6 +1,41 @@
 #!/usr/bin/env node
 
-console.error(
-  'The native Vercel CLI binary was not installed. Try reinstalling with `npm i -g @vercel/vc-native --force`.'
-);
-process.exit(1);
+// Fallback launcher used when postinstall did not replace this file with the
+// native binary (e.g. pnpm blocks dependency build scripts by default).
+// It resolves the platform package at runtime and forwards to its binary.
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const packageName = `@vercel/vc-native-${process.platform}-${process.arch}`;
+const binaryName = process.platform === 'win32' ? 'vercel.exe' : 'vercel';
+
+let binaryPath;
+try {
+  binaryPath = path.join(
+    path.dirname(require.resolve(`${packageName}/package.json`)),
+    'bin',
+    binaryName
+  );
+} catch {
+  console.error(
+    `The native Vercel CLI binary was not installed. Try manually installing "${packageName}", or reinstall with \`npm i -g @vercel/vc-native --force\`.`
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), {
+  stdio: 'inherit',
+  windowsHide: true,
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(result.status ?? 1);

--- a/packages/vc-native/test/shim.test.mjs
+++ b/packages/vc-native/test/shim.test.mjs
@@ -84,4 +84,67 @@ describe('@vercel/vc-native shim', () => {
       expect(stdout.trim()).toBe('native shim ok:arg-one,arg-two');
     }
   });
+
+  test('bin launcher falls back to the platform package binary when postinstall did not run', async () => {
+    const packageName = packageNames[process.platform]?.[process.arch];
+    if (!packageName || process.platform === 'win32') {
+      return;
+    }
+
+    const root = mkdtempSync(join(tmpdir(), 'vc-native-launcher-'));
+    const wrapperDir = join(root, 'node_modules', '@vercel', 'vc-native');
+    const platformDir = join(root, 'node_modules', ...packageName.split('/'));
+
+    await mkdir(join(wrapperDir, 'bin'), { recursive: true });
+    await mkdir(join(platformDir, 'bin'), { recursive: true });
+    await copyFile(
+      join(packageRoot, 'bin', 'vercel'),
+      join(wrapperDir, 'bin', 'vercel.exe')
+    );
+    await writeFile(
+      join(platformDir, 'package.json'),
+      JSON.stringify({ name: packageName })
+    );
+
+    const binaryPath = join(platformDir, 'bin', 'vercel');
+    await writeFile(
+      binaryPath,
+      '#!/usr/bin/env node\nconsole.log("native launcher ok:" + process.argv.slice(2).join(","));\nprocess.exit(7);\n'
+    );
+    await chmod(binaryPath, 0o755);
+
+    const launcher = join(wrapperDir, 'bin', 'vercel.exe');
+    await chmod(launcher, 0o755);
+    const result = await execFileAsync(process.execPath, [
+      launcher,
+      'arg-one',
+      'arg-two',
+    ]).catch(error => error);
+
+    expect(result.stdout.trim()).toBe('native launcher ok:arg-one,arg-two');
+    expect(result.code).toBe(7);
+  });
+
+  test('bin launcher reports a missing platform package', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const root = mkdtempSync(join(tmpdir(), 'vc-native-launcher-missing-'));
+    const wrapperDir = join(root, 'node_modules', '@vercel', 'vc-native');
+    await mkdir(join(wrapperDir, 'bin'), { recursive: true });
+    await copyFile(
+      join(packageRoot, 'bin', 'vercel'),
+      join(wrapperDir, 'bin', 'vercel.exe')
+    );
+
+    const result = await execFileAsync(process.execPath, [
+      join(wrapperDir, 'bin', 'vercel.exe'),
+    ]).catch(error => error);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(
+      'The native Vercel CLI binary was not installed'
+    );
+  });
 });


### PR DESCRIPTION
This PR fixes the `release-binary.yml` file for the current darwin64 release.
Additionally this persists a fix for the update feature on the binary version of the CLI