### PR TITLE
feat(frameworks): support per-slug remote opt-in for experimental presets

### DIFF
--- a/.changeset/framework-experimental-overrides.md
+++ b/.changeset/framework-experimental-overrides.md
@@ -1,0 +1,6 @@
+---
+'@vercel/fs-detectors': minor
+'vercel': patch
+---
+
+Support per-slug remote opt-in for experimental framework presets. Framework detection now accepts an `experimentalOverrides` map (e.g. `{ container: true }`); when `VERCEL_USE_EXPERIMENTAL_FRAMEWORKS` is not set, an experimental preset is still detected if its slug is enabled via the overrides. The CLI resolves these overrides (failing open) and threads them through project detection during `vc deploy` setup, so a preset like `container` can be graduated without requiring a CLI upgrade.

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -40,6 +40,7 @@ import type { EmojiLabel } from '../emoji';
 import { CantParseJSONFile, isAPIError } from '../errors-ts';
 import output from '../../output-manager';
 import { detectProjects } from '../projects/detect-projects';
+import { resolveExperimentalOverrides } from '../projects/experimental-frameworks';
 import readConfig from '../config/read-config';
 import { findSourceVercelConfigFile } from '../compile-vercel-config';
 import { frameworkList } from '@vercel/frameworks';
@@ -779,8 +780,15 @@ export default async function setupAndLink(
           };
 
           // Run the framework detection logic against the local filesystem.
+          // Experimental presets stay gated behind
+          // `VERCEL_USE_EXPERIMENTAL_FRAMEWORKS`, but a preset may also be
+          // remotely graduated per-slug (e.g. `{ container: true }`) without a
+          // CLI upgrade; resolve that opt-in and pass it to detection.
+          const experimentalOverrides =
+            await resolveExperimentalOverrides(client);
           const detectedProjectsForWorkspace = await detectProjects(
-            pathWithRootDirectory
+            pathWithRootDirectory,
+            experimentalOverrides
           );
 
           // Select the first framework detected, or use

--- a/packages/cli/src/util/projects/detect-projects.ts
+++ b/packages/cli/src/util/projects/detect-projects.ts
@@ -5,9 +5,13 @@ import {
   getWorkspacePackagePaths,
   getWorkspaces,
   LocalFileSystemDetector,
+  type ExperimentalOverrides,
 } from '@vercel/fs-detectors';
 
-export async function detectProjects(cwd: string) {
+export async function detectProjects(
+  cwd: string,
+  experimentalOverrides?: ExperimentalOverrides
+) {
   const fs = new LocalFileSystemDetector(cwd);
   const workspaces = await getWorkspaces({ fs });
   const detectedProjects = new Map<string, Framework[]>();
@@ -29,6 +33,7 @@ export async function detectProjects(cwd: string) {
       const frameworks = await detectFrameworks({
         fs: fs.chdir(join('.', p)),
         frameworkList,
+        experimentalOverrides,
       });
       if (frameworks.length === 0) return;
       detectedProjects.set(p.slice(1), frameworks);

--- a/packages/cli/src/util/projects/experimental-frameworks.ts
+++ b/packages/cli/src/util/projects/experimental-frameworks.ts
@@ -1,0 +1,68 @@
+import type { ExperimentalOverrides } from '@vercel/fs-detectors';
+import type Client from '../client';
+import output from '../../output-manager';
+
+/**
+ * API endpoint that returns which experimental framework presets have been
+ * remotely graduated (opted in) without requiring a CLI upgrade.
+ *
+ * NOTE: not configured/deployed yet. Until it exists, the fetch is expected to
+ * fail; we fail open (treat as "no overrides") so detection is unaffected.
+ */
+const ENDPOINT = '/v1/frameworks/experimental-overrides';
+
+interface ExperimentalOverridesResponse {
+  // Mirrors the agreed API shape: `{ overrideExperimental: { container: true } }`.
+  overrideExperimental?: ExperimentalOverrides;
+}
+
+// Per-process cache. Detection can run several times in one command (e.g. once
+// per workspace package), so resolve the remote value at most once. We cache
+// the in-flight promise so concurrent callers share a single request.
+let cached: Promise<ExperimentalOverrides> | undefined;
+
+/**
+ * Resolve the set of experimental framework presets that should be treated as
+ * enabled, keyed by slug (e.g. `{ container: true }`).
+ *
+ * Fails open: any error (endpoint missing, network failure, unexpected shape)
+ * resolves to `{}`, so the only effect is that experimental presets stay gated
+ * behind `VERCEL_USE_EXPERIMENTAL_FRAMEWORKS` exactly as they are today.
+ */
+export function resolveExperimentalOverrides(
+  client: Client
+): Promise<ExperimentalOverrides> {
+  if (!cached) {
+    cached = fetchExperimentalOverrides(client);
+  }
+  return cached;
+}
+
+async function fetchExperimentalOverrides(
+  client: Client
+): Promise<ExperimentalOverrides> {
+  try {
+    const res = await client.fetch<ExperimentalOverridesResponse>(ENDPOINT, {
+      // Detection blocks the interactive deploy/link flow, so keep this snappy;
+      // a missing/slow endpoint must not stall project setup.
+      retry: { retries: 0 },
+    });
+    const overrides = res?.overrideExperimental;
+    if (overrides && typeof overrides === 'object') {
+      return overrides;
+    }
+    return {};
+  } catch (err) {
+    output.debug(
+      `Failed to resolve experimental framework overrides: ${
+        (err as Error).message
+      }`
+    );
+    return {};
+  }
+}
+
+/** Test-only: reset the per-process cache. */
+export function resetExperimentalOverridesCache(): void {
+  cached = undefined;
+}

--- a/packages/fs-detectors/src/detect-framework.ts
+++ b/packages/fs-detectors/src/detect-framework.ts
@@ -7,6 +7,18 @@ interface BaseFramework {
   detectors?: Framework['detectors'];
 }
 
+/**
+ * Per-framework opt-in for experimental presets, keyed by framework slug.
+ *
+ * Resolved remotely by the caller (e.g. the CLI fetches and caches this) and
+ * passed in, so this package stays free of any network/auth dependency. A
+ * value of `true` for a slug includes that experimental framework in detection
+ * even when `VERCEL_USE_EXPERIMENTAL_FRAMEWORKS` is not set.
+ *
+ * Mirrors the API shape `{ overrideExperimental: { container: true } }`.
+ */
+export type ExperimentalOverrides = Record<string, boolean>;
+
 export interface DetectFrameworkOptions {
   fs: DetectorFilesystem;
   frameworkList: readonly BaseFramework[];
@@ -16,6 +28,13 @@ export interface DetectFrameworkOptions {
    * Defaults to false if neither is set.
    */
   useExperimentalFrameworks?: boolean;
+  /**
+   * Per-slug opt-in for experimental frameworks. Only consulted when
+   * `useExperimentalFrameworks`/the env var has not already enabled all
+   * experimental frameworks. An experimental framework whose slug maps to
+   * `true` here is included in detection.
+   */
+  experimentalOverrides?: ExperimentalOverrides;
 }
 
 export interface DetectFrameworkRecordOptions {
@@ -27,6 +46,13 @@ export interface DetectFrameworkRecordOptions {
    * Defaults to false if neither is set.
    */
   useExperimentalFrameworks?: boolean;
+  /**
+   * Per-slug opt-in for experimental frameworks. Only consulted when
+   * `useExperimentalFrameworks`/the env var has not already enabled all
+   * experimental frameworks. An experimental framework whose slug maps to
+   * `true` here is included in detection.
+   */
+  experimentalOverrides?: ExperimentalOverrides;
 }
 
 type MatchResult = {
@@ -53,10 +79,20 @@ function shouldIncludeExperimentalFrameworks(
 
 /**
  * Filters out experimental frameworks unless explicitly opted in.
+ *
+ * Inclusion rules for an experimental framework, in order:
+ *   1. `useExperimentalFrameworks` / `VERCEL_USE_EXPERIMENTAL_FRAMEWORKS`
+ *      enables ALL experimental frameworks (today's behavior).
+ *   2. Otherwise, the framework is included only if its slug is explicitly
+ *      enabled via `experimentalOverrides` (e.g. the remotely-fetched
+ *      `{ overrideExperimental: { container: true } }`).
+ *
+ * Non-experimental frameworks are always included.
  */
 function filterFrameworkList<T extends BaseFramework>(
   frameworkList: readonly T[],
-  useExperimentalFrameworks?: boolean
+  useExperimentalFrameworks?: boolean,
+  experimentalOverrides?: ExperimentalOverrides
 ): readonly T[] {
   if (shouldIncludeExperimentalFrameworks(useExperimentalFrameworks)) {
     return frameworkList;
@@ -64,7 +100,12 @@ function filterFrameworkList<T extends BaseFramework>(
   return frameworkList.filter(f => {
     // Check if framework has experimental property and filter it out if true
     const experimental = (f as { experimental?: boolean }).experimental;
-    return !experimental;
+    if (!experimental) {
+      return true;
+    }
+    // Per-slug remote opt-in (e.g. graduating a preset without a CLI upgrade).
+    const slug = (f as { slug?: string | null }).slug;
+    return Boolean(slug && experimentalOverrides?.[slug] === true);
   });
 }
 
@@ -214,10 +255,12 @@ export async function detectFramework({
   fs,
   frameworkList,
   useExperimentalFrameworks,
+  experimentalOverrides,
 }: DetectFrameworkOptions): Promise<string | null> {
   const filteredList = filterFrameworkList(
     frameworkList,
-    useExperimentalFrameworks
+    useExperimentalFrameworks,
+    experimentalOverrides
   );
   const result = await Promise.all(
     filteredList.map(async frameworkMatch => {
@@ -238,10 +281,12 @@ export async function detectFrameworks({
   fs,
   frameworkList,
   useExperimentalFrameworks,
+  experimentalOverrides,
 }: DetectFrameworkRecordOptions): Promise<Framework[]> {
   const filteredList = filterFrameworkList(
     frameworkList,
-    useExperimentalFrameworks
+    useExperimentalFrameworks,
+    experimentalOverrides
   );
   const result = await Promise.all(
     filteredList.map(async frameworkMatch => {
@@ -268,10 +313,12 @@ export async function detectFrameworkRecord({
   fs,
   frameworkList,
   useExperimentalFrameworks,
+  experimentalOverrides,
 }: DetectFrameworkRecordOptions): Promise<VersionedFramework | null> {
   const filteredList = filterFrameworkList(
     frameworkList,
-    useExperimentalFrameworks
+    useExperimentalFrameworks,
+    experimentalOverrides
   );
   const result = await Promise.all(
     filteredList.map(async frameworkMatch => {

--- a/packages/fs-detectors/src/index.ts
+++ b/packages/fs-detectors/src/index.ts
@@ -61,6 +61,7 @@ export {
   detectFrameworkRecord,
   detectFrameworkVersion,
 } from './detect-framework';
+export type { ExperimentalOverrides } from './detect-framework';
 export { getProjectPaths } from './get-project-paths';
 export { DetectorFilesystem } from './detectors/filesystem';
 export { LocalFileSystemDetector } from './detectors/local-file-system-detector';

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -306,6 +306,90 @@ describe('detectFramework()', () => {
   });
 
   it.each([
+    'Dockerfile.vercel',
+    'Containerfile.vercel',
+  ])('Detect the experimental container framework via `%s` when enabled per-slug via experimentalOverrides', async marker => {
+    // The env flag / `useExperimentalFrameworks` is NOT set, but the preset is
+    // remotely graduated for its slug, so it should be detected and win over
+    // the co-present Next.js app.
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({
+        dependencies: {
+          next: '14.0.0',
+        },
+      }),
+      [marker]: 'FROM node:20\nCMD ["node", "server.js"]',
+    });
+
+    expect(
+      await detectFramework({
+        fs,
+        frameworkList,
+        experimentalOverrides: { container: true },
+      })
+    ).toBe('container');
+  });
+
+  it('Does not detect an experimental framework when experimentalOverrides maps its slug to false', async () => {
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({
+        dependencies: {
+          next: '14.0.0',
+        },
+      }),
+      'Dockerfile.vercel': 'FROM node:20\nCMD ["node", "server.js"]',
+    });
+
+    expect(
+      await detectFramework({
+        fs,
+        frameworkList,
+        experimentalOverrides: { container: false },
+      })
+    ).toBe('nextjs');
+  });
+
+  it('Does not detect an experimental framework when experimentalOverrides only enables a different slug', async () => {
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({
+        dependencies: {
+          next: '14.0.0',
+        },
+      }),
+      'Dockerfile.vercel': 'FROM node:20\nCMD ["node", "server.js"]',
+    });
+
+    expect(
+      await detectFramework({
+        fs,
+        frameworkList,
+        experimentalOverrides: { 'some-other-framework': true },
+      })
+    ).toBe('nextjs');
+  });
+
+  it('Prefers the env flag over experimentalOverrides (flag enables all experimental presets)', async () => {
+    const fs = new VirtualFilesystem({
+      'package.json': JSON.stringify({
+        dependencies: {
+          next: '14.0.0',
+        },
+      }),
+      'Dockerfile.vercel': 'FROM node:20\nCMD ["node", "server.js"]',
+    });
+
+    // Even though overrides disable container, the explicit flag enables all
+    // experimental presets, so container is still detected.
+    expect(
+      await detectFramework({
+        fs,
+        frameworkList,
+        useExperimentalFrameworks: true,
+        experimentalOverrides: { container: false },
+      })
+    ).toBe('container');
+  });
+  it.each([
     'server.cjs',
     'server.js',
     'server.mjs',


### PR DESCRIPTION
## Summary

Framework auto-detection currently filters out `experimental` presets unless `VERCEL_USE_EXPERIMENTAL_FRAMEWORKS` is set (all-or-nothing, env-gated, version-locked to the installed CLI). This means a preset like `container` (which detects `Dockerfile.vercel` / `Containerfile.vercel`) won't be auto-detected during `vc deploy` unless the user exports the env var — a co-present framework (e.g. Hono/Next.js) wins instead.

This PR adds a **per-slug remote opt-in** so an experimental preset can be graduated without requiring a CLI upgrade.

## How it works

Detection (`@vercel/fs-detectors`) gains an optional `experimentalOverrides` input (a `Record<slug, boolean>`, mirroring the agreed API shape `{ overrideExperimental: { container: true } }`). Inclusion rules for an experimental preset, in order:

1. `useExperimentalFrameworks` / `VERCEL_USE_EXPERIMENTAL_FRAMEWORKS` → include **all** experimental presets (unchanged, today's behavior).
2. Otherwise → include the preset **iff** its slug is `true` in `experimentalOverrides`.

Non-experimental presets are always included.

## Layering

The `fs-detectors` package stays pure/offline (no network, no auth) — it just consumes the map. The **CLI** resolves the map and passes it down:

- New `util/projects/experimental-frameworks.ts` fetches the overrides from a (not-yet-configured) endpoint, **caches** the in-flight result per-process, and **fails open** (any error → `{}`), so a missing/slow endpoint never stalls or breaks `vc deploy` setup.
- `detectProjects` accepts and forwards the map; the interactive deploy/link path (`setup-and-link.ts`) resolves and threads it through.

> Note: the API endpoint (`/v1/frameworks/experimental-overrides`) is **not configured/deployed yet**. Until it exists the fetch fails open, so behavior is identical to today. Wiring it up is a follow-up.

## Testing

- Added unit tests in `@vercel/fs-detectors` covering: per-slug enable, slug set to `false`, a different slug enabled, and env-flag precedence over overrides.
- `unit.framework-detector.test.ts` passes in full. (The one unrelated failure in `unit.local-file-system-detector.test.ts` is a sandbox socket-bind `EINVAL`, not related to this change.)

## Changeset

`@vercel/fs-detectors`: minor (new public option + exported type), `vercel`: patch.