### PR TITLE
chore(connect): bump eve peer dependency

### DIFF
--- a/.changeset/connect-eve-peer.md
+++ b/.changeset/connect-eve-peer.md
@@ -1,0 +1,5 @@
+---
+"@vercel/connect": patch
+---
+
+Bump the optional `eve` peer dependency for `@vercel/connect/eve` to the next eve patch release that accepts the `auth.evict` hook emitted by Vercel Connect helpers.

--- a/packages/connect/docs/eve-authorization-helper.md
+++ b/packages/connect/docs/eve-authorization-helper.md
@@ -376,7 +376,7 @@ Why we shifted off Option A:
 
 Implementation summary:
 
-- `peerDependencies: { "eve": ">=0.6.0-beta.1" }` + `peerDependenciesMeta.eve.optional: true`.
+- `peerDependencies: { "eve": ">=0.13.7" }` + `peerDependenciesMeta.eve.optional: true`.
 - Subpath export `./eve` → `./dist/eve/index.js` / `./dist/eve/index.d.ts`.
 - `src/eve/` imports types and the two error classes from `eve/connections` and throws Eve's actual error instances. `src/index.ts` does **not** re-export anything from `eve/`.
 
@@ -396,10 +396,13 @@ packages/connect/src/
 {
   "exports": {
     ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
-    "./eve": { "types": "./dist/eve/index.d.ts", "default": "./dist/eve/index.js" },
+    "./eve": {
+      "types": "./dist/eve/index.d.ts",
+      "default": "./dist/eve/index.js",
+    },
   },
   "peerDependencies": {
-    "eve": ">=0.6.0-beta.1",
+    "eve": ">=0.13.7",
   },
   "peerDependenciesMeta": {
     "eve": { "optional": true },

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -53,7 +53,7 @@
     "@auth/core": ">=0.37.0",
     "ai": "^6 || ^7.0.0-beta.0",
     "better-auth": ">=1.5.0",
-    "eve": ">=0.6.0-beta.1"
+    "eve": ">=0.13.7"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/mcp": {


### PR DESCRIPTION
## Summary
- bump the optional `eve` peer dependency for `@vercel/connect/eve` from `>=0.6.0-beta.1` to `>=0.13.7`
- update the Connect Eve helper implementation note to match
- add a patch changeset for `@vercel/connect`

## Notes
- This is intentionally optimistic for the eve patch release that includes vercel/eve#265, where authored connection auth definitions accept the `auth.evict` hook emitted by Connect helpers.
- The devDependency stays on the currently published eve version so this repo can continue installing until that eve patch is published.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm prettier --check packages/connect/package.json packages/connect/docs/eve-authorization-helper.md .changeset/connect-eve-peer.md`
- `pnpm --filter @vercel/connect typecheck`
- `pnpm --filter @vercel/connect build`
- `pnpm --filter @vercel/cli-config build`
- `pnpm --filter @vercel/cli-exec build`
- `pnpm --filter @vercel/oidc build`
- `pnpm --filter @vercel/connect test`
- `git diff --check`