### PR TITLE
[connect] Auto-provision eve connectors

### DIFF
--- a/.changeset/connect-eve-provision.md
+++ b/.changeset/connect-eve-provision.md
@@ -1,0 +1,5 @@
+---
+"@vercel/connect": patch
+---
+
+Add default-on first-use connector provisioning to `connect()` from `@vercel/connect/eve`. When the helper runs inside a Vercel deployment, it now posts the eve connection URL and connector UID to the managed OAuth create/link endpoint before token or consent calls, so Connect can create a missing connector or link an existing one to the OIDC project and eligible environments. Pass `autoProvision: false` to keep managing the connector link manually.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -68,7 +68,7 @@ SDK's `toolApproval` option or `wrapMcpTools` from `@ai-sdk/policy-opa`.
 Non-AI-SDK MCP clients (the official MCP TypeScript SDK, Mastra, etc.)
 can import the same `connectAuthProvider` from `@vercel/connect/mcp`.
 
-### Eve
+### eve
 
 ```ts
 import { defineMcpClientConnection } from 'eve/connections';
@@ -79,6 +79,10 @@ export default defineMcpClientConnection({
   auth: connect('linear'),
 });
 ```
+
+By default, `connect()` provisions or links the connector for the deploying
+Vercel project on first use. Pass `autoProvision: false` when the connector is
+managed elsewhere.
 
 ### Better Auth
 

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -52,6 +52,7 @@ import {
   revokeToken,
   UserAuthorizationRequiredError,
 } from '../token.js';
+import { provisionEveOAuthConnector } from './provision-oauth-connector.js';
 
 /**
  * Authorization phase passed to {@link EveAuthorizationOptions.onError}
@@ -174,6 +175,23 @@ export interface EveAuthorizationOptions {
   readonly connectOptions?: ConnectOptions;
 
   /**
+   * Create or link the declared connector against the deploying Vercel
+   * project before the first token / authorization call. Defaults to
+   * `true`.
+   *
+   * The provision request is authenticated with the deployment OIDC token
+   * and carries the eve connection's `url` plus this connector UID. Connect
+   * creates the managed OAuth connector when missing, links an existing
+   * OAuth connector when the UID already exists, and scopes the new project
+   * link to the OIDC token's environment and higher promotion targets.
+   *
+   * Set this to `false` for callers that intentionally manage the connector
+   * linkage elsewhere. Opaque connector ids (`scl_...`) and connections
+   * without a URL are skipped automatically.
+   */
+  readonly autoProvision?: boolean;
+
+  /**
    * Re-validate the grant against Vercel Connect on every `getToken`
    * instead of trusting the in-process token cache.
    *
@@ -235,9 +253,10 @@ export type EveAuthorizationInput = string | EveAuthorizationOptions;
  * both forms address the same connector.
  *
  * The marker is purely metadata — it does not influence the runtime
- * token-fetching behaviour, which continues to be driven by the
+ * token-fetching identity, which continues to be driven by the
  * `getToken` / `startAuthorization` / `completeAuthorization`
- * callbacks.
+ * callbacks. When auto-provisioning is enabled, the same connector value is
+ * also sent as the managed OAuth UID.
  */
 export interface VercelConnectMetadata {
   readonly connector: string;
@@ -400,6 +419,7 @@ function buildInteractiveDefinition(
       connection,
     }: GetTokenOptions): Promise<TokenResult> {
       try {
+        await autoProvisionConnectorIfEnabled(options, connection);
         const response = await getTokenResponse(
           options.connector,
           await buildTokenParams(options, principal, connection),
@@ -420,6 +440,7 @@ function buildInteractiveDefinition(
       challenge: ConnectionAuthorizationChallenge;
     }> {
       try {
+        await autoProvisionConnectorIfEnabled(options, connection);
         // Eve's `webhook` parameter is semantically a browser-redirect
         // target — the orchestrator mints it via `createWebhook({
         // respondWith: buildAuthorizationCompletePage() })` so the
@@ -472,6 +493,7 @@ function buildInteractiveDefinition(
       connection,
     }: CompleteAuthorizationOptions): Promise<TokenResult> {
       try {
+        await autoProvisionConnectorIfEnabled(options, connection);
         const response = await getTokenResponse(
           options.connector,
           await buildTokenParams(options, principal, connection),
@@ -495,6 +517,7 @@ function buildNonInteractiveDefinition(
       connection,
     }: GetTokenOptions): Promise<TokenResult> {
       try {
+        await autoProvisionConnectorIfEnabled(options, connection);
         const response = await getTokenResponse(
           options.connector,
           await buildTokenParams(options, principal, connection),
@@ -506,6 +529,20 @@ function buildNonInteractiveDefinition(
       }
     },
   };
+}
+
+async function autoProvisionConnectorIfEnabled(
+  options: EveAuthorizationOptions,
+  connection: EveConnectionAuthorizationContext
+): Promise<void> {
+  if (options.autoProvision === false) {
+    return;
+  }
+  await provisionEveOAuthConnector({
+    connector: options.connector,
+    connection,
+    connectOptions: options.connectOptions,
+  });
 }
 
 /**

--- a/packages/connect/src/eve/provision-oauth-connector.ts
+++ b/packages/connect/src/eve/provision-oauth-connector.ts
@@ -1,0 +1,147 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+import type { ConnectOptions } from '../token.js';
+import { ConnectError, createConnectErrorFromResponse } from '../token.js';
+import type { EveConnectionAuthorizationContext } from './connection-authorization.js';
+
+const MANAGED_OAUTH_CONNECTOR_ENDPOINT =
+  'https://api.vercel.com/v1/connect/connectors/managed/oauth';
+
+const RESERVED_UID_PATTERN = /^(vc\/|[^/]*\.vercel\.com\/)/;
+const ALLOWED_RESERVED_UID_PREFIXES = ['mcp.vercel.com/'];
+const RESERVED_ID_PREFIXES = ['scl_', 'sca_', 'store_', 'ir_'];
+const INVALID_UID_CHARS = /[\s%#]/;
+
+const provisionCache = new Map<string, Promise<void>>();
+
+interface ProvisionEveOAuthConnectorOptions {
+  readonly connector: string;
+  readonly connection: EveConnectionAuthorizationContext;
+  readonly connectOptions?: ConnectOptions;
+}
+
+export async function provisionEveOAuthConnector({
+  connector,
+  connection,
+  connectOptions,
+}: ProvisionEveOAuthConnectorOptions): Promise<void> {
+  const serverUrl = resolveServerUrl(connection);
+  if (serverUrl === undefined || !isProvisionableConnectorUid(connector)) {
+    return;
+  }
+
+  const vercelToken =
+    connectOptions?.vercelToken ?? (await getVercelOidcToken());
+  const cacheKey = JSON.stringify({
+    connector,
+    serverUrl,
+    token: await tokenCacheKeyPart(vercelToken),
+  });
+  let promise = provisionCache.get(cacheKey);
+  if (promise === undefined) {
+    promise = provisionManagedOAuthConnector({
+      connector,
+      serverUrl,
+      vercelToken,
+    }).catch(error => {
+      if (isNonOAuthConnectorConflict(error)) {
+        return;
+      }
+      provisionCache.delete(cacheKey);
+      throw error;
+    });
+    provisionCache.set(cacheKey, promise);
+  }
+
+  await promise;
+}
+
+function resolveServerUrl(
+  connection: EveConnectionAuthorizationContext
+): string | undefined {
+  const url = connection.url;
+  if (typeof url !== 'string') {
+    return undefined;
+  }
+  const trimmed = url.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+function isProvisionableConnectorUid(connector: string): boolean {
+  if (connector === '' || INVALID_UID_CHARS.test(connector)) {
+    return false;
+  }
+
+  for (let index = 0; index < connector.length; index++) {
+    const code = connector.charCodeAt(index);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
+      return false;
+    }
+  }
+
+  const normalized = connector.toLowerCase();
+  if (RESERVED_ID_PREFIXES.some(prefix => normalized.startsWith(prefix))) {
+    return false;
+  }
+  if (
+    RESERVED_UID_PATTERN.test(normalized) &&
+    !ALLOWED_RESERVED_UID_PREFIXES.some(prefix => normalized.startsWith(prefix))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+async function tokenCacheKeyPart(token: string): Promise<string> {
+  const subtle = globalThis.crypto?.subtle;
+  if (subtle) {
+    const digest = await subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(token)
+    );
+    return Array.from(new Uint8Array(digest), byte =>
+      byte.toString(16).padStart(2, '0')
+    ).join('');
+  }
+
+  let hash = 2166136261;
+  for (let index = 0; index < token.length; index++) {
+    hash ^= token.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${token.length}:${hash >>> 0}`;
+}
+
+function isNonOAuthConnectorConflict(error: unknown): boolean {
+  return (
+    error instanceof ConnectError &&
+    error.status === 409 &&
+    /not an OAuth connector/i.test(error.message)
+  );
+}
+
+async function provisionManagedOAuthConnector({
+  connector,
+  serverUrl,
+  vercelToken,
+}: {
+  readonly connector: string;
+  readonly serverUrl: string;
+  readonly vercelToken: string;
+}): Promise<void> {
+  const response = await fetch(MANAGED_OAUTH_CONNECTOR_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${vercelToken}`,
+    },
+    body: JSON.stringify({ serverUrl, uid: connector }),
+  });
+
+  if (!response.ok) {
+    throw await createConnectErrorFromResponse(
+      response,
+      'Failed to provision connector'
+    );
+  }
+}

--- a/packages/connect/test/eve/connection-authorization.test.ts
+++ b/packages/connect/test/eve/connection-authorization.test.ts
@@ -23,6 +23,237 @@ const CONNECTION: EveConnectionAuthorizationContext = {
   url: 'https://mcp.example.com/sse',
 };
 
+describe('connect() adapter provisioning', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(getVercelOidcToken).mockResolvedValue('oidc_token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('provisions and links a UID connector before fetching a token', async () => {
+    const connector = 'mcp.example.com/provisioned';
+    fetchMock
+      .mockResolvedValueOnce(jsonProvisionResponse(connector))
+      .mockResolvedValueOnce(jsonTokenResponse('tok_provisioned', connector));
+
+    const definition = connect(connector) as InteractiveAuthorizationDefinition;
+
+    const result = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(result.token).toBe('tok_provisioned');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const [provisionUrl, provisionInit] = fetchMock.mock.calls[0];
+    expect(provisionUrl).toBe(
+      'https://api.vercel.com/v1/connect/connectors/managed/oauth'
+    );
+    expect(provisionInit).toMatchObject({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer oidc_token',
+      }),
+    });
+    expect(JSON.parse(provisionInit.body as string)).toEqual({
+      serverUrl: CONNECTION.url,
+      uid: connector,
+    });
+
+    const [tokenUrl] = fetchMock.mock.calls[1];
+    expect(tokenUrl).toBe(
+      'https://api.vercel.com/v1/connect/token/mcp.example.com%2Fprovisioned'
+    );
+  });
+
+  it('reuses successful provisioning for the same connector and server URL', async () => {
+    const connector = 'mcp.example.com/provision-cache';
+    fetchMock
+      .mockResolvedValueOnce(jsonProvisionResponse(connector))
+      .mockResolvedValueOnce(jsonTokenResponse('tok_first', connector))
+      .mockResolvedValueOnce(jsonTokenResponse('tok_second', connector));
+
+    const definition = connect({
+      connector,
+      validate: true,
+    }) as InteractiveAuthorizationDefinition;
+
+    const first = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+    const second = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(first.token).toBe('tok_first');
+    expect(second.token).toBe('tok_second');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(
+      fetchMock.mock.calls.filter(
+        ([url]) =>
+          url === 'https://api.vercel.com/v1/connect/connectors/managed/oauth'
+      )
+    ).toHaveLength(1);
+  });
+
+  it('keeps provision cache entries scoped to the Vercel token', async () => {
+    const connector = 'mcp.example.com/token-scoped-cache';
+    fetchMock
+      .mockResolvedValueOnce(jsonProvisionResponse(connector))
+      .mockResolvedValueOnce(jsonTokenResponse('tok_project_a', connector))
+      .mockResolvedValueOnce(jsonProvisionResponse(connector))
+      .mockResolvedValueOnce(jsonTokenResponse('tok_project_b', connector));
+
+    const projectA = connect({
+      connector,
+      validate: true,
+      connectOptions: { vercelToken: 'oidc_project_a' },
+    }) as InteractiveAuthorizationDefinition;
+    const projectB = connect({
+      connector,
+      validate: true,
+      connectOptions: { vercelToken: 'oidc_project_b' },
+    }) as InteractiveAuthorizationDefinition;
+
+    const first = await projectA.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+    const second = await projectB.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(first.token).toBe('tok_project_a');
+    expect(second.token).toBe('tok_project_b');
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls[0][1]?.headers).toMatchObject({
+      Authorization: 'Bearer oidc_project_a',
+    });
+    expect(fetchMock.mock.calls[2][1]?.headers).toMatchObject({
+      Authorization: 'Bearer oidc_project_b',
+    });
+  });
+
+  it('provisions before starting an interactive authorization flow', async () => {
+    const connector = 'mcp.example.com/start-authorization';
+    fetchMock
+      .mockResolvedValueOnce(jsonProvisionResponse(connector))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            request: 'req_1',
+            verifier: 'ver_1',
+            url: 'https://connect.vercel.com/authorize/req_1',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+
+    const definition = connect(connector) as InteractiveAuthorizationDefinition;
+
+    const { challenge } = await definition.startAuthorization({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+      callbackUrl: 'https://example.com/callback',
+    });
+
+    expect(challenge.url).toBe('https://connect.vercel.com/authorize/req_1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.vercel.com/v1/connect/connectors/managed/oauth'
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.vercel.com/v1/connect/authorize/mcp.example.com%2Fstart-authorization'
+    );
+  });
+
+  it('skips provisioning for opaque connector ids', async () => {
+    fetchMock.mockResolvedValueOnce(jsonTokenResponse('tok_opaque'));
+
+    const definition = connect(
+      'scl_existing'
+    ) as InteractiveAuthorizationDefinition;
+
+    const result = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(result.token).toBe('tok_opaque');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.vercel.com/v1/connect/token/scl_existing'
+    );
+  });
+
+  it('falls back to token fetching when an existing connector is not managed OAuth', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'conflict',
+              message:
+                'A connector with uid "linear" already exists and is not an OAuth connector.',
+            },
+          }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(jsonTokenResponse('tok_linear', 'linear'));
+
+    const definition = connect('linear') as InteractiveAuthorizationDefinition;
+
+    const result = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(result.token).toBe('tok_linear');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.vercel.com/v1/connect/connectors/managed/oauth'
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.vercel.com/v1/connect/token/linear'
+    );
+  });
+
+  it('allows callers to disable provisioning', async () => {
+    const connector = 'mcp.example.com/manual-link';
+    fetchMock.mockResolvedValueOnce(jsonTokenResponse('tok_manual', connector));
+
+    const definition = connect({
+      connector,
+      autoProvision: false,
+    }) as InteractiveAuthorizationDefinition;
+
+    const result = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(result.token).toBe('tok_manual');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.vercel.com/v1/connect/token/mcp.example.com%2Fmanual-link'
+    );
+  });
+});
+
 describe('connect() adapter evict', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -42,9 +273,10 @@ describe('connect() adapter evict', () => {
       .mockResolvedValueOnce(jsonTokenResponse('tok_stale'))
       .mockResolvedValueOnce(jsonTokenResponse('tok_fresh'));
 
-    const definition = connect(
-      'oauth/connection-auth-evict'
-    ) as InteractiveAuthorizationDefinition & {
+    const definition = connect({
+      connector: 'oauth/connection-auth-evict',
+      autoProvision: false,
+    }) as InteractiveAuthorizationDefinition & {
       readonly evict: (opts: {
         readonly principal: ConnectionPrincipal;
         readonly connection?: EveConnectionAuthorizationContext;
@@ -79,9 +311,10 @@ describe('connect() adapter evict', () => {
       .mockResolvedValueOnce(new Response(null, { status: 200 }))
       .mockResolvedValueOnce(jsonTokenResponse('tok_reauthorized'));
 
-    const definition = connect(
-      'oauth/connection-auth-revoke'
-    ) as InteractiveAuthorizationDefinition & {
+    const definition = connect({
+      connector: 'oauth/connection-auth-revoke',
+      autoProvision: false,
+    }) as InteractiveAuthorizationDefinition & {
       readonly evict: (opts: {
         readonly principal: ConnectionPrincipal;
         readonly connection?: EveConnectionAuthorizationContext;
@@ -127,9 +360,10 @@ describe('connect() adapter evict', () => {
       )
       .mockResolvedValueOnce(jsonTokenResponse('tok_after'));
 
-    const definition = connect(
-      'oauth/connection-auth-revoke-fallback'
-    ) as InteractiveAuthorizationDefinition & {
+    const definition = connect({
+      connector: 'oauth/connection-auth-revoke-fallback',
+      autoProvision: false,
+    }) as InteractiveAuthorizationDefinition & {
       readonly evict: (opts: {
         readonly principal: ConnectionPrincipal;
         readonly connection?: EveConnectionAuthorizationContext;
@@ -190,6 +424,7 @@ describe('connect() adapter subject mapping', () => {
 
     const definition = connect({
       connector: 'oauth/subject-create',
+      autoProvision: false,
       createSubject,
     }) as InteractiveAuthorizationDefinition;
 
@@ -240,6 +475,7 @@ describe('connect() adapter subject mapping', () => {
 
     const definition = connect({
       connector: 'oauth/subject-start-auth',
+      autoProvision: false,
       createSubject,
     }) as InteractiveAuthorizationDefinition;
 
@@ -280,6 +516,7 @@ describe('connect() adapter subject mapping', () => {
 
     const definition = connect({
       connector: 'oauth/subject-precedence',
+      autoProvision: false,
       createSubject,
       principalToSubject,
     }) as InteractiveAuthorizationDefinition;
@@ -309,6 +546,7 @@ describe('connect() adapter subject mapping', () => {
 
     const definition = connect({
       connector: 'oauth/subject-legacy',
+      autoProvision: false,
       principalToSubject,
     }) as InteractiveAuthorizationDefinition;
 
@@ -332,9 +570,10 @@ describe('connect() adapter subject mapping', () => {
   it('falls back to the default principal mapping when neither hook is set', async () => {
     fetchMock.mockResolvedValueOnce(jsonTokenResponse('tok_default'));
 
-    const definition = connect(
-      'oauth/subject-default'
-    ) as InteractiveAuthorizationDefinition;
+    const definition = connect({
+      connector: 'oauth/subject-default',
+      autoProvision: false,
+    }) as InteractiveAuthorizationDefinition;
 
     await definition.getToken({
       principal: PRINCIPAL,
@@ -352,17 +591,31 @@ describe('connect() adapter subject mapping', () => {
   });
 });
 
-function jsonTokenResponse(token: string): Response {
+function jsonTokenResponse(
+  token: string,
+  uid = 'oauth/connection-auth-evict'
+): Response {
   return new Response(
     JSON.stringify({
       token,
       expiresAt: Date.now() + 60 * 60 * 1000,
       connector: {
         id: 'scl_evict',
-        uid: 'oauth/connection-auth-evict',
+        uid,
         type: 'oauth',
       },
     }),
     { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function jsonProvisionResponse(uid: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: 'scl_provisioned',
+      uid,
+      type: 'oauth',
+    }),
+    { status: 201, headers: { 'Content-Type': 'application/json' } }
   );
 }


### PR DESCRIPTION
## Summary
- add default-on first-use provisioning to `@vercel/connect/eve` before token and authorization calls
- post `{ serverUrl, uid }` to the managed OAuth create/link endpoint using the deployment OIDC token
- cache successful provision attempts per connector/server URL/OIDC token and allow `autoProvision: false`
- skip opaque `scl_...` connector ids and fall back to token fetching when an existing connector is not managed OAuth
- add a patch changeset for `@vercel/connect`

Depends on vercel/api#77756 for the OIDC project-linking and environment-ceiling API behavior.

## Tests
- `pnpm --filter @vercel/connect test -- test/eve/connection-authorization.test.ts`
- `pnpm --filter @vercel/connect typecheck`
- `pnpm exec prettier --check .changeset/connect-eve-provision.md packages/connect/README.md packages/connect/src/eve/connection-authorization.ts packages/connect/src/eve/provision-oauth-connector.ts packages/connect/test/eve/connection-authorization.test.ts`
- `git diff --check`