### PR TITLE
[debug] hasPostponed debug logging (branch-only, do not merge)

### DIFF
--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -1,5 +1,6 @@
 import type { File, HasField, Chain } from './types';
 import { Lambda } from './lambda';
+import debug from './debug';
 
 function assertOptionalBoolean(
   value: unknown,
@@ -126,6 +127,11 @@ export class Prerender {
     // prerender, no fallback concept).
     assertOptionalBoolean(hasPostponed, 'hasPostponed');
     this.hasPostponed = hasPostponed;
+    debug(
+      `Prerender: constructed with hasPostponed=${hasPostponed}${
+        sourcePath ? ` sourcePath="${sourcePath}"` : ''
+      }`
+    );
 
     assertOptionalBoolean(hasFallback, 'hasFallback');
     this.hasFallback = hasFallback;

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -288,6 +288,10 @@ async function writeBuildResultV2(args: {
         );
       }
 
+      outputManager.debug(
+        `hasPostponed: writing prerender config for "${normalizedPath}": hasPostponed=${output.hasPostponed}`
+      );
+
       await writeLambda(
         repoRootPath,
         outputDir,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2704,6 +2704,14 @@ export const onPrerenderRoute =
       postponedState = getHTMLPostponedState({ appDir, routeFileNoExt });
       hasPostponed = Boolean(postponedState);
 
+      debug(
+        `hasPostponed: route="${routeKey}" file="${routeFileNoExt}" renderingMode=PARTIALLY_STATIC isBlocking=${isBlocking} -> postponedState=${
+          postponedState === null
+            ? 'null'
+            : `present(length=${postponedState.length})`
+        } hasPostponed=${hasPostponed}`
+      );
+
       const htmlPath = path.join(appDir, `${routeFileNoExt}.html`);
       if (fs.existsSync(htmlPath)) {
         const html = fs.readFileSync(htmlPath, 'utf8');
@@ -2722,12 +2730,22 @@ export const onPrerenderRoute =
           postponedPrerender = html;
           didPostpone = false;
         }
+
+        debug(
+          `hasPostponed: route="${routeKey}" assembled prerender from .html (didPostpone=${didPostpone})`
+        );
       }
 
       // NOTE: we don't validate the extension suffix of the data routes because
       // some routes (like those that have PPR client segment cache, and client
       // parsing all enabled) may be null because they only contain segment
       // data.
+    } else {
+      debug(
+        `hasPostponed: left undefined for route="${routeKey}" (renderingMode=${renderingMode}, hasAppDir=${Boolean(
+          appDir
+        )}, isBlocking=${isBlocking})`
+      );
     }
 
     if (postponedPrerender) {
@@ -4669,6 +4687,9 @@ function getHTMLPostponedState({
 }) {
   const metaPath = path.join(appDir, `${routeFileNoExt}.meta`);
   if (!fs.existsSync(metaPath)) {
+    debug(
+      `hasPostponed: no .meta file at "${metaPath}" -> postponedState=null`
+    );
     return null;
   }
 
@@ -4680,9 +4701,15 @@ function getHTMLPostponedState({
     !('postponed' in meta) ||
     typeof meta.postponed !== 'string'
   ) {
+    debug(
+      `hasPostponed: .meta at "${metaPath}" has no string "postponed" field -> postponedState=null`
+    );
     return null;
   }
 
+  debug(
+    `hasPostponed: .meta at "${metaPath}" has postponed state (length=${meta.postponed.length})`
+  );
   return meta.postponed;
 }
 


### PR DESCRIPTION
## Branch-only debug logging — not for merge

Adds gated debug logging tracing how `hasPostponed` is calculated and propagated through the build pipeline. **Intended for branch investigation only; should not be merged into `main`.** No changeset is included for this reason.

### What's logged

- **`@vercel/next`** (`packages/next/src/utils.ts`, `onPrerenderRoute`): per-route computation of `hasPostponed` — the `.meta` postponed-state lookup in `getHTMLPostponedState`, the resulting value, why it's left `undefined` for non-PPR routes, and the `.html` prerender assembly (`didPostpone`).
- **`@vercel/build-utils`** (`packages/build-utils/src/prerender.ts`): the `hasPostponed` value when a `Prerender` is constructed (with `sourcePath`).
- **Vercel CLI** (`packages/cli/src/util/build/write-build-result.ts`): the `hasPostponed` value when writing each `*.prerender-config.json`.

All messages are prefixed `hasPostponed:` for grepping, and gated behind existing debug flags (`BUILDER_DEBUG` / `VERCEL_DEBUG_PREFIX` for the builders, `--debug` for the CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)