### PR TITLE
Add runtime to project config

### DIFF
--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -49,6 +49,7 @@ export interface Config {
   buildCommand?: string;
   devCommand?: string;
   framework?: string | null;
+  runtime?: string | null;
   nodeVersion?: string;
   middleware?: boolean;
   [key: string]: unknown;
@@ -457,6 +458,7 @@ export interface BuilderFunctions {
 
 export interface ProjectSettings {
   framework?: string | null;
+  runtime?: string | null;
   devCommand?: string | null;
   installCommand?: string | null;
   buildCommand?: string | null;

--- a/packages/cli/src/util/input/edit-project-settings.ts
+++ b/packages/cli/src/util/input/edit-project-settings.ts
@@ -1,5 +1,10 @@
 import chalk from 'chalk';
-import { frameworkList, type Framework } from '@vercel/frameworks';
+import {
+  frameworkList,
+  runtimes,
+  type Framework,
+  type Runtime,
+} from '@vercel/frameworks';
 import type Client from '../client';
 import { isSettingValue } from '../is-setting-value';
 import type { ProjectSettings } from '@vercel-internals/types';
@@ -12,6 +17,7 @@ const settingMap = {
   installCommand: 'Install Command',
   outputDirectory: 'Output Directory',
   framework: 'Framework',
+  runtime: 'Runtime',
 } as const;
 type ConfigKeys = keyof typeof settingMap;
 const settingKeys = Object.keys(settingMap).sort() as unknown as readonly [
@@ -27,6 +33,7 @@ export async function editProjectSettings(
   client: Client,
   projectSettings: PartialProjectSettings | null,
   framework: Framework | null,
+  runtime: Runtime | null,
   autoConfirm: boolean,
   localConfigurationOverrides: PartialProjectSettings | null,
   configFileName = 'vercel.json'
@@ -37,6 +44,7 @@ export async function editProjectSettings(
       buildCommand: null,
       devCommand: null,
       framework: null,
+      runtime: null,
       commandForIgnoringBuildStep: null,
       installCommand: null,
       outputDirectory: null,
@@ -77,10 +85,37 @@ export async function editProjectSettings(
       );
 
       if (overrideFramework) {
+        const languageChanged =
+          overrideFramework.language !== framework?.language;
         framework = overrideFramework;
+        if (languageChanged) {
+          // If the framework language changed, reset the runtime.
+          runtime = null;
+        }
         output.print(
           `  Merging default Project Settings for ${framework.name}. Previously listed overrides are prioritized.\n`
         );
+      }
+    }
+
+    if (framework && localConfigurationOverrides.runtime) {
+      if (!framework.language) {
+        output.print(
+          `  Using "Other" framework, ignoring configured runtime "${localConfigurationOverrides.runtime}".\n`
+        );
+        runtime = null;
+      } else {
+        runtime = localConfigurationOverrides.runtime as Runtime;
+        const frameworkRuntimes = runtimes[framework.language];
+        if (
+          frameworkRuntimes.default !== runtime &&
+          !frameworkRuntimes.alternatives?.some(a => a.runtime === runtime)
+        ) {
+          output.print(
+            `  Configured runtime "${localConfigurationOverrides.runtime}" does not match the framework "${framework.name}".\n`
+          );
+          runtime = null;
+        }
       }
     }
   }
@@ -88,6 +123,7 @@ export async function editProjectSettings(
   // skip editing project settings if no framework is detected
   if (!framework) {
     settings.framework = null;
+    settings.runtime = null;
     return settings;
   }
 
@@ -118,12 +154,14 @@ export async function editProjectSettings(
   }
 
   settings.framework = framework.slug;
+  settings.runtime = runtime;
 
   // Now print defaults for the provided framework whether it was auto-detected or overwritten
   if (!framework.slug) {
     for (const setting of settingKeys) {
       if (
         setting === 'framework' ||
+        setting === 'runtime' ||
         setting === 'commandForIgnoringBuildStep'
       ) {
         continue;
@@ -158,6 +196,7 @@ export async function editProjectSettings(
     (acc, setting) => {
       const skip =
         setting === 'framework' ||
+        setting === 'runtime' ||
         setting === 'commandForIgnoringBuildStep' ||
         setting === 'installCommand' ||
         localConfigurationOverrides?.[setting];

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -17,7 +17,10 @@ import type Client from '../client';
 import type { Framework } from '@vercel/frameworks';
 import type { Project } from '@vercel-internals/types';
 import createProject from '../projects/create-project';
-import { detectProjects } from '../projects/detect-projects';
+import {
+  detectProjects,
+  type DetectedProject,
+} from '../projects/detect-projects';
 import { repoInfoToUrl } from '../git/repo-info-to-url';
 import { connectGitProvider, parseRepoUrl } from '../git/connect-git-provider';
 import { getGitConfigPath, getGitRootDirectory } from '../git-helpers';
@@ -249,7 +252,7 @@ async function discoverRepoProjects(
   // they will be ready by the time the projects are listed
   const detectedProjectsPromise = detectProjects(rootPath).catch(err => {
     output.debug(`Failed to detect local projects: ${err}`);
-    return new Map<string, Framework[]>();
+    return new Map<string, DetectedProject[]>();
   });
 
   const promptAction = existingRemoteName ? 'add' : 'link';
@@ -371,8 +374,8 @@ async function discoverRepoProjects(
           ? [new Separator('----- New Projects to be created -----')]
           : []),
         ...Array.from(detectedProjects.entries()).flatMap(
-          ([rootDirectory, frameworks]) =>
-            frameworks.map((framework, i) => {
+          ([rootDirectory, detected]) =>
+            detected.map(({ framework }, i) => {
               const name = slugify(
                 [
                   basename(rootDirectory) || basename(rootPath),

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -766,7 +766,8 @@ export default async function setupAndLink(
           // the "Other" preset if none was detected.
           const detectedProjects = detectedProjectsForWorkspace.get('') || [];
           const framework =
-            detectedProjects[0] ?? frameworkList.find(f => f.slug === null);
+            detectedProjects[0]?.framework ??
+            frameworkList.find(f => f.slug === null);
 
           settings = await editProjectSettings(
             client,

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -752,6 +752,7 @@ export default async function setupAndLink(
             buildCommand: localConfig?.buildCommand,
             devCommand: localConfig?.devCommand,
             framework: localConfig?.framework,
+            runtime: localConfig?.runtime,
             commandForIgnoringBuildStep: localConfig?.ignoreCommand,
             installCommand: localConfig?.installCommand,
             outputDirectory: localConfig?.outputDirectory,
@@ -768,11 +769,13 @@ export default async function setupAndLink(
           const framework =
             detectedProjects[0]?.framework ??
             frameworkList.find(f => f.slug === null);
+          const runtime = detectedProjects[0]?.runtime ?? null;
 
           settings = await editProjectSettings(
             client,
             {},
             framework,
+            runtime,
             autoConfirm,
             localConfigurationOverrides,
             configFileName

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -804,8 +804,11 @@ export default async function setupAndLink(
       settings.rootDirectory = rootDirectory;
     }
 
+    // Strip `runtime` until the Vercel API accepts it.
+    const { runtime: _runtime, ...settingsForApi } = settings;
+
     const project = await createProject(client, {
-      ...settings,
+      ...settingsForApi,
       name: newProjectName,
       vercelAuth: vercelAuthSetting,
       v0,

--- a/packages/cli/src/util/projects/detect-projects.ts
+++ b/packages/cli/src/util/projects/detect-projects.ts
@@ -1,16 +1,33 @@
 import { join } from 'path';
-import { frameworkList, type Framework } from '@vercel/frameworks';
+import {
+  frameworkList,
+  type Runtime,
+  type Framework,
+} from '@vercel/frameworks';
 import {
   detectFrameworks,
+  detectRuntime,
   getWorkspacePackagePaths,
   getWorkspaces,
   LocalFileSystemDetector,
 } from '@vercel/fs-detectors';
 
-export async function detectProjects(cwd: string) {
+export interface DetectedProject {
+  framework: Framework;
+  /**
+   * The runtime resolved for the framework's language. `undefined` when the
+   * framework has no `language` (e.g. the "Other" preset) and runtime
+   * detection is therefore skipped.
+   */
+  runtime: Runtime | undefined;
+}
+
+export async function detectProjects(
+  cwd: string
+): Promise<Map<string, DetectedProject[]>> {
   const fs = new LocalFileSystemDetector(cwd);
   const workspaces = await getWorkspaces({ fs });
-  const detectedProjects = new Map<string, Framework[]>();
+  const detectedProjects = new Map<string, DetectedProject[]>();
   const packagePaths = (
     await Promise.all(
       workspaces.map(workspace =>
@@ -26,12 +43,35 @@ export async function detectProjects(cwd: string) {
   }
   await Promise.all(
     packagePaths.map(async p => {
+      const packageFs = fs.chdir(join('.', p));
       const frameworks = await detectFrameworks({
-        fs: fs.chdir(join('.', p)),
+        fs: packageFs,
         frameworkList,
       });
       if (frameworks.length === 0) return;
-      detectedProjects.set(p.slice(1), frameworks);
+
+      const languages = [...new Set(frameworks.map(f => f.language))];
+      const runtimes = new Map(
+        await Promise.all(
+          languages.map(
+            async language =>
+              [
+                language,
+                language
+                  ? await detectRuntime({ fs: packageFs, language })
+                  : undefined,
+              ] as const
+          )
+        )
+      );
+
+      detectedProjects.set(
+        p.slice(1),
+        frameworks.map(framework => ({
+          framework,
+          runtime: runtimes.get(framework.language),
+        }))
+      );
     })
   );
   return detectedProjects;

--- a/packages/cli/src/util/projects/project-settings.ts
+++ b/packages/cli/src/util/projects/project-settings.ts
@@ -17,6 +17,7 @@ export type ProjectLinkAndSettings = Partial<ProjectLink> & {
     rootDirectory: Project['rootDirectory'];
     framework: Project['framework'];
     nodeVersion: Project['nodeVersion'];
+    runtime: Project['runtime'];
     analyticsId?: string;
   };
 };
@@ -47,6 +48,7 @@ export async function writeProjectSettings(
     settings: {
       createdAt: project.createdAt,
       framework: project.framework,
+      runtime: project.runtime,
       devCommand: project.devCommand,
       installCommand: project.installCommand,
       buildCommand: project.buildCommand,
@@ -95,6 +97,7 @@ export function pickOverrides(
     'buildCommand',
     'devCommand',
     'framework',
+    'runtime',
     'ignoreCommand',
     'installCommand',
     'outputDirectory',

--- a/packages/cli/test/unit/util/input/edit-project-settings.test.ts
+++ b/packages/cli/test/unit/util/input/edit-project-settings.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { Framework } from '@vercel/frameworks';
-import { frameworks } from '@vercel/frameworks';
+import { frameworks, Runtime, type Framework } from '@vercel/frameworks';
 import { editProjectSettings } from '../../../../src/util/input/edit-project-settings';
 import { client } from '../../../mocks/client';
 
@@ -18,6 +17,7 @@ describe('editProjectSettings', () => {
         client,
         null,
         otherFramework,
+        null,
         true,
         null
       );
@@ -25,6 +25,7 @@ describe('editProjectSettings', () => {
         buildCommand: null,
         devCommand: null,
         framework: null,
+        runtime: null,
         commandForIgnoringBuildStep: null,
         installCommand: null,
         outputDirectory: null,
@@ -52,10 +53,15 @@ describe('editProjectSettings', () => {
         client,
         projectSettings,
         otherFramework,
+        null,
         true,
         null
       );
-      expect(settings).toStrictEqual({ ...projectSettings, framework: null });
+      expect(settings).toStrictEqual({
+        ...projectSettings,
+        framework: null,
+        runtime: null,
+      });
       await expect(client.stderr).toOutput(
         'No framework detected. Default Project Settings:'
       );
@@ -79,12 +85,14 @@ describe('editProjectSettings', () => {
         client,
         projectSettings,
         nextJSFramework,
+        null,
         true,
         null
       );
       expect(settings).toStrictEqual({
         ...projectSettings,
         framework: nextJSFramework.slug,
+        runtime: null,
       });
       await expect(client.stderr).toOutput('Detected Next.js');
     });
@@ -111,10 +119,14 @@ describe('editProjectSettings', () => {
         client,
         projectSettings,
         nextJSFramework,
+        null,
         true,
         overrides
       );
-      expect(settings).toStrictEqual(overrides);
+      expect(settings).toStrictEqual({
+        ...overrides,
+        runtime: null,
+      });
       await expect(client.stderr).toOutput(
         'Local settings detected in vercel.json:'
       );
@@ -145,10 +157,14 @@ describe('editProjectSettings', () => {
         client,
         null,
         nextJSFramework,
+        null,
         true,
         overrides
       );
-      expect(settings).toStrictEqual(overrides);
+      expect(settings).toStrictEqual({
+        ...overrides,
+        runtime: null,
+      });
       await expect(client.stderr).toOutput(
         'Local settings detected in vercel.json:'
       );
@@ -179,10 +195,14 @@ describe('editProjectSettings', () => {
         client,
         null,
         null,
+        null,
         true,
         overrides
       );
-      expect(settings).toStrictEqual(overrides);
+      expect(settings).toStrictEqual({
+        ...overrides,
+        runtime: null,
+      });
       await expect(client.stderr).toOutput(
         'Local settings detected in vercel.json:'
       );
@@ -209,6 +229,7 @@ describe('editProjectSettings', () => {
         client,
         null,
         nextJSFramework,
+        null,
         true,
         overrides,
         'vercel.toml'
@@ -228,6 +249,7 @@ describe('editProjectSettings', () => {
         client,
         null,
         nextJSFramework,
+        null,
         true,
         overrides,
         'vercel.ts'
@@ -245,6 +267,7 @@ describe('editProjectSettings', () => {
         client,
         null,
         nextJSFramework,
+        null,
         false,
         null
       );
@@ -264,6 +287,7 @@ describe('editProjectSettings', () => {
         client,
         null,
         nextJSFramework,
+        null,
         false,
         null
       );
@@ -282,6 +306,7 @@ describe('editProjectSettings', () => {
         client,
         null,
         nextJSFramework,
+        null,
         false,
         null
       );
@@ -297,6 +322,7 @@ describe('editProjectSettings', () => {
         client,
         null,
         nextJSFramework,
+        null,
         false,
         null
       );
@@ -322,6 +348,7 @@ describe('editProjectSettings', () => {
         client,
         null,
         nextJSFramework,
+        null,
         false,
         null
       );
@@ -353,7 +380,14 @@ describe('editProjectSettings', () => {
 
   describe('detected line formatting', () => {
     test('uses bold "Detected" verb without the gray "> " log prefix', async () => {
-      await editProjectSettings(client, null, nextJSFramework, true, null);
+      await editProjectSettings(
+        client,
+        null,
+        nextJSFramework,
+        null,
+        true,
+        null
+      );
 
       const fullOutput = client.stderr.getFullOutput();
       // output.log prepends gray "> " — output.print does not.
@@ -364,7 +398,14 @@ describe('editProjectSettings', () => {
     });
 
     test('inline detail uses Title Case "Build Command" / "Output Directory"', async () => {
-      await editProjectSettings(client, null, nextJSFramework, true, null);
+      await editProjectSettings(
+        client,
+        null,
+        nextJSFramework,
+        null,
+        true,
+        null
+      );
 
       const fullOutput = client.stderr.getFullOutput();
       // Title Case matches the checkbox panel that follows.
@@ -376,7 +417,14 @@ describe('editProjectSettings', () => {
     });
 
     test('does not apply blue color to framework name', async () => {
-      await editProjectSettings(client, null, nextJSFramework, true, null);
+      await editProjectSettings(
+        client,
+        null,
+        nextJSFramework,
+        null,
+        true,
+        null
+      );
       const fullOutput = client.stderr.getFullOutput();
       // The framework name should be bold but not blue (no chalk.blue ANSI code).
       // chalk.blue ANSI sequence is \x1b[34m. The Detected line must NOT contain it.
@@ -390,9 +438,127 @@ describe('editProjectSettings', () => {
         fwk => fwk.name === 'Hono'
       ) as unknown as Framework;
       expect(honoFramework).toBeDefined();
-      await editProjectSettings(client, null, honoFramework, true, null);
+      await editProjectSettings(client, null, honoFramework, null, true, null);
       const fullOutput = client.stderr.getFullOutput();
       expect(fullOutput).not.toContain('🔥');
+    });
+  });
+
+  describe('runtime processing', () => {
+    test('passes the runtime parameter through to settings.runtime', async () => {
+      const settings = await editProjectSettings(
+        client,
+        null,
+        nextJSFramework,
+        Runtime.Bun,
+        true,
+        null
+      );
+      expect(settings.framework).toBe('nextjs');
+      expect(settings.runtime).toBe(Runtime.Bun);
+    });
+
+    test('sets settings.runtime to null when no framework is provided', async () => {
+      const settings = await editProjectSettings(
+        client,
+        null,
+        null,
+        Runtime.Bun,
+        true,
+        null
+      );
+      expect(settings.framework).toBeNull();
+      expect(settings.runtime).toBeNull();
+    });
+
+    test('accepts a vercel.json runtime override matching the framework default', async () => {
+      const overrides = { runtime: Runtime.Bun };
+      const settings = await editProjectSettings(
+        client,
+        null,
+        nextJSFramework,
+        Runtime.Node,
+        true,
+        overrides
+      );
+      expect(settings.runtime).toBe(Runtime.Bun);
+    });
+
+    test('nulls a runtime override that does not match the framework language', async () => {
+      const overrides = { runtime: Runtime.Python };
+      const settings = await editProjectSettings(
+        client,
+        null,
+        nextJSFramework,
+        Runtime.Node,
+        true,
+        overrides
+      );
+      expect(settings.runtime).toBeNull();
+      await expect(client.stderr).toOutput(
+        'Configured runtime "python" does not match the framework "Next.js".'
+      );
+    });
+
+    test('nulls a runtime override when the framework is "Other" (no language)', async () => {
+      const overrides = { runtime: Runtime.Node };
+      const settings = await editProjectSettings(
+        client,
+        null,
+        otherFramework,
+        Runtime.Node,
+        true,
+        overrides
+      );
+      expect(settings.runtime).toBeNull();
+      await expect(client.stderr).toOutput(
+        'Using "Other" framework, ignoring configured runtime "node".'
+      );
+    });
+
+    test('resets the runtime when a framework override changes the language', async () => {
+      const overrides = { framework: 'django' };
+      const settings = await editProjectSettings(
+        client,
+        null,
+        nextJSFramework,
+        Runtime.Bun,
+        true,
+        overrides
+      );
+      expect(settings.framework).toBe('django');
+      expect(settings.runtime).toBeNull();
+    });
+
+    test('preserves the runtime when a framework override keeps the same language', async () => {
+      const overrides = { framework: 'svelte' };
+      const settings = await editProjectSettings(
+        client,
+        null,
+        nextJSFramework,
+        Runtime.Bun,
+        true,
+        overrides
+      );
+      expect(settings.framework).toBe('svelte');
+      expect(settings.runtime).toBe(Runtime.Bun);
+    });
+
+    test('nulls a runtime override when a framework override changes language and does not match the runtime override', async () => {
+      const overrides = { framework: 'django', runtime: Runtime.Bun };
+      const settings = await editProjectSettings(
+        client,
+        null,
+        nextJSFramework,
+        Runtime.Node,
+        true,
+        overrides
+      );
+      expect(settings.framework).toBe('django');
+      expect(settings.runtime).toBeNull();
+      await expect(client.stderr).toOutput(
+        'Configured runtime "bun" does not match the framework "Django".'
+      );
     });
   });
 });

--- a/packages/cli/test/unit/util/projects/detect-projects.test.ts
+++ b/packages/cli/test/unit/util/projects/detect-projects.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'path';
-import type { Framework } from '@vercel/frameworks';
-import { detectProjects } from '../../../../src/util/projects/detect-projects';
+import {
+  detectProjects,
+  type DetectedProject,
+} from '../../../../src/util/projects/detect-projects';
+import { Runtime } from '@vercel/frameworks';
 
 const REPO_ROOT = join(__dirname, '../../../../../..');
 const EXAMPLES_DIR = join(REPO_ROOT, 'examples');
@@ -11,28 +14,31 @@ const FS_DETECTORS_FIXTURES = join(
 );
 
 function mapDetected(
-  detected: Map<string, Framework[]>
-): Array<[string, string[]]> {
+  detected: Map<string, DetectedProject[]>
+): Array<[string, [string, Runtime | undefined][]]> {
   return [...detected.entries()]
     .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([dir, frameworks]) => [dir, frameworks.map(f => f.slug as string)]);
+    .map(([dir, projects]) => [
+      dir,
+      projects.map(p => [p.framework.slug as string, p.runtime]),
+    ]);
 }
 
 describe('detectProjects()', () => {
   it('should match 1 Project in "nextjs" example', async () => {
     const dir = join(EXAMPLES_DIR, 'nextjs');
     const detected = await detectProjects(dir);
-    expect(mapDetected(detected)).toEqual([['', ['nextjs']]]);
+    expect(mapDetected(detected)).toEqual([['', [['nextjs', Runtime.Node]]]]);
   });
 
   it('should match "30-double-nested-workspaces"', async () => {
     const dir = join(FS_DETECTORS_FIXTURES, '30-double-nested-workspaces');
     const detected = await detectProjects(dir);
     expect(mapDetected(detected)).toEqual([
-      ['packages/backend/c', ['remix']],
-      ['packages/backend/d', ['nextjs']],
-      ['packages/frontend/a', ['hexo']],
-      ['packages/frontend/b', ['ember']],
+      ['packages/backend/c', [['remix', Runtime.Node]]],
+      ['packages/backend/d', [['nextjs', Runtime.Node]]],
+      ['packages/frontend/a', [['hexo', Runtime.Node]]],
+      ['packages/frontend/b', [['ember', Runtime.Node]]],
     ]);
   });
 });

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -180,6 +180,7 @@ export interface VercelConfig {
   devCommand?: string | null;
   installCommand?: string | null;
   framework?: string | null;
+  runtime?: string | null;
   outputDirectory?: string | null;
   images?: Images;
   crons?: Cron[];

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -5,6 +5,7 @@ import { Framework, Language } from './types';
 import { readConfigFile } from './read-config-file';
 
 export * from './types';
+export * from './runtimes';
 
 const { readdir, readFile, unlink } = promises;
 

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { existsSync, promises } from 'fs';
 
-import { Framework } from './types';
+import { Framework, Language } from './types';
 import { readConfigFile } from './read-config-file';
 
 export * from './types';
@@ -20,6 +20,7 @@ export const frameworks = [
   {
     name: 'Blitz.js (Legacy)',
     slug: 'blitzjs',
+    language: Language.JavaScript,
     demo: 'https://blitz-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/blitz.svg',
     tagline: 'Blitz.js: The Fullstack React Framework',
@@ -61,6 +62,7 @@ export const frameworks = [
   {
     name: 'Next.js',
     slug: 'nextjs',
+    language: Language.JavaScript,
     demo: 'https://nextjs-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/next.svg',
     darkModeLogo:
@@ -110,6 +112,7 @@ export const frameworks = [
   {
     name: 'Gatsby.js',
     slug: 'gatsby',
+    language: Language.JavaScript,
     demo: 'https://gatsby.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/gatsby.svg',
     tagline:
@@ -196,6 +199,7 @@ export const frameworks = [
   {
     name: 'Remix',
     slug: 'remix',
+    language: Language.JavaScript,
     demo: 'https://remix-run-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/remix-no-shadow.svg',
     tagline: 'Build Better Websites',
@@ -241,6 +245,7 @@ export const frameworks = [
   {
     name: 'React Router',
     slug: 'react-router',
+    language: Language.JavaScript,
     demo: 'https://react-router-v7-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/react-router.svg',
     darkModeLogo:
@@ -294,6 +299,7 @@ export const frameworks = [
   {
     name: 'Astro',
     slug: 'astro',
+    language: Language.JavaScript,
     demo: 'https://astro-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/astro.svg',
     darkModeLogo:
@@ -345,6 +351,7 @@ export const frameworks = [
   {
     name: 'Hexo',
     slug: 'hexo',
+    language: Language.JavaScript,
     demo: 'https://hexo-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/hexo.svg',
     tagline:
@@ -381,6 +388,7 @@ export const frameworks = [
   {
     name: 'Eleventy',
     slug: 'eleventy',
+    language: Language.JavaScript,
     demo: 'https://eleventy-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/eleventy.svg',
     tagline:
@@ -418,6 +426,7 @@ export const frameworks = [
   {
     name: 'Docusaurus (v2+)',
     slug: 'docusaurus-2',
+    language: Language.JavaScript,
     demo: 'https://docusaurus-2-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/docusaurus.svg',
     tagline:
@@ -505,6 +514,7 @@ export const frameworks = [
   {
     name: 'Docusaurus (v1)',
     slug: 'docusaurus',
+    language: Language.JavaScript,
     demo: 'https://docusaurus-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/docusaurus.svg',
     tagline:
@@ -556,6 +566,7 @@ export const frameworks = [
   {
     name: 'Preact',
     slug: 'preact',
+    language: Language.JavaScript,
     demo: 'https://preact-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/preact.svg',
     tagline:
@@ -603,6 +614,7 @@ export const frameworks = [
   {
     name: 'SolidStart (v1)',
     slug: 'solidstart-1',
+    language: Language.JavaScript,
     demo: 'https://solid-start-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/solid.svg',
     tagline: 'Simple and performant reactivity for building user interfaces.',
@@ -640,6 +652,7 @@ export const frameworks = [
   {
     name: 'SolidStart (v0)',
     slug: 'solidstart',
+    language: Language.JavaScript,
     demo: 'https://solid-start-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/solid.svg',
     tagline: 'Simple and performant reactivity for building user interfaces.',
@@ -678,6 +691,7 @@ export const frameworks = [
   {
     name: 'Dojo',
     slug: 'dojo',
+    language: Language.JavaScript,
     demo: 'https://dojo-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/dojo.png',
     tagline: 'Dojo is a modern progressive, TypeScript first framework.',
@@ -739,6 +753,7 @@ export const frameworks = [
   {
     name: 'Ember.js',
     slug: 'ember',
+    language: Language.JavaScript,
     demo: 'https://ember-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/ember.svg',
     tagline:
@@ -787,6 +802,7 @@ export const frameworks = [
   {
     name: 'Vue.js',
     slug: 'vue',
+    language: Language.JavaScript,
     demo: 'https://vue-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/vue.svg',
     tagline:
@@ -843,6 +859,7 @@ export const frameworks = [
   {
     name: 'Scully',
     slug: 'scully',
+    language: Language.JavaScript,
     demo: 'https://scully-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/scullyio-logo.png',
     tagline: 'Scully is a static site generator for Angular.',
@@ -878,6 +895,7 @@ export const frameworks = [
   {
     name: 'Ionic Angular',
     slug: 'ionic-angular',
+    language: Language.JavaScript,
     demo: 'https://ionic-angular-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/ionic.svg',
     tagline:
@@ -922,6 +940,7 @@ export const frameworks = [
   {
     name: 'Angular',
     slug: 'angular',
+    language: Language.JavaScript,
     demo: 'https://angular-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/angular.svg',
     tagline:
@@ -985,6 +1004,7 @@ export const frameworks = [
   {
     name: 'Polymer',
     slug: 'polymer',
+    language: Language.JavaScript,
     demo: 'https://polymer-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/polymer.svg',
     tagline:
@@ -1041,6 +1061,7 @@ export const frameworks = [
   {
     name: 'Svelte',
     slug: 'svelte',
+    language: Language.JavaScript,
     demo: 'https://svelte.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/svelte.svg',
     tagline:
@@ -1090,6 +1111,7 @@ export const frameworks = [
     // TODO: fix detected as "sveltekit-1"
     name: 'SvelteKit (v0)',
     slug: 'sveltekit',
+    language: Language.JavaScript,
     demo: 'https://sveltekit-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/svelte.svg',
     screenshot:
@@ -1132,6 +1154,7 @@ export const frameworks = [
   {
     name: 'SvelteKit',
     slug: 'sveltekit-1',
+    language: Language.JavaScript,
     demo: 'https://sveltekit-1-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/svelte.svg',
     screenshot:
@@ -1172,6 +1195,7 @@ export const frameworks = [
   {
     name: 'Ionic React',
     slug: 'ionic-react',
+    language: Language.JavaScript,
     demo: 'https://ionic-react-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/ionic.svg',
     tagline:
@@ -1232,6 +1256,7 @@ export const frameworks = [
   {
     name: 'Create React App',
     slug: 'create-react-app',
+    language: Language.JavaScript,
     demo: 'https://create-react-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/react.svg',
     tagline: 'Create React App allows you to get going with React in no time.',
@@ -1296,6 +1321,7 @@ export const frameworks = [
   {
     name: 'Gridsome',
     slug: 'gridsome',
+    language: Language.JavaScript,
     demo: 'https://gridsome-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/gridsome.svg',
     tagline:
@@ -1332,6 +1358,7 @@ export const frameworks = [
   {
     name: 'UmiJS',
     slug: 'umijs',
+    language: Language.JavaScript,
     demo: 'https://umijs-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/umi.svg',
     tagline:
@@ -1377,6 +1404,7 @@ export const frameworks = [
   {
     name: 'Sapper',
     slug: 'sapper',
+    language: Language.JavaScript,
     demo: 'https://sapper-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/svelte.svg',
     tagline:
@@ -1413,6 +1441,7 @@ export const frameworks = [
   {
     name: 'Saber',
     slug: 'saber',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/saber.svg',
     tagline:
       'Saber is a framework for building static sites in Vue.js that supports data from any source.',
@@ -1462,6 +1491,7 @@ export const frameworks = [
   {
     name: 'Stencil',
     slug: 'stencil',
+    language: Language.JavaScript,
     demo: 'https://stencil.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/stencil.svg',
     tagline:
@@ -1522,6 +1552,7 @@ export const frameworks = [
   {
     name: 'Nuxt',
     slug: 'nuxtjs',
+    language: Language.JavaScript,
     demo: 'https://nuxtjs-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/nuxt.svg',
     screenshot:
@@ -1591,6 +1622,7 @@ export const frameworks = [
   {
     name: 'RedwoodJS',
     slug: 'redwoodjs',
+    language: Language.JavaScript,
     demo: 'https://redwood-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/redwoodjs.svg',
     tagline: 'RedwoodJS is a full-stack framework for the Jamstack.',
@@ -1627,6 +1659,7 @@ export const frameworks = [
   {
     name: 'Hugo',
     slug: 'hugo',
+    language: Language.Go,
     demo: 'https://hugo-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/hugo.svg',
     tagline:
@@ -1680,6 +1713,7 @@ export const frameworks = [
   {
     name: 'Jekyll',
     slug: 'jekyll',
+    language: Language.Ruby,
     demo: 'https://jekyll-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/jekyll.svg',
     tagline:
@@ -1721,6 +1755,7 @@ export const frameworks = [
   {
     name: 'Brunch',
     slug: 'brunch',
+    language: Language.JavaScript,
     demo: 'https://brunch-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/brunch.svg',
     tagline:
@@ -1759,6 +1794,7 @@ export const frameworks = [
   {
     name: 'Middleman',
     slug: 'middleman',
+    language: Language.Ruby,
     demo: 'https://middleman-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/middleman.svg',
     tagline:
@@ -1794,6 +1830,7 @@ export const frameworks = [
   {
     name: 'Zola',
     slug: 'zola',
+    language: Language.Rust,
     demo: 'https://zola-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/zola.png',
     tagline: 'Everything you need to make a static site engine in one binary.',
@@ -1828,6 +1865,7 @@ export const frameworks = [
   {
     name: 'Hydrogen (v1)',
     slug: 'hydrogen',
+    language: Language.JavaScript,
     demo: 'https://hydrogen-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/hydrogen.svg',
     tagline: 'React framework for headless commerce',
@@ -1872,6 +1910,7 @@ export const frameworks = [
   {
     name: 'Vite',
     slug: 'vite',
+    language: Language.JavaScript,
     demo: 'https://vite-vue-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/vite.svg',
     tagline:
@@ -1910,6 +1949,7 @@ export const frameworks = [
   {
     name: 'TanStack Start',
     slug: 'tanstack-start',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/tanstack-start.svg',
     darkModeLogo:
       'https://api-frameworks.vercel.sh/framework-logos/tanstack-start-dark.svg',
@@ -1948,6 +1988,7 @@ export const frameworks = [
   {
     name: 'VitePress',
     slug: 'vitepress',
+    language: Language.JavaScript,
     demo: 'https://vitepress-starter-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/vite.svg',
     tagline: "VitePress is VuePress' little brother, built on top of Vite.",
@@ -1981,6 +2022,7 @@ export const frameworks = [
   {
     name: 'VuePress',
     slug: 'vuepress',
+    language: Language.JavaScript,
     demo: 'https://vuepress-starter-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/vuepress.png',
     tagline: 'Vue-powered Static Site Generator',
@@ -2014,6 +2056,7 @@ export const frameworks = [
   {
     name: 'Parcel',
     slug: 'parcel',
+    language: Language.JavaScript,
     demo: 'https://parcel-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/parcel.png',
     tagline:
@@ -2060,6 +2103,7 @@ export const frameworks = [
   {
     name: 'FastAPI',
     slug: 'fastapi',
+    language: Language.Python,
     demo: 'https://vercel-fastapi-gamma-smoky.vercel.app/',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/fastapi.svg',
     darkModeLogo:
@@ -2118,6 +2162,7 @@ export const frameworks = [
   {
     name: 'Flask',
     slug: 'flask',
+    language: Language.Python,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/flask.svg',
     tagline: 'The Python micro web framework',
     description: 'A Flask app, ready for production',
@@ -2171,6 +2216,7 @@ export const frameworks = [
   {
     name: 'FastHTML',
     slug: 'fasthtml',
+    language: Language.Python,
     demo: 'https://fasthtml-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/fasthtml.png',
     darkModeLogo:
@@ -2218,6 +2264,7 @@ export const frameworks = [
   {
     name: 'Django',
     slug: 'django',
+    language: Language.Python,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/django.svg',
     tagline:
       'Django is a high-level Python web framework that encourages rapid development and clean, pragmatic design. ',
@@ -2277,6 +2324,7 @@ export const frameworks = [
   {
     name: 'Ash',
     slug: 'ash',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/ash.svg',
     darkModeLogo:
       'https://api-frameworks.vercel.sh/framework-logos/ash-dark.svg',
@@ -2315,6 +2363,7 @@ export const frameworks = [
   {
     name: 'Eve',
     slug: 'eve',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/eve.svg',
     darkModeLogo:
       'https://api-frameworks.vercel.sh/framework-logos/eve-dark.svg',
@@ -2352,6 +2401,7 @@ export const frameworks = [
   {
     name: 'Sanity',
     slug: 'sanity',
+    language: Language.JavaScript,
     demo: 'https://template-studio-clean.sanity.dev',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/sanity.svg',
     darkModeLogo:
@@ -2413,6 +2463,7 @@ export const frameworks = [
   {
     name: 'Sanity (v2 - legacy)',
     slug: 'sanity-v2',
+    language: Language.JavaScript,
     demo: 'https://sanity-studio-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/sanity-v2.svg',
     tagline: 'The structured content platform.',
@@ -2464,6 +2515,7 @@ export const frameworks = [
   {
     name: 'Storybook',
     slug: 'storybook',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/storybook.svg',
     tagline: 'Frontend workshop for UI development',
     description:
@@ -2499,6 +2551,7 @@ export const frameworks = [
   {
     name: 'Nitro',
     slug: 'nitro',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/nitro.svg',
     demo: 'https://nitro-template.vercel.app',
     tagline: 'Nitro is a next generation server toolkit.',
@@ -2530,6 +2583,7 @@ export const frameworks = [
   {
     name: 'Hono',
     slug: 'hono',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/hono.svg',
     demo: 'https://hono.vercel.dev',
     tagline: 'Web framework built on Web Standards',
@@ -2756,6 +2810,7 @@ export const frameworks = [
   {
     name: 'Express',
     slug: 'express',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/express.svg',
     demo: 'https://express-vercel-example-demo.vercel.app/',
     darkModeLogo:
@@ -2982,6 +3037,7 @@ export const frameworks = [
   {
     name: 'H3',
     slug: 'h3',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/h3.svg',
     tagline: 'Universal, Tiny, and Fast Servers',
     description:
@@ -3207,6 +3263,7 @@ export const frameworks = [
   {
     name: 'Koa',
     slug: 'koa',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/koa.svg',
     tagline: 'Expressive middleware for Node.js using ES2017 async functions',
     description:
@@ -3432,6 +3489,7 @@ export const frameworks = [
   {
     name: 'NestJS',
     slug: 'nestjs',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/nestjs.svg',
     tagline:
       'Framework for building efficient, scalable Node.js server-side applications',
@@ -3717,6 +3775,7 @@ export const frameworks = [
   {
     name: 'Elysia',
     slug: 'elysia',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/elysia.svg',
     tagline: 'Ergonomic framework for humans',
     description:
@@ -3941,6 +4000,7 @@ export const frameworks = [
   {
     name: 'Fastify',
     slug: 'fastify',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/fastify.svg',
     darkModeLogo:
       'https://api-frameworks.vercel.sh/framework-logos/fastify-dark.svg',
@@ -4167,6 +4227,7 @@ export const frameworks = [
   {
     name: 'xmcp',
     slug: 'xmcp',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/xmcp.svg',
     demo: 'https://xmcp-template.vercel.app/',
     tagline: 'The MCP framework for building AI-powered tools',
@@ -4209,6 +4270,7 @@ export const frameworks = [
   {
     name: 'Python',
     slug: 'python',
+    language: Language.Python,
     runtimeFramework: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/python.svg',
     tagline:
@@ -4261,6 +4323,7 @@ export const frameworks = [
   {
     name: 'Ruby',
     slug: 'ruby',
+    language: Language.Ruby,
     experimental: true,
     runtimeFramework: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/ruby.svg',
@@ -4311,6 +4374,7 @@ export const frameworks = [
   {
     name: 'Rust',
     slug: 'rust',
+    language: Language.Rust,
     experimental: true,
     runtimeFramework: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/rust.svg',
@@ -4361,6 +4425,7 @@ export const frameworks = [
   {
     name: 'Axum',
     slug: 'axum',
+    language: Language.Rust,
     experimental: true,
     supersedes: ['rust'],
     logo: 'https://api-frameworks.vercel.sh/framework-logos/axum.svg',
@@ -4411,6 +4476,7 @@ export const frameworks = [
   {
     name: 'Actix Web',
     slug: 'actix-web',
+    language: Language.Rust,
     experimental: true,
     runtimeFramework: true,
     supersedes: ['rust'],
@@ -4462,6 +4528,7 @@ export const frameworks = [
   {
     name: 'Bun',
     slug: 'bun',
+    language: Language.JavaScript,
     runtimeFramework: true,
     experimental: true,
     supersedes: ['node'],
@@ -4548,6 +4615,7 @@ export const frameworks = [
   {
     name: 'Node',
     slug: 'node',
+    language: Language.JavaScript,
     runtimeFramework: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/node.svg',
     tagline:
@@ -4629,6 +4697,7 @@ export const frameworks = [
   {
     name: 'Go',
     slug: 'go',
+    language: Language.Go,
     runtimeFramework: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/go.svg',
     tagline: 'An open-source programming language supported by Google.',
@@ -4684,6 +4753,7 @@ export const frameworks = [
   {
     name: 'Services',
     slug: 'services',
+    language: Language.JavaScript,
     experimental: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/other.svg',
     tagline:
@@ -4712,6 +4782,7 @@ export const frameworks = [
   {
     name: 'Mastra',
     slug: 'mastra',
+    language: Language.JavaScript,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/mastra.svg',
     darkModeLogo:
       'https://api-frameworks.vercel.sh/framework-logos/mastra-dark.svg',

--- a/packages/frameworks/src/runtimes.ts
+++ b/packages/frameworks/src/runtimes.ts
@@ -1,0 +1,37 @@
+import { Language, Runtime, LanguageRuntimes } from './types';
+
+/**
+ * Per-language runtime configuration. Each language has a single default
+ * runtime; languages with more than one option declare detectors for the
+ * alternatives.
+ */
+export const runtimes: Record<Language, LanguageRuntimes> = {
+  [Language.JavaScript]: {
+    default: Runtime.Node,
+    alternatives: [
+      {
+        runtime: Runtime.Bun,
+        detectors: {
+          some: [
+            { path: 'bun.lock' },
+            { path: 'bun.lockb' },
+            {
+              path: 'package.json',
+              matchContent: '"engines"\\s*:\\s*\\{[^}]*"bun"\\s*:',
+            },
+            {
+              path: 'package.json',
+              matchContent: '"packageManager"\\s*:\\s*"bun@',
+            },
+          ],
+        },
+      },
+    ],
+  },
+  [Language.Python]: { default: Runtime.Python },
+  [Language.Go]: { default: Runtime.Go },
+  [Language.Ruby]: { default: Runtime.Ruby },
+  [Language.Rust]: { default: Runtime.Rust },
+};
+
+export default runtimes;

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -247,4 +247,9 @@ export interface Framework {
    * @example true
    */
   runtimeFramework?: boolean;
+  /**
+   * The language this framework is written in.
+   * @example Language.JavaScript
+   */
+  language?: Language;
 }

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -252,3 +252,37 @@ export interface Framework {
    */
   language?: Language;
 }
+
+/**
+ * The execution engine that runs a deployed function. The specific version
+ * (e.g. `nodejs24.x`) is detected separately by the builders.
+ */
+export enum Runtime {
+  Node = 'node',
+  Bun = 'bun',
+  Python = 'python',
+  Ruby = 'ruby',
+  Go = 'go',
+  Rust = 'rust',
+}
+
+/**
+ * A non-default runtime that may be selected for a language when its detectors
+ * match the project.
+ */
+export interface RuntimePreset {
+  runtime: Runtime;
+  detectors: {
+    every?: FrameworkDetectionItem[];
+    some?: FrameworkDetectionItem[];
+  };
+}
+
+/**
+ * Runtime configuration for a single language: the default runtime, plus any
+ * alternatives evaluated in order against project signals.
+ */
+export interface LanguageRuntimes {
+  default: Runtime;
+  alternatives?: RuntimePreset[];
+}

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -1,5 +1,17 @@
 import { Rewrite, Route } from '@vercel/routing-utils';
 
+/**
+ * The surface language a framework is written in. Drives runtime selection —
+ * e.g. a JavaScript framework can run on either the Node or Bun runtime.
+ */
+export enum Language {
+  JavaScript = 'javascript',
+  Python = 'python',
+  Ruby = 'ruby',
+  Go = 'go',
+  Rust = 'rust',
+}
+
 export interface FrameworkDetectionItem {
   /**
    * A file path to detect.

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -1,8 +1,7 @@
 import { Rewrite, Route } from '@vercel/routing-utils';
 
 /**
- * The surface language a framework is written in. Drives runtime selection —
- * e.g. a JavaScript framework can run on either the Node or Bun runtime.
+ * The surface language a framework is written in.
  */
 export enum Language {
   JavaScript = 'javascript',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -202,6 +202,7 @@ const Schema = {
       supersedes: { type: 'array', items: { type: 'string' } },
       experimental: { type: 'boolean' },
       runtimeFramework: { type: 'boolean' },
+      language: { type: 'string' },
     },
   },
 };

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -627,6 +627,10 @@ function detectFrontBuilder(
     config.framework = framework;
   }
 
+  if (projectSettings.runtime) {
+    config.runtime = projectSettings.runtime;
+  }
+
   if (projectSettings.devCommand) {
     config.devCommand = projectSettings.devCommand;
   }

--- a/packages/fs-detectors/src/detect-framework.ts
+++ b/packages/fs-detectors/src/detect-framework.ts
@@ -1,6 +1,7 @@
 import type { Framework, FrameworkDetectionItem } from '@vercel/frameworks';
 import { spawnSync } from 'child_process';
 import { DetectorFilesystem } from './detectors/filesystem';
+import { checkDetector } from './detectors/check';
 
 interface BaseFramework {
   slug: Framework['slug'];
@@ -88,63 +89,12 @@ async function matches(
     return;
   }
 
-  const check = async ({
-    path,
-    matchContent,
-    matchPackage,
-  }: FrameworkDetectionItem): Promise<MatchResult | undefined> => {
-    if (matchPackage && matchContent) {
-      throw new Error(
-        `Cannot specify "matchPackage" and "matchContent" in the same detector for "${framework.slug}"`
-      );
-    }
-    if (matchPackage && path) {
-      throw new Error(
-        `Cannot specify "matchPackage" and "path" in the same detector for "${framework.slug}" because "path" is assumed to be "package.json".`
-      );
-    }
-
-    if (!path && !matchPackage) {
-      throw new Error(
-        `Must specify either "path" or "matchPackage" in detector for "${framework.slug}".`
-      );
-    }
-
-    if (!path) {
-      path = 'package.json';
-    }
-
-    if (matchPackage) {
-      matchContent = `"(dev)?(d|D)ependencies":\\s*{[^}]*"${matchPackage}":\\s*"(.+?)"[^}]*}`;
-    }
-
-    if ((await fs.hasPath(path)) === false) {
-      return;
-    }
-
-    if (matchContent) {
-      if ((await fs.isFile(path)) === false) {
-        return;
-      }
-
-      const regex = new RegExp(matchContent, 'm');
-      const content = await fs.readFile(path);
-
-      const match = content.toString().match(regex);
-      if (!match) {
-        return;
-      }
-      if (matchPackage && match[3]) {
-        return {
-          framework,
-          detectedVersion: match[3],
-        };
-      }
-    }
-
-    return {
-      framework,
-    };
+  const check = async (
+    item: FrameworkDetectionItem
+  ): Promise<MatchResult | undefined> => {
+    const result = await checkDetector(fs, item);
+    if (!result) return undefined;
+    return { framework, ...result };
   };
 
   const result: (MatchResult | undefined)[] = [];

--- a/packages/fs-detectors/src/detect-runtime.ts
+++ b/packages/fs-detectors/src/detect-runtime.ts
@@ -1,0 +1,56 @@
+import type { Language, RuntimePreset, Runtime } from '@vercel/frameworks';
+import { runtimes } from '@vercel/frameworks';
+import { DetectorFilesystem } from './detectors/filesystem';
+import { checkDetector } from './detectors/check';
+
+export interface DetectRuntimeOptions {
+  fs: DetectorFilesystem;
+  /**
+   * The language to pick a runtime for.
+   */
+  language: Language;
+}
+
+/**
+ * Resolves the runtime to use for a given language by checking the project's
+ * filesystem against each registered alternative in order.
+ *
+ * Falls back to the language's default runtime when no alternative matches.
+ */
+export async function detectRuntime({
+  fs,
+  language,
+}: DetectRuntimeOptions): Promise<Runtime> {
+  const entry = runtimes[language];
+  if (entry.alternatives) {
+    for (const preset of entry.alternatives) {
+      if (await detectorsMatch(fs, preset.detectors)) {
+        return preset.runtime;
+      }
+    }
+  }
+  return entry.default;
+}
+
+async function detectorsMatch(
+  fs: DetectorFilesystem,
+  detectors: RuntimePreset['detectors']
+): Promise<boolean> {
+  const { every, some } = detectors;
+  if (every) {
+    for (const item of every) {
+      if (!(await checkDetector(fs, item))) return false;
+    }
+  }
+  if (some) {
+    let matched = false;
+    for (const item of some) {
+      if (await checkDetector(fs, item)) {
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) return false;
+  }
+  return true;
+}

--- a/packages/fs-detectors/src/detectors/check.ts
+++ b/packages/fs-detectors/src/detectors/check.ts
@@ -1,0 +1,60 @@
+import type { DetectorFilesystem } from './filesystem';
+import type { FrameworkDetectionItem } from '@vercel/frameworks';
+
+/**
+ * Successful match payload.
+ */
+export interface DetectorMatch {
+  /**
+   * The version captured by a `matchPackage` detector.
+   */
+  detectedVersion?: string;
+}
+
+/**
+ * Evaluate a single detector against the project filesystem.
+ *
+ * Returns `null` when the detector did not match, or a `DetectorMatch` object
+ * (possibly empty) when it did. The `detectedVersion` field is populated only
+ * for `matchPackage` detectors that captured a literal version.
+ */
+export async function checkDetector(
+  fs: DetectorFilesystem,
+  item: FrameworkDetectionItem
+): Promise<DetectorMatch | null> {
+  let { path, matchContent } = item;
+  const { matchPackage } = item;
+
+  if (matchPackage && matchContent) {
+    throw new Error(
+      'Cannot specify "matchPackage" and "matchContent" in the same detector'
+    );
+  }
+  if (matchPackage && path) {
+    throw new Error(
+      'Cannot specify "matchPackage" and "path" in the same detector ("path" is implicitly "package.json")'
+    );
+  }
+  if (!path && !matchPackage) {
+    throw new Error('Detector must specify either "path" or "matchPackage"');
+  }
+
+  if (!path) path = 'package.json';
+  if (matchPackage) {
+    matchContent = `"(dev)?(d|D)ependencies":\\s*\\{[^}]*"${matchPackage}":\\s*"(.+?)"[^}]*\\}`;
+  }
+
+  if (!(await fs.hasPath(path))) return null;
+
+  if (matchContent) {
+    if (!(await fs.isFile(path))) return null;
+    const content = (await fs.readFile(path)).toString();
+    const match = new RegExp(matchContent, 'm').exec(content);
+    if (!match) return null;
+    if (matchPackage && match[3]) {
+      return { detectedVersion: match[3] };
+    }
+  }
+
+  return {};
+}

--- a/packages/fs-detectors/src/index.ts
+++ b/packages/fs-detectors/src/index.ts
@@ -58,6 +58,7 @@ export {
   detectFrameworkRecord,
   detectFrameworkVersion,
 } from './detect-framework';
+export { detectRuntime, type DetectRuntimeOptions } from './detect-runtime';
 export { getProjectPaths } from './get-project-paths';
 export { DetectorFilesystem } from './detectors/filesystem';
 export { LocalFileSystemDetector } from './detectors/local-file-system-detector';

--- a/packages/fs-detectors/test/unit.runtime-detector.test.ts
+++ b/packages/fs-detectors/test/unit.runtime-detector.test.ts
@@ -1,0 +1,64 @@
+import { Language, Runtime } from '@vercel/frameworks';
+import { detectRuntime } from '../src';
+import VirtualFilesystem from './virtual-file-system';
+
+describe('detectRuntime', () => {
+  it('defaults JavaScript to Node when no bun signals are present', async () => {
+    const fs = new VirtualFilesystem({ 'package.json': '{}' });
+    expect(await detectRuntime({ fs, language: Language.JavaScript })).toBe(
+      Runtime.Node
+    );
+  });
+
+  it.each([
+    'bun.lock',
+    'bun.lockb',
+  ])('selects Bun for JavaScript when %s is present', async lockfile => {
+    const fs = new VirtualFilesystem({
+      'package.json': '{}',
+      [lockfile]: '',
+    });
+    expect(await detectRuntime({ fs, language: Language.JavaScript })).toBe(
+      Runtime.Bun
+    );
+  });
+
+  it('selects Bun when package.json declares engines.bun', async () => {
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({ engines: { bun: '1.x' } }),
+    });
+    expect(await detectRuntime({ fs, language: Language.JavaScript })).toBe(
+      Runtime.Bun
+    );
+  });
+
+  it('selects Bun when package.json declares packageManager bun@', async () => {
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({ packageManager: 'bun@1.2.0' }),
+    });
+    expect(await detectRuntime({ fs, language: Language.JavaScript })).toBe(
+      Runtime.Bun
+    );
+  });
+
+  it('does not match the engines.bun regex on engines.node', async () => {
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({ engines: { node: '20.x' } }),
+    });
+    expect(await detectRuntime({ fs, language: Language.JavaScript })).toBe(
+      Runtime.Node
+    );
+  });
+
+  it.each([
+    [Language.Python, Runtime.Python],
+    [Language.Ruby, Runtime.Ruby],
+    [Language.Go, Runtime.Go],
+    [Language.Rust, Runtime.Rust],
+  ])('returns the default runtime for %s', async (language, runtime) => {
+    const fs = new VirtualFilesystem({
+      'package.json': '{}',
+    });
+    expect(await detectRuntime({ fs, language })).toBe(runtime);
+  });
+});


### PR DESCRIPTION
- Adds a `runtime` field to the project settings which tracks the runtime (eg. `bun` vs `node`) for a given project.
- During project setup, detect the runtime along with the framework
- For existing project, default to `null`

This value will be passed to the builder, which will then be responsible for setting up the appropriate runtime.

To be resolved:
- How does each builder handle `bun` setup?
- What do we do with the `nodeVersion` setting?
- Does this affect non-js runtimes? (eg. `python` or `static-build`)