### PR TITLE
[python] Decode chunked WSGI request bodies in python runtime.

### DIFF
--- a/.changeset/python-runtime-chunked-request-body.md
+++ b/.changeset/python-runtime-chunked-request-body.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-runtime': patch
+---
+
+Decode `Transfer-Encoding: chunked` WSGI request bodies that arrive without a `Content-Length`, and strip the hop-by-hop framing header from the WSGI environ (PEP 3333).

--- a/python/vercel-runtime/src/vercel_runtime/utils.py
+++ b/python/vercel-runtime/src/vercel_runtime/utils.py
@@ -7,6 +7,7 @@ from typing import Protocol
 # Matches the platform request body limit.
 _MAX_CHUNKED_BODY_BYTES = 100 * 1024 * 1024
 _MAX_CHUNK_SIZE_LINE = 65536
+_MAX_TRAILER_BYTES = 8 * 1024
 
 
 def _is_main_guard_test(node: ast.AST) -> bool:
@@ -91,6 +92,16 @@ def read_wsgi_request_body(
     ``Transfer-Encoding: chunked`` request must be de-chunked here.
     """
     content_length_raw = _get_header(headers, "Content-Length")
+    transfer_encoding = _get_header(headers, "Transfer-Encoding") or ""
+    has_chunked = "chunked" in transfer_encoding.lower()
+
+    # RFC 9112 §6.3: a message with both framing headers may be a request
+    # smuggling attempt and must be rejected.
+    if content_length_raw is not None and has_chunked:
+        raise ValueError(
+            "request has both Content-Length and Transfer-Encoding: chunked"
+        )
+
     if content_length_raw is not None:
         try:
             content_length = int(content_length_raw)
@@ -104,8 +115,7 @@ def read_wsgi_request_body(
             return b""
         return rfile.read(content_length)
 
-    transfer_encoding = _get_header(headers, "Transfer-Encoding") or ""
-    if "chunked" in transfer_encoding.lower():
+    if has_chunked:
         return _read_chunked_body(rfile, max_bytes)
 
     return b""
@@ -126,11 +136,18 @@ def _read_chunked_body(rfile: _Readable, max_bytes: int) -> bytes:
         except ValueError as exc:
             raise ValueError(f"invalid chunk size: {size_token!r}") from exc
         if chunk_size == 0:
-            # Drain trailer headers up to the terminating blank line.
+            # Drain trailer headers up to the terminating blank line. Bounded
+            # so a hostile peer cannot pin the connection with endless lines.
+            trailer_total = 0
             while True:
                 trailer = rfile.readline(_MAX_CHUNK_SIZE_LINE)
                 if trailer in (b"\r\n", b"\n", b""):
                     break
+                trailer_total += len(trailer)
+                if trailer_total > _MAX_TRAILER_BYTES:
+                    raise ValueError(
+                        "chunked request trailer exceeds maximum size"
+                    )
             break
         total += chunk_size
         if total > max_bytes:

--- a/python/vercel-runtime/src/vercel_runtime/utils.py
+++ b/python/vercel-runtime/src/vercel_runtime/utils.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import ast
 import runpy
+from typing import Protocol
+
+# Matches the platform request body limit.
+_MAX_CHUNKED_BODY_BYTES = 100 * 1024 * 1024
+_MAX_CHUNK_SIZE_LINE = 65536
 
 
 def _is_main_guard_test(node: ast.AST) -> bool:
@@ -56,3 +61,85 @@ def has_main_guard(entrypoint_abs: str | None) -> bool:
 
 def run_entrypoint_as_main(entrypoint_abs: str) -> None:
     runpy.run_path(entrypoint_abs, run_name="__main__")
+
+
+class _Readable(Protocol):
+    def read(self, size: int = ..., /) -> bytes: ...
+    def readline(self, size: int = ..., /) -> bytes: ...
+
+
+class _HeaderLookup(Protocol):
+    def get(self, key: str, /) -> str | None: ...
+
+
+def _get_header(headers: _HeaderLookup, name: str) -> str | None:
+    # http.server headers are case-insensitive; a plain dict is not.
+    value = headers.get(name)
+    if value is not None:
+        return value
+    return headers.get(name.lower())
+
+
+def read_wsgi_request_body(
+    rfile: _Readable,
+    headers: _HeaderLookup,
+    max_bytes: int = _MAX_CHUNKED_BODY_BYTES,
+) -> bytes:
+    """Read a WSGI request body.
+
+    WSGI has no portable chunked-input support (PEP 3333), so a
+    ``Transfer-Encoding: chunked`` request must be de-chunked here.
+    """
+    content_length_raw = _get_header(headers, "Content-Length")
+    if content_length_raw is not None:
+        try:
+            content_length = int(content_length_raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid Content-Length: {content_length_raw!r}"
+            ) from exc
+        if content_length < 0:
+            raise ValueError(f"invalid Content-Length: {content_length_raw!r}")
+        if content_length == 0:
+            return b""
+        return rfile.read(content_length)
+
+    transfer_encoding = _get_header(headers, "Transfer-Encoding") or ""
+    if "chunked" in transfer_encoding.lower():
+        return _read_chunked_body(rfile, max_bytes)
+
+    return b""
+
+
+def _read_chunked_body(rfile: _Readable, max_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        size_line = rfile.readline(_MAX_CHUNK_SIZE_LINE)
+        if not size_line:
+            raise ValueError(
+                "could not read chunk size: unexpected end of stream"
+            )
+        size_token = size_line.split(b";", 1)[0].strip()
+        try:
+            chunk_size = int(size_token, 16)
+        except ValueError as exc:
+            raise ValueError(f"invalid chunk size: {size_token!r}") from exc
+        if chunk_size == 0:
+            # Drain trailer headers up to the terminating blank line.
+            while True:
+                trailer = rfile.readline(_MAX_CHUNK_SIZE_LINE)
+                if trailer in (b"\r\n", b"\n", b""):
+                    break
+            break
+        total += chunk_size
+        if total > max_bytes:
+            raise ValueError("chunked request body exceeds maximum size")
+        data = rfile.read(chunk_size)
+        if len(data) != chunk_size:
+            raise ValueError(
+                "could not read full chunk: unexpected end of stream"
+            )
+        chunks.append(data)
+        rfile.readline(_MAX_CHUNK_SIZE_LINE)
+    return b"".join(chunks)

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -894,7 +894,12 @@ if "VERCEL_IPC_PATH" in os.environ:
                         "_vc_service_root_path",
                         "",
                     )
-                    body = read_wsgi_request_body(self.rfile, self.headers)
+                    try:
+                        body = read_wsgi_request_body(self.rfile, self.headers)
+                    except ValueError as exc:
+                        self.log_error("invalid request body: %s", exc)
+                        self.send_error(400)
+                        return
                     env: dict[str, Any] = {
                         "CONTENT_LENGTH": str(len(body)),
                         "CONTENT_TYPE": self.headers.get("content-type", ""),

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -52,6 +52,7 @@ from vercel_runtime.routing import (
     apply_service_route_prefix_to_target,
     split_request_target,
 )
+from vercel_runtime.utils import read_wsgi_request_body
 from vercel_runtime.workers import (
     is_worker_service,
     maybe_bootstrap_worker_service_app,
@@ -893,9 +894,9 @@ if "VERCEL_IPC_PATH" in os.environ:
                         "_vc_service_root_path",
                         "",
                     )
-                    content_length = int(self.headers.get("Content-Length", 0))
+                    body = read_wsgi_request_body(self.rfile, self.headers)
                     env: dict[str, Any] = {
-                        "CONTENT_LENGTH": str(content_length),
+                        "CONTENT_LENGTH": str(len(body)),
                         "CONTENT_TYPE": self.headers.get("content-type", ""),
                         "SCRIPT_NAME": service_root_path,
                         "PATH_INFO": path,
@@ -910,7 +911,7 @@ if "VERCEL_IPC_PATH" in os.environ:
                         ),
                         "SERVER_PROTOCOL": "HTTP/1.1",
                         "wsgi.errors": sys.stderr,
-                        "wsgi.input": BytesIO(self.rfile.read(content_length)),
+                        "wsgi.input": BytesIO(body),
                         "wsgi.multiprocess": False,
                         "wsgi.multithread": False,
                         "wsgi.run_once": False,
@@ -923,6 +924,9 @@ if "VERCEL_IPC_PATH" in os.environ:
                         if isinstance(value, string_types):
                             env[key] = wsgi_encoding_dance(value)
                     for k, v in self.headers.items():
+                        # Hop-by-hop; body is already de-chunked (PEP 3333).
+                        if k.lower() == "transfer-encoding":
+                            continue
                         env["HTTP_" + k.replace("-", "_").upper()] = v
 
                     def start_response(

--- a/python/vercel-runtime/tests/fixtures/wsgi_echo_app.py
+++ b/python/vercel-runtime/tests/fixtures/wsgi_echo_app.py
@@ -1,0 +1,24 @@
+"""A WSGI application that echoes the request body and path as JSON."""
+
+import json
+
+
+def app(environ, start_response):
+    try:
+        length = int(environ.get("CONTENT_LENGTH") or 0)
+    except (TypeError, ValueError):
+        length = 0
+    body = environ["wsgi.input"].read(length) if length else b""
+    payload = {
+        "received": body.decode("utf-8", "replace"),
+        "path": environ.get("PATH_INFO", "/"),
+    }
+    data = json.dumps(payload).encode()
+    start_response(
+        "200 OK",
+        [
+            ("Content-Type", "application/json"),
+            ("Content-Length", str(len(data))),
+        ],
+    )
+    return [data]

--- a/python/vercel-runtime/tests/test_request_body.py
+++ b/python/vercel-runtime/tests/test_request_body.py
@@ -89,6 +89,30 @@ class TestReadWsgiRequestBody(unittest.TestCase):
                 rfile, _headers({"Transfer-Encoding": "chunked"})
             )
 
+    def test_both_content_length_and_chunked_raises(self) -> None:
+        raw = b"5\r\nhello\r\n0\r\n\r\n"
+        rfile = io.BytesIO(raw)
+        with self.assertRaises(ValueError):
+            utils.read_wsgi_request_body(
+                rfile,
+                _headers(
+                    {
+                        "Content-Length": "5",
+                        "Transfer-Encoding": "chunked",
+                    }
+                ),
+            )
+
+    def test_chunked_trailer_exceeds_max_raises(self) -> None:
+        # 0-size chunk followed by an oversized trailer block.
+        trailer_line = b"X-Trailer: " + b"a" * 200 + b"\r\n"
+        raw = b"0\r\n" + trailer_line * 100 + b"\r\n"
+        rfile = io.BytesIO(raw)
+        with self.assertRaises(ValueError):
+            utils.read_wsgi_request_body(
+                rfile, _headers({"Transfer-Encoding": "chunked"})
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/vercel-runtime/tests/test_request_body.py
+++ b/python/vercel-runtime/tests/test_request_body.py
@@ -1,0 +1,94 @@
+"""Unit tests for WSGI request-body reading (Content-Length + chunked)."""
+
+from __future__ import annotations
+
+import io
+import unittest
+
+from vercel_runtime import utils
+
+
+def _headers(d: dict[str, str]) -> dict[str, str]:
+    # http.server uses an email.message.Message; a plain dict with .get is
+    # sufficient for the helper, which only calls .get(name, default).
+    return d
+
+
+class TestReadWsgiRequestBody(unittest.TestCase):
+    def test_content_length_reads_exact_bytes(self) -> None:
+        rfile = io.BytesIO(b"hello world extra")
+        body = utils.read_wsgi_request_body(
+            rfile, _headers({"Content-Length": "11"})
+        )
+        self.assertEqual(body, b"hello world")
+
+    def test_no_length_no_chunked_returns_empty(self) -> None:
+        rfile = io.BytesIO(b"should not be read")
+        body = utils.read_wsgi_request_body(rfile, _headers({}))
+        self.assertEqual(body, b"")
+
+    def test_chunked_single_chunk(self) -> None:
+        raw = b"5\r\nhello\r\n0\r\n\r\n"
+        rfile = io.BytesIO(raw)
+        body = utils.read_wsgi_request_body(
+            rfile, _headers({"Transfer-Encoding": "chunked"})
+        )
+        self.assertEqual(body, b"hello")
+
+    def test_chunked_multiple_chunks(self) -> None:
+        raw = b"4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n"
+        rfile = io.BytesIO(raw)
+        body = utils.read_wsgi_request_body(
+            rfile, _headers({"Transfer-Encoding": "chunked"})
+        )
+        self.assertEqual(body, b"Wikipedia")
+
+    def test_chunked_with_extension_is_ignored(self) -> None:
+        raw = b"5;foo=bar\r\nhello\r\n0\r\n\r\n"
+        rfile = io.BytesIO(raw)
+        body = utils.read_wsgi_request_body(
+            rfile, _headers({"Transfer-Encoding": "chunked"})
+        )
+        self.assertEqual(body, b"hello")
+
+    def test_chunked_case_insensitive_header(self) -> None:
+        raw = b"3\r\nabc\r\n0\r\n\r\n"
+        rfile = io.BytesIO(raw)
+        body = utils.read_wsgi_request_body(
+            rfile, _headers({"transfer-encoding": "Chunked"})
+        )
+        self.assertEqual(body, b"abc")
+
+    def test_chunked_exceeds_max_bytes_raises(self) -> None:
+        raw = b"5\r\nhello\r\n0\r\n\r\n"
+        rfile = io.BytesIO(raw)
+        with self.assertRaises(ValueError):
+            utils.read_wsgi_request_body(
+                rfile, _headers({"Transfer-Encoding": "chunked"}), max_bytes=4
+            )
+
+    def test_invalid_content_length_raises(self) -> None:
+        rfile = io.BytesIO(b"hello")
+        with self.assertRaises(ValueError):
+            utils.read_wsgi_request_body(
+                rfile, _headers({"Content-Length": "not-a-number"})
+            )
+
+    def test_negative_content_length_raises(self) -> None:
+        rfile = io.BytesIO(b"hello")
+        with self.assertRaises(ValueError):
+            utils.read_wsgi_request_body(
+                rfile, _headers({"Content-Length": "-1"})
+            )
+
+    def test_chunked_truncated_mid_chunk_raises(self) -> None:
+        raw = b"5\r\nhel"
+        rfile = io.BytesIO(raw)
+        with self.assertRaises(ValueError):
+            utils.read_wsgi_request_body(
+                rfile, _headers({"Transfer-Encoding": "chunked"})
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -238,6 +238,64 @@ async def _http_post(
     )
 
 
+def _dechunk(data: bytes) -> bytes:
+    out = b""
+    while data:
+        size_line, _, rest = data.partition(b"\r\n")
+        size = int(size_line.split(b";")[0], 16)
+        if size == 0:
+            break
+        out += rest[:size]
+        data = rest[size + 2 :]
+    return out
+
+
+def _raw_chunked_post(
+    port: int,
+    path: str,
+    body: bytes,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, bytes]:
+    """Send a POST with a chunked body and NO Content-Length over a raw socket.
+
+    ``http.client`` always adds a Content-Length (or does its own chunking),
+    so to reproduce the proxy behaviour we write the raw HTTP/1.1 request.
+    Returns ``(status_code, response_body)``.
+    """
+    hdrs = {
+        "Host": "lambda",
+        "x-vercel-internal-invocation-id": "test-inv-1",
+        "x-vercel-internal-request-id": "42",
+        "x-vercel-internal-span-id": "span-1",
+        "x-vercel-internal-trace-id": "trace-1",
+        "Content-Type": "application/json",
+        "Transfer-Encoding": "chunked",
+        **(headers or {}),
+    }
+    request_line = f"POST {path} HTTP/1.1\r\n"
+    header_block = "".join(f"{k}: {v}\r\n" for k, v in hdrs.items())
+    chunk = f"{len(body):x}\r\n".encode() + body + b"\r\n0\r\n\r\n"
+    raw = request_line.encode() + header_block.encode() + b"\r\n" + chunk
+
+    with socket.create_connection(("127.0.0.1", port), timeout=10) as sock:
+        sock.sendall(raw)
+        sock.shutdown(socket.SHUT_WR)
+        buf = b""
+        while True:
+            part = sock.recv(65536)
+            if not part:
+                break
+            buf += part
+
+    head, _, resp_body = buf.partition(b"\r\n\r\n")
+    status_line = head.split(b"\r\n", 1)[0]
+    status_code = int(status_line.split(b" ")[1])
+    # If the response itself is chunked, strip framing for the assertion.
+    if b"transfer-encoding: chunked" in head.lower():
+        resp_body = _dechunk(resp_body)
+    return status_code, resp_body
+
+
 async def _read_stderr(
     proc: asyncio.subprocess.Process,
 ) -> str:
@@ -468,6 +526,31 @@ class TestWSGIApp(_RuntimeTestCase):
             self.assertEqual(
                 resp.read().decode(),
                 "GET /search?q=test",
+            )
+
+    async def test_wsgi_chunked_post_without_content_length(self) -> None:
+        ep_abs, ep_rel, mod = _make_entrypoint(
+            "wsgi_echo_app.py", self.tmp_path
+        )
+        async with _run_runtime(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            ipc_socket_path=self.n1.socket_path,
+        ):
+            ss = await self.n1.wait_for_message(
+                ServerStartedMessage, timeout=10.0
+            )
+            port = ss.payload.http_port
+
+            body = json.dumps({"message": "hello"}).encode()
+            status, resp = await asyncio.to_thread(
+                _raw_chunked_post, port, "/api/test", body
+            )
+            self.assertEqual(status, 200)
+            self.assertEqual(
+                json.loads(resp.decode()),
+                {"received": body.decode(), "path": "/api/test"},
             )
 
     async def test_wsgi_closeable_response(self) -> None:


### PR DESCRIPTION
## Summary

WSGI request bodies sent with Transfer-Encoding: chunked (no Content-Length) were silently dropped, since http.server does not de-chunk request bodies and PEP 3333 has no portable chunked-input support. This adds a read_wsgi_request_body helper that handles both Content-Length and chunked framing, materializes the body into a fixed-length wsgi.input, and strips the hop-by-hop Transfer-Encoding header from the environ.

This is the runtime-side fix is for defense-in-depth.

### Changes

- utils.read_wsgi_request_body: reads Content-Length bodies or decodes Transfer-Encoding: chunked with a 100 MB cap and bounded chunk-size lines. Raises ValueError on invalid/negative Content-Length or malformed chunk framing.
- vc_init.py: uses the helper, sets CONTENT_LENGTH from the decoded body, and skips Transfer-Encoding when building the WSGI environ (PEP 3333).