### PR TITLE
Autodetect Bun runtime if engines.bun is set.

### DIFF
--- a/.changeset/tender-gorillas-cover.md
+++ b/.changeset/tender-gorillas-cover.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Autodetect Bun runtime if engines.bun is set.

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -346,51 +346,126 @@ export async function getNodeVersion(
   meta: Meta = {},
   availableVersions = getAvailableNodeVersions()
 ): Promise<NodeVersion | BunVersion> {
-  if (config.bunVersion) {
-    return getSupportedBunVersion(config.bunVersion);
-  }
-
-  const latestVersion = getLatestNodeVersion(availableVersions);
-  if (meta.isDev) {
-    // Use the system-installed version of `node` in PATH for `vercel dev`
-    latestVersion.runtime = 'nodejs';
-    return latestVersion;
-  }
+  // All the different versions/sources to consider
   const { packageJson } = await findPackageJson(destPath, true);
-  const configuredVersion = config.nodeVersion || fallbackVersion;
+  const packageJsonNodeVersion = packageJson?.engines?.node;
+  const packageJsonBunVersion = packageJson?.engines?.bun;
 
-  const packageJsonVersion = packageJson?.engines?.node;
-  const supportedNodeVersion = await getSupportedNodeVersion(
-    packageJsonVersion || configuredVersion,
-    !packageJsonVersion,
-    availableVersions
-  );
+  const latestNodeVersion = getLatestNodeVersion(availableVersions);
 
-  if (packageJson?.engines?.node) {
-    const { node } = packageJson.engines;
-    if (
-      configuredVersion &&
-      !intersects(configuredVersion, supportedNodeVersion.range)
-    ) {
+  const packageJsonPackageManagerBunVersion =
+    packageJson?.packageManager?.startsWith('bun@')
+      ? packageJson.packageManager.split('@')[1]
+      : undefined;
+  const hasBunLock =
+    (await fs.pathExists(path.join(destPath, 'bun.lock'))) ||
+    (await fs.pathExists(path.join(destPath, 'bun.lockb')));
+
+  // Determine the target runtime
+  let targetRuntime: 'node' | 'bun';
+  if (packageJsonNodeVersion && packageJsonBunVersion) {
+    // If package.json specifies both Node and Bun
+    if (config.bunVersion) {
+      // if vercel.json specifies a bun version, use bun
+      targetRuntime = 'bun';
       console.warn(
-        `Warning: Due to "engines": { "node": "${node}" } in your \`package.json\` file, the Node.js Version defined in your Project Settings ("${configuredVersion}") will not apply, Node.js Version "${supportedNodeVersion.range}" will be used instead. Learn More: https://vercel.link/node-version`
+        `Warning detected "engines": { "node": ..., "bun": ... } in \`package.json\`. Since "bunVersion" is set in \`vercel.json\`, using "bun".`
+      );
+    } else {
+      // otherwise default to node
+      targetRuntime = 'node';
+      console.warn(
+        `Warning detected "engines": { "node": ..., "bun": ... } in \`package.json\`. Defaulting to "node".`
       );
     }
+  } else if (packageJsonNodeVersion) {
+    targetRuntime = 'node';
+    if (config.bunVersion) {
+      console.warn(
+        `Warning detected "engines": { "node": ... } in \`package.json\` and "bunVersion" in \`vercel.json\`. \`package.json\` takes precedence, using "node".`
+      );
+    }
+  } else if (
+    packageJsonBunVersion ||
+    config.bunVersion ||
+    packageJsonPackageManagerBunVersion ||
+    hasBunLock
+  ) {
+    targetRuntime = 'bun';
+  } else {
+    // If no target runtime is determined, fallback to the configured node version
+    targetRuntime = 'node';
+  }
 
-    if (coerce(node)?.raw === node) {
-      console.warn(
-        `Warning: Detected "engines": { "node": "${node}" } in your \`package.json\` with major.minor.patch, but only major Node.js Version can be selected. Learn More: https://vercel.link/node-version`
-      );
-    } else if (
-      validRange(node) &&
-      intersects(`${latestVersion.major + 1}.x`, node)
-    ) {
-      console.warn(
-        `Warning: Detected "engines": { "node": "${node}" } in your \`package.json\` that will automatically upgrade when a new major Node.js Version is released. Learn More: https://vercel.link/node-version`
-      );
+  // For `vercel dev`, return the latest node or bun version
+  if (meta.isDev) {
+    if (targetRuntime === 'node') {
+      // Use the system-installed version of `node` in PATH for `vercel dev`
+      latestNodeVersion.runtime = 'nodejs';
+      return latestNodeVersion;
+    } else {
+      // Hard coded for now...
+      return getSupportedBunVersion('1.x');
     }
   }
-  return supportedNodeVersion;
+
+  // Get the version for the target runtime
+  if (targetRuntime === 'node') {
+    const configuredNodeVersion = config.nodeVersion ?? fallbackVersion;
+
+    const supportedNodeVersion = await getSupportedNodeVersion(
+      packageJsonNodeVersion || configuredNodeVersion,
+      !packageJsonNodeVersion,
+      availableVersions
+    );
+
+    if (packageJson?.engines?.node) {
+      const { node } = packageJson.engines;
+      if (
+        configuredNodeVersion &&
+        !intersects(configuredNodeVersion, supportedNodeVersion.range)
+      ) {
+        console.warn(
+          `Warning: Due to "engines": { "node": "${node}" } in your \`package.json\` file, the Node.js Version defined in your Project Settings ("${configuredNodeVersion}") will not apply, Node.js Version "${supportedNodeVersion.range}" will be used instead. Learn More: https://vercel.link/node-version`
+        );
+      }
+
+      if (coerce(node)?.raw === node) {
+        console.warn(
+          `Warning: Detected "engines": { "node": "${node}" } in your \`package.json\` with major.minor.patch, but only major Node.js Version can be selected. Learn More: https://vercel.link/node-version`
+        );
+      } else if (
+        validRange(node) &&
+        intersects(`${latestNodeVersion.major + 1}.x`, node)
+      ) {
+        console.warn(
+          `Warning: Detected "engines": { "node": "${node}" } in your \`package.json\` that will automatically upgrade when a new major Node.js Version is released. Learn More: https://vercel.link/node-version`
+        );
+      }
+    }
+    return supportedNodeVersion;
+  } else {
+    // targetRuntime === 'bun'
+    if (packageJsonBunVersion) {
+      // engines.bun is set
+      return getSupportedBunVersion(packageJsonBunVersion);
+    }
+    if (config.bunVersion) {
+      // bunVersion is set in vercel.json
+      return getSupportedBunVersion(config.bunVersion);
+    }
+    if (packageJsonPackageManagerBunVersion) {
+      // packageManager is set to bun@<version>
+      return getSupportedBunVersion(packageJsonPackageManagerBunVersion);
+    }
+    if (hasBunLock) {
+      // bun.lock or bun.lockb is in the current dir
+      // For now, just hard code to 1.x. Perhaps in the future, configVersion could be used?
+      return getSupportedBunVersion('1.x');
+    }
+    // default to 1.x as a fallback
+    return getSupportedBunVersion('1.x');
+  }
 }
 
 /**

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -353,14 +353,6 @@ export async function getNodeVersion(
 
   const latestNodeVersion = getLatestNodeVersion(availableVersions);
 
-  const packageJsonPackageManagerBunVersion =
-    packageJson?.packageManager?.startsWith('bun@')
-      ? packageJson.packageManager.split('@')[1]
-      : undefined;
-  const hasBunLock =
-    (await fs.pathExists(path.join(destPath, 'bun.lock'))) ||
-    (await fs.pathExists(path.join(destPath, 'bun.lockb')));
-
   // Determine the target runtime
   let targetRuntime: 'node' | 'bun';
   if (packageJsonNodeVersion && packageJsonBunVersion) {
@@ -385,12 +377,7 @@ export async function getNodeVersion(
         `Warning detected "engines": { "node": ... } in \`package.json\` and "bunVersion" in \`vercel.json\`. \`package.json\` takes precedence, using "node".`
       );
     }
-  } else if (
-    packageJsonBunVersion ||
-    config.bunVersion ||
-    packageJsonPackageManagerBunVersion ||
-    hasBunLock
-  ) {
+  } else if (packageJsonBunVersion || config.bunVersion) {
     targetRuntime = 'bun';
   } else {
     // If no target runtime is determined, fallback to the configured node version
@@ -453,15 +440,6 @@ export async function getNodeVersion(
     if (config.bunVersion) {
       // bunVersion is set in vercel.json
       return getSupportedBunVersion(config.bunVersion);
-    }
-    if (packageJsonPackageManagerBunVersion) {
-      // packageManager is set to bun@<version>
-      return getSupportedBunVersion(packageJsonPackageManagerBunVersion);
-    }
-    if (hasBunLock) {
-      // bun.lock or bun.lockb is in the current dir
-      // For now, just hard code to 1.x. Perhaps in the future, configVersion could be used?
-      return getSupportedBunVersion('1.x');
     }
     // default to 1.x as a fallback
     return getSupportedBunVersion('1.x');

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -332,6 +332,7 @@ export namespace PackageJson {
     node?: string;
     npm?: string;
     pnpm?: string;
+    bun?: string;
   }
 
   export interface PublishConfig {

--- a/packages/build-utils/test/pkg-engines-bun/package.json
+++ b/packages/build-utils/test/pkg-engines-bun/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "engines": {
+    "bun": "1.x"
+  }
+}

--- a/packages/build-utils/test/pkg-engines-node-and-bun/package.json
+++ b/packages/build-utils/test/pkg-engines-node-and-bun/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "engines": {
+    "node": "22.x",
+    "bun": "1.x"
+  }
+}

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -179,6 +179,54 @@ it('should fail if the provided bun version is not valid', async () => {
   ).rejects.toThrow();
 });
 
+it('should resolve to Bun when package.json has engines.bun', async () => {
+  const result = await getNodeVersion(
+    path.join(__dirname, 'pkg-engines-bun'),
+    undefined,
+    {},
+    {}
+  );
+  expect(result).toHaveProperty('runtime', 'bun1.x');
+  expect(result).toHaveProperty('range', '1.x');
+  expect(warningMessages).toStrictEqual([]);
+});
+
+it('should default to Node when both engines.node and engines.bun are set, with a warning', async () => {
+  const result = await getNodeVersion(
+    path.join(__dirname, 'pkg-engines-node-and-bun'),
+    undefined,
+    {},
+    {}
+  );
+  expect(result).toHaveProperty('runtime', 'nodejs22.x');
+  expect(result).toHaveProperty('range', '22.x');
+  expect(warningMessages).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(
+        'Warning detected "engines": { "node": ..., "bun": ... } in `package.json`. Defaulting to "node".'
+      ),
+    ])
+  );
+});
+
+it('should resolve to Bun when both engines.node and engines.bun are set and config.bunVersion is provided', async () => {
+  const result = await getNodeVersion(
+    path.join(__dirname, 'pkg-engines-node-and-bun'),
+    undefined,
+    { bunVersion: '1.x' },
+    {}
+  );
+  expect(result).toHaveProperty('runtime', 'bun1.x');
+  expect(result).toHaveProperty('range', '1.x');
+  expect(warningMessages).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(
+        'Warning detected "engines": { "node": ..., "bun": ... } in `package.json`. Since "bunVersion" is set in `vercel.json`, using "bun".'
+      ),
+    ])
+  );
+});
+
 it('should select project setting from config when no package.json is found and fallback undefined', async () => {
   expect(
     await getNodeVersion('/tmp', undefined, { nodeVersion: '22.x' }, {})


### PR DESCRIPTION
This will allow bun to be automatically selected as the runtime without needing to set `bunVersion` in `vercel.json`.

Reworked `getNodeVersion` to pick `node` or `bun` based on the following priority:
- `engines.node`/`engines.bun`
  - if both are set, use `bun` if `config.bunVersion` is set, otherwise `node`
- `config.bunVersion`
- default to `node`

Also removed the `fallbackVersion` parameter since it was never directly passed in.