### PR TITLE
[cli] Support custom OpenAPI specs

### DIFF
--- a/.changeset/private-openapi-spec.md
+++ b/.changeset/private-openapi-spec.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Added `vc api --spec-url <url>` for loading endpoints from a custom OpenAPI spec instead of the default public Vercel spec. Custom specs are fetched fresh, can use the current CLI token to pass Vercel deployment protection via the SSO handshake, and replace the public spec entirely for listing, interactive selection, and tag/operation resolution.

--- a/packages/cli/src/commands/api/command.ts
+++ b/packages/cli/src/commands/api/command.ts
@@ -1,6 +1,16 @@
 import { packageName } from '../../util/pkg-name';
 import { formatOption } from '../../util/arg-common';
 
+const specUrlOption = {
+  name: 'spec-url',
+  shorthand: null,
+  type: String,
+  argument: 'URL',
+  deprecated: false,
+  description:
+    'Fetch endpoints from a custom OpenAPI spec URL instead of the public Vercel spec',
+} as const;
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -8,6 +18,7 @@ export const listSubcommand = {
   arguments: [],
   options: [
     formatOption,
+    specUrlOption,
     {
       name: 'refresh',
       shorthand: null,
@@ -24,6 +35,10 @@ export const listSubcommand = {
     {
       name: 'List all endpoints as JSON',
       value: `${packageName} api ls --format json`,
+    },
+    {
+      name: 'List endpoints from a custom OpenAPI spec',
+      value: `${packageName} api ls --spec-url https://openapi-internal.vercel.sh --refresh`,
     },
   ],
 } as const;
@@ -124,6 +139,7 @@ export const apiCommand = {
       deprecated: false,
       description: 'Force refresh the cached OpenAPI spec',
     },
+    specUrlOption,
     {
       name: 'generate',
       shorthand: null,
@@ -174,6 +190,10 @@ export const apiCommand = {
     {
       name: 'Interactive mode (select endpoint)',
       value: `${packageName} api`,
+    },
+    {
+      name: 'Interactive mode with a custom OpenAPI spec',
+      value: `${packageName} api --spec-url https://openapi-internal.vercel.sh --refresh`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -20,7 +20,7 @@ import {
   GLOBAL_CLI_QUERY_PARAMS,
 } from './operation-request-builder';
 import {
-  OpenApiCache,
+  createOpenApiCache,
   resolveEndpointByTagAndOperationId,
   type ResolveByTagOperationResult,
 } from '../../util/openapi';
@@ -95,9 +95,12 @@ export default async function api(client: Client): Promise<number> {
     if (lsFlags['--refresh']) telemetryClient.trackCliFlagRefresh(true);
     if (lsFlags['--format'])
       telemetryClient.trackCliOptionFormat(lsFlags['--format']);
+    if (lsFlags['--spec-url'])
+      telemetryClient.trackCliOptionSpecUrl(lsFlags['--spec-url']);
     return listEndpoints(
       client,
       lsFlags['--refresh'] ?? false,
+      lsFlags['--spec-url'],
       lsFlags['--format'] ?? 'table'
     );
   }
@@ -122,7 +125,8 @@ export default async function api(client: Client): Promise<number> {
     if (client.stdin.isTTY) {
       const selected = await promptEndpointSelection(
         client,
-        flags['--refresh'] ?? false
+        flags['--refresh'] ?? false,
+        flags['--spec-url']
       );
       if (!selected) {
         return 1;
@@ -188,6 +192,8 @@ export default async function api(client: Client): Promise<number> {
   if (flags['--verbose']) telemetryClient.trackCliFlagVerbose(true);
   if (flags['--raw']) telemetryClient.trackCliFlagRaw(true);
   if (flags['--refresh']) telemetryClient.trackCliFlagRefresh(true);
+  if (flags['--spec-url'])
+    telemetryClient.trackCliOptionSpecUrl(flags['--spec-url']);
   if (flags['--generate'])
     telemetryClient.trackCliOptionGenerate(flags['--generate']);
   if (flags['--dangerously-skip-permissions'])
@@ -210,14 +216,15 @@ export default async function api(client: Client): Promise<number> {
 }
 
 export async function printOperationHelpForTagCommand(
+  client: Client,
   flags: ParsedFlags,
   tag: string,
   operationId: string
 ): Promise<number> {
-  const openApi = new OpenApiCache();
+  const openApi = createOpenApiCache(client, flags['--spec-url']);
   const loaded = await openApi.loadWithSpinner(flags['--refresh'] ?? false);
   if (!loaded) {
-    output.error('Could not load API specification');
+    output.error(openApi.loadError ?? 'Could not load API specification');
     return 1;
   }
 
@@ -852,13 +859,17 @@ function outputResults(
 
 async function promptEndpointSelection(
   client: Client,
-  forceRefresh: boolean
+  forceRefresh: boolean,
+  specUrl: string | undefined
 ): Promise<SelectedEndpoint | null> {
   try {
-    const openApi = new OpenApiCache();
+    const openApi = createOpenApiCache(client, specUrl);
     const success = await openApi.loadWithSpinner(forceRefresh);
     if (!success) {
-      output.error('Could not load API specification for endpoint selection');
+      output.error(
+        openApi.loadError ??
+          'Could not load API specification for endpoint selection'
+      );
       return null;
     }
 
@@ -894,21 +905,22 @@ async function promptForEndpoint(
   client: Client,
   endpoints: EndpointInfo[]
 ): Promise<EndpointInfo> {
-  const allChoices = endpoints.map(ep => ({
-    name: `${colorizeMethodPadded(ep.method)} ${ep.path}`,
-    value: ep,
-    // Show full description if available, otherwise show summary
-    description: ep.description || ep.summary || undefined,
-    // Include summary in searchable metadata
-    summary: ep.summary,
-    tags: ep.tags,
-  }));
-
-  const total = allChoices.length;
+  const total = endpoints.length;
+  const buildChoices = () =>
+    endpoints.map(ep => ({
+      name: `${colorizeMethodPadded(ep.method)} ${ep.path}`,
+      value: ep,
+      // Show full description if available, otherwise show summary
+      description: ep.description || ep.summary || undefined,
+      // Include summary in searchable metadata
+      summary: ep.summary,
+      tags: ep.tags,
+    }));
 
   return client.input.search<EndpointInfo>({
     message: `Search for an API endpoint (${total} available):`,
     source: async (term: string | undefined) => {
+      const allChoices = buildChoices();
       if (!term) {
         return allChoices;
       }
@@ -935,12 +947,13 @@ async function promptForEndpoint(
 async function listEndpoints(
   client: Client,
   forceRefresh: boolean,
+  specUrl: string | undefined,
   format: string
 ): Promise<number> {
-  const openApi = new OpenApiCache();
+  const openApi = createOpenApiCache(client, specUrl);
   const success = await openApi.loadWithSpinner(forceRefresh);
   if (!success) {
-    output.error('Could not load API specification');
+    output.error(openApi.loadError ?? 'Could not load API specification');
     return 1;
   }
 
@@ -984,7 +997,10 @@ function groupEndpointsByPath(
 
   for (const ep of endpoints) {
     const existing = grouped.get(ep.path) || [];
-    existing.push({ method: ep.method, summary: ep.summary });
+    existing.push({
+      method: ep.method,
+      summary: ep.summary,
+    });
     grouped.set(ep.path, existing);
   }
 
@@ -1073,20 +1089,22 @@ async function promptForParameters(
   // Collect path parameter values (always required)
   let finalPath = path;
   for (const param of pathParams) {
-    const value = await client.input.text({
-      message: `Enter value for ${formatPathParam(param.name)}${formatDescription(param.description)}:`,
-      validate: createRequiredValidator(param.name),
-    });
+    const value = await promptForParameterValue(
+      client,
+      param,
+      `Enter value for ${formatPathParam(param.name)}${formatDescription(param.description)}:`
+    );
     finalPath = finalPath.replace(`{${param.name}}`, encodeURIComponent(value));
   }
 
   // Collect required query parameter values
   const queryValues: Record<string, string> = {};
   for (const param of requiredQueryParams) {
-    queryValues[param.name] = await client.input.text({
-      message: `Enter value for ${chalk.cyan(param.name)}${formatDescription(param.description)}:`,
-      validate: createRequiredValidator(param.name),
-    });
+    queryValues[param.name] = await promptForParameterValue(
+      client,
+      param,
+      `Enter value for ${chalk.cyan(param.name)}${formatDescription(param.description)}:`
+    );
   }
 
   // Select which optional query parameters to provide
@@ -1103,10 +1121,11 @@ async function promptForParameters(
     // Prompt for values of selected optional query params
     for (const paramName of selectedOptionalParams) {
       const param = optionalQueryParams.find(p => p.name === paramName)!;
-      queryValues[param.name] = await client.input.text({
-        message: `Enter value for ${chalk.cyan(param.name)}${formatDescription(param.description)}:`,
-        validate: createRequiredValidator(param.name),
-      });
+      queryValues[param.name] = await promptForParameterValue(
+        client,
+        param,
+        `Enter value for ${chalk.cyan(param.name)}${formatDescription(param.description)}:`
+      );
     }
   }
 
@@ -1143,6 +1162,36 @@ async function promptForParameters(
   }
 
   return { finalUrl: finalPath, bodyFields: bodyFieldValues };
+}
+
+/**
+ * Prompt for a single parameter value, honoring the schema's enum (select
+ * prompt) and default value when present.
+ */
+async function promptForParameterValue(
+  client: Client,
+  param: Parameter,
+  message: string
+): Promise<string> {
+  const schemaDefault =
+    param.schema?.default !== undefined
+      ? String(param.schema.default)
+      : undefined;
+
+  const enumValues = param.schema?.enum;
+  if (enumValues && enumValues.length > 0) {
+    return client.input.select<string>({
+      message,
+      choices: enumValues.map(v => ({ name: String(v), value: String(v) })),
+      default: schemaDefault,
+    });
+  }
+
+  return client.input.text({
+    message,
+    default: schemaDefault,
+    validate: createRequiredValidator(param.name),
+  });
 }
 
 /**
@@ -1223,12 +1272,12 @@ export async function runTagOperation(
 
   const finalFlags = { ...flags } as ParsedFlags;
 
-  const openApi = new OpenApiCache();
+  const openApi = createOpenApiCache(client, finalFlags['--spec-url']);
   const loaded = await openApi.loadWithSpinner(
     finalFlags['--refresh'] ?? false
   );
   if (!loaded) {
-    output.error('Could not load API specification');
+    output.error(openApi.loadError ?? 'Could not load API specification');
     return 1;
   }
 
@@ -1313,6 +1362,8 @@ export async function runTagOperation(
   if (finalFlags['--verbose']) telemetryClient.trackCliFlagVerbose(true);
   if (finalFlags['--raw']) telemetryClient.trackCliFlagRaw(true);
   if (finalFlags['--refresh']) telemetryClient.trackCliFlagRefresh(true);
+  if (finalFlags['--spec-url'])
+    telemetryClient.trackCliOptionSpecUrl(finalFlags['--spec-url']);
   if (finalFlags['--generate'])
     telemetryClient.trackCliOptionGenerate(finalFlags['--generate']);
   if (finalFlags['--dangerously-skip-permissions'])

--- a/packages/cli/src/commands/api/types.ts
+++ b/packages/cli/src/commands/api/types.ts
@@ -35,6 +35,7 @@ export interface ParsedFlags {
   '--verbose'?: boolean;
   '--raw'?: boolean;
   '--refresh'?: boolean;
+  '--spec-url'?: string;
   '--generate'?: string;
   '--format'?: string;
   '--dangerously-skip-permissions'?: boolean;

--- a/packages/cli/src/util/openapi/constants.ts
+++ b/packages/cli/src/util/openapi/constants.ts
@@ -4,6 +4,12 @@
 export const OPENAPI_URL = 'https://openapi.vercel.sh/';
 
 /**
+ * The vercel.com endpoint that exchanges a Vercel session for a deployment
+ * protection JWT (`_vercel_jwt`).
+ */
+export const SSO_API_URL = 'https://vercel.com/sso-api';
+
+/**
  * Filename for the cached OpenAPI spec
  */
 export const CACHE_FILE = 'openapi-spec.json';
@@ -17,6 +23,11 @@ export const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
  * Timeout for fetching the OpenAPI spec in milliseconds (10 seconds)
  */
 export const FETCH_TIMEOUT_MS = 10 * 1000;
+
+/**
+ * Maximum OpenAPI spec response size in bytes (50 MiB)
+ */
+export const MAX_OPENAPI_SPEC_BYTES = 50 * 1024 * 1024;
 
 /**
  * Sentinel `displayProperty` when the CLI renders the whole JSON object (no wrapper key).

--- a/packages/cli/src/util/openapi/index.ts
+++ b/packages/cli/src/util/openapi/index.ts
@@ -1,16 +1,13 @@
 export { OpenApiCache } from './openapi-cache';
+export { fetchSpecUrl, createOpenApiCache } from './spec-url';
+export { assertAllowedSpecUrl } from './spec-url-allowlist';
+export { readSpecResponse } from './read-spec-response';
 export * from './types';
 export * from './constants';
 export { foldNamingStyle, operationIdToKebabCase } from './fold-naming-style';
-export {
-  humanizeIdentifier,
-  humanReadableColumnLabel,
-} from './column-label';
+export { humanizeIdentifier, humanReadableColumnLabel } from './column-label';
 export { inferCliSubcommandAliases } from './infer-cli-aliases';
-export {
-  formatAsCard,
-  formatAsDataTable,
-} from './vercel-cli-table';
+export { formatAsCard, formatAsDataTable } from './vercel-cli-table';
 export * from './resolve-by-tag-operation';
 export {
   matchesCliApiTag,

--- a/packages/cli/src/util/openapi/openapi-cache.ts
+++ b/packages/cli/src/util/openapi/openapi-cache.ts
@@ -8,6 +8,8 @@ import {
   CACHE_TTL_MS,
   FETCH_TIMEOUT_MS,
 } from './constants';
+import { readSpecResponse } from './read-spec-response';
+import { assertAllowedSpecUrl } from './spec-url-allowlist';
 import type {
   OpenApiSpec,
   CachedSpec,
@@ -27,12 +29,28 @@ import type {
  * const bodyFields = cache.getBodyFields(endpoint);
  * ```
  */
+export interface OpenApiCacheOptions {
+  /**
+   * Custom OpenAPI spec URL. When provided, this spec replaces the default
+   * public spec entirely and is fetched fresh for each process run.
+   */
+  specUrl?: string;
+  fetchSpecUrl?: (url: string) => Promise<OpenApiSpec | null>;
+}
+
 export class OpenApiCache {
   private readonly cachePath: string;
+  private readonly specUrl: string | undefined;
+  private readonly fetchSpecUrl:
+    | ((url: string) => Promise<OpenApiSpec | null>)
+    | undefined;
   private spec: OpenApiSpec | null = null;
+  private error: string | null = null;
 
-  constructor() {
+  constructor(options?: OpenApiCacheOptions) {
     this.cachePath = join(getGlobalPathConfig(), CACHE_FILE);
+    this.specUrl = options?.specUrl;
+    this.fetchSpecUrl = options?.fetchSpecUrl;
   }
 
   /**
@@ -42,14 +60,28 @@ export class OpenApiCache {
     return this.spec !== null;
   }
 
+  get loadError(): string | null {
+    return this.error;
+  }
+
   /**
    * Load the OpenAPI spec, using cache if available and fresh.
    * Returns true if successful, false otherwise.
    */
   async load(forceRefresh = false): Promise<boolean> {
+    return this.loadSpec(forceRefresh);
+  }
+
+  async loadSpec(forceRefresh = false): Promise<boolean> {
+    this.error = null;
+
+    if (this.specUrl) {
+      return this.loadCustomSpec(this.specUrl);
+    }
+
     // Try to read from cache
     if (!forceRefresh) {
-      const cached = await this.readCache();
+      const cached = await this.readCache(this.cachePath);
       if (cached && !this.isExpired(cached.fetchedAt)) {
         output.debug('Using cached OpenAPI spec');
         this.spec = cached.spec;
@@ -60,18 +92,40 @@ export class OpenApiCache {
     // Fetch fresh spec
     try {
       output.debug('Fetching OpenAPI spec from ' + OPENAPI_URL);
-      this.spec = await this.fetchSpec();
-      await this.saveCache(this.spec);
+      this.spec = await this.fetchSpec(OPENAPI_URL);
+      await this.saveCache(this.cachePath, this.spec);
       return true;
     } catch (err) {
       output.debug(`Failed to fetch OpenAPI spec: ${err}`);
       // If fetch fails, try to use stale cache
-      const stale = await this.readCache();
+      const stale = await this.readCache(this.cachePath);
       if (stale) {
         output.debug('Using stale cached OpenAPI spec');
         this.spec = stale.spec;
         return true;
       }
+      return false;
+    }
+  }
+
+  private async loadCustomSpec(specUrl: string): Promise<boolean> {
+    try {
+      assertAllowedSpecUrl(specUrl);
+      output.debug('Fetching OpenAPI spec from ' + specUrl);
+      const spec = this.fetchSpecUrl
+        ? await this.fetchSpecUrl(specUrl)
+        : await this.fetchSpec(specUrl);
+      if (!spec) {
+        this.error = `Could not load OpenAPI spec from ${specUrl}.`;
+        return false;
+      }
+      this.validateSpec(spec, specUrl);
+      this.spec = spec;
+      return Boolean(this.spec);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.error = message;
+      output.debug(`Failed to fetch OpenAPI spec from ${specUrl}: ${message}`);
       return false;
     }
   }
@@ -216,9 +270,9 @@ export class OpenApiCache {
   /**
    * Read cached spec from disk
    */
-  private async readCache(): Promise<CachedSpec | null> {
+  private async readCache(cachePath: string): Promise<CachedSpec | null> {
     try {
-      const content = await readFile(this.cachePath, 'utf-8');
+      const content = await readFile(cachePath, 'utf-8');
       return JSON.parse(content) as CachedSpec;
     } catch {
       return null;
@@ -226,37 +280,67 @@ export class OpenApiCache {
   }
 
   /**
-   * Save spec to disk cache
+   * Save public spec to disk cache
    */
-  private async saveCache(spec: OpenApiSpec): Promise<void> {
+  private async saveCache(cachePath: string, spec: OpenApiSpec): Promise<void> {
     const cached: CachedSpec = {
       fetchedAt: Date.now(),
       spec,
     };
 
     // Ensure directory exists
-    const dir = join(this.cachePath, '..');
+    const dir = join(cachePath, '..');
     await mkdir(dir, { recursive: true });
 
-    await writeFile(this.cachePath, JSON.stringify(cached));
+    await writeFile(cachePath, JSON.stringify(cached));
     output.debug('Saved OpenAPI spec to cache');
   }
 
   /**
    * Fetch OpenAPI spec from remote with timeout
    */
-  private async fetchSpec(): Promise<OpenApiSpec> {
+  private async fetchSpec(url: string): Promise<OpenApiSpec> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
     try {
-      const response = await fetch(OPENAPI_URL, { signal: controller.signal });
+      const response = await fetch(url, { signal: controller.signal });
       if (!response.ok) {
         throw new Error(`Failed to fetch OpenAPI spec: ${response.status}`);
       }
-      return (await response.json()) as OpenApiSpec;
+      const spec = await readSpecResponse<OpenApiSpec>(response, url);
+      this.validateSpec(spec, url);
+      return spec;
     } finally {
       clearTimeout(timeoutId);
+    }
+  }
+
+  private validateSpec(spec: OpenApiSpec | null, url: string): void {
+    if (!spec || typeof spec !== 'object') {
+      throw new Error(
+        `Invalid OpenAPI spec from ${url}: expected a JSON object.`
+      );
+    }
+
+    if (typeof spec.openapi !== 'string' || !spec.openapi.startsWith('3.')) {
+      throw new Error(
+        `Invalid OpenAPI spec from ${url}: expected an OpenAPI 3.x document with an "openapi" field.`
+      );
+    }
+
+    if (!spec.paths || typeof spec.paths !== 'object') {
+      throw new Error(
+        `Invalid OpenAPI spec from ${url}: expected a "paths" object.`
+      );
+    }
+
+    for (const path of Object.keys(spec.paths)) {
+      if (!path.startsWith('/') || path.startsWith('//')) {
+        throw new Error(
+          `Invalid OpenAPI spec from ${url}: path "${path}" must be a relative API path.`
+        );
+      }
     }
   }
 
@@ -268,7 +352,7 @@ export class OpenApiCache {
   }
 
   /**
-   * Sort endpoints by path, then by method
+   * Sort endpoints by path, then by method.
    */
   private sortEndpoints(endpoints: EndpointInfo[]): EndpointInfo[] {
     return endpoints.sort((a, b) => {
@@ -279,7 +363,7 @@ export class OpenApiCache {
   }
 
   /**
-   * Extract all available endpoints from the spec
+   * Extract all available endpoints from the loaded spec.
    */
   private extractEndpoints(): EndpointInfo[] {
     const endpoints: EndpointInfo[] = [];
@@ -315,16 +399,19 @@ export class OpenApiCache {
   /**
    * Resolve a $ref to its actual schema
    */
-  private resolveSchemaRef(schema: Schema | undefined): Schema | undefined {
+  private resolveSchemaRef(
+    schema: Schema | undefined,
+    spec: OpenApiSpec = this.spec!
+  ): Schema | undefined {
     if (!schema) return undefined;
 
     if (schema.$ref) {
       // Parse $ref like "#/components/schemas/SchemaName"
       const match = schema.$ref.match(/^#\/components\/schemas\/(.+)$/);
-      if (match && this.spec!.components?.schemas) {
-        const resolved = this.spec!.components.schemas[match[1]];
+      if (match && spec.components?.schemas) {
+        const resolved = spec.components.schemas[match[1]];
         // Recursively resolve if the resolved schema also has a $ref
-        return this.resolveSchemaRef(resolved);
+        return this.resolveSchemaRef(resolved, spec);
       }
       return undefined;
     }
@@ -333,7 +420,7 @@ export class OpenApiCache {
     if (schema.allOf && schema.allOf.length > 0) {
       const merged: Schema = { type: 'object', properties: {}, required: [] };
       for (const subSchema of schema.allOf) {
-        const resolved = this.resolveSchemaRef(subSchema);
+        const resolved = this.resolveSchemaRef(subSchema, spec);
         if (resolved) {
           if (resolved.properties) {
             merged.properties = {

--- a/packages/cli/src/util/openapi/read-spec-response.ts
+++ b/packages/cli/src/util/openapi/read-spec-response.ts
@@ -1,0 +1,55 @@
+import { MAX_OPENAPI_SPEC_BYTES } from './constants';
+
+export async function readSpecResponse<T>(
+  response: Response,
+  url: string,
+  maxBytes = MAX_OPENAPI_SPEC_BYTES
+): Promise<T> {
+  const contentLength = response.headers.get('content-length');
+  if (contentLength) {
+    const bytes = Number(contentLength);
+    if (Number.isFinite(bytes) && bytes > maxBytes) {
+      throw new Error(
+        `OpenAPI spec from ${url} exceeds the ${maxBytes} byte limit.`
+      );
+    }
+  }
+
+  if (!response.body) {
+    throw new Error(`OpenAPI spec from ${url} returned an empty response.`);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    if (!value) {
+      continue;
+    }
+
+    totalBytes += value.byteLength;
+    if (totalBytes > maxBytes) {
+      await reader.cancel();
+      throw new Error(
+        `OpenAPI spec from ${url} exceeds the ${maxBytes} byte limit.`
+      );
+    }
+
+    chunks.push(value);
+  }
+
+  const buffer = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return JSON.parse(new TextDecoder().decode(buffer)) as T;
+}

--- a/packages/cli/src/util/openapi/spec-url-allowlist.ts
+++ b/packages/cli/src/util/openapi/spec-url-allowlist.ts
@@ -1,0 +1,19 @@
+const ALLOWED_SPEC_HOSTS = ['vercel.sh', 'vercel.tools'];
+
+export function assertAllowedSpecUrl(specUrl: string): URL {
+  const parsedUrl = new URL(specUrl);
+
+  if (parsedUrl.protocol !== 'https:') {
+    throw new Error('OpenAPI spec URL must use https');
+  }
+
+  if (!ALLOWED_SPEC_HOSTS.some(host => isHostOrSubdomain(parsedUrl, host))) {
+    throw new Error('OpenAPI spec URL must be on an allowed origin.');
+  }
+
+  return parsedUrl;
+}
+
+function isHostOrSubdomain(url: URL, host: string): boolean {
+  return url.hostname === host || url.hostname.endsWith(`.${host}`);
+}

--- a/packages/cli/src/util/openapi/spec-url.ts
+++ b/packages/cli/src/util/openapi/spec-url.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'crypto';
+import type Client from '../client';
+import output from '../../output-manager';
+import { OpenApiCache } from './openapi-cache';
+import { SSO_API_URL, FETCH_TIMEOUT_MS } from './constants';
+import { readSpecResponse } from './read-spec-response';
+import { assertAllowedSpecUrl } from './spec-url-allowlist';
+import type { OpenApiSpec } from './types';
+
+const MAX_REDIRECTS = 3;
+
+/**
+ * Fetch an OpenAPI spec URL. If the URL is protected by Vercel Authentication,
+ * complete the same SSO handshake the browser uses with the current CLI token.
+ */
+export async function fetchSpecUrl(
+  client: Client,
+  specUrl: string
+): Promise<OpenApiSpec | null> {
+  const specOrigin = assertAllowedSpecUrl(specUrl).origin;
+
+  const probe = await fetchWithTimeout(specUrl, { readSpec: true });
+  if (probe.response.ok) {
+    return probe.spec ?? null;
+  }
+
+  const nonce = getSetCookieValue(probe.response, '_vercel_sso_nonce');
+  if (!nonce) {
+    output.debug(
+      `OpenAPI spec URL returned ${probe.response.status} without a Vercel SSO nonce`
+    );
+    throw new Error(formatHttpError(specUrl, probe.response));
+  }
+
+  const token = client.authConfig.token;
+  if (!token) {
+    output.debug('OpenAPI spec URL requires Vercel authentication');
+    return null;
+  }
+
+  const hashedNonce = createHash('sha256').update(nonce).digest('hex');
+  const ssoUrl = `${SSO_API_URL}?url=${encodeURIComponent(
+    specUrl
+  )}&nonce=${hashedNonce}`;
+  const sso = await fetchWithTimeout(ssoUrl, {
+    cookie: `authorization=${encodeURIComponent(`Bearer ${token}`)}; isLoggedIn=1`,
+  });
+
+  const location = sso.response.headers.get('location');
+  if (!location || !location.includes('_vercel_jwt=')) {
+    output.debug('OpenAPI spec URL: user has no access');
+    throw new Error(formatHttpError(specUrl, sso.response));
+  }
+
+  const cookies = new Map([['_vercel_sso_nonce', nonce]]);
+  let url = location;
+  for (let i = 0; i <= MAX_REDIRECTS; i++) {
+    if (!isSameOriginUrl(url, specOrigin)) {
+      output.debug('OpenAPI spec URL: cross-origin redirect rejected');
+      return null;
+    }
+
+    const { response, spec } = await fetchWithTimeout(url, {
+      cookie: Array.from(cookies, ([name, value]) => `${name}=${value}`).join(
+        '; '
+      ),
+      readSpec: true,
+    });
+
+    if (response.ok) {
+      return spec ?? null;
+    }
+
+    const next = response.headers.get('location');
+    if (response.status >= 300 && response.status < 400 && next) {
+      const setJwt = getSetCookieValue(response, '_vercel_jwt');
+      if (setJwt) {
+        cookies.set('_vercel_jwt', setJwt);
+      }
+      const nextUrl = new URL(next, url).href;
+      if (!isSameOriginUrl(nextUrl, specOrigin)) {
+        output.debug('OpenAPI spec URL: cross-origin redirect rejected');
+        return null;
+      }
+      url = nextUrl;
+      continue;
+    }
+
+    output.debug(`OpenAPI spec URL: unexpected response ${response.status}`);
+    throw new Error(formatHttpError(url, response));
+  }
+
+  output.debug('OpenAPI spec URL: too many redirects');
+  return null;
+}
+
+export function createOpenApiCache(
+  client: Client,
+  specUrl?: string
+): OpenApiCache {
+  return new OpenApiCache(
+    specUrl
+      ? {
+          specUrl,
+          fetchSpecUrl: url => fetchSpecUrl(client, url),
+        }
+      : undefined
+  );
+}
+
+async function fetchWithTimeout(
+  url: string,
+  options?: { cookie?: string; readSpec?: boolean }
+): Promise<{ response: Response; spec?: OpenApiSpec }> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      redirect: 'manual',
+      signal: controller.signal,
+      headers: options?.cookie ? { cookie: options.cookie } : undefined,
+    });
+    const spec =
+      options?.readSpec && response.ok
+        ? await readSpecResponse<OpenApiSpec>(
+            response,
+            formatDiagnosticUrl(url)
+          )
+        : undefined;
+    return { response, spec };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function isSameOriginUrl(url: string, origin: string): boolean {
+  try {
+    return new URL(url).origin === origin;
+  } catch {
+    return false;
+  }
+}
+
+function formatHttpError(url: string, response: Response): string {
+  const statusText = response.statusText ? ` ${response.statusText}` : '';
+  return `Could not load OpenAPI spec from ${formatDiagnosticUrl(url)}: HTTP ${response.status}${statusText}.`;
+}
+
+function formatDiagnosticUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = '';
+    for (const key of parsed.searchParams.keys()) {
+      parsed.searchParams.set(key, '[redacted]');
+    }
+    return parsed.href;
+  } catch {
+    return url;
+  }
+}
+
+function getSetCookieValue(response: Response, name: string): string | null {
+  const header = response.headers.get('set-cookie');
+  if (!header) {
+    return null;
+  }
+  const match = header.match(new RegExp(`${name}=([^;,\\s]+)`));
+  return match ? match[1] : null;
+}

--- a/packages/cli/src/util/openapi/try-openapi-fallback.ts
+++ b/packages/cli/src/util/openapi/try-openapi-fallback.ts
@@ -55,7 +55,7 @@ export async function tryOpenApiFallback(
   }
 
   if (flags['--help']) {
-    return printOperationHelpForTagCommand(flags, tag, operationHint);
+    return printOperationHelpForTagCommand(client, flags, tag, operationHint);
   }
 
   return runTagOperation(client, {

--- a/packages/cli/src/util/telemetry/commands/api/index.ts
+++ b/packages/cli/src/util/telemetry/commands/api/index.ts
@@ -77,6 +77,15 @@ export class ApiTelemetryClient
     }
   }
 
+  trackCliOptionSpecUrl(specUrl: string | undefined) {
+    if (specUrl) {
+      this.trackCliOption({
+        option: 'spec-url',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagPaginate(value: boolean | undefined) {
     if (value) {
       this.trackCliFlag('paginate');

--- a/packages/cli/test/unit/commands/api/index.test.ts
+++ b/packages/cli/test/unit/commands/api/index.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import api from '../../../../src/commands/api';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('api', () => {
   describe('--help', () => {
@@ -239,6 +243,87 @@ describe('api', () => {
       const exitCode = await api(client);
 
       expect(exitCode).toEqual(1);
+    });
+  });
+
+  describe('--spec-url', () => {
+    it('lists endpoints from the custom spec only', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              openapi: '3.0.3',
+              info: { title: 'Custom API', version: '1.0.0' },
+              paths: {
+                '/custom-only': {
+                  get: {
+                    operationId: 'getCustomOnly',
+                    summary: 'Custom only',
+                    tags: ['custom'],
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }
+          )
+        )
+      );
+
+      client.setArgv(
+        'api',
+        'ls',
+        '--spec-url',
+        'https://api.vercel.tools/openapi.json',
+        '--format',
+        'json'
+      );
+
+      const exitCode = await api(client);
+      expect(exitCode).toEqual(0);
+
+      const endpoints = JSON.parse(client.stdout.getFullOutput());
+      expect(endpoints).toEqual([
+        expect.objectContaining({
+          method: 'GET',
+          path: '/custom-only',
+          operationId: 'getCustomOnly',
+        }),
+      ]);
+    });
+
+    it('prints a clear error when the custom URL is not an OpenAPI spec', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              generatedAt: '2026-06-10T17:01:31.100Z',
+              services: [],
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }
+          )
+        )
+      );
+
+      client.setArgv(
+        'api',
+        '--spec-url',
+        'https://api.vercel.tools/manifest.json',
+        '--refresh'
+      );
+
+      const exitCode = await api(client);
+      expect(exitCode).toEqual(1);
+      expect(client.getFullOutput()).toContain(
+        'Invalid OpenAPI spec from https://api.vercel.tools/manifest.json: expected an OpenAPI 3.x document with an "openapi" field.'
+      );
     });
   });
 

--- a/packages/cli/test/unit/util/openapi/spec-url.test.ts
+++ b/packages/cli/test/unit/util/openapi/spec-url.test.ts
@@ -1,0 +1,379 @@
+import { createHash } from 'crypto';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { OpenApiCache } from '../../../../src/util/openapi/openapi-cache';
+import { readSpecResponse } from '../../../../src/util/openapi/read-spec-response';
+import { fetchSpecUrl } from '../../../../src/util/openapi/spec-url';
+import {
+  MAX_OPENAPI_SPEC_BYTES,
+  SSO_API_URL,
+} from '../../../../src/util/openapi/constants';
+import type { OpenApiSpec } from '../../../../src/util/openapi/types';
+import { client } from '../../../mocks/client';
+
+const customSpec: OpenApiSpec = {
+  openapi: '3.0.3',
+  info: { title: 'Custom API', version: '1.0.0' },
+  paths: {
+    '/v1/internal/widgets': {
+      post: {
+        operationId: 'createWidget',
+        summary: 'Create a widget',
+        tags: ['internal'],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/Payload' },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Payload: {
+        type: 'object',
+        properties: { field: { type: 'string' } },
+        required: ['field'],
+      },
+    },
+  },
+};
+
+describe('OpenApiCache with a custom spec URL', () => {
+  it('uses only the custom spec, not the public spec', async () => {
+    const fetchSpec = vi.fn().mockResolvedValue(customSpec);
+    const cache = new OpenApiCache({
+      specUrl: 'https://openapi-internal.vercel.sh/',
+      fetchSpecUrl: fetchSpec,
+    });
+
+    await expect(cache.load()).resolves.toBe(true);
+
+    const endpoints = cache.getEndpoints();
+    expect(endpoints.map(e => e.operationId)).toEqual(['createWidget']);
+    expect(
+      endpoints.find(e => e.operationId === 'getProjects')
+    ).toBeUndefined();
+    expect(fetchSpec).toHaveBeenCalledWith(
+      'https://openapi-internal.vercel.sh/'
+    );
+  });
+
+  it('fetches the custom spec fresh on every load', async () => {
+    const fetchSpec = vi.fn().mockResolvedValue(customSpec);
+    const cache = new OpenApiCache({
+      specUrl: 'https://openapi-internal.vercel.sh/',
+      fetchSpecUrl: fetchSpec,
+    });
+
+    await cache.load();
+    await cache.load();
+
+    expect(fetchSpec).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects custom URLs that do not return an OpenAPI document', async () => {
+    const cache = new OpenApiCache({
+      specUrl: 'https://api.vercel.tools/manifest.json',
+      fetchSpecUrl: vi.fn().mockResolvedValue({
+        generatedAt: '2026-06-10T17:01:31.100Z',
+        services: [],
+      }),
+    });
+
+    await expect(cache.load()).resolves.toBe(false);
+    expect(cache.loadError).toBe(
+      'Invalid OpenAPI spec from https://api.vercel.tools/manifest.json: expected an OpenAPI 3.x document with an "openapi" field.'
+    );
+  });
+
+  it('rejects custom spec URLs outside allowed Vercel-owned hosts', async () => {
+    const fetchSpec = vi.fn().mockResolvedValue(customSpec);
+    const cache = new OpenApiCache({
+      specUrl: 'https://example.com/openapi.json',
+      fetchSpecUrl: fetchSpec,
+    });
+
+    await expect(cache.load()).resolves.toBe(false);
+    expect(cache.loadError).toBe(
+      'OpenAPI spec URL must be on an allowed origin.'
+    );
+    expect(fetchSpec).not.toHaveBeenCalled();
+  });
+
+  it('resolves custom spec $refs against the custom spec', async () => {
+    const cache = new OpenApiCache({
+      specUrl: 'https://openapi-internal.vercel.sh/',
+      fetchSpecUrl: vi.fn().mockResolvedValue(customSpec),
+    });
+
+    await cache.load();
+    const widget = cache.getEndpoints()[0];
+
+    const fields = cache.getBodyFields(widget);
+    expect(fields.map(f => f.name)).toEqual(['field']);
+    expect(fields[0].required).toBe(true);
+  });
+
+  it.each([
+    'https://attacker.test/collect',
+    '//attacker.test/collect',
+    'v1/missing-leading-slash',
+  ])('rejects non-relative spec path %s', async path => {
+    const cache = new OpenApiCache({
+      specUrl: 'https://openapi-internal.vercel.sh/',
+      fetchSpecUrl: vi.fn().mockResolvedValue({
+        ...customSpec,
+        paths: {
+          [path]: {
+            get: {
+              operationId: 'unsafePath',
+              tags: ['unsafe'],
+            },
+          },
+        },
+      }),
+    });
+
+    await expect(cache.load()).resolves.toBe(false);
+    expect(cache.loadError).toBe(
+      `Invalid OpenAPI spec from https://openapi-internal.vercel.sh/: path "${path}" must be a relative API path.`
+    );
+  });
+});
+
+describe('fetchSpecUrl (Vercel SSO handshake)', () => {
+  const SPEC_URL = 'https://openapi-internal.vercel.sh/';
+  const NONCE = 'test-nonce';
+  const HASHED_NONCE = createHash('sha256').update(NONCE).digest('hex');
+  const JWT = 'test-jwt';
+  const CALLBACK_URL = `${SPEC_URL}?_vercel_jwt=${JWT}`;
+
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  function jsonResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  function protectionResponse(): Response {
+    return new Response('', {
+      status: 401,
+      headers: {
+        'set-cookie': `_vercel_sso_nonce=${NONCE}; Max-Age=3600; Path=/; HttpOnly`,
+      },
+    });
+  }
+
+  function redirectResponse(location: string): Response {
+    return new Response('', { status: 302, headers: { location } });
+  }
+
+  beforeEach(() => {
+    client.reset();
+    client.authConfig.token = 'user-token';
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns a public custom spec directly', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(customSpec));
+
+    const spec = await fetchSpecUrl(client, SPEC_URL);
+    expect(spec).toEqual(customSpec);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('completes the deployment-protection SSO handshake', async () => {
+    const sessionJwt = 'session-jwt';
+    const callbackRedirect = new Response('', {
+      status: 302,
+      headers: {
+        location: SPEC_URL,
+        'set-cookie': `_vercel_jwt=${sessionJwt}; Path=/; HttpOnly`,
+      },
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(protectionResponse())
+      .mockResolvedValueOnce(redirectResponse(CALLBACK_URL))
+      .mockResolvedValueOnce(callbackRedirect)
+      .mockResolvedValueOnce(jsonResponse(customSpec));
+
+    const spec = await fetchSpecUrl(client, SPEC_URL);
+    expect(spec).toEqual(customSpec);
+
+    const [ssoUrl, ssoInit] = fetchMock.mock.calls[1];
+    expect(ssoUrl).toBe(
+      `${SSO_API_URL}?url=${encodeURIComponent(SPEC_URL)}&nonce=${HASHED_NONCE}`
+    );
+    expect(ssoInit.headers.cookie).toBe(
+      `authorization=${encodeURIComponent('Bearer user-token')}; isLoggedIn=1`
+    );
+
+    const [callbackUrl, callbackInit] = fetchMock.mock.calls[2];
+    expect(callbackUrl).toBe(CALLBACK_URL);
+    expect(callbackInit.headers.cookie).toBe(`_vercel_sso_nonce=${NONCE}`);
+
+    const [finalUrl, finalInit] = fetchMock.mock.calls[3];
+    expect(finalUrl).toBe(SPEC_URL);
+    expect(finalInit.headers.cookie).toBe(
+      `_vercel_sso_nonce=${NONCE}; _vercel_jwt=${sessionJwt}`
+    );
+  });
+
+  it('returns null when the user has no access', async () => {
+    fetchMock
+      .mockResolvedValueOnce(protectionResponse())
+      .mockResolvedValueOnce(redirectResponse('https://vercel.com/login'));
+
+    await expect(fetchSpecUrl(client, SPEC_URL)).rejects.toThrow(
+      `Could not load OpenAPI spec from ${SPEC_URL}: HTTP 302.`
+    );
+  });
+
+  it('shows the HTTP status when the spec URL cannot be loaded', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 403 }));
+
+    await expect(fetchSpecUrl(client, SPEC_URL)).rejects.toThrow(
+      `Could not load OpenAPI spec from ${SPEC_URL}: HTTP 403.`
+    );
+  });
+
+  it('rejects cross-origin SSO callback redirects before sending cookies', async () => {
+    fetchMock
+      .mockResolvedValueOnce(protectionResponse())
+      .mockResolvedValueOnce(
+        redirectResponse('https://attacker.vercel.sh/?_vercel_jwt=test-jwt')
+      );
+
+    await expect(fetchSpecUrl(client, SPEC_URL)).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls).not.toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([expect.stringContaining('attacker.vercel.sh')]),
+      ])
+    );
+  });
+
+  it('rejects cross-origin redirects after receiving the deployment protection JWT', async () => {
+    const sessionJwt = 'session-jwt';
+    const callbackRedirect = new Response('', {
+      status: 302,
+      headers: {
+        location: 'https://attacker.vercel.sh/openapi.json',
+        'set-cookie': `_vercel_jwt=${sessionJwt}; Path=/; HttpOnly`,
+      },
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(protectionResponse())
+      .mockResolvedValueOnce(redirectResponse(CALLBACK_URL))
+      .mockResolvedValueOnce(callbackRedirect);
+
+    await expect(fetchSpecUrl(client, SPEC_URL)).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls).not.toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([expect.stringContaining('attacker.vercel.sh')]),
+      ])
+    );
+  });
+
+  it('returns null when a protected spec is requested without credentials', async () => {
+    client.authConfig.token = undefined;
+    fetchMock.mockResolvedValueOnce(protectionResponse());
+
+    await expect(fetchSpecUrl(client, SPEC_URL)).resolves.toBeNull();
+  });
+
+  it('rejects non-https spec URLs', async () => {
+    await expect(fetchSpecUrl(client, 'file:///tmp/spec.json')).rejects.toThrow(
+      'OpenAPI spec URL must use https'
+    );
+  });
+
+  it('rejects hostnames that only share the allowed suffix text', async () => {
+    await expect(
+      fetchSpecUrl(client, 'https://attacker-vercel.sh/openapi.json')
+    ).rejects.toThrow('OpenAPI spec URL must be on an allowed origin.');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized direct spec responses by content-length', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-length': String(MAX_OPENAPI_SPEC_BYTES + 1) },
+      })
+    );
+
+    await expect(fetchSpecUrl(client, SPEC_URL)).rejects.toThrow(
+      `OpenAPI spec from ${SPEC_URL} exceeds the ${MAX_OPENAPI_SPEC_BYTES} byte limit.`
+    );
+  });
+
+  it('rejects oversized SSO-protected spec responses by content-length', async () => {
+    const sessionJwt = 'session-jwt';
+    const callbackRedirect = new Response('', {
+      status: 302,
+      headers: {
+        location: SPEC_URL,
+        'set-cookie': `_vercel_jwt=${sessionJwt}; Path=/; HttpOnly`,
+      },
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(protectionResponse())
+      .mockResolvedValueOnce(redirectResponse(CALLBACK_URL))
+      .mockResolvedValueOnce(callbackRedirect)
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'content-length': String(MAX_OPENAPI_SPEC_BYTES + 1) },
+        })
+      );
+
+    await expect(fetchSpecUrl(client, SPEC_URL)).rejects.toThrow(
+      `OpenAPI spec from ${SPEC_URL} exceeds the ${MAX_OPENAPI_SPEC_BYTES} byte limit.`
+    );
+  });
+
+  it('redacts JWT query values from SSO-protected spec errors', async () => {
+    fetchMock
+      .mockResolvedValueOnce(protectionResponse())
+      .mockResolvedValueOnce(redirectResponse(CALLBACK_URL))
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'content-length': String(MAX_OPENAPI_SPEC_BYTES + 1) },
+        })
+      );
+
+    await expect(fetchSpecUrl(client, SPEC_URL)).rejects.toThrow(
+      'OpenAPI spec from https://openapi-internal.vercel.sh/?_vercel_jwt=%5Bredacted%5D exceeds the 52428800 byte limit.'
+    );
+  });
+});
+
+describe('readSpecResponse', () => {
+  it('rejects responses that exceed the byte limit while streaming', async () => {
+    const response = new Response('12345678901');
+
+    await expect(
+      readSpecResponse(response, 'https://api.vercel.tools/openapi.json', 10)
+    ).rejects.toThrow(
+      'OpenAPI spec from https://api.vercel.tools/openapi.json exceeds the 10 byte limit.'
+    );
+  });
+});


### PR DESCRIPTION
## Why
`vc api` currently only reads the public OpenAPI spec, which blocks CLI-driven exploration and requests for endpoints that are available only from protected/internal specs.

## What
Adds `--spec-url <url>` to `vc api` and `vc api ls` so endpoint listing, interactive selection, help fallback, and tag/operation resolution can use a custom OpenAPI spec instead of the public spec.

## How
Custom specs are fetched fresh, restricted to HTTPS Vercel-owned hosts, validated as OpenAPI 3.x documents, capped at 50 MiB, and can complete Vercel Deployment Protection SSO using the current CLI token without logging JWT query values. Added targeted unit coverage for custom specs, validation, allowlist enforcement, SSO redirects, size limits, and redaction.

Tested manually and added coverage.