### PR TITLE
[cli] Support app-principal (vca_) tokens in scope resolution

### DIFF
--- a/.changeset/cli-app-principal-scope.md
+++ b/.changeset/cli-app-principal-scope.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Support Vercel App tokens (app principal, `vca_…`) in scope resolution. `getScope` no longer requires a user identity: with an app token the CLI resolves the team from `--scope <team-id>` or the linked project, and commands that genuinely need a user fail with a clear error instead of reporting the token as invalid.

--- a/packages/cli/src/commands/alias/set.ts
+++ b/packages/cli/src/commands/alias/set.ts
@@ -79,6 +79,18 @@ export default async function set(client: Client, argv: string[]) {
   if (args.length === 1) {
     const [aliasTarget] = args;
     telemetryClient.trackCliArgumentAlias(aliasTarget);
+
+    // Inferring the deployment means "the current user's latest deployment",
+    // which has no meaning for an app-principal token.
+    if (!user) {
+      output.error(
+        `Specify the deployment to alias when authenticating as a Vercel App: ${getCommandName(
+          'alias set <deployment> <alias>'
+        )}`
+      );
+      return 1;
+    }
+
     const deployment = handleCertError(
       await getDeploymentForAlias(
         client,

--- a/packages/cli/src/commands/curl/shared.ts
+++ b/packages/cli/src/commands/curl/shared.ts
@@ -508,7 +508,11 @@ export async function getDeploymentUrlAndToken(
 
   if (deploymentFlag) {
     // Get the accountId from the scope (team or user)
-    const accountId = scope.team?.id || scope.user.id;
+    const accountId = scope.team?.id ?? scope.user?.id;
+    if (!accountId) {
+      output.error('Could not determine the account for this request.');
+      return 1;
+    }
     const deploymentUrl = await getDeploymentUrlById(
       client,
       deploymentFlag,

--- a/packages/cli/src/commands/domains/move.ts
+++ b/packages/cli/src/commands/domains/move.ts
@@ -40,6 +40,18 @@ export default async function move(client: Client, argv: string[]) {
   telemetry.trackCliArgumentDestination(args[1]);
 
   const { contextName, user } = await getScope(client);
+
+  // Destination matching is defined in terms of the current user and their
+  // team memberships, neither of which exists for an app-principal token.
+  if (!user) {
+    output.error(
+      `${getCommandName(
+        'domains move'
+      )} requires a user identity and cannot be used when authenticating as a Vercel App.`
+    );
+    return 1;
+  }
+
   const { domainName, destination } = await getArgs(client, args);
   if (!isRootDomain(domainName)) {
     output.error(

--- a/packages/cli/src/commands/whoami/index.ts
+++ b/packages/cli/src/commands/whoami/index.ts
@@ -3,6 +3,7 @@ import { help } from '../help';
 import { whoamiCommand } from './command';
 
 import getScope from '../../util/get-scope';
+import { isVercelAppToken } from '../../util/is-vercel-app-token';
 import { parseArguments } from '../../util/get-args';
 import type Client from '../../util/client';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -10,6 +11,9 @@ import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { WhoamiTelemetryClient } from '../../util/telemetry/commands/whoami';
 import { validateJsonOutput } from '../../util/output-format';
+
+const APP_TOKEN_ERROR =
+  'You are authenticated as a Vercel App, so there is no user identity to display.';
 
 export default async function whoami(client: Client): Promise<number> {
   let parsedArgs = null;
@@ -43,8 +47,21 @@ export default async function whoami(client: Client): Promise<number> {
   const asJson = formatResult.jsonOutput;
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
 
+  // Check the token before resolving scope: an app token can never have a
+  // user identity, and getScope would otherwise fail on team resolution
+  // first in unlinked directories — a misleading two-step dead end.
+  if (isVercelAppToken(client.authConfig.token)) {
+    output.error(APP_TOKEN_ERROR);
+    return 1;
+  }
+
   const scope = await getScope(client, { resolveLocalScope: true });
   const { user, team, globalTeam } = scope;
+
+  if (!user) {
+    output.error(APP_TOKEN_ERROR);
+    return 1;
+  }
 
   // A local override exists when the effective team (from the linked project)
   // differs from the globally-selected team (from `vc switch`). We only treat

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,7 @@ import highlight from './util/output/highlight';
 import { parseArguments } from './util/get-args';
 import getUser from './util/get-user';
 import getTeams from './util/teams/get-teams';
+import { isVercelAppToken } from './util/is-vercel-app-token';
 import Client from './util/client';
 import { printError } from './util/error';
 import reportError from './util/report-error';
@@ -774,8 +775,36 @@ const main = async () => {
     parsedArgs.flags['--team'] ||
     localConfig?.scope;
 
+  const appPrincipal = isVercelAppToken(client.authConfig.token);
+
   if (
     typeof scope === 'string' &&
+    appPrincipal &&
+    targetCommand !== 'login' &&
+    targetCommand !== 'build' &&
+    targetCommand !== 'sandbox'
+  ) {
+    // App tokens have no user identity to resolve a slug against, and no
+    // team listing. The scope must be a team ID, which is validated by the
+    // API on the first team-scoped request.
+    if (!scope.startsWith('team_')) {
+      const scopeSource = parsedArgs.flags['--scope']
+        ? param('--scope')
+        : parsedArgs.flags['--team']
+          ? param('--team')
+          : 'the `scope` property in your project configuration';
+      output.prettyError({
+        message: `When authenticating as a Vercel App, the scope provided via ${scopeSource} must be a team ID (\`team_…\`).`,
+      });
+      return finishWithExitCode(1);
+    }
+
+    client.config.currentTeam = scope;
+  }
+
+  if (
+    typeof scope === 'string' &&
+    !appPrincipal &&
     targetCommand !== 'login' &&
     targetCommand !== 'build' &&
     targetCommand !== 'sandbox'

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -91,6 +91,43 @@ export class TeamDeleted extends NowError<'TEAM_DELETED', {}> {
 }
 
 /**
+ * Thrown when authenticating as a Vercel App (`vca_` token) and no team
+ * scope could be resolved. App tokens are not bound to a team, so one must
+ * be provided explicitly.
+ */
+export class AppTokenTeamRequired extends NowError<
+  'APP_TOKEN_TEAM_REQUIRED',
+  {}
+> {
+  constructor() {
+    super({
+      code: 'APP_TOKEN_TEAM_REQUIRED',
+      message:
+        'You are authenticated as a Vercel App, which has no default team. Specify one with `--scope <team-id>` or run in a directory linked to a team project.',
+      meta: {},
+    });
+  }
+}
+
+/**
+ * Thrown when authenticating as a Vercel App while the resolved scope is a
+ * personal account. App tokens can only act on teams.
+ */
+export class AppTokenPersonalScopeNotSupported extends NowError<
+  'APP_TOKEN_PERSONAL_SCOPE',
+  {}
+> {
+  constructor() {
+    super({
+      code: 'APP_TOKEN_PERSONAL_SCOPE',
+      message:
+        'This scope is a personal account, but you are authenticated as a Vercel App. Vercel Apps can only act on teams; specify one with `--scope <team-id>`.',
+      meta: {},
+    });
+  }
+}
+
+/**
  * Thrown when a user is requested to the backend but we get unauthorized
  * because the token is not valid anymore.
  */

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -3,7 +3,12 @@ import type Client from './client';
 import type { Org, Team, User } from '@vercel-internals/types';
 import getUser from './get-user';
 import getTeamById from './teams/get-team-by-id';
-import { TeamDeleted } from './errors-ts';
+import {
+  AppTokenPersonalScopeNotSupported,
+  AppTokenTeamRequired,
+  TeamDeleted,
+} from './errors-ts';
+import { isVercelAppToken } from './is-vercel-app-token';
 import { getLinkFromDir, getVercelDirectory } from './projects/link';
 import { getRepoLink, findProjectsFromPath } from './link/repo';
 import type { RepoProjectsConfig } from './link/repo';
@@ -12,7 +17,11 @@ import output from '../output-manager';
 export interface ScopeContext {
   org: Org;
   contextName: string;
-  user: User;
+  /**
+   * `null` when authenticating as a Vercel App (app-principal token) — there
+   * is no user identity attached to the token.
+   */
+  user: User | null;
   team: Team | null;
   /**
    * The team that's globally selected (via `vc switch` or as the northstar
@@ -31,7 +40,7 @@ export interface ScopeContext {
 
 interface BasicScopeContext {
   contextName: string;
-  user: User;
+  user: User | null;
   team: Team | null;
 }
 
@@ -60,21 +69,62 @@ export default async function getScope(
   client: Client,
   opts: GetScopeOptions = {}
 ): Promise<BasicScopeContext | ScopeContext> {
-  const user = await getUser(client);
-  let contextName = user.username || user.email;
+  const appPrincipal = isVercelAppToken(client.authConfig.token);
+
+  let user: User | null = null;
+  let contextName = '';
   let team: Team | null = null;
-  const defaultTeamId =
-    user.version === 'northstar' ? user.defaultTeamId : undefined;
-  const currentTeamOrDefaultTeamId = client.config.currentTeam || defaultTeamId;
 
-  if (currentTeamOrDefaultTeamId && opts.getTeam !== false) {
-    team = await getTeamById(client, currentTeamOrDefaultTeamId);
+  if (appPrincipal) {
+    // App tokens carry no user identity and no default team. The team must
+    // come from `--scope <team-id>` (already applied to `currentTeam`) or
+    // from the linked project.
+    let teamId = client.config.currentTeam;
 
-    if (!team) {
-      throw new TeamDeleted();
+    if (!teamId && !opts.resolveLocalScope) {
+      const { localOrgId } = await resolveLocalLink(client);
+
+      if (localOrgId) {
+        if (!localOrgId.startsWith('team_')) {
+          throw new AppTokenPersonalScopeNotSupported();
+        }
+        teamId = localOrgId;
+        client.config.currentTeam = teamId;
+      } else {
+        throw new AppTokenTeamRequired();
+      }
     }
 
-    contextName = team.slug;
+    if (teamId) {
+      if (opts.getTeam === false) {
+        contextName = teamId;
+      } else {
+        team = await getTeamById(client, teamId);
+
+        if (!team) {
+          throw new TeamDeleted();
+        }
+
+        contextName = team.slug;
+      }
+    }
+  } else {
+    user = await getUser(client);
+    contextName = user.username || user.email;
+    const defaultTeamId =
+      user.version === 'northstar' ? user.defaultTeamId : undefined;
+    const currentTeamOrDefaultTeamId =
+      client.config.currentTeam || defaultTeamId;
+
+    if (currentTeamOrDefaultTeamId && opts.getTeam !== false) {
+      team = await getTeamById(client, currentTeamOrDefaultTeamId);
+
+      if (!team) {
+        throw new TeamDeleted();
+      }
+
+      contextName = team.slug;
+    }
   }
 
   if (!opts.resolveLocalScope) {
@@ -85,6 +135,94 @@ export default async function getScope(
   const globalTeamId = client.config.currentTeam;
   const globalTeam = team;
 
+  const { localOrgId, repoLink } = await resolveLocalLink(client);
+
+  const isCrossTeamRepo = detectCrossTeamRepo(repoLink?.repoConfig);
+
+  const scopeMismatch = Boolean(
+    localOrgId && globalTeamId && globalTeamId !== localOrgId
+  );
+
+  let resolvedOrg: Org;
+  let resolvedContextName = contextName;
+  let resolvedTeam = team;
+  let linkedRepoResult: ScopeContext['linkedRepo'] = null;
+
+  if (repoLink?.repoConfig) {
+    linkedRepoResult = {
+      repoConfig: repoLink.repoConfig,
+      rootPath: repoLink.rootPath,
+    };
+  }
+
+  const userOrg = (): Org => {
+    if (!user) {
+      throw new AppTokenTeamRequired();
+    }
+    return { type: 'user', id: user.id, slug: user.username };
+  };
+
+  if (explicitScopeProvided) {
+    resolvedOrg = team
+      ? { type: 'team', id: team.id, slug: team.slug }
+      : userOrg();
+  } else if (localOrgId) {
+    client.config.currentTeam = localOrgId.startsWith('team_')
+      ? localOrgId
+      : undefined;
+
+    const correctedTeam = client.config.currentTeam
+      ? await getTeamById(client, client.config.currentTeam)
+      : null;
+    if (correctedTeam) {
+      resolvedOrg = {
+        type: 'team',
+        id: correctedTeam.id,
+        slug: correctedTeam.slug,
+      };
+      resolvedContextName = correctedTeam.slug;
+    } else {
+      if (appPrincipal) {
+        throw new AppTokenPersonalScopeNotSupported();
+      }
+      const correctedUser = await getUser(client);
+      resolvedOrg = {
+        type: 'user',
+        id: correctedUser.id,
+        slug: correctedUser.username,
+      };
+      resolvedContextName = correctedUser.username || correctedUser.email;
+    }
+    resolvedTeam = correctedTeam;
+  } else {
+    if (isCrossTeamRepo) {
+      output.warn(
+        `This repository has projects across multiple teams. ` +
+          `Use \`--scope\` to specify which team, or \`cd\` into a project directory.`
+      );
+    }
+    resolvedOrg = team
+      ? { type: 'team', id: team.id, slug: team.slug }
+      : userOrg();
+  }
+
+  return {
+    org: resolvedOrg,
+    contextName: resolvedContextName,
+    user,
+    team: resolvedTeam,
+    globalTeam,
+    linkedRepo: linkedRepoResult,
+    isCrossTeamRepo,
+    scopeMismatch,
+    explicitScopeProvided,
+  } satisfies ScopeContext;
+}
+
+async function resolveLocalLink(client: Client): Promise<{
+  localOrgId: string | undefined;
+  repoLink: Awaited<ReturnType<typeof getRepoLink>> | null;
+}> {
   const cwd = client.cwd;
   let projectLink: { orgId: string; projectId: string } | null = null;
   try {
@@ -127,76 +265,19 @@ export default async function getScope(
     }
   }
 
-  const isCrossTeamRepo = detectCrossTeamRepo(repoLink?.repoConfig);
-
-  const scopeMismatch = Boolean(
-    localOrgId && globalTeamId && globalTeamId !== localOrgId
-  );
-
-  let resolvedOrg: Org;
-  let resolvedContextName = contextName;
-  let resolvedTeam = team;
-  let linkedRepoResult: ScopeContext['linkedRepo'] = null;
-
-  if (repoLink?.repoConfig) {
-    linkedRepoResult = {
-      repoConfig: repoLink.repoConfig,
-      rootPath: repoLink.rootPath,
-    };
-  }
-
-  if (explicitScopeProvided) {
-    resolvedOrg = team
-      ? { type: 'team', id: team.id, slug: team.slug }
-      : { type: 'user', id: user.id, slug: user.username };
-  } else if (localOrgId) {
-    client.config.currentTeam = localOrgId.startsWith('team_')
-      ? localOrgId
-      : undefined;
-
-    const correctedTeam = client.config.currentTeam
-      ? await getTeamById(client, client.config.currentTeam)
-      : null;
-    const correctedUser = await getUser(client);
-    resolvedOrg = correctedTeam
-      ? { type: 'team', id: correctedTeam.id, slug: correctedTeam.slug }
-      : {
-          type: 'user',
-          id: correctedUser.id,
-          slug: correctedUser.username,
-        };
-    resolvedContextName = correctedTeam
-      ? correctedTeam.slug
-      : correctedUser.username || correctedUser.email;
-    resolvedTeam = correctedTeam;
-  } else {
-    if (isCrossTeamRepo) {
-      output.warn(
-        `This repository has projects across multiple teams. ` +
-          `Use \`--scope\` to specify which team, or \`cd\` into a project directory.`
-      );
-    }
-    resolvedOrg = team
-      ? { type: 'team', id: team.id, slug: team.slug }
-      : { type: 'user', id: user.id, slug: user.username };
-  }
-
-  return {
-    org: resolvedOrg,
-    contextName: resolvedContextName,
-    user,
-    team: resolvedTeam,
-    globalTeam,
-    linkedRepo: linkedRepoResult,
-    isCrossTeamRepo,
-    scopeMismatch,
-    explicitScopeProvided,
-  } satisfies ScopeContext;
+  return { localOrgId, repoLink };
 }
 
 export function applyScopeFromLink(client: Client, link: { org: Org }): void {
   const localOrgId = link.org.id;
   const globalTeamId = client.config.currentTeam;
+
+  if (
+    !localOrgId.startsWith('team_') &&
+    isVercelAppToken(client.authConfig.token)
+  ) {
+    throw new AppTokenPersonalScopeNotSupported();
+  }
 
   const scopeMismatch = Boolean(globalTeamId && globalTeamId !== localOrgId);
 

--- a/packages/cli/src/util/is-vercel-app-token.ts
+++ b/packages/cli/src/util/is-vercel-app-token.ts
@@ -1,0 +1,9 @@
+/**
+ * App-principal tokens are minted for a Vercel App (e.g. via the OAuth
+ * `client_credentials` grant). They authenticate as the app itself — there
+ * is no user identity attached, and no default team: the team must be
+ * supplied per-request.
+ */
+export function isVercelAppToken(token: string | undefined): boolean {
+  return Boolean(token?.startsWith('vca_'));
+}

--- a/packages/cli/src/util/report-error.ts
+++ b/packages/cli/src/util/report-error.ts
@@ -12,7 +12,7 @@ export default async function reportError(
   if (ignoreError(error)) {
     return;
   }
-  let user: User | undefined;
+  let user: User | null | undefined;
   let team: Team | null | undefined;
   let scopeError: Error | undefined;
 

--- a/packages/cli/test/unit/commands/domains/move.test.ts
+++ b/packages/cli/test/unit/commands/domains/move.test.ts
@@ -3,10 +3,23 @@ import { describe, expect, it } from 'vitest';
 import { client } from '../../../mocks/client';
 import domains from '../../../../src/commands/domains';
 import { useUser } from '../../../mocks/user';
-import { useTeams } from '../../../mocks/team';
+import { useTeam, useTeams } from '../../../mocks/team';
 import { useDomain } from '../../../mocks/domains';
 
 describe('domains mv', () => {
+  it('should error when authenticated as a Vercel App', async () => {
+    const team = useTeam();
+    client.authConfig.token = 'vca_dummy_token';
+    client.config.currentTeam = team.id;
+    client.setArgv('domains', 'move', 'example.com', 'dest', '--yes');
+
+    const exitCodePromise = domains(client);
+    await expect(client.stderr).toOutput(
+      'requires a user identity and cannot be used when authenticating as a Vercel App'
+    );
+    expect(await exitCodePromise).toEqual(1);
+  });
+
   describe('--help', () => {
     it('tracks telemetry', async () => {
       const command = 'domains';

--- a/packages/cli/test/unit/commands/whoami/index.test.ts
+++ b/packages/cli/test/unit/commands/whoami/index.test.ts
@@ -49,6 +49,29 @@ describe('whoami', () => {
     await expect(client.stderr).toOutput(`Active team: ${team.slug}`);
   });
 
+  it('should error when authenticated as a Vercel App', async () => {
+    const team = useTeam();
+    client.authConfig.token = 'vca_dummy_token';
+    client.config.currentTeam = team.id;
+
+    const exitCodePromise = whoami(client);
+    await expect(client.stderr).toOutput(
+      'Error: You are authenticated as a Vercel App'
+    );
+    expect(await exitCodePromise).toEqual(1);
+  });
+
+  it('should error in one step as a Vercel App without a team', async () => {
+    client.authConfig.token = 'vca_dummy_token';
+    client.cwd = setupTmpDir();
+
+    const exitCodePromise = whoami(client);
+    await expect(client.stderr).toOutput(
+      'Error: You are authenticated as a Vercel App'
+    );
+    expect(await exitCodePromise).toEqual(1);
+  });
+
   it('should flag a local override when a linked project uses a different team', async () => {
     useUser();
     // Both teams must be known so they can be resolved by ID.

--- a/packages/cli/test/unit/util/get-scope.test.ts
+++ b/packages/cli/test/unit/util/get-scope.test.ts
@@ -18,7 +18,7 @@ describe('getScope', () => {
 
     it('should return user if team is unspecified', async () => {
       const { contextName, team, user } = await getScope(client);
-      await expect(user.id).toEqual(mockUser.id);
+      await expect(user?.id).toEqual(mockUser.id);
       await expect(team).toBeNull();
       await expect(contextName).toEqual(mockUser.username);
     });
@@ -26,7 +26,7 @@ describe('getScope', () => {
     it('should return team if team is specified', async () => {
       client.config.currentTeam = mockTeam.id;
       const { contextName, team, user } = await getScope(client);
-      await expect(user.id).toEqual(mockUser.id);
+      await expect(user?.id).toEqual(mockUser.id);
       await expect(team?.id).toEqual(mockTeam.id);
       await expect(contextName).toEqual(mockTeam.slug);
     });
@@ -36,9 +36,37 @@ describe('getScope', () => {
       const { contextName, team, user } = await getScope(client, {
         getTeam: false,
       });
-      await expect(user.id).toEqual(mockUser.id);
+      await expect(user?.id).toEqual(mockUser.id);
       await expect(team).toBeNull();
       await expect(contextName).toEqual(mockUser.username);
+    });
+  });
+
+  describe('app principal', () => {
+    beforeEach(() => {
+      client.authConfig.token = 'vca_dummy_token';
+    });
+
+    it('should return team scope without fetching a user', async () => {
+      client.config.currentTeam = mockTeam.id;
+      const { contextName, team, user } = await getScope(client);
+      expect(user).toBeNull();
+      expect(team?.id).toEqual(mockTeam.id);
+      expect(contextName).toEqual(mockTeam.slug);
+    });
+
+    it('should throw when no team is specified', async () => {
+      await expect(getScope(client)).rejects.toThrow(/--scope/);
+    });
+
+    it('should return team id as context when getTeam is false', async () => {
+      client.config.currentTeam = mockTeam.id;
+      const { contextName, team, user } = await getScope(client, {
+        getTeam: false,
+      });
+      expect(user).toBeNull();
+      expect(team).toBeNull();
+      expect(contextName).toEqual(mockTeam.id);
     });
   });
 

--- a/packages/cli/test/unit/util/scope-context.test.ts
+++ b/packages/cli/test/unit/util/scope-context.test.ts
@@ -23,7 +23,7 @@ describe('resolveScopeContext', () => {
 
       expect(ctx.org.id).toEqual(mockTeam.id);
       expect(ctx.contextName).toEqual(mockTeam.slug);
-      expect(ctx.user.id).toEqual(mockUser.id);
+      expect(ctx.user?.id).toEqual(mockUser.id);
       expect(ctx.team?.id).toEqual(mockTeam.id);
       expect(ctx.linkedRepo).toBeNull();
       expect(ctx.isCrossTeamRepo).toBe(false);
@@ -270,8 +270,103 @@ describe('resolveScopeContext', () => {
       const ctx = await getScope(client, { resolveLocalScope: true });
 
       expect(ctx.org.id).toEqual(mockTeam.id);
-      expect(ctx.user.id).toEqual(mockUser.id);
+      expect(ctx.user?.id).toEqual(mockUser.id);
       expect(ctx.team?.id).toEqual(mockTeam.id);
+    });
+  });
+
+  describe('app principal', () => {
+    let mockTeam: ReturnType<typeof useTeam>;
+
+    beforeEach(() => {
+      mockTeam = useTeam('team_dummy');
+      client.authConfig.token = 'vca_dummy_token';
+    });
+
+    it('should resolve team from --scope', async () => {
+      client.config.currentTeam = mockTeam.id;
+      client.setArgv('projects', 'ls', '--scope', mockTeam.id);
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.user).toBeNull();
+      expect(ctx.org).toEqual({
+        type: 'team',
+        id: mockTeam.id,
+        slug: mockTeam.slug,
+      });
+      expect(ctx.contextName).toEqual(mockTeam.slug);
+    });
+
+    it('should resolve team from linked project', async () => {
+      const cwd = setupTmpDir();
+      client.cwd = cwd;
+
+      await outputFile(
+        join(cwd, '.vercel', 'project.json'),
+        JSON.stringify({ orgId: mockTeam.id, projectId: 'prj_123' })
+      );
+
+      const ctx = await getScope(client, { resolveLocalScope: true });
+
+      expect(ctx.user).toBeNull();
+      expect(ctx.org).toEqual({
+        type: 'team',
+        id: mockTeam.id,
+        slug: mockTeam.slug,
+      });
+      expect(ctx.team?.id).toEqual(mockTeam.id);
+    });
+
+    it('should resolve team from linked project without resolveLocalScope', async () => {
+      const cwd = setupTmpDir();
+      client.cwd = cwd;
+
+      await outputFile(
+        join(cwd, '.vercel', 'project.json'),
+        JSON.stringify({ orgId: mockTeam.id, projectId: 'prj_123' })
+      );
+
+      const ctx = await getScope(client);
+
+      expect(ctx.user).toBeNull();
+      expect(ctx.team?.id).toEqual(mockTeam.id);
+      expect(ctx.contextName).toEqual(mockTeam.slug);
+      expect(client.config.currentTeam).toEqual(mockTeam.id);
+    });
+
+    it('should throw for personal linked project without resolveLocalScope', async () => {
+      const cwd = setupTmpDir();
+      client.cwd = cwd;
+
+      await outputFile(
+        join(cwd, '.vercel', 'project.json'),
+        JSON.stringify({ orgId: 'user_abc123', projectId: 'prj_123' })
+      );
+
+      await expect(getScope(client)).rejects.toThrow(/personal account/);
+    });
+
+    it('should throw when linked project is on a personal account', async () => {
+      const cwd = setupTmpDir();
+      client.cwd = cwd;
+
+      await outputFile(
+        join(cwd, '.vercel', 'project.json'),
+        JSON.stringify({ orgId: 'user_abc123', projectId: 'prj_123' })
+      );
+
+      await expect(
+        getScope(client, { resolveLocalScope: true })
+      ).rejects.toThrow(/personal account/);
+    });
+
+    it('should throw when no team can be resolved', async () => {
+      client.cwd = setupTmpDir();
+
+      await expect(
+        getScope(client, { resolveLocalScope: true })
+      ).rejects.toThrow(/--scope/);
     });
   });
 });


### PR DESCRIPTION
## Summary

App-principal tokens (Vercel App tokens minted via the OAuth `client_credentials` grant, prefix `vca_`) carry no user identity. `getScope` unconditionally called `getUser` (`GET /v2/user`), so every scope-resolving command failed with a misleading **"token is not valid"** error — and `--scope` made it worse, since the entry point runs an additional `getUser` + `getTeams` to resolve the slug before any command dispatches.

This makes scope resolution principal-aware, with the API as the authorization boundary — the CLI does not pre-validate that the app may act on the team; unsupported endpoints surface their own 403s.

- **`getScope`**: `ScopeContext.user` / `BasicScopeContext.user` are now `User | null`. With an app token, `getUser` is skipped entirely; the team resolves from `--scope <team-id>` (via `currentTeam`) or the linked project (`.vercel/project.json` / `repo.json`) — in both the plain and `resolveLocalScope` paths, so all ~85 call sites behave consistently. No resolvable team throws `AppTokenTeamRequired`; a personal-account scope throws `AppTokenPersonalScopeNotSupported` (app tokens are team-only: the grant mints them with no team binding, and team endpoints require `?teamId`).
- **`index.ts`**: with an app token, `--scope` skips the `getUser`+`getTeams` slug resolution, requires a `team_` ID, and sets `currentTeam` directly. The error names the actual scope source (`--scope`, `--team`, or the `scope` property in project config).
- **Consumers of `scope.user`** (the only 5 of ~85 call sites that dereference it) fail at the point of genuine user dependency with clear errors: `whoami` (checked before `getScope` to avoid a two-step dead end), `domains move` (destination matching is user/teams-defined; guarded before the doomed `getTeams` call), `alias set` with an inferred deployment ("current user's latest deployment" has no meaning for an app). `curl` and `report-error` needed only type-level changes.
- **`applyScopeFromLink`**: throws the accurate personal-scope error for app tokens instead of silently clearing `currentTeam`.

User-token behavior is unchanged.

With a linked team project (or `--scope team_…`), commands now reach their endpoints, where support is determined by each endpoint's `requireUserPrincipal` opt-in — new endpoint opt-ins light up in the CLI with no further changes.