### PR TITLE
[@vercel/oidc] Deprecate getVercelOidcTokenSync in favor of getVercelOidcToken

### DIFF
--- a/.changeset/thick-singers-move.md
+++ b/.changeset/thick-singers-move.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+Deprecate `getVercelOidcTokenSync` in favor of `getVercelOidcToken`

--- a/packages/functions/docs/oidc/functions/getVercelOidcTokenSync.md
+++ b/packages/functions/docs/oidc/functions/getVercelOidcTokenSync.md
@@ -6,7 +6,17 @@
 
 > **getVercelOidcTokenSync**(): `string`
 
-Defined in: packages/oidc/dist/get-vercel-oidc-token-sync.d.ts:22
+Defined in: packages/oidc/dist/get-vercel-oidc-token-sync.d.ts:23
+
+## Returns
+
+`string`
+
+The OIDC token.
+
+## Deprecated
+
+Use `getVercelOidcToken` instead.
 
 Gets the current OIDC token from the request context or the environment variable.
 
@@ -17,12 +27,6 @@ It checks for the `x-vercel-oidc-token` header in the request context and falls 
 
 This function will not refresh the token if it is expired. For refreshing the token, use the @{link getVercelOidcToken} function.
 
-## Returns
-
-`string`
-
-The OIDC token.
-
 ## Throws
 
 If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set.
@@ -30,7 +34,6 @@ If the `x-vercel-oidc-token` header is missing from the request context and the 
 ## Example
 
 ```js
-// Using the OIDC token
 const token = getVercelOidcTokenSync();
 console.log('OIDC Token:', token);
 ```

--- a/packages/oidc/docs/README.md
+++ b/packages/oidc/docs/README.md
@@ -23,6 +23,6 @@
 - [exchangeVercelOidcToken](functions/exchangeVercelOidcToken.md)
 - [getContext](functions/getContext.md)
 - [getVercelOidcToken](functions/getVercelOidcToken.md)
-- [getVercelOidcTokenSync](functions/getVercelOidcTokenSync.md)
+- [~~getVercelOidcTokenSync~~](functions/getVercelOidcTokenSync.md)
 - [getVercelToken](functions/getVercelToken.md)
 - [verifyVercelOidcToken](functions/verifyVercelOidcToken.md)

--- a/packages/oidc/docs/functions/getVercelOidcTokenSync.md
+++ b/packages/oidc/docs/functions/getVercelOidcTokenSync.md
@@ -2,11 +2,21 @@
 
 ---
 
-# Function: getVercelOidcTokenSync()
+# ~~Function: getVercelOidcTokenSync()~~
 
 > **getVercelOidcTokenSync**(): `string`
 
-Defined in: [packages/oidc/src/get-vercel-oidc-token-sync.ts:24](https://github.com/vercel/vercel/blob/main/packages/oidc/src/get-vercel-oidc-token-sync.ts#L24)
+Defined in: [packages/oidc/src/get-vercel-oidc-token-sync.ts:25](https://github.com/vercel/vercel/blob/main/packages/oidc/src/get-vercel-oidc-token-sync.ts#L25)
+
+## Returns
+
+`string`
+
+The OIDC token.
+
+## Deprecated
+
+Use `getVercelOidcToken` instead.
 
 Gets the current OIDC token from the request context or the environment variable.
 
@@ -17,12 +27,6 @@ It checks for the `x-vercel-oidc-token` header in the request context and falls 
 
 This function will not refresh the token if it is expired. For refreshing the token, use the @{link getVercelOidcToken} function.
 
-## Returns
-
-`string`
-
-The OIDC token.
-
 ## Throws
 
 If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set.
@@ -30,7 +34,6 @@ If the `x-vercel-oidc-token` header is missing from the request context and the 
 ## Example
 
 ```js
-// Using the OIDC token
 const token = getVercelOidcTokenSync();
 console.log('OIDC Token:', token);
 ```

--- a/packages/oidc/src/get-vercel-oidc-token-sync.ts
+++ b/packages/oidc/src/get-vercel-oidc-token-sync.ts
@@ -1,6 +1,8 @@
 import { getContext } from './get-context';
 
 /**
+ * @deprecated Use `getVercelOidcToken` instead.
+ *
  * Gets the current OIDC token from the request context or the environment variable.
  *
  * Do not cache this value, as it is subject to change in production!
@@ -16,7 +18,6 @@ import { getContext } from './get-context';
  * @example
  *
  * ```js
- * // Using the OIDC token
  * const token = getVercelOidcTokenSync();
  * console.log('OIDC Token:', token);
  * ```


### PR DESCRIPTION
## Summary

`getVercelOidcTokenSync` cannot refresh an expired OIDC token, which makes it error-prone for long-running or production use. This marks it `@deprecated` and points callers to `getVercelOidcToken`, which handles refresh.

This is a JSDoc/annotation-only change (no runtime behavior change), released as a patch.

## Validation

- Annotation-only change; verified the deprecation surfaces on `getVercelOidcTokenSync` usages via the JSDoc `@deprecated` tag.

Made with [Cursor](https://cursor.com)