### PR TITLE
Mark flags command as not hidden

### DIFF
--- a/.changeset/flags-command-visible.md
+++ b/.changeset/flags-command-visible.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Unhide the `flags` command in CLI help output.

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -750,9 +750,6 @@ export const flagsCommand = {
   name: 'flags',
   aliases: [],
   description: 'Manage feature flags for a Vercel project',
-  // Hidden during initial rollout. Will be unhidden once the feature is
-  // generally available and public documentation is published.
-  hidden: true,
   arguments: [],
   subcommands: [
     listSubcommand,


### PR DESCRIPTION
## Summary
- Remove the hidden flag from the `flags` CLI command so it appears in help output