### PR TITLE
[cli] add invocation/session IDs to api calls as headers

### DIFF
--- a/.changeset/angry-carrots-give.md
+++ b/.changeset/angry-carrots-give.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Adding 2 additional headers to Vercel API calls

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -477,6 +477,14 @@ export default class Client extends EventEmitter implements Stdio {
     if (this.agentName) {
       headers.set('x-ai-agent', this.agentName);
     }
+    headers.set(
+      'x-vercel-cli-session-id',
+      this.telemetryEventStore.currentSessionId
+    );
+    headers.set(
+      'x-vercel-cli-invocation-id',
+      this.telemetryEventStore.currentInvocationId
+    );
 
     await this.ensureAuthorized();
 

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -446,6 +446,10 @@ export class TelemetryEventStore {
     return this.deviceId;
   }
 
+  get currentSessionId() {
+    return this.sessionId;
+  }
+
   get readonlyEvents() {
     return Array.from(this.events);
   }

--- a/packages/cli/test/unit/util/client.test.ts
+++ b/packages/cli/test/unit/util/client.test.ts
@@ -147,6 +147,16 @@ describe('Client', () => {
       await client.fetch('/v2/user');
     });
 
+    it('sends CLI tracing headers with every request', async () => {
+      client.scenario.get('/v2/user', (req, res) => {
+        expect(req.headers['x-vercel-cli-session-id']).toHaveLength(36);
+        expect(req.headers['x-vercel-cli-invocation-id']).toHaveLength(36);
+        res.json({ user: { uid: 'abc' } });
+      });
+
+      await client.fetch('/v2/user');
+    });
+
     it('should treat 3xx as errors when redirect is not manual', async () => {
       // When redirect is not set to 'manual', node-fetch follows the
       // redirect by default. If the redirect target doesn't exist, the


### PR DESCRIPTION
Adding 2 new headers to the Vercel API calls – `x-vercel-cli-session-id` and `x-vercel-cli-invocation-id`