### PR TITLE
[CLI] Show publicly accessible production URL in deploy output

### DIFF
--- a/.changeset/cli-deploy-visit-production-url.md
+++ b/.changeset/cli-deploy-visit-production-url.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Deploy/redeploy output now labels the commit-specific deployment URL as `Visit` and prints a separate `Production`/`Preview` line with the project's publicly accessible domain (matching the dashboard), instead of showing the first auto-generated alias which may be gated by Deployment Protection.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -64,6 +64,7 @@ import code from '../../util/output/code';
 import highlight from '../../util/output/highlight';
 import param from '../../util/output/param';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { getDeploymentTargetUrl } from '../../util/deploy/get-deployment-target-url';
 import stamp from '../../util/output/stamp';
 import { parseEnv } from '../../util/parse-env';
 import parseMeta from '../../util/parse-meta';
@@ -2164,12 +2165,12 @@ async function handleContinueDeployment({
           );
         }
 
-        const isProdDeployment = finalDeployment.target === 'production';
-        const previewUrl = `https://${finalDeployment.url}`;
+        // Only the commit-specific deployment URL is known at this point; the
+        // project's production/preview URL isn't assigned until later.
         printAlignedLabel(
-          isProdDeployment ? 'Production' : 'Preview',
-          chalk.cyan(previewUrl),
-          isProdDeployment ? { gutter: '▲' } : {}
+          'Visit',
+          chalk.cyan(`https://${finalDeployment.url}`),
+          { gutter: '▲' }
         );
 
         if (noWait) {
@@ -2198,14 +2199,15 @@ async function handleContinueDeployment({
         finalDeployment = event.payload;
         output.stopSpinner();
 
-        if (
-          finalDeployment.target === 'production' &&
-          finalDeployment.alias &&
-          finalDeployment.alias.length > 0
-        ) {
-          const primaryDomain = finalDeployment.alias[0];
-          const prodUrl = `https://${primaryDomain}`;
-          printAlignedLabel('Aliased', chalk.cyan(prodUrl), { gutter: '▲' });
+        // Show the publicly accessible production/preview URL (the project
+        // domain), not the auto-generated alias which may be protected.
+        const targetUrl = getDeploymentTargetUrl(finalDeployment);
+        if (targetUrl) {
+          printAlignedLabel(
+            targetUrl.label,
+            chalk.cyan(`https://${targetUrl.url}`),
+            { gutter: '▲' }
+          );
         }
       }
 

--- a/packages/cli/src/commands/redeploy/index.ts
+++ b/packages/cli/src/commands/redeploy/index.ts
@@ -3,6 +3,7 @@ import { checkDeploymentStatus } from '@vercel/client';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { getDeploymentTargetUrl } from '../../util/deploy/get-deployment-target-url';
 import { getCommandName } from '../../util/pkg-name';
 import { getDeploymentByIdOrURL } from '../../util/deploy/get-deployment-by-id-or-url';
 import getScope from '../../util/get-scope';
@@ -143,20 +144,13 @@ export default async function redeploy(client: Client): Promise<number> {
 
     output.stopSpinner();
 
-    const previewUrl = `https://${deployment.url}`;
-    let isProdDeployment: boolean = target === 'production';
-
-    if (customEnvironmentSlugOrId && customEnvironment) {
-      isProdDeployment = customEnvironment.type === 'production';
-    }
-
     printAlignedLabel('Inspect', chalk.cyan(deployment.inspectorUrl));
 
-    printAlignedLabel(
-      isProdDeployment ? 'Production' : 'Preview',
-      chalk.cyan(previewUrl),
-      isProdDeployment ? { gutter: '▲' } : {}
-    );
+    // Only the commit-specific deployment URL is known at this point; the
+    // project's production/preview URL isn't assigned until later.
+    printAlignedLabel('Visit', chalk.cyan(`https://${deployment.url}`), {
+      gutter: '▲',
+    });
 
     if (!client.stdout.isTTY) {
       client.stdout.write(`https://${deployment.url}`);
@@ -220,16 +214,19 @@ export default async function redeploy(client: Client): Promise<number> {
 
               if (
                 event.type === 'alias-assigned' &&
-                !Array.isArray(event.payload) &&
-                event.payload.target === 'production' &&
-                event.payload.alias &&
-                event.payload.alias.length > 0
+                !Array.isArray(event.payload)
               ) {
-                const primaryDomain = event.payload.alias[0];
-                const prodUrl = `https://${primaryDomain}`;
-                printAlignedLabel('Aliased', chalk.cyan(prodUrl), {
-                  gutter: '▲',
-                });
+                // Show the publicly accessible production/preview URL (the
+                // project domain), not the auto-generated alias which may be
+                // protected.
+                const targetUrl = getDeploymentTargetUrl(event.payload);
+                if (targetUrl) {
+                  printAlignedLabel(
+                    targetUrl.label,
+                    chalk.cyan(`https://${targetUrl.url}`),
+                    { gutter: '▲' }
+                  );
+                }
               }
 
               deployment = event.payload;

--- a/packages/cli/src/util/deploy/get-deployment-target-url.ts
+++ b/packages/cli/src/util/deploy/get-deployment-target-url.ts
@@ -43,8 +43,14 @@ export function getDeploymentTargetUrl(
   }
 
   // Preview deployments: surface the stable branch ("preview") alias rather
-  // than the commit-specific deployment URL.
-  const branchDomain = automaticAliases.find(alias => alias.includes('-git-'));
+  // than the commit-specific deployment URL. Vercel inserts a `-git-<branch>-`
+  // segment to build it: `<project>-git-<branch>-<scope>.vercel.app`. A project
+  // whose own name contains `-git-` could make a non-branch alias match too, so
+  // when several candidates match we prefer the longest, i.e. the one carrying
+  // the extra inserted branch segment.
+  const branchDomain = automaticAliases
+    .filter(alias => alias.includes('-git-'))
+    .sort((a, b) => b.length - a.length)[0];
   return branchDomain ? { label: 'Preview', url: branchDomain } : undefined;
 }
 

--- a/packages/cli/src/util/deploy/get-deployment-target-url.ts
+++ b/packages/cli/src/util/deploy/get-deployment-target-url.ts
@@ -1,0 +1,57 @@
+interface DeploymentAliasFields {
+  // Widened to `string` because custom environments use arbitrary target slugs.
+  target?: string | null;
+  alias?: string[];
+  automaticAliases?: string[];
+}
+
+/**
+ * The publicly shareable URL for a finished deployment, plus the label to
+ * print for it ("Production" or "Preview").
+ *
+ * A deployment record exposes several hostnames:
+ *   - `url`              – the immutable, commit-specific deployment URL
+ *   - `automaticAliases` – auto-generated system aliases (e.g.
+ *                          `<project>-<scope>` and
+ *                          `<project>-git-<branch>-<scope>`)
+ *   - `alias`            – everything assigned to the deployment, which also
+ *                          includes the project's production domains
+ *
+ * The dashboard surfaces the project's production domain (not the
+ * auto-generated alias) because, with Deployment Protection enabled, the
+ * auto-generated aliases are gated behind Vercel Authentication while the
+ * project domain is publicly accessible. We mirror that here: the project
+ * domains are the entries in `alias` that are not auto-generated.
+ *
+ * Returns `undefined` when no suitable alias has been assigned yet.
+ */
+export function getDeploymentTargetUrl(
+  deployment: DeploymentAliasFields
+): { label: string; url: string } | undefined {
+  const automaticAliases = deployment.automaticAliases ?? [];
+  const assignedAliases = deployment.alias ?? [];
+
+  if (deployment.target === 'production') {
+    // Project / custom production domains are the assigned aliases that are
+    // not auto-generated system aliases. Prefer a real custom domain over the
+    // Vercel-provided `*.vercel.app` domain when both are present.
+    const productionDomains = assignedAliases.filter(
+      alias => !automaticAliases.includes(alias)
+    );
+    const url = preferCustomDomain(productionDomains);
+    return url ? { label: 'Production', url } : undefined;
+  }
+
+  // Preview deployments: surface the stable branch ("preview") alias rather
+  // than the commit-specific deployment URL.
+  const branchDomain = automaticAliases.find(alias => alias.includes('-git-'));
+  return branchDomain ? { label: 'Preview', url: branchDomain } : undefined;
+}
+
+function preferCustomDomain(domains: string[]): string | undefined {
+  if (domains.length === 0) {
+    return undefined;
+  }
+  const customDomain = domains.find(domain => !domain.endsWith('.vercel.app'));
+  return customDomain ?? domains[0];
+}

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -24,6 +24,7 @@ import getProjectByNameOrId from '../projects/get-project-by-id-or-name';
 import type { ProjectNotFound } from '../errors-ts';
 import printEvents from '../events';
 import { printAlignedLabel } from '../output/print-aligned-label';
+import { getDeploymentTargetUrl } from './get-deployment-target-url';
 
 function printInspectUrl(inspectorUrl: string | null | undefined) {
   if (!inspectorUrl) {
@@ -201,14 +202,11 @@ export default async function processDeployment({
 
         printInspectUrl(deployment.inspectorUrl);
 
-        const isProdDeployment = deployment.target === 'production';
-        const previewUrl = `https://${deployment.url}`;
-
-        printAlignedLabel(
-          isProdDeployment ? 'Production' : 'Preview',
-          chalk.cyan(previewUrl),
-          isProdDeployment ? { gutter: '▲' } : {}
-        );
+        // Only the commit-specific deployment URL is known at this point; the
+        // project's production/preview URL isn't assigned until later.
+        printAlignedLabel('Visit', chalk.cyan(`https://${deployment.url}`), {
+          gutter: '▲',
+        });
 
         if (!jsonOutput && (quiet || process.env.FORCE_TTY === '1')) {
           process.stdout.write(`https://${event.payload.url}`);
@@ -288,13 +286,9 @@ export default async function processDeployment({
 
         stopSpinner();
         process.stderr.write(eraseLines(2));
-        const isProdDeployment = event.payload.target === 'production';
-        const previewUrl = `https://${event.payload.url}`;
-        printAlignedLabel(
-          isProdDeployment ? 'Production' : 'Preview',
-          chalk.cyan(previewUrl),
-          isProdDeployment ? { gutter: '▲' } : {}
-        );
+        printAlignedLabel('Visit', chalk.cyan(`https://${event.payload.url}`), {
+          gutter: '▲',
+        });
 
         if (v1ChecksPending || v2ChecksPending) {
           output.spinner('Running Checks…', 0);
@@ -359,14 +353,15 @@ export default async function processDeployment({
       if (event.type === 'alias-assigned') {
         stopSpinner();
 
-        if (
-          event.payload.target === 'production' &&
-          event.payload.alias &&
-          event.payload.alias.length > 0
-        ) {
-          const primaryDomain = event.payload.alias[0];
-          const prodUrl = `https://${primaryDomain}`;
-          printAlignedLabel('Aliased', chalk.cyan(prodUrl), { gutter: '▲' });
+        // Show the publicly accessible production/preview URL (the project
+        // domain), not the auto-generated alias which may be protected.
+        const targetUrl = getDeploymentTargetUrl(event.payload);
+        if (targetUrl) {
+          printAlignedLabel(
+            targetUrl.label,
+            chalk.cyan(`https://${targetUrl.url}`),
+            { gutter: '▲' }
+          );
         }
 
         event.payload.indications = indications;

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -842,10 +842,10 @@ test('deploys with only vercel.json and a static file', async () => {
 
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
 
-  // assert timing order of showing URLs vs status updates: Inspect and Preview
+  // assert timing order of showing URLs vs status updates: Inspect and Visit
   // rows print first, then build status (Queued/Building) transitions to Completing.
   expect(stripAnsi(stderr)).toMatch(
-    /Inspect[\s\S]+Preview[\s\S]+(Queued|Building)[\s\S]+Completing/
+    /Inspect[\s\S]+Visit[\s\S]+(Queued|Building)[\s\S]+Completing/
   );
 
   const { host } = new URL(stdout);

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -989,7 +989,7 @@ describe('deploy', () => {
       // remove first 3 lines which contains randomized data
       const output = client.getFullOutput().split('\n').slice(3).join('\n');
       expect(output).toContain('Building');
-      expect(output).toContain('Production  https');
+      expect(output).toContain('Visit');
       expect(output).toContain('Completing');
       expect(exitCode).toEqual(0);
     });
@@ -1785,17 +1785,17 @@ describe('deploy', () => {
 
       const exitCodePromise = deploy(client);
 
-      await expect(client.stderr).toOutput('Production ');
+      await expect(client.stderr).toOutput('Visit ');
       await expect(client.stderr).toOutput(
-        'Aliased     https://my-app.vercel.app'
+        'Production  https://my-app.vercel.app'
       );
 
       // Anti-regression: ANSI is stripped from toOutput, so assert the raw
-      // output still contains the gutter glyphs for both Production + Aliased
+      // output still contains the gutter glyphs for both Visit + Production
       // rows. A regression that drops `gutter: '▲'` would not fail toOutput.
       const stderrOutput = client.stderr.getFullOutput();
+      expect(stderrOutput).toContain('▲ Visit');
       expect(stderrOutput).toContain('▲ Production');
-      expect(stderrOutput).toContain('▲ Aliased');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -1868,7 +1868,7 @@ describe('deploy', () => {
 
       const exitCodePromise = deploy(client);
 
-      await expect(client.stderr).toOutput('Preview     https');
+      await expect(client.stderr).toOutput('Visit');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -1942,16 +1942,17 @@ describe('deploy', () => {
 
       const exitCodePromise = deploy(client);
 
-      await expect(client.stderr).toOutput('Production  https');
+      await expect(client.stderr).toOutput('Visit       https');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
 
       const stderrOutput = client.stderr.read().toString();
       expect(stderrOutput).not.toContain('Aliased');
-      // Anti-regression: production rows always render with the ▲ gutter
-      // glyph at column 0.
-      expect(stderrOutput).toContain('▲ Production');
+      // With no project domain assigned, only the commit-specific deployment
+      // URL is shown, under the "Visit" label with the ▲ gutter glyph.
+      expect(stderrOutput).not.toContain('Production');
+      expect(stderrOutput).toContain('▲ Visit');
     });
   });
 
@@ -2724,7 +2725,9 @@ describe('deploy', () => {
       const exitCodePromise = deploy(client);
 
       await expect(client.stderr).toOutput('Running Checks…');
-      await expect(client.stderr).toOutput('Aliased     https');
+      await expect(client.stderr).toOutput(
+        'Production  https://my-app.vercel.app'
+      );
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);

--- a/packages/cli/test/unit/commands/redeploy/index.test.ts
+++ b/packages/cli/test/unit/commands/redeploy/index.test.ts
@@ -120,7 +120,7 @@ describe('redeploy', () => {
     await expect(client.stderr).toOutput(
       `Fetching deployment "${fromDeployment.id}" in ${fromDeployment.creator?.username}`
     );
-    await expect(client.stderr).toOutput('Production  https');
+    await expect(client.stderr).toOutput('Visit       https');
 
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "redeploy"').toEqual(0);
@@ -155,7 +155,7 @@ describe('redeploy', () => {
       await expect(client.stderr).toOutput(
         `Fetching deployment "${fromDeployment.id}" in ${fromDeployment.creator?.username}`
       );
-      await expect(client.stderr).toOutput('Production  https');
+      await expect(client.stderr).toOutput('Visit       https');
 
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "redeploy"').toEqual(0);
@@ -172,7 +172,7 @@ describe('redeploy', () => {
       await expect(client.stderr).toOutput(
         `Fetching deployment "${fromDeployment.id}" in ${fromDeployment.creator?.username}`
       );
-      await expect(client.stderr).toOutput('Preview     https');
+      await expect(client.stderr).toOutput('Visit       https');
 
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "redeploy"').toEqual(0);
@@ -189,7 +189,7 @@ describe('redeploy', () => {
       await expect(client.stderr).toOutput(
         `Fetching deployment "${fromDeployment.id}" in ${fromDeployment.creator?.username}`
       );
-      await expect(client.stderr).toOutput('Preview     https');
+      await expect(client.stderr).toOutput('Visit       https');
 
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "redeploy"').toEqual(0);
@@ -206,7 +206,7 @@ describe('redeploy', () => {
       await expect(client.stderr).toOutput(
         `Fetching deployment "${fromDeployment.id}" in ${fromDeployment.creator?.username}`
       );
-      await expect(client.stderr).toOutput('Preview     https');
+      await expect(client.stderr).toOutput('Visit       https');
 
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "redeploy"').toEqual(0);

--- a/packages/cli/test/unit/util/deploy/get-deployment-target-url.test.ts
+++ b/packages/cli/test/unit/util/deploy/get-deployment-target-url.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { getDeploymentTargetUrl } from '../../../../src/util/deploy/get-deployment-target-url';
+
+describe('getDeploymentTargetUrl', () => {
+  it('returns the project production domain for production deployments', () => {
+    // `alias` minus `automaticAliases` are the publicly accessible project /
+    // custom production domains; the auto-generated aliases may be protected.
+    expect(
+      getDeploymentTargetUrl({
+        target: 'production',
+        alias: [
+          'my-app-rauchg.vercel.app',
+          'my-app-three-sepia.vercel.app',
+          'my-app-rauchg-rauchg.vercel.app',
+        ],
+        automaticAliases: [
+          'my-app-rauchg.vercel.app',
+          'my-app-rauchg-rauchg.vercel.app',
+        ],
+      })
+    ).toEqual({ label: 'Production', url: 'my-app-three-sepia.vercel.app' });
+  });
+
+  it('prefers a custom domain over the Vercel-provided domain', () => {
+    expect(
+      getDeploymentTargetUrl({
+        target: 'production',
+        alias: ['my-app-three-sepia.vercel.app', 'example.com'],
+        automaticAliases: [],
+      })
+    ).toEqual({ label: 'Production', url: 'example.com' });
+  });
+
+  it('falls back to the only assigned domain when there is no custom domain', () => {
+    expect(
+      getDeploymentTargetUrl({
+        target: 'production',
+        alias: ['my-app.vercel.app'],
+        automaticAliases: [],
+      })
+    ).toEqual({ label: 'Production', url: 'my-app.vercel.app' });
+  });
+
+  it('returns undefined for production deployments with no project domain', () => {
+    expect(
+      getDeploymentTargetUrl({
+        target: 'production',
+        alias: ['my-app-rauchg.vercel.app'],
+        automaticAliases: ['my-app-rauchg.vercel.app'],
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns the branch alias for preview deployments', () => {
+    expect(
+      getDeploymentTargetUrl({
+        target: null,
+        alias: ['my-app-git-feature-branch-rauchg.vercel.app'],
+        automaticAliases: ['my-app-git-feature-branch-rauchg.vercel.app'],
+      })
+    ).toEqual({
+      label: 'Preview',
+      url: 'my-app-git-feature-branch-rauchg.vercel.app',
+    });
+  });
+
+  it('returns undefined for preview deployments with no branch alias', () => {
+    expect(
+      getDeploymentTargetUrl({
+        target: null,
+        alias: [],
+        automaticAliases: [],
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/cli/test/unit/util/deploy/get-deployment-target-url.test.ts
+++ b/packages/cli/test/unit/util/deploy/get-deployment-target-url.test.ts
@@ -64,6 +64,24 @@ describe('getDeploymentTargetUrl', () => {
     });
   });
 
+  it('selects the branch alias even when the project name contains "-git-"', () => {
+    // For a project literally named `my-git-app`, multiple aliases contain
+    // `-git-`; the branch alias is the one with the extra inserted segment.
+    expect(
+      getDeploymentTargetUrl({
+        target: null,
+        alias: [],
+        automaticAliases: [
+          'my-git-app-acme.vercel.app',
+          'my-git-app-git-main-acme.vercel.app',
+        ],
+      })
+    ).toEqual({
+      label: 'Preview',
+      url: 'my-git-app-git-main-acme.vercel.app',
+    });
+  });
+
   it('returns undefined for preview deployments with no branch alias', () => {
     expect(
       getDeploymentTargetUrl({

--- a/packages/cli/test/unit/util/deploy/print-deployment-status.test.ts
+++ b/packages/cli/test/unit/util/deploy/print-deployment-status.test.ts
@@ -135,7 +135,7 @@ describe('printDeploymentStatus() — ready terminal state', () => {
     expect(ready).toBe('✓ Ready in 12s');
   });
 
-  it('Ready line has a leading blank line (separates from Aliased row)', async () => {
+  it('Ready line has a leading blank line (separates from the URL row)', async () => {
     // Anti-regression: the prior test uses allPrintedLines() which .trim()s
     // each call, so it cannot catch a regression that removes the leading
     // "\n" from the Ready string. Assert against the raw call argument.


### PR DESCRIPTION
## Why

When deploying with Deployment Protection enabled (now the default for new projects via `all_except_custom_domains`), the CLI's post-deploy URL points users at an auto-generated alias (e.g. `<project>-<scope>.vercel.app`) that is gated behind Vercel Authentication. The publicly shareable URL is the project's production domain (e.g. `<project>-<word>.vercel.app` or a custom domain) — which is what the dashboard already surfaces. This led to confusion where a freshly-deployed hobby project appeared to "require auth in prod" ([Slack thread](https://vercel.slack.com/archives/C01A2M9R8RZ/p1781235472096599)).

This aligns the CLI with the dashboard: the only URL known *during* a deploy (the immutable commit URL) is labeled `Visit`, and once aliasing completes we print the real public `Production` (or `Preview`) URL.

Before:
```
▲ Production  https://new-server-gpdywl615-rauchg.vercel.app
▲ Aliased     https://new-server-rauchg.vercel.app   ← auth-gated
```

After:
```
▲ Visit       https://new-server-gpdywl615-rauchg.vercel.app
▲ Production  https://new-server-three-sepia.vercel.app   ← public
```

The public URL is derived the same way as the dashboard/admin (`alias` minus `automaticAliases`, preferring custom domains), in a shared `getDeploymentTargetUrl` helper used by the `deploy`, `redeploy`, and `process-deployment` output paths. `Visit` always renders as a fallback when no public domain is assigned yet.

## Validation

- New unit tests for `getDeploymentTargetUrl` covering production project-domain selection, custom-domain preference, preview branch alias (incl. project names containing `-git-`), and the no-public-domain fallback.
- Updated and passing `deploy` (80), `redeploy` (13), and `print-deployment-status` unit tests.
- `Visit` (the commit URL) remains protection-gated by design — it's the only URL available mid-deploy — but the public `Production` URL now appears as soon as aliasing finishes.

Made with [Cursor](https://cursor.com)