### PR TITLE
[@vercel/backends] server.ts devserver

### DIFF
--- a/.changeset/warm-servers-listen.md
+++ b/.changeset/warm-servers-listen.md
@@ -1,0 +1,7 @@
+---
+'@vercel/backends': patch
+'@vercel/build-utils': patch
+'vercel': patch
+---
+
+Fix `vercel dev` for standalone Node servers, including projects without a `package.json`, and reuse the server process between requests.

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -41,7 +41,7 @@
     "path-to-regexp": "8.3.0",
     "resolve.exports": "2.0.3",
     "rolldown": "1.0.0-rc.1",
-    "srvx": "0.8.9",
+    "srvx": "0.11.16",
     "tsx": "4.21.0",
     "zod": "3.22.4"
   },

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@vercel/build-utils": "workspace:*",
     "@vercel/nft": "1.10.0",
+    "@vercel/node": "workspace:*",
     "execa": "3.2.0",
     "fs-extra": "11.1.0",
     "get-port": "5.1.1",

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@vercel/build-utils": "workspace:*",
     "@vercel/nft": "1.10.0",
-    "@vercel/node": "workspace:*",
     "execa": "3.2.0",
     "fs-extra": "11.1.0",
     "get-port": "5.1.1",

--- a/packages/backends/src/dev/spawn-srvx.ts
+++ b/packages/backends/src/dev/spawn-srvx.ts
@@ -3,7 +3,7 @@ import { createConnection } from 'node:net';
 import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { cloneEnv } from '@vercel/build-utils';
+import { cloneEnv, type StartDevServerSuccess } from '@vercel/build-utils';
 import getPort from 'get-port';
 
 const require_ = createRequire(import.meta.url);
@@ -13,19 +13,13 @@ const tsxPath = pathToFileURL(require_.resolve('tsx')).href;
 const STARTUP_TIMEOUT = 5 * 60_000;
 const SHUTDOWN_TIMEOUT = 5_000;
 
-export interface SpawnSrvxOptions {
+interface SpawnSrvxOptions {
   workPath: string;
   entrypoint: string;
   env?: NodeJS.ProcessEnv;
   publicDir: string;
   onStdout?: (data: Buffer) => void;
   onStderr?: (data: Buffer) => void;
-}
-
-export interface SpawnedSrvx {
-  pid: number;
-  port: number;
-  shutdown: () => Promise<void>;
 }
 
 function forwardOutput(
@@ -144,7 +138,9 @@ async function stopChild(child: ChildProcess): Promise<void> {
   await waitForExit(child, 1_000);
 }
 
-export async function spawnSrvx(opts: SpawnSrvxOptions): Promise<SpawnedSrvx> {
+export async function spawnSrvx(
+  opts: SpawnSrvxOptions
+): Promise<StartDevServerSuccess> {
   const port = await getPort({ host: '127.0.0.1' });
   const env = cloneEnv(process.env, opts.env, {
     HOST: '127.0.0.1',

--- a/packages/backends/src/dev/spawn-srvx.ts
+++ b/packages/backends/src/dev/spawn-srvx.ts
@@ -23,7 +23,6 @@ export interface SpawnSrvxOptions {
 }
 
 export interface SpawnedSrvx {
-  child: ChildProcess;
   pid: number;
   port: number;
   shutdown: () => Promise<void>;
@@ -188,7 +187,6 @@ export async function spawnSrvx(opts: SpawnSrvxOptions): Promise<SpawnedSrvx> {
   }
 
   return {
-    child,
     pid: child.pid,
     port,
     shutdown: () => stopChild(child),

--- a/packages/backends/src/dev/spawn-srvx.ts
+++ b/packages/backends/src/dev/spawn-srvx.ts
@@ -1,13 +1,14 @@
 import { fork, type ChildProcess } from 'node:child_process';
 import { createConnection } from 'node:net';
 import { createRequire } from 'node:module';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { cloneEnv, type StartDevServerSuccess } from '@vercel/build-utils';
 import getPort from 'get-port';
 
 const require_ = createRequire(import.meta.url);
 const srvxCliPath = require_.resolve('srvx/cli');
+const srvxBinPath = resolve(dirname(srvxCliPath), '../bin/srvx.mjs');
 const tsxPath = pathToFileURL(require_.resolve('tsx')).href;
 
 const STARTUP_TIMEOUT = 5 * 60_000;
@@ -18,6 +19,7 @@ interface SpawnSrvxOptions {
   entrypoint: string;
   env?: NodeJS.ProcessEnv;
   publicDir: string;
+  signal?: AbortSignal;
   onStdout?: (data: Buffer) => void;
   onStderr?: (data: Buffer) => void;
 }
@@ -56,7 +58,8 @@ function canConnect(port: number): Promise<boolean> {
 function waitUntilReady(
   child: ChildProcess,
   port: number,
-  entrypoint: string
+  entrypoint: string,
+  signal?: AbortSignal
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const deadline = Date.now() + STARTUP_TIMEOUT;
@@ -67,6 +70,7 @@ function waitUntilReady(
       if (retryTimer) clearTimeout(retryTimer);
       child.off('error', onError);
       child.off('exit', onExit);
+      signal?.removeEventListener('abort', onAbort);
     };
 
     const succeed = () => {
@@ -88,6 +92,10 @@ function waitUntilReady(
       const reason = signal ? `signal ${signal}` : `exit code ${code}`;
       fail(new Error(`Server \`${entrypoint}\` exited with ${reason}`));
     };
+    const onAbort = () => {
+      child.kill('SIGTERM');
+      fail(new Error(`Server \`${entrypoint}\` cancelled`));
+    };
 
     const probe = async () => {
       if (settled) return;
@@ -106,6 +114,11 @@ function waitUntilReady(
 
     child.once('error', onError);
     child.once('exit', onExit);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     void probe();
   });
 }
@@ -148,12 +161,11 @@ export async function spawnSrvx(
   });
   if (!env.NODE_ENV) env.NODE_ENV = 'development';
 
-  // Fork the CLI module directly so it enters srvx's IPC-aware serve path.
-  // Invoking the binary would add a watcher supervisor and obscure the PID
-  // that Backends owns. The Vercel CLI already watches source files and asks
-  // the builder to replace this process when they change.
+  // Fork the executable with IPC so srvx serves in this process. Running it as
+  // a regular command would add a watcher supervisor and obscure the PID that
+  // Backends owns. The Vercel CLI already handles source-file invalidation.
   const child = fork(
-    srvxCliPath,
+    srvxBinPath,
     [
       `--port=${port}`,
       '--host=127.0.0.1',
@@ -176,7 +188,7 @@ export async function spawnSrvx(
   }
 
   try {
-    await waitUntilReady(child, port, opts.entrypoint);
+    await waitUntilReady(child, port, opts.entrypoint, opts.signal);
   } catch (error) {
     await stopChild(child);
     throw error;

--- a/packages/backends/src/dev/spawn-srvx.ts
+++ b/packages/backends/src/dev/spawn-srvx.ts
@@ -1,0 +1,196 @@
+import { fork, type ChildProcess } from 'node:child_process';
+import { createConnection } from 'node:net';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { cloneEnv } from '@vercel/build-utils';
+import getPort from 'get-port';
+
+const require_ = createRequire(import.meta.url);
+const srvxCliPath = require_.resolve('srvx/cli');
+const tsxPath = pathToFileURL(require_.resolve('tsx')).href;
+
+const STARTUP_TIMEOUT = 5 * 60_000;
+const SHUTDOWN_TIMEOUT = 5_000;
+
+export interface SpawnSrvxOptions {
+  workPath: string;
+  entrypoint: string;
+  env?: NodeJS.ProcessEnv;
+  publicDir: string;
+  onStdout?: (data: Buffer) => void;
+  onStderr?: (data: Buffer) => void;
+}
+
+export interface SpawnedSrvx {
+  child: ChildProcess;
+  pid: number;
+  port: number;
+  shutdown: () => Promise<void>;
+}
+
+function forwardOutput(
+  callback: ((data: Buffer) => void) | undefined,
+  stream: NodeJS.WriteStream
+): (data: Buffer) => void {
+  return data => {
+    if (callback) {
+      callback(data);
+    } else {
+      stream.write(data.toString());
+    }
+  };
+}
+
+function canConnect(port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const socket = createConnection({ host: '127.0.0.1', port });
+    let settled = false;
+
+    const finish = (connected: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(connected);
+    };
+
+    socket.once('connect', () => finish(true));
+    socket.once('error', () => finish(false));
+    socket.setTimeout(100, () => finish(false));
+  });
+}
+
+function waitUntilReady(
+  child: ChildProcess,
+  port: number,
+  entrypoint: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + STARTUP_TIMEOUT;
+    let retryTimer: NodeJS.Timeout | undefined;
+    let settled = false;
+
+    const cleanup = () => {
+      if (retryTimer) clearTimeout(retryTimer);
+      child.off('error', onError);
+      child.off('exit', onExit);
+    };
+
+    const succeed = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const onError = (error: Error) => fail(error);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      const reason = signal ? `signal ${signal}` : `exit code ${code}`;
+      fail(new Error(`Server \`${entrypoint}\` exited with ${reason}`));
+    };
+
+    const probe = async () => {
+      if (settled) return;
+      if (await canConnect(port)) {
+        succeed();
+      } else if (Date.now() >= deadline) {
+        fail(
+          new Error(
+            `Server \`${entrypoint}\` did not listen on port ${port} within ${STARTUP_TIMEOUT}ms`
+          )
+        );
+      } else {
+        retryTimer = setTimeout(probe, 50);
+      }
+    };
+
+    child.once('error', onError);
+    child.once('exit', onExit);
+    void probe();
+  });
+}
+
+function waitForExit(child: ChildProcess, timeout: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise(resolve => {
+    const onExit = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      child.off('exit', onExit);
+      resolve(false);
+    }, timeout);
+    child.once('exit', onExit);
+  });
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+
+  child.kill('SIGTERM');
+  if (await waitForExit(child, SHUTDOWN_TIMEOUT)) return;
+
+  child.kill('SIGKILL');
+  await waitForExit(child, 1_000);
+}
+
+export async function spawnSrvx(opts: SpawnSrvxOptions): Promise<SpawnedSrvx> {
+  const port = await getPort({ host: '127.0.0.1' });
+  const env = cloneEnv(process.env, opts.env, {
+    HOST: '127.0.0.1',
+    PORT: String(port),
+  });
+  if (!env.NODE_ENV) env.NODE_ENV = 'development';
+
+  // Fork the CLI module directly so it enters srvx's IPC-aware serve path.
+  // Invoking the binary would add a watcher supervisor and obscure the PID
+  // that Backends owns. The Vercel CLI already watches source files and asks
+  // the builder to replace this process when they change.
+  const child = fork(
+    srvxCliPath,
+    [
+      `--port=${port}`,
+      '--host=127.0.0.1',
+      `--static=${resolve(opts.workPath, opts.publicDir)}`,
+      opts.entrypoint,
+    ],
+    {
+      cwd: opts.workPath,
+      env,
+      execArgv: ['--import', tsxPath],
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    }
+  );
+
+  child.stdout?.on('data', forwardOutput(opts.onStdout, process.stdout));
+  child.stderr?.on('data', forwardOutput(opts.onStderr, process.stderr));
+
+  if (!child.pid) {
+    throw new Error('srvx child failed to spawn');
+  }
+
+  try {
+    await waitUntilReady(child, port, opts.entrypoint);
+  } catch (error) {
+    await stopChild(child);
+    throw error;
+  }
+
+  return {
+    child,
+    pid: child.pid,
+    port,
+    shutdown: () => stopChild(child),
+  };
+}

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -48,6 +48,7 @@ import { Colors as c } from './cervel/utils.js';
 // Re-export introspection functions
 export { introspectApp } from './introspection/index.js';
 export { diagnostics } from './diagnostics.js';
+export { shouldServe, startDevServer } from './start-dev-server.js';
 
 export const version = 2;
 

--- a/packages/backends/src/start-dev-server.ts
+++ b/packages/backends/src/start-dev-server.ts
@@ -1,0 +1,202 @@
+import { createRequire } from 'node:module';
+import type {
+  Files,
+  ShouldServe,
+  StartDevServer,
+  StartDevServerSuccess,
+} from '@vercel/build-utils';
+import { findEntrypointWithHintOrThrow } from './find-entrypoint.js';
+
+const require_ = createRequire(import.meta.url);
+
+const getNodeStartDevServer = () =>
+  (require_('@vercel/node') as { startDevServer: StartDevServer })
+    .startDevServer;
+
+interface PersistentDevServer {
+  files: Files;
+  result: StartDevServerSuccess;
+  stopPromise?: Promise<void>;
+}
+
+interface PendingDevServer {
+  files: Files;
+  promise: Promise<PersistentDevServer | null>;
+}
+
+const persistentDevServers = new Map<string, PersistentDevServer>();
+const pendingDevServers = new Map<string, PendingDevServer>();
+
+let cleanupHandlersInstalled = false;
+let shuttingDown = false;
+
+function snapshotFiles(files: Files): Files {
+  return { ...files };
+}
+
+function filesAreEqual(previous: Files, current: Files): boolean {
+  const previousNames = Object.keys(previous);
+  const currentNames = Object.keys(current);
+  return (
+    previousNames.length === currentNames.length &&
+    previousNames.every(name => previous[name] === current[name])
+  );
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function forceKill(pid: number): void {
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    // The process has already exited.
+  }
+}
+
+function stopPersistentDevServer(
+  key: string,
+  server: PersistentDevServer
+): Promise<void> {
+  if (!server.stopPromise) {
+    server.stopPromise = (async () => {
+      if (persistentDevServers.get(key) === server) {
+        persistentDevServers.delete(key);
+      }
+
+      try {
+        if (server.result.shutdown) {
+          await server.result.shutdown();
+        } else {
+          forceKill(server.result.pid);
+        }
+      } catch {
+        forceKill(server.result.pid);
+      }
+    })();
+  }
+  return server.stopPromise;
+}
+
+function persistentResult(
+  key: string,
+  server: PersistentDevServer
+): StartDevServerSuccess {
+  return {
+    ...server.result,
+    persistent: true,
+    shutdown: () => stopPersistentDevServer(key, server),
+  };
+}
+
+function installCleanupHandlers(): void {
+  if (cleanupHandlersInstalled) return;
+  cleanupHandlersInstalled = true;
+
+  const killAll = () => {
+    shuttingDown = true;
+    for (const [key, server] of persistentDevServers) {
+      persistentDevServers.delete(key);
+      server.stopPromise = Promise.resolve();
+      forceKill(server.result.pid);
+    }
+  };
+
+  process.on('SIGINT', killAll);
+  process.on('SIGTERM', killAll);
+  process.on('exit', killAll);
+}
+
+export const shouldServe: ShouldServe = async opts => {
+  const requestPath = opts.requestPath.replace(/\/$/, '');
+  if (requestPath.startsWith('api') && opts.hasMatched) {
+    return false;
+  }
+  return true;
+};
+
+export const startDevServer: StartDevServer = async opts => {
+  // Multi-service projects have their own lifecycle and trigger handling.
+  // Keep their existing fallback behavior until the backends dev adapter
+  // supports every service type.
+  if (opts.service) {
+    return null;
+  }
+
+  const entrypoint = await findEntrypointWithHintOrThrow(
+    opts.workPath,
+    opts.entrypoint
+  );
+
+  const key = `${opts.workPath}::${entrypoint}`;
+  const files = snapshotFiles(opts.files);
+  installCleanupHandlers();
+
+  const existing = persistentDevServers.get(key);
+  if (existing) {
+    if (
+      filesAreEqual(existing.files, opts.files) &&
+      isProcessRunning(existing.result.pid)
+    ) {
+      return persistentResult(key, existing);
+    }
+    await stopPersistentDevServer(key, existing);
+  }
+
+  const pending = pendingDevServers.get(key);
+  if (pending) {
+    if (filesAreEqual(pending.files, opts.files)) {
+      const server = await pending.promise;
+      return server ? persistentResult(key, server) : null;
+    }
+
+    // A source change landed while the previous process was starting. Let it
+    // settle, then the recursive call will retire it and start current code.
+    try {
+      await pending.promise;
+    } catch {
+      // The changed source gets a fresh startup attempt below.
+    }
+    return startDevServer(opts);
+  }
+
+  process.env.EXPERIMENTAL_NODE_TYPESCRIPT_ERRORS = '1';
+  const pendingServer: PendingDevServer = {
+    files,
+    promise: Promise.resolve(null),
+  };
+  pendingServer.promise = (async () => {
+    const result = await getNodeStartDevServer()({
+      ...opts,
+      config: { ...opts.config, helpers: false },
+      entrypoint,
+      publicDir: opts.publicDir ?? 'public',
+    });
+    if (!result) return null;
+
+    const server: PersistentDevServer = { files, result };
+    if (shuttingDown) {
+      forceKill(result.pid);
+      return null;
+    }
+
+    persistentDevServers.set(key, server);
+    return server;
+  })();
+  pendingDevServers.set(key, pendingServer);
+
+  try {
+    const server = await pendingServer.promise;
+    return server ? persistentResult(key, server) : null;
+  } finally {
+    if (pendingDevServers.get(key) === pendingServer) {
+      pendingDevServers.delete(key);
+    }
+  }
+};

--- a/packages/backends/src/start-dev-server.ts
+++ b/packages/backends/src/start-dev-server.ts
@@ -5,6 +5,7 @@ import type {
   StartDevServerSuccess,
 } from '@vercel/build-utils';
 import { findEntrypointWithHintOrThrow } from './find-entrypoint.js';
+import { spawnSrvx } from './dev/spawn-srvx.js';
 
 interface PersistentDevServer {
   files: Files;
@@ -22,13 +23,6 @@ const pendingDevServers = new Map<string, PendingDevServer>();
 
 let cleanupHandlersInstalled = false;
 let shuttingDown = false;
-
-// @vercel/node is large and only needed by `vercel dev`, so load it on demand.
-const startNodeDevServer: StartDevServer = async opts => {
-  // @ts-expect-error -- @vercel/node's public types omit builder APIs.
-  const { startDevServer } = await import('@vercel/node');
-  return startDevServer(opts);
-};
 
 function snapshotFiles(files: Files): Files {
   return { ...files };
@@ -185,15 +179,14 @@ export const startDevServer: StartDevServer = async opts => {
     }
 
     const files = snapshotFiles(opts.files);
-    process.env.EXPERIMENTAL_NODE_TYPESCRIPT_ERRORS = '1';
-    const promise = startNodeDevServer({
-      ...opts,
-      config: { ...opts.config, helpers: false },
+    const promise = spawnSrvx({
+      workPath: opts.workPath,
       entrypoint,
       publicDir: opts.publicDir ?? 'public',
+      env: opts.meta?.env,
+      onStdout: opts.onStdout,
+      onStderr: opts.onStderr,
     }).then(async result => {
-      if (!result) return null;
-
       const server: PersistentDevServer = { files, result };
       if (shuttingDown) {
         await stopPersistentDevServer(key, server);

--- a/packages/backends/src/start-dev-server.ts
+++ b/packages/backends/src/start-dev-server.ts
@@ -9,12 +9,15 @@ import { spawnSrvx } from './dev/spawn-srvx.js';
 
 interface PersistentDevServer {
   files: Files;
+  env: NodeJS.ProcessEnv;
   result: StartDevServerSuccess;
   stopPromise?: Promise<void>;
 }
 
 interface PendingDevServer {
   files: Files;
+  env: NodeJS.ProcessEnv;
+  controller: AbortController;
   promise: Promise<PersistentDevServer | null>;
 }
 
@@ -37,6 +40,26 @@ function filesAreEqual(previous: Files, current: Files): boolean {
     previousNames.length === currentNames.length &&
     previousNames.every(name => previous[name] === current[name])
   );
+}
+
+function envsAreEqual(
+  previous: NodeJS.ProcessEnv,
+  current: NodeJS.ProcessEnv
+): boolean {
+  const previousNames = Object.keys(previous);
+  const currentNames = Object.keys(current);
+  return (
+    previousNames.length === currentNames.length &&
+    previousNames.every(name => previous[name] === current[name])
+  );
+}
+
+function stateMatches(
+  state: Pick<PersistentDevServer, 'files' | 'env'>,
+  files: Files,
+  env: NodeJS.ProcessEnv
+): boolean {
+  return filesAreEqual(state.files, files) && envsAreEqual(state.env, env);
 }
 
 function isProcessRunning(pid: number): boolean {
@@ -84,10 +107,16 @@ function persistentResult(
   key: string,
   server: PersistentDevServer
 ): StartDevServerSuccess {
+  const { pid } = server.result;
   return {
     ...server.result,
     persistent: true,
-    shutdown: () => stopPersistentDevServer(key, server),
+    shutdown: () => {
+      const current = persistentDevServers.get(key);
+      return current?.result.pid === pid
+        ? stopPersistentDevServer(key, current)
+        : Promise.resolve();
+    },
   };
 }
 
@@ -97,12 +126,18 @@ function installCleanupHandlers(): void {
 
   const stopAll = () => {
     shuttingDown = true;
+    for (const pending of pendingDevServers.values()) {
+      pending.controller.abort();
+    }
     for (const [key, server] of persistentDevServers) {
       void stopPersistentDevServer(key, server);
     }
   };
 
   const killAll = () => {
+    for (const pending of pendingDevServers.values()) {
+      pending.controller.abort();
+    }
     for (const server of persistentDevServers.values()) {
       terminateProcess(server.result.pid);
     }
@@ -129,12 +164,12 @@ export const startDevServer: StartDevServer = async opts => {
     return null;
   }
 
+  const key = `${opts.workPath}::${opts.entrypoint ?? '<detect>'}`;
   const entrypoint = await findEntrypointWithHintOrThrow(
     opts.workPath,
     opts.entrypoint
   );
-
-  const key = `${opts.workPath}::${entrypoint}`;
+  const env = { ...opts.meta?.env };
   installCleanupHandlers();
 
   // Reuse a live server, or retire stale state before starting one replacement.
@@ -144,7 +179,7 @@ export const startDevServer: StartDevServer = async opts => {
     if (existing) {
       if (
         !existing.stopPromise &&
-        filesAreEqual(existing.files, opts.files) &&
+        stateMatches(existing, opts.files, env) &&
         isProcessRunning(existing.result.pid)
       ) {
         return persistentResult(key, existing);
@@ -155,17 +190,19 @@ export const startDevServer: StartDevServer = async opts => {
 
     const pending = pendingDevServers.get(key);
     if (pending) {
+      if (!stateMatches(pending, opts.files, env)) {
+        pending.controller.abort();
+      }
+
       let server: PersistentDevServer | null;
       try {
         server = await pending.promise;
       } catch (error) {
-        if (filesAreEqual(pending.files, opts.files)) {
-          throw error;
-        }
+        if (stateMatches(pending, opts.files, env)) throw error;
         continue;
       }
 
-      if (filesAreEqual(pending.files, opts.files)) {
+      if (stateMatches(pending, opts.files, env)) {
         if (!server) return null;
         if (isProcessRunning(server.result.pid)) {
           return persistentResult(key, server);
@@ -179,15 +216,17 @@ export const startDevServer: StartDevServer = async opts => {
     }
 
     const files = snapshotFiles(opts.files);
+    const controller = new AbortController();
     const promise = spawnSrvx({
       workPath: opts.workPath,
       entrypoint,
       publicDir: opts.publicDir ?? 'public',
-      env: opts.meta?.env,
+      env,
+      signal: controller.signal,
       onStdout: opts.onStdout,
       onStderr: opts.onStderr,
     }).then(async result => {
-      const server: PersistentDevServer = { files, result };
+      const server: PersistentDevServer = { files, env, result };
       if (shuttingDown) {
         await stopPersistentDevServer(key, server);
         return null;
@@ -196,12 +235,17 @@ export const startDevServer: StartDevServer = async opts => {
       persistentDevServers.set(key, server);
       return server;
     });
-    const pendingServer: PendingDevServer = { files, promise };
+    const pendingServer: PendingDevServer = {
+      files,
+      env,
+      controller,
+      promise,
+    };
     pendingDevServers.set(key, pendingServer);
 
     try {
       const server = await promise;
-      if (!filesAreEqual(files, opts.files)) {
+      if (!stateMatches(pendingServer, opts.files, env)) {
         if (server) {
           await stopPersistentDevServer(key, server);
         }

--- a/packages/backends/src/start-dev-server.ts
+++ b/packages/backends/src/start-dev-server.ts
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module';
 import type {
   Files,
   ShouldServe,
@@ -6,12 +5,6 @@ import type {
   StartDevServerSuccess,
 } from '@vercel/build-utils';
 import { findEntrypointWithHintOrThrow } from './find-entrypoint.js';
-
-const require_ = createRequire(import.meta.url);
-
-const getNodeStartDevServer = () =>
-  (require_('@vercel/node') as { startDevServer: StartDevServer })
-    .startDevServer;
 
 interface PersistentDevServer {
   files: Files;
@@ -30,11 +23,20 @@ const pendingDevServers = new Map<string, PendingDevServer>();
 let cleanupHandlersInstalled = false;
 let shuttingDown = false;
 
+// @vercel/node is large and only needed by `vercel dev`, so load it on demand.
+const startNodeDevServer: StartDevServer = async opts => {
+  // @ts-expect-error -- @vercel/node's public types omit builder APIs.
+  const { startDevServer } = await import('@vercel/node');
+  return startDevServer(opts);
+};
+
 function snapshotFiles(files: Files): Files {
   return { ...files };
 }
 
 function filesAreEqual(previous: Files, current: Files): boolean {
+  // The CLI replaces a File object whenever its source changes, so reference
+  // equality against a shallow snapshot is enough to detect invalidation.
   const previousNames = Object.keys(previous);
   const currentNames = Object.keys(current);
   return (
@@ -52,7 +54,7 @@ function isProcessRunning(pid: number): boolean {
   }
 }
 
-function forceKill(pid: number): void {
+function terminateProcess(pid: number): void {
   try {
     process.kill(pid, 'SIGTERM');
   } catch {
@@ -66,18 +68,18 @@ function stopPersistentDevServer(
 ): Promise<void> {
   if (!server.stopPromise) {
     server.stopPromise = (async () => {
-      if (persistentDevServers.get(key) === server) {
-        persistentDevServers.delete(key);
-      }
-
       try {
         if (server.result.shutdown) {
           await server.result.shutdown();
         } else {
-          forceKill(server.result.pid);
+          terminateProcess(server.result.pid);
         }
       } catch {
-        forceKill(server.result.pid);
+        terminateProcess(server.result.pid);
+      } finally {
+        if (persistentDevServers.get(key) === server) {
+          persistentDevServers.delete(key);
+        }
       }
     })();
   }
@@ -99,21 +101,25 @@ function installCleanupHandlers(): void {
   if (cleanupHandlersInstalled) return;
   cleanupHandlersInstalled = true;
 
-  const killAll = () => {
+  const stopAll = () => {
     shuttingDown = true;
     for (const [key, server] of persistentDevServers) {
-      persistentDevServers.delete(key);
-      server.stopPromise = Promise.resolve();
-      forceKill(server.result.pid);
+      void stopPersistentDevServer(key, server);
     }
   };
 
-  process.on('SIGINT', killAll);
-  process.on('SIGTERM', killAll);
+  const killAll = () => {
+    for (const server of persistentDevServers.values()) {
+      terminateProcess(server.result.pid);
+    }
+  };
+
+  process.on('SIGINT', stopAll);
+  process.on('SIGTERM', stopAll);
   process.on('exit', killAll);
 }
 
-export const shouldServe: ShouldServe = async opts => {
+export const shouldServe: ShouldServe = opts => {
   const requestPath = opts.requestPath.replace(/\/$/, '');
   if (requestPath.startsWith('api') && opts.hasMatched) {
     return false;
@@ -135,68 +141,86 @@ export const startDevServer: StartDevServer = async opts => {
   );
 
   const key = `${opts.workPath}::${entrypoint}`;
-  const files = snapshotFiles(opts.files);
   installCleanupHandlers();
 
-  const existing = persistentDevServers.get(key);
-  if (existing) {
-    if (
-      filesAreEqual(existing.files, opts.files) &&
-      isProcessRunning(existing.result.pid)
-    ) {
-      return persistentResult(key, existing);
-    }
-    await stopPersistentDevServer(key, existing);
-  }
-
-  const pending = pendingDevServers.get(key);
-  if (pending) {
-    if (filesAreEqual(pending.files, opts.files)) {
-      const server = await pending.promise;
-      return server ? persistentResult(key, server) : null;
+  // Reuse a live server, or retire stale state before starting one replacement.
+  // Concurrent cold requests wait on the same pending start.
+  while (!shuttingDown) {
+    const existing = persistentDevServers.get(key);
+    if (existing) {
+      if (
+        !existing.stopPromise &&
+        filesAreEqual(existing.files, opts.files) &&
+        isProcessRunning(existing.result.pid)
+      ) {
+        return persistentResult(key, existing);
+      }
+      await stopPersistentDevServer(key, existing);
+      continue;
     }
 
-    // A source change landed while the previous process was starting. Let it
-    // settle, then the recursive call will retire it and start current code.
-    try {
-      await pending.promise;
-    } catch {
-      // The changed source gets a fresh startup attempt below.
-    }
-    return startDevServer(opts);
-  }
+    const pending = pendingDevServers.get(key);
+    if (pending) {
+      let server: PersistentDevServer | null;
+      try {
+        server = await pending.promise;
+      } catch (error) {
+        if (filesAreEqual(pending.files, opts.files)) {
+          throw error;
+        }
+        continue;
+      }
 
-  process.env.EXPERIMENTAL_NODE_TYPESCRIPT_ERRORS = '1';
-  const pendingServer: PendingDevServer = {
-    files,
-    promise: Promise.resolve(null),
-  };
-  pendingServer.promise = (async () => {
-    const result = await getNodeStartDevServer()({
+      if (filesAreEqual(pending.files, opts.files)) {
+        if (!server) return null;
+        if (isProcessRunning(server.result.pid)) {
+          return persistentResult(key, server);
+        }
+      }
+
+      if (server) {
+        await stopPersistentDevServer(key, server);
+      }
+      continue;
+    }
+
+    const files = snapshotFiles(opts.files);
+    process.env.EXPERIMENTAL_NODE_TYPESCRIPT_ERRORS = '1';
+    const promise = startNodeDevServer({
       ...opts,
       config: { ...opts.config, helpers: false },
       entrypoint,
       publicDir: opts.publicDir ?? 'public',
+    }).then(async result => {
+      if (!result) return null;
+
+      const server: PersistentDevServer = { files, result };
+      if (shuttingDown) {
+        await stopPersistentDevServer(key, server);
+        return null;
+      }
+
+      persistentDevServers.set(key, server);
+      return server;
     });
-    if (!result) return null;
+    const pendingServer: PendingDevServer = { files, promise };
+    pendingDevServers.set(key, pendingServer);
 
-    const server: PersistentDevServer = { files, result };
-    if (shuttingDown) {
-      forceKill(result.pid);
-      return null;
-    }
-
-    persistentDevServers.set(key, server);
-    return server;
-  })();
-  pendingDevServers.set(key, pendingServer);
-
-  try {
-    const server = await pendingServer.promise;
-    return server ? persistentResult(key, server) : null;
-  } finally {
-    if (pendingDevServers.get(key) === pendingServer) {
-      pendingDevServers.delete(key);
+    try {
+      const server = await promise;
+      if (!filesAreEqual(files, opts.files)) {
+        if (server) {
+          await stopPersistentDevServer(key, server);
+        }
+        continue;
+      }
+      return server ? persistentResult(key, server) : null;
+    } finally {
+      if (pendingDevServers.get(key) === pendingServer) {
+        pendingDevServers.delete(key);
+      }
     }
   }
+
+  return null;
 };

--- a/packages/backends/test/unit.start-dev-server.test.ts
+++ b/packages/backends/test/unit.start-dev-server.test.ts
@@ -12,6 +12,14 @@ import { startDevServer } from '../src/start-dev-server';
 const workPaths = new Set<string>();
 const shutdowns = new Set<() => Promise<void>>();
 
+interface TestServerResponse {
+  marker: string;
+  env: string;
+  pid: number;
+  requestCount: number;
+  url: string;
+}
+
 function filesFor(serverPath: string): Files {
   return {
     'server.ts': new FileFsRef({ fsPath: serverPath }),
@@ -38,10 +46,13 @@ server.listen(12345);
 `;
 }
 
-async function request(port: number, path: string): Promise<any> {
+async function request(
+  port: number,
+  path: string
+): Promise<TestServerResponse> {
   const response = await fetch(`http://127.0.0.1:${port}${path}`);
   expect(response.status).toBe(200);
-  return response.json();
+  return (await response.json()) as TestServerResponse;
 }
 
 afterEach(async () => {
@@ -83,37 +94,40 @@ describe('startDevServer', () => {
     ]);
     const initial = results[0];
     expect(initial).not.toBeNull();
+    if (!initial) throw new Error('Expected srvx to start');
+    expect(initial.persistent).toBe(true);
+    expect(initial.shutdown).toBeTypeOf('function');
     for (const result of results) {
       if (result?.shutdown) shutdowns.add(result.shutdown);
     }
     expect(results.map(result => result?.pid)).toEqual([
-      initial?.pid,
-      initial?.pid,
-      initial?.pid,
+      initial.pid,
+      initial.pid,
+      initial.pid,
     ]);
     expect(results.map(result => result?.port)).toEqual([
-      initial?.port,
-      initial?.port,
-      initial?.port,
+      initial.port,
+      initial.port,
+      initial.port,
     ]);
 
-    const first = await request(initial!.port, '/first');
-    const second = await request(initial!.port, '/second');
+    const first = await request(initial.port, '/first');
+    const second = await request(initial.port, '/second');
     expect(first).toMatchObject({
       marker: 'initial',
       env: 'from-meta',
-      pid: initial!.pid,
+      pid: initial.pid,
       requestCount: 1,
       url: '/first',
     });
     expect(second).toMatchObject({
-      pid: initial!.pid,
+      pid: initial.pid,
       requestCount: 2,
       url: '/second',
     });
 
     const staticResponse = await fetch(
-      `http://127.0.0.1:${initial!.port}/hello.txt`
+      `http://127.0.0.1:${initial.port}/hello.txt`
     );
     expect(await staticResponse.text()).toBe('hello static');
 
@@ -123,19 +137,20 @@ describe('startDevServer', () => {
       files: filesFor(serverPath),
     });
     expect(updated).not.toBeNull();
-    if (updated?.shutdown) shutdowns.add(updated.shutdown);
-    expect(updated?.pid).not.toBe(initial?.pid);
-    expect(await request(updated!.port, '/updated')).toMatchObject({
+    if (!updated) throw new Error('Expected srvx to reload');
+    if (updated.shutdown) shutdowns.add(updated.shutdown);
+    expect(updated.pid).not.toBe(initial.pid);
+    expect(await request(updated.port, '/updated')).toMatchObject({
       marker: 'updated',
       env: 'from-meta',
-      pid: updated!.pid,
+      pid: updated.pid,
       requestCount: 1,
       url: '/updated',
     });
 
-    await updated!.shutdown?.();
+    await updated.shutdown?.();
     await expect(
-      fetch(`http://127.0.0.1:${updated!.port}/after-shutdown`)
+      fetch(`http://127.0.0.1:${updated.port}/after-shutdown`)
     ).rejects.toThrow();
   });
 

--- a/packages/backends/test/unit.start-dev-server.test.ts
+++ b/packages/backends/test/unit.start-dev-server.test.ts
@@ -132,9 +132,10 @@ describe('startDevServer', () => {
     expect(await staticResponse.text()).toBe('hello static');
 
     await writeFile(serverPath, serverSource('updated'));
+    const updatedFiles = filesFor(serverPath);
     const updated = await startDevServer({
       ...opts,
-      files: filesFor(serverPath),
+      files: updatedFiles,
     });
     expect(updated).not.toBeNull();
     if (!updated) throw new Error('Expected srvx to reload');
@@ -148,9 +149,26 @@ describe('startDevServer', () => {
       url: '/updated',
     });
 
-    await updated.shutdown?.();
+    const reconfigured = await startDevServer({
+      ...opts,
+      files: updatedFiles,
+      meta: { env: { SRVX_TEST_ENV: 'updated-env' } },
+    });
+    expect(reconfigured).not.toBeNull();
+    if (!reconfigured) throw new Error('Expected srvx to restart');
+    if (reconfigured.shutdown) shutdowns.add(reconfigured.shutdown);
+    expect(reconfigured.pid).not.toBe(updated.pid);
+    expect(await request(reconfigured.port, '/updated-env')).toMatchObject({
+      marker: 'updated',
+      env: 'updated-env',
+      pid: reconfigured.pid,
+      requestCount: 1,
+      url: '/updated-env',
+    });
+
+    await reconfigured.shutdown?.();
     await expect(
-      fetch(`http://127.0.0.1:${updated.port}/after-shutdown`)
+      fetch(`http://127.0.0.1:${reconfigured.port}/after-shutdown`)
     ).rejects.toThrow();
   });
 

--- a/packages/backends/test/unit.start-dev-server.test.ts
+++ b/packages/backends/test/unit.start-dev-server.test.ts
@@ -1,0 +1,164 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  FileFsRef,
+  type Files,
+  type StartDevServerOptions,
+} from '@vercel/build-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { startDevServer } from '../src/start-dev-server';
+
+const workPaths = new Set<string>();
+const shutdowns = new Set<() => Promise<void>>();
+
+function filesFor(serverPath: string): Files {
+  return {
+    'server.ts': new FileFsRef({ fsPath: serverPath }),
+  };
+}
+
+function serverSource(marker: string): string {
+  return `
+import { createServer } from 'node:http';
+
+let requestCount = 0;
+const server = createServer((req, res) => {
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({
+    marker: ${JSON.stringify(marker)},
+    env: process.env.SRVX_TEST_ENV,
+    pid: process.pid,
+    requestCount: ++requestCount,
+    url: req.url,
+  }));
+});
+
+server.listen(12345);
+`;
+}
+
+async function request(port: number, path: string): Promise<any> {
+  const response = await fetch(`http://127.0.0.1:${port}${path}`);
+  expect(response.status).toBe(200);
+  return response.json();
+}
+
+afterEach(async () => {
+  await Promise.allSettled([...shutdowns].map(shutdown => shutdown()));
+  shutdowns.clear();
+  await Promise.all(
+    [...workPaths].map(workPath =>
+      rm(workPath, { recursive: true, force: true })
+    )
+  );
+  workPaths.clear();
+});
+
+describe('startDevServer', () => {
+  it('serves, reuses, reloads, and shuts down a package-less TypeScript server', async () => {
+    const workPath = await mkdtemp(join(tmpdir(), 'backends-srvx-dev-'));
+    workPaths.add(workPath);
+
+    const serverPath = join(workPath, 'server.ts');
+    await writeFile(serverPath, serverSource('initial'));
+    await mkdir(join(workPath, 'public'));
+    await writeFile(join(workPath, 'public', 'hello.txt'), 'hello static');
+
+    const opts: StartDevServerOptions = {
+      files: filesFor(serverPath),
+      entrypoint: 'package.json',
+      workPath,
+      repoRootPath: workPath,
+      config: {},
+      meta: { env: { SRVX_TEST_ENV: 'from-meta' } },
+      onStdout: () => {},
+      onStderr: () => {},
+    };
+
+    const results = await Promise.all([
+      startDevServer(opts),
+      startDevServer(opts),
+      startDevServer(opts),
+    ]);
+    const initial = results[0];
+    expect(initial).not.toBeNull();
+    for (const result of results) {
+      if (result?.shutdown) shutdowns.add(result.shutdown);
+    }
+    expect(results.map(result => result?.pid)).toEqual([
+      initial?.pid,
+      initial?.pid,
+      initial?.pid,
+    ]);
+    expect(results.map(result => result?.port)).toEqual([
+      initial?.port,
+      initial?.port,
+      initial?.port,
+    ]);
+
+    const first = await request(initial!.port, '/first');
+    const second = await request(initial!.port, '/second');
+    expect(first).toMatchObject({
+      marker: 'initial',
+      env: 'from-meta',
+      pid: initial!.pid,
+      requestCount: 1,
+      url: '/first',
+    });
+    expect(second).toMatchObject({
+      pid: initial!.pid,
+      requestCount: 2,
+      url: '/second',
+    });
+
+    const staticResponse = await fetch(
+      `http://127.0.0.1:${initial!.port}/hello.txt`
+    );
+    expect(await staticResponse.text()).toBe('hello static');
+
+    await writeFile(serverPath, serverSource('updated'));
+    const updated = await startDevServer({
+      ...opts,
+      files: filesFor(serverPath),
+    });
+    expect(updated).not.toBeNull();
+    if (updated?.shutdown) shutdowns.add(updated.shutdown);
+    expect(updated?.pid).not.toBe(initial?.pid);
+    expect(await request(updated!.port, '/updated')).toMatchObject({
+      marker: 'updated',
+      env: 'from-meta',
+      pid: updated!.pid,
+      requestCount: 1,
+      url: '/updated',
+    });
+
+    await updated!.shutdown?.();
+    await expect(
+      fetch(`http://127.0.0.1:${updated!.port}/after-shutdown`)
+    ).rejects.toThrow();
+  });
+
+  it('reports an entrypoint that exits before listening', async () => {
+    const workPath = await mkdtemp(join(tmpdir(), 'backends-srvx-error-'));
+    workPaths.add(workPath);
+
+    const serverPath = join(workPath, 'server.ts');
+    await writeFile(serverPath, "throw new Error('startup failure');");
+    const stderr: Buffer[] = [];
+
+    await expect(
+      startDevServer({
+        files: filesFor(serverPath),
+        entrypoint: 'package.json',
+        workPath,
+        repoRootPath: workPath,
+        config: {},
+        meta: {},
+        onStdout: () => {},
+        onStderr: data => stderr.push(data),
+      })
+    ).rejects.toThrow(/server\.ts.*exit code 1/i);
+    expect(Buffer.concat(stderr).toString()).toContain('startup failure');
+  });
+});

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -265,6 +265,12 @@ export interface StartDevServerSuccess {
   shutdown?: () => Promise<void>;
 
   /**
+   * Whether the builder owns this dev server's lifecycle across requests.
+   * Persistent servers are still shut down when `vercel dev` exits.
+   */
+  persistent?: boolean;
+
+  /**
    * Cron entries produced by the builder for this service.
    * Used by the dev orchestrator to schedule cron triggers.
    */

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -584,6 +584,32 @@ export async function getBuildMatches(
         mapToEntrypoint.set(src, originalSrc);
       }
     }
+    // The Node framework preset uses `package.json` as a stable build src,
+    // while @vercel/backends discovers the actual server entrypoint. A
+    // package.json is optional, so match a detected server file in dev while
+    // preserving the sentinel passed to the builder.
+    if (buildConfig.config?.framework === 'node' && !fileList.includes(src)) {
+      const originalSrc = src;
+      const nodeEntrypoints = [
+        'server.cjs',
+        'server.js',
+        'server.mjs',
+        'server.mts',
+        'server.ts',
+        'server.cts',
+        'src/server.cjs',
+        'src/server.js',
+        'src/server.mjs',
+        'src/server.mts',
+        'src/server.ts',
+        'src/server.cts',
+      ];
+      const existing = nodeEntrypoints.find(p => fileList.includes(p));
+      if (existing) {
+        src = existing;
+        mapToEntrypoint.set(src, originalSrc);
+      }
+    }
     // The Go framework preset keeps `index.go` as the stable build src for
     // deployment routing. In dev, if that sentinel file is absent, match one
     // of the known standalone entrypoints but still pass `index.go` through

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -590,21 +590,9 @@ export async function getBuildMatches(
     // preserving the sentinel passed to the builder.
     if (buildConfig.config?.framework === 'node' && !fileList.includes(src)) {
       const originalSrc = src;
-      const nodeEntrypoints = [
-        'server.cjs',
-        'server.js',
-        'server.mjs',
-        'server.mts',
-        'server.ts',
-        'server.cts',
-        'src/server.cjs',
-        'src/server.js',
-        'src/server.mjs',
-        'src/server.mts',
-        'src/server.ts',
-        'src/server.cts',
-      ];
-      const existing = nodeEntrypoints.find(p => fileList.includes(p));
+      const existing = fileList.find(path =>
+        /^(?:src\/)?server\.[cm]?[jt]s$/.test(path)
+      );
       if (existing) {
         src = existing;
         mapToEntrypoint.set(src, originalSrc);

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1163,10 +1163,7 @@ export default class DevServer {
       const pathname = url.parse(req.url || '/').pathname || '/';
       for (const match of this.buildMatches.values()) {
         const { builder } = match.builderWithPkg;
-        if (
-          (builder.version === 3 || builder.version === -1) &&
-          typeof builder.startDevServer === 'function'
-        ) {
+        if (typeof builder.startDevServer === 'function') {
           try {
             const result = await builder.startDevServer({
               files: this.files,
@@ -2118,8 +2115,8 @@ export default class DevServer {
       const { envConfigs, files, devCacheDir, cwd: workPath } = this;
       try {
         const { builder } = middleware.builderWithPkg;
-        if (builder.version === 3 || builder.version === -1) {
-          startMiddlewareResult = await builder.startDevServer?.({
+        if (typeof builder.startDevServer === 'function') {
+          startMiddlewareResult = await builder.startDevServer({
             files,
             entrypoint: middleware.entrypoint,
             workPath,
@@ -2597,16 +2594,11 @@ export default class DevServer {
     }
 
     // Before doing any asset matching, check if this builder supports the
-    // `startDevServer()` "optimization". In this case, the vercel dev server invokes
-    // `startDevServer()` on the builder for every HTTP request so that it boots
-    // up a single-serve dev HTTP server that vercel dev will proxy this HTTP request
-    // to. Once the proxied request is finished, vercel dev shuts down the dev
-    // server child process.
+    // `startDevServer()` optimization. Builders may own a persistent server
+    // across requests; all other dev servers retain the request-scoped
+    // lifecycle.
     const { builder, pkg: builderPkg } = match.builderWithPkg;
-    if (
-      (builder.version === 3 || builder.version === -1) &&
-      typeof builder.startDevServer === 'function'
-    ) {
+    if (typeof builder.startDevServer === 'function') {
       let devServerResult: StartDevServerResult = null;
       try {
         const { envConfigs, files, devCacheDir, cwd: workPath } = this;
@@ -2658,12 +2650,13 @@ export default class DevServer {
         // is also included in the request ID. So use the same `dev1` fake region.
         requestId = generateRequestId(this.podId, true);
 
-        const { port, pid, shutdown } = devServerResult;
+        const { port, pid, shutdown, persistent } = devServerResult;
         this.shutdownCallbacks.set(pid, shutdown);
-
-        res.once('close', () => {
-          this.killBuilderDevServer(pid);
-        });
+        if (!persistent) {
+          res.once('close', () => {
+            this.killBuilderDevServer(pid);
+          });
+        }
 
         debug(
           `Proxying to "${builderPkg.name}" dev server (port=${port}, pid=${pid})`

--- a/packages/cli/test/dev/fixtures/node-standalone/server.ts
+++ b/packages/cli/test/dev/fixtures/node-standalone/server.ts
@@ -1,0 +1,21 @@
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
+
+const instanceId = randomUUID();
+const marker = 'initial';
+let requestCount = 0;
+
+const server = createServer((req, res) => {
+  res.setHeader('content-type', 'application/json');
+  res.end(
+    JSON.stringify({
+      url: req.url,
+      pid: process.pid,
+      instanceId,
+      requestCount: ++requestCount,
+      marker,
+    })
+  );
+});
+
+server.listen(process.env.PORT ?? 3000);

--- a/packages/cli/test/dev/integration-2.test.ts
+++ b/packages/cli/test/dev/integration-2.test.ts
@@ -200,7 +200,7 @@ test(
 
 test(
   '[vercel dev] Should persist and reload Node standalone servers without package.json',
-  testFixtureStdio('node-standalone', async (testPath: any, port: number) => {
+  testFixtureStdio('node-standalone', async (_: unknown, port: number) => {
     interface NodeStandaloneResponse {
       instanceId: string;
       marker: string;
@@ -209,33 +209,22 @@ test(
       url: string;
     }
 
-    let devInstance: NodeStandaloneResponse | undefined;
+    const requestDev = async (path: string) => {
+      const response = await nodeFetch(`http://localhost:${port}${path}`);
+      expect(response.status).toBe(200);
+      return (await response.json()) as NodeStandaloneResponse;
+    };
 
-    await testPath(200, '/', (body: string, _res: unknown, isDev: boolean) => {
-      const response = JSON.parse(body) as NodeStandaloneResponse;
-      expect(response.url).toBe('/');
-      expect(response.marker).toBe('initial');
-      if (isDev) {
-        devInstance = response;
-      }
-    });
+    const devInstance = await requestDev('/');
+    expect(devInstance.url).toBe('/');
+    expect(devInstance.marker).toBe('initial');
 
-    await testPath(
-      200,
-      '/some/nested/path',
-      (body: string, _res: unknown, isDev: boolean) => {
-        const response = JSON.parse(body) as NodeStandaloneResponse;
-        expect(response.url).toBe('/some/nested/path');
-        expect(response.marker).toBe('initial');
-        if (isDev) {
-          expect(response.instanceId).toBe(devInstance?.instanceId);
-          expect(response.pid).toBe(devInstance?.pid);
-          expect(response.requestCount).toBe(
-            (devInstance?.requestCount ?? 0) + 1
-          );
-        }
-      }
-    );
+    const secondResponse = await requestDev('/some/nested/path');
+    expect(secondResponse.url).toBe('/some/nested/path');
+    expect(secondResponse.marker).toBe('initial');
+    expect(secondResponse.instanceId).toBe(devInstance.instanceId);
+    expect(secondResponse.pid).toBe(devInstance.pid);
+    expect(secondResponse.requestCount).toBe(devInstance.requestCount + 1);
 
     const serverPath = join(fixture('node-standalone'), 'server.ts');
     const originalSource = await fs.readFile(serverPath, 'utf8');
@@ -253,10 +242,9 @@ test(
       let updatedResponse: NodeStandaloneResponse | undefined;
       while (Date.now() < deadline) {
         try {
-          const response = await nodeFetch(`http://localhost:${port}/reloaded`);
-          const body = (await response.json()) as NodeStandaloneResponse;
-          if (body.marker === 'updated') {
-            updatedResponse = body;
+          const response = await requestDev('/reloaded');
+          if (response.marker === 'updated') {
+            updatedResponse = response;
             break;
           }
         } catch {
@@ -266,7 +254,7 @@ test(
       }
 
       expect(updatedResponse?.url).toBe('/reloaded');
-      expect(updatedResponse?.instanceId).not.toBe(devInstance?.instanceId);
+      expect(updatedResponse?.instanceId).not.toBe(devInstance.instanceId);
       expect(updatedResponse?.requestCount).toBe(1);
     } finally {
       await fs.writeFile(serverPath, originalSource);

--- a/packages/cli/test/dev/integration-2.test.ts
+++ b/packages/cli/test/dev/integration-2.test.ts
@@ -201,12 +201,18 @@ test(
 test(
   '[vercel dev] Should persist and reload Node standalone servers without package.json',
   testFixtureStdio('node-standalone', async (testPath: any, port: number) => {
-    let devInstance:
-      | { instanceId: string; pid: number; requestCount: number }
-      | undefined;
+    interface NodeStandaloneResponse {
+      instanceId: string;
+      marker: string;
+      pid: number;
+      requestCount: number;
+      url: string;
+    }
+
+    let devInstance: NodeStandaloneResponse | undefined;
 
     await testPath(200, '/', (body: string, _res: unknown, isDev: boolean) => {
-      const response = JSON.parse(body);
+      const response = JSON.parse(body) as NodeStandaloneResponse;
       expect(response.url).toBe('/');
       expect(response.marker).toBe('initial');
       if (isDev) {
@@ -218,7 +224,7 @@ test(
       200,
       '/some/nested/path',
       (body: string, _res: unknown, isDev: boolean) => {
-        const response = JSON.parse(body);
+        const response = JSON.parse(body) as NodeStandaloneResponse;
         expect(response.url).toBe('/some/nested/path');
         expect(response.marker).toBe('initial');
         if (isDev) {
@@ -244,11 +250,11 @@ test(
       );
 
       const deadline = Date.now() + 15_000;
-      let updatedResponse: any;
+      let updatedResponse: NodeStandaloneResponse | undefined;
       while (Date.now() < deadline) {
         try {
           const response = await nodeFetch(`http://localhost:${port}/reloaded`);
-          const body = await response.json();
+          const body = (await response.json()) as NodeStandaloneResponse;
           if (body.marker === 'updated') {
             updatedResponse = body;
             break;

--- a/packages/cli/test/dev/integration-2.test.ts
+++ b/packages/cli/test/dev/integration-2.test.ts
@@ -1,6 +1,9 @@
 import assert from 'assert';
+import fs from 'fs-extra';
 import { isIP } from 'net';
-import { exec, fixture, testFixture, testFixtureStdio } from './utils';
+import { join } from 'path';
+import nodeFetch from 'node-fetch';
+import { exec, fixture, sleep, testFixture, testFixtureStdio } from './utils';
 
 test('[vercel dev] validate redirects', async () => {
   const directory = fixture('invalid-redirects');
@@ -192,6 +195,76 @@ test(
       `/some/nested/path`,
       'Standalone Go: /some/nested/path'
     );
+  })
+);
+
+test(
+  '[vercel dev] Should persist and reload Node standalone servers without package.json',
+  testFixtureStdio('node-standalone', async (testPath: any, port: number) => {
+    let devInstance:
+      | { instanceId: string; pid: number; requestCount: number }
+      | undefined;
+
+    await testPath(200, '/', (body: string, _res: unknown, isDev: boolean) => {
+      const response = JSON.parse(body);
+      expect(response.url).toBe('/');
+      expect(response.marker).toBe('initial');
+      if (isDev) {
+        devInstance = response;
+      }
+    });
+
+    await testPath(
+      200,
+      '/some/nested/path',
+      (body: string, _res: unknown, isDev: boolean) => {
+        const response = JSON.parse(body);
+        expect(response.url).toBe('/some/nested/path');
+        expect(response.marker).toBe('initial');
+        if (isDev) {
+          expect(response.instanceId).toBe(devInstance?.instanceId);
+          expect(response.pid).toBe(devInstance?.pid);
+          expect(response.requestCount).toBe(
+            (devInstance?.requestCount ?? 0) + 1
+          );
+        }
+      }
+    );
+
+    const serverPath = join(fixture('node-standalone'), 'server.ts');
+    const originalSource = await fs.readFile(serverPath, 'utf8');
+
+    try {
+      await fs.writeFile(
+        serverPath,
+        originalSource.replace(
+          "const marker = 'initial';",
+          "const marker = 'updated';"
+        )
+      );
+
+      const deadline = Date.now() + 15_000;
+      let updatedResponse: any;
+      while (Date.now() < deadline) {
+        try {
+          const response = await nodeFetch(`http://localhost:${port}/reloaded`);
+          const body = await response.json();
+          if (body.marker === 'updated') {
+            updatedResponse = body;
+            break;
+          }
+        } catch {
+          // The previous server may be shutting down between polling requests.
+        }
+        await sleep(100);
+      }
+
+      expect(updatedResponse?.url).toBe('/reloaded');
+      expect(updatedResponse?.instanceId).not.toBe(devInstance?.instanceId);
+      expect(updatedResponse?.requestCount).toBe(1);
+    } finally {
+      await fs.writeFile(serverPath, originalSource);
+    }
   })
 );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,9 +269,6 @@ importers:
       '@vercel/nft':
         specifier: 1.10.0
         version: 1.10.0(rollup@4.60.4)
-      '@vercel/node':
-        specifier: workspace:*
-        version: link:../node
       execa:
         specifier: 3.2.0
         version: 3.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,8 +291,8 @@ importers:
         specifier: 1.0.0-rc.1
         version: 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       srvx:
-        specifier: 0.8.9
-        version: 0.8.9
+        specifier: 0.11.16
+        version: 0.11.16
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -7708,9 +7708,6 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie-es@2.0.1:
-    resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
-
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
@@ -11516,11 +11513,6 @@ packages:
 
   srvx@0.11.16:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
-    engines: {node: '>=20.16.0'}
-    hasBin: true
-
-  srvx@0.8.9:
-    resolution: {integrity: sha512-wYc3VLZHRzwYrWJhkEqkhLb31TI0SOkfYZDkUhXdp3NoCnNS0FqajiQszZZjfow/VYEuc6Q5sZh9nM6kPy2NBQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -18010,8 +18002,6 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie-es@2.0.1: {}
-
   cookie-signature@1.0.6: {}
 
   cookie-signature@1.2.2: {}
@@ -22407,10 +22397,6 @@ snapshots:
   sqlstring@2.3.3: {}
 
   srvx@0.11.16: {}
-
-  srvx@0.8.9:
-    dependencies:
-      cookie-es: 2.0.1
 
   ssh2@1.17.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       '@vercel/nft':
         specifier: 1.10.0
         version: 1.10.0(rollup@4.60.4)
+      '@vercel/node':
+        specifier: workspace:*
+        version: link:../node
       execa:
         specifier: 3.2.0
         version: 3.2.0


### PR DESCRIPTION
Implements proper `vc dev` support for Node preset `server.ts` servers which starts a persistent devserver reused across requests