### PR TITLE
[react-router] Support React Router v8

### DIFF
--- a/.changeset/react-router-v8-support.md
+++ b/.changeset/react-router-v8-support.md
@@ -1,0 +1,5 @@
+---
+'@vercel/react-router': patch
+---
+
+Support React Router v8 as a peer dependency

--- a/packages/react-router/edge/entry.server.ts
+++ b/packages/react-router/edge/entry.server.ts
@@ -6,7 +6,7 @@ import {
   type RenderToPipeableStreamOptions,
 } from 'react-dom/server';
 import { ServerRouter } from 'react-router';
-import type { AppLoadContext, EntryContext } from 'react-router';
+import type { EntryContext } from 'react-router';
 
 export type RenderOptions = {
   [K in keyof RenderToReadableStreamOptions &
@@ -22,7 +22,7 @@ export async function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   routerContext: EntryContext,
-  _loadContext?: AppLoadContext,
+  _loadContext?: unknown,
   options?: RenderOptions
 ): Promise<Response> {
   const body = await renderToReadableStream(

--- a/packages/react-router/entry.server.ts
+++ b/packages/react-router/entry.server.ts
@@ -5,7 +5,7 @@ import { createReadableStreamFromReadable } from '@react-router/node';
 import { isbot } from 'isbot';
 import { renderToPipeableStream } from 'react-dom/server';
 import { ServerRouter } from 'react-router';
-import type { AppLoadContext, EntryContext } from 'react-router';
+import type { EntryContext } from 'react-router';
 import type {
   RenderToPipeableStreamOptions,
   RenderToReadableStreamOptions,
@@ -27,7 +27,7 @@ export function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   routerContext: EntryContext,
-  _loadContext?: AppLoadContext,
+  _loadContext?: unknown,
   options?: RenderOptions
 ): Promise<Response> {
   return new Promise((resolve, reject) => {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -56,8 +56,8 @@
     "react-router": "7.1.3"
   },
   "peerDependencies": {
-    "@react-router/dev": "7",
-    "@react-router/node": "7",
+    "@react-router/dev": "7 || 8",
+    "@react-router/node": "7 || 8",
     "isbot": "5",
     "react": ">=18",
     "react-dom": ">=18"


### PR DESCRIPTION
## Summary

Closes #16730

React Router v8.0.1 is now `latest` on npm. This PR adds support for React Router v8 in `@vercel/react-router`.

## Changes

### 1. Widen peer dependencies (`packages/react-router/package.json`)

Changed `peerDependencies` for `@react-router/dev` and `@react-router/node` from `"7"` to `"7 || 8"` to accept both major versions.

### 2. Remove `AppLoadContext` type import (`packages/react-router/entry.server.ts` and `edge/entry.server.ts`)

`AppLoadContext` was removed in React Router v8 (replaced by the new `RouterContextProvider` middleware context model). The `_loadContext` parameter is unused (prefixed with `_`), so it is typed as `unknown` instead — this works under both v7 and v8 with no behavior change.