### PR TITLE
[python] Make sure we save the total bundle size for all builds

### DIFF
--- a/.changeset/python-bundle-size-telemetry.md
+++ b/.changeset/python-bundle-size-telemetry.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Record the `python.bundle.totalSizeBytes` build span tag before the bundle size-limit checks, so oversized functions that exceed the limit (and fail the build) still report their size instead of being omitted from telemetry.

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -101,6 +101,19 @@ interface DependencyAnalysis {
   totalBundleSize: number;
 }
 
+interface AnalyzeOptions {
+  /**
+   * Invoked once the source-only bundle size is known, BEFORE any
+   * size-limit enforcement that may throw.  This guarantees the size is
+   * always observable (e.g. for telemetry) even for oversized bundles that
+   * subsequently fail the build.
+   */
+  onSized?: (info: {
+    totalSizeBytes: number;
+    runtimeInstallEnabled: boolean;
+  }) => void;
+}
+
 export class PythonDependencyExternalizer {
   private venvPath: string;
   private vendorDir: string;
@@ -158,7 +171,10 @@ export class PythonDependencyExternalizer {
    * and determine whether runtime installation is needed.
    * Must be called before generateBundle().
    */
-  async analyze(files: Files): Promise<DependencyAnalysis> {
+  async analyze(
+    files: Files,
+    options: AnalyzeOptions = {}
+  ): Promise<DependencyAnalysis> {
     // Resolve site-packages dirs and scan distributions once.  Subsequent
     // calls to mirrorPackagesIntoVendor() and calculatePerPackageSizes()
     // read from these fields directly.
@@ -192,6 +208,14 @@ export class PythonDependencyExternalizer {
     const pythonOnHiveEnabled =
       process.env.VERCEL_PYTHON_ON_HIVE === '1' ||
       process.env.VERCEL_PYTHON_ON_HIVE === 'true';
+
+    // Surface the size BEFORE the size-limit checks below, which may throw.
+    // Otherwise oversized bundles (e.g. Hive > 1 GB) would never report their
+    // size, biasing any size telemetry toward builds that fit the limit.
+    options.onSized?.({
+      totalSizeBytes: this.totalBundleSize,
+      runtimeInstallEnabled,
+    });
 
     if (
       this.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES &&

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -987,13 +987,19 @@ from vercel_runtime.vc_init import vc_handler
     .trace(async bundleSpan => {
       // analyze() always computes source-only sizes so threshold
       // decisions are not inflated by bytecode overhead.
-      const depAnalysis = await depExternalizer.analyze(files);
-
-      bundleSpan.setAttributes({
-        'python.bundle.totalSizeBytes': String(depAnalysis.totalBundleSize),
-        'python.bundle.runtimeInstallEnabled': String(
-          depAnalysis.runtimeInstallEnabled
-        ),
+      //
+      // Record the size via the onSized callback (invoked before any
+      // size-limit enforcement that may throw) so the span is tagged even
+      // for oversized bundles that subsequently fail the build.
+      const depAnalysis = await depExternalizer.analyze(files, {
+        onSized: ({ totalSizeBytes, runtimeInstallEnabled }) => {
+          bundleSpan.setAttributes({
+            'python.bundle.totalSizeBytes': String(totalSizeBytes),
+            'python.bundle.runtimeInstallEnabled': String(
+              runtimeInstallEnabled
+            ),
+          });
+        },
       });
 
       if (depAnalysis.runtimeInstallEnabled) {

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -1012,6 +1012,93 @@ version = "8.1.7"
         fs.removeSync(tempDir);
       }
     });
+
+    it('invokes onSized with the size even when the bundle exceeds the Hive limit and throws', async () => {
+      process.env.VERCEL_PYTHON_ON_HIVE = '1';
+
+      const tempDir = path.join(tmpdir(), `dep-ext-onsized-hive-${Date.now()}`);
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      // Sparse file just over the 1 GB Hive limit (no real disk usage).
+      const bigFilePath = path.join(tempDir, 'big-file.dat');
+      const fd = fs.openSync(bigFilePath, 'w');
+      const oversized = HIVE_LAMBDA_SIZE_BYTES + 1024 * 1024;
+      fs.ftruncateSync(fd, oversized);
+      fs.closeSync(fd);
+
+      const ext = new PythonDependencyExternalizer({
+        venvPath: tempDir,
+        vendorDir: '_vendor',
+        workPath: tempDir,
+        uvLockPath: path.join(tempDir, 'uv.lock'),
+        uvProjectDir: tempDir,
+        projectName: 'test-project',
+        pythonMajor: 3,
+        pythonMinor: 12,
+        pythonPath: '/usr/bin/python3',
+        hasCustomCommand: false,
+      });
+
+      const files = {
+        'big-file.dat': new FileFsRef({ fsPath: bigFilePath }),
+      };
+
+      const onSized = vi.fn();
+
+      try {
+        await expect(ext.analyze(files, { onSized })).rejects.toThrow(
+          'exceeds the extended function size limit'
+        );
+        // The callback must have fired before the throw, carrying the size.
+        expect(onSized).toHaveBeenCalledTimes(1);
+        expect(onSized).toHaveBeenCalledWith({
+          totalSizeBytes: oversized,
+          runtimeInstallEnabled: false,
+        });
+      } finally {
+        fs.removeSync(tempDir);
+      }
+    });
+
+    it('invokes onSized on the under-threshold success path', async () => {
+      delete process.env.VERCEL_PYTHON_ON_HIVE;
+
+      const tempDir = path.join(tmpdir(), `dep-ext-onsized-ok-${Date.now()}`);
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      const smallFilePath = path.join(tempDir, 'small-file.dat');
+      fs.writeFileSync(smallFilePath, 'a'.repeat(100));
+
+      const ext = new PythonDependencyExternalizer({
+        venvPath: tempDir,
+        vendorDir: '_vendor',
+        workPath: tempDir,
+        uvLockPath: path.join(tempDir, 'uv.lock'),
+        uvProjectDir: tempDir,
+        projectName: 'test-project',
+        pythonMajor: 3,
+        pythonMinor: 12,
+        pythonPath: '/usr/bin/python3',
+        hasCustomCommand: false,
+      });
+
+      const files = {
+        'small-file.dat': new FileFsRef({ fsPath: smallFilePath }),
+      };
+
+      const onSized = vi.fn();
+
+      try {
+        await ext.analyze(files, { onSized });
+        expect(onSized).toHaveBeenCalledTimes(1);
+        expect(onSized).toHaveBeenCalledWith({
+          totalSizeBytes: 100,
+          runtimeInstallEnabled: false,
+        });
+      } finally {
+        fs.removeSync(tempDir);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
Currently the `totalBundleSize` attribute is only saved for builds that are successful