### PR TITLE
Change bun preset to use engines.bun instead of bun.lock.

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4475,7 +4475,8 @@ export const frameworks = [
     detectors: {
       every: [
         {
-          path: 'bun.lock',
+          path: 'package.json',
+          matchContent: '"engines"\\s*:\\s*\\{[^}]*"bun"\\s*:',
         },
       ],
       some: [

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4574,7 +4574,8 @@ export const frameworks = [
     detectors: {
       every: [
         {
-          path: 'bun.lock',
+          path: 'package.json',
+          matchContent: '"engines"\\s*:\\s*\\{[^}]*"bun"\\s*:',
         },
       ],
       some: [

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -323,10 +323,9 @@ describe('detectFramework()', () => {
     'src/server.mts',
     'src/server.ts',
     'src/server.cts',
-  ])('Detect Bun via `%s` + bun.lock', async entrypoint => {
+  ])('Detect Bun via `%s` + engines.bun', async entrypoint => {
     const fs = new VirtualFilesystem({
-      'package.json': JSON.stringify({}),
-      'bun.lock': '',
+      'package.json': JSON.stringify({ engines: { bun: '1.x' } }),
       [entrypoint]: '// server entrypoint',
     });
 
@@ -341,8 +340,7 @@ describe('detectFramework()', () => {
 
   it('Bun is not detected without a server entrypoint', async () => {
     const fs = new VirtualFilesystem({
-      'package.json': JSON.stringify({}),
-      'bun.lock': '',
+      'package.json': JSON.stringify({ engines: { bun: '1.x' } }),
     });
 
     expect(

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -370,10 +370,9 @@ describe('detectFramework()', () => {
     'src/server.mts',
     'src/server.ts',
     'src/server.cts',
-  ])('Detect Bun via `%s` + bun.lock', async entrypoint => {
+  ])('Detect Bun via `%s` + engines.bun', async entrypoint => {
     const fs = new VirtualFilesystem({
-      'package.json': JSON.stringify({}),
-      'bun.lock': '',
+      'package.json': JSON.stringify({ engines: { bun: '1.x' } }),
       [entrypoint]: '// server entrypoint',
     });
 
@@ -388,8 +387,7 @@ describe('detectFramework()', () => {
 
   it('Bun is not detected without a server entrypoint', async () => {
     const fs = new VirtualFilesystem({
-      'package.json': JSON.stringify({}),
-      'bun.lock': '',
+      'package.json': JSON.stringify({ engines: { bun: '1.x' } }),
     });
 
     expect(


### PR DESCRIPTION
`bun.lock` is not a reliable signal on whether a project is actually intended to use the bun runtime.