### PR TITLE
fix(build-utils): evaluate maxDuration limit at validation time

### DIFF
--- a/.changeset/cli-skip-max-duration-runtime-eval.md
+++ b/.changeset/cli-skip-max-duration-runtime-eval.md
@@ -1,0 +1,10 @@
+---
+'@vercel/build-utils': minor
+'vercel': patch
+---
+
+Evaluate the `maxDuration` upper bound at validation time so `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` works regardless of import order.
+
+The gate was read when `@vercel/build-utils`' `functionsSchema` was constructed and when the CLI compiled its `vercel.json` validator — both at module load. Any process that imports these modules before setting the env var baked in the default 900-second maximum and ignored the flag, failing with `Invalid vercel.json - functions[...].maxDuration should be <= 900`.
+
+`@vercel/build-utils` now exposes `getFunctionsSchema()`, which reads the limit at call time (the existing `functionsSchema` const is kept but deprecated). The CLI builds and compiles its config validator lazily, caching one validator per resolved limit, so setting the variable after import takes effect. Default behavior is unchanged — the 900s maximum, the lower bound, and the integer check are all still enforced when the variable is unset.

--- a/packages/build-utils/src/max-duration.ts
+++ b/packages/build-utils/src/max-duration.ts
@@ -19,6 +19,14 @@ export const DEFAULT_MAX_DURATION_LIMIT = 900;
  */
 export const SKIP_MAX_DURATION_LIMIT_ENV = 'VERCEL_CLI_SKIP_MAX_DURATION_LIMIT';
 
+// TODO: Once `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` is fully rolled out and the
+// server-side limit is authoritative for everyone, drop the client-side upper
+// bound entirely: remove this env var, `getMaxDurationLimit`, the `maximum`
+// branch of `getMaxDurationSchema`, and the lazy per-limit validator machinery
+// in the CLI (`packages/cli/src/util/validate-config.ts`). The `vercel.json`
+// schema can then be compiled once again with no `maxDuration` maximum, and the
+// lower-bound/integer checks become the only client-side validation.
+
 /**
  * Returns the client-side upper bound for `maxDuration` in seconds, or
  * `undefined` when the bound is skipped via {@link SKIP_MAX_DURATION_LIMIT_ENV}

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -72,7 +72,7 @@ const triggerEventSchema = {
   oneOf: [triggerEventSchemaV1, triggerEventSchemaV2],
 };
 
-export const functionsSchema = {
+export const getFunctionsSchema = () => ({
   type: 'object',
   minProperties: 1,
   maxProperties: 50,
@@ -125,7 +125,15 @@ export const functionsSchema = {
       },
     },
   },
-};
+});
+
+/**
+ * @deprecated Evaluated once at module load, so it does not reflect
+ * `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` when the variable is set after this
+ * module is first imported. Prefer {@link getFunctionsSchema}, which reads the
+ * limit at call time.
+ */
+export const functionsSchema = getFunctionsSchema();
 
 export const buildsSchema = {
   type: 'array',

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -9,8 +9,9 @@ import {
 } from '@vercel/routing-utils';
 import type { VercelConfig } from './dev/types';
 import {
-  functionsSchema,
+  getFunctionsSchema,
   buildsSchema,
+  getMaxDurationLimit,
   getMaxDurationSchema,
   NowBuildError,
   getPrettyError,
@@ -252,7 +253,7 @@ const envVarNamesSchema = {
   maxLength: 256,
 };
 
-const experimentalServicesCommonProperties = {
+const getExperimentalServicesCommonProperties = () => ({
   entrypoint: {
     type: 'string',
     minLength: 1,
@@ -322,7 +323,7 @@ const experimentalServicesCommonProperties = {
       },
     ],
   },
-};
+});
 
 const experimentalServicesRoutableProperties = {
   mount: experimentalServicesMountSchema,
@@ -338,13 +339,13 @@ const experimentalServicesRoutableProperties = {
   },
 };
 
-const experimentalServicesServiceConfigSchema = {
+const getExperimentalServicesServiceConfigSchema = () => ({
   oneOf: [
     {
       type: 'object',
       additionalProperties: false,
       properties: {
-        ...experimentalServicesCommonProperties,
+        ...getExperimentalServicesCommonProperties(),
         ...experimentalServicesRoutableProperties,
         type: {
           enum: ['web'],
@@ -356,7 +357,7 @@ const experimentalServicesServiceConfigSchema = {
       additionalProperties: false,
       required: ['type', 'trigger', 'schedule'],
       properties: {
-        ...experimentalServicesCommonProperties,
+        ...getExperimentalServicesCommonProperties(),
         type: {
           const: 'job',
         },
@@ -371,7 +372,7 @@ const experimentalServicesServiceConfigSchema = {
       additionalProperties: false,
       required: ['type', 'trigger', 'topics'],
       properties: {
-        ...experimentalServicesCommonProperties,
+        ...getExperimentalServicesCommonProperties(),
         type: {
           const: 'job',
         },
@@ -391,7 +392,7 @@ const experimentalServicesServiceConfigSchema = {
       additionalProperties: false,
       required: ['type', 'trigger', 'entrypoint'],
       properties: {
-        ...experimentalServicesCommonProperties,
+        ...getExperimentalServicesCommonProperties(),
         type: {
           const: 'job',
         },
@@ -405,7 +406,7 @@ const experimentalServicesServiceConfigSchema = {
       additionalProperties: false,
       required: ['type'],
       properties: {
-        ...experimentalServicesCommonProperties,
+        ...getExperimentalServicesCommonProperties(),
         type: {
           const: 'worker',
         },
@@ -430,7 +431,7 @@ const experimentalServicesServiceConfigSchema = {
       additionalProperties: false,
       required: ['type', 'schedule'],
       properties: {
-        ...experimentalServicesCommonProperties,
+        ...getExperimentalServicesCommonProperties(),
         type: {
           const: 'cron',
         },
@@ -438,21 +439,21 @@ const experimentalServicesServiceConfigSchema = {
       },
     },
   ],
-};
+});
 
 /**
  * Schema for experimental services configuration.
  * Map of service name to service configuration.
  * @experimental This feature is experimental and may change.
  */
-const experimentalServicesSchema = {
+const getExperimentalServicesSchema = () => ({
   type: 'object',
   propertyNames: {
     pattern: '^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$',
     maxLength: 64,
   },
-  additionalProperties: experimentalServicesServiceConfigSchema,
-};
+  additionalProperties: getExperimentalServicesServiceConfigSchema(),
+});
 
 /**
  * Schema for experimental service groups configuration.
@@ -514,7 +515,7 @@ const experimentalServicesV2BindingsSchema = {
   items: experimentalServicesV2BindingSchema,
 };
 
-const experimentalServicesV2ServiceConfigSchema = {
+const getExperimentalServicesV2ServiceConfigSchema = () => ({
   type: 'object',
   additionalProperties: false,
   required: ['root'],
@@ -537,7 +538,7 @@ const experimentalServicesV2ServiceConfigSchema = {
     ignoreCommand: experimentalServicesV2CommandSchema,
     outputDirectory: experimentalServicesV2PathSchema,
     bindings: experimentalServicesV2BindingsSchema,
-    functions: functionsSchema,
+    functions: getFunctionsSchema(),
     headers: headersSchema,
     redirects: redirectsSchema,
     rewrites: rewritesSchema,
@@ -545,44 +546,74 @@ const experimentalServicesV2ServiceConfigSchema = {
     cleanUrls: cleanUrlsSchema,
     trailingSlash: trailingSlashSchema,
   },
-};
+});
 
-const experimentalServicesV2Schema = {
+const getExperimentalServicesV2Schema = () => ({
   type: 'object',
   propertyNames: {
     pattern: '^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$',
     maxLength: 64,
   },
-  additionalProperties: experimentalServicesV2ServiceConfigSchema,
-};
+  additionalProperties: getExperimentalServicesV2ServiceConfigSchema(),
+});
 
-const vercelConfigSchema = {
-  type: 'object',
-  // These are not all possibilities because `vc dev`
-  // doesn't need to know about `regions`, `public`, etc.
-  additionalProperties: true,
-  properties: {
-    builds: buildsSchema,
-    routes: routesSchema,
-    cleanUrls: cleanUrlsSchema,
-    headers: headersSchema,
-    redirects: redirectsSchema,
-    rewrites: rewritesSchema,
-    trailingSlash: trailingSlashSchema,
-    functions: functionsSchema,
-    images: imagesSchema,
-    crons: cronsSchema,
-    bunVersion: { type: 'string' },
-    experimentalServices: experimentalServicesSchema,
-    experimentalServiceGroups: experimentalServiceGroupsSchema,
-    experimentalServicesV2: experimentalServicesV2Schema,
-  },
-};
+function buildVercelConfigSchema() {
+  return {
+    type: 'object',
+    // These are not all possibilities because `vc dev`
+    // doesn't need to know about `regions`, `public`, etc.
+    additionalProperties: true,
+    properties: {
+      builds: buildsSchema,
+      routes: routesSchema,
+      cleanUrls: cleanUrlsSchema,
+      headers: headersSchema,
+      redirects: redirectsSchema,
+      rewrites: rewritesSchema,
+      trailingSlash: trailingSlashSchema,
+      functions: getFunctionsSchema(),
+      images: imagesSchema,
+      crons: cronsSchema,
+      bunVersion: { type: 'string' },
+      experimentalServices: getExperimentalServicesSchema(),
+      experimentalServiceGroups: experimentalServiceGroupsSchema,
+      experimentalServicesV2: getExperimentalServicesV2Schema(),
+    },
+  };
+}
 
 const ajv = new Ajv();
-const validate = ajv.compile(vercelConfigSchema);
+
+/**
+ * The `maxDuration` upper bound is gated behind
+ * `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` (see `getMaxDurationSchema`), which may be
+ * set after this module is imported. Compiling the validator once at module load
+ * would bake in whatever limit was active at import time and ignore the variable,
+ * so instead we build and compile lazily, caching one validator per resolved
+ * limit (bounded vs. skipped).
+ *
+ * TODO: This machinery exists only to honor the runtime
+ * `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` toggle. Once the flag is fully rolled out
+ * and the client-side bound is dropped (see `max-duration.ts` in
+ * `@vercel/build-utils`), revert to a single statically compiled validator.
+ */
+const validatorCacheByLimit = new Map<
+  number | 'skipped',
+  ReturnType<typeof ajv.compile>
+>();
+
+function getConfigValidator() {
+  const cacheKey = getMaxDurationLimit() ?? 'skipped';
+  let validate = validatorCacheByLimit.get(cacheKey);
+  if (!validate) {
+    validate = ajv.compile(buildVercelConfigSchema());
+    validatorCacheByLimit.set(cacheKey, validate);
+  }
+  return validate;
+}
 
 export function validateConfig(config: VercelConfig): NowBuildError | null {
+  const validate = getConfigValidator();
   if (!validate(config)) {
     if (validate.errors && validate.errors[0]) {
       const error = validate.errors[0];

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { validateConfig } from '../../../../src/util/validate-config';
 
 describe('validateConfig', () => {
@@ -226,6 +226,48 @@ describe('validateConfig', () => {
     } as unknown as Parameters<typeof validateConfig>[0];
     const error = validateConfig(config);
     expect(error).toBeNull();
+  });
+
+  // Regression test for honoring the env var when it is set *after* this module
+  // is imported: `validateConfig` (and therefore `@vercel/build-utils`' functions
+  // schema) is imported at the top of this file, before the env var below is ever
+  // set. The gate must still take effect, which only works if the validator reads
+  // the env var at validation time instead of baking the bound in at module load.
+  describe('VERCEL_CLI_SKIP_MAX_DURATION_LIMIT', () => {
+    const ENV = 'VERCEL_CLI_SKIP_MAX_DURATION_LIMIT';
+
+    afterEach(() => {
+      delete process.env[ENV];
+    });
+
+    const configWith = (maxDuration: number) =>
+      ({ functions: { 'api/*.js': { maxDuration } } }) satisfies Parameters<
+        typeof validateConfig
+      >[0];
+
+    it('rejects maxDuration above the default 900s bound when unset', () => {
+      const error = validateConfig(configWith(1800));
+      expect(error).not.toBeNull();
+      expect(error?.message).toMatch(/900/);
+    });
+
+    it('allows maxDuration above 900s when set to "1" (defers to the server)', () => {
+      process.env[ENV] = '1';
+      expect(validateConfig(configWith(1800))).toBeNull();
+    });
+
+    it('still enforces the lower bound and integer check when skipped', () => {
+      process.env[ENV] = '1';
+      expect(validateConfig(configWith(0))).not.toBeNull();
+      expect(validateConfig(configWith(1.5))).not.toBeNull();
+    });
+
+    it('re-applies the 900s bound once the variable is unset again', () => {
+      process.env[ENV] = '1';
+      expect(validateConfig(configWith(1800))).toBeNull();
+      delete process.env[ENV];
+      expect(validateConfig(configWith(1800))).not.toBeNull();
+    });
   });
 
   it('should not error with experimentalServices mount config', async () => {


### PR DESCRIPTION
## What

`#16539` added `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` to skip the client-side 900s `maxDuration` upper bound and defer to server-side validation. The flag works for a normal `vercel build` invocation, but it is silently ignored when the relevant modules are imported *before* the variable is set — in that case deploys still fail with:

```
Invalid vercel.json - functions[...].maxDuration should be <= 900
```

even though the variable is set to `1`.

## Why

The bound was resolved at **module-load time** in two places:

- `@vercel/build-utils` built `functionsSchema` (`maxDuration: getMaxDurationSchema()`) as a module-level `const`.
- The CLI compiled its `vercel.json` validator once at import (`ajv.compile(...)`).

Both captured whatever `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` was at import time, so any process that imports these modules and sets the variable afterward keeps the default 900s maximum.

## How

- `@vercel/build-utils` now exposes `getFunctionsSchema()`, which evaluates the bound when called. The existing `functionsSchema` const is retained but deprecated (it still reflects import-time state).
- The CLI builds and compiles its config validator lazily, caching one compiled validator per resolved limit (bounded vs. skipped), so the variable is honored whenever it is set.

Default behavior is unchanged: when the variable is unset, the 900s maximum, the lower bound, and the integer check are all still enforced.

Both spots carry a `TODO` to remove this machinery once `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` is fully rolled out — at which point the client-side `maxDuration` bound is dropped entirely and the schema can be statically compiled again.

## Testing

- New regression tests in `validate-config` import the module first and set the variable afterward, asserting the bound is honored at validation time.
- Existing `build-utils`, `fs-detectors`, and CLI `validate-config` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)