### PR TITLE
python: support large functions and remove the python-on-hive size path

### DIFF
--- a/.changeset/tidy-poems-hide.md
+++ b/.changeset/tidy-poems-hide.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+python: support large functions on Hive via supportLargeFunctions and retire the python-on-hive size path

--- a/packages/python/src/compileall.ts
+++ b/packages/python/src/compileall.ts
@@ -2,20 +2,14 @@ import execa from 'execa';
 import { debug, FileFsRef, type Files } from '@vercel/build-utils';
 import fs from 'fs';
 import { join, sep } from 'path';
-
-export function isPythonOnHive(): boolean {
-  const hive = process.env.VERCEL_PYTHON_ON_HIVE;
-  return hive === '1' || hive === 'true';
-}
+import { isLargeFunctionsEnabled } from './large-functions';
 
 /**
- * Compileall is a Hive-only feature.  It runs only when the deployment is on
- * Hive *and* `VERCEL_PYTHON_COMPILEALL` is explicitly set to a truthy value
- * (`1`/`true`).  This makes the env var an opt-in toggle for the Hive rollout;
- * it has no effect off Hive.
+ * Compileall runs only for large functions *and* when `VERCEL_PYTHON_COMPILEALL`
+ * is set truthy (`1`/`true`) — an opt-in toggle, no effect otherwise.
  */
 export function isCompileAllEnabled(): boolean {
-  if (!isPythonOnHive()) return false;
+  if (!isLargeFunctionsEnabled()) return false;
 
   const val = process.env.VERCEL_PYTHON_COMPILEALL;
   if (val === undefined || val === '') return false;

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -30,6 +30,7 @@ import {
 } from './uv';
 import { detectTargetPlatform } from './platform-info';
 import { derivePycPath, type BytecodeCollectionResult } from './compileall';
+import { isLargeFunctionsEnabled } from './large-functions';
 
 const readFile = promisify(fs.readFile);
 
@@ -68,9 +69,9 @@ export const LAMBDA_SIZE_THRESHOLD_BYTES = 225 * 1024 * 1024;
 // for runtime overhead (.pyc generation, uv cache, metadata, etc.)
 export const LAMBDA_EPHEMERAL_STORAGE_BYTES = 500 * 1024 * 1024;
 
-// Extended limit for Python on Hive (Functions Beta). All dependencies are
-// bundled directly into the Lambda instead of using runtime installation.
-export const HIVE_LAMBDA_SIZE_BYTES = 1 * 1024 * 1024 * 1024;
+// Size limit for large functions: all deps bundled directly (no runtime
+// install), served on Hive.
+export const MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE = 5 * 1024 * 1024 * 1024;
 
 const BUNDLING_DOCS_LINK =
   'https://vercel.com/docs/functions/runtimes/python#controlling-what-gets-bundled';
@@ -146,18 +147,23 @@ export class PythonDependencyExternalizer {
     if (this.hasCustomCommand) {
       return false;
     }
-    const pythonOnHiveEnabled =
-      process.env.VERCEL_PYTHON_ON_HIVE === '1' ||
-      process.env.VERCEL_PYTHON_ON_HIVE === 'true';
-    if (pythonOnHiveEnabled) {
-      return false;
-    } else if (
-      this.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES &&
-      this.uvLockPath !== null
+    // Fits AWS Lambda directly, or there's no lock to defer from.
+    if (
+      this.totalBundleSize <= LAMBDA_SIZE_THRESHOLD_BYTES ||
+      this.uvLockPath === null
     ) {
-      return true;
+      return false;
     }
-    return false;
+    // Over the threshold with a lock to defer from. Large functions skip
+    // runtime install once deps exceed ephemeral storage (bundled for Hive);
+    // below that, runtime install still keeps it on Lambda.
+    if (
+      isLargeFunctionsEnabled() &&
+      this.totalBundleSize > LAMBDA_EPHEMERAL_STORAGE_BYTES
+    ) {
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -199,22 +205,22 @@ export class PythonDependencyExternalizer {
 
     const runtimeInstallEnabled = this.shouldEnableRuntimeInstall();
 
-    const pythonOnHiveEnabled =
-      process.env.VERCEL_PYTHON_ON_HIVE === '1' ||
-      process.env.VERCEL_PYTHON_ON_HIVE === 'true';
+    const largeFunctionsEnabled = isLargeFunctionsEnabled();
 
     // Surface the size BEFORE the size-limit checks below, which may throw.
-    // Otherwise oversized bundles (e.g. Hive > 1 GB) would never report their
-    // size, biasing any size telemetry toward builds that fit the limit.
+    // Otherwise oversized bundles would never report their size, biasing any
+    // size telemetry toward builds that fit the limit.
     options.onSized?.({
       totalSizeBytes: this.totalBundleSize,
       runtimeInstallEnabled,
     });
 
+    // Custom install commands can't use runtime install; enforced only when
+    // not bundling everything directly (large functions).
     if (
       this.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES &&
       this.hasCustomCommand &&
-      !pythonOnHiveEnabled
+      !largeFunctionsEnabled
     ) {
       const limitMB = (LAMBDA_SIZE_THRESHOLD_BYTES / (1024 * 1024)).toFixed(0);
       throw new NowBuildError({
@@ -232,11 +238,16 @@ export class PythonDependencyExternalizer {
       });
     }
 
-    // Enforce the extended 1 GB limit for Python on Hive (Functions Beta).
-    // All dependencies are bundled directly, so check the total uncompressed
-    // size before we proceed to avoid a slower failure at ZIP time.
-    if (pythonOnHiveEnabled && this.totalBundleSize > HIVE_LAMBDA_SIZE_BYTES) {
-      const limitMB = (HIVE_LAMBDA_SIZE_BYTES / (1024 * 1024)).toFixed(0);
+    // Enforce the large-function size limit up front (faster than failing at
+    // ZIP time). `>=` matches the platform's uncompressed-size check.
+    if (
+      largeFunctionsEnabled &&
+      this.totalBundleSize >= MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE
+    ) {
+      const limitMB = (
+        MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE /
+        (1024 * 1024)
+      ).toFixed(0);
       throw new NowBuildError({
         code: 'LAMBDA_SIZE_EXCEEDED',
         message:
@@ -260,8 +271,14 @@ export class PythonDependencyExternalizer {
    * Mutates `files` in place: adds vendor files (private + knapsack-selected
    * public), runtime config, and uv binary.
    * Must be called after analyze().
+   *
+   * If large functions are allowed and the bundle can't fit AWS Lambda, falls
+   * back to bundling everything for Hive and returns `fellBackToFullBundle:
+   * true` so the caller can apply the same compileall handling.
    */
-  async generateBundle(files: Files): Promise<void> {
+  async generateBundle(
+    files: Files
+  ): Promise<{ fellBackToFullBundle: boolean }> {
     if (!this.analyzed) {
       throw new Error(
         'PythonDependencyExternalizer.analyze() must be called before generateBundle()'
@@ -277,13 +294,15 @@ export class PythonDependencyExternalizer {
 
     const totalBundleSizeMB = (this.totalBundleSize / (1024 * 1024)).toFixed(2);
 
-    console.log(
-      `Bundle size (${totalBundleSizeMB} MB) exceeds limit. ` +
-        `Enabling runtime dependency installation.`
-    );
+    // When set, a bundle that can't fit AWS Lambda is bundled for Hive instead
+    // of failing the build.
+    const largeFunctionsEnabled = isLargeFunctionsEnabled();
 
     // Verify total deps won't exceed Lambda ephemeral storage (512 MB)
     if (this.totalBundleSize > LAMBDA_EPHEMERAL_STORAGE_BYTES) {
+      if (largeFunctionsEnabled) {
+        return this.bundleAllForHive(files);
+      }
       const ephemeralLimitMB = (
         LAMBDA_EPHEMERAL_STORAGE_BYTES /
         (1024 * 1024)
@@ -381,6 +400,9 @@ export class PythonDependencyExternalizer {
     );
 
     if (externalizablePublic.length === 0) {
+      if (largeFunctionsEnabled) {
+        return this.bundleAllForHive(files);
+      }
       throw new NowBuildError({
         code: 'RUNTIME_DEPENDENCY_INSTALLATION_FAILED',
         message:
@@ -472,6 +494,19 @@ export class PythonDependencyExternalizer {
       `Fixed overhead: ${(fixedOverhead / (1024 * 1024)).toFixed(2)} MB, ` +
         `runtime tooling: ${(runtimeToolingOverhead / (1024 * 1024)).toFixed(2)} MB, ` +
         `remaining capacity for public packages: ${(remainingCapacity / (1024 * 1024)).toFixed(2)} MB`
+    );
+
+    // The non-deferrable footprint (source + private/wheel-less packages +
+    // tooling) alone exceeds the threshold, so runtime install can't shrink the
+    // zip enough. Large functions bundle everything for Hive; otherwise the
+    // final-size check below throws.
+    if (largeFunctionsEnabled && remainingCapacity < 0) {
+      return this.bundleAllForHive(files);
+    }
+
+    console.log(
+      `Bundle size (${totalBundleSizeMB} MB) exceeds limit. ` +
+        `Enabling runtime dependency installation.`
     );
 
     // Build size map for externalizable public packages and run the knapsack algorithm
@@ -567,6 +602,10 @@ export class PythonDependencyExternalizer {
     // target 225 MB, so a slight overshoot here is safe.
     const finalBundleSize = await calculateBundleSize(files);
     if (finalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES + 100 * 1024) {
+      if (largeFunctionsEnabled) {
+        // Estimation overshoot past the threshold; bundle everything for Hive.
+        return this.bundleAllForHive(files);
+      }
       const finalSizeMB = (finalBundleSize / (1024 * 1024)).toFixed(2);
       const limitMB = (LAMBDA_SIZE_THRESHOLD_BYTES / (1024 * 1024)).toFixed(0);
       throw new NowBuildError({
@@ -581,6 +620,31 @@ export class PythonDependencyExternalizer {
         action: 'Learn More',
       });
     }
+
+    return { fellBackToFullBundle: false };
+  }
+
+  /**
+   * Discard any runtime-install artifacts added so far and bundle every
+   * dependency directly, for a function that will run on Hive. Returns the
+   * fell-back signal so the caller can apply the same compileall handling.
+   */
+  private bundleAllForHive(files: Files): { fellBackToFullBundle: true } {
+    for (const key of [
+      `${UV_BUNDLE_DIR}/_runtime_config.json`,
+      `${UV_BUNDLE_DIR}/uv`,
+      `${UV_BUNDLE_DIR}/pyproject.toml`,
+      `${UV_BUNDLE_DIR}/uv.lock`,
+    ]) {
+      delete files[key];
+    }
+    for (const [p, f] of Object.entries(this.allVendorFiles)) {
+      files[p] = f;
+    }
+    console.log(
+      'Bundle cannot fit AWS Lambda; bundling all dependencies to run on Hive.'
+    );
+    return { fellBackToFullBundle: true };
   }
 
   /**

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -43,7 +43,7 @@ import {
 } from './install';
 import {
   PythonDependencyExternalizer,
-  HIVE_LAMBDA_SIZE_BYTES,
+  MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE,
   lambdaKnapsack,
   calculateBundleSize,
 } from './dependency-externalizer';
@@ -1046,84 +1046,87 @@ export const build: BuildVX = async ({
         },
       });
 
-      if (depAnalysis.runtimeInstallEnabled) {
-        // >225 MB source-only: the lambda zip is packed full with source
-        // packages via knapsack.  No room for bytecode.
-        await depExternalizer.generateBundle(files);
-      } else {
-        // ≤225 MB source-only: bundle all dependencies.
-        addFiles(files, depAnalysis.allVendorFiles);
+      // Precompile bytecode and fill remaining capacity for a fully bundled
+      // function. collectAppBytecodeFiles only collects .pyc for .py files
+      // present in the bundle, so excluded source can't re-enter as .pyc.
+      // Shared by the direct-bundle path and the generateBundle Hive fallback.
+      const runCompileAllAndFillBytecode = async () => {
+        await builderSpan
+          .child('vc.builder.python.compileall')
+          .trace(async compileSpan => {
+            const sitePackageDirs = (
+              await getVenvSitePackagesDirs(venvPath)
+            ).filter(d => fs.existsSync(d));
+            const pythonBin = getVenvPythonBin(venvPath);
 
-        // Precompile bytecode and fill remaining Lambda capacity.
-        // compileall runs on the full workPath (with an exclude regex
-        // mirroring the glob excludes) and on site-packages.
-        // collectAppBytecodeFiles only collects .pyc for .py files
-        // present in the bundle, so excluded source files cannot
-        // re-enter the Lambda as generated .pyc files.
-        if (automaticCompileAllEnabled) {
-          await builderSpan
-            .child('vc.builder.python.compileall')
-            .trace(async compileSpan => {
-              const sitePackageDirs = (
-                await getVenvSitePackagesDirs(venvPath)
-              ).filter(d => fs.existsSync(d));
-              const pythonBin = getVenvPythonBin(venvPath);
-
-              console.log('Compiling Python application bytecode...');
-              await runCompileAll({
-                pythonBin,
-                filesOrDirectories: [workPath],
-                env: pythonEnv,
-                excludeRegex: getCompileAllAppExcludeRegex(workPath),
-              });
-
-              console.log('Compiling Python dependency bytecode...');
-              await runCompileAll({
-                pythonBin,
-                filesOrDirectories: sitePackageDirs,
-                env: pythonEnv,
-              });
-
-              compileSpan.setAttributes({
-                'python.compileall.enabled': 'true',
-                'python.compileall.sitePackageDirectoryCount': String(
-                  sitePackageDirs.length
-                ),
-              });
+            console.log('Compiling Python application bytecode...');
+            await runCompileAll({
+              pythonBin,
+              filesOrDirectories: [workPath],
+              env: pythonEnv,
+              excludeRegex: getCompileAllAppExcludeRegex(workPath),
             });
 
-          // Collect bytecode and fill remaining capacity.  Compileall only
-          // runs on Hive (see shouldUseCompileAll), so the Hive Lambda size
-          // threshold always applies here.
-          const currentSize = await calculateBundleSize(files);
-          let remainingCapacity = HIVE_LAMBDA_SIZE_BYTES - currentSize;
-
-          if (pythonVersion.major != null && pythonVersion.minor != null) {
-            const appBytecodeInfo = await collectAppBytecodeFiles({
-              workPath,
-              files,
-              pythonMajor: pythonVersion.major,
-              pythonMinor: pythonVersion.minor,
+            console.log('Compiling Python dependency bytecode...');
+            await runCompileAll({
+              pythonBin,
+              filesOrDirectories: sitePackageDirs,
+              env: pythonEnv,
             });
-            remainingCapacity = addBytecodeWithinCapacity(
-              files,
-              appBytecodeInfo,
-              remainingCapacity
-            );
-          }
 
-          const vendorBytecodeInfo = await depExternalizer.collectBytecodeFiles(
-            {
-              vendorDirName: vendorDir,
-            }
-          );
-          await addVendorBytecodeWithinCapacity({
-            files,
-            depExternalizer,
-            vendorDir,
-            bytecodeInfo: vendorBytecodeInfo,
-            capacity: remainingCapacity,
+            compileSpan.setAttributes({
+              'python.compileall.enabled': 'true',
+              'python.compileall.sitePackageDirectoryCount': String(
+                sitePackageDirs.length
+              ),
+            });
           });
+
+        // Fill remaining capacity up to the large-function size limit.
+        const currentSize = await calculateBundleSize(files);
+        let remainingCapacity =
+          MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE - currentSize;
+
+        if (pythonVersion.major != null && pythonVersion.minor != null) {
+          const appBytecodeInfo = await collectAppBytecodeFiles({
+            workPath,
+            files,
+            pythonMajor: pythonVersion.major,
+            pythonMinor: pythonVersion.minor,
+          });
+          remainingCapacity = addBytecodeWithinCapacity(
+            files,
+            appBytecodeInfo,
+            remainingCapacity
+          );
+        }
+
+        const vendorBytecodeInfo = await depExternalizer.collectBytecodeFiles({
+          vendorDirName: vendorDir,
+        });
+        await addVendorBytecodeWithinCapacity({
+          files,
+          depExternalizer,
+          vendorDir,
+          bytecodeInfo: vendorBytecodeInfo,
+          capacity: remainingCapacity,
+        });
+      };
+
+      if (depAnalysis.runtimeInstallEnabled) {
+        // Pack the zip and defer the rest to runtime install. If it can't fit
+        // Lambda, generateBundle bundles everything for Hive (which then takes
+        // compileall, below).
+        const { fellBackToFullBundle } =
+          await depExternalizer.generateBundle(files);
+        if (fellBackToFullBundle && automaticCompileAllEnabled) {
+          await runCompileAllAndFillBytecode();
+        }
+      } else {
+        // Bundle all deps directly (fits the threshold, or large functions on).
+        addFiles(files, depAnalysis.allVendorFiles);
+        if (automaticCompileAllEnabled) {
+          await runCompileAllAndFillBytecode();
         }
       }
     });

--- a/packages/python/src/large-functions.ts
+++ b/packages/python/src/large-functions.ts
@@ -1,0 +1,8 @@
+/**
+ * Whether large functions are enabled (via `VERCEL_SUPPORT_LARGE_FUNCTIONS`).
+ * When enabled, functions exceeding the AWS Lambda size limits run on Hive.
+ */
+export function isLargeFunctionsEnabled(): boolean {
+  const value = process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
+  return value === '1' || value === 'true';
+}

--- a/packages/python/test/compileall.test.ts
+++ b/packages/python/test/compileall.test.ts
@@ -25,7 +25,7 @@ import {
 
 const mockedExeca = vi.mocked(execa);
 const originalCompileAllEnv = process.env.VERCEL_PYTHON_COMPILEALL;
-const originalHiveEnv = process.env.VERCEL_PYTHON_ON_HIVE;
+const originalLargeFnEnv = process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
 const tmpDirs: string[] = [];
 
 afterEach(() => {
@@ -38,23 +38,23 @@ afterEach(() => {
   } else {
     process.env.VERCEL_PYTHON_COMPILEALL = originalCompileAllEnv;
   }
-  if (originalHiveEnv === undefined) {
-    delete process.env.VERCEL_PYTHON_ON_HIVE;
+  if (originalLargeFnEnv === undefined) {
+    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
   } else {
-    process.env.VERCEL_PYTHON_ON_HIVE = originalHiveEnv;
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = originalLargeFnEnv;
   }
 });
 
 describe('isCompileAllEnabled', () => {
   it('defaults to disabled', () => {
     delete process.env.VERCEL_PYTHON_COMPILEALL;
-    delete process.env.VERCEL_PYTHON_ON_HIVE;
+    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
 
     expect(isCompileAllEnabled()).toBe(false);
   });
 
-  it('enables compileall on Hive for truthy flag values', () => {
-    process.env.VERCEL_PYTHON_ON_HIVE = '1';
+  it('enables compileall for large functions with truthy flag values', () => {
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
 
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
     expect(isCompileAllEnabled()).toBe(true);
@@ -66,8 +66,8 @@ describe('isCompileAllEnabled', () => {
     expect(isCompileAllEnabled()).toBe(true);
   });
 
-  it('keeps compileall disabled on Hive for non-truthy flag values', () => {
-    process.env.VERCEL_PYTHON_ON_HIVE = '1';
+  it('keeps compileall disabled for large functions with non-truthy flag values', () => {
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
 
     delete process.env.VERCEL_PYTHON_COMPILEALL;
     expect(isCompileAllEnabled()).toBe(false);
@@ -82,26 +82,26 @@ describe('isCompileAllEnabled', () => {
     expect(isCompileAllEnabled()).toBe(false);
   });
 
-  it('never enables compileall off Hive, even when the flag is truthy', () => {
+  it('never enables compileall without large functions, even when the flag is truthy', () => {
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
-    delete process.env.VERCEL_PYTHON_ON_HIVE;
+    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
     expect(isCompileAllEnabled()).toBe(false);
 
-    process.env.VERCEL_PYTHON_ON_HIVE = '0';
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '0';
     expect(isCompileAllEnabled()).toBe(false);
 
-    process.env.VERCEL_PYTHON_ON_HIVE = 'false';
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = 'false';
     expect(isCompileAllEnabled()).toBe(false);
 
-    process.env.VERCEL_PYTHON_ON_HIVE = '';
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '';
     expect(isCompileAllEnabled()).toBe(false);
   });
 });
 
 describe('shouldUseCompileAll', () => {
-  it('enables compileall on Hive when the flag is set for non-custom builds', () => {
-    process.env.VERCEL_PYTHON_ON_HIVE = '1';
+  it('enables compileall for large functions when the flag is set for non-custom builds', () => {
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
     expect(
@@ -112,8 +112,8 @@ describe('shouldUseCompileAll', () => {
     ).toBe(true);
   });
 
-  it('does not enable compileall for custom commands, even on Hive with the flag set', () => {
-    process.env.VERCEL_PYTHON_ON_HIVE = '1';
+  it('does not enable compileall for custom commands, even with large functions and the flag set', () => {
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
     expect(
@@ -124,8 +124,8 @@ describe('shouldUseCompileAll', () => {
     ).toBe(false);
   });
 
-  it('does not enable compileall in dev even on Hive with the flag set', () => {
-    process.env.VERCEL_PYTHON_ON_HIVE = '1';
+  it('does not enable compileall in dev even with large functions and the flag set', () => {
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
     expect(
@@ -136,8 +136,8 @@ describe('shouldUseCompileAll', () => {
     ).toBe(false);
   });
 
-  it('does not enable compileall off Hive even when the flag is set', () => {
-    delete process.env.VERCEL_PYTHON_ON_HIVE;
+  it('does not enable compileall without large functions even when the flag is set', () => {
+    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
     expect(
@@ -148,8 +148,8 @@ describe('shouldUseCompileAll', () => {
     ).toBe(false);
   });
 
-  it('does not enable compileall on Hive without the flag', () => {
-    process.env.VERCEL_PYTHON_ON_HIVE = '1';
+  it('does not enable compileall for large functions without the flag', () => {
+    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
     delete process.env.VERCEL_PYTHON_COMPILEALL;
 
     expect(

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -9,10 +9,10 @@ import {
   lambdaKnapsack,
   LAMBDA_SIZE_THRESHOLD_BYTES,
   LAMBDA_EPHEMERAL_STORAGE_BYTES,
-  HIVE_LAMBDA_SIZE_BYTES,
+  MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE,
 } from '../src/dependency-externalizer';
 import { classifyPackages, parseUvLock } from '@vercel/python-analysis';
-import { FileFsRef, FileBlob } from '@vercel/build-utils';
+import { FileFsRef, FileBlob, type Files } from '@vercel/build-utils';
 import { detectTargetPlatform } from '../src/platform-info';
 import {
   UV_VERSION,
@@ -34,18 +34,22 @@ vi.mock('../src/install', async () => {
 
 describe('dependency externalizer support', () => {
   describe('shouldEnableRuntimeInstall', () => {
-    const originalEnv = process.env.VERCEL_PYTHON_ON_HIVE;
+    const originalLargeFunctionsEnv =
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
 
     afterEach(() => {
-      if (originalEnv === undefined) {
-        delete process.env.VERCEL_PYTHON_ON_HIVE;
+      if (originalLargeFunctionsEnv === undefined) {
+        delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       } else {
-        process.env.VERCEL_PYTHON_ON_HIVE = originalEnv;
+        process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = originalLargeFunctionsEnv;
       }
     });
 
     const oversized = LAMBDA_SIZE_THRESHOLD_BYTES + 1;
     const undersized = LAMBDA_SIZE_THRESHOLD_BYTES - 1;
+    // Exceeds even the ephemeral-storage budget, so runtime installation can't
+    // fit it on Lambda.
+    const ephemeralOversized = LAMBDA_EPHEMERAL_STORAGE_BYTES + 1;
 
     function createExternalizer({
       uvLockPath = '/path/to/uv.lock' as string | null,
@@ -70,37 +74,54 @@ describe('dependency externalizer support', () => {
     }
 
     it('returns true when bundle exceeds threshold and uvLockPath is present', () => {
-      delete process.env.VERCEL_PYTHON_ON_HIVE;
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       const ext = createExternalizer({ totalBundleSize: oversized });
       expect(ext.shouldEnableRuntimeInstall()).toBe(true);
     });
 
-    it('returns false when VERCEL_PYTHON_ON_HIVE is "1"', () => {
-      process.env.VERCEL_PYTHON_ON_HIVE = '1';
+    it('still attempts runtime install under VERCEL_SUPPORT_LARGE_FUNCTIONS when the bundle fits ephemeral storage', () => {
+      // Large functions keep deferrable bundles on Lambda via runtime install;
+      // Hive is only used when the deps can't fit ephemeral storage.
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
       const ext = createExternalizer({ totalBundleSize: oversized });
+      expect(ext.shouldEnableRuntimeInstall()).toBe(true);
+    });
+
+    it('skips runtime install under VERCEL_SUPPORT_LARGE_FUNCTIONS when the bundle exceeds ephemeral storage', () => {
+      // Too big for /tmp: bundle everything and serve on Hive instead.
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
+      const ext = createExternalizer({ totalBundleSize: ephemeralOversized });
       expect(ext.shouldEnableRuntimeInstall()).toBe(false);
     });
 
-    it('returns false when VERCEL_PYTHON_ON_HIVE is "true"', () => {
-      process.env.VERCEL_PYTHON_ON_HIVE = 'true';
-      const ext = createExternalizer({ totalBundleSize: oversized });
+    it('skips runtime install under VERCEL_SUPPORT_LARGE_FUNCTIONS when the bundle is under threshold', () => {
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
+      const ext = createExternalizer({ totalBundleSize: undersized });
       expect(ext.shouldEnableRuntimeInstall()).toBe(false);
     });
 
-    it('returns true when VERCEL_PYTHON_ON_HIVE is an unrecognised value', () => {
-      process.env.VERCEL_PYTHON_ON_HIVE = 'yes';
+    it('attempts runtime install when VERCEL_SUPPORT_LARGE_FUNCTIONS is an unrecognised value', () => {
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = 'yes';
       const ext = createExternalizer({ totalBundleSize: oversized });
+      expect(ext.shouldEnableRuntimeInstall()).toBe(true);
+    });
+
+    it('still attempts runtime install when the bundle exceeds ephemeral storage without large functions enabled', () => {
+      // Without large functions the ephemeral short-circuit does not apply, so
+      // it still attempts the hack (generateBundle later throws).
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
+      const ext = createExternalizer({ totalBundleSize: ephemeralOversized });
       expect(ext.shouldEnableRuntimeInstall()).toBe(true);
     });
 
     it('returns false when bundle is under threshold', () => {
-      delete process.env.VERCEL_PYTHON_ON_HIVE;
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       const ext = createExternalizer({ totalBundleSize: undersized });
       expect(ext.shouldEnableRuntimeInstall()).toBe(false);
     });
 
     it('returns false when uvLockPath is null', () => {
-      delete process.env.VERCEL_PYTHON_ON_HIVE;
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       const ext = createExternalizer({
         totalBundleSize: oversized,
         uvLockPath: null,
@@ -109,7 +130,7 @@ describe('dependency externalizer support', () => {
     });
 
     it('returns false when hasCustomCommand is true even with oversized bundle and uvLockPath', () => {
-      delete process.env.VERCEL_PYTHON_ON_HIVE;
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       const ext = createExternalizer({
         totalBundleSize: oversized,
         hasCustomCommand: true,
@@ -118,7 +139,7 @@ describe('dependency externalizer support', () => {
     });
 
     it('returns false when hasCustomCommand is true and bundle is under threshold', () => {
-      delete process.env.VERCEL_PYTHON_ON_HIVE;
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       const ext = createExternalizer({
         totalBundleSize: undersized,
         hasCustomCommand: true,
@@ -223,12 +244,12 @@ describe('dependency externalizer support', () => {
       );
     });
 
-    it('HIVE_LAMBDA_SIZE_BYTES is 1 GB', () => {
-      expect(HIVE_LAMBDA_SIZE_BYTES).toBe(1 * 1024 * 1024 * 1024);
+    it('MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE is 5 GB', () => {
+      expect(MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE).toBe(5 * 1024 * 1024 * 1024);
     });
 
-    it('Hive limit is greater than the ephemeral storage limit', () => {
-      expect(HIVE_LAMBDA_SIZE_BYTES).toBeGreaterThan(
+    it('large function limit is greater than the ephemeral storage limit', () => {
+      expect(MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE).toBeGreaterThan(
         LAMBDA_EPHEMERAL_STORAGE_BYTES
       );
     });
@@ -895,18 +916,19 @@ version = "8.1.7"
   });
 
   describe('analyze', () => {
-    const originalEnv = process.env.VERCEL_PYTHON_ON_HIVE;
+    const originalLargeFunctionsEnv =
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
 
     afterEach(() => {
-      if (originalEnv === undefined) {
-        delete process.env.VERCEL_PYTHON_ON_HIVE;
+      if (originalLargeFunctionsEnv === undefined) {
+        delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       } else {
-        process.env.VERCEL_PYTHON_ON_HIVE = originalEnv;
+        process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = originalLargeFunctionsEnv;
       }
     });
 
     it('throws user-friendly error for custom install command with oversized bundle', async () => {
-      delete process.env.VERCEL_PYTHON_ON_HIVE;
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
 
       const tempDir = path.join(tmpdir(), `dep-ext-analyze-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
@@ -968,7 +990,7 @@ version = "8.1.7"
     });
 
     it('does not throw for custom install command when bundle is under threshold', async () => {
-      delete process.env.VERCEL_PYTHON_ON_HIVE;
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
 
       const tempDir = path.join(tmpdir(), `dep-ext-analyze-ok-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
@@ -1001,16 +1023,19 @@ version = "8.1.7"
       }
     });
 
-    it('invokes onSized with the size even when the bundle exceeds the Hive limit and throws', async () => {
-      process.env.VERCEL_PYTHON_ON_HIVE = '1';
+    it('invokes onSized with the size even when the bundle exceeds the large-function limit and throws', async () => {
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
 
-      const tempDir = path.join(tmpdir(), `dep-ext-onsized-hive-${Date.now()}`);
+      const tempDir = path.join(
+        tmpdir(),
+        `dep-ext-onsized-large-${Date.now()}`
+      );
       fs.mkdirSync(tempDir, { recursive: true });
 
-      // Sparse file just over the 1 GB Hive limit (no real disk usage).
+      // Sparse file just over the 5 GB large-function limit (no real disk usage).
       const bigFilePath = path.join(tempDir, 'big-file.dat');
       const fd = fs.openSync(bigFilePath, 'w');
-      const oversized = HIVE_LAMBDA_SIZE_BYTES + 1024 * 1024;
+      const oversized = MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE + 1024 * 1024;
       fs.ftruncateSync(fd, oversized);
       fs.closeSync(fd);
 
@@ -1048,8 +1073,203 @@ version = "8.1.7"
       }
     });
 
+    it('attempts runtime install under supportLargeFunctions when the bundle fits ephemeral storage', async () => {
+      // Over the 225 MB Lambda threshold but within /tmp: keep it on Lambda via
+      // runtime install rather than sending it to Hive.
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
+
+      const tempDir = path.join(tmpdir(), `dep-ext-large-defer-${Date.now()}`);
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      const bigFilePath = path.join(tempDir, 'big-file.dat');
+      const fd = fs.openSync(bigFilePath, 'w');
+      const size = LAMBDA_SIZE_THRESHOLD_BYTES + 1024 * 1024;
+      fs.ftruncateSync(fd, size);
+      fs.closeSync(fd);
+
+      const ext = new PythonDependencyExternalizer({
+        venvPath: tempDir,
+        vendorDir: '_vendor',
+        workPath: tempDir,
+        uvLockPath: path.join(tempDir, 'uv.lock'),
+        uvProjectDir: tempDir,
+        projectName: 'test-project',
+        pythonMajor: 3,
+        pythonMinor: 12,
+        pythonPath: '/usr/bin/python3',
+        hasCustomCommand: false,
+      });
+
+      const files = {
+        'big-file.dat': new FileFsRef({ fsPath: bigFilePath }),
+      };
+
+      try {
+        const result = await ext.analyze(files);
+        expect(result.runtimeInstallEnabled).toBe(true);
+        expect(result.totalBundleSize).toBe(size);
+      } finally {
+        fs.removeSync(tempDir);
+      }
+    });
+
+    it('skips runtime install under supportLargeFunctions when the bundle exceeds ephemeral storage', async () => {
+      // Too big for /tmp: bundle everything (no runtime install) and let the
+      // platform route it to Hive.
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
+
+      const tempDir = path.join(tmpdir(), `dep-ext-large-hive-${Date.now()}`);
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      const bigFilePath = path.join(tempDir, 'big-file.dat');
+      const fd = fs.openSync(bigFilePath, 'w');
+      const size = LAMBDA_EPHEMERAL_STORAGE_BYTES + 1024 * 1024;
+      fs.ftruncateSync(fd, size);
+      fs.closeSync(fd);
+
+      const ext = new PythonDependencyExternalizer({
+        venvPath: tempDir,
+        vendorDir: '_vendor',
+        workPath: tempDir,
+        uvLockPath: path.join(tempDir, 'uv.lock'),
+        uvProjectDir: tempDir,
+        projectName: 'test-project',
+        pythonMajor: 3,
+        pythonMinor: 12,
+        pythonPath: '/usr/bin/python3',
+        hasCustomCommand: false,
+      });
+
+      const files = {
+        'big-file.dat': new FileFsRef({ fsPath: bigFilePath }),
+      };
+
+      try {
+        const result = await ext.analyze(files);
+        expect(result.runtimeInstallEnabled).toBe(false);
+        expect(result.totalBundleSize).toBe(size);
+      } finally {
+        fs.removeSync(tempDir);
+      }
+    });
+
+    it('throws the extended limit error under supportLargeFunctions when the bundle exceeds 5 GB', async () => {
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
+
+      const tempDir = path.join(tmpdir(), `dep-ext-large-over-${Date.now()}`);
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      // Sparse file just over the 5 GB large-function limit (no real disk use).
+      const bigFilePath = path.join(tempDir, 'big-file.dat');
+      const fd = fs.openSync(bigFilePath, 'w');
+      fs.ftruncateSync(fd, MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE + 1024 * 1024);
+      fs.closeSync(fd);
+
+      const ext = new PythonDependencyExternalizer({
+        venvPath: tempDir,
+        vendorDir: '_vendor',
+        workPath: tempDir,
+        uvLockPath: path.join(tempDir, 'uv.lock'),
+        uvProjectDir: tempDir,
+        projectName: 'test-project',
+        pythonMajor: 3,
+        pythonMinor: 12,
+        pythonPath: '/usr/bin/python3',
+        hasCustomCommand: false,
+      });
+
+      const files = {
+        'big-file.dat': new FileFsRef({ fsPath: bigFilePath }),
+      };
+
+      try {
+        await expect(ext.analyze(files)).rejects.toThrow(
+          'exceeds the extended function size limit'
+        );
+      } finally {
+        fs.removeSync(tempDir);
+      }
+    });
+
+    it('throws under supportLargeFunctions when the bundle is exactly at the 5 GB limit', async () => {
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
+
+      const tempDir = path.join(tmpdir(), `dep-ext-large-eq-${Date.now()}`);
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      // Sparse file exactly at the limit: must throw (>=), matching the
+      // authoritative uncompressed-size check applied downstream.
+      const bigFilePath = path.join(tempDir, 'big-file.dat');
+      const fd = fs.openSync(bigFilePath, 'w');
+      fs.ftruncateSync(fd, MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE);
+      fs.closeSync(fd);
+
+      const ext = new PythonDependencyExternalizer({
+        venvPath: tempDir,
+        vendorDir: '_vendor',
+        workPath: tempDir,
+        uvLockPath: path.join(tempDir, 'uv.lock'),
+        uvProjectDir: tempDir,
+        projectName: 'test-project',
+        pythonMajor: 3,
+        pythonMinor: 12,
+        pythonPath: '/usr/bin/python3',
+        hasCustomCommand: false,
+      });
+
+      const files = {
+        'big-file.dat': new FileFsRef({ fsPath: bigFilePath }),
+      };
+
+      try {
+        await expect(ext.analyze(files)).rejects.toThrow(
+          'exceeds the extended function size limit'
+        );
+      } finally {
+        fs.removeSync(tempDir);
+      }
+    });
+
+    it('does not throw the custom-install-command error under supportLargeFunctions', async () => {
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
+
+      const tempDir = path.join(tmpdir(), `dep-ext-large-custom-${Date.now()}`);
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      // Over the AWS Lambda threshold; with a custom command this throws on the
+      // standard path, but direct-bundle mode bundles it for Hive instead.
+      const bigFilePath = path.join(tempDir, 'big-file.dat');
+      const fd = fs.openSync(bigFilePath, 'w');
+      fs.ftruncateSync(fd, LAMBDA_SIZE_THRESHOLD_BYTES + 1024 * 1024);
+      fs.closeSync(fd);
+
+      const ext = new PythonDependencyExternalizer({
+        venvPath: tempDir,
+        vendorDir: '_vendor',
+        workPath: tempDir,
+        uvLockPath: path.join(tempDir, 'uv.lock'),
+        uvProjectDir: tempDir,
+        projectName: 'test-project',
+        pythonMajor: 3,
+        pythonMinor: 12,
+        pythonPath: '/usr/bin/python3',
+        hasCustomCommand: true,
+      });
+
+      const files = {
+        'big-file.dat': new FileFsRef({ fsPath: bigFilePath }),
+      };
+
+      try {
+        const result = await ext.analyze(files);
+        expect(result.runtimeInstallEnabled).toBe(false);
+      } finally {
+        fs.removeSync(tempDir);
+      }
+    });
+
     it('invokes onSized on the under-threshold success path', async () => {
-      delete process.env.VERCEL_PYTHON_ON_HIVE;
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
 
       const tempDir = path.join(tmpdir(), `dep-ext-onsized-ok-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
@@ -1086,6 +1306,97 @@ version = "8.1.7"
       } finally {
         fs.removeSync(tempDir);
       }
+    });
+  });
+
+  describe('generateBundle Hive fallback', () => {
+    const originalLargeFunctionsEnv =
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
+
+    afterEach(() => {
+      if (originalLargeFunctionsEnv === undefined) {
+        delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
+      } else {
+        process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = originalLargeFunctionsEnv;
+      }
+    });
+
+    // Build an externalizer in the post-analyze() state without a real venv:
+    // the ephemeral-storage check runs before any uv.lock work, so the fallback
+    // it triggers can be exercised by setting the analyzed fields directly.
+    function createAnalyzedExternalizer({
+      totalBundleSize,
+      allVendorFiles,
+    }: {
+      totalBundleSize: number;
+      allVendorFiles: Files;
+    }) {
+      const ext = new PythonDependencyExternalizer({
+        venvPath: '/tmp/venv',
+        vendorDir: '_vendor',
+        workPath: '/tmp/work',
+        uvLockPath: '/tmp/work/uv.lock',
+        uvProjectDir: '/tmp/work',
+        projectName: 'test-project',
+        pythonMajor: 3,
+        pythonMinor: 12,
+        pythonPath: '/usr/bin/python3',
+        hasCustomCommand: false,
+      });
+      (ext as any).analyzed = true;
+      (ext as any).totalBundleSize = totalBundleSize;
+      (ext as any).allVendorFiles = allVendorFiles;
+      return ext;
+    }
+
+    it('bundles all dependencies for Hive and discards runtime-install artifacts when deps exceed ephemeral storage under supportLargeFunctions', async () => {
+      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
+
+      const allVendorFiles: Files = {
+        '_vendor/pkg/__init__.py': new FileBlob({ data: 'a' }),
+        '_vendor/pkg/module.py': new FileBlob({ data: 'b' }),
+      };
+      const ext = createAnalyzedExternalizer({
+        totalBundleSize: LAMBDA_EPHEMERAL_STORAGE_BYTES + 1,
+        allVendorFiles,
+      });
+
+      // Pre-seed runtime-install artifacts to verify the fallback discards them.
+      const files: Files = {
+        '_uv/_runtime_config.json': new FileBlob({ data: '{}' }),
+        '_uv/uv': new FileBlob({ data: 'binary' }),
+        '_uv/pyproject.toml': new FileBlob({ data: '[project]' }),
+        '_uv/uv.lock': new FileBlob({ data: 'version = 1' }),
+      };
+
+      const result = await ext.generateBundle(files);
+
+      expect(result.fellBackToFullBundle).toBe(true);
+      // Every vendor file is bundled directly.
+      expect(files['_vendor/pkg/__init__.py']).toBe(
+        allVendorFiles['_vendor/pkg/__init__.py']
+      );
+      expect(files['_vendor/pkg/module.py']).toBe(
+        allVendorFiles['_vendor/pkg/module.py']
+      );
+      // Runtime-install artifacts are removed (the function runs on Hive).
+      expect(files['_uv/_runtime_config.json']).toBeUndefined();
+      expect(files['_uv/uv']).toBeUndefined();
+      expect(files['_uv/pyproject.toml']).toBeUndefined();
+      expect(files['_uv/uv.lock']).toBeUndefined();
+    });
+
+    it('throws when deps exceed ephemeral storage without supportLargeFunctions', async () => {
+      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
+
+      const ext = createAnalyzedExternalizer({
+        totalBundleSize: LAMBDA_EPHEMERAL_STORAGE_BYTES + 1,
+        allVendorFiles: {},
+      });
+
+      await expect(ext.generateBundle({})).rejects.toThrow(
+        'exceeds Lambda ephemeral storage limit'
+      );
     });
   });
 });

--- a/packages/python/test/fixtures/64-hive-compileall/vercel.json
+++ b/packages/python/test/fixtures/64-hive-compileall/vercel.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "env": {
-      "VERCEL_PYTHON_ON_HIVE": "1",
+      "VERCEL_SUPPORT_LARGE_FUNCTIONS": "1",
       "VERCEL_PYTHON_COMPILEALL": "1"
     }
   }


### PR DESCRIPTION
## Why

The Python builder targets the AWS Lambda uncompressed limit (~225 MB) and, above it, defers public dependencies to a cold-start install into `/tmp` (which works up to the ~500 MB ephemeral budget). But functions whose **non-deferrable** content alone exceeds the Lambda limit — large source/data files, private or source-only packages, or packages without a prebuilt wheel — or whose total dependencies exceed `/tmp`, fail the build outright, even though they can run on Hive with a much larger budget.

This makes the builder honor `VERCEL_SUPPORT_LARGE_FUNCTIONS`: those functions are bundled in full and run on Hive instead of failing, while anything that already fits AWS Lambda stays on AWS Lambda. It also removes the now-redundant `VERCEL_PYTHON_ON_HIVE` size path, which `VERCEL_SUPPORT_LARGE_FUNCTIONS` fully supersedes (proper size-based routing + a larger ceiling).

## What changes

With `VERCEL_SUPPORT_LARGE_FUNCTIONS` set, the builder routes by uncompressed bundle size:

- **≤ 225 MB** → bundled directly, runs on AWS Lambda (unchanged).
- **225–500 MB, deferrable** → kept on AWS Lambda via runtime install (unchanged).
- **Can't fit AWS Lambda** (non-deferrable footprint over the limit, total over `/tmp`, no compatible wheels, or a custom install command) → bundled in full (up to 5 GB) and run on Hive instead of failing the build.

Also:

- Size logic now keys off a single `isLargeFunctionsEnabled()` helper; the `VERCEL_PYTHON_ON_HIVE` size handling and its 1 GB constant are removed.
- The opt-in `compileall` bytecode step keys off `VERCEL_SUPPORT_LARGE_FUNCTIONS`, and the new bundle-everything fallback is eligible for it too.
- The builder's pre-flight size check uses `>=` to agree with the platform's uncompressed-size check at the exact boundary.

## Validation

- Unit tests for the size-band decision (`shouldEnableRuntimeInstall`), the `analyze()` ceiling/telemetry behavior across bands, and the `generateBundle` bundle-everything fallback (signal + runtime-artifact cleanup).
- `compileall` tests and the `64-hive-compileall` fixture updated to the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
