### PR TITLE
[CLI] fix(cli): preserve local env when refreshing OIDC on link

### DIFF
--- a/.changeset/tidy-ducks-link.md
+++ b/.changeset/tidy-ducks-link.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+---
+
+Refresh `VERCEL_OIDC_TOKEN` after `vercel link` without overwriting other
+variables or formatting in an existing `.env.local` file.

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { outputFile } from 'fs-extra';
+import { outputFile, readFile } from 'fs-extra';
 import { closeSync, openSync, readSync } from 'fs';
 import { resolve } from 'path';
 import type Client from '../../util/client';
@@ -13,6 +13,8 @@ import {
   buildDeltaString,
   createEnvObject,
 } from '../../util/env/diff-env-files';
+import { VERCEL_OIDC_TOKEN } from '../../util/env/constants';
+import { updateOidcTokenContents } from '../../util/env/update-oidc-token-contents';
 import { isErrnoException } from '@vercel/error-utils';
 import { addToGitIgnore } from '../../util/link/add-to-gitignore';
 import JSONparse from 'json-parse-better-errors';
@@ -37,6 +39,11 @@ import {
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
 
 const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
+
+export interface EnvPullOptions {
+  /** Refresh only VERCEL_OIDC_TOKEN while preserving all other file content. */
+  oidcTokenOnly?: boolean;
+}
 
 function readHeadSync(path: string, length: number) {
   const buffer = Buffer.alloc(length);
@@ -74,7 +81,8 @@ const VARIABLES_TO_IGNORE = [
 export default async function pull(
   client: Client,
   argv: string[],
-  source: EnvRecordsSource = 'vercel-cli:env:pull'
+  source: EnvRecordsSource = 'vercel-cli:env:pull',
+  options: EnvPullOptions = {}
 ) {
   const telemetryClient = new EnvPullTelemetryClient({
     opts: {
@@ -168,7 +176,8 @@ export default async function pull(
     gitBranch,
     client.cwd,
     source,
-    deploymentId
+    deploymentId,
+    options
   );
 
   return 0;
@@ -183,15 +192,16 @@ export async function envPullCommandLogic(
   gitBranch: string | undefined,
   cwd: string,
   source: EnvRecordsSource,
-  deploymentId?: string
+  deploymentId?: string,
+  { oidcTokenOnly = false }: EnvPullOptions = {}
 ) {
   const fullPath = resolve(cwd, filename);
   const head = tryReadHeadSync(fullPath, Buffer.byteLength(CONTENTS_PREFIX));
   const exists = typeof head !== 'undefined';
 
-  if (head === CONTENTS_PREFIX) {
+  if (head === CONTENTS_PREFIX && !oidcTokenOnly) {
     output.log(`Overwriting existing ${chalk.bold(filename)} file`);
-  } else if (exists && !skipConfirmation) {
+  } else if (exists && !skipConfirmation && !oidcTokenOnly) {
     if (client.nonInteractive) {
       outputActionRequired(client, {
         status: 'action_required',
@@ -222,15 +232,19 @@ export async function envPullCommandLogic(
 
   const projectSlugLink = formatProject(link.org.slug, link.project.name);
 
-  const downloadMessage = gitBranch
-    ? `Downloading \`${chalk.cyan(
-        environment
-      )}\` environment variables for ${projectSlugLink} and any overrides for branch ${chalk.cyan(
-        gitBranch
-      )}`
-    : `Downloading \`${chalk.cyan(
-        environment
-      )}\` environment variables for ${projectSlugLink}`;
+  const downloadMessage = oidcTokenOnly
+    ? `Downloading a fresh \`${chalk.cyan(
+        VERCEL_OIDC_TOKEN
+      )}\` for ${projectSlugLink}`
+    : gitBranch
+      ? `Downloading \`${chalk.cyan(
+          environment
+        )}\` environment variables for ${projectSlugLink} and any overrides for branch ${chalk.cyan(
+          gitBranch
+        )}`
+      : `Downloading \`${chalk.cyan(
+          environment
+        )}\` environment variables for ${projectSlugLink}`;
 
   output.log(downloadMessage);
 
@@ -249,7 +263,7 @@ export async function envPullCommandLogic(
 
   let deltaString = '';
   let oldEnv;
-  if (exists) {
+  if (exists && !oidcTokenOnly) {
     oldEnv = await createEnvObject(fullPath);
     if (oldEnv) {
       // Removes any double quotes from `records`, if they exist
@@ -261,16 +275,30 @@ export async function envPullCommandLogic(
     }
   }
 
-  const contents =
-    CONTENTS_PREFIX +
-    Object.keys(records)
-      .sort()
-      .filter(key => !VARIABLES_TO_IGNORE.includes(key))
-      .map(key => `${key}="${escapeValue(records[key])}"`)
-      .join('\n') +
-    '\n';
+  let contents: string;
+  let fileChanged = true;
 
-  await outputFile(fullPath, contents, 'utf8');
+  if (oidcTokenOnly) {
+    const existingContents = exists ? await readFile(fullPath, 'utf8') : '';
+    contents = updateOidcTokenContents(
+      existingContents,
+      records[VERCEL_OIDC_TOKEN] || undefined
+    );
+    fileChanged = contents !== existingContents;
+  } else {
+    contents =
+      CONTENTS_PREFIX +
+      Object.keys(records)
+        .sort()
+        .filter(key => !VARIABLES_TO_IGNORE.includes(key))
+        .map(key => `${key}="${escapeValue(records[key])}"`)
+        .join('\n') +
+      '\n';
+  }
+
+  if (fileChanged) {
+    await outputFile(fullPath, contents, 'utf8');
+  }
 
   if (deltaString) {
     output.print('\n' + deltaString);
@@ -279,7 +307,8 @@ export async function envPullCommandLogic(
   }
 
   let isGitIgnoreUpdated = false;
-  if (filename === '.env.local') {
+  const fileExistsAfterPull = exists || contents.length > 0;
+  if (filename === '.env.local' && fileExistsAfterPull) {
     // When the file is `.env.local`, we also add it to `.gitignore`
     // to avoid accidentally committing it to git.
     // We use '.env*' to match the default .gitignore from
@@ -289,7 +318,16 @@ export async function envPullCommandLogic(
     isGitIgnoreUpdated = await addToGitIgnore(rootPath, '.env*');
   }
 
+  if (!fileChanged && !isGitIgnoreUpdated) {
+    output.stopSpinner();
+    return;
+  }
+
   output.print('\n');
+  if (!fileChanged) {
+    printAlignedLabel('Updated', `.gitignore for ${filename}`, { gutter: '✓' });
+    return;
+  }
   printAlignedLabel(
     exists ? 'Updated' : 'Created',
     `${filename} file${isGitIgnoreUpdated ? ' and added it to .gitignore' : ''}`,

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -1,4 +1,5 @@
 import type Client from '../../util/client';
+import chalk from 'chalk';
 import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import cmd from '../../util/output/cmd';
@@ -12,10 +13,40 @@ import output from '../../output-manager';
 import { LinkTelemetryClient } from '../../util/telemetry/commands/link';
 import { getCommandAliases } from '..';
 import getScope, { detectExplicitScope } from '../../util/get-scope';
+import pull from '../env/pull';
+import { resolveProjectCwd } from '../../util/projects/find-project-root';
 
 const COMMAND_CONFIG = {
   add: getCommandAliases(addSubcommand),
 };
+
+function warnOidcRefreshFailed(): void {
+  output.print(
+    `${chalk.yellow('!')} Linked project, but failed to refresh VERCEL_OIDC_TOKEN in .env.local. Rerun the link command to retry.\n`
+  );
+}
+
+async function refreshOidcTokenAfterLink(
+  client: Client,
+  cwd: string
+): Promise<void> {
+  const originalCwd = client.cwd;
+  try {
+    client.cwd = await resolveProjectCwd(cwd);
+    output.print('\n');
+    const exitCode = await pull(client, ['--yes'], 'vercel-cli:link', {
+      oidcTokenOnly: true,
+    });
+
+    if (exitCode !== 0) {
+      warnOidcRefreshFailed();
+    }
+  } catch (_error) {
+    warnOidcRefreshFailed();
+  } finally {
+    client.cwd = originalCwd;
+  }
+}
 
 export default async function link(client: Client) {
   let parsedArgs = null;
@@ -136,11 +167,14 @@ export default async function link(client: Client) {
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
       searchAcrossTeams: !explicitScopeProvided,
+      pullEnv: false,
     });
 
     if (typeof link === 'number') {
       return link;
     }
+
+    await refreshOidcTokenAfterLink(client, cwd);
   }
 
   return 0;

--- a/packages/cli/src/util/env/update-oidc-token-contents.ts
+++ b/packages/cli/src/util/env/update-oidc-token-contents.ts
@@ -1,0 +1,52 @@
+import { VERCEL_OIDC_TOKEN } from './constants';
+
+const CONTENTS_HEADER = '# Created by Vercel CLI';
+
+/**
+ * Replaces the first OIDC token assignment, removes duplicates, and preserves
+ * all unrelated file content. When no assignment exists, a CLI-owned entry is
+ * appended using the file's existing line ending. Passing `undefined` removes
+ * stale token assignments.
+ */
+export function updateOidcTokenContents(
+  existing: string,
+  token: string | undefined
+): string {
+  const assignment = `${VERCEL_OIDC_TOKEN}="${escapeValue(token)}"`;
+  const oidcAssignment = new RegExp(
+    `^(\\uFEFF?)[\\t ]*(?:export[\\t ]+)?${VERCEL_OIDC_TOKEN}[\\t ]*=[^\\r\\n]*(\\r\\n|\\n|\\r|$)`,
+    'gm'
+  );
+  let tokenWritten = false;
+
+  const withoutDuplicates = existing.replace(
+    oidcAssignment,
+    (_match, byteOrderMark: string, lineEnding: string) => {
+      if (token !== undefined && !tokenWritten) {
+        tokenWritten = true;
+        return `${byteOrderMark}${assignment}${lineEnding}`;
+      }
+      return byteOrderMark;
+    }
+  );
+
+  if (token === undefined || tokenWritten) {
+    return withoutDuplicates;
+  }
+
+  const lineEnding = withoutDuplicates.match(/\r\n|\n|\r/)?.[0] ?? '\n';
+  const hasTrailingLineEnding = /(?:\r\n|\n|\r)$/.test(withoutDuplicates);
+  const hasTrailingBlankLine = /(?:\r\n|\n|\r){2}$/.test(withoutDuplicates);
+  const separator =
+    withoutDuplicates.length === 0 || hasTrailingBlankLine
+      ? ''
+      : hasTrailingLineEnding
+        ? lineEnding
+        : `${lineEnding}${lineEnding}`;
+
+  return `${withoutDuplicates}${separator}${CONTENTS_HEADER}${lineEnding}${assignment}${lineEnding}`;
+}
+
+function escapeValue(value: string | undefined): string {
+  return value ? value.replace(/\n/g, '\\n').replace(/\r/g, '\\r') : '';
+}

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -1129,9 +1129,9 @@ test('[vc link] should show project prompts but not framework when `builds` defi
   // Ensure the exit code is right
   expect(output.exitCode, formatOutput(output)).toBe(0);
 
-  // Ensure .gitignore is created
+  // Ensure .gitignore includes the link metadata and refreshed OIDC env file
   const gitignore = await readFile(path.join(dir, '.gitignore'), 'utf8');
-  expect(gitignore).toBe('.vercel\n');
+  expect(gitignore).toBe('.vercel\n.env*\n');
 
   // Ensure .vercel/project.json and .vercel/README.txt are created
   expect(

--- a/packages/cli/test/integration-link-env-pull.test.ts
+++ b/packages/cli/test/integration-link-env-pull.test.ts
@@ -35,7 +35,7 @@ afterAll(async () => {
   }
 });
 
-test('[vc link] should skip env pull prompt when creating new project', async () => {
+test('[vc link] should refresh OIDC when creating a new project', async () => {
   const dir = await setupE2EFixture('project-link-gitignore');
   const projectName = `link-env-pull-${Math.random().toString(36).split('.')[1]}`;
 
@@ -76,14 +76,21 @@ test('[vc link] should skip env pull prompt when creating new project', async ()
   expect(await fs.pathExists(path.join(dir, '.vercel/project.json'))).toBe(
     true
   );
+  expect(await fs.readFile(path.join(dir, '.env.local'), 'utf8')).toMatch(
+    /^# Created by Vercel CLI\nVERCEL_OIDC_TOKEN="[^"\n]+"\n$/
+  );
 });
 
-test('[vc link] should not create .env.local when linking new project', async () => {
+test('[vc link] should preserve existing .env.local when refreshing OIDC', async () => {
   const dir = await setupE2EFixture('project-link-gitignore');
   const projectName = `link-env-decline-${Math.random().toString(36).split('.')[1]}`;
 
   await fs.remove(path.join(dir, '.vercel'));
-  await fs.remove(path.join(dir, '.env.local'));
+  await fs.writeFile(
+    path.join(dir, '.env.local'),
+    'LOCAL_ONLY=keep\nVERCEL_OIDC_TOKEN=stale-token\nTAIL=keep\n',
+    'utf8'
+  );
 
   const vc = execCli(binaryPath, ['link', `--project=${projectName}`], {
     cwd: dir,
@@ -120,7 +127,11 @@ test('[vc link] should not create .env.local when linking new project', async ()
     true
   );
 
-  expect(await fs.pathExists(path.join(dir, '.env.local'))).toBe(false);
+  const envContents = await fs.readFile(path.join(dir, '.env.local'), 'utf8');
+  expect(envContents).toMatch(
+    /^LOCAL_ONLY=keep\nVERCEL_OIDC_TOKEN="[^"\n]+"\nTAIL=keep\n$/
+  );
+  expect(envContents).not.toContain('stale-token');
 });
 
 test('[vc link] should work with --yes flag and auto-confirm all prompts', async () => {
@@ -145,5 +156,8 @@ test('[vc link] should work with --yes flag and auto-confirm all prompts', async
 
   expect(await fs.pathExists(path.join(dir, '.vercel/project.json'))).toBe(
     true
+  );
+  expect(await fs.readFile(path.join(dir, '.env.local'), 'utf8')).toMatch(
+    /^# Created by Vercel CLI\nVERCEL_OIDC_TOKEN="[^"\n]+"\n$/
   );
 });

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -3,13 +3,16 @@ import fs from 'fs-extra';
 import path from 'path';
 import { parse } from 'dotenv';
 import env from '../../../../src/commands/env';
-import { getAcrValuesFromWWWAuthenticate } from '../../../../src/commands/env/pull';
+import pull, {
+  getAcrValuesFromWWWAuthenticate,
+} from '../../../../src/commands/env/pull';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
 import { defaultProject, envs, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 import { performDeviceCodeFlow } from '../../../../src/commands/login/future';
+import { VERCEL_OIDC_TOKEN } from '../../../../src/util/env/constants';
 
 vi.mock('../../../../src/commands/login/future', async importOriginal => ({
   ...(await importOriginal<
@@ -113,6 +116,94 @@ describe('env pull', () => {
         value: 'TRUE',
       },
     ]);
+  });
+
+  it('writes only OIDC for link-origin pulls', async () => {
+    const project = {
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+    };
+    let pullCount = 0;
+
+    useUser();
+    useTeams('team_dummy');
+    client.scenario.get(
+      `/v3/env/pull/${project.id}/:target?/:gitBranch?`,
+      (_req, res) => {
+        pullCount += 1;
+        res.json({
+          env: {
+            SPECIAL_FLAG: 'remote-value',
+            [VERCEL_OIDC_TOKEN]: `fresh-token-${pullCount}`,
+          },
+        });
+      }
+    );
+    useProject(project);
+    const cwd = setupUnitFixture('vercel-env-pull');
+    client.cwd = cwd;
+
+    await expect(
+      pull(client, ['--yes'], 'vercel-cli:link', { oidcTokenOnly: true })
+    ).resolves.toEqual(0);
+
+    let contents = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(contents).toBe(
+      '# Created by Vercel CLI\nVERCEL_OIDC_TOKEN="fresh-token-1"\n'
+    );
+    expect(contents).not.toContain('SPECIAL_FLAG');
+
+    await expect(
+      pull(client, ['--yes'], 'vercel-cli:link', { oidcTokenOnly: true })
+    ).resolves.toEqual(0);
+
+    contents = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(contents).toBe(
+      '# Created by Vercel CLI\nVERCEL_OIDC_TOKEN="fresh-token-2"\n'
+    );
+    expect(contents.match(/^VERCEL_OIDC_TOKEN=/gm)).toHaveLength(1);
+  });
+
+  it('preserves every other entry while refreshing OIDC for link-origin pulls', async () => {
+    const project = {
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+    };
+
+    useUser();
+    useTeams('team_dummy');
+    client.scenario.get(
+      `/v3/env/pull/${project.id}/:target?/:gitBranch?`,
+      (_req, res) => {
+        res.json({
+          env: {
+            SPECIAL_FLAG: 'remote-value',
+            [VERCEL_OIDC_TOKEN]: 'fresh-token',
+          },
+        });
+      }
+    );
+    useProject(project);
+
+    const cwd = setupUnitFixture('vercel-env-pull');
+    await fs.writeFile(
+      path.join(cwd, '.env.local'),
+      'LOCAL_ONLY=value\nSPECIAL_FLAG=local-value\nexport VERCEL_OIDC_TOKEN=stale-token\nTAIL=keep',
+      'utf8'
+    );
+    client.cwd = cwd;
+
+    await expect(
+      pull(client, ['--yes'], 'vercel-cli:link', { oidcTokenOnly: true })
+    ).resolves.toEqual(0);
+
+    const contents = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(contents).toBe(
+      'LOCAL_ONLY=value\nSPECIAL_FLAG=local-value\nVERCEL_OIDC_TOKEN="fresh-token"\nTAIL=keep'
+    );
+    expect(contents).not.toContain('remote-value');
   });
 
   it('should retry after fresh authentication when sensitive env vars require a challenge', async () => {

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -697,7 +697,8 @@ describe('link', () => {
       expect(mockPull).toHaveBeenCalledWith(
         expect.objectContaining({ cwd }),
         ['--yes'],
-        'vercel-cli:link'
+        'vercel-cli:link',
+        { oidcTokenOnly: true }
       );
     });
 
@@ -880,11 +881,6 @@ describe('link', () => {
       /^\s{0,2}Config\s+\.vercel\/project\.json/m
     );
 
-    await expect(client.stderr).toOutput(
-      'Pull development environment variables into .env.local?'
-    );
-    client.stdin.write('n\n');
-
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
     const plainOutput = stripAnsi(client.stderr.getFullOutput());
@@ -892,8 +888,8 @@ describe('link', () => {
       /^\s{0,2}Directory\s+.+\n\nSearching for existing projects…\n\n\s{0,2}Found existing project/m
     );
     expect(plainOutput).toMatch(/Link directory to project\?.*\n\n✓ Linked\s+/);
-    expect(plainOutput).toMatch(
-      /✓ Linked\s+.+\n\n\? Pull development environment variables into \.env\.local\?/
+    expect(plainOutput).not.toContain(
+      'Pull development environment variables into .env.local?'
     );
     expectLinkRowsUseExpectedGlyphs(client.stderr.getFullOutput(), [
       'Directory',
@@ -1593,11 +1589,6 @@ describe('link', () => {
         `✓ Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('n\n');
-
       const exitCode = await exitCodePromise;
       selectSpy.mockRestore();
 
@@ -1614,8 +1605,8 @@ describe('link', () => {
     });
   });
 
-  describe('environment variable pull prompt', () => {
-    it('should prompt to pull environment variables after successful linking', async () => {
+  describe('OIDC token refresh', () => {
+    it('automatically refreshes OIDC after successful linking', async () => {
       useUser({ version: 'northstar' });
       const cwd = setupTmpDir();
       const [team] = useTeams('team_dummy') as Team[];
@@ -1637,23 +1628,19 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `✓ Linked          ${team.slug}/${project.name}`
       );
-
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('y\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
 
       expect(mockPull).toHaveBeenCalledWith(
         expect.objectContaining({ cwd }),
-        [],
-        'vercel-cli:link'
+        ['--yes'],
+        'vercel-cli:link',
+        { oidcTokenOnly: true }
       );
     });
 
-    it('should not call env pull when user declines the prompt', async () => {
+    it('does not prompt before refreshing OIDC', async () => {
       useUser({ version: 'northstar' });
       const cwd = setupTmpDir();
       const [team] = useTeams('team_dummy') as Team[];
@@ -1676,16 +1663,18 @@ describe('link', () => {
         `✓ Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('n\n');
-
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
 
-      // Verify env pull was NOT called
-      expect(mockPull).not.toHaveBeenCalled();
+      expect(client.stderr.getFullOutput()).not.toContain(
+        'Pull development environment variables into .env.local?'
+      );
+      expect(mockPull).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd }),
+        ['--yes'],
+        'vercel-cli:link',
+        { oidcTokenOnly: true }
+      );
     });
 
     it('should handle env pull failure gracefully', async () => {
@@ -1715,12 +1704,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput(
-        'Failed to pull environment variables. You can run `vc env pull` manually.'
+        'Linked project, but failed to refresh VERCEL_OIDC_TOKEN in .env.local.'
       );
 
       const exitCode = await exitCodePromise;
@@ -1728,8 +1712,9 @@ describe('link', () => {
 
       expect(mockPull).toHaveBeenCalledWith(
         expect.objectContaining({ cwd }),
-        [],
-        'vercel-cli:link'
+        ['--yes'],
+        'vercel-cli:link',
+        { oidcTokenOnly: true }
       );
     });
 
@@ -1760,12 +1745,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput(
-        'Failed to pull environment variables. You can run `vc env pull` manually.'
+        'Linked project, but failed to refresh VERCEL_OIDC_TOKEN in .env.local.'
       );
 
       const exitCode = await exitCodePromise;
@@ -1773,12 +1753,13 @@ describe('link', () => {
 
       expect(mockPull).toHaveBeenCalledWith(
         expect.objectContaining({ cwd }),
-        [],
-        'vercel-cli:link'
+        ['--yes'],
+        'vercel-cli:link',
+        { oidcTokenOnly: true }
       );
     });
 
-    it('should pass empty args to env pull when link command does not use --yes', async () => {
+    it('uses --yes internally without treating it as target selection', async () => {
       useUser({ version: 'northstar' });
       const cwd = setupTmpDir();
       const [team] = useTeams('team_dummy') as Team[];
@@ -1801,19 +1782,14 @@ describe('link', () => {
         `✓ Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('y\n');
-
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
 
-      // Verify env pull was called with empty args since link didn't use --yes
       expect(mockPull).toHaveBeenCalledWith(
         expect.objectContaining({ cwd }),
-        [],
-        'vercel-cli:link'
+        ['--yes'],
+        'vercel-cli:link',
+        { oidcTokenOnly: true }
       );
     });
 
@@ -1840,11 +1816,6 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `✓ Linked          ${team.slug}/${project.name}`
       );
-
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('y\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -1882,12 +1853,7 @@ describe('link', () => {
       );
 
       await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput(
-        'Failed to pull environment variables. You can run `vc env pull` manually.'
+        'Linked project, but failed to refresh VERCEL_OIDC_TOKEN in .env.local.'
       );
 
       const exitCode = await exitCodePromise;
@@ -1944,11 +1910,6 @@ describe('link', () => {
         `✓ Linked          ${team.slug}/${project.name}`
       );
 
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('n\n');
-
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "link"').toEqual(0);
 
@@ -1993,11 +1954,6 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `✓ Linked          ${team.slug}/${project.name}`
       );
-
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('n\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -2247,11 +2203,6 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `✓ Linked          ${teamA.slug}/${projectA.name}`
       );
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('n\n');
-
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
       const plainOutput = stripAnsi(client.stderr.getFullOutput());
@@ -2398,11 +2349,6 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `✓ Linked          ${teamA.slug}/${expectedProject.name}`
       );
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('n\n');
-
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
       expectLinkRowsUseExpectedGlyphs(client.stderr.getFullOutput(), [
@@ -2473,11 +2419,6 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `✓ Linked          ${teamA.slug}/${repoProject.name}`
       );
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('n\n');
-
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
     });
@@ -2527,11 +2468,6 @@ describe('link', () => {
       await expect(client.stderr).toOutput(
         `✓ Linked          ${limitedTeam.slug}/${limitedProject.name}`
       );
-      await expect(client.stderr).toOutput(
-        'Pull development environment variables into .env.local?'
-      );
-      client.stdin.write('n\n');
-
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
       const plainOutput = stripAnsi(client.stderr.getFullOutput());
@@ -2698,11 +2634,6 @@ describe('link', () => {
 
         await expect(client.stderr).toOutput('✓ Linked          ');
 
-        await expect(client.stderr).toOutput(
-          'Pull development environment variables into .env.local?'
-        );
-        client.stdin.write('n\n');
-
         const exitCode = await exitCodePromise;
         expect(exitCode).toEqual(0);
 
@@ -2751,11 +2682,6 @@ describe('link', () => {
         client.stdin.write('\n');
 
         await expect(client.stderr).toOutput('✓ Linked          ');
-
-        await expect(client.stderr).toOutput(
-          'Pull development environment variables into .env.local?'
-        );
-        client.stdin.write('n\n');
 
         const exitCode = await exitCodePromise;
         expect(exitCode).toEqual(0);

--- a/packages/cli/test/unit/util/env/update-oidc-token-contents.test.ts
+++ b/packages/cli/test/unit/util/env/update-oidc-token-contents.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { updateOidcTokenContents } from '../../../../src/util/env/update-oidc-token-contents';
+
+describe('updateOidcTokenContents', () => {
+  it('appends one OIDC token without changing existing variables', () => {
+    const existing = 'LOCAL_ONLY=value\nSPECIAL_FLAG=local-value\n';
+
+    expect(updateOidcTokenContents(existing, 'fresh-token')).toBe(
+      `${existing}\n# Created by Vercel CLI\nVERCEL_OIDC_TOKEN="fresh-token"\n`
+    );
+  });
+
+  it('appends after a file without a final newline', () => {
+    expect(updateOidcTokenContents('LOCAL_ONLY=value', 'fresh-token')).toBe(
+      'LOCAL_ONLY=value\n\n# Created by Vercel CLI\nVERCEL_OIDC_TOKEN="fresh-token"\n'
+    );
+  });
+
+  it('replaces an exported token while preserving CRLF and other bytes', () => {
+    const existing =
+      '\uFEFFLOCAL_ONLY=value\r\nexport VERCEL_OIDC_TOKEN = "stale-token"\r\nTAIL=keep';
+
+    expect(updateOidcTokenContents(existing, 'fresh-token')).toBe(
+      '\uFEFFLOCAL_ONLY=value\r\nVERCEL_OIDC_TOKEN="fresh-token"\r\nTAIL=keep'
+    );
+  });
+
+  it('removes duplicate OIDC token assignments', () => {
+    const existing =
+      'VERCEL_OIDC_TOKEN=stale-one\nLOCAL_ONLY=value\n  export VERCEL_OIDC_TOKEN=stale-two\nTAIL=keep\n';
+
+    expect(updateOidcTokenContents(existing, 'fresh-token')).toBe(
+      'VERCEL_OIDC_TOKEN="fresh-token"\nLOCAL_ONLY=value\nTAIL=keep\n'
+    );
+  });
+
+  it('removes stale OIDC assignments when no token is returned', () => {
+    const existing =
+      'LOCAL_ONLY=value\nVERCEL_OIDC_TOKEN=stale-token\nTAIL=keep\n';
+
+    expect(updateOidcTokenContents(existing, undefined)).toBe(
+      'LOCAL_ONLY=value\nTAIL=keep\n'
+    );
+  });
+});


### PR DESCRIPTION
This prevents overwriting existing variables from env pull on OIDC refresh