### PR TITLE
[cli] Stop sending `public` field as project configuration

### DIFF
--- a/.changeset/sanitize-public-deploy-config.md
+++ b/.changeset/sanitize-public-deploy-config.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Stop sending the legacy public deployment field as project configuration.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -447,9 +447,6 @@ async function handleInitDeployment(
       vercelOutputDir: undefined,
       rootDirectory,
       quiet,
-      wantsPublic: Boolean(
-        parsedArguments.flags['--public'] || localConfig.public
-      ),
       nowConfig: {
         ...localConfig,
         images: undefined,
@@ -1364,9 +1361,6 @@ async function handleDefaultDeploy(
       vercelOutputDir,
       rootDirectory,
       quiet,
-      wantsPublic: Boolean(
-        parsedArguments.flags['--public'] || localConfig.public
-      ),
       nowConfig: {
         ...localConfig,
         images: undefined,

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -33,7 +33,6 @@ export interface CreateOptions {
   // Latest
   name: string;
   project?: string;
-  wantsPublic: boolean;
   prebuilt?: boolean;
   vercelOutputDir?: string;
   rootDirectory?: string | null;
@@ -115,7 +114,6 @@ export default class Now {
       prebuilt = false,
       vercelOutputDir,
       rootDirectory,
-      wantsPublic,
       meta,
       gitMetadata,
       regions,
@@ -141,11 +139,13 @@ export default class Now {
   ) {
     const hashes: any = {};
 
+    const config = { ...nowConfig };
+    delete config.public;
+
     const requestBody = {
-      ...nowConfig,
+      ...config,
       env,
       build,
-      public: wantsPublic || nowConfig.public,
       name,
       project,
       meta,

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1134,7 +1134,9 @@ describe('deploy', () => {
       expect(mock).toHaveBeenCalledWith(
         ...Object.values({
           ...baseCreateDeployArgs,
-          createArgs: expect.objectContaining({ wantsPublic: true }),
+          createArgs: expect.not.objectContaining({
+            wantsPublic: expect.anything(),
+          }),
         })
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -537,6 +537,51 @@ describe('deploy', () => {
     ]);
   });
 
+  it('should not send the legacy `public` field when `--public` is used', async () => {
+    const user = useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+    });
+
+    let body: any;
+    client.scenario.post(`/v13/deployments`, (req, res) => {
+      body = req.body;
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_public_test',
+      });
+    });
+    client.scenario.get(`/v13/deployments/dpl_public_test`, (req, res) => {
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_public_test',
+        readyState: 'READY',
+        aliasAssigned: true,
+        alias: [],
+      });
+    });
+
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    client.setArgv('deploy', '--public');
+    const exitCode = await deploy(client);
+    expect(exitCode).toEqual(0);
+    expect(body).not.toHaveProperty('public');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'flag:public', value: 'TRUE' },
+      { key: 'target_environment', value: 'preview' },
+      { key: 'output:deployment-id', value: 'dpl_public_test' },
+    ]);
+  });
+
   it('should upload missing files', async () => {
     const cwd = setupUnitFixture('commands/deploy/static');
     client.cwd = cwd;


### PR DESCRIPTION
https://github.com/vercel/api/pull/75343 removed the legacy deployment-level `public` opt-in surface. The CLI was still forwarding `public` in the create deployment payload, where the API now treats it as config and rejects it.

The Vercel CLI still forwards deployment config from the request body, and this behavior was covered by integration tests that began failing on CLI PRs after the API contract changed.

This PR stops forwarding the legacy `public` field in deployment create requests. The `--public` flag remains accepted by the CLI, and default deploy telemetry for the flag is preserved, but the flag is no longer converted into deployment/create payload state.