### PR TITLE
[cli] Fix `vercel dev` forcing case-sensitive routing for legacy configs

### DIFF
--- a/.changeset/fix-dev-routing-case-sensitivity.md
+++ b/.changeset/fix-dev-routing-case-sensitivity.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+Fix `vercel dev` always matching routes case-sensitively for legacy configs
+
+`hasNewRoutingProperties` compared `typeof value !== undefined` (the value) instead of `!== 'undefined'` (the string). `typeof` always returns a string, so every comparison was true and the function always returned `true`, forcing case-sensitive route matching in `vercel dev` even for legacy `routes`-only configs (which should match case-insensitively).

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -3448,13 +3448,13 @@ function filterFrontendBuilds(build: Builder) {
   return !frontendRuntimeSet.has(name || '');
 }
 
-function hasNewRoutingProperties(vercelConfig: VercelConfig) {
+export function hasNewRoutingProperties(vercelConfig: VercelConfig) {
   return (
-    typeof vercelConfig.cleanUrls !== undefined ||
-    typeof vercelConfig.headers !== undefined ||
-    typeof vercelConfig.redirects !== undefined ||
-    typeof vercelConfig.rewrites !== undefined ||
-    typeof vercelConfig.trailingSlash !== undefined
+    typeof vercelConfig.cleanUrls !== 'undefined' ||
+    typeof vercelConfig.headers !== 'undefined' ||
+    typeof vercelConfig.redirects !== 'undefined' ||
+    typeof vercelConfig.rewrites !== 'undefined' ||
+    typeof vercelConfig.trailingSlash !== 'undefined'
   );
 }
 

--- a/packages/cli/test/unit/util/dev/server.test.ts
+++ b/packages/cli/test/unit/util/dev/server.test.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'stream';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { describe, expect, it, vi } from 'vitest';
-import DevServer from '../../../../src/util/dev/server';
+import DevServer, { hasNewRoutingProperties } from '../../../../src/util/dev/server';
 
 vi.mock('../../../../src/output-manager', () => ({
   default: {
@@ -95,5 +95,21 @@ describe('DevServer queue routes', () => {
         originalMessageId: 'original-message-id',
       })
     );
+  });
+});
+
+describe('hasNewRoutingProperties', () => {
+  it('returns false for a legacy config without new routing properties', () => {
+    expect(hasNewRoutingProperties({})).toBe(false);
+    expect(hasNewRoutingProperties({ routes: [] })).toBe(false);
+  });
+
+  it('returns true when a new routing property is present', () => {
+    expect(hasNewRoutingProperties({ cleanUrls: true })).toBe(true);
+    expect(hasNewRoutingProperties({ redirects: [] })).toBe(true);
+    expect(hasNewRoutingProperties({ headers: [] })).toBe(true);
+    expect(hasNewRoutingProperties({ rewrites: [] })).toBe(true);
+    // A defined-but-falsy value still counts as present.
+    expect(hasNewRoutingProperties({ trailingSlash: false })).toBe(true);
   });
 });


### PR DESCRIPTION
## Bug

`hasNewRoutingProperties` (`packages/cli/src/util/dev/server.ts`) compares `typeof value` against the **value** `undefined` instead of the **string** `'undefined'`:

```ts
return (
  typeof vercelConfig.cleanUrls !== undefined ||
  typeof vercelConfig.headers !== undefined ||
  typeof vercelConfig.redirects !== undefined ||
  typeof vercelConfig.rewrites !== undefined ||
  typeof vercelConfig.trailingSlash !== undefined
);
```

`typeof x` always returns a string, and any string `!== undefined` (the value) is always `true`, so the function **always returns `true`** regardless of the config.

The result sets case sensitivity for `vercel dev` route matching:
- `server.ts`: `this.caseSensitive = hasNewRoutingProperties(vercelConfig);`
- `router.ts`: `const flags = devServer && devServer.isCaseSensitive() ? '' : 'i';`

So **every** config — including legacy `routes`-only configs that should match **case-insensitively** — is forced to **case-sensitive** matching in `vercel dev`. (The repo's own router test stubs `isCaseSensitive: () => false` for the legacy default, confirming the intended behavior.)

## Reproduction

```
hasNewRoutingProperties({ routes: [] })   // before: true   (expected false)
hasNewRoutingProperties({})               // before: true   (expected false)
hasNewRoutingProperties({ cleanUrls:true })  // true  (correct)
hasNewRoutingProperties({ trailingSlash:false })  // true (correct — defined)
```

## Fix

Compare against the string `'undefined'` so only configs that actually define a new routing property are treated as case-sensitive. `trailingSlash: false` (defined but falsy) still correctly counts as present.

## Test

Exports `hasNewRoutingProperties` and adds unit tests in `server.test.ts` for the legacy (`false`) and new-property (`true`) cases. A changeset (`vercel: patch`) is included.