### PR TITLE
rust: add waitUntil support

### DIFF
--- a/.changeset/rust-runtime-wait-until.md
+++ b/.changeset/rust-runtime-wait-until.md
@@ -1,4 +1,0 @@
----
----
-
-Add `waitUntil` support to the `vercel_runtime` Rust crate. Background futures registered via `AppState::wait_until` are spawned immediately and drained at process shutdown (SIGTERM), bounded by a 30s timeout, mirroring the Node.js runtime's behavior. The per-request `end` IPC message is unchanged and is never delayed by background work.

--- a/.changeset/rust-runtime-wait-until.md
+++ b/.changeset/rust-runtime-wait-until.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `waitUntil` support to the `vercel_runtime` Rust crate. Background futures registered via `AppState::wait_until` are spawned immediately and drained at process shutdown (SIGTERM), bounded by a 30s timeout, mirroring the Node.js runtime's behavior. The per-request `end` IPC message is unchanged and is never delayed by background work.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vercel_runtime"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/crates/vercel_runtime/Cargo.toml
+++ b/crates/vercel_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vercel_runtime"
-version = "2.3.1"
+version = "2.4.0"
 edition = "2024"
 description = "Vercel Runtime for Rust"
 license = "Apache-2.0"

--- a/crates/vercel_runtime/src/awaiter.rs
+++ b/crates/vercel_runtime/src/awaiter.rs
@@ -1,0 +1,79 @@
+//! Background work collector for `waitUntil`-style tasks.
+//!
+//! This mirrors the behavior of the Node.js runtime's `Awaiter`
+//! (`packages/node/src/awaiter.ts`). Crucially, `waitUntil` is implemented
+//! entirely in-process: there is **no** dedicated IPC message. The per-request
+//! `end` IPC message is sent immediately after the handler responds and is
+//! **never** delayed by background work. Registered futures are drained only at
+//! process shutdown (SIGTERM), bounded by [`WAIT_UNTIL_TIMEOUT`].
+//!
+//! Like the Node implementation:
+//! - A future registered via [`Awaiter::wait_until`] runs regardless of whether
+//!   the originating handler succeeded or errored.
+//! - Errors/panics in a background future are swallowed (logged) and never abort
+//!   the drain or affect other background work (the analog of `.catch(onError)`).
+//! - The drain loops until the set is empty so futures that schedule further
+//!   `wait_until` work are also awaited (the analog of the two-batch drain).
+
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+use tokio::task::JoinHandle;
+
+/// Default time (in seconds) to wait for background work to finish at shutdown
+/// before giving up. Matches `WAIT_UNTIL_TIMEOUT` in `@vercel/node`.
+pub const WAIT_UNTIL_TIMEOUT: u64 = 30;
+
+/// Collects background futures registered via `waitUntil` and drains them at
+/// shutdown. Cheaply cloneable; all clones share the same underlying task set.
+#[derive(Clone, Default)]
+pub struct Awaiter {
+    handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
+}
+
+impl Awaiter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a background future to be awaited at shutdown.
+    ///
+    /// The future is spawned onto the current Tokio runtime immediately so it
+    /// makes progress between requests. Any panic in the future is caught by the
+    /// runtime and logged when the handle is joined during the drain, mirroring
+    /// the Node runtime's error swallowing.
+    pub fn wait_until<F>(&self, future: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let handle = tokio::spawn(future);
+        if let Ok(mut handles) = self.handles.lock() {
+            handles.push(handle);
+        }
+    }
+
+    /// Drain all currently-registered background tasks, looping until none
+    /// remain so that tasks which register further `wait_until` work are also
+    /// awaited.
+    pub async fn awaiting(&self) {
+        loop {
+            let batch = {
+                let Ok(mut handles) = self.handles.lock() else {
+                    return;
+                };
+                if handles.is_empty() {
+                    return;
+                }
+                std::mem::take(&mut *handles)
+            };
+
+            for handle in batch {
+                // A panic in the task surfaces as a JoinError; swallow it so one
+                // failing task cannot abort the drain.
+                if let Err(e) = handle.await {
+                    eprintln!("waitUntil task failed: {e}");
+                }
+            }
+        }
+    }
+}

--- a/crates/vercel_runtime/src/awaiter.rs
+++ b/crates/vercel_runtime/src/awaiter.rs
@@ -5,7 +5,10 @@
 //! entirely in-process: there is **no** dedicated IPC message. The per-request
 //! `end` IPC message is sent immediately after the handler responds and is
 //! **never** delayed by background work. Registered futures are drained only at
-//! process shutdown (SIGTERM), bounded by [`WAIT_UNTIL_TIMEOUT`].
+//! process shutdown (SIGTERM). In production the drain is unbounded (background
+//! work runs until it resolves or the function times out); in `vc dev` it is
+//! bounded by [`WAIT_UNTIL_TIMEOUT`] so a hung task cannot keep the dev process
+//! alive.
 //!
 //! Like the Node implementation:
 //! - A future registered via [`Awaiter::wait_until`] runs regardless of whether
@@ -20,8 +23,9 @@ use std::sync::{Arc, Mutex};
 
 use tokio::task::JoinHandle;
 
-/// Default time (in seconds) to wait for background work to finish at shutdown
-/// before giving up. Matches `WAIT_UNTIL_TIMEOUT` in `@vercel/node`.
+/// Time (in seconds) to wait for background work to finish at shutdown before
+/// giving up. Only applied in `vc dev`; production drains are unbounded. Matches
+/// the `WAIT_UNTIL_TIMEOUT` dev fallback in `@vercel/node`.
 pub const WAIT_UNTIL_TIMEOUT: u64 = 30;
 
 /// Collects background futures registered via `waitUntil` and drains them at

--- a/crates/vercel_runtime/src/lib.rs
+++ b/crates/vercel_runtime/src/lib.rs
@@ -355,21 +355,31 @@ where
         let (stream, _) = tokio::select! {
             accepted = listener.accept() => accepted?,
             _ = &mut shutdown => {
-                // Drain background `waitUntil` work, bounded by the timeout, then
-                // exit. The per-request `end` IPC message has already been sent
-                // for each completed request, so this only affects background
-                // tasks. This mirrors the Node.js runtime's `onExit` behavior.
-                if tokio::time::timeout(
-                    std::time::Duration::from_secs(crate::awaiter::WAIT_UNTIL_TIMEOUT),
-                    AWAITER.awaiting(),
-                )
-                .await
-                .is_err()
-                {
-                    eprintln!(
-                        "A waitUntil() task is still running after {}s and was abandoned at shutdown.",
-                        crate::awaiter::WAIT_UNTIL_TIMEOUT
-                    );
+                // Drain background `waitUntil` work, then exit. The per-request
+                // `end` IPC message has already been sent for each completed
+                // request, so this only affects background tasks. This mirrors
+                // the Node.js runtime's `onExit` behavior.
+                //
+                // In `vc dev` (signalled by `VERCEL_DEV=1`) we bound the drain by
+                // `WAIT_UNTIL_TIMEOUT` so a hung task cannot keep the dev process
+                // alive. In production there is no artificial cap: background work
+                // runs until it resolves or the function itself times out, which
+                // matches the Node.js bridge.
+                if std::env::var("VERCEL_DEV").as_deref() == Ok("1") {
+                    if tokio::time::timeout(
+                        std::time::Duration::from_secs(crate::awaiter::WAIT_UNTIL_TIMEOUT),
+                        AWAITER.awaiting(),
+                    )
+                    .await
+                    .is_err()
+                    {
+                        eprintln!(
+                            "A waitUntil() task is still running after {}s and was abandoned at shutdown.",
+                            crate::awaiter::WAIT_UNTIL_TIMEOUT
+                        );
+                    }
+                } else {
+                    AWAITER.awaiting().await;
                 }
                 return Ok(());
             }

--- a/crates/vercel_runtime/src/lib.rs
+++ b/crates/vercel_runtime/src/lib.rs
@@ -29,8 +29,8 @@ mod types;
 use crate::awaiter::Awaiter;
 
 lazy_static::lazy_static! {
-    /// Process-global collector of `waitUntil` background work. Shared by every
-    /// request and drained once at shutdown (see [`run`]).
+    /// Process-global collector of `waitUntil` background work.
+    /// Shared by every request and drained once at shutdown (see [`run`]).
     static ref AWAITER: Awaiter = Awaiter::new();
 }
 
@@ -153,9 +153,8 @@ impl AppState {
     /// sent. The future is spawned immediately and awaited at process shutdown
     /// (bounded by [`awaiter::WAIT_UNTIL_TIMEOUT`]).
     ///
-    /// Mirrors `waitUntil` in the Node.js runtime: the future runs regardless of
-    /// whether the handler succeeded or errored, and a panic in the future is
-    /// isolated from the rest of the runtime.
+    /// This future runs regardless of whether the handler succeeded or errored.
+    /// A panic in the future is isolated from the rest of the runtime.
     pub fn wait_until<F>(&self, future: F)
     where
         F: std::future::Future<Output = ()> + Send + 'static,
@@ -341,7 +340,6 @@ where
                     sigterm.recv().await;
                 }
                 Err(_) => {
-                    // Fall back to Ctrl-C if SIGTERM cannot be registered.
                     let _ = tokio::signal::ctrl_c().await;
                 }
             }
@@ -360,7 +358,7 @@ where
                 // Drain background `waitUntil` work, bounded by the timeout, then
                 // exit. The per-request `end` IPC message has already been sent
                 // for each completed request, so this only affects background
-                // tasks, mirroring the Node.js runtime's `onExit` behavior.
+                // tasks. This mirrors the Node.js runtime's `onExit` behavior.
                 if tokio::time::timeout(
                     std::time::Duration::from_secs(crate::awaiter::WAIT_UNTIL_TIMEOUT),
                     AWAITER.awaiting(),

--- a/crates/vercel_runtime/src/lib.rs
+++ b/crates/vercel_runtime/src/lib.rs
@@ -19,11 +19,20 @@ pub mod axum;
 #[cfg(feature = "actix")]
 pub mod actix;
 
+pub mod awaiter;
 #[cfg(unix)]
 mod ipc;
 #[cfg(unix)]
 mod ipc_utils;
 mod types;
+
+use crate::awaiter::Awaiter;
+
+lazy_static::lazy_static! {
+    /// Process-global collector of `waitUntil` background work. Shared by every
+    /// request and drained once at shutdown (see [`run`]).
+    static ref AWAITER: Awaiter = Awaiter::new();
+}
 
 use crate::types::IntoFunctionResponse;
 
@@ -129,11 +138,29 @@ impl Default for LogContext {
 #[derive(Clone)]
 pub struct AppState {
     pub log_context: LogContext,
+    awaiter: Awaiter,
 }
 
 impl AppState {
     pub fn new(log_context: LogContext) -> Self {
-        Self { log_context }
+        Self {
+            log_context,
+            awaiter: AWAITER.clone(),
+        }
+    }
+
+    /// Register a background future to keep running after the response has been
+    /// sent. The future is spawned immediately and awaited at process shutdown
+    /// (bounded by [`awaiter::WAIT_UNTIL_TIMEOUT`]).
+    ///
+    /// Mirrors `waitUntil` in the Node.js runtime: the future runs regardless of
+    /// whether the handler succeeded or errored, and a panic in the future is
+    /// isolated from the rest of the runtime.
+    pub fn wait_until<F>(&self, future: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        self.awaiter.wait_until(future);
     }
 }
 
@@ -303,8 +330,52 @@ where
         println!("Dev server listening: {}", port);
     }
 
+    // Shutdown signal future. On Unix the host terminates the process with
+    // SIGTERM; on other platforms fall back to Ctrl-C. When it fires we stop
+    // accepting new connections and drain any pending `waitUntil` work.
+    let shutdown = async {
+        #[cfg(unix)]
+        {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sigterm) => {
+                    sigterm.recv().await;
+                }
+                Err(_) => {
+                    // Fall back to Ctrl-C if SIGTERM cannot be registered.
+                    let _ = tokio::signal::ctrl_c().await;
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    };
+    tokio::pin!(shutdown);
+
     loop {
-        let (stream, _) = listener.accept().await?;
+        let (stream, _) = tokio::select! {
+            accepted = listener.accept() => accepted?,
+            _ = &mut shutdown => {
+                // Drain background `waitUntil` work, bounded by the timeout, then
+                // exit. The per-request `end` IPC message has already been sent
+                // for each completed request, so this only affects background
+                // tasks, mirroring the Node.js runtime's `onExit` behavior.
+                if tokio::time::timeout(
+                    std::time::Duration::from_secs(crate::awaiter::WAIT_UNTIL_TIMEOUT),
+                    AWAITER.awaiting(),
+                )
+                .await
+                .is_err()
+                {
+                    eprintln!(
+                        "A waitUntil() task is still running after {}s and was abandoned at shutdown.",
+                        crate::awaiter::WAIT_UNTIL_TIMEOUT
+                    );
+                }
+                return Ok(());
+            }
+        };
         let io = TokioIo::new(stream);
         #[cfg(unix)]
         let ipc_stream_clone = ipc_stream.clone();


### PR DESCRIPTION
# Problem

The `vercel_runtime` Rust crate had no way to run background work after a response was sent. Unlike the Node.js runtime, it lacked a `waitUntil` primitive, so tasks like logging, analytics, or cache revalidation had to complete before responding (or be dropped).

# Solution

Add `waitUntil` to the crate, mirroring the Node.js `Awaiter` semantics:

- New `Awaiter` (`src/awaiter.rs`) spawns registered futures immediately and tracks them in a process-global set.
- `AppState::wait_until(future)` exposes the API to handlers.
- On shutdown (SIGTERM, with Ctrl-C fallback), the accept loop drains pending tasks bounded by a 30s timeout.
- The per-request `end` IPC message is unchanged and never delayed by background work; tasks run regardless of handler success or error, and a panicking task is isolated from the rest of the runtime.

`waitUntil` is implemented entirely in-process