### PR TITLE
Remove deprecated public field from builder e2e deployments

### DIFF
--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -63,7 +63,6 @@ async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
 
   const nowDeployPayload = {
     version: 2,
-    public: true,
     name: projectName,
     files,
     meta: {},


### PR DESCRIPTION
## Summary
- Remove the legacy `public: true` field from the shared builder e2e deployment helper.
- This field is no longer accepted by `/v13/deployments`  removed `public` from the deployment config schema.
- Fixes builder e2e failures where deployment creation fails before builder-specific tests run.