### PR TITLE
[vercel-workers] honor Dramatiq native retry options

### DIFF
--- a/.changeset/dramatiq-retry-options.md
+++ b/.changeset/dramatiq-retry-options.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-workers': patch
+---
+
+[vercel-workers] Honor per-actor Dramatiq retry options.

--- a/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/.gitignore
+++ b/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/.gitignore
@@ -1,0 +1,47 @@
+# Vercel
+.vercel
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+env/
+ENV/
+.venv
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# Environment variables
+.env
+.env.local

--- a/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/app.py
+++ b/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/app.py
@@ -1,0 +1,76 @@
+import time
+from logging import getLogger
+from uuid import uuid4
+
+from flask import Flask, jsonify, render_template_string, request
+from vercel.cache import get_cache
+
+from worker.broker import broker
+from worker.tasks import flaky_job
+
+logger = getLogger(__name__)
+
+app = Flask(__name__)
+
+INDEX_HTML = """
+<!doctype html>
+<html>
+  <body>
+    <h1>Hello from Flask web service</h1>
+  </body>
+</html>
+"""
+
+
+@app.get("/")
+def root():
+    return render_template_string(INDEX_HTML)
+
+
+@app.post("/enqueue")
+def enqueue():
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        payload = {}
+
+    incoming_request_id = payload.get("request_id")
+    payload["request_id"] = str(incoming_request_id) if incoming_request_id else str(uuid4())
+
+    try:
+        message = flaky_job.send(payload)
+    except Exception as exc:
+        logger.error(f"Failed to enqueue job: {exc}")
+        return jsonify({"ok": False, "error": str(exc)}), 500
+
+    return jsonify(
+        {
+            "ok": True,
+            "jobId": message.message_id,
+            "requestId": payload["request_id"],
+            "queueName": message.queue_name,
+            "actorName": message.actor_name,
+            "broker": broker.__class__.__name__,
+        }
+    )
+
+
+@app.get("/status/<topic>/<request_id>")
+def status(topic: str, request_id: str):
+    cache = get_cache(namespace=topic)
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        result = cache.get(request_id)
+        if result is not None:
+            return jsonify({"ok": True, "processed": True, "result": result})
+        time.sleep(0.5)
+    return jsonify({"ok": False, "processed": False, "error": "timeout"}), 504
+
+
+@app.get("/health")
+def health():
+    return jsonify({"status": "ok"})
+
+
+@app.errorhandler(404)
+def not_found_handler(error):
+    return jsonify({"detail": "404 from Flask web service"}), 404

--- a/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/probes.json
+++ b/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/probes.json
@@ -1,0 +1,33 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "Hello from Flask web service"
+    },
+    {
+      "path": "/health",
+      "status": 200,
+      "mustContain": "ok"
+    },
+    {
+      "path": "/enqueue",
+      "method": "POST",
+      "body": { "request_id": "probe-19-retries" },
+      "status": 200,
+      "mustContain": "probe-19-retries"
+    },
+    {
+      "path": "/status/jobs/probe-19-retries",
+      "status": 200,
+      "mustContain": "probe-19-retries",
+      "retries": 10,
+      "retryDelay": 2000
+    },
+    {
+      "path": "/does-not-exist",
+      "status": 404,
+      "mustContain": "404 from Flask web service"
+    }
+  ]
+}

--- a/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/pyproject.toml
+++ b/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "services-worker-dramatiq-retries"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+  "flask",
+  "dramatiq",
+  "vercel",
+  "vercel-workers"
+]

--- a/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/vercel.json
+++ b/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/vercel.json
@@ -1,0 +1,18 @@
+{
+  "uploadNowJson": true,
+  "projectSettings": {
+    "framework": "services"
+  },
+  "experimentalServices": {
+    "web": {
+      "framework": "flask",
+      "entrypoint": "app.py",
+      "routePrefix": "/"
+    },
+    "worker": {
+      "type": "worker",
+      "entrypoint": "worker/run.py",
+      "topics": ["jobs"]
+    }
+  }
+}

--- a/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/worker/broker.py
+++ b/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/worker/broker.py
@@ -1,0 +1,7 @@
+import dramatiq
+from vercel.workers.dramatiq import VercelQueuesBroker
+
+
+# Explicitly configure Dramatiq to publish via Vercel Queues.
+broker = VercelQueuesBroker()
+dramatiq.set_broker(broker)

--- a/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/worker/run.py
+++ b/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/worker/run.py
@@ -1,0 +1,5 @@
+from worker.broker import broker
+from worker import tasks
+
+
+__all__ = ['broker', 'tasks']

--- a/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/worker/tasks.py
+++ b/packages/fs-detectors/test/fixtures/e2e/19-services-worker-dramatiq-retries/worker/tasks.py
@@ -1,0 +1,29 @@
+import dramatiq
+from vercel.cache import get_cache
+
+FAIL_UNTIL_ATTEMPT = 7
+
+
+@dramatiq.actor(queue_name='jobs', max_retries=10, min_backoff=500, max_backoff=2000)
+def flaky_job(payload: dict):
+    request_id = str(payload['request_id'])
+    cache = get_cache(namespace='jobs')
+
+    attempts_key = f'{request_id}:attempts'
+    attempts = int(cache.get(attempts_key) or 0) + 1
+    cache.set(attempts_key, attempts, options={'ttl': 300})
+
+    if attempts < FAIL_UNTIL_ATTEMPT:
+        raise RuntimeError(f'transient failure on attempt {attempts}')
+
+    cache.set(
+        request_id,
+        {
+            'ok': True,
+            'attempts': attempts,
+            'summary': f'processed after {attempts} attempts',
+            'payload': payload,
+        },
+        options={'ttl': 300},
+    )
+    return {'ok': True, 'attempts': attempts}

--- a/python/vercel-workers/src/vercel/workers/dramatiq/app.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import math
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from typing import Any
@@ -46,18 +45,12 @@ class DramatiqWorkerConfig:
     """
     Runtime config used by the callback route.
 
-    This controls how we receive/lock and retry messages.
+    This controls how we receive/lock messages.
     """
 
     visibility_timeout_seconds: int = 30
     visibility_refresh_interval_seconds: float = 10.0
     timeout: float | None = 10.0
-
-    # Retry policy for task exceptions.
-    max_retries: int = 3
-    retry_backoff_base_ms: int = 5000
-    retry_backoff_factor: float = 2.0
-    max_retry_delay_ms: int = 60 * 60 * 1000  # 1 hour
 
     @classmethod
     def from_broker_options(cls, broker: VercelQueuesBroker) -> DramatiqWorkerConfig:
@@ -116,24 +109,6 @@ def get_asgi_app(broker: VercelQueuesBroker) -> ASGI:
         on_startup=_on_startup,
         on_shutdown=_on_shutdown,
     )
-
-
-def _retry_delay_ms(cfg: DramatiqWorkerConfig, attempt: int) -> int:
-    """
-    Compute retry delay with exponential backoff.
-
-    attempt is 1-based.
-    """
-    delay: float
-    base = float(cfg.retry_backoff_base_ms)
-    factor = float(cfg.retry_backoff_factor)
-    if attempt <= 1:
-        delay = base
-    else:
-        delay = base * math.pow(factor, attempt - 1)
-    if not math.isfinite(delay):
-        delay = float(cfg.max_retry_delay_ms)
-    return int(max(0, min(float(cfg.max_retry_delay_ms), delay)))
 
 
 def handle_queue_callback(
@@ -198,145 +173,49 @@ def handle_queue_callback(
         # Parse the envelope and convert to Dramatiq message
         dramatiq_message = _envelope_to_message(payload)
 
-        try:
-            # Execute the task
-            outcome = _execute_message(broker, dramatiq_message)
-            timeout_seconds = outcome.get("timeoutSeconds")
+        # Dramatiq's Retries middleware (default for brokers) re-enqueues retries as
+        # separate delayed messages and marks the current one failed via message.fail(),
+        # so in the normal case the original message is acked and then deleted here
+        # and Vercel Queues does not redeliver it.
+        # If there's no Retries middleware, then it will raise exception and re-deliver
+        # because of 500
+        outcome = _execute_message(broker, dramatiq_message)
+        status = outcome["status"]
 
-            if timeout_seconds is not None:
-                if receipt_handle:
-                    _finalize_visibility(
-                        extender,
-                        lambda: queue_callback.change_visibility(
-                            queue_name,
-                            consumer_group,
-                            message_id,
-                            receipt_handle,
-                            int(timeout_seconds),
-                            timeout=cfg.timeout,
-                        ),
-                    )
-                body = json.dumps(
-                    {
-                        "ok": True,
-                        "delayed": True,
-                        "timeoutSeconds": int(timeout_seconds),
-                        "queue": queue_name,
-                        "consumer": consumer_group,
-                        "messageId": message_id,
-                        "deliveryCount": delivery_count,
-                        "createdAt": created_at,
-                    }
-                ).encode("utf-8")
-                return (
-                    200,
-                    [("Content-Type", "application/json"), ("Content-Length", str(len(body)))],
-                    body,
-                )
-
-            # Success: ack (delete) the message
-            if receipt_handle:
-                _finalize_visibility(
-                    extender,
-                    lambda: queue_callback.delete_message(
-                        queue_name,
-                        consumer_group,
-                        message_id,
-                        receipt_handle,
-                        timeout=cfg.timeout,
-                    ),
-                )
-
-            body = json.dumps(
-                {
-                    "ok": True,
-                    "queue": queue_name,
-                    "consumer": consumer_group,
-                    "messageId": message_id,
-                    "deliveryCount": delivery_count,
-                    "createdAt": created_at,
-                }
-            ).encode("utf-8")
-            return (
-                200,
-                [("Content-Type", "application/json"), ("Content-Length", str(len(body)))],
-                body,
+        if receipt_handle:
+            _finalize_visibility(
+                extender,
+                lambda: queue_callback.delete_message(
+                    queue_name,
+                    consumer_group,
+                    message_id,
+                    receipt_handle,
+                    timeout=cfg.timeout,
+                ),
             )
 
-        except KeyboardInterrupt:
-            raise
-        except Exception as exc:
-            # Handle task execution error with retry logic
-            attempt = delivery_count
+        body_payload: dict[str, Any] = {
+            "ok": status != "failed",
+            "status": status,
+            "queue": queue_name,
+            "consumer": consumer_group,
+            "messageId": message_id,
+            "deliveryCount": delivery_count,
+            "createdAt": created_at,
+        }
+        if status == "retried":
+            body_payload["retries"] = outcome.get("retries")
+        elif status == "failed":
+            exc = outcome.get("exception")
+            body_payload["error"] = str(exc)
+            body_payload["errorType"] = type(exc).__name__
 
-            if attempt < int(cfg.max_retries):
-                delay_ms = _retry_delay_ms(cfg, attempt)
-                delay_seconds = int(delay_ms / 1000)
-
-                if receipt_handle:
-                    _finalize_visibility(
-                        extender,
-                        lambda: queue_callback.change_visibility(
-                            queue_name,
-                            consumer_group,
-                            message_id,
-                            receipt_handle,
-                            int(delay_seconds),
-                            timeout=cfg.timeout,
-                        ),
-                    )
-
-                body = json.dumps(
-                    {
-                        "ok": True,
-                        "delayed": True,
-                        "timeoutSeconds": delay_seconds,
-                        "queue": queue_name,
-                        "consumer": consumer_group,
-                        "messageId": message_id,
-                        "deliveryCount": delivery_count,
-                        "createdAt": created_at,
-                        "error": str(exc),
-                        "errorType": type(exc).__name__,
-                    }
-                ).encode("utf-8")
-                return (
-                    200,
-                    [("Content-Type", "application/json"), ("Content-Length", str(len(body)))],
-                    body,
-                )
-
-            # Terminal failure: ack (delete) to prevent infinite retries
-            if receipt_handle:
-                _finalize_visibility(
-                    extender,
-                    lambda: queue_callback.delete_message(
-                        queue_name,
-                        consumer_group,
-                        message_id,
-                        receipt_handle,
-                        timeout=cfg.timeout,
-                    ),
-                )
-
-            body = json.dumps(
-                {
-                    "ok": False,
-                    "failed": True,
-                    "queue": queue_name,
-                    "consumer": consumer_group,
-                    "messageId": message_id,
-                    "deliveryCount": delivery_count,
-                    "createdAt": created_at,
-                    "error": str(exc),
-                    "errorType": type(exc).__name__,
-                }
-            ).encode("utf-8")
-            return (
-                200,
-                [("Content-Type", "application/json"), ("Content-Length", str(len(body)))],
-                body,
-            )
+        body = json.dumps(body_payload).encode("utf-8")
+        return (
+            200,
+            [("Content-Type", "application/json"), ("Content-Length", str(len(body)))],
+            body,
+        )
 
     except ValueError as exc:
         err = json.dumps(

--- a/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/broker.py
@@ -333,10 +333,12 @@ class VercelQueuesBroker(Broker):
 
         envelope = _message_to_envelope(message, queue_name, encoder=self.encoder)
 
-        # Use message_id for idempotency by default
-        idempotency_key = (
-            message.message_id if self._cfg.use_message_id_as_idempotency_key else None
-        )
+        # Use message_id for idempotency by default, but for retries reuse the
+        # same message_id + retries, so the message would be considered new
+        idempotency_key = None
+        if self._cfg.use_message_id_as_idempotency_key:
+            retries = message.options.get("retries", 0)
+            idempotency_key = f"{message.message_id}:{retries}"
 
         # Compute send-time delay from the delay parameter (milliseconds).
         delay_duration = int(delay / 1000) if delay and delay > 0 else None

--- a/python/vercel-workers/src/vercel/workers/dramatiq/worker.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/worker.py
@@ -118,32 +118,22 @@ class PollingWorker:
             # Parse the envelope and convert to Dramatiq message
             dramatiq_message = _envelope_to_message(payload)
 
-            # Execute the task
+            # Execute the task. Retries are re-enqueued as
+            # separate messages by Dramatiq
             outcome = self._execute_message(dramatiq_message)
-            timeout_seconds = outcome.get("timeoutSeconds")
 
-            if timeout_seconds is not None:
-                queue_callback.change_visibility(
-                    self.queue_name,
-                    self.consumer_group,
-                    message_id,
-                    receipt_handle,
-                    int(timeout_seconds),
-                    timeout=self.timeout,
-                )
-            else:
-                queue_callback.delete_message(
-                    self.queue_name,
-                    self.consumer_group,
-                    message_id,
-                    receipt_handle,
-                    timeout=self.timeout,
-                )
+            queue_callback.delete_message(
+                self.queue_name,
+                self.consumer_group,
+                message_id,
+                receipt_handle,
+                timeout=self.timeout,
+            )
 
             if self.debug:
                 print(
-                    f"[dramatiq polling] completed task {dramatiq_message.actor_name} "
-                    f"(message {message_id})"
+                    f"[dramatiq polling] {outcome['status']} task "
+                    f"{dramatiq_message.actor_name} (message {message_id})"
                 )
 
         except Exception:
@@ -219,9 +209,14 @@ def _execute_message(broker: VercelQueuesBroker, message: Message) -> dict[str, 
     """
     Execute a Dramatiq message.
 
-    Returns:
-        {"ack": True} on success
-        {"timeoutSeconds": N} for retry
+    Depending on broker configuration it could schedule a retry
+    of a message if Retries middleware is configured.
+
+    Returns one of:
+        {"status": "success"} on success
+        {"status": "skipped"} when the message was explicitly skipped
+        {"status": "retried", "retries": n} when Dramatiq scheduled a retry
+        {"status": "failed", "exception": e} when Dramatiq decided that it's a final error
     """
     actor = broker.get_actor(message.actor_name)
     if actor is None:
@@ -235,18 +230,18 @@ def _execute_message(broker: VercelQueuesBroker, message: Message) -> dict[str, 
         if not proxy.failed:
             res = actor(*message.args, **message.kwargs)
         broker.emit_after("process_message", proxy, result=res)
-        return {"ack": True}
+        return {"status": "success"}
     except dramatiq.middleware.SkipMessage as exc:
         if proxy.failed:
             proxy.stuff_exception(exc)
         broker.emit_after("skip_message", proxy)
-        return {"ack": True}
+        return {"status": "skipped"}
     except Exception as exc:
         proxy.stuff_exception(exc)
+        retries_before = message.options.get("retries", 0)
         broker.emit_after("process_message", proxy, exception=exc)
-        if isinstance(exc, dramatiq.Retry):
-            delay = getattr(exc, "delay", None)
-            if delay is not None:
-                return {"timeoutSeconds": int(delay / 1000)}
-            return {"timeoutSeconds": 60}
+        if proxy.failed:
+            return {"status": "failed", "exception": exc}
+        if message.options.get("retries", 0) > retries_before:
+            return {"status": "retried", "retries": message.options["retries"]}
         raise

--- a/python/vercel-workers/tests/test_dramatiq_adapter.py
+++ b/python/vercel-workers/tests/test_dramatiq_adapter.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import Callable
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -22,6 +25,7 @@ from vercel.workers.dramatiq import (
     VercelDramatiqEncoder,
     VercelQueuesBroker,
     VercelQueuesBrokerOptions,
+    handle_queue_callback,
 )
 from vercel.workers.dramatiq.broker import (
     _envelope_to_message,
@@ -228,10 +232,6 @@ class TestDramatiqWorkerConfig:
         assert cfg.visibility_timeout_seconds == 30
         assert cfg.visibility_refresh_interval_seconds == 10.0
         assert cfg.timeout == 10.0
-        assert cfg.max_retries == 3
-        assert cfg.retry_backoff_base_ms == 5000
-        assert cfg.retry_backoff_factor == 2.0
-        assert cfg.max_retry_delay_ms == 60 * 60 * 1000
 
     def test_from_broker_options(self):
         broker = VercelQueuesBroker(
@@ -335,7 +335,7 @@ class TestMiddlewarePipeline:
         )
 
         result = _execute_message(broker, message)
-        assert result == {"ack": True}
+        assert result == {"status": "success"}
 
         mw.before_process_message.assert_called_once()
         mw.after_process_message.assert_called_once()
@@ -392,36 +392,35 @@ class TestMiddlewarePipeline:
 
         result = _execute_message(broker, message)
 
-        assert result == {"ack": True}
+        assert result == {"status": "skipped"}
         mw.before_process_message.assert_called_once()
         mw.after_skip_message.assert_called_once()
         mw.after_process_message.assert_not_called()
 
-    def test_middleware_called_on_retry(self):
-        mw = MagicMock(spec=dramatiq.Middleware)
-        mw.actor_options = set()
-        mw.ephemeral_options = set()
-        broker = VercelQueuesBroker(middleware=[mw])
+    @patch("vercel.workers.dramatiq.broker.send")
+    def test_explicit_retry_reenqueues_with_delay(self, mock_send: MagicMock):
+        mock_send.return_value = {"messageId": "msg-retry"}
+        broker = VercelQueuesBroker(middleware=[dramatiq.middleware.Retries()])
 
         @dramatiq.actor(broker=broker, queue_name="test-mw")
         def retrying_actor():
             raise dramatiq.Retry(delay=5000)
 
-        message = Message(
-            queue_name="test-mw",
-            actor_name="retrying_actor",
-            args=(),
-            kwargs={},
-            options={},
+        result = _execute_message(
+            broker,
+            Message(
+                queue_name="test-mw",
+                actor_name="retrying_actor",
+                args=(),
+                kwargs={},
+                options={},
+            ),
         )
 
-        result = _execute_message(broker, message)
-
-        assert result == {"timeoutSeconds": 5}
-        mw.before_process_message.assert_called_once()
-        mw.after_process_message.assert_called_once()
-        call_kwargs = mw.after_process_message.call_args
-        assert isinstance(call_kwargs.kwargs["exception"], dramatiq.Retry)
+        assert result["status"] == "retried"
+        assert result["retries"] == 1
+        mock_send.assert_called_once()
+        assert mock_send.call_args.kwargs["delay"] == 5
 
 
 class TestEncoderIntegration:
@@ -568,7 +567,7 @@ class TestAsyncActors:
         )
 
         result = _execute_message(async_broker, message)
-        assert result == {"ack": True}
+        assert result == {"status": "success"}
 
     def test_async_actor_exception_propagates(self, async_broker):
         @dramatiq.actor(broker=async_broker, queue_name="test-async")
@@ -585,3 +584,175 @@ class TestAsyncActors:
 
         with pytest.raises(RuntimeError, match="test"):
             _execute_message(async_broker, message)
+
+
+def _make_message(
+    actor_name: str,
+    *,
+    options: dict[str, Any] | None = None,
+    message_id: str = "abc",
+) -> Message:
+    return Message(
+        queue_name="q",
+        actor_name=actor_name,
+        args=(),
+        kwargs={},
+        options=options or {},
+        message_id=message_id,
+    )
+
+
+class TestRetryOptions:
+    @patch("vercel.workers.dramatiq.broker.send")
+    def test_max_retries_honored_then_terminal(self, mock_send: MagicMock):
+        mock_send.return_value = {"messageId": "m"}
+        broker = VercelQueuesBroker()  # default middleware includes Retries
+
+        @dramatiq.actor(broker=broker, queue_name="q", max_retries=2)
+        def always_fails():
+            raise RuntimeError("boom")
+
+        def deliver(retries: int) -> dict[str, Any]:
+            options = {"retries": retries} if retries else None
+            return _execute_message(broker, _make_message("always_fails", options=options))
+
+        assert deliver(0) == {"status": "retried", "retries": 1}
+        assert deliver(1) == {"status": "retried", "retries": 2}
+        assert deliver(2)["status"] == "failed"
+        assert mock_send.call_count == 2
+
+    @patch("vercel.workers.dramatiq.broker.send")
+    def test_throws_is_not_retried(self, mock_send: MagicMock):
+        broker = VercelQueuesBroker()
+
+        @dramatiq.actor(broker=broker, queue_name="q", throws=(ValueError,))
+        def raises_value_error():
+            raise ValueError("nope")
+
+        result = _execute_message(broker, _make_message("raises_value_error"))
+        assert result["status"] == "failed"
+        mock_send.assert_not_called()
+
+    @patch("vercel.workers.dramatiq.broker.send")
+    def test_retry_when_controls_retry(self, mock_send: MagicMock):
+        mock_send.return_value = {"messageId": "m"}
+        broker = VercelQueuesBroker()
+
+        def retry_when(retries: int, exception: Exception) -> bool:
+            return retries < 1
+
+        @dramatiq.actor(broker=broker, queue_name="q", retry_when=retry_when)
+        def maybe_retry():
+            raise RuntimeError("x")
+
+        def deliver(retries: int) -> dict[str, Any]:
+            options = {"retries": retries} if retries else None
+            return _execute_message(broker, _make_message("maybe_retry", options=options))
+
+        assert deliver(0)["status"] == "retried"
+        assert deliver(1)["status"] == "failed"
+
+    @patch("vercel.workers.dramatiq.broker.send")
+    def test_backoff_respects_actor_bounds(self, mock_send: MagicMock):
+        mock_send.return_value = {"messageId": "m"}
+        broker = VercelQueuesBroker()
+
+        @dramatiq.actor(broker=broker, queue_name="q", min_backoff=1000, max_backoff=2000)
+        def fails():
+            raise RuntimeError("x")
+
+        _execute_message(broker, _make_message("fails"))
+        mock_send.assert_called_once()
+        delay_seconds = mock_send.call_args.kwargs["delay"]
+        assert delay_seconds is not None
+        assert 0 <= delay_seconds <= 2
+
+    @patch("vercel.workers.dramatiq.broker.send")
+    def test_idempotency_key_includes_retries(self, mock_send: MagicMock):
+        mock_send.return_value = {"messageId": "m"}
+        broker = VercelQueuesBroker()
+
+        @dramatiq.actor(broker=broker, queue_name="q")
+        def noop():
+            pass
+
+        broker.enqueue(_make_message("noop", options={"retries": 2}))
+        assert mock_send.call_args.kwargs["idempotency_key"] == "abc:2"
+
+    @patch("vercel.workers.dramatiq.broker.send")
+    def test_idempotency_key_initial_send(self, mock_send: MagicMock):
+        mock_send.return_value = {"messageId": "m"}
+        broker = VercelQueuesBroker()
+
+        @dramatiq.actor(broker=broker, queue_name="q")
+        def noop():
+            pass
+
+        broker.enqueue(_make_message("noop"))
+        assert mock_send.call_args.kwargs["idempotency_key"] == "abc:0"
+
+
+class _FakeExtender:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def finalize(self, fn: Callable[[], None]) -> None:
+        fn()
+
+
+class TestRetriesCallbackBehaviour:
+    def _invoke(
+        self, broker: VercelQueuesBroker, message: Message, mock_qc: MagicMock
+    ) -> tuple[int, list[tuple[str, str]], bytes]:
+        envelope = _message_to_envelope(message, message.queue_name, encoder=broker.encoder)
+        mock_qc.is_v2beta_callback.return_value = False
+        mock_qc.parse_cloudevent.return_value = (message.queue_name, "default", message.message_id)
+        mock_qc.receive_message_by_id.return_value = (envelope, 0, "2026-01-01", "rh")
+        mock_qc.VisibilityExtender.return_value = _FakeExtender()
+        return handle_queue_callback(broker, b"{}", {})
+
+    @patch("vercel.workers.dramatiq.broker.send")
+    @patch("vercel.workers.dramatiq.app.queue_callback")
+    def test_callback_acks_on_retry(self, mock_qc: MagicMock, mock_send: MagicMock):
+        mock_send.return_value = {"messageId": "m"}
+        broker = VercelQueuesBroker()
+
+        @dramatiq.actor(broker=broker, queue_name="q", max_retries=3)
+        def fails():
+            raise RuntimeError("x")
+
+        status_code, _headers, body = self._invoke(broker, _make_message("fails"), mock_qc)
+
+        assert status_code == 200
+        payload = json.loads(body)
+        assert payload["status"] == "retried"
+        assert payload["ok"] is True
+        mock_qc.delete_message.assert_called_once()
+
+    @patch("vercel.workers.dramatiq.broker.send")
+    @patch("vercel.workers.dramatiq.app.queue_callback")
+    def test_callback_acks_on_terminal_failure(self, mock_qc: MagicMock, mock_send: MagicMock):
+        mock_send.return_value = {"messageId": "m"}
+        broker = VercelQueuesBroker()
+
+        @dramatiq.actor(broker=broker, queue_name="q", max_retries=1)
+        def fails():
+            raise RuntimeError("boom")
+
+        message = _make_message("fails", options={"retries": 1})
+        status_code, _headers, body = self._invoke(broker, message, mock_qc)
+
+        assert status_code == 200
+        payload = json.loads(body)
+        assert payload["status"] == "failed"
+        assert payload["ok"] is False
+        assert payload["errorType"] == "RuntimeError"
+        mock_qc.delete_message.assert_called_once()
+        # Terminal failure does not re-enqueue.
+        mock_send.assert_not_called()


### PR DESCRIPTION
Make the Dramatiq adapter to respect the default retry options for actors (via built-in middlewares) and rely on re-delivery via Vercel Queues only in unusual cases, e.g. when a handler hangs or crashes