### PR TITLE
[cli] Deduplicate the team billing URL into a shared helper

### DIFF
--- a/.changeset/dedupe-team-billing-url.md
+++ b/.changeset/dedupe-team-billing-url.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Deduplicate the team billing settings URL into a shared `getTeamBillingUrl` helper.

--- a/packages/cli/src/commands/microfrontends/add-to-group.ts
+++ b/packages/cli/src/commands/microfrontends/add-to-group.ts
@@ -7,6 +7,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { parseArguments } from '../../util/get-args';
 import { printError } from '../../util/error';
 import { isAPIError } from '../../util/errors-ts';
+import { getTeamBillingUrl } from '../../util/billing-url';
 import type { MicrofrontendsGroupResponse } from './types';
 import {
   ensureMicrofrontendsContext,
@@ -74,7 +75,7 @@ export default async function addToGroup(client: Client): Promise<number> {
 
   if (isLimitedPlan && totalAfter > freeProjects) {
     const planName = isProTrialPlan ? 'Pro Trial' : 'Hobby';
-    const url = `https://vercel.com/${teamSlug}/~/settings/billing`;
+    const url = getTeamBillingUrl(teamSlug);
     output.log(
       `You've reached the microfrontends project limit for ${planName}. Upgrade to Pro to add more projects.`
     );
@@ -155,7 +156,7 @@ export default async function addToGroup(client: Client): Promise<number> {
   if (selectedGroup.projects.length >= maxMicrofrontendsPerGroup) {
     if (isLimitedPlan) {
       const planName = isProTrialPlan ? 'Pro Trial' : 'Hobby';
-      const url = `https://vercel.com/${teamSlug}/~/settings/billing`;
+      const url = getTeamBillingUrl(teamSlug);
       output.log(
         `You've reached the microfrontends project limit for ${planName}. Upgrade to Pro to add more projects.`
       );

--- a/packages/cli/src/commands/microfrontends/create-group.ts
+++ b/packages/cli/src/commands/microfrontends/create-group.ts
@@ -11,6 +11,7 @@ import { parseArguments } from '../../util/get-args';
 import { printError } from '../../util/error';
 import getProjectByIdOrName from '../../util/projects/get-project-by-id-or-name';
 import { isAPIError, ProjectNotFound } from '../../util/errors-ts';
+import { getTeamBillingUrl } from '../../util/billing-url';
 import type { Project } from '@vercel-internals/types';
 import type { MicrofrontendsGroupResponse } from './types';
 import {
@@ -68,7 +69,7 @@ export default async function createGroup(client: Client): Promise<number> {
   if (groups.length >= maxMicrofrontendsGroupsPerTeam) {
     if (isLimitedPlan) {
       const planName = isProTrialPlan ? 'Pro Trial' : 'Hobby';
-      const url = `https://vercel.com/${teamSlug}/~/settings/billing`;
+      const url = getTeamBillingUrl(teamSlug);
       output.log(
         `You've reached the microfrontends group limit for ${planName}. Upgrade to Pro to create more groups.`
       );

--- a/packages/cli/src/util/billing-url.ts
+++ b/packages/cli/src/util/billing-url.ts
@@ -1,0 +1,7 @@
+/**
+ * Build the URL to a team's billing settings, where upgrades and payment
+ * methods are managed. Shared so the various "upgrade to Pro" / payment nudges
+ * point at the same place.
+ */
+export const getTeamBillingUrl = (teamSlug: string) =>
+  `https://vercel.com/${teamSlug}/~/settings/billing`;

--- a/packages/cli/src/util/buy/handle-purchase-error.ts
+++ b/packages/cli/src/util/buy/handle-purchase-error.ts
@@ -2,9 +2,7 @@ import open from 'open';
 import { errorToString } from '@vercel/error-utils';
 import output from '../../output-manager';
 import { isAPIError } from '../errors-ts';
-
-const getBillingUrl = (teamSlug: string) =>
-  `https://vercel.com/${teamSlug}/~/settings/billing`;
+import { getTeamBillingUrl } from '../billing-url';
 
 interface HandlePurchaseErrorOptions {
   /** When true (TTY), automatically opens the billing page in the browser for payment-related errors. */
@@ -17,7 +15,7 @@ function tryOpenBillingPage(
 ): void {
   if (!openBrowser) return;
   const billingUrl = teamSlug
-    ? getBillingUrl(teamSlug)
+    ? getTeamBillingUrl(teamSlug)
     : 'https://vercel.com/dashboard';
   void open(billingUrl).catch((err: unknown) => {
     output.debug(`Failed to open browser: ${err}`);
@@ -51,7 +49,7 @@ export function handlePurchaseError(
     }
     if (err.code === 'missing_stripe_customer') {
       const billingUrl = teamSlug
-        ? getBillingUrl(teamSlug)
+        ? getTeamBillingUrl(teamSlug)
         : 'https://vercel.com/dashboard';
       const dashboardHint = teamSlug
         ? ` Please add one: ${output.link(billingUrl, billingUrl)}`

--- a/packages/cli/test/unit/util/billing-url.test.ts
+++ b/packages/cli/test/unit/util/billing-url.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { getTeamBillingUrl } from '../../../src/util/billing-url';
+
+describe('getTeamBillingUrl', () => {
+  it('builds the team billing settings URL from a team slug', () => {
+    expect(getTeamBillingUrl('acme')).toBe(
+      'https://vercel.com/acme/~/settings/billing'
+    );
+  });
+});


### PR DESCRIPTION
The team billing URL (`vercel.com/{team}/~/settings/billing`) was hardcoded in 5 places — the buy purchase-error handler and 4 microfrontends call sites.

**Fix:** extract it into a shared `getTeamBillingUrl(teamSlug)` helper. Pure refactor — rendered URLs are byte-identical. (Out of scope: unifying the other distinct billing destinations — `account/plan`, `account/billing`, `dashboard/settings/billing` — a product decision.)

**Test:** `pnpm test test/unit/util/billing-url.test.ts` — existing buy/microfrontends tests still assert the exact URL.

_Found via an Expansion & Upsell Surface Audit of the CLI._