### PR TITLE
fix(test): remove deprecated public field from deployment fixtures

### DIFF
--- a/.changeset/remove-public-deployment-fixtures.md
+++ b/.changeset/remove-public-deployment-fixtures.md
@@ -1,6 +1,7 @@
 ---
 'vercel': patch
 '@vercel/client': patch
+'@vercel/config': patch
 ---
 
-Remove deprecated `public` field from deployment test fixtures and helpers after the API stopped accepting public deployments.
+Remove deprecated `public` from deployment test fixtures and helpers, and stop the CLI from sending the removed `public` field on deploy (including the `--public` flag).

--- a/.changeset/remove-public-deployment-fixtures.md
+++ b/.changeset/remove-public-deployment-fixtures.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+'@vercel/client': patch
+---
+
+Remove deprecated `public` field from deployment test fixtures and helpers after the API stopped accepting public deployments.

--- a/packages/cli/src/commands/deploy/command.ts
+++ b/packages/cli/src/commands/deploy/command.ts
@@ -28,13 +28,6 @@ export const initSubcommand = {
       description: 'Retain build cache when using "--force"',
     },
     {
-      name: 'public',
-      shorthand: 'p',
-      type: Boolean,
-      deprecated: false,
-      description: 'Deployment is public (`/_src`) is exposed)',
-    },
-    {
       name: 'env',
       shorthand: 'e',
       type: [String],
@@ -187,13 +180,6 @@ export const deployCommand = {
       type: Boolean,
       deprecated: false,
       description: 'Retain build cache when using "--force"',
-    },
-    {
-      name: 'public',
-      shorthand: 'p',
-      type: Boolean,
-      deprecated: false,
-      description: 'Deployment is public (`/_src`) is exposed)',
     },
     {
       name: 'env',

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -447,9 +447,6 @@ async function handleInitDeployment(
       vercelOutputDir: undefined,
       rootDirectory,
       quiet,
-      wantsPublic: Boolean(
-        parsedArguments.flags['--public'] || localConfig.public
-      ),
       nowConfig: {
         ...localConfig,
         images: undefined,
@@ -960,7 +957,6 @@ async function handleDefaultDeploy(
   telemetryClient.trackCliFlagSkipDomain(
     parsedArguments.flags['--skip-domain']
   );
-  telemetryClient.trackCliFlagPublic(parsedArguments.flags['--public']);
   telemetryClient.trackCliFlagLogs(parsedArguments.flags['--logs']);
   telemetryClient.trackCliFlagNoLogs(parsedArguments.flags['--no-logs']);
   telemetryClient.trackCliFlagGuidance(parsedArguments.flags['--guidance']);
@@ -1364,9 +1360,6 @@ async function handleDefaultDeploy(
       vercelOutputDir,
       rootDirectory,
       quiet,
-      wantsPublic: Boolean(
-        parsedArguments.flags['--public'] || localConfig.public
-      ),
       nowConfig: {
         ...localConfig,
         images: undefined,

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -158,7 +158,10 @@ export default class Now {
     // Ignore specific items from vercel.json
     delete requestBody.scope;
     delete requestBody.github;
-    delete requestBody.public;
+    // `public` is no longer part of `VercelConfig`, but a user's
+    // vercel.json may still contain a stale value that must be stripped
+    // before sending to the API.
+    delete (requestBody as Record<string, unknown>).public;
 
     const deployment = await processDeployment({
       now: this,

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -33,7 +33,6 @@ export interface CreateOptions {
   // Latest
   name: string;
   project?: string;
-  wantsPublic: boolean;
   prebuilt?: boolean;
   vercelOutputDir?: string;
   rootDirectory?: string | null;
@@ -115,7 +114,6 @@ export default class Now {
       prebuilt = false,
       vercelOutputDir,
       rootDirectory,
-      wantsPublic,
       meta,
       gitMetadata,
       regions,
@@ -145,7 +143,6 @@ export default class Now {
       ...nowConfig,
       env,
       build,
-      public: wantsPublic || nowConfig.public,
       name,
       project,
       meta,
@@ -161,6 +158,7 @@ export default class Now {
     // Ignore specific items from vercel.json
     delete requestBody.scope;
     delete requestBody.github;
+    delete requestBody.public;
 
     const deployment = await processDeployment({
       now: this,

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -189,11 +189,7 @@ test.skip('assign a domain to a project', async () => {
   const domain = `project-domain.${team.slug}.vercel.app`;
   const directory = await setupE2EFixture('static-deployment');
 
-  const deploymentOutput = await execCli(binaryPath, [
-    directory,
-    '--public',
-    '--yes',
-  ]);
+  const deploymentOutput = await execCli(binaryPath, [directory, '--yes']);
   expect(deploymentOutput.exitCode, formatOutput(deploymentOutput)).toBe(0);
 
   const host = deploymentOutput.stdout?.trim().replace('https://', '');
@@ -224,7 +220,6 @@ test('ensure `github` and `scope` are not sent to the API', async () => {
   expect(output.exitCode, formatOutput(output)).toBe(0);
 });
 
-// TODO: fix: --public does not make deployments public
 // biome-ignore lint/suspicious/noSkippedTests: temporarily disabled
 test.skip('should show prompts to set up project during first deploy', async () => {
   const dir = await setupE2EFixture('project-link-deploy');
@@ -480,15 +475,11 @@ test('use `rootDirectory` from project when deploying', async () => {
 
   const directory = await setupE2EFixture('project-root-directory');
 
-  const firstDeploy = execCli(
-    binaryPath,
-    [directory, '--name', projectName, '--public'],
-    {
-      env: {
-        FORCE_TTY: '1',
-      },
-    }
-  );
+  const firstDeploy = execCli(binaryPath, [directory, '--name', projectName], {
+    env: {
+      FORCE_TTY: '1',
+    },
+  });
   await setupProject(
     firstDeploy,
     projectName,
@@ -509,7 +500,7 @@ test('use `rootDirectory` from project when deploying', async () => {
 
   expect(projectResponse.status, await projectResponse.text()).toBe(200);
 
-  const secondResult = await execCli(binaryPath, [directory, '--public']);
+  const secondResult = await execCli(binaryPath, [directory]);
   expect(secondResult.exitCode, formatOutput(secondResult)).toBe(0);
 
   const { href } = new URL(secondResult.stdout);
@@ -892,7 +883,7 @@ test.skip(
     async function tryDeploy(cwd: string) {
       const { exitCode, stdout, stderr } = await execCli(
         binaryPath,
-        ['--public', '--yes'],
+        ['--yes'],
         {
           cwd,
           stdio: 'inherit',
@@ -921,7 +912,6 @@ test.skip(
   6 * 60 * 1000
 );
 
-// TODO: fix: --public does not make deployments public
 // biome-ignore lint/suspicious/noSkippedTests: temporarily disabled
 test.skip('deploy pnpm twice using pnp and symlink=false', async () => {
   const directory = path.join(__dirname, 'fixtures/unit/pnpm-pnp-symlink');
@@ -929,7 +919,7 @@ test.skip('deploy pnpm twice using pnp and symlink=false', async () => {
   await remove(path.join(directory, '.vercel'));
 
   function deploy() {
-    return execCli(binaryPath, [directory, '--name', session, '--public'], {
+    return execCli(binaryPath, [directory, '--name', session], {
       env: {
         FORCE_TTY: '1',
       },
@@ -1528,7 +1518,6 @@ test('[vc build] should not include .vercel when zeroConfig is true and outputDi
   expect(dir).toContain('index.txt');
 });
 
-// TODO: fix: --public does not make deployments public
 // biome-ignore lint/suspicious/noSkippedTests: temporarily disabled
 test.skip('vercel.json configuration overrides in a new project prompt user and merges settings correctly', async () => {
   let directory = await setupE2EFixture(
@@ -1604,7 +1593,7 @@ test('vercel.json configuration overrides in an existing project do not prompt u
   async function deploy(autoConfirm = false) {
     const deployment = await execCli(
       binaryPath,
-      [directory, '--public'].concat(autoConfirm ? ['--yes'] : [])
+      [directory].concat(autoConfirm ? ['--yes'] : [])
     );
     expect(deployment.exitCode, formatOutput(deployment)).toBe(0);
     return deployment;

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -161,12 +161,11 @@ test.skip('login with unregistered user', async () => {
   expect(last).toContain(goal);
 });
 
-// TODO: fix: --public does not make deployments public
 // biome-ignore lint/suspicious/noSkippedTests: temporarily disabled
 test.skip('ignore files specified in .nowignore', async () => {
   const directory = await setupE2EFixture('nowignore');
 
-  const args = ['--debug', '--public', '--name', session, '--yes'];
+  const args = ['--debug', '--name', session, '--yes'];
   const targetCall = await execCli(binaryPath, args, {
     cwd: directory,
   });
@@ -179,12 +178,11 @@ test.skip('ignore files specified in .nowignore', async () => {
   expect(presentFile.status).toBe(200);
 });
 
-// TODO: fix: --public does not make deployments public
 // biome-ignore lint/suspicious/noSkippedTests: temporarily disabled
 test.skip('ignore files specified in .nowignore via allowlist', async () => {
   const directory = await setupE2EFixture('nowignore-allowlist');
 
-  const args = ['--debug', '--public', '--name', session, '--yes'];
+  const args = ['--debug', '--name', session, '--yes'];
   const targetCall = await execCli(binaryPath, args, {
     cwd: directory,
   });
@@ -225,7 +223,6 @@ test.skip('domains inspect', async () => {
     directory,
     `--name=${projectName}`,
     '--yes',
-    '--public',
   ]);
 
   expect(output.exitCode, formatOutput(output)).toBe(0);
@@ -290,14 +287,12 @@ test('try to move an invalid domain', async () => {
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
 });
 
-// TODO: fix: --public does not make deployments public
 // biome-ignore lint/suspicious/noSkippedTests: temporarily disabled
 test.skip('ensure we render a warning for deployments with no files', async () => {
   const directory = await setupE2EFixture('empty-directory');
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     directory,
-    '--public',
     '--name',
     session,
     '--yes',
@@ -324,7 +319,7 @@ test('ensure we render a prompt when deploying home directory', async () => {
 
   const { stderr, stdout, exitCode } = await execCli(
     binaryPath,
-    [directory, '--public', '--name', session, '--force'],
+    [directory, '--name', session, '--force'],
     {
       input: 'N\n',
     }
@@ -344,7 +339,6 @@ test('ensure the `scope` property works with email', async () => {
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     directory,
-    '--public',
     '--name',
     session,
     '--force',
@@ -374,7 +368,6 @@ test('ensure the `scope` property works with username', async () => {
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     directory,
-    '--public',
     '--name',
     session,
     '--force',
@@ -403,7 +396,6 @@ test('reject deprecated now.json during deploy', async () => {
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     directory,
-    '--public',
     '--yes',
   ]);
 
@@ -422,7 +414,6 @@ test('try to create a builds deployments with wrong vercel.json', async () => {
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     directory,
-    '--public',
     '--yes',
   ]);
 
@@ -438,13 +429,9 @@ test('try to create a builds deployments with wrong vercel.json', async () => {
 test('try to create a builds deployments with wrong `build.env` property', async () => {
   const directory = await setupE2EFixture('builds-wrong-build-env');
 
-  const { exitCode, stdout, stderr } = await execCli(
-    binaryPath,
-    ['--public', '--yes'],
-    {
-      cwd: directory,
-    }
-  );
+  const { exitCode, stdout, stderr } = await execCli(binaryPath, ['--yes'], {
+    cwd: directory,
+  });
 
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
   expect(stderr).toContain(
@@ -460,7 +447,6 @@ test('create a builds deployments with no actual builds', async () => {
 
   const { exitCode, stdout, stderr } = await execCli(binaryPath, [
     directory,
-    '--public',
     '--name',
     session,
     '--force',
@@ -478,7 +464,7 @@ test('create a builds deployments with no actual builds', async () => {
 test('create a staging deployment', async () => {
   const directory = await setupE2EFixture('static-deployment');
 
-  const args = ['--debug', '--public', '--name', session];
+  const args = ['--debug', '--name', session];
   const targetCall = await execCli(binaryPath, [
     directory,
     '--target=staging',
@@ -500,7 +486,7 @@ test('create a staging deployment', async () => {
 test('create a production deployment', async () => {
   const directory = await setupE2EFixture('static-deployment');
 
-  const args = ['--debug', '--public', '--name', session];
+  const args = ['--debug', '--name', session];
   const targetCall = await execCli(binaryPath, [
     directory,
     '--target=production',
@@ -647,7 +633,6 @@ test('`vercel rm` removes a deployment', async () => {
   {
     const { exitCode, stdout, stderr } = await execCli(binaryPath, [
       directory,
-      '--public',
       '--name',
       session,
       '--force',
@@ -735,7 +720,6 @@ test('alias set accepts an alias URL as the first argument', async () => {
   try {
     const deployment = await execCli(binaryPath, [
       directory,
-      '--public',
       '--name',
       projectName,
       '--force',
@@ -848,12 +832,7 @@ test('vercel hasOwnProperty not a valid subcommand', async () => {
 
 test('create zero-config deployment', async () => {
   const fixturePath = await setupE2EFixture('zero-config-next-js');
-  const output = await execCli(binaryPath, [
-    fixturePath,
-    '--force',
-    '--public',
-    '--yes',
-  ]);
+  const output = await execCli(binaryPath, [fixturePath, '--force', '--yes']);
 
   expect(output.exitCode, formatOutput(output)).toBe(0);
 
@@ -878,12 +857,7 @@ test('next unsupported functions config shows warning link', async () => {
   const fixturePath = await setupE2EFixture(
     'zero-config-next-js-functions-warning'
   );
-  const output = await execCli(binaryPath, [
-    fixturePath,
-    '--force',
-    '--public',
-    '--yes',
-  ]);
+  const output = await execCli(binaryPath, [fixturePath, '--force', '--yes']);
 
   expect(output.exitCode, formatOutput(output)).toBe(0);
   expect(output.stderr).toMatch(
@@ -963,7 +937,7 @@ test('invalid `--token`', async () => {
 
 test('deploy a Lambda with a specific runtime', async () => {
   const directory = await setupE2EFixture('lambda-with-php-runtime');
-  const output = await execCli(binaryPath, [directory, '--public', '--yes']);
+  const output = await execCli(binaryPath, [directory, '--yes']);
 
   expect(output.exitCode, formatOutput(output)).toBe(0);
 
@@ -988,7 +962,6 @@ test('use build-env', async () => {
 
   const { exitCode, stdout, stderr } = await execCli(binaryPath, [
     directory,
-    '--public',
     '--yes',
   ]);
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1277,12 +1277,6 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 to the  
                                 linked  
                                 project)
-  -p,  --public                 Deploym…
-                                is      
-                                public  
-                                (\`/_src…
-                                is      
-                                exposed)
        --regions <REGION>       Set     
                                 default 
                                 regions 
@@ -1435,7 +1429,6 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 \`--target=production\`)                          
        --project <NAME_OR_ID>   Project name or ID (defaults to the linked      
                                 project)                                        
-  -p,  --public                 Deployment is public (\`/_src\`) is exposed)      
        --regions <REGION>       Set default regions to enable the deployment on 
        --skip-domain            Disable the automatic promotion (aliasing) of   
                                 the relevant domains to a new production        
@@ -1509,7 +1502,6 @@ exports[`help command > deploy help output snapshots > deploy help column width 
        --prebuilt               Use in combination with \`vc build\`. Deploy an existing build                            
        --prod                   Create a production deployment (shorthand for \`--target=production\`)                    
        --project <NAME_OR_ID>   Project name or ID (defaults to the linked project)                                     
-  -p,  --public                 Deployment is public (\`/_src\`) is exposed)                                              
        --regions <REGION>       Set default regions to enable the deployment on                                         
        --skip-domain            Disable the automatic promotion (aliasing) of the relevant domains to a new production  
                                 deployment. You can use \`vc promote\` to complete the domain-assignment process later    

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1080,24 +1080,6 @@ describe('deploy', () => {
         { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
     });
-    it('--public', async () => {
-      client.cwd = setupUnitFixture('commands/deploy/static');
-      client.setArgv('deploy', '--public');
-      const exitCode = await deploy(client);
-      expect(exitCode).toEqual(0);
-
-      expect(mock).toHaveBeenCalledWith(
-        ...Object.values({
-          ...baseCreateDeployArgs,
-          createArgs: expect.objectContaining({ wantsPublic: true }),
-        })
-      );
-      expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'flag:public', value: 'TRUE' },
-        { key: 'target_environment', value: 'preview' },
-        { key: 'output:deployment-id', value: 'dpl_archive_test' },
-      ]);
-    });
     it('--env', async () => {
       client.cwd = setupUnitFixture('commands/deploy/static');
       client.setArgv('deploy', '--env', 'KEY1=value', '--env', 'KEY2=value2');

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -204,7 +204,6 @@ describe('validateConfig', () => {
   it('should not error with complete config', async () => {
     const config = {
       version: 2,
-      public: true,
       regions: ['sfo1', 'iad1'],
       cleanUrls: true,
       headers: [{ source: '/', headers: [{ key: 'x-id', value: '123' }] }],

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -157,7 +157,6 @@ export interface VercelConfig {
   name?: string;
   meta?: string[];
   version?: number;
-  public?: boolean;
   env?: Dictionary<string>;
   build?: {
     env?: Dictionary<string>;
@@ -234,7 +233,6 @@ export interface DeploymentOptions {
   source?: string;
   target?: string;
   name?: string;
-  public?: boolean;
   meta?: Dictionary<string>;
   projectSettings?: ProjectSettings;
   gitMetadata?: GitMetadata;

--- a/packages/client/tests/fixtures/v2-file-permissions/vercel.json
+++ b/packages/client/tests/fixtures/v2-file-permissions/vercel.json
@@ -1,4 +1,3 @@
 {
-  "version": 2,
-  "public": true
+  "version": 2
 }

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -491,10 +491,6 @@ export interface VercelConfig {
    */
   name?: string;
   /**
-   * Whether a deployment's source and logs are available publicly
-   */
-  public?: boolean;
-  /**
    * A list of redirect definitions.
    */
   redirects?: Redirect[];

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -63,7 +63,6 @@ async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
 
   const nowDeployPayload = {
     version: 2,
-    public: true,
     name: projectName,
     files,
     meta: {},


### PR DESCRIPTION
## Summary
- Remove hardcoded `public: true` from the shared `now-deploy.js` E2E deployment helper
- Remove `"public": true` from the `@vercel/client` v2 file-permissions fixture
- Drop `public` from the CLI validate config unit test sample config

After the API change that removed `publicSource` / public deployments, deployment requests that include `public` are rejected with:

`Invalid request: should NOT have additional property 'public'. Please remove it.`

This was causing widespread builder E2E failures (`@vercel/go`, `@vercel/node`, `@vercel/firewall`, etc.).

## Test plan
- [ ] Builder E2E jobs pass (especially `@vercel/go`, `@vercel/node`, `@vercel/firewall`)
- [ ] `@vercel/client` integration tests pass
- [ ] CLI validate unit tests pass


Made with [Cursor](https://cursor.com)