### PR TITLE
fix(cli): resolve per-directory links against the repository root (VERCEL_RESOLVE_ROOT_DIRECTORY)

### DIFF
--- a/.changeset/resolve-root-directory.md
+++ b/.changeset/resolve-root-directory.md
@@ -1,0 +1,12 @@
+---
+'vercel': patch
+---
+
+Add opt-in resolution of per-directory project links against the repository root (gated behind `VERCEL_RESOLVE_ROOT_DIRECTORY=1`).
+
+A project linked in place (`apps/api/.vercel/project.json`) is anchored by the link's physical location. When `vc build` runs from that directory, it previously treated the linked subdirectory as the repository root and interpreted the project's `rootDirectory` setting as an offset from there. That broke common setups:
+
+- A `rootDirectory` that restates the link's own location (e.g. `apps/api` for a link at `apps/api`) double-appended into `apps/api/apps/api`, failing with `ENOENT … /apps/api/apps/api/.next/package.json`.
+- A null `rootDirectory` left the repository root mis-detected as the subdirectory, so dependencies hoisted above it were not traced (runtime `Cannot find module`).
+
+With the flag enabled, a per-directory link is resolved like a repo-level link: the repository root is detected (workspace markers, then git) and the project is expressed as its path relative to that root. The link's physical location is authoritative — a redundant `rootDirectory` is absorbed silently, and a mismatched one is ignored with an advisory rather than applied — so these setups "just work" regardless of which directory the command is run from. Behavior is unchanged when the flag is not set.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -129,7 +129,10 @@ import { pullEnvRecords } from '../../util/env/get-env-records';
 import { buildCommand } from './command';
 import { validatePackageManifest } from '../../util/validate-package-manifest';
 import { shouldEmbedFlagsDefinitions } from '../../util/flags/build-embedding';
-import { resolveRepoRoot } from '../../util/build/repo-root';
+import {
+  resolveRepoRoot,
+  resolvePerDirectoryLinkRoot,
+} from '../../util/build/repo-root';
 
 /** Build a plain suggested command with global flags (e.g. --cwd, --non-interactive) appended. */
 function buildCommandWithGlobalFlags(
@@ -338,7 +341,11 @@ export default async function main(client: Client): Promise<number> {
     }
   }
 
-  const projectRootDirectory = link?.projectRootDirectory ?? '';
+  // The directory the build was invoked from, before any repo-root
+  // re-anchoring below. Used to resolve a per-directory link's true location.
+  const invokedCwd = cwd;
+  const hasRepoLevelLink = Boolean(link?.repoRoot);
+  let projectRootDirectory = link?.projectRootDirectory ?? '';
   if (link?.repoRoot) {
     cwd = client.cwd = link.repoRoot;
   }
@@ -426,6 +433,46 @@ export default async function main(client: Client): Promise<number> {
     client.cwd = cwd;
     client.setArgv(originalArgv);
     project = await readProjectSettings(vercelDir);
+  }
+
+  // Per-directory link (`<dir>/.vercel/project.json`) resolution. A repo-level
+  // (`repo.json`) link already reported its `repoRoot` and offset above; a
+  // per-directory link does not, so the build would otherwise treat the linked
+  // subdirectory as the repository root.
+  //
+  // Resolve the link against the true repository root so it behaves like a
+  // repo-level link: re-anchor `cwd` to the detected root and express the
+  // project as its path relative to that root. The link's physical location is
+  // authoritative — a redundant or mismatched `rootDirectory` setting is
+  // absorbed rather than applied (which previously produced broken paths like
+  // `apps/api/apps/api`). The `rootDirectory` setting lives in the project
+  // settings (just read above), not on the link, so this runs here.
+  // Gated behind an opt-in env var while it bakes.
+  if (
+    !hasRepoLevelLink &&
+    link &&
+    project?.settings &&
+    process.env.VERCEL_RESOLVE_ROOT_DIRECTORY === '1'
+  ) {
+    const resolved = resolvePerDirectoryLinkRoot(
+      invokedCwd,
+      project.settings.rootDirectory
+    );
+    if (resolved.advisory) {
+      output.warn(resolved.advisory);
+    }
+    if (resolved.resolvedRootDirectory !== '') {
+      output.debug(
+        `Resolved per-directory link: repoRoot=${resolved.repoRoot}, ` +
+          `rootDirectory=${resolved.resolvedRootDirectory} (was cwd=${invokedCwd})`
+      );
+      projectRootDirectory = resolved.resolvedRootDirectory;
+      // Normalize the setting to the resolved value so the downstream
+      // `workPath` derivation (`cwd + settings.rootDirectory`) lands at the
+      // project, consistent with how a repo-level link behaves.
+      project.settings.rootDirectory = resolved.resolvedRootDirectory;
+      cwd = client.cwd = resolved.repoRoot;
+    }
   }
 
   // Delete output directory from potential previous build

--- a/packages/cli/src/util/build/repo-root.ts
+++ b/packages/cli/src/util/build/repo-root.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join, parse } from 'node:path';
+import { dirname, join, parse, relative } from 'node:path';
 import { getGitRootDirectory } from '../git-helpers';
 
 /**
@@ -105,4 +105,89 @@ function isWorkspaceRoot(dir: string): boolean {
   }
 
   return false;
+}
+
+/**
+ * Result of resolving a per-directory link (`apps/api/.vercel/project.json`)
+ * against the detected repository root.
+ */
+export interface PerDirectoryLinkRoot {
+  /** The detected repository root (an ancestor of, or equal to, `anchorDir`). */
+  repoRoot: string;
+  /**
+   * The project's root directory relative to `repoRoot` (the "resolved root
+   * directory"). Empty string when the link is at the repo root.
+   */
+  resolvedRootDirectory: string;
+  /**
+   * Set when the link's `rootDirectory` setting disagrees with the link's
+   * physical location. The setting is ignored (the location wins); this
+   * message explains what happened so the user can clean up their config.
+   */
+  advisory?: string;
+}
+
+/**
+ * Resolves a per-directory link to its canonical `(repoRoot,
+ * resolvedRootDirectory)` against the detected repository root.
+ *
+ * A per-directory link (`<dir>/.vercel/project.json`) is anchored by its
+ * physical location: the project lives at `anchorDir`, full stop. The repo
+ * root is detected independently by walking up from `anchorDir`. The project's
+ * root directory relative to that root is therefore always `relative(repoRoot,
+ * anchorDir)` — the link's own location expressed against the root.
+ *
+ * The link's stored `rootDirectory` is treated as advisory only. It commonly
+ * (and harmlessly) restates the link's location (e.g. a link at `apps/api`
+ * with `rootDirectory: "apps/api"`); such redundancy is absorbed silently.
+ * Any other non-empty value disagrees with the physical location and is
+ * ignored — the location always wins — with an advisory returned so the caller
+ * can surface it. The build is never moved to a location other than where the
+ * link physically sits.
+ *
+ * @param anchorDir absolute path to the directory containing `.vercel`
+ * @param rootDirectorySetting the project's `rootDirectory` setting, if any
+ */
+export function resolvePerDirectoryLinkRoot(
+  anchorDir: string,
+  rootDirectorySetting: string | null | undefined
+): PerDirectoryLinkRoot {
+  const repoRoot = resolveRepoRoot({ cwd: anchorDir });
+  const resolvedRootDirectory = normalizeRelative(
+    relative(repoRoot, anchorDir)
+  );
+
+  // The link is at (or above) the detected root, or no distinct root was
+  // found: nothing to resolve, the setting keeps its normal meaning.
+  if (resolvedRootDirectory === '') {
+    return { repoRoot, resolvedRootDirectory: '' };
+  }
+
+  const setting = normalizeRelative(rootDirectorySetting ?? '');
+  if (setting === '' || setting === resolvedRootDirectory) {
+    // Nullish, or a redundant restatement of the link's location — absorb.
+    return { repoRoot, resolvedRootDirectory };
+  }
+
+  // The setting names somewhere other than the link's location. The physical
+  // location wins; surface the disagreement so the user can fix their config.
+  return {
+    repoRoot,
+    resolvedRootDirectory,
+    advisory:
+      `Ignoring "rootDirectory" setting "${setting}" for the project linked in ` +
+      `"${anchorDir}": a project linked in this directory always builds from ` +
+      `"${resolvedRootDirectory}" (its path relative to the repository root ` +
+      `"${repoRoot}"). Remove the "rootDirectory" setting, or configure it at ` +
+      `the repository root instead.`,
+  };
+}
+
+/** Normalizes a relative path: strips leading `./`, trailing slashes, and `.`. */
+function normalizeRelative(p: string): string {
+  const normalized = p
+    .replace(/\\/g, '/')
+    .replace(/^\.\//, '')
+    .replace(/\/+$/, '');
+  return normalized === '.' ? '' : normalized;
 }

--- a/packages/cli/test/unit/commands/build/monorepo.test.ts
+++ b/packages/cli/test/unit/commands/build/monorepo.test.ts
@@ -925,3 +925,119 @@ describe('repository-root detection builds (VERCEL_DETECT_REPO_ROOT)', () => {
     }
   );
 });
+
+// Per-directory link resolution, gated behind `VERCEL_RESOLVE_ROOT_DIRECTORY`.
+//
+// A project linked in place (`apps/api/.vercel/project.json`) is anchored by
+// the link's physical location. Running `vc build` from there should resolve
+// the repository root and express the project as its path relative to that
+// root — regardless of whether the `rootDirectory` setting is null (config #3)
+// or a redundant restatement of the location (config #4, a common
+// misconfiguration). The latter previously produced a broken `apps/api/apps/api`
+// path; here it must "just work".
+describe('per-directory link resolution (VERCEL_RESOLVE_ROOT_DIRECTORY)', () => {
+  beforeEach(() => {
+    delete process.env.__VERCEL_BUILD_RUNNING;
+    delete process.env.VERCEL_TRACING_DISABLE_AUTOMATIC_FETCH_INSTRUMENTATION;
+    process.env.VERCEL_RESOLVE_ROOT_DIRECTORY = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_RESOLVE_ROOT_DIRECTORY;
+  });
+
+  async function setupApiFixture(rootDirectorySetting: string | null) {
+    const monorepoRoot = setupUnitFixture(
+      'commands/build/turborepo-hono-standalone'
+    );
+    const appDir = join(monorepoRoot, 'apps', 'api');
+
+    await execa('git', ['init'], { cwd: monorepoRoot });
+    await execa('pnpm', ['install', '--ignore-scripts'], {
+      cwd: monorepoRoot,
+    });
+
+    // Write the per-directory link's `project.json` with the desired
+    // `rootDirectory` setting (the fixture is a throwaway temp copy).
+    const projectJsonPath = join(appDir, '.vercel', 'project.json');
+    await writeFile(
+      projectJsonPath,
+      JSON.stringify({
+        projectId: 'prj_turborepo_hono_standalone',
+        orgId: 'team_dummy',
+        settings: {
+          framework: 'hono',
+          rootDirectory: rootDirectorySetting,
+          nodeVersion: '24.x',
+        },
+      })
+    );
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'prj_turborepo_hono_standalone',
+      name: 'turborepo-hono-standalone',
+      framework: 'hono',
+      rootDirectory: rootDirectorySetting,
+    });
+
+    return { monorepoRoot, appDir };
+  }
+
+  it.skipIf(process.platform === 'win32')(
+    'builds from a subdirectory with a null rootDirectory (config #3)',
+    async () => {
+      const { monorepoRoot, appDir } = await setupApiFixture(null);
+      const output = join(appDir, '.vercel/output');
+
+      client.cwd = appDir;
+      client.setArgv('build', '--yes');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      const indexFuncDir = join(output, 'functions', 'index.func');
+      expect(await fs.pathExists(indexFuncDir)).toBe(true);
+
+      const vcConfig = await fs.readJSON(join(indexFuncDir, '.vc-config.json'));
+      expect(vcConfig.handler).toEqual('apps/api/src/index.js');
+
+      await expectModuleResolvesInIsolatedFunc(
+        indexFuncDir,
+        monorepoRoot,
+        'apps/api/src',
+        'hono'
+      );
+    }
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'absorbs a redundant rootDirectory restating the location (config #4)',
+    async () => {
+      // The common misconfiguration: a link at `apps/api` whose project also
+      // has `rootDirectory: "apps/api"`. Previously this double-appended into
+      // `apps/api/apps/api` and crashed; now it just works.
+      const { monorepoRoot, appDir } = await setupApiFixture('apps/api');
+      const output = join(appDir, '.vercel/output');
+
+      client.cwd = appDir;
+      client.setArgv('build', '--yes');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      const indexFuncDir = join(output, 'functions', 'index.func');
+      expect(await fs.pathExists(indexFuncDir)).toBe(true);
+
+      const vcConfig = await fs.readJSON(join(indexFuncDir, '.vc-config.json'));
+      expect(vcConfig.handler).toEqual('apps/api/src/index.js');
+
+      await expectModuleResolvesInIsolatedFunc(
+        indexFuncDir,
+        monorepoRoot,
+        'apps/api/src',
+        'hono'
+      );
+    }
+  );
+});

--- a/packages/cli/test/unit/util/build/repo-root.test.ts
+++ b/packages/cli/test/unit/util/build/repo-root.test.ts
@@ -6,6 +6,7 @@ import execa from 'execa';
 import {
   resolveRepoRoot,
   findWorkspaceRoot,
+  resolvePerDirectoryLinkRoot,
 } from '../../../../src/util/build/repo-root';
 
 const mkdirp = (p: string) => mkdir(p, { recursive: true });
@@ -147,6 +148,76 @@ describe('repo-root', () => {
       // No workspace marker, and tmpdir is not inside a git repo.
       const resolved = resolveRepoRoot({ cwd: appDir });
       expect(resolved).toEqual(appDir);
+    });
+  });
+
+  describe('resolvePerDirectoryLinkRoot', () => {
+    async function setupMonorepo() {
+      const appDir = join(root, 'apps', 'api');
+      await mkdirp(appDir);
+      await writeFile(
+        join(root, 'pnpm-workspace.yaml'),
+        'packages:\n  - apps/*\n'
+      );
+      return appDir;
+    }
+
+    it('resolves a null rootDirectory to the link location (config #3)', async () => {
+      const appDir = await setupMonorepo();
+      const result = resolvePerDirectoryLinkRoot(appDir, null);
+      expect(result.repoRoot).toEqual(root);
+      expect(result.resolvedRootDirectory).toEqual('apps/api');
+      expect(result.advisory).toBeUndefined();
+    });
+
+    it('absorbs a redundant rootDirectory equal to the location (config #4)', async () => {
+      const appDir = await setupMonorepo();
+      const result = resolvePerDirectoryLinkRoot(appDir, 'apps/api');
+      expect(result.repoRoot).toEqual(root);
+      expect(result.resolvedRootDirectory).toEqual('apps/api');
+      // Redundant restatement is absorbed silently — no advisory.
+      expect(result.advisory).toBeUndefined();
+    });
+
+    it('absorbs a redundant rootDirectory with ./ and trailing slash noise', async () => {
+      const appDir = await setupMonorepo();
+      const result = resolvePerDirectoryLinkRoot(appDir, './apps/api/');
+      expect(result.resolvedRootDirectory).toEqual('apps/api');
+      expect(result.advisory).toBeUndefined();
+    });
+
+    it('ignores a mismatched rootDirectory and returns an advisory', async () => {
+      const appDir = await setupMonorepo();
+      const result = resolvePerDirectoryLinkRoot(appDir, 'apps/web');
+      // Location wins: still resolves to the link's own location.
+      expect(result.resolvedRootDirectory).toEqual('apps/api');
+      expect(result.advisory).toMatch(
+        /Ignoring "rootDirectory" setting "apps\/web"/
+      );
+      expect(result.advisory).toMatch(/always builds from "apps\/api"/);
+    });
+
+    it('treats a deeper rootDirectory as a mismatch (no deeper offset)', async () => {
+      // A link at apps/api with rootDirectory "server" does NOT build
+      // apps/api/server — the link location is authoritative.
+      const appDir = await setupMonorepo();
+      const result = resolvePerDirectoryLinkRoot(appDir, 'server');
+      expect(result.resolvedRootDirectory).toEqual('apps/api');
+      expect(result.advisory).toMatch(
+        /Ignoring "rootDirectory" setting "server"/
+      );
+    });
+
+    it('returns empty resolvedRootDirectory when the link is at the repo root', async () => {
+      await writeFile(
+        join(root, 'pnpm-workspace.yaml'),
+        'packages:\n  - apps/*\n'
+      );
+      // Link anchored at the root itself: nothing to re-anchor, setting keeps
+      // its normal meaning (handled by the caller's default path).
+      const result = resolvePerDirectoryLinkRoot(root, 'apps/api');
+      expect(result.resolvedRootDirectory).toEqual('');
+      expect(result.advisory).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
> **Stacked on #16722** (`jeffsee/standalone-monorepo-repo-root`). Review/merge that first; this PR's base is that branch so the diff is scoped to the per-directory-link resolution.

## Problem

A project linked **in place** — `apps/api/.vercel/project.json` — is anchored by the link's physical location. But when `vc build` runs from that directory, it treats the linked subdirectory as the repository root and interprets the project's `rootDirectory` setting as an offset from there. Two extremely common shapes break:

- **Redundant restatement (config #4):** a link at `apps/api` whose project also has `rootDirectory: "apps/api"`. `join(cwd, rootDirectory)` double-appends → `apps/api/apps/api`, failing with `ENOENT … /apps/api/apps/api/.next/package.json` (the error reported on NEXT-4944).
- **Null rootDirectory (config #3):** the repository root is mis-detected as the subdirectory, so dependencies hoisted above it aren't traced → runtime `Cannot find module`.

This is the "should it even matter which directory the command is run from?" problem: it shouldn't, but today it does.

## Approach (opt-in via `VERCEL_RESOLVE_ROOT_DIRECTORY=1`)

Resolve a per-directory link the same way a repo-level (`repo.json`) link already resolves: detect the repository root and express the project as its path relative to that root. The model:

- The **link's physical location is authoritative.** The project lives where the `.vercel` folder is, full stop.
- `repoRoot` is detected independently (workspace markers → git → the directory itself).
- `resolvedRootDirectory = relative(repoRoot, linkDir)`.
- The stored `rootDirectory` setting is **advisory only**:
  - nullish → silent;
  - equals the resolved location (the common misconfig) → absorbed silently;
  - anything else → ignored (location wins) with a clear advisory telling the user to remove or relocate the setting.

A per-directory link never builds anywhere other than where it physically sits, so these setups "just work" regardless of the invocation directory. When the flag is unset, behavior is unchanged.

Mechanically: after the project settings are read, a per-directory link with no repo-level `repoRoot` re-anchors `cwd` to the detected root, sets the project offset to the resolved value, and normalizes `settings.rootDirectory` so the existing `workPath = cwd + rootDirectory` derivation lands at the project — exactly mirroring the repo-level link path.

## Verified against the real reproduction

`vercel-support/standalone-repro` (`apps/api` linked in place):

- config #3 (`rootDirectory: null`) → resolves `repoRoot=<repo>`, `rootDirectory=apps/api`, handler `apps/api/src/index.js`, `hono` resolves at runtime.
- config #4 (`rootDirectory: "apps/api"`) → no more `apps/api/apps/api`; builds cleanly, exit 0.
- sideways (`rootDirectory: "apps/web"`) → advisory printed, builds `apps/api` anyway.

## Testing

- **`repo-root.test.ts`**: `resolvePerDirectoryLinkRoot` unit tests — null, redundant (incl. `./`/trailing-slash noise), mismatch, deeper-path (treated as mismatch, no deeper offset), and link-at-root cases.
- **`monorepo.test.ts`**: integration tests for config #3 and #4 that build from the subdirectory and resolve the dependency from an isolated copy of the function. Both verified to **fail without the fix** (config #4 with the `apps/api/apps/api` crash).

Addresses NEXT-4944 (and complements the repo-root tracing fix in #16722 / PIPE-6621). Flag-gated for dogfooding before becoming default.
