### PR TITLE
[python-runtime] Set missing supportsMultiPayloads flag, fixing WebSocket 403

### DIFF
--- a/.changeset/python-fluid-compute.md
+++ b/.changeset/python-fluid-compute.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-runtime': patch
+---
+
+Set missing `supportsMultiPayloads` flag on Python Lambda output, fixing WebSocket upgrades returning 403

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -1091,6 +1091,7 @@ from vercel_runtime.vc_init import vc_handler
     architecture: target.architecture,
     environment: lambdaEnv,
     supportsResponseStreaming: true,
+    supportsMultiPayloads: true,
   });
 
   // Write project manifest for diagnostics (best-effort, never fails the build).


### PR DESCRIPTION
Set `supportsMultiPayloads: true` on the Lambda output so the routing layer assigns n1MaxConcurrency > 1.  Without this flag Python functions are treated as legacy single-concurrency serverless, which causes WebSocket upgrades to be rejected with 403 (Fluid Compute (N1MC) requests only).