### PR TITLE
[services] Add deploy-manifest as an extension of project manifest.

### DIFF
--- a/.changeset/clean-fans-hunt.md
+++ b/.changeset/clean-fans-hunt.md
@@ -1,0 +1,6 @@
+---
+'@vercel/build-utils': minor
+'vercel': minor
+---
+
+Add deploy-manifest as an extension of project manifest.

--- a/packages/build-utils/src/deploy-manifest.ts
+++ b/packages/build-utils/src/deploy-manifest.ts
@@ -1,0 +1,11 @@
+import type { PackageManifest } from './package-manifest';
+
+export interface DeployManifestService extends PackageManifest {
+  root: string;
+  builder: string;
+}
+
+export interface DeployManifest {
+  manifestVersion: '2.0';
+  services: Record<string, DeployManifestService>;
+}

--- a/packages/build-utils/src/deploy-manifest.ts
+++ b/packages/build-utils/src/deploy-manifest.ts
@@ -1,11 +1,11 @@
 import type { PackageManifest } from './package-manifest';
 
-export interface DeployManifestService extends PackageManifest {
+export interface DeployManifestBuild extends PackageManifest {
   root: string;
   builder: string;
 }
 
 export interface DeployManifest {
   manifestVersion: '2.0';
-  services: Record<string, DeployManifestService>;
+  builds: Record<string, DeployManifestBuild>;
 }

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -149,6 +149,7 @@ export {
   getMaxDurationSchema,
 } from './max-duration';
 export * from './package-manifest';
+export * from './deploy-manifest';
 export { generateProjectManifest } from './node-diagnostics';
 export * from './types';
 export * from './errors';

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -8,7 +8,7 @@ import { readdirSync, statSync } from 'fs';
 
 import {
   download,
-  FileBlob,
+  type FileBlob,
   FileFsRef,
   getDiscontinuedNodeVersions,
   getInstalledPackageVersion,
@@ -48,10 +48,6 @@ import {
   type Lambda,
   type TriggerEvent,
   sanitizeConsumerName,
-  downloadFile,
-  type DeployManifest,
-  type DeployManifestService,
-  type PackageManifest,
 } from '@vercel/build-utils';
 import type { VercelConfig } from '@vercel/client';
 import { fileNameSymbol } from '@vercel/client';
@@ -132,6 +128,7 @@ import { pullEnvRecords } from '../../util/env/get-env-records';
 import { buildCommand } from './command';
 import { validatePackageManifest } from '../../util/validate-package-manifest';
 import { shouldEmbedFlagsDefinitions } from '../../util/flags/build-embedding';
+import { writeManifests } from './manifest';
 
 /** Build a plain suggested command with global flags (e.g. --cwd, --non-interactive) appended. */
 function buildCommandWithGlobalFlags(
@@ -1833,69 +1830,7 @@ async function doBuild(
 
   // Aggregate individual package-manifest.json files from builders into
   // a single project-manifest.json and deploy-manifest.json keyed by service workspace.
-  if (packageManifests.length > 0) {
-    const projectManifest: Record<string, unknown> = {};
-    const deployManifest: DeployManifest = {
-      manifestVersion: '2.0',
-      services: {},
-    };
-    for (const {
-      workspace,
-      buildConfig,
-      manifest,
-      service,
-      builderUse,
-    } of packageManifests) {
-      const key = `${builderUse}:${workspace}`;
-      projectManifest[key] = {
-        ...manifest,
-        workspace,
-        builder: builderUse,
-        framework: service?.framework ?? buildConfig.framework,
-        serviceName: service?.name,
-        serviceType:
-          service && isExperimentalService(service) ? service.type : undefined,
-        routePrefix:
-          service && isExperimentalService(service)
-            ? service.routePrefix
-            : undefined,
-      };
-      const deployService: DeployManifestService = {
-        ...(manifest as unknown as PackageManifest),
-        root: workspace,
-        builder: builderUse,
-      };
-      deployManifest.services[key] = deployService;
-    }
-    if (Object.keys(projectManifest).length > 0) {
-      const projectManifestBlob = new FileBlob({
-        data: JSON.stringify(projectManifest),
-      });
-      diagnostics['project-manifest.json'] = projectManifestBlob;
-      ops.push(
-        downloadFile(
-          projectManifestBlob,
-          join(outputDir, 'diagnostics', 'project-manifest.json')
-        ).then(
-          () => undefined,
-          err => err
-        )
-      );
-      const deployManifestBlob = new FileBlob({
-        data: JSON.stringify(deployManifest),
-      });
-      diagnostics['deploy-manifest.json'] = deployManifestBlob;
-      ops.push(
-        downloadFile(
-          deployManifestBlob,
-          join(outputDir, 'diagnostics', 'deploy-manifest.json')
-        ).then(
-          () => undefined,
-          err => err
-        )
-      );
-    }
-  }
+  await writeManifests(packageManifests, diagnostics, ops, outputDir);
 
   if (corepackShimDir) {
     cleanupCorepack(corepackShimDir);

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -49,6 +49,9 @@ import {
   type TriggerEvent,
   sanitizeConsumerName,
   downloadFile,
+  type DeployManifest,
+  type DeployManifestService,
+  type PackageManifest,
 } from '@vercel/build-utils';
 import type { VercelConfig } from '@vercel/client';
 import { fileNameSymbol } from '@vercel/client';
@@ -1829,9 +1832,13 @@ async function doBuild(
   }
 
   // Aggregate individual package-manifest.json files from builders into
-  // a single project-manifest.json keyed by service workspace.
+  // a single project-manifest.json and deploy-manifest.json keyed by service workspace.
   if (packageManifests.length > 0) {
     const projectManifest: Record<string, unknown> = {};
+    const deployManifest: DeployManifest = {
+      manifestVersion: '2.0',
+      services: {},
+    };
     for (const {
       workspace,
       buildConfig,
@@ -1839,7 +1846,8 @@ async function doBuild(
       service,
       builderUse,
     } of packageManifests) {
-      projectManifest[`${builderUse}:${workspace}`] = {
+      const key = `${builderUse}:${workspace}`;
+      projectManifest[key] = {
         ...manifest,
         workspace,
         builder: builderUse,
@@ -1852,6 +1860,12 @@ async function doBuild(
             ? service.routePrefix
             : undefined,
       };
+      const deployService: DeployManifestService = {
+        ...(manifest as unknown as PackageManifest),
+        root: workspace,
+        builder: builderUse,
+      };
+      deployManifest.services[key] = deployService;
     }
     if (Object.keys(projectManifest).length > 0) {
       const projectManifestBlob = new FileBlob({
@@ -1862,6 +1876,19 @@ async function doBuild(
         downloadFile(
           projectManifestBlob,
           join(outputDir, 'diagnostics', 'project-manifest.json')
+        ).then(
+          () => undefined,
+          err => err
+        )
+      );
+      const deployManifestBlob = new FileBlob({
+        data: JSON.stringify(deployManifest),
+      });
+      diagnostics['deploy-manifest.json'] = deployManifestBlob;
+      ops.push(
+        downloadFile(
+          deployManifestBlob,
+          join(outputDir, 'diagnostics', 'deploy-manifest.json')
         ).then(
           () => undefined,
           err => err

--- a/packages/cli/src/commands/build/manifest.ts
+++ b/packages/cli/src/commands/build/manifest.ts
@@ -4,7 +4,7 @@ import {
   downloadFile,
   isExperimentalService,
   type Config,
-  type DeployManifestService,
+  type DeployManifestBuild,
   type Files,
   type PackageManifest,
   type Service,
@@ -26,7 +26,7 @@ export async function writeManifests(
   if (packageManifests.length === 0) return;
 
   const projectManifest: Record<string, unknown> = {};
-  const deployManifestServices: Record<string, DeployManifestService> = {};
+  const deployManifestBuilds: Record<string, DeployManifestBuild> = {};
 
   for (const {
     workspace,
@@ -49,7 +49,7 @@ export async function writeManifests(
           ? service.routePrefix
           : undefined,
     };
-    deployManifestServices[key] = {
+    deployManifestBuilds[key] = {
       ...(manifest as unknown as PackageManifest),
       root: workspace,
       builder: builderUse,
@@ -75,7 +75,7 @@ export async function writeManifests(
   const deployManifestBlob = new FileBlob({
     data: JSON.stringify({
       manifestVersion: '2.0',
-      services: deployManifestServices,
+      builds: deployManifestBuilds,
     }),
   });
   diagnostics['deploy-manifest.json'] = deployManifestBlob;

--- a/packages/cli/src/commands/build/manifest.ts
+++ b/packages/cli/src/commands/build/manifest.ts
@@ -1,0 +1,91 @@
+import { join } from 'path';
+import {
+  FileBlob,
+  downloadFile,
+  isExperimentalService,
+  type Config,
+  type DeployManifestService,
+  type Files,
+  type PackageManifest,
+  type Service,
+} from '@vercel/build-utils';
+
+export async function writeManifests(
+  packageManifests: Array<{
+    workspace: string;
+    key: string;
+    buildConfig: Config;
+    manifest: Record<string, unknown>;
+    service?: Service;
+    builderUse: string;
+  }>,
+  diagnostics: Files,
+  ops: Promise<Error | void>[],
+  outputDir: string
+): Promise<void> {
+  if (packageManifests.length === 0) return;
+
+  const projectManifest: Record<string, unknown> = {};
+  const deployManifestServices: Record<string, DeployManifestService> = {};
+
+  for (const {
+    workspace,
+    buildConfig,
+    manifest,
+    service,
+    builderUse,
+  } of packageManifests) {
+    const key = `${builderUse}:${workspace}`;
+    projectManifest[key] = {
+      ...manifest,
+      workspace,
+      builder: builderUse,
+      framework: service?.framework ?? buildConfig.framework,
+      serviceName: service?.name,
+      serviceType:
+        service && isExperimentalService(service) ? service.type : undefined,
+      routePrefix:
+        service && isExperimentalService(service)
+          ? service.routePrefix
+          : undefined,
+    };
+    deployManifestServices[key] = {
+      ...(manifest as unknown as PackageManifest),
+      root: workspace,
+      builder: builderUse,
+    };
+  }
+
+  if (Object.keys(projectManifest).length === 0) return;
+
+  const projectManifestBlob = new FileBlob({
+    data: JSON.stringify(projectManifest),
+  });
+  diagnostics['project-manifest.json'] = projectManifestBlob;
+  ops.push(
+    downloadFile(
+      projectManifestBlob,
+      join(outputDir, 'diagnostics', 'project-manifest.json')
+    ).then(
+      () => undefined,
+      err => err
+    )
+  );
+
+  const deployManifestBlob = new FileBlob({
+    data: JSON.stringify({
+      manifestVersion: '2.0',
+      services: deployManifestServices,
+    }),
+  });
+  diagnostics['deploy-manifest.json'] = deployManifestBlob;
+  ops.push(
+    downloadFile(
+      deployManifestBlob,
+      join(outputDir, 'diagnostics', 'deploy-manifest.json')
+    ).then(
+      () => undefined,
+      err => err
+    )
+  );
+}


### PR DESCRIPTION
The existing project manifest is too focused on the builds to contain everything we'd like to know about deployments, eg. routing.

This PR adds a `deploy-manifest.json` which contains the existing project manifest in the `services` field and a `manifestVersion` set to `2.0`. This will be emitted alongside the current `project-manifest.json` so that the deployment event consumers switch to using it before the project manifest is removed.