### PR TITLE
[cli] add support for dashboard deployment URLs and deployment IDs without prefixes to vc inspect

### DIFF
--- a/.changeset/brown-ligers-walk.md
+++ b/.changeset/brown-ligers-walk.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`vercel inspect` now supports Vercel dashboard URLs and deployment IDs without prefixes.

--- a/packages/cli/src/commands/inspect/index.ts
+++ b/packages/cli/src/commands/inspect/index.ts
@@ -3,7 +3,6 @@ import { isErrnoException } from '@vercel/error-utils';
 import chalk from 'chalk';
 import ms from 'ms';
 import title from 'title';
-import { URL } from 'url';
 import type Client from '../../util/client';
 import { isDeploying } from '../../util/deploy/is-deploying';
 import { displayBuildLogs } from '../../util/logs';
@@ -11,15 +10,17 @@ import { printError } from '../../util/error';
 import { parseArguments } from '../../util/get-args';
 import getDeployment from '../../util/get-deployment';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import getScope from '../../util/get-scope';
+import getScope, { detectExplicitScope } from '../../util/get-scope';
 import readStandardInput from '../../util/input/read-standard-input';
 import buildsList from '../../util/output/builds';
 import elapsed from '../../util/output/elapsed';
 import indent from '../../util/output/indent';
 import { validateJsonOutput } from '../../util/output-format';
 import routesList from '../../util/output/routes';
+import { parseDeploymentUrl } from '../../util/parse-deployment-url';
 import { getCommandName } from '../../util/pkg-name';
 import sleep from '../../util/sleep';
+import getTeams from '../../util/teams/get-teams';
 import { help } from '../help';
 import { inspectCommand } from './command';
 import output from '../../output-manager';
@@ -89,6 +90,19 @@ export default async function inspect(client: Client) {
 
   let contextName: string | null = null;
 
+  // Parse the deployment URL to extract scope and normalize deployment ID
+  const parsed = parseDeploymentUrl(deploymentIdOrHost);
+  deploymentIdOrHost = parsed.deploymentIdOrHost;
+  // If a scope was extracted from a dashboard URL and no explicit scope was provided,
+  // use the scope from the URL
+  if (parsed.scope && !detectExplicitScope(client)) {
+    const teams = await getTeams(client);
+    const team = teams.find(t => t.slug === parsed.scope);
+    if (team) {
+      client.config.currentTeam = team.id;
+    }
+  }
+
   try {
     ({ contextName } = await getScope(client));
   } catch (err: unknown) {
@@ -113,10 +127,6 @@ export default async function inspect(client: Client) {
   }
   const asJson = formatResult.jsonOutput;
   const startTimestamp = Date.now();
-
-  try {
-    deploymentIdOrHost = new URL(deploymentIdOrHost).hostname;
-  } catch {}
   output.spinner(
     `Fetching deployment "${deploymentIdOrHost}" in ${chalk.bold(contextName)}`
   );

--- a/packages/cli/src/util/parse-deployment-url.ts
+++ b/packages/cli/src/util/parse-deployment-url.ts
@@ -1,0 +1,58 @@
+import { URL } from 'url';
+
+/**
+ * Parses a Vercel dashboard deployment URL or normalizes a deployment ID.
+ *
+ * Handles:
+ * - Dashboard URLs: `https://vercel.com/{scope}/{project}/{deploymentId}`
+ * - Deployment URLs: `https://my-app-abc123.vercel.app`
+ * - Deployment IDs with prefix: `dpl_3qQucGyR7QyigKYWa7idzzXeWKwG`
+ * - Deployment IDs without prefix: `3qQucGyR7QyigKYWa7idzzXeWKwG`
+ */
+export interface ParsedDeploymentUrl {
+  deploymentIdOrHost: string;
+  scope?: string;
+}
+
+export function parseDeploymentUrl(input: string): ParsedDeploymentUrl {
+  let url: URL;
+
+  try {
+    url = new URL(input);
+  } catch {
+    return normalizeDeploymentId(input);
+  }
+
+  if (url.hostname === 'vercel.com' || url.hostname === 'www.vercel.com') {
+    return parseVercelDashboardUrl(url);
+  }
+
+  return { deploymentIdOrHost: url.hostname };
+}
+
+function parseVercelDashboardUrl(url: URL): ParsedDeploymentUrl {
+  const pathParts = url.pathname.split('/').filter(Boolean);
+
+  if (pathParts.length >= 3) {
+    const [scope, , deploymentId] = pathParts;
+    return {
+      deploymentIdOrHost:
+        normalizeDeploymentId(deploymentId).deploymentIdOrHost,
+      scope,
+    };
+  }
+
+  return { deploymentIdOrHost: url.hostname };
+}
+
+export function normalizeDeploymentId(input: string): ParsedDeploymentUrl {
+  if (input.includes('.')) {
+    return { deploymentIdOrHost: input };
+  }
+
+  if (input.startsWith('dpl_')) {
+    return { deploymentIdOrHost: input };
+  }
+
+  return { deploymentIdOrHost: `dpl_${input}` };
+}

--- a/packages/cli/test/unit/commands/inspect/index.test.ts
+++ b/packages/cli/test/unit/commands/inspect/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
-import { useTeams } from '../../../mocks/team';
+import { useTeam } from '../../../mocks/team';
 import { useBuildLogs, useDeployment } from '../../../mocks/deployment';
 import inspect from '../../../../src/commands/inspect';
 import sleep from '../../../../src/util/sleep';
@@ -456,8 +456,7 @@ describe('inspect', () => {
     describe('dashboard URL parsing', () => {
       it('sets team scope from dashboard URL', async () => {
         const user = useUser();
-        const teams = useTeams();
-        const team = teams[0];
+        const team = useTeam();
         const deployment = useDeployment({ creator: user });
 
         client.setArgv(
@@ -471,8 +470,7 @@ describe('inspect', () => {
 
       it('does not override explicit --scope flag', async () => {
         const user = useUser();
-        const teams = useTeams();
-        const team = teams[0];
+        const team = useTeam();
         const deployment = useDeployment({ creator: user });
 
         client.config.currentTeam = team.id;

--- a/packages/cli/test/unit/commands/inspect/index.test.ts
+++ b/packages/cli/test/unit/commands/inspect/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
 import { useBuildLogs, useDeployment } from '../../../mocks/deployment';
 import inspect from '../../../../src/commands/inspect';
 import sleep from '../../../../src/util/sleep';
@@ -450,6 +451,54 @@ describe('inspect', () => {
         status	● Ready
         "
       `);
+    });
+
+    describe('dashboard URL parsing', () => {
+      it('sets team scope from dashboard URL', async () => {
+        const user = useUser();
+        const teams = useTeams();
+        const team = teams[0];
+        const deployment = useDeployment({ creator: user });
+
+        client.setArgv(
+          'inspect',
+          `https://vercel.com/${team.slug}/my-project/${deployment.id}`
+        );
+        const exitCode = await inspect(client);
+        expect(exitCode).toEqual(0);
+        expect(client.config.currentTeam).toEqual(team.id);
+      });
+
+      it('does not override explicit --scope flag', async () => {
+        const user = useUser();
+        const teams = useTeams();
+        const team = teams[0];
+        const deployment = useDeployment({ creator: user });
+
+        client.config.currentTeam = team.id;
+        client.setArgv(
+          'inspect',
+          `https://vercel.com/other-team/my-project/${deployment.id}`,
+          '--scope',
+          team.slug
+        );
+        const exitCode = await inspect(client);
+        expect(exitCode).toEqual(0);
+        expect(client.config.currentTeam).toEqual(team.id);
+      });
+
+      it('resolves bare deployment ID with dpl_ prefix', async () => {
+        const user = useUser();
+        const deployment = useDeployment({ creator: user });
+        const bareId = deployment.id.replace('dpl_', '');
+
+        client.setArgv('inspect', bareId);
+        const exitCode = await inspect(client);
+        expect(exitCode).toEqual(0);
+        await expect(client.stderr).toOutput(
+          `Fetched deployment "${deployment.url}"`
+        );
+      });
     });
   });
 });

--- a/packages/cli/test/unit/util/parse-deployment-url.test.ts
+++ b/packages/cli/test/unit/util/parse-deployment-url.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { parseDeploymentUrl } from '../../../src/util/parse-deployment-url';
+
+describe('parseDeploymentUrl', () => {
+  describe('dashboard URLs', () => {
+    it('parses vercel.com dashboard URL with scope and deployment ID', () => {
+      const result = parseDeploymentUrl(
+        'https://vercel.com/vercel/vercel-site/3qQucGyR7QyigKYWa7idzzXeWKwG'
+      );
+      expect(result).toEqual({
+        deploymentIdOrHost: 'dpl_3qQucGyR7QyigKYWa7idzzXeWKwG',
+        scope: 'vercel',
+      });
+    });
+
+    it('handles dashboard URL with dpl_ prefixed ID', () => {
+      const result = parseDeploymentUrl(
+        'https://vercel.com/my-team/my-project/dpl_abc123'
+      );
+      expect(result).toEqual({
+        deploymentIdOrHost: 'dpl_abc123',
+        scope: 'my-team',
+      });
+    });
+
+    it('handles dashboard URL with trailing slash', () => {
+      const result = parseDeploymentUrl(
+        'https://vercel.com/vercel/vercel-site/abc123/'
+      );
+      expect(result).toEqual({
+        deploymentIdOrHost: 'dpl_abc123',
+        scope: 'vercel',
+      });
+    });
+
+    it('does not treat other vercel.com subdomains as dashboard URLs', () => {
+      const result = parseDeploymentUrl(
+        'https://admin.vercel.com/some/internal/path'
+      );
+      expect(result).toEqual({
+        deploymentIdOrHost: 'admin.vercel.com',
+      });
+      expect(result.scope).toBeUndefined();
+    });
+  });
+
+  describe('deployment URLs', () => {
+    it('extracts hostname from https deployment URL', () => {
+      const result = parseDeploymentUrl('https://my-app-abc123.vercel.app');
+      expect(result).toEqual({
+        deploymentIdOrHost: 'my-app-abc123.vercel.app',
+      });
+    });
+
+    it('extracts hostname from http deployment URL', () => {
+      const result = parseDeploymentUrl('http://my-app.vercel.app');
+      expect(result).toEqual({
+        deploymentIdOrHost: 'my-app.vercel.app',
+      });
+    });
+  });
+
+  describe('deployment IDs', () => {
+    it('adds dpl_ prefix to bare deployment ID', () => {
+      const result = parseDeploymentUrl('3qQucGyR7QyigKYWa7idzzXeWKwG');
+      expect(result).toEqual({
+        deploymentIdOrHost: 'dpl_3qQucGyR7QyigKYWa7idzzXeWKwG',
+      });
+    });
+
+    it('preserves dpl_ prefix if already present', () => {
+      const result = parseDeploymentUrl('dpl_3qQucGyR7QyigKYWa7idzzXeWKwG');
+      expect(result).toEqual({
+        deploymentIdOrHost: 'dpl_3qQucGyR7QyigKYWa7idzzXeWKwG',
+      });
+    });
+
+    it('does not add prefix to hostnames (contain dots)', () => {
+      const result = parseDeploymentUrl('my-app.vercel.app');
+      expect(result).toEqual({
+        deploymentIdOrHost: 'my-app.vercel.app',
+      });
+    });
+  });
+});


### PR DESCRIPTION
`vercel inspect` seems to be the go to command for agents investigating specific Vercel deployments – 

1. `vercel inspect https://vercel.com/vercel/project/abcdefghi1345`
2. `vercel inspect --scope vercel abcdefghi1345` 

should both work natively. 