### PR TITLE
[@vercel/frameworks] update Eve framework logos

### DIFF
--- a/.changeset/eve-framework-logos.md
+++ b/.changeset/eve-framework-logos.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Replace placeholder Eve framework logos with the official triangle mark used in Eve docs.

--- a/packages/frameworks/logos/eve-dark.svg
+++ b/packages/frameworks/logos/eve-dark.svg
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" role="img" aria-label="Eve">
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 102 102" role="img" aria-label="Eve">
   <title>Eve</title>
-  <path fill="#fff" d="M12 2 2 19.5h20L12 2Zm0 4.7 6.1 10.6H5.9L12 6.7Z"/>
+  <rect width="102" height="102" fill="#fff"/>
+  <path d="M49.2811 66.9377L75.0311 34.9622H68.1393L47.9096 60.1058L42.4236 66.9377H49.2811Z" fill="#000"/>
+  <path d="M0 34.9622H42.4048V40.0704H0V34.9622Z" fill="#000"/>
+  <rect y="48.2844" width="27.6587" height="5.10824" fill="#000"/>
+  <rect y="61.816" width="27.6588" height="5.10824" fill="#000"/>
+  <rect width="32.2696" height="5.10824" transform="matrix(-1 0 0 1 101.9 34.9622)" fill="#000"/>
+  <rect width="27.6587" height="5.10824" transform="matrix(-1 0 0 1 101.9 48.2844)" fill="#000"/>
+  <rect width="27.6588" height="5.10824" transform="matrix(-1 0 0 1 101.9 61.816)" fill="#000"/>
 </svg>

--- a/packages/frameworks/logos/eve-dark.svg
+++ b/packages/frameworks/logos/eve-dark.svg
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Eve">
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" role="img" aria-label="Eve">
   <title>Eve</title>
-  <rect width="48" height="48" rx="8" fill="#fff"/>
-  <text x="24" y="24" fill="#000"
-        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
-        font-size="14" font-weight="700" letter-spacing="1"
-        text-anchor="middle" dominant-baseline="central">EVE</text>
+  <path fill="#fff" d="M12 2 2 19.5h20L12 2Zm0 4.7 6.1 10.6H5.9L12 6.7Z"/>
 </svg>

--- a/packages/frameworks/logos/eve.svg
+++ b/packages/frameworks/logos/eve.svg
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Eve">
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" role="img" aria-label="Eve">
   <title>Eve</title>
-  <rect width="48" height="48" rx="8" fill="#000"/>
-  <text x="24" y="24" fill="#fff"
-        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
-        font-size="14" font-weight="700" letter-spacing="1"
-        text-anchor="middle" dominant-baseline="central">EVE</text>
+  <path fill="#000" d="M12 2 2 19.5h20L12 2Zm0 4.7 6.1 10.6H5.9L12 6.7Z"/>
 </svg>

--- a/packages/frameworks/logos/eve.svg
+++ b/packages/frameworks/logos/eve.svg
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" role="img" aria-label="Eve">
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 102 102" role="img" aria-label="Eve">
   <title>Eve</title>
-  <path fill="#000" d="M12 2 2 19.5h20L12 2Zm0 4.7 6.1 10.6H5.9L12 6.7Z"/>
+  <rect width="102" height="102" fill="#000"/>
+  <path d="M49.2811 66.9377L75.0311 34.9622H68.1393L47.9096 60.1058L42.4236 66.9377H49.2811Z" fill="#fff"/>
+  <path d="M0 34.9622H42.4048V40.0704H0V34.9622Z" fill="#fff"/>
+  <rect y="48.2844" width="27.6587" height="5.10824" fill="#fff"/>
+  <rect y="61.816" width="27.6588" height="5.10824" fill="#fff"/>
+  <rect width="32.2696" height="5.10824" transform="matrix(-1 0 0 1 101.9 34.9622)" fill="#fff"/>
+  <rect width="27.6587" height="5.10824" transform="matrix(-1 0 0 1 101.9 48.2844)" fill="#fff"/>
+  <rect width="27.6588" height="5.10824" transform="matrix(-1 0 0 1 101.9 61.816)" fill="#fff"/>
 </svg>


### PR DESCRIPTION
## Summary

- Replace placeholder Eve framework logos (`EVE` text in a rounded square) with the official Eve square mark (white mark on solid black square).
- Light mode (`eve.svg`): white mark on black square — the official asset as provided.
- Dark mode (`eve-dark.svg`): color-inverted variant (black mark on white square), following the same convention as `ash.svg` / `ash-dark.svg`.

## Validation

- `pnpm build --filter @vercel/frameworks`
- `pnpm --filter @vercel/frameworks test -- test/frameworks.unit.test.ts` (logo file existence + URL prefix checks pass)
- After deploy to `api-frameworks.vercel.sh`, Eve should show the square mark in the dashboard framework picker and import flow.