### PR TITLE
[cli] Fix deploy size-limit warning crashing before its upgrade hint

### DIFF
--- a/.changeset/fix-size-limit-cta.md
+++ b/.changeset/fix-size-limit-cta.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix the deploy size-limit warning so it prints the skipped file and plan upgrade link instead of crashing.

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -137,8 +137,6 @@ export default class Now {
     isSettingUpProject: boolean,
     archive?: ArchiveFormat
   ) {
-    const hashes: any = {};
-
     const requestBody = {
       ...nowConfig,
       env,
@@ -194,11 +192,9 @@ export default class Now {
       deployment.warnings.forEach((warning: any) => {
         if (warning.reason === 'size_limit_exceeded') {
           const { sha, limit } = warning;
-          const n = hashes[sha].names.pop();
 
-          warn(`Skipping file ${n} (size exceeded ${bytes(limit)}`);
+          warn(`Skipping file ${sha} (size exceeded ${bytes(limit)})`);
 
-          hashes[sha].names.unshift(n); // Move name (hack, if duplicate matches we report them in order)
           sizeExceeded++;
         } else if (warning.reason === 'node_version_not_found') {
           warn(`Requested node version ${warning.wanted} is not available`);

--- a/packages/cli/test/unit/util/now-size-limit-warning.test.ts
+++ b/packages/cli/test/unit/util/now-size-limit-warning.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../mocks/client';
+import type { Org } from '@vercel-internals/types';
+
+// Mock the deployment pipeline so we can hand `Now.create` a deployment that
+// carries a `size_limit_exceeded` warning, exercising the warning/CTA branch in
+// util/index.ts.
+const processDeployment = vi.hoisted(() => vi.fn());
+vi.mock('../../../src/util/deploy/process-deployment', () => ({
+  default: processDeployment,
+}));
+
+import Now from '../../../src/util/index';
+
+const org: Org = { type: 'user', id: 'user_1', slug: 'acme' };
+
+function baseCreateOptions() {
+  return {
+    name: 'my-project',
+    wantsPublic: false,
+    meta: {},
+    env: {},
+    build: { env: {} },
+    deployStamp: () => '',
+  } as any;
+}
+
+describe('Now.create — size_limit_exceeded warning', () => {
+  beforeEach(() => {
+    client.reset();
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Previously this branch crashed on `hashes[sha].names.pop()` (`hashes` was
+  // never populated), so the warning and upgrade CTA were unreachable. Now it
+  // should warn about the skipped file and surface the plan upgrade link.
+  it('warns about the skipped file and prints the upgrade CTA', async () => {
+    // The API returns the deployment with a per-file size warning instead of
+    // failing the whole deploy.
+    processDeployment.mockResolvedValue({
+      id: 'dpl_test',
+      warnings: [
+        {
+          reason: 'size_limit_exceeded',
+          sha: 'abc123',
+          limit: 100 * 1024 * 1024,
+        },
+      ],
+    });
+
+    const now = new Now({ client });
+
+    const deployment = await now.create(
+      '/tmp/whatever',
+      baseCreateOptions(),
+      org,
+      false
+    );
+    expect(deployment.id).toBe('dpl_test');
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Skipping file abc123');
+    expect(stderr).toContain('exceeded the limit for your plan');
+    expect(stderr).toContain('https://vercel.com/account/plan');
+  });
+});


### PR DESCRIPTION
The `size_limit_exceeded` deploy warning crashed on `hashes[sha].names` — `hashes` is never populated (leftover now-cli state), so the per-file warning and the `vercel.com/account/plan` upgrade link were never shown.

**Fix:** drop the dead `hashes` map, identify the skipped file by its `sha`, and fix the message's unbalanced paren so the warning + link print.

**Test:** `pnpm test test/unit/util/now-size-limit-warning.test.ts` — now asserts the warning + link print (previously asserted the crash).

<img width="1040" height="560" alt="pr-16692-size-limit" src="https://github.com/user-attachments/assets/0296fcaa-737c-4fe2-8924-9ca795a30bf9" />

_Found via an Expansion & Upsell Surface Audit of the CLI._
