### PR TITLE
[cli] Fix non-interactive `env add <name> preview` looping on git_branch_required

### DIFF
--- a/.changeset/env-add-preview-all-branches.md
+++ b/.changeset/env-add-preview-all-branches.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix non-interactive `env add <name> preview --value <value> --yes` looping on `git_branch_required`. The branch-prompt fallback now honors the same "two positionals = all Preview branches" convention as the validation block, so the suggested "Add to all Preview branches" retry command actually succeeds instead of returning the same action_required error.

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -811,10 +811,15 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
+  // When nonInteractive and exactly two positionals (name, preview), treat as
+  // "all Preview branches" — same convention as the validation block above.
+  // Without this escape the suggested "omit for all Preview branches" retry
+  // command loops back into the same action_required error.
   if (
     envGitBranch === undefined &&
     envTargets.length === 1 &&
-    envTargets[0] === 'preview'
+    envTargets[0] === 'preview' &&
+    !(client.nonInteractive && args.length === 2)
   ) {
     if (client.nonInteractive) {
       outputActionRequired(

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -1226,75 +1226,60 @@ describe('env add', () => {
         logSpy.mockRestore();
       });
 
-      it('uses --value when provided and reaches next prompt (e.g. git_branch_required)', async () => {
-        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-          throw new Error('exit');
-        });
-        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      it('adds to all Preview branches when branch omitted with --value', async () => {
+        const envName = 'PREVIEW_VAR';
+        try {
+          client.nonInteractive = true;
+          client.setArgv(
+            'env',
+            'add',
+            envName,
+            'preview',
+            '--value',
+            'my-secret-value',
+            '--yes'
+          );
+          const exitCodePromise = env(client);
 
-        client.nonInteractive = true;
-        client.setArgv(
-          'env',
-          'add',
-          'PREVIEW_VAR',
-          'preview',
-          '--value',
-          'my-secret-value',
-          '--yes'
-        );
-        const exitCodePromise = env(client);
+          await expect(exitCodePromise).resolves.toBe(0);
 
-        await expect(exitCodePromise).rejects.toThrow('exit');
-        const payload = JSON.parse(
-          logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
-        );
-        expect(payload.reason).toBe('git_branch_required');
-        expect(
-          payload.next.some(
-            (n: { command: string }) =>
-              n.command.includes('preview') && n.command.includes('<gitbranch>')
-          )
-        ).toBe(true);
-
-        exitSpy.mockRestore();
-        logSpy.mockRestore();
+          const savedEnv = envs.find(currentEnv => currentEnv.key === envName);
+          expect(savedEnv?.value).toBe('my-secret-value');
+          expect(savedEnv?.target).toEqual(['preview']);
+          expect(savedEnv?.gitBranch).toBeUndefined();
+        } finally {
+          const savedEnvIndex = envs.findIndex(
+            currentEnv => currentEnv.key === envName
+          );
+          if (savedEnvIndex !== -1) {
+            envs.splice(savedEnvIndex, 1);
+          }
+        }
       });
 
-      it('outputs action_required when preview target and git branch not passed (no third argument)', async () => {
-        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-          throw new Error('exit');
-        });
-        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      it('adds to all Preview branches when branch omitted with stdin value', async () => {
+        const envName = 'PREVIEW_VAR_STDIN';
+        try {
+          client.nonInteractive = true;
+          client.stdin.isTTY = false;
+          client.setArgv('env', 'add', envName, 'preview', '--yes');
+          const exitCodePromise = env(client);
+          setImmediate(() => client.stdin.emit('data', 'value-via-stdin'));
 
-        client.nonInteractive = true;
-        client.stdin.isTTY = false;
-        client.setArgv('env', 'add', 'PREVIEW_VAR', 'preview', '--yes');
-        const exitCodePromise = env(client);
-        setImmediate(() => client.stdin.emit('data', 'value-via-stdin'));
+          await expect(exitCodePromise).resolves.toBe(0);
 
-        await expect(exitCodePromise).rejects.toThrow('exit');
-        expect(logSpy).toHaveBeenCalled();
-        const payload = JSON.parse(
-          logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
-        );
-        expect(payload).toMatchObject({
-          status: 'action_required',
-          reason: 'git_branch_required',
-          message: expect.stringMatching(/Git branch|third argument|Preview/),
-          next: expect.any(Array),
-        });
-        expect(payload.next.length).toBeGreaterThanOrEqual(1);
-        expect(
-          payload.next.some(
-            (n: { command: string }) =>
-              n.command.includes('preview') &&
-              (n.command.includes('<gitbranch>') ||
-                n.command.includes('--value'))
-          )
-        ).toBe(true);
-
-        exitSpy.mockRestore();
-        logSpy.mockRestore();
+          const savedEnv = envs.find(currentEnv => currentEnv.key === envName);
+          expect(savedEnv?.value).toBe('value-via-stdin');
+          expect(savedEnv?.target).toEqual(['preview']);
+          expect(savedEnv?.gitBranch).toBeUndefined();
+        } finally {
+          const savedEnvIndex = envs.findIndex(
+            currentEnv => currentEnv.key === envName
+          );
+          if (savedEnvIndex !== -1) {
+            envs.splice(savedEnvIndex, 1);
+          }
+        }
       });
 
       it('does not output git_branch_required when branch is passed as third argument for preview', async () => {


### PR DESCRIPTION
### Problem

In non-interactive (agent/CI) mode, adding an env var to all Preview branches is impossible — the CLI's own suggested command loops back into the same error:

```
$ vercel env add MY_KEY preview --value secret --yes
{
  "status": "action_required",
  "reason": "git_branch_required",
  "message": "Add MY_KEY to which Git branch for Preview? Pass branch as third argument, or omit for all Preview branches.",
  "next": [
    { "command": "vercel env add MY_KEY preview <gitbranch> --value <value> --yes", "when": "Add to a specific Git branch" },
    { "command": "vercel env add MY_KEY preview --value <value> --yes", "when": "Add to all Preview branches" }
  ]
}
```

Running the suggested "Add to all Preview branches" command returns the exact same `action_required` payload, infinitely.

### Cause

`env add` has two branch checks. The validation block already implements the escape hatch:

```ts
// When nonInteractive and exactly two positionals (name, preview), treat as "all Preview branches"; otherwise require branch
if (
  envTargetArg === 'preview' &&
  envGitBranch === undefined &&
  !(client.nonInteractive && args.length === 2)
) {
  missing.push('git_branch_required');
}
```

…but the branch-prompt fallback further down (`add.ts` ~L814) never got the same escape, so it fires unconditionally for `nonInteractive` + `preview` + no branch — after the validation block has already passed the command as valid.

### Fix

Apply the identical `!(client.nonInteractive && args.length === 2)` escape to the prompt fallback, so two positionals (`<name> preview`) in non-interactive mode mean "all Preview branches", matching both the validation block's convention and the CLI's own suggested command.

Interactive behavior is unchanged (`client.nonInteractive` is false → condition unchanged), and passing an explicit third positional branch is unchanged.

### Tests

Updated the two unit tests that codified the looping behavior to assert the new success path:
- `adds to all Preview branches when branch omitted with --value` — asserts exit 0 and the env saved with `target: ['preview']`, no `gitBranch`
- `adds to all Preview branches when branch omitted with stdin value` — same via stdin

Verified manually against a live project: the previously-looping command now returns `Added Environment Variable … [199ms]`.
