### PR TITLE
[python] Override exclude-newer when install vercel-runtime et al

### DIFF
--- a/.changeset/five-kangaroos-explain.md
+++ b/.changeset/five-kangaroos-explain.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Override uv's exclude-newer when install vercel-runtime/vercel-workers

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -364,11 +364,21 @@ async function installInjectedPackage({
   const localDir = join(__dirname, '..', '..', '..', 'python', name);
   const isLocalDev = fs.existsSync(join(localDir, 'pyproject.toml'));
   const dep = envOverride || (isLocalDev ? localDir : pinned);
+  // override exclude-newer, since we want vercel-runtime updates to
+  // take effect immediately after release
+  const noExclude = ['--exclude-newer-package', `${name}=false`];
   debug(`Installing ${dep}`);
   await uv.pip({
     venvPath,
     projectDir,
-    args: ['install', '--link-mode', 'copy', ...pipPlatformArgs, dep],
+    args: [
+      'install',
+      '--link-mode',
+      'copy',
+      ...pipPlatformArgs,
+      ...noExclude,
+      dep,
+    ],
   });
 }
 


### PR DESCRIPTION
Couldn't think of a good way to do an automated test here (unit tests
mock out uv, E2E tests inject a path to a wheel), so verified
manually:

 * deleted `python/vercel-runtime/pyproject.toml` so that the
  `isLocalDev` path is ignored
 * ran a build against something with exclude-newer;
   verified it failed on main, passed with this
