### PR TITLE
[cli] add `traces create` as an alias for `curl --trace`

### DIFF
--- a/.changeset/traces-create-command.md
+++ b/.changeset/traces-create-command.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] Add `traces create` as an alias for `curl --trace`

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
         id: auth
       - run: cargo publish
         working-directory: crates/vercel_runtime

--- a/packages/cli/src/commands/curl/command.ts
+++ b/packages/cli/src/commands/curl/command.ts
@@ -1,5 +1,9 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import {
+  deploymentOption,
+  protectionBypassOption,
+  yesOption,
+} from '../../util/arg-common';
 
 export const curlCommand = {
   name: 'curl',
@@ -18,23 +22,8 @@ export const curlCommand = {
       description:
         'Skip confirmation when linking is required (e.g. in non-interactive mode)',
     },
-    {
-      name: 'deployment',
-      shorthand: null,
-      type: String,
-      deprecated: false,
-      description: 'The deployment ID or URL to target',
-      argument: 'ID|URL',
-    },
-    {
-      name: 'protection-bypass',
-      shorthand: null,
-      type: String,
-      deprecated: false,
-      description:
-        'Protection bypass secret for accessing protected deployments',
-      argument: 'SECRET',
-    },
+    deploymentOption,
+    protectionBypassOption,
     {
       name: 'trace',
       shorthand: null,

--- a/packages/cli/src/commands/curl/index.ts
+++ b/packages/cli/src/commands/curl/index.ts
@@ -12,6 +12,23 @@ import {
 import { trace } from './trace';
 
 export default async function curl(client: Client): Promise<number> {
+  return runCurl(client, {});
+}
+
+/**
+ * Shared execution for `vercel curl` and its aliases (e.g. `vercel traces
+ * create`). Handles argument setup, URL/token resolution, and either spawning
+ * curl directly or running the `--trace` capture flow.
+ *
+ * `forceTrace` makes the trace flow run regardless of the `--trace` flag, which
+ * is how `traces create` aliases `curl --trace`. `args` overrides the parsed
+ * argument list (post `argv.slice(2)`); callers like `traces create` pass the
+ * args with their own subcommand prefix already stripped.
+ */
+export async function runCurl(
+  client: Client,
+  { forceTrace = false, args }: { forceTrace?: boolean; args?: string[] }
+): Promise<number> {
   const telemetryClient = new CurlTelemetryClient({
     opts: {
       store: client.telemetryEventStore,
@@ -20,6 +37,7 @@ export default async function curl(client: Client): Promise<number> {
 
   const setup = setupCurlLikeCommand(client, curlCommand, telemetryClient, {
     allowFullUrl: true,
+    args,
   });
 
   if (typeof setup === 'number') {
@@ -32,9 +50,10 @@ export default async function curl(client: Client): Promise<number> {
     deploymentFlag,
     protectionBypassFlag,
     toolFlags,
-    trace: traceFlag,
     json: jsonFlag,
   } = setup;
+
+  const traceFlag = forceTrace || setup.trace;
 
   const result = isFullUrl
     ? await getFullUrlAndToken(client, path, protectionBypassFlag)

--- a/packages/cli/src/commands/curl/shared.ts
+++ b/packages/cli/src/commands/curl/shared.ts
@@ -167,12 +167,15 @@ export function setupCurlLikeCommand(
   client: Client,
   command: Command,
   telemetryClient: CommandTelemetryClient,
-  options: { allowFullUrl?: boolean } = {}
+  options: { allowFullUrl?: boolean; args?: string[] } = {}
 ): CommandSetupResult | number {
   const { print } = output;
 
   if (options.allowFullUrl) {
-    const parsed = parseCurlLikeArgs(client.argv.slice(2), command.name);
+    const parsed = parseCurlLikeArgs(
+      options.args ?? client.argv.slice(2),
+      command.name
+    );
 
     if (parsed.help) {
       print(help(command, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/traces/command.ts
+++ b/packages/cli/src/commands/traces/command.ts
@@ -1,5 +1,9 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import {
+  deploymentOption,
+  protectionBypassOption,
+  yesOption,
+} from '../../util/arg-common';
 
 export const getSubcommand = {
   name: 'get',
@@ -78,23 +82,8 @@ export const createSubcommand = {
     'Capture a session trace for a request (alias for `vercel curl --trace`).',
   arguments: [{ name: 'path', required: true }],
   options: [
-    {
-      name: 'deployment',
-      shorthand: null,
-      type: String,
-      deprecated: false,
-      description: 'The deployment ID or URL to target',
-      argument: 'ID|URL',
-    },
-    {
-      name: 'protection-bypass',
-      shorthand: null,
-      type: String,
-      deprecated: false,
-      description:
-        'Protection bypass secret for accessing protected deployments',
-      argument: 'SECRET',
-    },
+    deploymentOption,
+    protectionBypassOption,
     {
       name: 'json',
       shorthand: null,

--- a/packages/cli/src/commands/traces/command.ts
+++ b/packages/cli/src/commands/traces/command.ts
@@ -1,4 +1,5 @@
 import { packageName } from '../../util/pkg-name';
+import { yesOption } from '../../util/arg-common';
 
 export const getSubcommand = {
   name: 'get',
@@ -70,12 +71,65 @@ export const getSubcommand = {
   ],
 } as const;
 
+export const createSubcommand = {
+  name: 'create',
+  aliases: [],
+  description:
+    'Capture a session trace for a request (alias for `vercel curl --trace`).',
+  arguments: [{ name: 'path', required: true }],
+  options: [
+    {
+      name: 'deployment',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'The deployment ID or URL to target',
+      argument: 'ID|URL',
+    },
+    {
+      name: 'protection-bypass',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Protection bypass secret for accessing protected deployments',
+      argument: 'SECRET',
+    },
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Emit { response, requestId } as JSON on stdout',
+    },
+    {
+      ...yesOption,
+      description:
+        'Skip the production confirmation prompt (e.g. in non-interactive mode)',
+    },
+  ],
+  examples: [
+    {
+      name: 'Capture a session trace for a request',
+      value: `${packageName} traces create /api/hello`,
+    },
+    {
+      name: 'Target a specific deployment',
+      value: `${packageName} traces create /api/status --deployment https://your-project-abc123.vercel.app`,
+    },
+    {
+      name: 'Pass curl flags after the separator',
+      value: `${packageName} traces create /api/test -- --request POST --data '{"name": "John"}'`,
+    },
+  ],
+} as const;
+
 export const tracesCommand = {
   name: 'traces',
   aliases: [],
   description: 'Fetch traces captured for a Vercel project.',
   arguments: [{ name: 'requestId', required: false }],
-  subcommands: [getSubcommand],
+  subcommands: [getSubcommand, createSubcommand],
   options: [],
   examples: [
     {
@@ -85,6 +139,10 @@ export const tracesCommand = {
     {
       name: 'Print the raw trace JSON',
       value: `${packageName} traces get req_1234567890 --json`,
+    },
+    {
+      name: 'Capture a session trace for a request',
+      value: `${packageName} traces create /api/hello`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/traces/index.ts
+++ b/packages/cli/src/commands/traces/index.ts
@@ -8,13 +8,16 @@ import { help } from '../help';
 import { getCommandAliases } from '..';
 import { TracesTelemetryClient } from '../../util/telemetry/commands/traces';
 import {
+  createSubcommand as createSubcommandMetadata,
   getSubcommand as getSubcommandMetadata,
   tracesCommand,
 } from './command';
 import get from './get';
+import { runCurl } from '../curl';
 
 const COMMAND_CONFIG = {
   get: getCommandAliases(getSubcommandMetadata),
+  create: getCommandAliases(createSubcommandMetadata),
 };
 
 export default async function traces(client: Client): Promise<number> {
@@ -42,14 +45,33 @@ export default async function traces(client: Client): Promise<number> {
 
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('traces', subcommandOriginal);
-    const isGet = subcommand === getSubcommandMetadata.name;
+    const subMetadata =
+      subcommand === createSubcommandMetadata.name
+        ? createSubcommandMetadata
+        : subcommand === getSubcommandMetadata.name
+          ? getSubcommandMetadata
+          : undefined;
     output.print(
-      help(isGet ? getSubcommandMetadata : tracesCommand, {
-        parent: isGet ? tracesCommand : undefined,
+      help(subMetadata ?? tracesCommand, {
+        parent: subMetadata ? tracesCommand : undefined,
         columns: client.stderr.columns,
       })
     );
     return 2;
+  }
+
+  if (subcommand === createSubcommandMetadata.name) {
+    // `traces create` is an alias for `vercel curl --trace`. Strip the
+    // `traces create` prefix (mirroring parseCurlLikeArgs' leading-token strip)
+    // and hand the remaining args to the shared curl runner with the trace flow
+    // forced on. Passing `args` explicitly avoids mutating `client.argv` (which
+    // is the live `process.argv` in production).
+    const userArgs = client.argv.slice(2);
+    const withoutCmd =
+      userArgs[0] === tracesCommand.name ? userArgs.slice(1) : userArgs;
+    const withoutSub =
+      withoutCmd[0] === subcommandOriginal ? withoutCmd.slice(1) : withoutCmd;
+    return runCurl(client, { forceTrace: true, args: withoutSub });
   }
 
   return get(client, telemetry);

--- a/packages/cli/src/commands/traces/index.ts
+++ b/packages/cli/src/commands/traces/index.ts
@@ -4,7 +4,7 @@ import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { help } from '../help';
+import { help, type Command } from '../help';
 import { getCommandAliases } from '..';
 import { TracesTelemetryClient } from '../../util/telemetry/commands/traces';
 import {
@@ -18,6 +18,11 @@ import { runCurl } from '../curl';
 const COMMAND_CONFIG = {
   get: getCommandAliases(getSubcommandMetadata),
   create: getCommandAliases(createSubcommandMetadata),
+};
+
+const SUBCOMMAND_METADATA: Record<string, Command> = {
+  [getSubcommandMetadata.name]: getSubcommandMetadata,
+  [createSubcommandMetadata.name]: createSubcommandMetadata,
 };
 
 export default async function traces(client: Client): Promise<number> {
@@ -46,11 +51,9 @@ export default async function traces(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('traces', subcommandOriginal);
     const subMetadata =
-      subcommand === createSubcommandMetadata.name
-        ? createSubcommandMetadata
-        : subcommand === getSubcommandMetadata.name
-          ? getSubcommandMetadata
-          : undefined;
+      typeof subcommand === 'string'
+        ? SUBCOMMAND_METADATA[subcommand]
+        : undefined;
     output.print(
       help(subMetadata ?? tracesCommand, {
         parent: subMetadata ? tracesCommand : undefined,
@@ -61,17 +64,14 @@ export default async function traces(client: Client): Promise<number> {
   }
 
   if (subcommand === createSubcommandMetadata.name) {
-    // `traces create` is an alias for `vercel curl --trace`. Strip the
-    // `traces create` prefix (mirroring parseCurlLikeArgs' leading-token strip)
-    // and hand the remaining args to the shared curl runner with the trace flow
-    // forced on. Passing `args` explicitly avoids mutating `client.argv` (which
-    // is the live `process.argv` in production).
-    const userArgs = client.argv.slice(2);
-    const withoutCmd =
-      userArgs[0] === tracesCommand.name ? userArgs.slice(1) : userArgs;
-    const withoutSub =
-      withoutCmd[0] === subcommandOriginal ? withoutCmd.slice(1) : withoutCmd;
-    return runCurl(client, { forceTrace: true, args: withoutSub });
+    // `traces create` is an alias for `vercel curl --trace`. The router
+    // dispatched here off `client.argv`, so the first two tokens are always
+    // `traces create` (like `curl`, this assumes no global flags precede the
+    // command token). Drop that prefix and hand the rest to the shared curl
+    // runner with the trace flow forced on. Passing `args` explicitly avoids
+    // mutating `client.argv` (which is the live `process.argv` in production).
+    const args = client.argv.slice(4);
+    return runCurl(client, { forceTrace: true, args });
   }
 
   return get(client, telemetry);

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -71,6 +71,7 @@ export const help = () => `
       target               [cmd]       Manage custom environments for your Project
       teams                            Manages your teams
       telemetry            [cmd]       Enable or disable telemetry collection
+      traces               [cmd]       Fetch and capture traces for your project's deployment
       upgrade                          Upgrade the Vercel CLI to the latest version
       usage                            Show billing usage for the current billing period
       webhooks             [cmd]       Manages webhooks [beta]

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -252,6 +252,24 @@ export const projectOption = {
   deprecated: false,
 } as const;
 
+export const deploymentOption = {
+  name: 'deployment',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+  description: 'The deployment ID or URL to target',
+  argument: 'ID|URL',
+} as const;
+
+export const protectionBypassOption = {
+  name: 'protection-bypass',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+  description: 'Protection bypass secret for accessing protected deployments',
+  argument: 'SECRET',
+} as const;
+
 type GlobalOpt = (typeof globalCommandOptions)[number];
 
 const GLOBAL_LONG_TO_OPT = new Map<string, GlobalOpt>();

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -66,6 +66,7 @@ exports[`base level help output > help 1`] = `
       target               [cmd]       Manage custom environments for your Project
       teams                            Manages your teams
       telemetry            [cmd]       Enable or disable telemetry collection
+      traces               [cmd]       Fetch and capture traces for your project's deployment
       upgrade                          Upgrade the Vercel CLI to the latest version
       usage                            Show billing usage for the current billing period
       webhooks             [cmd]       Manages webhooks [beta]

--- a/packages/cli/test/unit/commands/traces/create.test.ts
+++ b/packages/cli/test/unit/commands/traces/create.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Readable } from 'stream';
+import { client } from '../../../mocks/client';
+import traces from '../../../../src/commands/traces';
+import { useUser } from '../../../mocks/user';
+import { useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+// Redirect the trace-session-token-provider's on-disk cache into a tmpdir per
+// test so we don't pollute the user's `~/.vercel`. `vi.hoisted` runs before
+// `vi.mock` so the ref is set when the mock factory executes during hoisting.
+const globalConfigRef = vi.hoisted(() => ({ dir: '' }));
+vi.mock('../../../../src/util/config/global-path', () => ({
+  default: () => globalConfigRef.dir,
+}));
+
+const PREVIEW_ALIAS = 'static-project-abc123.vercel.app';
+const DEPLOYMENT_ID = 'dpl_test_abc123';
+const TRACE_TOKEN = 'jwt-trace-token-deadbeef';
+const X_VERCEL_ID = 'sfo1::abc-1234567890-deadbeef';
+// The trace flow parses everything after the last `::` out of `x-vercel-id`.
+const REQUEST_ID = 'abc-1234567890-deadbeef';
+const USER_ID = 'u_test_user_abc';
+
+let spawnMock: ReturnType<typeof vi.fn>;
+
+interface SpawnResponse {
+  status?: number;
+  bodyText?: string;
+  xVercelId?: string | null;
+  exitCode?: number;
+}
+
+/**
+ * Mock `spawn` that emulates curl writing response headers to the path passed
+ * via `--dump-header <path>`, and streaming the body when stdout is piped
+ * (our --json mode).
+ */
+function installSpawnMock(config: SpawnResponse = {}) {
+  const {
+    status = 200,
+    bodyText = '',
+    xVercelId = X_VERCEL_ID,
+    exitCode = 0,
+  } = config;
+
+  spawnMock.mockImplementation((_cmd: string, args: string[], opts: any) => {
+    const dumpIdx = args.indexOf('--dump-header');
+    const headerPath = dumpIdx !== -1 ? args[dumpIdx + 1] : undefined;
+
+    if (headerPath) {
+      const reason = status === 200 ? 'OK' : 'Unauthorized';
+      const lines = [
+        `HTTP/1.1 ${status} ${reason}`,
+        'content-type: text/plain',
+      ];
+      if (xVercelId) {
+        lines.push(`x-vercel-id: ${xVercelId}`);
+      }
+      writeFileSync(headerPath, lines.join('\r\n') + '\r\n\r\n');
+    }
+
+    const stdoutPiped = opts?.stdio?.[1] === 'pipe';
+    const stdout = stdoutPiped ? Readable.from([bodyText]) : null;
+
+    const listeners: Record<string, Function[]> = {};
+    const child: any = {
+      stdout,
+      on(event: string, handler: Function) {
+        (listeners[event] ||= []).push(handler);
+        if (event === 'close') {
+          setTimeout(() => handler(exitCode), 0);
+        }
+        return child;
+      },
+    };
+    return child;
+  });
+}
+
+function mockSessionEndpoint() {
+  client.scenario.post('/v1/projects/traces/session', (_req, res) => {
+    res.json({ token: TRACE_TOKEN, expiresAt: Date.now() + 5 * 60 * 1000 });
+  });
+}
+
+function mockDeploymentLookup(target: 'production' | null = null) {
+  client.scenario.get('/v13/deployments/:host', (_req, res) => {
+    res.json({
+      id: DEPLOYMENT_ID,
+      url: `${DEPLOYMENT_ID}.vercel.app`,
+      target,
+      ownerId: 'team_dummy',
+      projectId: 'static',
+    });
+  });
+}
+
+async function setupLinkedProject() {
+  const { setupUnitFixture } = await import(
+    '../../../helpers/setup-unit-fixture'
+  );
+  client.cwd = setupUnitFixture('commands/deploy/static');
+
+  useUser({ id: USER_ID });
+  useTeams('team_dummy');
+  useProject({
+    id: 'static',
+    name: 'static-project',
+    latestDeployments: [{ url: PREVIEW_ALIAS }],
+  });
+  client.authConfig.userId = USER_ID;
+}
+
+describe('traces create', () => {
+  beforeEach(async () => {
+    client.reset();
+    client.stdin.isTTY = true;
+    globalConfigRef.dir = mkdtempSync(join(tmpdir(), 'traces-create-config-'));
+    const childProcess = await import('child_process');
+    spawnMock = vi.mocked(childProcess.spawn);
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    rmSync(globalConfigRef.dir, { recursive: true, force: true });
+  });
+
+  describe('--help', () => {
+    it('prints the create subcommand help', async () => {
+      client.setArgv('traces', 'create', '--help');
+      const exitCode = await traces(client);
+      expect(exitCode).toEqual(2);
+      expect(client.getFullOutput()).toContain(
+        'alias for `vercel curl --trace`'
+      );
+    });
+  });
+
+  describe('argument parsing', () => {
+    it('rejects when no path is provided', async () => {
+      client.setArgv('traces', 'create');
+      const exitCode = await traces(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('requires a URL or API path');
+    });
+  });
+
+  it('forces the trace flow and prints the follow-up command', async () => {
+    await setupLinkedProject();
+    mockDeploymentLookup();
+    mockSessionEndpoint();
+    installSpawnMock();
+
+    client.setArgv(
+      'traces',
+      'create',
+      '/api/hello',
+      '--protection-bypass',
+      'test-secret'
+    );
+    const exitCode = await traces(client);
+
+    expect(exitCode).toEqual(0);
+
+    // The shared trace flow ran: curl was spawned with the session cookie and
+    // the header dump, even though `--trace` was never passed explicitly.
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0];
+    expect(args).toContain('--dump-header');
+    expect(args).toContain(
+      `Cookie: _vercel_tracing=${TRACE_TOKEN}; _vercel_session=${USER_ID}`
+    );
+    expect(args).toEqual(
+      expect.arrayContaining(['--url', `https://${PREVIEW_ALIAS}/api/hello`])
+    );
+
+    expect(client.stderr.getFullOutput()).toContain(
+      `Run \`vercel traces get ${REQUEST_ID}\` to fetch the trace.`
+    );
+
+    // The shared curl runner emits the path argument, the passed-through
+    // --protection-bypass option, and the forced trace flag. (The
+    // `traces`/`create` command attribution is emitted by the root dispatch,
+    // which this direct-invocation test bypasses.)
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'argument:path', value: 'slash' },
+      { key: 'option:protection-bypass', value: '[REDACTED]' },
+      { key: 'flag:trace', value: 'TRUE' },
+    ]);
+  });
+
+  it('emits a JSON envelope with --json', async () => {
+    await setupLinkedProject();
+    mockDeploymentLookup();
+    mockSessionEndpoint();
+    installSpawnMock({ bodyText: '{"hello":"world"}' });
+
+    let stdoutBuf = '';
+    vi.spyOn(client.stdout, 'write').mockImplementation((chunk: any) => {
+      stdoutBuf += chunk;
+      return true;
+    });
+
+    client.setArgv(
+      'traces',
+      'create',
+      '/api/hello',
+      '--json',
+      '--protection-bypass',
+      'test-secret'
+    );
+    const exitCode = await traces(client);
+
+    expect(exitCode).toEqual(0);
+    const parsed = JSON.parse(stdoutBuf);
+    expect(parsed.requestId).toBe(REQUEST_ID);
+    expect(parsed.response).toBe('{"hello":"world"}');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `vercel traces create <path>` subcommand that is a thin alias for `vercel curl --trace`, and surfaces `traces` in the main `vercel --help` (it was previously missing from the hardcoded command list).

```
$ vercel traces create /api/hello
# …runs the curl trace flow and prints:
Run `vercel traces get <requestId>` to fetch the trace.
```

## What changed

- **Shared `runCurl`** — extracted the `curl` command body into `runCurl(client, { forceTrace, args })`. `curl()` calls it with defaults; `traces create` calls it with `forceTrace: true`, reusing the exact same setup → URL/token resolution → `trace()` pipeline.
- **`setupCurlLikeCommand`** — gains an optional `args` override (used only in the `allowFullUrl` branch) so `traces create` can hand over args with its `traces create` prefix already stripped, without mutating the live `process.argv`. Additive only — `curl` and `api` callers are unchanged.
- **`traces create` metadata + routing** — new `createSubcommand` (arg `path`; options `--deployment`, `--protection-bypass`, `--json`, `--yes`; `--trace` is implied), added to `tracesCommand.subcommands`, with a `--help` branch. `get` stays the default subcommand.
- **Main help** — added the `traces` line to the Advanced section in `src/help.ts`.

## Test plan

- New `test/unit/commands/traces/create.test.ts`: `--help`, no-path error, forced-trace happy path (asserts the session cookie + `traces get` follow-up), and `--json` envelope.
- Updated the `args.test.ts` help snapshot for the new `traces` line.
- All affected suites green: `traces`, `curl`, `api`, `args` (199 tests).
- Smoke-tested the built CLI: `vercel --help`, `vercel traces --help`, `vercel traces create --help`, and the no-path error path.

## Notes

- Telemetry: the command is attributed to `traces`/`create` by the root dispatch; flag/argument events are emitted under the shared `CurlTelemetryClient`.
- Minor: `vercel traces create` with no path emits an error that references `vercel curl <url|path>` (it comes from the shared curl path). Left as-is to keep the alias thin — happy to special-case the message if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)