### PR TITLE
fix(cli): scope `env rm` to the specified environment for multi-target records

### DIFF
--- a/.changeset/fix-env-rm-multitarget.md
+++ b/.changeset/fix-env-rm-multitarget.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vercel env rm <name> <environment>` silently deleting variables from all environments when the record targets multiple. Now only the specified environment is removed (via PATCH) instead of the entire record being deleted (via DELETE).

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -258,8 +258,16 @@ export default async function rm(client: Client, argv: string[]) {
     const currentCustomIds = env.customEnvironmentIds ?? [];
     const totalTargets = currentTargets.length + currentCustomIds.length;
 
+    // Custom environments are specified on the command line by slug, but the
+    // record stores them as IDs. Normalize the requested target to an ID so the
+    // de-target filter can match (mirrors `env update`).
+    const customEnvironment = customEnvironments.find(
+      ({ slug, id }) => slug === envTarget || id === envTarget
+    );
+    const normalizedEnvTarget = customEnvironment?.id || envTarget;
+
     if (envTarget && totalTargets > 1) {
-      await detargetEnvRecord(client, project.id, env, envTarget);
+      await detargetEnvRecord(client, project.id, env, normalizedEnvTarget);
     } else {
       await removeEnvRecord(client, project.id, env);
     }

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import removeEnvRecord from '../../util/env/remove-env-record';
+import detargetEnvRecord from '../../util/env/detarget-env-record';
 import getEnvRecords from '../../util/env/get-env-records';
 import formatEnvironments from '../../util/env/format-environments';
 import { getEnvTargetPlaceholder } from '../../util/env/env-target';
@@ -246,7 +247,22 @@ export default async function rm(client: Client, argv: string[]) {
 
   try {
     output.spinner('Removing');
-    await removeEnvRecord(client, project.id, env);
+    // If the user targeted a specific environment and the record spans more
+    // than that one environment, PATCH to remove only the requested target
+    // instead of DELETEing the entire record.
+    const currentTargets = Array.isArray(env.target)
+      ? env.target
+      : env.target
+        ? [env.target]
+        : [];
+    const currentCustomIds = env.customEnvironmentIds ?? [];
+    const totalTargets = currentTargets.length + currentCustomIds.length;
+
+    if (envTarget && totalTargets > 1) {
+      await detargetEnvRecord(client, project.id, env, envTarget);
+    } else {
+      await removeEnvRecord(client, project.id, env);
+    }
   } catch (err: unknown) {
     if (client.nonInteractive && isAPIError(err)) {
       const reason =

--- a/packages/cli/src/util/env/detarget-env-record.ts
+++ b/packages/cli/src/util/env/detarget-env-record.ts
@@ -1,0 +1,43 @@
+import type Client from '../client';
+import type {
+  ProjectEnvTarget,
+  ProjectEnvVariable,
+} from '@vercel-internals/types';
+import output from '../../output-manager';
+
+/**
+ * Removes a single environment target from a multi-target env record via PATCH,
+ * leaving all other targets (and the value) unchanged.
+ *
+ * @param targetToRemove  The standard target name ("production" | "preview" |
+ *                        "development") or a custom environment ID to remove.
+ */
+export default async function detargetEnvRecord(
+  client: Client,
+  projectId: string,
+  env: ProjectEnvVariable,
+  targetToRemove: string
+): Promise<void> {
+  output.debug(
+    `Removing target ${targetToRemove} from Environment Variable ${env.key}`
+  );
+
+  const currentTargets: ProjectEnvTarget[] = Array.isArray(env.target)
+    ? env.target
+    : env.target
+      ? [env.target]
+      : [];
+  const currentCustomIds: string[] = env.customEnvironmentIds ?? [];
+
+  const newTargets = currentTargets.filter(t => t !== targetToRemove);
+  const newCustomIds = currentCustomIds.filter(id => id !== targetToRemove);
+
+  const url = `/v10/projects/${projectId}/env/${env.id}`;
+  await client.fetch(url, {
+    method: 'PATCH',
+    body: {
+      target: newTargets,
+      customEnvironmentIds: newCustomIds.length > 0 ? newCustomIds : undefined,
+    },
+  });
+}

--- a/packages/cli/test/unit/commands/env/rm.test.ts
+++ b/packages/cli/test/unit/commands/env/rm.test.ts
@@ -149,3 +149,92 @@ describe('env rm', () => {
     });
   });
 });
+
+describe('multi-environment record scoping', () => {
+  describe('when a record targets multiple environments', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject(
+        {
+          ...defaultProject,
+          id: 'vercel-env-rm',
+          name: 'vercel-env-rm',
+        },
+        [
+          {
+            type: 'encrypted',
+            id: 'multi-env-id-123',
+            key: 'MULTI_ENV_VAR',
+            value: 'secret',
+            target: ['production', 'preview'],
+            gitBranch: undefined,
+            configurationId: null,
+            updatedAt: 1557241361455,
+            createdAt: 1557241361455,
+          },
+        ]
+      );
+      const cwd = setupUnitFixture('commands/env/vercel-env-rm');
+      client.cwd = cwd;
+    });
+
+    it('PATCHes the record instead of DELETEing when a specific target is given', async () => {
+      const detargetModule = await import(
+        '../../../../src/util/env/detarget-env-record'
+      );
+      const detargetSpy = vi
+        .spyOn(detargetModule, 'default')
+        .mockResolvedValue(undefined);
+
+      const removeModule = await import(
+        '../../../../src/util/env/remove-env-record'
+      );
+      const removeSpy = vi
+        .spyOn(removeModule, 'default')
+        .mockResolvedValue(undefined);
+
+      client.setArgv('env', 'rm', 'MULTI_ENV_VAR', 'preview', '--yes');
+      const exitCode = await env(client);
+
+      expect(exitCode).toBe(0);
+      expect(detargetSpy).toHaveBeenCalledOnce();
+      expect(removeSpy).not.toHaveBeenCalled();
+
+      const [, , envArg, targetArg] = detargetSpy.mock.calls[0] as Parameters<
+        typeof detargetModule.default
+      >;
+      expect(envArg.key).toBe('MULTI_ENV_VAR');
+      expect(targetArg).toBe('preview');
+
+      detargetSpy.mockRestore();
+      removeSpy.mockRestore();
+    });
+
+    it('DELETEs the record when no specific target is given', async () => {
+      const detargetModule = await import(
+        '../../../../src/util/env/detarget-env-record'
+      );
+      const detargetSpy = vi
+        .spyOn(detargetModule, 'default')
+        .mockResolvedValue(undefined);
+
+      const removeModule = await import(
+        '../../../../src/util/env/remove-env-record'
+      );
+      const removeSpy = vi
+        .spyOn(removeModule, 'default')
+        .mockResolvedValue(undefined);
+
+      client.setArgv('env', 'rm', 'MULTI_ENV_VAR', '--yes');
+      const exitCode = await env(client);
+
+      expect(exitCode).toBe(0);
+      expect(removeSpy).toHaveBeenCalledOnce();
+      expect(detargetSpy).not.toHaveBeenCalled();
+
+      detargetSpy.mockRestore();
+      removeSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #16622

`vercel env rm <name> <environment>` previously issued an unconditional `DELETE` that removed the **entire** record, silently wiping the variable from every environment it was attached to (including Production when only Preview was requested).

## Root cause

`remove-env-record.ts` always sends `DELETE /v10/projects/:id/env/:envId` — the whole record, regardless of how many environments the record targets.

## Fix

After picking the record, if the user supplied a specific `<environment>` argument **and** the record spans more than one environment, the CLI now issues a `PATCH` request that removes only the requested target from the `target` / `customEnvironmentIds` arrays (via a new `detarget-env-record.ts` helper). The Vercel API already supports this shape — the dashboard uses the same PATCH path.

The existing `DELETE` path is preserved for two cases that genuinely need it:
- **No target argument was given** — user asked to remove the entire variable
- **The record targets exactly one environment** — nothing else would be lost

## Changes

- `packages/cli/src/util/env/detarget-env-record.ts` — new helper that PATCHes a record with the remaining targets (minus the one being removed)
- `packages/cli/src/commands/env/rm.ts` — import and use `detargetEnvRecord` when appropriate
- `packages/cli/test/unit/commands/env/rm.test.ts` — two new tests covering the PATCH-vs-DELETE branching

## Before / after

```
# Before (broken): variable removed from Production too
$ vercel env rm ZZ_VAR preview --yes
Removed Environment Variable  [251ms]
$ vercel env ls
> No Environment Variables found

# After (fixed): only Preview target is removed
$ vercel env rm ZZ_VAR preview --yes
Removed Environment Variable  [251ms]
$ vercel env ls
name     environments  created
ZZ_VAR   Production    13s ago
```