### PR TITLE
[next] Add support for stable Cache Components without experimental PPR

### DIFF
--- a/.changeset/yellow-adults-smash.md
+++ b/.changeset/yellow-adults-smash.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Add support for stable Cache Components without experimental PPR

--- a/packages/next/src/server-launcher.ts
+++ b/packages/next/src/server-launcher.ts
@@ -54,7 +54,9 @@ module.exports = serve(nextServer.getRequestHandler());
 // If available, add `getRequestHandlerWithMetadata` to the export if it's
 // required by the configuration.
 if (
-  (conf.experimental?.ppr || conf.experimental?.cacheComponents) &&
+  (conf.experimental?.ppr ||
+    conf.experimental?.cacheComponents ||
+    conf.cacheComponents) &&
   'getRequestHandlerWithMetadata' in nextServer &&
   typeof nextServer.getRequestHandlerWithMetadata === 'function'
 ) {


### PR DESCRIPTION
We want to stop using `config.experimental.ppr` in Next.js internals. Right now that field is derived from `config.cacheComponents` so this shouldn't affect existing Next.js versions. Only future versions that only have `config.cacheComponents`.