### PR TITLE
Increase Connex polling timeout

### DIFF
--- a/.changeset/long-connex-polling.md
+++ b/.changeset/long-connex-polling.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Increase Connex setup polling timeout to 115 minutes.

--- a/packages/cli/src/util/connex/request-code.ts
+++ b/packages/cli/src/util/connex/request-code.ts
@@ -11,7 +11,7 @@ export interface ConnexResult {
 }
 
 const POLL_INTERVAL_MS = 2000;
-const MAX_POLL_DURATION_MS = 30 * 60 * 1000;
+const MAX_POLL_DURATION_MS = 115 * 60 * 1000;
 const MAX_EARLY_404_COUNT = 3;
 
 /**


### PR DESCRIPTION
## Summary

- Increase Connex setup polling timeout from 30 minutes to 115 minutes
- Add a changeset for the CLI patch release

## Tests

- Not run; constant-only change
- Pre-commit ran biome format/lint on staged TypeScript files