### PR TITLE
[container] Fix service build output so requests reach the function

### DIFF
--- a/.changeset/container-service-catchall-route.md
+++ b/.changeset/container-service-catchall-route.md
@@ -1,0 +1,5 @@
+---
+'@vercel/container': patch
+---
+
+Fix container service build output so requests reach the function. Container services now do a normal build, emitting the function at the natural `index` path inside the nested `services/<name>/` output along with a catch-all route, instead of namespacing under `_svc/<name>/index` with no route to it. Previously a request to the service root never matched the function.

--- a/packages/container/src/index.ts
+++ b/packages/container/src/index.ts
@@ -1,4 +1,3 @@
-import { getInternalServiceFunctionPath } from '@vercel/build-utils';
 import type { BuildOptions, BuildResultV2, Span } from '@vercel/build-utils';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
@@ -367,13 +366,19 @@ export async function build(options: BuildOptions): Promise<BuildResultV2> {
 
   const command = normalizeCommand(options.config.command);
 
-  const outputPath = options.service?.name
-    ? getInternalServiceFunctionPath(options.service.name).replace(/^\//, '')
-    : 'index';
+  // Do a normal build: the function lands at the natural `index` path inside
+  // the nested `services/<name>/` output, and a catch-all route in the
+  // service's isolated route table forwards requests to it. Without the
+  // catch-all the service has no `/` route, so the top-level service rewrite
+  // resolves to nothing (vercel/vercel#16648).
+  const isService = Boolean(options.service?.name);
+  const routes = isService
+    ? [{ handle: 'filesystem' as const }, { src: '/(.*)', dest: '/index' }]
+    : undefined;
 
   return {
     output: {
-      [outputPath]: {
+      index: {
         type: 'Lambda',
         files: {},
         // For `runtime: 'container'` the OCI image reference is carried in
@@ -385,5 +390,6 @@ export async function build(options: BuildOptions): Promise<BuildResultV2> {
         ...(command ? { command } : {}),
       } as any,
     },
+    ...(routes ? { routes } : {}),
   };
 }

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -212,24 +212,46 @@ describe('@vercel/container', () => {
     });
   });
 
-  it('emits service builds at the internal service function path', async () => {
+  it('does a normal build with a catch-all route for services', async () => {
+    // The function lands at the natural `index` path (no `_svc` namespacing) so
+    // the nested `services/<name>/` output "just works", with a catch-all route
+    // to reach it.
     const result = expectTypicalBuildResult(
       await build({
         ...createBuildOptions({}),
         entrypoint: 'docker.io/library/nginx:1.27',
         service: {
           name: 'api',
-          type: 'web',
         },
       })
     );
 
-    expect(result.output).toHaveProperty('_svc/api/index');
-    expect(result.output['_svc/api/index']).toMatchObject({
+    expect(result.output).toHaveProperty('index');
+    expect(result.output).not.toHaveProperty('_svc/api/index');
+    expect(result.output.index).toMatchObject({
       handler: 'docker.io/library/nginx:1.27',
       runtime: 'container',
       environment: {},
     });
+
+    // Without a catch-all, a request to the service root never reaches the
+    // Lambda inside the isolated per-service route table.
+    expect(result.routes).toEqual([
+      { handle: 'filesystem' },
+      { src: '/(.*)', dest: '/index' },
+    ]);
+  });
+
+  it('does not emit routes for non-service builds', async () => {
+    const result = expectTypicalBuildResult(
+      await build({
+        ...createBuildOptions({}),
+        entrypoint: 'docker.io/library/nginx:1.27',
+      })
+    );
+
+    expect(result.output).toHaveProperty('index');
+    expect(result.routes).toBeUndefined();
   });
 
   async function runDockerfileBuild(options?: {
@@ -295,12 +317,12 @@ describe('@vercel/container', () => {
       await build({
         ...createBuildOptions({ runtime: 'container' }),
         ...(options?.entrypoint ? { entrypoint: options.entrypoint } : {}),
-        service: { name: 'api', type: 'web' },
+        service: { name: 'api' },
         ...(options?.meta ? { meta: options.meta } : {}),
       } as any)
     );
 
-    expect(result.output['_svc/api/index']).toMatchObject({
+    expect(result.output.index).toMatchObject({
       type: 'Lambda',
       runtime: 'container',
       handler: `vcr.vercel.com/acme/my-app/api@${digest}`,
@@ -473,7 +495,7 @@ describe('@vercel/container', () => {
 
     await build({
       ...createBuildOptions({ runtime: 'container' }),
-      service: { name: 'api', type: 'web' },
+      service: { name: 'api' },
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -505,11 +527,11 @@ describe('@vercel/container', () => {
     const result = expectTypicalBuildResult(
       await build({
         ...createBuildOptions({ runtime: 'container' }),
-        service: { name: 'api', type: 'web' },
+        service: { name: 'api' },
       })
     );
 
-    expect(result.output['_svc/api/index']).toMatchObject({
+    expect(result.output.index).toMatchObject({
       handler: `vcr.vercel.com/acme/my-app/api@${digest}`,
     });
   });
@@ -521,7 +543,7 @@ describe('@vercel/container', () => {
     await expect(
       build({
         ...createBuildOptions({ runtime: 'container' }),
-        service: { name: 'api', type: 'web' },
+        service: { name: 'api' },
       })
     ).rejects.toThrow(/Missing VERCEL_OIDC_TOKEN/);
   });
@@ -545,7 +567,7 @@ describe('@vercel/container', () => {
 
     await build({
       ...createBuildOptions({ runtime: 'container' }),
-      service: { name: 'api', type: 'web' },
+      service: { name: 'api' },
     });
 
     // An OIDC token cannot mint another OIDC token, so without a user/CLI auth
@@ -576,7 +598,7 @@ describe('@vercel/container', () => {
 
     await build({
       ...createBuildOptions({ runtime: 'container' }),
-      service: { name: 'api', type: 'web' },
+      service: { name: 'api' },
     });
 
     // The mint request must authenticate with the CLI auth token, not the OIDC
@@ -614,7 +636,7 @@ describe('@vercel/container', () => {
     await expect(
       build({
         ...createBuildOptions({ runtime: 'container' }),
-        service: { name: 'api', type: 'web' },
+        service: { name: 'api' },
       })
     ).resolves.toBeDefined();
   });
@@ -646,7 +668,7 @@ describe('@vercel/container', () => {
     await expect(
       build({
         ...createBuildOptions({ runtime: 'container' }),
-        service: { name: 'api', type: 'web' },
+        service: { name: 'api' },
       })
     ).rejects.toThrow(/vercel-enable-vcr/);
 
@@ -692,7 +714,7 @@ describe('@vercel/container', () => {
       const result = await startDevServer({
         ...createBuildOptions({ runtime: 'container' }),
         entrypoint: 'apps/svc/Dockerfile',
-        service: { name: 'api', type: 'web' },
+        service: { name: 'api' },
         meta: {
           isDev: true,
           env: {
@@ -754,7 +776,7 @@ describe('@vercel/container', () => {
       const result = await startDevServer({
         ...createBuildOptions({}),
         entrypoint: 'grycap/cowsay:latest',
-        service: { name: 'api', type: 'web' },
+        service: { name: 'api' },
         meta: { isDev: true },
       } as any);
 
@@ -786,7 +808,7 @@ describe('@vercel/container', () => {
       const result = await startDevServer({
         ...createBuildOptions({}),
         entrypoint: 'grycap/cowsay:latest',
-        service: { name: 'api', type: 'web' },
+        service: { name: 'api' },
         // The orchestrator pre-allocates a host port and passes it as
         // `meta.port`; service bindings target it, so the container must be
         // published on exactly this port (not a Docker-chosen ephemeral one).
@@ -826,7 +848,7 @@ describe('@vercel/container', () => {
         startDevServer({
           ...createBuildOptions({}),
           entrypoint: 'grycap/cowsay:latest',
-          service: { name: 'api', type: 'web' },
+          service: { name: 'api' },
           meta: { isDev: true, env: { SECRET: 'do-not-leak' } },
         } as any)
       ).rejects.toThrow(/exited \(code 1\) before becoming ready/);
@@ -857,7 +879,7 @@ describe('@vercel/container', () => {
       const result = await startDevServer({
         ...createBuildOptions({}),
         entrypoint: 'grycap/cowsay:latest',
-        service: { name: 'api', type: 'web' },
+        service: { name: 'api' },
         meta: { isDev: true },
       } as any);
 


### PR DESCRIPTION
## Problem

Container services namespace their function under `_svc/<name>/index` but emit **no route** to it. Unlike `@vercel/python`, the container builder produced no catch-all service route, so the service has no `/` route — the top-level service rewrite resolves to nothing and requests to the service root never reach the function.

This showed up in build outputs as the function landing at `services/<name>/_svc/oci/index` with nothing routing to it, instead of being reachable at the service root like the working non-container example (where `/api/frontend` maps to `services/web/index`).

## Fix

Do a normal build, matching how working (non-container) services behave:

- Emit the function at the natural `index` path inside the nested `services/<name>/` output (no `_svc/<name>` namespacing).
- Emit a catch-all route (`{ handle: 'filesystem' }` + `/(.*) -> /index`) into the service's isolated per-service route table so requests reach the function.

As the services author put it: just put the build output at the path you want to call it at and it just works.

## Testing

- Updated `@vercel/container` unit tests: services now build to `index` with a catch-all route; non-service builds emit no routes.
- `pnpm test-unit`, `pnpm type-check`, and prettier all pass.