### PR TITLE
Enable customEnvironment in buy addon CLI

### DIFF
--- a/.changeset/mean-lobsters-check.md
+++ b/.changeset/mean-lobsters-check.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow `vercel buy addon customEnvironment <quantity>` by adding `customEnvironment` to the CLI add-on allowlist and help examples.

--- a/packages/cli/src/commands/buy/command.ts
+++ b/packages/cli/src/commands/buy/command.ts
@@ -49,12 +49,13 @@ export const creditsSubcommand = {
 } as const;
 
 // TODO(mingchungx): Add other addons
-export const SUPPORTED_ADDON_ALIASES = ['siem'] as const;
+export const SUPPORTED_ADDON_ALIASES = ['siem', 'customEnvironment'] as const;
 export type AddonAlias = (typeof SUPPORTED_ADDON_ALIASES)[number];
 
 // TODO(mingchungx): Add other labels
 export const ADDON_LABELS: Record<AddonAlias, string> = {
   siem: 'SIEM',
+  customEnvironment: 'Custom Environments',
 };
 
 export const addonSubcommand = {
@@ -83,6 +84,10 @@ export const addonSubcommand = {
     {
       name: 'Purchase 1 unit of the SIEM addon',
       value: `${packageName} buy addon siem 1`,
+    },
+    {
+      name: 'Purchase 1 unit of the Custom Environments addon',
+      value: `${packageName} buy addon customEnvironment 1`,
     },
   ],
 } as const;
@@ -166,6 +171,10 @@ export const buyCommand = {
     {
       name: 'Purchase the SIEM addon',
       value: `${packageName} buy addon siem 1`,
+    },
+    {
+      name: 'Purchase the Custom Environments addon',
+      value: `${packageName} buy addon customEnvironment 1`,
     },
     {
       name: 'Upgrade to Pro',

--- a/packages/cli/test/unit/commands/buy/addon.test.ts
+++ b/packages/cli/test/unit/commands/buy/addon.test.ts
@@ -110,6 +110,14 @@ describe('buy addon', () => {
       expect(exitCode).toBe(1);
       await expect(client.stderr).toOutput('Use --yes');
     });
+
+    it('purchases customEnvironment addon successfully', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv('buy', 'addon', 'customEnvironment', '1', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe('confirmation prompt', () => {
@@ -221,6 +229,27 @@ describe('buy addon', () => {
       const stdoutOutput = client.stdout.getFullOutput();
       const parsed = JSON.parse(stdoutOutput);
       expect(parsed.productAlias).toBe('siem');
+      expect(parsed.quantity).toBe(1);
+      expect(parsed.subscriptionIntent.id).toBe('subint_test_123');
+    });
+
+    it('outputs JSON for customEnvironment addon', async () => {
+      setupTeam();
+      useBuyEndpoint();
+      client.setArgv(
+        'buy',
+        'addon',
+        'customEnvironment',
+        '1',
+        '--yes',
+        '--format=json'
+      );
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(0);
+
+      const stdoutOutput = client.stdout.getFullOutput();
+      const parsed = JSON.parse(stdoutOutput);
+      expect(parsed.productAlias).toBe('customEnvironment');
       expect(parsed.quantity).toBe(1);
       expect(parsed.subscriptionIntent.id).toBe('subint_test_123');
     });


### PR DESCRIPTION
## Summary
- add `customEnvironment` to the CLI `buy addon` supported alias list
- add a friendly label for prompt/success output
- add unit coverage for successful `customEnvironment` purchase and JSON output

## Test plan
- [x] `pnpm install --filter ./packages/cli...`
- [x] `pnpm --dir packages/cli vitest-unit test/unit/commands/buy/addon.test.ts`
- [ ] `pnpm --dir packages/cli vitest run test/unit/commands/buy/addon.test.ts` *(fails in local clone due unresolved workspace package `@vercel/error-utils` before full repo bootstrap/build)*

Made with [Cursor](https://cursor.com)