### PR TITLE
Update @vercel/connect OAuth provider default scopes

### DIFF
--- a/.changeset/bright-connect-scopes.md
+++ b/.changeset/bright-connect-scopes.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Update the Better Auth and Auth.js provider default scopes to request `openid`, `profile`, and `email`.

--- a/packages/connect/src/authjs/connect-provider.ts
+++ b/packages/connect/src/authjs/connect-provider.ts
@@ -31,6 +31,7 @@ import { tryGetVercelTeamId, withTeamId } from '../internal/team-id.js';
 const CONNECT_AUTHORIZATION_URL = 'https://connect.vercel.com/oauth/authorize';
 const CONNECT_TOKEN_URL = 'https://connect.vercel.com/oauth/token';
 const CONNECT_USERINFO_URL = 'https://connect.vercel.com/oauth/userinfo';
+const DEFAULT_SCOPES = ['openid', 'profile', 'email'] as const;
 
 /** Userinfo payload returned by Vercel Connect's OIDC userinfo endpoint. */
 export interface ConnectProfile {
@@ -63,7 +64,7 @@ export interface AuthJsConnectOptions {
   /**
    * Scopes to request. `offline_access` is added automatically so
    * the Vercel Connect side can mint refresh tokens. Defaults to
-   * `["openid"]`.
+   * `["openid", "profile", "email"]`.
    */
   readonly scopes?: readonly string[];
 
@@ -84,7 +85,7 @@ export function connect(
 ): OAuth2Config<ConnectProfile> {
   const fetchVercelToken = options.getVercelOidcToken ?? getVercelOidcToken;
   const scope = Array.from(
-    new Set([...(options.scopes ?? ['openid']), 'offline_access'])
+    new Set([...(options.scopes ?? DEFAULT_SCOPES), 'offline_access'])
   ).join(' ');
 
   return {

--- a/packages/connect/src/betterauth/connect-provider.ts
+++ b/packages/connect/src/betterauth/connect-provider.ts
@@ -36,6 +36,7 @@ import { ConnectError, createConnectErrorFromResponse } from '../token.js';
 const CONNECT_AUTHORIZATION_URL = 'https://connect.vercel.com/oauth/authorize';
 const CONNECT_TOKEN_URL = 'https://connect.vercel.com/oauth/token';
 const CONNECT_USERINFO_URL = 'https://connect.vercel.com/oauth/userinfo';
+const DEFAULT_SCOPES = ['openid', 'profile', 'email'] as const;
 
 /** Options accepted by {@link connect}. */
 export interface BetterAuthConnectOptions {
@@ -55,7 +56,8 @@ export interface BetterAuthConnectOptions {
 
   /**
    * Scopes to request. `offline_access` is added automatically so the
-   * Vercel Connect side can mint refresh tokens. Defaults to `["openid"]`.
+   * Vercel Connect side can mint refresh tokens. Defaults to
+   * `["openid", "profile", "email"]`.
    */
   readonly scopes?: readonly string[];
 
@@ -74,7 +76,7 @@ export interface BetterAuthConnectOptions {
 export function connect(options: BetterAuthConnectOptions): GenericOAuthConfig {
   const fetchVercelToken = options.getVercelOidcToken ?? getVercelOidcToken;
   const scopes = Array.from(
-    new Set([...(options.scopes ?? ['openid']), 'offline_access'])
+    new Set([...(options.scopes ?? DEFAULT_SCOPES), 'offline_access'])
   );
 
   return {

--- a/packages/connect/test/authjs/connect-provider.test.ts
+++ b/packages/connect/test/authjs/connect-provider.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { connect } from '../../src/authjs/connect-provider.js';
+
+describe('Auth.js connect provider', () => {
+  it('requests OpenID profile and email scopes by default', () => {
+    const provider = connect({
+      id: 'linear',
+      name: 'Linear',
+      connector: 'oauth/linear',
+    });
+
+    expect(provider.authorization).toMatchObject({
+      params: {
+        scope: 'openid profile email offline_access',
+      },
+    });
+  });
+});

--- a/packages/connect/test/betterauth/connect-provider.test.ts
+++ b/packages/connect/test/betterauth/connect-provider.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { connect } from '../../src/betterauth/connect-provider.js';
+
+describe('Better Auth connect provider', () => {
+  it('requests OpenID profile and email scopes by default', () => {
+    const provider = connect({
+      providerId: 'linear',
+      connector: 'oauth/linear',
+    });
+
+    expect(provider.scopes).toEqual([
+      'openid',
+      'profile',
+      'email',
+      'offline_access',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- default Auth.js and Better Auth Connect providers to request openid, profile, and email
- keep automatic offline_access append for refresh-token minting
- add focused provider tests and a patch changeset

## Tests
- pnpm --filter @vercel/connect test -- packages/connect/test/authjs/connect-provider.test.ts packages/connect/test/betterauth/connect-provider.test.ts
- pnpm --filter @vercel/connect typecheck
- pnpm exec tsc -p packages/connect/test/tsconfig.json --noEmit
- git diff --check