### PR TITLE
[python] Apply functions config to framework builds

### DIFF
--- a/.changeset/python-functions-entrypoint.md
+++ b/.changeset/python-functions-entrypoint.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python': patch
+'@vercel/fs-detectors': patch
+---
+
+Apply `functions` config to Python framework builds using the resolved Python entrypoint.

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -876,9 +876,10 @@ function checkUnusedFunctions(
     frontendBuilder &&
     (isOfficialRuntime('express', frontendBuilder.use) ||
       isOfficialRuntime('hono', frontendBuilder.use) ||
+      isOfficialRuntime('python', frontendBuilder.use) ||
       isOfficialRuntime('backends', frontendBuilder.use))
   ) {
-    // Skip for backends because function names aren't statically defined
+    // Skip for runtimes that resolve function names inside the builder.
     return null;
   }
 

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -789,6 +789,34 @@ describe('Test `detectBuilders`', () => {
     });
   });
 
+  it('passes entrypoint functions config through to Python framework builders', async () => {
+    const functions = {
+      'app/main.py': {
+        memory: 512,
+        maxDuration: 30,
+      },
+    };
+
+    const { builders } = await invokeDetectBuildersAndThrow(
+      ['pyproject.toml', 'app/main.py'],
+      null,
+      {
+        functions,
+        projectSettings: { framework: 'fastapi' },
+      }
+    );
+
+    expect(builders).toContainEqual({
+      src: '<detect>',
+      use: '@vercel/python',
+      config: {
+        zeroConfig: true,
+        framework: 'fastapi',
+        functions,
+      },
+    });
+  });
+
   it('extend with functions', async () => {
     const pkg = {
       scripts: { build: 'next build' },

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -23,6 +23,7 @@ import {
   BUILDER_COMPILE_STEP,
   BUILDER_PRE_DEPLOY_STEP,
   sanitizeConsumerName,
+  getLambdaOptionsFromFunction,
   type BuildOptions,
   type GlobOptions,
   type BuildVX,
@@ -400,6 +401,39 @@ function getTargetPlatform(isDev: boolean): TargetPlatform {
   }
 
   return { uvPlatform: UV_LINUX_TARGET, architecture: 'x86_64' };
+}
+
+async function getPythonLambdaOptions({
+  config,
+  entrypoint,
+}: {
+  config: BuildOptions['config'];
+  entrypoint: string;
+}) {
+  if (!config?.functions) {
+    return {};
+  }
+
+  const sources = new Set<string>([entrypoint]);
+  if (entrypoint.endsWith('.py')) {
+    sources.add(entrypoint.slice(0, -'.py'.length));
+  }
+
+  for (const sourceFile of sources) {
+    const lambdaOptions = await getLambdaOptionsFromFunction({
+      sourceFile,
+      config,
+    });
+
+    if (Object.keys(lambdaOptions).length > 0) {
+      // Python resolves the target wheel platform before the Lambda is created,
+      // so the Lambda architecture must stay aligned with that build target.
+      delete lambdaOptions.architecture;
+      return lambdaOptions;
+    }
+  }
+
+  return {};
 }
 
 /**
@@ -1170,10 +1204,16 @@ export const build: BuildVX = async ({
     [`${handlerPyFilename}.py`]: new FileBlob({ data: runtimeTrampoline }),
   };
 
+  const lambdaOptions = await getPythonLambdaOptions({
+    config,
+    entrypoint,
+  });
+
   const output = new Lambda({
     files: webFiles,
     handler: `${handlerPyFilename}.vc_handler`,
     runtime: pythonVersion.runtime,
+    ...lambdaOptions,
     architecture: target.architecture,
     environment: lambdaEnv,
     supportsResponseStreaming: true,

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1369,6 +1369,45 @@ describe('fastapi entrypoint discovery - positive cases', () => {
     fs.removeSync(workPath);
   });
 
+  it('applies functions config to the resolved FastAPI entrypoint', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-fastapi-functions-config-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+    makeMockPython('3.9');
+
+    const files = {
+      'app/main.py': new FileBlob({
+        data: 'from fastapi import FastAPI\napp = FastAPI()\n',
+      }),
+    } as Record<string, FileBlob>;
+    await download(files, workPath);
+
+    const result = await build({
+      workPath,
+      files,
+      entrypoint: '<detect>',
+      meta: { isDev: true },
+      config: {
+        framework: 'fastapi',
+        functions: {
+          'app/main.py': {
+            memory: 512,
+            maxDuration: 30,
+          },
+        },
+      },
+      repoRootPath: workPath,
+    });
+
+    const lambda = getBuildOutputV2Lambda(result) as any;
+    expect(lambda.memory).toBe(512);
+    expect(lambda.maxDuration).toBe(30);
+
+    fs.removeSync(workPath);
+  });
+
   it('discovers src/index.py containing FastAPI', async () => {
     const workPath = path.join(
       tmpdir(),


### PR DESCRIPTION
## Summary
- apply `functions` config inside the Python builder after resolving the real source entrypoint, e.g. `app/main.py`
- allow Python framework builders to defer `functions` validation until the entrypoint is known
- add focused detector and Python builder coverage

## Tests
- `pnpm --dir packages/fs-detectors test test/unit.builds-and-routes-detector.test.ts`
- `pnpm --dir packages/python test-unit`