### PR TITLE
fix(backends): restore nft fs caching to fix build perf regression

### DIFF
--- a/.changeset/backends-nft-fs-cache.md
+++ b/.changeset/backends-nft-fs-cache.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Fix a `@vercel/backends` performance regression. Passing `stat`/`readlink`/`readFile` overrides to `nodeFileTrace` replaces @vercel/nft's internal `CachedFileSystem`, so repeated (mostly missing) path probes during module resolution became uncached syscalls that throw on every miss. The `stat`/`readlink` overrides are now only applied when there are in-memory rolldown output files to serve, and all fs overrides are memoized (including negative results) to restore nft's caching.

--- a/packages/backends/src/rolldown/nft.ts
+++ b/packages/backends/src/rolldown/nft.ts
@@ -49,6 +49,75 @@ export const nft = async (
       ),
       ...virtualFiles.keys(),
     ];
+
+    // Overriding these replaces nft's internal CachedFileSystem, so we only
+    // override stat/readlink when there are virtual files to serve and memoize
+    // every override (including ENOENT results) to keep nft's caching.
+    const statOverride = memoize(async (fsPath: string) => {
+      const virtual = virtualFiles.get(fsPath);
+      if (virtual !== undefined) return createVirtualFileStat(virtual);
+
+      try {
+        return await stat(fsPath);
+      } catch (error: unknown) {
+        if (
+          isNativeError(error) &&
+          'code' in error &&
+          (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+        ) {
+          return null;
+        }
+        throw error;
+      }
+    });
+
+    const readlinkOverride = memoize(async (fsPath: string) => {
+      if (virtualFiles.has(fsPath)) return null;
+
+      try {
+        return await readlink(fsPath);
+      } catch (error: unknown) {
+        if (
+          isNativeError(error) &&
+          'code' in error &&
+          (error.code === 'EINVAL' ||
+            error.code === 'ENOENT' ||
+            error.code === 'ENOTDIR')
+        ) {
+          return null;
+        }
+        throw error;
+      }
+    });
+
+    // `readFile` is always overridden: nft can't parse TypeScript (we transform
+    // it here) and it also serves virtual files.
+    const readFileOverride = memoize(async (fsPath: string) => {
+      const virtual = virtualFiles.get(fsPath);
+      if (virtual !== undefined) return virtual;
+
+      try {
+        let source: string | Buffer = await readFile(fsPath);
+
+        // NFT doesn't support TypeScript, so we need to transform the source code.
+        if (isTypeScriptFile(fsPath)) {
+          const transformResult = await transform(fsPath, source.toString());
+          source = transformResult.code;
+        }
+
+        return source;
+      } catch (error: unknown) {
+        if (
+          isNativeError(error) &&
+          'code' in error &&
+          (error.code === 'ENOENT' || error.code === 'EISDIR')
+        ) {
+          return null;
+        }
+        throw error;
+      }
+    });
+
     const nftResult = await nodeFileTrace(traceRoots, {
       base: args.repoRootPath,
       processCwd: args.workPath,
@@ -57,66 +126,10 @@ export const nft = async (
       moduleSyncCatchall: true,
       conditions: args.conditions,
       ignore: ignorePatterns.length > 0 ? ignorePatterns : undefined,
-      async stat(fsPath) {
-        if (virtualFiles.has(fsPath)) {
-          return createVirtualFileStat(virtualFiles.get(fsPath)!);
-        }
-
-        try {
-          return await stat(fsPath);
-        } catch (error: unknown) {
-          if (
-            isNativeError(error) &&
-            'code' in error &&
-            (error.code === 'ENOENT' || error.code === 'ENOTDIR')
-          ) {
-            return null;
-          }
-          throw error;
-        }
-      },
-      async readlink(fsPath) {
-        if (virtualFiles.has(fsPath)) return null;
-
-        try {
-          return await readlink(fsPath);
-        } catch (error: unknown) {
-          if (
-            isNativeError(error) &&
-            'code' in error &&
-            (error.code === 'EINVAL' ||
-              error.code === 'ENOENT' ||
-              error.code === 'ENOTDIR')
-          ) {
-            return null;
-          }
-          throw error;
-        }
-      },
-      async readFile(fsPath) {
-        if (virtualFiles.has(fsPath)) return virtualFiles.get(fsPath)!;
-
-        try {
-          let source: string | Buffer = await readFile(fsPath);
-
-          // NFT doesn't support TypeScript, so we need to transform the source code.
-          if (isTypeScriptFile(fsPath)) {
-            const transformResult = await transform(fsPath, source.toString());
-            source = transformResult.code;
-          }
-
-          return source;
-        } catch (error: unknown) {
-          if (
-            isNativeError(error) &&
-            'code' in error &&
-            (error.code === 'ENOENT' || error.code === 'EISDIR')
-          ) {
-            return null;
-          }
-          throw error;
-        }
-      },
+      readFile: readFileOverride,
+      ...(virtualFiles.size > 0
+        ? { stat: statOverride, readlink: readlinkOverride }
+        : {}),
     });
     for (const file of nftResult.fileList) {
       const absolutePath = join(args.repoRootPath, file);
@@ -169,6 +182,19 @@ export const nft = async (
   };
 
   await nftSpan.trace(runNft);
+};
+
+/** Memoizes an async fs lookup by path, caching negative/ENOENT results too. */
+const memoize = <T>(fn: (path: string) => Promise<T>) => {
+  const cache = new Map<string, Promise<T>>();
+  return (path: string): Promise<T> => {
+    let cached = cache.get(path);
+    if (cached === undefined) {
+      cached = fn(path);
+      cache.set(path, cached);
+    }
+    return cached;
+  };
 };
 
 const JS_LIKE_EXTENSIONS = new Set([


### PR DESCRIPTION
## Summary

`vc.builder.backends.nft` regressed 2-3x (P50 ~13.8s → ~39.2s on affected projects), roughly doubling overall `vc.builder.backends.build` time. Bisected to #16361, which added `stat`/`readlink`/`readFile` overrides to `nodeFileTrace`.

The problem: passing `stat`/`readlink`/`readFile` to `nodeFileTrace` **replaces** `@vercel/nft`'s internal `CachedFileSystem`, which otherwise caches stat/readlink/readFile results — including negative (`ENOENT`) lookups. Module resolution probes the same mostly-missing candidate paths repeatedly while walking `node_modules` up the tree, so the un-memoized overrides turned every repeat into a fresh syscall that throws-and-catches on each miss.

The fix:
- Only override `stat`/`readlink` when there are in-memory rolldown output (virtual) files to serve. The rolldown span has none, so it falls back to nft's native cached fs (restoring the pre-#16361 behavior).
- Memoize all fs overrides (including `ENOENT` results) so the `traceFiles` span — which must keep the overrides to resolve virtual files — regains nft's caching.

## Test plan

- [x] `pnpm type-check` clean
- [x] `@vercel/nft` virtual-file trace correctness test passes (CJS/ESM unchanged)
- [x] Full backends build fixture suite (32 tests) passes — including `07-hono-ts-paths-import`, cjs/esm interop fixtures, `17-turborepo-hono-monorepo`, and `21-elysia-vercel-repro` — with emitted lambdas booting correctly
- [x] Local benchmark: memoized/native path ~200ms vs un-memoized ~1186ms (~5x) on a synthetic monorepo graph

Made with [Cursor](https://cursor.com)