### PR TITLE
[build-utils] Discontinue Node 20 on October 1

### DIFF
--- a/.changeset/tidy-pandas-retire.md
+++ b/.changeset/tidy-pandas-retire.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Set the Node.js 20 discontinuation date to October 1, 2026.

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -23,6 +23,7 @@ export const NODE_VERSIONS: NodeVersion[] = [
     major: 20,
     range: '20.x',
     runtime: 'nodejs20.x',
+    discontinueDate: new Date('2026-10-01'),
   }),
   new NodeVersion({
     major: 18,

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -398,6 +398,29 @@ it('should warn for deprecated versions, soon to be discontinued', async () => {
   }
 });
 
+it('should discontinue Node.js 20 on October 1, 2026', async () => {
+  const realDateNow = Date.now;
+  try {
+    global.Date.now = () => new Date('2026-09-30').getTime();
+
+    expect(await getSupportedNodeVersion('20.x', false)).toHaveProperty(
+      'major',
+      20
+    );
+    expect(warningMessages).toStrictEqual([
+      'Error: Node.js version 20.x is deprecated. Deployments created on or after 2026-10-01 will fail to build. Please set "engines": { "node": "24.x" } in your `package.json` file to use Node.js 24.',
+    ]);
+
+    global.Date.now = () => new Date('2026-10-01').getTime();
+
+    await expect(getSupportedNodeVersion('20.x', false)).rejects.toThrow(
+      'Node.js Version "20.x" is discontinued and must be upgraded.'
+    );
+  } finally {
+    global.Date.now = realDateNow;
+  }
+});
+
 it('should support initialHeaders and initialStatus correctly', async () => {
   new Prerender({
     expiration: 1,


### PR DESCRIPTION
### Summary
Set the Node 20 discontinuation date to October 1, 2026. This will show a warning in the build logs, and will stop builds after that date.

### Context

Node 20 has been EOL since April 30, 2026. Deprecate it on Vercel ~3 months from now.
