### PR TITLE
[cli] Render deploy summary ▲ gutter once

### DIFF
--- a/.changeset/violet-bobcats-clap.md
+++ b/.changeset/violet-bobcats-clap.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Render the ▲ gutter once per deploy summary: on the Aliased row, falling back to the Production row when no Aliased row will print (`--no-wait`, `--skip-domain`)

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -2166,10 +2166,12 @@ async function handleContinueDeployment({
 
         const isProdDeployment = finalDeployment.target === 'production';
         const previewUrl = `https://${finalDeployment.url}`;
+        // The ▲ gutter belongs on the Aliased row, which only prints when we
+        // wait for alias assignment — with noWait it falls back to Production.
         printAlignedLabel(
           isProdDeployment ? 'Production' : 'Preview',
           chalk.cyan(previewUrl),
-          isProdDeployment ? { gutter: '▲' } : {}
+          isProdDeployment && noWait ? { gutter: '▲' } : {}
         );
 
         if (noWait) {

--- a/packages/cli/src/commands/redeploy/index.ts
+++ b/packages/cli/src/commands/redeploy/index.ts
@@ -152,10 +152,12 @@ export default async function redeploy(client: Client): Promise<number> {
 
     printAlignedLabel('Inspect', chalk.cyan(deployment.inspectorUrl));
 
+    // The ▲ gutter belongs on the Aliased row, which only prints when we
+    // wait for alias assignment — with --no-wait it falls back to Production.
     printAlignedLabel(
       isProdDeployment ? 'Production' : 'Preview',
       chalk.cyan(previewUrl),
-      isProdDeployment ? { gutter: '▲' } : {}
+      isProdDeployment && noWait ? { gutter: '▲' } : {}
     );
 
     if (!client.stdout.isTTY) {

--- a/packages/cli/src/commands/redeploy/index.ts
+++ b/packages/cli/src/commands/redeploy/index.ts
@@ -182,6 +182,19 @@ export default async function redeploy(client: Client): Promise<number> {
         !rollingRelease
       ) {
         output.spinner('Completing…', 0);
+
+        // The status polling loop is skipped, so render the Aliased row
+        // (and its ▲ gutter) here instead of in the alias-assigned handler.
+        if (
+          deployment.target === 'production' &&
+          deployment.alias &&
+          deployment.alias.length > 0
+        ) {
+          output.stopSpinner();
+          const primaryDomain = deployment.alias[0];
+          const prodUrl = `https://${primaryDomain}`;
+          printAlignedLabel('Aliased', chalk.cyan(prodUrl), { gutter: '▲' });
+        }
       } else {
         try {
           const clientOptions: VercelClientOptions = {

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -87,6 +87,12 @@ export default async function processDeployment({
 
   const client = now._client;
 
+  // The ▲ gutter belongs on the Aliased row, which only prints when we wait
+  // for alias assignment and domains are auto-assigned. When that row won't
+  // print (--no-wait, --skip-domain), fall back to ▲ on the Production row.
+  const aliasedRowWillPrint =
+    !noWait && requestBody.autoAssignCustomDomains !== false;
+
   const { env = {} } = requestBody;
   const token = now._token;
   if (!token) {
@@ -207,7 +213,7 @@ export default async function processDeployment({
         printAlignedLabel(
           isProdDeployment ? 'Production' : 'Preview',
           chalk.cyan(previewUrl),
-          isProdDeployment ? { gutter: '▲' } : {}
+          isProdDeployment && !aliasedRowWillPrint ? { gutter: '▲' } : {}
         );
 
         if (!jsonOutput && (quiet || process.env.FORCE_TTY === '1')) {
@@ -293,7 +299,7 @@ export default async function processDeployment({
         printAlignedLabel(
           isProdDeployment ? 'Production' : 'Preview',
           chalk.cyan(previewUrl),
-          isProdDeployment ? { gutter: '▲' } : {}
+          isProdDeployment && !aliasedRowWillPrint ? { gutter: '▲' } : {}
         );
 
         if (v1ChecksPending || v2ChecksPending) {

--- a/packages/cli/src/util/output/print-aligned-label.ts
+++ b/packages/cli/src/util/output/print-aligned-label.ts
@@ -8,12 +8,14 @@ export const ALIGNED_LABEL_WIDTH = 12;
  *
  * Layout (column 0 is the leftmost terminal column):
  *   "  Linked      acme/web"     (no gutter:  "  " + 12-char label = value at col 14)
- *   "▲ Production  https://..."  (gutter '▲': "▲ " + 12-char label = value at col 14)
+ *   "▲ Aliased     https://..."  (gutter '▲': "▲ " + 12-char label = value at col 14)
  *
  * The 2-char prefix is the CLI's "gutter" — column 0 is reserved for
- * semantic glyphs (▲ Vercel/Production, ✓ Ready, ? prompt). Everything else
- * lives at column 2+ as indented body content. See the deploy-flow design
- * doc for the full gutter system.
+ * semantic glyphs (▲ production URL, ✓ Ready, ? prompt). The ▲ renders at
+ * most once per deploy summary: on the Aliased row, or on the Production
+ * row when no Aliased row will print. Everything else lives at column 2+
+ * as indented body content. See the deploy-flow design doc for the full
+ * gutter system.
  */
 export function printAlignedLabel(
   label: string,

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1791,16 +1791,133 @@ describe('deploy', () => {
       );
 
       // Anti-regression: ANSI is stripped from toOutput, so assert the raw
-      // output still contains the gutter glyphs for both Production + Aliased
-      // rows. A regression that drops `gutter: '▲'` would not fail toOutput.
+      // output renders the ▲ gutter exactly once — on the Aliased row, not
+      // the Production row. `toOutput` alone would not catch a gutter change.
       const stderrOutput = client.stderr.getFullOutput();
-      expect(stderrOutput).toContain('▲ Production');
+      expect(stderrOutput).not.toContain('▲ Production');
       expect(stderrOutput).toContain('▲ Aliased');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
       expect(projectFetchCount).toEqual(1);
       expect(callCount).toEqual(2);
+    });
+
+    it('should display the ▲ gutter on Production when --no-wait skips the Aliased row', async () => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.post(`/v13/deployments`, (req, res) => {
+        res.json({
+          creator: {
+            uid: user.id,
+            username: user.username,
+          },
+          id: 'dpl_no_wait',
+          url: 'test-no-wait.vercel.app',
+          readyState: 'QUEUED',
+          target: 'production',
+        });
+      });
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--prod', '--yes', '--no-wait');
+
+      const exitCodePromise = deploy(client);
+
+      await expect(client.stderr).toOutput('Production ');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      // The Aliased row never prints with --no-wait, so the ▲ gutter falls
+      // back to the Production row.
+      const stderrOutput = client.stderr.getFullOutput();
+      expect(stderrOutput).toContain('▲ Production');
+      expect(stderrOutput).not.toContain('Aliased');
+    });
+
+    it('should display the ▲ gutter on Production when --skip-domain skips the Aliased row', async () => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.scenario.post(`/v13/deployments`, (req, res) => {
+        res.json({
+          creator: {
+            uid: user.id,
+            username: user.username,
+          },
+          id: 'dpl_skip_domain',
+          url: 'test-skip-domain.vercel.app',
+          target: 'production',
+        });
+      });
+
+      client.scenario.get(`/v13/deployments/dpl_skip_domain`, (req, res) => {
+        res.json({
+          creator: {
+            uid: user.id,
+            username: user.username,
+          },
+          id: 'dpl_skip_domain',
+          url: 'test-skip-domain.vercel.app',
+          readyState: 'READY',
+          aliasAssigned: true,
+          target: 'production',
+          alias: [],
+        });
+      });
+
+      client.scenario.get(
+        `/v10/now/deployments/dpl_skip_domain`,
+        (req, res) => {
+          res.json({
+            creator: {
+              uid: user.id,
+              username: user.username,
+            },
+            id: 'dpl_skip_domain',
+            url: 'test-skip-domain.vercel.app',
+            readyState: 'READY',
+            aliasAssigned: true,
+            target: 'production',
+            alias: [],
+          });
+        }
+      );
+
+      client.scenario.get(
+        `/v3/now/deployments/dpl_skip_domain/events`,
+        (req, res) => {
+          res.end();
+        }
+      );
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--prod', '--yes', '--skip-domain');
+
+      const exitCodePromise = deploy(client);
+
+      await expect(client.stderr).toOutput('Production ');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      // The Aliased row never prints with --skip-domain, so the ▲ gutter
+      // falls back to the Production row.
+      const stderrOutput = client.stderr.getFullOutput();
+      expect(stderrOutput).toContain('▲ Production');
+      expect(stderrOutput).not.toContain('Aliased');
     });
 
     it('should not display aliased domain for preview deployments', async () => {
@@ -1949,9 +2066,10 @@ describe('deploy', () => {
 
       const stderrOutput = client.stderr.read().toString();
       expect(stderrOutput).not.toContain('Aliased');
-      // Anti-regression: production rows always render with the ▲ gutter
-      // glyph at column 0.
-      expect(stderrOutput).toContain('▲ Production');
+      // The deployment waited for aliases, so the ▲ gutter was reserved for
+      // the Aliased row — when the server then assigns no aliases, no ▲ is
+      // rendered at all (accepted edge case).
+      expect(stderrOutput).not.toContain('▲');
     });
   });
 

--- a/packages/cli/test/unit/commands/redeploy/index.test.ts
+++ b/packages/cli/test/unit/commands/redeploy/index.test.ts
@@ -141,6 +141,37 @@ describe('redeploy', () => {
 
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "redeploy"').toEqual(0);
+
+    // The Aliased row never prints with --no-wait, so the ▲ gutter falls
+    // back to the Production row.
+    const stderrOutput = client.stderr.getFullOutput();
+    expect(stderrOutput).toContain('▲ Production');
+  });
+
+  it('should display the ▲ gutter only on the Aliased row when waiting for aliases', async () => {
+    const { fromDeployment, toDeployment } = initRedeployTest();
+    toDeployment.readyState = 'BUILDING';
+    toDeployment.aliasAssigned = false;
+    client.setArgv('redeploy', fromDeployment.id);
+
+    const exitCodePromise = redeploy(client);
+    await expect(client.stderr).toOutput('Production  https');
+
+    // let the status poller observe the alias assignment
+    toDeployment.readyState = 'READY';
+    toDeployment.aliasAssigned = true;
+    toDeployment.alias = ['my-app.vercel.app'];
+
+    await expect(client.stderr).toOutput(
+      'Aliased     https://my-app.vercel.app'
+    );
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "redeploy"').toEqual(0);
+
+    const stderrOutput = client.stderr.getFullOutput();
+    expect(stderrOutput).not.toContain('▲ Production');
+    expect(stderrOutput).toContain('▲ Aliased');
   });
 
   describe('--target', () => {

--- a/packages/cli/test/unit/commands/redeploy/index.test.ts
+++ b/packages/cli/test/unit/commands/redeploy/index.test.ts
@@ -148,6 +148,25 @@ describe('redeploy', () => {
     expect(stderrOutput).toContain('▲ Production');
   });
 
+  it('should display the ▲ Aliased row when the deployment is already ready and aliased', async () => {
+    const { fromDeployment, toDeployment } = initRedeployTest();
+    // already READY + aliasAssigned: the status polling loop is skipped
+    toDeployment.alias = ['my-app.vercel.app'];
+    client.setArgv('redeploy', fromDeployment.id);
+
+    const exitCodePromise = redeploy(client);
+    await expect(client.stderr).toOutput(
+      'Aliased     https://my-app.vercel.app'
+    );
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "redeploy"').toEqual(0);
+
+    const stderrOutput = client.stderr.getFullOutput();
+    expect(stderrOutput).not.toContain('▲ Production');
+    expect(stderrOutput).toContain('▲ Aliased');
+  });
+
   it('should display the ▲ gutter only on the Aliased row when waiting for aliases', async () => {
     const { fromDeployment, toDeployment } = initRedeployTest();
     toDeployment.readyState = 'BUILDING';


### PR DESCRIPTION
Deploy summary rendered the ▲ gutter on both the Production and Aliased rows. Now it renders exactly once: on the Aliased row, falling back to the Production row when no Aliased row will print (`--no-wait`, `--skip-domain`, redeploy `--no-wait`).

Since Production prints on the streamed `created` event before alias outcome is known, the gutter uses a predictor: `!noWait && autoAssignCustomDomains !== false` means Aliased will follow. Applies to `deploy`, `redeploy`, and the continue-deployment path; preview rows are unchanged.

Tests cover prod+alias (▲ only on Aliased), `--no-wait` and `--skip-domain` fallbacks, and redeploy parity.

| Before | After |
|---|---|
| `▲ Production` + `▲ Aliased` | `  Production` + `▲ Aliased` |