### PR TITLE
[cli] Next.js ws shim: bridge WebSocket close to response close

### DIFF
--- a/.changeset/giant-glasses-speak.md
+++ b/.changeset/giant-glasses-speak.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Bridge WebSocket close to response close

--- a/packages/cli/src/util/dev/next-dev-websocket-shim-preload.cjs
+++ b/packages/cli/src/util/dev/next-dev-websocket-shim-preload.cjs
@@ -110,6 +110,7 @@ function emitWebSocketRequest({
       }
       consumed = true;
 
+      const closeResponse = createResponseCloseEmitter(response);
       if (typeof response.detachSocket === 'function') {
         response.detachSocket(socket);
       }
@@ -120,6 +121,7 @@ function emitWebSocketRequest({
         requestContext.run(context, () => {
           req.emit('aborted');
           abortController.abort();
+          closeResponse();
         });
       });
       socket.once('error', noop);
@@ -166,6 +168,24 @@ function suppressFrameworkResponse(response) {
   };
   response.end = function end() {
     return this;
+  };
+}
+
+function createResponseCloseEmitter(response) {
+  let closed = false;
+  response.once('close', () => {
+    closed = true;
+  });
+
+  return () => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    // Frameworks like Next.js use ServerResponse "close" as their request
+    // lifecycle hook. Upgraded requests detach the socket, so bridge that
+    // hook to the WebSocket close.
+    response.emit('close');
   };
 }
 

--- a/packages/cli/test/unit/util/dev/next-dev-websocket-shim-preload.test.ts
+++ b/packages/cli/test/unit/util/dev/next-dev-websocket-shim-preload.test.ts
@@ -96,6 +96,15 @@ describe('next dev websocket shim preload', () => {
     });
   });
 
+  it('emits response close when the upgraded socket closes', async () => {
+    await expect(
+      runShimScenario('response-close-after-upgrade')
+    ).resolves.toMatchObject({
+      closeEvents: 1,
+      waitUntilDone: true,
+    });
+  });
+
   it('does not crash when the upgraded socket emits an error', async () => {
     await expect(
       runShimScenario('socket-error-after-upgrade')
@@ -260,6 +269,29 @@ const server = http.createServer((req, res) => {
       return;
     }
 
+    if (scenario === 'response-close-after-upgrade') {
+      let closeEvents = 0;
+      let waitUntilDone = false;
+
+      ctx.waitUntil(
+        new Promise(resolve => {
+          res.on('close', () => {
+            closeEvents += 1;
+            resolve();
+          });
+        }).then(() => {
+          waitUntilDone = true;
+        })
+      );
+
+      const { socket } = consumeUpgrade();
+      socket.once('close', () => {
+        setTimeout(() => finish({ closeEvents, waitUntilDone }), 10);
+      });
+      socket.end(textFrame('ok'));
+      return;
+    }
+
     if (scenario === 'socket-error-after-upgrade') {
       const { socket } = consumeUpgrade();
       setImmediate(() => {
@@ -316,6 +348,11 @@ server.listen(0, '127.0.0.1', async () => {
       const client = net.createConnection({ host: '127.0.0.1', port });
       await once(client, 'connect');
       client.write(upgradeRequest('/ws'));
+      return;
+    }
+
+    if (scenario === 'response-close-after-upgrade') {
+      await websocketRequest(port, '/ws');
       return;
     }
 


### PR DESCRIPTION
See https://github.com/vercel/functions/pull/3317 + [Slack](https://vercel.slack.com/archives/C09P6P21S06/p1781961551936629) for the full PR description + discussion.

This PR mirrors the updated runtime logic to the local dev shim.