### PR TITLE
fix(cli): correct `vercel alerts rules` description to cover full rule config

### DIFF
--- a/.changeset/cli-alerts-rules-description.md
+++ b/.changeset/cli-alerts-rules-description.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Correct the `vercel alerts rules` help description: the subcommands manage full alert-rule configuration (alert types, sensitivity, project scope, and notification routing), not notification routing alone.

--- a/packages/cli/src/commands/alerts/rules/command.ts
+++ b/packages/cli/src/commands/alerts/rules/command.ts
@@ -150,7 +150,7 @@ export const rulesAggregateCommand = {
   name: 'rules',
   aliases: [],
   description:
-    'Create, list, update, or delete alert notification rules (dashboard parity).',
+    'Create, list, update, or delete alert rules: the configured triggers (alert types, sensitivity, project scope) and their notification routing (dashboard Settings > Alerts parity).',
   arguments: [],
   subcommands: [
     rulesLsSubcommand,


### PR DESCRIPTION
## Problem

`vercel alerts rules --help` describes the subcommand tree as managing "alert notification rules (dashboard parity)". That undersells the payload: `GET /alerts/v2/alert-rules` (which `rules ls` passes through unprojected with `--format json`) returns the full configured rule — `alertTypes` (the trigger anomaly types + filters), `sensitivityLevel`, `projectId`, and the notification routing — i.e. the same objects the dashboard's Settings > Alerts page renders (`vercel/front` `apps/vercel-site/swr/alerts/use-alert-rules.ts` fetches the same endpoint).

The "notification rules" label has caused real confusion about whether a read path for configured alert rules exists at all (internal thread: https://vercel.slack.com/archives/C0ALWGPTDR6/p1780938057489279 — the alerts team itself initially believed no such command existed).

## Changes

- `rules` aggregate description now states what the rules actually contain: configured triggers (alert types, sensitivity, project scope) and notification routing, with the dashboard parity target named concretely (Settings > Alerts).
- Changeset (patch).

Companion docs fix in vercel/front for the `cli/alerts` page, which inherited the old label.