### PR TITLE
Update @vercel/connect ai peer range

### DIFF
--- a/.changeset/connect-ai-beta-range.md
+++ b/.changeset/connect-ai-beta-range.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Update the optional AI SDK peer dependency range to accept the `ai@7.0.0` beta line.

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@ai-sdk/mcp": "^1 || ^2",
     "@auth/core": ">=0.37.0",
-    "ai": "^6 || ^7 || >=7.0.0-beta.0",
+    "ai": "^6 || ^7.0.0-beta.0",
     "better-auth": ">=1.5.0",
     "eve": ">=0.6.0-beta.1"
   },

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@ai-sdk/mcp": "^1 || ^2",
     "@auth/core": ">=0.37.0",
-    "ai": "^6 || ^7",
+    "ai": "^6 || ^7 || >=7.0.0-beta.0",
     "better-auth": ">=1.5.0",
     "eve": ">=0.6.0-beta.1"
   },


### PR DESCRIPTION
## Summary
- update @vercel/connect's optional ai peer dependency range to accept the ai@7.0.0 beta line
- add a patch changeset

x-ref: [slack thread](https://vercel.slack.com/archives/C0AMN8UE0TX/p1781559043480749)

## Tests
- pnpm prettier --check packages/connect/package.json .changeset/connect-ai-beta-range.md