### PR TITLE
python: update functions bundle size limits

### DIFF
--- a/.changeset/funny-shrimps-dance.md
+++ b/.changeset/funny-shrimps-dance.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+python: update functions bundle size limits

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -59,16 +59,10 @@ function shouldStripVendorFile(filePath: string): boolean {
   return false;
 }
 
-// AWS Lambda uncompressed size limit is 250MB, but we use 245MB to leave room
-// for the standard Lambda layers (rusty runtime, lambdawrapper). When the
-// OpenTelemetry collector layer is also attached, we reserve an additional 5MB.
-const LAMBDA_BASE_SIZE_THRESHOLD_BYTES = 225 * 1024 * 1024;
-const OTEL_LAYER_RESERVATION_BYTES = 5 * 1024 * 1024;
-
-export const LAMBDA_SIZE_THRESHOLD_BYTES =
-  process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER === '1'
-    ? LAMBDA_BASE_SIZE_THRESHOLD_BYTES - OTEL_LAYER_RESERVATION_BYTES
-    : LAMBDA_BASE_SIZE_THRESHOLD_BYTES;
+// AWS Lambda uncompressed size limit is 250MB, but we use 225MB to leave room
+// for the Lambda layers (rusty runtime, lambdawrapper, OpenTelemetry collector)
+// that count toward the limit but aren't part of this bundle.
+export const LAMBDA_SIZE_THRESHOLD_BYTES = 225 * 1024 * 1024;
 
 // AWS Lambda ephemeral storage (/tmp) is 512MB. Use 500MB to leave a buffer
 // for runtime overhead (.pyc generation, uv cache, metadata, etc.)

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -62,7 +62,7 @@ function shouldStripVendorFile(filePath: string): boolean {
 // AWS Lambda uncompressed size limit is 250MB, but we use 245MB to leave room
 // for the standard Lambda layers (rusty runtime, lambdawrapper). When the
 // OpenTelemetry collector layer is also attached, we reserve an additional 5MB.
-const LAMBDA_BASE_SIZE_THRESHOLD_BYTES = 245 * 1024 * 1024;
+const LAMBDA_BASE_SIZE_THRESHOLD_BYTES = 225 * 1024 * 1024;
 const OTEL_LAYER_RESERVATION_BYTES = 5 * 1024 * 1024;
 
 export const LAMBDA_SIZE_THRESHOLD_BYTES =
@@ -570,7 +570,7 @@ export class PythonDependencyExternalizer {
     // are included in the bundle, which can push total size over the threshold.
     // Allow 100 KB of tolerance for rounding and estimation discrepancies in the
     // knapsack capacity budget.  The actual AWS Lambda limit is 250 MB and we
-    // target 245 MB, so a slight overshoot here is safe.
+    // target 225 MB, so a slight overshoot here is safe.
     const finalBundleSize = await calculateBundleSize(files);
     if (finalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES + 100 * 1024) {
       const finalSizeMB = (finalBundleSize / (1024 * 1024)).toFixed(2);

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -1047,11 +1047,11 @@ export const build: BuildVX = async ({
       });
 
       if (depAnalysis.runtimeInstallEnabled) {
-        // >245 MB source-only: the lambda zip is packed full with source
+        // >225 MB source-only: the lambda zip is packed full with source
         // packages via knapsack.  No room for bytecode.
         await depExternalizer.generateBundle(files);
       } else {
-        // ≤245 MB source-only: bundle all dependencies.
+        // ≤225 MB source-only: bundle all dependencies.
         addFiles(files, depAnalysis.allVendorFiles);
 
         // Precompile bytecode and fill remaining Lambda capacity.

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -209,20 +209,8 @@ describe('dependency externalizer support', () => {
   });
 
   describe('Lambda size constants', () => {
-    it('LAMBDA_SIZE_THRESHOLD_BYTES is 225 MB by default', () => {
+    it('LAMBDA_SIZE_THRESHOLD_BYTES is 225 MB', () => {
       expect(LAMBDA_SIZE_THRESHOLD_BYTES).toBe(225 * 1024 * 1024);
-    });
-
-    it('LAMBDA_SIZE_THRESHOLD_BYTES is 220 MB when otel layer is present', async () => {
-      process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER = '1';
-      try {
-        vi.resetModules();
-        const mod = await import('../src/dependency-externalizer');
-        expect(mod.LAMBDA_SIZE_THRESHOLD_BYTES).toBe(220 * 1024 * 1024);
-      } finally {
-        delete process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER;
-        vi.resetModules();
-      }
     });
 
     it('LAMBDA_EPHEMERAL_STORAGE_BYTES is 500 MB', () => {

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -209,16 +209,16 @@ describe('dependency externalizer support', () => {
   });
 
   describe('Lambda size constants', () => {
-    it('LAMBDA_SIZE_THRESHOLD_BYTES is 245 MB by default', () => {
-      expect(LAMBDA_SIZE_THRESHOLD_BYTES).toBe(245 * 1024 * 1024);
+    it('LAMBDA_SIZE_THRESHOLD_BYTES is 225 MB by default', () => {
+      expect(LAMBDA_SIZE_THRESHOLD_BYTES).toBe(225 * 1024 * 1024);
     });
 
-    it('LAMBDA_SIZE_THRESHOLD_BYTES is 240 MB when otel layer is present', async () => {
+    it('LAMBDA_SIZE_THRESHOLD_BYTES is 220 MB when otel layer is present', async () => {
       process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER = '1';
       try {
         vi.resetModules();
         const mod = await import('../src/dependency-externalizer');
-        expect(mod.LAMBDA_SIZE_THRESHOLD_BYTES).toBe(240 * 1024 * 1024);
+        expect(mod.LAMBDA_SIZE_THRESHOLD_BYTES).toBe(220 * 1024 * 1024);
       } finally {
         delete process.env.VERCEL_DEPLOYMENT_HAS_OTEL_LAYER;
         vi.resetModules();
@@ -923,7 +923,7 @@ version = "8.1.7"
       const tempDir = path.join(tmpdir(), `dep-ext-analyze-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
 
-      // Create a sparse file that reports > 245 MB without using real disk space
+      // Create a sparse file that reports > 225 MB without using real disk space
       const bigFilePath = path.join(tempDir, 'big-file.dat');
       const fd = fs.openSync(bigFilePath, 'w');
       fs.ftruncateSync(fd, LAMBDA_SIZE_THRESHOLD_BYTES + 1024 * 1024);


### PR DESCRIPTION
This needs to align with Vercel's upstream validation enforced in the build-container. Both build-container and Next builder are using 25MiB internal buffer.

Because this gives us enough buffer, removing `OTEL_LAYER_RESERVATION_BYTES` constant as well