### PR TITLE
[python-runtime] Emit catch-all routes for V2 services

### DIFF
--- a/.changeset/python-service-v2-routes.md
+++ b/.changeset/python-service-v2-routes.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Emit catch-all routes for services V2 so requests reach the Python Lambda

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -1219,11 +1219,19 @@ export const build: BuildVX = async ({
     ? await glob('**', { cwd: djangoStatic.cdnOutputDir })
     : {};
 
-  // for services routing is handled by fs-detectors, for legacy builds
-  // we still need to provide catch-all route
-  const routes = service?.name
+  // Non-web V1 services (cron, worker, job) must not emit a catch-all route
+  // because their routes are merged into a shared top-level table and would
+  // shadow other services (see #15960). Web services and V2 services (which
+  // have isolated per-service route tables) need the catch-all to reach the
+  // Lambda.
+  const isNonWebService =
+    service?.name && service.type && service.type !== 'web';
+  const routes = isNonWebService
     ? undefined
-    : [{ handle: 'filesystem' }, { src: '/(.*)', dest: `/${lambdaPath}` }];
+    : [
+        { handle: 'filesystem' as const },
+        { src: '/(.*)', dest: `/${lambdaPath}` },
+      ];
 
   return {
     resultVersion: 2,

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -2712,7 +2712,7 @@ describe('dynamic cron detection', () => {
   });
 });
 
-describe('non-web services should not generate catch-all routes', () => {
+describe('non-web V1 services should not generate catch-all routes', () => {
   let mockWorkPath: string;
 
   beforeEach(() => {
@@ -2799,14 +2799,30 @@ describe('non-web services should not generate catch-all routes', () => {
     expect(v2result.output['_svc/my-worker/index']).toBeDefined();
     expect(v2result.routes).toBeUndefined();
   });
+});
 
-  it('web service returns V2 with no routes', async () => {
+describe('V2 services should generate catch-all routes', () => {
+  let mockWorkPath: string;
+
+  beforeEach(() => {
+    mockWorkPath = path.join(tmpdir(), `python-service-routes-${Date.now()}`);
+    fs.mkdirSync(mockWorkPath, { recursive: true });
+    makeMockPython('3.11');
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(mockWorkPath)) {
+      fs.removeSync(mockWorkPath);
+    }
+  });
+
+  it('V2 service returns catch-all routes', async () => {
     const files = {
       'main.py': new FileBlob({
         data: 'from fastapi import FastAPI; app = FastAPI()',
       }),
       'pyproject.toml': new FileBlob({
-        data: '[project]\nname = "my-api"\nversion = "0.0.1"\ndependencies = ["fastapi"]\n',
+        data: '[project]\nname = "my-backend"\nversion = "0.0.1"\ndependencies = ["fastapi"]\n',
       }),
     } as Record<string, FileBlob>;
     await download(files, mockWorkPath);
@@ -2818,12 +2834,15 @@ describe('non-web services should not generate catch-all routes', () => {
       meta: { isDev: false },
       config: { framework: 'fastapi' },
       repoRootPath: mockWorkPath,
-      service: { type: 'web', name: 'my-api' },
+      service: { name: 'my-backend' },
     });
 
     const v2result = getBuildOutputV2(result);
-    expect(v2result.output['_svc/my-api/index']).toBeDefined();
-    expect(v2result.routes).toBeUndefined();
+    expect(v2result.output['_svc/my-backend/index']).toBeDefined();
+    expect(v2result.routes).toEqual([
+      { handle: 'filesystem' },
+      { src: '/(.*)', dest: '/_svc/my-backend/index' },
+    ]);
   });
 });
 


### PR DESCRIPTION
The Python builder was skipping route generation for all services (#15960), which was correct for V1 non-web services (cron, worker) whose routes merge into a shared top-level table. However, V2 services have isolated per-service route tables, so they need the catch-all route to reach the Lambda. Without it, the backend service config.json has an empty route table and all requests 404.

Now only skip routes for non-web V1 services (where service.type is set to "cron", "worker", etc.). V2 services don't set service.type, so they correctly get the catch-all route.