### PR TITLE
[cli] Adopt v2 flag list endpoints with tag/creator/maintainer filters

### DIFF
--- a/.changeset/flags-ls-v2-filters.md
+++ b/.changeset/flags-ls-v2-filters.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-`vercel flags ls` now uses the v2 flag list endpoint and supports filtering by `--tag`, `--created-by`, and `--maintainer-id`.
+`vercel flags ls` now uses the v2 flag list endpoint and supports filtering by `--tag`, `--created-by`, and `--maintainer-id`, plus `--limit` to cap the number of flags returned.

--- a/.changeset/flags-ls-v2-filters.md
+++ b/.changeset/flags-ls-v2-filters.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`vercel flags ls` now uses the v2 flag list endpoint and supports filtering by `--tag`, `--created-by`, and `--maintainer-id`.

--- a/.changeset/flags-ls-v2-filters.md
+++ b/.changeset/flags-ls-v2-filters.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-`vercel flags ls` now uses the v2 flag list endpoint and supports filtering by `--tag`, `--created-by`, and `--maintainer-id`, plus `--limit` to cap the number of flags returned.
+`vercel flags ls` now uses the v2 flag list endpoint and supports filtering by `--tag`, `--created-by`, and `--maintainer-id`, plus cursor pagination via `--limit` (page size) and `--next` (resume cursor).

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -50,8 +50,17 @@ export const listSubcommand = {
       shorthand: null,
       type: Number,
       deprecated: false,
-      description: 'Maximum number of flags to return (defaults to all)',
+      description:
+        'Return a single page of at most NUMBER flags (1-100) instead of all',
       argument: 'NUMBER',
+    },
+    {
+      name: 'next',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Pagination cursor from a previous list response',
+      argument: 'CURSOR',
     },
     {
       name: 'json',
@@ -75,8 +84,12 @@ export const listSubcommand = {
       value: `${packageName} flags ls --tag checkout --created-by user_123 --maintainer-id user_456`,
     },
     {
-      name: 'List at most 10 flags',
+      name: 'List the first page of 10 flags',
       value: `${packageName} flags ls --limit 10`,
+    },
+    {
+      name: 'List the next page using the cursor from the previous page',
+      value: `${packageName} flags ls --limit 10 --next <cursor>`,
     },
     {
       name: 'List flags as JSON',

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -20,6 +20,32 @@ export const listSubcommand = {
       argument: 'STATE',
     },
     {
+      name: 'tag',
+      shorthand: null,
+      type: [String],
+      deprecated: false,
+      description: 'Filter flags by tag (repeatable; all must match)',
+      argument: 'TAG',
+    },
+    {
+      name: 'created-by',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description:
+        'Filter flags by the id of the user or team that created them',
+      argument: 'ID',
+    },
+    {
+      name: 'maintainer-id',
+      shorthand: null,
+      type: [String],
+      deprecated: false,
+      description:
+        'Filter flags by maintainer user id (repeatable; any may match)',
+      argument: 'ID',
+    },
+    {
       name: 'json',
       shorthand: null,
       type: Boolean,
@@ -35,6 +61,10 @@ export const listSubcommand = {
     {
       name: 'List archived flags',
       value: `${packageName} flags ls --state archived`,
+    },
+    {
+      name: 'Filter flags by tag, creator, and maintainer',
+      value: `${packageName} flags ls --tag checkout --created-by user_123 --maintainer-id user_456`,
     },
     {
       name: 'List flags as JSON',

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -46,6 +46,14 @@ export const listSubcommand = {
       argument: 'ID',
     },
     {
+      name: 'limit',
+      shorthand: null,
+      type: Number,
+      deprecated: false,
+      description: 'Maximum number of flags to return (defaults to all)',
+      argument: 'NUMBER',
+    },
+    {
       name: 'json',
       shorthand: null,
       type: Boolean,
@@ -65,6 +73,10 @@ export const listSubcommand = {
     {
       name: 'Filter flags by tag, creator, and maintainer',
       value: `${packageName} flags ls --tag checkout --created-by user_123 --maintainer-id user_456`,
+    },
+    {
+      name: 'List at most 10 flags',
+      value: `${packageName} flags ls --limit 10`,
     },
     {
       name: 'List flags as JSON',

--- a/packages/cli/src/commands/flags/ls.ts
+++ b/packages/cli/src/commands/flags/ls.ts
@@ -7,6 +7,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { getLinkedProject } from '../../util/projects/link';
 import { getCommandName } from '../../util/pkg-name';
+import getCommandFlags from '../../util/get-command-flags';
 import { getFlags, MAX_FLAGS_PAGE_LIMIT } from '../../util/flags/get-flags';
 import formatTable from '../../util/format-table';
 import stamp from '../../util/output/stamp';
@@ -112,7 +113,9 @@ export default async function ls(
       printFlagsTable(sortedFlags);
       if (nextCursor) {
         const nextCmd = buildNextPageCommand(
-          { state, tags, createdBy, maintainerIds, limit },
+          flags,
+          tags,
+          maintainerIds,
           nextCursor
         );
         output.log(`To display the next page, run ${getCommandName(nextCmd)}`);
@@ -128,34 +131,27 @@ export default async function ls(
 }
 
 function buildNextPageCommand(
-  options: {
-    state: 'active' | 'archived';
-    tags?: string[];
-    createdBy?: string;
-    maintainerIds?: string[];
-    limit?: number;
-  },
+  flags: { [key: string]: unknown },
+  tags: string[] | undefined,
+  maintainerIds: string[] | undefined,
   nextCursor: string
 ): string {
-  const { state, tags, createdBy, maintainerIds, limit } = options;
-  const parts = ['flags ls'];
-  if (state !== 'active') {
-    parts.push(`--state ${state}`);
-  }
-  for (const tag of tags ?? []) {
-    parts.push(`--tag ${tag}`);
-  }
-  if (createdBy) {
-    parts.push(`--created-by ${createdBy}`);
-  }
-  for (const maintainerId of maintainerIds ?? []) {
-    parts.push(`--maintainer-id ${maintainerId}`);
-  }
-  if (limit !== undefined) {
-    parts.push(`--limit ${limit}`);
-  }
-  parts.push(`--next ${nextCursor}`);
-  return parts.join(' ');
+  // Forward all passed flags (including globals like --scope/--cwd) except the
+  // cursor and repeatable filters. getCommandFlags joins arrays with commas, so
+  // re-append --tag/--maintainer-id explicitly to preserve one value per flag.
+  const baseFlags = getCommandFlags(flags, [
+    '_',
+    '--tag',
+    '--maintainer-id',
+    '--next',
+    '--json',
+  ]);
+  const repeatable = [
+    ...(tags ?? []).map(tag => `--tag ${tag}`),
+    ...(maintainerIds ?? []).map(id => `--maintainer-id ${id}`),
+  ];
+  const suffix = repeatable.length > 0 ? ` ${repeatable.join(' ')}` : '';
+  return `flags ls${baseFlags}${suffix} --next ${nextCursor}`;
 }
 
 function outputJson(client: Client, flags: Flag[], next: string | null) {

--- a/packages/cli/src/commands/flags/ls.ts
+++ b/packages/cli/src/commands/flags/ls.ts
@@ -40,12 +40,19 @@ export default async function ls(
   const tags = flags['--tag'] as string[] | undefined;
   const createdBy = flags['--created-by'] as string | undefined;
   const maintainerIds = flags['--maintainer-id'] as string[] | undefined;
+  const limit = flags['--limit'] as number | undefined;
   const json = flags['--json'] as boolean | undefined;
+
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+    output.error('The --limit option must be a positive integer.');
+    return 1;
+  }
 
   telemetryClient.trackCliOptionState(state);
   telemetryClient.trackCliOptionTag(tags);
   telemetryClient.trackCliOptionCreatedBy(createdBy);
   telemetryClient.trackCliOptionMaintainerId(maintainerIds);
+  telemetryClient.trackCliOptionLimit(limit);
   telemetryClient.trackCliFlagJson(json);
 
   const link = await getLinkedProject(client);
@@ -73,6 +80,7 @@ export default async function ls(
       tags,
       createdBy,
       maintainerIds,
+      limit,
     });
     output.stopSpinner();
 

--- a/packages/cli/src/commands/flags/ls.ts
+++ b/packages/cli/src/commands/flags/ls.ts
@@ -45,6 +45,14 @@ export default async function ls(
   const next = flags['--next'] as string | undefined;
   const json = flags['--json'] as boolean | undefined;
 
+  telemetryClient.trackCliOptionState(state);
+  telemetryClient.trackCliOptionTag(tags);
+  telemetryClient.trackCliOptionCreatedBy(createdBy);
+  telemetryClient.trackCliOptionMaintainerId(maintainerIds);
+  telemetryClient.trackCliOptionLimit(limit);
+  telemetryClient.trackCliOptionNext(next);
+  telemetryClient.trackCliFlagJson(json);
+
   if (
     limit !== undefined &&
     (!Number.isInteger(limit) || limit < 1 || limit > MAX_FLAGS_PAGE_LIMIT)
@@ -54,14 +62,6 @@ export default async function ls(
     );
     return 1;
   }
-
-  telemetryClient.trackCliOptionState(state);
-  telemetryClient.trackCliOptionTag(tags);
-  telemetryClient.trackCliOptionCreatedBy(createdBy);
-  telemetryClient.trackCliOptionMaintainerId(maintainerIds);
-  telemetryClient.trackCliOptionLimit(limit);
-  telemetryClient.trackCliOptionNext(next);
-  telemetryClient.trackCliFlagJson(json);
 
   const link = await getLinkedProject(client);
   if (link.status === 'error') {
@@ -97,11 +97,8 @@ export default async function ls(
     );
     output.stopSpinner();
 
-    // Sort by updatedAt descending (most recently updated first)
-    const sortedFlags = flagsList.sort((a, b) => b.updatedAt - a.updatedAt);
-
     if (json) {
-      outputJson(client, sortedFlags, nextCursor);
+      outputJson(client, flagsList, nextCursor);
     } else if (flagsList.length === 0) {
       output.log(
         `No ${state} feature flags found for ${projectSlugLink} ${chalk.gray(lsStamp())}`
@@ -110,7 +107,7 @@ export default async function ls(
       output.log(
         `${plural('feature flag', flagsList.length, true)} found for ${projectSlugLink} ${chalk.gray(lsStamp())}`
       );
-      printFlagsTable(sortedFlags);
+      printFlagsTable(flagsList);
       if (nextCursor) {
         const nextCmd = buildNextPageCommand(
           flags,
@@ -147,11 +144,22 @@ function buildNextPageCommand(
     '--json',
   ]);
   const repeatable = [
-    ...(tags ?? []).map(tag => `--tag ${tag}`),
-    ...(maintainerIds ?? []).map(id => `--maintainer-id ${id}`),
+    ...(tags ?? []).map(tag => `--tag ${quoteArg(tag)}`),
+    ...(maintainerIds ?? []).map(id => `--maintainer-id ${quoteArg(id)}`),
   ];
   const suffix = repeatable.length > 0 ? ` ${repeatable.join(' ')}` : '';
   return `flags ls${baseFlags}${suffix} --next ${nextCursor}`;
+}
+
+// Wrap a value in single quotes only when it contains characters the shell
+// would otherwise interpret, so the printed next-page command stays
+// copy-pasteable for tags that include spaces or special characters. The
+// cursor is base64url and therefore always shell-safe.
+function quoteArg(value: string): string {
+  if (/^[A-Za-z0-9_./@:-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function outputJson(client: Client, flags: Flag[], next: string | null) {

--- a/packages/cli/src/commands/flags/ls.ts
+++ b/packages/cli/src/commands/flags/ls.ts
@@ -7,7 +7,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { getLinkedProject } from '../../util/projects/link';
 import { getCommandName } from '../../util/pkg-name';
-import { getFlags } from '../../util/flags/get-flags';
+import { getFlags, MAX_FLAGS_PAGE_LIMIT } from '../../util/flags/get-flags';
 import formatTable from '../../util/format-table';
 import stamp from '../../util/output/stamp';
 import output from '../../output-manager';
@@ -41,10 +41,16 @@ export default async function ls(
   const createdBy = flags['--created-by'] as string | undefined;
   const maintainerIds = flags['--maintainer-id'] as string[] | undefined;
   const limit = flags['--limit'] as number | undefined;
+  const next = flags['--next'] as string | undefined;
   const json = flags['--json'] as boolean | undefined;
 
-  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
-    output.error('The --limit option must be a positive integer.');
+  if (
+    limit !== undefined &&
+    (!Number.isInteger(limit) || limit < 1 || limit > MAX_FLAGS_PAGE_LIMIT)
+  ) {
+    output.error(
+      `The --limit option must be an integer between 1 and ${MAX_FLAGS_PAGE_LIMIT}.`
+    );
     return 1;
   }
 
@@ -53,6 +59,7 @@ export default async function ls(
   telemetryClient.trackCliOptionCreatedBy(createdBy);
   telemetryClient.trackCliOptionMaintainerId(maintainerIds);
   telemetryClient.trackCliOptionLimit(limit);
+  telemetryClient.trackCliOptionNext(next);
   telemetryClient.trackCliFlagJson(json);
 
   const link = await getLinkedProject(client);
@@ -75,20 +82,25 @@ export default async function ls(
   output.spinner(`Fetching ${state} feature flags for ${projectSlugLink}`);
 
   try {
-    const flagsList = await getFlags(client, project.id, {
-      state,
-      tags,
-      createdBy,
-      maintainerIds,
-      limit,
-    });
+    const { flags: flagsList, next: nextCursor } = await getFlags(
+      client,
+      project.id,
+      {
+        state,
+        tags,
+        createdBy,
+        maintainerIds,
+        limit,
+        cursor: next,
+      }
+    );
     output.stopSpinner();
 
     // Sort by updatedAt descending (most recently updated first)
     const sortedFlags = flagsList.sort((a, b) => b.updatedAt - a.updatedAt);
 
     if (json) {
-      outputJson(client, sortedFlags);
+      outputJson(client, sortedFlags, nextCursor);
     } else if (flagsList.length === 0) {
       output.log(
         `No ${state} feature flags found for ${projectSlugLink} ${chalk.gray(lsStamp())}`
@@ -98,6 +110,13 @@ export default async function ls(
         `${plural('feature flag', flagsList.length, true)} found for ${projectSlugLink} ${chalk.gray(lsStamp())}`
       );
       printFlagsTable(sortedFlags);
+      if (nextCursor) {
+        const nextCmd = buildNextPageCommand(
+          { state, tags, createdBy, maintainerIds, limit },
+          nextCursor
+        );
+        output.log(`To display the next page, run ${getCommandName(nextCmd)}`);
+      }
     }
   } catch (err) {
     output.stopSpinner();
@@ -108,7 +127,38 @@ export default async function ls(
   return 0;
 }
 
-function outputJson(client: Client, flags: Flag[]) {
+function buildNextPageCommand(
+  options: {
+    state: 'active' | 'archived';
+    tags?: string[];
+    createdBy?: string;
+    maintainerIds?: string[];
+    limit?: number;
+  },
+  nextCursor: string
+): string {
+  const { state, tags, createdBy, maintainerIds, limit } = options;
+  const parts = ['flags ls'];
+  if (state !== 'active') {
+    parts.push(`--state ${state}`);
+  }
+  for (const tag of tags ?? []) {
+    parts.push(`--tag ${tag}`);
+  }
+  if (createdBy) {
+    parts.push(`--created-by ${createdBy}`);
+  }
+  for (const maintainerId of maintainerIds ?? []) {
+    parts.push(`--maintainer-id ${maintainerId}`);
+  }
+  if (limit !== undefined) {
+    parts.push(`--limit ${limit}`);
+  }
+  parts.push(`--next ${nextCursor}`);
+  return parts.join(' ');
+}
+
+function outputJson(client: Client, flags: Flag[], next: string | null) {
   const jsonOutput = {
     flags: flags.map(flag => ({
       id: flag.id,
@@ -120,6 +170,7 @@ function outputJson(client: Client, flags: Flag[]) {
       createdAt: flag.createdAt,
       updatedAt: flag.updatedAt,
     })),
+    pagination: { next },
   };
   client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
 }

--- a/packages/cli/src/commands/flags/ls.ts
+++ b/packages/cli/src/commands/flags/ls.ts
@@ -37,9 +37,15 @@ export default async function ls(
 
   const { flags } = parsedArgs;
   const state = (flags['--state'] as 'active' | 'archived') || 'active';
+  const tags = flags['--tag'] as string[] | undefined;
+  const createdBy = flags['--created-by'] as string | undefined;
+  const maintainerIds = flags['--maintainer-id'] as string[] | undefined;
   const json = flags['--json'] as boolean | undefined;
 
   telemetryClient.trackCliOptionState(state);
+  telemetryClient.trackCliOptionTag(tags);
+  telemetryClient.trackCliOptionCreatedBy(createdBy);
+  telemetryClient.trackCliOptionMaintainerId(maintainerIds);
   telemetryClient.trackCliFlagJson(json);
 
   const link = await getLinkedProject(client);
@@ -62,7 +68,12 @@ export default async function ls(
   output.spinner(`Fetching ${state} feature flags for ${projectSlugLink}`);
 
   try {
-    const flagsList = await getFlags(client, project.id, state);
+    const flagsList = await getFlags(client, project.id, {
+      state,
+      tags,
+      createdBy,
+      maintainerIds,
+    });
     output.stopSpinner();
 
     // Sort by updatedAt descending (most recently updated first)

--- a/packages/cli/src/util/flags/get-flags.ts
+++ b/packages/cli/src/util/flags/get-flags.ts
@@ -8,41 +8,47 @@ export interface GetFlagsOptions {
   createdBy?: string;
   maintainerIds?: string[];
   /**
-   * Maximum number of flags to return. When omitted, all flags are fetched by
-   * following pagination cursors.
+   * Page size. When set (or when `cursor` is provided), a single page is
+   * returned and `next` exposes the cursor to resume from. When omitted, all
+   * flags are fetched by following pagination cursors.
    */
   limit?: number;
+  /** Resume from a `next` cursor returned by a previous call. */
+  cursor?: string;
 }
 
-// The v2 endpoint paginates with a small default page size, so request the
-// maximum allowed per page to minimize round-trips.
-const MAX_PAGE_LIMIT = 100;
+export interface GetFlagsResult {
+  flags: Flag[];
+  next: string | null;
+}
+
+// The v2 endpoint caps the page size at 100, so request that much when
+// fetching the full list to minimize round-trips.
+export const MAX_FLAGS_PAGE_LIMIT = 100;
 
 export async function getFlags(
   client: Client,
   projectId: string,
   options: GetFlagsOptions = {}
-): Promise<Flag[]> {
-  const { state = 'active', tags, createdBy, maintainerIds, limit } = options;
+): Promise<GetFlagsResult> {
+  const {
+    state = 'active',
+    tags,
+    createdBy,
+    maintainerIds,
+    limit,
+    cursor,
+  } = options;
   output.debug(`Fetching feature flags for project ${projectId}`);
 
   const basePath = `/v2/projects/${encodeURIComponent(projectId)}/feature-flags/flags`;
-  const flags: Flag[] = [];
-  let cursor: string | undefined;
 
-  // Follow `pagination.next` cursors to gather the requested flags. Without a
-  // limit this lists everything; with a limit we stop once we have enough.
-  do {
-    const pageLimit =
-      limit === undefined
-        ? MAX_PAGE_LIMIT
-        : Math.min(MAX_PAGE_LIMIT, limit - flags.length);
-
+  const buildQuery = (pageLimit: number, pageCursor?: string) => {
     const query = new URLSearchParams();
     query.set('state', state);
     query.set('limit', String(pageLimit));
-    if (cursor) {
-      query.set('cursor', cursor);
+    if (pageCursor) {
+      query.set('cursor', pageCursor);
     }
     if (createdBy) {
       query.set('createdBy', createdBy);
@@ -53,19 +59,33 @@ export async function getFlags(
     for (const maintainerId of maintainerIds ?? []) {
       query.append('maintainerIds', maintainerId);
     }
+    return query.toString();
+  };
 
+  // Paging mode: return a single page and surface the cursor to resume from.
+  if (limit !== undefined || cursor !== undefined) {
+    const pageLimit = Math.min(
+      limit ?? MAX_FLAGS_PAGE_LIMIT,
+      MAX_FLAGS_PAGE_LIMIT
+    );
     const response = await client.fetch<FlagsListResponse>(
-      `${basePath}?${query.toString()}`
+      `${basePath}?${buildQuery(pageLimit, cursor)}`
+    );
+    return { flags: response.data, next: response.pagination?.next ?? null };
+  }
+
+  // Otherwise follow `pagination.next` cursors to gather the full list.
+  const flags: Flag[] = [];
+  let pageCursor: string | undefined;
+  do {
+    const response = await client.fetch<FlagsListResponse>(
+      `${basePath}?${buildQuery(MAX_FLAGS_PAGE_LIMIT, pageCursor)}`
     );
     flags.push(...response.data);
-    cursor = response.pagination?.next ?? undefined;
+    pageCursor = response.pagination?.next ?? undefined;
+  } while (pageCursor);
 
-    if (limit !== undefined && flags.length >= limit) {
-      break;
-    }
-  } while (cursor);
-
-  return limit === undefined ? flags : flags.slice(0, limit);
+  return { flags, next: null };
 }
 
 export async function getFlag(

--- a/packages/cli/src/util/flags/get-flags.ts
+++ b/packages/cli/src/util/flags/get-flags.ts
@@ -13,7 +13,11 @@ export interface GetFlagsOptions {
    * flags are fetched by following pagination cursors.
    */
   limit?: number;
-  /** Resume from a `next` cursor returned by a previous call. */
+  /**
+   * Resume from a `next` cursor returned by a previous call. Unlike the repo's
+   * usual timestamp-based `--next`, the v2 endpoint is cursor-based, so we
+   * follow `pagination.next` cursors here instead of using `fetchPaginated`.
+   */
   cursor?: string;
 }
 

--- a/packages/cli/src/util/flags/get-flags.ts
+++ b/packages/cli/src/util/flags/get-flags.ts
@@ -9,6 +9,11 @@ export interface GetFlagsOptions {
   maintainerIds?: string[];
 }
 
+// The v2 endpoint paginates with a small default page size, so request the
+// maximum allowed per page to minimize round-trips while still listing all
+// flags.
+const MAX_PAGE_LIMIT = 100;
+
 export async function getFlags(
   client: Client,
   projectId: string,
@@ -21,11 +26,12 @@ export async function getFlags(
   const flags: Flag[] = [];
   let cursor: string | undefined;
 
-  // The v2 endpoint paginates (default 25 per page), so follow cursors to
-  // gather the full list and preserve the previous "list everything" behavior.
+  // Follow `pagination.next` cursors to gather the full list and preserve the
+  // previous "list everything" behavior.
   do {
     const query = new URLSearchParams();
     query.set('state', state);
+    query.set('limit', String(MAX_PAGE_LIMIT));
     if (cursor) {
       query.set('cursor', cursor);
     }

--- a/packages/cli/src/util/flags/get-flags.ts
+++ b/packages/cli/src/util/flags/get-flags.ts
@@ -7,11 +7,15 @@ export interface GetFlagsOptions {
   tags?: string[];
   createdBy?: string;
   maintainerIds?: string[];
+  /**
+   * Maximum number of flags to return. When omitted, all flags are fetched by
+   * following pagination cursors.
+   */
+  limit?: number;
 }
 
 // The v2 endpoint paginates with a small default page size, so request the
-// maximum allowed per page to minimize round-trips while still listing all
-// flags.
+// maximum allowed per page to minimize round-trips.
 const MAX_PAGE_LIMIT = 100;
 
 export async function getFlags(
@@ -19,19 +23,24 @@ export async function getFlags(
   projectId: string,
   options: GetFlagsOptions = {}
 ): Promise<Flag[]> {
-  const { state = 'active', tags, createdBy, maintainerIds } = options;
+  const { state = 'active', tags, createdBy, maintainerIds, limit } = options;
   output.debug(`Fetching feature flags for project ${projectId}`);
 
   const basePath = `/v2/projects/${encodeURIComponent(projectId)}/feature-flags/flags`;
   const flags: Flag[] = [];
   let cursor: string | undefined;
 
-  // Follow `pagination.next` cursors to gather the full list and preserve the
-  // previous "list everything" behavior.
+  // Follow `pagination.next` cursors to gather the requested flags. Without a
+  // limit this lists everything; with a limit we stop once we have enough.
   do {
+    const pageLimit =
+      limit === undefined
+        ? MAX_PAGE_LIMIT
+        : Math.min(MAX_PAGE_LIMIT, limit - flags.length);
+
     const query = new URLSearchParams();
     query.set('state', state);
-    query.set('limit', String(MAX_PAGE_LIMIT));
+    query.set('limit', String(pageLimit));
     if (cursor) {
       query.set('cursor', cursor);
     }
@@ -50,9 +59,13 @@ export async function getFlags(
     );
     flags.push(...response.data);
     cursor = response.pagination?.next ?? undefined;
+
+    if (limit !== undefined && flags.length >= limit) {
+      break;
+    }
   } while (cursor);
 
-  return flags;
+  return limit === undefined ? flags : flags.slice(0, limit);
 }
 
 export async function getFlag(

--- a/packages/cli/src/util/flags/get-flags.ts
+++ b/packages/cli/src/util/flags/get-flags.ts
@@ -2,17 +2,51 @@ import type Client from '../client';
 import type { Flag, FlagsListResponse, FlagSettings } from './types';
 import output from '../../output-manager';
 
+export interface GetFlagsOptions {
+  state?: 'active' | 'archived';
+  tags?: string[];
+  createdBy?: string;
+  maintainerIds?: string[];
+}
+
 export async function getFlags(
   client: Client,
   projectId: string,
-  state: 'active' | 'archived' = 'active'
+  options: GetFlagsOptions = {}
 ): Promise<Flag[]> {
+  const { state = 'active', tags, createdBy, maintainerIds } = options;
   output.debug(`Fetching feature flags for project ${projectId}`);
 
-  const url = `/v1/projects/${encodeURIComponent(projectId)}/feature-flags/flags?state=${state}`;
-  const response = await client.fetch<FlagsListResponse>(url);
+  const basePath = `/v2/projects/${encodeURIComponent(projectId)}/feature-flags/flags`;
+  const flags: Flag[] = [];
+  let cursor: string | undefined;
 
-  return response.data;
+  // The v2 endpoint paginates (default 25 per page), so follow cursors to
+  // gather the full list and preserve the previous "list everything" behavior.
+  do {
+    const query = new URLSearchParams();
+    query.set('state', state);
+    if (cursor) {
+      query.set('cursor', cursor);
+    }
+    if (createdBy) {
+      query.set('createdBy', createdBy);
+    }
+    for (const tag of tags ?? []) {
+      query.append('tags', tag);
+    }
+    for (const maintainerId of maintainerIds ?? []) {
+      query.append('maintainerIds', maintainerId);
+    }
+
+    const response = await client.fetch<FlagsListResponse>(
+      `${basePath}?${query.toString()}`
+    );
+    flags.push(...response.data);
+    cursor = response.pagination?.next ?? undefined;
+  } while (cursor);
+
+  return flags;
 }
 
 export async function getFlag(

--- a/packages/cli/src/util/flags/types.ts
+++ b/packages/cli/src/util/flags/types.ts
@@ -94,6 +94,8 @@ export interface Flag {
   revision: number;
   seed: number;
   typeName: 'flag';
+  tags?: string[];
+  maintainerIds?: string[];
   metadata?: {
     creator?: {
       id: string;
@@ -104,6 +106,9 @@ export interface Flag {
 
 export interface FlagsListResponse {
   data: Flag[];
+  pagination?: {
+    next: string | null;
+  };
 }
 
 export interface FlagVersion {

--- a/packages/cli/src/util/telemetry/commands/flags/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/ls.ts
@@ -15,4 +15,31 @@ export class FlagsLsTelemetryClient extends TelemetryClient {
       this.trackCliFlag('json');
     }
   }
+
+  trackCliOptionTag(tags: string[] | undefined) {
+    if (tags && tags.length > 0) {
+      this.trackCliOption({
+        option: 'tag',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionCreatedBy(createdBy: string | undefined) {
+    if (createdBy) {
+      this.trackCliOption({
+        option: 'created-by',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionMaintainerId(maintainerIds: string[] | undefined) {
+    if (maintainerIds && maintainerIds.length > 0) {
+      this.trackCliOption({
+        option: 'maintainer-id',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/flags/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/ls.ts
@@ -42,4 +42,13 @@ export class FlagsLsTelemetryClient extends TelemetryClient {
       });
     }
   }
+
+  trackCliOptionLimit(limit: number | undefined) {
+    if (limit !== undefined) {
+      this.trackCliOption({
+        option: 'limit',
+        value: String(limit),
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/flags/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/ls.ts
@@ -51,4 +51,13 @@ export class FlagsLsTelemetryClient extends TelemetryClient {
       });
     }
   }
+
+  trackCliOptionNext(next: string | undefined) {
+    if (next) {
+      this.trackCliOption({
+        option: 'next',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/test/mocks/flags.ts
+++ b/packages/cli/test/mocks/flags.ts
@@ -240,13 +240,38 @@ export function useFlags(
     }
   );
 
-  // List flags
+  // List flags (v2: paginated, supports tag/createdBy/maintainerId filters)
   client.scenario.get(
-    '/v1/projects/:projectId/feature-flags/flags',
+    '/v2/projects/:projectId/feature-flags/flags',
     (req, res) => {
       const state = req.query.state || 'active';
-      const filteredFlags = flagsList.filter(f => f.state === state);
-      res.json({ data: filteredFlags });
+      const createdBy = req.query.createdBy as string | undefined;
+      const tags = toArray(req.query.tags);
+      const maintainerIds = toArray(req.query.maintainerIds);
+
+      let filteredFlags = flagsList.filter(f => f.state === state);
+      if (createdBy) {
+        filteredFlags = filteredFlags.filter(f => f.createdBy === createdBy);
+      }
+      if (tags.length > 0) {
+        filteredFlags = filteredFlags.filter(f =>
+          tags.every(tag => (f.tags ?? []).includes(tag))
+        );
+      }
+      if (maintainerIds.length > 0) {
+        filteredFlags = filteredFlags.filter(f =>
+          maintainerIds.some(id => (f.maintainerIds ?? []).includes(id))
+        );
+      }
+
+      const limit = 25;
+      const offset = req.query.cursor ? Number(req.query.cursor) : 0;
+      const page = filteredFlags.slice(offset, offset + limit);
+      const nextOffset = offset + limit;
+      const next =
+        nextOffset < filteredFlags.length ? String(nextOffset) : null;
+
+      res.json({ data: page, pagination: { next } });
     }
   );
 
@@ -552,6 +577,16 @@ export function useFlags(
   );
 
   return { flags: flagsList, sdkKeys: sdkKeysList, segments: segmentsList };
+}
+
+function toArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+  if (typeof value === 'string') {
+    return [value];
+  }
+  return [];
 }
 
 function applySegmentOperationsForMock(

--- a/packages/cli/test/mocks/flags.ts
+++ b/packages/cli/test/mocks/flags.ts
@@ -264,7 +264,10 @@ export function useFlags(
         );
       }
 
-      const limit = req.query.limit ? Number(req.query.limit) : 25;
+      // The CLI always sends `limit`; fall back to a single full page otherwise.
+      const limit = req.query.limit
+        ? Number(req.query.limit)
+        : filteredFlags.length;
       const offset = req.query.cursor ? Number(req.query.cursor) : 0;
       const page = filteredFlags.slice(offset, offset + limit);
       const nextOffset = offset + limit;

--- a/packages/cli/test/mocks/flags.ts
+++ b/packages/cli/test/mocks/flags.ts
@@ -264,7 +264,7 @@ export function useFlags(
         );
       }
 
-      const limit = 25;
+      const limit = req.query.limit ? Number(req.query.limit) : 25;
       const offset = req.query.cursor ? Number(req.query.cursor) : 0;
       const page = filteredFlags.slice(offset, offset + limit);
       const nextOffset = offset + limit;

--- a/packages/cli/test/unit/commands/flags/ls.test.ts
+++ b/packages/cli/test/unit/commands/flags/ls.test.ts
@@ -130,8 +130,8 @@ describe('flags ls', () => {
     });
 
     it('follows pagination cursors to list all flags', async () => {
-      // Exceed the mock page size of 25 to force multiple pages.
-      for (let i = 0; i < 30; i++) {
+      // Exceed the max page size (100) to force multiple pages.
+      for (let i = 0; i < 120; i++) {
         flagsList.push({
           ...JSON.parse(JSON.stringify(flagsList[0])),
           id: `flag_page_${i}`,

--- a/packages/cli/test/unit/commands/flags/ls.test.ts
+++ b/packages/cli/test/unit/commands/flags/ls.test.ts
@@ -183,6 +183,24 @@ describe('flags ls', () => {
       );
     });
 
+    it('quotes filter values that contain shell metacharacters in the next-page command', async () => {
+      for (let i = 0; i < 3; i++) {
+        flagsList.push({
+          ...JSON.parse(JSON.stringify(flagsList[0])),
+          id: `flag_tagged_${i}`,
+          slug: `tagged-flag-${i}`,
+          tags: ['needs review'],
+        });
+      }
+
+      client.setArgv('flags', 'ls', '--tag', 'needs review', '--limit', '1');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput(
+        "flags ls --limit 1 --tag 'needs review' --next 1"
+      );
+    });
+
     it('rejects a --limit below 1', async () => {
       client.setArgv('flags', 'ls', '--limit', '0');
       const exitCode = await flags(client);

--- a/packages/cli/test/unit/commands/flags/ls.test.ts
+++ b/packages/cli/test/unit/commands/flags/ls.test.ts
@@ -81,6 +81,73 @@ describe('flags ls', () => {
     });
   });
 
+  describe('filters', () => {
+    it('tracks tag, created-by, and maintainer-id options', async () => {
+      client.setArgv(
+        'flags',
+        'ls',
+        '--tag',
+        'checkout',
+        '--created-by',
+        'user_123',
+        '--maintainer-id',
+        'user_456'
+      );
+      await flags(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:ls', value: 'ls' },
+        { key: 'option:state', value: 'active' },
+        { key: 'option:tag', value: '[REDACTED]' },
+        { key: 'option:created-by', value: '[REDACTED]' },
+        { key: 'option:maintainer-id', value: '[REDACTED]' },
+      ]);
+    });
+
+    it('filters flags by tag via the v2 endpoint', async () => {
+      flagsList[0].tags = ['checkout'];
+      flagsList[1].tags = ['growth'];
+
+      client.setArgv('flags', 'ls', '--tag', 'checkout', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.flags).toHaveLength(1);
+      expect(parsed.flags[0].slug).toEqual('my-feature');
+    });
+
+    it('filters flags by maintainer id (any may match)', async () => {
+      flagsList[0].maintainerIds = ['user_a'];
+      flagsList[1].maintainerIds = ['user_b'];
+
+      client.setArgv('flags', 'ls', '--maintainer-id', 'user_b', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.flags).toHaveLength(1);
+      expect(parsed.flags[0].slug).toEqual('another-feature');
+    });
+
+    it('follows pagination cursors to list all flags', async () => {
+      // Exceed the mock page size of 25 to force multiple pages.
+      for (let i = 0; i < 30; i++) {
+        flagsList.push({
+          ...JSON.parse(JSON.stringify(flagsList[0])),
+          id: `flag_page_${i}`,
+          slug: `paged-flag-${i}`,
+        });
+      }
+
+      client.setArgv('flags', 'ls', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.flags).toHaveLength(flagsList.length);
+    });
+  });
+
   describe('--json', () => {
     it('outputs valid JSON with flag data', async () => {
       client.setArgv('flags', 'ls', '--json');

--- a/packages/cli/test/unit/commands/flags/ls.test.ts
+++ b/packages/cli/test/unit/commands/flags/ls.test.ts
@@ -165,6 +165,24 @@ describe('flags ls', () => {
       expect(parsed.pagination.next).toEqual('20');
     });
 
+    it('prints a next-page command preserving filters in table output', async () => {
+      for (let i = 0; i < 3; i++) {
+        flagsList.push({
+          ...JSON.parse(JSON.stringify(flagsList[0])),
+          id: `flag_tagged_${i}`,
+          slug: `tagged-flag-${i}`,
+          tags: ['checkout'],
+        });
+      }
+
+      client.setArgv('flags', 'ls', '--tag', 'checkout', '--limit', '1');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput(
+        'flags ls --limit 1 --tag checkout --next 1'
+      );
+    });
+
     it('rejects a --limit below 1', async () => {
       client.setArgv('flags', 'ls', '--limit', '0');
       const exitCode = await flags(client);

--- a/packages/cli/test/unit/commands/flags/ls.test.ts
+++ b/packages/cli/test/unit/commands/flags/ls.test.ts
@@ -129,8 +129,8 @@ describe('flags ls', () => {
       expect(parsed.flags[0].slug).toEqual('another-feature');
     });
 
-    it('limits the number of flags returned', async () => {
-      for (let i = 0; i < 120; i++) {
+    it('returns a single page with a cursor when --limit is set', async () => {
+      for (let i = 0; i < 30; i++) {
         flagsList.push({
           ...JSON.parse(JSON.stringify(flagsList[0])),
           id: `flag_page_${i}`,
@@ -144,14 +144,42 @@ describe('flags ls', () => {
 
       const parsed = JSON.parse(client.stdout.getFullOutput());
       expect(parsed.flags).toHaveLength(10);
+      expect(parsed.pagination.next).toEqual('10');
     });
 
-    it('rejects a non-positive --limit', async () => {
+    it('resumes from a --next cursor', async () => {
+      for (let i = 0; i < 30; i++) {
+        flagsList.push({
+          ...JSON.parse(JSON.stringify(flagsList[0])),
+          id: `flag_page_${i}`,
+          slug: `paged-flag-${i}`,
+        });
+      }
+
+      client.setArgv('flags', 'ls', '--limit', '10', '--next', '10', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.flags).toHaveLength(10);
+      expect(parsed.pagination.next).toEqual('20');
+    });
+
+    it('rejects a --limit below 1', async () => {
       client.setArgv('flags', 'ls', '--limit', '0');
       const exitCode = await flags(client);
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput(
-        'The --limit option must be a positive integer.'
+        'The --limit option must be an integer between 1 and 100.'
+      );
+    });
+
+    it('rejects a --limit above 100', async () => {
+      client.setArgv('flags', 'ls', '--limit', '101');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'The --limit option must be an integer between 1 and 100.'
       );
     });
 

--- a/packages/cli/test/unit/commands/flags/ls.test.ts
+++ b/packages/cli/test/unit/commands/flags/ls.test.ts
@@ -129,6 +129,32 @@ describe('flags ls', () => {
       expect(parsed.flags[0].slug).toEqual('another-feature');
     });
 
+    it('limits the number of flags returned', async () => {
+      for (let i = 0; i < 120; i++) {
+        flagsList.push({
+          ...JSON.parse(JSON.stringify(flagsList[0])),
+          id: `flag_page_${i}`,
+          slug: `paged-flag-${i}`,
+        });
+      }
+
+      client.setArgv('flags', 'ls', '--limit', '10', '--json');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(0);
+
+      const parsed = JSON.parse(client.stdout.getFullOutput());
+      expect(parsed.flags).toHaveLength(10);
+    });
+
+    it('rejects a non-positive --limit', async () => {
+      client.setArgv('flags', 'ls', '--limit', '0');
+      const exitCode = await flags(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'The --limit option must be a positive integer.'
+      );
+    });
+
     it('follows pagination cursors to list all flags', async () => {
       // Exceed the max page size (100) to force multiple pages.
       for (let i = 0; i < 120; i++) {

--- a/skills/vercel-cli/references/flags.md
+++ b/skills/vercel-cli/references/flags.md
@@ -27,6 +27,21 @@ vercel flags list --json                                  # output as JSON
 vercel flags inspect my-feature                           # show flag details
 ```
 
+Filter the list with `--tag` (repeatable, all must match), `--created-by` (user or team id), and `--maintainer-id` (repeatable, any may match):
+
+```bash
+vercel flags list --tag checkout --tag beta               # flags tagged checkout AND beta
+vercel flags list --created-by user_123                    # flags created by a user/team
+vercel flags list --maintainer-id user_456                 # flags maintained by a user
+```
+
+By default the list returns every flag. Use `--limit` (page size, 1-100) for a single page; the command prints a `--next <cursor>` command to fetch the following page. `--json` output includes `pagination.next`.
+
+```bash
+vercel flags list --limit 25                               # first page of 25
+vercel flags list --limit 25 --next <cursor>              # next page
+```
+
 ## Opening in Dashboard
 
 ```bash


### PR DESCRIPTION
## Summary

- Switch `vercel flags ls` to the v2 project flag list endpoint (`/v2/projects/{id}/feature-flags/flags`).
- Add server-side filters: `--tag` (repeatable, AND), `--created-by`, `--maintainer-id` (repeatable, OR).
- Add cursor pagination: `--limit` sets the page size (1-100) and prints a `--next <cursor>` hint; `--next` resumes from a cursor. `--json` output includes `pagination.next`.
- Default (no flags) still lists all flags by following cursors internally, so existing usage is unchanged.
- Track new options in telemetry (filter/cursor values redacted).

CLI counterpart to FLA-3016 (dashboard) and FLA-3000 (backend endpoints).

Resolves FLA-3049.

## Example
`npx https://vercel-7zto4se05.vercel.sh/tarballs/vercel.tgz flags list --maintainer-id InlernZBbA4dJZruwg25B7gX`

Prints
```
> 1 feature flag found for vercel/vercel-site [405ms]

 Name                               Kind       State     Variants    Updated    
 enable-paginated-flags-list        boolean    active           2    10d ago    
 ``` 
## Prompt example with Opus 4.8
> Using the vercel cli version from https://vercel-7zto4se05.vercel.sh/tarballs/vercel.tgz  (use `npx https://vercel-7zto4se05.vercel.sh/tarballs/vercel.tgz `), can you see which flags within ~/projects/front/apps/vercel-site belong to me?

<img width="1724" height="712" alt="CleanShot 2026-06-26 at 10 22 19@2x" src="https://github.com/user-attachments/assets/b6ec070b-7604-4b48-b89e-fb1c88f754a6" />


## Test plan

- [ ] `pnpm test-unit` for flags commands (filtering, pagination/`--limit`/`--next`, telemetry, JSON output)
- [ ] Manual: `vercel flags ls --tag <t> --created-by <id> --maintainer-id <id>`
- [ ] Manual: `vercel flags ls --limit 10`, then follow the printed `--next <cursor>` command