### PR TITLE
[services] `experimentalServicesV2` -> `services`

### DIFF
--- a/.changeset/canonical-services-config.md
+++ b/.changeset/canonical-services-config.md
@@ -1,0 +1,8 @@
+---
+'@vercel/build-utils': minor
+'@vercel/client': minor
+'@vercel/fs-detectors': minor
+'vercel': minor
+---
+
+Add `services` as the canonical multi-service project configuration and keep `experimentalServicesV2` as a deprecated backwards-compatible alias.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -1028,10 +1028,10 @@ export type ExperimentalServices = Record<string, ExperimentalServiceConfig>;
  */
 export type ExperimentalServiceGroups = Record<string, string[]>;
 
-export interface ExperimentalServiceV2Binding {
+export interface ServiceBinding {
   /** Must be `"service"` for Service-to-Service HTTP bindings. */
   type: 'service';
-  /** Target service name from `experimentalServicesV2`. */
+  /** Target service name from `services`. */
   service: string;
   /** Generated value shape, must be `"url"`. */
   format: 'url';
@@ -1039,12 +1039,8 @@ export interface ExperimentalServiceV2Binding {
   env: string;
 }
 
-/**
- * Configuration for a service in `experimentalServicesV2` in `vercel.json`.
- *
- * @experimental This feature is experimental and may change.
- */
-export interface ExperimentalServiceV2Config {
+/** Configuration for a service in `vercel.json#services`. */
+export interface ServiceConfig {
   /** Path to the service root, relative to `vercel.json`. */
   root: string;
   /** Framework for this service. */
@@ -1065,7 +1061,7 @@ export interface ExperimentalServiceV2Config {
   outputDirectory?: string;
 
   /** Caller-side bindings that grant this service access to another service. */
-  bindings?: ExperimentalServiceV2Binding[];
+  bindings?: ServiceBinding[];
 
   /** Function configuration scoped to this service root. */
   functions?: BuilderFunctions;
@@ -1079,15 +1075,17 @@ export interface ExperimentalServiceV2Config {
   trailingSlash?: boolean;
 }
 
-/**
- * Map of service name to service configuration for `experimentalServicesV2`.
- *
- * @experimental This feature is experimental and may change.
- */
-export type ExperimentalServicesV2 = Record<
-  string,
-  ExperimentalServiceV2Config
->;
+/** Map of service name to service configuration for `vercel.json#services`. */
+export type Services = Record<string, ServiceConfig>;
+
+/** @deprecated Use `ServiceBinding` instead. */
+export type ExperimentalServiceV2Binding = ServiceBinding;
+
+/** @deprecated Use `ServiceConfig` instead. */
+export type ExperimentalServiceV2Config = ServiceConfig;
+
+/** @deprecated Use `Services` instead. */
+export type ExperimentalServicesV2 = Services;
 
 /**
  * Result of a runtime builder's normalized entrypoint detection.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -202,7 +202,7 @@ function getGeneratedServiceAlreadyBuiltWarning(service: Service) {
     `Detected already-built service "${service.name}" from lazily generated ` +
     `\`.vercel/output/config.json\` (framework: ${framework}, entrypoint: ${entrypoint}). ` +
     'It will not be treated as a service because its build output already exists at the top level. ' +
-    'Configure it in `vercel.json` as an `experimentalServicesV2` entry to remove this warning.'
+    'Configure it in `vercel.json` as a `services` entry to remove this warning.'
   );
 }
 
@@ -774,19 +774,16 @@ async function doBuild(
   let zeroConfigFallbackRoutes: Route[] = [];
   let detectedServices: ExperimentalService[] | undefined;
   let detectedResolvedServices: Service[] | undefined;
-  const localConfigWithServicesV2 = localConfig as VercelConfig & {
-    experimentalServicesV2?: ExperimentalServicesV2;
-  };
   const hasExperimentalServicesV1ConfiguredInVercelConfig = hasNonEmptyObject(
     localConfig.experimentalServices
   );
   const hasExperimentalServicesV2ConfiguredInVercelConfig = hasNonEmptyObject(
-    localConfigWithServicesV2.experimentalServicesV2
+    localConfig.services ?? localConfig.experimentalServicesV2
   );
   const configuredExperimentalServicesV2 =
     hasExperimentalServicesV2ConfiguredInVercelConfig &&
-    localConfigWithServicesV2.experimentalServicesV2
-      ? localConfigWithServicesV2.experimentalServicesV2
+    (localConfig.services ?? localConfig.experimentalServicesV2)
+      ? (localConfig.services ?? localConfig.experimentalServicesV2)
       : undefined;
   let nestExperimentalServicesV2Output =
     hasExperimentalServicesV2ConfiguredInVercelConfig;
@@ -811,9 +808,8 @@ async function doBuild(
     const detectedBuilders = await span.child('vc.detectBuilders').trace(() =>
       detectBuilders(files, pkg, {
         ...localConfig,
-        ...(configuredExperimentalServicesV2 && {
-          experimentalServicesV2: configuredExperimentalServicesV2,
-        }),
+        services: undefined,
+        experimentalServicesV2: configuredExperimentalServicesV2,
         projectSettings,
         ignoreBuildScript: true,
         featHandleMiss: true,
@@ -1732,11 +1728,13 @@ async function doBuild(
         .trace(() =>
           detectBuilders(files, pkg, {
             ...localConfig,
+            services: undefined,
             ...(generatedExperimentalServicesV2Config
               ? {
                   experimentalServicesV2: generatedExperimentalServicesV2Config,
                 }
               : {
+                  experimentalServicesV2: undefined,
                   experimentalServices: generatedExperimentalServicesV1Config,
                 }),
             projectSettings,

--- a/packages/cli/src/util/projects/detect-services.ts
+++ b/packages/cli/src/util/projects/detect-services.ts
@@ -43,6 +43,7 @@ async function hasExperimentalServicesConfig(cwd: string): Promise<boolean> {
     return (
       (config.experimentalServices != null &&
         typeof config.experimentalServices === 'object') ||
+      (config.services != null && typeof config.services === 'object') ||
       (config.experimentalServicesV2 != null &&
         typeof config.experimentalServicesV2 === 'object')
     );

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -477,19 +477,19 @@ const experimentalServiceGroupsSchema = {
   },
 };
 
-const experimentalServicesV2PathSchema = {
+const servicesPathSchema = {
   type: 'string',
   minLength: 1,
   maxLength: 512,
 };
 
-const experimentalServicesV2CommandSchema = {
+const servicesCommandSchema = {
   type: 'string',
   minLength: 1,
   maxLength: 2048,
 };
 
-const experimentalServicesV2BindingSchema = {
+const servicesBindingSchema = {
   type: 'object',
   additionalProperties: false,
   required: ['type', 'service', 'format', 'env'],
@@ -509,18 +509,18 @@ const experimentalServicesV2BindingSchema = {
   },
 };
 
-const experimentalServicesV2BindingsSchema = {
+const servicesBindingsSchema = {
   type: 'array',
   maxItems: 100,
-  items: experimentalServicesV2BindingSchema,
+  items: servicesBindingSchema,
 };
 
-const getExperimentalServicesV2ServiceConfigSchema = () => ({
+const getServicesServiceConfigSchema = () => ({
   type: 'object',
   additionalProperties: false,
   required: ['root'],
   properties: {
-    root: experimentalServicesV2PathSchema,
+    root: servicesPathSchema,
     framework: {
       type: 'string',
       minLength: 1,
@@ -531,13 +531,13 @@ const getExperimentalServicesV2ServiceConfigSchema = () => ({
       minLength: 1,
       maxLength: 256,
     },
-    entrypoint: experimentalServicesV2PathSchema,
-    installCommand: experimentalServicesV2CommandSchema,
-    buildCommand: experimentalServicesV2CommandSchema,
-    devCommand: experimentalServicesV2CommandSchema,
-    ignoreCommand: experimentalServicesV2CommandSchema,
-    outputDirectory: experimentalServicesV2PathSchema,
-    bindings: experimentalServicesV2BindingsSchema,
+    entrypoint: servicesPathSchema,
+    installCommand: servicesCommandSchema,
+    buildCommand: servicesCommandSchema,
+    devCommand: servicesCommandSchema,
+    ignoreCommand: servicesCommandSchema,
+    outputDirectory: servicesPathSchema,
+    bindings: servicesBindingsSchema,
     functions: getFunctionsSchema(),
     headers: headersSchema,
     redirects: redirectsSchema,
@@ -548,13 +548,13 @@ const getExperimentalServicesV2ServiceConfigSchema = () => ({
   },
 });
 
-const getExperimentalServicesV2Schema = () => ({
+const getServicesSchema = () => ({
   type: 'object',
   propertyNames: {
     pattern: '^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$',
     maxLength: 64,
   },
-  additionalProperties: getExperimentalServicesV2ServiceConfigSchema(),
+  additionalProperties: getServicesServiceConfigSchema(),
 });
 
 function buildVercelConfigSchema() {
@@ -577,7 +577,8 @@ function buildVercelConfigSchema() {
       bunVersion: { type: 'string' },
       experimentalServices: getExperimentalServicesSchema(),
       experimentalServiceGroups: experimentalServiceGroupsSchema,
-      experimentalServicesV2: getExperimentalServicesV2Schema(),
+      services: getServicesSchema(),
+      experimentalServicesV2: getServicesSchema(),
     },
   };
 }
@@ -659,26 +660,39 @@ export function validateConfig(config: VercelConfig): NowBuildError | null {
     });
   }
 
-  const hasExperimentalServicesV2 = Boolean(config.experimentalServicesV2);
+  const hasServices = config.services != null;
+  const hasExperimentalServicesV2 = config.experimentalServicesV2 != null;
 
-  if (hasExperimentalServicesV2 && hasExperimentalServices) {
+  if (hasServices && hasExperimentalServicesV2) {
     return new NowBuildError({
-      code: 'EXPERIMENTAL_SERVICES_V2_AND_EXPERIMENTAL_SERVICES',
+      code: 'SERVICES_AND_EXPERIMENTAL_SERVICES_V2',
       message:
-        'The `experimentalServicesV2` property cannot be used in conjunction with the `experimentalServices` property. Please use only one services configuration.',
+        'The `services` property cannot be used in conjunction with its deprecated alias `experimentalServicesV2`. Please use only `services`.',
     });
   }
 
-  if (hasExperimentalServicesV2 && config.builds) {
+  const servicesConfig = config.services ?? config.experimentalServicesV2;
+  const servicesConfigKey = hasServices ? 'services' : 'experimentalServicesV2';
+  const servicesErrorCodePrefix = hasServices
+    ? 'SERVICES'
+    : 'EXPERIMENTAL_SERVICES_V2';
+
+  if (servicesConfig && hasExperimentalServices) {
     return new NowBuildError({
-      code: 'EXPERIMENTAL_SERVICES_V2_AND_BUILDS',
-      message:
-        'The `experimentalServicesV2` property cannot be used in conjunction with the `builds` property. Please remove one of them.',
+      code: `${servicesErrorCodePrefix}_AND_EXPERIMENTAL_SERVICES`,
+      message: `The \`${servicesConfigKey}\` property cannot be used in conjunction with the \`experimentalServices\` property. Please use only one services configuration.`,
     });
   }
 
-  // with `experimentalServicesV2` some fields could be present only in services declaration
-  if (hasExperimentalServicesV2) {
+  if (servicesConfig && config.builds) {
+    return new NowBuildError({
+      code: `${servicesErrorCodePrefix}_AND_BUILDS`,
+      message: `The \`${servicesConfigKey}\` property cannot be used in conjunction with the \`builds\` property. Please remove one of them.`,
+    });
+  }
+
+  // In services mode some fields can be present only in service declarations.
+  if (servicesConfig) {
     const ambiguousTopLevel: string[] = [];
     if (config.functions != null) {
       ambiguousTopLevel.push('functions');
@@ -706,27 +720,25 @@ export function validateConfig(config: VercelConfig): NowBuildError | null {
       const count = ambiguousTopLevel.length;
       const fields = ambiguousTopLevel.map(field => `\`${field}\``).join(', ');
       return new NowBuildError({
-        code: 'EXPERIMENTAL_SERVICES_V2_AND_TOP_LEVEL_BUILD_SETTINGS',
+        code: `${servicesErrorCodePrefix}_AND_TOP_LEVEL_BUILD_SETTINGS`,
         message:
-          `The top-level ${count > 1 ? 'properties' : 'property'} ${fields} cannot be used with \`experimentalServicesV2\` ` +
+          `The top-level ${count > 1 ? 'properties' : 'property'} ${fields} cannot be used with \`${servicesConfigKey}\` ` +
           `because the owning service is ambiguous. ` +
-          `Move ${count > 1 ? 'them' : 'it'} under the relevant service in \`experimentalServicesV2\`.`,
+          `Move ${count > 1 ? 'them' : 'it'} under the relevant service in \`${servicesConfigKey}\`.`,
       });
     }
   }
 
-  if (config.experimentalServicesV2) {
-    const serviceNames = new Set(Object.keys(config.experimentalServicesV2));
-    for (const [serviceName, serviceConfig] of Object.entries(
-      config.experimentalServicesV2
-    )) {
+  if (servicesConfig) {
+    const serviceNames = new Set(Object.keys(servicesConfig));
+    for (const [serviceName, serviceConfig] of Object.entries(servicesConfig)) {
       for (const binding of serviceConfig.bindings ?? []) {
         if (!serviceNames.has(binding.service)) {
           return new NowBuildError({
-            code: 'EXPERIMENTAL_SERVICES_V2_BINDING_UNKNOWN_SERVICE',
+            code: `${servicesErrorCodePrefix}_BINDING_UNKNOWN_SERVICE`,
             message:
               `Service "${serviceName}" declares a binding to unknown service "${binding.service}". ` +
-              `Add "${binding.service}" to \`experimentalServicesV2\` or fix the binding.`,
+              `Add "${binding.service}" to \`${servicesConfigKey}\` or fix the binding.`,
           });
         }
       }

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -2626,7 +2626,7 @@ fs.writeFileSync(
     ]);
   });
 
-  it('should nest vercel.json experimentalServicesV2 outputs under service directories', async () => {
+  it('should normalize vercel.json services to the V2 build output wire format', async () => {
     const cwd = await getWriteableDirectory();
     const output = join(cwd, '.vercel', 'output');
     await fs.ensureDir(join(cwd, '.vercel'));
@@ -2642,7 +2642,7 @@ fs.writeFileSync(
       private: true,
     });
     await fs.writeJSON(join(cwd, 'vercel.json'), {
-      experimentalServicesV2: {
+      services: {
         ui: {
           root: '.',
           entrypoint: 'ui.js',
@@ -2942,7 +2942,7 @@ writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ version: 3 }, nul
       const exitCode = await build(client);
       expect(exitCode).toBe(0);
       await expect(client.stderr).toOutput(
-        'Detected already-built service "ui" from lazily generated `.vercel/output/config.json` (framework: vite, entrypoint: package.json). It will not be treated as a service because its build output already exists at the top level. Configure it in `vercel.json` as an `experimentalServicesV2` entry to remove this warning.'
+        'Detected already-built service "ui" from lazily generated `.vercel/output/config.json` (framework: vite, entrypoint: package.json). It will not be treated as a service because its build output already exists at the top level. Configure it in `vercel.json` as a `services` entry to remove this warning.'
       );
 
       const config = await fs.readJSON(join(output, 'config.json'));

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { validateConfig } from '../../../../src/util/validate-config';
 
 describe('validateConfig', () => {
-  describe('experimentalServicesV2', () => {
-    it('should not error with a valid config', () => {
+  describe('services', () => {
+    it('should not error with a valid canonical config', () => {
       const error = validateConfig({
-        experimentalServicesV2: {
+        services: {
           my_frontend: {
             root: 'frontend/',
             framework: 'nextjs',
@@ -26,6 +26,48 @@ describe('validateConfig', () => {
         },
       } satisfies Parameters<typeof validateConfig>[0]);
       expect(error).toBeNull();
+    });
+
+    it('should keep experimentalServicesV2 as a backwards-compatible alias', () => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          api: { root: 'api', framework: 'express' },
+        },
+      });
+
+      expect(error).toBeNull();
+    });
+
+    it('should reject services together with experimentalServicesV2', () => {
+      const error = validateConfig({
+        services: { web: { root: '.', framework: 'nextjs' } },
+        experimentalServicesV2: {
+          api: { root: 'api', framework: 'express' },
+        },
+      });
+
+      expect(error?.code).toBe('SERVICES_AND_EXPERIMENTAL_SERVICES_V2');
+    });
+
+    it('should report canonical services validation errors', () => {
+      const error = validateConfig({
+        services: {
+          web: {
+            root: '.',
+            bindings: [
+              {
+                type: 'service',
+                service: 'ghost',
+                format: 'url',
+                env: 'GHOST_URL',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(error?.code).toBe('SERVICES_BINDING_UNKNOWN_SERVICE');
+      expect(error?.message).toContain('`services`');
     });
 
     it('should not error with a service-local route table and functions', () => {
@@ -324,9 +366,7 @@ describe('validateConfig', () => {
     expect(error).toBeNull();
   });
 
-  it('should ignore the removed `services` property', () => {
-    // The CLI config schema is `additionalProperties: true`,
-    // so the error would come from the API
+  it('should validate the `services` property', () => {
     const error = validateConfig({
       services: {
         frontend: {
@@ -335,7 +375,7 @@ describe('validateConfig', () => {
         },
       },
     } as any);
-    expect(error).toBeNull();
+    expect(error).not.toBeNull();
   });
 
   it('should not error with experimentalServices static schedule arrays', () => {

--- a/packages/cli/test/unit/util/projects/detect-services.test.ts
+++ b/packages/cli/test/unit/util/projects/detect-services.test.ts
@@ -380,12 +380,12 @@ mount = "/api"`
       expect(result?.services).toHaveLength(2);
     });
 
-    it('should return services when vercel.json has experimentalServicesV2', async () => {
+    it('should return services when vercel.json has services', async () => {
       await mkdir(join(tempDir, 'backend'), { recursive: true });
       await writeFile(
         join(tempDir, 'vercel.json'),
         JSON.stringify({
-          experimentalServicesV2: {
+          services: {
             backend: { root: 'backend', entrypoint: 'index.py' },
           },
         })
@@ -466,11 +466,11 @@ mount = "/api"`
       await expect(isExperimentalServicesEnabled(tempDir)).resolves.toBe(true);
     });
 
-    it('should return true when vercel.json has experimentalServicesV2', async () => {
+    it('should return true when vercel.json has services', async () => {
       await writeFile(
         join(tempDir, 'vercel.json'),
         JSON.stringify({
-          experimentalServicesV2: {
+          services: {
             frontend: { root: 'frontend', framework: 'nextjs' },
           },
         })

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -8,6 +8,7 @@ import type {
   ExperimentalServices,
   ExperimentalServiceGroups,
   ExperimentalServicesV2,
+  Services,
 } from '@vercel/build-utils';
 import type { Header, Route, Redirect, Rewrite } from '@vercel/routing-utils';
 
@@ -198,7 +199,11 @@ export interface VercelConfig {
    */
   experimentalServiceGroups?: ExperimentalServiceGroups;
   /**
-   * @experimental This feature is experimental and may change.
+   * Configures multiple services in this project.
+   */
+  services?: Services;
+  /**
+   * @deprecated Use `services` instead.
    */
   experimentalServicesV2?: ExperimentalServicesV2;
 }

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -10,6 +10,7 @@ import type {
   BuilderFunctions,
   ExperimentalServices,
   ExperimentalServicesV2,
+  Services,
   ProjectSettings,
   Service,
 } from '@vercel/build-utils';
@@ -70,6 +71,7 @@ export interface Options {
   tag?: string;
   functions?: BuilderFunctions;
   experimentalServices?: ExperimentalServices;
+  services?: Services;
   experimentalServicesV2?: ExperimentalServicesV2;
   ignoreBuildScript?: boolean;
   projectSettings?: ProjectSettings;
@@ -149,13 +151,34 @@ export async function detectBuilders(
 }> {
   const {
     experimentalServices: experimentalServicesV1,
+    services,
     experimentalServicesV2,
     projectSettings = {},
   } = options;
+  if (services != null && experimentalServicesV2 != null) {
+    return {
+      builders: null,
+      errors: [
+        {
+          code: 'SERVICES_AND_EXPERIMENTAL_SERVICES_V2',
+          message:
+            'The `services` option cannot be used in conjunction with its deprecated alias `experimentalServicesV2`. Please use only `services`.',
+        },
+      ],
+      warnings: [],
+      defaultRoutes: null,
+      redirectRoutes: null,
+      rewriteRoutes: null,
+      errorRoutes: null,
+    };
+  }
   const { framework } = projectSettings;
-  const configuredServices = experimentalServicesV2 ?? experimentalServicesV1;
-  const configuredServicesType = experimentalServicesV2
-    ? 'experimentalServicesV2'
+  const servicesConfig = services ?? experimentalServicesV2;
+  const configuredServices = servicesConfig ?? experimentalServicesV1;
+  const configuredServicesType = servicesConfig
+    ? services
+      ? 'services'
+      : 'experimentalServicesV2'
     : 'experimentalServices';
   const hasServicesConfig =
     configuredServices != null && typeof configuredServices === 'object';

--- a/packages/fs-detectors/src/index.ts
+++ b/packages/fs-detectors/src/index.ts
@@ -48,6 +48,9 @@ export type {
   ExperimentalServiceV2Config,
   ExperimentalServicesV2,
   ExperimentalServiceV2Binding,
+  ServiceBinding,
+  ServiceConfig,
+  Services,
   ServicesRoutes,
   ServiceDetectionError,
 } from './services/types';

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -160,18 +160,39 @@ export async function detectServices(
     });
   }
 
+  if (
+    vercelConfig?.services != null &&
+    vercelConfig.experimentalServicesV2 != null
+  ) {
+    return withResolvedResult({
+      services: [],
+      source: 'configured',
+      useImplicitEnvInjection: false,
+      routes: emptyRoutes(),
+      errors: [
+        {
+          code: 'SERVICES_AND_EXPERIMENTAL_SERVICES_V2',
+          message:
+            'The `services` property cannot be used in conjunction with its deprecated alias `experimentalServicesV2`. Please use only `services`.',
+        },
+      ],
+      warnings: [],
+    });
+  }
+
   const hasProvidedConfiguredServices =
     providedConfiguredServices &&
     Object.keys(providedConfiguredServices).length > 0;
 
-  // `experimentalServicesV2` dispatch
+  // `services` dispatch (`experimentalServicesV2` is a deprecated alias).
   const experimentalServicesV2 =
     hasProvidedConfiguredServices &&
-    providedConfiguredServicesType === 'experimentalServicesV2'
+    (providedConfiguredServicesType === 'services' ||
+      providedConfiguredServicesType === 'experimentalServicesV2')
       ? (providedConfiguredServices as ExperimentalServicesV2)
       : hasProvidedConfiguredServices
         ? undefined
-        : vercelConfig?.experimentalServicesV2;
+        : (vercelConfig?.services ?? vercelConfig?.experimentalServicesV2);
   if (
     experimentalServicesV2 &&
     Object.keys(experimentalServicesV2).length > 0

--- a/packages/fs-detectors/src/services/types.ts
+++ b/packages/fs-detectors/src/services/types.ts
@@ -9,6 +9,9 @@ import type {
   ExperimentalServices,
   ExperimentalServicesV2,
   ExperimentalServiceV2Binding,
+  ServiceBinding,
+  ServiceConfig,
+  Services,
   ExperimentalService,
   ExperimentalServiceV2,
   ServiceRuntime,
@@ -29,6 +32,9 @@ export type {
   ExperimentalServiceV2Config,
   ExperimentalServicesV2,
   ExperimentalServiceV2Binding,
+  ServiceBinding,
+  ServiceConfig,
+  Services,
   ExperimentalService,
   ExperimentalServiceV2,
   ServiceRuntime,
@@ -83,8 +89,9 @@ export interface ServicesRoutes {
 
 export type ConfiguredServicesType =
   | 'experimentalServices'
+  | 'services'
   | 'experimentalServicesV2';
-export type ConfiguredServices = ExperimentalServices | ExperimentalServicesV2;
+export type ConfiguredServices = ExperimentalServices | Services;
 export type InferredServicesConfig = ExperimentalServices;
 
 export interface ResolvedServicesResult {
@@ -107,7 +114,7 @@ export interface InferredServicesResult {
 export interface DetectServicesResult extends ResolvedServicesResult {
   /**
    * Source of service definitions:
-   * - `configured`: loaded from explicit project configuration (`vercel.json#experimentalServices` or `vercel.json#experimentalServicesV2`)
+   * - `configured`: loaded from explicit project configuration (`vercel.json#experimentalServices`, `vercel.json#services`, or the deprecated `vercel.json#experimentalServicesV2` alias)
    * - `auto-detected`: inferred from project structure
    */
   // TODO: replace consumption of top-level fields with these nested objects in caller before removal of top-level fields.

--- a/packages/fs-detectors/src/services/utils.ts
+++ b/packages/fs-detectors/src/services/utils.ts
@@ -15,6 +15,7 @@ import type {
   ServiceRuntime,
   ExperimentalServices,
   ExperimentalServicesV2,
+  Services,
   ServiceDetectionError,
   ServiceDetectionWarning,
   ResolvedService,
@@ -221,6 +222,7 @@ export function inferServiceRuntime(config: {
 export interface ReadVercelConfigResult {
   config: {
     experimentalServices?: ExperimentalServices;
+    services?: Services;
     experimentalServicesV2?: ExperimentalServicesV2;
   } | null;
   error: ServiceDetectionError | null;

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -156,7 +156,7 @@ describe('Test `detectBuilders`', () => {
     );
   });
 
-  it('should use services builders when experimentalServicesV2 is configured without the services framework', async () => {
+  it('should use services builders when services is configured without the services framework', async () => {
     const workPath = join(
       __dirname,
       'fixtures',
@@ -165,7 +165,7 @@ describe('Test `detectBuilders`', () => {
     );
     const { builders, services, errors, useImplicitEnvInjection } =
       await detectBuilders([], undefined, {
-        experimentalServicesV2: {
+        services: {
           web: {
             root: '.',
             runtime: 'python',

--- a/packages/fs-detectors/test/unit.detect-services-v2.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services-v2.test.ts
@@ -12,11 +12,11 @@ function servicesV2(services: { schema: string }[]): ExperimentalServiceV2[] {
   );
 }
 
-describe('detectServices (experimentalServicesV2)', () => {
-  it('resolves a node backend framework service to @vercel/backends', async () => {
+describe('detectServices (services)', () => {
+  it('resolves canonical services config to @vercel/backends', async () => {
     const fs = new VirtualFilesystem({
       'vercel.json': vercelJson({
-        experimentalServicesV2: {
+        services: {
           api: { root: 'api', framework: 'express' },
         },
       }),
@@ -42,6 +42,26 @@ describe('detectServices (experimentalServicesV2)', () => {
     });
     expect(api.builder.use).toBe('@vercel/backends');
     expect(api.builder.src).toBe('api/index.js');
+  });
+
+  it('rejects services together with its deprecated alias', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        services: { web: { root: 'web', framework: 'nextjs' } },
+        experimentalServicesV2: {
+          api: { root: 'api', framework: 'express' },
+        },
+      }),
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.services).toEqual([]);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        code: 'SERVICES_AND_EXPERIMENTAL_SERVICES_V2',
+      }),
+    ]);
   });
 
   it('resolves a runtime + file entrypoint service to the runtime builder', async () => {


### PR DESCRIPTION
Add `services` as the canonical multi-service project configuration and keep `experimentalServicesV2` as a deprecated backwards-compatible alias.