### PR TITLE
[vc dev] stop adding / to bindings for services

### DIFF
--- a/.changeset/fix-service-binding-trailing-slash.md
+++ b/.changeset/fix-service-binding-trailing-slash.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[vc dev] Remove the trailing slash from service binding URL env vars injected by `vercel dev`.

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -722,7 +722,7 @@ export class ServicesOrchestrator {
       if (targetPort === undefined) {
         continue;
       }
-      perServiceEnv[binding.env] = `http://127.0.0.1:${targetPort}/`;
+      perServiceEnv[binding.env] = `http://127.0.0.1:${targetPort}`;
     }
 
     const env = cloneEnv(

--- a/packages/cli/test/dev/fixtures/services-v2-bindings/gateway/server.js
+++ b/packages/cli/test/dev/fixtures/services-v2-bindings/gateway/server.js
@@ -1,7 +1,6 @@
 // Public gateway service. It is bound to one internal service per runtime and
 // reaches each one through the injected binding env var (no public route to the
-// targets). Binding values are URL bases ending in "/", so relative paths are
-// appended directly per the `new URL("path", BASE)` contract.
+// targets).
 const http = require('http');
 
 const port = process.env.PORT || 3000;
@@ -30,11 +29,11 @@ const server = http.createServer(async (req, res) => {
       return;
     }
     if (req.url === '/call/py') {
-      res.end(await callBinding(process.env.PY_API_URL, 'hello'));
+      res.end(await callBinding(process.env.PY_API_URL, '/hello'));
       return;
     }
     if (req.url === '/call/go') {
-      res.end(await callBinding(process.env.GO_API_URL, 'ping'));
+      res.end(await callBinding(process.env.GO_API_URL, '/ping'));
       return;
     }
     if (req.url === '/call/ruby') {

--- a/packages/cli/test/dev/integration-5.test.ts
+++ b/packages/cli/test/dev/integration-5.test.ts
@@ -786,14 +786,14 @@ describe('[vercel dev] experimentalServicesV2 service bindings', () => {
     try {
       await readyResolver;
 
-      // Each binding env var is injected as a local URL base ending in "/".
+      // Each binding env var is injected as a local URL base with no trailing slash.
       const info = await nodeFetch(`http://localhost:${port}/binding-info`);
       expect(info.status).toBe(200);
       const infoJson = await info.json();
-      expect(infoJson.node_api_url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
-      expect(infoJson.py_api_url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
-      expect(infoJson.go_api_url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
-      expect(infoJson.ruby_api_url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+      expect(infoJson.node_api_url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      expect(infoJson.py_api_url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      expect(infoJson.go_api_url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      expect(infoJson.ruby_api_url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
 
       // The gateway reaches each internal service (one per runtime) through its
       // binding. None of the targets are publicly routed.


### PR DESCRIPTION
Remove the trailing slash from service binding URL env vars injected by `vercel dev`