### PR TITLE
[ci] Don't follow redirects on fetch assertions

### DIFF
--- a/.changeset/fix-vercel-auth-e2e-assertion.md
+++ b/.changeset/fix-vercel-auth-e2e-assertion.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the Vercel Auth project-creation e2e test by disabling redirect-following so a protected deployment's 401 is observed directly instead of following the SSO redirect to a 200 login page.

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -1719,8 +1719,11 @@ test.each([
 
   const { href } = new URL(output.stdout);
 
-  // Send a test request to the deployment
-  const response = await nodeFetch(href);
+  // Send a test request to the deployment. Use `redirect: 'manual'` so a
+  // protected deployment's auth response is observed directly: otherwise
+  // node-fetch follows the SSO redirect to the login page and reports its 200,
+  // masking the 401.
+  const response = await nodeFetch(href, { redirect: 'manual' });
   expect(response.status).toBe(expectedStatus);
 
   const projectResponse = await apiFetch(`/projects/${projectName}`, {

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -1659,18 +1659,18 @@ test('vercel.json configuration overrides in an existing project do not prompt u
 test.each([
   {
     vercelAuth: 'none',
-    expectedStatus: 200,
+    expectProtected: false,
   },
   {
     vercelAuth: 'standard',
-    expectedStatus: 401,
+    expectProtected: true,
   },
 ] as const)('[vc deploy] should allow a project to be created with Vercel Auth disabled or enabled with prompts - vercelAuth: %s', async ({
   vercelAuth,
-  expectedStatus,
+  expectProtected,
 }: {
   vercelAuth: 'none' | 'standard';
-  expectedStatus: number;
+  expectProtected: boolean;
 }) => {
   const dir = await setupE2EFixture('project-vercel-auth');
   const projectName = `project-vercel-auth-${
@@ -1719,12 +1719,31 @@ test.each([
 
   const { href } = new URL(output.stdout);
 
-  // Send a test request to the deployment. Use `redirect: 'manual'` so a
-  // protected deployment's auth response is observed directly: otherwise
-  // node-fetch follows the SSO redirect to the login page and reports its 200,
-  // masking the 401.
+  // Send an unauthenticated request to the deployment. Use `redirect:
+  // 'manual'` so the deployment's own gate response is observed: otherwise
+  // node-fetch follows the SSO redirect to the login page and reports its
+  // 200, masking the protection.
+  //
+  // A protected deployment gates anonymous requests with either a terminal
+  // 401 or a 3xx redirect to the SSO login flow (vercel.com/sso-api),
+  // depending on the request. Accept both. A public deployment is served
+  // directly with a 200.
   const response = await nodeFetch(href, { redirect: 'manual' });
-  expect(response.status).toBe(expectedStatus);
+
+  if (expectProtected) {
+    const location = response.headers.get('location') ?? '';
+    const isSsoRedirect =
+      response.status >= 300 &&
+      response.status < 400 &&
+      location.includes('/sso-api');
+    const isProtected = response.status === 401 || isSsoRedirect;
+    expect(
+      isProtected,
+      `expected a protected response (401 or SSO redirect), got ${response.status} location=${location}\n${formatOutput(output)}`
+    ).toBe(true);
+  } else {
+    expect(response.status, formatOutput(output)).toBe(200);
+  }
 
   const projectResponse = await apiFetch(`/projects/${projectName}`, {
     method: 'DELETE',


### PR DESCRIPTION
## What

Fixes the flaky e2e test `[vc deploy] should allow a project to be created with Vercel Auth disabled or enabled with prompts` (`vercelAuth: 'standard'`), which was failing with `expected 200 to be 401`.

The test now fetches the deployment with `redirect: 'manual'` and asserts the protection behaviour directly:
- **protected** (`standard`) → a `3xx` redirect to the SSO login flow (`location` contains `/sso-api`)
- **public** (`none`) → `200`

## Why it was failing

The deployment was protected the whole time — the test was just misreading the response.

- An anonymous request to a protected deployment returns `302 → https://vercel.com/sso-api?...` (confirmed manually with `curl -I`).
- The test used plain `node-fetch`, which **follows redirects by default**, so it followed `302 → /sso-api → /login` and read the final `200` (the login page). That produced `expected 200 to be 401`.
- The original assertion also expected a terminal `401`, but protection now surfaces as a `302` redirect to SSO.

Disabling redirect-following and asserting the redirect-to-`/sso-api` makes the test reflect the real, current protection behaviour and robust to the exact redirect status.

## Scope

Test-only. No CLI/runtime source changes — the project-creation flow already protects deployments correctly. Changeset has empty frontmatter since nothing in a published package changed.

## Validation

- Reproduced manually: protected deployment returns `302 → /sso-api` (`curl -I`); public returns `200`.
- `biome lint` on the changed test — clean.
