### PR TITLE
[cli] Retry flaky live E2E integration tests

### DIFF
--- a/.changeset/retry-flaky-live-e2e.md
+++ b/.changeset/retry-flaky-live-e2e.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: retry flaky live E2E integration tests. No release needed.

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -16,7 +16,13 @@ import type { CLIProcess } from './helpers/types';
 import { randomBytes } from 'crypto';
 
 const TEST_TIMEOUT = 3 * 60 * 1000;
-vi.setConfig({ testTimeout: TEST_TIMEOUT, hookTimeout: TEST_TIMEOUT });
+// retry: these tests drive the real CLI against the live API and occasionally
+// stall on startup; per-test retries de-flake without masking real failures.
+vi.setConfig({
+  testTimeout: TEST_TIMEOUT,
+  hookTimeout: TEST_TIMEOUT,
+  retry: 2,
+});
 
 const binaryPath = path.resolve(__dirname, '../scripts/start.js');
 

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -21,7 +21,11 @@ import type { CLIProcess } from './helpers/types';
 import stripAnsi from 'strip-ansi';
 
 const TEST_TIMEOUT = 3 * 60 * 1000;
-vi.setConfig({ testTimeout: TEST_TIMEOUT, hookTimeout: TEST_TIMEOUT });
+vi.setConfig({
+  testTimeout: TEST_TIMEOUT,
+  hookTimeout: TEST_TIMEOUT,
+  retry: 2,
+});
 
 const binaryPath = path.resolve(__dirname, `../scripts/start.js`);
 const example = (name: string) =>

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -25,7 +25,11 @@ import { teamPromise, userPromise } from './helpers/get-account';
 import { apiFetch } from './helpers/api-fetch';
 
 const TEST_TIMEOUT = 3 * 60 * 1000;
-vi.setConfig({ testTimeout: TEST_TIMEOUT, hookTimeout: TEST_TIMEOUT });
+vi.setConfig({
+  testTimeout: TEST_TIMEOUT,
+  hookTimeout: TEST_TIMEOUT,
+  retry: 2,
+});
 
 const binaryPath = path.resolve(__dirname, `../scripts/start.js`);
 

--- a/packages/cli/test/integration-link-env-pull.test.ts
+++ b/packages/cli/test/integration-link-env-pull.test.ts
@@ -11,7 +11,11 @@ import {
 import formatOutput from './helpers/format-output';
 
 const TEST_TIMEOUT = 3 * 60 * 1000;
-vi.setConfig({ testTimeout: TEST_TIMEOUT, hookTimeout: TEST_TIMEOUT });
+vi.setConfig({
+  testTimeout: TEST_TIMEOUT,
+  hookTimeout: TEST_TIMEOUT,
+  retry: 2,
+});
 
 const binaryPath = path.resolve(__dirname, '../scripts/start.js');
 


### PR DESCRIPTION
## Problem

- The `integration-*` E2E tests drive the real CLI against the live API and intermittently stall on startup, timing out at the first prompt.
- The CI file-level retry doesn't help: a different subtest flakes on each attempt, so the file never fully passes in one run.

## Solution

- Add `retry: 2` to the four live E2E test files so each test retries independently.

## Implementation details

- Set via the existing `vi.setConfig` in `integration-1/2/3` and `integration-link-env-pull`, scoped to those files so unit tests still fail fast.
- Empty changeset: test-only, no release.