### PR TITLE
[python] Make sure oidc headers get routed to vercel.headers on all paths

### DIFF
--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -1082,6 +1082,8 @@ if (
             for sc_header in SC_HEADERS_STRIP_ON_NO_LEAK:
                 headers.pop(sc_header, None)
 
+        set_vercel_headers_from_http_headers(headers)
+
         # `_thread.start_new_thread` does not propagate contextvars
         captured_ctx = contextvars.copy_context()
         _thread.start_new_thread(
@@ -1089,6 +1091,7 @@ if (
             (server.handle_request,),  # type: ignore[attr-defined]
         )
         clear_runtime_cache_context()
+        clear_vercel_headers_context()
 
         if (body is not None and len(body) > 0) and (
             encoding is not None and encoding == "base64"
@@ -1374,7 +1377,12 @@ else:
                 )
 
                 asgi_instance = app(self.scope, self.receive, self.send)
-                _asgi_runner.run(asgi_instance)
+                # asyncio.Runner reuses the context from its first run
+                # (lifespan startup), so pass the current context to deliver
+                # this request's contextvars (OIDC headers, cache) to the app.
+                _asgi_runner.run(
+                    asgi_instance, context=contextvars.copy_context()
+                )
                 return self.response
 
             def put_message(self, message: dict[str, Any]) -> None:

--- a/python/vercel-runtime/tests/fixtures/_oidc_sdk_stub/vercel/headers.py
+++ b/python/vercel-runtime/tests/fixtures/_oidc_sdk_stub/vercel/headers.py
@@ -1,0 +1,26 @@
+"""Minimal stand-in for the vercel SDK's header context (test fixture).
+
+The runtime calls ``vercel.headers.set_headers()`` to publish a request's
+headers into a contextvar; this stub mirrors that contract so a fixture app can
+read the OIDC token back the way the real SDK does.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_headers: ContextVar[Mapping[str, str] | None] = ContextVar(
+    "vercel_headers", default=None
+)
+
+
+def set_headers(headers: Mapping[str, str] | None) -> None:
+    _headers.set(headers)
+
+
+def get_headers() -> Mapping[str, str] | None:
+    return _headers.get()

--- a/python/vercel-runtime/tests/fixtures/_oidc_sdk_stub/vercel/oidc/__init__.py
+++ b/python/vercel-runtime/tests/fixtures/_oidc_sdk_stub/vercel/oidc/__init__.py
@@ -1,0 +1,20 @@
+"""Minimal stand-in for ``vercel.oidc.get_vercel_oidc_token`` (test fixture).
+
+Resolves the OIDC token the way the real SDK does: the per-request
+``x-vercel-oidc-token`` header (published into the context by the runtime),
+falling back to the ``VERCEL_OIDC_TOKEN`` env var.
+"""
+
+from __future__ import annotations
+
+import os
+
+from vercel.headers import get_headers
+
+
+def get_vercel_oidc_token() -> str:
+    headers = get_headers() or {}
+    token = headers.get("x-vercel-oidc-token")
+    if token:
+        return token
+    return os.environ.get("VERCEL_OIDC_TOKEN", "")

--- a/python/vercel-runtime/tests/fixtures/oidc_context_app.py
+++ b/python/vercel-runtime/tests/fixtures/oidc_context_app.py
@@ -1,0 +1,27 @@
+"""ASGI app that returns the OIDC token resolved from the request context.
+
+Regression fixture for per-request contextvar propagation: the runtime
+publishes the request's OIDC header into vercel's context before dispatching,
+and this app reads it back the way the SDK does. If the per-request context
+doesn't reach the app, ``get_vercel_oidc_token()`` falls back to the
+``VERCEL_OIDC_TOKEN`` env var.
+"""
+
+from vercel.oidc import get_vercel_oidc_token
+
+
+async def app(scope, receive, send):
+    if scope["type"] != "http":
+        return
+
+    body = get_vercel_oidc_token().encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/plain")],
+        }
+    )
+    await send(
+        {"type": "http.response.body", "body": body, "more_body": False}
+    )

--- a/python/vercel-runtime/tests/fixtures/oidc_http_handler.py
+++ b/python/vercel-runtime/tests/fixtures/oidc_http_handler.py
@@ -1,0 +1,20 @@
+"""BaseHTTPRequestHandler that returns the OIDC token from the request context.
+
+Regression fixture for the raw-handler path: the runtime must publish the
+request's OIDC header into vercel's context (captured into the handler thread)
+so handler code can resolve the token the way the SDK does, rather than only
+reading the wire header.
+"""
+
+from http.server import BaseHTTPRequestHandler
+
+from vercel.oidc import get_vercel_oidc_token
+
+
+class handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        token = get_vercel_oidc_token()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(token.encode())

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -137,6 +137,7 @@ async def _invoke_lambda(
     module_name: str,
     event: dict[str, Any],
     variable_name: str = "app",
+    extra_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Run vc_init.py in legacy mode and call vc_handler.
 
@@ -151,6 +152,8 @@ async def _invoke_lambda(
         "__VC_HANDLER_VARIABLE_NAME": variable_name,
     }
     env.pop("VERCEL_IPC_PATH", None)
+    if extra_env:
+        env.update(extra_env)
 
     result_r, result_w = os.pipe()
     env["_RESULT_FD"] = str(result_w)
@@ -878,6 +881,41 @@ class TestASGIApp(_RuntimeTestCase):
             self.assertEqual(resp.status, 200)
             self.assertEqual(resp.read().decode(), "env-token")
 
+    async def test_oidc_token_reaches_app_via_request_context(self) -> None:
+        # Server mode (uvicorn + ASGIMiddleware) already sets and awaits the
+        # app in the same context, so the OIDC contextvar should reach the app.
+        # This guards that propagation against future refactors. A stub `vercel`
+        # SDK lets the app read the token from context, not the wire header.
+        ep_abs, ep_rel, mod = _make_entrypoint(
+            "oidc_context_app.py", self.tmp_path
+        )
+        stub_path = str(_FIXTURES / "_oidc_sdk_stub")
+        pythonpath = os.pathsep.join(
+            p for p in (stub_path, os.environ.get("PYTHONPATH", "")) if p
+        )
+        async with _run_runtime(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            ipc_socket_path=self.n1.socket_path,
+            extra_env={
+                "PYTHONPATH": pythonpath,
+                "VERCEL_OIDC_TOKEN": "env-fallback-token",
+            },
+        ):
+            ss = await self.n1.wait_for_message(
+                ServerStartedMessage, timeout=10.0
+            )
+            port = ss.payload.http_port
+
+            resp = await _http_get(
+                port,
+                "/",
+                headers={"x-vercel-oidc-token": "per-request-token"},
+            )
+            self.assertEqual(resp.status, 200)
+            self.assertEqual(resp.read().decode(), "per-request-token")
+
     async def test_sc_headers_stripped_per_no_leak_flag(self) -> None:
         ep_abs, ep_rel, mod = _make_entrypoint("asgi_app.py", self.tmp_path)
         async with _run_runtime(
@@ -1597,6 +1635,38 @@ class TestLambdaHTTPHandler(_LambdaTestCase):
         self.assertEqual(result["statusCode"], 200)
         self.assertIn("GET /hello", result["body"])
 
+    async def test_oidc_token_reaches_handler_via_request_context(
+        self,
+    ) -> None:
+        # The raw-handler path runs the handler in a thread with a copied
+        # context, so the runtime must publish the request's OIDC header into
+        # that context. The fixture resolves the token via the SDK (context),
+        # not the wire header; a regression would show the env fallback below.
+        ep_abs, ep_rel, mod = _make_entrypoint(
+            "oidc_http_handler.py", self.tmp_path
+        )
+        stub_path = str(_FIXTURES / "_oidc_sdk_stub")
+        pythonpath = os.pathsep.join(
+            p for p in (stub_path, os.environ.get("PYTHONPATH", "")) if p
+        )
+        result = await _invoke_lambda(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            event=_lambda_event(
+                "GET",
+                "/",
+                headers={"x-vercel-oidc-token": "per-request-token"},
+            ),
+            variable_name="handler",
+            extra_env={
+                "PYTHONPATH": pythonpath,
+                "VERCEL_OIDC_TOKEN": "env-fallback-token",
+            },
+        )
+        self.assertEqual(result["statusCode"], 200)
+        self.assertEqual(result["body"], "per-request-token")
+
     async def test_post_with_base64_body(self) -> None:
         ep_abs, ep_rel, mod = _make_entrypoint("http_handler.py", self.tmp_path)
         result = await _invoke_lambda(
@@ -1724,6 +1794,38 @@ class TestLambdaASGI(_LambdaTestCase):
         self.assertEqual(result["statusCode"], 200)
         body = base64.b64decode(result["body"]).decode()
         self.assertEqual(body, "text/html,application/json")
+
+    async def test_oidc_token_reaches_app_via_request_context(self) -> None:
+        # The runtime publishes the request's OIDC header into vercel's context
+        # before dispatching the ASGI app. Because the ASGI app runs on a
+        # persistent asyncio.Runner, the per-request context must be passed
+        # explicitly or the app sees the context frozen at lifespan startup. A
+        # stub `vercel` SDK on the path lets the app read the token back; if
+        # propagation regresses it would instead see the env fallback below.
+        ep_abs, ep_rel, mod = _make_entrypoint(
+            "oidc_context_app.py", self.tmp_path
+        )
+        stub_path = str(_FIXTURES / "_oidc_sdk_stub")
+        pythonpath = os.pathsep.join(
+            p for p in (stub_path, os.environ.get("PYTHONPATH", "")) if p
+        )
+        result = await _invoke_lambda(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            event=_lambda_event(
+                "GET",
+                "/",
+                headers={"x-vercel-oidc-token": "per-request-token"},
+            ),
+            extra_env={
+                "PYTHONPATH": pythonpath,
+                "VERCEL_OIDC_TOKEN": "env-fallback-token",
+            },
+        )
+        self.assertEqual(result["statusCode"], 200)
+        body = base64.b64decode(result["body"]).decode()
+        self.assertEqual(body, "per-request-token")
 
 
 class TestLambdaASGILifespan(_LambdaTestCase):


### PR DESCRIPTION
They never got threaded through on the non-VERCEL_IPC_PATH case (the
route was run with an asyncio.Runner that didn't get the context
passed in).

I'm honestly not totally sure when non-VERCEL_IPC_PATH is used anymore
though?
