### PR TITLE
[cli] connect: harden terminal output and `--data` credential input

### DIFF
--- a/.changeset/connect-data-flag-file-stdin.md
+++ b/.changeset/connect-data-flag-file-stdin.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`vercel connect create --data` now accepts `@<path>` to read the JSON from a file and `@-` to read it from stdin, so non-managed connector credentials (e.g. client secrets) no longer have to be passed inline where they leak into shell history and process listings. Inline `--data` still works but now warns when it looks like it contains a secret.

--- a/.changeset/connect-strip-ansi-all-commands.md
+++ b/.changeset/connect-strip-ansi-all-commands.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Strip ANSI escape sequences from team-controlled connector names, UIDs, and project names in all `vercel connect` command output (`attach`, `detach`, `remove`, `revoke-tokens`, and the `list` table's type/projects cells), not just the `list` UID/name cells. Prevents terminal escape injection from maliciously-named connectors visible across a team.

--- a/packages/cli/src/commands/connex/attach.ts
+++ b/packages/cli/src/commands/connex/attach.ts
@@ -9,6 +9,7 @@ import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name'
 import { ProjectNotFound } from '../../util/errors-ts';
 import { envTargetChoices, isValidEnvTarget } from '../../util/env/env-target';
 import { normalizeRepeatableStringFilters } from '../../util/command-validation';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
 import { packageName } from '../../util/pkg-name';
 import {
   MAX_TRIGGER_DESTINATIONS,
@@ -123,7 +124,7 @@ export async function attach(
     }
 
     projectId = resolvedProject.id;
-    projectName = resolvedProject.name;
+    projectName = sanitizeForTerminal(resolvedProject.name);
   } else {
     const linked = await getLinkedProject(client);
     if (linked.status === 'error') {
@@ -141,7 +142,7 @@ export async function attach(
       client.config.currentTeam = undefined;
     }
     projectId = linked.project.id;
-    projectName = linked.project.name;
+    projectName = sanitizeForTerminal(linked.project.name);
   }
 
   // Resolve client identity → canonical id + display name. The base GET
@@ -165,7 +166,9 @@ export async function attach(
   }
   output.stopSpinner();
 
-  const displayName = target.uid || target.name || target.id;
+  const displayName = sanitizeForTerminal(
+    target.uid || target.name || target.id
+  );
 
   // Pre-flight: trigger-destination planning.
   let desiredDestination: ConnexTriggerDestination | undefined;

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -34,7 +34,7 @@ export const createSubcommand = {
       argument: 'JSON',
       deprecated: false,
       description:
-        'JSON object for non-managed connector creation. When set, posts directly to the connector create API.',
+        'JSON object for non-managed connector creation. When set, posts directly to the connector create API. Pass `@<path>` to read from a file or `@-` to read from stdin — recommended for secrets (e.g. client secrets), which leak into shell history when passed inline.',
     },
     {
       name: 'connector-type',
@@ -94,8 +94,12 @@ export const createSubcommand = {
       value: `${packageName} connect create mcp.linear.app --name linear --data '{"clientId":"abc123"}'`,
     },
     {
-      name: 'Create a non-managed connector with an explicit connector type',
-      value: `${packageName} connect create slack --name my-bot --connector-type slack --data '{"appId":"A123","appName":"my-bot","clientId":"abc","clientSecret":"secret"}'`,
+      name: 'Create a non-managed connector, reading credentials from a file (keeps secrets out of shell history)',
+      value: `${packageName} connect create slack --name my-bot --connector-type slack --data @slack-app.json`,
+    },
+    {
+      name: 'Create a non-managed connector, reading credentials from stdin',
+      value: `cat slack-app.json | ${packageName} connect create slack --name my-bot --connector-type slack --data @-`,
     },
     {
       name: 'Output as JSON',

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -1,3 +1,6 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { text } from 'node:stream/consumers';
 import open from 'open';
 import output from '../../output-manager';
 import type Client from '../../util/client';
@@ -60,18 +63,33 @@ export async function create(
     return 1;
   }
 
-  const hasDataFlag = dataFlag !== undefined;
-  const isDataFlagEmpty = hasDataFlag && dataFlag.trim().length === 0;
+  const isNonManagedCreate = dataFlag !== undefined;
+
+  // Resolve the --data source up front (inline JSON, `@<path>` to read a
+  // file, or `@-` to read stdin) so credentials can be supplied without
+  // leaking into shell history / process listings, and so we fail fast on a
+  // bad source before team selection or any network call.
   let nonManagedData: JSONObject | undefined;
-  if (hasDataFlag && !isDataFlagEmpty) {
+  let isDataFlagEmpty = false;
+  if (dataFlag !== undefined) {
     try {
-      nonManagedData = parseDataFlag(dataFlag);
+      const rawData = await resolveDataFlag(dataFlag, client);
+      if (rawData.trim().length === 0) {
+        isDataFlagEmpty = true;
+      } else {
+        nonManagedData = parseDataFlag(rawData);
+        // Inline JSON (anything not read from a file or stdin) is exposed in
+        // shell history and `ps`; nudge toward `@<path>`/`@-` when it looks
+        // like it carries a secret.
+        if (!dataFlag.startsWith('@')) {
+          warnInlineSecret(nonManagedData);
+        }
+      }
     } catch (err) {
       output.error((err as Error).message);
       return 1;
     }
   }
-  const isNonManagedCreate = hasDataFlag;
 
   // Preflight branding validation BEFORE team selection / network / upload.
   // This includes hex format, icon path readability, AND magic-byte check —
@@ -342,6 +360,64 @@ export async function create(
     );
   }
   return brandingPatchFailed ? 1 : 0;
+}
+
+/**
+ * Reads the entire stdin stream to EOF and returns it as a string. Used for
+ * the explicit `--data @-` request, where the full credential payload must be
+ * captured. Unlike `readStandardInput`, this has no time cap and accumulates
+ * every chunk, so slow producers and multi-chunk payloads are read in full.
+ * Returns '' when stdin is a TTY (nothing is piped, so reading would block).
+ */
+async function readStdinToEnd(stdin: Client['stdin']): Promise<string> {
+  if (stdin.isTTY) {
+    return '';
+  }
+  return text(stdin);
+}
+
+/**
+ * Resolves a `--data` flag value to the raw JSON string. Supports inline
+ * JSON, `@<path>` to read a file (relative paths resolved against `cwd`),
+ * and `@-` to read from stdin. File/stdin sources keep secrets out of argv,
+ * shell history, and process listings.
+ */
+async function resolveDataFlag(raw: string, client: Client): Promise<string> {
+  if (!raw.startsWith('@')) {
+    return raw;
+  }
+  const source = raw.slice(1);
+  if (source === '-') {
+    return readStdinToEnd(client.stdin);
+  }
+  if (source.length === 0) {
+    throw new Error(
+      'Invalid --data value. Use `@<path>` to read from a file or `@-` to read from stdin.'
+    );
+  }
+  try {
+    return await readFile(resolve(client.cwd, source), 'utf8');
+  } catch (err) {
+    throw new Error(
+      `Could not read --data file at "${source}": ${(err as Error).message}`
+    );
+  }
+}
+
+const SECRET_KEY_PATTERN =
+  /secret|password|passwd|token|api[-_]?key|private[-_]?key|credential/i;
+
+/**
+ * Warns when inline `--data` JSON contains a credential-looking key, since
+ * inline flag values leak into shell history and `ps` output.
+ */
+function warnInlineSecret(data: JSONObject): void {
+  const secretKey = Object.keys(data).find(key => SECRET_KEY_PATTERN.test(key));
+  if (secretKey) {
+    output.warn(
+      `--data was passed inline and appears to contain a credential ("${secretKey}"). Inline flag values leak into shell history and process listings. Pass \`--data @<path>\` to read from a file or \`--data @-\` to read from stdin instead.`
+    );
+  }
 }
 
 function parseDataFlag(raw: string): JSONObject {

--- a/packages/cli/src/commands/connex/detach.ts
+++ b/packages/cli/src/commands/connex/detach.ts
@@ -7,6 +7,7 @@ import { selectConnexTeam } from '../../util/connex/select-team';
 import { getLinkedProject } from '../../util/projects/link';
 import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
 import { ProjectNotFound } from '../../util/errors-ts';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
 import { packageName } from '../../util/pkg-name';
 import type { ConnexClientIdentity, ConnexClientProject } from './types';
 
@@ -69,7 +70,7 @@ export async function detach(
     }
 
     projectId = resolvedProject.id;
-    projectName = resolvedProject.name;
+    projectName = sanitizeForTerminal(resolvedProject.name);
   } else {
     const linked = await getLinkedProject(client);
     if (linked.status === 'error') {
@@ -87,7 +88,7 @@ export async function detach(
       client.config.currentTeam = undefined;
     }
     projectId = linked.project.id;
-    projectName = linked.project.name;
+    projectName = sanitizeForTerminal(linked.project.name);
   }
 
   // Resolve client identity → canonical id + display name.
@@ -109,7 +110,9 @@ export async function detach(
   }
   output.stopSpinner();
 
-  const displayName = target.uid || target.name || target.id;
+  const displayName = sanitizeForTerminal(
+    target.uid || target.name || target.id
+  );
 
   // Pre-fetch existing attachment. If absent, treat as a no-op success.
   let existingAttachment: ConnexClientProject | undefined;

--- a/packages/cli/src/commands/connex/list.ts
+++ b/packages/cli/src/commands/connex/list.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
-import stripAnsi from 'strip-ansi';
 import output from '../../output-manager';
 import type Client from '../../util/client';
 import { validateJsonOutput } from '../../util/output-format';
 import { printError } from '../../util/error';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
 import { selectConnexTeam } from '../../util/connex/select-team';
 import { getLinkedProject } from '../../util/projects/link';
 import table from '../../util/output/table';
@@ -208,16 +208,17 @@ export async function list(
   }
   const rows = clients.map(c => {
     const row = [
-      stripAnsi(c.uid || '') || chalk.gray('–'),
+      sanitizeForTerminal(c.uid || '') || chalk.gray('–'),
       c.id,
-      stripAnsi(c.name || '') || chalk.gray('–'),
-      c.typeName || c.type,
+      sanitizeForTerminal(c.name || '') || chalk.gray('–'),
+      sanitizeForTerminal(c.typeName || c.type),
     ];
     if (unscoped) {
       const projectsInclude = c.includes?.projects;
       const names = (projectsInclude?.items ?? [])
         .map(p => p.project?.name)
-        .filter((n): n is string => Boolean(n));
+        .filter((n): n is string => Boolean(n))
+        .map(sanitizeForTerminal);
       const more = projectsInclude?.hasMore === true;
       let cell: string;
       if (names.length === 0 && !more) {

--- a/packages/cli/src/commands/connex/remove.ts
+++ b/packages/cli/src/commands/connex/remove.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import output from '../../output-manager';
 import type Client from '../../util/client';
 import { validateJsonOutput } from '../../util/output-format';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
 import { selectConnexTeam } from '../../util/connex/select-team';
 import type {
   ConnexClientIdentity,
@@ -64,7 +65,7 @@ export async function remove(
   }
   output.stopSpinner();
 
-  const displayName = target.uid || target.id;
+  const displayName = sanitizeForTerminal(target.uid || target.id);
 
   let projectLinks: ConnexClientProject[];
   try {

--- a/packages/cli/src/commands/connex/revoke-tokens.ts
+++ b/packages/cli/src/commands/connex/revoke-tokens.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import output from '../../output-manager';
 import type Client from '../../util/client';
 import { validateJsonOutput } from '../../util/output-format';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
 import { selectConnexTeam } from '../../util/connex/select-team';
 import type { ConnexClientIdentity } from './types';
 
@@ -81,7 +82,9 @@ export async function revokeTokens(
   }
   output.stopSpinner();
 
-  const displayName = target.name || target.uid || target.id;
+  const displayName = sanitizeForTerminal(
+    target.name || target.uid || target.id
+  );
   const supportsRevocation = target.supportsRevocation !== false;
 
   // Resolve subjectScope: flag → interactive TTY → error

--- a/packages/cli/src/util/connex/sanitize.ts
+++ b/packages/cli/src/util/connex/sanitize.ts
@@ -1,0 +1,18 @@
+import stripAnsi from 'strip-ansi';
+
+/**
+ * Strip ANSI/VT100 escape sequences from a team-controlled value before it
+ * reaches the terminal.
+ *
+ * Connector names, UIDs, and project names are free-form and visible across
+ * a team, so a malicious team member can embed escape sequences that, when
+ * rendered by another member's terminal, allow cursor manipulation, output
+ * spoofing, or hyperlink spoofing. Run every such value through this helper
+ * at the point it is assigned for human-readable output.
+ *
+ * Do NOT use this for `--format=json` output: JSON consumers expect the raw
+ * value, and `JSON.stringify` already escapes control characters.
+ */
+export function sanitizeForTerminal(value: string): string {
+  return stripAnsi(value);
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -827,7 +827,8 @@ exports[`help command > connex help output snapshots > connex create subcommand 
        --background-color <HEX>  Background color for the connector icon (e.g. #1A2B3C)                                      
        --connector-type <TYPE>   Connector type for non-managed creation. By default, the type is resolved from the service. 
        --data <JSON>             JSON object for non-managed connector creation. When set, posts directly to the connector   
-                                 create API.                                                                                 
+                                 create API. Pass \`@<path>\` to read from a file or \`@-\` to read from stdin — recommended for 
+                                 secrets (e.g. client secrets), which leak into shell history when passed inline.            
   -F,  --format <FORMAT>         Specify the output format (json)                                                            
        --icon <PATH>             Path to a PNG or JPEG image to use as the connector icon (uploaded to Vercel)               
   -n,  --name <NAME>             Name of the connector                                                                       
@@ -870,9 +871,13 @@ exports[`help command > connex help output snapshots > connex create subcommand 
 
     $ vercel connect create mcp.linear.app --name linear --data '{"clientId":"abc123"}'
 
-  - Create a non-managed connector with an explicit connector type
+  - Create a non-managed connector, reading credentials from a file (keeps secrets out of shell history)
 
-    $ vercel connect create slack --name my-bot --connector-type slack --data '{"appId":"A123","appName":"my-bot","clientId":"abc","clientSecret":"secret"}'
+    $ vercel connect create slack --name my-bot --connector-type slack --data @slack-app.json
+
+  - Create a non-managed connector, reading credentials from stdin
+
+    $ cat slack-app.json | vercel connect create slack --name my-bot --connector-type slack --data @-
 
   - Output as JSON
 

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -202,6 +202,175 @@ describe('connex create', () => {
     );
   });
 
+  it('should read non-managed --data from a file with @<path>', async () => {
+    let postBody: any;
+    client.scenario.get('/v1/connect/services/:service', (_req, res) => {
+      res.json({ types: [{ type: 'api-key' }] });
+    });
+    client.scenario.post('/v1/connect/connectors', (req, res) => {
+      postBody = req.body;
+      res.json(
+        fakeConnexClient({ id: 'scl_file1', uid: 'uid_file1', type: 'api-key' })
+      );
+    });
+
+    const dataPath = await writeTmpFile(
+      'creds.json',
+      Buffer.from('{"clientId":"abc123","clientSecret":"shh"}')
+    );
+
+    client.setArgv(
+      'connect',
+      'create',
+      'mcp.linear.app',
+      '--name',
+      'linear',
+      '--data',
+      `@${dataPath}`
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(postBody.data).toEqual({ clientId: 'abc123', clientSecret: 'shh' });
+    // A file source must not trigger the inline-secret warning.
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'leak into shell history'
+    );
+  });
+
+  it('should read non-managed --data from stdin with @-', async () => {
+    let postBody: any;
+    client.scenario.get('/v1/connect/services/:service', (_req, res) => {
+      res.json({ types: [{ type: 'api-key' }] });
+    });
+    client.scenario.post('/v1/connect/connectors', (req, res) => {
+      postBody = req.body;
+      res.json(
+        fakeConnexClient({
+          id: 'scl_stdin1',
+          uid: 'uid_stdin1',
+          type: 'api-key',
+        })
+      );
+    });
+
+    (client.stdin as any).isTTY = false;
+    client.setArgv(
+      'connect',
+      'create',
+      'mcp.linear.app',
+      '--name',
+      'linear',
+      '--data',
+      '@-'
+    );
+
+    const exitCodePromise = connect(client);
+    // resolveDataFlag reads stdin to EOF, so deliver the payload and end the
+    // stream.
+    client.stdin.end('{"clientId":"fromstdin"}');
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(postBody.data).toEqual({ clientId: 'fromstdin' });
+  });
+
+  it('should read multi-chunk and delayed stdin from @- without truncating or timing out', async () => {
+    let postBody: any;
+    client.scenario.get('/v1/connect/services/:service', (_req, res) => {
+      res.json({ types: [{ type: 'api-key' }] });
+    });
+    client.scenario.post('/v1/connect/connectors', (req, res) => {
+      postBody = req.body;
+      res.json(
+        fakeConnexClient({
+          id: 'scl_stdin2',
+          uid: 'uid_stdin2',
+          type: 'api-key',
+        })
+      );
+    });
+
+    (client.stdin as any).isTTY = false;
+    client.setArgv(
+      'connect',
+      'create',
+      'mcp.linear.app',
+      '--name',
+      'linear',
+      '--data',
+      '@-'
+    );
+
+    const exitCodePromise = connect(client);
+    // Split the payload across chunks and start writing only after the old
+    // 500ms readStandardInput cap would have fired — proves the full read
+    // waits for EOF rather than resolving early or dropping later chunks.
+    const full =
+      '{"clientId":"abc","clientSecret":"shh-this-is-a-long-secret"}';
+    const mid = Math.floor(full.length / 2);
+    setTimeout(() => {
+      client.stdin.write(full.slice(0, mid));
+      client.stdin.end(full.slice(mid));
+    }, 600);
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(postBody.data).toEqual({
+      clientId: 'abc',
+      clientSecret: 'shh-this-is-a-long-secret',
+    });
+  });
+
+  it('should warn when inline --data appears to contain a secret', async () => {
+    client.scenario.get('/v1/connect/services/:service', (_req, res) => {
+      res.json({ types: [{ type: 'api-key' }] });
+    });
+    client.scenario.post('/v1/connect/connectors', (_req, res) => {
+      res.json(
+        fakeConnexClient({ id: 'scl_warn1', uid: 'uid_warn1', type: 'api-key' })
+      );
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'mcp.linear.app',
+      '--name',
+      'linear',
+      '--data',
+      '{"clientId":"abc","clientSecret":"shh"}'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('appears to contain a credential');
+    expect(stderr).toContain('clientSecret');
+    expect(stderr).toContain('leak into shell history');
+  });
+
+  it('should error when --data @<path> file cannot be read', async () => {
+    client.setArgv(
+      'connect',
+      'create',
+      'mcp.linear.app',
+      '--name',
+      'linear',
+      '--data',
+      '@/does/not/exist-xyz.json'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Could not read --data file'
+    );
+  });
+
   it('should default non-managed connector type to oauth when service discovery returns 404', async () => {
     let discoveryHit = false;
     let postBody: any;

--- a/packages/cli/test/unit/commands/connex/list.test.ts
+++ b/packages/cli/test/unit/commands/connex/list.test.ts
@@ -302,6 +302,46 @@ describe('connex list', () => {
       expect(stderr).not.toContain('\x1b[1A');
     });
 
+    it('should strip ansi from the type cell and project names', async () => {
+      client.scenario.get('/v1/connect/connectors', (_req, res) => {
+        res.json({
+          clients: [
+            {
+              id: 'scl_unsafe',
+              uid: 'slack/unsafe',
+              name: 'Connector',
+              type: 'slack',
+              typeName: 'Sla\x1b[31mck',
+              createdAt: Date.now() - 60_000,
+              includes: {
+                projects: {
+                  items: [
+                    {
+                      projectId: 'proj_1',
+                      project: { id: 'proj_1', name: 'evil\x1b[2Jproj' },
+                    },
+                  ],
+                  hasMore: false,
+                  cursor: null,
+                },
+              },
+            },
+          ],
+        });
+      });
+
+      client.setArgv('connect', 'list', '--all-projects');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Slack');
+      expect(stderr).toContain('evilproj');
+      expect(stderr).not.toContain('\x1b[31m');
+      expect(stderr).not.toContain('\x1b[2J');
+    });
+
     it('should render empty-state without project context', async () => {
       client.scenario.get('/v1/connect/connectors', (_req, res) => {
         res.json({ clients: [] });

--- a/packages/cli/test/unit/commands/connex/revoke-tokens.test.ts
+++ b/packages/cli/test/unit/commands/connex/revoke-tokens.test.ts
@@ -133,6 +133,37 @@ describe('connex revoke-tokens', () => {
     expect(client.stderr.getFullOutput()).toContain('Confirmation required');
   });
 
+  it('strips ansi from the connector name in output', async () => {
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({
+        id: CONNECTOR_ID,
+        uid: CONNECTOR_UID,
+        name: 'Evil\x1b[2J Bot',
+      });
+    });
+    client.scenario.delete(
+      '/v1/connect/connectors/:clientId/tokens',
+      (_req, res) => {
+        res.json(DEFAULT_REVOKE_RESULT);
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'revoke-tokens',
+      CONNECTOR_ID,
+      '--my-tokens',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Evil Bot');
+    expect(stderr).not.toContain('\x1b[2J');
+  });
+
   it('revokes my tokens with --my-tokens --yes and sends the correct body', async () => {
     let requestBody: unknown;
 


### PR DESCRIPTION
Two small hardening improvements for the `vercel connect` commands. Neither is a high-severity issue — both reduce footguns around team-controlled output and credential input.

## 1. Strip ANSI escapes from team-controlled values everywhere

Connector names, UIDs, and project names are free-form and visible across a team, so they can contain terminal escape sequences. A previous fix only stripped them in the `connect list` UID/name cells. This extends stripping to every command that renders those values — `attach`, `detach`, `remove`, `revoke-tokens`, and the `list` type/projects cells — via a shared `sanitizeForTerminal()` helper. JSON output stays raw.

## 2. Let `connect create --data` read credentials from a file or stdin

Non-managed connector creation could only take credentials (incl. client secrets) as an inline `--data` JSON string, which lands in shell history and process listings. `--data` now also accepts:

- `@<path>` — read JSON from a file
- `@-` — read JSON from stdin (read to EOF; no truncation)

Inline `--data` still works but now warns when it looks like it carries a secret. Help text and examples updated accordingly.

## Tests

- Regression coverage for ANSI stripping across the affected commands and `list` cells.
- New cases for `--data @file`, `--data @-` (including multi-chunk / delayed stdin), inline JSON, and the inline-secret warning.
- Full `connex` unit suite passing; help snapshot regenerated.