### PR TITLE
[cli] keep generated services root output in place

### DIFF
--- a/.changeset/quiet-services-root.md
+++ b/.changeset/quiet-services-root.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Keep Build Output API output at the root when generated `experimentalServicesV2` config identifies an already-built entrypoint as a service, and disable immutable static asset env flags for service-specific builds.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -84,7 +84,6 @@ import { scopeRoutesToServiceOwnership } from '../../util/build/service-route-ow
 import { sortBuilders } from '../../util/build/sort-builders';
 import {
   OUTPUT_DIR,
-  relocateRootBuildOutputToService,
   writeBuildResult,
   isLambda,
   type PathOverride,
@@ -172,12 +171,38 @@ interface BuildOutputConfig {
   deploymentId?: string;
 }
 
+const SERVICE_BUILD_IMMUTABLE_ENV_VARS = [
+  'VERCEL_IMMUTABLE_STATIC_FILES_ENABLED',
+] as const;
+
 function hasNonEmptyObject(value: unknown): value is Record<string, unknown> {
   return (
     value != null &&
     typeof value === 'object' &&
     !Array.isArray(value) &&
     Object.keys(value).length > 0
+  );
+}
+
+function unsetServiceBuildImmutableEnvVars(
+  restoreEnv: Map<string, string | undefined>
+) {
+  for (const key of SERVICE_BUILD_IMMUTABLE_ENV_VARS) {
+    if (!restoreEnv.has(key)) {
+      restoreEnv.set(key, process.env[key]);
+    }
+    delete process.env[key];
+  }
+}
+
+function getGeneratedServiceAlreadyBuiltWarning(service: Service) {
+  const framework = service.framework ?? 'unknown';
+  const entrypoint = service.entrypoint ?? service.builder.src ?? 'unknown';
+  return (
+    `Detected already-built service "${service.name}" from lazily generated ` +
+    `\`.vercel/output/config.json\` (framework: ${framework}, entrypoint: ${entrypoint}). ` +
+    'It will not be treated as a service because its build output already exists at the top level. ' +
+    'Configure it in `vercel.json` as an `experimentalServicesV2` entry to remove this warning.'
   );
 }
 
@@ -960,7 +985,6 @@ async function doBuild(
     detectedServices?.some(isQueueBackedService);
   const synthesizedServiceCrons: Cron[] = [];
   const serviceByBuilder = new Map<Builder, Service>();
-  const workPathByBuilder = new Map<Builder, string>();
   const serviceFileOverrides = new Map<Builder, Record<string, PathOverride>>();
   if (getHasDetectedServices()) {
     for (const service of detectedResolvedServices!) {
@@ -1037,7 +1061,6 @@ async function doBuild(
               `entrypoint "${buildEntrypoint}" (original: "${build.src}")`
           );
         }
-        workPathByBuilder.set(build, buildWorkPath);
 
         // Set VERCEL_PROJECT_SETTINGS_* env vars.
         // For services: use service-specific values instead of project-level settings
@@ -1209,6 +1232,9 @@ async function doBuild(
             process.env[key] = value;
             output.debug(`Injected service URL env var: ${key}=${value}`);
           }
+        }
+        if (service) {
+          unsetServiceBuildImmutableEnvVars(restoreEnv);
         }
         let buildResult: BuildResultV2 | BuildResultV3;
         let rawBuildResult: BuildResultV2 | BuildResultV3 | BuildResultVX;
@@ -1659,14 +1685,26 @@ async function doBuild(
       throw generatedConfig;
     }
 
+    const defaultGeneratedOutputDir = join(workPath, OUTPUT_DIR);
+    const generatedConfigs = [generatedConfig];
+    if (resolve(outputDir) !== resolve(defaultGeneratedOutputDir)) {
+      const defaultGeneratedConfig = await readJSONFile<BuildOutputConfig>(
+        join(defaultGeneratedOutputDir, 'config.json')
+      );
+      if (defaultGeneratedConfig instanceof CantParseJSONFile) {
+        throw defaultGeneratedConfig;
+      }
+      generatedConfigs.push(defaultGeneratedConfig);
+    }
+
     const generatedExperimentalServicesV2Config =
       getGeneratedExperimentalServicesV2Config([
-        generatedConfig,
+        ...generatedConfigs,
         ...buildResults.values(),
       ]);
     const generatedExperimentalServicesV1Config =
       getGeneratedExperimentalServicesV1Config([
-        generatedConfig,
+        ...generatedConfigs,
         ...buildResults.values(),
       ]);
 
@@ -1682,9 +1720,12 @@ async function doBuild(
       detectedExperimentalServicesV2Config =
         generatedExperimentalServicesV2Config;
       detectedExperimentalServicesV2RootRoutes =
-        generatedExperimentalServicesV2Config &&
-        Array.isArray(generatedConfig?.routes)
-          ? generatedConfig.routes
+        generatedExperimentalServicesV2Config
+          ? generatedConfigs.find(
+              config =>
+                hasNonEmptyObject(config?.experimentalServicesV2) &&
+                Array.isArray(config?.routes)
+            )?.routes
           : undefined;
       const generatedBuilders = await span
         .child('vc.detectGeneratedServices')
@@ -1745,23 +1786,13 @@ async function doBuild(
 
       const buildsToRun: Builder[] = [];
       const seenBuildsToRun = new Set<string>();
-      const relocatedGeneratedServiceBuilds = new Set<Builder>();
       for (const service of detectedResolvedServices || []) {
-        serviceByBuilder.set(service.builder, service);
         const alreadyExecutedBuild = getAlreadyExecutedBuild(service.builder);
         if (alreadyExecutedBuild) {
-          serviceByBuilder.set(alreadyExecutedBuild, service);
-          if (
-            generatedExperimentalServicesV2Config &&
-            nestExperimentalServicesV2Output &&
-            !relocatedGeneratedServiceBuilds.has(alreadyExecutedBuild)
-          ) {
-            await relocateRootBuildOutputToService({
-              outputDir,
-              service,
-              workPath: workPathByBuilder.get(alreadyExecutedBuild) ?? workPath,
-            });
-            relocatedGeneratedServiceBuilds.add(alreadyExecutedBuild);
+          if (generatedExperimentalServicesV2Config) {
+            output.warn(getGeneratedServiceAlreadyBuiltWarning(service));
+          } else {
+            serviceByBuilder.set(alreadyExecutedBuild, service);
           }
           continue;
         }
@@ -1770,6 +1801,7 @@ async function doBuild(
           serviceBuilderIdentity &&
           !seenBuildsToRun.has(serviceBuilderIdentity)
         ) {
+          serviceByBuilder.set(service.builder, service);
           seenBuildsToRun.add(serviceBuilderIdentity);
           buildsToRun.push(service.builder);
         }
@@ -2009,8 +2041,7 @@ async function doBuild(
       : undefined;
   const explicitRootRoutes = appendBuildOutputRouteTables(
     routesResult.routes,
-    detectedExperimentalServicesV2RootRoutes,
-    existingConfig?.routes
+    detectedExperimentalServicesV2RootRoutes ?? existingConfig?.routes
   );
 
   // Write out the final `config.json` file based on the

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -2813,7 +2813,7 @@ createServer((_req, res) => {
     ).toBe(true);
   });
 
-  it('should build experimentalServicesV2 discovered from generated Build Output config into service directories', async () => {
+  it('should keep already-built generated experimentalServicesV2 output at root and nest new services', async () => {
     const cwd = await getWriteableDirectory();
     const output = join(cwd, '.vercel', 'output');
     await fs.ensureDir(join(cwd, '.vercel'));
@@ -2844,6 +2844,20 @@ const countPath = join(process.cwd(), 'build-count.txt');
 const count = existsSync(countPath) ? Number(readFileSync(countPath, 'utf8')) : 0;
 writeFileSync(countPath, String(count + 1));
 
+const immutableEnvVars = [
+  'VERCEL_IMMUTABLE_STATIC_FILES_ENABLED'
+];
+writeFileSync(
+  join(process.cwd(), 'root-immutable-env.json'),
+  JSON.stringify(
+    Object.fromEntries(
+      immutableEnvVars.map(name => [name, process.env[name] ?? null])
+    ),
+    null,
+    2
+  )
+);
+
 const outputDir = join(process.cwd(), '.vercel', 'output');
 mkdirSync(outputDir, { recursive: true });
 const staticDir = join(outputDir, 'static');
@@ -2853,64 +2867,242 @@ writeFileSync(
   join(outputDir, 'config.json'),
   JSON.stringify({
     version: 3,
-    routes: [{ src: '/ui/(.*)', service: 'ui' }],
+    routes: [
+      { src: '/backend/(.*)', service: 'backend' },
+      { src: '/ui/(.*)', service: 'ui' }
+    ],
     experimentalServicesV2: {
       ui: {
         root: '.',
         entrypoint: 'package.json',
         framework: 'vite',
         rewrites: [{ source: '/(.*)', destination: '/$1' }]
+      },
+      backend: {
+        root: 'backend',
+        entrypoint: 'package.json',
+        framework: 'vite',
+        rewrites: [{ source: '/backend/(.*)', destination: '/$1' }]
       }
     }
   }, null, 2)
 );
 `
     );
+    await fs.outputJSON(join(cwd, 'backend', 'package.json'), {
+      private: true,
+      scripts: {
+        build: 'node build.mjs',
+      },
+    });
+    await fs.outputFile(
+      join(cwd, 'backend', 'build.mjs'),
+      `
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const immutableEnvVars = [
+  'VERCEL_IMMUTABLE_STATIC_FILES_ENABLED'
+];
+const immutableEnvValues = Object.fromEntries(
+  immutableEnvVars.map(name => [name, process.env[name] ?? null])
+);
+writeFileSync(
+  join(process.cwd(), 'service-immutable-env.json'),
+  JSON.stringify(immutableEnvValues, null, 2)
+);
+const leakedImmutableEnvVars = Object.entries(immutableEnvValues)
+  .filter(([, value]) => value !== null)
+  .map(([name]) => name);
+if (leakedImmutableEnvVars.length > 0) {
+  throw new Error(
+    'Immutable env leaked into service build: ' + leakedImmutableEnvVars.join(', ')
+  );
+}
+
+const outputDir = join(process.cwd(), '.vercel', 'output');
+const staticDir = join(outputDir, 'static');
+mkdirSync(staticDir, { recursive: true });
+writeFileSync(join(staticDir, 'backend.html'), 'backend output');
+writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ version: 3 }, null, 2));
+`
+    );
+
+    const immutableEnvVars = ['VERCEL_IMMUTABLE_STATIC_FILES_ENABLED'];
+    const originalImmutableEnv = new Map(
+      immutableEnvVars.map(name => [name, process.env[name]])
+    );
+
+    try {
+      for (const name of immutableEnvVars) {
+        process.env[name] = '1';
+      }
+
+      client.cwd = cwd;
+      const exitCode = await build(client);
+      expect(exitCode).toBe(0);
+      await expect(client.stderr).toOutput(
+        'Detected already-built service "ui" from lazily generated `.vercel/output/config.json` (framework: vite, entrypoint: package.json). It will not be treated as a service because its build output already exists at the top level. Configure it in `vercel.json` as an `experimentalServicesV2` entry to remove this warning.'
+      );
+
+      const config = await fs.readJSON(join(output, 'config.json'));
+      expect(config.services).toBeUndefined();
+      expect(config.experimentalServices).toBeUndefined();
+      expect(config.experimentalServicesV2).toEqual({
+        backend: expect.objectContaining({
+          root: 'backend',
+          framework: 'vite',
+          rewrites: [{ source: '/backend/(.*)', destination: '/$1' }],
+        }),
+        ui: expect.objectContaining({
+          root: '.',
+          framework: 'vite',
+          rewrites: [{ source: '/(.*)', destination: '/$1' }],
+        }),
+      });
+      expect(config.routes).toEqual(
+        expect.arrayContaining([
+          { handle: 'filesystem' },
+          { src: '/backend/(.*)', service: 'backend' },
+          { src: '/ui/(.*)', service: 'ui' },
+          expect.objectContaining({ dest: '/$1', check: true }),
+        ])
+      );
+      expect(
+        config.routes.filter(
+          (route: { handle?: string }) => route.handle === 'filesystem'
+        )
+      ).toHaveLength(1);
+      expect(await fs.readFile(join(cwd, 'build-count.txt'), 'utf8')).toBe('1');
+      expect(await fs.readJSON(join(cwd, 'root-immutable-env.json'))).toEqual(
+        Object.fromEntries(immutableEnvVars.map(name => [name, '1']))
+      );
+      expect(
+        await fs.readJSON(join(cwd, 'backend', 'service-immutable-env.json'))
+      ).toEqual(Object.fromEntries(immutableEnvVars.map(name => [name, null])));
+      expect(await fs.readFile(join(output, 'static/index.html'), 'utf8')).toBe(
+        'root output'
+      );
+      expect(await fs.pathExists(join(output, 'services/ui'))).toBe(false);
+
+      const backendConfig = await fs.readJSON(
+        join(output, 'services/backend/config.json')
+      );
+      expect(backendConfig.routes).toEqual(
+        expect.arrayContaining([
+          { handle: 'filesystem' },
+          expect.objectContaining({ dest: '/$1', check: true }),
+        ])
+      );
+      expect(
+        backendConfig.routes.filter(
+          (route: { handle?: string }) => route.handle === 'filesystem'
+        )
+      ).toHaveLength(1);
+      expect(
+        await fs.readFile(
+          join(output, 'services/backend/static/backend.html'),
+          'utf8'
+        )
+      ).toBe('backend output');
+      expect(await fs.pathExists(join(output, 'functions'))).toBe(false);
+    } finally {
+      for (const [name, value] of originalImmutableEnv) {
+        if (value === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = value;
+        }
+      }
+    }
+  });
+
+  it('should detect generated experimentalServicesV2 from default output when using --output', async () => {
+    const cwd = await getWriteableDirectory();
+    const output = join(cwd, 'custom-output');
+    await fs.ensureDir(join(cwd, '.vercel'));
+    await fs.writeJSON(join(cwd, '.vercel', 'project.json'), {
+      orgId: '.',
+      projectId: '.',
+      settings: {
+        framework: null,
+        installCommand: '',
+      },
+    });
+    await fs.writeJSON(join(cwd, 'package.json'), {
+      private: true,
+      scripts: {
+        build: 'node build.mjs',
+      },
+    });
+    await fs.outputFile(
+      join(cwd, 'build.mjs'),
+      `
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const outputDir = join(process.cwd(), '.vercel', 'output');
+mkdirSync(join(outputDir, 'static'), { recursive: true });
+writeFileSync(join(outputDir, 'static', 'index.html'), 'root output');
+writeFileSync(
+  join(outputDir, 'config.json'),
+  JSON.stringify({
+    version: 3,
+    routes: [{ src: '^/api/(.*)$', service: 'backend' }],
+    experimentalServicesV2: {
+      backend: {
+        root: 'backend',
+        entrypoint: 'package.json',
+        framework: 'vite'
+      }
+    }
+  }, null, 2)
+);
+`
+    );
+    await fs.outputJSON(join(cwd, 'backend', 'package.json'), {
+      private: true,
+      scripts: {
+        build: 'node build.mjs',
+      },
+    });
+    await fs.outputFile(
+      join(cwd, 'backend', 'build.mjs'),
+      `
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const outputDir = join(process.cwd(), '.vercel', 'output');
+mkdirSync(join(outputDir, 'static'), { recursive: true });
+writeFileSync(join(outputDir, 'static', 'backend.html'), 'backend output');
+writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ version: 3 }, null, 2));
+`
+    );
 
     client.cwd = cwd;
+    client.setArgv('build', '--output', output);
     const exitCode = await build(client);
     expect(exitCode).toBe(0);
 
     const config = await fs.readJSON(join(output, 'config.json'));
-    expect(config.services).toBeUndefined();
-    expect(config.experimentalServices).toBeUndefined();
     expect(config.experimentalServicesV2).toEqual({
-      ui: expect.objectContaining({
-        root: '.',
+      backend: expect.objectContaining({
+        root: 'backend',
         framework: 'vite',
-        rewrites: [{ source: '/(.*)', destination: '/$1' }],
       }),
     });
     expect(config.routes).toEqual(
-      expect.arrayContaining([
-        { handle: 'filesystem' },
-        { src: '/ui/(.*)', service: 'ui' },
-        expect.objectContaining({ dest: '/$1', check: true }),
-      ])
+      expect.arrayContaining([{ src: '^/api/(.*)$', service: 'backend' }])
+    );
+    expect(await fs.readFile(join(output, 'static/index.html'), 'utf8')).toBe(
+      'root output'
     );
     expect(
-      config.routes.filter(
-        (route: { handle?: string }) => route.handle === 'filesystem'
+      await fs.readFile(
+        join(output, 'services/backend/static/backend.html'),
+        'utf8'
       )
-    ).toHaveLength(1);
-    expect(await fs.readFile(join(cwd, 'build-count.txt'), 'utf8')).toBe('1');
-    const uiConfig = await fs.readJSON(join(output, 'services/ui/config.json'));
-    expect(uiConfig.routes).toEqual(
-      expect.arrayContaining([
-        { handle: 'filesystem' },
-        expect.objectContaining({ dest: '/$1', check: true }),
-      ])
-    );
-    expect(
-      uiConfig.routes.filter(
-        (route: { handle?: string }) => route.handle === 'filesystem'
-      )
-    ).toHaveLength(1);
-    expect(
-      await fs.readFile(join(output, 'services/ui/static/index.html'), 'utf8')
-    ).toBe('root output');
-    expect(await fs.pathExists(join(output, 'static'))).toBe(false);
-    expect(await fs.pathExists(join(output, 'functions'))).toBe(false);
+    ).toBe('backend output');
   });
 
   it('should ignore generated experimentalServices when vercel.json configures experimentalServices', async () => {


### PR DESCRIPTION
## Summary
- keep already-built generated experimentalServicesV2 root output at .vercel/output
- nest newly built service outputs under .vercel/output/services/{serviceName}
- unset immutable static asset env flags for service-specific builds

x-ref: [slack thread](https://vercel.slack.com/archives/C0AAMF0G970/p1781802148139749?thread_ts=1781792350.206899&cid=C0AAMF0G970)

## Tests
- pnpm --filter vercel test test/unit/commands/build/index.test.ts -t experimentalServicesV2
- pnpm --filter vercel type-check