### PR TITLE
[@vercel/connect] Allow AI SDK 7 prerelease peers

### DIFF
--- a/.changeset/quiet-connect-canaries.md
+++ b/.changeset/quiet-connect-canaries.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Allow AI SDK 7.0 prerelease versions to satisfy the optional `ai` peer dependency.

--- a/packages/connect/docs/ai-sdk-mcp-integration.md
+++ b/packages/connect/docs/ai-sdk-mcp-integration.md
@@ -236,7 +236,7 @@ durable store. So there is no long-lived function-timeout exposure.
 },
 "peerDependencies": {
   "@ai-sdk/mcp": "^1 || ^2",   // OAuthClientProvider interface is identical across 1.x/2.x
-  "ai": "^6 || ^7"             // works with both major lines
+  "ai": "^6 || ^7.0.0-0"       // works with 6.x, stable 7.x, and 7.0 prereleases
 },
 "peerDependenciesMeta": {
   "@ai-sdk/mcp": { "optional": true },

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@ai-sdk/mcp": "^1 || ^2",
     "@auth/core": ">=0.37.0",
-    "ai": "^6 || ^7",
+    "ai": "^6 || ^7.0.0-0",
     "better-auth": ">=1.5.0",
     "eve": ">=0.6.0-beta.1"
   },


### PR DESCRIPTION
## Summary
- widen @vercel/connect's optional ai peer range to `^6 || ^7.0.0-0` so npm accepts Eve's pinned `7.0.0-canary.*` runtime
- update the AI SDK/MCP integration packaging note
- add a patch changeset for @vercel/connect

## Validation
- `pnpm dlx semver@7 -r '^6 || ^7' 7.0.0-canary.171 7.0.0 7.2.3 8.0.0-alpha.1 8.0.0` rejects the canary and accepts stable 7.x
- `pnpm dlx semver@7 -r '^6 || ^7.0.0-0' 7.0.0-canary.171 7.0.0-beta.116 7.0.0 7.2.3 8.0.0-alpha.1 8.0.0` accepts 7.0 prereleases and stable 7.x
- `pnpm --filter @vercel/connect typecheck`