### PR TITLE
[remix] Fix React Router SPA catch-all

### DIFF
--- a/.changeset/react-router-spa-catchall.md
+++ b/.changeset/react-router-spa-catchall.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Fix React Router SPA subroute refreshes by routing the catch-all through `index.html` when no index SSR function is emitted.

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -546,6 +546,7 @@ export const build: BuildV2 = async ({
   const prerenderRewrites: { src: string; dest: string }[] = [];
 
   const routes: any[] = [];
+  let hasReactRouterIndexFunction = false;
 
   for (const [id, functionId] of Object.entries(
     buildManifest.routeIdToServerBundleId ?? {}
@@ -593,6 +594,9 @@ export const build: BuildV2 = async ({
 
     output[path] = func;
     if (isReactRouter) {
+      if (path === 'index') {
+        hasReactRouterIndexFunction = true;
+      }
       // Emit parallel entries so the filesystem handle resolves the
       // single-fetch URL(s) for this route to the same bundle. Note that
       // the root index route uses `/_root.data` rather than `/index.data`.
@@ -634,12 +638,16 @@ export const build: BuildV2 = async ({
 
   // For the 404 case, invoke the Function (or serve the static file
   // for `ssr: false` mode) at the `/` path. Remix will serve its 404 route.
-  // React Router uses the `index` output key (not `/`) so runtime-only paths
-  // like `/__manifest` reach the SSR handler instead of a prerendered
-  // `index.html` when the root route was statically generated.
+  // React Router SSR builds use the `index` output key (not `/`) so
+  // runtime-only paths like `/__manifest` reach the SSR handler instead of a
+  // prerendered `index.html`. SPA builds do not emit that function, so their
+  // catch-all must continue to resolve through `/` and serve `index.html`.
   routes.push({
     src: '/(.*)',
-    dest: isReactRouter ? getReactRouterCatchAllDest() : '/',
+    dest:
+      isReactRouter && hasReactRouterIndexFunction
+        ? getReactRouterCatchAllDest()
+        : '/',
   });
 
   // Routes to call after a file has been matched.

--- a/packages/remix/test/unit.find-prerendered-html-file.test.ts
+++ b/packages/remix/test/unit.find-prerendered-html-file.test.ts
@@ -164,6 +164,37 @@ describe('react-router runtime route resolution with prerendered index', () => {
   });
 });
 
+function getSimulatedCatchAllDest(hasReactRouterIndexFunction: boolean) {
+  return hasReactRouterIndexFunction ? getReactRouterCatchAllDest() : '/';
+}
+
+describe('react-router SPA build output', () => {
+  const staticFiles = new Set(['index.html', 'assets/app.js']);
+
+  function simulateSpaBuildOutput() {
+    return {
+      catchAllDest: getSimulatedCatchAllDest(false),
+    };
+  }
+
+  it('routes the catch-all through `/` when no index SSR function exists', () => {
+    const { catchAllDest } = simulateSpaBuildOutput();
+    expect(catchAllDest).toBe('/');
+  });
+
+  it('serves `index.html` for SPA subroute refreshes', () => {
+    const { catchAllDest } = simulateSpaBuildOutput();
+    expect(
+      resolveReactRouterRequest('/dashboard/settings', {
+        prerenderRewrites: [],
+        catchAllDest,
+        hasIndexSsrFunction: false,
+        staticFiles,
+      })
+    ).toBe('static-html');
+  });
+});
+
 // Integration-style assertion that mirrors the per-route loop in
 // `build-vite.ts` for React Router. Given a synthetic route manifest and a
 // set of static-file keys that mimic what `prerender()` would have written
@@ -220,6 +251,7 @@ describe('react-router prerender build output', () => {
     const dataAssignments: { dataPath: string; kind: 'function' }[] = [];
     const prerenderRewrites: { src: string; dest: string }[] = [];
     const dynamicRules: { src: string; dest: string }[] = [];
+    let hasReactRouterIndexFunction = false;
 
     for (const route of Object.values(routes)) {
       const { path, rePath } = getPathFromRoute(route, routes);
@@ -235,6 +267,9 @@ describe('react-router prerender build output', () => {
       }
 
       assignments.push({ kind: 'function', path });
+      if (path === 'index') {
+        hasReactRouterIndexFunction = true;
+      }
       for (const dataPath of getReactRouterDataPaths(path)) {
         if (!staticFileKeys.has(dataPath)) {
           dataAssignments.push({ dataPath, kind: 'function' });
@@ -255,7 +290,7 @@ describe('react-router prerender build output', () => {
       dataAssignments,
       prerenderRewrites,
       dynamicRules,
-      catchAllDest: getReactRouterCatchAllDest(),
+      catchAllDest: getSimulatedCatchAllDest(hasReactRouterIndexFunction),
     };
   }
 


### PR DESCRIPTION
## Summary
- Fixes React Router v7 `ssr: false` SPA catch-all routing so subroute refreshes serve `index.html` instead of targeting a missing `index` output.
- Keeps the existing React Router SSR/prerender behavior from #16448 by routing to `index` only when the index SSR function was actually emitted.
- Adds regression coverage and a patch changeset for `@vercel/remix-builder`.

## Root Cause
#16448 changed the React Router catch-all from `/` to `index` so runtime-only SSR paths like `/__manifest` would hit the index function when the root route is prerendered. SPA builds do not emit an index SSR function, so `/(.*) -> index` pointed at a missing output key and caused hard-refreshes on client routes to return the Vercel platform 404.

## Validation
- Ran the focused regression test:

```sh
cd /Users/codywong/dev/vercel/packages/remix
pnpm test test/unit.find-prerendered-html-file.test.ts
```

Output:

```txt
✓ test/unit.find-prerendered-html-file.test.ts  (20 tests) 5ms
Test Files  1 passed (1)
Tests  20 passed (20)
```

- Manually copied the existing React Router preset fixture to `/tmp`, changed `ssr: true` to `ssr: false`, and invoked the local builder against that SPA fixture via a temporary Vitest test.

Key output:

```txt
SPA Mode: index.html has been written to your build/client directory
Removing the server build in /private/tmp/pipe-6709-react-router-spa/build/server due to ssr:false

PIPE-6709 manual summary {
  "catchAll": {
    "src": "/(.*)",
    "dest": "/"
  },
  "hasIndexHtml": true,
  "hasIndexFunction": false,
  "outputKeys": [
    "index.html"
  ]
}

✓ test/manual.pipe-6709.test.ts  (1 test) 5524ms
Test Files  1 passed (1)
Tests  1 passed (1)
```

This validates that React Router `ssr:false` output includes `index.html`, does not include an `index` function, and routes the catch-all to `/` instead of the missing `index` output. The temporary manual test file was removed afterward.

Linear: https://linear.app/vercel/issue/PIPE-6709/bug-react-router-v7-spa-subroute-hard-refresh-returns-vercel
Fixes PIPE-6709.