### PR TITLE
fix(cli): treat non-interactive `env add <name> preview` as all Preview branches

### DIFF
--- a/.changeset/env-add-preview-non-interactive.md
+++ b/.changeset/env-add-preview-non-interactive.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vercel env add <name> preview` in non-interactive mode failing with `git_branch_required` when no git branch argument is passed. Omitting the third argument now adds the variable to all Preview branches, matching the behavior the error's own suggested next command already described.

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -814,7 +814,11 @@ export default async function add(client: Client, argv: string[]) {
   if (
     envGitBranch === undefined &&
     envTargets.length === 1 &&
-    envTargets[0] === 'preview'
+    envTargets[0] === 'preview' &&
+    // When nonInteractive and exactly two positionals (name, preview), treat
+    // as "all Preview branches" — same convention as the missing-requirements
+    // check above, whose suggested next command would otherwise fail here again
+    !(client.nonInteractive && args.length === 2)
   ) {
     if (client.nonInteractive) {
       outputActionRequired(

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -1226,75 +1226,63 @@ describe('env add', () => {
         logSpy.mockRestore();
       });
 
-      it('uses --value when provided and reaches next prompt (e.g. git_branch_required)', async () => {
-        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-          throw new Error('exit');
-        });
-        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
+      it('adds to all Preview branches when --value is provided and no git branch argument', async () => {
+        const envName = 'PREVIEW_VAR';
         client.nonInteractive = true;
         client.setArgv(
           'env',
           'add',
-          'PREVIEW_VAR',
+          envName,
           'preview',
           '--value',
           'my-secret-value',
           '--yes'
         );
-        const exitCodePromise = env(client);
 
-        await expect(exitCodePromise).rejects.toThrow('exit');
-        const payload = JSON.parse(
-          logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
-        );
-        expect(payload.reason).toBe('git_branch_required');
-        expect(
-          payload.next.some(
-            (n: { command: string }) =>
-              n.command.includes('preview') && n.command.includes('<gitbranch>')
-          )
-        ).toBe(true);
+        try {
+          const exitCodePromise = env(client);
+          await expect(exitCodePromise).resolves.toBe(0);
 
-        exitSpy.mockRestore();
-        logSpy.mockRestore();
+          const savedEnv = envs.find(currentEnv => currentEnv.key === envName);
+          expect(savedEnv).toBeDefined();
+          expect(savedEnv?.target).toEqual(['preview']);
+          expect(savedEnv?.gitBranch).toBeUndefined();
+          expect(savedEnv?.value).toBe('my-secret-value');
+        } finally {
+          const savedEnvIndex = envs.findIndex(
+            currentEnv => currentEnv.key === envName
+          );
+          if (savedEnvIndex !== -1) {
+            envs.splice(savedEnvIndex, 1);
+          }
+        }
       });
 
-      it('outputs action_required when preview target and git branch not passed (no third argument)', async () => {
-        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-          throw new Error('exit');
-        });
-        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
+      it('adds to all Preview branches when value comes from stdin and no git branch argument', async () => {
+        const envName = 'PREVIEW_VAR_STDIN';
         client.nonInteractive = true;
         client.stdin.isTTY = false;
-        client.setArgv('env', 'add', 'PREVIEW_VAR', 'preview', '--yes');
-        const exitCodePromise = env(client);
-        setImmediate(() => client.stdin.emit('data', 'value-via-stdin'));
+        client.setArgv('env', 'add', envName, 'preview', '--yes');
 
-        await expect(exitCodePromise).rejects.toThrow('exit');
-        expect(logSpy).toHaveBeenCalled();
-        const payload = JSON.parse(
-          logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
-        );
-        expect(payload).toMatchObject({
-          status: 'action_required',
-          reason: 'git_branch_required',
-          message: expect.stringMatching(/Git branch|third argument|Preview/),
-          next: expect.any(Array),
-        });
-        expect(payload.next.length).toBeGreaterThanOrEqual(1);
-        expect(
-          payload.next.some(
-            (n: { command: string }) =>
-              n.command.includes('preview') &&
-              (n.command.includes('<gitbranch>') ||
-                n.command.includes('--value'))
-          )
-        ).toBe(true);
+        try {
+          const exitCodePromise = env(client);
+          setImmediate(() => client.stdin.emit('data', 'value-via-stdin'));
 
-        exitSpy.mockRestore();
-        logSpy.mockRestore();
+          await expect(exitCodePromise).resolves.toBe(0);
+
+          const savedEnv = envs.find(currentEnv => currentEnv.key === envName);
+          expect(savedEnv).toBeDefined();
+          expect(savedEnv?.target).toEqual(['preview']);
+          expect(savedEnv?.gitBranch).toBeUndefined();
+          expect(savedEnv?.value).toBe('value-via-stdin');
+        } finally {
+          const savedEnvIndex = envs.findIndex(
+            currentEnv => currentEnv.key === envName
+          );
+          if (savedEnvIndex !== -1) {
+            envs.splice(savedEnvIndex, 1);
+          }
+        }
       });
 
       it('does not output git_branch_required when branch is passed as third argument for preview', async () => {


### PR DESCRIPTION
### Description

In non-interactive mode, adding a Preview environment variable without a git-branch argument is impossible — the CLI rejects the exact command its own error output suggests:

```console
$ vercel env add APP_ENV preview --value preview --yes
{
  "status": "action_required",
  "reason": "git_branch_required",
  "message": "Add APP_ENV to which Git branch for Preview? Pass branch as third argument, or omit for all Preview branches.",
  "next": [
    { "command": "vercel env add APP_ENV preview <gitbranch> --value <value> --yes", "when": "Add to a specific Git branch" },
    { "command": "vercel env add APP_ENV preview --value <value> --yes", "when": "Add to all Preview branches" }
  ],
  "hint": "Run one of the commands in next[] to complete without prompting."
}
```

The second `next[]` command is character-for-character the command that was just rejected, so scripts and agents following the `hint` loop forever. Production and Development adds work fine; only Preview is affected. Reproduced on 54.12.2 (current latest).

### Root cause

Both checks come from the non-interactive mode work in #14912:

- The missing-requirements check in `add.ts` deliberately allows this form — its comment reads *"When nonInteractive and exactly two positionals (name, preview), treat as 'all Preview branches'; otherwise require branch"* — via the escape `!(client.nonInteractive && args.length === 2)`.
- The later git-branch prompt site has no such escape, and in non-interactive mode it unconditionally emits `action_required: git_branch_required` and exits 1. In non-interactive mode this site is *only* reachable in exactly the case the first check deliberately allowed through, so the intended "all Preview branches" path could never complete.

### Fix

Apply the same two-positionals convention to the prompt site, so the add proceeds with no `gitBranch` (= all Preview branches) — the same outcome as pressing Enter at the interactive prompt ("leave empty for all Preview branches"). Interactive behavior is unchanged.

Two existing tests asserted the dead-end (`git_branch_required` for `--value`/stdin without a branch argument); they now assert the add succeeds and that the created variable targets `["preview"]` with no `gitBranch`.

### Verification

- `vitest run test/unit/commands/env/` — 115/115 pass.
- Built the CLI and ran it against a scratch project:
  - `env add NAME preview --value <v> --yes` → exit 0, `env ls` shows the variable targeting Preview (all branches).
  - `printf '%s' <v> | env add NAME preview` → exit 0.
  - `env add NAME preview <branch> --value <v> --yes` still passes the guard (unchanged).

### Related issues

Fixes #16442. Also addresses #16111, #16190, #16436, and the non-interactive cases of #15415 and #15763.

Note: #15840 / #15841 attempted a fix for the interactive `--yes`/`--force` variant in April, but they predate the `env add` reordering in #16430 and no longer apply to the current flow; this PR takes the narrower route of honoring the convention the non-interactive check already documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
