### PR TITLE
[build-utils][next] Add `hasFallback`, `htmlSize`, `isDynamicRoute` to Prerender

### DIFF
--- a/.changeset/ppr-shell-metadata.md
+++ b/.changeset/ppr-shell-metadata.md
@@ -1,0 +1,12 @@
+---
+'@vercel/build-utils': minor
+'@vercel/next': minor
+---
+
+Add `hasFallback`, `htmlSize`, and `isDynamicRoute` to `Prerender`
+
+These optional fields surface per-route PPR shell metadata in the Build Output so consumers can classify prerenders (e.g. full shell vs. empty shell vs. concrete prerender):
+
+- `hasFallback` — whether a dynamic route template had a static fallback (`undefined` for concrete prerenders)
+- `htmlSize` — byte size of the prerendered `.html` shell (`0` for an empty shell, `undefined` when there's no `.html`)
+- `isDynamicRoute` — whether the entry came from a dynamic route template rather than a concrete prerender

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -20,6 +20,9 @@ interface PrerenderOptions {
   exposeErrBody?: boolean;
   partialFallback?: boolean;
   hasPostponed?: boolean;
+  hasFallback?: boolean;
+  htmlSize?: number;
+  isDynamicRoute?: boolean;
 }
 
 export class Prerender {
@@ -57,6 +60,25 @@ export class Prerender {
    * not provide the signal.
    */
   public hasPostponed?: boolean;
+  /**
+   * `true` when the route's dynamic template had a static fallback page (the
+   * prerender-manifest `fallback` was a string). `false` for blocking/omitted
+   * dynamic templates (manifest `fallback` was `null`/`false`). `undefined` for
+   * concrete prerenders, where the notion of a fallback doesn't apply.
+   */
+  public hasFallback?: boolean;
+  /**
+   * Byte size on disk of the route's prerendered `.html` shell. `0` for an
+   * empty shell (PPR template that postponed everything). `undefined` when
+   * there's no `.html` on disk (pages router, route handlers, edge).
+   */
+  public htmlSize?: number;
+  /**
+   * `true` when this entry came from a dynamic route template (the
+   * prerender-manifest `dynamicRoutes` section: fallback, blocking, or omitted)
+   * rather than a concrete prerender.
+   */
+  public isDynamicRoute?: boolean;
 
   constructor({
     expiration,
@@ -77,6 +99,9 @@ export class Prerender {
     exposeErrBody,
     partialFallback,
     hasPostponed,
+    hasFallback,
+    htmlSize,
+    isDynamicRoute,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
@@ -92,6 +117,34 @@ export class Prerender {
       );
     }
     this.hasPostponed = hasPostponed;
+
+    // Assigned unconditionally (like `hasPostponed`) so the tri-state
+    // (`true` | `false` | `undefined`) round-trips intact. `false` (blocking /
+    // omitted template) must stay distinct from `undefined` (concrete
+    // prerender, no fallback concept).
+    if (hasFallback !== undefined && typeof hasFallback !== 'boolean') {
+      throw new Error(
+        'The `hasFallback` argument for `Prerender` must be a boolean or undefined.'
+      );
+    }
+    this.hasFallback = hasFallback;
+
+    if (
+      htmlSize !== undefined &&
+      (!Number.isInteger(htmlSize) || htmlSize < 0)
+    ) {
+      throw new Error(
+        'The `htmlSize` argument for `Prerender` must be a non-negative integer or undefined.'
+      );
+    }
+    this.htmlSize = htmlSize;
+
+    if (isDynamicRoute !== undefined && typeof isDynamicRoute !== 'boolean') {
+      throw new Error(
+        'The `isDynamicRoute` argument for `Prerender` must be a boolean or undefined.'
+      );
+    }
+    this.isDynamicRoute = isDynamicRoute;
 
     this.lambda = lambda;
     if (this.lambda) {

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -1,6 +1,17 @@
 import type { File, HasField, Chain } from './types';
 import { Lambda } from './lambda';
 
+function assertOptionalBoolean(
+  value: unknown,
+  name: string
+): asserts value is boolean | undefined {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new Error(
+      `The \`${name}\` argument for \`Prerender\` must be a boolean or undefined.`
+    );
+  }
+}
+
 interface PrerenderOptions {
   expiration: number | false;
   staleExpiration?: number;
@@ -107,27 +118,20 @@ export class Prerender {
     this.expiration = expiration;
     this.staleExpiration = staleExpiration;
     this.sourcePath = sourcePath;
-    // Assigned unconditionally (like `staleExpiration`) so the tri-state
-    // (`true` | `false` | `undefined`) round-trips intact. Do not adopt the
-    // `partialFallback`/`exposeErrBody` idiom below, which collapses `false`
-    // into `undefined`.
-    if (hasPostponed !== undefined && typeof hasPostponed !== 'boolean') {
-      throw new Error(
-        'The `hasPostponed` argument for `Prerender` must be a boolean or undefined.'
-      );
-    }
+    // These tri-state flags are assigned unconditionally (like
+    // `staleExpiration`) so `true` | `false` | `undefined` round-trips intact.
+    // Do not adopt the `partialFallback`/`exposeErrBody` idiom below, which
+    // collapses `false` into `undefined`: for `hasFallback`, `false` (blocking
+    // / omitted template) must stay distinct from `undefined` (concrete
+    // prerender, no fallback concept).
+    assertOptionalBoolean(hasPostponed, 'hasPostponed');
     this.hasPostponed = hasPostponed;
 
-    // Assigned unconditionally (like `hasPostponed`) so the tri-state
-    // (`true` | `false` | `undefined`) round-trips intact. `false` (blocking /
-    // omitted template) must stay distinct from `undefined` (concrete
-    // prerender, no fallback concept).
-    if (hasFallback !== undefined && typeof hasFallback !== 'boolean') {
-      throw new Error(
-        'The `hasFallback` argument for `Prerender` must be a boolean or undefined.'
-      );
-    }
+    assertOptionalBoolean(hasFallback, 'hasFallback');
     this.hasFallback = hasFallback;
+
+    assertOptionalBoolean(isDynamicRoute, 'isDynamicRoute');
+    this.isDynamicRoute = isDynamicRoute;
 
     if (
       htmlSize !== undefined &&
@@ -138,13 +142,6 @@ export class Prerender {
       );
     }
     this.htmlSize = htmlSize;
-
-    if (isDynamicRoute !== undefined && typeof isDynamicRoute !== 'boolean') {
-      throw new Error(
-        'The `isDynamicRoute` argument for `Prerender` must be a boolean or undefined.'
-      );
-    }
-    this.isDynamicRoute = isDynamicRoute;
 
     this.lambda = lambda;
     if (this.lambda) {

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -595,6 +595,143 @@ it('should round-trip hasPostponed as a tri-state', async () => {
   ).toThrow('The `hasPostponed` argument for `Prerender` must be a boolean');
 });
 
+it('should round-trip hasFallback as a tri-state', async () => {
+  // Like `hasPostponed`, the api repo needs to tell `false` (blocking/omitted
+  // template, no fallback) apart from `undefined` (concrete prerender, the
+  // concept doesn't apply), so `false` must NOT collapse to `undefined`.
+  const withFallback = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    hasFallback: true,
+  });
+  expect(withFallback.hasFallback).toBe(true);
+
+  const noFallback = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    hasFallback: false,
+  });
+  expect(noFallback.hasFallback).toBe(false);
+
+  const concrete = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+  });
+  expect(concrete.hasFallback).toBeUndefined();
+
+  expect(
+    () =>
+      new Prerender({
+        expiration: 1,
+        fallback: null,
+        group: 1,
+        bypassToken: 'some-long-bypass-token-to-make-it-work',
+        // @ts-expect-error - intentionally invalid to assert validation
+        hasFallback: 'yes',
+      })
+  ).toThrow('The `hasFallback` argument for `Prerender` must be a boolean');
+});
+
+it('should round-trip isDynamicRoute as a tri-state', async () => {
+  const dynamic = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    isDynamicRoute: true,
+  });
+  expect(dynamic.isDynamicRoute).toBe(true);
+
+  const concrete = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    isDynamicRoute: false,
+  });
+  expect(concrete.isDynamicRoute).toBe(false);
+
+  const unset = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+  });
+  expect(unset.isDynamicRoute).toBeUndefined();
+
+  expect(
+    () =>
+      new Prerender({
+        expiration: 1,
+        fallback: null,
+        group: 1,
+        bypassToken: 'some-long-bypass-token-to-make-it-work',
+        // @ts-expect-error - intentionally invalid to assert validation
+        isDynamicRoute: 'yes',
+      })
+  ).toThrow('The `isDynamicRoute` argument for `Prerender` must be a boolean');
+});
+
+it('should validate htmlSize as a non-negative integer', async () => {
+  const emptyShell = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    htmlSize: 0,
+  });
+  expect(emptyShell.htmlSize).toBe(0);
+
+  const fullShell = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    htmlSize: 5491,
+  });
+  expect(fullShell.htmlSize).toBe(5491);
+
+  const noHtml = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+  });
+  expect(noHtml.htmlSize).toBeUndefined();
+
+  expect(
+    () =>
+      new Prerender({
+        expiration: 1,
+        fallback: null,
+        group: 1,
+        bypassToken: 'some-long-bypass-token-to-make-it-work',
+        htmlSize: -1,
+      })
+  ).toThrow(
+    'The `htmlSize` argument for `Prerender` must be a non-negative integer'
+  );
+
+  expect(
+    () =>
+      new Prerender({
+        expiration: 1,
+        fallback: null,
+        group: 1,
+        bypassToken: 'some-long-bypass-token-to-make-it-work',
+        htmlSize: 1.5,
+      })
+  ).toThrow(
+    'The `htmlSize` argument for `Prerender` must be a non-negative integer'
+  );
+});
+
 it('should support passQuery correctly', async () => {
   new Prerender({
     expiration: 1,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2503,6 +2503,25 @@ export const onPrerenderRoute =
       });
     }
 
+    // `fallbackRoutes` ∪ `blockingFallbackRoutes` ∪ `omittedRoutes` is exactly
+    // the prerender-manifest `dynamicRoutes` section, so these flags let us
+    // surface dynamic-template facts on the resulting `Prerender` outputs
+    // without re-reading the manifest:
+    //   - `isDynamicRoute`: this entry came from a dynamic template rather than
+    //     a concrete prerender.
+    //   - `hasFallback`: the template had a static fallback (`isFallback`),
+    //     `false` for blocking/omitted templates, `undefined` for concrete
+    //     prerenders where the concept doesn't apply.
+    // Named to avoid shadowing the imported `isDynamicRoute` helper used
+    // elsewhere in this function.
+    const routeIsDynamic = Boolean(isFallback || isBlocking || isOmitted);
+    let hasFallback: boolean | undefined;
+    if (isFallback) {
+      hasFallback = true;
+    } else if (isBlocking || isOmitted) {
+      hasFallback = false;
+    }
+
     // Get the route file as it'd be mounted in the builder output
     let routeFileNoExt = routeKey === '/' ? '/index' : routeKey;
     let origRouteFileNoExt = routeFileNoExt;
@@ -2643,6 +2662,23 @@ export const onPrerenderRoute =
 
     const isOmittedOrNotFound = isOmitted || isNotFound;
     let htmlFallbackFsRef: File | null = null;
+
+    // Byte size of the prerendered `.html` shell on disk, surfaced on the HTML
+    // `Prerender` below. Computed independently of the PPR/postpone branch so
+    // it covers all app routes (incl. blocking templates whose shell is 0
+    // bytes). A bare `statSync` in a try/catch is one syscall — `existsSync`
+    // would add a redundant `stat` — and naturally yields `undefined` when
+    // there's no `.html` (pages router, route handlers, edge).
+    let htmlSize: number | undefined;
+    if (appDir) {
+      try {
+        htmlSize = fs.statSync(
+          path.join(appDir, `${routeFileNoExt}.html`)
+        ).size;
+      } catch {
+        // No `.html` on disk for this route; leave `htmlSize` undefined.
+      }
+    }
 
     // If enabled, try to get the postponed route information from the file
     // system and use it to assemble the prerender.
@@ -3117,6 +3153,9 @@ export const onPrerenderRoute =
           allowHeader,
           partialFallback: partialFallback || undefined,
           hasPostponed,
+          hasFallback,
+          htmlSize,
+          isDynamicRoute: routeIsDynamic,
 
           ...(isNotFound
             ? {
@@ -3168,6 +3207,8 @@ export const onPrerenderRoute =
           allowHeader,
           partialFallback: undefined,
           hasPostponed,
+          hasFallback,
+          isDynamicRoute: routeIsDynamic,
 
           ...(isNotFound
             ? {
@@ -3274,6 +3315,8 @@ export const onPrerenderRoute =
               allowHeader,
               partialFallback: undefined,
               hasPostponed,
+              hasFallback,
+              isDynamicRoute: routeIsDynamic,
               chain: {
                 outputPath: normalizePathData(outputPathData),
                 headers: routesManifest.ppr.chain.headers,
@@ -3403,6 +3446,8 @@ export const onPrerenderRoute =
                 allowHeader,
                 partialFallback: undefined,
                 hasPostponed,
+                hasFallback,
+                isDynamicRoute: routeIsDynamic,
 
                 // These routes are always only static, so they should not
                 // permit any bypass unless it's for preview

--- a/packages/next/test/integration/segment-cache-cc.test.js
+++ b/packages/next/test/integration/segment-cache-cc.test.js
@@ -83,6 +83,58 @@ describe('clientSegmentCache prerender headers', () => {
       prerender('_next/data/' + buildId(output) + '/legacy.json').hasPostponed
     ).toBeUndefined();
   });
+
+  it('should surface hasFallback, htmlSize and isDynamicRoute on Prerender outputs', async () => {
+    const fixturePath = path.join(__dirname, 'segment-cache-cc');
+
+    const {
+      buildResult: { output },
+    } = await runBuildLambda(fixturePath);
+
+    const prerender = key => {
+      expect(output[key], `expected output[${key}] to exist`).toBeDefined();
+      expect(output[key].type).toBe('Prerender');
+      return output[key];
+    };
+
+    // Concrete prerenders (manifest `routes`): not dynamic templates, so
+    // `isDynamicRoute` is `false` and `hasFallback` doesn't apply (`undefined`).
+    // Their HTML shell exists on disk, so `htmlSize` is a byte count.
+    for (const key of ['index', 'careers', 'careers/foobar-1']) {
+      expect(prerender(key).isDynamicRoute).toBe(false);
+      expect(prerender(key).hasFallback).toBeUndefined();
+      expect(typeof prerender(key).htmlSize).toBe('number');
+      expect(prerender(key).htmlSize).toBeGreaterThan(0);
+    }
+
+    // PPR route that postpones but is still a concrete prerender.
+    expect(prerender('dynamic-suspense').isDynamicRoute).toBe(false);
+    expect(prerender('dynamic-suspense').hasFallback).toBeUndefined();
+    expect(typeof prerender('dynamic-suspense').htmlSize).toBe('number');
+
+    // The two route-level booleans mirror onto the data (`.rsc`) outputs, but
+    // `htmlSize` is HTML-only — the `.rsc` entry isn't an HTML shell.
+    expect(prerender('dynamic-suspense.rsc').isDynamicRoute).toBe(false);
+    expect(prerender('dynamic-suspense.rsc').hasFallback).toBeUndefined();
+    expect(prerender('dynamic-suspense.rsc').htmlSize).toBeUndefined();
+
+    // `[slug]` dynamic template with a static fallback shell: it lives in the
+    // manifest `dynamicRoutes`/`fallbackRoutes` section, so `isDynamicRoute` is
+    // `true` and `hasFallback` is `true`.
+    expect(prerender('careers/[slug]').isDynamicRoute).toBe(true);
+    expect(prerender('careers/[slug]').hasFallback).toBe(true);
+    expect(typeof prerender('careers/[slug]').htmlSize).toBe('number');
+    expect(prerender('careers/[slug].rsc').isDynamicRoute).toBe(true);
+    expect(prerender('careers/[slug].rsc').hasFallback).toBe(true);
+    expect(prerender('careers/[slug].rsc').htmlSize).toBeUndefined();
+
+    // Pages-router route: not from the app `dynamicRoutes` section, and there's
+    // no app `.html` shell, so `isDynamicRoute` is `false` and both
+    // `hasFallback` and `htmlSize` are `undefined`.
+    expect(prerender('legacy').isDynamicRoute).toBe(false);
+    expect(prerender('legacy').hasFallback).toBeUndefined();
+    expect(prerender('legacy').htmlSize).toBeUndefined();
+  });
 });
 
 // The pages-router data route key embeds the build ID, which varies per build.


### PR DESCRIPTION
## Summary

Adds three optional fields to the `Prerender` object so the Build Output carries per-route PPR shell metadata. Consumers (dashboard via `deploy_metadata.json`) can use these — together with the existing `hasPostponed` — to classify routes as fully static / full shell / empty shell / no-prerender.

- **`hasFallback?: boolean`** — the dynamic route template had a static fallback (manifest `fallback` was a string). `false` for blocking/omitted templates, `undefined` for concrete prerenders where the concept doesn't apply.
- **`htmlSize?: number`** — byte size of the prerendered `.html` shell on disk. `0` for an empty shell (template that postponed everything), `undefined` when there's no `.html` (pages router, route handlers, edge).
- **`isDynamicRoute?: boolean`** — the entry came from a dynamic route template (manifest `dynamicRoutes` section) rather than a concrete prerender.

Mirrors the existing `hasPostponed` field added previously.

## Implementation

- **`@vercel/build-utils`** (`prerender.ts`): new optional fields on `PrerenderOptions` + public fields, validated and assigned unconditionally to preserve the tri-state (`true`/`false`/`undefined`) — `false` must not collapse to `undefined`. `htmlSize` is validated as a non-negative integer. `SerializedPrerender` and the deserialize path are derived from the class, so they pick up the fields automatically.
- **`@vercel/next`** (`utils.ts`, `onPrerenderRoute`):
  - `isDynamicRoute` / `hasFallback` derived from the existing `isFallback` / `isBlocking` / `isOmitted` route flags — these already encode the normalized manifest `fallback` string-vs-null split, so no manifest re-read.
  - `htmlSize` computed via a single `fs.statSync(...).size` in a try/catch (no redundant `existsSync`), gated on `appDir`, hoisted above the PPR/postpone branch so it covers all app routes including blocking 0-byte shells.
  - `hasFallback` + `isDynamicRoute` set on all four `Prerender` construction sites (mirroring `hasPostponed`); `htmlSize` set only on the HTML prerender.

## Testing

- **build-utils unit** (`unit.test.ts`): tri-state round-trip + validation throws for all three fields.
- **next integration** (`segment-cache-cc.test.js`): asserts the fields across concrete prerenders, a PPR route, a `[slug]` dynamic fallback template, `.rsc` data outputs (booleans mirror, `htmlSize` is HTML-only), and a pages-router route.

All pass; `tsc --noEmit` clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)