### PR TITLE
[python] Remove compileall from lambda paths, default to off.

### DIFF
--- a/.changeset/python-compileall-hive-only.md
+++ b/.changeset/python-compileall-hive-only.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Scope `compileall` bytecode precompilation to Hive deployments. It now runs only when `VERCEL_PYTHON_ON_HIVE` is set and is gated behind `VERCEL_PYTHON_COMPILEALL` as an explicit opt-in flag (default off). The dev and custom-command guards are unchanged.

--- a/packages/python/src/compileall.ts
+++ b/packages/python/src/compileall.ts
@@ -3,20 +3,25 @@ import { debug, FileFsRef, type Files } from '@vercel/build-utils';
 import fs from 'fs';
 import { join, sep } from 'path';
 
-// Enabled by default for hive unless explicitly opted out
-export function isCompileAllEnabled(): boolean {
-  const val = process.env.VERCEL_PYTHON_COMPILEALL;
-  if (val !== undefined && val !== '') {
-    const lower = val.toLowerCase();
-    return lower === '1' || lower === 'true';
-  }
-
+export function isPythonOnHive(): boolean {
   const hive = process.env.VERCEL_PYTHON_ON_HIVE;
-  if (hive === '1' || hive === 'true') {
-    return true;
-  }
+  return hive === '1' || hive === 'true';
+}
 
-  return false;
+/**
+ * Compileall is a Hive-only feature.  It runs only when the deployment is on
+ * Hive *and* `VERCEL_PYTHON_COMPILEALL` is explicitly set to a truthy value
+ * (`1`/`true`).  This makes the env var an opt-in toggle for the Hive rollout;
+ * it has no effect off Hive.
+ */
+export function isCompileAllEnabled(): boolean {
+  if (!isPythonOnHive()) return false;
+
+  const val = process.env.VERCEL_PYTHON_COMPILEALL;
+  if (val === undefined || val === '') return false;
+
+  const lower = val.toLowerCase();
+  return lower === '1' || lower === 'true';
 }
 
 export function shouldUseCompileAll({
@@ -28,16 +33,8 @@ export function shouldUseCompileAll({
 }): boolean {
   if (isDev) return false;
 
-  // Explicit VERCEL_PYTHON_COMPILEALL overrides all other guards,
-  // including the custom-command guard.  This is the only way for
-  // custom-command users to opt into bytecode compilation.
-  const val = process.env.VERCEL_PYTHON_COMPILEALL;
-  if (val !== undefined && val !== '') {
-    const lower = val.toLowerCase();
-    return lower === '1' || lower === 'true';
-  }
-
-  // Without explicit opt-in, custom commands never get compileall.
+  // Custom commands never get compileall: they may produce their own bytecode
+  // or bypass the venv layout compileall assumes.
   if (hasCustomCommand) return false;
 
   return isCompileAllEnabled();

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -42,7 +42,6 @@ import {
 } from './install';
 import {
   PythonDependencyExternalizer,
-  LAMBDA_SIZE_THRESHOLD_BYTES,
   HIVE_LAMBDA_SIZE_BYTES,
   lambdaKnapsack,
   calculateBundleSize,
@@ -1044,15 +1043,11 @@ from vercel_runtime.vc_init import vc_handler
               });
             });
 
-          // Collect bytecode and fill remaining capacity.
-          const pythonOnHiveEnabled =
-            process.env.VERCEL_PYTHON_ON_HIVE === '1' ||
-            process.env.VERCEL_PYTHON_ON_HIVE === 'true';
-          const activeThreshold = pythonOnHiveEnabled
-            ? HIVE_LAMBDA_SIZE_BYTES
-            : LAMBDA_SIZE_THRESHOLD_BYTES;
+          // Collect bytecode and fill remaining capacity.  Compileall only
+          // runs on Hive (see shouldUseCompileAll), so the Hive Lambda size
+          // threshold always applies here.
           const currentSize = await calculateBundleSize(files);
-          let remainingCapacity = activeThreshold - currentSize;
+          let remainingCapacity = HIVE_LAMBDA_SIZE_BYTES - currentSize;
 
           if (pythonVersion.major != null && pythonVersion.minor != null) {
             const appBytecodeInfo = await collectAppBytecodeFiles({

--- a/packages/python/test/compileall.test.ts
+++ b/packages/python/test/compileall.test.ts
@@ -53,7 +53,9 @@ describe('isCompileAllEnabled', () => {
     expect(isCompileAllEnabled()).toBe(false);
   });
 
-  it('enables compileall for truthy env values', () => {
+  it('enables compileall on Hive for truthy flag values', () => {
+    process.env.VERCEL_PYTHON_ON_HIVE = '1';
+
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
     expect(isCompileAllEnabled()).toBe(true);
 
@@ -64,7 +66,12 @@ describe('isCompileAllEnabled', () => {
     expect(isCompileAllEnabled()).toBe(true);
   });
 
-  it('keeps compileall disabled for other env values', () => {
+  it('keeps compileall disabled on Hive for non-truthy flag values', () => {
+    process.env.VERCEL_PYTHON_ON_HIVE = '1';
+
+    delete process.env.VERCEL_PYTHON_COMPILEALL;
+    expect(isCompileAllEnabled()).toBe(false);
+
     process.env.VERCEL_PYTHON_COMPILEALL = '';
     expect(isCompileAllEnabled()).toBe(false);
 
@@ -75,28 +82,11 @@ describe('isCompileAllEnabled', () => {
     expect(isCompileAllEnabled()).toBe(false);
   });
 
-  it('enables compileall by default when VERCEL_PYTHON_ON_HIVE is set', () => {
-    delete process.env.VERCEL_PYTHON_COMPILEALL;
+  it('never enables compileall off Hive, even when the flag is truthy', () => {
+    process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
-    process.env.VERCEL_PYTHON_ON_HIVE = '1';
-    expect(isCompileAllEnabled()).toBe(true);
-
-    process.env.VERCEL_PYTHON_ON_HIVE = 'true';
-    expect(isCompileAllEnabled()).toBe(true);
-  });
-
-  it('respects explicit disable even when VERCEL_PYTHON_ON_HIVE is set', () => {
-    process.env.VERCEL_PYTHON_ON_HIVE = '1';
-
-    process.env.VERCEL_PYTHON_COMPILEALL = '0';
+    delete process.env.VERCEL_PYTHON_ON_HIVE;
     expect(isCompileAllEnabled()).toBe(false);
-
-    process.env.VERCEL_PYTHON_COMPILEALL = 'false';
-    expect(isCompileAllEnabled()).toBe(false);
-  });
-
-  it('does not enable compileall for non-truthy VERCEL_PYTHON_ON_HIVE', () => {
-    delete process.env.VERCEL_PYTHON_COMPILEALL;
 
     process.env.VERCEL_PYTHON_ON_HIVE = '0';
     expect(isCompileAllEnabled()).toBe(false);
@@ -110,20 +100,21 @@ describe('isCompileAllEnabled', () => {
 });
 
 describe('shouldUseCompileAll', () => {
-  it('explicit VERCEL_PYTHON_COMPILEALL=1 overrides custom command guard', () => {
+  it('enables compileall on Hive when the flag is set for non-custom builds', () => {
+    process.env.VERCEL_PYTHON_ON_HIVE = '1';
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
     expect(
       shouldUseCompileAll({
         isDev: false,
-        hasCustomCommand: true,
+        hasCustomCommand: false,
       })
     ).toBe(true);
   });
 
-  it('Hive auto-enable does not override custom command guard', () => {
-    delete process.env.VERCEL_PYTHON_COMPILEALL;
+  it('does not enable compileall for custom commands, even on Hive with the flag set', () => {
     process.env.VERCEL_PYTHON_ON_HIVE = '1';
+    process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
     expect(
       shouldUseCompileAll({
@@ -133,7 +124,8 @@ describe('shouldUseCompileAll', () => {
     ).toBe(false);
   });
 
-  it('does not enable compileall in dev even when explicitly set', () => {
+  it('does not enable compileall in dev even on Hive with the flag set', () => {
+    process.env.VERCEL_PYTHON_ON_HIVE = '1';
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
     expect(
@@ -144,7 +136,8 @@ describe('shouldUseCompileAll', () => {
     ).toBe(false);
   });
 
-  it('enables compileall for non-custom builds when explicitly set', () => {
+  it('does not enable compileall off Hive even when the flag is set', () => {
+    delete process.env.VERCEL_PYTHON_ON_HIVE;
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
     expect(
@@ -152,12 +145,12 @@ describe('shouldUseCompileAll', () => {
         isDev: false,
         hasCustomCommand: false,
       })
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('does not enable compileall without explicit opt-in or Hive', () => {
+  it('does not enable compileall on Hive without the flag', () => {
+    process.env.VERCEL_PYTHON_ON_HIVE = '1';
     delete process.env.VERCEL_PYTHON_COMPILEALL;
-    delete process.env.VERCEL_PYTHON_ON_HIVE;
 
     expect(
       shouldUseCompileAll({

--- a/packages/python/test/fixtures/64-hive-compileall/vercel.json
+++ b/packages/python/test/fixtures/64-hive-compileall/vercel.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "env": {
-      "VERCEL_PYTHON_ON_HIVE": "1"
+      "VERCEL_PYTHON_ON_HIVE": "1",
+      "VERCEL_PYTHON_COMPILEALL": "1"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Feature flag the python `compileall` feature
- Remove it from the lambda deployment path
- 
There's not much benefit to enabling `compileall` for functions deploying to lambda since it could easily put them over the 250MB threshold.