### PR TITLE
fix(cli): resolve orphaned domain alias after project deletion

### DIFF
--- a/.changeset/fix-orphaned-domain-alias.md
+++ b/.changeset/fix-orphaned-domain-alias.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fixed orphaned domain alias remaining after project deletion by checking for and removing the alias when deleting a domain via `vercel domains rm`.

--- a/packages/cli/src/commands/domains/rm.ts
+++ b/packages/cli/src/commands/domains/rm.ts
@@ -7,6 +7,7 @@ import deleteCertById from '../../util/certs/delete-cert-by-id';
 import getDomainByName from '../../util/domains/get-domain-by-name';
 import getScope from '../../util/get-scope';
 import removeAliasById from '../../util/alias/remove-alias-by-id';
+import findAliasByAliasOrId from '../../util/alias/find-alias-by-alias-or-id';
 import removeDomainByName from '../../util/domains/remove-domain-by-name';
 import stamp from '../../util/output/stamp';
 import * as ERRORS from '../../util/errors-ts';
@@ -62,6 +63,35 @@ export default async function rm(client: Client, argv: string[]) {
 
   const domain = await getDomainByName(client, contextName, domainName);
   if (domain instanceof DomainNotFound || domain.name !== domainName) {
+    let alias;
+    try {
+      alias = await findAliasByAliasOrId(client, domainName);
+    } catch (err: unknown) {
+      if (!ERRORS.isAPIError(err) || err.status !== 404) {
+        throw err;
+      }
+    }
+
+    if (alias) {
+      const skipConfirmation = opts['--yes'] || false;
+      if (
+        !skipConfirmation &&
+        !(await client.input.confirm(
+          `Domain not found, but an alias ${param(domainName)} exists. Are you sure you want to remove it?`,
+          false
+        ))
+      ) {
+        output.log('Canceled');
+        return 0;
+      }
+      const removeStamp = stamp();
+      await removeAliasById(client, alias.uid);
+      output.success(
+        `Alias ${chalk.bold(alias.alias)} removed ${removeStamp()}`
+      );
+      return 0;
+    }
+
     output.error(
       `Domain not found by "${domainName}" under ${chalk.bold(contextName)}`
     );

--- a/packages/cli/test/unit/commands/domains/rm.test.ts
+++ b/packages/cli/test/unit/commands/domains/rm.test.ts
@@ -101,5 +101,42 @@ describe('domains rm', () => {
         ]);
       });
     });
+
+    describe('orphaned alias', () => {
+      it('should remove the alias if domain is not found globally', async () => {
+        useUser();
+        // Domain not found globally
+        client.scenario.get(
+          '/v4/domains/example-one.com',
+          (_req, res) => {
+            res.status(404).json({
+              error: {
+                code: 'not_found',
+                message: 'Domain not found',
+              },
+            });
+          }
+        );
+        // Alias is found
+        let deleteCalled = false;
+        client.scenario.get('/now/aliases/:aliasOrId', (req, res) => {
+          expect(req.params.aliasOrId).toEqual('example-one.com');
+          res.json({
+            uid: 'alias-id-123',
+            alias: 'example-one.com',
+            createdAt: Date.now() - 10000,
+          });
+        });
+        client.scenario.delete('/now/aliases/alias-id-123', (_req, res) => {
+          deleteCalled = true;
+          res.json({});
+        });
+
+        client.setArgv('domains', 'rm', 'example-one.com', '--yes');
+        const exitCode = await domains(client);
+        expect(exitCode).toEqual(0);
+        expect(deleteCalled).toBe(true);
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes #16661

### Description
This PR resolves the issue where deleting a project leaves an orphaned custom domain alias, locking the domain in an unusable state. 
When a user attempts to remove the domain, `vercel domains rm` fails because the domain is not found globally in the team's domain registry. At the same time, the user cannot reassign/add the domain to another project because the orphaned alias still holds the domain mapping.

### Changes
- Updated `packages/cli/src/commands/domains/rm.ts` so that when a domain is not found globally under the team's registry (`DomainNotFound`), it checks if an alias exists for this domain name using `findAliasByAliasOrId`.
- If an alias is found, it prompts for user confirmation (unless `--yes` is specified) and deletes the alias.
- Added a unit test covering this scenario in `packages/cli/test/unit/commands/domains/rm.test.ts`.
- Included a changeset file `.changeset/fix-orphaned-domain-alias.md`.