### PR TITLE
[CLI] Rename traces `--view` gantt to waterfall

### DIFF
--- a/.changeset/traces-view-waterfall.md
+++ b/.changeset/traces-view-waterfall.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Rename the `gantt` value for `vercel traces get --view` to `waterfall`.

--- a/packages/cli/src/commands/traces/command.ts
+++ b/packages/cli/src/commands/traces/command.ts
@@ -41,7 +41,7 @@ export const getSubcommand = {
       name: 'view',
       shorthand: null,
       type: String,
-      argument: 'timeline|tree|gantt',
+      argument: 'timeline|tree|waterfall',
       deprecated: false,
       description:
         'Dashboard view to open. Only valid with --open. Defaults to timeline.',
@@ -69,8 +69,8 @@ export const getSubcommand = {
       value: `${packageName} traces get req_1234567890 --open`,
     },
     {
-      name: 'Open the trace in the Vercel Dashboard with the gantt view',
-      value: `${packageName} traces get req_1234567890 --open --view gantt`,
+      name: 'Open the trace in the Vercel Dashboard with the waterfall view',
+      value: `${packageName} traces get req_1234567890 --open --view waterfall`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/traces/get.ts
+++ b/packages/cli/src/commands/traces/get.ts
@@ -18,7 +18,7 @@ import { renderMarkdown } from './render-markdown';
 import { resolveScope } from './scope-resolver';
 import type { TracesTelemetryClient } from '../../util/telemetry/commands/traces';
 
-const VIEW_OPTIONS = ['timeline', 'tree', 'gantt'] as const;
+const VIEW_OPTIONS = ['timeline', 'tree', 'waterfall'] as const;
 type View = (typeof VIEW_OPTIONS)[number];
 
 function isView(value: string): value is View {

--- a/packages/cli/test/unit/commands/traces/get.test.ts
+++ b/packages/cli/test/unit/commands/traces/get.test.ts
@@ -320,18 +320,25 @@ describe('vercel traces get', () => {
       );
     });
 
-    it('appends ?view=gantt when --view=gantt', async () => {
+    it('appends ?view=waterfall when --view=waterfall', async () => {
       mockLinkedProject();
       client.scenario.get('/v1/projects/traces', (_req, res) => {
         res.json({ trace: sampleTrace });
       });
 
-      client.setArgv('traces', 'get', 'req_gantt', '--open', '--view', 'gantt');
+      client.setArgv(
+        'traces',
+        'get',
+        'req_waterfall',
+        '--open',
+        '--view',
+        'waterfall'
+      );
       const exitCode = await traces(client);
 
       expect(exitCode).toBe(0);
       expect(mockedOpen).toHaveBeenCalledWith(
-        'https://vercel.com/my-team/traces-project/logs/traces/trace_001?view=gantt'
+        'https://vercel.com/my-team/traces-project/logs/traces/trace_001?view=waterfall'
       );
     });
 
@@ -370,7 +377,7 @@ describe('vercel traces get', () => {
 
       expect(exitCode).toBe(1);
       expect(client.stderr.getFullOutput()).toContain(
-        '`--view` must be one of: timeline, tree, gantt. Received: flamegraph'
+        '`--view` must be one of: timeline, tree, waterfall. Received: flamegraph'
       );
       expect(mockedOpen).not.toHaveBeenCalled();
     });
@@ -515,7 +522,7 @@ describe('vercel traces get', () => {
       expect(payload.status).toBe('error');
       expect(payload.reason).toBe('invalid_arguments');
       expect(payload.message).toBe(
-        '`--view` must be one of: timeline, tree, gantt. Received: flamegraph'
+        '`--view` must be one of: timeline, tree, waterfall. Received: flamegraph'
       );
 
       exitSpy.mockRestore();


### PR DESCRIPTION
## Summary

Renames the `gantt` value of `vercel traces get --view` to `waterfall`.

The `--view` option now accepts `timeline | tree | waterfall`. The value flows through to the dashboard URL as `?view=waterfall`.

## Changes

- `packages/cli/src/commands/traces/get.ts` — `VIEW_OPTIONS` validation tuple `gantt` → `waterfall` (drives accepted value, validation error, and the `?view=` URL param).
- `packages/cli/src/commands/traces/command.ts` — `--view` argument hint and the example command/description.
- `packages/cli/test/unit/commands/traces/get.test.ts` — updated the view test and the two invalid-`--view` error-message assertions.
- `.changeset/traces-view-waterfall.md` — added (`vercel`: patch).

## Testing

The `packages/cli` unit suite could not be run in this environment due to a pre-existing, unrelated install failure (the `@rolldown/binding-darwin-arm64` native binding is missing, so `@vercel/backends` fails to build and vitest can't resolve its import — this blocks all CLI tests, not this change). The edits are pure string-literal renames of a `const` tuple, command metadata, and matching test strings, verified by inspection; no `gantt` references remain in `packages/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)