### PR TITLE
docs(vercel-cli skill): add dashboard path to the domains reference

### DIFF
--- a/.changeset/cli-skill-domains-dashboard-path.md
+++ b/.changeset/cli-skill-domains-dashboard-path.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a "Dashboard Path" section to the `vercel-cli` skill's domains reference. The reference was CLI-only, so agents consuming it (e.g. Vercel Agent in the dashboard side panel) answered "how do I add a domain I own?" with `vercel domains add ...` code blocks — instructions a dashboard user has nowhere to run. The new section documents the Settings → Domains flow and links the add-a-domain docs walkthrough so surface-appropriate guidance is available alongside the commands.

--- a/skills/vercel-cli/references/domains-and-dns.md
+++ b/skills/vercel-cli/references/domains-and-dns.md
@@ -23,6 +23,15 @@ Most users only need `vercel alias` — domains and DNS are auto-configured when
 
 Or manually alias: `vercel alias set <deployment-url> example.com`
 
+## Dashboard Path
+
+The same flow is available without the CLI — prefer it when guiding someone who is working in the Vercel dashboard rather than a terminal:
+
+1. On the project: **Settings → Domains → Add Domain** (`https://vercel.com/<team>/<project>/settings/domains`).
+2. After the domain is added, the dashboard displays the exact DNS records to set at the registrar: an **A** record for apex domains, a project-specific **CNAME** for subdomains, or Vercel nameservers (required for wildcard domains).
+
+Full walkthrough: [Adding & Configuring a Custom Domain](https://vercel.com/docs/domains/working-with-domains/add-a-domain).
+
 ## Domain Discovery
 
 ### Search


### PR DESCRIPTION
## Problem

The `vercel-cli` skill's domains reference is CLI-only: its "Typical Flow" starts at `vercel domains add ...` and never mentions that the same flow exists in the dashboard. Agents consuming the skill inherit that framing — Vercel Agent, asked from the dashboard side panel how to add an already-owned domain, answered with `vercel domains add` code blocks, which a side-panel user has nowhere to run (reported in #feedback-product, 2026-06-12: "It's suggesting CLI commands. I think most people won't know what to do with them").

Trace evidence from the agents-side eval (`vercel/agents#1777`): every failing trial's single tool call was a read of exactly this reference file, and the answers mirrored its CLI framing. The behavioral fix landed in the agent's prompt (`vercel/agents#1778`); this PR fixes the knowledge source so the dashboard path is available where the agent actually reads, letting the prompt carry only the generic surface policy.

## Changes

- `skills/vercel-cli/references/domains-and-dns.md`: new "Dashboard Path" section after "Typical Flow" — Settings → Domains → Add Domain, what the dashboard shows afterward (A / project-specific CNAME / nameservers for wildcards), and a link to the [add-a-domain docs walkthrough](https://vercel.com/docs/domains/working-with-domains/add-a-domain). Content mirrors that docs page.
- Empty-frontmatter changeset (docs-only, no version bump), matching the convention from #16468.
