### PR TITLE
Support Node framework preset without a package.json

### DIFF
--- a/.changeset/node-preset-no-package-json.md
+++ b/.changeset/node-preset-no-package-json.md
@@ -1,0 +1,9 @@
+---
+'@vercel/frameworks': patch
+'@vercel/backends': patch
+---
+
+Allow the Node framework preset to work without a `package.json`. The `node`
+framework is now detected from a `server.*` entrypoint alone, and the
+`@vercel/backends` builder defaults the module format to ESM (`"module"`) when
+no `package.json` is present instead of erroring with "Unable to resolve format".

--- a/packages/backends/src/rolldown/resolve-format.ts
+++ b/packages/backends/src/rolldown/resolve-format.ts
@@ -43,7 +43,10 @@ export const resolveEntrypointAndFormat = async (
     }
   }
   if (!resolvedFormat) {
-    throw new Error(`Unable to resolve format for ${args.entrypoint}`);
+    // No `package.json` (and no explicit `defaultFormat`) to infer the module
+    // format from. Default to ESM so a bare `server.ts`/`server.js` works out
+    // of the box without requiring a `package.json` with `"type": "module"`.
+    resolvedFormat = 'esm';
   }
   const resolvedExtension = resolvedFormat === 'esm' ? 'mjs' : 'cjs';
   return { format: resolvedFormat, extension: resolvedExtension };

--- a/packages/backends/test/unit.resolve-format.test.ts
+++ b/packages/backends/test/unit.resolve-format.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { resolveEntrypointAndFormat } from '../src/rolldown/resolve-format';
+
+describe('resolveEntrypointAndFormat', () => {
+  it('defaults to ESM for server.ts when no package.json exists', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'be-fmt-no-pkg-'));
+    try {
+      await writeFile(join(dir, 'server.ts'), '// server', 'utf-8');
+      await expect(
+        resolveEntrypointAndFormat({ entrypoint: 'server.ts', workPath: dir })
+      ).resolves.toEqual({ format: 'esm', extension: 'mjs' });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('defaults to ESM for server.js when no package.json exists', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'be-fmt-no-pkg-js-'));
+    try {
+      await writeFile(join(dir, 'server.js'), '// server', 'utf-8');
+      await expect(
+        resolveEntrypointAndFormat({ entrypoint: 'server.js', workPath: dir })
+      ).resolves.toEqual({ format: 'esm', extension: 'mjs' });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors the explicit defaultFormat when no package.json exists', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'be-fmt-default-'));
+    try {
+      await writeFile(join(dir, 'server.ts'), '// server', 'utf-8');
+      await expect(
+        resolveEntrypointAndFormat({
+          entrypoint: 'server.ts',
+          workPath: dir,
+          defaultFormat: 'cjs',
+        })
+      ).resolves.toEqual({ format: 'cjs', extension: 'cjs' });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('infers CJS from package.json without "type": "module"', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'be-fmt-cjs-'));
+    try {
+      await writeFile(join(dir, 'server.ts'), '// server', 'utf-8');
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ name: 'x' }),
+        'utf-8'
+      );
+      await expect(
+        resolveEntrypointAndFormat({ entrypoint: 'server.ts', workPath: dir })
+      ).resolves.toEqual({ format: 'cjs', extension: 'cjs' });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('infers ESM from package.json with "type": "module"', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'be-fmt-esm-'));
+    try {
+      await writeFile(join(dir, 'server.ts'), '// server', 'utf-8');
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ name: 'x', type: 'module' }),
+        'utf-8'
+      );
+      await expect(
+        resolveEntrypointAndFormat({ entrypoint: 'server.ts', workPath: dir })
+      ).resolves.toEqual({ format: 'esm', extension: 'mjs' });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4473,11 +4473,6 @@ export const frameworks = [
     useRuntime: { src: 'package.json', use: '@vercel/backends' },
     ignoreRuntimes: ['@vercel/node'],
     detectors: {
-      every: [
-        {
-          path: 'package.json',
-        },
-      ],
       some: [
         {
           path: 'server.cjs',

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -271,6 +271,32 @@ describe('detectFramework()', () => {
     ).toBe('node');
   });
 
+  it.each([
+    'server.cjs',
+    'server.js',
+    'server.mjs',
+    'server.mts',
+    'server.ts',
+    'server.cts',
+    'src/server.cjs',
+    'src/server.js',
+    'src/server.mjs',
+    'src/server.mts',
+    'src/server.ts',
+    'src/server.cts',
+  ])('Detect Node via `%s` without a package.json', async entrypoint => {
+    const fs = new VirtualFilesystem({
+      [entrypoint]: '// server entrypoint',
+    });
+
+    expect(
+      await detectFramework({
+        fs,
+        frameworkList,
+      })
+    ).toBe('node');
+  });
+
   it('Detect frameworks based on ascending order in framework list', async () => {
     const fs = new VirtualFilesystem({
       'package.json': JSON.stringify({


### PR DESCRIPTION
## Summary

- Detect the `node` framework preset from a `server.*` entrypoint alone, dropping the `package.json` requirement from its detector.
- Default the `@vercel/backends` module format to ESM (`"module"`) when no `package.json` is present, instead of throwing `Error: Unable to resolve format for server.ts`.

This lets a bare `server.ts`/`server.js` (no `package.json`) be detected and built out of the box. `findEntrypoint` already tolerated a missing `package.json`, so these were the only two remaining blockers.

Existing behavior is preserved: when a `package.json` exists, format is still inferred from `"type"` (ESM for `module`, CJS otherwise), and cron services still default to CJS via their explicit `defaultFormat`.

## Changes

- `packages/frameworks/src/frameworks.ts` — remove the `package.json` `every` clause from the `node` detector.
- `packages/backends/src/rolldown/resolve-format.ts` — default to ESM when format can't otherwise be resolved.

## Test plan

- [x] `packages/backends/test/unit.resolve-format.test.ts` — ESM default without `package.json` for `.ts`/`.js`, explicit `defaultFormat` override, CJS/ESM inference from `package.json`.
- [x] `packages/fs-detectors/test/unit.framework-detector.test.ts` — detect `node` from all 12 `server.*` variants without a `package.json`.
- [x] Detector suites (456 tests), frameworks schema test, and `type-check` pass.

Made with [Cursor](https://cursor.com)