### PR TITLE
feat(@vercel/connect): support function-valued params resolver in connectSlackCredentials for multi-workspace Slack installation selection

### DIFF
--- a/.changeset/connect-eve-slack-installation-resolver.md
+++ b/.changeset/connect-eve-slack-installation-resolver.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+`connectSlackCredentials` now accepts a lazy resolver function as its `params` argument (type `ConnectSlackCredentialsParamsResolver`), enabling context-aware Slack installation selection. A single Eve route can serve multiple Slack workspace installations through the same connector by computing `installationId` from request-scoped context (e.g. `AsyncLocalStorage`) at `botToken()` invocation time. Existing object-params and no-args callers are fully backward compatible.

--- a/packages/connect/src/eve/index.ts
+++ b/packages/connect/src/eve/index.ts
@@ -35,4 +35,5 @@ export {
 export {
   connectSlackCredentials,
   type ConnectSlackCredentialsParams,
+  type ConnectSlackCredentialsParamsResolver,
 } from './slack-credentials.js';

--- a/packages/connect/src/eve/slack-credentials.ts
+++ b/packages/connect/src/eve/slack-credentials.ts
@@ -18,6 +18,36 @@ import { vercelOidc } from 'eve/channels/auth';
 export type ConnectSlackCredentialsParams = Omit<ConnectTokenParams, 'subject'>;
 
 /**
+ * A lazy resolver function that returns {@link ConnectSlackCredentialsParams}
+ * (or a Promise thereof) when called.
+ *
+ * Use this form with {@link connectSlackCredentials} to select an
+ * `installationId` at `botToken()` invocation time — for example, by
+ * reading a workspace-id from AsyncLocalStorage that was populated by an
+ * inbound Slack event's `team_id` field.
+ *
+ * @example
+ * ```ts
+ * const store = new AsyncLocalStorage<{ teamId: string }>();
+ *
+ * const resolver: ConnectSlackCredentialsParamsResolver = () => {
+ *   const { teamId } = store.getStore()!;
+ *   return { installationId: teamId };
+ * };
+ *
+ * export default slackRoute({
+ *   credentials: connectSlackCredentials("scl_...", resolver),
+ *   async handler(event, context) {
+ *     return store.run({ teamId: event.team_id }, () => yourHandler(event, context));
+ *   },
+ * });
+ * ```
+ */
+export type ConnectSlackCredentialsParamsResolver = () =>
+  | ConnectSlackCredentialsParams
+  | Promise<ConnectSlackCredentialsParams>;
+
+/**
  * Build {@link SlackChannelCredentials} backed by a Vercel Connect
  * connector that stores a Slack workspace's bot token.
  *
@@ -35,6 +65,8 @@ export type ConnectSlackCredentialsParams = Omit<ConnectTokenParams, 'subject'>;
  * of {@link getToken}, allowing callers to pass through fields like
  * `installationId`, `scopes`, or `validityBufferMs`.
  *
+ * ### Static params (single workspace)
+ *
  * ```ts
  * import { slackRoute } from "eve/channels/slack";
  * import { connectSlackCredentials } from "@vercel/connect/eve";
@@ -44,21 +76,59 @@ export type ConnectSlackCredentialsParams = Omit<ConnectTokenParams, 'subject'>;
  * });
  * ```
  *
- * Multi-workspace deployments can select a specific workspace install
- * via `installationId`:
+ * Single workspace with a pinned installation:
  *
  * ```ts
  * connectSlackCredentials("scl_...", { installationId: workspaceId });
  * ```
+ *
+ * ### Function params (multi-workspace)
+ *
+ * Pass a {@link ConnectSlackCredentialsParamsResolver} to select the
+ * `installationId` dynamically at `botToken()` invocation time.  This
+ * lets one Eve route serve multiple Slack workspace installations through
+ * the same connector by reading request-scoped context (e.g.
+ * `AsyncLocalStorage` populated from the inbound event's `team_id`):
+ *
+ * ```ts
+ * import { AsyncLocalStorage } from "node:async_hooks";
+ * import { slackRoute } from "eve/channels/slack";
+ * import { connectSlackCredentials } from "@vercel/connect/eve";
+ *
+ * const store = new AsyncLocalStorage<{ teamId: string }>();
+ *
+ * export default slackRoute({
+ *   credentials: connectSlackCredentials("scl_...", () => ({
+ *     installationId: store.getStore()!.teamId,
+ *   })),
+ *   async handler(event, context) {
+ *     return store.run({ teamId: event.team_id }, () =>
+ *       yourHandler(event, context)
+ *     );
+ *   },
+ * });
+ * ```
+ *
+ * The resolver is re-invoked on every `botToken()` call, so the
+ * `installationId` is always resolved from the current async context.
  */
 export function connectSlackCredentials(
   connector: string,
-  params: ConnectSlackCredentialsParams = {},
+  params?:
+    | ConnectSlackCredentialsParams
+    | ConnectSlackCredentialsParamsResolver,
   options?: ConnectOptions
 ): SlackChannelCredentials {
   return {
-    botToken: () =>
-      getToken(connector, { ...params, subject: { type: 'app' } }, options),
+    botToken: async () => {
+      const resolvedParams =
+        typeof params === 'function' ? await params() : (params ?? {});
+      return getToken(
+        connector,
+        { ...resolvedParams, subject: { type: 'app' } },
+        options
+      );
+    },
     webhookVerifier: vercelOidc(),
   };
 }

--- a/packages/connect/test/eve/channel-credentials.test.ts
+++ b/packages/connect/test/eve/channel-credentials.test.ts
@@ -78,6 +78,73 @@ describe('Eve channel credential helpers', () => {
     });
   });
 
+  it('resolves Slack botToken using a function-valued params resolver', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonTokenResponse('slack_token_ws1'))
+      .mockResolvedValueOnce(jsonTokenResponse('slack_token_ws2'));
+
+    let call = 0;
+    const resolver = () => {
+      call++;
+      return { installationId: `workspace-${call}` };
+    };
+
+    const credentials = connectSlackCredentials('oauth/slack', resolver, {
+      vercelToken: 'vercel_token',
+    });
+
+    expect(credentials.botToken).toEqual(expect.any(Function));
+
+    // First invocation uses installationId from first resolver call
+    await expect(resolveToken(credentials.botToken)).resolves.toBe(
+      'slack_token_ws1'
+    );
+    const [url1, init1] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url1).toBe(
+      `https://api.vercel.com/v1/connect/token/${encodeURIComponent('oauth/slack')}`
+    );
+    expect(JSON.parse(init1.body as string)).toEqual({
+      installationId: 'workspace-1',
+      subject: { type: 'app' },
+    });
+
+    // Second invocation re-invokes resolver — different installationId
+    await expect(resolveToken(credentials.botToken)).resolves.toBe(
+      'slack_token_ws2'
+    );
+    const [url2, init2] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(url2).toBe(
+      `https://api.vercel.com/v1/connect/token/${encodeURIComponent('oauth/slack')}`
+    );
+    expect(JSON.parse(init2.body as string)).toEqual({
+      installationId: 'workspace-2',
+      subject: { type: 'app' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves Slack botToken using an async params resolver (Promise)', async () => {
+    fetchMock.mockResolvedValue(jsonTokenResponse('slack_async_token'));
+
+    const asyncResolver = async () => ({
+      installationId: 'async-workspace',
+    });
+
+    const credentials = connectSlackCredentials('oauth/slack', asyncResolver, {
+      vercelToken: 'vercel_token',
+    });
+
+    expect(credentials.botToken).toEqual(expect.any(Function));
+    await expect(resolveToken(credentials.botToken)).resolves.toBe(
+      'slack_async_token'
+    );
+    expectTokenRequest('oauth/slack', {
+      installationId: 'async-workspace',
+      subject: { type: 'app' },
+    });
+  });
+
   function expectTokenRequest(
     connector: string,
     body: Record<string, unknown>


### PR DESCRIPTION
## Summary

Addresses #16770.

### Problem

`connectSlackCredentials` previously only accepted a static `params` object, pinning a single `installationId`. This made it impossible for one Eve Slack route to serve multiple Slack workspace installations through the same connector without per-workspace connectors or env-var maps.

### Solution

Allow the `params` argument to be a **lazy resolver function** evaluated on every `botToken()` call:

```ts
type ConnectSlackCredentialsParamsResolver =
  () => ConnectSlackCredentialsParams | Promise<ConnectSlackCredentialsParams>;
```

When a function is passed, it is awaited each time `botToken()` is invoked, enabling the installation to be selected from request-scoped context (e.g. `AsyncLocalStorage` populated from the inbound event's `team_id`):

```ts
const store = new AsyncLocalStorage<{ teamId: string }>();

export default slackRoute({
  credentials: connectSlackCredentials('scl_...', () => ({
    installationId: store.getStore()!.teamId,
  })),
  async handler(event, context) {
    return store.run({ teamId: event.team_id }, () =>
      yourHandler(event, context)
    );
  },
});
```

### Changes

- **`packages/connect/src/eve/slack-credentials.ts`**: Extended `params` to accept `ConnectSlackCredentialsParamsResolver` in addition to the static object form; updated JSDoc with multi-workspace example.
- **`packages/connect/src/eve/index.ts`**: Exported the new `ConnectSlackCredentialsParamsResolver` type.
- **`packages/connect/test/eve/channel-credentials.test.ts`**: Added tests for sync resolver (re-invoked per call), async resolver (Promise), and confirmed existing static-object test continues to pass.
- **`.changeset/connect-eve-slack-installation-resolver.md`**: Minor changeset for `@vercel/connect`.

### Backward Compatibility

Fully backward compatible. All existing callers passing a static object or no `params` continue to behave identically.

### Note on Eve context forwarding

The Eve framework does not currently forward installation/team context into `botToken()` (the type is `() => string | Promise<string>` with no argument). Until Eve forwards context directly (see vercel/eve#222), applications using the resolver pattern must propagate context themselves via `AsyncLocalStorage` or similar. This helper provides the ergonomic escape hatch for that pattern today.