### PR TITLE
[ci] Fix zizmor lint action

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
         id: auth
       - run: cargo publish
         working-directory: crates/vercel_runtime


### PR DESCRIPTION
The "Lint GitHub Actions" action was failing on the zizmor step because the `# v1` comment is treated by zizmor’s `ref-version-mismatch` audit as a promise that the hash corresponds to the current/latest matching `v1` release line, but the actual hash resolves to `v1.0.3`. It broke today because `1.0.5` was released so the versions drifted.

Since we're pinning to a specific hash, using the correct pinned version should resolve this.

Passing run on this PR: https://github.com/vercel/vercel/actions/runs/27636427756/job/81724772100?pr=16681