### PR TITLE
[cli] Make `vercel blob` store commands work for agents

### DIFF
--- a/.changeset/blob-create-store-non-interactive.md
+++ b/.changeset/blob-create-store-non-interactive.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-[cli] Make `vercel blob create-store` work non-interactively for agents
+[cli] Make `vercel blob` store commands work non-interactively for agents

--- a/.changeset/blob-create-store-non-interactive.md
+++ b/.changeset/blob-create-store-non-interactive.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] Make `vercel blob create-store` work non-interactively for agents

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -90,7 +90,6 @@ export default async function addStore(
     });
   }
   if (!accessFlag) {
-    // No-op interactively; emits JSON and exits in non-interactive mode.
     outputAgentError(client, {
       status: 'error',
       reason: 'missing_arguments',
@@ -124,7 +123,6 @@ export default async function addStore(
         },
       });
     } else {
-      // No-op interactively; emits JSON and exits in non-interactive mode.
       outputAgentError(client, {
         status: 'error',
         reason: 'missing_arguments',

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -47,10 +47,8 @@ export default async function addStore(
     flags,
   } = parsedArgs;
 
-  // Agents and `--non-interactive` callers must never be prompted. Prompting
-  // after the store was created is what produced duplicate stores: the prompt
-  // throws on a non-TTY stdin, the agent treats it as a failure and retries,
-  // and a second store is created.
+  // Never prompt non-interactively: a prompt after the store is created throws
+  // on agents' non-TTY stdin, and the retry creates a duplicate store.
   const interactive = client.stdin.isTTY && !client.nonInteractive;
 
   const yes = flags['--yes'] ?? false;
@@ -152,10 +150,8 @@ export default async function addStore(
 
   const link = await getLinkedProject(client);
 
-  // Non-interactive callers cannot answer the "link to project?" prompt. Require
-  // an explicit --yes (or --environment) up front instead of prompting. Gating
-  // here, before the store is created, means a blocked run creates nothing, so
-  // the suggested --yes re-run creates and links exactly one store.
+  // Gate before creating the store: a blocked run creates nothing, so the
+  // suggested --yes retry creates and links exactly one store, not a duplicate.
   if (
     link.status === 'linked' &&
     client.nonInteractive &&

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -89,7 +89,8 @@ export default async function addStore(
       ],
     });
   }
-  if (!accessFlag && client.nonInteractive) {
+  if (!accessFlag) {
+    // No-op interactively; emits JSON and exits in non-interactive mode.
     outputAgentError(client, {
       status: 'error',
       reason: 'missing_arguments',
@@ -123,22 +124,21 @@ export default async function addStore(
         },
       });
     } else {
-      if (client.nonInteractive) {
-        outputAgentError(client, {
-          status: 'error',
-          reason: 'missing_arguments',
-          message: 'Missing required argument: name.',
-          next: [
-            {
-              command: buildCommandWithGlobalFlags(
-                client.argv,
-                `blob create-store <name> --access ${access} --yes`
-              ),
-              when: 'create the blob store and link it to the project',
-            },
-          ],
-        });
-      }
+      // No-op interactively; emits JSON and exits in non-interactive mode.
+      outputAgentError(client, {
+        status: 'error',
+        reason: 'missing_arguments',
+        message: 'Missing required argument: name.',
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              `blob create-store <name> --access ${access} --yes`
+            ),
+            when: 'create the blob store and link it to the project',
+          },
+        ],
+      });
       output.error('Missing required argument: name');
       return 1;
     }

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -14,6 +14,11 @@ import {
   VALID_ENVIRONMENTS,
   validateEnvironments,
 } from '../../util/integration/post-provision-setup';
+import {
+  outputAgentError,
+  buildCommandWithYes,
+  buildCommandWithGlobalFlags,
+} from '../../util/agent-output';
 
 export default async function addStore(
   client: Client,
@@ -42,6 +47,12 @@ export default async function addStore(
     flags,
   } = parsedArgs;
 
+  // Agents and `--non-interactive` callers must never be prompted. Prompting
+  // after the store was created is what produced duplicate stores: the prompt
+  // throws on a non-TTY stdin, the agent treats it as a failure and retries,
+  // and a second store is created.
+  const interactive = client.stdin.isTTY && !client.nonInteractive;
+
   const yes = flags['--yes'] ?? false;
   const environmentFlags = flags['--environment'];
 
@@ -49,15 +60,19 @@ export default async function addStore(
   if (environmentFlags?.length) {
     const envValidation = validateEnvironments(environmentFlags);
     if (!envValidation.valid) {
-      output.error(
-        `Invalid environment value: ${envValidation.invalid.map(e => `"${e}"`).join(', ')}. Must be one of: ${VALID_ENVIRONMENTS.join(', ')}`
-      );
+      const message = `Invalid environment value: ${envValidation.invalid.map(e => `"${e}"`).join(', ')}. Must be one of: ${VALID_ENVIRONMENTS.join(', ')}`;
+      outputAgentError(client, {
+        status: 'error',
+        reason: 'invalid_arguments',
+        message,
+      });
+      output.error(message);
       return 1;
     }
   }
 
   let accessFlag = flags['--access'];
-  if (!accessFlag && client.stdin.isTTY) {
+  if (!accessFlag && interactive) {
     accessFlag = await client.input.select<'public' | 'private'>({
       message: 'Choose the access type for the blob store',
       choices: [
@@ -76,6 +91,22 @@ export default async function addStore(
       ],
     });
   }
+  if (!accessFlag && client.nonInteractive) {
+    outputAgentError(client, {
+      status: 'error',
+      reason: 'missing_arguments',
+      message: "Missing required --access flag. Must be 'public' or 'private'.",
+      next: [
+        {
+          command: buildCommandWithGlobalFlags(
+            client.argv,
+            'blob create-store <name> --access private --yes'
+          ),
+          when: 'create a private blob store and link it to the project',
+        },
+      ],
+    });
+  }
   const access = parseAccessFlag(accessFlag);
   if (!access) return 1;
 
@@ -83,19 +114,36 @@ export default async function addStore(
 
   let name = nameArg;
   if (!name) {
-    if (!client.stdin.isTTY) {
+    if (interactive) {
+      name = await client.input.text({
+        message: 'Enter a name for your blob store',
+        validate: value => {
+          if (value.length < 5) {
+            return 'Name must be at least 5 characters long';
+          }
+          return true;
+        },
+      });
+    } else {
+      if (client.nonInteractive) {
+        outputAgentError(client, {
+          status: 'error',
+          reason: 'missing_arguments',
+          message: 'Missing required argument: name.',
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                `blob create-store <name> --access ${access} --yes`
+              ),
+              when: 'create the blob store and link it to the project',
+            },
+          ],
+        });
+      }
       output.error('Missing required argument: name');
       return 1;
     }
-    name = await client.input.text({
-      message: 'Enter a name for your blob store',
-      validate: value => {
-        if (value.length < 5) {
-          return 'Name must be at least 5 characters long';
-        }
-        return true;
-      },
-    });
   }
 
   telemetryClient.trackCliArgumentName(name);
@@ -103,6 +151,30 @@ export default async function addStore(
   telemetryClient.trackCliOptionRegion(flags['--region']);
 
   const link = await getLinkedProject(client);
+
+  // Non-interactive callers cannot answer the "link to project?" prompt. Require
+  // an explicit --yes (or --environment) up front instead of prompting. Gating
+  // here, before the store is created, means a blocked run creates nothing, so
+  // the suggested --yes re-run creates and links exactly one store.
+  if (
+    link.status === 'linked' &&
+    client.nonInteractive &&
+    !yes &&
+    !environmentFlags?.length
+  ) {
+    outputAgentError(client, {
+      status: 'error',
+      reason: 'confirmation_required',
+      message: `Creating a blob store and linking it to ${link.project.name} requires confirmation. Re-run with --yes to create the store and link it to all environments, or pass --environment to choose which ones.`,
+      next: [
+        {
+          command: buildCommandWithYes(client.argv),
+          when: 'create the store and link it to all environments',
+        },
+      ],
+    });
+    return 1;
+  }
 
   let storeId: string;
   let storeRegion: string | undefined;
@@ -139,11 +211,18 @@ export default async function addStore(
   output.log(`Access: ${access}. Learn more: ${output.link(docsUrl, docsUrl)}`);
 
   if (link.status === 'linked') {
-    let shouldLink = yes;
-    if (!shouldLink) {
+    // --yes or an explicit --environment list both mean "link without asking".
+    let shouldLink = yes || Boolean(environmentFlags?.length);
+    if (!shouldLink && interactive) {
       shouldLink = await client.input.confirm(
         `Would you like to link this blob store to ${link.project.name}?`,
         true
+      );
+    }
+
+    if (!shouldLink && !interactive) {
+      output.log(
+        `Not linked to ${chalk.bold(link.project.name)}. Pass --yes when creating to link the store to your project automatically.`
       );
     }
 
@@ -151,9 +230,7 @@ export default async function addStore(
       let environments: string[];
       if (environmentFlags?.length) {
         environments = environmentFlags;
-      } else if (yes) {
-        environments = [...VALID_ENVIRONMENTS];
-      } else {
+      } else if (interactive && !yes) {
         environments = await client.input.checkbox({
           message: 'Select environments',
           choices: [
@@ -162,6 +239,8 @@ export default async function addStore(
             { name: 'Development', value: 'development', checked: true },
           ],
         });
+      } else {
+        environments = [...VALID_ENVIRONMENTS];
       }
 
       output.spinner(

--- a/packages/cli/src/commands/blob/store-add.ts
+++ b/packages/cli/src/commands/blob/store-add.ts
@@ -47,8 +47,7 @@ export default async function addStore(
     flags,
   } = parsedArgs;
 
-  // Never prompt non-interactively: a prompt after the store is created throws
-  // on agents' non-TTY stdin, and the retry creates a duplicate store.
+  // Prompting after the store is created flakes agents into duplicate stores.
   const interactive = client.stdin.isTTY && !client.nonInteractive;
 
   const yes = flags['--yes'] ?? false;
@@ -148,8 +147,7 @@ export default async function addStore(
 
   const link = await getLinkedProject(client);
 
-  // Gate before creating the store: a blocked run creates nothing, so the
-  // suggested --yes retry creates and links exactly one store, not a duplicate.
+  // Gate before creating so a blocked run creates nothing (no duplicate on retry).
   if (
     link.status === 'linked' &&
     client.nonInteractive &&

--- a/packages/cli/src/commands/blob/store-empty.ts
+++ b/packages/cli/src/commands/blob/store-empty.ts
@@ -16,6 +16,7 @@ import {
   formatStoreLabel,
   formatConnectedProjects,
 } from '../../util/blob/confirm';
+import { outputAgentError, buildCommandWithYes } from '../../util/agent-output';
 
 export default async function emptyStore(
   client: Client,
@@ -43,6 +44,8 @@ export default async function emptyStore(
   const {
     flags: { '--yes': yes },
   } = parsedArgs;
+
+  const interactive = client.stdin.isTTY && !client.nonInteractive;
 
   telemetryClient.trackCliFlagYes(yes);
 
@@ -87,7 +90,20 @@ export default async function emptyStore(
     const message = `Are you sure you want to delete all files in ${label}?${projectsInfo} This action cannot be undone.`;
 
     if (!yes) {
-      if (!client.stdin.isTTY) {
+      if (!interactive) {
+        if (client.nonInteractive) {
+          outputAgentError(client, {
+            status: 'error',
+            reason: 'confirmation_required',
+            message: `Deleting all files in ${label} cannot be undone and requires confirmation. Re-run with --yes.`,
+            next: [
+              {
+                command: buildCommandWithYes(client.argv),
+                when: 'empty the blob store without prompting',
+              },
+            ],
+          });
+        }
         output.error(
           'Missing --yes flag. This is a destructive operation, use --yes to confirm.'
         );

--- a/packages/cli/src/commands/blob/store-empty.ts
+++ b/packages/cli/src/commands/blob/store-empty.ts
@@ -91,19 +91,18 @@ export default async function emptyStore(
 
     if (!yes) {
       if (!interactive) {
-        if (client.nonInteractive) {
-          outputAgentError(client, {
-            status: 'error',
-            reason: 'confirmation_required',
-            message: `Deleting all files in ${label} cannot be undone and requires confirmation. Re-run with --yes.`,
-            next: [
-              {
-                command: buildCommandWithYes(client.argv),
-                when: 'empty the blob store without prompting',
-              },
-            ],
-          });
-        }
+        // No-op interactively; emits JSON and exits in non-interactive mode.
+        outputAgentError(client, {
+          status: 'error',
+          reason: 'confirmation_required',
+          message: `Deleting all files in ${label} cannot be undone and requires confirmation. Re-run with --yes.`,
+          next: [
+            {
+              command: buildCommandWithYes(client.argv),
+              when: 'empty the blob store without prompting',
+            },
+          ],
+        });
         output.error(
           'Missing --yes flag. This is a destructive operation, use --yes to confirm.'
         );

--- a/packages/cli/src/commands/blob/store-empty.ts
+++ b/packages/cli/src/commands/blob/store-empty.ts
@@ -91,7 +91,6 @@ export default async function emptyStore(
 
     if (!yes) {
       if (!interactive) {
-        // No-op interactively; emits JSON and exits in non-interactive mode.
         outputAgentError(client, {
           status: 'error',
           reason: 'confirmation_required',

--- a/packages/cli/src/commands/blob/store-get.ts
+++ b/packages/cli/src/commands/blob/store-get.ts
@@ -63,22 +63,21 @@ export default async function getStore(
         },
       });
     } else {
-      if (client.nonInteractive) {
-        outputAgentError(client, {
-          status: 'error',
-          reason: 'missing_arguments',
-          message: 'Missing required argument: storeId.',
-          next: [
-            {
-              command: buildCommandWithGlobalFlags(
-                client.argv,
-                'blob get-store <storeId>'
-              ),
-              when: 'get the blob store details',
-            },
-          ],
-        });
-      }
+      // No-op interactively; emits JSON and exits in non-interactive mode.
+      outputAgentError(client, {
+        status: 'error',
+        reason: 'missing_arguments',
+        message: 'Missing required argument: storeId.',
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'blob get-store <storeId>'
+            ),
+            when: 'get the blob store details',
+          },
+        ],
+      });
       output.error('Missing required argument: storeId');
       return 1;
     }

--- a/packages/cli/src/commands/blob/store-get.ts
+++ b/packages/cli/src/commands/blob/store-get.ts
@@ -63,7 +63,6 @@ export default async function getStore(
         },
       });
     } else {
-      // No-op interactively; emits JSON and exits in non-interactive mode.
       outputAgentError(client, {
         status: 'error',
         reason: 'missing_arguments',

--- a/packages/cli/src/commands/blob/store-get.ts
+++ b/packages/cli/src/commands/blob/store-get.ts
@@ -12,6 +12,10 @@ import {
   formatStoreDetails,
   type StoreDetails,
 } from '../../util/blob/format-store';
+import {
+  outputAgentError,
+  buildCommandWithGlobalFlags,
+} from '../../util/agent-output';
 
 export default async function getStore(
   client: Client,
@@ -40,25 +44,44 @@ export default async function getStore(
     args: [storeIdArg],
   } = parsedArgs;
 
+  const interactive = client.stdin.isTTY && !client.nonInteractive;
+
   let storeId: string | undefined = storeIdArg;
   if (!storeId) {
     storeId = getStoreIdFromAuth(rwToken) ?? undefined;
   }
 
   if (!storeId) {
-    if (!client.stdin.isTTY) {
+    if (interactive) {
+      storeId = await client.input.text({
+        message: 'Enter the ID of the blob store you want to get info about',
+        validate: value => {
+          if (value.length !== 22) {
+            return 'ID must be 22 characters long';
+          }
+          return true;
+        },
+      });
+    } else {
+      if (client.nonInteractive) {
+        outputAgentError(client, {
+          status: 'error',
+          reason: 'missing_arguments',
+          message: 'Missing required argument: storeId.',
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                'blob get-store <storeId>'
+              ),
+              when: 'get the blob store details',
+            },
+          ],
+        });
+      }
       output.error('Missing required argument: storeId');
       return 1;
     }
-    storeId = await client.input.text({
-      message: 'Enter the ID of the blob store you want to get info about',
-      validate: value => {
-        if (value.length !== 22) {
-          return 'ID must be 22 characters long';
-        }
-        return true;
-      },
-    });
   }
 
   telemetryClient.trackCliArgumentStoreId(storeId);

--- a/packages/cli/src/commands/blob/store-list.ts
+++ b/packages/cli/src/commands/blob/store-list.ts
@@ -72,6 +72,9 @@ export default async function listStores(
   const jsonOutput = parsedArgs.flags['--json'] ?? false;
   const noProjects = parsedArgs.flags['--no-projects'] ?? false;
 
+  const interactive =
+    client.stdin.isTTY && client.stdout.isTTY && !client.nonInteractive;
+
   const telemetryClient = new BlobListStoresTelemetryClient({
     opts: {
       store: client.telemetryEventStore,
@@ -157,7 +160,7 @@ export default async function listStores(
       : `Blob stores:`;
     output.log(header);
 
-    if (!client.stdin.isTTY || !client.stdout.isTTY) {
+    if (!interactive) {
       output.print(
         table(buildTableRows(stores, noProjects), { hsep: 3 }).replace(
           /^/gm,

--- a/packages/cli/src/commands/blob/store-remove.ts
+++ b/packages/cli/src/commands/blob/store-remove.ts
@@ -59,7 +59,6 @@ export default async function removeStore(
         },
       });
     } else {
-      // No-op interactively; emits JSON and exits in non-interactive mode.
       outputAgentError(client, {
         status: 'error',
         reason: 'missing_arguments',
@@ -106,7 +105,6 @@ export default async function removeStore(
 
     if (!yes) {
       if (!interactive) {
-        // No-op interactively; emits JSON and exits in non-interactive mode.
         outputAgentError(client, {
           status: 'error',
           reason: 'confirmation_required',

--- a/packages/cli/src/commands/blob/store-remove.ts
+++ b/packages/cli/src/commands/blob/store-remove.ts
@@ -59,22 +59,21 @@ export default async function removeStore(
         },
       });
     } else {
-      if (client.nonInteractive) {
-        outputAgentError(client, {
-          status: 'error',
-          reason: 'missing_arguments',
-          message: 'Missing required argument: storeId.',
-          next: [
-            {
-              command: buildCommandWithGlobalFlags(
-                client.argv,
-                'blob delete-store <storeId> --yes'
-              ),
-              when: 'delete the blob store',
-            },
-          ],
-        });
-      }
+      // No-op interactively; emits JSON and exits in non-interactive mode.
+      outputAgentError(client, {
+        status: 'error',
+        reason: 'missing_arguments',
+        message: 'Missing required argument: storeId.',
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'blob delete-store <storeId> --yes'
+            ),
+            when: 'delete the blob store',
+          },
+        ],
+      });
       output.error('Missing required argument: storeId');
       return 1;
     }
@@ -107,19 +106,18 @@ export default async function removeStore(
 
     if (!yes) {
       if (!interactive) {
-        if (client.nonInteractive) {
-          outputAgentError(client, {
-            status: 'error',
-            reason: 'confirmation_required',
-            message: `Removing ${label} cannot be undone and requires confirmation. Re-run with --yes.`,
-            next: [
-              {
-                command: buildCommandWithYes(client.argv),
-                when: 'remove the blob store without prompting',
-              },
-            ],
-          });
-        }
+        // No-op interactively; emits JSON and exits in non-interactive mode.
+        outputAgentError(client, {
+          status: 'error',
+          reason: 'confirmation_required',
+          message: `Removing ${label} cannot be undone and requires confirmation. Re-run with --yes.`,
+          next: [
+            {
+              command: buildCommandWithYes(client.argv),
+              when: 'remove the blob store without prompting',
+            },
+          ],
+        });
         output.error(
           'Confirmation required. Use --yes to skip confirmation in non-interactive environments.'
         );

--- a/packages/cli/src/commands/blob/store-remove.ts
+++ b/packages/cli/src/commands/blob/store-remove.ts
@@ -11,6 +11,11 @@ import {
   formatStoreLabel,
   formatConnectedProjects,
 } from '../../util/blob/confirm';
+import {
+  outputAgentError,
+  buildCommandWithYes,
+  buildCommandWithGlobalFlags,
+} from '../../util/agent-output';
 
 export default async function removeStore(
   client: Client,
@@ -34,6 +39,8 @@ export default async function removeStore(
     flags: { '--yes': yes },
   } = parsedArgs;
 
+  const interactive = client.stdin.isTTY && !client.nonInteractive;
+
   let storeId: string | undefined = storeIdArg;
 
   if (!storeId) {
@@ -41,19 +48,36 @@ export default async function removeStore(
   }
 
   if (!storeId) {
-    if (!client.stdin.isTTY) {
+    if (interactive) {
+      storeId = await client.input.text({
+        message: 'Enter the ID of the blob store you want to remove',
+        validate: value => {
+          if (value.length !== 22) {
+            return 'ID must be 22 characters long';
+          }
+          return true;
+        },
+      });
+    } else {
+      if (client.nonInteractive) {
+        outputAgentError(client, {
+          status: 'error',
+          reason: 'missing_arguments',
+          message: 'Missing required argument: storeId.',
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                'blob delete-store <storeId> --yes'
+              ),
+              when: 'delete the blob store',
+            },
+          ],
+        });
+      }
       output.error('Missing required argument: storeId');
       return 1;
     }
-    storeId = await client.input.text({
-      message: 'Enter the ID of the blob store you want to remove',
-      validate: value => {
-        if (value.length !== 22) {
-          return 'ID must be 22 characters long';
-        }
-        return true;
-      },
-    });
   }
 
   const link = await getLinkedProject(client);
@@ -82,7 +106,20 @@ export default async function removeStore(
     );
 
     if (!yes) {
-      if (!client.stdin.isTTY) {
+      if (!interactive) {
+        if (client.nonInteractive) {
+          outputAgentError(client, {
+            status: 'error',
+            reason: 'confirmation_required',
+            message: `Removing ${label} cannot be undone and requires confirmation. Re-run with --yes.`,
+            next: [
+              {
+                command: buildCommandWithYes(client.argv),
+                when: 'remove the blob store without prompting',
+              },
+            ],
+          });
+        }
         output.error(
           'Confirmation required. Use --yes to skip confirmation in non-interactive environments.'
         );

--- a/packages/cli/test/helpers/wait-for-prompt.ts
+++ b/packages/cli/test/helpers/wait-for-prompt.ts
@@ -13,8 +13,7 @@ function getPromptErrorDetails(
 export default async function waitForPrompt(
   cp: CLIProcess,
   rawAssertion: string | RegExp | ((chunk: string) => boolean),
-  // 10s, not 5s: the first prompt waits on CLI startup plus a live API call,
-  // which intermittently exceeds 5s on CI runners and flakes E2E tests.
+  // 10s not 5s: CLI startup + a live API call can exceed 5s on CI and flake.
   timeout = 10000
 ) {
   let assertion: (chunk: string) => boolean;

--- a/packages/cli/test/helpers/wait-for-prompt.ts
+++ b/packages/cli/test/helpers/wait-for-prompt.ts
@@ -13,7 +13,9 @@ function getPromptErrorDetails(
 export default async function waitForPrompt(
   cp: CLIProcess,
   rawAssertion: string | RegExp | ((chunk: string) => boolean),
-  timeout = 5000
+  // 10s, not 5s: the first prompt waits on CLI startup plus a live API call,
+  // which intermittently exceeds 5s on CI runners and flakes E2E tests.
+  timeout = 10000
 ) {
   let assertion: (chunk: string) => boolean;
   if (typeof rawAssertion === 'string') {

--- a/packages/cli/test/helpers/wait-for-prompt.ts
+++ b/packages/cli/test/helpers/wait-for-prompt.ts
@@ -13,8 +13,7 @@ function getPromptErrorDetails(
 export default async function waitForPrompt(
   cp: CLIProcess,
   rawAssertion: string | RegExp | ((chunk: string) => boolean),
-  // 10s not 5s: CLI startup + a live API call can exceed 5s on CI and flake.
-  timeout = 10000
+  timeout = 5000
 ) {
   let assertion: (chunk: string) => boolean;
   if (typeof rawAssertion === 'string') {

--- a/packages/cli/test/unit/commands/blob/store-add.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-add.test.ts
@@ -797,4 +797,136 @@ describe('blob store add', () => {
       expect(mockedOutput.stopSpinner).not.toHaveBeenCalled();
     });
   });
+
+  describe('non-interactive mode (agents)', () => {
+    beforeEach(() => {
+      client.nonInteractive = true;
+      vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+        throw new Error('exit');
+      }) as () => never);
+    });
+
+    it('does not prompt or create a store without --yes when linked, emitting confirmation_required', async () => {
+      client.setArgv(
+        'blob',
+        'create-store',
+        'agent-store',
+        '--access',
+        'private'
+      );
+
+      await expect(
+        addStore(client, ['agent-store', '--access', 'private'])
+      ).rejects.toThrow('exit');
+
+      // Nothing is created on a blocked run, so the --yes retry can't duplicate.
+      expect(client.fetch).not.toHaveBeenCalled();
+      expect(client.input.confirm).not.toHaveBeenCalled();
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'confirmation_required',
+        message: expect.stringMatching(/confirmation|--yes/),
+        next: expect.arrayContaining([
+          expect.objectContaining({
+            command: expect.stringContaining('--yes'),
+          }),
+        ]),
+      });
+    });
+
+    it('creates and links to all environments with --yes and never prompts', async () => {
+      const exitCode = await addStore(client, [
+        'agent-store',
+        '--access',
+        'private',
+        '--yes',
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(client.input.checkbox).not.toHaveBeenCalled();
+      expect(mockedConnectResourceToProject).toHaveBeenCalledWith(
+        client,
+        'proj_123',
+        'store_test123',
+        ['production', 'preview', 'development'],
+        { accountId: 'org_123' }
+      );
+    });
+
+    it('creates and links to the given --environment list without --yes', async () => {
+      const exitCode = await addStore(client, [
+        'agent-store',
+        '--access',
+        'private',
+        '--environment',
+        'production',
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(mockedConnectResourceToProject).toHaveBeenCalledWith(
+        client,
+        'proj_123',
+        'store_test123',
+        ['production'],
+        { accountId: 'org_123' }
+      );
+    });
+
+    it('emits missing_arguments when --access is absent', async () => {
+      await expect(addStore(client, ['agent-store'])).rejects.toThrow('exit');
+
+      expect(client.fetch).not.toHaveBeenCalled();
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_arguments',
+        message: expect.stringContaining('--access'),
+      });
+    });
+
+    it('emits missing_arguments when the name is absent', async () => {
+      await expect(addStore(client, ['--access', 'private'])).rejects.toThrow(
+        'exit'
+      );
+
+      expect(client.fetch).not.toHaveBeenCalled();
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_arguments',
+        message: expect.stringContaining('name'),
+      });
+    });
+
+    it('creates the store without a confirmation gate when not linked', async () => {
+      mockedGetLinkedProject.mockResolvedValue({
+        org: null,
+        project: null,
+        status: 'not_linked',
+      });
+
+      const exitCode = await addStore(client, [
+        'standalone-store',
+        '--access',
+        'private',
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(client.fetch).toHaveBeenCalledWith('/v1/storage/stores/blob', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'standalone-store',
+          region: 'iad1',
+          access: 'private',
+        }),
+        accountId: undefined,
+      });
+      expect(mockedConnectResourceToProject).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/blob/store-empty.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-empty.test.ts
@@ -393,4 +393,64 @@ describe('blob empty-store', () => {
       ]);
     });
   });
+
+  describe('non-interactive mode (agents)', () => {
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      client.nonInteractive = true;
+      // The mock throws to simulate process.exit terminating; the command's
+      // try/catch may swallow it, so we assert on the spy, not a rejection.
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+        _code?: number
+      ) => {
+        throw new Error('exit');
+      }) as () => never);
+    });
+
+    it('requires --yes and emits confirmation_required instead of prompting', async () => {
+      await emptyStore(client, [], fullToken).catch(() => {});
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(confirmInputMock).not.toHaveBeenCalled();
+      expect(mockedBlob.del).not.toHaveBeenCalled();
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'confirmation_required',
+        message: expect.stringMatching(/--yes/),
+        next: expect.arrayContaining([
+          expect.objectContaining({
+            command: expect.stringContaining('--yes'),
+          }),
+        ]),
+      });
+    });
+
+    it('empties without prompting when --yes is passed', async () => {
+      mockedBlob.list.mockReset();
+      mockedBlob.list
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/a.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        .mockResolvedValueOnce({
+          blobs: [{ url: 'https://example.com/a.txt' }],
+          cursor: '',
+          hasMore: false,
+        } as any)
+        .mockResolvedValueOnce({
+          blobs: [],
+          cursor: '',
+          hasMore: false,
+        } as any);
+
+      const exitCode = await emptyStore(client, ['--yes'], fullToken);
+
+      expect(exitCode).toBe(0);
+      expect(confirmInputMock).not.toHaveBeenCalled();
+      expect(mockedBlob.del).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/blob/store-empty.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-empty.test.ts
@@ -395,15 +395,11 @@ describe('blob empty-store', () => {
   });
 
   describe('non-interactive mode (agents)', () => {
-    let exitSpy: ReturnType<typeof vi.spyOn>;
-
     beforeEach(() => {
       client.nonInteractive = true;
       // The mock throws to simulate process.exit terminating; the command's
       // try/catch may swallow it, so we assert on the spy, not a rejection.
-      exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
-        _code?: number
-      ) => {
+      vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
         throw new Error('exit');
       }) as () => never);
     });
@@ -411,7 +407,7 @@ describe('blob empty-store', () => {
     it('requires --yes and emits confirmation_required instead of prompting', async () => {
       await emptyStore(client, [], fullToken).catch(() => {});
 
-      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(vi.mocked(process.exit)).toHaveBeenCalledWith(1);
       expect(confirmInputMock).not.toHaveBeenCalled();
       expect(mockedBlob.del).not.toHaveBeenCalled();
       const payload = JSON.parse(client.stdout.getFullOutput());

--- a/packages/cli/test/unit/commands/blob/store-get.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-get.test.ts
@@ -749,4 +749,32 @@ describe('blob store get', () => {
       );
     });
   });
+
+  describe('non-interactive mode (agents)', () => {
+    beforeEach(() => {
+      client.nonInteractive = true;
+      vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+        throw new Error('exit');
+      }) as () => never);
+    });
+
+    it('emits missing_arguments instead of prompting for a store id', async () => {
+      await expect(getStore(client, [], noToken)).rejects.toThrow('exit');
+
+      expect(textInputMock).not.toHaveBeenCalled();
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_arguments',
+        message: expect.stringContaining('storeId'),
+      });
+    });
+
+    it('still works when the store id is provided', async () => {
+      const exitCode = await getStore(client, ['store_provided_123456'], token);
+
+      expect(exitCode).toBe(0);
+      expect(textInputMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/blob/store-list.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-list.test.ts
@@ -499,4 +499,20 @@ describe('blob list-stores', () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  describe('non-interactive mode (agents)', () => {
+    beforeEach(() => {
+      client.nonInteractive = true;
+    });
+
+    it('prints the table without the picker even in a TTY', async () => {
+      const exitCode = await listStores(client, []);
+
+      expect(exitCode).toBe(0);
+      expect(selectInputMock).not.toHaveBeenCalled();
+      expect(mockedOutput.print).toHaveBeenCalledWith(
+        expect.stringContaining('my-store')
+      );
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/blob/store-remove.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-remove.test.ts
@@ -697,4 +697,63 @@ describe('blob store remove', () => {
       );
     });
   });
+
+  describe('non-interactive mode (agents)', () => {
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      client.nonInteractive = true;
+      // The mock throws to simulate process.exit terminating; the command's
+      // try/catch may swallow it, so we assert on the spy, not a rejection.
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+        _code?: number
+      ) => {
+        throw new Error('exit');
+      }) as () => never);
+    });
+
+    it('requires --yes and emits confirmation_required instead of prompting', async () => {
+      await removeStore(client, ['store_1234567890123456'], noToken).catch(
+        () => {}
+      );
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(confirmInputMock).not.toHaveBeenCalled();
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'confirmation_required',
+        message: expect.stringMatching(/--yes/),
+        next: expect.arrayContaining([
+          expect.objectContaining({
+            command: expect.stringContaining('--yes'),
+          }),
+        ]),
+      });
+    });
+
+    it('emits missing_arguments when no store id is available', async () => {
+      await removeStore(client, [], noToken).catch(() => {});
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_arguments',
+        message: expect.stringContaining('storeId'),
+      });
+    });
+
+    it('deletes without prompting when --yes is passed', async () => {
+      const exitCode = await removeStore(
+        client,
+        ['store_1234567890123456', '--yes'],
+        noToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(confirmInputMock).not.toHaveBeenCalled();
+      expect(mockedOutput.success).toHaveBeenCalledWith('Blob store deleted');
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/blob/store-remove.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-remove.test.ts
@@ -699,15 +699,11 @@ describe('blob store remove', () => {
   });
 
   describe('non-interactive mode (agents)', () => {
-    let exitSpy: ReturnType<typeof vi.spyOn>;
-
     beforeEach(() => {
       client.nonInteractive = true;
       // The mock throws to simulate process.exit terminating; the command's
       // try/catch may swallow it, so we assert on the spy, not a rejection.
-      exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
-        _code?: number
-      ) => {
+      vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
         throw new Error('exit');
       }) as () => never);
     });
@@ -717,7 +713,7 @@ describe('blob store remove', () => {
         () => {}
       );
 
-      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(vi.mocked(process.exit)).toHaveBeenCalledWith(1);
       expect(confirmInputMock).not.toHaveBeenCalled();
       const payload = JSON.parse(client.stdout.getFullOutput());
       expect(payload).toMatchObject({
@@ -735,7 +731,7 @@ describe('blob store remove', () => {
     it('emits missing_arguments when no store id is available', async () => {
       await removeStore(client, [], noToken).catch(() => {});
 
-      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(vi.mocked(process.exit)).toHaveBeenCalledWith(1);
       const payload = JSON.parse(client.stdout.getFullOutput());
       expect(payload).toMatchObject({
         status: 'error',


### PR DESCRIPTION
## Problem

- Asking an agent to create a Blob store made two stores and looped.
- The `blob` store commands prompt and ignore `--non-interactive`, so an agent hangs on the prompt, and `create-store` retries into a duplicate.

## Solution

- The `blob` store commands only prompt in an interactive terminal now.
- `create-store`, `delete-store`, and `empty-store` return the exact `--yes` command to re-run instead of prompting for confirmation.
- `get-store` returns a clear error naming the missing store id, and `list-stores` prints its table instead of opening the picker.

## Implementation details

- Each command gates prompts on `client.nonInteractive`, not just `client.stdin.isTTY`.
- Non-interactive failures emit structured JSON (`confirmation_required` / `missing_arguments`) with a `next[]` step.
- `create-store` gates the create+link decision before creating, so a blocked retry can't duplicate.
- An explicit `--environment` list counts as intent to link.