### PR TITLE
Add vercel-cli-approvers as code owner of CLI skills

### DIFF
--- a/.changeset/codeowners-cli-skills.md
+++ b/.changeset/codeowners-cli-skills.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add @vercel/vercel-cli-approvers as code owner for the CLI skills directory.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,6 +50,7 @@
 /packages/frameworks/                    @vercel/ci-cd @vercel/vercel-cli-approvers
 /packages/error-utils/                   @vercel/ci-cd @vercel/vercel-cli-approvers
 /packages/detect-agent/                  @vercel/ci-cd @vercel/vercel-cli-approvers
+/skills/vercel-cli/                      @vercel/ci-cd @vercel/vercel-cli-approvers
 /packages/connect/                       @vercel/ci-cd @vercel/marketplace
 /packages/python*                        @vercel/ci-cd @vercel/team-python
 /python                                  @vercel/ci-cd @vercel/team-python


### PR DESCRIPTION
## Summary
- Add `/skills/vercel-cli/` to `.github/CODEOWNERS`, owned by `@vercel/ci-cd @vercel/vercel-cli-approvers`.

Previously this directory only matched the catch-all `* → @vercel/ci-cd` rule, so any change to the CLI skill docs required a `@vercel/ci-cd` review even though `@vercel/vercel-cli-approvers` is the relevant owner for CLI-related content.