### PR TITLE
[react-router] allow React Router v8 as peer dependency

### DIFF
--- a/.changeset/react-router-v8-peer.md
+++ b/.changeset/react-router-v8-peer.md
@@ -1,0 +1,5 @@
+---
+'@vercel/react-router': patch
+---
+
+[react-router] Allow React Router v8 as a peer dependency.

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -56,8 +56,8 @@
     "react-router": "7.1.3"
   },
   "peerDependencies": {
-    "@react-router/dev": "7",
-    "@react-router/node": "7",
+    "@react-router/dev": "7 || 8",
+    "@react-router/node": "7 || 8",
     "isbot": "5",
     "react": ">=18",
     "react-dom": ">=18"


### PR DESCRIPTION
### Summary

`@vercel/react-router@1.3.1` pins `@react-router/dev` and `@react-router/node` peerDependencies to `"7"`, so installing `react-router@8` alongside `vercelPreset()` produces a peer-dependency mismatch.

React Router v8 preserves the route-module/config surface the preset relies on (the preset only reads route config via `ts-morph` + `@vercel/static-config`), so widening to `"7 || 8"` is sufficient — no code changes required.

### Change

```diff
-    "@react-router/dev": "7",
-    "@react-router/node": "7",
+    "@react-router/dev": "7 || 8",
+    "@react-router/node": "7 || 8",
```

Changeset included.

### Notes

- No prior issue or PR tracks this (searched `vercel/vercel`).
- Maintainers may optionally bump the package's own devDependencies to 8.x to exercise CI against v8.