### PR TITLE
ci: bump changesets/action to v1.9.0 to fix github-api PR-reopen race

### DIFF
--- a/.changeset/bump-changesets-action.md
+++ b/.changeset/bump-changesets-action.md
@@ -1,0 +1,4 @@
+---
+---
+
+Bump `changesets/action` to v1.9.0 to fix a github-api commit-mode race that could close the Version Packages release PR without reopening it (leaving it closed with 0 changes).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,11 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm ci:version
           publish: pnpm ci:publish # npm publish
-          commitMode: "github-api" # allows release commits and tags to be signed using $GITHUB_TOKEN
+          commitMode: 'github-api' # allows release commits and tags to be signed using $GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
## What

Bump `changesets/action` from `6a0a831` (v1.7.0) to `a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d` (v1.9.0).

## Why

We use `commitMode: "github-api"` so release commits/tags are signed via `GITHUB_TOKEN` (this is a hard requirement, so we keep it). On older versions, the github-api force-push temporarily reset the `changeset-release/main` branch to the base commit. GitHub interprets that as 'nothing to merge' and auto-closes the open Version Packages PR, and an overlapping run's reopen could fail — leaving the PR closed with 0 changes (e.g. #16803).

v1.9.0 fixes this directly:

> #645 — Improved force-push handling when using `commitMode: "github-api"` so updating an existing branch no longer temporarily resets the target branch to the base commit, avoiding cases where GitHub closes open pull requests during the update. This should remove a possibility of a GitHub state race that caused the force-pushed PRs not being reopened.

It also includes #488 (v1.5.3), which hardens PR reopening under github-api mode.

Stayed on the latest stable v1 rather than v2.x, which is still `-next` prerelease with breaking changes.

## Notes

Workflow-only change; changeset has empty frontmatter per repo conventions.