### PR TITLE
fix(cli): correct error reason and message when env variable already exists

### DIFF
--- a/.changeset/cool-falcons-explode.md
+++ b/.changeset/cool-falcons-explode.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix misleading `branch_not_found` reason and `on branch undefined` message when adding an environment variable that already exists; suggest `--force` instead

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -10,7 +10,7 @@ import {
 import readStandardInput from '../../util/input/read-standard-input';
 import param from '../../util/output/param';
 import { emoji, prependEmoji } from '../../util/emoji';
-import { isKnownError } from '../../util/env/known-error';
+import { isKnownError, isDuplicateEnvError } from '../../util/env/known-error';
 import {
   getEnvKeyWarnings,
   normalizeStdinEnvValue,
@@ -885,6 +885,30 @@ export default async function add(client: Client, argv: string[]) {
       envGitBranch
     );
   } catch (err: unknown) {
+    if (isDuplicateEnvError(err)) {
+      const message = `A variable with the name \`${envName}\` already exists for the target ${envTargets.join(
+        ', '
+      )}${envGitBranch ? ` on branch ${envGitBranch}` : ''}. Use --force to overwrite it.`;
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          {
+            status: 'error',
+            reason: 'env_already_exists',
+            message,
+            next: [
+              {
+                command: buildCommandWithYes([...client.argv, '--force']),
+                when: 'Overwriting the existing value is intended (destructive: confirm with the user first)',
+              },
+            ],
+          },
+          1
+        );
+      }
+      output.error(message);
+      return 1;
+    }
     if (client.nonInteractive && isAPIError(err)) {
       const reason =
         (err as { slug?: string }).slug ||

--- a/packages/cli/src/util/env/known-error.ts
+++ b/packages/cli/src/util/env/known-error.ts
@@ -29,8 +29,20 @@ const knownErrorsCodes = new Set([
   'VALUE_INVALID_TYPE',
 ]);
 
+const duplicateEnvErrorCodes = new Set([
+  'ENV_ALREADY_EXISTS',
+  'ENV_CONFLICT',
+  'EXISTING_KEY_AND_TARGET',
+]);
+
 export function isKnownError(error: unknown) {
   const code = isErrnoException(error) ? error.code : null;
   if (!code) return false;
   return knownErrorsCodes.has(code.toUpperCase());
+}
+
+export function isDuplicateEnvError(error: unknown) {
+  const code = isErrnoException(error) ? error.code : null;
+  if (!code) return false;
+  return duplicateEnvErrorCodes.has(code.toUpperCase());
 }

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -1379,6 +1379,65 @@ describe('env add', () => {
         exitSpy.mockRestore();
         logSpy.mockRestore();
       });
+
+      it.each([
+        'ENV_ALREADY_EXISTS',
+        'ENV_CONFLICT',
+        'EXISTING_KEY_AND_TARGET',
+      ])('outputs env_already_exists with --force suggestion when the variable already exists (%s)', async code => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('exit');
+        });
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        vi.spyOn(addEnvRecordModule, 'default').mockRejectedValue(
+          Object.assign(
+            new Error(
+              'A variable with the name `MY_VAR` already exists for the target production on branch undefined (400)'
+            ),
+            {
+              status: 400,
+              code,
+              serverMessage:
+                'A variable with the name `MY_VAR` already exists for the target production on branch undefined',
+            }
+          )
+        );
+
+        client.nonInteractive = true;
+        client.setArgv(
+          'env',
+          'add',
+          'MY_VAR',
+          'production',
+          '--value',
+          'secret',
+          '--yes',
+          '--non-interactive'
+        );
+        client.cwd = setupUnitFixture('vercel-env-pull');
+
+        const exitCodePromise = env(client);
+
+        await expect(exitCodePromise).rejects.toThrow('exit');
+        const payload = JSON.parse(
+          logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
+        );
+        expect(payload).toMatchObject({
+          status: 'error',
+          reason: 'env_already_exists',
+          message: expect.stringContaining('--force'),
+        });
+        expect(payload.message).not.toContain('undefined');
+        expect(payload.next[0].command).toContain('--force');
+
+        vi.restoreAllMocks();
+        exitSpy.mockRestore();
+        logSpy.mockRestore();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

The CLI inferred the error `reason` by keyword-matching the server message: any message containing the word "branch" was classified as `branch_not_found`. When adding a variable that already exists, the backend message happens to contain "on branch undefined", so duplicates were misclassified and the raw broken message was printed as is, with no actionable remedy.

This PR detects duplicates with the API's structured `err.code` (observed: `ENV_CONFLICT`), emits `reason: "env_already_exists"` with a clean message and a `--force` hint. The branch is only shown when one was actually provided, so the backend's "on branch undefined" is no longer surfaced. The `next` suggestion is flagged destructive so agents confirm before overwriting. Other error paths are untouched.

Without fix:

```
Error: A variable with the name `MY_VAR` already exists for the target production on branch undefined
{ "reason": "branch_not_found", ... }
```

With fix:

```
Error: A variable with the name `MY_VAR` already exists for the target production. Use --force to overwrite it.
{ "reason": "env_already_exists", "next": [{ "command": "vercel env add MY_VAR production --value … --force", "when": "Overwriting the existing value is intended (destructive: confirm with the user first)" }] }
```

## Test plan

- [x] `pnpm vitest run packages/cli/test/unit/commands/env/add.test.ts` (43/43, new test covers the three duplicate codes)
- [x] Reproduced before/after against a real project

Fixes #16588 (the backend message bug "on branch undefined" is documented there)
