### PR TITLE
fix(backends): avoid globbing project root when outputDirectory is "."

### DIFF
--- a/.changeset/backends-output-dir-dot.md
+++ b/.changeset/backends-output-dir-dot.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Fix build failure when `outputDirectory` is set to the project root (e.g. `.`). The builder no longer globs the working tree as build output in that case, avoiding tracing errors from package-manager symlinks in `node_modules`.

--- a/packages/backends/src/build.ts
+++ b/packages/backends/src/build.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { type Files, glob, type BuildOptions } from '@vercel/build-utils';
 import { findEntrypoint } from './find-entrypoint.js';
 import {
@@ -36,10 +36,15 @@ export const maybeDoBuildCommand = async (
   if (buildCommandResult && outputSetting) {
     if (outputSetting) {
       const _outputDir = join(args.workPath, outputSetting);
-      const _entrypoint = await findEntrypointInOutputDir(_outputDir);
-      if (_entrypoint) {
-        outputDir = _outputDir;
-        entrypoint = _entrypoint;
+      // Skip when `outputDirectory` is the project root itself (e.g. `.`):
+      // globbing it would sweep in `node_modules` and break tracing. Fall back
+      // to the rolldown bundle instead.
+      if (resolve(_outputDir) !== resolve(args.workPath)) {
+        const _entrypoint = await findEntrypointInOutputDir(_outputDir);
+        if (_entrypoint) {
+          outputDir = _outputDir;
+          entrypoint = _entrypoint;
+        }
       }
     } else {
       const commonOutputDirectories = ['dist', 'build', 'output'];

--- a/packages/backends/test/unit.test.ts
+++ b/packages/backends/test/unit.test.ts
@@ -18,6 +18,7 @@ import {
   mkdir,
   realpath,
   symlink,
+  stat,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import type { IncomingMessage } from 'node:http';
@@ -256,6 +257,111 @@ it.skipIf(process.platform === 'win32')(
         repoRootPath: workDir,
       })
     ).resolves.toBeDefined();
+  },
+  30000
+);
+
+it.skipIf(process.platform === 'win32')(
+  'does not emit a directory symlink as a lambda file when outputDirectory is "."',
+  async () => {
+    // A workspace package linked into node_modules as a directory symlink must
+    // not be globbed into the build when outputDirectory is the project root.
+    const repoRoot = await realpath(
+      await mkdtemp(join(tmpdir(), 'backends-outputdir-dot-'))
+    );
+
+    // Workspace package linked into the app's node_modules (never imported).
+    const pkgDir = join(repoRoot, 'packages-internal/test-dd');
+    await mkdir(join(pkgDir, 'bin'), { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: '@internal/test-dd', version: '1.0.0' })
+    );
+    await writeFile(join(pkgDir, 'utils.js'), 'module.exports = {};\n');
+
+    const workDir = join(repoRoot, 'app');
+    await mkdir(join(workDir, 'src'), { recursive: true });
+    await writeFile(
+      join(workDir, 'package.json'),
+      JSON.stringify({
+        name: '@testserver/create-server',
+        version: '1.0.0',
+        type: 'module',
+        main: 'src/app.ts',
+        dependencies: { hono: '4.10.0' },
+        devDependencies: { '@internal/test-dd': '1.0.0' },
+      })
+    );
+    await writeFile(
+      join(workDir, 'src/app.ts'),
+      [
+        "import { Hono } from 'hono';",
+        'const app = new Hono();',
+        "app.get('/', c => c.text('ok'));",
+        'export default app;',
+      ].join('\n')
+    );
+
+    await mkdir(join(workDir, 'node_modules/@internal'), { recursive: true });
+    await symlink(
+      '../../../packages-internal/test-dd',
+      join(workDir, 'node_modules/@internal/test-dd'),
+      'dir'
+    );
+    // Minimal hono package so rolldown can resolve the entrypoint import.
+    const honoDir = join(workDir, 'node_modules/hono');
+    await mkdir(honoDir, { recursive: true });
+    await writeFile(
+      join(honoDir, 'package.json'),
+      JSON.stringify({
+        name: 'hono',
+        version: '4.10.0',
+        type: 'module',
+        main: 'index.js',
+      })
+    );
+    await writeFile(
+      join(honoDir, 'index.js'),
+      'export class Hono { get() {} }\n'
+    );
+
+    const result = (await build({
+      files: {},
+      workPath: workDir,
+      config: {
+        ...defaultConfig,
+        outputDirectory: '.',
+        buildCommand: "echo 'noop'",
+        projectSettings: {
+          ...defaultConfig.projectSettings,
+          installCommand: 'true',
+          buildCommand: "echo 'noop'",
+          outputDirectory: '.',
+        },
+      },
+      meta,
+      entrypoint: 'package.json',
+      repoRootPath: repoRoot,
+    })) as BuildResultV2Typical;
+
+    const lambda = result.output.index as unknown as NodejsLambda;
+    const files = lambda.files ?? {};
+
+    // No lambda file should resolve to a directory.
+    const directoryEntries: string[] = [];
+    for (const [key, file] of Object.entries(files)) {
+      const fsPath = (file as { fsPath?: string }).fsPath;
+      if (!fsPath) continue;
+      try {
+        if ((await stat(fsPath)).isDirectory()) {
+          directoryEntries.push(key);
+        }
+      } catch {
+        directoryEntries.push(key);
+      }
+    }
+
+    expect(directoryEntries).toEqual([]);
   },
   30000
 );


### PR DESCRIPTION
### Summary

When a backends project sets `outputDirectory` to the project root (e.g. `.`), the build fails with:

```
Error: File <repo>/<dir> does not exist.
```

`maybeDoBuildCommand` reuses the configured `outputDirectory` as a source of prebuilt server output by globbing it. When that directory is the project root itself, the glob walks the entire working tree, including `node_modules`. Any package-manager symlink there that points to a directory (e.g. a workspace dependency linked under `node_modules`) is then handed to file tracing, which treats it as a file and throws.

### Change

Skip reusing the output directory when it resolves to the working directory itself. In that case there is no dedicated build output to collect, so the build falls back to bundling from source. A real output directory (e.g. `outputDirectory: "dist"`) is unaffected.

### Test plan

- Adds a unit test that builds an app whose `outputDirectory` is `.` with a workspace dependency linked into `node_modules` as a directory symlink, and asserts no emitted lambda file resolves to a directory.
- `pnpm test-unit` (backends) passes.
