### PR TITLE
fix(next): mark missing /_next/static 404 fallback as no-store (ENET-2314)

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1135,6 +1135,7 @@ export const build: BuildV2 = async buildOptions => {
           ),
           headers: {
             'content-type': 'text/plain; charset=utf-8',
+            'cache-control': 'private, no-store',
           },
         },
 
@@ -2828,6 +2829,7 @@ export const build: BuildV2 = async buildOptions => {
         dest: path.join('/', entryDirectory, '_next/static/not-found.txt'),
         headers: {
           'content-type': 'text/plain; charset=utf-8',
+          'cache-control': 'private, no-store',
         },
       },
 

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2619,6 +2619,7 @@ export async function serverBuild({
         ),
         headers: {
           'content-type': 'text/plain; charset=utf-8',
+          'cache-control': 'private, no-store',
         },
       },
 


### PR DESCRIPTION
## Summary

- Add `cache-control: private, no-store` to the `handle: miss` route that rewrites missing `/_next/static/*` assets to `not-found.txt`
- Applied in both builder code paths (`index.ts` and `server-build.ts`)

## Problem

When a static chunk is missing on a deployment (common during rolling releases), the Next builder emits a miss route that returns HTTP 404 with plain-text body from `not-found.txt`. Without explicit cache headers, downstream caches can treat these responses like normal static assets.

## Fix

Set `cache-control: private, no-store` on the miss route headers so new deployments emit non-cacheable 404 fallbacks at the origin.

This is defense in depth alongside the proxy change that prevents CDN caching of these 404s for existing deployments.

## Test plan

- [ ] Build a Next.js project and confirm the generated routes include `cache-control: private, no-store` on the `/_next/static/.+` miss route
- [ ] Deploy with rolling release held at partial traffic; verify missing static asset 404 is not CDN-cached after proxy fix ships

## Related

- ENET-2314
- Primary fix: https://github.com/vercel/proxy/pull/new/fix/enet-2314-no-cdn-cache-next-static-404 (update with actual URL after creation)


Made with [Cursor](https://cursor.com)