### PR TITLE
[cli][container] Emit build trace spans on failure

### DIFF
--- a/.changeset/container-build-failure-spans.md
+++ b/.changeset/container-build-failure-spans.md
@@ -1,0 +1,13 @@
+---
+'vercel': patch
+'@vercel/container': patch
+---
+
+Emit build trace spans on failure. `vc build` previously only stopped the root
+span and wrote the trace diagnostics file on the success path, so a failed build
+returned through `finishWithExitCode` and dropped its entire trace — leaving the
+Datadog trace empty. The trace is now flushed on both the success and error
+paths (run once via a guard). Additionally, `@vercel/container`'s `withSpan`
+records the error (`error`, `error.message`, `error.type`) on the span before
+re-throwing, so a failed step such as a rejected container registry login is
+distinguishable in the trace instead of looking like a successful span.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -412,6 +412,35 @@ const main = async () => {
 
   let earlyGetUserPromise: Promise<User | undefined> | undefined;
   let telemetrySaved = false;
+  let traceFlushed = false;
+
+  // Stop the root span and write the trace diagnostics file. Runs at most once,
+  // on both the success and error paths, so a failed build still emits its
+  // spans (previously the flush only ran on success and failures dropped the
+  // entire trace). Only `vc build` sets `traceDiagnosticsPath`, so traces are
+  // not written for other commands (deploy, env, etc.).
+  const flushTrace = async () => {
+    if (traceFlushed) {
+      return;
+    }
+    traceFlushed = true;
+
+    rootSpan.stop();
+
+    if (!client?.traceDiagnosticsPath) {
+      return;
+    }
+    try {
+      await mkdir(join(client.traceDiagnosticsPath, '..'), { recursive: true });
+      await writeFile(
+        client.traceDiagnosticsPath,
+        JSON.stringify(traceReporter.events)
+      );
+    } catch (err) {
+      output.error('Failed to write diagnostics trace file');
+      output.prettyError(err);
+    }
+  };
 
   const getStringProperty = (
     value: unknown,
@@ -511,6 +540,7 @@ const main = async () => {
 
   const finishWithExitCode = async (code: number) => {
     await saveTelemetry();
+    await flushTrace();
     return code;
   };
 
@@ -1301,23 +1331,7 @@ const main = async () => {
   }
 
   await saveTelemetry();
-
-  rootSpan.stop();
-
-  // Flush trace events to disk. Only `vc build` sets traceDiagnosticsPath,
-  // so traces are not written for other commands (deploy, env, etc.).
-  if (client.traceDiagnosticsPath) {
-    try {
-      await mkdir(join(client.traceDiagnosticsPath, '..'), { recursive: true });
-      await writeFile(
-        client.traceDiagnosticsPath,
-        JSON.stringify(traceReporter.events)
-      );
-    } catch (err) {
-      output.error('Failed to write diagnostics trace file');
-      output.prettyError(err);
-    }
-  }
+  await flushTrace();
 
   return exitCode;
 };

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -3322,6 +3322,38 @@ writeFileSync(
     );
   });
 
+  it('still writes trace spans when the build fails', async () => {
+    // Regression: a failed build previously returned through finishWithExitCode
+    // before the trace was flushed, so the whole trace was dropped. The trace
+    // must now be written on the error path too.
+    const cwd = fixture('node-error');
+    const outputDir = join(cwd, '.vercel/output');
+    const tracePath = join(outputDir, 'diagnostics', 'cli_traces.json');
+
+    await fs.remove(tracePath);
+
+    const cliPath = join(__dirname, '../../../../dist/vc.js');
+    let exitCode = 0;
+    try {
+      execSync(`node ${cliPath} build`, { cwd, stdio: 'pipe' });
+    } catch (err) {
+      exitCode = (err as { status?: number }).status ?? 1;
+    }
+
+    // The build fails...
+    expect(exitCode).toBe(1);
+
+    // ...but the trace file is still written, with spans up to and including
+    // the builder where the failure happened.
+    expect(await fs.pathExists(tracePath)).toBe(true);
+    const events = await fs.readJSON(tracePath);
+    expect(events.length).toBeGreaterThan(0);
+    const names = new Set(events.map((e: any) => e.name as string));
+    expect(names.has('vc.cli')).toBe(true);
+    expect(names.has('vc.doBuild')).toBe(true);
+    expect(names.has('vc.builder')).toBe(true);
+  });
+
   describe('--project', () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "type-check": "tsc --noEmit",
-    "test-unit": "vitest run --config ../../vitest.config.mts test/unit.test.ts",
-    "vitest-unit": "glob --absolute 'test/unit.test.ts'"
+    "test-unit": "vitest run --config ../../vitest.config.mts test/unit.*test.*",
+    "vitest-unit": "glob --absolute 'test/unit.*test.*'"
   },
   "files": [
     "dist"

--- a/packages/container/src/util.ts
+++ b/packages/container/src/util.ts
@@ -51,6 +51,12 @@ export function delay(ms: number): Promise<void> {
  * Run `fn` inside a child span of `parent` so the container build flow is
  * traceable in the build container. When tracing is disabled (no parent span,
  * e.g. some local invocations) `fn` runs directly.
+ *
+ * If `fn` throws, the error is recorded on the span (as `error` plus
+ * `error.message` / `error.type`) before being re-thrown, so a failed step
+ * (e.g. a rejected registry login) is distinguishable in the trace instead of
+ * looking like a successful span. The span is still stopped/reported by
+ * `Span.trace`'s `finally`.
  */
 export async function withSpan<T>(
   parent: Span | undefined,
@@ -61,7 +67,20 @@ export async function withSpan<T>(
   if (!parent) {
     return fn(undefined);
   }
-  return parent.child(name, attrs).trace(span => fn(span));
+  const span = parent.child(name, attrs);
+  return span.trace(async s => {
+    try {
+      return await fn(s);
+    } catch (err) {
+      const error = err as Error;
+      s.setAttributes({
+        error: 'true',
+        'error.message': error?.message ?? String(err),
+        'error.type': error?.name ?? 'Error',
+      });
+      throw err;
+    }
+  });
 }
 
 /** Stringify a value for use as a span tag (tags must be strings). */

--- a/packages/container/test/unit.util.test.ts
+++ b/packages/container/test/unit.util.test.ts
@@ -1,0 +1,80 @@
+import type { Reporter, TraceEvent } from '@vercel/build-utils';
+import { Span } from '@vercel/build-utils';
+import { describe, expect, it } from 'vitest';
+import { withSpan } from '../src/util';
+
+class CollectingReporter implements Reporter {
+  public events: TraceEvent[] = [];
+  report(event: TraceEvent) {
+    this.events.push(event);
+  }
+}
+
+function rootSpan() {
+  const reporter = new CollectingReporter();
+  const span = new Span({ name: 'root', reporter });
+  return { reporter, span };
+}
+
+describe('withSpan', () => {
+  it('reports the span and runs without a parent (tracing disabled)', async () => {
+    // No parent span: fn runs directly and nothing is reported.
+    const result = await withSpan(undefined, 'noop', {}, () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('reports a child span on success', async () => {
+    const { reporter, span } = rootSpan();
+
+    const result = await withSpan(span, 'step', { foo: 'bar' }, () => 'ok');
+
+    expect(result).toBe('ok');
+    const event = reporter.events.find(e => e.name === 'step');
+    expect(event).toBeDefined();
+    expect(event?.tags).toMatchObject({ foo: 'bar' });
+    // No error tags on success.
+    expect(event?.tags).not.toHaveProperty('error');
+  });
+
+  it('records the error on the span and re-throws when fn rejects', async () => {
+    const { reporter, span } = rootSpan();
+
+    const boom = new TypeError('registry login denied');
+
+    await expect(
+      withSpan(span, 'container.registry_login', {}, async () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+
+    // The span is still reported (Span.trace stops it in a finally) and now
+    // carries the error so the failed step is distinguishable in the trace.
+    const event = reporter.events.find(
+      e => e.name === 'container.registry_login'
+    );
+    expect(event).toBeDefined();
+    expect(event?.tags).toMatchObject({
+      error: 'true',
+      'error.message': 'registry login denied',
+      'error.type': 'TypeError',
+    });
+  });
+
+  it('falls back to sensible error tags for non-Error throws', async () => {
+    const { reporter, span } = rootSpan();
+
+    await expect(
+      withSpan(span, 'step', {}, async () => {
+        // eslint-disable-next-line no-throw-literal
+        throw 'plain string failure';
+      })
+    ).rejects.toBe('plain string failure');
+
+    const event = reporter.events.find(e => e.name === 'step');
+    expect(event?.tags).toMatchObject({
+      error: 'true',
+      'error.message': 'plain string failure',
+      'error.type': 'Error',
+    });
+  });
+});


### PR DESCRIPTION
## Problem

While investigating a container registry login rejection, the Datadog trace for the failed build showed **no spans**.

Two root causes:

1. **CLI dropped the whole trace on failure.** `vc build` only stopped the root span and wrote `cli_traces.json` on the success path. Any thrown error (e.g. a rejected registry login bubbling up through `doBuild`) returns via `finishWithExitCode(1)` *before* the flush, so the entire in-memory span buffer was discarded.
2. **Container builder spans had no error info.** `@vercel/container`'s `withSpan` never recorded the error when its `fn` threw — so even when a span *was* emitted, a failed step (like `container.registry_login`) looked identical to a successful one (no `error` tag, no message).

## Fix

- **`vercel`**: extract a single guarded `flushTrace()` that stops the root span and writes the diagnostics file, and call it on **both** the success and error paths (via `finishWithExitCode`). Runs at most once. Non-build commands still write nothing (`traceDiagnosticsPath` only set by `vc build`).
- **`@vercel/container`**: `withSpan` now records `error` / `error.message` / `error.type` on the span before re-throwing, so failed steps are distinguishable in the trace. The span is still stopped/reported by `Span.trace`'s `finally`.

## Tests

- `vercel`: new test that runs `vc build` against a failing fixture (`node-error`) through the real CLI binary and asserts `cli_traces.json` is still written with `vc.cli` / `vc.doBuild` / `vc.builder` spans. (This test fails without the fix.) Existing positive and non-build trace tests still pass.
- `@vercel/container`: new `withSpan` unit tests covering success, error attribution, and non-`Error` throws. Updated `test-unit` glob so the new file is picked up.

## Validation

- `@vercel/container`: 36/36 (`test-unit`), type-check clean.
- `vercel`: the three trace tests pass against the built CLI. (Note: `vercel` has pre-existing, unrelated `tsc` errors in `detect-services.test.ts` / a `convertRewrites` import — present on `main`, not introduced here.)

## Note on follow-up

`Span` in `@vercel/build-utils` has no first-class error/status field — the error info rides as tags. Whether Datadog renders these as APM errors depends on how the host reporter maps tags to `error.msg` / `status:error`; that mapping lives outside this repo and may warrant a follow-up so failed spans are colored/filterable as errors in the UI.
