### PR TITLE
[cli] integration add: install declared agent skills after provisioning

### DIFF
--- a/.changeset/integration-add-skill-suggestion.md
+++ b/.changeset/integration-add-skill-suggestion.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-[cli] `integration add` now installs a product's declared agent skills after provisioning. It reads the product's `agentSkills` (public GitHub `SKILL.md` links) and normalizes each to `npx skills add <repo-url> --skill <name>`. Install is the default: in an interactive terminal it prompts first (default yes); non-interactive callers (agents, CI) can't be prompted, so they proceed with the default and auto-install via `npx --yes skills add`. `--format=json` stays read-only — it never installs and instead surfaces a `skills` array (each entry tagged `kind: "agent-skill"`). Non-GitHub or unparseable entries are skipped.
+[cli] `integration add` now installs a product's declared agent skills after provisioning. It reads the product's `agentSkills` (public GitHub `SKILL.md` links) and runs `npx skills add` for each — prompting first in an interactive terminal (default yes), or auto-installing for non-interactive callers (agents, CI). `--format=json` stays read-only: it surfaces a `skills` array instead of installing. Non-GitHub or unparseable links are skipped.

--- a/.changeset/integration-add-skill-suggestion.md
+++ b/.changeset/integration-add-skill-suggestion.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] `integration add` now suggests `npx skills add …` commands for a product's declared agent skills. After provisioning, it reads the product's `agentSkills` (public GitHub `SKILL.md` links), normalizes each to a ready-to-run `npx skills add <repo-url> --skill <name>` command, and prints them (and surfaces them as a `skills` array in `--format=json`). Non-GitHub or unparseable entries are skipped, and the CLI only suggests the command — running `npx skills add` is left to the user/agent.

--- a/.changeset/integration-add-skill-suggestion.md
+++ b/.changeset/integration-add-skill-suggestion.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-[cli] `integration add` now suggests `npx skills add …` commands for a product's declared agent skills. After provisioning, it reads the product's `agentSkills` (public GitHub `SKILL.md` links), normalizes each to a ready-to-run `npx skills add <repo-url> --skill <name>` command, and prints them (and surfaces them as a `skills` array in `--format=json`). Non-GitHub or unparseable entries are skipped, and the CLI only suggests the command — running `npx skills add` is left to the user/agent.
+[cli] `integration add` now installs a product's declared agent skills after provisioning. It reads the product's `agentSkills` (public GitHub `SKILL.md` links) and normalizes each to `npx skills add <repo-url> --skill <name>`. Install is the default: in an interactive terminal it prompts first (default yes); non-interactive callers (agents, CI) can't be prompted, so they proceed with the default and auto-install via `npx --yes skills add`. `--format=json` stays read-only — it never installs and instead surfaces a `skills` array (each entry tagged `kind: "agent-skill"`). Non-GitHub or unparseable entries are skipped.

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -11,6 +11,7 @@ import { fetchInstallations } from '../../util/integration/fetch-installations';
 import { acceptTermsViaBrowser } from '../../util/integration/accept-terms-via-browser';
 import { promptForTermAcceptance } from '../../util/integration/prompt-for-terms';
 import { selectProduct } from '../../util/integration/select-product';
+import { resolveProductSkills } from '../../util/integration/skill-suggestion';
 import { runClaimForResource } from '../integration-resource/claim';
 import { getResources } from '../../util/integration-resource/get-resources';
 import { packageName } from '../../util/pkg-name';
@@ -568,6 +569,21 @@ export async function addAutoProvision(
     }
   );
 
+  // Suggest installing the product's declared agent skills (from `agentSkills`).
+  // We only *print* the `npx skills add` command — running it is left to the
+  // user/agent so it lands in the right project, with consent.
+  const skills = resolveProductSkills(product);
+
+  if (skills.length && !options.asJson) {
+    const noun = skills.length === 1 ? 'the agent skill' : 'agent skills';
+    output.log(
+      `Install ${noun} so your AI tools can use ${chalk.bold(product.name)}:`
+    );
+    for (const skill of skills) {
+      output.log(indent(chalk.cyan(skill.command), 4));
+    }
+  }
+
   if (options.asJson) {
     const warnings: string[] = [];
     if (setupResult.connectError) {
@@ -622,6 +638,7 @@ export async function addAutoProvision(
       environments: setupResult.environments,
       envPulled: setupResult.envPulled,
       guideCommand,
+      skills,
       warnings,
     };
 

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -592,6 +592,9 @@ export async function addAutoProvision(
     if (runInstall) {
       output.log(`Installing ${noun} for ${chalk.bold(product.name)}…`);
       for (const skill of skills) {
+        // Echo the command before running it, so the publisher code being
+        // executed is visible in interactive, CI, and agent transcripts.
+        output.log(indent(chalk.cyan(skill.command), 4));
         // `--yes` is required: without it `npx` prompts to install the `skills`
         // package and hangs in non-interactive (agent/CI) contexts.
         const args = [

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -1,8 +1,10 @@
 import chalk from 'chalk';
+import execa from 'execa';
 import { errorToString } from '@vercel/error-utils';
 import open from 'open';
 import output from '../../output-manager';
 import type Client from '../../util/client';
+import { canPrompt } from '../../util/flags/can-prompt';
 import getScope from '../../util/get-scope';
 import indent from '../../util/output/indent';
 import { autoProvisionResource } from '../../util/integration/auto-provision-resource';
@@ -569,18 +571,54 @@ export async function addAutoProvision(
     }
   );
 
-  // Suggest installing the product's declared agent skills (from `agentSkills`).
-  // We only *print* the `npx skills add` command — running it is left to the
-  // user/agent so it lands in the right project, with consent.
+  // Install the product's declared agent skills (from `agentSkills`). Install
+  // is the default: in an interactive terminal we ask first; non-interactive
+  // callers (agents, CI) can't be prompted, so they proceed with the default
+  // and auto-install. JSON mode never reaches here (read-only — `skills[]` is
+  // surfaced in the JSON payload instead).
   const skills = resolveProductSkills(product);
 
   if (skills.length && !options.asJson) {
     const noun = skills.length === 1 ? 'the agent skill' : 'agent skills';
-    output.log(
-      `Install ${noun} so your AI tools can use ${chalk.bold(product.name)}:`
-    );
-    for (const skill of skills) {
-      output.log(indent(chalk.cyan(skill.command), 4));
+
+    let runInstall = !canPrompt(client);
+    if (canPrompt(client)) {
+      runInstall = await client.input.confirm(
+        `Install ${noun} so your AI tools can use ${chalk.bold(product.name)}?`,
+        true
+      );
+    }
+
+    if (runInstall) {
+      output.log(`Installing ${noun} for ${chalk.bold(product.name)}…`);
+      for (const skill of skills) {
+        // `--yes` is required: without it `npx` prompts to install the `skills`
+        // package and hangs in non-interactive (agent/CI) contexts.
+        const args = [
+          '--yes',
+          'skills',
+          'add',
+          skill.repoUrl,
+          ...(skill.skill ? ['--skill', skill.skill] : []),
+        ];
+        const result = await execa('npx', args, {
+          cwd: client.cwd,
+          stdio: 'inherit',
+          reject: false,
+        });
+        if (result.exitCode !== 0) {
+          output.warn(
+            `Failed to install ${skill.skill ?? skill.repoUrl}. Run it manually: ${chalk.cyan(skill.command)}`
+          );
+        }
+      }
+    } else {
+      output.log(
+        `Install ${noun} so your AI tools can use ${chalk.bold(product.name)}:`
+      );
+      for (const skill of skills) {
+        output.log(indent(chalk.cyan(skill.command), 4));
+      }
     }
   }
 

--- a/packages/cli/src/util/integration/skill-suggestion.ts
+++ b/packages/cli/src/util/integration/skill-suggestion.ts
@@ -1,0 +1,81 @@
+import type { IntegrationProduct } from './types';
+
+export interface ResolvedSkill {
+  /** What a consumer (e.g. an AI agent) should do with this entry. */
+  action: 'install';
+  /** The GitHub repo URL passed to `npx skills add`. */
+  repoUrl: string;
+  /** The skill name (the folder that holds SKILL.md), when the link points at one. */
+  skill?: string;
+  /** Ready-to-run install command. */
+  command: string;
+  /** The original `agentSkills` entry this was derived from. */
+  source: string;
+}
+
+/**
+ * Resolve `npx skills add` suggestions for a freshly-provisioned product from
+ * its declared `agentSkills`. Each entry is expected to be a public GitHub
+ * `SKILL.md` (or skill-folder) link — the publisher is the source of truth.
+ * Non-GitHub or unparseable entries are skipped. Returns [] when nothing
+ * usable is declared.
+ */
+export function resolveProductSkills(
+  product: Pick<IntegrationProduct, 'agentSkills'>
+): ResolvedSkill[] {
+  const resolved: ResolvedSkill[] = [];
+  for (const entry of product.agentSkills ?? []) {
+    const skill = resolveSkillFromUrl(entry);
+    if (skill) {
+      resolved.push(skill);
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Turn a GitHub skill link into an `npx skills add` command.
+ *
+ * Example:
+ *   https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md
+ *   → npx skills add https://github.com/shopify/shopify-ai-toolkit --skill shopify-dev
+ *
+ * Owner/repo are lowercased — GitHub resolves them case-insensitively and that
+ * matches skills.sh's canonical form. The skill name (the directory containing
+ * SKILL.md) is preserved as-is, since it must match the real folder. Returns
+ * null for non-GitHub or unparseable URLs.
+ */
+export function resolveSkillFromUrl(value: string): ResolvedSkill | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+
+  if (url.hostname.replace(/^www\./, '') !== 'github.com') {
+    return null;
+  }
+
+  // segments: <owner>/<repo>/(blob|tree)/<branch>/<...path>/<skill>/SKILL.md
+  const segments = url.pathname.split('/').filter(Boolean);
+  const [owner, repo, kind, , ...rest] = segments;
+  if (!owner || !repo) {
+    return null;
+  }
+
+  const repoUrl = `https://github.com/${owner.toLowerCase()}/${repo.toLowerCase()}`;
+
+  let skill: string | undefined;
+  if (kind === 'blob' || kind === 'tree') {
+    // The skill is the directory that holds SKILL.md.
+    const parts = rest.filter(part => part.toLowerCase() !== 'skill.md');
+    skill = parts[parts.length - 1];
+  }
+
+  const command = skill
+    ? `npx skills add ${repoUrl} --skill ${skill}`
+    : `npx skills add ${repoUrl}`;
+
+  return { action: 'install', repoUrl, skill, command, source: value };
+}

--- a/packages/cli/src/util/integration/skill-suggestion.ts
+++ b/packages/cli/src/util/integration/skill-suggestion.ts
@@ -1,29 +1,17 @@
 import type { IntegrationProduct } from './types';
 
 export interface ResolvedSkill {
-  /**
-   * What kind of entry this is. A descriptive tag, not a directive — the skill
-   * is only ever suggested; nothing is installed by resolving it.
-   */
-  kind: 'agent-skill';
-  /** Whether the publisher recommends this skill for the product. */
-  recommended: true;
-  /** The GitHub repo URL passed to `npx skills add`. */
+  /** GitHub repo URL passed to `npx skills add`. */
   repoUrl: string;
-  /** The skill name (the folder that holds SKILL.md), when the link points at one. */
+  /** Skill directory (the folder holding SKILL.md), when the link points at one. */
   skill?: string;
   /** Ready-to-run install command. */
   command: string;
-  /** The original `agentSkills` entry this was derived from. */
-  source: string;
 }
 
 /**
- * Resolve `npx skills add` suggestions for a freshly-provisioned product from
- * its declared `agentSkills`. Each entry is expected to be a public GitHub
- * `SKILL.md` (or skill-folder) link — the publisher is the source of truth.
- * Non-GitHub or unparseable entries are skipped. Returns [] when nothing
- * usable is declared.
+ * Resolve `npx skills add` suggestions from a product's declared `agentSkills`.
+ * Non-GitHub or unparseable entries are skipped.
  */
 export function resolveProductSkills(
   product: Pick<IntegrationProduct, 'agentSkills'>
@@ -39,16 +27,12 @@ export function resolveProductSkills(
 }
 
 /**
- * Turn a GitHub skill link into an `npx skills add` command.
+ * Turn a GitHub skill link into an `npx skills add` command, e.g.
+ * `.../Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md` →
+ * `npx skills add https://github.com/shopify/shopify-ai-toolkit --skill shopify-dev`.
  *
- * Example:
- *   https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md
- *   → npx skills add https://github.com/shopify/shopify-ai-toolkit --skill shopify-dev
- *
- * Owner/repo are lowercased — GitHub resolves them case-insensitively and that
- * matches skills.sh's canonical form. The skill name (the directory containing
- * SKILL.md) is preserved as-is, since it must match the real folder. Returns
- * null for non-GitHub or unparseable URLs.
+ * Owner/repo are lowercased to match skills.sh's canonical form; the skill
+ * directory is kept as-is. Returns null for non-GitHub or unparseable URLs.
  */
 export function resolveSkillFromUrl(value: string): ResolvedSkill | null {
   let url: URL;
@@ -62,9 +46,10 @@ export function resolveSkillFromUrl(value: string): ResolvedSkill | null {
     return null;
   }
 
-  // segments: <owner>/<repo>/(blob|tree)/<branch>/<...path>/<skill>/SKILL.md
-  const segments = url.pathname.split('/').filter(Boolean);
-  const [owner, repo, kind, , ...rest] = segments;
+  // <owner>/<repo>/(blob|tree)/<branch>/<path...>/<skill>/SKILL.md
+  const [owner, repo, kind, , ...rest] = url.pathname
+    .split('/')
+    .filter(Boolean);
   if (!owner || !repo) {
     return null;
   }
@@ -73,7 +58,6 @@ export function resolveSkillFromUrl(value: string): ResolvedSkill | null {
 
   let skill: string | undefined;
   if (kind === 'blob' || kind === 'tree') {
-    // The skill is the directory that holds SKILL.md.
     const parts = rest.filter(part => part.toLowerCase() !== 'skill.md');
     skill = parts[parts.length - 1];
   }
@@ -82,12 +66,5 @@ export function resolveSkillFromUrl(value: string): ResolvedSkill | null {
     ? `npx skills add ${repoUrl} --skill ${skill}`
     : `npx skills add ${repoUrl}`;
 
-  return {
-    kind: 'agent-skill',
-    recommended: true,
-    repoUrl,
-    skill,
-    command,
-    source: value,
-  };
+  return { repoUrl, skill, command };
 }

--- a/packages/cli/src/util/integration/skill-suggestion.ts
+++ b/packages/cli/src/util/integration/skill-suggestion.ts
@@ -1,8 +1,13 @@
 import type { IntegrationProduct } from './types';
 
 export interface ResolvedSkill {
-  /** What a consumer (e.g. an AI agent) should do with this entry. */
-  action: 'install';
+  /**
+   * What kind of entry this is. A descriptive tag, not a directive — the skill
+   * is only ever suggested; nothing is installed by resolving it.
+   */
+  kind: 'agent-skill';
+  /** Whether the publisher recommends this skill for the product. */
+  recommended: true;
   /** The GitHub repo URL passed to `npx skills add`. */
   repoUrl: string;
   /** The skill name (the folder that holds SKILL.md), when the link points at one. */
@@ -77,5 +82,12 @@ export function resolveSkillFromUrl(value: string): ResolvedSkill | null {
     ? `npx skills add ${repoUrl} --skill ${skill}`
     : `npx skills add ${repoUrl}`;
 
-  return { action: 'install', repoUrl, skill, command, source: value };
+  return {
+    kind: 'agent-skill',
+    recommended: true,
+    repoUrl,
+    skill,
+    command,
+    source: value,
+  };
 }

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -85,6 +85,11 @@ export interface IntegrationProduct {
   guides?: IntegrationGuide[];
   snippets?: IntegrationSnippet[];
   resourceLinks?: IntegrationResourceLink[];
+  /**
+   * Public links to the product's agent skills (e.g. a GitHub `SKILL.md` URL).
+   * Used to suggest `npx skills add …` commands after provisioning.
+   */
+  agentSkills?: string[];
 }
 
 type InstallationType = 'marketplace' | 'external';

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -85,10 +85,7 @@ export interface IntegrationProduct {
   guides?: IntegrationGuide[];
   snippets?: IntegrationSnippet[];
   resourceLinks?: IntegrationResourceLink[];
-  /**
-   * Public links to the product's agent skills (e.g. a GitHub `SKILL.md` URL).
-   * Used to suggest `npx skills add …` commands after provisioning.
-   */
+  /** Public GitHub `SKILL.md` links used to suggest `npx skills add …` after provisioning. */
   agentSkills?: string[];
 }
 

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -192,6 +192,26 @@ const integrations: Record<string, Integration> = {
       },
     ],
   },
+  'acme-skills': {
+    id: 'acme-skills',
+    name: 'Acme Integration With Skills',
+    slug: 'acme-skills',
+    eulaDocUri: 'https://example.com/eula',
+    privacyDocUri: 'https://example.com/privacy',
+    products: [
+      {
+        id: 'acme-product',
+        name: 'Acme Product',
+        slug: 'acme',
+        type: 'storage',
+        shortDescription: 'The Acme product',
+        metadataSchema: metadataSchema1,
+        agentSkills: [
+          'https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md',
+        ],
+      },
+    ],
+  },
   'acme-two-products': {
     id: 'acme-two-products',
     name: 'Acme Integration Two Products',

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import open from 'open';
+import execa from 'execa';
 import integrationCommand from '../../../../src/commands/integration';
 import install from '../../../../src/commands/install';
 import pull from '../../../../src/commands/env/pull';
@@ -35,14 +36,22 @@ vi.mock(
   }
 );
 
+vi.mock('execa', () => {
+  return {
+    default: vi.fn().mockResolvedValue({ exitCode: 0 }),
+  };
+});
+
 const openMock = vi.mocked(open);
 const pullMock = vi.mocked(pull);
 const connectMock = vi.mocked(connectResourceToProject);
+const execaMock = vi.mocked(execa);
 
 beforeEach(() => {
   openMock.mockReset().mockResolvedValue(undefined as never);
   pullMock.mockClear();
   connectMock.mockClear();
+  execaMock.mockReset().mockResolvedValue({ exitCode: 0 } as never);
   // Mock Math.random to get predictable resource names (gray-apple suffix)
   vi.spyOn(Math, 'random').mockReturnValue(0);
 });
@@ -2625,6 +2634,98 @@ describe('integration add (auto-provision)', () => {
       expect(exitCode).toEqual(0);
       // No JSON on stdout
       expect(client.stdout.getFullOutput()).toBe('');
+    });
+  });
+
+  describe('agent skills', () => {
+    beforeEach(() => {
+      useAutoProvision({ responseKey: 'provisioned' });
+    });
+
+    it('installs declared skills when the user accepts the prompt', async () => {
+      client.setArgv('integration', 'add', 'acme-skills');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned: acme-gray-apple'
+      );
+      await expect(client.stderr).toOutput(
+        'Install the agent skill so your AI tools can use Acme Product?'
+      );
+      client.stdin.write('y\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(execaMock).toHaveBeenCalledWith(
+        'npx',
+        [
+          '--yes',
+          'skills',
+          'add',
+          'https://github.com/shopify/shopify-ai-toolkit',
+          '--skill',
+          'shopify-dev',
+        ],
+        expect.objectContaining({ stdio: 'inherit', reject: false })
+      );
+    });
+
+    it('prints the install hint and does not run when declined', async () => {
+      client.setArgv('integration', 'add', 'acme-skills');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Install the agent skill so your AI tools can use Acme Product?'
+      );
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput(
+        'npx skills add https://github.com/shopify/shopify-ai-toolkit --skill shopify-dev'
+      );
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(execaMock).not.toHaveBeenCalled();
+    });
+
+    it('auto-installs (no prompt) when non-interactive', async () => {
+      client.stdin.isTTY = false;
+      client.setArgv('integration', 'add', 'acme-skills');
+      const exitCode = await integrationCommand(client);
+
+      expect(exitCode).toEqual(0);
+      expect(execaMock).toHaveBeenCalledWith(
+        'npx',
+        [
+          '--yes',
+          'skills',
+          'add',
+          'https://github.com/shopify/shopify-ai-toolkit',
+          '--skill',
+          'shopify-dev',
+        ],
+        expect.objectContaining({ stdio: 'inherit', reject: false })
+      );
+    });
+
+    it('surfaces skills in --format=json and never runs them', async () => {
+      client.setArgv('integration', 'add', 'acme-skills', '--format=json');
+      const exitCode = await integrationCommand(client);
+
+      expect(exitCode).toEqual(0);
+      const jsonOutput = JSON.parse(client.stdout.getFullOutput());
+      expect(jsonOutput.skills).toEqual([
+        {
+          kind: 'agent-skill',
+          recommended: true,
+          repoUrl: 'https://github.com/shopify/shopify-ai-toolkit',
+          skill: 'shopify-dev',
+          command:
+            'npx skills add https://github.com/shopify/shopify-ai-toolkit --skill shopify-dev',
+          source:
+            'https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md',
+        },
+      ]);
+      expect(execaMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -2715,14 +2715,10 @@ describe('integration add (auto-provision)', () => {
       const jsonOutput = JSON.parse(client.stdout.getFullOutput());
       expect(jsonOutput.skills).toEqual([
         {
-          kind: 'agent-skill',
-          recommended: true,
           repoUrl: 'https://github.com/shopify/shopify-ai-toolkit',
           skill: 'shopify-dev',
           command:
             'npx skills add https://github.com/shopify/shopify-ai-toolkit --skill shopify-dev',
-          source:
-            'https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md',
         },
       ]);
       expect(execaMock).not.toHaveBeenCalled();

--- a/packages/cli/test/unit/util/integration/skill-suggestion.test.ts
+++ b/packages/cli/test/unit/util/integration/skill-suggestion.test.ts
@@ -11,14 +11,10 @@ describe('resolveSkillFromUrl', () => {
         'https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md'
       )
     ).toEqual({
-      kind: 'agent-skill',
-      recommended: true,
       repoUrl: 'https://github.com/shopify/shopify-ai-toolkit',
       skill: 'shopify-dev',
       command:
         'npx skills add https://github.com/shopify/shopify-ai-toolkit --skill shopify-dev',
-      source:
-        'https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md',
     });
   });
 

--- a/packages/cli/test/unit/util/integration/skill-suggestion.test.ts
+++ b/packages/cli/test/unit/util/integration/skill-suggestion.test.ts
@@ -11,7 +11,8 @@ describe('resolveSkillFromUrl', () => {
         'https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md'
       )
     ).toEqual({
-      action: 'install',
+      kind: 'agent-skill',
+      recommended: true,
       repoUrl: 'https://github.com/shopify/shopify-ai-toolkit',
       skill: 'shopify-dev',
       command:

--- a/packages/cli/test/unit/util/integration/skill-suggestion.test.ts
+++ b/packages/cli/test/unit/util/integration/skill-suggestion.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveProductSkills,
+  resolveSkillFromUrl,
+} from '../../../../src/util/integration/skill-suggestion';
+
+describe('resolveSkillFromUrl', () => {
+  it('parses a GitHub SKILL.md URL (lowercases owner/repo, keeps skill dir)', () => {
+    expect(
+      resolveSkillFromUrl(
+        'https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md'
+      )
+    ).toEqual({
+      action: 'install',
+      repoUrl: 'https://github.com/shopify/shopify-ai-toolkit',
+      skill: 'shopify-dev',
+      command:
+        'npx skills add https://github.com/shopify/shopify-ai-toolkit --skill shopify-dev',
+      source:
+        'https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md',
+    });
+  });
+
+  it('handles /tree/ links pointing at the skill folder (no SKILL.md)', () => {
+    const resolved = resolveSkillFromUrl(
+      'https://github.com/neondatabase/agent-skills/tree/main/neon-postgres'
+    );
+    expect(resolved?.command).toBe(
+      'npx skills add https://github.com/neondatabase/agent-skills --skill neon-postgres'
+    );
+    expect(resolved?.skill).toBe('neon-postgres');
+  });
+
+  it('omits --skill when SKILL.md sits at the repo root', () => {
+    const resolved = resolveSkillFromUrl(
+      'https://github.com/acme/skill-repo/blob/main/SKILL.md'
+    );
+    expect(resolved?.command).toBe(
+      'npx skills add https://github.com/acme/skill-repo'
+    );
+    expect(resolved?.skill).toBeUndefined();
+  });
+
+  it('omits --skill for a bare repo URL', () => {
+    const resolved = resolveSkillFromUrl('https://github.com/acme/skill-repo');
+    expect(resolved?.command).toBe(
+      'npx skills add https://github.com/acme/skill-repo'
+    );
+  });
+
+  it('returns null for non-GitHub URLs', () => {
+    expect(
+      resolveSkillFromUrl('https://skills.sh/acme/skill-repo/my-skill')
+    ).toBeNull();
+    expect(resolveSkillFromUrl('https://example.com/SKILL.md')).toBeNull();
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(resolveSkillFromUrl('not a url')).toBeNull();
+    expect(resolveSkillFromUrl('')).toBeNull();
+  });
+
+  it('returns null when owner or repo is missing', () => {
+    expect(resolveSkillFromUrl('https://github.com/acme')).toBeNull();
+  });
+});
+
+describe('resolveProductSkills', () => {
+  it('resolves every valid GitHub entry and skips the rest', () => {
+    const resolved = resolveProductSkills({
+      agentSkills: [
+        'https://github.com/Shopify/Shopify-AI-Toolkit/blob/main/skills/shopify-dev/SKILL.md',
+        'https://skills.sh/acme/repo/skill', // non-GitHub → skipped
+        'not a url', // unparseable → skipped
+        'https://github.com/acme/widgets/blob/main/skills/widget/SKILL.md',
+      ],
+    });
+
+    expect(resolved.map(s => s.command)).toEqual([
+      'npx skills add https://github.com/shopify/shopify-ai-toolkit --skill shopify-dev',
+      'npx skills add https://github.com/acme/widgets --skill widget',
+    ]);
+  });
+
+  it('returns an empty array when nothing is declared', () => {
+    expect(resolveProductSkills({})).toEqual([]);
+    expect(resolveProductSkills({ agentSkills: [] })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

After `integration add` provisions a product, the user (or AI agent) still has to discover and manually install the product's declared agent skills. The CLI already knows them (`agentSkills`), so it should help install them.

## What

- After provisioning, resolves the product's `agentSkills` (public GitHub `SKILL.md` links) to `npx skills add <repo> --skill <name>` and installs them.
- **Install is the default**, gated by context:
  - **Interactive (TTY):** prompts first — `Install …? (Y/n)`, default **yes**.
  - **Non-interactive (agents, CI):** can't be prompted, so proceeds with the default and **auto-installs** via `npx --yes skills add …` (`--yes` avoids npx hanging on its package-install prompt).
  - **`--format=json`:** read-only — never installs; surfaces a `skills` array (each entry tagged `kind: "agent-skill"`).
- Non-GitHub / unparseable `agentSkills` entries are skipped.

## Validation

- Unit tests for skill-URL resolution and the add flow: TTY accept, TTY decline, non-interactive auto-install (asserts `npx --yes skills add …`), and JSON read-only. Focused suites green; `pnpm build` / lint pass.