### PR TITLE
[@vercel/connect] add context-aware createSubject hook to connect() eve adapter

### DIFF
--- a/.changeset/connect-eve-create-subject.md
+++ b/.changeset/connect-eve-create-subject.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add a context-aware `createSubject` hook to `connect()` from `@vercel/connect/eve`. The new `createSubject?: (principal, ctx) => ConnectTokenSubject` option receives both the framework-resolved principal and Eve's per-connection authorization context (currently the declared server `url`), unblocking jwt-bearer-style connectors whose subject/assertion needs more than the principal — custom claims, the connection URL, or an audience derived from it. The adapter now threads the `connection` context Eve already passes to `getToken` / `startAuthorization` / `completeAuthorization` (previously dropped) into subject resolution, and the context type is exported as `EveConnectionAuthorizationContext`. Precedence is `createSubject` > `principalToSubject` > default principal mapping; `principalToSubject` keeps working but is now deprecated in favor of `createSubject`.

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -62,18 +62,41 @@ export type ConnectAuthorizationPhase =
   | 'startAuthorization'
   | 'completeAuthorization';
 
+/**
+ * Eve's per-connection authorization context — the `connection` argument
+ * Eve's runtime hands to every `getToken` / `startAuthorization` /
+ * `completeAuthorization` callback alongside the resolved principal.
+ * Currently carries the connection's declared server `url`; Eve documents
+ * the shape as strictly additive, so destructuring only the fields you
+ * need stays forward-compatible.
+ *
+ * eve 0.6.0-beta.1 declares this type as
+ * `ConnectionAuthorizationContext` but does not re-export it from
+ * `eve/connections` (or any other public subpath), so it is derived
+ * structurally here from the exported authorization definition — this is
+ * exactly the type Eve passes at runtime. Once eve exports the type
+ * directly, this alias can switch to a plain re-export without a
+ * breaking change.
+ */
+export type EveConnectionAuthorizationContext = Parameters<
+  NonInteractiveAuthorizationDefinition['getToken']
+>[0]['connection'];
+
 interface GetTokenOptions {
   readonly principal: ConnectionPrincipal;
+  readonly connection: EveConnectionAuthorizationContext;
 }
 
 interface StartAuthorizationOptions {
   readonly principal: ConnectionPrincipal;
+  readonly connection: EveConnectionAuthorizationContext;
   readonly callbackUrl?: string;
   readonly webhook?: string;
 }
 
 interface CompleteAuthorizationOptions {
   readonly principal: ConnectionPrincipal;
+  readonly connection: EveConnectionAuthorizationContext;
 }
 
 /** Options accepted by {@link connect}. */
@@ -114,10 +137,30 @@ export interface EveAuthorizationOptions {
   readonly tokenParams?: Omit<ConnectTokenParams, 'subject'>;
 
   /**
+   * Builds the Vercel Connect token subject from the framework-resolved
+   * principal plus the connection's authorization context (Eve's
+   * per-connection metadata — currently the declared server `url`).
+   *
+   * Needed by jwt-bearer-style connectors whose subject/assertion
+   * depends on more than the principal: custom claims, the connection
+   * URL, or an audience derived from it. Takes precedence over the
+   * deprecated {@link principalToSubject}. When neither is set, the
+   * default mapping applies — app principals map to `{ type: "app" }`
+   * and user principals map to `{ type: "user", id, issuer }`.
+   */
+  readonly createSubject?: (
+    principal: ConnectionPrincipal,
+    ctx: EveConnectionAuthorizationContext
+  ) => ConnectTokenSubject | Promise<ConnectTokenSubject>;
+
+  /**
    * Override how Eve's framework-resolved principal is mapped to a
    * Vercel Connect token subject. When omitted, app principals map to
    * `{ type: "app" }` and user principals map to
    * `{ type: "user", id, issuer }`.
+   *
+   * @deprecated Use {@link createSubject}, which also receives the
+   * connection authorization context.
    */
   readonly principalToSubject?: (
     principal: ConnectionPrincipal
@@ -234,9 +277,17 @@ export type EveConnectAuthorizationDefinition<
    * failed or duplicate revoke is swallowed so it never masks the error
    * that triggered eviction, and the local cache entry is dropped either
    * way.
+   *
+   * Pass `connection` (Eve's per-connection authorization context) when
+   * the connection uses {@link EveAuthorizationOptions.createSubject}:
+   * the cache entry is keyed by the resolved subject, and a
+   * context-dependent subject can only be reproduced with the context in
+   * hand. Without it, eviction falls back to the legacy
+   * principal-only mapping and may miss the entry.
    */
   readonly evict: (opts: {
     readonly principal: ConnectionPrincipal;
+    readonly connection?: EveConnectionAuthorizationContext;
     readonly revoke?: boolean;
   }) => Promise<void>;
 };
@@ -300,10 +351,11 @@ function makeEvict(
   options: EveAuthorizationOptions
 ): (opts: {
   readonly principal: ConnectionPrincipal;
+  readonly connection?: EveConnectionAuthorizationContext;
   readonly revoke?: boolean;
 }) => Promise<void> {
-  return async ({ principal, revoke }) => {
-    const params = await buildTokenParams(options, principal);
+  return async ({ principal, connection, revoke }) => {
+    const params = await buildTokenParams(options, principal, connection);
     if (revoke) {
       try {
         // Destructive: tears down the grant at Vercel Connect (refresh
@@ -343,11 +395,14 @@ function buildInteractiveDefinition(
   return {
     principalType: 'user',
 
-    async getToken({ principal }: GetTokenOptions): Promise<TokenResult> {
+    async getToken({
+      principal,
+      connection,
+    }: GetTokenOptions): Promise<TokenResult> {
       try {
         const response = await getTokenResponse(
           options.connector,
-          await buildTokenParams(options, principal),
+          await buildTokenParams(options, principal, connection),
           getTokenConnectOptions(options)
         );
         return { token: response.token, expiresAt: response.expiresAt };
@@ -358,6 +413,7 @@ function buildInteractiveDefinition(
 
     async startAuthorization({
       principal,
+      connection,
       callbackUrl,
       webhook,
     }: StartAuthorizationOptions): Promise<{
@@ -387,7 +443,7 @@ function buildInteractiveDefinition(
         // in production.
         const response = await startAuthorization(
           options.connector,
-          await buildTokenParams(options, principal),
+          await buildTokenParams(options, principal, connection),
           {
             ...options.connectOptions,
             callbackUrl: callbackUrl ?? webhook,
@@ -413,11 +469,12 @@ function buildInteractiveDefinition(
 
     async completeAuthorization({
       principal,
+      connection,
     }: CompleteAuthorizationOptions): Promise<TokenResult> {
       try {
         const response = await getTokenResponse(
           options.connector,
-          await buildTokenParams(options, principal),
+          await buildTokenParams(options, principal, connection),
           options.connectOptions
         );
         return { token: response.token, expiresAt: response.expiresAt };
@@ -433,11 +490,14 @@ function buildNonInteractiveDefinition(
 ): NonInteractiveAuthorizationDefinition {
   return {
     principalType: 'app',
-    async getToken({ principal }: GetTokenOptions): Promise<TokenResult> {
+    async getToken({
+      principal,
+      connection,
+    }: GetTokenOptions): Promise<TokenResult> {
       try {
         const response = await getTokenResponse(
           options.connector,
-          await buildTokenParams(options, principal),
+          await buildTokenParams(options, principal, connection),
           getTokenConnectOptions(options)
         );
         return { token: response.token, expiresAt: response.expiresAt };
@@ -465,13 +525,41 @@ function getTokenConnectOptions(
 
 async function buildTokenParams(
   options: EveAuthorizationOptions,
-  principal: ConnectionPrincipal
+  principal: ConnectionPrincipal,
+  connection: EveConnectionAuthorizationContext | undefined
 ): Promise<ConnectTokenParams> {
-  const toSubject = options.principalToSubject ?? principalToSubject;
   return {
     ...options.tokenParams,
-    subject: await toSubject(principal),
+    subject: await resolveSubject(options, principal, connection),
   };
+}
+
+/**
+ * Resolves the Vercel Connect token subject for `principal`, applying
+ * the documented precedence: {@link EveAuthorizationOptions.createSubject}
+ * (when the connection context is in hand), then the deprecated
+ * {@link EveAuthorizationOptions.principalToSubject}, then the default
+ * principal mapping.
+ *
+ * Eve's runtime passes `connection` to every authorization callback, so
+ * on the `getToken` / `startAuthorization` / `completeAuthorization`
+ * paths `createSubject` always receives it. Only the adapter's own
+ * `evict` entry point may run without a context (its callers predate the
+ * context plumbing); in that case the resolution falls back past
+ * `createSubject` so eviction stays best-effort instead of throwing.
+ */
+function resolveSubject(
+  options: EveAuthorizationOptions,
+  principal: ConnectionPrincipal,
+  connection: EveConnectionAuthorizationContext | undefined
+): ConnectTokenSubject | Promise<ConnectTokenSubject> {
+  if (options.createSubject !== undefined && connection !== undefined) {
+    return options.createSubject(principal, connection);
+  }
+  if (options.principalToSubject !== undefined) {
+    return options.principalToSubject(principal);
+  }
+  return principalToSubject(principal);
 }
 
 function principalToSubject(

--- a/packages/connect/src/eve/index.ts
+++ b/packages/connect/src/eve/index.ts
@@ -11,6 +11,7 @@ export {
   type EveAuthorizationInput,
   type EveAuthorizationOptions,
   type EveConnectAuthorizationDefinition,
+  type EveConnectionAuthorizationContext,
   type ConnectAuthorizationPhase,
   type VercelConnectMetadata,
 } from './connection-authorization.js';

--- a/packages/connect/test/eve/connection-authorization.test.ts
+++ b/packages/connect/test/eve/connection-authorization.test.ts
@@ -4,7 +4,10 @@ import type {
   InteractiveAuthorizationDefinition,
 } from 'eve/connections';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { connect } from '../../src/eve/index.js';
+import {
+  connect,
+  type EveConnectionAuthorizationContext,
+} from '../../src/eve/index.js';
 
 vi.mock('@vercel/oidc', () => ({
   getVercelOidcToken: vi.fn(),
@@ -14,6 +17,10 @@ const PRINCIPAL: ConnectionPrincipal = {
   type: 'user',
   id: 'user_evict',
   issuer: 'https://oidc.vercel.com',
+};
+
+const CONNECTION: EveConnectionAuthorizationContext = {
+  url: 'https://mcp.example.com/sse',
 };
 
 describe('connect() adapter evict', () => {
@@ -40,15 +47,25 @@ describe('connect() adapter evict', () => {
     ) as InteractiveAuthorizationDefinition & {
       readonly evict: (opts: {
         readonly principal: ConnectionPrincipal;
+        readonly connection?: EveConnectionAuthorizationContext;
       }) => Promise<void>;
     };
 
-    const first = await definition.getToken({ principal: PRINCIPAL });
+    const first = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
     // Without eviction this would serve `tok_stale` from the cache.
-    const cached = await definition.getToken({ principal: PRINCIPAL });
+    const cached = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
 
-    await definition.evict({ principal: PRINCIPAL });
-    const refetched = await definition.getToken({ principal: PRINCIPAL });
+    await definition.evict({ principal: PRINCIPAL, connection: CONNECTION });
+    const refetched = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
 
     expect(first.token).toBe('tok_stale');
     expect(cached.token).toBe('tok_stale');
@@ -67,13 +84,24 @@ describe('connect() adapter evict', () => {
     ) as InteractiveAuthorizationDefinition & {
       readonly evict: (opts: {
         readonly principal: ConnectionPrincipal;
+        readonly connection?: EveConnectionAuthorizationContext;
         readonly revoke?: boolean;
       }) => Promise<void>;
     };
 
-    const first = await definition.getToken({ principal: PRINCIPAL });
-    await definition.evict({ principal: PRINCIPAL, revoke: true });
-    const refetched = await definition.getToken({ principal: PRINCIPAL });
+    const first = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+    await definition.evict({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+      revoke: true,
+    });
+    const refetched = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
 
     expect(first.token).toBe('tok_initial');
     expect(refetched.token).toBe('tok_reauthorized');
@@ -104,20 +132,223 @@ describe('connect() adapter evict', () => {
     ) as InteractiveAuthorizationDefinition & {
       readonly evict: (opts: {
         readonly principal: ConnectionPrincipal;
+        readonly connection?: EveConnectionAuthorizationContext;
         readonly revoke?: boolean;
       }) => Promise<void>;
     };
 
-    const before = await definition.getToken({ principal: PRINCIPAL });
+    const before = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
     // A failed revoke must not throw out of evict.
     await expect(
-      definition.evict({ principal: PRINCIPAL, revoke: true })
+      definition.evict({
+        principal: PRINCIPAL,
+        connection: CONNECTION,
+        revoke: true,
+      })
     ).resolves.toBeUndefined();
-    const after = await definition.getToken({ principal: PRINCIPAL });
+    const after = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
 
     expect(before.token).toBe('tok_before');
     expect(after.token).toBe('tok_after');
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('connect() adapter subject mapping', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(getVercelOidcToken).mockResolvedValue('oidc_token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('passes the principal and connection context to createSubject and sends its return as the token subject', async () => {
+    fetchMock.mockResolvedValueOnce(jsonTokenResponse('tok_create_subject'));
+
+    const createSubject = vi.fn(
+      (
+        principal: ConnectionPrincipal,
+        ctx: EveConnectionAuthorizationContext
+      ) => ({
+        type: 'jwt-bearer' as const,
+        sub: principal.type === 'user' ? principal.id : 'app',
+        aud: ctx.url,
+      })
+    );
+
+    const definition = connect({
+      connector: 'oauth/subject-create',
+      createSubject,
+    }) as InteractiveAuthorizationDefinition;
+
+    const result = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(result.token).toBe('tok_create_subject');
+    expect(createSubject).toHaveBeenCalledTimes(1);
+    expect(createSubject).toHaveBeenCalledWith(PRINCIPAL, CONNECTION);
+
+    const [tokenUrl, tokenInit] = fetchMock.mock.calls[0];
+    expect(tokenUrl).toBe(
+      'https://api.vercel.com/v1/connect/token/oauth%2Fsubject-create'
+    );
+    expect(JSON.parse(tokenInit.body as string)).toMatchObject({
+      subject: {
+        type: 'jwt-bearer',
+        sub: PRINCIPAL.type === 'user' ? PRINCIPAL.id : 'app',
+        aud: CONNECTION.url,
+      },
+    });
+  });
+
+  it('threads the connection context into startAuthorization subjects', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          request: 'req_1',
+          verifier: 'ver_1',
+          url: 'https://connect.vercel.com/authorize/req_1',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const createSubject = vi.fn(
+      (
+        _principal: ConnectionPrincipal,
+        ctx: EveConnectionAuthorizationContext
+      ) => ({
+        type: 'jwt-bearer' as const,
+        sub: 'user_evict',
+        additionalClaims: { server_url: ctx.url },
+      })
+    );
+
+    const definition = connect({
+      connector: 'oauth/subject-start-auth',
+      createSubject,
+    }) as InteractiveAuthorizationDefinition;
+
+    const { challenge } = await definition.startAuthorization({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+      callbackUrl: 'https://example.com/callback',
+    });
+
+    expect(challenge.url).toBe('https://connect.vercel.com/authorize/req_1');
+    expect(createSubject).toHaveBeenCalledWith(PRINCIPAL, CONNECTION);
+
+    const [authorizeUrl, authorizeInit] = fetchMock.mock.calls[0];
+    expect(authorizeUrl).toBe(
+      'https://api.vercel.com/v1/connect/authorize/oauth%2Fsubject-start-auth'
+    );
+    expect(JSON.parse(authorizeInit.body as string)).toMatchObject({
+      subject: {
+        type: 'jwt-bearer',
+        sub: 'user_evict',
+        additionalClaims: { server_url: CONNECTION.url },
+      },
+      returnUrl: 'https://example.com/callback',
+    });
+  });
+
+  it('prefers createSubject over principalToSubject when both are set', async () => {
+    fetchMock.mockResolvedValueOnce(jsonTokenResponse('tok_precedence'));
+
+    const createSubject = vi.fn(() => ({
+      type: 'jwt-bearer' as const,
+      sub: 'from_create_subject',
+    }));
+    const principalToSubject = vi.fn(() => ({
+      type: 'user' as const,
+      id: 'from_principal_to_subject',
+    }));
+
+    const definition = connect({
+      connector: 'oauth/subject-precedence',
+      createSubject,
+      principalToSubject,
+    }) as InteractiveAuthorizationDefinition;
+
+    await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(createSubject).toHaveBeenCalledWith(PRINCIPAL, CONNECTION);
+    expect(principalToSubject).not.toHaveBeenCalled();
+
+    const [, tokenInit] = fetchMock.mock.calls[0];
+    expect(JSON.parse(tokenInit.body as string)).toMatchObject({
+      subject: { type: 'jwt-bearer', sub: 'from_create_subject' },
+    });
+  });
+
+  it('still honors the deprecated principalToSubject when createSubject is unset', async () => {
+    fetchMock.mockResolvedValueOnce(jsonTokenResponse('tok_legacy_hook'));
+
+    const principalToSubject = vi.fn(() => ({
+      type: 'user' as const,
+      id: 'legacy_mapped_id',
+      issuer: 'https://legacy.example.com',
+    }));
+
+    const definition = connect({
+      connector: 'oauth/subject-legacy',
+      principalToSubject,
+    }) as InteractiveAuthorizationDefinition;
+
+    await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(principalToSubject).toHaveBeenCalledWith(PRINCIPAL);
+
+    const [, tokenInit] = fetchMock.mock.calls[0];
+    expect(JSON.parse(tokenInit.body as string)).toMatchObject({
+      subject: {
+        type: 'user',
+        id: 'legacy_mapped_id',
+        issuer: 'https://legacy.example.com',
+      },
+    });
+  });
+
+  it('falls back to the default principal mapping when neither hook is set', async () => {
+    fetchMock.mockResolvedValueOnce(jsonTokenResponse('tok_default'));
+
+    const definition = connect(
+      'oauth/subject-default'
+    ) as InteractiveAuthorizationDefinition;
+
+    await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    const [, tokenInit] = fetchMock.mock.calls[0];
+    expect(JSON.parse(tokenInit.body as string)).toMatchObject({
+      subject: {
+        type: 'user',
+        id: 'user_evict',
+        issuer: 'https://oidc.vercel.com',
+      },
+    });
   });
 });
 


### PR DESCRIPTION
### Why

Eve's runtime invokes every authorization callback with a per-connection authorization context alongside the framework-resolved principal — `getToken({ connection, principal })`, `startAuthorization({ connection, principal, callbackUrl })`, `completeAuthorization({ connection, principal, ... })`. The `connect()` adapter's internal option interfaces only declared `principal` and silently dropped that context.

That gap blocks jwt-bearer-style connectors: their token subject/assertion often depends on more than the principal — custom claims, the connection's server URL, or an audience derived from it. The existing `principalToSubject` hook only sees the principal, so there is no way to build such a subject today.

### What

- **New `createSubject?: (principal, ctx) => ConnectTokenSubject | Promise<ConnectTokenSubject>`** on `EveAuthorizationOptions`. Builds the Vercel Connect token subject from the principal **plus** the connection's authorization context (currently `{ url }`, additive per Eve's docs).
- **Precedence**: `createSubject` > `principalToSubject` > default mapping (app → `{ type: 'app' }`, user → `{ type: 'user', id, issuer }`).
- **`principalToSubject` is deprecated** (still fully working) with a `@deprecated` pointer to `createSubject`.
- **Context threading**: the internal `GetTokenOptions` / `StartAuthorizationOptions` / `CompleteAuthorizationOptions` interfaces now accept the `connection` context Eve already passes, and all three callbacks thread it into `buildTokenParams`. The adapter's own `evict()` additionally accepts an optional `connection` so context-dependent subjects can evict/revoke the matching cache entry (falls back to the legacy mapping when absent, keeping eviction best-effort).
- **Context type export**: eve `0.6.0-beta.1` declares `ConnectionAuthorizationContext` but does not re-export it from `eve/connections` (or any public subpath), so the adapter derives it structurally from the exported authorization definition and re-exports it as `EveConnectionAuthorizationContext`. Once eve exports the type directly this becomes a plain re-export.

### Tests

`packages/connect/test/eve/connection-authorization.test.ts` (mocked-fetch style):

- `createSubject` receives `(principal, connection)` and its return is sent as `subject` on the token request (`getToken`) and the authorize request (`startAuthorization`)
- `createSubject` wins over `principalToSubject` when both are set (legacy hook not called)
- `principalToSubject` alone still maps the subject (back-compat)
- default principal mapping unchanged when neither hook is set
- existing evict/revoke tests updated to pass the `connection` context Eve always provides (also fixes pre-existing type errors in the test file against eve's callback signatures)

`pnpm --filter @vercel/connect typecheck && build && test` all pass (42 tests).

### Notes

- Independent of the in-flight connector-name PR (#16623). A minor merge conflict is possible in the `EveAuthorizationOptions` JSDoc area; whichever lands second rebases trivially.
- The `eve` devDependency stays pinned at `0.6.0-beta.1` — a bump is handled separately (blocked by the minimumReleaseAge gate).