### PR TITLE
[CLI] changing plugin behavior in CLI

### DIFF
--- a/.changeset/calm-plugin-updates.md
+++ b/.changeset/calm-plugin-updates.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update Claude Code Vercel plugin prompts and remember accepted plugin updates for future automatic updates.

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ junit.xml
 !packages/cli/test/unit/commands/target/**
 .claude/settings.local.json
 .pnpm-store
+.env*

--- a/packages/cli/src/util/agent/auto-install-agentic.ts
+++ b/packages/cli/src/util/agent/auto-install-agentic.ts
@@ -49,7 +49,10 @@ const promptedAtSchema = z.codec(
 
 const agentPreferencesSchema = z.object({
   pluginDeclined: z.boolean().optional(),
+  pluginAutoUpdate: z.boolean().optional(),
   lastPromptedAt: promptedAtSchema.optional(),
+  lastPluginAutoUpdateAttemptedAt: promptedAtSchema.optional(),
+  lastPluginAutoUpdateAttemptedKey: z.string().optional(),
 });
 
 type AgentPreferences = z.output<typeof agentPreferencesSchema>;
@@ -256,12 +259,32 @@ function wasPromptedToday(prefs: AgentPreferences): boolean {
     : false;
 }
 
+function wasPluginAutoUpdateAttemptedToday(
+  prefs: AgentPreferences,
+  attemptKey: string
+): boolean {
+  return (
+    prefs.lastPluginAutoUpdateAttemptedKey === attemptKey &&
+    !!prefs.lastPluginAutoUpdateAttemptedAt &&
+    isSameDay(prefs.lastPluginAutoUpdateAttemptedAt, new Date())
+  );
+}
+
 async function markPromptedToday(
   client: Client,
   prefs: AgentPreferences
 ): Promise<void> {
   prefs.lastPromptedAt = new Date();
   await writePrefs(client, prefs);
+}
+
+function markPluginAutoUpdateAttempted(
+  prefs: AgentPreferences,
+  attemptKey?: string
+): void {
+  if (!attemptKey) return;
+  prefs.lastPluginAutoUpdateAttemptedAt = new Date();
+  prefs.lastPluginAutoUpdateAttemptedKey = attemptKey;
 }
 
 async function runCommand(
@@ -420,40 +443,57 @@ function hasClaudeMigrationActions(plan: ClaudePluginMigrationPlan): boolean {
   );
 }
 
+function getClaudeAutoUpdateAttemptKey(
+  status: ClaudePluginStatus,
+  plan: ClaudePluginMigrationPlan
+): string {
+  return [
+    status.state,
+    status.legacy?.version ?? 'none',
+    status.official?.version ?? 'none',
+    status.latestVersion ?? 'unknown',
+    plan.installOfficial ? 'install' : '',
+    plan.updateOfficial ? 'update' : '',
+    plan.removeLegacy ? 'remove-legacy' : '',
+    plan.removeLegacyMarketplace ? 'remove-marketplace' : '',
+  ].join(':');
+}
+
 export function buildClaudePromptCopy(
   status: ClaudePluginStatus,
   plan: ClaudePluginMigrationPlan
 ): { message: string; confirm: string } {
   if (plan.installOfficial && status.state === 'none') {
     return {
-      message: '',
-      confirm:
-        'Working with Vercel is easier with the Vercel Plugin for Claude Code. Would you like to install it?',
+      message: 'Vercel Plugin for Claude Code is not installed.',
+      confirm: 'Would you like to install it now?',
     };
   }
 
   if (plan.installOfficial && status.state === 'legacy-only') {
     return {
-      message: '',
-      confirm:
-        'Working with Vercel is easier with the latest Vercel Plugin for Claude Code. Would you like to update it?',
+      message:
+        'Update available for Vercel Plugin for Claude Code (legacy -> official).',
+      confirm: 'Would you like to update now?',
     };
   }
 
   if (status.state === 'both' && plan.removeLegacy) {
     return {
-      message: '',
-      confirm:
-        'Working with Vercel is easier with the latest Vercel Plugin for Claude Code. Would you like to update it?',
+      message:
+        'Vercel Plugin for Claude Code has a legacy install to clean up.',
+      confirm: 'Would you like to update now?',
     };
   }
 
   if (plan.updateOfficial) {
-    const fromVersion = status.official?.version ?? 'your current version';
-    const toVersion = status.latestVersion ?? 'the latest version';
+    const fromVersion = status.official?.version;
+    const toVersion = status.latestVersion;
+    const versionRange =
+      fromVersion && toVersion ? ` (v${fromVersion} -> v${toVersion})` : '';
     return {
-      message: '',
-      confirm: `Working with Vercel is easier with the latest Vercel Plugin for Claude Code. Would you like to update from ${fromVersion} to ${toVersion}?`,
+      message: `Update available for Vercel Plugin for Claude Code${versionRange}.`,
+      confirm: 'Would you like to update now?',
     };
   }
 
@@ -626,7 +666,7 @@ export async function autoInstallVercelPlugin(
     const prefs = await readPrefs(client);
     const applyMode = options?.mode === 'apply';
 
-    if (!prefs.pluginDeclined || applyMode) {
+    if (!prefs.pluginDeclined || prefs.pluginAutoUpdate || applyMode) {
       const targets = await getPluginTargets(client.agentName, client.cwd);
       const uninstalledTargets: string[] = [];
       const claudeStatus = targets.includes('claude-code')
@@ -635,6 +675,10 @@ export async function autoInstallVercelPlugin(
       const claudePlan = claudeStatus
         ? buildClaudePluginMigrationPlan(claudeStatus)
         : undefined;
+      const claudeAutoUpdateAttemptKey =
+        claudeStatus && claudePlan
+          ? getClaudeAutoUpdateAttemptKey(claudeStatus, claudePlan)
+          : undefined;
 
       for (const target of targets) {
         if (target === 'claude-code') {
@@ -650,12 +694,28 @@ export async function autoInstallVercelPlugin(
       }
 
       if (uninstalledTargets.length > 0) {
+        if (prefs.pluginAutoUpdate) {
+          if (
+            claudeAutoUpdateAttemptKey &&
+            wasPluginAutoUpdateAttemptedToday(prefs, claudeAutoUpdateAttemptKey)
+          ) {
+            return;
+          }
+
+          prefs.pluginDeclined = false;
+          markPluginAutoUpdateAttempted(prefs, claudeAutoUpdateAttemptKey);
+          await writePrefs(client, prefs);
+          await applyPluginActions(uninstalledTargets, claudePlan);
+          return;
+        }
+
         if (!applyMode && wasPromptedToday(prefs)) {
           return;
         }
 
         if (applyMode) {
           prefs.pluginDeclined = false;
+          prefs.pluginAutoUpdate = true;
           await writePrefs(client, prefs);
           await applyPluginActions(uninstalledTargets, claudePlan);
           return;
@@ -681,10 +741,12 @@ export async function autoInstallVercelPlugin(
         await markPromptedToday(client, prefs);
         if (accepted) {
           prefs.pluginDeclined = false;
+          prefs.pluginAutoUpdate = true;
           await writePrefs(client, prefs);
           await applyPluginActions(uninstalledTargets, claudePlan);
         } else {
           prefs.pluginDeclined = true;
+          prefs.pluginAutoUpdate = false;
           await writePrefs(client, prefs);
         }
       }

--- a/packages/cli/test/unit/util/auto-install-agentic.test.ts
+++ b/packages/cli/test/unit/util/auto-install-agentic.test.ts
@@ -262,7 +262,7 @@ describe('buildClaudePromptCopy', () => {
 });
 
 describe('autoInstallVercelPlugin', () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: { mockRestore(): void };
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('no'));

--- a/packages/cli/test/unit/util/auto-install-agentic.test.ts
+++ b/packages/cli/test/unit/util/auto-install-agentic.test.ts
@@ -1,8 +1,15 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { KNOWN_AGENTS } from '@vercel/detect-agent';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
 import {
   autoInstallVercelPlugin,
   buildClaudePromptCopy,
@@ -13,6 +20,26 @@ import {
   projectHasUsedClaudeCode,
 } from '../../../src/util/agent/auto-install-agentic';
 import { client } from '../../mocks/client';
+
+function mockClaudeCommand(stdout = '[]', exitCode = 0) {
+  spawnMock.mockReturnValue({
+    stdout: {
+      on(event: string, callback: (chunk: Buffer) => void) {
+        if (event === 'data' && stdout) {
+          callback(Buffer.from(stdout));
+        }
+      },
+    },
+    stderr: {
+      on() {},
+    },
+    on(event: string, callback: (code: number) => void) {
+      if (event === 'close') {
+        callback(exitCode);
+      }
+    },
+  });
+}
 
 describe('comparePluginVersions', () => {
   it('compares dot-separated versions', () => {
@@ -163,11 +190,10 @@ describe('buildClaudePromptCopy', () => {
       }
     );
 
-    expect(copy.message).toBe('');
-    expect(copy.confirm).toContain(
-      'Working with Vercel is easier with the Vercel Plugin for Claude Code'
+    expect(copy.message).toBe(
+      'Vercel Plugin for Claude Code is not installed.'
     );
-    expect(copy.confirm).toContain('Would you like to install it?');
+    expect(copy.confirm).toBe('Would you like to install it now?');
   });
 
   it('uses migration copy for the old Claude marketplace install', () => {
@@ -185,11 +211,10 @@ describe('buildClaudePromptCopy', () => {
       }
     );
 
-    expect(copy.message).toBe('');
-    expect(copy.confirm).toContain(
-      'Working with Vercel is easier with the latest Vercel Plugin for Claude Code'
+    expect(copy.message).toBe(
+      'Update available for Vercel Plugin for Claude Code (legacy -> official).'
     );
-    expect(copy.confirm).toContain('Would you like to update it?');
+    expect(copy.confirm).toBe('Would you like to update now?');
   });
 
   it('uses cleanup copy when both Claude installs exist', () => {
@@ -208,11 +233,10 @@ describe('buildClaudePromptCopy', () => {
       }
     );
 
-    expect(copy.message).toBe('');
-    expect(copy.confirm).toContain(
-      'Working with Vercel is easier with the latest Vercel Plugin for Claude Code'
+    expect(copy.message).toBe(
+      'Vercel Plugin for Claude Code has a legacy install to clean up.'
     );
-    expect(copy.confirm).toContain('Would you like to update it?');
+    expect(copy.confirm).toBe('Would you like to update now?');
   });
 
   it('uses update copy for an outdated official Claude install', () => {
@@ -230,15 +254,27 @@ describe('buildClaudePromptCopy', () => {
       }
     );
 
-    expect(copy.message).toBe('');
-    expect(copy.confirm).toContain(
-      'Working with Vercel is easier with the latest Vercel Plugin for Claude Code'
+    expect(copy.message).toBe(
+      'Update available for Vercel Plugin for Claude Code (v0.32.6 -> v0.32.7).'
     );
-    expect(copy.confirm).toContain('0.32.6 to 0.32.7');
+    expect(copy.confirm).toBe('Would you like to update now?');
   });
 });
 
 describe('autoInstallVercelPlugin', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('no'));
+    spawnMock.mockReset();
+    mockClaudeCommand();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    client.reset();
+  });
+
   it('swallows unreadable prefs files', async () => {
     const configDir = await mkdtemp(join(tmpdir(), 'vercel-cli-agent-prefs-'));
 
@@ -248,6 +284,98 @@ describe('autoInstallVercelPlugin', () => {
       await writeFile(join(configDir, 'agent-preferences.json'), '{', 'utf8');
 
       await expect(autoInstallVercelPlugin(client)).resolves.toBeUndefined();
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it('enables automatic plugin updates after accepting the plugin prompt', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'vercel-cli-agent-prefs-'));
+
+    try {
+      client.setArgv('--global-config', configDir);
+      client.agentName = KNOWN_AGENTS.CLAUDE;
+      client.stdin.write('y\n');
+
+      await autoInstallVercelPlugin(client);
+
+      const prefs = JSON.parse(
+        await readFile(join(configDir, 'agent-preferences.json'), 'utf8')
+      );
+      expect(prefs.pluginDeclined).toBe(false);
+      expect(prefs.pluginAutoUpdate).toBe(true);
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it('applies plugin updates without prompting when automatic updates are enabled', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'vercel-cli-agent-prefs-'));
+
+    try {
+      client.setArgv('--global-config', configDir);
+      client.agentName = KNOWN_AGENTS.CLAUDE;
+      await writeFile(
+        join(configDir, 'agent-preferences.json'),
+        JSON.stringify({ pluginAutoUpdate: true }),
+        'utf8'
+      );
+      const confirmSpy = vi.spyOn(client.input, 'confirm');
+
+      await autoInstallVercelPlugin(client);
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(spawnMock).toHaveBeenCalledWith(
+        'claude',
+        ['plugins', 'install', 'vercel@claude-plugins-official'],
+        expect.any(Object)
+      );
+      const prefs = JSON.parse(
+        await readFile(join(configDir, 'agent-preferences.json'), 'utf8')
+      );
+      expect(prefs.pluginDeclined).toBe(false);
+      expect(prefs.pluginAutoUpdate).toBe(true);
+      expect(prefs.lastPluginAutoUpdateAttemptedAt).toEqual(expect.any(String));
+      expect(prefs.lastPluginAutoUpdateAttemptedKey).toEqual(
+        expect.any(String)
+      );
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not retry the same automatic plugin update more than once per day', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'vercel-cli-agent-prefs-'));
+
+    try {
+      client.setArgv('--global-config', configDir);
+      client.agentName = KNOWN_AGENTS.CLAUDE;
+      await writeFile(
+        join(configDir, 'agent-preferences.json'),
+        JSON.stringify({ pluginAutoUpdate: true }),
+        'utf8'
+      );
+
+      await autoInstallVercelPlugin(client);
+      const prefs = JSON.parse(
+        await readFile(join(configDir, 'agent-preferences.json'), 'utf8')
+      );
+      const firstCallCount = spawnMock.mock.calls.length;
+      spawnMock.mockClear();
+
+      await writeFile(
+        join(configDir, 'agent-preferences.json'),
+        JSON.stringify(prefs),
+        'utf8'
+      );
+      await autoInstallVercelPlugin(client);
+
+      expect(firstCallCount).toBeGreaterThan(0);
+      expect(spawnMock).not.toHaveBeenCalledWith(
+        'claude',
+        ['plugins', 'install', 'vercel@claude-plugins-official'],
+        expect.any(Object)
+      );
     } finally {
       await rm(configDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Updates the Claude Code Vercel Plugin prompt copy to match the CLI update style.

Also persists accepted plugin updates as automatic for future runs, with a same-day retry guard so stale/out-of-sync plugin version detection does not repeatedly attempt the same update